### PR TITLE
fix(checker): suppress TS2376 when TS17009 already covers this-before-super

### DIFF
--- a/crates/tsz-checker/src/classes/super_checker.rs
+++ b/crates/tsz-checker/src/classes/super_checker.rs
@@ -548,6 +548,65 @@ impl<'a> CheckerState<'a> {
         false
     }
 
+    /// Returns `true` when the constructor body has a `this`-before-super
+    /// access that would trigger TS17009. Used to suppress the redundant TS2376
+    /// emission: TS17009 (this-before-super) subsumes TS2376 (super-not-first).
+    fn constructor_has_pre_super_this_reference(&self, ctor_idx: NodeIndex) -> bool {
+        use tsz_scanner::SyntaxKind;
+
+        let Some(ctor_node) = self.ctx.arena.get(ctor_idx) else {
+            return false;
+        };
+        let Some(ctor) = self.ctx.arena.get_constructor(ctor_node) else {
+            return false;
+        };
+        if ctor.body.is_none() {
+            return false;
+        }
+        let Some(body_node) = self.ctx.arena.get(ctor.body) else {
+            return false;
+        };
+        let Some(block) = self.ctx.arena.get_block(body_node) else {
+            return false;
+        };
+
+        let Some(first_super_stmt_index) = block
+            .statements
+            .nodes
+            .iter()
+            .position(|&stmt| self.is_super_call_statement(stmt))
+        else {
+            return false;
+        };
+
+        let pre_super_statements = &block.statements.nodes[..first_super_stmt_index];
+        if pre_super_statements.is_empty() {
+            return false;
+        }
+
+        for i in 0..self.ctx.arena.len() {
+            let node_idx = NodeIndex(i as u32);
+            let Some(node) = self.ctx.arena.get(node_idx) else {
+                continue;
+            };
+            if !self.is_directly_in_constructor_body(node_idx, ctor_idx) {
+                continue;
+            }
+            let in_pre_super = pre_super_statements
+                .iter()
+                .any(|&stmt| self.is_descendant_of_node(node_idx, stmt) || node_idx == stmt);
+            if !in_pre_super {
+                continue;
+            }
+            if node.kind == SyntaxKind::ThisKeyword as u16
+                && self.is_this_before_super_in_derived_constructor(node_idx)
+            {
+                return true;
+            }
+        }
+        false
+    }
+
     fn is_additional_super_call_after_first_root_level_super_statement(
         &self,
         idx: NodeIndex,
@@ -903,12 +962,17 @@ impl<'a> CheckerState<'a> {
             }
 
             if !self.is_super_call_first_statement_in_constructor(idx) {
+                // TS17009 (this-before-super) subsumes TS2376 (super-not-first).
+                // Only emit TS2376 when the constructor has a pre-super `super`
+                // property reference but NOT a pre-super `this` reference: when
+                // `this` is accessed before `super`, TS17009 is already emitted at
+                // that site and reporting TS2376 here is redundant.
                 let should_emit_ts2376 =
                     self.enclosing_constructor_node(idx)
                         .is_some_and(|ctor_idx| {
                             self.constructor_has_pre_super_this_or_super_property_reference(
                                 ctor_idx,
-                            )
+                            ) && !self.constructor_has_pre_super_this_reference(ctor_idx)
                         });
 
                 if should_emit_ts2376 {

--- a/crates/tsz-checker/src/classes/super_checker.rs
+++ b/crates/tsz-checker/src/classes/super_checker.rs
@@ -548,10 +548,16 @@ impl<'a> CheckerState<'a> {
         false
     }
 
-    /// Returns `true` when the constructor body has a `this`-before-super
-    /// access that would trigger TS17009. Used to suppress the redundant TS2376
-    /// emission: TS17009 (this-before-super) subsumes TS2376 (super-not-first).
-    fn constructor_has_pre_super_this_reference(&self, ctor_idx: NodeIndex) -> bool {
+    /// Returns `true` for the narrow `tsc` diagnostic-priority case where a
+    /// single pre-super `this` reference lives in an expression statement.
+    ///
+    /// `tsc` still reports TS2376 when the pre-super `this` appears in a
+    /// declaration initializer, or when multiple pre-super `this` references
+    /// occur before the first root-level `super()` call.
+    fn constructor_has_single_pre_super_this_expression_statement(
+        &self,
+        ctor_idx: NodeIndex,
+    ) -> bool {
         use tsz_scanner::SyntaxKind;
 
         let Some(ctor_node) = self.ctx.arena.get(ctor_idx) else {
@@ -584,6 +590,8 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
+        let mut this_reference_count = 0;
+
         for i in 0..self.ctx.arena.len() {
             let node_idx = NodeIndex(i as u32);
             let Some(node) = self.ctx.arena.get(node_idx) else {
@@ -592,19 +600,32 @@ impl<'a> CheckerState<'a> {
             if !self.is_directly_in_constructor_body(node_idx, ctor_idx) {
                 continue;
             }
-            let in_pre_super = pre_super_statements
-                .iter()
-                .any(|&stmt| self.is_descendant_of_node(node_idx, stmt) || node_idx == stmt);
-            if !in_pre_super {
-                continue;
-            }
             if node.kind == SyntaxKind::ThisKeyword as u16
                 && self.is_this_before_super_in_derived_constructor(node_idx)
             {
-                return true;
+                let Some(containing_statement) = pre_super_statements
+                    .iter()
+                    .copied()
+                    .find(|&stmt| self.is_descendant_of_node(node_idx, stmt) || node_idx == stmt)
+                else {
+                    continue;
+                };
+
+                let Some(statement_node) = self.ctx.arena.get(containing_statement) else {
+                    return false;
+                };
+                if statement_node.kind != syntax_kind_ext::EXPRESSION_STATEMENT {
+                    return false;
+                }
+
+                this_reference_count += 1;
+                if this_reference_count > 1 {
+                    return false;
+                }
             }
         }
-        false
+
+        this_reference_count == 1
     }
 
     fn is_additional_super_call_after_first_root_level_super_statement(
@@ -962,17 +983,17 @@ impl<'a> CheckerState<'a> {
             }
 
             if !self.is_super_call_first_statement_in_constructor(idx) {
-                // TS17009 (this-before-super) subsumes TS2376 (super-not-first).
-                // Only emit TS2376 when the constructor has a pre-super `super`
-                // property reference but NOT a pre-super `this` reference: when
-                // `this` is accessed before `super`, TS17009 is already emitted at
-                // that site and reporting TS2376 here is redundant.
+                // TS17009 suppresses TS2376 only for the narrow `tsc`
+                // expression-statement case. Declaration initializers and
+                // multiple pre-super `this` references still retain TS2376.
                 let should_emit_ts2376 =
                     self.enclosing_constructor_node(idx)
                         .is_some_and(|ctor_idx| {
                             self.constructor_has_pre_super_this_or_super_property_reference(
                                 ctor_idx,
-                            ) && !self.constructor_has_pre_super_this_reference(ctor_idx)
+                            ) && !self.constructor_has_single_pre_super_this_expression_statement(
+                                ctor_idx,
+                            )
                         });
 
                 if should_emit_ts2376 {

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -811,6 +811,9 @@ mod strict_null_manual;
 #[path = "tests/string_literal_union_display_order_tests.rs"]
 mod string_literal_union_display_order_tests;
 #[cfg(test)]
+#[path = "tests/super_call_ts2376_ts17009_priority_tests.rs"]
+mod super_call_ts2376_ts17009_priority_tests;
+#[cfg(test)]
 #[path = "../tests/symbol_index_signature_tests.rs"]
 mod symbol_index_signature_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/super_call_ts2376_ts17009_priority_tests.rs
+++ b/crates/tsz-checker/src/tests/super_call_ts2376_ts17009_priority_tests.rs
@@ -1,8 +1,8 @@
 //! Tests for TS2376/TS17009 diagnostic prioritization in derived class constructors.
 //!
-//! When `this` is accessed before `super()`, tsc emits only TS17009 at the `this`
-//! site. tsz previously emitted both TS17009 and TS2376; the fix suppresses TS2376
-//! when `constructor_has_pre_super_this_reference` is true.
+//! For the narrow single-expression-statement case, `tsc` emits only TS17009 at
+//! the `this` site. It still emits TS2376 for declaration initializers and
+//! multiple pre-super `this` references in position-sensitive constructors.
 //!
 //! Issue: <https://github.com/mohsen1/tsz/issues/9678>
 
@@ -34,7 +34,7 @@ class Derived extends Base {
     );
     assert!(
         ts2376.is_empty(),
-        "Expected no TS2376 when TS17009 already covers this-before-super; got: {diags:?}"
+        "Expected no TS2376 for the single pre-super this expression statement; got: {diags:?}"
     );
 }
 
@@ -64,7 +64,69 @@ class Dog extends Animal {
     );
     assert!(
         ts2376.is_empty(),
-        "Expected no TS2376 when TS17009 is emitted; got: {diags:?}"
+        "Expected no TS2376 for the single pre-super this expression statement; got: {diags:?}"
+    );
+}
+
+/// `tsc` keeps TS2376 when the pre-super `this` reference appears inside a
+/// declaration initializer rather than as a standalone expression statement.
+#[test]
+fn this_before_super_in_variable_initializer_keeps_ts2376() {
+    let diags = check_source_diagnostics(
+        r#"
+class Base {}
+class Derived extends Base {
+    x = 1;
+    constructor() {
+        const value = this.x;
+        super();
+    }
+}
+"#,
+    );
+
+    let ts17009: Vec<_> = diags.iter().filter(|d| d.code == 17009).collect();
+    let ts2376: Vec<_> = diags.iter().filter(|d| d.code == 2376).collect();
+
+    assert!(
+        !ts17009.is_empty(),
+        "Expected TS17009 for this-before-super; got: {diags:?}"
+    );
+    assert!(
+        !ts2376.is_empty(),
+        "Expected TS2376 when this-before-super is in a variable initializer; got: {diags:?}"
+    );
+}
+
+/// `tsc` also keeps TS2376 when multiple pre-super `this` references appear
+/// before the first root-level `super()` call.
+#[test]
+fn multiple_this_references_before_super_keep_ts2376() {
+    let diags = check_source_diagnostics(
+        r#"
+class Base {}
+class Derived extends Base {
+    x = 1;
+    y: number;
+    constructor() {
+        this.x = 2;
+        this.y = 3;
+        super();
+    }
+}
+"#,
+    );
+
+    let ts17009: Vec<_> = diags.iter().filter(|d| d.code == 17009).collect();
+    let ts2376: Vec<_> = diags.iter().filter(|d| d.code == 2376).collect();
+
+    assert!(
+        !ts17009.is_empty(),
+        "Expected TS17009 for this-before-super; got: {diags:?}"
+    );
+    assert!(
+        !ts2376.is_empty(),
+        "Expected TS2376 when multiple pre-super this references precede super(); got: {diags:?}"
     );
 }
 
@@ -106,8 +168,8 @@ class Child extends Base {
 }
 
 /// Mixed case: both `super.property` and `this` appear before `super()`.
-/// TS17009 subsumes TS2376 — only TS17009 should fire (at the `this` site),
-/// and TS2376 must be suppressed even though `super.property` is also present.
+/// The single `this` expression-statement still suppresses TS2376 even when a
+/// separate pre-super `super.property` expression appears first.
 #[test]
 fn super_property_and_this_before_super_emits_ts17009_only() {
     let diags = check_source_diagnostics(
@@ -135,7 +197,7 @@ class Mixed extends Base {
     );
     assert!(
         ts2376.is_empty(),
-        "Expected no TS2376 when TS17009 already covers the mixed case; got: {diags:?}"
+        "Expected no TS2376 for the mixed single-this expression-statement case; got: {diags:?}"
     );
 }
 

--- a/crates/tsz-checker/src/tests/super_call_ts2376_ts17009_priority_tests.rs
+++ b/crates/tsz-checker/src/tests/super_call_ts2376_ts17009_priority_tests.rs
@@ -1,0 +1,121 @@
+//! Tests for TS2376/TS17009 diagnostic prioritization in derived class constructors.
+//!
+//! When `this` is accessed before `super()`, tsc emits only TS17009 at the `this`
+//! site. tsz previously emitted both TS17009 and TS2376; the fix suppresses TS2376
+//! when `constructor_has_pre_super_this_reference` is true.
+//!
+//! Issue: <https://github.com/mohsen1/tsz/issues/9678>
+
+use crate::test_utils::check_source_diagnostics;
+
+/// tsc: TS17009 at `this.x` — no TS2376.
+/// tsz previously also emitted TS2376 at the `super()` call.
+#[test]
+fn this_before_super_with_initialized_field_emits_only_ts17009() {
+    let diags = check_source_diagnostics(
+        r#"
+class Base {}
+class Derived extends Base {
+    x = 1;
+    constructor() {
+        this.x;
+        super();
+    }
+}
+"#,
+    );
+
+    let ts17009: Vec<_> = diags.iter().filter(|d| d.code == 17009).collect();
+    let ts2376: Vec<_> = diags.iter().filter(|d| d.code == 2376).collect();
+
+    assert!(
+        !ts17009.is_empty(),
+        "Expected TS17009 for this-before-super; got: {diags:?}"
+    );
+    assert!(
+        ts2376.is_empty(),
+        "Expected no TS2376 when TS17009 already covers this-before-super; got: {diags:?}"
+    );
+}
+
+/// Same fix applies when the field name and iteration variable differ from the
+/// first test — the rule is structural, not identifier-specific.
+#[test]
+fn this_before_super_different_field_name_emits_only_ts17009() {
+    let diags = check_source_diagnostics(
+        r#"
+class Animal {}
+class Dog extends Animal {
+    name: string = "rex";
+    constructor() {
+        console.log(this.name);
+        super();
+    }
+}
+"#,
+    );
+
+    let ts17009: Vec<_> = diags.iter().filter(|d| d.code == 17009).collect();
+    let ts2376: Vec<_> = diags.iter().filter(|d| d.code == 2376).collect();
+
+    assert!(
+        !ts17009.is_empty(),
+        "Expected TS17009 for this-before-super; got: {diags:?}"
+    );
+    assert!(
+        ts2376.is_empty(),
+        "Expected no TS2376 when TS17009 is emitted; got: {diags:?}"
+    );
+}
+
+/// When `super.property` is accessed before `super()` but `this` is NOT
+/// accessed, TS17009 must not fire (it is only for `this`-before-super).
+#[test]
+fn super_property_before_super_call_does_not_emit_ts17009() {
+    let diags = check_source_diagnostics(
+        r#"
+class Base {
+    value = 0;
+}
+class Child extends Base {
+    constructor() {
+        super.value;
+        super();
+    }
+}
+"#,
+    );
+
+    let ts17009: Vec<_> = diags.iter().filter(|d| d.code == 17009).collect();
+
+    assert!(
+        ts17009.is_empty(),
+        "Expected no TS17009 when only super.property (not this) precedes super(); got: {diags:?}"
+    );
+}
+
+/// A correctly ordered constructor with `this` after `super()` must produce
+/// neither TS17009 nor TS2376.
+#[test]
+fn this_after_super_no_diagnostics() {
+    let diags = check_source_diagnostics(
+        r#"
+class Base {}
+class Derived extends Base {
+    x = 1;
+    constructor() {
+        super();
+        this.x;
+    }
+}
+"#,
+    );
+
+    let ts17009: Vec<_> = diags.iter().filter(|d| d.code == 17009).collect();
+    let ts2376: Vec<_> = diags.iter().filter(|d| d.code == 2376).collect();
+
+    assert!(
+        ts17009.is_empty() && ts2376.is_empty(),
+        "Expected no TS17009/TS2376 when this follows super(); got: {diags:?}"
+    );
+}

--- a/crates/tsz-checker/src/tests/super_call_ts2376_ts17009_priority_tests.rs
+++ b/crates/tsz-checker/src/tests/super_call_ts2376_ts17009_priority_tests.rs
@@ -69,15 +69,21 @@ class Dog extends Animal {
 }
 
 /// When `super.property` is accessed before `super()` but `this` is NOT
-/// accessed, TS17009 must not fire (it is only for `this`-before-super).
+/// accessed, TS2376 must fire (super-not-first), and TS17009 must NOT fire
+/// (it is only for `this`-before-super).
+///
+/// NOTE: `Child` must have an initialized property so that the class is
+/// "position-sensitive" — without one, `has_position_sensitive_members` is
+/// false and tsz (like tsc) skips the TS2376 placement check entirely.
 #[test]
-fn super_property_before_super_call_does_not_emit_ts17009() {
+fn super_property_before_super_call_emits_ts2376_not_ts17009() {
     let diags = check_source_diagnostics(
         r#"
 class Base {
     value = 0;
 }
 class Child extends Base {
+    x = 1;
     constructor() {
         super.value;
         super();
@@ -87,10 +93,49 @@ class Child extends Base {
     );
 
     let ts17009: Vec<_> = diags.iter().filter(|d| d.code == 17009).collect();
+    let ts2376: Vec<_> = diags.iter().filter(|d| d.code == 2376).collect();
 
     assert!(
         ts17009.is_empty(),
         "Expected no TS17009 when only super.property (not this) precedes super(); got: {diags:?}"
+    );
+    assert!(
+        !ts2376.is_empty(),
+        "Expected TS2376 when super.property precedes super() in a position-sensitive constructor; got: {diags:?}"
+    );
+}
+
+/// Mixed case: both `super.property` and `this` appear before `super()`.
+/// TS17009 subsumes TS2376 — only TS17009 should fire (at the `this` site),
+/// and TS2376 must be suppressed even though `super.property` is also present.
+#[test]
+fn super_property_and_this_before_super_emits_ts17009_only() {
+    let diags = check_source_diagnostics(
+        r#"
+class Base {
+    value = 0;
+}
+class Mixed extends Base {
+    x = 1;
+    constructor() {
+        super.value;
+        this.x;
+        super();
+    }
+}
+"#,
+    );
+
+    let ts17009: Vec<_> = diags.iter().filter(|d| d.code == 17009).collect();
+    let ts2376: Vec<_> = diags.iter().filter(|d| d.code == 2376).collect();
+
+    assert!(
+        !ts17009.is_empty(),
+        "Expected TS17009 for this-before-super in mixed super.property+this case; got: {diags:?}"
+    );
+    assert!(
+        ts2376.is_empty(),
+        "Expected no TS2376 when TS17009 already covers the mixed case; got: {diags:?}"
     );
 }
 


### PR DESCRIPTION
## Agent
AgentName: M1-C
Runner: claude-sonnet-4-6

## Track
Track 8: Diagnostics, Display, Parser Options, And Feature Gates — checker diagnostic prioritization fix.

## Invariant
When a derived-class constructor accesses `this` before `super()`, `tsc` suppresses TS2376 only for the narrow single pre-super `this` expression-statement case; declaration initializers and multiple pre-super `this` references in position-sensitive constructors still retain TS2376. This PR makes tsz match that checker diagnostic-prioritization rule.

## Scope
- `crates/tsz-checker/src/classes/super_checker.rs`: narrow TS2376 suppression to a single pre-super `this` expression statement.
- `crates/tsz-checker/src/tests/super_call_ts2376_ts17009_priority_tests.rs`: cover the suppressing expression-statement shapes plus declaration-initializer and multiple-reference cases that must keep TS2376.
- `crates/tsz-checker/src/lib.rs`: focused test registration.

## Structural Rule
TS17009 is more specific for the narrow case where a single pre-super `this` expression statement is the offending reference before `super()`. If the pre-super reference is in a declaration initializer, or if multiple pre-super `this` references occur before the first root-level `super()` call, `tsc` keeps the constructor-level TS2376 for position-sensitive derived classes.

## Project Corpus Impact
- Row: n/a
- Bug family: duplicate/redundant diagnostics vs missing required TS2376 diagnostics
- Evidence: checker-only diagnostic-prioritization change; no project corpus row is directly affected.

## Verification
- `git fetch origin main && git rebase origin/main`
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- touched-file line-cap audit: all changed files under 2000 lines
- `python3 scripts/arch/arch_guard.py`
- `cargo nextest run -p tsz-checker --lib super_call_ts2376` -> 7 passed
- `scripts/safe-run.sh --limit 50% -- ./scripts/conformance/conformance.sh run --filter "strictModeInConstructor" --verbose` -> `FINAL RESULTS: 1/1 passed (100.0%)`
- `scripts/safe-run.sh --limit 50% -- ./scripts/conformance/conformance.sh run --filter "derivedClassParameterProperties" --verbose` -> `FINAL RESULTS: 1/1 passed (100.0%)`

## Coordination Notes
- AgentName: M1-C
- Fixes issue #9678.
- Earlier ready-review CI run `26492003769` failed `conformance-aggregate` because TS2376 was suppressed too broadly for `strictModeInConstructor` and `derivedClassParameterProperties`; head `d836f2deaebf29d643e0bb09c89a141797e34336` narrows the rule and passes both focused filters locally.
- Exact-head draft light CI is green on `d836f2deaebf29d643e0bb09c89a141797e34336`: `CI Light Summary`, `lint`, `dist-binaries`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, and `GitGuardian Security Checks` passed. Marked ready for review on 2026-05-27 so heavy CI can run.
- No merge-queue label requested by this implementation lane.