### PR TITLE
refactor(checker): bundle call diagnostic relation routing

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/diagnostics.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/diagnostics.rs
@@ -588,32 +588,37 @@ impl<'a> CheckerState<'a> {
                             .get_generator_yield_type_argument(actual_return)
                             .zip(self.get_generator_yield_type_argument(expected_return))
                             .is_some_and(|(actual_yield, expected_yield)| {
-                                !self.diagnostic_relation_boolean_guard(
-                                    actual_yield,
-                                    expected_yield,
-                                ) && !self.diagnostic_relation_boolean_guard(
-                                    expected_yield,
-                                    actual_yield,
-                                )
+                                !self
+                                    .assign_relation_outcome(actual_yield, expected_yield)
+                                    .related
+                                    && !self
+                                        .assign_relation_outcome(expected_yield, actual_yield)
+                                        .related
                             })
                             || self
                                 .get_generator_return_type_argument(actual_return)
                                 .zip(self.get_generator_return_type_argument(expected_return))
                                 .is_some_and(|(actual_gen_return, expected_gen_return)| {
-                                    !self.diagnostic_relation_boolean_guard(
-                                        actual_gen_return,
-                                        expected_gen_return,
-                                    ) && !self.diagnostic_relation_boolean_guard(
-                                            expected_gen_return,
+                                    !self
+                                        .assign_relation_outcome(
                                             actual_gen_return,
+                                            expected_gen_return,
                                         )
+                                        .related
+                                        && !self
+                                            .assign_relation_outcome(
+                                                expected_gen_return,
+                                                actual_gen_return,
+                                            )
+                                            .related
                                 })
                             || self
                                 .get_generator_next_type_argument(actual_return)
                                 .zip(self.get_generator_next_type_argument(expected_return))
                                 .is_some_and(|(actual_next, expected_next)| {
                                     !self
-                                        .diagnostic_relation_boolean_guard(expected_next, actual_next)
+                                        .assign_relation_outcome(expected_next, actual_next)
+                                        .related
                                 });
 
                         // When the expected return type is `void`, there is never
@@ -653,10 +658,9 @@ impl<'a> CheckerState<'a> {
                             } else {
                                 generator_component_mismatch
                                     || (expected_return != TypeId::VOID
-                                        && !self.diagnostic_relation_boolean_guard(
-                                            actual_return,
-                                            expected_return,
-                                        ))
+                                        && !self
+                                            .assign_relation_outcome(actual_return, expected_return)
+                                            .related)
                             };
                         (return_type_mismatch, generator_component_mismatch)
                     })

