### PR TITLE
refactor(checker): route overlap helper relations

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -754,6 +754,9 @@ mod object_spread_optional_merge_tests;
 #[path = "tests/optional_key_extraction_tests.rs"]
 mod optional_key_extraction_tests;
 #[cfg(test)]
+#[path = "tests/overlap_relation_helper_routing_arch_tests.rs"]
+mod overlap_relation_helper_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/overload_anchor_at_argument_tests.rs"]
 mod overload_anchor_at_argument_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/overlap_relation_helper_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/overlap_relation_helper_routing_arch_tests.rs
@@ -1,0 +1,31 @@
+use std::fs;
+use std::path::PathBuf;
+
+#[test]
+fn overlap_relation_helpers_use_relation_outcome_boundary() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let source =
+        fs::read_to_string(manifest_dir.join("src/types/utilities/overlap_relation_helpers.rs"))
+            .expect("read overlap relation helper source");
+
+    assert!(
+        source.contains("assign_relation_outcome(left, right).related"),
+        "left-to-right overlap assignability should route through RelationOutcome"
+    );
+    assert!(
+        source.contains("assign_relation_outcome(right, left).related"),
+        "right-to-left overlap assignability should route through RelationOutcome"
+    );
+    assert!(
+        source.contains("assign_relation_outcome(lt, rt).related"),
+        "signature parameter overlap should route through RelationOutcome"
+    );
+    assert!(
+        source.contains("assign_relation_outcome(lret, rret).related"),
+        "signature return overlap should route through RelationOutcome"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard"),
+        "diagnostic overlap helpers should not regress to raw boolean relation guards"
+    );
+}

--- a/crates/tsz-checker/src/types/utilities/overlap_relation_helpers.rs
+++ b/crates/tsz-checker/src/types/utilities/overlap_relation_helpers.rs
@@ -10,12 +10,12 @@ impl<'a> CheckerState<'a> {
         right: TypeId,
         skip_signature_only_assignability: bool,
     ) -> (bool, bool) {
-        let left_to_right = !skip_signature_only_assignability
-            && self.diagnostic_relation_boolean_guard(left, right);
+        let left_to_right =
+            !skip_signature_only_assignability && self.assign_relation_outcome(left, right).related;
         let right_to_left = if left_to_right || skip_signature_only_assignability {
             false
         } else {
-            self.diagnostic_relation_boolean_guard(right, left)
+            self.assign_relation_outcome(right, left).related
         };
 
         if tracing::enabled!(tracing::Level::TRACE) {
@@ -83,14 +83,14 @@ impl<'a> CheckerState<'a> {
                     } else {
                         rp.type_id
                     };
-                    left_to_right &= self.diagnostic_relation_boolean_guard(lt, rt);
-                    right_to_left &= self.diagnostic_relation_boolean_guard(rt, lt);
+                    left_to_right &= self.assign_relation_outcome(lt, rt).related;
+                    right_to_left &= self.assign_relation_outcome(rt, lt).related;
                     if !left_to_right && !right_to_left {
                         break;
                     }
                 }
-                if (left_to_right && self.diagnostic_relation_boolean_guard(lret, rret))
-                    || (right_to_left && self.diagnostic_relation_boolean_guard(rret, lret))
+                if (left_to_right && self.assign_relation_outcome(lret, rret).related)
+                    || (right_to_left && self.assign_relation_outcome(rret, lret).related)
                 {
                     return true;
                 }


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker relation diagnostics / query-boundary routing.

## Invariant
When diagnostic overlap helpers compare assignability directions between candidate types or signatures, checker still owns the overlap diagnostic flow while relation truth flows through the shared assignability boundary.

## Scope
- `crates/tsz-checker/src/types/utilities/overlap_relation_helpers.rs`
- `crates/tsz-checker/src/tests/overlap_relation_helper_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation-routing tech debt for diagnostic overlap helpers
- Evidence: behavior-preserving boundary routing only; local focused arch test asserts overlap helpers use `assign_relation_outcome(...).related` and no raw boolean relation guard.

## Verification
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `cargo nextest run -p tsz-checker --lib overlap_relation_helpers_use_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `git rev-list --left-right --count HEAD...origin/main` -> `1 0`

## Coordination Notes
- Opened as draft for light CI.
- No open PR reported touching `crates/tsz-checker/src/types/utilities/overlap_relation_helpers.rs` during overlap check.
- Does not alter solver policy, variance, any propagation, or cache keys.
