### PR TITLE
refactor(checker): route promise this relation

### DIFF
--- a/crates/tsz-checker/src/checkers/promise_checker.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker.rs
@@ -643,7 +643,7 @@ impl<'a> CheckerState<'a> {
         for sig in &sigs {
             if let Some(expected_this) = sig.this_type
                 && expected_this != TypeId::VOID
-                && !self.diagnostic_relation_boolean_guard(type_id, expected_this)
+                && !self.assign_relation_outcome(type_id, expected_this).related
             {
                 rejected_this_type.get_or_insert(expected_this);
                 continue;

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -760,6 +760,9 @@ mod private_brands;
 #[path = "tests/promise_like_infer_tests.rs"]
 mod promise_like_infer_tests;
 #[cfg(test)]
+#[path = "tests/promise_this_relation_routing_arch_tests.rs"]
+mod promise_this_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/property_alias_display_tests.rs"]
 mod property_alias_display_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/promise_this_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/promise_this_relation_routing_arch_tests.rs
@@ -1,0 +1,25 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn await_thenable_this_validation_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("src/checkers/promise_checker.rs"),
+    )
+    .expect("failed to read promise_checker.rs");
+
+    let helper = source
+        .split("fn extract_awaited_type_from_valid_thenable")
+        .nth(1)
+        .and_then(|rest| rest.split("let awaited_type =").next())
+        .expect("failed to isolate thenable await helper");
+
+    assert!(
+        helper.contains("assign_relation_outcome(type_id, expected_this).related"),
+        "await thenable this-type validation should route through assign_relation_outcome"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard(type_id, expected_this)"),
+        "await thenable this-type validation should not use the raw boolean relation guard"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker relation diagnostics / query-boundary routing.

## Invariant
When await validates a thenable `then` signature's required `this` type before deciding whether to emit the invalid await-operand diagnostic, relation truth flows through the shared `assign_relation_outcome` boundary; the checker keeps the await diagnostic and source span policy.

## Scope
- `crates/tsz-checker/src/checkers/promise_checker.rs`
- `crates/tsz-checker/src/tests/promise_this_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: checker diagnostic-routing refactor only; no solver policy/cache, parser, binder, emitter, project corpus fixture, or baseline changes.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib await_thenable_this_validation_uses_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `git rev-list --left-right --count HEAD...origin/main` = `1 0`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Fresh branch from current `origin/main` in `/Users/mohsen/code/tsz-m1b-fresh-origin-main-20260527-060539`.
- Checked open PR file overlap before editing; no open PR owned `promise_checker.rs` or the promise checker boundary file.
- Non-overlap: does not touch solver policy internals, variance, any propagation, cache keys, JSX, call elaboration, property receiver, remapped missing-property, enum statement-helper, or object-literal PR files.