### PR TITLE
perf(cli): surface slow semantic check files

### DIFF
--- a/crates/tsz-cli/src/driver/check_file.rs
+++ b/crates/tsz-cli/src/driver/check_file.rs
@@ -255,6 +255,7 @@ fn run_check_on_existing_checker<'a>(
     // discarded so `--noCheck` still suppresses type errors.
     let run_checker_for_decl_emit = no_check && compiler_options.emit_declarations;
     if !no_check || run_checker_for_decl_emit {
+        let check_start = tsz_common::perf_counters::enabled_fast().then(std::time::Instant::now);
         tsz::checker::reset_stack_overflow_flag();
         checker.check_source_file(file.source_file);
         let mut checker_diagnostics = std::mem::take(&mut checker.ctx.diagnostics);
@@ -271,6 +272,13 @@ fn run_check_on_existing_checker<'a>(
             program_has_unsupported_js_root,
             program_context.has_deprecation_diagnostics,
         );
+        if let Some(start) = check_start {
+            tsz_common::perf_counters::record_slow_check_file_timing(
+                &file.file_name,
+                start.elapsed().as_nanos() as u64,
+                checker_diagnostics.len() as u64,
+            );
+        }
 
         if !no_check {
             file_diagnostics.extend(checker_diagnostics);

--- a/crates/tsz-common/src/perf_counters/definitions.rs
+++ b/crates/tsz-common/src/perf_counters/definitions.rs
@@ -913,6 +913,7 @@ impl SourceFileSymbolArenaCacheEligibilityOutcome {
 pub const DELEGATE_DECLARATION_FILE_MISS_RESIDUE_LIMIT: usize = 128;
 pub const DELEGATE_SOURCE_FILE_MISS_RESIDUE_LIMIT: usize = 128;
 pub const DIRECT_SOURCE_FILE_TYPE_ALIAS_BODY_REJECTION_RESIDUE_LIMIT: usize = 128;
+pub const SLOW_CHECK_FILE_TIMING_LIMIT: usize = 32;
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct DelegateDeclarationFileMissResidue {
@@ -946,6 +947,13 @@ pub struct DirectSourceFileTypeAliasBodyRejectionResidue {
     pub count: u64,
 }
 
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SlowCheckFileTiming {
+    pub file: String,
+    pub elapsed_ms: f64,
+    pub diagnostics: u64,
+}
+
 #[derive(Debug, Copy, Clone)]
 pub struct DirectSourceFileTypeAliasBodyRejectionResidueInput<'a> {
     pub name: &'a str,
@@ -969,6 +977,7 @@ static DELEGATE_SOURCE_FILE_MISS_RESIDUES: OnceLock<Mutex<Vec<DelegateSourceFile
 static DIRECT_SOURCE_FILE_TYPE_ALIAS_BODY_REJECTION_RESIDUES: OnceLock<
     Mutex<Vec<DirectSourceFileTypeAliasBodyRejectionResidue>>,
 > = OnceLock::new();
+static SLOW_CHECK_FILE_TIMINGS: OnceLock<Mutex<Vec<SlowCheckFileTiming>>> = OnceLock::new();
 
 fn delegate_declaration_file_miss_residues(
 ) -> &'static Mutex<Vec<DelegateDeclarationFileMissResidue>> {
@@ -982,6 +991,10 @@ fn delegate_source_file_miss_residues() -> &'static Mutex<Vec<DelegateSourceFile
 fn direct_source_file_type_alias_body_rejection_residues(
 ) -> &'static Mutex<Vec<DirectSourceFileTypeAliasBodyRejectionResidue>> {
     DIRECT_SOURCE_FILE_TYPE_ALIAS_BODY_REJECTION_RESIDUES.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+fn slow_check_file_timings() -> &'static Mutex<Vec<SlowCheckFileTiming>> {
+    SLOW_CHECK_FILE_TIMINGS.get_or_init(|| Mutex::new(Vec::new()))
 }
 
 pub const COMPUTE_TYPE_OF_SYMBOL_INTERFACE_SIMPLE_OBJECT_TYPE_REFERENCE_REJECT_RESIDUE_LIMIT:

--- a/crates/tsz-common/src/perf_counters/runtime.rs
+++ b/crates/tsz-common/src/perf_counters/runtime.rs
@@ -1467,6 +1467,31 @@ pub fn record_direct_actual_lib_intl_interface_outcome(
     c.direct_actual_lib_intl_interface_outcome[outcome.as_index()].fetch_add(1, Ordering::Relaxed);
 }
 
+/// Record one semantic `check_source_file` duration in attribution mode.
+///
+/// This intentionally stores only a bounded top-N list. The call site gates
+/// `Instant::now()` behind [`enabled_fast`], so timing-mode runs where
+/// `TSZ_PERF_COUNTERS` is unset do not pay for clock reads.
+pub fn record_slow_check_file_timing(file: &str, elapsed_ns: u64, diagnostics: u64) {
+    if !enabled_fast() {
+        return;
+    }
+    let mut rows = slow_check_file_timings()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    rows.push(SlowCheckFileTiming {
+        file: file.to_owned(),
+        elapsed_ms: elapsed_ns as f64 / 1_000_000.0,
+        diagnostics,
+    });
+    rows.sort_by(|a, b| {
+        b.elapsed_ms
+            .total_cmp(&a.elapsed_ms)
+            .then_with(|| a.file.cmp(&b.file))
+    });
+    rows.truncate(SLOW_CHECK_FILE_TIMING_LIMIT);
+}
+
 /// Record a raw `SymbolId`-shaped `DefId` redirect inside
 /// `TypeEnvironment::resolve_lazy`.
 ///

--- a/crates/tsz-common/src/perf_counters/snapshot.rs
+++ b/crates/tsz-common/src/perf_counters/snapshot.rs
@@ -1,6 +1,6 @@
 /// Stable schema version for `PerfCounterSnapshot`. Bump when the JSON
 /// shape changes in a way the bench harness must adapt to.
-pub const PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION: u32 = 2;
+pub const PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION: u32 = 3;
 
 /// Frozen value-object view of the counter state. Built by
 /// [`PerfCounters::snapshot`]; serializable to JSON via serde.
@@ -239,6 +239,12 @@ pub struct PerfCounterSnapshot {
     /// order. This splits the post-#6191 `symbol_arenas` residue into
     /// cacheable first misses versus structural non-cacheable cases.
     pub source_file_symbol_arena_cache_eligibility_outcomes: Vec<NamedCount>,
+    /// Top semantic `check_source_file` durations observed in attribution mode.
+    ///
+    /// This is a bounded list of the slowest files, sorted by descending
+    /// elapsed time. It is empty when `TSZ_PERF_COUNTERS` is unset or no file
+    /// ran semantic checking.
+    pub slow_check_file_timings: Vec<SlowCheckFileTiming>,
 }
 
 /// Per-bucket "is this wired up to its producer?" flag. Lets the bench
@@ -685,6 +691,7 @@ impl PerfCounters {
                     count: load(&c.source_file_symbol_arena_cache_eligibility_outcome[i]),
                 })
                 .collect(),
+            slow_check_file_timings: Self::snapshot_slow_check_file_timings(),
         }
     }
 
