### PR TITLE
refactor(checker): route jsx component prop relations

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
@@ -693,7 +693,7 @@ impl<'a> CheckerState<'a> {
                 if !crate::query_boundaries::common::is_template_literal_type(
                     self.ctx.types,
                     key_type,
-                ) || !self.diagnostic_relation_boolean_guard(tag_literal, key_type)
+                ) || !self.assign_relation_outcome(tag_literal, key_type).related
                 {
                     continue;
                 }
@@ -715,16 +715,22 @@ impl<'a> CheckerState<'a> {
             while i < best_matches.len() {
                 let (best_key, _) = best_matches[i];
                 let candidate_more_specific = self
-                    .diagnostic_relation_boolean_guard(candidate_key, best_key)
-                    && !self.diagnostic_relation_boolean_guard(best_key, candidate_key);
+                    .assign_relation_outcome(candidate_key, best_key)
+                    .related
+                    && !self
+                        .assign_relation_outcome(best_key, candidate_key)
+                        .related;
                 if candidate_more_specific {
                     best_matches.swap_remove(i);
                     continue;
                 }
 
                 let best_more_specific = self
-                    .diagnostic_relation_boolean_guard(best_key, candidate_key)
-                    && !self.diagnostic_relation_boolean_guard(candidate_key, best_key);
+                    .assign_relation_outcome(best_key, candidate_key)
+                    .related
+                    && !self
+                        .assign_relation_outcome(candidate_key, best_key)
+                        .related;
                 if best_more_specific {
                     candidate_is_best = false;
                     break;
@@ -897,7 +903,7 @@ impl<'a> CheckerState<'a> {
             return;
         }
         let tag_type = self.ctx.types.literal_string(tag);
-        if self.diagnostic_relation_boolean_guard(tag_type, evaluated) {
+        if self.assign_relation_outcome(tag_type, evaluated).related {
             return;
         }
 

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -199,6 +199,9 @@ mod jsdoc_this_arrow_tests;
 #[path = "../tests/jsx_component_attribute_tests.rs"]
 mod jsx_component_attribute_tests;
 #[cfg(test)]
+#[path = "tests/jsx_component_props_relation_routing_arch_tests.rs"]
+mod jsx_component_props_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/lib_abstract_member_ts2515_tests.rs"]
 mod lib_abstract_member_ts2515_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/jsx_component_props_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_component_props_relation_routing_arch_tests.rs
@@ -1,0 +1,29 @@
+use std::fs;
+
+#[test]
+fn jsx_component_props_tag_relations_use_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/checkers/jsx/orchestration/component_props.rs")
+        .expect("failed to read JSX component props orchestration source");
+    let start = source
+        .find("pub(in crate::checkers_domain::jsx) fn get_jsx_intrinsic_props_from_template_literal_index_signatures")
+        .expect("missing template literal intrinsic props helper");
+    let end = source[start..]
+        .find("fn jsx_element_type_for_validation")
+        .expect("missing JSX element type validation helper")
+        + start;
+    let helpers = &source[start..end];
+
+    assert_eq!(
+        helpers.matches("assign_relation_outcome").count(),
+        6,
+        "JSX component prop tag relation checks should route through assign_relation_outcome"
+    );
+    assert!(
+        helpers.contains(".related"),
+        "JSX component prop tag relation checks should use the relation outcome decision"
+    );
+    assert!(
+        !helpers.contains("diagnostic_relation_boolean_guard"),
+        "JSX component prop tag relation checks should not regress to the raw boolean relation guard"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker relation diagnostics refactor

## Invariant
When JSX intrinsic tag prop resolution compares template-literal tag keys or validates a tag against `JSX.ElementType`, tsz should make the compatibility decision through the shared assignability relation outcome boundary while JSX orchestration keeps tag lookup and diagnostic spans.

## Scope
- `crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs`
- `crates/tsz-checker/src/tests/jsx_component_props_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation-boundary routing
- Evidence: behavior-preserving refactor of JSX tag/key relation guards, covered by a source-level architecture test and local checker/architecture verification.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib jsx_component_props_tag_relations_use_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `git rev-list --left-right --count HEAD...origin/main` = `1 0`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Draft PR for M1-B relation-routing runway.
- Does not touch active object-literal/excess-property work (#10430), JSX spread work (#10431), JSX union props (#10429), JSX generic spread (#10426), JSX text child (#10425), or overload parameter routing (#10423).
- No solver policy or cache-key changes; M4-B solver-policy work is unaffected.
