### PR TITLE
fix(checker): render string-mapping intrinsic aliases structurally in TS2322

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1486,6 +1486,10 @@ name = "bare_alias_display_tests"
 path = "tests/bare_alias_display_tests.rs"
 
 [[test]]
+name = "string_mapping_alias_display_tests"
+path = "tests/string_mapping_alias_display_tests.rs"
+
+[[test]]
 name = "class_arrow_property_type_inference_tests"
 path = "tests/class_arrow_property_type_inference_tests.rs"
 

--- a/crates/tsz-checker/src/error_reporter/assignability_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_alias_display.rs
@@ -166,6 +166,10 @@ impl<'a> CheckerState<'a> {
             ))
                 && !annotation_text.contains("| undefined"))
             || alias_display_queries::is_literal_for_alias_display(self.ctx.types, source_fact)
+            || alias_display_queries::is_string_intrinsic_for_alias_display(
+                self.ctx.types,
+                source_fact,
+            )
         {
             return None;
         }

--- a/crates/tsz-checker/src/query_boundaries/assignability_alias_display.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability_alias_display.rs
@@ -137,3 +137,15 @@ pub(crate) fn is_literal_for_alias_display(db: &dyn TypeDatabase, type_id: TypeI
     tsz_solver::type_queries::is_literal_or_literal_union_type(db, type_id)
         || common::is_template_literal_type(db, type_id)
 }
+
+/// A deferred string-mapping intrinsic (`Uppercase`/`Lowercase`/`Capitalize`/
+/// `Uncapitalize` over a non-literal argument). tsc always renders these in
+/// their structural `Intrinsic<arg>` form in assignability diagnostics, never
+/// via a type-alias name, so the declared-annotation source rewrite must not
+/// repaint such a source with its alias name.
+pub(crate) fn is_string_intrinsic_for_alias_display(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> bool {
+    common::is_string_intrinsic_type(db, type_id)
+}

--- a/crates/tsz-checker/tests/string_mapping_alias_display_tests.rs
+++ b/crates/tsz-checker/tests/string_mapping_alias_display_tests.rs
@@ -1,0 +1,160 @@
+//! Diagnostic-display tests for string-mapping intrinsic aliases in TS2322.
+//!
+//! Structural rule: when the failing *source* of a TS2322 resolves to a
+//! deferred string-mapping intrinsic (`Uppercase`/`Lowercase`/`Capitalize`/
+//! `Uncapitalize` over a non-literal argument), tsc renders the structural
+//! `Intrinsic<arg>` form — never the type-alias name — in both source and
+//! target positions. tsz previously evaluated the *target* annotation to the
+//! structural intrinsic but rewrote the *source* back to its declared alias
+//! name, leaking an asymmetric `U` (source) vs `Uppercase<string>` (target).
+//!
+//! The rule is keyed on the structural `StringIntrinsic` shape, so it is
+//! independent of the chosen alias name: each case below is repeated with a
+//! different alias spelling to guard against name hardcoding (§25).
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+fn ts2322(source: &str) -> String {
+    let diagnostics = check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            strict_null_checks: true,
+            strict_function_types: true,
+            ..CheckerOptions::default()
+        },
+    );
+    diagnostics
+        .iter()
+        .find(|diag| diag.code == 2322)
+        .unwrap_or_else(|| panic!("expected TS2322, got: {diagnostics:#?}"))
+        .message_text
+        .clone()
+}
+
+#[test]
+fn lowercase_alias_source_renders_structurally() {
+    let msg = ts2322(
+        r#"
+type Lower = Lowercase<string>;
+declare let v: Lower;
+const x: Uppercase<string> = v;
+"#,
+    );
+    assert!(
+        msg.contains("Type 'Lowercase<string>' is not assignable to type 'Uppercase<string>'."),
+        "source string-mapping alias must render structurally, got: {msg}"
+    );
+    assert!(
+        !msg.contains("'Lower'"),
+        "source must not leak the alias name `Lower`, got: {msg}"
+    );
+}
+
+#[test]
+fn lowercase_alias_source_is_name_independent() {
+    // Same shape, different alias spelling: the structural rule must not depend
+    // on the user-chosen alias name.
+    let msg = ts2322(
+        r#"
+type Zebra = Lowercase<string>;
+declare let v: Zebra;
+const x: Uppercase<string> = v;
+"#,
+    );
+    assert!(
+        msg.contains("Type 'Lowercase<string>' is not assignable to type 'Uppercase<string>'."),
+        "renamed source alias must still render structurally, got: {msg}"
+    );
+    assert!(
+        !msg.contains("'Zebra'"),
+        "source must not leak the alias name `Zebra`, got: {msg}"
+    );
+}
+
+#[test]
+fn uppercase_alias_source_renders_structurally() {
+    let msg = ts2322(
+        r#"
+type Upper = Uppercase<string>;
+declare let v: Upper;
+const x: Lowercase<string> = v;
+"#,
+    );
+    assert!(
+        msg.contains("Type 'Uppercase<string>' is not assignable to type 'Lowercase<string>'."),
+        "source string-mapping alias must render structurally, got: {msg}"
+    );
+    assert!(!msg.contains("'Upper'"), "got: {msg}");
+}
+
+#[test]
+fn capitalize_alias_source_renders_structurally() {
+    let msg = ts2322(
+        r#"
+type Cap = Capitalize<string>;
+declare let v: Cap;
+const x: `A${string}` = v;
+"#,
+    );
+    assert!(
+        msg.contains("Type 'Capitalize<string>' is not assignable to type '`A${string}`'."),
+        "source string-mapping alias must render structurally, got: {msg}"
+    );
+    assert!(!msg.contains("'Cap'"), "got: {msg}");
+}
+
+#[test]
+fn uncapitalize_alias_source_renders_structurally() {
+    let msg = ts2322(
+        r#"
+type Unc = Uncapitalize<string>;
+declare let v: Unc;
+const x: `a${string}` = v;
+"#,
+    );
+    assert!(
+        msg.contains("Type 'Uncapitalize<string>' is not assignable to type '`a${string}`'."),
+        "source string-mapping alias must render structurally, got: {msg}"
+    );
+    assert!(!msg.contains("'Unc'"), "got: {msg}");
+}
+
+#[test]
+fn nested_string_mapping_alias_source_renders_structurally() {
+    let msg = ts2322(
+        r#"
+type Nested = Lowercase<Uppercase<string>>;
+declare let v: Nested;
+const x: Uppercase<string> = v;
+"#,
+    );
+    assert!(
+        msg.contains(
+            "Type 'Lowercase<Uppercase<string>>' is not assignable to type 'Uppercase<string>'."
+        ),
+        "nested string-mapping alias source must render the full structural form, got: {msg}"
+    );
+    assert!(!msg.contains("'Nested'"), "got: {msg}");
+}
+
+#[test]
+fn non_string_mapping_object_alias_source_keeps_its_name() {
+    // Negative case: the structural-display rule is scoped to string-mapping
+    // intrinsics. An ordinary object/type alias must still preserve its name in
+    // the source position, exactly as before — proving the fix did not broadly
+    // disable declared-alias source display.
+    let msg = ts2322(
+        r#"
+type Named = { a: number };
+declare let v: Named;
+const x: boolean = v;
+"#,
+    );
+    assert!(
+        msg.contains("Type 'Named' is not assignable to type 'boolean'."),
+        "ordinary object alias must keep its name in the source position, got: {msg}"
+    );
+}

