### PR TITLE
fix(dts): escape variadic tuple call string literal type text

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
@@ -216,8 +216,16 @@ impl<'a> DeclarationEmitter<'a> {
             k if k == SyntaxKind::StringLiteral as u16
                 || k == SyntaxKind::NoSubstitutionTemplateLiteral as u16 =>
             {
-                let raw = self.get_source_slice(node.pos, node.end)?;
-                Some(format!("\"{}\"", raw.trim().trim_matches(&['"', '\''][..])))
+                // Use the scanner's cooked string value and re-escape for a
+                // double-quoted string literal type. Raw source slicing with
+                // trim_matches broke for single-quoted strings containing `"`
+                // (produced unescaped `"`) and for no-substitution template
+                // literals (backtick delimiters were not stripped).
+                let lit = self.arena.get_literal(node)?;
+                Some(format!(
+                    "\"{}\"",
+                    super::escape_string_for_double_quote(&lit.text)
+                ))
             }
             k if k == SyntaxKind::NumericLiteral as u16 => self
                 .get_source_slice(node.pos, node.end)

--- a/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
@@ -350,6 +350,44 @@ fn test_variadic_tuple_call_return_materializes_prefix_or_constraint() {
     );
 }
 
+/// String literal arguments to variadic tuple calls must be properly escaped when
+/// materialised into the `.d.ts` tuple literal type.  The previous raw-slice
+/// path (`trim_matches` on source text) broke for:
+/// - Single-quoted strings containing `"` → unescaped double quote in output.
+/// - No-substitution template literals → backtick delimiters not stripped.
+/// - Template literals containing `"` → unescaped double quote in output.
+#[test]
+fn test_variadic_tuple_call_escapes_string_literal_content() {
+    let source = r#"
+declare function tag<Items extends readonly [string, ...string[]]>(
+    ...values: readonly [...Items, number]
+): [...Items, number];
+
+export const a = tag('has"quote', 1);
+export const b = tag(`backtick`, 1);
+export const c = tag(`back"tick`, 1);
+export const d = tag("back\\slash", 1);
+"#;
+    let output = emit_dts_with_binding(source);
+
+    assert!(
+        output.contains(r#"export declare const a: ["has\"quote", number];"#),
+        "Single-quoted string with embedded double quote must be escaped in .d.ts tuple type: {output}"
+    );
+    assert!(
+        output.contains(r#"export declare const b: ["backtick", number];"#),
+        "No-substitution template literal must strip backtick delimiters in .d.ts tuple type: {output}"
+    );
+    assert!(
+        output.contains(r#"export declare const c: ["back\"tick", number];"#),
+        "Template literal with embedded double quote must be escaped in .d.ts tuple type: {output}"
+    );
+    assert!(
+        output.contains(r#"export declare const d: ["back\\slash", number];"#),
+        "String with embedded backslash must be double-escaped in .d.ts tuple type: {output}"
+    );
+}
+
 // =============================================================================
 // 7. Ambient / Declare Declarations
 // =============================================================================


### PR DESCRIPTION
## Agent
AgentName: Studio-D
Runner: remote-sonnet46

## Track
Track 9 — Emit/DTS parity.

## Invariant
When declaration emit materializes a `StringLiteral` or `NoSubstitutionTemplateLiteral` argument into a public tuple literal type, it must preserve TypeScript-compatible string-literal escaping. It must not derive public type text by trimming a source token and re-wrapping it in double quotes.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs`
- `crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs`

Structural rule: when DTS emit materializes any string or no-substitution-template literal value into a double-quoted TypeScript literal type, it must use the scanner-cooked value plus `escape_string_for_double_quote`, not raw source slicing.

Root cause: the previous implementation used `get_source_slice` plus delimiter trimming, then wrapped the result in `"..."`. That breaks single-quoted strings containing double quotes, no-substitution template literals, and escaped backslashes.

## Project Corpus Impact
- Row: n/a
- Bug family: DTS emit — string literal type text production in variadic tuple calls
- Evidence: emitter unit coverage only; no project-corpus fixture updated.

## Verification
- `cargo test -p tsz-emitter -- declaration_emitter::tests::generics_and_ambient` passed in the runner environment.
- `cargo clippy -p tsz-emitter --all-targets -- -D warnings` passed in the runner environment.

## Coordination Notes
- Closes #10498.
- This draft overlaps #10504, which is already the active Studio-D PR for the same #10498 DTS string-literal escaping fix and is currently queued through the repo-local merge queue.
- Keep this draft off queue unless #10504 fails or the owner explicitly chooses to carry work forward from this branch.
- Runner identity `remote-sonnet46` is contributor metadata only; canonical ownership is `agent:Studio-D`.

---
Generated by Claude Code session_01D92QbSPhnYRhR6XF9U4FBR.
