### PR TITLE
fix(emit/dts): unroll object-returning recursive const-arrow applications

### DIFF
--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -77,6 +77,10 @@ path = "tests/tsc_compat_tests.rs"
 name = "recursive_defaulted_template_accumulator_tests"
 path = "tests/recursive_defaulted_template_accumulator_tests.rs"
 
+[[test]]
+name = "recursive_const_arrow_dts_emit_tests"
+path = "tests/recursive_const_arrow_dts_emit_tests.rs"
+
 [dev-dependencies]
 tempfile = { workspace = true }
 

--- a/crates/tsz-cli/tests/recursive_const_arrow_dts_emit_tests.rs
+++ b/crates/tsz-cli/tests/recursive_const_arrow_dts_emit_tests.rs
@@ -1,0 +1,229 @@
+//! DTS emit for recursive generic const-arrow functions (issue #8683).
+//!
+//! When the inferred return type of a generic const-arrow contains a recursive
+//! application `App(Lazy(f), args)` of its own value symbol `f`, declaration emit
+//! must expand it by instantiating `f`'s return type with `args` and recursing up
+//! to the depth limit (then `/*elided*/ any`), regardless of whether `f`'s return
+//! type is a function or an object literal. It must never print `f<args>` — a value
+//! symbol used in type position, which `tsc --noEmitOnError` rejects.
+//!
+//! PR #9383 fixed the function-returning half (a block-scoped const-arrow whose
+//! def is recorded in `def_types`). The object-returning half regressed to the
+//! named-reference path because a top-level const-arrow's resolved type lives in
+//! `symbol_types`, not `def_types`; the printer now falls back through
+//! `def_to_symbol` so both shapes unroll identically.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(name: &str) -> std::io::Result<Self> {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("tsz_recursive_const_arrow_dts_{name}_{nanos}"));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+/// Compile `source` with declaration emit and return the generated `.d.ts` text.
+/// Returns `None` when the tsz binary is unavailable (lets the test self-skip).
+fn emit_dts(name: &str, source: &str) -> Option<String> {
+    let tsz_bin = find_tsz_binary()?;
+    let temp = TempDir::new(name).expect("temp dir");
+    let src_path = temp.path.join("repro.ts");
+    std::fs::write(&src_path, source).expect("write repro file");
+
+    let output = Command::new(tsz_bin)
+        .args([
+            "repro.ts",
+            "--declaration",
+            "--emitDeclarationOnly",
+            "--target",
+            "es2015",
+            "--lib",
+            "es6",
+            "--pretty",
+            "false",
+        ])
+        .current_dir(&temp.path)
+        .output()
+        .expect("run tsz declaration emit");
+
+    let dts = std::fs::read_to_string(temp.path.join("repro.d.ts")).unwrap_or_else(|_| {
+        panic!(
+            "expected repro.d.ts to be emitted.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    Some(dts)
+}
+
+fn assert_unrolls_without_value_in_type_position(dts: &str, value_name: &str) {
+    // The recursive application must never surface as `value<...>` (a value used
+    // in type position). That is the exact illegal output `tsc` rejects.
+    assert!(
+        !dts.contains(&format!("{value_name}<")),
+        "recursive application leaked the value symbol `{value_name}` into type \
+         position instead of unrolling:\n{dts}"
+    );
+    // tsc caps the unroll at the depth limit and bottoms out with `/*elided*/ any`.
+    assert!(
+        dts.contains("/*elided*/ any"),
+        "expected depth-limited recursion to bottom out at `/*elided*/ any`:\n{dts}"
+    );
+}
+
+/// Reported repro from `declarationsWithRecursiveInternalTypesProduceUniqueTypeParams`:
+/// a top-level generic const-arrow returning an object literal whose method recurses
+/// on the const itself. The object return type must unroll, not print `testRecFun<...>`.
+#[test]
+fn object_returning_recursive_const_arrow_unrolls_in_dts() {
+    let Some(dts) = emit_dts(
+        "object_return",
+        r#"
+export const testRecFun = <T extends Object>(parent: T) => {
+    return {
+        result: parent,
+        deeper: <U extends Object>(child: U) =>
+            testRecFun<T & U>({ ...parent, ...child })
+    };
+};
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert_unrolls_without_value_in_type_position(&dts, "testRecFun");
+    // First inner level keeps the source name; shadowed re-introductions are renamed.
+    assert!(
+        dts.contains("deeper: <U extends Object>"),
+        "expected first level to keep the source type-parameter name:\n{dts}"
+    );
+    assert!(
+        dts.contains("deeper: <U_1 extends Object>")
+            && dts.contains("deeper: <U_2 extends Object>"),
+        "expected shadowed re-introductions to be uniquely renamed (U_1, U_2):\n{dts}"
+    );
+    // The accumulated intersection grows one member per level.
+    assert!(
+        dts.contains("result: T & U & U_1"),
+        "expected the result intersection to accumulate across levels:\n{dts}"
+    );
+}
+
+/// The same rule, with different type-parameter and property names, proves the
+/// fix is structural and not keyed to `T`/`U`/`deeper`/`testRecFun` spellings.
+#[test]
+fn object_returning_recursion_dts_unroll_is_not_hardcoded_to_names() {
+    let Some(dts) = emit_dts(
+        "renamed",
+        r#"
+export const build = <P extends Object>(node: P) => {
+    return {
+        value: node,
+        nest: <C extends Object>(extra: C) =>
+            build<P & C>({ ...node, ...extra })
+    };
+};
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert_unrolls_without_value_in_type_position(&dts, "build");
+    assert!(
+        dts.contains("nest: <C extends Object>")
+            && dts.contains("nest: <C_1 extends Object>")
+            && dts.contains("nest: <C_2 extends Object>"),
+        "expected renamed iteration variable to unroll as C, C_1, C_2:\n{dts}"
+    );
+    assert!(
+        dts.contains("value: P & C & C_1"),
+        "expected the accumulated intersection to use the renamed parameters:\n{dts}"
+    );
+}
+
+/// Regression guard for PR #9383: a const-arrow whose recursion returns a *function*
+/// (via a block-scoped helper) must keep unrolling its quantifier chain in DTS.
+#[test]
+fn function_returning_recursive_const_arrow_still_unrolls_in_dts() {
+    let Some(dts) = emit_dts(
+        "function_return",
+        r#"
+export const make = <T>(t: T) => {
+    const step = <U>(u: U) => {
+        return Object.assign(
+            <K extends keyof U>(key: K) => step<U[K]>(u[key]),
+            { get: () => u });
+    };
+    return step<T>(t);
+};
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert_unrolls_without_value_in_type_position(&dts, "make");
+    assert_unrolls_without_value_in_type_position(&dts, "step");
+    assert!(
+        dts.contains("<K_1 extends keyof") && dts.contains("<K_10 extends keyof"),
+        "expected the function-returning recursion to unroll its quantifier chain:\n{dts}"
+    );
+}
+
+/// Negative case: a non-recursive generic const-arrow returning an object must emit
+/// the plain object shape with no depth-limit sentinel. This proves the expansion
+/// fires only for genuinely recursive applications, not for every generic const.
+#[test]
+fn non_recursive_generic_const_arrow_does_not_emit_elided_sentinel() {
+    let Some(dts) = emit_dts(
+        "non_recursive",
+        r#"
+export const wrap = <T>(t: T) => ({ value: t, again: t });
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        !dts.contains("/*elided*/ any"),
+        "non-recursive const-arrow must not trigger depth-limited expansion:\n{dts}"
+    );
+    assert!(
+        dts.contains("value: T") && dts.contains("again: T"),
+        "expected the plain object return shape to be emitted:\n{dts}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/types/printer/symbol_resolution.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/symbol_resolution.rs
@@ -185,6 +185,28 @@ impl<'a> TypePrinter<'a> {
         self.type_cache?.def_types.get(&def_id.0).copied()
     }
 
+    /// Resolve the function type backing a recursive `App(Lazy(def_id), args)`
+    /// for depth-limited DTS expansion.
+    ///
+    /// A `TypeEnvironment`-bound def (e.g. an inner block-scoped const-arrow)
+    /// is recorded in `def_types`. A top-level const-arrow whose recursion
+    /// targets its own value symbol has no environment binding — its resolved
+    /// type lives in `symbol_types` keyed by the symbol — so fall back through
+    /// `def_to_symbol`. The self-referential guards used by the inline symbol
+    /// fallbacks are deliberately skipped: a recursive function shape legitimately
+    /// references its own symbol, and that reference is what the expansion unrolls.
+    fn recursive_application_function_type(
+        &self,
+        def_id: tsz_solver::def::DefId,
+    ) -> Option<TypeId> {
+        if let Some(def_type) = self.def_type_fallback(def_id) {
+            return Some(def_type);
+        }
+        let cache = self.type_cache?;
+        let sym_id = cache.def_to_symbol.get(&def_id).copied()?;
+        cache.symbol_types.get(&sym_id).copied()
+    }
+
     /// tsc caps recursive generic function DTS expansion at 10 levels; beyond that it
     /// emits `/*elided*/ any` to prevent infinite output. This method implements that
     /// depth guard: given the already-resolved `shape_id` and the concrete `type_args`,
@@ -668,7 +690,7 @@ impl<'a> TypePrinter<'a> {
             // expanded depth-limitedly (up to 10 levels, then `/*elided*/ any`) rather than
             // printed as a named type reference like "fnName<Args>".
             let recursive_shape_id = visitor::lazy_def_id(self.interner, app.base)
-                .and_then(|def_id| self.def_type_fallback(def_id))
+                .and_then(|def_id| self.recursive_application_function_type(def_id))
                 .and_then(|func_type| visitor::function_shape_id(self.interner, func_type))
                 .filter(|&shape_id| {
                     !self


### PR DESCRIPTION
AgentName: Studio-D
Original contributor: `linux-cloud-opus47-1m-vibrant-lovelace`

## Track
Track 9 — declaration emit (`.d.ts`) parity with `tsc`.

## Invariant
When the inferred return type of a generic const-arrow contains a recursive application `App(Lazy(f), args)` of its **own value symbol** `f`, declaration emit must depth-expand it — instantiate `f`'s return type with `args` and recurse up to the depth limit (then `/*elided*/ any`) — regardless of whether `f`'s return type is a function or an object literal. It must never print `f<args>` (a value symbol in type position), which `tsc --noEmitOnError` rejects.

## Structural rule
> When a generic const-arrow's return type contains `App(Lazy(f), args)` where `f` is its own value symbol, the DTS printer resolves `f`'s backing function shape and depth-expands the application; this matches `tsc`, which unrolls the recursive return shape (object or function) up to its depth limit.

## Scope
One private helper + one call-site rewire in `crates/tsz-emitter/src/emitter/types/printer/symbol_resolution.rs`.

PR #9383 (merged) fixed the **function-returning** half of `declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts` (the `updateIfChanged` case), where the recursion targets a block-scoped const whose def is recorded in `def_types`. The **object-returning** half (`testRecFun`) still regressed to the named-reference path: a top-level const-arrow whose recursion targets its own value symbol has no `TypeEnvironment` binding, so its resolved type lives in `symbol_types` (keyed by symbol), not `def_types`. The printer's recursive-expansion lookup only consulted `def_types`, missed, and fell through to printing the illegal `testRecFun<T & U>`.

The fix resolves the recursive application's backing function type through `def_types` first, then falls back via `def_to_symbol -> symbol_types`. The self-reference guards used by the inline symbol fallbacks (`symbol_type_fallback` / `non_qualifiable_symbol_inline_fallback`) are deliberately skipped: a recursive function shape legitimately references its own symbol, and that reference is exactly what the expansion unrolls.

The fallback is bounded by the existing call-site filters (`function_shape_id` + non-empty `type_params`), so it only newly matches generic **function-value** application bases — the #8683 shape. Classes (`Callable`), interfaces (`Object`), and generic type aliases (already in `def_types`) are unaffected and keep their named-reference rendering.

## Adjacent-case test matrix
New end-to-end CLI test `crates/tsz-cli/tests/recursive_const_arrow_dts_emit_tests.rs` (spawns the real `tsz` binary, full checker→emitter pipeline):
1. **Reported repro** — object-returning recursion (`testRecFun`): unrolls with renamed shadowed vars `U_1`/`U_2`, accumulates `result: T & U & U_1`, bottoms out at `/*elided*/ any`, never emits `testRecFun<`.
2. **Renamed names** (`build`/`P`/`C`/`nest`/`value`) — proves the rule is structural, not keyed to `T`/`U`/`deeper`/`testRecFun` spellings.
3. **Function-returning recursion** — regression guard for #9383 (`K_1`…`K_10` chain still unrolls).
4. **Negative case** — non-recursive generic const-arrow must NOT emit `/*elided*/ any`.

## Verification
- Built `.target/debug/tsz`; emitted the full `declarationsWithRecursiveInternalTypesProduceUniqueTypeParams` fixture (`--module commonjs --target es2015 --declaration --lib es6`) and diffed against the `tsc` baseline → **identical, byte-for-byte** (both `updateIfChanged` and `testRecFun`).
- `cargo test -p tsz-cli --test recursive_const_arrow_dts_emit_tests` → 4/4 pass.
- `cargo test -p tsz-emitter` → no new failures (9 pre-existing failures reproduce identically on `origin/main` `0c8d810` with the change stashed; unrelated jsdoc/mapped-type/decorator/es5 areas).
- `cargo clippy -p tsz-emitter --all-targets -- -D warnings` → clean.
- `cargo fmt --check`, `git diff --check`, `python3 scripts/arch/arch_guard.py` → all pass.
- `git merge-tree --write-tree origin/main HEAD` → clean, no conflicts. Both touched source files < 2000 lines.

## Project Corpus Impact
- Row: `declarationsWithRecursiveInternalTypesProduceUniqueTypeParams` (emit DTS).
- Bug family: declaration emit — recursive const-arrow application expansion (object-returning half).
- Evidence: tsz DTS now matches the `tsc` baseline byte-for-byte for the fixture; before this change the `testRecFun` const emitted illegal `testRecFun<T & U>` (value in type position) instead of the 10-level unrolled object chain.

## Coordination Notes
Claimed #8683 (released by two prior owners — the rename half was a red herring; #9383 landed the function-returning half). `WIP` label + signed claim comment posted on the issue. No overlapping open PR references #8683. Reviewed locally with `/simplify` (extra-high-effort review): no correctness, regression, reuse, or altitude findings — the fallback is at the correct layer and reuse of the guarded symbol fallbacks was explicitly rejected for the self-referential shape.

Closes #8683

_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_015uiXFBi4QjGUagXMNpgGFU)_