### PR TITLE
refactor(checker): structural primitive index-key membership in constraint validation

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
@@ -1384,28 +1384,11 @@ impl<'a> CheckerState<'a> {
                             }
                             // Fall through to perform the constraint check
                         }
-                        let base_allows_primitive_key = |this: &Self, candidate: TypeId| {
-                            let display = this.format_type_diagnostic(candidate);
-                            candidate == TypeId::STRING
-                                || candidate == TypeId::NUMBER
-                                || candidate == TypeId::SYMBOL
-                                || display == "string | number"
-                                || display == "string | number | symbol"
-                                || crate::query_boundaries::common::union_members(
-                                    this.ctx.types,
-                                    candidate,
-                                )
-                                .is_some_and(|members| {
-                                    members.into_iter().any(|member| {
-                                        matches!(
-                                            member,
-                                            TypeId::STRING | TypeId::NUMBER | TypeId::SYMBOL
-                                        )
-                                    })
-                                })
-                        };
                         if query::contains_free_type_parameters(self.ctx.types, base)
-                            && !base_allows_primitive_key(self, base)
+                            && !crate::query_boundaries::type_predicates::base_admits_any_primitive_index_key(
+                                self.ctx.types.as_type_database(),
+                                &[base],
+                            )
                         {
                             // Base constraint itself contains free type parameters
                             // (e.g., from outer generic scope). Defer check.
@@ -1465,42 +1448,22 @@ impl<'a> CheckerState<'a> {
                         .is_some()
                             && {
                                 // Decide membership *structurally* per primitive_key.
-                                // A display-string match ("string | number" /
-                                // "string | number | symbol") is per-base, not
-                                // per-key, so it would falsely admit SYMBOL
-                                // when base is `string | number` and emit a
-                                // spurious TS2344. Use TypeId equality and
-                                // union_members on both the unevaluated and
-                                // evaluated base — the latter recovers cases
-                                // where keyof/indexed-access bases only
-                                // decompose into a Union after evaluation.
+                                // Both the unevaluated and evaluated base are
+                                // checked so keyof/indexed-access bases that only
+                                // decompose into a Union after evaluation are
+                                // still recognized.
                                 let base_evaluated = self.evaluate_type_for_assignability(base);
-                                let base_members = crate::query_boundaries::common::union_members(
-                                    self.ctx.types,
-                                    base,
-                                );
-                                let base_evaluated_members =
-                                    crate::query_boundaries::common::union_members(
-                                        self.ctx.types,
-                                        base_evaluated,
+                                let present =
+                                    crate::query_boundaries::type_predicates::present_primitive_index_keys(
+                                        self.ctx.types.as_type_database(),
+                                        &[base, base_evaluated],
                                     );
-                                [TypeId::STRING, TypeId::NUMBER, TypeId::SYMBOL]
-                                    .into_iter()
-                                    .any(|primitive_key| {
-                                        let in_base = base == primitive_key
-                                            || base_evaluated == primitive_key
-                                            || base_members
-                                                .as_ref()
-                                                .is_some_and(|m| m.contains(&primitive_key))
-                                            || base_evaluated_members
-                                                .as_ref()
-                                                .is_some_and(|m| m.contains(&primitive_key));
-                                        in_base
-                                            && !self.diagnostic_relation_boolean_guard(
-                                                primitive_key,
-                                                inst_constraint,
-                                            )
-                                    })
+                                present.into_iter().any(|primitive_key| {
+                                    !self.diagnostic_relation_boolean_guard(
+                                        primitive_key,
+                                        inst_constraint,
+                                    )
+                                })
                             }
                             && let Some(&arg_idx) = type_args_list.nodes.get(i)
                         {

--- a/crates/tsz-checker/src/query_boundaries/type_predicates.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_predicates.rs
@@ -20,6 +20,47 @@ pub(crate) fn contains_conditional_with_application_extends(
     tsz_solver::type_queries::contains_conditional_with_application_extends(db, type_id)
 }
 
+/// Primitive index-key types: the only types tsc treats as valid bare keys for
+/// `keyof`/index-signature constraint membership.
+const PRIMITIVE_INDEX_KEYS: [TypeId; 3] = [TypeId::STRING, TypeId::NUMBER, TypeId::SYMBOL];
+
+/// Which of `string` / `number` / `symbol` a base index-key type admits.
+///
+/// A primitive key is admitted when one of the candidate `forms` is that key
+/// directly or has it as a union member. Callers pass the raw base and, where a
+/// `keyof`/indexed-access base only decomposes into a `Union` after evaluation,
+/// the evaluated base as well, so the structural decision covers both shapes.
+///
+/// This is the structural replacement for matching the rendered `"string |
+/// number"` / `"string | number | symbol"` text: that match is per-base rather
+/// than per-key, so it would falsely admit `symbol` when the base is only
+/// `string | number`. Operating on `TypeId` structure keeps the decision
+/// per-key and independent of how a type is spelled or aliased.
+pub(crate) fn present_primitive_index_keys(db: &dyn TypeDatabase, forms: &[TypeId]) -> Vec<TypeId> {
+    let form_members: Vec<Option<Vec<TypeId>>> = forms
+        .iter()
+        .map(|&form| tsz_solver::type_queries::get_union_members(db, form))
+        .collect();
+
+    PRIMITIVE_INDEX_KEYS
+        .into_iter()
+        .filter(|primitive_key| {
+            forms.contains(primitive_key)
+                || form_members.iter().any(|members| {
+                    members
+                        .as_ref()
+                        .is_some_and(|members| members.contains(primitive_key))
+                })
+        })
+        .collect()
+}
+
+/// True when any of `string` / `number` / `symbol` is admitted by the base
+/// index-key `forms`. See [`present_primitive_index_keys`].
+pub(crate) fn base_admits_any_primitive_index_key(db: &dyn TypeDatabase, forms: &[TypeId]) -> bool {
+    !present_primitive_index_keys(db, forms).is_empty()
+}
+
 pub(crate) fn is_this_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     tsz_solver::type_queries::is_this_type(db, type_id)
 }
@@ -124,6 +165,92 @@ mod tests {
         assert!(!is_top_level_error_or_error_union_member(
             &db,
             non_error_union
+        ));
+    }
+
+    #[test]
+    fn present_primitive_index_keys_detects_direct_primitive_keys() {
+        let db = TypeInterner::new();
+        assert_eq!(
+            present_primitive_index_keys(&db, &[TypeId::STRING]),
+            vec![TypeId::STRING]
+        );
+        assert_eq!(
+            present_primitive_index_keys(&db, &[TypeId::NUMBER]),
+            vec![TypeId::NUMBER]
+        );
+        assert_eq!(
+            present_primitive_index_keys(&db, &[TypeId::SYMBOL]),
+            vec![TypeId::SYMBOL]
+        );
+    }
+
+    #[test]
+    fn present_primitive_index_keys_is_per_key_not_per_base() {
+        // The core regression guard: `string | number` admits string and number
+        // but must NOT admit symbol. A rendered-string match on the *base*
+        // ("string | number") would have falsely admitted symbol.
+        let db = TypeInterner::new();
+        let string_number = db.union(vec![TypeId::STRING, TypeId::NUMBER]);
+        let present = present_primitive_index_keys(&db, &[string_number]);
+        assert!(present.contains(&TypeId::STRING));
+        assert!(present.contains(&TypeId::NUMBER));
+        assert!(!present.contains(&TypeId::SYMBOL));
+    }
+
+    #[test]
+    fn present_primitive_index_keys_is_independent_of_union_spelling() {
+        // Order/spelling of the union members must not change the structural
+        // answer (no rendered-text dependence).
+        let db = TypeInterner::new();
+        let forward = db.union(vec![TypeId::STRING, TypeId::NUMBER, TypeId::SYMBOL]);
+        let reversed = db.union(vec![TypeId::SYMBOL, TypeId::NUMBER, TypeId::STRING]);
+        let mut a = present_primitive_index_keys(&db, &[forward]);
+        let mut b = present_primitive_index_keys(&db, &[reversed]);
+        a.sort_by_key(|t| t.0);
+        b.sort_by_key(|t| t.0);
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 3);
+    }
+
+    #[test]
+    fn present_primitive_index_keys_ignores_non_primitive_members() {
+        let db = TypeInterner::new();
+        let mixed = db.union(vec![TypeId::STRING, TypeId::BOOLEAN, TypeId::OBJECT]);
+        assert_eq!(
+            present_primitive_index_keys(&db, &[mixed]),
+            vec![TypeId::STRING]
+        );
+
+        let non_primitive = db.union(vec![TypeId::BOOLEAN, TypeId::OBJECT]);
+        assert!(present_primitive_index_keys(&db, &[non_primitive]).is_empty());
+        assert!(present_primitive_index_keys(&db, &[TypeId::BOOLEAN]).is_empty());
+    }
+
+    #[test]
+    fn present_primitive_index_keys_recovers_key_from_any_form() {
+        // A primitive present only in a later (e.g. evaluated) form is still
+        // recognized — this is the raw + evaluated base coverage callers rely on.
+        let db = TypeInterner::new();
+        let evaluated = db.union(vec![TypeId::NUMBER, TypeId::SYMBOL]);
+        let present = present_primitive_index_keys(&db, &[TypeId::BOOLEAN, evaluated]);
+        assert!(present.contains(&TypeId::NUMBER));
+        assert!(present.contains(&TypeId::SYMBOL));
+        assert!(!present.contains(&TypeId::STRING));
+    }
+
+    #[test]
+    fn base_admits_any_primitive_index_key_matches_presence() {
+        let db = TypeInterner::new();
+        let string_number = db.union(vec![TypeId::STRING, TypeId::NUMBER]);
+        let non_primitive = db.union(vec![TypeId::BOOLEAN, TypeId::OBJECT]);
+
+        assert!(base_admits_any_primitive_index_key(&db, &[string_number]));
+        assert!(base_admits_any_primitive_index_key(&db, &[TypeId::SYMBOL]));
+        assert!(!base_admits_any_primitive_index_key(&db, &[non_primitive]));
+        assert!(!base_admits_any_primitive_index_key(
+            &db,
+            &[TypeId::BOOLEAN]
         ));
     }
 }


### PR DESCRIPTION
## Agent
AgentName: M1-C
Original contributor: web-opus47-render-decision

## Track
Track 10 / §25 anti-hardcoding — replace rendered-type decisions with structural queries (issue #8775).

## Invariant
A checker *decision* about whether a generic base / index-key type admits a primitive index key (`string` / `number` / `symbol`) must be made from `TypeId` structure, not from the rendered display text of the type. The decision is per primitive key, not per base, so it must never admit `symbol` merely because the base renders as `string | number`.

## Scope
- `crates/tsz-checker/src/query_boundaries/type_predicates.rs`
  - Add `present_primitive_index_keys(db, forms)` and `base_admits_any_primitive_index_key(db, forms)` — structural helpers that report which of `string`/`number`/`symbol` a base admits via direct `TypeId` equality and `union_members` over the supplied (raw and, when relevant, evaluated) forms.
  - Add focused unit coverage.
- `crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs`
  - Remove the `base_allows_primitive_key` closure that gated a TS2344 decision on `format_type_diagnostic(candidate)` matching the literals `"string | number"` / `"string | number | symbol"`; route the guard through `base_admits_any_primitive_index_key`.
  - Route the sibling per-key `keyof` block (which already implemented the correct structural rule inline) through `present_primitive_index_keys`, unifying the two previously divergent sites behind one helper.
- No solver behavior change; no roadmap update (routine §25 burn-down slice).

### Structural rule
> When a generic base / index-key type is, evaluates to, or has as a union member any of `string` / `number` / `symbol`, it admits that primitive index key; tsc decides this per key from the type structure, so tsz now decides it from `TypeId` structure (direct equality + `union_members` on the raw and evaluated forms) instead of from the rendered `"string | number"` text.

### Why this is behavior-preserving
The deleted display-string branch was dead in its context: it only ran under `contains_free_type_parameters(base)`, and a type that renders to the concrete `string | number` / `string | number | symbol` union has no free type parameters, so it could never reach the guard. The remaining direct-equality and union-member checks are preserved. The sibling `keyof` block's logic is reproduced exactly by the shared helper (same key set, same iteration order, same `&mut self` relation-guard calls).

## Project Corpus Impact
- Row: n/a
- Bug family: rendered-type (`format_type_diagnostic`) decision use in generic constraint validation (§25)
- Evidence: architecture/anti-hardcoding cleanup; focused `tsz-checker` unit coverage; no project-corpus row identified for this checker-internal refactor.

## Verification
- `cargo check -p tsz-checker`
- `cargo clippy -p tsz-checker --lib -- -D warnings`
- `cargo fmt -p tsz-checker -- --check`
- `cargo test -p tsz-checker --lib primitive_index_key` — 6/6 new tests pass.
- `cargo test -p tsz-checker --lib rendered_type_decision_patterns_do_not_grow` — architecture ratchet still green.
- `cargo test -p tsz-checker --lib ts2344` — 31/31 pass.
- `constraint` / `keyof` families: the only failures (`reverse_mapped_dependent_default_uses_inferred_literal_not_constraint`, `type_param_property_access_with_mapped_constraint`, and three `keyof` display tests) reproduce identically on a clean `git stash` of this branch, so they are pre-existing local failures (TypeScript lib submodule not checked out locally per §19.5), not introduced here.
- No full conformance / emit / fourslash suites run locally (CI owns those).

### Test matrix (§26)
- Direct primitive keys (`string`, `number`, `symbol`).
- `string | number` admits string and number but **not** symbol (core regression guard).
- Union spelling/order independence (`string|number|symbol` vs reversed).
- Non-primitive members ignored (`string | boolean | object` → only string; `boolean | object` → none).
- Multi-form recovery (a key present only in a later/evaluated form is still found).
- `base_admits_any_primitive_index_key` presence consistency.

## Coordination Notes
- AgentName: M1-C
- Original contributor: web-opus47-render-decision
- Claims #8775. Prior claims on that issue are stale (PR #9162 was closed unmerged on 2026-05-21); confirmed no other open PR touches these sites.
- Focused burn-down slice; issue stays open for the remaining audited sites per its own "burn them down with small PRs" guidance.

_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQAGYBgPPdRZsPwsm7y79D)_
