### PR TITLE
refactor(checker): route union index signature relations

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -865,6 +865,9 @@ mod union_call_resolution_tests;
 #[path = "tests/union_constraint_relation_routing_arch_tests.rs"]
 mod union_constraint_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/union_index_signature_relation_routing_arch_tests.rs"]
+mod union_index_signature_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/union_multi_overload_unified_sig_tests.rs"]
 mod union_multi_overload_unified_sig_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
@@ -55,10 +55,10 @@ impl<'a> CheckerState<'a> {
                         continue;
                     }
                     applicable_index_value_types.push(string_index.value_type);
-                    if self.diagnostic_relation_boolean_guard(
-                        source_prop.type_id,
-                        string_index.value_type,
-                    ) {
+                    if self
+                        .assign_relation_outcome(source_prop.type_id, string_index.value_type)
+                        .related
+                    {
                         accepted_by_index = true;
                         break;
                     }
@@ -70,10 +70,10 @@ impl<'a> CheckerState<'a> {
                         continue;
                     }
                     applicable_index_value_types.push(number_index.value_type);
-                    if self.diagnostic_relation_boolean_guard(
-                        source_prop.type_id,
-                        number_index.value_type,
-                    ) {
+                    if self
+                        .assign_relation_outcome(source_prop.type_id, number_index.value_type)
+                        .related
+                    {
                         accepted_by_index = true;
                         break;
                     }
@@ -99,7 +99,10 @@ impl<'a> CheckerState<'a> {
             ) {
                 continue;
             }
-            if self.diagnostic_relation_boolean_guard(source_prop.type_id, target_value_type) {
+            if self
+                .assign_relation_outcome(source_prop.type_id, target_value_type)
+                .related
+            {
                 continue;
             }
 

--- a/crates/tsz-checker/src/tests/union_index_signature_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/union_index_signature_relation_routing_arch_tests.rs
@@ -1,0 +1,24 @@
+use std::fs;
+
+#[test]
+fn union_index_signature_value_checks_use_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        "src/state/state_checking/property/union_index_signature_diagnostics.rs",
+    )
+    .expect("failed to read union index signature diagnostics source");
+
+    let function_start = source
+        .find("pub(super) fn try_union_index_signature_value_check(")
+        .expect("find union index signature diagnostic helper");
+    let helper = &source[function_start..];
+
+    assert!(
+        helper.matches(".assign_relation_outcome(").count() >= 3
+            && helper.matches(".related").count() >= 3,
+        "union index-signature value diagnostics should route relation truth through relation outcomes"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard("),
+        "union index-signature value diagnostics should not use raw boolean relation guards"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor only: checker relation diagnostic query-boundary routing.

## Invariant
When object-literal union index-signature diagnostics compare a source property value against applicable string/number index value types, the checker still owns source spans and diagnostic emission; this PR routes the assignability truth through `assign_relation_outcome(...).related` instead of raw diagnostic boolean guards.

## Scope
- `crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs`
- `crates/tsz-checker/src/tests/union_index_signature_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only routing change; no solver policy, relation flags, cache keys, diagnostic text, or conformance baselines changed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib union_index_signature_value_checks_use_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `scripts/agents/ensure-agent-labels.sh --audit`
- post-rebase `git rev-list --left-right --count origin/main...HEAD` -> `0 1`

## Coordination Notes
- Fresh worktree branch from `origin/main`: `codex/m1b-union-index-signature-relations-20260527`.
- Exact overlap check for `crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs` returned no open PRs before publishing.
- This slice avoids active M1-B/M4-A generic, JSX, assignability reporter, class, call-error, and indexed-access PR files.
- Draft only; no merge queue or auto-merge requested.
