### PR TITLE
fix(solver): allow fixed tuple numeric props for array interfaces

### DIFF
--- a/crates/tsz-checker/tests/interface_extends_array_json_tests.rs
+++ b/crates/tsz-checker/tests/interface_extends_array_json_tests.rs
@@ -524,3 +524,55 @@ const arr2: JSONValue = [1, 2, 3];
         "Expected array literals to be assignable to JSONValue with website libs. Got: {diags:#?}"
     );
 }
+
+/// A fixed tuple with a known numeric slot satisfies an interface that extends
+/// `Array<T>` and declares the same numeric property. A plain array cannot
+/// prove that the property is present, so the tuple facts must be preserved.
+#[test]
+fn fixed_tuple_satisfies_numeric_property_on_array_interface() {
+    let source = r#"
+interface IndexedNumbers extends Array<Number> {
+  2: number;
+}
+
+function ok(): IndexedNumbers {
+  return <[number, number, number]>[1, 2, 3];
+}
+
+function renamed(): IndexedNumbers {
+  return <[number, number, number]>[4, 5, 6];
+}
+"#;
+    let diags = check(source);
+    let errors = ts2322(&diags);
+    assert!(
+        errors.is_empty(),
+        "Expected fixed tuple numeric property to satisfy Array interface target. Got: {diags:#?}"
+    );
+}
+
+/// The fixed-tuple rule must not make open arrays or shorter tuples satisfy a
+/// required numeric property they cannot prove is present.
+#[test]
+fn array_interface_numeric_property_still_requires_known_tuple_slot() {
+    let source = r#"
+interface IndexedNumbers extends Array<Number> {
+  2: number;
+}
+
+function arraySource(xs: number[]): IndexedNumbers {
+  return xs;
+}
+
+function shortTuple(): IndexedNumbers {
+  return <[number, number]>[1, 2];
+}
+"#;
+    let diags = check(source);
+    let errors = ts2322(&diags);
+    assert_eq!(
+        errors.len(),
+        2,
+        "Expected TS2322 for both plain array and short tuple sources. Got: {diags:#?}"
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -2518,6 +2518,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     return SubtypeResult::True;
                 }
                 // Target has non-empty properties + index signature.
+                if let Some(result) =
+                    self.check_tuple_numeric_props_array_interface_subtype(source, target)
+                {
+                    return result;
+                }
                 // Try the Array<T> interface for full structural comparison.
                 if let Some(elem) = array_element_type(self.interner, source).or_else(|| {
                     crate::type_queries::get_tuple_element_type_union(self.interner, source)

--- a/crates/tsz-solver/src/relations/subtype/rules/tuples.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/tuples.rs
@@ -9,7 +9,7 @@
 
 use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::operations::iterators::get_iterator_info;
-use crate::types::{TupleElement, TupleListId, TypeData, TypeId};
+use crate::types::{PropertyInfo, TupleElement, TupleListId, TypeData, TypeId};
 use crate::utils::{self, TupleRestExpansion};
 use crate::visitor::{
     array_element_type, is_type_parameter, object_shape_id, object_with_index_shape_id,
@@ -493,6 +493,108 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         }
 
         Some(direct)
+    }
+
+    /// Check a fixed tuple against an indexed target whose array surface is
+    /// otherwise satisfiable, but which also declares required numeric members.
+    ///
+    /// Plain arrays cannot prove that an arbitrary numeric property is present.
+    /// Fixed tuples can prove that for in-bounds fixed slots, so
+    /// `[number, number, number]` satisfies `interface I extends Array<Number>
+    /// { 2: number }` while `number[]` and `[number, number]` do not.
+    pub(crate) fn check_tuple_numeric_props_array_interface_subtype(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> Option<SubtypeResult> {
+        let tuple_id = tuple_list_id(self.interner, source)?;
+        let elements = self.interner.tuple_list(tuple_id).to_vec();
+        let element_type =
+            crate::type_queries::get_tuple_element_type_union(self.interner, source)?;
+
+        let target_shape_id = object_with_index_shape_id(self.interner, target)?;
+        let target_shape = self.interner.object_shape(target_shape_id);
+        let target_props = target_shape.properties.clone();
+        let target_number_index = target_shape.number_index;
+        let target_string_index = target_shape.string_index;
+
+        let array_base = self.resolver.get_array_base_type()?;
+        let params = self.resolver.get_array_base_type_params();
+        let instantiated_array = if params.is_empty() {
+            array_base
+        } else {
+            let subst = TypeSubstitution::from_args(self.interner, params, &[element_type]);
+            instantiate_type(self.interner, array_base, &subst)
+        };
+        let source_array_eval = self.evaluate_type(instantiated_array);
+        let source_shape_id = object_shape_id(self.interner, source_array_eval)
+            .or_else(|| object_with_index_shape_id(self.interner, source_array_eval))?;
+        let source_props = self
+            .interner
+            .object_shape(source_shape_id)
+            .properties
+            .clone();
+
+        let mut used_tuple_numeric_property = false;
+        for target_prop in target_props.iter().filter(|prop| !prop.optional) {
+            if self.array_property_satisfies(&source_props, target_prop) {
+                continue;
+            }
+
+            match self.tuple_numeric_property_satisfies(&elements, target_prop) {
+                Some(true) => used_tuple_numeric_property = true,
+                Some(false) => return Some(SubtypeResult::False),
+                None => return None,
+            }
+        }
+
+        if !used_tuple_numeric_property {
+            return None;
+        }
+
+        if target_string_index.is_some() {
+            return Some(SubtypeResult::False);
+        }
+
+        if let Some(number_index) = target_number_index
+            && !self
+                .check_subtype(element_type, number_index.value_type)
+                .is_true()
+        {
+            return Some(SubtypeResult::False);
+        }
+
+        Some(SubtypeResult::True)
+    }
+
+    fn array_property_satisfies(
+        &mut self,
+        source_props: &[PropertyInfo],
+        target_prop: &PropertyInfo,
+    ) -> bool {
+        let Ok(index) = source_props.binary_search_by_key(&target_prop.name, |prop| prop.name)
+        else {
+            return false;
+        };
+        self.check_subtype(source_props[index].type_id, target_prop.type_id)
+            .is_true()
+    }
+
+    fn tuple_numeric_property_satisfies(
+        &mut self,
+        elements: &[TupleElement],
+        target_prop: &PropertyInfo,
+    ) -> Option<bool> {
+        let name = self.interner.resolve_atom(target_prop.name);
+        let index = name.parse::<usize>().ok()?;
+        let element = elements.get(index)?;
+        if element.rest {
+            return Some(false);
+        }
+        Some(
+            self.check_subtype(element.type_id, target_prop.type_id)
+                .is_true(),
+        )
     }
 
     pub(crate) fn recursive_array_alias_element_matches_array_interface(


### PR DESCRIPTION
## Agent
AgentName: M1-C
Runner: claude-sonnet-4-6

## Track
Track 8: Diagnostics, Display, Parser Options, And Feature Gates — accepted-regression burn-down through solver relation parity.

## Invariant
When a fixed tuple has a known numeric slot, `tsc` allows that slot to satisfy a required numeric property on an interface that extends `Array<T>`; plain arrays and shorter tuples still cannot prove the property exists. This PR makes tsz preserve that fixed-tuple relation fact in the solver tuple/array-interface path.

## Scope
- `crates/tsz-solver/src/relations/subtype/rules/tuples.rs`: add a conservative tuple-to-indexed-array-interface relation helper for required numeric properties.
- `crates/tsz-solver/src/relations/subtype/core.rs`: route tuple sources with non-empty indexed object targets through the helper before the broad Array-interface fallback.
- `crates/tsz-checker/tests/interface_extends_array_json_tests.rs`: add positive fixed-tuple coverage plus negative plain-array and short-tuple coverage.

## Adjacent Case Matrix
- Fixed tuple with slot `2` assigned to `interface IndexedNumbers extends Array<Number> { 2: number }` succeeds.
- Same structural target with a renamed function/source expression still succeeds, proving the rule is not alias-name-based.
- Plain `number[]` assigned to the target still fails because it cannot prove property `2` is present.
- Short `[number, number]` assigned to the target still fails because slot `2` is absent.
- Existing recursive JSON `interface JSONArray extends Array<JSONValue>` tests still pass.

## Project Corpus Impact
- Row: n/a
- Bug family: accepted-regression fingerprint-only / tuple-to-array-interface relation false positive
- Evidence: fixes focused conformance witness `TypeScript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts`; no project corpus row is directly affected.

## Verification
- `git fetch origin main && git rebase origin/main`
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `python3 scripts/arch/arch_guard.py`
- `cargo nextest run -p tsz-checker --lib fixed_tuple_satisfies_numeric_property_on_array_interface array_interface_numeric_property_still_requires_known_tuple_slot` -> 2 passed before final module run
- `cargo nextest run -p tsz-checker --lib interface_extends_array_json_tests` -> 15 passed
- `scripts/safe-run.sh --limit 50% -- cargo clippy --profile ci-lint -p tsz-solver -p tsz-checker --all-targets -- -D warnings` -> passed after removing copy-option clones
- `scripts/safe-run.sh --limit 50% -- ./scripts/conformance/conformance.sh run --filter "destructuringArrayBindingPatternAndAssignment2" --verbose` -> `FINAL RESULTS: 1/1 passed (100.0%)`, `Fingerprint-only: 0`
- Attempted `cargo nextest run -p tsz-solver --lib -E 'test(file_size_ceiling)'`; it fails on current `origin/main` because `src/evaluation/evaluate_rules/mapped.rs` is 1968 lines while `file_size_baselines.txt` still records 1955. This PR does not touch that file. `relations/subtype/core.rs` remains under its existing 2862-line oversized baseline.
- Draft light CI passed for exact head `2916b847aa6cac3df56f3b144253ea9a59342e0f`: `CI Light Summary`, `lint`, `unit`, `unit-cloudbuild`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, and `GitGuardian Security Checks`.

## Coordination Notes
- AgentName: M1-C
- Fixes #10469 and burns down one accepted-regression path from #10306/#7596 when landed.
- Head `2916b847aa6cac3df56f3b144253ea9a59342e0f` fixed the draft lint failure from `clippy::clone_on_copy`; exact-head draft light CI is green and the PR is ready for heavy CI/manager review.
- While refreshed light CI ran, opened #10480 for the separate `mappedTypeInferenceFromApparentType.ts` accepted-regression witness.
- No `merge-queue` label requested by this implementation lane.
