### PR TITLE
refactor(checker): route call display overlap relation

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
@@ -1105,7 +1105,7 @@ impl<'a> CheckerState<'a> {
     }
 
     fn types_overlap_for_diagnostic_display(&mut self, left: TypeId, right: TypeId) -> bool {
-        self.diagnostic_relation_boolean_guard(left, right)
-            || self.diagnostic_relation_boolean_guard(right, left)
+        self.assign_relation_outcome(left, right).related
+            || self.assign_relation_outcome(right, left).related
     }
 }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -454,6 +454,9 @@ mod call_architecture_tests;
 #[path = "tests/call_context_relation_routing_arch_tests.rs"]
 mod call_context_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/call_display_format_relation_routing_arch_tests.rs"]
+mod call_display_format_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/call_spread_constructor_parameters_tests.rs"]
 mod call_spread_constructor_parameters_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/call_display_format_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/call_display_format_relation_routing_arch_tests.rs
@@ -1,0 +1,26 @@
+use std::fs;
+
+#[test]
+fn call_display_overlap_uses_relation_outcome_boundary() {
+    let source =
+        fs::read_to_string("src/error_reporter/call_errors/display_formatting_parameters.rs")
+            .expect("failed to read display_formatting_parameters.rs");
+    let start = source
+        .find("fn types_overlap_for_diagnostic_display")
+        .expect("missing display overlap helper");
+    let helper = &source[start..];
+
+    assert_eq!(
+        helper.matches("assign_relation_outcome(").count(),
+        2,
+        "display overlap helper should route both relation directions through assign_relation_outcome"
+    );
+    assert!(
+        helper.matches(".related").count() >= 2,
+        "display overlap helper should use relation outcome decisions"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard("),
+        "display overlap helper should not regress to raw boolean relation guards"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor-only checker relation diagnostic routing for #8227 / query-boundary cleanup.

## Invariant
When call-parameter diagnostic display formatting decides whether two candidate types overlap for presentation, the formatter owns the display choice, but assignability truth is read through the shared relation outcome boundary.

## Scope
- `crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs`
- `crates/tsz-checker/src/tests/call_display_format_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only diagnostic-routing cleanup; no solver policy, cache-key, parser, binder, emitter, or project-corpus fixture behavior changes.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib call_display_overlap_uses_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `git rev-list --left-right --count HEAD...origin/main` = `1 0`

## Coordination Notes
- Reused `/Users/mohsen/code/tsz-m1b-fresh-origin-main-20260527-060539`; branch created from current `origin/main` after checking newest M1-B PRs for red CI.
- Non-overlap: avoids active JSX, render-failure, property-receiver, call-anchor, array-elaboration, call-elaboration, and solver-policy PRs; this slice only touches call parameter display-format overlap routing.
- Draft PR for M1-B coordination; no WIP label requested.
