### PR TITLE
refactor(checker): route jsx overload relations

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/overloads.rs
+++ b/crates/tsz-checker/src/checkers/jsx/overloads.rs
@@ -456,7 +456,7 @@ impl<'a> CheckerState<'a> {
             // is not assignable to type parameters like `P`, so we can't just assume
             // empty attrs match when the shape can't be resolved.
             let attrs_type = self.build_attrs_object_type_from_info(&info.attrs);
-            return self.diagnostic_relation_boolean_guard(attrs_type, props_type);
+            return self.assign_relation_outcome(attrs_type, props_type).related;
         };
 
         let has_string_index = shape.string_index.is_some();
@@ -535,7 +535,7 @@ impl<'a> CheckerState<'a> {
             // and explicit-excess checks have already passed, defer to the
             // canonical assignability gate before rejecting the overload.
             let attrs_type = self.build_attrs_object_type_from_info(&info.attrs);
-            return self.diagnostic_relation_boolean_guard(attrs_type, props_type);
+            return self.assign_relation_outcome(attrs_type, props_type).related;
         }
 
         true
@@ -646,7 +646,7 @@ impl<'a> CheckerState<'a> {
     /// keeps overload matching aligned with the canonical generic-constraint
     /// path without naming any particular helper alias.
     fn jsx_attr_assignable_to_expected(&mut self, attr_type: TypeId, expected: TypeId) -> bool {
-        self.diagnostic_relation_boolean_guard(attr_type, expected)
+        self.assign_relation_outcome(attr_type, expected).related
             || self.jsx_attr_assignable_after_referenced_constraints(attr_type, expected)
     }
 
@@ -692,8 +692,9 @@ impl<'a> CheckerState<'a> {
         }
         let restricted = self.resolve_lazy_type(restricted);
         let restricted_evaluated = self.evaluate_type_for_assignability(restricted);
-        self.diagnostic_relation_boolean_guard(restricted_evaluated, expected)
-            || self.diagnostic_relation_boolean_guard(restricted, expected)
+        self.assign_relation_outcome(restricted_evaluated, expected)
+            .related
+            || self.assign_relation_outcome(restricted, expected).related
     }
 
     /// Build an object type from collected JSX attribute info.

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -199,6 +199,9 @@ mod jsdoc_this_arrow_tests;
 #[path = "../tests/jsx_component_attribute_tests.rs"]
 mod jsx_component_attribute_tests;
 #[cfg(test)]
+#[path = "tests/jsx_overload_relation_routing_arch_tests.rs"]
+mod jsx_overload_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/lib_abstract_member_ts2515_tests.rs"]
 mod lib_abstract_member_ts2515_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/jsx_overload_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_overload_relation_routing_arch_tests.rs
@@ -1,0 +1,29 @@
+use std::fs;
+
+#[test]
+fn jsx_overload_matching_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/checkers/jsx/overloads.rs")
+        .expect("failed to read JSX overload source");
+    let start = source
+        .find("fn jsx_attrs_match_overload")
+        .expect("missing JSX attrs overload matcher");
+    let end = source[start..]
+        .find("/// Build an object type from collected JSX attribute info.")
+        .expect("missing attrs object builder")
+        + start;
+    let helpers = &source[start..end];
+
+    assert_eq!(
+        helpers.matches("assign_relation_outcome").count(),
+        5,
+        "JSX overload relation checks should route through assign_relation_outcome"
+    );
+    assert!(
+        helpers.contains(".related"),
+        "JSX overload relation checks should use the relation outcome decision"
+    );
+    assert!(
+        !helpers.contains("diagnostic_relation_boolean_guard"),
+        "JSX overload matching should not regress to the raw boolean relation guard"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker relation diagnostics refactor

## Invariant
When JSX overload resolution falls back from pointwise prop checks to whole-attribute or constrained-attribute compatibility checks, tsz should make the compatibility decision through the shared assignability relation outcome boundary while JSX overload code keeps candidate selection and diagnostic anchoring.

## Scope
- `crates/tsz-checker/src/checkers/jsx/overloads.rs`
- `crates/tsz-checker/src/tests/jsx_overload_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation-boundary routing
- Evidence: behavior-preserving refactor of JSX overload relation guards, covered by a source-level architecture test and local checker/architecture verification.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib jsx_overload_matching_uses_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `git rev-list --left-right --count HEAD...origin/main` = `1 0`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Draft PR for M1-B relation-routing runway.
- Does not touch active JSX component props (#10432), JSX spread (#10431), generic constrained excess-property (#10430), JSX union props (#10429), JSX generic spread (#10426), JSX text child (#10425), or overload parameter compatibility (#10423) files.
- No solver policy, relation cache-key, variance, or any-propagation changes; M4-B solver-policy work is unaffected.
