### PR TITLE
fix(emitter): suppress duplicate exports_1 for conditionally-assigned vars in System module

### DIFF
--- a/crates/tsz-emitter/src/emitter/module_wrapper/tests.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/tests.rs
@@ -1,3 +1,4 @@
 mod amd_bundle;
 mod amd_import_equals;
 mod system_emit;
+mod system_emit_var_hoisting;

--- a/crates/tsz-emitter/src/emitter/module_wrapper/tests/system_emit_var_hoisting.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/tests/system_emit_var_hoisting.rs
@@ -1,0 +1,98 @@
+use crate::emitter::{ModuleKind, Printer, PrinterOptions};
+use tsz_common::ScriptTarget;
+
+fn emit_system(source: &str) -> String {
+    let mut parser = tsz_parser::ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut printer = Printer::with_options(
+        &parser.arena,
+        PrinterOptions {
+            module: ModuleKind::System,
+            target: ScriptTarget::ESNext,
+            ..Default::default()
+        },
+    );
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+// When a `var` is declared inside a conditional block and re-exported via
+// `export { name }`, tsc emits `exports_1("name", name)` ONLY at the
+// assignment site inside the block — not as an additional unconditional
+// call at the execute-body level.
+#[test]
+fn system_conditional_var_no_duplicate_export() {
+    let output = emit_system(
+        r#"if (false) {
+    var y = 1;
+}
+export { y };
+"#,
+    );
+    let expected = r#"System.register([], function (exports_1, context_1) {
+    "use strict";
+    var y;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {
+            if (false) {
+                y = 1;
+                exports_1("y", y);
+            }
+        }
+    };
+});
+"#;
+    assert_eq!(
+        output, expected,
+        "Conditional var export must not emit a duplicate unconditional exports_1 call.\nOutput:\n{output}"
+    );
+}
+
+// Same structural rule with a different iteration-variable name to confirm
+// the fix is not tied to the spelling `y`.
+#[test]
+fn system_conditional_var_no_duplicate_export_different_name() {
+    let output = emit_system(
+        r#"if (false) {
+    var count = 42;
+}
+export { count };
+"#,
+    );
+    assert!(
+        !output.contains("exports_1(\"count\", count);\n        }\n    };"),
+        "No unconditional exports_1 call should follow the closing brace of the if block.\nOutput:\n{output}"
+    );
+    let execute_exports_count = output.matches("exports_1(\"count\", count)").count();
+    assert_eq!(
+        execute_exports_count, 1,
+        "exports_1 for `count` should appear exactly once (inside the if block).\nOutput:\n{output}"
+    );
+}
+
+// A var assigned in multiple branches should still only be exported at each
+// assignment site, not additionally at the end of execute.
+#[test]
+fn system_multi_branch_var_no_duplicate_export() {
+    let output = emit_system(
+        r#"if (true) {
+    var z = 1;
+} else {
+    var z = 2;
+}
+export { z };
+"#,
+    );
+    let execute_exports_count = output.matches("exports_1(\"z\", z)").count();
+    assert!(
+        execute_exports_count <= 2,
+        "exports_1 for `z` should not appear more than twice (once per branch).\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("exports_1(\"z\", z);\n        }\n    };"),
+        "No trailing unconditional exports_1 call after the if/else block.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -941,6 +941,7 @@ impl<'a> Printer<'a> {
                 self.write_export_binding_start(&export_name);
                 self.write(&local_name);
                 self.write_export_binding_end();
+                self.system_folded_export_names.insert(local_name);
             }
             return;
         }


### PR DESCRIPTION
## Agent
AgentName: Studio-C
Runner: claude-sonnet-4-6 / dazzling-johnson-yQTQ3

## Track
Track 9 — Emit / JS parity

## Invariant
When `tsc` emits System module output for a `var` declared inside a conditional block and re-exported via `export { name }`, it emits `exports_1("name", name)` **only** at the assignment site inside the block — not as an additional unconditional call at the end of the execute body.

## Scope
One-line fix in `crates/tsz-emitter/src/emitter/statements/core.rs` plus a new test file. No solver/checker/binder/conformance changes.

### Structural rule

> When a `var` is assigned inside a nested block (if/while/for body) in a System module execute body and the variable is re-exported via `export { name }`, tsc emits `exports_1("name", name)` inline at the assignment site. The later `export { name }` statement must not emit a second unconditional call.

### Root cause

`emit_variable_statement` has a *deferred-export* path (lines 878–946 of `statements/core.rs`) that activates for `var` declarations inside nested blocks within the System execute body. This path correctly emitted the inline `exports_1` call after the assignment, but it never inserted the local name into `system_folded_export_names`. Without that entry, the later top-level `export { y }` statement found the name absent from the fold set and emitted a duplicate `exports_1("y", y)`.

### Fix

```rust
// statements/core.rs — deferred-export loop
for (local_name, export_name) in deferred_exports {
    self.write_line();
    self.write_export_binding_start(&export_name);
    self.write(&local_name);
    self.write_export_binding_end();
+   self.system_folded_export_names.insert(local_name);
}
```

This matches the behaviour of the lowered-assignment path (lines 999–1016) and the namespace/enum folding paths in `system_emit.rs`, both of which already insert into `system_folded_export_names`.

### Affected emit test

`topLevelVarHoistingSystem` — was `+1/-1 lines` (one extra `exports_1("y", y);` after the if block). Now produces byte-identical output to the tsc baseline.

**Before:**
```javascript
execute: function () {
    if (false) {
        y = 1;
        exports_1("y", y);
    }
    exports_1("y", y);  // ← spurious duplicate
}
```

**After:**
```javascript
execute: function () {
    if (false) {
        y = 1;
        exports_1("y", y);
    }
}
```

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit — System module conditional var re-export
- Evidence: direct `tsz` invocation on `topLevelVarHoistingSystem.ts` confirmed the fix; new unit tests cover the structural rule with two name spellings and a multi-branch case

## Verification

New unit tests (all pass locally):
```
test emitter::module_wrapper::tests::system_emit_var_hoisting::system_conditional_var_no_duplicate_export ... ok
test emitter::module_wrapper::tests::system_emit_var_hoisting::system_conditional_var_no_duplicate_export_different_name ... ok
test emitter::module_wrapper::tests::system_emit_var_hoisting::system_multi_branch_var_no_duplicate_export ... ok
```

Full `tsz-emitter` test suite: 2954 passed, 9 failed — the 9 failures are pre-existing and unchanged (verified by stashing the fix and confirming the same 9 fail on base).

## Coordination Notes
- No overlap with open draft PRs. PR #10463 covers different emitter fixes (ES5 destructuring, static block await, CJS namespace merge). No other open PR touches `system_folded_export_names` or the deferred-export path.
- The new test file `system_emit_var_hoisting.rs` is added as a separate module to avoid pushing the already-oversized `system_emit.rs` (2342 lines) further over the §19 2000-line limit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHj9Ci7qaQfohAWJHYBjsu)_