### PR TITLE
chore(agents): surface PR runway noise

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -26,6 +26,18 @@
   discoveries, scope changes, and coordination notes. Other agents use draft
   PRs, PR comments, and review comments to decide whether their task duplicates
   active work.
+- Do not park draft PRs and forget them. Owned open PRs are your active runway,
+  not a backlog shelf. Before opening a new branch or PR, run the live owned
+  work checks and first drive PRs you already own toward merge: land them via
+  `merge-queue`, mark them ready once verified, keep them draft/WIP only with a
+  fresh signed blocker or handoff comment, or close them only as an
+  evidence-linked duplicate/superseded PR. Opening a new PR is appropriate only
+  when your owned PRs are queued, intentionally stacked, explicitly blocked
+  with current notes, handed off, or the user explicitly redirects you.
+- Keep draft runway small. More than two unstacked draft PRs for one
+  `agent:*` owner, or a draft with no fresh commit/comment for 24 hours, is a
+  coordination smell. Update, rebase, mark ready, hand off, or add a signed
+  blocker comment before starting new work.
 - Never merge WIP branches. A branch is WIP if its PR is draft, has the `WIP`
   label, has a `[WIP]` title prefix, or the PR/branch description says it is
   WIP. Remove the label/prefix and mark the PR ready only after implementation,
@@ -381,6 +393,17 @@ them as TSZ repo skills.
   work is duplicate or superseded, link the successor, summarize what was
   preserved, and include the exact branch/commit evidence in the closing
   comment.
+- **Drain owned PRs before creating new ones.** At the start of each work
+  cycle, run `scripts/agents/list-owned-work.sh --pr-state <AgentName>` and,
+  when coordinating across lanes, `node scripts/ci/pr-ownership-report.mjs`.
+  If you own open PRs, actively move each one to `merge-queue`, ready,
+  refreshed draft/WIP with a signed blocker, signed handoff/help-wanted, or
+  evidence-linked duplicate/superseded closure before starting unrelated new
+  PR work.
+- **Queue green ready PRs instead of leaving them idle.** If an owned ready
+  `main` PR has passing PR-head `CI Summary` and `GitGuardian Security Checks`,
+  is not dirty/conflicting, and is not WIP/blocked, add `merge-queue`. If you do
+  not enqueue it, leave a signed comment naming the blocker and next action.
 - **Shared GitHub identity.** All agents push as the same GitHub user
   (`mohsen1`). Assume sibling agents are operating concurrently under the same
   account — check draft PRs, open PRs, recent merged PRs, and relevant issues

--- a/docs/plan/agents/LAUNCH.md
+++ b/docs/plan/agents/LAUNCH.md
@@ -5,10 +5,12 @@ relaunching a lane under the same canonical `AgentName`.
 
 Every session starts by reading its own goal file from repo source, then keeps
 using that file as the remote-control surface. If live PRs still carry the
-lane's `agent:*` label, finish, close with evidence, or hand them off before
-new issue work. If no lane PRs are open, start from that lane's metric and bug
-intake. Cleanup work must ratchet a named metric down or unblock one of the
-listed release gates.
+lane's `agent:*` label, finish them, enqueue them, document the blocker, close
+with evidence, or hand them off before new issue work. Agents should not park
+drafts and start fresh PRs; owned open PRs are the current work queue. If no
+lane PRs are open or actionable, start from that lane's metric and bug intake.
+Cleanup work must ratchet a named metric down or unblock one of the listed
+release gates.
 
 ## M1
 

--- a/docs/plan/agents/README.md
+++ b/docs/plan/agents/README.md
@@ -71,26 +71,44 @@ Rules:
 3. Use only the canonical labels above. Replace generated runner labels or
    `agnet:*` typos before marking work ready.
 4. Every PR body and substantive PR comment includes `AgentName`.
