### PR TITLE
refactor(checker): bundle class index relation routing

### DIFF
--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -1032,8 +1032,8 @@ impl<'a> CheckerState<'a> {
                                 // Different bases provide conflicting index signatures.
                                 // tsc emits TS2430 ("incorrectly extends") against the
                                 // later base, not TS2320 ("cannot simultaneously extend").
-                                if !self.diagnostic_relation_boolean_guard(prev_val, value_type)
-                                    && !self.diagnostic_relation_boolean_guard(value_type, prev_val)
+                                if !self.assign_relation_outcome(prev_val, value_type).related
+                                    && !self.assign_relation_outcome(value_type, prev_val).related
                                 {
                                     // The later base's index signature conflicts with
                                     // what was inherited from earlier bases.

--- a/crates/tsz-checker/src/classes/class_implements_checker/core.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/core.rs
@@ -1501,7 +1501,9 @@ impl<'a> CheckerState<'a> {
                         } else {
                             interface_type
                         };
-                        if !self.diagnostic_relation_boolean_guard(class_instance_type, target_type)
+                        if !self
+                            .assign_relation_outcome(class_instance_type, target_type)
+                            .related
                         {
                             let analysis = self
                                 .analyze_assignability_failure(class_instance_type, target_type);

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -115,6 +115,9 @@ mod class_extends_index_relation_routing_arch_tests;
 #[path = "tests/class_implements_index_relation_routing_arch_tests.rs"]
 mod class_implements_index_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/class_implements_whole_type_relation_routing_arch_tests.rs"]
+mod class_implements_whole_type_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/class_member_closure_tests.rs"]
 mod class_member_closure_tests;
 #[cfg(test)]
@@ -181,11 +184,17 @@ mod imported_generator_iterable_tests;
 #[path = "tests/index_sig_param_intersection_validity_tests.rs"]
 mod index_sig_param_intersection_validity_tests;
 #[cfg(test)]
+#[path = "tests/index_signature_check_relation_routing_arch_tests.rs"]
+mod index_signature_check_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/interface_heritage_index_relation_routing_arch_tests.rs"]
 mod interface_heritage_index_relation_routing_arch_tests;
 #[cfg(test)]
 #[path = "tests/interface_heritage_property_index_relation_routing_arch_tests.rs"]
 mod interface_heritage_property_index_relation_routing_arch_tests;
+#[cfg(test)]
+#[path = "tests/interface_index_conflict_relation_routing_arch_tests.rs"]
+mod interface_index_conflict_relation_routing_arch_tests;
 #[cfg(test)]
 #[path = "../tests/isolated_declarations_unannotated_param_tests.rs"]
 mod isolated_declarations_unannotated_param_tests;
@@ -475,6 +484,9 @@ mod callable_interface_assignment_tests;
 #[path = "tests/callable_union_relation_routing_arch_tests.rs"]
 mod callable_union_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/class_boundary_fallback_relation_routing_arch_tests.rs"]
+mod class_boundary_fallback_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/class_duplicate_extends_skip_resolution_tests.rs"]
 mod class_duplicate_extends_skip_resolution_tests;
 #[cfg(test)]
@@ -537,6 +549,9 @@ mod dispatch_tests;
 #[cfg(test)]
 #[path = "tests/do_while_exit_narrowing_tests.rs"]
 mod do_while_exit_narrowing_tests;
+#[cfg(test)]
+#[path = "tests/duplicate_identifier_relation_routing_arch_tests.rs"]
+mod duplicate_identifier_relation_routing_arch_tests;
 #[cfg(test)]
 #[path = "tests/dynamic_import_relation_routing_arch_tests.rs"]
 mod dynamic_import_relation_routing_arch_tests;
@@ -607,8 +622,14 @@ mod in_narrow_bare_type_param_chained_tests;
 #[path = "tests/in_operator_relation_routing_arch_tests.rs"]
 mod in_operator_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/index_signature_property_relation_routing_arch_tests.rs"]
+mod index_signature_property_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/index_signature_value_relation_routing_arch_tests.rs"]
 mod index_signature_value_relation_routing_arch_tests;
+#[cfg(test)]
+#[path = "tests/initializer_relation_routing_arch_tests.rs"]
+mod initializer_relation_routing_arch_tests;
 #[cfg(test)]
 #[path = "../tests/interface_extends_array_json_tests.rs"]
 mod interface_extends_array_json_tests;
@@ -757,6 +778,9 @@ mod object_spread_optional_merge_tests;
 #[path = "tests/optional_key_extraction_tests.rs"]
 mod optional_key_extraction_tests;
 #[cfg(test)]
+#[path = "tests/overlap_relation_helper_routing_arch_tests.rs"]
+mod overlap_relation_helper_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/overload_anchor_at_argument_tests.rs"]
 mod overload_anchor_at_argument_tests;
 #[cfg(test)]
@@ -769,11 +793,17 @@ mod polymorphic_this_relation_routing_arch_tests;
 #[path = "../tests/private_brands.rs"]
 mod private_brands;
 #[cfg(test)]
+#[path = "tests/private_member_relation_routing_arch_tests.rs"]
+mod private_member_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/promise_like_infer_tests.rs"]
 mod promise_like_infer_tests;
 #[cfg(test)]
 #[path = "tests/property_alias_display_tests.rs"]
 mod property_alias_display_tests;
+#[cfg(test)]
+#[path = "tests/property_index_key_relation_routing_arch_tests.rs"]
+mod property_index_key_relation_routing_arch_tests;
 #[cfg(test)]
 #[path = "../tests/recursive_alias_application_target_display_tests.rs"]
 mod recursive_alias_application_target_display_tests;
@@ -864,6 +894,9 @@ mod union_call_resolution_tests;
 #[cfg(test)]
 #[path = "tests/union_constraint_relation_routing_arch_tests.rs"]
 mod union_constraint_relation_routing_arch_tests;
+#[cfg(test)]
+#[path = "tests/union_index_signature_relation_routing_arch_tests.rs"]
+mod union_index_signature_relation_routing_arch_tests;
 #[cfg(test)]
 #[path = "tests/union_multi_overload_unified_sig_tests.rs"]
 mod union_multi_overload_unified_sig_tests;

--- a/crates/tsz-checker/src/query_boundaries/class.rs
+++ b/crates/tsz-checker/src/query_boundaries/class.rs
@@ -394,7 +394,7 @@ pub(crate) fn interface_overload_trailing_signature_assignable(
     allow_fresh_generic_retry: bool,
 ) -> bool {
     checker.is_assignable_to_no_erase_generics(source, target)
-        || (allow_fresh_generic_retry && checker.diagnostic_relation_boolean_guard(source, target))
+        || (allow_fresh_generic_retry && checker.assign_relation_outcome(source, target).related)
 }
 
 /// Check if a DIRECT (own) member type mismatch should be reported (TS2416).
@@ -430,7 +430,7 @@ pub(crate) fn should_report_own_member_type_mismatch(
     // source vs `IteratorResult<T, void>` target — `any` is a universal sink
     // for the standard relation but the strict path keeps the args nominally
     // distinct). tsc does not emit TS2416 here.
-    if checker.diagnostic_relation_boolean_guard(source, target) {
+    if checker.assign_relation_outcome(source, target).related {
         return false;
     }
     if source_this_parameter_is_acceptable_for_target_without_this(checker, source, target) {

--- a/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
@@ -55,10 +55,10 @@ impl<'a> CheckerState<'a> {
                         continue;
                     }
                     applicable_index_value_types.push(string_index.value_type);
-                    if self.diagnostic_relation_boolean_guard(
-                        source_prop.type_id,
-                        string_index.value_type,
-                    ) {
+                    if self
+                        .assign_relation_outcome(source_prop.type_id, string_index.value_type)
+                        .related
+                    {
                         accepted_by_index = true;
                         break;
                     }
@@ -70,10 +70,10 @@ impl<'a> CheckerState<'a> {
                         continue;
                     }
                     applicable_index_value_types.push(number_index.value_type);
-                    if self.diagnostic_relation_boolean_guard(
-                        source_prop.type_id,
-                        number_index.value_type,
-                    ) {
+                    if self
+                        .assign_relation_outcome(source_prop.type_id, number_index.value_type)
+                        .related
+                    {
                         accepted_by_index = true;
                         break;
                     }
@@ -99,7 +99,10 @@ impl<'a> CheckerState<'a> {
             ) {
                 continue;
             }
-            if self.diagnostic_relation_boolean_guard(source_prop.type_id, target_value_type) {
+            if self
+                .assign_relation_outcome(source_prop.type_id, target_value_type)
+                .related
+            {
                 continue;
             }
 

--- a/crates/tsz-checker/src/state/state_checking/property_index_key_helpers.rs
+++ b/crates/tsz-checker/src/state/state_checking/property_index_key_helpers.rs
@@ -31,7 +31,7 @@ impl<'a> CheckerState<'a> {
 
         let prop_literal =
             crate::query_boundaries::common::create_string_literal_type(self.ctx.types, prop_name);
-        self.diagnostic_relation_boolean_guard(prop_literal, key_type)
+        self.assign_relation_outcome(prop_literal, key_type).related
     }
 
     pub(super) fn index_value_type_is_deferred(&self, type_id: TypeId) -> bool {

--- a/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
@@ -147,7 +147,8 @@ impl<'a> CheckerState<'a> {
         let Some(function_type) = self.global_function_type_id() else {
             return false;
         };
-        self.diagnostic_relation_boolean_guard(decorator_type, function_type)
+        self.assign_relation_outcome(decorator_type, function_type)
+            .related
     }
 
     fn global_function_type_id(&mut self) -> Option<TypeId> {

--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
@@ -439,10 +439,12 @@ impl<'a> CheckerState<'a> {
                 }
 
                 let key_assignable = self
-                    .diagnostic_relation_boolean_guard(key_type, previous_key_type)
+                    .assign_relation_outcome(key_type, previous_key_type)
+                    .related
                     || self.template_pattern_key_is_subset(key_type, previous_key_type);
-                let value_assignable =
-                    self.diagnostic_relation_boolean_guard(value_type, previous_value_type);
+                let value_assignable = self
+                    .assign_relation_outcome(value_type, previous_value_type)
+                    .related;
                 if key_assignable && !value_assignable {
                     let key_type_str = self.format_type(key_type);
                     let value_type_str = self.format_type(value_type);
@@ -595,7 +597,8 @@ impl<'a> CheckerState<'a> {
             // Only emit when we have own number index nodes to anchor the error,
             // OR when both signatures are inherited (anchor on container).
             let is_assignable = self
-                .diagnostic_relation_boolean_guard(number_idx.value_type, string_idx.value_type);
+                .assign_relation_outcome(number_idx.value_type, string_idx.value_type)
+                .related;
             if !is_assignable {
                 let num_value_str = self.format_type(number_idx.value_type);
                 let str_value_str = self.format_type(string_idx.value_type);
@@ -648,8 +651,9 @@ impl<'a> CheckerState<'a> {
         if let (Some(static_num_type), Some(static_str_type)) =
             (static_number_value_type, static_string_value_type)
         {
-            let is_assignable =
-                self.diagnostic_relation_boolean_guard(static_num_type, static_str_type);
+            let is_assignable = self
+                .assign_relation_outcome(static_num_type, static_str_type)
+                .related;
             if !is_assignable {
                 let num_value_str = self.format_type(static_num_type);
                 let str_value_str = self.format_type(static_str_type);

--- a/crates/tsz-checker/src/state/state_checking_members/statement_helpers.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_helpers.rs
@@ -212,8 +212,12 @@ impl<'a> CheckerState<'a> {
             // assignable to number or string, tsc's evaluator would likely succeed
             // (the import resolves to a const with a literal value).
             if eval_result.is_none()
-                && (self.diagnostic_relation_boolean_guard(init_type, TypeId::NUMBER)
-                    || self.diagnostic_relation_boolean_guard(init_type, TypeId::STRING))
+                && (self
+                    .assign_relation_outcome(init_type, TypeId::NUMBER)
+                    .related
+                    || self
+                        .assign_relation_outcome(init_type, TypeId::STRING)
+                        .related)
             {
                 continue;
             }

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs
@@ -91,7 +91,10 @@ impl<'a> CheckerState<'a> {
                 {
                     return true;
                 }
-                if self.diagnostic_relation_boolean_guard(object_type, declaring_type) {
+                if self
+                    .assign_relation_outcome(object_type, declaring_type)
+                    .related
+                {
                     return true;
                 }
                 // Last resort: check if the object type has the private property
@@ -105,7 +108,10 @@ impl<'a> CheckerState<'a> {
                 )
                 .is_success()
             }
-            _ => self.diagnostic_relation_boolean_guard(object_type, declaring_type),
+            _ => {
+                self.assign_relation_outcome(object_type, declaring_type)
+                    .related
+            }
         }
     }
 
@@ -699,7 +705,9 @@ impl<'a> CheckerState<'a> {
                 &property_name,
             )
         } else if self.types_have_same_private_brand(object_type_for_check, declaring_type)
-            || self.diagnostic_relation_boolean_guard(object_type_for_check, declaring_type)
+            || self
+                .assign_relation_outcome(object_type_for_check, declaring_type)
+                .related
         {
             true
         } else {
@@ -752,7 +760,8 @@ impl<'a> CheckerState<'a> {
                         } else if self.types_have_same_private_brand(object_type_for_check, ty) {
                             true
                         } else {
-                            self.diagnostic_relation_boolean_guard(object_type_for_check, ty)
+                            self.assign_relation_outcome(object_type_for_check, ty)
+                                .related
                         }
                     })
             });

--- a/crates/tsz-checker/src/state/variable_checking/initializer_policy.rs
+++ b/crates/tsz-checker/src/state/variable_checking/initializer_policy.rs
@@ -551,13 +551,13 @@ impl<'a> CheckerState<'a> {
                             let elaborated_obj =
                                 self.initializer_reaches_object_literal_through_wrappers(
                                     facts.initializer,
-                                ) && !self.diagnostic_relation_boolean_guard(
-                                    checked_init_type,
-                                    declared_type,
-                                ) && self.try_elaborate_object_literal_properties_for_var_init(
-                                    facts.initializer,
-                                    declared_type,
-                                );
+                                ) && !self
+                                    .assign_relation_outcome(checked_init_type, declared_type)
+                                    .related
+                                    && self.try_elaborate_object_literal_properties_for_var_init(
+                                        facts.initializer,
+                                        declared_type,
+                                    );
                             if !elaborated_obj {
                                 let skip_generic_outer_error = self
                                     .ctx
@@ -611,10 +611,9 @@ impl<'a> CheckerState<'a> {
                                         declared_type,
                                     )))
                                 && !(initializer_is_function
-                                    && !self.diagnostic_relation_boolean_guard(
-                                        checked_init_type,
-                                        declared_type,
-                                    )
+                                    && !self
+                                        .assign_relation_outcome(checked_init_type, declared_type)
+                                        .related
                                     && self.try_elaborate_assignment_source_error(
                                         facts.initializer,
                                         declared_type,
@@ -673,14 +672,14 @@ impl<'a> CheckerState<'a> {
                                     // contextual-typing decisions (`callsOnComplexSignatures`).
                                     if !(self.initializer_reaches_object_literal_through_wrappers(
                                         facts.initializer,
-                                    ) && !self.diagnostic_relation_boolean_guard(
-                                        checked_init_type,
-                                        declared_type,
-                                    ) && self
-                                        .try_elaborate_object_literal_properties_for_var_init(
-                                            facts.initializer,
-                                            declared_type,
-                                        ))
+                                    ) && !self
+                                        .assign_relation_outcome(checked_init_type, declared_type)
+                                        .related
+                                        && self
+                                            .try_elaborate_object_literal_properties_for_var_init(
+                                                facts.initializer,
+                                                declared_type,
+                                            ))
                                     {
                                         // Disable callable-with-type-params suppression
                                         // for variable declarations. The suppression is
@@ -691,10 +690,12 @@ impl<'a> CheckerState<'a> {
                                         // (e.g., (cb: (x: string, ...rest: T) => void) => void
                                         //   vs (cb: (...args: never) => void) => void)
                                         if jsdoc_new_expression_relation
-                                            && !self.diagnostic_relation_boolean_guard(
-                                                checked_init_type,
-                                                declared_type,
-                                            )
+                                            && !self
+                                                .assign_relation_outcome(
+                                                    checked_init_type,
+                                                    declared_type,
+                                                )
+                                                .related
                                         {
                                             self.error_type_not_assignable_generic_at(
                                                 checked_init_type,

--- a/crates/tsz-checker/src/tests/class_boundary_fallback_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/class_boundary_fallback_relation_routing_arch_tests.rs
@@ -1,0 +1,41 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn class_member_fallback_relations_use_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("src/query_boundaries/class.rs"),
+    )
+    .expect("failed to read class.rs");
+
+    let overload_helper = source
+        .split("pub(crate) fn interface_overload_trailing_signature_assignable")
+        .nth(1)
+        .and_then(|tail| {
+            tail.split("pub(crate) fn should_report_own_member_type_mismatch")
+                .next()
+        })
+        .expect("failed to isolate interface overload fallback helper");
+    assert!(
+        overload_helper.contains("checker.assign_relation_outcome(source, target).related"),
+        "interface overload fallback should route standard relation truth through assign_relation_outcome"
+    );
+    assert!(
+        !overload_helper.contains("diagnostic_relation_boolean_guard(source, target)"),
+        "interface overload fallback should not use the raw diagnostic boolean guard"
+    );
+
+    let own_member_helper = source
+        .split("pub(crate) fn should_report_own_member_type_mismatch")
+        .nth(1)
+        .and_then(|tail| tail.split("fn is_coinductive_return_type_cycle").next())
+        .expect("failed to isolate own member mismatch helper");
+    assert!(
+        own_member_helper.contains("checker.assign_relation_outcome(source, target).related"),
+        "own member mismatch fallback should route standard relation truth through assign_relation_outcome"
+    );
+    assert!(
+        !own_member_helper.contains("diagnostic_relation_boolean_guard(source, target)"),
+        "own member mismatch fallback should not use the raw diagnostic boolean guard"
+    );
+}

--- a/crates/tsz-checker/src/tests/class_implements_whole_type_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/class_implements_whole_type_relation_routing_arch_tests.rs
@@ -1,0 +1,31 @@
+use std::fs;
+use std::path::PathBuf;
+
+#[test]
+fn class_implements_whole_type_uses_relation_outcome_boundary() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let source =
+        fs::read_to_string(manifest_dir.join("src/classes/class_implements_checker/core.rs"))
+            .expect("read class implements checker source");
+
+    let helper = source
+        .split("let check_whole_type =")
+        .nth(1)
+        .expect("find class implements whole-type relation block")
+        .split("let has_already_reported_missing_member")
+        .next()
+        .expect("slice whole-type relation block");
+
+    assert!(
+        helper.contains("assign_relation_outcome(class_instance_type, target_type)"),
+        "class implements whole-type compatibility should route through RelationOutcome"
+    );
+    assert!(
+        helper.contains(".related"),
+        "class implements whole-type compatibility should inspect RelationOutcome.related"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard"),
+        "class implements whole-type compatibility should not regress to raw boolean relation guards"
+    );
+}

--- a/crates/tsz-checker/src/tests/decorator_return_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/decorator_return_relation_routing_arch_tests.rs
@@ -25,4 +25,22 @@ fn decorator_return_diagnostics_use_relation_outcome_boundary() {
         !source.contains("diagnostic_relation_boolean_guard(return_type, TypeId::VOID)"),
         "void-or-any decorator return diagnostics should not pre-gate with a raw boolean relation"
     );
+
+    let callee_probe_start = source
+        .find("fn decorator_callee_is_untyped_function")
+        .expect("find decorator callee Function probe");
+    let callee_probe_end = callee_probe_start
+        + source[callee_probe_start..]
+            .find("fn global_function_type_id")
+            .expect("find end of decorator callee Function probe");
+    let callee_probe = &source[callee_probe_start..callee_probe_end];
+
+    assert!(
+        callee_probe.contains("assign_relation_outcome(decorator_type, function_type)"),
+        "decorator Function fallback should route relation probing through assign_relation_outcome"
+    );
+    assert!(
+        !callee_probe.contains("diagnostic_relation_boolean_guard(decorator_type, function_type)"),
+        "decorator Function fallback should not use a raw boolean relation guard"
+    );
 }

--- a/crates/tsz-checker/src/tests/duplicate_identifier_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/duplicate_identifier_relation_routing_arch_tests.rs
@@ -1,0 +1,20 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn duplicate_identifier_helpers_use_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/types/type_checking/duplicate_identifier_relation_helpers.rs"),
+    )
+    .expect("failed to read duplicate_identifier_relation_helpers.rs");
+
+    assert!(
+        source.matches("assign_relation_outcome(").count() >= 5,
+        "duplicate declaration relation helpers should route through assign_relation_outcome"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard("),
+        "duplicate declaration relation helpers should not use the raw boolean relation guard"
+    );
+}

--- a/crates/tsz-checker/src/tests/enum_computed_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/enum_computed_relation_routing_arch_tests.rs
@@ -14,7 +14,11 @@ fn computed_enum_member_ts18033_uses_relation_outcome_boundary() {
         "computed enum-member TS18033 diagnostics should route the final relation through assign_relation_outcome"
     );
     assert!(
-        !source.contains("if !self.diagnostic_relation_boolean_guard(init_type, TypeId::NUMBER)"),
-        "computed enum-member TS18033 diagnostics should not pre-gate final emission with a raw boolean relation"
+        source.contains("assign_relation_outcome(init_type, TypeId::STRING)"),
+        "computed enum-member import fallback should route string assignability through assign_relation_outcome"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard"),
+        "computed enum-member diagnostics should not regress to raw boolean relation guards"
     );
 }

--- a/crates/tsz-checker/src/tests/index_signature_check_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/index_signature_check_relation_routing_arch_tests.rs
@@ -1,0 +1,32 @@
+use std::fs;
+use std::path::PathBuf;
+
+#[test]
+fn index_signature_checks_use_relation_outcome_boundary() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let source = fs::read_to_string(
+        manifest_dir.join("src/state/state_checking_members/index_signature_checks.rs"),
+    )
+    .expect("read index signature checking source");
+
+    assert!(
+        source.contains("assign_relation_outcome(key_type, previous_key_type)"),
+        "template pattern index key compatibility should route through RelationOutcome"
+    );
+    assert!(
+        source.contains("assign_relation_outcome(value_type, previous_value_type)"),
+        "template pattern index value compatibility should route through RelationOutcome"
+    );
+    assert!(
+        source.contains("assign_relation_outcome(number_idx.value_type, string_idx.value_type)"),
+        "instance number-to-string index compatibility should route through RelationOutcome"
+    );
+    assert!(
+        source.contains("assign_relation_outcome(static_num_type, static_str_type)"),
+        "static number-to-string index compatibility should route through RelationOutcome"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard"),
+        "index signature checking should not regress to raw boolean relation guards"
+    );
+}

--- a/crates/tsz-checker/src/tests/index_signature_property_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/index_signature_property_relation_routing_arch_tests.rs
@@ -1,0 +1,34 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn index_signature_property_checks_use_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/state/state_checking_members/index_signature_key_helpers.rs"),
+    )
+    .expect("failed to read index_signature_key_helpers.rs");
+
+    let function_start = source
+        .find("fn property_type_assignable_to_index_type")
+        .expect("find property/index compatibility helper");
+    let function_end = function_start
+        + source[function_start..]
+            .find("pub(crate) fn format_ts2411_type")
+            .expect("find end of property/index compatibility helper");
+    let helper = &source[function_start..function_end];
+    let compact_helper: String = helper.chars().filter(|ch| !ch.is_whitespace()).collect();
+
+    assert!(
+        compact_helper.contains("assign_relation_outcome(member,index_value_type).related"),
+        "union property members should route index-signature value checks through relation outcome"
+    );
+    assert!(
+        compact_helper.contains("assign_relation_outcome(prop_type,index_value_type).related"),
+        "property/index value checks should route through relation outcome"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard"),
+        "property/index value checks should not use raw boolean relation guards"
+    );
+}

--- a/crates/tsz-checker/src/tests/initializer_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/initializer_relation_routing_arch_tests.rs
@@ -1,0 +1,19 @@
+use std::{fs, path::PathBuf};
+
+#[test]
+fn variable_initializer_diagnostics_use_relation_outcome_boundary() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src/state/variable_checking/initializer_policy.rs");
+    let source = fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+
+    assert_eq!(
+        source.matches("assign_relation_outcome").count(),
+        4,
+        "variable initializer diagnostic probes should route through assign_relation_outcome"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard("),
+        "variable initializer diagnostics should not regress to raw boolean relation guards"
+    );
+}

--- a/crates/tsz-checker/src/tests/interface_index_conflict_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/interface_index_conflict_relation_routing_arch_tests.rs
@@ -1,0 +1,30 @@
+use std::fs;
+use std::path::PathBuf;
+
+#[test]
+fn interface_index_conflicts_use_relation_outcome_boundary() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let source = fs::read_to_string(manifest_dir.join("src/classes/class_checker_compat.rs"))
+        .expect("read class checker compatibility source");
+
+    let helper = source
+        .split("Different bases provide conflicting index signatures.")
+        .nth(1)
+        .expect("find inherited interface index-signature conflict block")
+        .split("The later base's index signature conflicts")
+        .next()
+        .expect("slice relation decision block");
+
+    assert!(
+        helper.contains("assign_relation_outcome(prev_val, value_type).related"),
+        "inherited interface index conflict checks should route previous-to-current relations through RelationOutcome"
+    );
+    assert!(
+        helper.contains("assign_relation_outcome(value_type, prev_val).related"),
+        "inherited interface index conflict checks should route current-to-previous relations through RelationOutcome"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard"),
+        "inherited interface index conflict checks should not regress to raw boolean relation guards"
+    );
+}

--- a/crates/tsz-checker/src/tests/overlap_relation_helper_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/overlap_relation_helper_routing_arch_tests.rs
@@ -1,0 +1,31 @@
+use std::fs;
+use std::path::PathBuf;
+
+#[test]
+fn overlap_relation_helpers_use_relation_outcome_boundary() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let source =
+        fs::read_to_string(manifest_dir.join("src/types/utilities/overlap_relation_helpers.rs"))
+            .expect("read overlap relation helper source");
+
+    assert!(
+        source.contains("assign_relation_outcome(left, right).related"),
+        "left-to-right overlap assignability should route through RelationOutcome"
+    );
+    assert!(
+        source.contains("assign_relation_outcome(right, left).related"),
+        "right-to-left overlap assignability should route through RelationOutcome"
+    );
+    assert!(
+        source.contains("assign_relation_outcome(lt, rt).related"),
+        "signature parameter overlap should route through RelationOutcome"
+    );
+    assert!(
+        source.contains("assign_relation_outcome(lret, rret).related"),
+        "signature return overlap should route through RelationOutcome"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard"),
+        "diagnostic overlap helpers should not regress to raw boolean relation guards"
+    );
+}

--- a/crates/tsz-checker/src/tests/private_member_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/private_member_relation_routing_arch_tests.rs
@@ -1,0 +1,20 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn private_member_access_compatibility_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/state/type_analysis/computed_helpers_private.rs"),
+    )
+    .expect("failed to read computed_helpers_private.rs");
+
+    assert!(
+        source.matches("assign_relation_outcome(").count() >= 4,
+        "private member compatibility should route fallback relation checks through assign_relation_outcome"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard("),
+        "private member compatibility should not use the raw boolean relation guard"
+    );
+}

--- a/crates/tsz-checker/src/tests/property_index_key_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/property_index_key_relation_routing_arch_tests.rs
@@ -1,0 +1,16 @@
+use std::fs;
+
+#[test]
+fn property_index_key_acceptance_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/state/state_checking/property_index_key_helpers.rs")
+        .expect("failed to read property_index_key_helpers.rs");
+
+    assert!(
+        source.contains("assign_relation_outcome(prop_literal, key_type).related"),
+        "string index key acceptance should route assignability through RelationOutcome.related"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard"),
+        "string index key acceptance should not regress to the raw boolean relation guard"
+    );
+}

--- a/crates/tsz-checker/src/tests/union_index_signature_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/union_index_signature_relation_routing_arch_tests.rs
@@ -1,0 +1,24 @@
+use std::fs;
+
+#[test]
+fn union_index_signature_value_checks_use_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        "src/state/state_checking/property/union_index_signature_diagnostics.rs",
+    )
+    .expect("failed to read union index signature diagnostics source");
+
+    let function_start = source
+        .find("pub(super) fn try_union_index_signature_value_check(")
+        .expect("find union index signature diagnostic helper");
+    let helper = &source[function_start..];
+
+    assert!(
+        helper.matches(".assign_relation_outcome(").count() >= 3
+            && helper.matches(".related").count() >= 3,
+        "union index-signature value diagnostics should route relation truth through relation outcomes"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard("),
+        "union index-signature value diagnostics should not use raw boolean relation guards"
+    );
+}

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifier_relation_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifier_relation_helpers.rs
@@ -5,8 +5,8 @@ use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
     pub(super) fn duplicate_decl_types_match(&mut self, left: TypeId, right: TypeId) -> bool {
-        self.diagnostic_relation_boolean_guard(left, right)
-            && self.diagnostic_relation_boolean_guard(right, left)
+        self.assign_relation_outcome(left, right).related
+            && self.assign_relation_outcome(right, left).related
     }
 
     pub(super) fn duplicate_decl_type_matches_index(
@@ -14,7 +14,8 @@ impl<'a> CheckerState<'a> {
         property_type: TypeId,
         index_type: TypeId,
     ) -> bool {
-        self.diagnostic_relation_boolean_guard(property_type, index_type)
+        self.assign_relation_outcome(property_type, index_type)
+            .related
     }
 
     pub(super) fn duplicate_index_types_overlap(
@@ -22,7 +23,10 @@ impl<'a> CheckerState<'a> {
         local_type: TypeId,
         existing_type: TypeId,
     ) -> bool {
-        self.diagnostic_relation_boolean_guard(local_type, existing_type)
-            || self.diagnostic_relation_boolean_guard(existing_type, local_type)
+        self.assign_relation_outcome(local_type, existing_type)
+            .related
+            || self
+                .assign_relation_outcome(existing_type, local_type)
+                .related
     }
 }

--- a/crates/tsz-checker/src/types/utilities/overlap_relation_helpers.rs
+++ b/crates/tsz-checker/src/types/utilities/overlap_relation_helpers.rs
@@ -10,12 +10,12 @@ impl<'a> CheckerState<'a> {
         right: TypeId,
         skip_signature_only_assignability: bool,
     ) -> (bool, bool) {
-        let left_to_right = !skip_signature_only_assignability
-            && self.diagnostic_relation_boolean_guard(left, right);
+        let left_to_right =
+            !skip_signature_only_assignability && self.assign_relation_outcome(left, right).related;
         let right_to_left = if left_to_right || skip_signature_only_assignability {
             false
         } else {
-            self.diagnostic_relation_boolean_guard(right, left)
+            self.assign_relation_outcome(right, left).related
         };
 
         if tracing::enabled!(tracing::Level::TRACE) {
@@ -83,14 +83,14 @@ impl<'a> CheckerState<'a> {
                     } else {
                         rp.type_id
                     };
-                    left_to_right &= self.diagnostic_relation_boolean_guard(lt, rt);
-                    right_to_left &= self.diagnostic_relation_boolean_guard(rt, lt);
+                    left_to_right &= self.assign_relation_outcome(lt, rt).related;
+                    right_to_left &= self.assign_relation_outcome(rt, lt).related;
                     if !left_to_right && !right_to_left {
                         break;
                     }
                 }
-                if (left_to_right && self.diagnostic_relation_boolean_guard(lret, rret))
-                    || (right_to_left && self.diagnostic_relation_boolean_guard(rret, lret))
+                if (left_to_right && self.assign_relation_outcome(lret, rret).related)
+                    || (right_to_left && self.assign_relation_outcome(rret, lret).related)
                 {
                     return true;
                 }


### PR DESCRIPTION
## Agent
AgentName: M1-B
Owner label: agent:M1-B
Bundling coordinator: Studio-F

## Track
Checker relation diagnostics / query-boundary routing refactor bundle.

## Invariant
When class, index-signature, member, initializer, enum, decorator, duplicate-identifier, private-member, and overlap helpers need relation truth for existing checker-owned diagnostic decisions, relation truth flows through `assign_relation_outcome(...).related` while diagnostic selection, suppression, and rendering stay behavior-preserving.

## Scope
- Bundle successor for the class/index/member half of the non-JSX M1-B relation-routing draft PR drain.
- Routes existing relation probes in class/interface compatibility, class implements whole-type checks, class boundary fallback, property/index key checks, index signature property/value checks, union index-signature value diagnostics, enum computed fallback, variable initializer elaboration, decorator Function callee handling, private member access, duplicate identifier helpers, and overlap helpers.
- Adds or updates focused architecture tests for each routed helper and registers them in `crates/tsz-checker/src/lib.rs`.

## Bundled PRs
- #10410 decorator Function callee relation
- #10412 index property relation outcome
- #10418 property index key relation
- #10420 enum fallback relation outcome
- #10422 initializer relation outcome
- #10454 private member access relations
- #10456 duplicate identifier relations
- #10458 interface index conflict relations
- #10460 index signature check relations
- #10461 overlap helper relations
- #10464 class implements whole-type relation
- #10466 class boundary fallback relations
- #10478 union index signature relations

## Superseded PRs
- #10410
- #10412
- #10418
- #10420
- #10422
- #10454
- #10456
- #10458
- #10460
- #10461
- #10464
- #10478

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation-routing tech debt for class/index/member/initializer diagnostic helpers
- Evidence: behavior-preserving boundary routing only; no solver policy, variance, any-propagation, diagnostic rendering text, or cache-key change intended. Local architecture tests assert these paths use `assign_relation_outcome` instead of raw diagnostic boolean probes.

## Verification
- `cargo fmt --check`
- `git diff --cached --check`
- `cargo nextest run -p tsz-checker --lib -E 'test(/relation_outcome_boundary/)'` -> 35 passed, 5203 skipped
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Rebuilt from current `origin/main` at `0c8d8106fa`.
- Successor branch: `codex/m1b-override-type-compat-relation-20260527`
- Successor head: `738cb89003ad4ad4ad759c277827f9d32c56e34d`
- Cherry-picked selected heads with `--no-commit` and resolved only test registration conflicts in `crates/tsz-checker/src/lib.rs` by keeping the compatible union.
- Included #10412 and #10422 because their dirty/conflicting state was resolved trivially as `lib.rs` registration union only; no code conflict was required.
- Folded newly opened #10478 into this same successor because it was the same owner, base `main`, non-JSX, and in the index-signature relation-routing family.
- Kept this PR draft; do not merge until the M1-B owner/maintainer marks it ready after any desired CI follow-up.

