### PR TITLE
refactor(checker): route destructuring rest relation outcome

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
@@ -428,13 +428,12 @@ impl<'a> CheckerState<'a> {
         if self.should_suppress_assignability_for_parse_recovery(spread_expr, spread_expr) {
             return;
         }
-        if self.diagnostic_relation_boolean_guard(source, rest_target_type) {
-            return;
-        }
-
         // Use the canonical assign relation outcome so the weak-union hint is collected
         // alongside the failure reason and can be reused by the skip gate.
         let outcome = self.assign_relation_outcome(source, rest_target_type);
+        if outcome.related {
+            return;
+        }
         if self.should_skip_weak_union_error_with_outcome(
             source,
             rest_target_type,

--- a/crates/tsz-checker/src/tests/destructuring_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/destructuring_relation_routing_arch_tests.rs
@@ -45,3 +45,21 @@ fn destructuring_default_checks_use_relation_outcome_boundary() {
         "destructuring default/property relation checks should not use raw boolean guards"
     );
 }
+
+#[test]
+fn object_rest_destructuring_uses_single_relation_outcome() {
+    let source = fs::read_to_string("src/assignability/assignment_checker/destructuring.rs")
+        .expect("failed to read assignment_checker/destructuring.rs");
+    let compact_source: String = source.chars().filter(|c| !c.is_whitespace()).collect();
+
+    assert!(
+        compact_source
+            .contains("letoutcome=self.assign_relation_outcome(source,rest_target_type);")
+            && compact_source.contains("ifoutcome.related{return;}"),
+        "object rest destructuring should use the shared relation outcome for the rest target decision"
+    );
+    assert!(
+        !compact_source.contains("diagnostic_relation_boolean_guard(source,rest_target_type)"),
+        "object rest destructuring must not pre-gate the rest target decision with a raw boolean guard"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track: checker relation diagnostic/query-boundary routing refactor

## Invariant
When object destructuring rest assignment checks the computed rest source against the rest target type, `tsc` treats it as one assignment relation question; this PR keeps checker-owned anchoring, display, and suppression logic while routing both the related decision and weak-union metadata through one `RelationOutcome` from `CheckerState::assign_relation_outcome`.

## Scope
- `crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs`
- `crates/tsz-checker/src/tests/destructuring_relation_routing_arch_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation-routing architecture cleanup
- Evidence: behavior-preserving removal of a duplicate raw boolean pre-check in favor of the existing assignability relation outcome boundary; no project row behavior change intended.

## Verification
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `cargo nextest run -p tsz-checker --lib destructuring_relation_routing_arch_tests`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Draft PR for M1-B relation-routing cleanup.
- Exact open-PR file overlap checked before publishing: no open PR touched either changed file.
- Branch was rebased onto current `origin/main`; local divergence before push was `0 1`.
- No `WIP` label and no merge queue/auto-merge requested.