### PR TITLE
fix(checker): share protected declarations across union intersection arms

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -30,6 +30,10 @@ dashmap = { workspace = true }
 stacker = "0.1.23"
 
 [[test]]
+name = "union_protected_intersection_property_tests"
+path = "tests/union_protected_intersection_property_tests.rs"
+
+[[test]]
 name = "array_element_naked_inference_tests"
 path = "tests/array_element_naked_inference_tests.rs"
 

--- a/crates/tsz-checker/src/checkers/property_checker.rs
+++ b/crates/tsz-checker/src/checkers/property_checker.rs
@@ -2,6 +2,7 @@
 
 mod private_error;
 mod super_static_access;
+mod union_restricted_property;
 
 use crate::classes_domain::class_summary::ClassMemberKind;
 use crate::query_boundaries::type_computation::complex::{
@@ -830,110 +831,6 @@ impl<'a> CheckerState<'a> {
             return false;
         }
         self.is_assignment_operator(binary.operator_token)
-    }
-
-    /// AST classes in which `property_name` is declared as a *restricted*
-    /// (private/protected) member, reachable from `member`.
-    ///
-    /// A single class contributes its own (possibly inherited) declaring class.
-    /// An intersection contributes every constituent's restricted declaration,
-    /// because an intersection's apparent property merges the declarations of
-    /// all its constituents. `None` means the member exposes `property_name`
-    /// only publicly, lacks it, or is not a class type — in any of those cases
-    /// it cannot share a restricted declaration with another union member.
-    fn restricted_property_declarations(
-        &mut self,
-        member: tsz_solver::TypeId,
-        property_name: &str,
-        is_static: bool,
-    ) -> Option<Vec<NodeIndex>> {
-        let intersection_parts =
-            crate::query_boundaries::property_access::intersection_members(self.ctx.types, member)
-                .or_else(|| {
-                    self.ctx.types.get_display_alias(member).and_then(|alias| {
-                        crate::query_boundaries::property_access::intersection_members(
-                            self.ctx.types,
-                            alias,
-                        )
-                    })
-                });
-        if let Some(parts) = intersection_parts {
-            let mut declarations: Vec<NodeIndex> = Vec::new();
-            for part in parts {
-                let part = self.resolve_type_for_property_access(part);
-                if let Some(class_idx) = self.get_class_decl_from_type(part)
-                    && let Some(info) =
-                        self.find_member_access_info(class_idx, property_name, is_static)
-                    && !declarations.contains(&info.declaring_class_idx)
-                {
-                    declarations.push(info.declaring_class_idx);
-                }
-            }
-            return (!declarations.is_empty()).then_some(declarations);
-        }
-
-        let resolved = self.resolve_type_for_property_access(member);
-        let class_idx = self.get_class_decl_from_type(resolved)?;
-        let info = self.find_member_access_info(class_idx, property_name, is_static)?;
-        Some(vec![info.declaring_class_idx])
-    }
-
-    /// tsc exposes a restricted (private/protected) member on a union only when
-    /// every constituent shares a *common declaration* of it — not merely an
-    /// identically-named symbol (see the
-    /// `unionPropertyOfProtectedAndIntersectionProperty` conformance test). A
-    /// constituent that exposes the member publicly, lacks it, or declares it
-    /// in an unrelated class breaks that sharing and makes the property absent.
-    ///
-    /// The "common declaration" comparison is keyed on declaring-class identity,
-    /// so it is independent of the class/property/type-parameter names chosen.
-    pub(crate) fn union_restricted_property_is_missing(
-        &mut self,
-        property_name: &str,
-        object_type: tsz_solver::TypeId,
-    ) -> bool {
-        use crate::query_boundaries::state::checking;
-
-        if self.ctx.enclosing_class.is_some() {
-            return false;
-        }
-
-        let Some(members) = checking::union_members(self.ctx.types, object_type) else {
-            return false;
-        };
-
-        if members.len() < 2 {
-            return false;
-        }
-
-        let is_static = self.is_constructor_type(object_type);
-
-        let mut has_restricted = false;
-        let mut has_conflict = false;
-        // Declarations of the first constituent that exposes the member as
-        // restricted; later constituents must share at least one of them.
-        let mut shared_declarations: Option<Vec<NodeIndex>> = None;
-
-        for member in members {
-            match self.restricted_property_declarations(member, property_name, is_static) {
-                Some(declarations) => {
-                    has_restricted = true;
-                    match &shared_declarations {
-                        None => shared_declarations = Some(declarations),
-                        Some(reference) => {
-                            if !declarations.iter().any(|decl| reference.contains(decl)) {
-                                has_conflict = true;
-                            }
-                        }
-                    }
-                }
-                // Public, missing, or non-class member: a different declaration
-                // from any restricted member.
-                None => has_conflict = true,
-            }
-        }
-
-        has_restricted && has_conflict
     }
 
     fn intersection_private_property_is_missing(

--- a/crates/tsz-checker/src/checkers/property_checker.rs
+++ b/crates/tsz-checker/src/checkers/property_checker.rs
@@ -98,7 +98,7 @@ impl<'a> CheckerState<'a> {
             .and_then(|node| self.ctx.arena.get_identifier(node))
             .is_some();
 
-        if self.union_restricted_property_is_missing(object_expr, property_name, object_type) {
+        if self.union_restricted_property_is_missing(property_name, object_type) {
             self.error_property_not_exist_at(property_name, object_type, error_node);
             return false;
         }
@@ -832,17 +832,63 @@ impl<'a> CheckerState<'a> {
         self.is_assignment_operator(binary.operator_token)
     }
 
-    /// Check if a union type has a property that should be treated as "not existing"
-    /// because one or more members have it as private/protected while other members
-    /// have it publicly or from a different declaring class.
+    /// AST classes in which `property_name` is declared as a *restricted*
+    /// (private/protected) member, reachable from `member`.
     ///
-    /// Matches tsc's `createUnionOrIntersectionProperty` logic: when a property has a
-    /// private/protected declaration in one constituent but is missing, public, or has
-    /// a different declaration in another constituent, the property doesn't exist on
-    /// the union type (TS2339) rather than getting a specific accessibility error.
-    fn union_restricted_property_is_missing(
+    /// A single class contributes its own (possibly inherited) declaring class.
+    /// An intersection contributes every constituent's restricted declaration,
+    /// because an intersection's apparent property merges the declarations of
+    /// all its constituents. `None` means the member exposes `property_name`
+    /// only publicly, lacks it, or is not a class type — in any of those cases
+    /// it cannot share a restricted declaration with another union member.
+    fn restricted_property_declarations(
         &mut self,
-        _object_expr: NodeIndex,
+        member: tsz_solver::TypeId,
+        property_name: &str,
+        is_static: bool,
+    ) -> Option<Vec<NodeIndex>> {
+        let intersection_parts =
+            crate::query_boundaries::property_access::intersection_members(self.ctx.types, member)
+                .or_else(|| {
+                    self.ctx.types.get_display_alias(member).and_then(|alias| {
+                        crate::query_boundaries::property_access::intersection_members(
+                            self.ctx.types,
+                            alias,
+                        )
+                    })
+                });
+        if let Some(parts) = intersection_parts {
+            let mut declarations: Vec<NodeIndex> = Vec::new();
+            for part in parts {
+                let part = self.resolve_type_for_property_access(part);
+                if let Some(class_idx) = self.get_class_decl_from_type(part)
+                    && let Some(info) =
+                        self.find_member_access_info(class_idx, property_name, is_static)
+                    && !declarations.contains(&info.declaring_class_idx)
+                {
+                    declarations.push(info.declaring_class_idx);
+                }
+            }
+            return (!declarations.is_empty()).then_some(declarations);
+        }
+
+        let resolved = self.resolve_type_for_property_access(member);
+        let class_idx = self.get_class_decl_from_type(resolved)?;
+        let info = self.find_member_access_info(class_idx, property_name, is_static)?;
+        Some(vec![info.declaring_class_idx])
+    }
+
+    /// tsc exposes a restricted (private/protected) member on a union only when
+    /// every constituent shares a *common declaration* of it — not merely an
+    /// identically-named symbol (see the
+    /// `unionPropertyOfProtectedAndIntersectionProperty` conformance test). A
+    /// constituent that exposes the member publicly, lacks it, or declares it
+    /// in an unrelated class breaks that sharing and makes the property absent.
+    ///
+    /// The "common declaration" comparison is keyed on declaring-class identity,
+    /// so it is independent of the class/property/type-parameter names chosen.
+    pub(crate) fn union_restricted_property_is_missing(
+        &mut self,
         property_name: &str,
         object_type: tsz_solver::TypeId,
     ) -> bool {
@@ -863,42 +909,31 @@ impl<'a> CheckerState<'a> {
         let is_static = self.is_constructor_type(object_type);
 
         let mut has_restricted = false;
-        let mut has_other = false;
-        let mut first_declaring_class: Option<NodeIndex> = None;
+        let mut has_conflict = false;
+        // Declarations of the first constituent that exposes the member as
+        // restricted; later constituents must share at least one of them.
+        let mut shared_declarations: Option<Vec<NodeIndex>> = None;
 
         for member in members {
-            let member = self.resolve_type_for_property_access(member);
-            let Some(class_idx) = self.get_class_decl_from_type(member) else {
-                // Non-class member in the union (e.g., object literal type).
-                // Treated as a different declaration from any class member.
-                has_other = true;
-                continue;
-            };
-
-            match self.find_member_access_info(class_idx, property_name, is_static) {
-                Some(access_info) => {
-                    // Property is restricted (private/protected) in this member
+            match self.restricted_property_declarations(member, property_name, is_static) {
+                Some(declarations) => {
                     has_restricted = true;
-                    if let Some(first_decl) = first_declaring_class {
-                        if first_decl != access_info.declaring_class_idx {
-                            // Different declaring class — counts as "other"
-                            has_other = true;
+                    match &shared_declarations {
+                        None => shared_declarations = Some(declarations),
+                        Some(reference) => {
+                            if !declarations.iter().any(|decl| reference.contains(decl)) {
+                                has_conflict = true;
+                            }
                         }
-                    } else {
-                        first_declaring_class = Some(access_info.declaring_class_idx);
                     }
                 }
-                None => {
-                    // Property is public or not found in this class member
-                    has_other = true;
-                }
+                // Public, missing, or non-class member: a different declaration
+                // from any restricted member.
+                None => has_conflict = true,
             }
         }
 
-        // If any member has a restricted property and there's at least one member
-        // with a different declaration (public, missing, or different class),
-        // the property doesn't exist on the union type.
-        has_restricted && has_other
+        has_restricted && has_conflict
     }
 
     fn intersection_private_property_is_missing(

--- a/crates/tsz-checker/src/checkers/property_checker/union_restricted_property.rs
+++ b/crates/tsz-checker/src/checkers/property_checker/union_restricted_property.rs
@@ -1,0 +1,117 @@
+//! Union/intersection restricted-property (`private`/`protected`) presence rule.
+//!
+//! Extracted from `property_checker.rs` to keep that module under the 2000-LOC
+//! ceiling. Mirrors tsc's `createUnionOrIntersectionProperty`: a union exposes a
+//! restricted member only when every constituent shares a common declaration of
+//! it, and an intersection constituent contributes the declarations of all of
+//! its parts.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// AST classes in which `property_name` is declared as a *restricted*
+    /// (private/protected) member, reachable from `member`.
+    ///
+    /// A single class contributes its own (possibly inherited) declaring class.
+    /// An intersection contributes every constituent's restricted declaration,
+    /// because an intersection's apparent property merges the declarations of
+    /// all its constituents. `None` means the member exposes `property_name`
+    /// only publicly, lacks it, or is not a class type — in any of those cases
+    /// it cannot share a restricted declaration with another union member.
+    fn restricted_property_declarations(
+        &mut self,
+        member: TypeId,
+        property_name: &str,
+        is_static: bool,
+    ) -> Option<Vec<NodeIndex>> {
+        let intersection_parts =
+            crate::query_boundaries::property_access::intersection_members(self.ctx.types, member)
+                .or_else(|| {
+                    self.ctx.types.get_display_alias(member).and_then(|alias| {
+                        crate::query_boundaries::property_access::intersection_members(
+                            self.ctx.types,
+                            alias,
+                        )
+                    })
+                });
+        if let Some(parts) = intersection_parts {
+            let mut declarations: Vec<NodeIndex> = Vec::new();
+            for part in parts {
+                let part = self.resolve_type_for_property_access(part);
+                if let Some(class_idx) = self.get_class_decl_from_type(part)
+                    && let Some(info) =
+                        self.find_member_access_info(class_idx, property_name, is_static)
+                    && !declarations.contains(&info.declaring_class_idx)
+                {
+                    declarations.push(info.declaring_class_idx);
+                }
+            }
+            return (!declarations.is_empty()).then_some(declarations);
+        }
+
+        let resolved = self.resolve_type_for_property_access(member);
+        let class_idx = self.get_class_decl_from_type(resolved)?;
+        let info = self.find_member_access_info(class_idx, property_name, is_static)?;
+        Some(vec![info.declaring_class_idx])
+    }
+
+    /// tsc exposes a restricted (private/protected) member on a union only when
+    /// every constituent shares a *common declaration* of it — not merely an
+    /// identically-named symbol (see the
+    /// `unionPropertyOfProtectedAndIntersectionProperty` conformance test). A
+    /// constituent that exposes the member publicly, lacks it, or declares it
+    /// in an unrelated class breaks that sharing and makes the property absent.
+    ///
+    /// The "common declaration" comparison is keyed on declaring-class identity,
+    /// so it is independent of the class/property/type-parameter names chosen.
+    pub(crate) fn union_restricted_property_is_missing(
+        &mut self,
+        property_name: &str,
+        object_type: TypeId,
+    ) -> bool {
+        use crate::query_boundaries::state::checking;
+
+        if self.ctx.enclosing_class.is_some() {
+            return false;
+        }
+
+        let Some(members) = checking::union_members(self.ctx.types, object_type) else {
+            return false;
+        };
+
+        if members.len() < 2 {
+            return false;
+        }
+
+        let is_static = self.is_constructor_type(object_type);
+
+        let mut has_restricted = false;
+        let mut has_conflict = false;
+        // Declarations of the first constituent that exposes the member as
+        // restricted; later constituents must share at least one of them.
+        let mut shared_declarations: Option<Vec<NodeIndex>> = None;
+
+        for member in members {
+            match self.restricted_property_declarations(member, property_name, is_static) {
+                Some(declarations) => {
+                    has_restricted = true;
+                    match &shared_declarations {
+                        None => shared_declarations = Some(declarations),
+                        Some(reference) => {
+                            if !declarations.iter().any(|decl| reference.contains(decl)) {
+                                has_conflict = true;
+                            }
+                        }
+                    }
+                }
+                // Public, missing, or non-class member: a different declaration
+                // from any restricted member.
+                None => has_conflict = true,
+            }
+        }
+
+        has_restricted && has_conflict
+    }
+}

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
@@ -631,52 +631,17 @@ impl<'a> CheckerState<'a> {
         })
     }
 
+    /// Indexed-access (`(A | B)["k"]`) form of the union restricted-property
+    /// rule. Delegates to the shared
+    /// [`CheckerState::union_restricted_property_is_missing`] so the type-level
+    /// and expression-level (`x.k`) paths stay in lockstep, including the
+    /// intersection-constituent "common declaration" handling.
     pub(super) fn union_restricted_literal_property_is_missing(
         &mut self,
         property_name: &str,
         object_type: TypeId,
     ) -> bool {
-        use crate::query_boundaries::state::checking;
-
-        if self.ctx.enclosing_class.is_some() {
-            return false;
-        }
-
-        let Some(members) = checking::union_members(self.ctx.types, object_type) else {
-            return false;
-        };
-        if members.len() < 2 {
-            return false;
-        }
-
-        let is_static = self.is_constructor_type(object_type);
-        let mut has_restricted = false;
-        let mut has_other = false;
-        let mut first_declaring_class: Option<NodeIndex> = None;
-
-        for member in members {
-            let member = self.resolve_type_for_property_access(member);
-            let Some(class_idx) = self.get_class_decl_from_type(member) else {
-                has_other = true;
-                continue;
-            };
-
-            match self.find_member_access_info(class_idx, property_name, is_static) {
-                Some(access_info) => {
-                    has_restricted = true;
-                    if let Some(first_decl) = first_declaring_class {
-                        if first_decl != access_info.declaring_class_idx {
-                            has_other = true;
-                        }
-                    } else {
-                        first_declaring_class = Some(access_info.declaring_class_idx);
-                    }
-                }
-                None => has_other = true,
-            }
-        }
-
-        has_restricted && has_other
+        self.union_restricted_property_is_missing(property_name, object_type)
     }
 
     pub(super) fn error_at_index_type_span(

--- a/crates/tsz-checker/tests/union_protected_intersection_property_tests.rs
+++ b/crates/tsz-checker/tests/union_protected_intersection_property_tests.rs
@@ -1,0 +1,131 @@
+//! Regression coverage for issue #10459 / the tsc conformance test
+//! `unionPropertyOfProtectedAndIntersectionProperty.ts`.
+//!
+//! Rule: a union exposes a protected/private member only when every constituent
+//! shares a *common declaration* of it. An intersection constituent contributes
+//! the declarations of all of its parts, so `(Foo | (Foo & Bar))["foo"]` is OK
+//! (the intersection arm carries `Foo`'s protected `foo`, shared with the plain
+//! `Foo` arm), while `(Foo | Bar)["foo"]` still errors because the two protected
+//! declarations are unrelated.
+//!
+//! The comparison is keyed on declaring-class identity, never on class /
+//! property / type-parameter names, so the tests vary all of those.
+
+use tsz_checker::test_utils::check_source_code_messages;
+
+fn ts2339_count(diags: &[(u32, String)]) -> usize {
+    diags.iter().filter(|(code, _)| *code == 2339).count()
+}
+
+#[test]
+fn union_with_intersection_arm_sharing_protected_declaration_is_accessible() {
+    let diags = check_source_code_messages(
+        r#"
+class Foo { protected foo = 0; }
+class Bar { protected foo = 0; }
+type Ok = (Foo | (Foo & Bar))["foo"];
+"#,
+    );
+    assert_eq!(
+        ts2339_count(&diags),
+        0,
+        "an intersection arm sharing a protected declaration must expose the member: {diags:?}"
+    );
+}
+
+#[test]
+fn union_of_unrelated_protected_declarations_still_errors() {
+    let diags = check_source_code_messages(
+        r#"
+class Foo { protected foo = 0; }
+class Bar { protected foo = 0; }
+type Bad = (Foo | Bar)["foo"];
+"#,
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|(code, message)| *code == 2339 && message.contains("Foo | Bar")),
+        "unrelated protected declarations on a union must still report TS2339: {diags:?}"
+    );
+}
+
+#[test]
+fn intersection_protected_rule_is_independent_of_names() {
+    // Same shapes as the repro but with renamed classes and a renamed property,
+    // proving the fix keys on declaration identity rather than spellings.
+    let diags = check_source_code_messages(
+        r#"
+class Alpha { protected slot = ""; }
+class Beta { protected slot = ""; }
+type Ok = (Alpha | (Alpha & Beta))["slot"];
+type Bad = (Alpha | Beta)["slot"];
+"#,
+    );
+    let ts2339: Vec<&(u32, String)> = diags.iter().filter(|(code, _)| *code == 2339).collect();
+    assert_eq!(
+        ts2339.len(),
+        1,
+        "exactly the unrelated union should report TS2339: {diags:?}"
+    );
+    assert!(
+        ts2339[0].1.contains("Alpha | Beta"),
+        "the single TS2339 must be for the unrelated `Alpha | Beta` union: {diags:?}"
+    );
+}
+
+#[test]
+fn union_with_intersection_arm_sharing_inherited_protected_declaration_is_accessible() {
+    // `Sub` inherits `value` from `Base`; the `(Base & Mix)` arm also carries
+    // `Base`'s declaration, so the union shares a common declaration.
+    let diags = check_source_code_messages(
+        r#"
+class Base { protected value = 0; }
+class Mix { protected value = 0; }
+class Sub extends Base {}
+type Ok = (Sub | (Base & Mix))["value"];
+"#,
+    );
+    assert_eq!(
+        ts2339_count(&diags),
+        0,
+        "an inherited shared protected declaration must expose the member: {diags:?}"
+    );
+}
+
+#[test]
+fn union_three_members_unrelated_protected_arm_breaks_sharing() {
+    // The `(Foo & Bar)` arm shares with `Foo`, but the third arm `Baz` declares
+    // its own unrelated protected `foo`, so the union no longer shares a common
+    // declaration.
+    let diags = check_source_code_messages(
+        r#"
+class Foo { protected foo = 0; }
+class Bar { protected foo = 0; }
+class Baz { protected foo = 0; }
+type Bad = (Foo | (Foo & Bar) | Baz)["foo"];
+"#,
+    );
+    assert!(
+        ts2339_count(&diags) >= 1,
+        "a third unrelated protected arm must break the shared declaration: {diags:?}"
+    );
+}
+
+#[test]
+fn union_of_public_properties_from_different_classes_is_accessible() {
+    // Public members from different classes were never gated by this rule;
+    // guard against the fix over-reaching into public unions.
+    let diags = check_source_code_messages(
+        r#"
+class A { x = 0; }
+class B { x = ""; }
+type Ok = (A | B)["x"];
+"#,
+    );
+    assert_eq!(
+        ts2339_count(&diags),
+        0,
+        "public properties on a union must remain accessible: {diags:?}"
+    );
+}

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -12,7 +12,6 @@ TypeScript/tests/cases/compiler/jsxComplexSignatureHasApplicabilityError.tsx
 TypeScript/tests/cases/compiler/mappedTypeInferenceFromApparentType.ts
 TypeScript/tests/cases/compiler/reorderProperties.ts
 TypeScript/tests/cases/compiler/temporal.ts
-TypeScript/tests/cases/compiler/unionPropertyOfProtectedAndIntersectionProperty.ts
 TypeScript/tests/cases/conformance/controlFlow/controlFlowGenericTypes.ts
 TypeScript/tests/cases/conformance/es2019/globalThisAmbientModules.ts
 TypeScript/tests/cases/conformance/es2024/sharedMemory.ts


### PR DESCRIPTION
## Agent
AgentName: M1-C
Contributor: web-opus47 (Claude Code on web runner identity; not a canonical lane)

## Track
Conformance — TS2339 / protected-member union property. Picked up from the
`agent:M1-C` accepted-regression triage batch (tracker #10306). Fixes #10459.

## Invariant
When a union member is an intersection, `tsc` merges that constituent's
declarations into the union's apparent property, so a protected/private member
stays accessible iff every constituent shares a common declaration of it; this
PR makes tsz do the same through the checker's shared union restricted-property
gate (keyed on declaring-class identity, not symbol or name identity).

## Scope
False-positive `TS2339` on indexed-access and property-access of a
protected/private member through a union whose arm is an intersection — e.g.
`(Foo | (Foo & Bar))["foo"]` — which `tsc` accepts.

- `(Foo | Bar)["foo"]` → still `TS2339` (the two protected `foo`s are unrelated).
- `(Foo | (Foo & Bar))["foo"]` → now OK (the intersection arm carries `Foo`'s
  `foo`, shared with the plain `Foo` arm).

Root cause: the checker treated any intersection union-member as a "different
declaration" (because `get_class_decl_from_type` returns `None` for an
intersection), lumping `(Foo | (Foo & Bar))["foo"]` in with the genuinely
unrelated `(Foo | Bar)["foo"]`. The fix walks intersection constituents and
collects each one's restricted declaring class, then keeps the member only when
the constituents share a common declaration. It also unifies the two previously
duplicated copies — the `x.k` expression path in `property_checker.rs` and the
`(A | B)["k"]` type path in `indexed_access_helpers.rs` — onto one shared helper
so they cannot drift again.

Known fallback: an intersection that mixes a protected member in one constituent
with a *public* member of the same name in another is not specially modeled (the
public declaration is not added to the shared set); such shapes fall back to the
normal restricted-only comparison. None of the issue's adjacent cases hit this.

## Project Corpus Impact
- Row: `unionPropertyOfProtectedAndIntersectionProperty.ts` (compiler conformance)
- Bug family: protected/private apparent-property synthesis on unions containing intersection arms
- Evidence: direct `tsz` CLI run on the test at the pinned submodule SHA matches the tsc baseline (single `TS2339`); the accepted-regression entry was removed so the ready conformance gate re-validates

## Verification
- `cargo test -p tsz-checker --test union_protected_intersection_property_tests` — 6/6 pass (adjacent-case matrix: reported repro; unrelated-union negative guard; renamed classes + property; inherited shared declaration; three-member unrelated arm; public-union regression guard).
- Existing union/protected regression tests still pass:
  `union_restricted_property_access_*`, `union_public_and_protected_*`,
  `union_public_and_private_*`, `union_three_member_mixed_*`,
  `union_restricted_property_access_same_declaring_class_is_allowed`, plus
  `protected_intersection_owner_display_tests` and
  `indexed_access_resolved_union_property_tests` (26 related tests, 0 failures).
- Direct CLI check on the real test at the pinned submodule SHA: `tsz` now emits
  exactly one diagnostic — `TS2339 ... 'Foo | Bar'` at the `_4` line — matching
  the tsc baseline's single error; the previously-extra `_5`
  (`Foo | (Foo & Bar)`) false positive is gone.
- Removed the test from `scripts/conformance/conformance-accepted-regressions.txt`.
- `cargo clippy -p tsz-checker --lib` clean.

## Coordination Notes
Picked up from the `agent:M1-C` triage batch (tracker #10306); M1-C's active
branch is the html-import work (#10440), so this backlog item was unclaimed.
Issue #10459 is marked and carries a signed claim comment. Running as the
`web-opus47` web runner; using the canonical `M1-C` lane for ownership per
Reviewer guidance. GitHub auto-merge has been disabled — landing will go through
the repo-local `merge-queue` after exact-head gates pass; I am not adding the
`merge-queue` label myself.