### PR TITLE
refactor(checker): route class implements whole-type relation

### DIFF
--- a/crates/tsz-checker/src/classes/class_implements_checker/core.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/core.rs
@@ -1501,7 +1501,9 @@ impl<'a> CheckerState<'a> {
                         } else {
                             interface_type
                         };
-                        if !self.diagnostic_relation_boolean_guard(class_instance_type, target_type)
+                        if !self
+                            .assign_relation_outcome(class_instance_type, target_type)
+                            .related
                         {
                             let analysis = self
                                 .analyze_assignability_failure(class_instance_type, target_type);

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -115,6 +115,9 @@ mod class_extends_index_relation_routing_arch_tests;
 #[path = "tests/class_implements_index_relation_routing_arch_tests.rs"]
 mod class_implements_index_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/class_implements_whole_type_relation_routing_arch_tests.rs"]
+mod class_implements_whole_type_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/class_member_closure_tests.rs"]
 mod class_member_closure_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/class_implements_whole_type_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/class_implements_whole_type_relation_routing_arch_tests.rs
@@ -1,0 +1,31 @@
+use std::fs;
+use std::path::PathBuf;
+
+#[test]
+fn class_implements_whole_type_uses_relation_outcome_boundary() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let source =
+        fs::read_to_string(manifest_dir.join("src/classes/class_implements_checker/core.rs"))
+            .expect("read class implements checker source");
+
+    let helper = source
+        .split("let check_whole_type =")
+        .nth(1)
+        .expect("find class implements whole-type relation block")
+        .split("let has_already_reported_missing_member")
+        .next()
+        .expect("slice whole-type relation block");
+
+    assert!(
+        helper.contains("assign_relation_outcome(class_instance_type, target_type)"),
+        "class implements whole-type compatibility should route through RelationOutcome"
+    );
+    assert!(
+        helper.contains(".related"),
+        "class implements whole-type compatibility should inspect RelationOutcome.related"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard"),
+        "class implements whole-type compatibility should not regress to raw boolean relation guards"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker relation diagnostics / query-boundary routing.

## Invariant
When the class implements checker performs the whole-type implemented-heritage compatibility check, checker still owns TS2720/TS2420 diagnostic selection and follow-up failure analysis while relation truth flows through the shared assignability boundary.

## Scope
- `crates/tsz-checker/src/classes/class_implements_checker/core.rs`
- `crates/tsz-checker/src/tests/class_implements_whole_type_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation-routing tech debt for class implements whole-type compatibility
- Evidence: behavior-preserving boundary routing only; no solver policy, variance, any-propagation, or cache-key changes. Local focused architecture test verifies the call path uses `assign_relation_outcome(...).related` instead of the raw boolean guard.

## Verification
- `git fetch origin main`
- `git rev-list --left-right --count HEAD...origin/main` -> `1 0`
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `cargo nextest run -p tsz-checker --lib class_implements_whole_type_uses_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Draft PR for light CI.
- Open PR file-overlap check found no open PR touching `crates/tsz-checker/src/classes/class_implements_checker/core.rs` before publishing.
- This slice is intentionally narrow: it routes an existing checker relation truth probe through the existing assignability boundary and leaves diagnostic rendering, failure analysis, solver policy, variance, any propagation, and cache keys unchanged.
