### PR TITLE
refactor(checker): route remapped missing property relation

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
@@ -976,7 +976,7 @@ impl<'a> CheckerState<'a> {
             return false;
         }
         let evaluated = self.evaluate_concrete_remapped_mapped_type_with_resolution(resolved);
-        if evaluated == resolved || self.diagnostic_relation_boolean_guard(evaluated, target) {
+        if evaluated == resolved || self.assign_relation_outcome(evaluated, target).related {
             return false;
         }
         let analysis = self.analyze_assignability_failure(evaluated, target);

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -772,6 +772,9 @@ mod recursive_path_default_type_param_tests;
 #[path = "tests/relation_flags_boundary_contract_tests.rs"]
 mod relation_flags_boundary_contract_tests;
 #[cfg(test)]
+#[path = "tests/remapped_missing_property_relation_routing_arch_tests.rs"]
+mod remapped_missing_property_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/repro_parserreal.rs"]
 mod repro_parserreal;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/remapped_missing_property_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/remapped_missing_property_relation_routing_arch_tests.rs
@@ -1,0 +1,28 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn remapped_missing_property_skip_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("src/error_reporter/assignability_helpers.rs"),
+    )
+    .expect("failed to read assignability_helpers.rs");
+
+    let helper = source
+        .split("pub(crate) fn try_report_concrete_remapped_mapped_missing_property")
+        .nth(1)
+        .and_then(|rest| {
+            rest.split("fn report_concrete_remapped_mapped_missing_property")
+                .next()
+        })
+        .expect("failed to isolate remapped missing-property helper");
+
+    assert!(
+        helper.contains("assign_relation_outcome(evaluated, target).related"),
+        "remapped missing-property diagnostic skip should route through assign_relation_outcome"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard(evaluated, target)"),
+        "remapped missing-property diagnostic skip should not use the raw boolean relation guard"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker relation diagnostics / query-boundary routing.

## Invariant
When remapped mapped missing-property diagnostics decide whether the evaluated source is already assignable to the target, relation truth flows through the shared `assign_relation_outcome` boundary; the checker keeps only diagnostic rendering and anchor selection.

## Scope
- `crates/tsz-checker/src/error_reporter/assignability_helpers.rs`
- `crates/tsz-checker/src/tests/remapped_missing_property_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: checker diagnostic-routing refactor only; no solver policy/cache, parser, binder, emitter, project corpus fixture, or baseline changes.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib remapped_missing_property_skip_uses_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `git rev-list --left-right --count HEAD...origin/main` = `1 0`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Fresh branch from current `origin/main` in `/Users/mohsen/code/tsz-m1b-fresh-origin-main-20260527-060539`.
- Avoided statement-helper enum path because draft PR #10420 already owns that file/scope.
- Non-overlap: does not touch solver policy internals, variance, any propagation, cache keys, or active JSX/call elaboration PR files.