### PR TITLE
refactor(checker): route required mapped source relations

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/mapped_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mapped_constraint_helpers.rs
@@ -262,7 +262,9 @@ impl<'a> CheckerState<'a> {
         self.ensure_relation_input_ready(type_arg_resolved);
         let type_arg_evaluated = self.evaluate_type_with_resolution(type_arg_resolved);
         type_arg_evaluated == source
-            || self.diagnostic_relation_boolean_guard(type_arg_evaluated, source)
+            || self
+                .assign_relation_outcome(type_arg_evaluated, source)
+                .related
             || self.type_satisfies_required_source_properties(type_arg_resolved, &properties)
             || (type_arg_evaluated != type_arg_resolved
                 && self.type_satisfies_required_source_properties(type_arg_evaluated, &properties))
@@ -334,7 +336,7 @@ impl<'a> CheckerState<'a> {
             if arg_prop.type_id != source_prop.type_id {
                 let arg_type = self.evaluate_type_for_assignability(arg_prop.type_id);
                 let source_type = self.evaluate_type_for_assignability(source_prop.type_id);
-                if !self.diagnostic_relation_boolean_guard(arg_type, source_type) {
+                if !self.assign_relation_outcome(arg_type, source_type).related {
                     return false;
                 }
             }
@@ -372,7 +374,7 @@ impl<'a> CheckerState<'a> {
             let arg_type = self.get_type_from_type_node(arg_type_node);
             let source_type = self.get_type_from_type_node(source_type_node);
             if arg_type != source_type
-                && !self.diagnostic_relation_boolean_guard(arg_type, source_type)
+                && !self.assign_relation_outcome(arg_type, source_type).related
             {
                 return false;
             }

--- a/crates/tsz-checker/src/tests/mapped_true_base_constraint_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/mapped_true_base_constraint_relation_routing_arch_tests.rs
@@ -26,3 +26,29 @@ fn mapped_true_base_constraint_uses_relation_outcome_boundary() {
         "evaluated and resolved true-base constraint relations should route through RelationOutcome"
     );
 }
+
+#[test]
+fn required_mapped_constraint_helpers_use_relation_outcome_boundary() {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src/checkers/generic_checker/mapped_constraint_helpers.rs");
+    let source = fs::read_to_string(&source_path).expect("read mapped constraint helper source");
+
+    let function_start = source
+        .find("pub(super) fn required_mapped_constraint_source_is_required_and_arg_satisfies")
+        .expect("find required mapped constraint helper");
+    let rest = &source[function_start..];
+    let function_end = rest
+        .find("\n    fn type_literal_alias_property_nodes")
+        .expect("find next unrelated helper");
+    let function = &rest[..function_end];
+
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "required mapped constraint relation decisions must use the shared relation outcome boundary"
+    );
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        3,
+        "argument, collected-property, and alias-property relations should route through RelationOutcome"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track: checker relation diagnostic/query-boundary routing refactor

## Invariant
When the required-mapped constraint shortcut checks whether a type argument or matching required source property is assignable to the source shape, `tsc` treats it as the same assignment relation question; this PR keeps the checker-owned shortcut but routes relation truth through `RelationOutcome` via `CheckerState::assign_relation_outcome`.

## Scope
- `crates/tsz-checker/src/checkers/generic_checker/mapped_constraint_helpers.rs`
- `crates/tsz-checker/src/tests/mapped_true_base_constraint_relation_routing_arch_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation-routing architecture cleanup
- Evidence: behavior-preserving migration from raw boolean diagnostic guards to the existing assignability relation outcome boundary; no project row behavior change intended.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib mapped_true_base_constraint_relation_routing_arch_tests`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Draft PR for M1-B relation-routing cleanup.
- Exact open-PR file overlap checked before publishing: no open PR touched either changed file.
- Branch was rebased onto current `origin/main`; local divergence before push was `0 1`.
- No `WIP` label and no merge queue/auto-merge requested.