### PR TITLE
refactor(checker): bundle assignment/display relation routing

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics/display_types.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics/display_types.rs
@@ -69,7 +69,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // Check assignability using the actual types (return types)
-        if self.diagnostic_relation_boolean_guard(source, target) {
+        if self.assign_relation_outcome(source, target).related {
             return true;
         }
 

--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -1005,7 +1005,9 @@ impl<'a> CheckerState<'a> {
                             || op == SyntaxKind::GreaterThanGreaterThanGreaterThanToken as u16;
 
                         if is_compound_like
-                            && self.diagnostic_relation_boolean_guard(right_type, widened_left)
+                            && self
+                                .assign_relation_outcome(right_type, widened_left)
+                                .related
                         {
                             check_assignability = false;
                         }
@@ -1734,7 +1736,9 @@ impl<'a> CheckerState<'a> {
             self.deferred_generic_element_write_target(left_idx, source_type)
         {
             if (source_type != generic_target
-                && !self.diagnostic_relation_boolean_guard(source_type, generic_target))
+                && !self
+                    .assign_relation_outcome(source_type, generic_target)
+                    .related)
                 || (source_type != generic_target
                     && !crate::query_boundaries::common::contains_type_parameters(
                         self.ctx.types,

--- a/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
@@ -554,10 +554,9 @@ impl<'a> CheckerState<'a> {
                                             || target_type == TypeId::ERROR
                                             || default_type == TypeId::ANY
                                             || default_type == TypeId::ERROR
-                                            || self.diagnostic_relation_boolean_guard(
-                                                default_type,
-                                                target_type,
-                                            );
+                                            || self
+                                                .assign_relation_outcome(default_type, target_type)
+                                                .related;
                                         if default_assignable {
                                             // Default is fine but property type might not be.
                                             self.check_destructuring_leaf_assignability_with_default(
@@ -841,7 +840,9 @@ impl<'a> CheckerState<'a> {
                 .unwrap_or_else(|| self.get_type_of_node(default_expr));
             if default_type != TypeId::ANY
                 && default_type != TypeId::ERROR
-                && !self.diagnostic_relation_boolean_guard(default_type, target_type)
+                && !self
+                    .assign_relation_outcome(default_type, target_type)
+                    .related
             {
                 if self.try_report_object_default_property_mismatch(
                     default_expr,
@@ -923,7 +924,7 @@ impl<'a> CheckerState<'a> {
         // Ensure both types are fully resolved before relation checking.
         self.ensure_relation_input_ready(prop_type);
         self.ensure_relation_input_ready(target_type);
-        if self.diagnostic_relation_boolean_guard(prop_type, target_type) {
+        if self.assign_relation_outcome(prop_type, target_type).related {
             return;
         }
         // Emit TS2322 directly. Format source type from the TypeId rather
@@ -989,7 +990,10 @@ impl<'a> CheckerState<'a> {
             else {
                 continue;
             };
-            if self.diagnostic_relation_boolean_guard(source_type, target_prop_type) {
+            if self
+                .assign_relation_outcome(source_type, target_prop_type)
+                .related
+            {
                 continue;
             }
             let source_for_display = {

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -103,6 +103,12 @@ mod assertion_overlap_object_primitive_tests;
 #[path = "../tests/assertion_overlap_template_literal_tests.rs"]
 mod assertion_overlap_template_literal_tests;
 #[cfg(test)]
+#[path = "tests/assignability_display_relation_routing_arch_tests.rs"]
+mod assignability_display_relation_routing_arch_tests;
+#[cfg(test)]
+#[path = "tests/assignment_ops_relation_routing_arch_tests.rs"]
+mod assignment_ops_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/async_imported_promise_tests.rs"]
 mod async_imported_promise_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/assignability_display_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/assignability_display_relation_routing_arch_tests.rs
@@ -1,0 +1,21 @@
+use std::fs;
+
+#[test]
+fn assignability_display_type_check_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/assignability/assignability_diagnostics/display_types.rs")
+        .expect("failed to read display types source");
+
+    let function_start = source
+        .find("fn check_assignable_or_report_at_with_display_types_and_options(")
+        .expect("find display-type assignability helper");
+    let helper = &source[function_start..];
+
+    assert!(
+        helper.contains("self.assign_relation_outcome(source, target).related"),
+        "display-type assignability relation truth should route through relation outcomes"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard(source, target)"),
+        "display-type assignability should not use the raw boolean relation guard"
+    );
+}

--- a/crates/tsz-checker/src/tests/assignment_ops_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/assignment_ops_relation_routing_arch_tests.rs
@@ -1,0 +1,21 @@
+use std::fs;
+
+#[test]
+fn assignment_ops_relation_checks_use_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/assignability/assignment_checker/assignment_ops.rs")
+        .expect("failed to read assignment_ops.rs");
+    let compact_source: String = source.chars().filter(|c| !c.is_whitespace()).collect();
+
+    assert!(
+        compact_source.contains("assign_relation_outcome(right_type,widened_left).related")
+            && compact_source
+                .contains("assign_relation_outcome(source_type,generic_target).related"),
+        "assignment operation diagnostic relation checks should route through relation outcomes"
+    );
+    assert!(
+        !compact_source.contains("diagnostic_relation_boolean_guard(right_type,widened_left)")
+            && !compact_source
+                .contains("diagnostic_relation_boolean_guard(source_type,generic_target)"),
+        "assignment operation diagnostic relation checks should not use raw boolean guards"
+    );
+}

--- a/crates/tsz-checker/src/tests/destructuring_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/destructuring_relation_routing_arch_tests.rs
@@ -20,3 +20,28 @@ fn array_destructuring_unchecked_element_uses_relation_diagnostic_helper() {
          a raw diagnostic relation boolean"
     );
 }
+
+#[test]
+fn destructuring_default_checks_use_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/assignability/assignment_checker/destructuring.rs")
+        .expect("failed to read assignment_checker/destructuring.rs");
+    let compact_source: String = source.chars().filter(|c| !c.is_whitespace()).collect();
+
+    assert!(
+        compact_source
+            .matches("assign_relation_outcome(default_type,target_type).related")
+            .count()
+            >= 2
+            && compact_source.contains("assign_relation_outcome(prop_type,target_type).related")
+            && compact_source
+                .contains("assign_relation_outcome(source_type,target_prop_type).related"),
+        "destructuring default/property relation checks should route through relation outcomes"
+    );
+    assert!(
+        !compact_source.contains("diagnostic_relation_boolean_guard(default_type,target_type)")
+            && !compact_source.contains("diagnostic_relation_boolean_guard(prop_type,target_type)")
+            && !compact_source
+                .contains("diagnostic_relation_boolean_guard(source_type,target_prop_type)",),
+        "destructuring default/property relation checks should not use raw boolean guards"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor only: checker assignment/display relation diagnostic query-boundary routing.

## Invariant
When checker-owned assignment/display diagnostics need relation truth for TS2322-family recovery, the checker still owns diagnostic anchors, suppression, and display formatting; this PR routes the relation truth through `assign_relation_outcome(...).related` instead of raw boolean diagnostic relation guards.

## Scope
- `crates/tsz-checker/src/assignability/assignability_diagnostics/display_types.rs`
- `crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs`
- `crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs`
- `crates/tsz-checker/src/lib.rs`
- `crates/tsz-checker/src/tests/assignability_display_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/tests/destructuring_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/tests/assignment_ops_relation_routing_arch_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only routing bundle; no solver policy, relation flags, cache keys, diagnostic text, conformance baselines, or project corpus fixture behavior changed.

## Verification
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `cargo nextest run -p tsz-checker --lib -E 'test(assignability_display_type_check_uses_relation_outcome_boundary) or test(destructuring_default_checks_use_relation_outcome_boundary) or test(assignment_ops_relation_checks_use_relation_outcome_boundary)'`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `git rev-list --left-right --count origin/main...HEAD` -> `0 1`

## Coordination Notes
- Successor draft for same-owner `agent:M1-B` relation-routing bundle: #10484.
- Bundles #10479, #10481, and the original #10484 into successor head `34cc709963`.
- Supersedes #10479 and #10481; both receive signed closure comments pointing here.
- Skipped #10430 because it is a TS2353 call-finalization bug fix, not relation-routing cleanup.
- Rebuilt from current `origin/main` (`0c8d8106fa`) in `/Users/mohsen/code/tsz-bundle-m1b-assignment-display`.
- Only conflict was `crates/tsz-checker/src/lib.rs` test-module registration; resolved by keeping both new test modules.
- Draft only; no merge queue or auto-merge requested.