### PR TITLE
refactor(checker): route property receiver display relations

### DIFF
--- a/crates/tsz-checker/src/error_reporter/property_receiver_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/property_receiver_formatting.rs
@@ -69,8 +69,12 @@ impl<'a> CheckerState<'a> {
         if matches!(declared_element_type, TypeId::ERROR | TypeId::UNKNOWN) {
             return None;
         }
-        if !self.diagnostic_relation_boolean_guard(type_id, declared_element_type)
-            && !self.diagnostic_relation_boolean_guard(declared_element_type, type_id)
+        if !self
+            .assign_relation_outcome(type_id, declared_element_type)
+            .related
+            && !self
+                .assign_relation_outcome(declared_element_type, type_id)
+                .related
         {
             return None;
         }
@@ -124,8 +128,12 @@ impl<'a> CheckerState<'a> {
         if matches!(index_value_type, TypeId::ERROR | TypeId::UNKNOWN) {
             return None;
         }
-        if !self.diagnostic_relation_boolean_guard(actual_type, index_value_type)
-            && !self.diagnostic_relation_boolean_guard(index_value_type, actual_type)
+        if !self
+            .assign_relation_outcome(actual_type, index_value_type)
+            .related
+            && !self
+                .assign_relation_outcome(index_value_type, actual_type)
+                .related
         {
             return None;
         }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -748,6 +748,9 @@ mod promise_like_infer_tests;
 #[path = "tests/property_alias_display_tests.rs"]
 mod property_alias_display_tests;
 #[cfg(test)]
+#[path = "tests/property_receiver_relation_routing_arch_tests.rs"]
+mod property_receiver_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/recursive_alias_application_target_display_tests.rs"]
 mod recursive_alias_application_target_display_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/property_receiver_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/property_receiver_relation_routing_arch_tests.rs
@@ -1,0 +1,29 @@
+use std::fs;
+
+#[test]
+fn property_receiver_display_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/error_reporter/property_receiver_formatting.rs")
+        .expect("failed to read property receiver formatting source");
+    let start = source
+        .find("pub(crate) fn element_access_receiver_declared_element_display")
+        .expect("missing declared element display helper");
+    let end = source[start..]
+        .find("fn element_access_argument_prefers_number_index")
+        .expect("missing element access argument helper")
+        + start;
+    let helpers = &source[start..end];
+
+    assert_eq!(
+        helpers.matches("assign_relation_outcome").count(),
+        4,
+        "property receiver display relation checks should route through assign_relation_outcome"
+    );
+    assert!(
+        helpers.contains(".related"),
+        "property receiver display relation checks should use the relation outcome decision"
+    );
+    assert!(
+        !helpers.contains("diagnostic_relation_boolean_guard"),
+        "property receiver display should not regress to the raw boolean relation guard"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker relation diagnostics refactor

## Invariant
When property/index diagnostic formatting decides whether a declared receiver element or index-value type is comparable enough to display, tsz should make that compatibility decision through the shared assignability relation outcome boundary while the error reporter keeps formatting and span ownership.

## Scope
- `crates/tsz-checker/src/error_reporter/property_receiver_formatting.rs`
- `crates/tsz-checker/src/tests/property_receiver_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation-boundary routing
- Evidence: behavior-preserving refactor of diagnostic display relation guards, covered by a source-level architecture test and local checker/architecture verification.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib property_receiver_display_uses_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `git rev-list --left-right --count HEAD...origin/main` = `1 0`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Draft PR for M1-B relation-routing runway.
- Does not touch active JSX overload (#10434), JSX component props (#10432), JSX spread (#10431), generic constrained excess-property (#10430), JSX union props (#10429), or overload parameter compatibility (#10423) files.
- No solver policy, relation cache-key, variance, or any-propagation changes; M4-B solver-policy work is unaffected.
