### PR TITLE
refactor(checker): route array elaboration relation

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
@@ -150,7 +150,10 @@ impl<'a> CheckerState<'a> {
                     if elem_type.is_any_unknown_or_error() {
                         continue;
                     }
-                    if !self.diagnostic_relation_boolean_guard(elem_type, target_element) {
+                    if !self
+                        .assign_relation_outcome(elem_type, target_element)
+                        .related
+                    {
                         if self.array_elaboration_widening_required_for_display(
                             elem_type,
                             target_element,

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -427,6 +427,9 @@ mod architecture_contract_tests;
 #[path = "tests/architecture_contract_tests.rs"]
 mod architecture_contract_tests_src;
 #[cfg(test)]
+#[path = "tests/array_elaboration_relation_routing_arch_tests.rs"]
+mod array_elaboration_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/array_isarray_mutual_subtype_narrowing_tests.rs"]
 mod array_isarray_mutual_subtype_narrowing_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/array_elaboration_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/array_elaboration_relation_routing_arch_tests.rs
@@ -1,0 +1,29 @@
+use std::fs;
+
+#[test]
+fn array_elaboration_element_probe_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/error_reporter/call_errors/elaboration_array_mismatch.rs")
+        .expect("failed to read elaboration_array_mismatch.rs");
+    let start = source
+        .find("SubtypeFailureReason::ArrayElementMismatch")
+        .expect("missing array element mismatch branch");
+    let end = start
+        + source[start..]
+            .find("            _ => false,")
+            .expect("missing end of array element mismatch branch");
+    let branch = &source[start..end];
+
+    assert_eq!(
+        branch.matches("assign_relation_outcome(").count(),
+        1,
+        "array element elaboration should route the element relation through assign_relation_outcome"
+    );
+    assert!(
+        branch.contains(".related"),
+        "array element elaboration should use the shared relation outcome decision"
+    );
+    assert!(
+        !branch.contains("diagnostic_relation_boolean_guard("),
+        "array element elaboration should not regress to the raw boolean relation guard"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor-only checker relation diagnostic routing for #8227 / query-boundary cleanup.

## Invariant
When call-error elaboration chooses an array-literal element diagnostic from an `ArrayElementMismatch`, checker elaboration owns the element anchor and message shape, but assignability truth is read through the shared relation outcome boundary.

## Scope
- `crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs`
- `crates/tsz-checker/src/tests/array_elaboration_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only diagnostic-routing cleanup; no solver policy, cache-key, parser, binder, emitter, or project-corpus fixture behavior changes.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib array_elaboration_element_probe_uses_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `git rev-list --left-right --count HEAD...origin/main` = `1 0`

## Coordination Notes
- Reused `/Users/mohsen/code/tsz-m1b-fresh-origin-main-20260527-060539` after syncing #10439; branch created from current `origin/main`.
- Non-overlap: avoids active JSX, render-failure, property-receiver, call-anchor, and solver-policy PRs; this slice only touches array-literal call-error elaboration routing.
- Draft PR for M1-B coordination; no WIP label requested.
