### PR TITLE
fix(dts): escape variadic tuple call string literal prefixes

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
@@ -216,8 +216,11 @@ impl<'a> DeclarationEmitter<'a> {
             k if k == SyntaxKind::StringLiteral as u16
                 || k == SyntaxKind::NoSubstitutionTemplateLiteral as u16 =>
             {
-                let raw = self.get_source_slice(node.pos, node.end)?;
-                Some(format!("\"{}\"", raw.trim().trim_matches(&['"', '\''][..])))
+                let lit = self.arena.get_literal(node)?;
+                Some(format!(
+                    "\"{}\"",
+                    super::escape_string_for_double_quote(&lit.text)
+                ))
             }
             k if k == SyntaxKind::NumericLiteral as u16 => self
                 .get_source_slice(node.pos, node.end)

--- a/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
@@ -350,6 +350,41 @@ fn test_variadic_tuple_call_return_materializes_prefix_or_constraint() {
     );
 }
 
+#[test]
+fn test_variadic_tuple_call_return_escapes_string_literal_prefixes() {
+    // The materialized prefix literal must carry TypeScript-compatible
+    // string-literal escaping derived from the cooked literal value, not from
+    // trimming the source token and re-wrapping it in quotes. The reported
+    // shapes that the source-slice approach mangled:
+    //   - a single-quoted string with an embedded double quote,
+    //   - a no-substitution template literal (backticks are not quote chars),
+    //   - a double-quoted string containing a backslash.
+    let output = emit_dts_with_binding(
+        r#"
+    declare function collect<Items extends readonly [string, ...string[]]>(
+        ...values: readonly [...Items, number]
+    ): [...Items, number];
+
+    export const sq = collect('a"b', 1);
+    export const tmpl = collect(`c"d`, 1);
+    export const bs = collect("e\\f", 1);
+    "#,
+    );
+
+    assert!(
+        output.contains(r#"export declare const sq: ["a\"b", number];"#),
+        "Single-quoted prefix with an embedded double quote must be re-escaped: {output}"
+    );
+    assert!(
+        output.contains(r#"export declare const tmpl: ["c\"d", number];"#),
+        "No-substitution template prefix must emit an escaped double-quoted literal: {output}"
+    );
+    assert!(
+        output.contains(r#"export declare const bs: ["e\\f", number];"#),
+        "Prefix containing a backslash must preserve the escaped backslash: {output}"
+    );
+}
+
 // =============================================================================
 // 7. Ambient / Declare Declarations
 // =============================================================================


### PR DESCRIPTION
## Agent
AgentName: Studio-D
Contributor: opus47-web (remote execution / vibrant-lovelace-I7VJk) — contributor identity only, not an ownership lane.

Closes #10498.

## Track
Declaration emit (d.ts) string-literal correctness. Follow-up to the merged variadic-tuple-call materialization slice #10393 and its unresolved Reviewer blocker about string-literal escaping.

## Invariant
Behavior-changing only for literals whose cooked value is not identical to a naive de-quote of the source token; all other literals emit byte-identical text. When declaration emit materializes a string or no-substitution-template literal into a public tuple literal type, it must preserve TypeScript-compatible string-literal escaping rather than deriving the text from a trimmed source token.

## Structural rule
> When d.ts emit materializes a string or no-substitution-template literal argument into a public tuple literal type, tsc emits the *cooked* value re-escaped for a double-quoted string-literal type; this change makes tsz derive the same text from the scanner's cooked `LiteralData.text` via the shared `escape_string_for_double_quote` helper instead of slicing/trimming the raw source token.

The rule keys on the literal's structural kind and cooked value — not on the test name, alias spellings, source text, file names, or rendered type strings.

## Scope
`crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs` — `literal_argument_type_text` previously did `format!("\"{}\"", raw.trim().trim_matches(&['"', '\'']))` over `get_source_slice(...)`. That corrupted:
- single-quoted strings with embedded double quotes (`collect('a"b', 1)` → invalid `"a"b"`),
- no-substitution template literals (backticks are never in the trim set → `` "`c"d`" ``),
- backslash/escape sequences.

The fix reads the cooked literal value (`LiteralData.text`) and re-escapes it through the existing `escape_string_for_double_quote` helper — the exact path `js_literal_type_text` already uses for string-literal type text. Owner layer: emitter; the escaping helper is shared infrastructure, so this is a generalization to the canonical mechanism rather than a per-shape special case.

## Adjacent cases covered
New test `test_variadic_tuple_call_return_escapes_string_literal_prefixes`:
- single-quoted string with an embedded double quote → `["a\"b", number]`,
- no-substitution template literal with an embedded double quote → `["c\"d", number]`,
- double-quoted string containing a backslash → `["e\\f", number]`.

The pre-existing `test_variadic_tuple_call_return_materializes_prefix_or_constraint` continues to cover the plain-prefix, multi-prefix, and constraint-fallback (negative) paths.

## Project Corpus Impact
- Row: n/a (no project-corpus row regresses or improves; this is a d.ts text-correctness fix).
- Bug family: d.ts string-literal escaping in materialized tuple literal types.
- Evidence: emitter-only; covered by the new and existing `tsz-emitter` declaration-emitter unit tests. Heavy emit/conformance/fourslash/WASM suites run on this ready PR's CI.

## Verification
- `cargo build -p tsz-emitter` clean.
- `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings` clean.
- `cargo test -p tsz-emitter --lib variadic_tuple_call_return` → 2 passed (new + existing).
- The 7 unrelated `declaration_emitter::tests` failures in this sandbox reproduce on clean `main` (verified by stashing this diff) and are environment-only; they do not touch this path.
- Branch is even with `origin/main` (no divergence, no conflicts).

## Coordination Notes
Picked up via random-issue selection; verified no open PR referenced #10498 before starting. Canonical owner lane is `agent:Studio-D` (label applied); `opus47-web` is the contributor runner only — thanks to ReviewHelper for the label attribution.

Landing path is the **repo-local merge queue**, per @Reviewer. GitHub auto-merge is **off** and will stay off — it is not used as a queue signal or CI watcher. Next action: wait for the full exact-head check picture (`conformance-*`, `emit`, `fourslash-*`, project canary, etc.) to complete; only if every required check is green do I add the `merge-queue` label after re-reviewing this exact head. The linked issue's WIP label clears automatically when this merges via `Closes #10498`.

https://claude.ai/code/session_01LbUeJUsaNZn8rbuWWprTmq