### PR TITLE
refactor(checker): route call error anchor relations

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors_anchors.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_anchors.rs
@@ -199,7 +199,9 @@ impl<'a> CheckerState<'a> {
                     || arg_type == widened_actual_type;
                 let mismatches_expected = expected_type != TypeId::ERROR
                     && expected_type != TypeId::UNKNOWN
-                    && !self.diagnostic_relation_boolean_guard(arg_type, expected_type);
+                    && !self
+                        .assign_relation_outcome(arg_type, expected_type)
+                        .related;
 
                 if matches_actual {
                     actual_matches.push(arg_idx);
@@ -294,7 +296,10 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
             saw_expected = true;
-            if self.diagnostic_relation_boolean_guard(first_arg_type, expected_type) {
+            if self
+                .assign_relation_outcome(first_arg_type, expected_type)
+                .related
+            {
                 return false;
             }
         }
@@ -380,7 +385,10 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
 
-            if !self.diagnostic_relation_boolean_guard(source_prop_type, target_prop_type) {
+            if !self
+                .assign_relation_outcome(source_prop_type, target_prop_type)
+                .related
+            {
                 return self
                     .literal_argument_mismatch_anchor(prop_value_idx, target_prop_type)
                     .or(Some(prop_name_idx));
@@ -452,7 +460,10 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
 
-            if !self.diagnostic_relation_boolean_guard(elem_type, target_element_type) {
+            if !self
+                .assign_relation_outcome(elem_type, target_element_type)
+                .related
+            {
                 return Some(elem_idx);
             }
         }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -451,6 +451,9 @@ mod call_architecture_tests;
 #[path = "tests/call_context_relation_routing_arch_tests.rs"]
 mod call_context_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/call_error_anchor_relation_routing_arch_tests.rs"]
+mod call_error_anchor_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/call_spread_constructor_parameters_tests.rs"]
 mod call_spread_constructor_parameters_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/call_error_anchor_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/call_error_anchor_relation_routing_arch_tests.rs
@@ -1,0 +1,33 @@
+use std::fs;
+
+#[test]
+fn call_error_anchor_mismatch_probes_use_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/error_reporter/call_errors_anchors.rs")
+        .expect("failed to read call_errors_anchors.rs");
+
+    assert_eq!(
+        source.matches("assign_relation_outcome(").count(),
+        4,
+        "call error anchoring should route mismatch probes through assign_relation_outcome"
+    );
+    assert_eq!(
+        source.matches("diagnostic_relation_boolean_guard(").count(),
+        0,
+        "call error anchoring should not regress to the raw boolean relation guard"
+    );
+    assert!(
+        source.contains(".assign_relation_outcome(arg_type, expected_type)")
+            || source.contains("assign_relation_outcome(arg_type, expected_type)"),
+        "literal argument anchoring should route argument-vs-parameter probes through the boundary"
+    );
+    assert!(
+        source.contains(".assign_relation_outcome(source_prop_type, target_prop_type)")
+            || source.contains("assign_relation_outcome(source_prop_type, target_prop_type)"),
+        "object literal anchoring should route property mismatch probes through the boundary"
+    );
+    assert!(
+        source.contains(".assign_relation_outcome(elem_type, target_element_type)")
+            || source.contains("assign_relation_outcome(elem_type, target_element_type)"),
+        "array literal anchoring should route element mismatch probes through the boundary"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor-only checker relation diagnostic routing for #8227 / query-boundary cleanup.

## Invariant
When call error diagnostics choose an argument/property/element anchor from relation mismatch probes, checker span selection stays in `error_reporter`, but assignability truth is read through the shared relation outcome boundary.

## Scope
- `crates/tsz-checker/src/error_reporter/call_errors_anchors.rs`
- `crates/tsz-checker/src/tests/call_error_anchor_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only diagnostic-routing cleanup; no solver policy, cache-key, parser, binder, emitter, or project-corpus fixture behavior changes.

## Verification
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `cargo nextest run -p tsz-checker --lib call_error_anchor_mismatch_probes_use_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `git rev-list --left-right --count HEAD...origin/main` = `1 0`

## Coordination Notes
- Opened from fresh worktree `/Users/mohsen/code/tsz-m1b-fresh-origin-main-20260527-060539` based on `origin/main` and rebased after `origin/main` advanced.
- Non-overlap: avoids active JSX, render-failure, property-receiver, and solver-policy PRs; this slice only touches call-error anchor routing.
- Draft PR for M1-B coordination; no WIP label requested.
