### PR TITLE
refactor(checker): route conditional filter relations

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
@@ -188,8 +188,12 @@ impl<'a> CheckerState<'a> {
                 let true_resolved = self.resolve_lazy_type(true_type);
                 let true_evaluated = self.evaluate_type_for_assignability(true_resolved);
                 let constraint_evaluated = self.evaluate_type_for_assignability(constraint);
-                if self.diagnostic_relation_boolean_guard(true_evaluated, constraint_evaluated)
-                    || self.diagnostic_relation_boolean_guard(true_resolved, constraint)
+                if self
+                    .assign_relation_outcome(true_evaluated, constraint_evaluated)
+                    .related
+                    || self
+                        .assign_relation_outcome(true_resolved, constraint)
+                        .related
                 {
                     return true;
                 }
@@ -200,8 +204,11 @@ impl<'a> CheckerState<'a> {
                 let extends_resolved = self.resolve_lazy_type(extends_type);
                 let extends_evaluated = self.evaluate_type_for_assignability(extends_resolved);
                 return self
-                    .diagnostic_relation_boolean_guard(extends_evaluated, constraint_evaluated)
-                    || self.diagnostic_relation_boolean_guard(extends_resolved, constraint);
+                    .assign_relation_outcome(extends_evaluated, constraint_evaluated)
+                    .related
+                    || self
+                        .assign_relation_outcome(extends_resolved, constraint)
+                        .related;
             }
 
             let Some(app) =

--- a/crates/tsz-checker/src/tests/conditional_constraint_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/conditional_constraint_relation_routing_arch_tests.rs
@@ -27,3 +27,26 @@ fn conditional_result_branches_use_relation_outcome_boundary() {
         "the raw and evaluated branch relations should both route through RelationOutcome"
     );
 }
+
+#[test]
+fn conditional_filter_helper_uses_relation_outcome_boundary() {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src/checkers/generic_checker/conditional_constraint_helpers.rs");
+    let source =
+        fs::read_to_string(&source_path).expect("read conditional constraint helper source");
+
+    let function_start = source
+        .find("pub(crate) fn type_alias_application_filters_to_constraint")
+        .expect("find conditional filter helper");
+    let function = &source[function_start..];
+
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "conditional filter relation decisions must use the shared relation outcome boundary"
+    );
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        4,
+        "the true and extends relation probes should route through RelationOutcome"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor only: checker relation diagnostic query-boundary routing.

## Invariant
When a conditional type alias filters to a constraint, checker still owns the constraint-suppression decision, and this PR routes the true-branch and extends-branch relation probes through `assign_relation_outcome(...).related` instead of raw diagnostic boolean guards.

## Scope
- `crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs`: route `type_alias_application_filters_to_constraint` relation probes through the shared assignment `RelationOutcome` boundary.
- `crates/tsz-checker/src/tests/conditional_constraint_relation_routing_arch_tests.rs`: extend the existing architecture guard for the conditional filter helper.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only routing change; no solver policy, relation flags, cache keys, diagnostic text, or conformance baselines changed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib conditional_filter_helper_uses_relation_outcome_boundary` -> 1 passed, 5316 skipped
- `python3 scripts/arch/arch_guard.py` -> passed
- `scripts/arch/check-checker-boundaries.sh` -> passed
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `scripts/agents/ensure-agent-labels.sh --audit` -> clean
- Post-rebase `git rev-list --left-right --count origin/main...HEAD` -> `0 1`

## Coordination Notes
- AgentName: M1-B
- Fresh branch from `origin/main`: `codex/m1b-conditional-filter-relation-20260527`.
- Head commit `d61e7bb859` after rebasing onto latest `origin/main`.
- Exact overlap check for the touched files returned no open PRs before publishing.
- Draft only; no queue or auto-merge requested.

