### PR TITLE
refactor(checker): route generic mapped key boundary relations

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/checkers/generic.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/generic.rs
@@ -284,7 +284,10 @@ pub(crate) fn mapped_key_constraint_semantically_filters_current_object_keys(
 ) -> bool {
     let constraint_eval = checker.evaluate_type_with_env(constraint_type);
     let keyof_object_param = checker.ctx.types.factory().keyof(object_type);
-    if checker.diagnostic_relation_boolean_guard(constraint_eval, keyof_object_param) {
+    if checker
+        .assign_relation_outcome(constraint_eval, keyof_object_param)
+        .related
+    {
         return true;
     }
 
@@ -313,7 +316,10 @@ pub(crate) fn mapped_key_constraint_semantically_filters_current_object_keys(
         {
             return true;
         }
-        if checker.diagnostic_relation_boolean_guard(next_eval, keyof_object_param) {
+        if checker
+            .assign_relation_outcome(next_eval, keyof_object_param)
+            .related
+        {
             return true;
         }
         if !crate::query_boundaries::common::is_type_parameter_like(checker.ctx.types, next_eval) {
@@ -354,7 +360,9 @@ fn mapped_key_constraint_filters_current_object_keys(
                         evaluated,
                         object_type,
                         object_type_for_check,
-                    ) || checker.diagnostic_relation_boolean_guard(evaluated, keyof_object)
+                    ) || checker
+                        .assign_relation_outcome(evaluated, keyof_object)
+                        .related
                 });
         }
 
@@ -840,5 +848,24 @@ mod tests {
         db.store_display_alias(evaluated, keyof);
 
         assert!(!constraint_has_keyof_surface(&db, evaluated));
+    }
+
+    #[test]
+    fn mapped_key_constraint_filtering_uses_relation_outcome_boundary() {
+        let source = include_str!("generic.rs");
+        let legacy = concat!("diagnostic_relation", "_boolean_guard(");
+
+        assert!(
+            source.contains(".assign_relation_outcome(constraint_eval, keyof_object_param)")
+                && source.contains(".assign_relation_outcome(next_eval, keyof_object_param)")
+                && source.contains(".assign_relation_outcome(evaluated, keyof_object)"),
+            "mapped-key constraint filtering should route relation probes through \
+             the shared relation outcome boundary"
+        );
+        assert!(
+            !source.contains(legacy),
+            "generic query-boundary helpers should not use raw diagnostic relation \
+             boolean guards"
+        );
     }
 }


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor only: checker relation diagnostic query-boundary routing.

## Invariant
When a generic mapped-key constraint is tested against the current object key space, checker still owns the mapped-key suppression decision, and this PR routes the relation probes through `assign_relation_outcome(...).related` instead of raw diagnostic boolean guards.

## Scope
- `crates/tsz-checker/src/query_boundaries/checkers/generic.rs`: route mapped-key constraint filtering relation probes through the shared assignment `RelationOutcome` boundary and add an in-file architecture guard test.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only routing change; no solver policy, relation flags, cache keys, diagnostic text, or conformance baselines changed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib mapped_key_constraint_filtering_uses_relation_outcome_boundary` -> 1 passed, 5329 skipped
- `python3 scripts/arch/arch_guard.py` -> passed
- `scripts/arch/check-checker-boundaries.sh` -> passed
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `scripts/agents/ensure-agent-labels.sh --audit` -> clean
- Post-rebase `git rev-list --left-right --count origin/main...HEAD` -> `0 1`

## Coordination Notes
- AgentName: M1-B
- Fresh branch from `origin/main`: `codex/m1b-generic-mapped-key-boundary-relation-20260527`.
- Head commit `5068e25a01` after rebasing onto latest `origin/main`.
- Exact overlap check for `crates/tsz-checker/src/query_boundaries/checkers/generic.rs` returned no open PRs before publishing.
- Draft only; no queue or auto-merge requested.
