### PR TITLE
refactor(solver): use typed no-unchecked policy

### DIFF
--- a/crates/tsz-solver/tests/relation_no_unchecked_indexed_cache_tests.rs
+++ b/crates/tsz-solver/tests/relation_no_unchecked_indexed_cache_tests.rs
@@ -6,7 +6,7 @@ use crate::intern::TypeInterner;
 use crate::relations::relation_queries::{
     RelationContext, RelationKind, RelationPolicy, query_relation,
 };
-use crate::types::{RelationCacheKey, TypeData, TypeId};
+use crate::types::{RelationCacheKey, RelationFlags, TypeData, TypeId};
 
 #[test]
 fn subtype_cache_no_unchecked_indexed_access_policy_matches_uncached_relation_query() {
@@ -16,10 +16,9 @@ fn subtype_cache_no_unchecked_indexed_access_policy_matches_uncached_relation_qu
     let string_array = interner.array(TypeId::STRING);
     let indexed_string = interner.intern(TypeData::IndexAccess(string_array, TypeId::NUMBER));
 
-    let ordinary = RelationPolicy::from_flags(RelationCacheKey::FLAG_STRICT_NULL_CHECKS);
-    let no_unchecked = RelationPolicy::from_flags(
-        RelationCacheKey::FLAG_STRICT_NULL_CHECKS
-            | RelationCacheKey::FLAG_NO_UNCHECKED_INDEXED_ACCESS,
+    let ordinary = RelationPolicy::from_relation_flags(RelationFlags::STRICT_NULL_CHECKS);
+    let no_unchecked = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_NULL_CHECKS | RelationFlags::NO_UNCHECKED_INDEXED_ACCESS,
     );
     let ordinary_key =
         RelationCacheKey::for_subtype(indexed_string, TypeId::STRING, ordinary.cache_config());


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Semantic campaign / solver relation policy-cache contract cleanup (#8207).

## Invariant
When a solver relation-cache test already knows the `noUncheckedIndexedAccess` semantic mode, it should construct `RelationPolicy` from typed `RelationFlags`; packed `u16` constants stay reserved for legacy compatibility-edge coverage.

## Scope
- Migrate `crates/tsz-solver/tests/relation_no_unchecked_indexed_cache_tests.rs` from `RelationPolicy::from_flags(...)` / `RelationCacheKey::FLAG_*` policy inputs to `RelationPolicy::from_relation_flags(...)`.
- Keep typed `RelationCacheKey` construction because the test still verifies cache partitioning.
- No production relation semantics changed.

## Project Corpus Impact
- Row: n/a
- Bug family: relation policy/cache-key contract
- Evidence: solver test-only refactor; no project corpus behavior change expected.

## Verification
- `cargo nextest run -p tsz-solver -E 'test(subtype_cache_no_unchecked_indexed_access_policy_matches_uncached_relation_query)'`
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `python3 scripts/arch/arch_guard.py`
- `rg -n "RelationPolicy::from_flags|RelationCacheKey::FLAG_" crates/tsz-solver/tests/relation_no_unchecked_indexed_cache_tests.rs` returns no matches.

## Coordination Notes
AgentName: M4-B

Small #8207 follow-up after #10497 and #10506. Avoids M1-B checker relation-routing work and Studio-B query-cache sharing work; this only narrows one solver cache-agreement test away from packed policy inputs.
