### PR TITLE
refactor(checker): route duplicate identifier relations

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -535,6 +535,9 @@ mod dispatch_tests;
 #[path = "tests/do_while_exit_narrowing_tests.rs"]
 mod do_while_exit_narrowing_tests;
 #[cfg(test)]
+#[path = "tests/duplicate_identifier_relation_routing_arch_tests.rs"]
+mod duplicate_identifier_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/dynamic_import_relation_routing_arch_tests.rs"]
 mod dynamic_import_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/duplicate_identifier_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/duplicate_identifier_relation_routing_arch_tests.rs
@@ -1,0 +1,20 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn duplicate_identifier_helpers_use_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/types/type_checking/duplicate_identifier_relation_helpers.rs"),
+    )
+    .expect("failed to read duplicate_identifier_relation_helpers.rs");
+
+    assert!(
+        source.matches("assign_relation_outcome(").count() >= 5,
+        "duplicate declaration relation helpers should route through assign_relation_outcome"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard("),
+        "duplicate declaration relation helpers should not use the raw boolean relation guard"
+    );
+}

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifier_relation_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifier_relation_helpers.rs
@@ -5,8 +5,8 @@ use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
     pub(super) fn duplicate_decl_types_match(&mut self, left: TypeId, right: TypeId) -> bool {
-        self.diagnostic_relation_boolean_guard(left, right)
-            && self.diagnostic_relation_boolean_guard(right, left)
+        self.assign_relation_outcome(left, right).related
+            && self.assign_relation_outcome(right, left).related
     }
 
     pub(super) fn duplicate_decl_type_matches_index(
@@ -14,7 +14,8 @@ impl<'a> CheckerState<'a> {
         property_type: TypeId,
         index_type: TypeId,
     ) -> bool {
-        self.diagnostic_relation_boolean_guard(property_type, index_type)
+        self.assign_relation_outcome(property_type, index_type)
+            .related
     }
 
     pub(super) fn duplicate_index_types_overlap(
@@ -22,7 +23,10 @@ impl<'a> CheckerState<'a> {
         local_type: TypeId,
         existing_type: TypeId,
     ) -> bool {
-        self.diagnostic_relation_boolean_guard(local_type, existing_type)
-            || self.diagnostic_relation_boolean_guard(existing_type, local_type)
+        self.assign_relation_outcome(local_type, existing_type)
+            .related
+            || self
+                .assign_relation_outcome(existing_type, local_type)
+                .related
     }
 }


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker relation diagnostics / query-boundary routing.

## Invariant
When duplicate declaration diagnostics compare declaration or index-signature types for equality or overlap, relation truth flows through the shared `assign_relation_outcome` boundary; duplicate-declaration code keeps diagnostic orchestration.

## Scope
- `crates/tsz-checker/src/types/type_checking/duplicate_identifier_relation_helpers.rs`
- `crates/tsz-checker/src/tests/duplicate_identifier_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: checker diagnostic-routing refactor only; no solver policy/cache, parser, binder, emitter, project corpus fixture, or baseline changes.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib duplicate_identifier_helpers_use_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `git rev-list --left-right --count HEAD...origin/main` = `1 0`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Fresh branch from current `origin/main` in `/Users/mohsen/code/tsz-m1b-fresh-origin-main-20260527-060539`.
- Checked open PR file overlap before editing; no open PR owned `duplicate_identifier_relation_helpers.rs`.
- Non-overlap: does not touch solver policy internals, variance, any propagation, cache keys, JSX, call elaboration, property receiver, remapped missing-property, promise this, private member access, enum statement-helper, or object-literal PR files.