### PR TITLE
refactor(checker): route indexed key-space relations

### DIFF
--- a/crates/tsz-checker/src/tests/indexed_access_constraint_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/indexed_access_constraint_relation_routing_arch_tests.rs
@@ -26,3 +26,29 @@ fn indexed_access_constraint_uses_relation_outcome_boundary() {
         "the keyed-object to object-keys relation should route through RelationOutcome"
     );
 }
+
+#[test]
+fn indexed_access_key_space_helpers_use_relation_outcome_boundary() {
+    let source_path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("src/types/computation/access_helpers.rs");
+    let source = fs::read_to_string(&source_path).expect("read access helper source");
+
+    let function_start = source
+        .find("pub(crate) fn narrow_string_index_signature_rejects_index")
+        .expect("find narrow string index helper");
+    let rest = &source[function_start..];
+    let function_end = rest
+        .find("\n    pub(crate) fn is_generic_key_space")
+        .expect("find next helper");
+    let function = &rest[..function_end];
+
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "indexed-access key-space diagnostics must use the shared relation outcome boundary"
+    );
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        3,
+        "string-index, constrained-keyof, and union-member key-space checks should route through RelationOutcome"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -469,7 +469,9 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        !self.diagnostic_relation_boolean_guard(index_type, string_index.key_type)
+        !self
+            .assign_relation_outcome(index_type, string_index.key_type)
+            .related
     }
 
     /// Check if an index type is "generic" — i.e., it cannot be resolved to a
@@ -930,7 +932,8 @@ impl<'a> CheckerState<'a> {
 
         let object_key_space = self.ctx.types.evaluate_keyof(object_constraint);
         let source_key_space = self.ctx.types.evaluate_keyof(key_source);
-        self.diagnostic_relation_boolean_guard(source_key_space, object_key_space)
+        self.assign_relation_outcome(source_key_space, object_key_space)
+            .related
     }
 
     pub(crate) fn should_report_union_generic_key_mismatch_ts2536(
@@ -949,7 +952,9 @@ impl<'a> CheckerState<'a> {
 
         members.iter().any(|&member| {
             let member_keyof = self.ctx.types.evaluate_keyof(member);
-            !self.diagnostic_relation_boolean_guard(index_type, member_keyof)
+            !self
+                .assign_relation_outcome(index_type, member_keyof)
+                .related
         })
     }
 


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track: checker relation diagnostic/query-boundary routing refactor

## Invariant
When indexed-access diagnostics compare key-space types for string-index, constrained-object `keyof`, or union-member TS2536 decisions, `tsc` treats those as relation questions over key spaces; this PR keeps checker-owned diagnostic orchestration while routing relation truth through `RelationOutcome` via `CheckerState::assign_relation_outcome`.

## Scope
- `crates/tsz-checker/src/types/computation/access_helpers.rs`
- `crates/tsz-checker/src/tests/indexed_access_constraint_relation_routing_arch_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation-routing architecture cleanup
- Evidence: behavior-preserving migration from raw boolean diagnostic guards to the existing assignability relation outcome boundary; no project row behavior change intended.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib indexed_access_constraint_relation_routing_arch_tests`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Draft PR for M1-B relation-routing cleanup.
- Exact open-PR file overlap checked before publishing: no open PR touched either changed file.
- Branch was rebased onto current `origin/main`; local divergence before push was `0 1`.
- No `WIP` label and no merge queue/auto-merge requested.