-5. Draft PRs are coordination state. Do not merge work that is draft, labelled
-   `WIP`, titled `[WIP]`, or described as blocked/not ready.
-6. If no open PR runway remains, issues may be used as intake context, but
+5. Draft PRs are active runway, not storage. Do not merge work that is draft,
+   labelled `WIP`, titled `[WIP]`, or described as blocked/not ready.
+6. A session drains owned PRs before opening unrelated new PRs. Valid runway
+   outcomes are: `merge-queue`, ready with verified PR-head checks, refreshed
+   draft/WIP with a signed blocker, signed handoff/help-wanted, or
+   evidence-linked duplicate/superseded closure.
+7. Keep draft runway small: at most two unstacked draft PRs per `agent:*`
+   owner unless the extras are intentional stack children or carry fresh signed
+   blocker comments. A draft with no fresh commit/comment for 24 hours needs
+   update, rebase, handoff, or a blocker note before new work starts.
+8. If no open PR runway remains, issues may be used as intake context, but
    durable ownership should still become an early draft PR with a real body.
-7. If a session pauses or abandons work, leave a signed comment with findings,
+9. If a session pauses or abandons work, leave a signed comment with findings,
    blocker or reason, verification already run, and next owner/action.
 
 ## Live Intake Rule
 
-Every implementation lane starts with its live PRs:
+Every implementation lane starts with its live PRs. Owned PRs are the work
+queue; issues are intake only after that queue is either drained or explicitly
+blocked.
 
 1. Run the lane's `Start Every Cycle` commands.
-2. If open PRs carry the lane label, complete, mark ready, close as
-   duplicate/superseded with evidence, or hand off with a signed comment before
-   starting new issue work.
-3. If no lane PRs are open, choose the next issue or metric row from that
-   lane's current assignment. Cluster by structural invariant rather than
-   starting one branch per issue.
-4. Open or update a draft PR early. The PR body is the live coordination state.
-5. Keep issue labels, PR labels, and PR body `AgentName` aligned.
+2. If open PRs carry the lane label, inspect each one and move it to the next
+   concrete state before starting new issue work: fix/rebase it, mark it ready,
+   add `merge-queue`, restore draft/WIP with a signed blocker, hand it off, or
+   close it only as duplicate/superseded with evidence.
+3. If an owned ready `main` PR has passing PR-head `CI Summary` and
+   `GitGuardian Security Checks`, is not dirty/conflicting, and is not WIP or
+   blocked, add `merge-queue`. If not, leave a signed blocker/next-action
+   comment instead of leaving it idle.
+4. Treat stale drafts as live debt. Drafts older than 24 hours without fresh
+   commits/comments, and owners over two unstacked drafts, must be refreshed,
+   handed off, marked help-wanted, or documented as blocked before new PRs.
+5. If no lane PRs are open or actionable, choose the next issue or metric row
+   from that lane's current assignment. Cluster by structural invariant rather
+   than starting one branch per issue.
+6. Open or update a draft PR early. The PR body is the live coordination state.
+7. Keep issue labels, PR labels, and PR body `AgentName` aligned.
 
 Useful live checks:
 
@@ -99,6 +117,7 @@ scripts/agents/ensure-agent-labels.sh --audit
 scripts/agents/list-owned-work.sh --all
 scripts/agents/list-owned-work.sh --pr-state Studio-F
 node scripts/ci/pr-ownership-report.mjs
