### PR TITLE
refactor(checker): route jsx boundary relation

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/checkers/jsx.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/jsx.rs
@@ -88,7 +88,7 @@ pub(crate) fn types_are_assignable(
     source: TypeId,
     target: TypeId,
 ) -> bool {
-    checker.diagnostic_relation_boolean_guard(source, target)
+    checker.assign_relation_outcome(source, target).related
 }
 
 pub(crate) fn has_object_shape(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
@@ -348,4 +348,24 @@ fn contains_anonymous_object_surface_inner(
             .iter()
             .any(|&member| contains_anonymous_object_surface_inner(db, def_store, member, visited))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn types_are_assignable_uses_relation_outcome_boundary() {
+        let source = include_str!("jsx.rs");
+        let legacy = concat!("diagnostic_relation", "_boolean_guard(");
+
+        assert!(
+            source.contains("checker.assign_relation_outcome(source, target).related"),
+            "JSX assignability boundary should route relation decisions through \
+             the shared relation outcome boundary"
+        );
+        assert!(
+            !source.contains(legacy),
+            "JSX assignability boundary should not use raw diagnostic relation \
+             boolean guards"
+        );
+    }
 }


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor only: checker relation diagnostic query-boundary routing.

## Invariant
When JSX checker code asks the query-boundary helper whether two types are assignable, checker still owns the JSX diagnostic orchestration, and this PR routes relation truth through `assign_relation_outcome(...).related` instead of the raw diagnostic boolean guard.

## Scope
- `crates/tsz-checker/src/query_boundaries/checkers/jsx.rs`: route `types_are_assignable` through the shared assignment `RelationOutcome` boundary and add an in-file architecture guard test.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only routing change; no solver policy, relation flags, cache keys, diagnostic text, or conformance baselines changed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib types_are_assignable_uses_relation_outcome_boundary` -> 1 passed, 5292 skipped
- `python3 scripts/arch/arch_guard.py` -> passed
- `scripts/arch/check-checker-boundaries.sh` -> passed
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `scripts/agents/ensure-agent-labels.sh --audit` -> clean
- Post-rebase `git rev-list --left-right --count origin/main...HEAD` -> `0 1`

## Coordination Notes
- AgentName: M1-B
- Fresh worktree: `/Users/mohsen/code/tsz-m1b-fresh-origin-main-20260527-060539`.
- Branch rebased onto latest `origin/main` before push; head commit `e52171e871`.
- Exact overlap check for `crates/tsz-checker/src/query_boundaries/checkers/jsx.rs` returned no open PRs before publishing.
- Avoids active JSX bundle files in #10425 and indexed-access behavior work in #10485; draft only, no queue or auto-merge requested.