@@ -811,6 +818,20 @@ impl PerfCounters {
                 .then_with(|| a.symbol.cmp(&b.symbol))
                 .then_with(|| a.declaration_count.cmp(&b.declaration_count))
         });
+        rows
+    }
+
+    fn snapshot_slow_check_file_timings() -> Vec<SlowCheckFileTiming> {
+        let mut rows = slow_check_file_timings()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        rows.sort_by(|a, b| {
+            b.elapsed_ms
+                .total_cmp(&a.elapsed_ms)
+                .then_with(|| a.file.cmp(&b.file))
+        });
+        rows.truncate(SLOW_CHECK_FILE_TIMING_LIMIT);
         rows
     }
 

--- a/crates/tsz-common/src/perf_counters/tests.rs
+++ b/crates/tsz-common/src/perf_counters/tests.rs
@@ -2,10 +2,10 @@ mod json_tests {
     use super::*;
 
     #[test]
-    fn schema_version_is_two() {
+    fn schema_version_is_three() {
         // Bumping schema_version is a breaking change for the bench harness;
         // make the intent explicit.
-        assert_eq!(PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION, 2);
+        assert_eq!(PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION, 3);
     }
 
     #[test]
@@ -48,10 +48,51 @@ mod json_tests {
             "direct_actual_lib_intl_interface_outcomes",
             "cross_file_cache_miss_causes",
             "source_file_symbol_arena_cache_eligibility_outcomes",
+            "slow_check_file_timings",
         ] {
             assert!(json.get(key).is_some(), "missing top-level key: {key}");
         }
-        assert_eq!(json["schema_version"], 2);
+        assert_eq!(json["schema_version"], 3);
+    }
+
+    #[test]
+    fn slow_check_file_timings_keep_slowest_rows_sorted() {
+        {
+            let mut rows = slow_check_file_timings()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            rows.push(SlowCheckFileTiming {
+                file: "fast.ts".to_string(),
+                elapsed_ms: 1.0,
+                diagnostics: 0,
+            });
+            rows.push(SlowCheckFileTiming {
+                file: "slow.ts".to_string(),
+                elapsed_ms: 12.5,
+                diagnostics: 2,
+            });
+            rows.push(SlowCheckFileTiming {
+                file: "middle.ts".to_string(),
+                elapsed_ms: 4.0,
+                diagnostics: 1,
+            });
+        }
+
+        let json = serde_json::to_value(PerfCounters::snapshot()).expect("serializes");
+        let rows = json["slow_check_file_timings"]
+            .as_array()
+            .expect("slow_check_file_timings is array");
+        assert!(
+            rows.len() >= 3,
+            "expected recorded timing rows in snapshot: {rows:?}"
+        );
+        assert_eq!(rows[0]["file"], "slow.ts");
+        assert_eq!(rows[0]["diagnostics"], 2);
+        assert!(
+            rows[0]["elapsed_ms"].as_f64().unwrap_or_default()
+                >= rows[1]["elapsed_ms"].as_f64().unwrap_or_default(),
+            "rows must be sorted by descending elapsed_ms"
+        );
     }
 
     #[test]
@@ -1740,7 +1781,7 @@ mod json_tests {
         let raw = std::fs::read_to_string(&path).expect("read back");
         // Round-trip through serde to confirm structure.
         let value: serde_json::Value = serde_json::from_str(&raw).expect("valid JSON");
-        assert_eq!(value["schema_version"], 2);
+        assert_eq!(value["schema_version"], 3);
         assert!(value["wired"].is_object());
         // The atomic-rename `.json.tmp` should not be left behind.
         let tmp = path.with_extension("json.tmp");

--- a/scripts/perf/query-perf-counters.py
+++ b/scripts/perf/query-perf-counters.py
@@ -133,6 +133,14 @@ def print_summary(snap: dict) -> None:
         f"  compute_type_of_symbol  calls={fmt_int(cot_calls)}  "
         f"hits={fmt_int(cot_hits)}  hit%={cot_hit_pct:.2f}"
     )
+    slow_files = snap.get("slow_check_file_timings") or []
+    if slow_files:
+        print("  slowest semantic check files:")
+        for row in slow_files[:10]:
+            print(
+                f"    {row['elapsed_ms']:>8.2f} ms  "
+                f"diags={fmt_int(row.get('diagnostics', 0)):>4}  {row['file']}"
+            )
     print()
     print("overlay copy:")
     print(
@@ -244,6 +252,16 @@ def print_diff(post: dict, base: dict) -> None:
         "compute_type_of_symbol_cache_hits",
     ):
         print(f"  {delta(post['checker'], base['checker'], k)}")
+    post_slow = post.get("slow_check_file_timings") or []
+    base_slow = base.get("slow_check_file_timings") or []
+    if post_slow or base_slow:
+        print("  slowest semantic check file:")
+        if base_slow:
+            b = base_slow[0]
+            print(f"    baseline {b['elapsed_ms']:.2f} ms  {b['file']}")
+        if post_slow:
+            a = post_slow[0]
+            print(f"    current  {a['elapsed_ms']:.2f} ms  {a['file']}")
     print()
     post_rows = {r["reason"]: r for r in by_reason_rows(post, optional=True)}
     base_rows = {r["reason"]: r for r in by_reason_rows(base, optional=True)}

--- a/scripts/perf/test_query_perf_counters.py
+++ b/scripts/perf/test_query_perf_counters.py
@@ -11,7 +11,7 @@ SCRIPT = Path(__file__).with_name("query-perf-counters.py")
 
 def sample_snapshot(*, type_environment_core: int = 7, import_type: int = 3):
     return {
-        "schema_version": 2,
+        "schema_version": 3,
         "mode": "attribution",
         "enabled": True,
         "delegate": {
@@ -63,6 +63,10 @@ def sample_snapshot(*, type_environment_core: int = 7, import_type: int = 3):
                 "overlay_copy_max_entries": 30,
             },
         ],
+        "slow_check_file_timings": [
+            {"file": "src/deep.ts", "elapsed_ms": 12.5, "diagnostics": 1},
+            {"file": "src/shallow.ts", "elapsed_ms": 2.0, "diagnostics": 0},
+        ],
     }
 
 
