### PR TITLE
fix(checker): gate defineProperty prototype evidence by identity

### DIFF
--- a/crates/tsz-checker/src/tests/object_define_property_identity_tests.rs
+++ b/crates/tsz-checker/src/tests/object_define_property_identity_tests.rs
@@ -1,7 +1,7 @@
 //! `Object.defineProperty` descriptor typing must be gated by the actual
 //! builtin/global `Object` value, not by an arbitrary binding named `Object`.
 
-use crate::test_utils::{check_source_diagnostics, diagnostic_codes};
+use crate::test_utils::{check_js_source_diagnostics, check_source_diagnostics, diagnostic_codes};
 
 fn assert_no_code(source: &str, code: u32) {
     let diags = check_source_diagnostics(source);
@@ -9,6 +9,15 @@ fn assert_no_code(source: &str, code: u32) {
     assert!(
         !codes.contains(&code),
         "expected no TS{code}, got codes {codes:?}\nDiagnostics: {diags:#?}",
+    );
+}
+
+fn assert_js_has_code(source: &str, code: u32) {
+    let diags = check_js_source_diagnostics(source);
+    let codes = diagnostic_codes(&diags);
+    assert!(
+        codes.contains(&code),
+        "expected TS{code}, got codes {codes:?}\nDiagnostics: {diags:#?}",
     );
 }
 
@@ -32,6 +41,30 @@ Object.defineProperty({}, "x", {
 });
 "#,
         2339,
+    );
+}
+
+#[test]
+fn local_object_define_property_does_not_mark_js_function_constructable() {
+    assert_js_has_code(
+        r#"
+const Object = {
+    /**
+     * @param {*} target
+     * @param {string} key
+     * @param {*} descriptor
+     */
+    defineProperty(target, key, descriptor) {}
+};
+
+function C() {}
+Object.defineProperty(C.prototype, "x", {
+    get() { return 1; }
+});
+
+new C();
+"#,
+        7009,
     );
 }
 

--- a/crates/tsz-checker/src/types/computation/complex_constructors.rs
+++ b/crates/tsz-checker/src/types/computation/complex_constructors.rs
@@ -1273,16 +1273,7 @@ impl<'a> CheckerState<'a> {
         let Some(callee_access) = self.ctx.arena.get_access_expr(callee_node) else {
             return false;
         };
-        let Some(object_node) = self.ctx.arena.get(callee_access.expression) else {
-            return false;
-        };
-        if object_node.kind != SyntaxKind::Identifier as u16 {
-            return false;
-        }
-        let Some(object_ident) = self.ctx.arena.get_identifier(object_node) else {
-            return false;
-        };
-        if object_ident.escaped_text != "Object" {
+        if !self.prototype_define_property_base_is_global_object(callee_access.expression) {
             return false;
         }
         let Some(name_node) = self.ctx.arena.get(callee_access.name_or_argument) else {
@@ -1323,6 +1314,28 @@ impl<'a> CheckerState<'a> {
             return false;
         };
         proto_ident.escaped_text == "prototype"
+    }
+
+    fn prototype_define_property_base_is_global_object(&self, idx: NodeIndex) -> bool {
+        let Some(base_ident) = self.ctx.arena.get_identifier_at(idx) else {
+            return false;
+        };
+        if base_ident.escaped_text != "Object" {
+            return false;
+        }
+        let is_object_lib_symbol = |sym_id| {
+            self.ctx
+                .binder
+                .get_symbol(sym_id)
+                .is_some_and(|symbol| symbol.escaped_name == "Object")
+                && (self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id)
+                    || self.ctx.symbol_is_from_lib(sym_id))
+        };
+
+        if let Some(sym_id) = self.resolve_identifier_symbol_without_tracking(idx) {
+            return is_object_lib_symbol(sym_id);
+        }
+        !self.known_global_value_has_local_shadow(idx, "Object")
     }
 
     /// Resolve a self-referencing class constructor in a static initializer.


### PR DESCRIPTION
## Agent
AgentName: M4-D

## Track
Checker identity repair; JS constructor prototype evidence for `Object.defineProperty`.

## Invariant
When `Object.defineProperty(F.prototype, ...)` is used as JS constructor evidence, a resolved local value named `Object` must not trigger the built-in prototype shortcut; unresolved no-lib global `Object` behavior remains unchanged for existing JS constructor tests.

## Scope
- `crates/tsz-checker/src/types/computation/complex_constructors.rs`
- `crates/tsz-checker/src/tests/object_define_property_identity_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: symbol/lib identity for JS prototype evidence
- Evidence: focused checker unit coverage only; no project-corpus row targeted.

## Verification
- `cargo nextest run -p tsz-checker --lib -E 'test(object_define_property_identity_tests::)'`
- `cargo nextest run -p tsz-checker --test js_constructor_property_tests -E 'test(test_plain_function_constructor_with_define_property_prototype_is_constructable)'`
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `python3 scripts/arch/arch_guard.py --json`
- Ready CI on head `1a9216e03ce7`: `CI Summary`, conformance aggregate, fourslash aggregate, emit, unit, WASM, project compile, lint, PR body, and GitGuardian all green.

## Coordination Notes
- AgentName: M4-D
- PR-head checks are green for pushed head `1a9216e03ce7`; `merge-queue` label has been applied.
- Queue should test the synthetic latest-main merge; current `origin/main` at queue time was `ba515868c8f`.
- Previous `project-corpus-pr-body` failures on earlier heads were transient GitHub API parse failures in `check-pr-ready-state.mjs`; the current remote body contains the required AgentName and Project Corpus Impact fields and the PR-body gate is green.
- Overlap check: no other open M4-D PRs/issues; nearby open PRs are relation-routing, emit/DTS, LSP, and separate lib/module identity lanes.
- This PR intentionally avoids the oversized `error_reporter/properties.rs` path and keeps the change to constructor prototype evidence.
