### PR TITLE
refactor(checker): route call elaboration mutual relation

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -102,8 +102,8 @@ impl<'a> CheckerState<'a> {
     }
 
     fn types_are_mutually_assignable(&mut self, left: TypeId, right: TypeId) -> bool {
-        self.diagnostic_relation_boolean_guard(left, right)
-            && self.diagnostic_relation_boolean_guard(right, left)
+        self.assign_relation_outcome(left, right).related
+            && self.assign_relation_outcome(right, left).related
     }
 
     pub(in crate::error_reporter::call_errors) fn contextual_constraint_parameter_display(

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -451,6 +451,9 @@ mod call_architecture_tests;
 #[path = "tests/call_context_relation_routing_arch_tests.rs"]
 mod call_context_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/call_elaboration_mutual_relation_routing_arch_tests.rs"]
+mod call_elaboration_mutual_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/call_spread_constructor_parameters_tests.rs"]
 mod call_spread_constructor_parameters_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/call_elaboration_mutual_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/call_elaboration_mutual_relation_routing_arch_tests.rs
@@ -1,0 +1,29 @@
+use std::fs;
+
+#[test]
+fn call_elaboration_mutual_assignability_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/error_reporter/call_errors/elaboration.rs")
+        .expect("failed to read elaboration.rs");
+    let start = source
+        .find("fn types_are_mutually_assignable")
+        .expect("missing mutual assignability helper");
+    let end = start
+        + source[start..]
+            .find("pub(in crate::error_reporter::call_errors) fn contextual_constraint_parameter_display")
+            .expect("missing next call elaboration helper");
+    let helper = &source[start..end];
+
+    assert_eq!(
+        helper.matches("assign_relation_outcome(").count(),
+        2,
+        "mutual assignability display helper should route both relation directions through assign_relation_outcome"
+    );
+    assert!(
+        helper.matches(".related").count() >= 2,
+        "mutual assignability display helper should use relation outcome decisions"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard("),
+        "mutual assignability display helper should not regress to raw boolean relation guards"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor-only checker relation diagnostic routing for #8227 / query-boundary cleanup.

## Invariant
When call-error elaboration decides whether two contextual key-space display types are mutually assignable, checker display selection owns the presentation choice, but assignability truth is read through the shared relation outcome boundary.

## Scope
- `crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs`
- `crates/tsz-checker/src/tests/call_elaboration_mutual_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only diagnostic-routing cleanup; no solver policy, cache-key, parser, binder, emitter, or project-corpus fixture behavior changes.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib call_elaboration_mutual_assignability_uses_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `git rev-list --left-right --count HEAD...origin/main` = `1 0`

## Coordination Notes
- Reused `/Users/mohsen/code/tsz-m1b-fresh-origin-main-20260527-060539`; branch created from current `origin/main` after checking #10441/#10439 for red CI.
- Non-overlap: avoids active JSX, render-failure, property-receiver, call-anchor, array-elaboration, and solver-policy PRs; this slice only touches contextual call-error elaboration mutual relation routing.
- Draft PR for M1-B coordination; no WIP label requested.