--- a/crates/tsz-checker/tests/string_mapping_alias_display_tests.rs
+++ b/crates/tsz-checker/tests/string_mapping_alias_display_tests.rs
@@ -123,6 +123,40 @@ const x: `a${string}` = v;
 }
 
 #[test]
+fn capitalize_alias_source_is_name_independent() {
+    // Different alias spelling for `Capitalize` proves the rule is keyed on the
+    // structural shape, not the alias name `Cap`.
+    let msg = ts2322(
+        r#"
+type Headline = Capitalize<string>;
+declare let v: Headline;
+const x: `A${string}` = v;
+"#,
+    );
+    assert!(
+        msg.contains("Type 'Capitalize<string>' is not assignable to type '`A${string}`'."),
+        "renamed Capitalize source must render structurally, got: {msg}"
+    );
+    assert!(!msg.contains("'Headline'"), "got: {msg}");
+}
+
+#[test]
+fn uncapitalize_alias_source_is_name_independent() {
+    let msg = ts2322(
+        r#"
+type Slug = Uncapitalize<string>;
+declare let v: Slug;
+const x: `a${string}` = v;
+"#,
+    );
+    assert!(
+        msg.contains("Type 'Uncapitalize<string>' is not assignable to type '`a${string}`'."),
+        "renamed Uncapitalize source must render structurally, got: {msg}"
+    );
+    assert!(!msg.contains("'Slug'"), "got: {msg}");
+}
+
+#[test]
 fn nested_string_mapping_alias_source_renders_structurally() {
     let msg = ts2322(
         r#"

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -24,6 +24,5 @@ TypeScript/tests/cases/conformance/node/esmModuleExports2.ts
 TypeScript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
-TypeScript/tests/cases/conformance/types/literal/stringMappingOverPatternLiterals.ts
 TypeScript/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts
 TypeScript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference1.ts


### PR DESCRIPTION
AgentName: M1-C

Fixes #10467.

Contributor/runner: m4-max-opus47-web (remote web session). Canonical lane `M1-C` adopted because this PR resolves a conformance accepted-regression in M1-C's lane (issue #10467, aggregate tracker #10306).

## Track
Conformance / diagnostic type-display parity.

## Invariant / Structural rule
> When the failing **source** of a `TS2322` resolves to a deferred string-mapping intrinsic (`Uppercase`/`Lowercase`/`Capitalize`/`Uncapitalize` over a non-literal argument), tsc renders the structural `Intrinsic<arg>` form in **both** source and target positions, never the type-alias name; this change makes tsz do the same.

The rule is keyed on the structural `StringIntrinsic` shape, never on the intrinsic's user-visible name, so it holds for any alias spelling.

## Root cause
tsz already evaluates the **target** annotation to the structural intrinsic before display, so `const x: Uppercase<string> = …` correctly shows `Uppercase<string>`. But for the **source**, `declared_generic_alias_assignment_pair_display` rewrites the display to the source expression's *declared annotation text* (`type U = Uppercase<string>` → `U`). That rewrite is correct for ordinary object/generic aliases but wrong for string-mapping intrinsics, producing an asymmetric `U` (source) vs `Uppercase<string>` (target) in the message — a fingerprint-only divergence (`tsz error; tsc error`, codes already matched).

## Scope
- `error_reporter/assignability_alias_display.rs`: add a skip condition to the declared-alias source rewrite when the source type is a string-mapping intrinsic (alongside the existing `is_literal_for_alias_display` / `is_object_for_alias_display` skips). Falls through to the structural base display.
- `query_boundaries/assignability_alias_display.rs`: add `is_string_intrinsic_for_alias_display`, a boundary predicate over `common::is_string_intrinsic_type`, matching the module's `is_*_for_alias_display` convention.
- `tests/string_mapping_alias_display_tests.rs` (new): unit coverage.
- `conformance-accepted-regressions.txt`: drop the now-passing `stringMappingOverPatternLiterals.ts`.

Owning layer: checker diagnostic-display policy (relation correctness is unchanged — the same `TS2322` codes are emitted; only the rendered source type changes).

## Project Corpus Impact
- Row: n/a (diagnostic-display parity, no benchmark fixture changes)
- Bug family: string-mapping intrinsic alias display in TS2322
- Evidence: `conformance/types/literal/stringMappingOverPatternLiterals.ts` — verified locally that all 30 tsc diagnostic fingerprints now match (built `tsz`, diffed source-position displays against `scripts/conformance/tsc-cache-full.json`); entry removed from the accepted-regression allowlist so the aggregate gate re-covers it.

## Verification
- `cargo test -p tsz-checker --test string_mapping_alias_display_tests` → all pass (four intrinsics, nested `Lowercase<Uppercase<string>>`, multiple alias spellings for name-independence per §25, plus a negative case proving ordinary object aliases still keep their name).
- Built `tsz` and reproduced every distinct display form from the test's tsc fingerprint set; source now renders `Lowercase<string>` / `Uppercase<string>` / `Lowercase<Uppercase<string>>` / `Capitalize<string>` / `Uncapitalize<string>` (was `L` / `U` / `LU` / `Cap` / `Unc`).
- Negative probe confirms the source is the structural intrinsic, not `any`.
- `cargo clippy -p tsz-checker --all-targets` clean (doc-comment identifiers backticked per §19.6).
- Confirmed the pre-existing `ts2322_tests` (3) and `cross_file_intrinsic_identifier_tests` (1) failures are present on clean `main` without this change — this display-only fix introduces no new failures.

## Adjacent cases / fallback
- Source string-mapping aliases with **no declared annotation** (call/return position) already render structurally via the base path (the rewrite returns early), so they are unaffected.
- Evaluated intrinsics over literals (`Uppercase<"foo">` → `"FOO"`) are not `StringIntrinsic`, so literal display is preserved.

## Coordination Notes
Issue #10467 is in the `agent:M1-C` conformance accepted-regression lane (aggregate tracker #10306); `agent:M1-C` label applied to keep merge-queue routing canonical. No open PR targeted this fingerprint fix — #10265 only *retires already-passing* entries and does not touch display. Also closed #8707 as already-fixed-on-main during intake (verified via repro). Contributor identity `m4-max-opus47-web` retained here as coordination detail only.

_Generated by Claude Code._