### PR TITLE
refactor(checker): route interface index conflict relations

### DIFF
--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -1032,8 +1032,8 @@ impl<'a> CheckerState<'a> {
                                 // Different bases provide conflicting index signatures.
                                 // tsc emits TS2430 ("incorrectly extends") against the
                                 // later base, not TS2320 ("cannot simultaneously extend").
-                                if !self.diagnostic_relation_boolean_guard(prev_val, value_type)
-                                    && !self.diagnostic_relation_boolean_guard(value_type, prev_val)
+                                if !self.assign_relation_outcome(prev_val, value_type).related
+                                    && !self.assign_relation_outcome(value_type, prev_val).related
                                 {
                                     // The later base's index signature conflicts with
                                     // what was inherited from earlier bases.

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -187,6 +187,9 @@ mod interface_heritage_index_relation_routing_arch_tests;
 #[path = "tests/interface_heritage_property_index_relation_routing_arch_tests.rs"]
 mod interface_heritage_property_index_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/interface_index_conflict_relation_routing_arch_tests.rs"]
+mod interface_index_conflict_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/isolated_declarations_unannotated_param_tests.rs"]
 mod isolated_declarations_unannotated_param_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/interface_index_conflict_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/interface_index_conflict_relation_routing_arch_tests.rs
@@ -1,0 +1,30 @@
+use std::fs;
+use std::path::PathBuf;
+
+#[test]
+fn interface_index_conflicts_use_relation_outcome_boundary() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let source = fs::read_to_string(manifest_dir.join("src/classes/class_checker_compat.rs"))
+        .expect("read class checker compatibility source");
+
+    let helper = source
+        .split("Different bases provide conflicting index signatures.")
+        .nth(1)
+        .expect("find inherited interface index-signature conflict block")
+        .split("The later base's index signature conflicts")
+        .next()
+        .expect("slice relation decision block");
+
+    assert!(
+        helper.contains("assign_relation_outcome(prev_val, value_type).related"),
+        "inherited interface index conflict checks should route previous-to-current relations through RelationOutcome"
+    );
+    assert!(
+        helper.contains("assign_relation_outcome(value_type, prev_val).related"),
+        "inherited interface index conflict checks should route current-to-previous relations through RelationOutcome"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard"),
+        "inherited interface index conflict checks should not regress to raw boolean relation guards"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker relation diagnostics / query-boundary routing.

## Invariant
When distinct base interfaces provide incompatible index-signature value types, checker still owns the later-base TS2430 diagnostic anchor while relation truth flows through the shared assignability boundary.

## Scope
- `crates/tsz-checker/src/classes/class_checker_compat.rs`
- `crates/tsz-checker/src/tests/interface_index_conflict_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation-routing tech debt for inherited interface index-signature conflicts
- Evidence: behavior-preserving boundary routing only; local focused arch test asserts the compatibility block uses `assign_relation_outcome(...).related` in both directions and no raw boolean relation guard.

## Verification
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `cargo nextest run -p tsz-checker --lib interface_index_conflicts_use_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `git rev-list --left-right --count HEAD...origin/main` -> `1 0`

## Coordination Notes
- Opened as draft for light CI.
- No open PR reported touching `crates/tsz-checker/src/classes/class_checker_compat.rs` during overlap check.
- Does not alter solver policy, variance, any propagation, or cache keys.