--- a/crates/tsz-checker/src/checkers/parameter_checker.rs
+++ b/crates/tsz-checker/src/checkers/parameter_checker.rs
@@ -1300,9 +1300,12 @@ impl<'a> CheckerState<'a> {
                     let any_array = factory.array(TypeId::ANY);
                     let readonly_any_array = factory.readonly_type(any_array);
 
-                    if !self.diagnostic_relation_boolean_guard(declared_type, readonly_any_array)
+                    if !self
+                        .assign_relation_outcome(declared_type, readonly_any_array)
+                        .related
                         && !self
-                            .diagnostic_relation_boolean_guard(array_check_type, readonly_any_array)
+                            .assign_relation_outcome(array_check_type, readonly_any_array)
+                            .related
                     {
                         // tsc anchors TS2370 at the parameter (including the
                         // `...` token) rather than at its type annotation or
@@ -1333,7 +1336,10 @@ impl<'a> CheckerState<'a> {
                     let factory = self.ctx.types.factory();
                     let any_array = factory.array(TypeId::ANY);
                     let readonly_any_array = factory.readonly_type(any_array);
-                    if !self.diagnostic_relation_boolean_guard(init_type, readonly_any_array) {
+                    if !self
+                        .assign_relation_outcome(init_type, readonly_any_array)
+                        .related
+                    {
                         self.error_at_node(
                             param_idx,
                             "A rest parameter must be of an array type.",

--- a/crates/tsz-checker/src/checkers/promise_checker.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker.rs
@@ -643,7 +643,7 @@ impl<'a> CheckerState<'a> {
         for sig in &sigs {
             if let Some(expected_this) = sig.this_type
                 && expected_this != TypeId::VOID
-                && !self.diagnostic_relation_boolean_guard(type_id, expected_this)
+                && !self.assign_relation_outcome(type_id, expected_this).related
             {
                 rejected_this_type.get_or_insert(expected_this);
                 continue;

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -136,7 +136,6 @@ impl<'a> CheckerState<'a> {
         if source_prop.optional || source_prop.visibility != tsz_solver::Visibility::Public {
             return false;
         }
-
         let Some(target_prop) = self
             .property_info_for_any_missing_property_satisfaction_type(target_types, property_name)
         else {
@@ -145,18 +144,19 @@ impl<'a> CheckerState<'a> {
         if target_prop.visibility != tsz_solver::Visibility::Public {
             return false;
         }
-
         let read_ok = if source_prop.is_method || target_prop.is_method {
             self.diagnostic_relation_boolean_guard_bivariant(
                 source_prop.type_id,
                 target_prop.type_id,
             )
         } else {
-            self.diagnostic_relation_boolean_guard(source_prop.type_id, target_prop.type_id)
+            self.assign_relation_outcome(source_prop.type_id, target_prop.type_id)
+                .related
         };
         let write_ok = target_prop.readonly
             || self
-                .diagnostic_relation_boolean_guard(target_prop.write_type, source_prop.write_type);
+                .assign_relation_outcome(target_prop.write_type, source_prop.write_type)
+                .related;
 
         read_ok && write_ok
     }
@@ -948,7 +948,7 @@ impl<'a> CheckerState<'a> {
         let mismatched: Vec<TypeId> = members
             .iter()
             .copied()
-            .filter(|&m| !self.diagnostic_relation_boolean_guard(m, target_eval))
+            .filter(|&m| !self.assign_relation_outcome(m, target_eval).related)
             .collect();
         if mismatched.len() == members.len()
             && members.len() == 2

--- a/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
@@ -976,7 +976,7 @@ impl<'a> CheckerState<'a> {
             return false;
         }
         let evaluated = self.evaluate_concrete_remapped_mapped_type_with_resolution(resolved);
-        if evaluated == resolved || self.diagnostic_relation_boolean_guard(evaluated, target) {
+        if evaluated == resolved || self.assign_relation_outcome(evaluated, target).related {
             return false;
         }
         let analysis = self.analyze_assignability_failure(evaluated, target);

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
@@ -1105,7 +1105,7 @@ impl<'a> CheckerState<'a> {
     }
 
     fn types_overlap_for_diagnostic_display(&mut self, left: TypeId, right: TypeId) -> bool {
-        self.diagnostic_relation_boolean_guard(left, right)
-            || self.diagnostic_relation_boolean_guard(right, left)
+        self.assign_relation_outcome(left, right).related
+            || self.assign_relation_outcome(right, left).related
     }
 }

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -102,8 +102,8 @@ impl<'a> CheckerState<'a> {
     }
 
     fn types_are_mutually_assignable(&mut self, left: TypeId, right: TypeId) -> bool {
-        self.diagnostic_relation_boolean_guard(left, right)
-            && self.diagnostic_relation_boolean_guard(right, left)
+        self.assign_relation_outcome(left, right).related
+            && self.assign_relation_outcome(right, left).related
     }
 
     pub(in crate::error_reporter::call_errors) fn contextual_constraint_parameter_display(

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
@@ -150,7 +150,10 @@ impl<'a> CheckerState<'a> {
                     if elem_type.is_any_unknown_or_error() {
                         continue;
                     }
-                    if !self.diagnostic_relation_boolean_guard(elem_type, target_element) {
+                    if !self
+                        .assign_relation_outcome(elem_type, target_element)
+                        .related
+                    {
                         if self.array_elaboration_widening_required_for_display(
                             elem_type,
                             target_element,

--- a/crates/tsz-checker/src/error_reporter/call_errors_anchors.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_anchors.rs
@@ -199,7 +199,9 @@ impl<'a> CheckerState<'a> {
                     || arg_type == widened_actual_type;
                 let mismatches_expected = expected_type != TypeId::ERROR
                     && expected_type != TypeId::UNKNOWN
-                    && !self.diagnostic_relation_boolean_guard(arg_type, expected_type);
+                    && !self
+                        .assign_relation_outcome(arg_type, expected_type)
+                        .related;
 
                 if matches_actual {
                     actual_matches.push(arg_idx);
@@ -294,7 +296,10 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
             saw_expected = true;
-            if self.diagnostic_relation_boolean_guard(first_arg_type, expected_type) {
+            if self
+                .assign_relation_outcome(first_arg_type, expected_type)
+                .related
+            {
                 return false;
             }
         }
@@ -380,7 +385,10 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
 
-            if !self.diagnostic_relation_boolean_guard(source_prop_type, target_prop_type) {
+            if !self
+                .assign_relation_outcome(source_prop_type, target_prop_type)
+                .related
+            {
                 return self
                     .literal_argument_mismatch_anchor(prop_value_idx, target_prop_type)
                     .or(Some(prop_name_idx));
@@ -452,7 +460,10 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
 
-            if !self.diagnostic_relation_boolean_guard(elem_type, target_element_type) {
+            if !self
+                .assign_relation_outcome(elem_type, target_element_type)
+                .related
+            {
                 return Some(elem_idx);
             }
         }

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -1585,8 +1585,12 @@ impl<'a> CheckerState<'a> {
             // eliminated declared union members; the subset check handles
             // surviving members structurally compatible with eliminated ones.
             let expr_is_assignability_narrower = expr_display_type != declared_type
-                && self.diagnostic_relation_boolean_guard(expr_display_type, declared_type)
-                && !self.diagnostic_relation_boolean_guard(declared_type, expr_display_type);
+                && self
+                    .assign_relation_outcome(expr_display_type, declared_type)
+                    .related
+                && !self
+                    .assign_relation_outcome(declared_type, expr_display_type)
+                    .related;
             let expr_is_union_subset_narrower = expr_display_type != declared_type
                 && self.is_strict_union_member_subset(expr_display_type, declared_type);
             !(expr_is_assignability_narrower || expr_is_union_subset_narrower)

--- a/crates/tsz-checker/src/error_reporter/property_receiver_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/property_receiver_formatting.rs
@@ -69,8 +69,12 @@ impl<'a> CheckerState<'a> {
         if matches!(declared_element_type, TypeId::ERROR | TypeId::UNKNOWN) {
             return None;
         }
-        if !self.diagnostic_relation_boolean_guard(type_id, declared_element_type)
-            && !self.diagnostic_relation_boolean_guard(declared_element_type, type_id)
+        if !self
+            .assign_relation_outcome(type_id, declared_element_type)
+            .related
+            && !self
+                .assign_relation_outcome(declared_element_type, type_id)
+                .related
         {
             return None;
         }
@@ -124,8 +128,12 @@ impl<'a> CheckerState<'a> {
         if matches!(index_value_type, TypeId::ERROR | TypeId::UNKNOWN) {
             return None;
         }
-        if !self.diagnostic_relation_boolean_guard(actual_type, index_value_type)
-            && !self.diagnostic_relation_boolean_guard(index_value_type, actual_type)
+        if !self
+            .assign_relation_outcome(actual_type, index_value_type)
+            .related
+            && !self
+                .assign_relation_outcome(index_value_type, actual_type)
+                .related
         {
             return None;
         }

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -173,7 +173,9 @@ impl<'a> CheckerState<'a> {
             .iter()
             .zip(inner_target.params.iter())
             .any(|(source_param, target_param)| {
-                !self.diagnostic_relation_boolean_guard(target_param.type_id, source_param.type_id)
+                !self
+                    .assign_relation_outcome(target_param.type_id, source_param.type_id)
+                    .related
             })
     }
 

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -103,6 +103,9 @@ mod assertion_overlap_object_primitive_tests;
 #[path = "../tests/assertion_overlap_template_literal_tests.rs"]
 mod assertion_overlap_template_literal_tests;
 #[cfg(test)]
+#[path = "tests/assignability_reporter_relation_routing_arch_tests.rs"]
+mod assignability_reporter_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/async_imported_promise_tests.rs"]
 mod async_imported_promise_tests;
 #[cfg(test)]
@@ -439,6 +442,9 @@ mod architecture_contract_tests;
 #[path = "tests/architecture_contract_tests.rs"]
 mod architecture_contract_tests_src;
 #[cfg(test)]
+#[path = "tests/array_elaboration_relation_routing_arch_tests.rs"]
+mod array_elaboration_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/array_isarray_mutual_subtype_narrowing_tests.rs"]
 mod array_isarray_mutual_subtype_narrowing_tests;
 #[cfg(test)]
@@ -460,8 +466,23 @@ mod builtin_iterator_implements_tests;
 #[path = "tests/call_architecture_tests.rs"]
 mod call_architecture_tests;
 #[cfg(test)]
+#[path = "tests/call_checker_diagnostic_relation_routing_arch_tests.rs"]
+mod call_checker_diagnostic_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/call_context_relation_routing_arch_tests.rs"]
 mod call_context_relation_routing_arch_tests;
+#[cfg(test)]
+#[path = "tests/call_display_format_relation_routing_arch_tests.rs"]
+mod call_display_format_relation_routing_arch_tests;
+#[cfg(test)]
+#[path = "tests/call_elaboration_mutual_relation_routing_arch_tests.rs"]
+mod call_elaboration_mutual_relation_routing_arch_tests;
+#[cfg(test)]
+#[path = "tests/call_error_anchor_relation_routing_arch_tests.rs"]
+mod call_error_anchor_relation_routing_arch_tests;
+#[cfg(test)]
+#[path = "tests/call_result_relation_routing_arch_tests.rs"]
+mod call_result_relation_routing_arch_tests;
 #[cfg(test)]
 #[path = "tests/call_spread_constructor_parameters_tests.rs"]
 mod call_spread_constructor_parameters_tests;
@@ -511,6 +532,9 @@ mod conditional_never_param_inference_tests;
 #[path = "tests/const_asserted_return_type_tests.rs"]
 mod const_asserted_return_type_tests;
 #[cfg(test)]
+#[path = "tests/contextual_new_relation_routing_arch_tests.rs"]
+mod contextual_new_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/contextual_return_wrapper_tests.rs"]
 mod contextual_return_wrapper_tests;
 #[cfg(test)]
@@ -528,6 +552,9 @@ mod destructured_discriminant_source_narrowing_tests;
 #[cfg(test)]
 #[path = "tests/destructuring_relation_routing_arch_tests.rs"]
 mod destructuring_relation_routing_arch_tests;
+#[cfg(test)]
+#[path = "tests/diagnostic_source_relation_routing_arch_tests.rs"]
+mod diagnostic_source_relation_routing_arch_tests;
 #[cfg(test)]
 #[path = "tests/direct_generic_return_tests.rs"]
 mod direct_generic_return_tests;
@@ -760,6 +787,9 @@ mod optional_key_extraction_tests;
 #[path = "tests/overload_anchor_at_argument_tests.rs"]
 mod overload_anchor_at_argument_tests;
 #[cfg(test)]
+#[path = "tests/overload_param_relation_routing_arch_tests.rs"]
+mod overload_param_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/partial_pick_indexed_access_write_tests.rs"]
 mod partial_pick_indexed_access_write_tests;
 #[cfg(test)]
@@ -772,8 +802,14 @@ mod private_brands;
 #[path = "tests/promise_like_infer_tests.rs"]
 mod promise_like_infer_tests;
 #[cfg(test)]
+#[path = "tests/promise_this_relation_routing_arch_tests.rs"]
+mod promise_this_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/property_alias_display_tests.rs"]
 mod property_alias_display_tests;
+#[cfg(test)]
+#[path = "tests/property_receiver_relation_routing_arch_tests.rs"]
+mod property_receiver_relation_routing_arch_tests;
 #[cfg(test)]
 #[path = "../tests/recursive_alias_application_target_display_tests.rs"]
 mod recursive_alias_application_target_display_tests;
@@ -790,8 +826,17 @@ mod recursive_path_default_type_param_tests;
 #[path = "tests/relation_flags_boundary_contract_tests.rs"]
 mod relation_flags_boundary_contract_tests;
 #[cfg(test)]
+#[path = "tests/remapped_missing_property_relation_routing_arch_tests.rs"]
+mod remapped_missing_property_relation_routing_arch_tests;
+#[cfg(test)]
+#[path = "tests/render_failure_relation_routing_arch_tests.rs"]
+mod render_failure_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/repro_parserreal.rs"]
 mod repro_parserreal;
+#[cfg(test)]
+#[path = "tests/rest_parameter_relation_routing_arch_tests.rs"]
+mod rest_parameter_relation_routing_arch_tests;
 #[cfg(test)]
 #[path = "tests/return_context_promise_identity_tests.rs"]
 mod return_context_promise_identity_tests;

--- a/crates/tsz-checker/src/state/state_checking_members/overload_compatibility.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/overload_compatibility.rs
@@ -901,7 +901,8 @@ impl<'a> CheckerState<'a> {
                     self.replace_return_type(impl_stripped, tsz_solver::TypeId::ANY);
                 let overload_with_any_ret =
                     self.replace_return_type(overload_stripped, tsz_solver::TypeId::ANY);
-                self.diagnostic_relation_boolean_guard(impl_with_any_ret, overload_with_any_ret)
+                self.assign_relation_outcome(impl_with_any_ret, overload_with_any_ret)
+                    .related
             }
             _ => {
                 // If we can't get return types, fall back to bivariant assignability

--- a/crates/tsz-checker/src/tests/array_elaboration_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/array_elaboration_relation_routing_arch_tests.rs
@@ -1,0 +1,29 @@
+use std::fs;
+
+#[test]
+fn array_elaboration_element_probe_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/error_reporter/call_errors/elaboration_array_mismatch.rs")
+        .expect("failed to read elaboration_array_mismatch.rs");
+    let start = source
+        .find("SubtypeFailureReason::ArrayElementMismatch")
+        .expect("missing array element mismatch branch");
+    let end = start
+        + source[start..]
+            .find("            _ => false,")
+            .expect("missing end of array element mismatch branch");
+    let branch = &source[start..end];
+
+    assert_eq!(
+        branch.matches("assign_relation_outcome(").count(),
+        1,
+        "array element elaboration should route the element relation through assign_relation_outcome"
+    );
+    assert!(
+        branch.contains(".related"),
+        "array element elaboration should use the shared relation outcome decision"
+    );
+    assert!(
+        !branch.contains("diagnostic_relation_boolean_guard("),
+        "array element elaboration should not regress to the raw boolean relation guard"
+    );
+}

--- a/crates/tsz-checker/src/tests/assignability_reporter_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/assignability_reporter_relation_routing_arch_tests.rs
@@ -1,0 +1,55 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn assignability_reporter_relation_probes_use_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("src/error_reporter/assignability.rs"),
+    )
+    .expect("failed to read assignability.rs");
+
+    let missing_property_helper = source
+        .split("fn missing_property_is_satisfied_by_source")
+        .nth(1)
+        .and_then(|tail| {
+            tail.split("fn should_suppress_outer_callback_return_assignability")
+                .next()
+        })
+        .expect("failed to isolate missing-property satisfaction helper");
+    assert!(
+        missing_property_helper
+            .contains("assign_relation_outcome(source_prop.type_id, target_prop.type_id)"),
+        "missing-property read compatibility should route through assign_relation_outcome"
+    );
+    assert!(
+        missing_property_helper
+            .contains("assign_relation_outcome(target_prop.write_type, source_prop.write_type)"),
+        "missing-property write compatibility should route through assign_relation_outcome"
+    );
+    assert!(
+        !missing_property_helper.contains("diagnostic_relation_boolean_guard(source_prop.type_id"),
+        "missing-property read compatibility should not use the raw diagnostic boolean guard"
+    );
+    assert!(
+        !missing_property_helper
+            .contains("diagnostic_relation_boolean_guard(target_prop.write_type"),
+        "missing-property write compatibility should not use the raw diagnostic boolean guard"
+    );
+
+    let exact_optional_helper = source
+        .split("fn exact_optional_source_for_message")
+        .nth(1)
+        .and_then(|tail| {
+            tail.split("fn format_exact_optional_target_type_for_message")
+                .next()
+        })
+        .expect("failed to isolate exact optional display helper");
+    assert!(
+        exact_optional_helper.contains("assign_relation_outcome(m, target_eval).related"),
+        "exact optional mismatch filtering should route through assign_relation_outcome"
+    );
+    assert!(
+        !exact_optional_helper.contains("diagnostic_relation_boolean_guard(m, target_eval)"),
+        "exact optional mismatch filtering should not use the raw diagnostic boolean guard"
+    );
+}

--- a/crates/tsz-checker/src/tests/call_checker_diagnostic_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/call_checker_diagnostic_relation_routing_arch_tests.rs
@@ -1,0 +1,35 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn call_checker_generator_recovery_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("src/checkers/call_checker/diagnostics.rs"),
+    )
+    .expect("failed to read call checker diagnostics");
+
+    let recovery_block = source
+        .split("let is_generator_callback = func.asterisk_token;")
+        .nth(1)
+        .and_then(|tail| tail.split("let should_force_argument_mismatch").next())
+        .expect("failed to isolate generator recovery diagnostics block");
+    let compact_recovery_block: String = recovery_block.split_whitespace().collect();
+
+    for relation in [
+        "assign_relation_outcome(actual_yield,expected_yield)",
+        "assign_relation_outcome(expected_yield,actual_yield)",
+        "assign_relation_outcome(actual_gen_return,expected_gen_return,)",
+        "assign_relation_outcome(expected_gen_return,actual_gen_return,)",
+        "assign_relation_outcome(expected_next,actual_next)",
+        "assign_relation_outcome(actual_return,expected_return)",
+    ] {
+        assert!(
+            compact_recovery_block.contains(relation),
+            "generator recovery diagnostics should route {relation} through assign_relation_outcome"
+        );
+    }
+    assert!(
+        !recovery_block.contains("diagnostic_relation_boolean_guard("),
+        "generator recovery diagnostics should not use raw diagnostic boolean relation probes"
+    );
+}

--- a/crates/tsz-checker/src/tests/call_display_format_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/call_display_format_relation_routing_arch_tests.rs
@@ -1,0 +1,26 @@
+use std::fs;
+
+#[test]
+fn call_display_overlap_uses_relation_outcome_boundary() {
+    let source =
+        fs::read_to_string("src/error_reporter/call_errors/display_formatting_parameters.rs")
+            .expect("failed to read display_formatting_parameters.rs");
+    let start = source
+        .find("fn types_overlap_for_diagnostic_display")
+        .expect("missing display overlap helper");
+    let helper = &source[start..];
+
+    assert_eq!(
+        helper.matches("assign_relation_outcome(").count(),
+        2,
+        "display overlap helper should route both relation directions through assign_relation_outcome"
+    );
+    assert!(
+        helper.matches(".related").count() >= 2,
+        "display overlap helper should use relation outcome decisions"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard("),
+        "display overlap helper should not regress to raw boolean relation guards"
+    );
+}

--- a/crates/tsz-checker/src/tests/call_elaboration_mutual_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/call_elaboration_mutual_relation_routing_arch_tests.rs
@@ -1,0 +1,29 @@
+use std::fs;
+
+#[test]
+fn call_elaboration_mutual_assignability_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/error_reporter/call_errors/elaboration.rs")
+        .expect("failed to read elaboration.rs");
+    let start = source
+        .find("fn types_are_mutually_assignable")
+        .expect("missing mutual assignability helper");
+    let end = start
+        + source[start..]
+            .find("pub(in crate::error_reporter::call_errors) fn contextual_constraint_parameter_display")
+            .expect("missing next call elaboration helper");
+    let helper = &source[start..end];
+
+    assert_eq!(
+        helper.matches("assign_relation_outcome(").count(),
+        2,
+        "mutual assignability display helper should route both relation directions through assign_relation_outcome"
+    );
+    assert!(
+        helper.matches(".related").count() >= 2,
+        "mutual assignability display helper should use relation outcome decisions"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard("),
+        "mutual assignability display helper should not regress to raw boolean relation guards"
+    );
+}

--- a/crates/tsz-checker/src/tests/call_error_anchor_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/call_error_anchor_relation_routing_arch_tests.rs
@@ -1,0 +1,33 @@
+use std::fs;
+
+#[test]
+fn call_error_anchor_mismatch_probes_use_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/error_reporter/call_errors_anchors.rs")
+        .expect("failed to read call_errors_anchors.rs");
+
+    assert_eq!(
+        source.matches("assign_relation_outcome(").count(),
+        4,
+        "call error anchoring should route mismatch probes through assign_relation_outcome"
+    );
+    assert_eq!(
+        source.matches("diagnostic_relation_boolean_guard(").count(),
+        0,
+        "call error anchoring should not regress to the raw boolean relation guard"
+    );
+    assert!(
+        source.contains(".assign_relation_outcome(arg_type, expected_type)")
+            || source.contains("assign_relation_outcome(arg_type, expected_type)"),
+        "literal argument anchoring should route argument-vs-parameter probes through the boundary"
+    );
+    assert!(
+        source.contains(".assign_relation_outcome(source_prop_type, target_prop_type)")
+            || source.contains("assign_relation_outcome(source_prop_type, target_prop_type)"),
+        "object literal anchoring should route property mismatch probes through the boundary"
+    );
+    assert!(
+        source.contains(".assign_relation_outcome(elem_type, target_element_type)")
+            || source.contains("assign_relation_outcome(elem_type, target_element_type)"),
+        "array literal anchoring should route element mismatch probes through the boundary"
+    );
+}

--- a/crates/tsz-checker/src/tests/call_result_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/call_result_relation_routing_arch_tests.rs
@@ -1,0 +1,43 @@
+use std::fs;
+
+#[test]
+fn call_result_recovery_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/types/computation/call_result.rs")
+        .expect("failed to read call_result.rs");
+
+    let recovery_start = source
+        .find("fn correlated_union_call_recovery_return")
+        .expect("missing correlated_union_call_recovery_return helper");
+    let recovery_end = recovery_start
+        + source[recovery_start..]
+            .find("fn finalize_call_return_like_success")
+            .expect("missing finalize_call_return_like_success helper");
+    let recovery_helper = &source[recovery_start..recovery_end];
+
+    assert!(
+        recovery_helper.contains("assign_relation_outcome(actual, param_union).related"),
+        "correlated union call recovery should route assignability through RelationOutcome.related"
+    );
+    assert!(
+        !recovery_helper.contains("diagnostic_relation_boolean_guard"),
+        "correlated union call recovery should not regress to the raw boolean relation guard"
+    );
+
+    let argument_start = source
+        .find("fn report_polymorphic_this_indexed_conditional_arg")
+        .expect("missing report_polymorphic_this_indexed_conditional_arg helper");
+    let argument_end = argument_start
+        + source[argument_start..]
+            .find("fn error_argument_not_assignable_preserving_param_display")
+            .expect("missing error_argument_not_assignable_preserving_param_display helper");
+    let argument_helper = &source[argument_start..argument_end];
+
+    assert!(
+        argument_helper.contains("assign_relation_outcome(arg_types[2], target).related"),
+        "polymorphic-this argument diagnostics should route assignability through RelationOutcome.related"
+    );
+    assert!(
+        !argument_helper.contains("diagnostic_relation_boolean_guard"),
+        "polymorphic-this argument diagnostics should not regress to the raw boolean relation guard"
+    );
+}

--- a/crates/tsz-checker/src/tests/contextual_new_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/contextual_new_relation_routing_arch_tests.rs
@@ -1,0 +1,32 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn contextual_new_argument_recovery_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/types/computation/complex_contextual_new.rs"),
+    )
+    .expect("failed to read complex_contextual_new.rs");
+
+    let function_start = source
+        .find("fn generic_new_argument_accepts_contextual_parameter")
+        .expect("find contextual new argument helper");
+    let function_end = function_start
+        + source[function_start..]
+            .find(
+                "pub(crate) fn recover_new_expression_return_type_after_contextual_argument_match",
+            )
+            .expect("find end of contextual new argument helper");
+    let helper = &source[function_start..function_end];
+    let compact_helper: String = helper.chars().filter(|ch| !ch.is_whitespace()).collect();
+
+    assert!(
+        compact_helper.contains("assign_relation_outcome(contextual_actual,expected).related"),
+        "contextual new argument recovery should route compatibility through relation outcome"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard"),
+        "contextual new argument recovery should not use a raw boolean relation guard"
+    );
+}

--- a/crates/tsz-checker/src/tests/diagnostic_source_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/diagnostic_source_relation_routing_arch_tests.rs
@@ -1,0 +1,29 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn diagnostic_source_display_narrowing_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("src/error_reporter/core/diagnostic_source.rs"),
+    )
+    .expect("failed to read diagnostic_source.rs");
+
+    let narrowing_block = source
+        .split("let expr_is_assignability_narrower =")
+        .nth(1)
+        .and_then(|tail| tail.split("let expr_is_union_subset_narrower").next())
+        .expect("failed to isolate diagnostic source display narrowing block");
+
+    assert!(
+        narrowing_block.contains("assign_relation_outcome(expr_display_type, declared_type)"),
+        "diagnostic source display narrowing should route expression-to-declared relation through assign_relation_outcome"
+    );
+    assert!(
+        narrowing_block.contains("assign_relation_outcome(declared_type, expr_display_type)"),
+        "diagnostic source display narrowing should route declared-to-expression relation through assign_relation_outcome"
+    );
+    assert!(
+        !narrowing_block.contains("diagnostic_relation_boolean_guard("),
+        "diagnostic source display narrowing should not use raw diagnostic boolean relation probes"
+    );
+}

--- a/crates/tsz-checker/src/tests/overload_param_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/overload_param_relation_routing_arch_tests.rs
@@ -1,0 +1,20 @@
+use std::{fs, path::PathBuf};
+
+#[test]
+fn overload_parameter_signature_check_uses_relation_outcome_boundary() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src/state/state_checking_members/overload_compatibility.rs");
+    let source = fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+
+    assert!(
+        source.contains("assign_relation_outcome(impl_with_any_ret, overload_with_any_ret)"),
+        "overload parameter-only compatibility should use the shared relation outcome boundary"
+    );
+    assert!(
+        !source.contains(
+            "diagnostic_relation_boolean_guard(impl_with_any_ret, overload_with_any_ret)"
+        ),
+        "overload parameter-only compatibility should not use the legacy boolean guard"
+    );
+}

--- a/crates/tsz-checker/src/tests/promise_this_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/promise_this_relation_routing_arch_tests.rs
@@ -1,0 +1,25 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn await_thenable_this_validation_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("src/checkers/promise_checker.rs"),
+    )
+    .expect("failed to read promise_checker.rs");
+
+    let helper = source
+        .split("fn extract_awaited_type_from_valid_thenable")
+        .nth(1)
+        .and_then(|rest| rest.split("let awaited_type =").next())
+        .expect("failed to isolate thenable await helper");
+
+    assert!(
+        helper.contains("assign_relation_outcome(type_id, expected_this).related"),
+        "await thenable this-type validation should route through assign_relation_outcome"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard(type_id, expected_this)"),
+        "await thenable this-type validation should not use the raw boolean relation guard"
+    );
+}

--- a/crates/tsz-checker/src/tests/property_receiver_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/property_receiver_relation_routing_arch_tests.rs
@@ -1,0 +1,29 @@
+use std::fs;
+
+#[test]
+fn property_receiver_display_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/error_reporter/property_receiver_formatting.rs")
+        .expect("failed to read property receiver formatting source");
+    let start = source
+        .find("pub(crate) fn element_access_receiver_declared_element_display")
+        .expect("missing declared element display helper");
+    let end = source[start..]
+        .find("fn element_access_argument_prefers_number_index")
+        .expect("missing element access argument helper")
+        + start;
+    let helpers = &source[start..end];
+
+    assert_eq!(
+        helpers.matches("assign_relation_outcome").count(),
+        4,
+        "property receiver display relation checks should route through assign_relation_outcome"
+    );
+    assert!(
+        helpers.contains(".related"),
+        "property receiver display relation checks should use the relation outcome decision"
+    );
+    assert!(
+        !helpers.contains("diagnostic_relation_boolean_guard"),
+        "property receiver display should not regress to the raw boolean relation guard"
+    );
+}

--- a/crates/tsz-checker/src/tests/remapped_missing_property_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/remapped_missing_property_relation_routing_arch_tests.rs
@@ -1,0 +1,28 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn remapped_missing_property_skip_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("src/error_reporter/assignability_helpers.rs"),
+    )
+    .expect("failed to read assignability_helpers.rs");
+
+    let helper = source
+        .split("pub(crate) fn try_report_concrete_remapped_mapped_missing_property")
+        .nth(1)
+        .and_then(|rest| {
+            rest.split("fn report_concrete_remapped_mapped_missing_property")
+                .next()
+        })
+        .expect("failed to isolate remapped missing-property helper");
+
+    assert!(
+        helper.contains("assign_relation_outcome(evaluated, target).related"),
+        "remapped missing-property diagnostic skip should route through assign_relation_outcome"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard(evaluated, target)"),
+        "remapped missing-property diagnostic skip should not use the raw boolean relation guard"
+    );
+}

--- a/crates/tsz-checker/src/tests/render_failure_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/render_failure_relation_routing_arch_tests.rs
@@ -1,0 +1,29 @@
+use std::fs;
+
+#[test]
+fn strict_callback_inner_parameter_mismatch_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/error_reporter/render_failure.rs")
+        .expect("failed to read render failure source");
+    let start = source
+        .find("fn strict_callback_inner_parameter_mismatch_exists")
+        .expect("missing strict callback inner parameter mismatch helper");
+    let end = source[start..]
+        .find("fn no_union_member_matches_switch_source_display")
+        .expect("missing next render failure helper")
+        + start;
+    let helper = &source[start..end];
+
+    assert_eq!(
+        helper.matches("assign_relation_outcome").count(),
+        1,
+        "strict callback inner parameter mismatch should route through assign_relation_outcome"
+    );
+    assert!(
+        helper.contains(".related"),
+        "strict callback inner parameter mismatch should use the relation outcome decision"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard"),
+        "strict callback inner parameter mismatch should not regress to the raw boolean relation guard"
+    );
+}

--- a/crates/tsz-checker/src/tests/rest_parameter_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/rest_parameter_relation_routing_arch_tests.rs
@@ -1,0 +1,41 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn rest_parameter_array_diagnostics_use_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("src/checkers/parameter_checker.rs"),
+    )
+    .expect("failed to read parameter_checker.rs");
+
+    let function_start = source
+        .find("fn check_rest_parameter_types")
+        .expect("find rest parameter validation helper");
+    let function_end = function_start
+        + source[function_start..]
+            .find(
+                "// =============================================================================",
+            )
+            .expect("find end of rest parameter validation helper");
+    let helper = &source[function_start..function_end];
+    let compact_helper: String = helper.chars().filter(|ch| !ch.is_whitespace()).collect();
+
+    assert!(
+        compact_helper
+            .contains("assign_relation_outcome(declared_type,readonly_any_array).related"),
+        "rest parameter declared type should route array compatibility through relation outcome"
+    );
+    assert!(
+        compact_helper
+            .contains("assign_relation_outcome(array_check_type,readonly_any_array).related"),
+        "rest parameter resolved type should route array compatibility through relation outcome"
+    );
+    assert!(
+        compact_helper.contains("assign_relation_outcome(init_type,readonly_any_array).related"),
+        "rest parameter initializer type should route array compatibility through relation outcome"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard"),
+        "TS2370 rest parameter array diagnostics should not use raw boolean relation guards"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -57,7 +57,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let param_union = self.ctx.types.factory().union(param_types);
-        if !self.diagnostic_relation_boolean_guard(actual, param_union) {
+        if !self.assign_relation_outcome(actual, param_union).related {
             return None;
         }
 
@@ -220,7 +220,7 @@ impl<'a> CheckerState<'a> {
         else {
             return false;
         };
-        if self.diagnostic_relation_boolean_guard(arg_types[2], target) {
+        if self.assign_relation_outcome(arg_types[2], target).related {
             return false;
         }
         self.error_argument_not_assignable_preserving_param_display(arg_types[2], target, args[2]);

--- a/crates/tsz-checker/src/types/computation/complex_contextual_new.rs
+++ b/crates/tsz-checker/src/types/computation/complex_contextual_new.rs
@@ -29,7 +29,9 @@ impl<'a> CheckerState<'a> {
 
         contextual_actual != TypeId::ANY
             && contextual_actual != TypeId::ERROR
-            && self.diagnostic_relation_boolean_guard(contextual_actual, expected)
+            && self
+                .assign_relation_outcome(contextual_actual, expected)
+                .related
     }
 
     pub(crate) fn recover_new_expression_return_type_after_contextual_argument_match(


### PR DESCRIPTION
## Agent
AgentName: M1-B
Owner label: agent:M1-B
Bundling coordinator: Studio-F

## Track
Checker relation diagnostics / query-boundary routing refactor bundle.

## Invariant
When call, parameter, promise, and diagnostic reporter helpers need relation truth for existing checker-owned diagnostic decisions, relation truth flows through `assign_relation_outcome(...).related` while diagnostic anchoring, elaboration, suppression, rendering, and checker orchestration stay behavior-preserving.

## Scope
- Bundle successor for the call/reporting half of the non-JSX M1-B relation-routing draft PR drain.
- Routes existing relation probes in call checker diagnostics, call result recovery, overload/rest/contextual-new checks, promise `this` validation, assignment reporter helpers, call error anchoring/elaboration/display, property receiver formatting, render failure callback handling, remapped missing-property display, and diagnostic source narrowing.
- Adds focused architecture tests for each routed helper and registers them in `crates/tsz-checker/src/lib.rs`.

## Bundled PRs
- #10413 rest parameter array relation
- #10415 contextual new relation outcome
- #10417 call result relation outcome
- #10423 overload parameter relation
- #10435 property receiver display relations
- #10436 render failure callback relations
- #10439 call error anchor relations
- #10441 array elaboration relation
- #10444 call elaboration mutual relation
- #10445 call display overlap relation
- #10450 remapped missing property relation
- #10453 promise this relation
- #10470 assignability reporter relations
- #10472 call checker diagnostic relations
- #10473 diagnostic source display relations

## Superseded PRs
- #10413
- #10415
- #10417
- #10423
- #10435
- #10436
- #10439
- #10441
- #10444
- #10445
- #10450
- #10453
- #10470
- #10473

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation-routing tech debt for diagnostic/reporting helpers
- Evidence: behavior-preserving boundary routing only; no solver policy, variance, any-propagation, diagnostic rendering text, or cache-key change intended. Local architecture tests assert these paths use `assign_relation_outcome` instead of raw diagnostic boolean probes.

## Verification
- `cargo fmt --check`
- `git diff --cached --check`
- `cargo nextest run -p tsz-checker --lib -E 'test(/relation_outcome_boundary/)'` -> 39 passed, 5203 skipped
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Rebuilt from current `origin/main` at `0c8d8106fa`.
- Successor branch: `codex/m1b-property-error-index-relations-20260527`
- Successor head: `98a8b84b58c6e4afb8968fe4c2c82ac13e6c9ced`
- Cherry-picked selected heads with `--no-commit` and resolved only test registration conflicts in `crates/tsz-checker/src/lib.rs` by keeping the compatible union.
- Kept this PR draft; do not merge until the M1-B owner/maintainer marks it ready after any desired CI follow-up.