+node scripts/ci/pr-ownership-report.mjs --json /tmp/tsz-pr-ownership.json
 gh issue list --repo mohsen1/tsz --state open --limit 200 --json number,title,labels,updatedAt,url
 ```
 
@@ -215,15 +234,17 @@ smaller:
 ## Launch Checklist
 
 1. Merge this coordination update or tell sessions to read this branch.
-2. Confirm live PR runway state with `node scripts/ci/pr-ownership-report.mjs`.
+2. Confirm live PR runway state, draft parking risks, and queue candidates with
+   `node scripts/ci/pr-ownership-report.mjs`.
 3. Confirm labels with `scripts/agents/ensure-agent-labels.sh --audit`.
 4. Confirm cheap release metrics with the owning lane commands:
    conformance dashboard, emit families, project row summary, and architecture
    guard.
 5. For each session, run `scripts/agents/disk-preflight.sh <AgentName>`.
 6. Start each Codex session with the prompt from `docs/plan/agents/LAUNCH.md`.
-7. Each session opens or updates a draft PR early and keeps the PR body current
-   with root cause, scope changes, verification, and handoff notes.
+7. Each session drains owned PRs before creating unrelated new PRs, then opens
+   or updates a draft PR early for any new lane work and keeps the PR body
+   current with root cause, scope changes, verification, and handoff notes.
 8. Reviewer stays ongoing. It reviews changed PRs and waits when the queue is
    empty; its goal is not completed merely because no PR is currently
    reviewable.

--- a/docs/plan/agents/TEMPLATE.md
+++ b/docs/plan/agents/TEMPLATE.md
@@ -32,14 +32,18 @@ scripts/agents/list-owned-work.sh <AgentName>
 ## Existing Work To Inspect First
 
 - Live owned PRs from `scripts/agents/list-owned-work.sh <AgentName>`.
+- Draft parking risks and queue candidates from
+  `node scripts/ci/pr-ownership-report.mjs`.
 - Open issues with the lane's subsystem labels.
 - Recent merged PRs touching the same invariant.
 - Current dashboard/artifact data for the lane's release gate.
 
 ## Non-Overlap Rules
 
-- Complete, close with evidence, or hand off live lane PRs before new issue
-  work.
+- Move live lane PRs to `merge-queue`, ready, refreshed draft/WIP with a signed
+  blocker, evidence-linked closure, or signed handoff before new issue work.
+- Keep at most two unstacked draft PRs unless extras are intentional stack
+  children or carry fresh signed blocker comments.
 - Do not duplicate another active PR's invariant. Comment there instead.
 - If you take over, leave a signed comment and update `agent:*` labels.
 - State the structural rule; never patch one test name, source spelling,

--- a/scripts/ci/pr-ownership-report.mjs
+++ b/scripts/ci/pr-ownership-report.mjs
@@ -2,6 +2,11 @@
 import fs from "node:fs";
 import { spawnSync } from "node:child_process";
 
+const QUEUE_LABEL = "merge-queue";
+const REQUIRED_PR_CHECKS = ["CI Summary", "GitGuardian Security Checks"];
+const DEFAULT_DRAFT_STALE_HOURS = 24;
+const DEFAULT_UNSTACKED_DRAFT_BUDGET = 2;
+
 function fail(message) {
   console.error(`error: ${message}`);
   process.exit(1);
@@ -32,6 +37,9 @@ function normalizePr(raw) {
   const labels = Array.isArray(raw.labels)
     ? raw.labels.map((label) => (typeof label === "string" ? label : label?.name)).filter(Boolean)
     : [];
+  const statusCheckRollup = Array.isArray(raw.statusCheckRollup)
+    ? raw.statusCheckRollup.map(normalizeCheck).filter(Boolean)
+    : [];
   return {
     number: Number(raw.number),
     title: String(raw.title ?? ""),
@@ -43,7 +51,18 @@ function normalizePr(raw) {
     mergeable: String(raw.mergeable || "UNKNOWN"),
     autoMergeArmed: Boolean(raw.autoMergeRequest),
     labels,
+    statusCheckRollup,
     body: String(raw.body ?? ""),
+  };
+}
+
+function normalizeCheck(raw) {
+  if (!raw || typeof raw !== "object") return null;
+  return {
+    name: String(raw.name || raw.context || ""),
+    state: raw.state ? String(raw.state).toUpperCase() : "",
+    status: raw.status ? String(raw.status).toUpperCase() : "",
+    conclusion: raw.conclusion ? String(raw.conclusion).toUpperCase() : "",
   };
 }
 
@@ -70,6 +89,47 @@ function loadPulls(fixture) {
     fail(result.stderr.trim() || "gh pr list failed");
   }
   return JSON.parse(result.stdout).map(normalizePr);
+}
+
+function shouldHydrateRequiredChecks(pr) {
+  return (
+    !pr.isDraft &&
+    pr.baseRefName === "main" &&
+    !pr.labels.includes(QUEUE_LABEL) &&
+    !isWipPr({ labels: pr.labels, title: pr.title })
+  );
+}
+
+function loadRequiredChecks(number) {
+  const result = spawnSync(
+    "gh",
+    ["pr", "view", String(number), "--json", "statusCheckRollup"],
+    { encoding: "utf8" },
+  );
+  if (result.status !== 0) {
+    console.error(
+      `warning: could not load status checks for PR #${number}: ${result.stderr.trim() || "gh pr view failed"}`,
+    );
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(result.stdout);
+    return Array.isArray(parsed.statusCheckRollup)
+      ? parsed.statusCheckRollup.map(normalizeCheck).filter(Boolean)
+      : [];
+  } catch (error) {
+    console.error(`warning: could not parse status checks for PR #${number}: ${error.message}`);
+    return [];
+  }
+}
+
+function hydrateRequiredChecks(pulls) {
+  for (const pr of pulls) {
+    if (shouldHydrateRequiredChecks(pr)) {
+      pr.statusCheckRollup = loadRequiredChecks(pr.number);
+    }
+  }
+  return pulls;
 }
 
 function agentNameFrom(body) {
@@ -232,7 +292,48 @@ function ownerCountSummary(entry, now) {
   return `${entry.owner}: ${entry.count}${oldest}`;
 }
 
+function ageHours(updatedAt, now) {
+  const updatedMs = Date.parse(updatedAt || "");
+  const nowMs = Date.parse(now || "");
+  if (!Number.isFinite(updatedMs) || !Number.isFinite(nowMs)) return null;
+  return Math.max(0, Math.floor((nowMs - updatedMs) / 3_600_000));
+}
+
+function checkBucket(check) {
+  if (!check) return "missing";
+  if (check.state) {
+    if (check.state === "SUCCESS") return "pass";
+    if (["PENDING", "EXPECTED"].includes(check.state)) return "pending";
+    return "fail";
+  }
+  if (check.status && check.status !== "COMPLETED") return "pending";
+  if (["SUCCESS", "NEUTRAL", "SKIPPED"].includes(check.conclusion)) return "pass";
+  if (!check.conclusion) return "pending";
+  return "fail";
+}
+
+function requiredCheckSummary(pr) {
+  const buckets = REQUIRED_PR_CHECKS.map((name) => {
+    const check = pr.statusCheckRollup.find((candidate) => candidate.name === name);
+    return { name, bucket: checkBucket(check) };
+  });
+  return {
+    buckets,
+    allPassed: buckets.every((bucket) => bucket.bucket === "pass"),
+    text: buckets.map((bucket) => `${bucket.name}=${bucket.bucket}`).join(", "),
+  };
+}
+
 function makeReport(pulls) {
+  const now = reportNow();
+  const staleDraftHours = Number.parseInt(
+    process.env.TSZ_PR_DRAFT_STALE_HOURS || String(DEFAULT_DRAFT_STALE_HOURS),
+    10,
+  );
+  const unstackedDraftBudget = Number.parseInt(
+    process.env.TSZ_PR_UNSTACKED_DRAFT_BUDGET || String(DEFAULT_UNSTACKED_DRAFT_BUDGET),
+    10,
+  );
   const normalized = pulls.map((pr) => ({
     number: pr.number,
     title: pr.title,
@@ -244,6 +345,7 @@ function makeReport(pulls) {
     mergeable: pr.mergeable,
     autoMergeArmed: pr.autoMergeArmed,
     labels: pr.labels.sort(),
+    statusCheckRollup: pr.statusCheckRollup,
     agentName: agentNameFrom(pr.body),
     agentLabels: agentLabelsFrom(pr.labels),
     issueRefs: uniqueIssueRefs(issueRefsFrom(`${pr.title}\n${pr.body}`), pr.number),
@@ -432,6 +534,86 @@ function makeReport(pulls) {
     .values()]
     .sort((a, b) => b.open - a.open || a.owner.localeCompare(b.owner));
 
+  const draftRunwayByOwner = [...normalized
+    .filter((pr) => pr.draft)
+    .reduce((summaries, pr) => {
+      const owner = ownerOf(pr);
+      if (!summaries.has(owner)) {
+        summaries.set(owner, {
+          owner,
+          draft: 0,
+          unstackedDraft: 0,
+          staleDraft: 0,
+          oldestUpdatedAt: null,
+        });
+      }
+      const summary = summaries.get(owner);
+      summary.draft += 1;
+      if (pr.stackRole !== "stack child" && pr.stackRole !== "stack middle") {
+        summary.unstackedDraft += 1;
+      }
+      const age = ageHours(pr.updatedAt, now);
+      if (age !== null && age >= staleDraftHours) {
+        summary.staleDraft += 1;
+      }
+      if (pr.updatedAt && (!summary.oldestUpdatedAt || pr.updatedAt < summary.oldestUpdatedAt)) {
+        summary.oldestUpdatedAt = pr.updatedAt;
+      }
+      return summaries;
+    }, new Map())
+    .values()]
+    .map((entry) => ({
+      ...entry,
+      overBudget: entry.unstackedDraft > unstackedDraftBudget,
+    }))
+    .sort(
+      (a, b) =>
+        b.unstackedDraft - a.unstackedDraft ||
+        b.staleDraft - a.staleDraft ||
+        a.owner.localeCompare(b.owner),
+    );
+
+  const draftParkingOwners = draftRunwayByOwner.filter((entry) => entry.overBudget || entry.staleDraft > 0);
+  const staleDraftPrs = normalized
+    .filter((pr) => pr.draft && !isWipPr(pr))
+    .map((pr) => ({
+      number: pr.number,
+      agentName: pr.agentName,
+      agentLabel: pr.agentLabels.length === 1 ? `agent:${pr.agentLabels[0]}` : null,
+      updatedAt: pr.updatedAt,
+      ageHours: ageHours(pr.updatedAt, now),
+      stackRole: pr.stackRole,
+      title: pr.title,
+    }))
+    .filter((pr) => pr.ageHours !== null && pr.ageHours >= staleDraftHours)
+    .sort((a, b) => (a.agentName || "").localeCompare(b.agentName || "") || a.number - b.number);
+
+  const readyMainMissingQueueLabelPrs = normalized
+    .filter((pr) => (
+      !pr.draft
+      && pr.base === "main"
+      && !isWipPr(pr)
+      && !pr.labels.includes(QUEUE_LABEL)
+    ))
+    .map((pr) => {
+      const checks = requiredCheckSummary(pr);
+      return {
+        number: pr.number,
+        agentName: pr.agentName,
+        agentLabel: pr.agentLabels.length === 1 ? `agent:${pr.agentLabels[0]}` : null,
+        updatedAt: pr.updatedAt,
+        mergeStateStatus: pr.mergeStateStatus,
+        mergeable: pr.mergeable,
+        checks: checks.buckets,
+        checkSummary: checks.text,
+        queueCandidate: checks.allPassed
+          && pr.mergeStateStatus !== "DIRTY"
+          && pr.mergeable !== "CONFLICTING",
+        title: pr.title,
+      };
+    })
+    .sort((a, b) => Number(b.queueCandidate) - Number(a.queueCandidate) || a.number - b.number);
+
   return {
     generatedAt: new Date().toISOString(),
     counts: {
@@ -441,11 +623,20 @@ function makeReport(pulls) {
       stacked: stacks.reduce((sum, stack) => sum + stack.children.length, 0),
       missingAgentName: normalized.filter((pr) => pr.agentName === null).length,
       agentLabelMismatches: agentLabelMismatches.length,
+      mergeQueued: normalized.filter((pr) => pr.labels.includes(QUEUE_LABEL)).length,
+      readyMissingQueueLabel: readyMainMissingQueueLabelPrs.length,
+      queueCandidates: readyMainMissingQueueLabelPrs.filter((pr) => pr.queueCandidate).length,
+      draftParkingOwners: draftParkingOwners.length,
+      staleDraftPrs: staleDraftPrs.length,
     },
     byBase: [...byBase.entries()]
       .map(([base, prs]) => ({ base, prs: prs.sort((a, b) => a - b) }))
       .sort((a, b) => a.base.localeCompare(b.base)),
     ownerSummaries,
+    draftRunwayByOwner,
+    draftParkingOwners,
+    staleDraftPrs,
+    readyMainMissingQueueLabelPrs,
     stacks,
     duplicateTitleScopes,
     duplicateIssueRefs,
@@ -468,7 +659,7 @@ function printMarkdown(report) {
   console.log("# Open PR Ownership Report");
   console.log("");
   console.log(
-    `Open: ${report.counts.open}; draft: ${report.counts.draft}; ready: ${report.counts.ready}; stacked children: ${report.counts.stacked}; missing AgentName: ${report.counts.missingAgentName}; AgentName/label mismatches: ${report.counts.agentLabelMismatches}`,
+    `Open: ${report.counts.open}; draft: ${report.counts.draft}; ready: ${report.counts.ready}; merge-queued: ${report.counts.mergeQueued}; ready missing queue label: ${report.counts.readyMissingQueueLabel}; queue candidates: ${report.counts.queueCandidates}; draft parking owners: ${report.counts.draftParkingOwners}; stale drafts: ${report.counts.staleDraftPrs}; stacked children: ${report.counts.stacked}; missing AgentName: ${report.counts.missingAgentName}; AgentName/label mismatches: ${report.counts.agentLabelMismatches}`,
   );
   console.log("");
   console.log("## Owner Summary");
@@ -486,6 +677,49 @@ function printMarkdown(report) {
       console.log(
         `| ${owner.owner} | ${owner.open} | ${owner.ready} | ${owner.draft} | ${owner.wip} | ${owner.stackedChildren} | ${owner.blockedReadyMain} | ${owner.conflictingReadyMain} | ${owner.conflictingMain} | ${owner.autoMergeArmed} |`,
       );
+    }
+  }
+  console.log("");
+  console.log("## Queue Admission");
+  if (report.readyMainMissingQueueLabelPrs.length === 0) {
+    console.log("- none");
+  } else {
+    console.log("");
+    console.log("| PR | Owner | Queue candidate | Merge state | Checks | Title |");
+    console.log("|----|-------|-----------------|-------------|--------|-------|");
+    for (const pr of report.readyMainMissingQueueLabelPrs) {
+      const owner = ownerOf(pr);
+      const candidate = pr.queueCandidate ? "yes" : "no";
+      console.log(
+        `| #${pr.number} | ${owner} | ${candidate} | ${pr.mergeStateStatus}/${pr.mergeable} | ${pr.checkSummary.replace(/\|/g, "\\|")} | ${pr.title.replace(/\|/g, "\\|")} |`,
+      );
+    }
+  }
+  console.log("");
+  console.log("## Draft Parking Risks");
+  if (report.draftParkingOwners.length === 0 && report.staleDraftPrs.length === 0) {
+    console.log("- none");
+  } else {
+    if (report.draftParkingOwners.length) {
+      console.log("");
+      console.log("Owners over draft budget or carrying stale drafts:");
+      for (const owner of report.draftParkingOwners) {
+        const budget = owner.overBudget ? "over budget" : "within budget";
+        console.log(
+          `- ${owner.owner}: drafts ${owner.draft}; unstacked ${owner.unstackedDraft}; stale ${owner.staleDraft}; ${budget}; oldest updated ${shortDate(owner.oldestUpdatedAt)} (${elapsedAge(owner.oldestUpdatedAt, now)})`,
+        );
+      }
+    }
+    if (report.staleDraftPrs.length) {
+      console.log("");
+      console.log("Stale draft PRs:");
+      for (const pr of report.staleDraftPrs) {
+        const owner = ownerOf(pr);
+        const stack = pr.stackRole ? `; ${pr.stackRole}` : "";
+        console.log(
+          `- #${pr.number}: ${owner}; updated ${shortDate(pr.updatedAt)}; age ${pr.ageHours}h${stack}; ${pr.title}`,
+        );
+      }
     }
   }
   console.log("");
@@ -629,7 +863,11 @@ function printMarkdown(report) {
 }
 
 const args = parseArgs(process.argv.slice(2));
-const report = makeReport(loadPulls(args.fixture));
+const pulls = loadPulls(args.fixture);
+if (!args.fixture) {
+  hydrateRequiredChecks(pulls);
+}
+const report = makeReport(pulls);
 if (args.outputJson) {
   fs.writeFileSync(args.outputJson, `${JSON.stringify(report, null, 2)}\n`);
 }

--- a/scripts/ci/test-pr-ownership-report.mjs
+++ b/scripts/ci/test-pr-ownership-report.mjs
@@ -110,6 +110,10 @@ withTempDir((dir) => {
       mergeable: "MERGEABLE",
       autoMergeRequest: null,
       labels: ["agent:epsilon"],
+      statusCheckRollup: [
+        { name: "CI Summary", status: "COMPLETED", conclusion: "SUCCESS" },
+        { name: "GitGuardian Security Checks", status: "COMPLETED", conclusion: "SUCCESS" },
+      ],
       body: "AgentName: epsilon\n",
     },
     {
@@ -151,9 +155,18 @@ withTempDir((dir) => {
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /Open PR Ownership Report/);
   assert.match(result.stdout, /AgentName\/label mismatches: 1/);
+  assert.match(result.stdout, /queue candidates: 1/);
   assert.match(
     result.stdout,
     /Owner Summary[\s\S]*\| agent:delta \| 2 \| 0 \| 2 \| 0 \| 0 \| 0 \| 0 \| 1 \| 0 \|[\s\S]*\| agent:zeta \| 2 \| 1 \| 1 \| 0 \| 0 \| 0 \| 1 \| 1 \| 0 \|[\s\S]*\| unowned \| 2 \| 0 \| 2 \| 0 \| 1 \| 0 \| 0 \| 0 \| 0 \|[\s\S]*\| delta \| 1 \| 0 \| 1 \| 0 \| 0 \| 0 \| 0 \| 0 \| 0 \|/,
+  );
+  assert.match(
+    result.stdout,
+    /Queue Admission[\s\S]*#17 \| agent:epsilon \| yes \| BLOCKED\/MERGEABLE \| CI Summary=pass, GitGuardian Security Checks=pass[\s\S]*#18 \| agent:zeta \| no \| DIRTY\/CONFLICTING \| CI Summary=missing, GitGuardian Security Checks=missing/,
+  );
+  assert.match(
+    result.stdout,
+    /Draft Parking Risks[\s\S]*agent:delta: drafts 2; unstacked 2; stale 1; within budget; oldest updated 2026-05-22 \(4d 3h\)[\s\S]*#19: agent:delta; updated 2026-05-22; age 99h; fix\(checker\): conflicting draft branch/,
   );
   assert.match(result.stdout, /agent\/mapped-a: root #10; children #12/);
   assert.match(result.stdout, /unknown-base: unknown root; children #13/);
@@ -196,6 +209,11 @@ withTempDir((dir) => {
     stacked: 2,
     missingAgentName: 2,
     agentLabelMismatches: 1,
+    mergeQueued: 0,
+    readyMissingQueueLabel: 2,
+    queueCandidates: 1,
+    draftParkingOwners: 1,
+    staleDraftPrs: 1,
   });
   assert.deepEqual(report.byBase, [
     { base: "agent/mapped-a", prs: [12] },
@@ -298,6 +316,59 @@ withTempDir((dir) => {
       conflictingReadyMain: 0,
       conflictingMain: 0,
       autoMergeArmed: 0,
+    },
+  ]);
+  assert.deepEqual(report.draftParkingOwners, [
+    {
+      owner: "agent:delta",
+      draft: 2,
+      unstackedDraft: 2,
+      staleDraft: 1,
+      oldestUpdatedAt: "2026-05-22T08:00:00Z",
+      overBudget: false,
+    },
+  ]);
+  assert.deepEqual(report.staleDraftPrs, [
+    {
+      number: 19,
+      agentName: "delta",
+      agentLabel: "agent:delta",
+      updatedAt: "2026-05-22T08:00:00Z",
+      ageHours: 99,
+      stackRole: null,
+      title: "fix(checker): conflicting draft branch",
+    },
+  ]);
+  assert.deepEqual(report.readyMainMissingQueueLabelPrs, [
+    {
+      number: 17,
+      agentName: "epsilon",
+      agentLabel: "agent:epsilon",
+      updatedAt: "2026-05-23T09:15:00Z",
+      mergeStateStatus: "BLOCKED",
+      mergeable: "MERGEABLE",
+      checks: [
+        { name: "CI Summary", bucket: "pass" },
+        { name: "GitGuardian Security Checks", bucket: "pass" },
+      ],
+      checkSummary: "CI Summary=pass, GitGuardian Security Checks=pass",
+      queueCandidate: true,
+      title: "fix(checker): ready but blocked",
+    },
+    {
+      number: 18,
+      agentName: "zeta",
+      agentLabel: "agent:zeta",
+      updatedAt: "2026-05-24T10:20:30Z",
+      mergeStateStatus: "DIRTY",
+      mergeable: "CONFLICTING",
+      checks: [
+        { name: "CI Summary", bucket: "missing" },
+        { name: "GitGuardian Security Checks", bucket: "missing" },
+      ],
+      checkSummary: "CI Summary=missing, GitGuardian Security Checks=missing",
+      queueCandidate: false,
+      title: "fix(solver): conflicting ready branch",
     },
   ]);
   assert.deepEqual(report.stacks, [


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / ownership hygiene

## Invariant
Owned open PRs are active runway. Agents must drain or document existing owned PRs before opening unrelated new work, and ready green PRs should move into the repo-local `merge-queue` instead of idling.

## Scope
- Update `AGENTS.md`/`.claude/CLAUDE.md` with explicit draft parking and owned-PR runway rules.
- Update multi-agent launch docs/prompts to require draining owned PRs before new PRs.
- Extend `scripts/ci/pr-ownership-report.mjs` with queue-admission and draft-parking sections.
- Keep status-check hydration narrow so the report does not fetch every PR's full check rollup.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs/script-only coordination change; no compiler, conformance, emit, or project-corpus behavior changes.

## Verification
- `node scripts/ci/test-pr-ownership-report.mjs`
- `git diff --check origin/main..HEAD`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/tsz-pr-ownership-after.json`

## Coordination Notes
- Live report at 2026-05-27T06:03:26Z showed 87 open PRs, 76 drafts, 2 merge-queued PRs, 7 ready main PRs missing `merge-queue`, 2 queue candidates, and 5 owners over draft budget.
- This PR is ready, not draft, to avoid adding to the parked-draft problem it is trying to fix.
