### PR TITLE
fix(dts): summarize expando assignment surfaces

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
@@ -765,10 +765,13 @@ impl<'a> DeclarationEmitter<'a> {
             self.get_identifier_text(func.name).is_some_and(|name| {
                 self.namespace_member_referenced_by_exported_object_literal(func_idx, &name)
             });
+        let used_by_exported_function_return =
+            self.namespace_member_decl_returned_by_exported_function(func_idx);
         if !is_exported
             && !self.should_emit_public_api_member(&func.modifiers)
             && !self.should_emit_public_api_dependency(func.name)
             && !used_by_exported_object_literal
+            && !used_by_exported_function_return
         {
             return;
         }
@@ -925,6 +928,13 @@ impl<'a> DeclarationEmitter<'a> {
         {
             self.write(": ");
             self.write(&return_type_text);
+        } else if let Some(type_text) = func_body
+            .is_some()
+            .then(|| self.returned_late_bound_function_typeof_text(func_body))
+            .flatten()
+        {
+            self.write(": ");
+            self.write(&type_text);
         } else if let (Some(return_type_text), true) =
             self.function_body_return_hint(func, func_body)
         {
@@ -1061,6 +1071,13 @@ impl<'a> DeclarationEmitter<'a> {
                         let _ = self.emit_non_portable_function_return_diagnostics(
                             &type_text, func_body, func_name,
                         );
+                    } else if let Some(type_text) = func_body
+                        .is_some()
+                        .then(|| self.returned_late_bound_function_typeof_text(func_body))
+                        .flatten()
+                    {
+                        self.write(": ");
+                        self.write(&type_text);
                     } else if let Some(type_text) = func_body
                         .is_some()
                         .then(|| {
@@ -1278,6 +1295,12 @@ impl<'a> DeclarationEmitter<'a> {
     ) -> bool {
         if self.body_returns_void(func_body) {
             self.write(": void");
+            return true;
+        }
+
+        if let Some(type_text) = self.returned_late_bound_function_typeof_text(func_body) {
+            self.write(": ");
+            self.write(&type_text);
             return true;
         }
 

--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
@@ -1064,6 +1064,20 @@ impl<'a> DeclarationEmitter<'a> {
                     } else if let Some(type_text) = func_body
                         .is_some()
                         .then(|| {
+                            self.function_body_local_function_expando_return_type_text(func_body)
+                        })
+                        .flatten()
+                    {
+                        let (type_text, _) =
+                            self.function_return_type_text_for_declaration_scope(func, &type_text);
+                        self.emit_non_portable_function_return_diagnostics(
+                            &type_text, func_body, func_name,
+                        );
+                        self.write(": ");
+                        self.write(&type_text);
+                    } else if let Some(type_text) = func_body
+                        .is_some()
+                        .then(|| {
                             self.function_body_single_spread_object_literal_type_text(func_body)
                         })
                         .flatten()

--- a/crates/tsz-emitter/src/declaration_emitter/exports/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/exports/mod.rs
@@ -838,6 +838,13 @@ impl<'a> DeclarationEmitter<'a> {
         } else if let Some(return_type_text) = self.jsdoc_return_type_text_for_node(func_idx) {
             self.write(": ");
             self.write(&return_type_text);
+        } else if let Some(type_text) = func_body
+            .is_some()
+            .then(|| self.returned_late_bound_function_typeof_text(func_body))
+            .flatten()
+        {
+            self.write(": ");
+            self.write(&type_text);
         } else if let Some(type_text) = preferred_return.as_ref()
             && direct_function_return
         {
@@ -866,6 +873,13 @@ impl<'a> DeclarationEmitter<'a> {
         } else if func_body.is_some()
             && self.emit_js_returned_define_property_function_type(func_body)
         {
+        } else if let Some(type_text) = func_body
+            .is_some()
+            .then(|| self.returned_late_bound_function_typeof_text(func_body))
+            .flatten()
+        {
+            self.write(": ");
+            self.write(&type_text);
         } else if let (Some(interner), Some(cache)) = (&self.type_interner, &self.type_cache) {
             // No explicit return type, try to infer it from the type cache
             let func_type_id = cache
@@ -889,6 +903,13 @@ impl<'a> DeclarationEmitter<'a> {
                         && self.body_returns_void(func_body)
                     {
                         self.write(": void");
+                    } else if let Some(type_text) = func_body
+                        .is_some()
+                        .then(|| self.returned_late_bound_function_typeof_text(func_body))
+                        .flatten()
+                    {
+                        self.write(": ");
+                        self.write(&type_text);
                     } else if let Some(type_text) = func_body
                         .is_some()
                         .then(|| {
@@ -1706,6 +1727,13 @@ impl<'a> DeclarationEmitter<'a> {
         } else if let Some(return_type_text) = self.jsdoc_return_type_text_for_node(func_idx) {
             self.write(": ");
             self.write(&return_type_text);
+        } else if let Some(type_text) = func_body
+            .is_some()
+            .then(|| self.returned_late_bound_function_typeof_text(func_body))
+            .flatten()
+        {
+            self.write(": ");
+            self.write(&type_text);
         } else if let Some(type_text) = preferred_return.as_ref()
             && direct_function_return
         {
@@ -1757,6 +1785,13 @@ impl<'a> DeclarationEmitter<'a> {
                         && self.body_returns_void(func_body)
                     {
                         self.write(": void");
+                    } else if let Some(type_text) = func_body
+                        .is_some()
+                        .then(|| self.returned_late_bound_function_typeof_text(func_body))
+                        .flatten()
+                    {
+                        self.write(": ");
+                        self.write(&type_text);
                     } else if let Some(type_text) = func_body
                         .is_some()
                         .then(|| {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/late_bound_function_analysis.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/late_bound_function_analysis.rs
@@ -706,6 +706,15 @@ impl<'a> DeclarationEmitter<'a> {
                 &declared_members,
                 &mut members,
             );
+            if members.is_empty() && root_symbol.is_some() {
+                self.collect_late_bound_assignment_members_from_node(
+                    scope_idx,
+                    &root_name,
+                    None,
+                    &declared_members,
+                    &mut members,
+                );
+            }
             return members;
         }
 
@@ -723,6 +732,20 @@ impl<'a> DeclarationEmitter<'a> {
                 &declared_members,
                 &mut members,
             );
+        }
+        if members.is_empty() && root_symbol.is_some() {
+            for &stmt_idx in &source_file.statements.nodes {
+                if self.source_is_js_file && self.js_class_static_member_stmts.contains(&stmt_idx) {
+                    continue;
+                }
+                self.collect_late_bound_assignment_members_from_node(
+                    stmt_idx,
+                    &root_name,
+                    None,
+                    &declared_members,
+                    &mut members,
+                );
+            }
         }
 
         members

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/late_bound_function_analysis.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/late_bound_function_analysis.rs
@@ -564,10 +564,40 @@ impl<'a> DeclarationEmitter<'a> {
                     existing.property_name_text == member.property_name_text
                 })
         {
-            *existing = member;
+            if let Some(type_text) = Self::late_bound_repeated_object_assignment_union_type_text(
+                &existing.type_text,
+                &member.type_text,
+            ) {
+                existing.type_text = type_text;
+            } else {
+                *existing = member;
+            }
         } else {
             members.push(member);
         }
+    }
+
+    fn late_bound_repeated_object_assignment_union_type_text(
+        existing_type_text: &str,
+        next_type_text: &str,
+    ) -> Option<String> {
+        let mut arms = Self::split_top_level_union_type_parts(existing_type_text);
+        arms.push(next_type_text.trim().to_string());
+        if arms.len() < 2
+            || !arms
+                .iter()
+                .all(|arm| Self::is_object_literal_type_text(arm))
+        {
+            return None;
+        }
+
+        Self::expand_object_union_arms_from_sibling_properties(&mut arms);
+        Some(arms.join(" | "))
+    }
+
+    fn is_object_literal_type_text(type_text: &str) -> bool {
+        let trimmed = type_text.trim();
+        trimmed.starts_with('{') && trimmed.ends_with('}')
     }
 
     fn declared_late_bound_namespace_member_names(&self, root_name: &str) -> FxHashSet<String> {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/late_bound_function_analysis.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/late_bound_function_analysis.rs
@@ -696,12 +696,22 @@ impl<'a> DeclarationEmitter<'a> {
                 .get_node_symbol(root_name_idx)
                 .or_else(|| binder.file_locals.get(&root_name))
         });
+        let mut members = Vec::new();
+        let declared_members = self.declared_late_bound_namespace_member_names(&root_name);
+        if let Some(scope_idx) = self.containing_module_block_scope(root_name_idx) {
+            self.collect_late_bound_assignment_members_from_node(
+                scope_idx,
+                &root_name,
+                root_symbol,
+                &declared_members,
+                &mut members,
+            );
+            return members;
+        }
+
         let Some(source_file) = self.arena.source_files.first() else {
             return Vec::new();
         };
-
-        let mut members = Vec::new();
-        let declared_members = self.declared_late_bound_namespace_member_names(&root_name);
         for &stmt_idx in &source_file.statements.nodes {
             if self.source_is_js_file && self.js_class_static_member_stmts.contains(&stmt_idx) {
                 continue;
@@ -716,6 +726,84 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         members
+    }
+
+    fn containing_module_block_scope(&self, node_idx: NodeIndex) -> Option<NodeIndex> {
+        let mut current = node_idx;
+        while let Some(parent_idx) = self.arena.parent_of(current) {
+            let Some(parent_node) = self.arena.get(parent_idx) else {
+                break;
+            };
+            if parent_node.kind == syntax_kind_ext::MODULE_BLOCK {
+                return Some(parent_idx);
+            }
+            current = parent_idx;
+        }
+        None
+    }
+
+    pub(in crate::declaration_emitter) fn returned_late_bound_function_typeof_text(
+        &self,
+        body_idx: NodeIndex,
+    ) -> Option<String> {
+        if !self.inside_non_ambient_namespace {
+            return None;
+        }
+        let returned_identifier = self.function_body_unique_return_identifier(body_idx)?;
+        let name = self.get_identifier_text(returned_identifier)?;
+        if !self.returned_identifier_resolves_to_function_declaration(returned_identifier)
+            && !self.containing_module_block_has_function_declaration(returned_identifier, &name)
+        {
+            return None;
+        }
+        Some(format!("typeof {name}"))
+    }
+
+    fn returned_identifier_resolves_to_function_declaration(
+        &self,
+        identifier_idx: NodeIndex,
+    ) -> bool {
+        let Some(sym_id) = self.value_reference_symbol(identifier_idx) else {
+            return false;
+        };
+        let Some(binder) = self.binder else {
+            return false;
+        };
+        let Some(symbol) = binder.symbols.get(sym_id) else {
+            return false;
+        };
+        symbol.declarations.iter().copied().any(|decl_idx| {
+            self.function_declaration_from_symbol_decl(decl_idx)
+                .is_some()
+        })
+    }
+
+    fn containing_module_block_has_function_declaration(
+        &self,
+        node_idx: NodeIndex,
+        name: &str,
+    ) -> bool {
+        let Some(scope_idx) = self.containing_module_block_scope(node_idx) else {
+            return false;
+        };
+        let Some(scope_node) = self.arena.get(scope_idx) else {
+            return false;
+        };
+        let Some(module_block) = self.arena.get_module_block(scope_node) else {
+            return false;
+        };
+        let Some(statements) = module_block.statements.as_ref() else {
+            return false;
+        };
+        statements.nodes.iter().copied().any(|stmt_idx| {
+            let Some(stmt_node) = self.arena.get(stmt_idx) else {
+                return false;
+            };
+            let Some(func) = self.arena.get_function(stmt_node) else {
+                return false;
+            };
+            self.get_identifier_text(func.name).as_deref() == Some(name)
+        })
     }
 
     pub(in crate::declaration_emitter) fn collect_late_bound_assignment_members_in_node(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/late_bound_function_analysis.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/late_bound_function_analysis.rs
@@ -688,6 +688,26 @@ impl<'a> DeclarationEmitter<'a> {
         members
     }
 
+    pub(in crate::declaration_emitter) fn collect_late_bound_assignment_members_in_node(
+        &self,
+        root_name_idx: NodeIndex,
+        scope_idx: NodeIndex,
+    ) -> Vec<LateBoundAssignmentMember> {
+        let Some(root_name) = self.get_identifier_text(root_name_idx) else {
+            return Vec::new();
+        };
+        let declared_members = FxHashSet::default();
+        let mut members = Vec::new();
+        self.collect_late_bound_assignment_members_from_node(
+            scope_idx,
+            &root_name,
+            None,
+            &declared_members,
+            &mut members,
+        );
+        members
+    }
+
     pub(in crate::declaration_emitter) fn should_emit_ts_late_bound_function_namespace(
         &self,
         func_idx: NodeIndex,

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/returned_function_initializer.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/returned_function_initializer.rs
@@ -338,7 +338,10 @@ impl<'a> DeclarationEmitter<'a> {
         None
     }
 
-    fn function_declaration_from_symbol_decl(&self, decl_idx: NodeIndex) -> Option<NodeIndex> {
+    pub(in crate::declaration_emitter) fn function_declaration_from_symbol_decl(
+        &self,
+        decl_idx: NodeIndex,
+    ) -> Option<NodeIndex> {
         let mut current = decl_idx;
         for _ in 0..8 {
             let node = self.arena.get(current)?;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/returned_function_initializer.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/returned_function_initializer.rs
@@ -326,7 +326,10 @@ impl<'a> DeclarationEmitter<'a> {
         None
     }
 
-    fn variable_declaration_from_symbol_decl(&self, decl_idx: NodeIndex) -> Option<NodeIndex> {
+    pub(in crate::declaration_emitter) fn variable_declaration_from_symbol_decl(
+        &self,
+        decl_idx: NodeIndex,
+    ) -> Option<NodeIndex> {
         let mut current = decl_idx;
         for _ in 0..8 {
             let node = self.arena.get(current)?;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/returned_function_initializer.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/returned_function_initializer.rs
@@ -356,7 +356,7 @@ impl<'a> DeclarationEmitter<'a> {
         None
     }
 
-    fn enclosing_function_data(
+    pub(in crate::declaration_emitter) fn enclosing_function_data(
         &self,
         from_idx: NodeIndex,
     ) -> Option<&tsz_parser::parser::node::FunctionData> {
@@ -385,12 +385,156 @@ impl<'a> DeclarationEmitter<'a> {
             .as_ref()
             .map(|type_params| self.collect_type_param_names(type_params))
             .unwrap_or_default();
+        if let Some(binding_name) = self.function_initializer_binding_name(inner_idx)
+            && let Some(type_text) = self.source_function_initializer_expando_type_text(
+                outer_func,
+                binding_name,
+                inner_idx,
+                inner_func,
+                &outer_type_param_names,
+            )
+        {
+            return Some(type_text);
+        }
         self.source_nested_function_type_text(
             Some(outer_func),
             inner_idx,
             inner_func,
             &outer_type_param_names,
         )
+    }
+
+    pub(in crate::declaration_emitter) fn source_function_initializer_expando_type_text(
+        &self,
+        outer_func: &tsz_parser::parser::node::FunctionData,
+        binding_name: NodeIndex,
+        inner_idx: NodeIndex,
+        inner_func: &tsz_parser::parser::node::FunctionData,
+        outer_type_param_names: &[String],
+    ) -> Option<String> {
+        let members =
+            self.collect_late_bound_assignment_members_in_node(binding_name, outer_func.body);
+        if members.is_empty() {
+            return None;
+        }
+        let call_signature = self
+            .source_nested_function_call_signature_text(
+                Some(outer_func),
+                inner_idx,
+                inner_func,
+                outer_type_param_names,
+            )
+            .or_else(|| {
+                self.source_nested_function_fallback_call_signature_text(
+                    Some(outer_func),
+                    inner_idx,
+                    inner_func,
+                    outer_type_param_names,
+                )
+            })?;
+        let mut lines = vec![format!("    {call_signature};")];
+        for member in members {
+            lines.push(format!(
+                "    {}: {};",
+                member.property_name_text, member.type_text
+            ));
+        }
+        Some(format!("{{\n{}\n}}", lines.join("\n")))
+    }
+
+    fn source_nested_function_fallback_call_signature_text(
+        &self,
+        outer_func: Option<&tsz_parser::parser::node::FunctionData>,
+        inner_idx: NodeIndex,
+        inner_func: &tsz_parser::parser::node::FunctionData,
+        outer_type_param_names: &[String],
+    ) -> Option<String> {
+        let mut outer_type_param_names = outer_type_param_names.to_vec();
+        if let Some(type_params) = outer_func.and_then(|func| func.type_parameters.as_ref()) {
+            for name in self.collect_type_param_names(type_params) {
+                if !outer_type_param_names.contains(&name) {
+                    outer_type_param_names.push(name);
+                }
+            }
+        }
+        let inner_type_params = inner_func.type_parameters.as_ref();
+        let inner_renames = inner_type_params.map_or_else(Vec::new, |type_params| {
+            self.shadowed_function_type_param_renames(type_params, &outer_type_param_names)
+        });
+        let type_params_text = inner_type_params
+            .filter(|type_params| !type_params.nodes.is_empty())
+            .and_then(|type_params| {
+                let params = type_params
+                    .nodes
+                    .iter()
+                    .copied()
+                    .map(|param_idx| {
+                        self.source_function_type_parameter_text(param_idx, &inner_renames)
+                    })
+                    .collect::<Option<Vec<_>>>()?;
+                Some(format!("<{}>", params.join(", ")))
+            })
+            .unwrap_or_default();
+        let jsdoc = self.returned_function_expression_jsdoc(inner_idx, inner_func);
+        let jsdoc_function_parts = jsdoc
+            .as_deref()
+            .and_then(Self::parse_jsdoc_type_text)
+            .and_then(|type_text| Self::parse_function_type_text(&type_text));
+        let mut used_param_names = Vec::new();
+        let mut params = Vec::with_capacity(inner_func.parameters.nodes.len());
+        for (position, param_idx) in inner_func.parameters.nodes.iter().copied().enumerate() {
+            params.push(self.source_function_parameter_text(
+                param_idx,
+                position,
+                &inner_renames,
+                jsdoc.as_deref(),
+                jsdoc_function_parts.as_ref(),
+                &mut used_param_names,
+            )?);
+        }
+        let return_text = self
+            .source_nested_function_fallback_return_type_text(inner_func)
+            .unwrap_or_else(|| "any".to_string());
+        Some(format!(
+            "{type_params_text}({}): {return_text}",
+            params.join(", ")
+        ))
+    }
+
+    fn source_nested_function_fallback_return_type_text(
+        &self,
+        inner_func: &tsz_parser::parser::node::FunctionData,
+    ) -> Option<String> {
+        if inner_func.body.is_none() {
+            return None;
+        }
+        if self.body_returns_void(inner_func.body) {
+            return Some("void".to_string());
+        }
+        let body_node = self.arena.get(inner_func.body)?;
+        if body_node.kind == syntax_kind_ext::BLOCK {
+            return self
+                .function_body_preferred_return_type_text(inner_func.body)
+                .filter(|text| !text.is_empty() && text != "any");
+        }
+        self.preferred_expression_type_text(inner_func.body)
+            .or_else(|| self.infer_fallback_type_text_at(inner_func.body, 0))
+            .filter(|text| !text.is_empty() && text != "any")
+    }
+
+    fn function_initializer_binding_name(&self, initializer: NodeIndex) -> Option<NodeIndex> {
+        let mut current = initializer;
+        for _ in 0..8 {
+            let parent_idx = self.arena.parent_of(current)?;
+            let parent_node = self.arena.get(parent_idx)?;
+            if let Some(decl) = self.arena.get_variable_declaration(parent_node)
+                && decl.initializer == initializer
+            {
+                return Some(decl.name);
+            }
+            current = parent_idx;
+        }
+        None
     }
 
     pub(in crate::declaration_emitter) fn source_nested_function_type_text(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
@@ -2,6 +2,7 @@
 
 use super::super::DeclarationEmitter;
 use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
@@ -124,6 +125,10 @@ impl<'a> DeclarationEmitter<'a> {
         &self,
         expr_idx: NodeIndex,
     ) -> Option<String> {
+        if let Some(type_text) = self.local_variable_function_expando_type_text(expr_idx) {
+            return Some(type_text);
+        }
+
         let expr_node = self.arena.get(expr_idx)?;
         if expr_node.kind != SyntaxKind::Identifier as u16 {
             return None;
@@ -164,6 +169,115 @@ impl<'a> DeclarationEmitter<'a> {
                     )
                     .unwrap_or(type_text),
                 );
+            }
+        }
+        None
+    }
+
+    pub(in crate::declaration_emitter) fn local_variable_function_expando_type_text(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind != SyntaxKind::Identifier as u16 {
+            return None;
+        }
+        let outer_func = self.enclosing_function_data(expr_idx)?;
+        let name = self.get_identifier_text(expr_idx)?;
+        let outer_type_param_names = outer_func
+            .type_parameters
+            .as_ref()
+            .map(|type_params| self.collect_type_param_names(type_params))
+            .unwrap_or_default();
+        if let Some(sym_id) = self.value_reference_symbol(expr_idx)
+            && let Some(binder) = self.binder
+            && let Some(symbol) = binder.symbols.get(sym_id)
+        {
+            for decl_idx in symbol.declarations.iter().copied() {
+                let decl_node = self.arena.get(decl_idx)?;
+                let Some(var_decl) = self.arena.get_variable_declaration(decl_node) else {
+                    continue;
+                };
+                let Some(init_node) = self.arena.get(var_decl.initializer) else {
+                    continue;
+                };
+                if init_node.kind != syntax_kind_ext::ARROW_FUNCTION
+                    && init_node.kind != syntax_kind_ext::FUNCTION_EXPRESSION
+                {
+                    continue;
+                }
+                let inner_func = self.arena.get_function(init_node)?;
+                if let Some(type_text) = self.source_function_initializer_expando_type_text(
+                    outer_func,
+                    var_decl.name,
+                    var_decl.initializer,
+                    inner_func,
+                    &outer_type_param_names,
+                ) {
+                    return Some(type_text);
+                }
+            }
+        }
+
+        let (binding_name, initializer, inner_func) =
+            self.local_function_initializer_for_name_in_node(outer_func.body, &name)?;
+        self.source_function_initializer_expando_type_text(
+            outer_func,
+            binding_name,
+            initializer,
+            inner_func,
+            &outer_type_param_names,
+        )
+    }
+
+    fn local_function_initializer_for_name_in_node(
+        &self,
+        node_idx: NodeIndex,
+        name: &str,
+    ) -> Option<(
+        NodeIndex,
+        NodeIndex,
+        &tsz_parser::parser::node::FunctionData,
+    )> {
+        let node = self.arena.get(node_idx)?;
+        if let Some(var_decl) = self.arena.get_variable_declaration(node)
+            && self.get_identifier_text(var_decl.name).as_deref() == Some(name)
+        {
+            let init_node = self.arena.get(var_decl.initializer)?;
+            if init_node.kind == syntax_kind_ext::ARROW_FUNCTION
+                || init_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
+            {
+                return Some((
+                    var_decl.name,
+                    var_decl.initializer,
+                    self.arena.get_function(init_node)?,
+                ));
+            }
+        }
+
+        if let Some(var_data) = self.arena.get_variable(node) {
+            for decl_idx in var_data.declarations.nodes.iter().copied() {
+                if let Some(found) =
+                    self.local_function_initializer_for_name_in_node(decl_idx, name)
+                {
+                    return Some(found);
+                }
+            }
+        }
+
+        if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
+            || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
+            || node.kind == syntax_kind_ext::ARROW_FUNCTION
+            || node.kind == syntax_kind_ext::CLASS_DECLARATION
+            || node.kind == syntax_kind_ext::CLASS_EXPRESSION
+            || node.kind == syntax_kind_ext::MODULE_DECLARATION
+        {
+            return None;
+        }
+
+        for child_idx in self.arena.get_children(node_idx) {
+            if let Some(found) = self.local_function_initializer_for_name_in_node(child_idx, name) {
+                return Some(found);
             }
         }
         None

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
@@ -129,6 +130,12 @@ impl<'a> DeclarationEmitter<'a> {
             k if k == syntax_kind_ext::NEW_EXPRESSION => {
                 self.preferred_expression_type_text(node_id)
             }
+            k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => self
+                .declaration_summary_primitive_expression_type_text(node_id, depth)
+                .or_else(|| self.preferred_expression_type_text(node_id)),
+            k if k == syntax_kind_ext::CALL_EXPRESSION => self
+                .declaration_summary_primitive_expression_type_text(node_id, depth)
+                .or_else(|| self.preferred_expression_type_text(node_id)),
             k if k == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION => {
                 self.infer_object_literal_type_text_at(node_id, depth)
             }
@@ -205,12 +212,433 @@ impl<'a> DeclarationEmitter<'a> {
         node_id: NodeIndex,
         depth: u32,
     ) -> Option<String> {
+        if let Some(text) = self.declaration_summary_primitive_expression_type_text(node_id, depth)
+        {
+            return Some(text);
+        }
         // Try preferred expression first (finds declared types)
-        if let Some(text) = self.preferred_expression_type_text(node_id) {
+        if let Some(text) = self
+            .preferred_expression_type_text(node_id)
+            .filter(|text| text != "any")
+        {
             return Some(text);
         }
         // Then try structural fallback
         self.infer_fallback_type_text_at(node_id, depth)
+    }
+
+    pub(in crate::declaration_emitter) fn declaration_summary_primitive_expression_type_text(
+        &self,
+        expr_idx: NodeIndex,
+        depth: u32,
+    ) -> Option<String> {
+        if depth > 8 {
+            return None;
+        }
+        let expr_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(expr_idx);
+        let expr_node = self.arena.get(expr_idx)?;
+        match expr_node.kind {
+            k if k == syntax_kind_ext::BINARY_EXPRESSION => self
+                .short_circuit_expression_type_text(expr_idx)
+                .or_else(|| self.infer_arithmetic_binary_type_text(expr_idx, depth + 1)),
+            k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => self
+                .late_bound_property_access_type_text(expr_idx)
+                .or_else(|| {
+                    self.value_reference_symbol_type_text(expr_idx)
+                        .filter(|text| text != "any" && text != "unknown")
+                })
+                .or_else(|| self.namespace_property_access_type_text(expr_idx, depth + 1))
+                .or_else(|| self.length_property_access_type_text(expr_idx, depth + 1))
+                .or_else(|| self.class_instance_property_access_type_text(expr_idx)),
+            k if k == syntax_kind_ext::CALL_EXPRESSION => self
+                .late_bound_call_return_type_text(expr_idx)
+                .or_else(|| self.well_known_method_call_return_type_text(expr_idx))
+                .or_else(|| self.direct_call_primitive_return_type_text(expr_idx, depth + 1))
+                .or_else(|| self.call_expression_source_return_type_text(expr_idx))
+                .or_else(|| {
+                    self.get_node_type_or_names(&[expr_idx])
+                        .filter(|type_id| {
+                            !matches!(
+                                *type_id,
+                                tsz_solver::types::TypeId::ANY
+                                    | tsz_solver::types::TypeId::UNKNOWN
+                                    | tsz_solver::types::TypeId::ERROR
+                            )
+                        })
+                        .map(|type_id| self.print_type_id(type_id))
+                }),
+            k if k == syntax_kind_ext::NEW_EXPRESSION => {
+                self.nameable_new_expression_type_text(expr_idx)
+            }
+            _ => None,
+        }
+    }
+
+    fn length_property_access_type_text(&self, expr_idx: NodeIndex, depth: u32) -> Option<String> {
+        let expr_node = self.arena.get(expr_idx)?;
+        let access = self.arena.get_access_expr(expr_node)?;
+        if self.get_identifier_text(access.name_or_argument).as_deref() != Some("length") {
+            return None;
+        }
+        let receiver_type =
+            self.declaration_summary_primitive_expression_type_text(access.expression, depth)?;
+        matches!(receiver_type.as_str(), "string" | "any[]")
+            .then(|| "number".to_string())
+            .or_else(|| receiver_type.ends_with("[]").then(|| "number".to_string()))
+    }
+
+    fn class_instance_property_access_type_text(&self, expr_idx: NodeIndex) -> Option<String> {
+        let expr_node = self.arena.get(expr_idx)?;
+        let access = self.arena.get_access_expr(expr_node)?;
+        let property_name = self.get_identifier_text(access.name_or_argument)?;
+        let receiver = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(access.expression);
+        let class_idx = self
+            .js_new_expression_class_declaration(receiver)
+            .or_else(|| self.class_expression_declaration_for_new_expression(receiver))?;
+        let class_node = self.arena.get(class_idx)?;
+        let class = self.arena.get_class(class_node)?;
+
+        for &member_idx in &class.members.nodes {
+            let Some(info) = self.class_member_info(member_idx) else {
+                continue;
+            };
+            if info.is_static {
+                continue;
+            }
+            let Some(member_node) = self.arena.get(member_idx) else {
+                continue;
+            };
+            let Some(prop) = self.arena.get_property_decl(member_node) else {
+                continue;
+            };
+            if self.get_identifier_text(prop.name).as_deref() != Some(property_name.as_str()) {
+                continue;
+            }
+            if prop.type_annotation.is_some() {
+                return self.emit_type_node_text(prop.type_annotation);
+            }
+            if prop.initializer.is_some() {
+                return self
+                    .declaration_summary_primitive_expression_type_text(prop.initializer, 0)
+                    .or_else(|| self.infer_fallback_type_text_at(prop.initializer, 0))
+                    .or_else(|| {
+                        self.get_node_type_or_names(&[member_idx, prop.name])
+                            .filter(|type_id| {
+                                !matches!(
+                                    *type_id,
+                                    tsz_solver::types::TypeId::ANY
+                                        | tsz_solver::types::TypeId::UNKNOWN
+                                        | tsz_solver::types::TypeId::ERROR
+                                )
+                            })
+                            .map(|type_id| self.print_type_id(type_id))
+                    });
+            }
+        }
+        None
+    }
+
+    fn class_expression_declaration_for_new_expression(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<NodeIndex> {
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind != syntax_kind_ext::NEW_EXPRESSION {
+            return None;
+        }
+        let new_expr = self.arena.get_call_expr(expr_node)?;
+        let callee_node = self.arena.get(new_expr.expression)?;
+        if callee_node.kind != SyntaxKind::Identifier as u16 {
+            return None;
+        }
+        let sym_id = self.value_reference_symbol(new_expr.expression)?;
+        let binder = self.binder?;
+        let symbol = binder.symbols.get(sym_id)?;
+
+        for decl_idx in symbol.declarations.iter().copied() {
+            let decl_idx = self.variable_declaration_from_symbol_decl(decl_idx)?;
+            let decl_node = self.arena.get(decl_idx)?;
+            let decl = self.arena.get_variable_declaration(decl_node)?;
+            let initializer = self
+                .arena
+                .skip_parenthesized_and_assertions_and_comma(decl.initializer);
+            let init_node = self.arena.get(initializer)?;
+            if init_node.kind == syntax_kind_ext::CLASS_EXPRESSION {
+                return Some(initializer);
+            }
+        }
+        None
+    }
+
+    fn late_bound_property_access_type_text(&self, expr_idx: NodeIndex) -> Option<String> {
+        let (root_idx, path) = self.property_access_root_idx_and_path(expr_idx)?;
+        let first = path.first()?;
+        let member_type = self
+            .collect_ts_late_bound_assignment_members(root_idx)
+            .into_iter()
+            .find(|member| member.property_name_text == *first)
+            .map(|member| member.type_text)?;
+
+        Self::nested_object_property_type_text(member_type, &path[1..])
+    }
+
+    fn namespace_property_access_type_text(
+        &self,
+        expr_idx: NodeIndex,
+        depth: u32,
+    ) -> Option<String> {
+        if depth > 8 {
+            return None;
+        }
+        let (root_idx, path) = self.property_access_root_idx_and_path(expr_idx)?;
+        if path.len() != 1 {
+            return None;
+        }
+        let root_name = self.get_identifier_text(root_idx)?;
+        let property_name = path.first()?;
+        let source_file = self.arena.source_files.first()?;
+
+        for &stmt_idx in &source_file.statements.nodes {
+            let Some(stmt_node) = self.arena.get(stmt_idx) else {
+                continue;
+            };
+            if stmt_node.kind != syntax_kind_ext::MODULE_DECLARATION {
+                continue;
+            }
+            let Some(module) = self.arena.get_module(stmt_node) else {
+                continue;
+            };
+            if self.get_identifier_text(module.name).as_deref() != Some(root_name.as_str()) {
+                continue;
+            }
+            if let Some(type_text) =
+                self.namespace_value_member_type_text(module.body, property_name, 0)
+            {
+                return Some(type_text);
+            }
+        }
+        None
+    }
+
+    fn namespace_value_member_type_text(
+        &self,
+        node_idx: NodeIndex,
+        member_name: &str,
+        depth: u32,
+    ) -> Option<String> {
+        if depth > 8 {
+            return None;
+        }
+        let node = self.arena.get(node_idx)?;
+        if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
+            || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
+            || node.kind == syntax_kind_ext::ARROW_FUNCTION
+            || node.kind == syntax_kind_ext::CLASS_DECLARATION
+            || node.kind == syntax_kind_ext::CLASS_EXPRESSION
+            || node.kind == syntax_kind_ext::MODULE_DECLARATION
+        {
+            return None;
+        }
+
+        if let Some(var_decl) = self.arena.get_variable_declaration(node)
+            && self.get_identifier_text(var_decl.name).as_deref() == Some(member_name)
+        {
+            if var_decl.type_annotation.is_some() {
+                return self.emit_type_node_text(var_decl.type_annotation);
+            }
+            if var_decl.initializer.is_some() {
+                return self
+                    .declaration_summary_primitive_expression_type_text(
+                        var_decl.initializer,
+                        depth + 1,
+                    )
+                    .or_else(|| self.infer_fallback_type_text_at(var_decl.initializer, depth + 1))
+                    .or_else(|| self.js_namespace_value_member_type_text(var_decl.initializer));
+            }
+            return self
+                .get_node_type_or_names(&[node_idx, var_decl.name])
+                .filter(|type_id| {
+                    !matches!(
+                        *type_id,
+                        tsz_solver::types::TypeId::ANY
+                            | tsz_solver::types::TypeId::UNKNOWN
+                            | tsz_solver::types::TypeId::ERROR
+                    )
+                })
+                .map(|type_id| self.print_type_id(type_id));
+        }
+
+        for child_idx in self.arena.get_children(node_idx) {
+            if let Some(type_text) =
+                self.namespace_value_member_type_text(child_idx, member_name, depth + 1)
+            {
+                return Some(type_text);
+            }
+        }
+        None
+    }
+
+    fn late_bound_call_return_type_text(&self, expr_idx: NodeIndex) -> Option<String> {
+        let expr_node = self.arena.get(expr_idx)?;
+        let call = self.arena.get_call_expr(expr_node)?;
+        let callee_type = self.late_bound_property_access_type_text(call.expression)?;
+        Self::function_type_return_type_text(&callee_type)
+    }
+
+    fn well_known_method_call_return_type_text(&self, expr_idx: NodeIndex) -> Option<String> {
+        let expr_node = self.arena.get(expr_idx)?;
+        let call = self.arena.get_call_expr(expr_node)?;
+        let callee_node = self.arena.get(call.expression)?;
+        if callee_node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            return None;
+        }
+        let access = self.arena.get_access_expr(callee_node)?;
+        match self.get_identifier_text(access.name_or_argument)?.as_str() {
+            "toString" => Some("string".to_string()),
+            _ => None,
+        }
+    }
+
+    fn direct_call_primitive_return_type_text(
+        &self,
+        expr_idx: NodeIndex,
+        depth: u32,
+    ) -> Option<String> {
+        if depth > 8 {
+            return None;
+        }
+        let expr_node = self.arena.get(expr_idx)?;
+        let call = self.arena.get_call_expr(expr_node)?;
+        let callee = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(call.expression);
+        let callee_node = self.arena.get(callee)?;
+        if callee_node.kind != SyntaxKind::Identifier as u16 {
+            return None;
+        }
+        let sym_id = self.value_reference_symbol(callee)?;
+        let binder = self.binder?;
+        let symbol = binder.symbols.get(sym_id)?;
+
+        let mut found = None;
+        for decl_idx in symbol.declarations.iter().copied() {
+            let Some(func) = self.callable_function_from_symbol_decl(self.arena, decl_idx) else {
+                continue;
+            };
+            let type_text = if func.type_annotation.is_some() {
+                self.emit_type_node_text(func.type_annotation)
+            } else if func.body.is_some() {
+                self.function_body_single_return_expression(func.body)
+                    .and_then(|return_expr| {
+                        self.declaration_summary_primitive_expression_type_text(
+                            return_expr,
+                            depth + 1,
+                        )
+                        .or_else(|| self.infer_fallback_type_text_at(return_expr, depth + 1))
+                    })
+                    .or_else(|| self.function_body_preferred_return_type_text(func.body))
+            } else {
+                None
+            };
+            let Some(type_text) = type_text.filter(|text| !text.is_empty() && text != "any") else {
+                continue;
+            };
+            if found.replace(type_text).is_some() {
+                return None;
+            }
+        }
+        found
+    }
+
+    fn property_access_root_idx_and_path(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<(NodeIndex, Vec<String>)> {
+        let expr_idx = self.skip_parenthesized_expression(expr_idx)?;
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind == SyntaxKind::Identifier as u16 {
+            return Some((expr_idx, Vec::new()));
+        }
+        if expr_node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            return None;
+        }
+
+        let access = self.arena.get_access_expr(expr_node)?;
+        let (root_idx, mut path) = self.property_access_root_idx_and_path(access.expression)?;
+        path.push(self.get_identifier_text(access.name_or_argument)?);
+        Some((root_idx, path))
+    }
+
+    fn nested_object_property_type_text(type_text: String, path: &[String]) -> Option<String> {
+        let mut current = type_text;
+        for property in path {
+            current = Self::object_union_property_type_text(&current, property)?;
+        }
+        Some(current)
+    }
+
+    fn object_union_property_type_text(type_text: &str, property: &str) -> Option<String> {
+        let mut parts = Vec::new();
+        for arm in Self::split_top_level_union_type_parts(type_text) {
+            for line in arm.lines() {
+                let Some(name) = Self::object_type_property_name_from_line(line) else {
+                    continue;
+                };
+                if name != property {
+                    continue;
+                }
+                let Some(value_type) = Self::object_literal_property_value_type(line) else {
+                    continue;
+                };
+                let value_type = value_type.trim();
+                if !parts.iter().any(|existing: &String| existing == value_type) {
+                    parts.push(value_type.to_string());
+                }
+            }
+        }
+        (!parts.is_empty()).then(|| parts.join(" | "))
+    }
+
+    fn function_type_return_type_text(type_text: &str) -> Option<String> {
+        let arrow = Self::top_level_arrow_index(type_text)?;
+        let return_type = type_text.get(arrow + 2..)?.trim();
+        (!return_type.is_empty()).then(|| return_type.to_string())
+    }
+
+    fn top_level_arrow_index(type_text: &str) -> Option<usize> {
+        let mut paren_depth = 0u32;
+        let mut bracket_depth = 0u32;
+        let mut brace_depth = 0u32;
+        let mut angle_depth = 0u32;
+        let bytes = type_text.as_bytes();
+        let mut idx = 0usize;
+        while idx + 1 < bytes.len() {
+            match bytes[idx] {
+                b'=' if bytes[idx + 1] == b'>'
+                    && paren_depth == 0
+                    && bracket_depth == 0
+                    && brace_depth == 0
+                    && angle_depth == 0 =>
+                {
+                    return Some(idx);
+                }
+                b'(' => paren_depth += 1,
+                b')' => paren_depth = paren_depth.saturating_sub(1),
+                b'[' => bracket_depth += 1,
+                b']' => bracket_depth = bracket_depth.saturating_sub(1),
+                b'{' => brace_depth += 1,
+                b'}' => brace_depth = brace_depth.saturating_sub(1),
+                b'<' => angle_depth += 1,
+                b'>' => angle_depth = angle_depth.saturating_sub(1),
+                _ => {}
+            }
+            idx += 1;
+        }
+        None
     }
 
     pub(crate) fn preferred_expression_type_text(&self, expr_idx: NodeIndex) -> Option<String> {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_instantiation.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_instantiation.rs
@@ -629,7 +629,11 @@ impl<'a> DeclarationEmitter<'a> {
 
         self.short_circuit_const_literal_reference_type_text(expr_idx)
             .or_else(|| self.js_literal_type_text(expr_idx))
-            .or_else(|| self.preferred_expression_type_text(expr_idx))
+            .or_else(|| self.declaration_summary_primitive_expression_type_text(expr_idx, 0))
+            .or_else(|| {
+                self.preferred_expression_type_text(expr_idx)
+                    .filter(|text| text != "any")
+            })
             .or_else(|| self.infer_fallback_type_text_at(expr_idx, 0))
             .or_else(|| {
                 let expr_idx = self.skip_parenthesized_expression_via_parent_node(expr_idx)?;
@@ -641,7 +645,13 @@ impl<'a> DeclarationEmitter<'a> {
                 }
                 self.short_circuit_const_literal_reference_type_text(expr_idx)
                     .or_else(|| self.js_literal_type_text(expr_idx))
-                    .or_else(|| self.preferred_expression_type_text(expr_idx))
+                    .or_else(|| {
+                        self.declaration_summary_primitive_expression_type_text(expr_idx, 0)
+                    })
+                    .or_else(|| {
+                        self.preferred_expression_type_text(expr_idx)
+                            .filter(|text| text != "any")
+                    })
                     .or_else(|| self.infer_fallback_type_text_at(expr_idx, 0))
             })
     }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
@@ -48,6 +48,15 @@ impl<'a> DeclarationEmitter<'a> {
         (!type_text.trim().is_empty()).then_some(type_text)
     }
 
+    pub(in crate::declaration_emitter) fn function_body_local_function_expando_return_type_text(
+        &self,
+        body_idx: NodeIndex,
+    ) -> Option<String> {
+        let returned_identifier = self.function_body_unique_return_identifier(body_idx)?;
+        self.local_variable_function_expando_type_text(returned_identifier)
+            .filter(|text| !text.is_empty())
+    }
+
     fn function_parameter_type_annotation(
         &self,
         func: &tsz_parser::parser::node::FunctionData,
@@ -1175,6 +1184,11 @@ impl<'a> DeclarationEmitter<'a> {
                     && let Some(text) = self
                         .preferred_expression_type_text(ret.expression)
                         .filter(|text| !text.is_empty() && text != "any")
+                {
+                    text
+                } else if let Some(text) = self
+                    .local_variable_function_expando_type_text(ret.expression)
+                    .filter(|text| !text.is_empty())
                 {
                     text
                 } else if let Some(text) = self

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
@@ -328,6 +328,14 @@ impl<'a> DeclarationEmitter<'a> {
             {
                 return Some(type_text);
             }
+            if let Some(return_expr) = self.single_return_expression(func.body)
+                && let Some(type_text) = self
+                    .declaration_summary_primitive_expression_type_text(return_expr, 0)
+                    .or_else(|| self.infer_fallback_type_text_at(return_expr, 0))
+                    .filter(|text| !text.is_empty() && text != "any")
+            {
+                return Some(type_text);
+            }
             return self.function_body_preferred_return_type_text(func.body);
         }
 

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -387,6 +387,21 @@ impl<'a> DeclarationEmitter<'a> {
                 self.write(": ");
                 self.write(&type_text);
             } else if has_initializer
+                && self
+                    .arena
+                    .get(initializer)
+                    .is_some_and(|node| node.kind == syntax_kind_ext::BINARY_EXPRESSION)
+                && let Some(type_text) = self
+                    .short_circuit_expression_type_text(initializer)
+                    .or_else(|| self.infer_arithmetic_binary_type_text(initializer, 0))
+                    .or_else(|| {
+                        self.preferred_expression_type_text(initializer)
+                            .filter(|text| text != "any")
+                    })
+            {
+                self.write(": ");
+                self.write(&type_text);
+            } else if has_initializer
                 && let Some(type_text) =
                     self.previous_duplicate_variable_declaration_type_text(decl_idx, decl_name)
             {
@@ -697,17 +712,6 @@ impl<'a> DeclarationEmitter<'a> {
                     .get(initializer)
                     .is_some_and(|node| node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION)
                 && let Some(type_text) = self.property_access_source_accessor_type_text(initializer)
-            {
-                self.write(": ");
-                self.write(&type_text);
-            } else if has_initializer
-                && self
-                    .arena
-                    .get(initializer)
-                    .is_some_and(|node| node.kind == syntax_kind_ext::BINARY_EXPRESSION)
-                && let Some(type_text) = self
-                    .short_circuit_expression_type_text(initializer)
-                    .or_else(|| self.preferred_expression_type_text(initializer))
             {
                 self.write(": ");
                 self.write(&type_text);

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -316,6 +316,9 @@ impl<'a> DeclarationEmitter<'a> {
         } else {
             let is_unique_symbol =
                 keyword == "const" && has_initializer && self.is_symbol_call(initializer);
+            let is_mutable_function_initializer = keyword != "const"
+                && has_initializer
+                && self.is_js_function_initializer(initializer);
 
             // For `const x = null` / `const x = undefined`, tsc always emits `: any`.
             // For `let`/`var`, tsc preserves the solver's type (e.g., `let x: null`).
@@ -634,35 +637,42 @@ impl<'a> DeclarationEmitter<'a> {
                     );
                 }
             } else if has_initializer
-                && (self.emit_ts_late_bound_function_initializer_type_annotation(
-                    decl_name,
-                    initializer,
-                ) || ((self.function_initializer_has_type_predicate(
-                    decl_idx,
-                    decl_name,
-                    initializer,
-                ) || self.function_initializer_needs_source_signature(initializer)
-                    || self.function_initializer_has_inline_parameter_comments(initializer)
-                    || self.function_initializer_is_self_returning_for(initializer, decl_name)
-                    || self.function_initializer_returns_unique_identifier(initializer)
-                    || self.function_initializer_has_typeof_in_param_annotations(initializer)
-                    || self.function_initializer_has_destructured_parameters(initializer)
-                    || self.function_initializer_has_inferred_return_via_symbol(
-                        decl_idx,
+                && ((!is_mutable_function_initializer
+                    && self.emit_ts_late_bound_function_initializer_type_annotation(
                         decl_name,
                         initializer,
                     ))
-                    && {
-                        self.maybe_emit_non_portable_function_return_diagnostic(
-                            decl_name,
-                            initializer,
-                        );
-                        self.emit_function_initializer_type_annotation(
+                    || ((self.function_initializer_has_type_predicate(
+                        decl_idx,
+                        decl_name,
+                        initializer,
+                    ) || self.function_initializer_needs_source_signature(initializer)
+                        || self.function_initializer_has_inline_parameter_comments(initializer)
+                        || self
+                            .function_initializer_is_self_returning_for(initializer, decl_name)
+                        || self.function_initializer_returns_unique_identifier(initializer)
+                        || (keyword != "const"
+                            && self.function_initializer_has_parameter_type_annotations(
+                                initializer,
+                            ))
+                        || self.function_initializer_has_typeof_in_param_annotations(initializer)
+                        || self.function_initializer_has_destructured_parameters(initializer)
+                        || self.function_initializer_has_inferred_return_via_symbol(
                             decl_idx,
                             decl_name,
                             initializer,
-                        )
-                    }))
+                        ))
+                        && {
+                            self.maybe_emit_non_portable_function_return_diagnostic(
+                                decl_name,
+                                initializer,
+                            );
+                            self.emit_function_initializer_type_annotation(
+                                decl_idx,
+                                decl_name,
+                                initializer,
+                            )
+                        }))
             {
             } else if has_initializer
                 && self

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl_function_initializers.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl_function_initializers.rs
@@ -743,6 +743,30 @@ impl<'a> DeclarationEmitter<'a> {
         })
     }
 
+    pub(in crate::declaration_emitter) fn function_initializer_has_parameter_type_annotations(
+        &self,
+        initializer: NodeIndex,
+    ) -> bool {
+        let Some(init_node) = self.arena.get(initializer) else {
+            return false;
+        };
+        if init_node.kind != syntax_kind_ext::ARROW_FUNCTION
+            && init_node.kind != syntax_kind_ext::FUNCTION_EXPRESSION
+        {
+            return false;
+        }
+        let Some(func) = self.arena.get_function(init_node) else {
+            return false;
+        };
+
+        func.parameters.nodes.iter().copied().any(|param_idx| {
+            self.arena
+                .get(param_idx)
+                .and_then(|param_node| self.arena.get_parameter(param_node))
+                .is_some_and(|param| param.type_annotation.is_some())
+        })
+    }
+
     pub(in crate::declaration_emitter) fn function_initializer_needs_source_signature(
         &self,
         initializer: NodeIndex,

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/visibility.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/visibility.rs
@@ -139,6 +139,14 @@ impl<'a> DeclarationEmitter<'a> {
         if self.has_export_modifier(modifiers) {
             return false;
         }
+        // A non-exported namespace member is still part of the public surface
+        // when an exported namespace function returns it by identifier; the
+        // exported return type must be nameable as `typeof Member`.
+        if let Some(idx) = decl_idx
+            && self.namespace_member_decl_returned_by_exported_function(idx)
+        {
+            return false;
+        }
         // If the member is referenced by the exported API surface, keep it
         if let Some(idx) = decl_idx
             && self.is_ns_member_used_by_exports(idx)
@@ -147,6 +155,22 @@ impl<'a> DeclarationEmitter<'a> {
         }
         // Non-exported member inside non-ambient namespace: skip
         true
+    }
+
+    pub(crate) fn namespace_member_decl_returned_by_exported_function(
+        &self,
+        decl_idx: NodeIndex,
+    ) -> bool {
+        let Some(decl_node) = self.arena.get(decl_idx) else {
+            return false;
+        };
+        let Some(name_idx) = self.get_declaration_name_idx(decl_node) else {
+            return false;
+        };
+        let Some(name) = self.get_identifier_text(name_idx) else {
+            return false;
+        };
+        self.namespace_member_returned_by_exported_function(decl_idx, &name)
     }
 
     /// Check if a non-exported namespace member's symbol appears in `used_symbols`.
@@ -230,6 +254,7 @@ impl<'a> DeclarationEmitter<'a> {
             return used.contains_key(&sym_id) && self.symbol_parent_matches(sym_id, direct_parent);
         }
         self.namespace_member_referenced_by_exported_object_literal(decl_idx, &name)
+            || self.namespace_member_returned_by_exported_function(decl_idx, &name)
     }
 
     fn symbol_parent_matches(
@@ -261,6 +286,65 @@ impl<'a> DeclarationEmitter<'a> {
                 self.exported_variable_statement_initializer_references_name(stmt_idx, name)
             })
         }) || self.object_literal_member_references_name(name)
+    }
+
+    fn namespace_member_returned_by_exported_function(
+        &self,
+        decl_idx: NodeIndex,
+        name: &str,
+    ) -> bool {
+        let Some(module_block_idx) = self.containing_module_block_for_decl(decl_idx) else {
+            return false;
+        };
+        let Some(module_block_node) = self.arena.get(module_block_idx) else {
+            return false;
+        };
+        let Some(module_block) = self.arena.get_module_block(module_block_node) else {
+            return false;
+        };
+        let Some(statements) = module_block.statements.as_ref() else {
+            return false;
+        };
+
+        statements.nodes.iter().copied().any(|stmt_idx| {
+            let Some(stmt_node) = self.arena.get(stmt_idx) else {
+                return false;
+            };
+            let func_idx = if stmt_node.kind == syntax_kind_ext::EXPORT_DECLARATION {
+                self.arena
+                    .get_export_decl(stmt_node)
+                    .and_then(|export| {
+                        self.arena
+                            .get(export.export_clause)
+                            .map(|_| export.export_clause)
+                    })
+                    .unwrap_or(stmt_idx)
+            } else {
+                stmt_idx
+            };
+            let Some(func_node) = self.arena.get(func_idx) else {
+                return false;
+            };
+            let Some(func) = self.arena.get_function(func_node) else {
+                return false;
+            };
+            if !self.statement_has_effective_export(stmt_idx) {
+                return false;
+            }
+            func.body.is_some() && self.function_body_returns_identifier(func.body, name)
+        })
+    }
+
+    fn containing_module_block_for_decl(&self, decl_idx: NodeIndex) -> Option<NodeIndex> {
+        let mut current = decl_idx;
+        while let Some(parent_idx) = self.arena.parent_of(current) {
+            let parent_node = self.arena.get(parent_idx)?;
+            if parent_node.kind == syntax_kind_ext::MODULE_BLOCK {
+                return Some(parent_idx);
+            }
+            current = parent_idx;
+        }
+        None
     }
 
     fn object_literal_member_references_name(&self, name: &str) -> bool {

--- a/crates/tsz-emitter/src/declaration_emitter/tests/js_expando_features.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/js_expando_features.rs
@@ -1,0 +1,44 @@
+use super::*;
+
+#[test]
+fn mutable_function_expando_variable_keeps_callable_signature() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+const ConstFn = function (n: number) {
+    return n.toString();
+};
+ConstFn.prop = 1;
+
+var VarFn = function (n: number) {
+    return n.toString();
+};
+VarFn.prop = 1;
+
+let RenamedArrow = (flag: boolean) => flag ? 1 : 0;
+RenamedArrow.meta = "value";
+"#,
+    );
+
+    assert!(
+        output.contains("declare const ConstFn: {\n    (n: number): any;\n    prop: number;\n};"),
+        "Expected const function expression to keep expando static surface: {output}"
+    );
+    assert!(
+        output.contains("declare var VarFn: (n: number) => any;"),
+        "Expected mutable function expression to emit its own callable signature: {output}"
+    );
+    assert!(
+        output.contains("declare let RenamedArrow: (flag: boolean) => any;"),
+        "Expected mutable arrow function to emit its own callable signature: {output}"
+    );
+    assert!(
+        !output.contains("declare var VarFn: {\n    (n: number): any;\n    prop: number;\n};"),
+        "Did not expect mutable function expression to merge expando static surface: {output}"
+    );
+    assert!(
+        !output.contains(
+            "declare let RenamedArrow: {\n    (flag: boolean): any;\n    meta: string;\n};"
+        ),
+        "Did not expect mutable arrow function to merge expando static surface: {output}"
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/tests/js_expando_features.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/js_expando_features.rs
@@ -106,3 +106,41 @@ Renamed.state = { code: 200 };
         "Expected renamed arrow expando assignment to emit normalized object union: {output}"
     );
 }
+
+#[test]
+fn namespace_returned_local_function_expando_emits_typeof_merge() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+namespace Boxed {
+    function Builder(): void {}
+    Builder.count = 1;
+    export function make() {
+        return Builder;
+    }
+}
+
+namespace Renamed {
+    function Factory(flag: boolean) {
+        return flag;
+    }
+    Factory.label = "ready";
+    export function getFactory() {
+        return Factory;
+    }
+}
+"#,
+    );
+
+    assert!(
+        output.contains(
+            "function Builder(): void;\n    namespace Builder {\n        var count: number;\n    }\n    export function make(): typeof Builder;"
+        ),
+        "Expected returned namespace-local function expando to emit a function/namespace merge and typeof return: {output}"
+    );
+    assert!(
+        output.contains(
+            "function Factory(flag: boolean): boolean;\n    namespace Factory {\n        var label: string;\n    }\n    export function getFactory(): typeof Factory;"
+        ),
+        "Expected renamed namespace-local function expando to emit a function/namespace merge and typeof return: {output}"
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/tests/js_expando_features.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/js_expando_features.rs
@@ -24,7 +24,7 @@ RenamedArrow.meta = "value";
         "Expected const function expression to keep expando static surface: {output}"
     );
     assert!(
-        output.contains("declare var VarFn: (n: number) => any;"),
+        output.contains("declare var VarFn: (n: number) => string;"),
         "Expected mutable function expression to emit its own callable signature: {output}"
     );
     assert!(
@@ -142,5 +142,144 @@ namespace Renamed {
             "function Factory(flag: boolean): boolean;\n    namespace Factory {\n        var label: string;\n    }\n    export function getFactory(): typeof Factory;"
         ),
         "Expected renamed namespace-local function expando to emit a function/namespace merge and typeof return: {output}"
+    );
+}
+
+#[test]
+fn expando_arithmetic_initializer_uses_member_call_and_instance_facts() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+function Count(n: number) {
+    return n.toString();
+}
+Count.value = 1;
+Count.next = function(n: number) {
+    return n + 1;
+};
+var total = Count.value + Count.next(2) + Count(3).length;
+
+const Make = function(name: string) {
+    return name;
+};
+Make.info = { size: 1 };
+Make.info = { label: "" };
+Make.bump = function(value: number) {
+    return value + 1;
+};
+var score = (Make.info.size || 0) + Make.bump(1) + Make("x").length;
+
+class Box {
+    n = 1;
+}
+Box.extra = 2;
+Box.pick = function(n: number) {
+    return n;
+};
+var classTotal = Box.extra + Box.pick(1) + new Box().n;
+
+var Expr = class {
+    n = 1;
+};
+Expr.extra = 2;
+Expr.pick = function(n: number) {
+    return n;
+};
+var exprTotal = Expr.extra + Expr.pick(1) + new Expr().n;
+"#,
+    );
+
+    assert!(
+        output.contains("declare var total: number;"),
+        "Expected expando arithmetic initializer to use member/call facts: {output}"
+    );
+    assert!(
+        output.contains("declare var score: number;"),
+        "Expected nested object expando arithmetic initializer to use union member facts: {output}"
+    );
+    assert!(
+        output.contains("declare var classTotal: number;"),
+        "Expected class expando arithmetic initializer to use instance member facts: {output}"
+    );
+    assert!(
+        output.contains("declare var exprTotal: number;"),
+        "Expected class-expression expando arithmetic initializer to use instance member facts: {output}"
+    );
+}
+
+#[test]
+fn repeated_expando_arithmetic_var_declarations_keep_number_facts() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+function Decl(n: number) {
+    return n.toString();
+}
+Decl.prop = 2;
+Decl.m = function(n: number) {
+    return n + 1;
+};
+var n = Decl.prop + Decl.m(12) + Decl(101).length;
+
+const Expr = function(n: number) {
+    return n.toString();
+};
+Expr.prop = { x: 2 };
+Expr.prop = { y: "" };
+Expr.m = function(n: number) {
+    return n + 1;
+};
+var n = (Expr.prop.x || 0) + Expr.m(12) + Expr(101).length;
+
+function Merge(n: number) {
+    return n * 100;
+}
+Merge.p1 = 111;
+namespace Merge {
+    export var p2 = 222;
+}
+namespace Merge {
+    export var p3 = 333;
+}
+var n = Merge.p1 + Merge.p2 + Merge.p3 + Merge(1);
+var merged = Merge.p1 + Merge.p2 + Merge.p3 + Merge(1);
+var fromP1 = Merge.p1;
+var fromP1P2 = Merge.p1 + Merge.p2;
+var fromP1P2P3 = Merge.p1 + Merge.p2 + Merge.p3;
+var fromP1Call = Merge.p1 + Merge(1);
+var fromCall = Merge(1);
+var fromNs = Merge.p2 + Merge.p3;
+"#,
+    );
+
+    assert!(
+        output.matches("declare var n: number;").count() >= 3,
+        "Expected repeated expando arithmetic declarations to keep number facts: {output}"
+    );
+    assert!(
+        output.contains("declare var merged: number;"),
+        "Expected namespace-merged arithmetic declarations to keep number facts: {output}"
+    );
+    assert!(
+        output.contains("declare var fromP1: number;"),
+        "Expected late-bound namespace members to keep value facts: {output}"
+    );
+    assert!(
+        output.contains("declare var fromP1P2: number;"),
+        "Expected late-bound and namespace members to compose in arithmetic: {output}"
+    );
+    assert!(
+        output.contains("declare var fromP1P2P3: number;"),
+        "Expected three namespace members to compose in arithmetic: {output}"
+    );
+    assert!(
+        output.contains("declare var fromP1Call: number;"),
+        "Expected late-bound members and direct calls to compose in arithmetic: {output}"
+    );
+    assert!(
+        output.contains("declare var fromCall: number;"),
+        "Expected namespace-merged direct calls to keep return facts: {output}"
+    );
+    assert!(
+        output.contains("declare var fromNs: number;"),
+        "Expected namespace exports to keep value facts: {output}"
     );
 }

--- a/crates/tsz-emitter/src/declaration_emitter/tests/js_expando_features.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/js_expando_features.rs
@@ -76,3 +76,33 @@ function makeFlagged(flag: boolean) {
         "Expected returned arrow expando property to keep assigned member type: {output}"
     );
 }
+
+#[test]
+fn repeated_object_expando_assignments_emit_normalized_union() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+const Build = function (label: string) {
+    return label.length;
+};
+Build.config = { count: 1 };
+Build.config = { name: "ready" };
+
+const Renamed = (enabled: boolean) => enabled;
+Renamed.state = { ok: true };
+Renamed.state = { code: 200 };
+"#,
+    );
+
+    assert!(
+        output.contains(
+            "config: {\n        count: number;\n        name?: undefined;\n    } | {\n        name: string;\n        count?: undefined;\n    };"
+        ),
+        "Expected repeated object expando assignment to emit normalized object union: {output}"
+    );
+    assert!(
+        output.contains(
+            "state: {\n        ok: boolean;\n        code?: undefined;\n    } | {\n        code: number;\n        ok?: undefined;\n    };"
+        ),
+        "Expected renamed arrow expando assignment to emit normalized object union: {output}"
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/tests/js_expando_features.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/js_expando_features.rs
@@ -42,3 +42,37 @@ RenamedArrow.meta = "value";
         "Did not expect mutable arrow function to merge expando static surface: {output}"
     );
 }
+
+#[test]
+fn returned_local_function_expando_keeps_assigned_member_type() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+function makeCounter(seed: number) {
+    const next = function (step: number) {
+        return seed + step;
+    };
+    next.total = seed + 1;
+    return next;
+}
+
+function makeFlagged(flag: boolean) {
+    let choose = (value: string) => value.length;
+    choose.ready = flag;
+    return choose;
+}
+"#,
+    );
+
+    assert!(
+        output.contains(
+            "declare function makeCounter(seed: number): {\n    (step: number): number;\n    total: number;\n};"
+        ),
+        "Expected returned function expression expando property to keep assigned member type: {output}"
+    );
+    assert!(
+        output.contains(
+            "declare function makeFlagged(flag: boolean): {\n    (value: string): any;\n    ready: boolean;\n};"
+        ),
+        "Expected returned arrow expando property to keep assigned member type: {output}"
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/tests/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/mod.rs
@@ -298,6 +298,7 @@ mod export_specifiers;
 mod fix_verification;
 mod generics_and_ambient;
 mod js_define_property;
+mod js_expando_features;
 mod jsdoc_template_defaults;
 mod misc_features;
 mod misc_inference_features;


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Declaration emit parity / stacked DTS fix on #10433.

## Invariant
When an unannotated public declaration exposes expando assignment facts, declaration emit should summarize the callable surface, assigned object-member surface, namespace-local returned function nameability, and primitive arithmetic use-sites from structured declaration/public API summaries. This PR changes the declaration summary path only.

## Scope
- Reuses late-bound assignment member collection inside an enclosing function body for returned local function expandos.
- Adds returned-local function expando summaries for declaration return inference.
- Preserves repeated object-literal assignments to the same expando property as a normalized object-union surface instead of overwriting with the last assignment.
- Preserves namespace-local function declarations returned by exported namespace functions, emits their late-bound function/namespace merge, and prints the exported return as `typeof LocalFunction`.
- Adds declaration-summary primitive inference for arithmetic over expando statics, namespace exports, direct callable returns, `.length`, and class/class-expression instance properties.
- Lets binary initializer summaries override duplicate-`var` fallback `any` when the initializer itself has declaration facts.
- Adds focused unit coverage for returned function expression/arrow expandos, repeated object expando assignment unions, namespace-local returned expando functions, expando arithmetic, namespace-merged arithmetic, and duplicate `var` arithmetic declarations.

## Project Corpus Impact
- Row: declaration emit `typeFromPropertyAssignment29`
- Bug family: expando assignment declaration summary / arithmetic use-site inference
- Evidence: focused DTS run now passes `typeFromPropertyAssignment29` locally, including the former `ExpandoNested.total: any`, `ExpandoExpr.prop` missing-union-arm, `Ns.ExpandoNamespace` object-return, and all remaining `declare var n: any` arithmetic-expression hunks.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-emitter -E 'test(mutable_function_expando_variable_keeps_callable_signature) or test(returned_local_function_expando_keeps_assigned_member_type) or test(repeated_object_expando_assignments_emit_normalized_union) or test(namespace_returned_local_function_expando_emits_typeof_merge) or test(expando_arithmetic_initializer_uses_member_call_and_instance_facts) or test(repeated_expando_arithmetic_var_declarations_keep_number_facts)'`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=typeFromPropertyAssignment29 --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-type-from-prop29-arithmetic-after4.json`
- `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`

## Coordination Notes
- Stacked on #10433 (`fix(dts): keep mutable function expandos callable`) because both touch the same `typeFromPropertyAssignment29` expando family.
- This branch now contains four small commits: returned local function expandos, repeated object expando assignment unions, namespace-local returned expando function `typeof` emission, and expando arithmetic summaries.
- Overlap check found no separate active returned-local, repeated-object, namespace-returned, or expando-arithmetic PR; #10433 is the direct dependency.
- Draft state is intentional: keep stacked until #10433 lands or is otherwise rebased by Studio-D/manager.