@@ -89,6 +93,8 @@ class QueryPerfCountersTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("perf-counter JSON:", result.stdout)
         self.assertIn("delegate (cross-arena symbol resolution):", result.stdout)
+        self.assertIn("slowest semantic check files:", result.stdout)
+        self.assertIn("src/deep.ts", result.stdout)
         self.assertIn("Dominant: TypeEnvironmentCore = 7", result.stdout)
         self.assertIn("Top non-baseline T2.2 target: ImportType = 3", result.stdout)
 


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 performance measurement/tooling: green-row `ts-essentials-project` semantic-check attribution for #7378.

## Invariant
When `TSZ_PERF_COUNTERS` attribution mode is enabled, tsz records a bounded top-N list of semantic `check_source_file` durations by file; when counters are disabled, timing-mode/compiler behavior is unchanged and no clock read is taken.

## Scope
- Add `slow_check_file_timings` to the perf-counter JSON snapshot and bump the schema to 3.
- Record semantic check duration around `checker.check_source_file` in the CLI check path only when perf counters are enabled.
- Teach `scripts/perf/query-perf-counters.py` to print the slowest semantic-check files.
- Cover the schema/ordering and Python report output in focused tests.

## Project Corpus Impact
- Row: `ts-essentials-project`
- Bug family: green-row semantic-check attribution for the remaining 2x `tsgo` target gap (#7378)
- Evidence: latest local companion artifact `/private/tmp/studio-b-ts-essentials-project-20260527102613.tsgo-winners.json` still reports one eligible green row below target (`tsz_ms=85.94`, `tsgo_ms=74.41`, target gap factor `2.3099`); this PR adds attribution needed to identify the next semantic-check hotspot without changing compiler semantics.

## Verification
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/perf/test_query_perf_counters.py`
- `cargo nextest run -p tsz-common perf_counters`
- `cargo check -p tsz-cli`
- Smoke: `TSZ_PERF_COUNTERS=1 cargo run -q -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json /tmp/studio-b-slow-check-smoke.json --noEmit /tmp/tsz-slow-check-*/a.ts`, then `python3 scripts/perf/query-perf-counters.py --json /tmp/studio-b-slow-check-smoke.json` showed schema `3` and a `slowest semantic check files` row.

## Coordination Notes
- Opened after Studio-B PR #10490 merged.
- Overlap check found no open Studio-B PRs; open PR/agent-label audit was clean before publishing.
- This is measurement/tooling only. It does not claim a timing win; it makes the next green-row speed slice targetable.
