### PR TITLE
refactor(checker): route private member access relations

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -763,6 +763,9 @@ mod polymorphic_this_relation_routing_arch_tests;
 #[path = "../tests/private_brands.rs"]
 mod private_brands;
 #[cfg(test)]
+#[path = "tests/private_member_relation_routing_arch_tests.rs"]
+mod private_member_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/promise_like_infer_tests.rs"]
 mod promise_like_infer_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs
@@ -91,7 +91,10 @@ impl<'a> CheckerState<'a> {
                 {
                     return true;
                 }
-                if self.diagnostic_relation_boolean_guard(object_type, declaring_type) {
+                if self
+                    .assign_relation_outcome(object_type, declaring_type)
+                    .related
+                {
                     return true;
                 }
                 // Last resort: check if the object type has the private property
@@ -105,7 +108,10 @@ impl<'a> CheckerState<'a> {
                 )
                 .is_success()
             }
-            _ => self.diagnostic_relation_boolean_guard(object_type, declaring_type),
+            _ => {
+                self.assign_relation_outcome(object_type, declaring_type)
+                    .related
+            }
         }
     }
 
@@ -699,7 +705,9 @@ impl<'a> CheckerState<'a> {
                 &property_name,
             )
         } else if self.types_have_same_private_brand(object_type_for_check, declaring_type)
-            || self.diagnostic_relation_boolean_guard(object_type_for_check, declaring_type)
+            || self
+                .assign_relation_outcome(object_type_for_check, declaring_type)
+                .related
         {
             true
         } else {
@@ -752,7 +760,8 @@ impl<'a> CheckerState<'a> {
                         } else if self.types_have_same_private_brand(object_type_for_check, ty) {
                             true
                         } else {
-                            self.diagnostic_relation_boolean_guard(object_type_for_check, ty)
+                            self.assign_relation_outcome(object_type_for_check, ty)
+                                .related
                         }
                     })
             });

--- a/crates/tsz-checker/src/tests/private_member_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/private_member_relation_routing_arch_tests.rs
@@ -1,0 +1,20 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn private_member_access_compatibility_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/state/type_analysis/computed_helpers_private.rs"),
+    )
+    .expect("failed to read computed_helpers_private.rs");
+
+    assert!(
+        source.matches("assign_relation_outcome(").count() >= 4,
+        "private member compatibility should route fallback relation checks through assign_relation_outcome"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard("),
+        "private member compatibility should not use the raw boolean relation guard"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker relation diagnostics / query-boundary routing.

## Invariant
When private-member access compatibility asks whether the object type is assignable to the declaring type before emitting or suppressing private-access diagnostics, relation truth flows through the shared `assign_relation_outcome` boundary; checker code keeps private-brand, shadowing, fallback shape, and diagnostic span policy.

## Scope
- `crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs`
- `crates/tsz-checker/src/tests/private_member_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: checker diagnostic-routing refactor only; no solver policy/cache, parser, binder, emitter, project corpus fixture, or baseline changes.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib private_member_access_compatibility_uses_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `git rev-list --left-right --count HEAD...origin/main` = `1 0`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Fresh branch from current `origin/main` in `/Users/mohsen/code/tsz-m1b-fresh-origin-main-20260527-060539`.
- Checked open PR file overlap before editing; no open PR owned `computed_helpers_private.rs`.
- Skipped `binary_operator_diagnostics.rs` because the `in` operator relation path was already migrated on main.
- Non-overlap: does not touch solver policy internals, variance, any propagation, cache keys, JSX, call elaboration, property receiver, remapped missing-property, promise this, enum statement-helper, or object-literal PR files.