### PR TITLE
refactor(checker): route infer constraint relations

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/infer_conditional_constraints.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/infer_conditional_constraints.rs
@@ -143,8 +143,11 @@ impl<'a> CheckerState<'a> {
         );
         let restricted = self.resolve_lazy_type(restricted);
         let restricted_evaluated = self.evaluate_type_for_assignability(restricted);
-        self.diagnostic_relation_boolean_guard(restricted_evaluated, inst_constraint)
-            || self.diagnostic_relation_boolean_guard(restricted, inst_constraint)
+        self.assign_relation_outcome(restricted_evaluated, inst_constraint)
+            .related
+            || self
+                .assign_relation_outcome(restricted, inst_constraint)
+                .related
     }
 
     /// Some aliases compute a constrained result through a conditional `infer`
@@ -190,8 +193,11 @@ impl<'a> CheckerState<'a> {
         );
         let restricted = self.resolve_lazy_type(restricted);
         let restricted_evaluated = self.evaluate_type_for_assignability(restricted);
-        self.diagnostic_relation_boolean_guard(restricted_evaluated, inst_constraint)
-            || self.diagnostic_relation_boolean_guard(restricted, inst_constraint)
+        self.assign_relation_outcome(restricted_evaluated, inst_constraint)
+            .related
+            || self
+                .assign_relation_outcome(restricted, inst_constraint)
+                .related
     }
 
     pub(super) fn type_arg_satisfies_via_hidden_infer_constraints(
@@ -234,7 +240,8 @@ impl<'a> CheckerState<'a> {
             &substitution,
         );
         let restricted = self.resolve_lazy_type(restricted);
-        self.diagnostic_relation_boolean_guard(restricted, inst_constraint)
+        self.assign_relation_outcome(restricted, inst_constraint)
+            .related
             || self.base_union_members_satisfy_constraint(restricted, inst_constraint)
     }
 

--- a/crates/tsz-checker/src/tests/infer_conditional_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/infer_conditional_relation_routing_arch_tests.rs
@@ -27,3 +27,59 @@ fn infer_result_check_constraint_uses_relation_outcome_boundary() {
         "the evaluated and raw restricted relations should both route through RelationOutcome"
     );
 }
+
+#[test]
+fn infer_result_referenced_constraints_use_relation_outcome_boundary() {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src/checkers/generic_checker/infer_conditional_constraints.rs");
+    let source =
+        fs::read_to_string(&source_path).expect("read infer conditional constraint helper source");
+
+    let function_start = source
+        .find("pub(super) fn infer_result_satisfies_via_referenced_constraints")
+        .expect("find referenced-constraint helper");
+    let rest = &source[function_start..];
+    let function_end = rest
+        .find("\n    pub(super) fn type_arg_satisfies_via_hidden_infer_constraints")
+        .expect("find hidden-infer helper");
+    let function = &rest[..function_end];
+
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "infer-result referenced-constraint relation decisions must use the \
+         shared relation outcome boundary"
+    );
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        2,
+        "the evaluated and raw restricted relations should both route through RelationOutcome"
+    );
+}
+
+#[test]
+fn hidden_infer_constraints_use_relation_outcome_boundary() {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src/checkers/generic_checker/infer_conditional_constraints.rs");
+    let source =
+        fs::read_to_string(&source_path).expect("read infer conditional constraint helper source");
+
+    let function_start = source
+        .find("pub(super) fn type_arg_satisfies_via_hidden_infer_constraints")
+        .expect("find hidden-infer helper");
+    let rest = &source[function_start..];
+    let function_end = rest
+        .find("\n    pub(super) fn infer_result_satisfies_array_like_constraint")
+        .expect("find array-like helper");
+    let function = &rest[..function_end];
+
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "hidden-infer constraint relation decisions must use the shared relation \
+         outcome boundary"
+    );
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        1,
+        "the restricted relation should route through RelationOutcome"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor only: checker relation diagnostic query-boundary routing.

## Invariant
When generic infer-conditional helpers substitute referenced or hidden constraints before testing a type argument against an instantiated constraint, checker still owns the suppression decision, and this PR routes those relation probes through `assign_relation_outcome(...).related` instead of raw diagnostic boolean guards.

## Scope
- `crates/tsz-checker/src/checkers/generic_checker/infer_conditional_constraints.rs`: route referenced-constraint and hidden-infer constraint relation probes through the shared assignment `RelationOutcome` boundary.
- `crates/tsz-checker/src/tests/infer_conditional_relation_routing_arch_tests.rs`: extend source-level architecture coverage for those helpers.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only routing change; no solver policy, relation flags, cache keys, diagnostic text, or conformance baselines changed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib infer_result_referenced_constraints_use_relation_outcome_boundary hidden_infer_constraints_use_relation_outcome_boundary` -> 2 passed, 5329 skipped
- `python3 scripts/arch/arch_guard.py` -> passed
- `scripts/arch/check-checker-boundaries.sh` -> passed
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `scripts/agents/ensure-agent-labels.sh --audit` -> clean
- Post-rebase `git rev-list --left-right --count origin/main...HEAD` -> `0 1`

## Coordination Notes
- AgentName: M1-B
- Fresh branch from `origin/main`: `codex/m1b-infer-constraint-relation-routing-20260527`.
- Head commit `91a9962e55`; branch was checked against latest `origin/main` before publishing.
- Exact overlap check for the touched files returned no open PRs before publishing.
- Draft only; no queue or auto-merge requested.
