### PR TITLE
refactor(checker): route display type relation

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics/display_types.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics/display_types.rs
@@ -69,7 +69,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // Check assignability using the actual types (return types)
-        if self.diagnostic_relation_boolean_guard(source, target) {
+        if self.assign_relation_outcome(source, target).related {
             return true;
         }
 

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -103,6 +103,9 @@ mod assertion_overlap_object_primitive_tests;
 #[path = "../tests/assertion_overlap_template_literal_tests.rs"]
 mod assertion_overlap_template_literal_tests;
 #[cfg(test)]
+#[path = "tests/assignability_display_relation_routing_arch_tests.rs"]
+mod assignability_display_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/async_imported_promise_tests.rs"]
 mod async_imported_promise_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/assignability_display_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/assignability_display_relation_routing_arch_tests.rs
@@ -1,0 +1,21 @@
+use std::fs;
+
+#[test]
+fn assignability_display_type_check_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/assignability/assignability_diagnostics/display_types.rs")
+        .expect("failed to read display types source");
+
+    let function_start = source
+        .find("fn check_assignable_or_report_at_with_display_types_and_options(")
+        .expect("find display-type assignability helper");
+    let helper = &source[function_start..];
+
+    assert!(
+        helper.contains("self.assign_relation_outcome(source, target).related"),
+        "display-type assignability relation truth should route through relation outcomes"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard(source, target)"),
+        "display-type assignability should not use the raw boolean relation guard"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor only: checker relation diagnostic query-boundary routing.

## Invariant
When assignability diagnostics compare actual source/target types while rendering alternate display types, the checker still owns diagnostic anchors and display-type rendering; this PR routes the relation truth through `assign_relation_outcome(...).related` instead of the raw boolean diagnostic guard.

## Scope
- `crates/tsz-checker/src/assignability/assignability_diagnostics/display_types.rs`
- `crates/tsz-checker/src/tests/assignability_display_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only routing change; no solver policy, relation flags, cache keys, diagnostic text, or conformance baselines changed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib assignability_display_type_check_uses_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `scripts/agents/ensure-agent-labels.sh --audit`
- post-rebase `git rev-list --left-right --count origin/main...HEAD` -> `0 1`

## Coordination Notes
- Fresh branch from `origin/main`: `codex/m1b-assignability-display-type-relations-20260527`.
- Exact overlap check for `crates/tsz-checker/src/assignability/assignability_diagnostics/display_types.rs` returned no open PRs before publishing.
- This slice intentionally leaves display-specific `SubtypeFailureReason` rendering in the checker; only the relation truth moved to the existing boundary.
- Draft only; no merge queue or auto-merge requested.
