### PR TITLE
refactor(dts): precompute statement jsdoc facts

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
@@ -643,26 +643,22 @@ impl<'a> DeclarationEmitter<'a> {
 
         self.current_statement_jsdoc_chain =
             self.leading_jsdoc_comment_chain_for_pos(stmt_node.pos);
-        let jsdoc_chain = self.current_statement_jsdoc_chain.clone();
 
         let has_jsdoc_type_function_signature = self
             .statement_jsdoc_type_function_signature_node(stmt_idx)
             .is_some();
+        let jsdoc_facts = Self::statement_jsdoc_declaration_facts(
+            self.current_statement_jsdoc_chain.clone(),
+            has_jsdoc_type_function_signature,
+        );
         let is_effectively_exported = self.statement_has_effective_export(stmt_idx);
         let has_leading_jsdoc_typedef = self.source_is_js_file
             && self.js_export_equals_names.is_empty()
             && is_effectively_exported
-            && !has_jsdoc_type_function_signature
-            && jsdoc_chain
-                .iter()
-                .any(|jsdoc| Self::jsdoc_contains_type_alias_tag(jsdoc));
+            && !jsdoc_facts.has_type_function_signature()
+            && jsdoc_facts.has_type_alias_tag();
         if has_leading_jsdoc_typedef {
-            // Reuse the already-computed jsdoc_chain instead of re-walking comments.
-            for jsdoc in &jsdoc_chain {
-                if let Some(decl) = Self::parse_jsdoc_type_alias_decl(jsdoc) {
-                    self.emit_rendered_jsdoc_type_alias(decl, is_effectively_exported);
-                }
-            }
+            self.emit_jsdoc_type_alias_facts(&jsdoc_facts, is_effectively_exported);
         }
 
         let jsdoc_overload_function_node =
@@ -671,38 +667,36 @@ impl<'a> DeclarationEmitter<'a> {
             .is_some_and(|func_idx| !self.jsdoc_overload_signatures_for_node(func_idx).is_empty());
 
         let effective_chain: Vec<String> = if has_leading_jsdoc_typedef {
-            jsdoc_chain
-                .iter()
-                .filter(|jsdoc| !Self::jsdoc_contains_type_alias_tag(jsdoc))
-                .cloned()
-                .collect()
+            jsdoc_facts.comments_without_type_alias_tags()
         } else {
-            jsdoc_chain
+            jsdoc_facts.comments().to_vec()
         };
+        let effective_facts = Self::statement_jsdoc_declaration_facts(
+            effective_chain,
+            jsdoc_facts.has_type_function_signature(),
+        );
 
         if has_jsdoc_overload_signatures {
             // JSDoc overload comments are emitted with each overload signature.
-        } else if has_jsdoc_type_function_signature {
-            let filtered = Self::jsdoc_chain_without_type_or_alias_tags(&effective_chain);
+        } else if effective_facts.has_type_function_signature() {
+            let filtered = effective_facts.comments_without_type_or_alias_tags();
             if !self.emit_jsdoc_comment_chain_preserving_source_for_pos_verbatim(
                 stmt_node.pos,
                 &filtered,
             ) {
                 self.emit_jsdoc_comment_chain(&filtered);
             }
-        } else if effective_chain
-            .iter()
-            .any(|jsdoc| Self::jsdoc_has_function_signature_tags(jsdoc))
+        } else if effective_facts.has_function_signature_tags()
             && self.hoisted_jsdoc_source_comment_is_multiline(stmt_node.pos)
         {
             if !self.emit_jsdoc_comment_chain_preserving_source_for_pos_verbatim(
                 stmt_node.pos,
-                &effective_chain,
+                effective_facts.comments(),
             ) {
-                self.emit_jsdoc_comment_chain(&effective_chain);
+                self.emit_jsdoc_comment_chain(effective_facts.comments());
             }
         } else {
-            self.emit_jsdoc_comment_chain(&effective_chain);
+            self.emit_jsdoc_comment_chain(effective_facts.comments());
         }
         let saved_comment_idx = self.comment_emit_idx;
         self.comment_emit_idx = self

--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_statements.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_statements.rs
@@ -166,10 +166,11 @@ impl<'a> DeclarationEmitter<'a> {
         let saved_comment_idx = self.comment_emit_idx;
         self.current_statement_jsdoc_chain =
             self.emittable_jsdoc_comment_chain_for_pos(stmt_node.pos);
-        let has_jsdoc_type_alias = self
-            .current_statement_jsdoc_chain
-            .iter()
-            .any(|jsdoc| Self::jsdoc_contains_type_alias_tag(jsdoc));
+        let jsdoc_facts = Self::statement_jsdoc_declaration_facts(
+            self.current_statement_jsdoc_chain.clone(),
+            has_jsdoc_type_function_signature,
+        );
+        let has_jsdoc_type_alias = jsdoc_facts.has_type_alias_tag();
         // True when emit_leading_jsdoc_type_aliases_for_pos was called above, so the raw
         // @typedef comment blocks should be suppressed from the JSDoc chain.
         let emitted_leading_typedef_aliases = self.source_is_js_file
@@ -202,12 +203,16 @@ impl<'a> DeclarationEmitter<'a> {
             self.emit_leading_jsdoc_comments(stmt_node.pos);
             self.writer.truncate(before_jsdoc_len);
             let mut filtered = if has_jsdoc_type_function_signature {
-                Self::jsdoc_chain_without_type_or_alias_tags(&self.current_statement_jsdoc_chain)
+                jsdoc_facts.comments_without_type_or_alias_tags()
             } else {
-                self.current_statement_jsdoc_chain.clone()
+                jsdoc_facts.comments().to_vec()
             };
             if suppress_jsdoc_type_alias_comments {
-                filtered.retain(|jsdoc| !Self::jsdoc_contains_type_alias_tag(jsdoc));
+                filtered = Self::statement_jsdoc_declaration_facts(
+                    filtered,
+                    has_jsdoc_type_function_signature,
+                )
+                .comments_without_type_alias_tags();
             }
             if has_jsdoc_type_function_signature {
                 if !self.emit_jsdoc_comment_chain_preserving_source_for_pos_verbatim(

--- a/crates/tsz-emitter/src/declaration_emitter/core/jsdoc_statement_facts.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/jsdoc_statement_facts.rs
@@ -1,0 +1,82 @@
+use super::DeclarationEmitter;
+use crate::declaration_emitter::helpers::JsdocTypeAliasDecl;
+
+pub(in crate::declaration_emitter) struct StatementJsdocDeclarationFacts {
+    comments: Vec<String>,
+    type_alias_decls: Vec<JsdocTypeAliasDecl>,
+    has_type_alias_tag: bool,
+    has_type_function_signature: bool,
+    has_function_signature_tags: bool,
+}
+
+impl StatementJsdocDeclarationFacts {
+    pub(in crate::declaration_emitter) fn comments(&self) -> &[String] {
+        &self.comments
+    }
+
+    pub(in crate::declaration_emitter) const fn has_type_alias_tag(&self) -> bool {
+        self.has_type_alias_tag
+    }
+
+    pub(in crate::declaration_emitter) const fn has_type_function_signature(&self) -> bool {
+        self.has_type_function_signature
+    }
+
+    pub(in crate::declaration_emitter) const fn has_function_signature_tags(&self) -> bool {
+        self.has_function_signature_tags
+    }
+
+    pub(in crate::declaration_emitter) fn type_alias_decls(&self) -> &[JsdocTypeAliasDecl] {
+        &self.type_alias_decls
+    }
+
+    pub(in crate::declaration_emitter) fn comments_without_type_alias_tags(&self) -> Vec<String> {
+        self.comments
+            .iter()
+            .filter(|jsdoc| !DeclarationEmitter::jsdoc_contains_type_alias_tag(jsdoc))
+            .cloned()
+            .collect()
+    }
+
+    pub(in crate::declaration_emitter) fn comments_without_type_or_alias_tags(
+        &self,
+    ) -> Vec<String> {
+        DeclarationEmitter::jsdoc_chain_without_type_or_alias_tags(&self.comments)
+    }
+}
+
+impl<'a> DeclarationEmitter<'a> {
+    pub(in crate::declaration_emitter) fn statement_jsdoc_declaration_facts(
+        comments: Vec<String>,
+        has_type_function_signature: bool,
+    ) -> StatementJsdocDeclarationFacts {
+        let has_type_alias_tag = comments
+            .iter()
+            .any(|jsdoc| Self::jsdoc_contains_type_alias_tag(jsdoc));
+        let has_function_signature_tags = comments
+            .iter()
+            .any(|jsdoc| Self::jsdoc_has_function_signature_tags(jsdoc));
+        let type_alias_decls = comments
+            .iter()
+            .filter_map(|jsdoc| Self::parse_jsdoc_type_alias_decl(jsdoc))
+            .collect();
+
+        StatementJsdocDeclarationFacts {
+            comments,
+            type_alias_decls,
+            has_type_alias_tag,
+            has_type_function_signature,
+            has_function_signature_tags,
+        }
+    }
+
+    pub(in crate::declaration_emitter) fn emit_jsdoc_type_alias_facts(
+        &mut self,
+        facts: &StatementJsdocDeclarationFacts,
+        exported: bool,
+    ) {
+        for decl in facts.type_alias_decls() {
+            self.emit_rendered_jsdoc_type_alias(decl.clone(), exported);
+        }
+    }
+}

--- a/crates/tsz-emitter/src/declaration_emitter/core/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/mod.rs
@@ -17,6 +17,7 @@ mod js_emit_namespace_exports;
 mod js_emit_synthetic;
 mod js_return_type_fallback;
 mod js_synthetic_members;
+mod jsdoc_statement_facts;
 mod preamble;
 mod setup;
 

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs
@@ -130,6 +130,7 @@ type JsStaticMethodAugmentationEntry = (
     Vec<(NodeIndex, NodeIndex)>,
 );
 
+#[derive(Clone)]
 pub(in crate::declaration_emitter) struct JsdocTypeAliasDecl {
     pub(in crate::declaration_emitter) name: String,
     pub(in crate::declaration_emitter) type_params: Vec<String>,


### PR DESCRIPTION
## Agent
AgentName: Studio-E

## Track
Studio-E JSDoc/JavaScript declaration emit; refactor-only boundary cleanup for #9333.

## Invariant
When declaration emit handles a statement JSDoc comment chain, JSDoc declaration facts are identified before statement printing. This PR moves per-statement JSDoc alias/comment decisions into a small precomputed facts helper while keeping declaration emit as an OUTPUT consumer.

## Scope
- Add `StatementJsdocDeclarationFacts` for per-statement JSDoc comment chains.
- Route hoisted function declarations and ordinary statement declaration JSDoc decisions through the precomputed facts.
- Keep emitted DTS behavior intended to remain unchanged; no checker/solver semantic validation or output surgery is added.

## Project Corpus Impact
- Row: n/a
- Bug family: JSDoc/JavaScript declaration emit boundary cleanup
- Evidence: behavior-preserving refactor only; no project-corpus row was run locally.

Issue intake fields are coordination context only; every PR still needs this section filled in or explicitly marked `n/a`.

## Verification
- `cargo check -p tsz-emitter` passed before the clean rebase.
- `cargo nextest run -p tsz-emitter test_js_leading_jsdoc_typedef_before_function_is_emitted` passed before the clean rebase.
- `cargo nextest run -p tsz-emitter test_js_function_declaration_type_alias_signature_preserves_non_type_jsdoc_comments` passed before the clean rebase.
- `git diff --check origin/main...HEAD` passed after rebasing to head `b2b7387be5`.
- Exact-head draft CI for `b2b7387be5916817db98a76562d51ab2c94d3bbd` passed `CI Light Summary`, `lint`, `dist-binaries`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, and `GitGuardian Security Checks` in run https://github.com/mohsen1/tsz/actions/runs/26494720882.
- Exact-head ready-review CI for `b2b7387be5916817db98a76562d51ab2c94d3bbd` passed `CI Summary`, `project-corpus-pr-body`, `lint`, `dist-binaries`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `emit`, `conformance-*`, `conformance-aggregate`, `fourslash-*`, `fourslash-aggregate`, `lsp-e2e`, `wasm`, `wasm-web`, `project-compile-guard`, `project-compile-canary`, and `GitGuardian Security Checks` in run https://github.com/mohsen1/tsz/actions/runs/26495079667.
- Broader local probe `cargo nextest run -p tsz-emitter jsdoc` ran 104 filtered tests before the rebase: 103 passed, 1 failed in `test_jsdoc_typedef_same_line_link_description_is_preserved`.
- Follow-up probe from clean `origin/main` worktree (`/Users/mohsen/code/tsz-studio-a-metrics` at `fee8384559d5eba4014e23a9a28ed5e33973f905`) with `CARGO_TARGET_DIR=/Users/mohsen/code/tsz-studio-e-jsdoc-facts-20260527/.target cargo nextest run -p tsz-emitter test_jsdoc_typedef_same_line_link_description_is_preserved` also failed with the same output, so that failure was pre-existing and outside this refactor at the time tested.

## Coordination Notes
- Rebased cleanly onto current `origin/main` and force-pushed with lease; current branch check: `git rev-list --left-right --count origin/main...HEAD` returned `0 1`.
- Marked ready after exact-head draft light CI passed for `b2b7387be5916817db98a76562d51ab2c94d3bbd`.
- Ready-review CI is green for the exact head after rerunning the stale metadata-only body check against the corrected PR body.
- No auto-merge requested or enabled. Added `merge-queue` after re-verifying exact-head ready CI and ownership under the current repo queue policy; waiting for queue-owned `Queue Tested` and landing.

