### PR TITLE
fix(checker): accept array keyof into string index

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -1027,6 +1027,7 @@ impl<'a> CheckerState<'a> {
             if self.keyof_index_valid_for_string_indexed_object(
                 object_type_for_check,
                 index_type_for_check,
+                index_constraint,
             ) {
                 return;
             }

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
@@ -884,6 +884,7 @@ impl<'a> CheckerState<'a> {
         &mut self,
         object_type: TypeId,
         index_type_for_check: TypeId,
+        index_constraint: Option<TypeId>,
     ) -> bool {
         let has_plain_string_index = self
             .ctx
@@ -895,6 +896,46 @@ impl<'a> CheckerState<'a> {
             return false;
         }
         let string_or_number = self.ctx.types.union2(TypeId::STRING, TypeId::NUMBER);
-        self.diagnostic_relation_boolean_guard(index_type_for_check, string_or_number)
+        if self
+            .string_index_candidate_is_string_or_number_key(index_type_for_check, string_or_number)
+        {
+            return true;
+        }
+        if let Some(constraint) = index_constraint {
+            let evaluated_constraint = self.evaluate_type_with_env(constraint);
+            return self
+                .string_index_candidate_is_string_or_number_key(constraint, string_or_number)
+                || self.string_index_candidate_is_string_or_number_key(
+                    evaluated_constraint,
+                    string_or_number,
+                );
+        }
+        false
+    }
+
+    fn string_index_candidate_is_string_or_number_key(
+        &mut self,
+        candidate: TypeId,
+        string_or_number: TypeId,
+    ) -> bool {
+        self.diagnostic_relation_boolean_guard(candidate, string_or_number)
+            || self.keyof_candidate_target_is_array_like(candidate)
+    }
+
+    fn keyof_candidate_target_is_array_like(&mut self, candidate: TypeId) -> bool {
+        let Some(target) =
+            crate::query_boundaries::state::checking::keyof_target(self.ctx.types, candidate)
+        else {
+            return false;
+        };
+        self.type_or_constraint_is_array_like(target)
+    }
+
+    fn type_or_constraint_is_array_like(&mut self, type_id: TypeId) -> bool {
+        if self.indexed_access_type_has_array_like_length(type_id) {
+            return true;
+        }
+        let evaluated = self.evaluate_type_with_env(type_id);
+        evaluated != type_id && self.indexed_access_type_has_array_like_length(evaluated)
     }
 }

--- a/crates/tsz-checker/tests/ts2536_keyof_string_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/ts2536_keyof_string_index_signature_tests.rs
@@ -7,7 +7,10 @@
 //! could include `symbol` (e.g., an unconstrained type parameter or `keyof T` for
 //! generic `T`).
 
-use tsz_checker::test_utils::check_source_diagnostics;
+use tsz_checker::test_utils::{
+    DEFAULT_LIB_NAMES, check_source_diagnostics, check_source_with_libs, load_lib_files,
+    strict_checker_options,
+};
 
 fn count(diags: &[tsz_checker::diagnostics::Diagnostic], code: u32) -> usize {
     diags.iter().filter(|d| d.code == code).count()
@@ -17,6 +20,15 @@ fn diag_summary(diags: &[tsz_checker::diagnostics::Diagnostic]) -> Vec<(u32, Str
     diags
         .iter()
         .map(|d| (d.code, d.message_text.clone()))
+        .collect()
+}
+
+fn strict_codes_with_libs(source: &str) -> Vec<u32> {
+    let libs = load_lib_files(DEFAULT_LIB_NAMES);
+    check_source_with_libs(source, "test.ts", strict_checker_options(), &libs)
+        .into_iter()
+        .map(|d| d.code)
+        .filter(|code| *code != 2318)
         .collect()
 }
 
@@ -120,6 +132,28 @@ type Snapshot<Arr extends unknown[]> = { [Idx in keyof Arr]: Registry[Idx] };
         0,
         "Registry[Idx in keyof (Arr extends unknown[])] must not emit TS2536; got: {:?}",
         diag_summary(&diags)
+    );
+}
+
+#[test]
+fn strict_mapped_apparent_type_assignment_keeps_only_ts2322() {
+    let source = r#"
+type Obj = {
+    [s: string]: number;
+};
+
+type SourceFn = <T>(target: { [K in keyof T]: T[K] }) => void;
+type TargetFn = <Arr extends string[]>(source: { [Idx in keyof Arr]: Obj[Idx] }) => void;
+
+declare let sourceFn: SourceFn;
+declare let targetFn: TargetFn;
+targetFn = sourceFn;
+"#;
+    let codes = strict_codes_with_libs(source);
+    assert_eq!(
+        codes,
+        vec![2322],
+        "strict function assignment should keep TS2322 but suppress false TS2536; got {codes:?}"
     );
 }
 

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -9,7 +9,6 @@ TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElabora
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 TypeScript/tests/cases/compiler/jsxComplexSignatureHasApplicabilityError.tsx
-TypeScript/tests/cases/compiler/mappedTypeInferenceFromApparentType.ts
 TypeScript/tests/cases/compiler/reorderProperties.ts
 TypeScript/tests/cases/compiler/temporal.ts
 TypeScript/tests/cases/compiler/unionPropertyOfProtectedAndIntersectionProperty.ts


