### PR TITLE
fix(checker): preserve keyof generic call parameter display

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -942,6 +942,10 @@ name = "ts2344_keyof_constraint_display_tests"
 path = "tests/ts2344_keyof_constraint_display_tests.rs"
 
 [[test]]
+name = "keyof_call_parameter_display_tests"
+path = "tests/keyof_call_parameter_display_tests.rs"
+
+[[test]]
 name = "ts2344_extra_with_2314_suppression_tests"
 path = "tests/ts2344_extra_with_2314_suppression_tests.rs"
 

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
@@ -438,6 +438,10 @@ impl<'a> CheckerState<'a> {
             return display;
         }
 
+        if let Some(display) = self.contextual_keyof_parameter_display(param_type, arg_idx) {
+            return display;
+        }
+
         if let Some(display) = self.generic_call_parameter_alias_display(param_type, arg_idx)
             && (display.contains("IterableIterator<") || !display.contains("IterableIterator"))
             && (display.contains("Promise<") || !display.contains("Promise"))
@@ -460,10 +464,6 @@ impl<'a> CheckerState<'a> {
 
         if let Some(display) = self.instantiated_call_parameter_display(arg_idx) {
             return self.strip_synthetic_optional_from_display_for_arg(display, arg_type);
-        }
-
-        if let Some(display) = self.contextual_keyof_parameter_display(param_type, arg_idx) {
-            return display;
         }
 
         if let Some(display_type) =

--- a/crates/tsz-checker/tests/keyof_call_parameter_display_tests.rs
+++ b/crates/tsz-checker/tests/keyof_call_parameter_display_tests.rs
@@ -1,0 +1,85 @@
+//! Tests for generic call-argument diagnostics whose parameter is constrained
+//! by `keyof` another argument.
+//!
+//! Structural rule: when a generic call parameter instantiates to the same key
+//! space as `keyof` a named argument type, TS2345 should render the parameter
+//! as `keyof <named type>` instead of the expanded finite literal-key union.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::Diagnostic;
+
+fn check_strict(source: &str) -> Vec<Diagnostic> {
+    tsz_checker::test_utils::check_source(source, "test.ts", CheckerOptions::default())
+}
+
+fn ts2345_messages(source: &str) -> Vec<String> {
+    check_strict(source)
+        .into_iter()
+        .filter(|diag| diag.code == 2345)
+        .map(|diag| diag.message_text)
+        .collect()
+}
+
+#[test]
+fn generic_keyof_parameter_displays_keyof_named_argument_type() {
+    let messages = ts2345_messages(
+        r#"
+class Shape {
+    name: string;
+    width: number;
+    height: number;
+    visible: boolean;
+}
+
+function getProperty<T, K extends keyof T>(obj: T, key: K) {
+    return obj[key];
+}
+
+declare const shape: Shape;
+getProperty(shape, "size");
+"#,
+    );
+
+    assert_eq!(messages.len(), 1, "expected one TS2345, got: {messages:?}");
+    assert!(
+        messages[0].contains("parameter of type 'keyof Shape'"),
+        "expected `keyof Shape` parameter display, got: {:?}",
+        messages[0]
+    );
+    assert!(
+        !messages[0].contains("\"name\" | \"width\" | \"height\" | \"visible\""),
+        "parameter display must not expand to the literal key union, got: {:?}",
+        messages[0]
+    );
+}
+
+#[test]
+fn generic_keyof_parameter_displays_keyof_named_argument_type_renamed() {
+    let messages = ts2345_messages(
+        r#"
+interface RecordShape {
+    alpha: string;
+    beta: number;
+}
+
+function readField<Obj, Field extends keyof Obj>(value: Obj, field: Field) {
+    return value[field];
+}
+
+declare const value: RecordShape;
+readField(value, "gamma");
+"#,
+    );
+
+    assert_eq!(messages.len(), 1, "expected one TS2345, got: {messages:?}");
+    assert!(
+        messages[0].contains("parameter of type 'keyof RecordShape'"),
+        "expected renamed `keyof RecordShape` display, got: {:?}",
+        messages[0]
+    );
+    assert!(
+        !messages[0].contains("\"alpha\" | \"beta\""),
+        "parameter display must not depend on expanded key spelling, got: {:?}",
+        messages[0]
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-C
Runner: claude-sonnet-4-6

## Track
Track 8: Diagnostics, Display, Parser Options, And Feature Gates — rendered diagnostic debt inside the accepted-regression runway.

## Invariant
When a generic call parameter instantiates to the same key space as `keyof` a named argument type, `tsc` renders the failed parameter as `keyof <named type>`; this PR makes tsz prefer the existing contextual `keyof` display policy before generic alias expansion can print the finite literal-key union.

## Owner Layer
Checker diagnostic display policy. The semantic assignability result is unchanged; the checker only chooses the user-facing TS2345 parameter display. The key-space comparison still uses existing type relation/query helpers, not source text, rendered strings, file names, or binder-name spelling.

## Scope
- `crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs`: prioritize the existing contextual `keyof` parameter display before generic call alias display.
- `crates/tsz-checker/tests/keyof_call_parameter_display_tests.rs`: add two renamed-shape TS2345 display tests.
- `crates/tsz-checker/Cargo.toml`: register the new focused test target.

## Adjacent Case Matrix
- `getProperty<T, K extends keyof T>(shape: Shape, key: K)` now displays the bad key parameter as `keyof Shape` instead of the expanded key union.
- Renamed `readField<Obj, Field extends keyof Obj>(value: RecordShape, field: Field)` proves the rule is not tied to `T`, `K`, or `Shape` spellings.
- Existing TS2344 `keyof` constraint display tests still pass.
- Existing generic conflicting argument display smoke test still passes.
- The broader `keyofAndIndexedAccess` accepted-regression filter still fails for remaining TS2322/TS2349 issues; this PR intentionally does not edit the accepted-regression list.

## Project Corpus Impact
- Row: n/a
- Bug family: accepted-regression fingerprint-only / generic `keyof` call parameter display
- Evidence: display-only checker diagnostic change with focused unit tests; no project corpus row is directly affected.

## Verification
Final rebased head: `839c7a64c2502a548290c9d4a791e042028d9845`.
Base includes `origin/main` at `47ffd458ac69278ec8cfd978a27e7ffcea9f13c4`.

Exact-head checks on `839c7a64c2502a548290c9d4a791e042028d9845`:
- `cargo fmt --check` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `cargo nextest run -p tsz-checker --test keyof_call_parameter_display_tests --test ts2344_keyof_constraint_display_tests --test generic_conflicting_argument_type_display_tests` -> 8 passed
- `python3 scripts/conformance/query-conformance.py --dashboard` -> exact `12582/12582`, accepted-regression gate `20 listed tests`

Focused conformance evidence from immediately prior rebased head `0a215b3cbd0ec3141c5938fd21e5b8da2cbce88a` before the final docs/test-only main refresh:
- `scripts/safe-run.sh --limit 50% -- ./scripts/conformance/conformance.sh run --filter "keyofAndIndexedAccess" --verbose` -> still `1/3 passed`; intended TS2345 `keyof Shape` fingerprint mismatches are gone, retained failures are two TS2322 extra fingerprints plus one extra TS2349

## Coordination Notes
- AgentName: M1-C
- Fresh worktree: `/Users/mohsen/code/tsz-m1c-keyof-indexed-access-20260527`, created from `origin/main`.
- Head: `839c7a64c2502a548290c9d4a791e042028d9845`.
- Related accepted-regression ownership: #8432 and #10306.
- Does not close `keyofAndIndexedAccess`; remaining work is semantic TS2322/TS2349, not this display slice.
- Ready-for-review CI is running on the refreshed head. No `merge-queue` label requested by this implementation lane.
