### PR TITLE
fix(checker): preserve keyof key-union source/target display in TS2322

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability_keyof_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_keyof_alias_display.rs
@@ -7,6 +7,43 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
+    /// True when `ty` is a `keyof X` whose operand `X` resolves to a concrete
+    /// object type (a plain `Object`/`ObjectWithIndex` shape, directly or via a
+    /// non-generic alias). Such a `keyof` reduces to a finite unit-literal key
+    /// set that provides a literal context for an assignment-source literal, so
+    /// the source literal must be displayed as-written (not widened). A `keyof`
+    /// whose operand is a mapped/computed/generic type has no such context.
+    pub(in crate::error_reporter) fn keyof_target_has_concrete_object_operand(
+        &mut self,
+        ty: TypeId,
+    ) -> bool {
+        let Some(operand) = crate::query_boundaries::common::keyof_inner_type(self.ctx.types, ty)
+        else {
+            return false;
+        };
+        let is_object = |db: &dyn tsz_solver::construction::TypeDatabase, t: TypeId| {
+            matches!(
+                db.lookup(t),
+                Some(tsz_solver::TypeData::Object(_) | tsz_solver::TypeData::ObjectWithIndex(_))
+            )
+        };
+        if is_object(self.ctx.types, operand) {
+            return true;
+        }
+        if let Some(def_id) = crate::query_boundaries::common::lazy_def_id(self.ctx.types, operand)
+        {
+            if let Some(body) = self.ctx.type_env.borrow().get_def(def_id) {
+                return is_object(self.ctx.types, body);
+            }
+            if let Some(def) = self.ctx.definition_store.get(def_id)
+                && let Some(body) = def.body
+            {
+                return is_object(self.ctx.types, body);
+            }
+        }
+        false
+    }
+
     pub(crate) fn keyof_type_alias_body_display(&mut self, ty: TypeId) -> Option<String> {
         if let Some(def_id) = self
             .ctx

--- a/crates/tsz-checker/src/error_reporter/assignability_keyof_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_keyof_alias_display.rs
@@ -7,12 +7,14 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
-    /// True when `ty` is a `keyof X` whose operand `X` resolves to a concrete
-    /// object type (a plain `Object`/`ObjectWithIndex` shape, directly or via a
-    /// non-generic alias). Such a `keyof` reduces to a finite unit-literal key
-    /// set that provides a literal context for an assignment-source literal, so
-    /// the source literal must be displayed as-written (not widened). A `keyof`
-    /// whose operand is a mapped/computed/generic type has no such context.
+    /// True when `ty` is a `keyof X` whose operand `X` resolves to a plain object
+    /// type with no string/number index signature. Only that shape yields a
+    /// finite unit-literal key set (`"a" | "b"`, `0 | 1`), which tsc treats as a
+    /// literal context — the assignment-source literal must then be displayed
+    /// as-written, not widened. An index signature contributes the `string` or
+    /// `number` primitive base to the key set, and a mapped/computed/generic
+    /// operand has no statically-enumerable literal keys; both lack a literal
+    /// context, so tsc widens the source there.
     pub(in crate::error_reporter) fn keyof_target_has_concrete_object_operand(
         &mut self,
         ty: TypeId,
@@ -21,27 +23,32 @@ impl<'a> CheckerState<'a> {
         else {
             return false;
         };
-        let is_object = |db: &dyn tsz_solver::construction::TypeDatabase, t: TypeId| {
-            matches!(
-                db.lookup(t),
-                Some(tsz_solver::TypeData::Object(_) | tsz_solver::TypeData::ObjectWithIndex(_))
-            )
-        };
-        if is_object(self.ctx.types, operand) {
-            return true;
-        }
-        if let Some(def_id) = crate::query_boundaries::common::lazy_def_id(self.ctx.types, operand)
-        {
-            if let Some(body) = self.ctx.type_env.borrow().get_def(def_id) {
-                return is_object(self.ctx.types, body);
-            }
-            if let Some(def) = self.ctx.definition_store.get(def_id)
-                && let Some(body) = def.body
+        // Resolve a non-generic alias operand to its body so the object shape is
+        // visible; a direct object operand already exposes its shape.
+        let resolved =
+            if crate::query_boundaries::common::object_shape_for_type(self.ctx.types, operand)
+                .is_some()
             {
-                return is_object(self.ctx.types, body);
-            }
-        }
-        false
+                operand
+            } else if let Some(def_id) =
+                crate::query_boundaries::common::lazy_def_id(self.ctx.types, operand)
+            {
+                self.ctx
+                    .type_env
+                    .borrow()
+                    .get_def(def_id)
+                    .or_else(|| {
+                        self.ctx
+                            .definition_store
+                            .get(def_id)
+                            .and_then(|def| def.body)
+                    })
+                    .unwrap_or(operand)
+            } else {
+                operand
+            };
+        crate::query_boundaries::common::object_shape_for_type(self.ctx.types, resolved)
+            .is_some_and(|shape| shape.string_index.is_none() && shape.number_index.is_none())
     }
 
     pub(crate) fn keyof_type_alias_body_display(&mut self, ty: TypeId) -> Option<String> {

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -193,13 +193,26 @@ impl<'a> CheckerState<'a> {
             let widened = self.widen_type_for_display(source);
             return self.format_assignability_type_for_message(widened, target);
         }
-        if crate::query_boundaries::common::literal_value(self.ctx.types, source).is_some()
+        // A `keyof` target only widens the source literal in the message when the
+        // key set has no literal context. A concrete `keyof R` (operand is a plain
+        // object type) reduces to a finite unit-literal key set (`"a" | "b"`,
+        // `unique symbol | "str"`) that provides a literal context, so tsc renders
+        // the source literal as-written. A generic/deferred `keyof T` (operand is a
+        // mapped/computed type whose keys cannot be statically enumerated) has the
+        // apparent key universe `string | number | symbol` and no literal context,
+        // so tsc widens the source to its primitive base. Gate the keyof widening
+        // paths on the operand NOT being a concrete object so concrete key unions
+        // keep the source literal spelling.
+        let keyof_target_widens_source = !self.keyof_target_has_concrete_object_operand(target);
+        if keyof_target_widens_source
+            && crate::query_boundaries::common::literal_value(self.ctx.types, source).is_some()
             && self.keyof_type_alias_body_display(target).is_some()
         {
             let widened = self.widen_type_for_display(source);
             return self.format_assignability_type_for_message(widened, target);
         }
-        if let Some(target_expr) = self.assignment_target_expression(anchor_idx)
+        if keyof_target_widens_source
+            && let Some(target_expr) = self.assignment_target_expression(anchor_idx)
             && self
                 .keyof_type_alias_annotation_display_for_expression(target_expr)
                 .is_some()
@@ -207,7 +220,8 @@ impl<'a> CheckerState<'a> {
             let widened = self.widen_type_for_display(source);
             return self.format_assignability_type_for_message(widened, target);
         }
-        if let Some(annotation) = self.direct_assignment_target_annotation_text(anchor_idx)
+        if keyof_target_widens_source
+            && let Some(annotation) = self.direct_assignment_target_annotation_text(anchor_idx)
             && self
                 .keyof_type_alias_annotation_display(&annotation)
                 .is_some()

--- a/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
+++ b/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
@@ -803,6 +803,148 @@ function g<T>() {
     );
 }
 
+// Issue #9695: `keyof <named object>` display must not (a) widen the source
+// literal for a concrete (non-generic) key union, nor (b) repaint a structurally
+// identical user-written literal union as `keyof X`.
+
+#[test]
+fn test_concrete_keyof_alias_target_preserves_source_literal() {
+    // Facet 1: a concrete `keyof R` reached through an alias is a finite literal
+    // key union, which tsc treats as a literal context — the source `"z"` must
+    // NOT widen to `string`.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type R = { a: number; b: string };
+type K = keyof R;
+const k: K = "z";
+"#,
+    );
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2322 && message.contains("Type '\"z\"' is not assignable to type 'keyof R'")
+        }),
+        "Expected concrete keyof alias target to preserve source literal '\"z\"'.\nActual: {diagnostics:#?}"
+    );
+    assert!(
+        !diagnostics.iter().any(|(code, message)| {
+            *code == 2322 && message.contains("Type 'string' is not assignable to type 'keyof R'")
+        }),
+        "Did not expect widened 'string' source for concrete keyof target.\nActual: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn test_concrete_keyof_alias_target_preserves_source_literal_renamed() {
+    // Same rule with different alias/object/key spellings — proves the fix is
+    // structural, not keyed on the names `R`/`K`/`a`/`b`.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type Shape = { foo: number; bar: string };
+type Keys = keyof Shape;
+const key: Keys = "nope";
+"#,
+    );
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2322
+                && message.contains("Type '\"nope\"' is not assignable to type 'keyof Shape'")
+        }),
+        "Expected renamed concrete keyof alias target to preserve source literal.\nActual: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn test_concrete_keyof_numeric_keys_preserve_source_literal() {
+    // Number-literal key union variant: source `5` must stay `5`.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type N = { 0: number; 1: string };
+type KN = keyof N;
+const n: KN = 5;
+"#,
+    );
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2322 && message.contains("Type '5' is not assignable to type 'keyof N'")
+        }),
+        "Expected concrete numeric keyof target to preserve source literal '5'.\nActual: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn test_literal_union_annotation_not_repainted_as_keyof() {
+    // Facet 2: a user-written literal union `"a" | "b"` is structurally identical
+    // to the interned `keyof R` key set, but must render by its members — never as
+    // `keyof R` — even though both appear in the same program.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type R = { a: number; b: string };
+const k1: keyof R = "z";
+const k2: "a" | "b" = "z";
+"#,
+    );
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2322 && message.contains("Type '\"z\"' is not assignable to type 'keyof R'")
+        }),
+        "Expected the `keyof R` annotation to render as 'keyof R'.\nActual: {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2322
+                && message.contains("Type '\"z\"' is not assignable to type '\"a\" | \"b\"'")
+        }),
+        "Expected the literal-union annotation to render as '\"a\" | \"b\"', not 'keyof R'.\nActual: {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .filter(|(code, message)| *code == 2322
+                && message.contains("is not assignable to type 'keyof R'"))
+            .count()
+            == 1,
+        "Expected exactly one 'keyof R' target rendering (only the keyof annotation).\nActual: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn test_numeric_literal_union_annotation_not_repainted_as_keyof() {
+    // Facet 2, numeric variant with renamed object: `0 | 1` must not become
+    // `keyof N`.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type N = { 0: number; 1: string };
+const a: keyof N = 5;
+const b: 0 | 1 = 5;
+"#,
+    );
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2322 && message.contains("Type '5' is not assignable to type '0 | 1'")
+        }),
+        "Expected the literal-union annotation to render as '0 | 1', not 'keyof N'.\nActual: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn test_generic_keyof_target_still_widens_source_literal() {
+    // Negative control: a generic/deferred `keyof T` provides no literal context,
+    // so tsc widens the source literal — this behavior must be preserved.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+function f<T extends { a: number }>(k: keyof T) {
+    k = "hello";
+}
+"#,
+    );
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2322 && message.contains("Type 'string' is not assignable to type 'keyof T'")
+        }),
+        "Expected generic keyof target to widen source literal to 'string'.\nActual: {diagnostics:#?}"
+    );
+}
+
 #[test]
 fn test_generic_string_index_constraint_allows_read_but_rejects_write_via_dot_access() {
     let diagnostics = compile_and_get_diagnostics(

--- a/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
+++ b/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
@@ -927,6 +927,35 @@ const b: 0 | 1 = 5;
 }
 
 #[test]
+fn test_indexed_keyof_target_widens_invalid_literal_source() {
+    // Negative control: `keyof R` where `R` has a string index signature is NOT
+    // a finite unit-literal key set — the key set includes the `string` primitive
+    // base. tsc widens an invalid literal source there (`true` -> `boolean`,
+    // `1n` -> `bigint`), so the concrete-object literal-context rule must exclude
+    // objects with index signatures.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type R = { [key: string]: number; a: number };
+type K = keyof R;
+const k: K = true;
+const k2: K = 1n;
+"#,
+    );
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2322 && message.contains("Type 'boolean' is not assignable to type 'keyof R'")
+        }),
+        "Expected indexed keyof target to widen boolean-literal source to 'boolean'.\nActual: {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2322 && message.contains("Type 'bigint' is not assignable to type 'keyof R'")
+        }),
+        "Expected indexed keyof target to widen bigint-literal source to 'bigint'.\nActual: {diagnostics:#?}"
+    );
+}
+
+#[test]
 fn test_generic_keyof_target_still_widens_source_literal() {
     // Negative control: a generic/deferred `keyof T` provides no literal context,
     // so tsc widens the source literal — this behavior must be preserved.

--- a/crates/tsz-solver/src/diagnostics/format/keyof_alias_display_tests.rs
+++ b/crates/tsz-solver/src/diagnostics/format/keyof_alias_display_tests.rs
@@ -1,0 +1,43 @@
+//! Focused tests for the `keyof` display-alias suppression rule (issue #9695).
+//!
+//! Kept in a dedicated shard rather than the oversized `tests.rs` so the
+//! touched file stays well under the repository file-size cap.
+
+use super::*;
+use crate::construction::TypeInterner;
+use crate::types::PropertyInfo;
+
+#[test]
+fn keyof_display_alias_does_not_repaint_unit_literal_union() {
+    // `keyof R` evaluates to the interned literal union `"a" | "b"` and may
+    // record a global `union -> KeyOf(R)` display alias. That alias must never
+    // repaint a structurally identical user-written literal union: a bare
+    // unit-literal union is what a user spells directly, and tsc renders it by
+    // members. The `keyof Name` spelling is preserved through the `KeyOf` node,
+    // not by repainting the shared union.
+    let db = TypeInterner::new();
+    let def_store = crate::def::DefinitionStore::new();
+
+    // A named object `R` with a def so the keyof operand resolves to a name.
+    let r_object = db.object(vec![
+        PropertyInfo::new(db.intern_string("a"), TypeId::NUMBER),
+        PropertyInfo::new(db.intern_string("b"), TypeId::STRING),
+    ]);
+    let r_def = def_store.register(crate::def::DefinitionInfo::interface(
+        db.intern_string("R"),
+        vec![],
+        vec![PropertyInfo::new(db.intern_string("a"), TypeId::NUMBER)],
+    ));
+    def_store.register_type_to_def(r_object, r_def);
+
+    let keyof_r = db.keyof(r_object);
+    let literal_union = db.union(vec![db.literal_string("a"), db.literal_string("b")]);
+    db.store_display_alias(literal_union, keyof_r);
+
+    let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+    assert_eq!(
+        fmt.format(literal_union),
+        "\"a\" | \"b\"",
+        "A unit-literal union must render by members, never as `keyof R`"
+    );
+}

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -172,6 +172,25 @@ impl<'a> TypeFormatter<'a> {
             && members.contains(&TypeId::SYMBOL)
     }
 
+    /// True when `key` is a `Union` whose members are all unit types: literal
+    /// values, enum members, or unique symbols. Such a union is exactly what a
+    /// user can spell directly as an annotation (`"a" | "b"`, `0 | 1`), so it
+    /// must be rendered by its members rather than redirected to a shared
+    /// `keyof X` display alias that would repaint unrelated annotations.
+    fn union_is_all_unit_literals(&self, key: &TypeData) -> bool {
+        let TypeData::Union(list_id) = key else {
+            return false;
+        };
+        let members = self.interner.type_list(*list_id);
+        !members.is_empty()
+            && members.iter().all(|&m| {
+                matches!(
+                    self.interner.lookup(m),
+                    Some(TypeData::Literal(_) | TypeData::Enum(_, _) | TypeData::UniqueSymbol(_))
+                )
+            })
+    }
+
     fn scalar_mapped_alias_application_display(
         &self,
         type_id: TypeId,
@@ -1294,27 +1313,38 @@ impl<'a> TypeFormatter<'a> {
             // operand has a named definition (interface/class/alias) so that
             // anonymous keyof (`keyof { a: string }`) still shows the expanded
             // union form, matching tsc behavior.
-            let use_keyof_alias =
-                if let Some(TypeData::KeyOf(keyof_operand)) = self.interner.lookup(alias_origin) {
-                    self.def_store.is_some_and(|ds| {
-                        ds.find_def_for_type(keyof_operand).is_some()
-                            || matches!(
-                                self.interner.lookup(keyof_operand),
-                                Some(TypeData::Lazy(def_id)) if ds.get(def_id).is_some()
-                            )
-                            || self.interner.get_display_alias(keyof_operand).is_some_and(
-                                |operand_alias| {
-                                    ds.find_def_for_type(operand_alias).is_some()
-                                        || matches!(
-                                            self.interner.lookup(operand_alias),
-                                            Some(TypeData::Lazy(def_id)) if ds.get(def_id).is_some()
-                                        )
-                                },
-                            )
-                    })
-                } else {
-                    false
-                };
+            let use_keyof_alias = if self.union_is_all_unit_literals(&key) {
+                // A bare union of unit literals (`"a" | "b"`, `0 | 1`, enum
+                // members, unique symbols) is indistinguishable from a
+                // user-written union annotation: the same structural type is
+                // interned once and shared. tsc only spells `keyof X` for an
+                // index type — which tsz preserves as a `KeyOf` node (handled
+                // by the `KeyOf` arm above) — and always renders a bare union
+                // by its members. Following a global `union -> keyof X`
+                // display alias here would repaint unrelated user-written
+                // literal-union annotations, so never do it for this shape.
+                false
+            } else if let Some(TypeData::KeyOf(keyof_operand)) = self.interner.lookup(alias_origin)
+            {
+                self.def_store.is_some_and(|ds| {
+                    ds.find_def_for_type(keyof_operand).is_some()
+                        || matches!(
+                            self.interner.lookup(keyof_operand),
+                            Some(TypeData::Lazy(def_id)) if ds.get(def_id).is_some()
+                        )
+                        || self.interner.get_display_alias(keyof_operand).is_some_and(
+                            |operand_alias| {
+                                ds.find_def_for_type(operand_alias).is_some()
+                                    || matches!(
+                                        self.interner.lookup(operand_alias),
+                                        Some(TypeData::Lazy(def_id)) if ds.get(def_id).is_some()
+                                    )
+                            },
+                        )
+                })
+            } else {
+                false
+            };
 
             // Application aliases: for Union types that expanded from a generic type alias
             // (e.g., `IteratorResult<T>` → `IteratorYieldResult<T> | IteratorReturnResult<TReturn>`),

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -14,6 +14,8 @@ mod property_names;
 // `cargo test --release`. Gate the module on `debug_assertions` so the
 // release-mode test build doesn't try to run (or compile) tests that have
 // nothing to capture.
+#[cfg(test)]
+mod keyof_alias_display_tests;
 #[cfg(all(test, debug_assertions))]
 pub mod test_tracing;
 #[cfg(test)]

--- a/crates/tsz-solver/src/diagnostics/format/tests.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests.rs
@@ -2321,6 +2321,41 @@ fn format_keyof_type() {
 }
 
 #[test]
+fn keyof_display_alias_does_not_repaint_unit_literal_union() {
+    // Issue #9695: `keyof R` evaluates to the interned literal union `"a" | "b"`
+    // and may record a global `union -> KeyOf(R)` display alias. That alias must
+    // never repaint a structurally identical user-written literal union: a bare
+    // unit-literal union is what a user spells directly, and tsc renders it by
+    // members. The `keyof Name` spelling is preserved through the `KeyOf` node,
+    // not by repainting the shared union.
+    let db = TypeInterner::new();
+    let def_store = crate::def::DefinitionStore::new();
+
+    // A named object `R` with a def so the keyof operand resolves to a name.
+    let r_object = db.object(vec![
+        PropertyInfo::new(db.intern_string("a"), TypeId::NUMBER),
+        PropertyInfo::new(db.intern_string("b"), TypeId::STRING),
+    ]);
+    let r_def = def_store.register(crate::def::DefinitionInfo::interface(
+        db.intern_string("R"),
+        vec![],
+        vec![PropertyInfo::new(db.intern_string("a"), TypeId::NUMBER)],
+    ));
+    def_store.register_type_to_def(r_object, r_def);
+
+    let keyof_r = db.keyof(r_object);
+    let literal_union = db.union(vec![db.literal_string("a"), db.literal_string("b")]);
+    db.store_display_alias(literal_union, keyof_r);
+
+    let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+    assert_eq!(
+        fmt.format(literal_union),
+        "\"a\" | \"b\"",
+        "A unit-literal union must render by members, never as `keyof R`"
+    );
+}
+
+#[test]
 fn format_keyof_intersection_distributes() {
     let db = TypeInterner::new();
     let mut fmt = TypeFormatter::new(&db);

--- a/crates/tsz-solver/src/diagnostics/format/tests.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests.rs
@@ -2321,41 +2321,6 @@ fn format_keyof_type() {
 }
 
 #[test]
-fn keyof_display_alias_does_not_repaint_unit_literal_union() {
-    // Issue #9695: `keyof R` evaluates to the interned literal union `"a" | "b"`
-    // and may record a global `union -> KeyOf(R)` display alias. That alias must
-    // never repaint a structurally identical user-written literal union: a bare
-    // unit-literal union is what a user spells directly, and tsc renders it by
-    // members. The `keyof Name` spelling is preserved through the `KeyOf` node,
-    // not by repainting the shared union.
-    let db = TypeInterner::new();
-    let def_store = crate::def::DefinitionStore::new();
-
-    // A named object `R` with a def so the keyof operand resolves to a name.
-    let r_object = db.object(vec![
-        PropertyInfo::new(db.intern_string("a"), TypeId::NUMBER),
-        PropertyInfo::new(db.intern_string("b"), TypeId::STRING),
-    ]);
-    let r_def = def_store.register(crate::def::DefinitionInfo::interface(
-        db.intern_string("R"),
-        vec![],
-        vec![PropertyInfo::new(db.intern_string("a"), TypeId::NUMBER)],
-    ));
-    def_store.register_type_to_def(r_object, r_def);
-
-    let keyof_r = db.keyof(r_object);
-    let literal_union = db.union(vec![db.literal_string("a"), db.literal_string("b")]);
-    db.store_display_alias(literal_union, keyof_r);
-
-    let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
-    assert_eq!(
-        fmt.format(literal_union),
-        "\"a\" | \"b\"",
-        "A unit-literal union must render by members, never as `keyof R`"
-    );
-}
-
-#[test]
 fn format_keyof_intersection_distributes() {
     let db = TypeInterner::new();
     let mut fmt = TypeFormatter::new(&db);


### PR DESCRIPTION
## Summary
Fixes #9695. A `TS2322` whose target is a `keyof <object>` key union mis-rendered the source/target type display in two ways that diverged from `tsc`:

1. **Source literal widened** (`"z"` → `string`) whenever the target was reached through a `keyof` type alias, even for a concrete `keyof R` whose key set is a finite literal union.
2. **Target cross-contamination**: a user-written literal union annotation (`"a" | "b"`) was rendered as `keyof R`, because `keyof R` evaluates to the interned union `"a" | "b"` and records a global `union → keyof R` display alias that the formatter reused for any structurally identical union.

AgentName: M1-C

Runner: vibrant-lovelace-opus47

## Structural rule
> When an assignment's target is a `keyof X`, `tsc` spells `keyof X` only for an *index type* (a `KeyOf` node, which tsz preserves distinctly) and renders a bare unit-literal union by its members; it widens the source literal only when the key set has no literal context (a generic/deferred `keyof T`), not for a concrete finite key union.

Two fixes implement that rule:
- **Solver formatter** (`diagnostics/format/mod.rs`): never follow a `keyof` display alias for a `Union` whose members are all unit types (literals, enum members, unique symbols). Such a union is indistinguishable from a user-written annotation; the `keyof X` spelling is preserved through the `KeyOf` node, not by repainting the shared interned union.
- **Checker** (`error_reporter`): gate the `keyof` source-literal widening on the operand **not** being a concrete object type. A concrete `keyof R` keeps the source literal; a generic `keyof T` (mapped/computed operand, no statically-enumerable keys) still widens, matching `tsc`.

## Track
Conformance / type-display parity (TS2322).

## Invariant
- `keyof Named` references remain `KeyOf` nodes and display as `keyof Named` (unchanged).
- Bare unit-literal unions render by members and are never repainted as `keyof X`.
- Generic/deferred `keyof T` targets still widen the source literal (preserved by the existing `test_assignment_diagnostic_widens_literal_for_named_keyof_display_target` test).

## Scope
- `crates/tsz-solver/src/diagnostics/format/mod.rs` — `union_is_all_unit_literals` guard on `use_keyof_alias`.
- `crates/tsz-checker/src/error_reporter/assignability_keyof_alias_display.rs` — `keyof_target_has_concrete_object_operand` helper.
- `crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs` — gate the three keyof widening paths.
- Tests added in both crates.

### Adjacent-case test matrix
- Facet 1 concrete keyof alias keeps `"z"` (`test_concrete_keyof_alias_target_preserves_source_literal`), plus renamed object/keys and numeric-key variants.
- Facet 2 literal union not repainted (`test_literal_union_annotation_not_repainted_as_keyof`), plus numeric-key variant.
- Negative control: generic `keyof T` still widens (`test_generic_keyof_target_still_widens_source_literal`).
- Solver-level: `keyof_display_alias_does_not_repaint_unit_literal_union`.

### Known residual gaps (documented, out of scope)
The deepest root cause is that `keyof Named` interns into the shared union and relies on a global display-alias rather than a per-reference `KeyOf` identity. A fully fundamental fix would preserve `keyof Named` as a distinct identity end-to-end (large solver refactor). The display-layer fix here matches `tsc` for the issue's facets and controls; it does not change these rarer cases (same root cause):
- A program defining **both** `type K = keyof R` and `type U = "a" | "b"` plus a bare literal-union annotation: the shared union still resolves to one alias name.
- `keyof` of a **non-generic key-remapping mapped type** that strips index signatures (operand is a `Mapped`, so the source still widens). The genericity signal is erased post-evaluation, so this is indistinguishable from the realistic generic case the existing test requires to widen.

## Project Corpus Impact
- Row: n/a (diagnostic type-display only; no inference/assignability decision changes).
- Bug family: TS2322 keyof key-union source/target rendering.
- Evidence: verified against `tsc` 5.x on the issue repros + controls (concrete vs generic keyof, renamed keys, numeric keys, literal-union alias); new owning-crate unit tests in `tsz-checker` and `tsz-solver`.

## Verification
- `cargo build -p tsz-cli`; manual diff vs `tsc --noEmit --strict` on all issue facets + controls (match exactly).
- `cargo test -p tsz-solver --lib diagnostics::format` (200 pass) + new solver test.
- `cargo test -p tsz-checker --test conformance_issues_errors` (286 pass; only 2 pre-existing failures that also fail on clean `main`, unrelated).
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets` clean.
- Pre-existing unrelated failures on this base (`template_*`/`any` conditional/file-size-ceiling) confirmed present on clean `main`.

## Coordination Notes
- Picked up #9695 (no open PR referenced it, no prior WIP marker); issue marked WIP with a signed comment.
- No overlap with current `origin/main`; rebased onto `0670ad0`.
- Heavy CI (conformance/emit/fourslash/WASM) runs on ready; will address any failures.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NQNS3iYCTJfAgfEGHvSvHx)_