### PR TITLE
refactor(solver): name typed relation flag policy

### DIFF
--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -119,12 +119,21 @@ impl RelationPolicy {
     /// > `strict_function_types_does_not_imply_strict_any` regression test.
     pub const fn from_flags(flags: u16) -> Self {
         let typed_flags = Self::cache_flags_from_packed(flags);
+        Self::from_relation_flags(typed_flags)
+    }
+
+    /// Construct a policy from typed relation flags.
+    ///
+    /// Use this when callers already have [`RelationFlags`]. The packed
+    /// [`RelationPolicy::from_flags`] constructor is reserved for compatibility
+    /// edges that still receive checker-style `u16` masks.
+    pub const fn from_relation_flags(flags: RelationFlags) -> Self {
         // erase_generics defaults to true unless the NO_ERASE_GENERICS flag is set.
         // This preserves backward compatibility while allowing specific paths
         // (implements/extends checking) to disable erasure.
-        let erase_generics = !typed_flags.contains(RelationFlags::NO_ERASE_GENERICS);
+        let erase_generics = !flags.contains(RelationFlags::NO_ERASE_GENERICS);
         Self {
-            flags: typed_flags,
+            flags,
             strict_subtype_checking: false,
             strict_any_propagation: false,
             any_propagation_mode: AnyPropagationMode::All,

--- a/crates/tsz-solver/tests/relation_bivariant_rest_cache_tests.rs
+++ b/crates/tsz-solver/tests/relation_bivariant_rest_cache_tests.rs
@@ -32,9 +32,9 @@ fn subtype_cache_bivariant_rest_policy_matches_uncached_relation_query() {
         interner.array(TypeId::UNKNOWN),
     )]));
 
-    let strict = RelationPolicy::from_flags(RelationFlags::STRICT_FUNCTION_TYPES.bits() as u16);
-    let bivariant = RelationPolicy::from_flags(
-        (RelationFlags::STRICT_FUNCTION_TYPES | RelationFlags::ALLOW_BIVARIANT_REST).bits() as u16,
+    let strict = RelationPolicy::from_relation_flags(RelationFlags::STRICT_FUNCTION_TYPES);
+    let bivariant = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_FUNCTION_TYPES | RelationFlags::ALLOW_BIVARIANT_REST,
     );
     let strict_key = RelationCacheKey::for_subtype(source, target, strict.cache_config());
     let bivariant_key = RelationCacheKey::for_subtype(source, target, bivariant.cache_config());

