### PR TITLE
fix(dts): format mapped noinfer object constraints

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/tests/type_formatting.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/type_formatting.rs
@@ -1851,6 +1851,29 @@ fn mapped_type_named_tuple_union_constraint_stays_inline_renamed_var() {
     );
 }
 
+#[test]
+fn mapped_type_keyof_noinfer_object_constraint_formats_multiline() {
+    let output = emit_dts("export type M = { [K in keyof NoInfer<{ a: string, b: string }>]: K };");
+    assert!(
+        output.contains(
+            "export type M = {\n    [K in keyof NoInfer<{\n        a: string;\n        b: string;\n    }>]: K;\n};"
+        ),
+        "Object type literals inside mapped constraints should use structured multiline formatting: {output}"
+    );
+}
+
+#[test]
+fn mapped_type_keyof_noinfer_object_constraint_formats_multiline_renamed_var() {
+    let output =
+        emit_dts("export type M = { [P in keyof NoInfer<{ left: number, right: boolean }>]: P };");
+    assert!(
+        output.contains(
+            "export type M = {\n    [P in keyof NoInfer<{\n        left: number;\n        right: boolean;\n    }>]: P;\n};"
+        ),
+        "Object type literal formatting should not depend on mapped variable or property names: {output}"
+    );
+}
+
 /// A union-of-named-tuples used as a top-level type alias must be preserved
 /// in output (no regression for non-mapped-type positions).
 #[test]

--- a/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
@@ -1415,8 +1415,10 @@ impl<'a> DeclarationEmitter<'a> {
         &mut self,
         constraint_idx: NodeIndex,
     ) {
+        let contains_type_literal = self.type_node_contains_type_literal(constraint_idx, 0);
         if let Some(node) = self.arena.get(constraint_idx)
             && let Some(text) = self.get_source_slice(node.pos, node.end)
+            && !contains_type_literal
         {
             let text = Self::mapped_type_constraint_source_text(&text);
             if !text.is_empty() {
@@ -1427,7 +1429,9 @@ impl<'a> DeclarationEmitter<'a> {
 
         // tsc keeps mapped-type constraint expressions on a single line; suppress multiline tuple formatting.
         let saved_indent = self.indent_level;
-        self.indent_level = 0;
+        if !contains_type_literal {
+            self.indent_level = 0;
+        }
         self.emit_type(constraint_idx);
         self.indent_level = saved_indent;
     }
@@ -1496,6 +1500,22 @@ impl<'a> DeclarationEmitter<'a> {
             .get_children(type_idx)
             .into_iter()
             .any(|child_idx| self.type_node_contains_mapped_type(child_idx, depth + 1))
+    }
+
+    fn type_node_contains_type_literal(&self, type_idx: NodeIndex, depth: usize) -> bool {
+        if type_idx.is_none() || depth > 128 {
+            return false;
+        }
+        let Some(node) = self.arena.get(type_idx) else {
+            return false;
+        };
+        if node.kind == syntax_kind_ext::TYPE_LITERAL {
+            return true;
+        }
+        self.arena
+            .get_children(type_idx)
+            .into_iter()
+            .any(|child_idx| self.type_node_contains_type_literal(child_idx, depth + 1))
     }
 
     fn mapped_type_constraint_source_text(text: &str) -> &str {


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Track 9 declaration emit parity; focused DTS type-formatting/public API summary fix.

## Invariant
When a mapped type constraint contains a nested object type literal, `tsc` emits that object type literal with structured multiline formatting instead of reusing the compact source text; this PR makes tsz do the same through the declaration emitter type-syntax boundary.

## Owner Layer
- Owner: declaration emitter type syntax emission for mapped-type constraints.
- This does not add checker diagnostics, solver reach-through, fresh semantic validation during printing, or output surgery.
- The existing source-text fast path remains for constraints that do not contain object type literals, preserving single-line tuple/union constraint behavior.

## Adjacent-Case Matrix
- Reported witness: `noInfer` `type T32 = { [K in keyof NoInfer<{ a: string, b: string }>]: K }` now formats the object type literal across multiple lines like `tsc`.
- Equivalent renamed mapped variable/property case: unit coverage for `[P in keyof NoInfer<{ left: number, right: boolean }>]` proves the rule is structural and not tied to `K`, `a`, or `b`.
- Negative/fallback case: existing unit coverage keeps `[K in [x: string] | [y: number]]` inline, including a renamed `P` variant, so the source-text path still owns non-object-literal constraints.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/type_emission.rs`
- `crates/tsz-emitter/src/declaration_emitter/tests/type_formatting.rs`

## Project Corpus Impact
- Row: declaration emit conformance, `noInfer`
- Bug family: mapped type constraint formatting flattened nested object type literals inside `NoInfer`/type-reference arguments
- Evidence: `scripts/safe-run.sh scripts/emit/run.sh --filter=noInfer --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-noinfer-after-rebase.json` still fails on the unrelated `mutate1` inference hunk, but the mapped constraint formatting hunk is eliminated.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-emitter mapped_type_keyof_noinfer_object_constraint_formats_multiline mapped_type_named_tuple_union_constraint_stays_inline`
- `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=noInfer --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-noinfer-after-rebase.json` (expected remaining row failure outside this slice)

## Coordination Notes
AgentName: Studio-D. Overlap check: `gh pr list --state open --search "noInfer OR stringLiteralTypesOverloads02 OR spreadObjectOrFalsy OR stringLiteralTypesAndLogicalOrExpressions01" --json number,title,isDraft,headRefName,labels,url --limit 30` found no active DTS `noInfer` formatting owner; the only `noInfer`-adjacent result was unrelated conformance strictness bookkeeping. Branch was rebased onto `origin/main` after main advanced to `0670ad009a` before commit/push. The remaining live `noInfer` failure is inference-owned (`mutate1: unknown` expected vs `number` actual), not a declaration formatter gap.

- Marked ready by Studio-D on 2026-05-27 after exact-head draft light CI passed for head `91265478c0e2ca4a31f5fb730f8ff0346f60a6b5`; auto-merge and `merge-queue` remain off for manager/queue ownership after ready-review CI completes.