### PR TITLE
test(lsp): cover document color project wrapper

### DIFF
--- a/crates/tsz-lsp/tests/project_tests/feature_wrappers.rs
+++ b/crates/tsz-lsp/tests/project_tests/feature_wrappers.rs
@@ -227,6 +227,43 @@ fn test_project_get_document_links() {
 }
 
 #[test]
+fn test_project_get_document_colors_hex_literals() {
+    let mut project = Project::new();
+    project.set_file(
+        "test.ts".to_string(),
+        "const primary = \"#336699\";\nconst overlay = `#ff008080`;\nconst short = \"#0f8\";\n"
+            .to_string(),
+    );
+
+    let colors = project
+        .get_document_colors("test.ts")
+        .expect("document colors should be available for existing files");
+
+    assert_eq!(colors.len(), 3);
+    assert_eq!(colors[0].range.start, Position::new(0, 17));
+    assert_eq!(colors[0].range.end, Position::new(0, 24));
+    assert_eq!(colors[1].range.start, Position::new(1, 17));
+    assert_eq!(colors[1].range.end, Position::new(1, 26));
+    assert_eq!(colors[2].range.start, Position::new(2, 15));
+    assert_eq!(colors[2].range.end, Position::new(2, 19));
+
+    assert_eq!(colors[0].color.red, 0x33 as f64 / 255.0);
+    assert_eq!(colors[0].color.green, 0x66 as f64 / 255.0);
+    assert_eq!(colors[0].color.blue, 0x99 as f64 / 255.0);
+    assert_eq!(colors[0].color.alpha, 1.0);
+
+    assert_eq!(colors[1].color.red, 1.0);
+    assert_eq!(colors[1].color.green, 0.0);
+    assert_eq!(colors[1].color.blue, 0x80 as f64 / 255.0);
+    assert_eq!(colors[1].color.alpha, 0x80 as f64 / 255.0);
+
+    assert_eq!(colors[2].color.red, 0.0);
+    assert_eq!(colors[2].color.green, 1.0);
+    assert_eq!(colors[2].color.blue, 0x88 as f64 / 255.0);
+    assert_eq!(colors[2].color.alpha, 1.0);
+}
+
+#[test]
 fn test_project_get_linked_editing_ranges_jsx() {
     let mut project = Project::new();
     project.set_file(
@@ -379,6 +416,12 @@ fn test_project_prepare_call_hierarchy_returns_none_for_missing_file() {
 fn test_project_get_document_links_returns_none_for_missing_file() {
     let project = Project::new();
     assert!(project.get_document_links("missing.ts").is_none());
+}
+
+#[test]
+fn test_project_get_document_colors_returns_none_for_missing_file() {
+    let project = Project::new();
+    assert!(project.get_document_colors("missing.ts").is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Agent
AgentName: Studio-E

## Track
Studio-E LSP/WASM consumer boundary; test-only smoke coverage for documentColor from docs/plan/LSP_ROADMAP.md.

## Invariant
When the project-level LSP facade is asked for document colors, it should expose the split DocumentColorProvider result for existing files and return None for missing files without owning type semantics.

## Scope
- Add project-wrapper smoke coverage for Project::get_document_colors on hex string/template literals.
- Add missing-file coverage for the same wrapper.
- No LSP protocol output, checker, solver, parser, binder, or emit behavior changes.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: LSP test-only smoke coverage; no compiler/project-corpus behavior change.

## Verification
- `cargo fmt --check` passed at head `0704876d112fb967e9b5b2bc0071ee0d4f0b4868`.
- `git diff --check origin/main...HEAD` passed at head `0704876d112fb967e9b5b2bc0071ee0d4f0b4868`.
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/target cargo nextest run -p tsz-lsp -E 'test(test_project_get_document_colors_hex_literals) | test(test_project_get_document_colors_returns_none_for_missing_file)'` passed: 2 tests run, 2 passed.
- Ready CI passed at head `0704876d112fb967e9b5b2bc0071ee0d4f0b4868`: `CI Summary`, `GitGuardian Security Checks`, lint, unit, conformance, emit, fourslash, LSP e2e, WASM, and project compile guard all passed.
- Ready CI run: https://github.com/mohsen1/tsz/actions/runs/26507060239.
- Earlier local run against the old empty commit could not complete because the filesystem ran out of space while writing `.target/debug/deps`; the stale worktree was removed and disk recovered before the verified run above.

## Coordination Notes
- AgentName: Studio-E.
- PR #10471 landed; this draft is independent and test-only.
- Avoids touching oversized crates/tsz-cli/src/bin/tsz_lsp.rs and crates/tsz-lsp/src/signature_help.rs; those need dedicated split PRs because both exceed the 2000-line rule.
- Ready CI passed for exact head `0704876d112fb967e9b5b2bc0071ee0d4f0b4868`; queued via `merge-queue` for the repo-local synthetic latest-`main` merge gate.



