### PR TITLE
docs(plan): refresh accepted regression count

### DIFF
--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -53,7 +53,7 @@ denominators.
 | Surface | Current |
 | --- | ---: |
 | Diagnostic conformance | `100.0%` exact (`12,582 / 12,582`) |
-| Accepted-regression strictness | `21` listed tests |
+| Accepted-regression strictness | `20` listed tests |
 | JavaScript emit | `96.8%` (`13,094 / 13,530`) in checked-in emit snapshot and README |
 | Declaration emit | `96.2%` (`1,606 / 1,669`) in checked-in emit snapshot and README |
 | Fourslash / language service | `99.9%` (`6,558 / 6,562`) |


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Release metric truth / roadmap metric refresh.

## Invariant
When the accepted-regression artifact changes on `origin/main`, the public roadmap strictness metric should match the current listed-test count; this PR updates only that reporting surface.

## Scope
- `docs/plan/ROADMAP.md`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only public metric refresh; project corpus row metadata and artifacts unchanged.

## Verification
- `sed '/^#/d;/^[[:space:]]*$/d' scripts/conformance/conformance-accepted-regressions.txt | wc -l | tr -d ' '` -> `20`
- `python3 scripts/conformance/query-conformance.py --dashboard` -> `12582/12582`, accepted-regression strictness `20`
- `python3 scripts/emit/query-emit.py --families` -> JavaScript `436` failures/timeouts, Declaration `63` failures/timeouts
- `node scripts/bench/project-row-summary.mjs --markdown` -> all 12 rows consistent
- `node scripts/bench/validate-project-metadata.mjs`
- `gh issue list --state open --limit 500 --label bug --json number --jq 'length'` -> `24`
- `git diff --check`
- Draft PR CI for exact head `762b99c8210d6f150b125dd7d2350fe1592aad19`: `CI Light Summary`, `gate`, and `GitGuardian Security Checks` passed.

## Coordination Notes
- No open `agent:Studio-A` PRs were present before opening this one.
- Open draft #10265 (`agent:M1-C`) touches the accepted-regression artifact and roadmap from older evidence, but its body still describes a `24`-entry set; `origin/main` currently has `20` accepted-regression entries. This PR is roadmap-only and records the current `origin/main` metric.
- Ready for review/queue after exact-head draft checks passed; merge queue remains the landing gate.
