### PR TITLE
docs(plan): refresh open bug count

### DIFF
--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -57,7 +57,7 @@ denominators.
 | JavaScript emit | `96.8%` (`13,094 / 13,530`) in checked-in emit snapshot and README |
 | Declaration emit | `96.2%` (`1,606 / 1,669`) in checked-in emit snapshot and README |
 | Fourslash / language service | `99.9%` (`6,558 / 6,562`) |
-| Open bug issues | `25` open `bug` issues in live GitHub orientation |
+| Open bug issues | `24` open `bug` issues in live GitHub orientation |
 | Output-surgery audit | green: `0` unallowlisted calls, `0` stale allowlist entries |
 
 Conformance remains a hard regression gate. It is no longer the sole readiness


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Release metric truth / roadmap metric refresh.

## Invariant
When live GitHub issue labels change, the public roadmap bug metric should match the current open `bug` issue count; this PR updates only that reporting surface.

## Scope
- `docs/plan/ROADMAP.md`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only public metric refresh; project corpus row metadata and artifacts unchanged.

## Verification
- `gh issue list --state open --limit 500 --label bug --json number --jq 'length'` -> `24`
- `python3 scripts/conformance/query-conformance.py --dashboard` -> `12582/12582`, accepted-regression strictness `21`
- `python3 scripts/emit/query-emit.py --families` -> JavaScript `436` failures/timeouts, Declaration `63` failures/timeouts
- `node scripts/bench/project-row-summary.mjs --markdown` -> all 12 rows consistent
- `node scripts/bench/validate-project-metadata.mjs`
- `git diff --check`
- Draft PR CI for exact head `2cd3c6a2a276aefef580b1900b6a1c2dc636b1f0`: `CI Light Summary`, `gate`, and `GitGuardian Security Checks` passed.

## Coordination Notes
- No open `agent:Studio-A` PRs were present before opening this one.
- No overlapping open metric/roadmap PR was found for the bug count refresh.
- Ready for review/queue after exact-head draft checks passed; merge queue remains the landing gate.
