### PR TITLE
docs(plan): refresh open bug metric

### DIFF
--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -57,7 +57,7 @@ denominators.
 | JavaScript emit | `96.8%` (`13,094 / 13,530`) in checked-in emit snapshot and README |
 | Declaration emit | `96.2%` (`1,606 / 1,669`) in checked-in emit snapshot and README |
 | Fourslash / language service | `99.9%` (`6,558 / 6,562`) |
-| Open bug issues | `32` open `bug` issues in live GitHub orientation |
+| Open bug issues | `31` open `bug` issues in live GitHub orientation |
 | Output-surgery audit | green: `0` unallowlisted calls, `0` stale allowlist entries |
 
 Conformance remains a hard regression gate. It is no longer the sole readiness


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Release metrics / roadmap public metric truth.

## Invariant
When live GitHub issue orientation reports a different open `bug` count, the roadmap public metrics table should carry the current live count instead of a stale copied value.

## Scope
- `docs/plan/ROADMAP.md`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only public metric refresh; project corpus row metadata and artifacts are unchanged.

## Verification
- Earlier refreshed-head evidence: live counts briefly returned to `31`, and PR #10455 passed `CI Summary`, `project-corpus-pr-body`, `gate`, and `GitGuardian Security Checks` for head `7267e29dc837471213ef5b0bdfbe26858d9f2a72`.
- Current blocker evidence: `gh issue list --state open --limit 500 --label bug --json number | jq -r 'length'` now reports `32` again.
- Current aggregate orientation: `gh issue list --state open --limit 500 --json number,labels | jq -r 'def has($n): any(.labels[]?; .name==$n); [length, (map(select(has("bug")))|length), (map(select(has("performance")))|length), (map(select(has("tech debt")))|length), (map(select(has("bench")))|length), (map(select(has("benchmark")))|length), (map(select(has("conformance")))|length), (map(select(has("emit")))|length), (map(select(has("accepted-regression")))|length)] | @tsv'` -> `104 32 9 0 5 0 11 13 9`
- Current `origin/main` already records `32` open `bug` issues, so this branch's `31` update must not merge while that remains true.

## Coordination Notes
- Blocked/WIP as of 2026-05-27: live GitHub orientation returned to `32` open `bug` issues, matching current `origin/main`; this branch's `31` update is stale again.
- Moved back to draft so it cannot be queued accidentally.
- Next owner/action: Studio-A should either close this PR if `32` remains durable, or refresh the branch if live orientation moves back to `31` (or another durable value).
