### PR TITLE
refactor(checker): route render failure callback relations

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -173,7 +173,9 @@ impl<'a> CheckerState<'a> {
             .iter()
             .zip(inner_target.params.iter())
             .any(|(source_param, target_param)| {
-                !self.diagnostic_relation_boolean_guard(target_param.type_id, source_param.type_id)
+                !self
+                    .assign_relation_outcome(target_param.type_id, source_param.type_id)
+                    .related
             })
     }
 

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -763,6 +763,9 @@ mod recursive_path_default_type_param_tests;
 #[path = "tests/relation_flags_boundary_contract_tests.rs"]
 mod relation_flags_boundary_contract_tests;
 #[cfg(test)]
+#[path = "tests/render_failure_relation_routing_arch_tests.rs"]
+mod render_failure_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/repro_parserreal.rs"]
 mod repro_parserreal;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/render_failure_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/render_failure_relation_routing_arch_tests.rs
@@ -1,0 +1,29 @@
+use std::fs;
+
+#[test]
+fn strict_callback_inner_parameter_mismatch_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/error_reporter/render_failure.rs")
+        .expect("failed to read render failure source");
+    let start = source
+        .find("fn strict_callback_inner_parameter_mismatch_exists")
+        .expect("missing strict callback inner parameter mismatch helper");
+    let end = source[start..]
+        .find("fn no_union_member_matches_switch_source_display")
+        .expect("missing next render failure helper")
+        + start;
+    let helper = &source[start..end];
+
+    assert_eq!(
+        helper.matches("assign_relation_outcome").count(),
+        1,
+        "strict callback inner parameter mismatch should route through assign_relation_outcome"
+    );
+    assert!(
+        helper.contains(".related"),
+        "strict callback inner parameter mismatch should use the relation outcome decision"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard"),
+        "strict callback inner parameter mismatch should not regress to the raw boolean relation guard"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker relation diagnostics refactor

## Invariant
When diagnostic rendering checks whether nested strict-callback parameter types are incompatible, tsz should make that compatibility decision through the shared assignability relation outcome boundary while render-failure code keeps message selection and formatting ownership.

## Scope
- `crates/tsz-checker/src/error_reporter/render_failure.rs`
- `crates/tsz-checker/src/tests/render_failure_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation-boundary routing
- Evidence: behavior-preserving refactor of a diagnostic rendering relation guard, covered by a source-level architecture test and local checker/architecture verification.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib strict_callback_inner_parameter_mismatch_uses_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `git rev-list --left-right --count HEAD...origin/main` = `1 0`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Draft PR for M1-B relation-routing runway.
- Does not touch active property receiver (#10435), JSX overload (#10434), JSX component props (#10432), JSX spread (#10431), generic constrained excess-property (#10430), or JSX union props (#10429) files.
- No solver policy, relation cache-key, variance, or any-propagation changes; M4-B solver-policy work is unaffected.