--- a/crates/tsz-solver/tests/relation_cache_config_tests.rs
+++ b/crates/tsz-solver/tests/relation_cache_config_tests.rs
@@ -609,10 +609,9 @@ fn subtype_cache_strict_readonly_identity_matches_uncached_policy() {
     let source = interner.object(vec![PropertyInfo::readonly(property, TypeId::STRING)]);
     let target = interner.object(vec![PropertyInfo::new(property, TypeId::STRING)]);
 
-    let ordinary_policy = RelationPolicy::from_flags(RelationCacheKey::FLAG_STRICT_NULL_CHECKS);
-    let readonly_identity_policy = RelationPolicy::from_flags(
-        RelationCacheKey::FLAG_STRICT_NULL_CHECKS
-            | RelationFlags::STRICT_READONLY_IDENTITY.bits() as u16,
+    let ordinary_policy = RelationPolicy::from_relation_flags(RelationFlags::STRICT_NULL_CHECKS);
+    let readonly_identity_policy = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_NULL_CHECKS | RelationFlags::STRICT_READONLY_IDENTITY,
     );
     let ordinary_key =
         RelationCacheKey::for_subtype(source, target, ordinary_policy.cache_config());
@@ -850,9 +849,10 @@ fn allow_erased_generic_signature_retry_partitions_cache_entries() {
 fn in_callback_param_check_partitions_cache_entries() {
     // Set transiently during function-signature comparison; callback-mode
     // results must live in a separate slot from ordinary comparisons.
-    assert_packed_flag_partitions(
+    assert_subtype_partitions(
         "in_callback_param_check",
-        RelationFlags::IN_CALLBACK_PARAM_CHECK.bits() as u16,
+        RelationPolicy::from_relation_flags(RelationFlags::IN_CALLBACK_PARAM_CHECK),
+        RelationPolicy::from_relation_flags(RelationFlags::empty()),
     );
 }
 
@@ -860,9 +860,10 @@ fn in_callback_param_check_partitions_cache_entries() {
 fn strict_readonly_identity_partitions_cache_entries() {
     // Toggled during conditional-type distribution; results computed under
     // this mode must not share a slot with ordinary relation results.
-    assert_packed_flag_partitions(
+    assert_subtype_partitions(
         "strict_readonly_identity",
-        RelationFlags::STRICT_READONLY_IDENTITY.bits() as u16,
+        RelationPolicy::from_relation_flags(RelationFlags::STRICT_READONLY_IDENTITY),
+        RelationPolicy::from_relation_flags(RelationFlags::empty()),
     );
 }
 
@@ -874,9 +875,9 @@ fn subtype_cache_strict_readonly_identity_policy_matches_uncached_relation_query
     let source = interner.object(vec![PropertyInfo::readonly(prop, TypeId::NUMBER)]);
     let target = interner.object(vec![PropertyInfo::new(prop, TypeId::NUMBER)]);
 
-    let ordinary = RelationPolicy::from_flags(0);
+    let ordinary = RelationPolicy::from_relation_flags(RelationFlags::empty());
     let strict_readonly =
-        RelationPolicy::from_flags(RelationFlags::STRICT_READONLY_IDENTITY.bits() as u16);
+        RelationPolicy::from_relation_flags(RelationFlags::STRICT_READONLY_IDENTITY);
     let ordinary_key = RelationCacheKey::for_subtype(source, target, ordinary.cache_config());
     let strict_key = RelationCacheKey::for_subtype(source, target, strict_readonly.cache_config());
 

--- a/crates/tsz-solver/tests/relation_cache_config_tests/cache_agreement.rs
+++ b/crates/tsz-solver/tests/relation_cache_config_tests/cache_agreement.rs
@@ -109,16 +109,15 @@ fn legacy_flag_constants_match_typed_bitflags() {
 }
 
 #[test]
-fn policy_cache_config_preserves_packed_extended_bits() {
-    let packed = (RelationFlags::STRICT_SUBTYPE_CHECKING
+fn policy_cache_config_preserves_typed_extended_bits() {
+    let typed_flags = RelationFlags::STRICT_SUBTYPE_CHECKING
         | RelationFlags::STRICT_ANY_PROPAGATION
         | RelationFlags::SKIP_WEAK_TYPE_CHECKS
         | RelationFlags::ASSUME_RELATED_ON_CYCLE
         | RelationFlags::IN_CALLBACK_PARAM_CHECK
-        | RelationFlags::STRICT_READONLY_IDENTITY)
-        .bits() as u16;
+        | RelationFlags::STRICT_READONLY_IDENTITY;
 
-    let config = RelationPolicy::from_flags(packed).cache_config();
+    let config = RelationPolicy::from_relation_flags(typed_flags).cache_config();
 
     assert!(
         config
@@ -145,30 +144,73 @@ fn policy_cache_config_preserves_packed_extended_bits() {
 }
 
 #[test]
-fn policy_cache_config_preserves_all_assigned_packed_bits() {
+fn policy_cache_config_preserves_all_assigned_typed_bits() {
     let all_flags = RelationFlags::all();
-    let config = RelationPolicy::from_flags(all_flags.bits() as u16).cache_config();
+    let config = RelationPolicy::from_relation_flags(all_flags).cache_config();
 
     assert_eq!(
         config.flags, all_flags,
-        "explicit packed-bit projection must preserve every assigned relation flag",
+        "typed flag projection must preserve every assigned relation flag",
+    );
+}
+
+#[test]
+fn relation_policy_from_relation_flags_preserves_typed_bits() {
+    let typed_flags = RelationFlags::STRICT_NULL_CHECKS
+        | RelationFlags::STRICT_FUNCTION_TYPES
+        | RelationFlags::NO_ERASE_GENERICS
+        | RelationFlags::IN_CALLBACK_PARAM_CHECK
+        | RelationFlags::STRICT_READONLY_IDENTITY;
+
+    let typed = RelationPolicy::from_relation_flags(typed_flags);
+    let packed = RelationPolicy::from_flags(typed_flags.bits() as u16);
+
+    assert_eq!(
+        typed.cache_config(),
+        packed.cache_config(),
+        "typed relation flags must produce the same cache config as the legacy edge",
+    );
+    assert!(
+        typed.strict_null_checks(),
+        "typed constructor should preserve strict-null policy",
+    );
+    assert!(
+        typed.strict_function_types(),
+        "typed constructor should preserve strict-function policy",
+    );
+    assert!(
+        !typed.erase_generics,
+        "typed constructor should preserve NO_ERASE_GENERICS",
+    );
+    assert!(
+        typed
+            .cache_config()
+            .flags
+            .contains(RelationFlags::IN_CALLBACK_PARAM_CHECK),
+        "typed constructor should preserve transient callback relation mode",
+    );
+    assert_eq!(
+        typed.legacy_packed_flags(),
+        typed_flags.bits() as u16,
+        "compatibility edges should still be able to observe the packed bit layout",
     );
 }
 
 #[test]
 fn relation_policy_typed_accessors_preserve_packed_relation_bits() {
-    let packed = RelationCacheKey::FLAG_STRICT_NULL_CHECKS
-        | RelationCacheKey::FLAG_STRICT_FUNCTION_TYPES
-        | RelationCacheKey::FLAG_EXACT_OPTIONAL_PROPERTY_TYPES
-        | RelationCacheKey::FLAG_NO_UNCHECKED_INDEXED_ACCESS
-        | RelationCacheKey::FLAG_DISABLE_METHOD_BIVARIANCE
-        | RelationCacheKey::FLAG_ALLOW_VOID_RETURN
-        | RelationCacheKey::FLAG_ALLOW_BIVARIANT_REST
-        | RelationCacheKey::FLAG_ALLOW_BIVARIANT_PARAM_COUNT
-        | RelationCacheKey::FLAG_ALLOW_ERASED_GENERIC_SIGNATURE_RETRY
-        | RelationFlags::STRICT_READONLY_IDENTITY.bits() as u16;
-    let enabled = RelationPolicy::from_flags(packed);
-    let disabled = RelationPolicy::from_flags(0);
+    let enabled = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_NULL_CHECKS
+            | RelationFlags::STRICT_FUNCTION_TYPES
+            | RelationFlags::EXACT_OPTIONAL_PROPERTY_TYPES
+            | RelationFlags::NO_UNCHECKED_INDEXED_ACCESS
+            | RelationFlags::DISABLE_METHOD_BIVARIANCE
+            | RelationFlags::ALLOW_VOID_RETURN
+            | RelationFlags::ALLOW_BIVARIANT_REST
+            | RelationFlags::ALLOW_BIVARIANT_PARAM_COUNT
+            | RelationFlags::ALLOW_ERASED_GENERIC_SIGNATURE_RETRY
+            | RelationFlags::STRICT_READONLY_IDENTITY,
+    );
+    let disabled = RelationPolicy::from_relation_flags(RelationFlags::empty());
 
     assert!(enabled.strict_null_checks());
     assert!(enabled.strict_function_types());

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -322,7 +322,7 @@ fn subtype_cache_strict_readonly_identity_matches_uncached_property_policy() {
 
     let permissive_policy = RelationPolicy::from_flags(0);
     let strict_policy =
-        RelationPolicy::from_flags(RelationFlags::STRICT_READONLY_IDENTITY.bits() as u16);
+        RelationPolicy::from_relation_flags(RelationFlags::STRICT_READONLY_IDENTITY);
 
     let permissive_uncached = query_relation(
         &interner,
@@ -404,10 +404,9 @@ fn assignability_cache_disable_method_bivariance_matches_uncached_method_policy(
     let target = interner.object(vec![PropertyInfo::method(run, animal_method)]);
 
     let bivariant_policy =
-        RelationPolicy::from_flags(RelationFlags::STRICT_FUNCTION_TYPES.bits() as u16);
-    let sound_policy = RelationPolicy::from_flags(
-        (RelationFlags::STRICT_FUNCTION_TYPES | RelationFlags::DISABLE_METHOD_BIVARIANCE).bits()
-            as u16,
+        RelationPolicy::from_relation_flags(RelationFlags::STRICT_FUNCTION_TYPES);
+    let sound_policy = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_FUNCTION_TYPES | RelationFlags::DISABLE_METHOD_BIVARIANCE,
     );
 
     let bivariant_uncached = query_relation(


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Solver relation policy/cache key contracts (#8207).

## Invariant
Callers that already hold typed `RelationFlags` should construct `RelationPolicy` through a typed boundary. The legacy packed `u16` constructor remains the compatibility edge, and both paths must produce the same `RelationCacheConfig` for the same flag bits.

## Scope
- Add `RelationPolicy::from_relation_flags(RelationFlags)` and route `from_flags(u16)` through it after the packed compatibility projection.
- Migrate the focused relation cache-policy tests for strict-readonly identity, callback-parameter mode, all-assigned flags, and bivariant rest/method policy construction onto the typed constructor.
- Keep explicit legacy packed-flag assertions where they prove compatibility behavior.

## Project Corpus Impact
- Row: n/a
- Bug family: relation policy/cache-key contract
- Evidence: solver-only constructor/test refactor; no project corpus row changes expected.

## Verification
- `cargo nextest run -p tsz-solver -E 'test(relation_policy_from_relation_flags_preserves_typed_bits)'` (red before implementation; passed after implementation)
- `cargo nextest run -p tsz-solver -E 'test(relation_policy_from_relation_flags_preserves_typed_bits) + test(policy_cache_config_preserves_typed_extended_bits) + test(policy_cache_config_preserves_all_assigned_typed_bits) + test(relation_policy_typed_accessors_preserve_packed_relation_bits) + test(relation_policy_legacy_packed_flags_accessor_preserves_input_bits) + test(in_callback_param_check_partitions_cache_entries) + test(strict_readonly_identity_partitions_cache_entries) + test(subtype_cache_strict_readonly_identity_matches_uncached_policy) + test(subtype_cache_strict_readonly_identity_matches_uncached_property_policy) + test(assignability_cache_disable_method_bivariance_matches_uncached_method_policy) + test(subtype_cache_bivariant_rest_policy_matches_uncached_relation_query)'`
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/safe-run.sh cargo clippy -p tsz-solver --all-targets -- -D warnings`

## Coordination Notes
AgentName: M4-B

Draft PR opened early for M4-B ownership visibility. This intentionally avoids M1-B checker relation-routing work and leaves broader legacy `RelationPolicy::from_flags` migrations for later small slices.
