### PR TITLE
refactor(checker): route destructuring default relations

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
@@ -554,10 +554,9 @@ impl<'a> CheckerState<'a> {
                                             || target_type == TypeId::ERROR
                                             || default_type == TypeId::ANY
                                             || default_type == TypeId::ERROR
-                                            || self.diagnostic_relation_boolean_guard(
-                                                default_type,
-                                                target_type,
-                                            );
+                                            || self
+                                                .assign_relation_outcome(default_type, target_type)
+                                                .related;
                                         if default_assignable {
                                             // Default is fine but property type might not be.
                                             self.check_destructuring_leaf_assignability_with_default(
@@ -841,7 +840,9 @@ impl<'a> CheckerState<'a> {
                 .unwrap_or_else(|| self.get_type_of_node(default_expr));
             if default_type != TypeId::ANY
                 && default_type != TypeId::ERROR
-                && !self.diagnostic_relation_boolean_guard(default_type, target_type)
+                && !self
+                    .assign_relation_outcome(default_type, target_type)
+                    .related
             {
                 if self.try_report_object_default_property_mismatch(
                     default_expr,
@@ -923,7 +924,7 @@ impl<'a> CheckerState<'a> {
         // Ensure both types are fully resolved before relation checking.
         self.ensure_relation_input_ready(prop_type);
         self.ensure_relation_input_ready(target_type);
-        if self.diagnostic_relation_boolean_guard(prop_type, target_type) {
+        if self.assign_relation_outcome(prop_type, target_type).related {
             return;
         }
         // Emit TS2322 directly. Format source type from the TypeId rather
@@ -989,7 +990,10 @@ impl<'a> CheckerState<'a> {
             else {
                 continue;
             };
-            if self.diagnostic_relation_boolean_guard(source_type, target_prop_type) {
+            if self
+                .assign_relation_outcome(source_type, target_prop_type)
+                .related
+            {
                 continue;
             }
             let source_for_display = {

--- a/crates/tsz-checker/src/tests/destructuring_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/destructuring_relation_routing_arch_tests.rs
@@ -20,3 +20,28 @@ fn array_destructuring_unchecked_element_uses_relation_diagnostic_helper() {
          a raw diagnostic relation boolean"
     );
 }
+
+#[test]
+fn destructuring_default_checks_use_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/assignability/assignment_checker/destructuring.rs")
+        .expect("failed to read assignment_checker/destructuring.rs");
+    let compact_source: String = source.chars().filter(|c| !c.is_whitespace()).collect();
+
+    assert!(
+        compact_source
+            .matches("assign_relation_outcome(default_type,target_type).related")
+            .count()
+            >= 2
+            && compact_source.contains("assign_relation_outcome(prop_type,target_type).related")
+            && compact_source
+                .contains("assign_relation_outcome(source_type,target_prop_type).related"),
+        "destructuring default/property relation checks should route through relation outcomes"
+    );
+    assert!(
+        !compact_source.contains("diagnostic_relation_boolean_guard(default_type,target_type)")
+            && !compact_source.contains("diagnostic_relation_boolean_guard(prop_type,target_type)")
+            && !compact_source
+                .contains("diagnostic_relation_boolean_guard(source_type,target_prop_type)",),
+        "destructuring default/property relation checks should not use raw boolean guards"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor only: checker relation diagnostic query-boundary routing.

## Invariant
When destructuring default values or effective destructured property types are compared against assignment targets, the checker still owns TS2322 anchors and display formatting; this PR routes relation truth through `assign_relation_outcome(...).related` instead of raw diagnostic boolean guards.

## Scope
- `crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs`
- `crates/tsz-checker/src/tests/destructuring_relation_routing_arch_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only routing change; no solver policy, relation flags, cache keys, diagnostic text, or conformance baselines changed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib destructuring_default_checks_use_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `scripts/agents/ensure-agent-labels.sh --audit`
- post-rebase `git rev-list --left-right --count origin/main...HEAD` -> `0 1`

## Coordination Notes
- Fresh branch from `origin/main`: `codex/m1b-destructuring-default-relations-20260527`.
- Exact overlap check for the touched destructuring implementation/test files returned no open PRs before publishing.
- This slice avoids active bundled call/class/JSX/generic PR files and does not touch solver policy internals.
- Draft only; no merge queue or auto-merge requested.
