### PR TITLE
refactor(checker): route diagnostic source display relations

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -1585,8 +1585,12 @@ impl<'a> CheckerState<'a> {
             // eliminated declared union members; the subset check handles
             // surviving members structurally compatible with eliminated ones.
             let expr_is_assignability_narrower = expr_display_type != declared_type
-                && self.diagnostic_relation_boolean_guard(expr_display_type, declared_type)
-                && !self.diagnostic_relation_boolean_guard(declared_type, expr_display_type);
+                && self
+                    .assign_relation_outcome(expr_display_type, declared_type)
+                    .related
+                && !self
+                    .assign_relation_outcome(declared_type, expr_display_type)
+                    .related;
             let expr_is_union_subset_narrower = expr_display_type != declared_type
                 && self.is_strict_union_member_subset(expr_display_type, declared_type);
             !(expr_is_assignability_narrower || expr_is_union_subset_narrower)

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -529,6 +529,9 @@ mod destructured_discriminant_source_narrowing_tests;
 #[path = "tests/destructuring_relation_routing_arch_tests.rs"]
 mod destructuring_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/diagnostic_source_relation_routing_arch_tests.rs"]
+mod diagnostic_source_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/direct_generic_return_tests.rs"]
 mod direct_generic_return_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/diagnostic_source_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/diagnostic_source_relation_routing_arch_tests.rs
@@ -1,0 +1,29 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn diagnostic_source_display_narrowing_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("src/error_reporter/core/diagnostic_source.rs"),
+    )
+    .expect("failed to read diagnostic_source.rs");
+
+    let narrowing_block = source
+        .split("let expr_is_assignability_narrower =")
+        .nth(1)
+        .and_then(|tail| tail.split("let expr_is_union_subset_narrower").next())
+        .expect("failed to isolate diagnostic source display narrowing block");
+
+    assert!(
+        narrowing_block.contains("assign_relation_outcome(expr_display_type, declared_type)"),
+        "diagnostic source display narrowing should route expression-to-declared relation through assign_relation_outcome"
+    );
+    assert!(
+        narrowing_block.contains("assign_relation_outcome(declared_type, expr_display_type)"),
+        "diagnostic source display narrowing should route declared-to-expression relation through assign_relation_outcome"
+    );
+    assert!(
+        !narrowing_block.contains("diagnostic_relation_boolean_guard("),
+        "diagnostic source display narrowing should not use raw diagnostic boolean relation probes"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker relation diagnostics / query-boundary routing refactor.

## Invariant
When diagnostic source display decides whether a flow-narrowed expression is strictly narrower than its declaration, checker still owns the display-selection decision while the bidirectional relation truth flows through the shared assignability outcome boundary.

## Scope
- `crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs`
- `crates/tsz-checker/src/tests/diagnostic_source_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation-routing tech debt for diagnostic source display
- Evidence: behavior-preserving boundary routing only; no solver policy, variance, any-propagation, diagnostic rendering, or cache-key changes. Local architecture test verifies this display-narrowing block uses `assign_relation_outcome(...).related` instead of raw diagnostic boolean relation probes.

## Verification
- `git fetch origin main`
- `git rebase origin/main` -> clean rebase
- `git rev-list --left-right --count HEAD...origin/main` -> `1 0`
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `cargo nextest run -p tsz-checker --lib diagnostic_source_display_narrowing_uses_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Draft PR for light CI.
- Open PR file-overlap check found no open PR touching `crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs` before publishing.
- This slice only routes existing standard assignability probes in the diagnostic source display-narrowing block; checker display selection remains unchanged.
