### PR TITLE
refactor(checker): route index signature check relations

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -181,6 +181,9 @@ mod imported_generator_iterable_tests;
 #[path = "tests/index_sig_param_intersection_validity_tests.rs"]
 mod index_sig_param_intersection_validity_tests;
 #[cfg(test)]
+#[path = "tests/index_signature_check_relation_routing_arch_tests.rs"]
+mod index_signature_check_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/interface_heritage_index_relation_routing_arch_tests.rs"]
 mod interface_heritage_index_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
@@ -439,10 +439,12 @@ impl<'a> CheckerState<'a> {
                 }
 
                 let key_assignable = self
-                    .diagnostic_relation_boolean_guard(key_type, previous_key_type)
+                    .assign_relation_outcome(key_type, previous_key_type)
+                    .related
                     || self.template_pattern_key_is_subset(key_type, previous_key_type);
-                let value_assignable =
-                    self.diagnostic_relation_boolean_guard(value_type, previous_value_type);
+                let value_assignable = self
+                    .assign_relation_outcome(value_type, previous_value_type)
+                    .related;
                 if key_assignable && !value_assignable {
                     let key_type_str = self.format_type(key_type);
                     let value_type_str = self.format_type(value_type);
@@ -595,7 +597,8 @@ impl<'a> CheckerState<'a> {
             // Only emit when we have own number index nodes to anchor the error,
             // OR when both signatures are inherited (anchor on container).
             let is_assignable = self
-                .diagnostic_relation_boolean_guard(number_idx.value_type, string_idx.value_type);
+                .assign_relation_outcome(number_idx.value_type, string_idx.value_type)
+                .related;
             if !is_assignable {
                 let num_value_str = self.format_type(number_idx.value_type);
                 let str_value_str = self.format_type(string_idx.value_type);
@@ -648,8 +651,9 @@ impl<'a> CheckerState<'a> {
         if let (Some(static_num_type), Some(static_str_type)) =
             (static_number_value_type, static_string_value_type)
         {
-            let is_assignable =
-                self.diagnostic_relation_boolean_guard(static_num_type, static_str_type);
+            let is_assignable = self
+                .assign_relation_outcome(static_num_type, static_str_type)
+                .related;
             if !is_assignable {
                 let num_value_str = self.format_type(static_num_type);
                 let str_value_str = self.format_type(static_str_type);

--- a/crates/tsz-checker/src/tests/index_signature_check_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/index_signature_check_relation_routing_arch_tests.rs
@@ -1,0 +1,32 @@
+use std::fs;
+use std::path::PathBuf;
+
+#[test]
+fn index_signature_checks_use_relation_outcome_boundary() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let source = fs::read_to_string(
+        manifest_dir.join("src/state/state_checking_members/index_signature_checks.rs"),
+    )
+    .expect("read index signature checking source");
+
+    assert!(
+        source.contains("assign_relation_outcome(key_type, previous_key_type)"),
+        "template pattern index key compatibility should route through RelationOutcome"
+    );
+    assert!(
+        source.contains("assign_relation_outcome(value_type, previous_value_type)"),
+        "template pattern index value compatibility should route through RelationOutcome"
+    );
+    assert!(
+        source.contains("assign_relation_outcome(number_idx.value_type, string_idx.value_type)"),
+        "instance number-to-string index compatibility should route through RelationOutcome"
+    );
+    assert!(
+        source.contains("assign_relation_outcome(static_num_type, static_str_type)"),
+        "static number-to-string index compatibility should route through RelationOutcome"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard"),
+        "index signature checking should not regress to raw boolean relation guards"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker relation diagnostics / query-boundary routing.

## Invariant
When index-signature checks compare template-pattern key/value compatibility or number-to-string index value compatibility, checker still owns the TS2413/index-signature diagnostic anchors while relation truth flows through the shared assignability boundary.

## Scope
- `crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs`
- `crates/tsz-checker/src/tests/index_signature_check_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation-routing tech debt for index-signature compatibility diagnostics
- Evidence: behavior-preserving boundary routing only; local focused arch test asserts the index-signature check module uses `assign_relation_outcome(...).related` and no raw boolean relation guard.

## Verification
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `cargo nextest run -p tsz-checker --lib index_signature_checks_use_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `git rev-list --left-right --count HEAD...origin/main` -> `1 0`

## Coordination Notes
- Opened as draft for light CI.
- No open PR reported touching `crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs` during overlap check.
- Does not alter solver policy, variance, any propagation, or cache keys.