### PR DESCRIPTION
## Agent
AgentName: M1-C
Runner: claude-sonnet-4-6

## Track
Track 8: Diagnostics, Display, Parser Options, And Feature Gates — accepted-regression burn-down through indexed-access diagnostic parity.

## Invariant
When a mapped key is constrained by `keyof A` and `A` is provably array-like, `tsc` treats that key space as valid for a target object with a plain string index signature; this PR makes tsz suppress only the false TS2536 while preserving the surrounding TS2322 assignability diagnostic.

## Owner Layer
Checker indexed-access validation, using solver-backed query-boundary classifiers for array-like constraints. The checker still owns the diagnostic location and suppression decision; the semantic array-like fact comes from existing query-boundary type classification rather than source text, rendered type text, or binder-name spelling.

## Scope
- `crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs`: extend the string-index key validity helper to inspect index constraints and `keyof` targets whose constraints are array-like.
- `crates/tsz-checker/src/types/type_checking/indexed_access.rs`: pass the resolved index constraint into that helper.
- `crates/tsz-checker/tests/ts2536_keyof_string_index_signature_tests.rs`: add strict/lib-aware function assignment coverage with renamed mapped variables.
- `scripts/conformance/conformance-accepted-regressions.txt`: remove the now-passing `mappedTypeInferenceFromApparentType.ts` accepted-regression entry.

## Adjacent Case Matrix
- `Obj[Idx]` inside `{ [Idx in keyof Arr]: ... }` with `Arr extends string[]` no longer emits TS2536 under strict libs.
- Existing mapped array-key coverage with renamed `Arr`/`Idx` still passes.
- Existing generic `K extends keyof T` and renamed `Prop extends keyof Src` negatives still emit TS2536, preserving symbol-possible key spaces.
- The conformance witness still emits TS2322 for the incompatible function assignment; only the extra TS2536 is removed.

## Project Corpus Impact
- Row: n/a
- Bug family: accepted-regression false-positive TS2536 / mapped array-key string-index validation
- Evidence: focused conformance witness `TypeScript/tests/cases/compiler/mappedTypeInferenceFromApparentType.ts` passed 1/1; no project corpus row is directly affected.

## Verification
Final rebased head: `b4e034731d4292f2a4762f480266bd891ceaa3c6`.

- `cargo fmt --check` -> passed on final head
- `git diff --check origin/main...HEAD` -> passed on final head
- `cargo nextest run -p tsz-checker --test ts2536_keyof_string_index_signature_tests strict_mapped_apparent_type_assignment_keeps_only_ts2322 type_level_k_extends_keyof_generic_t_emits_ts2536 type_level_prop_extends_keyof_generic_src_emits_ts2536 type_level_mapped_keyof_array_constraint_no_ts2536 type_level_mapped_keyof_array_constraint_renamed_param_no_ts2536` -> 5 passed on final head
- `python3 scripts/conformance/query-conformance.py --dashboard` -> exact `12582/12582`, accepted-regression gate `23 listed tests` on final head after latest `origin/main` merges
- `scripts/safe-run.sh --limit 50% -- ./scripts/conformance/conformance.sh run --filter "mappedTypeInferenceFromApparentType" --verbose` -> `FINAL RESULTS: 1/1 passed (100.0%)`, `Fingerprint-only: 0` on an earlier rebased head before later clean main fast-forwards; final head reran the focused unit matrix/dashboard
- `cargo nextest run -p tsz-checker --test ts2536_keyof_string_index_signature_tests` -> 14 passed before rebases
- `python3 scripts/arch/arch_guard.py` still fails on pre-existing #8225 direct `query_boundaries::common` quarantine debt in assignability files; this PR adds no new `query_boundaries::common` references.
- Fresh draft light CI is running/pending for final head `b4e034731d4292f2a4762f480266bd891ceaa3c6`.

## Coordination Notes
- AgentName: M1-C
- Fixes #10480 and burns down one accepted-regression path from #10306/#7596 when landed.
- Fresh worktree: `/Users/mohsen/code/tsz-m1c-mapped-apparent-ts2536-20260527`, created from `origin/main`.
- Head: `b4e034731d4292f2a4762f480266bd891ceaa3c6`.
- Rebased repeatedly on 2026-05-27 as `origin/main` advanced through adjacent checker/DTS work; final local check before push was `origin/main...HEAD = 0 1`.
- Draft while refreshed light CI runs on the rebased head. Mark ready after exact-head draft CI is green.
- No `merge-queue` label requested by this implementation lane.
