### PR TITLE
chore(emit): clarify output surgery audit pass summary

### DIFF
--- a/scripts/emit/audit-output-surgery.py
+++ b/scripts/emit/audit-output-surgery.py
@@ -317,6 +317,19 @@ def print_report(findings: list[Finding], allowlist: dict[str, AllowEntry]) -> N
             print(f"  {finding.line_no}: {finding.text}")
 
 
+def format_pass_summary(findings: list[Finding], failures: list[str]) -> str:
+    summary = summarize_failures(failures)
+    return (
+        "Output-surgery audit passed: "
+        f"total_findings={len(findings)}, "
+        f"files_with_findings={len(grouped_counts(findings))}, "
+        f"unallowlisted_calls={summary.unallowlisted}, "
+        f"over_allowlist_files={summary.over_allowlist_files}, "
+        f"over_allowlist_excess_calls={summary.over_allowlist_excess_calls}, "
+        f"stale_allowlist_files={summary.stale_allowlist_files}."
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--list", action="store_true", help="print all tracked findings")
@@ -353,10 +366,7 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  - {failure}", file=sys.stderr)
         return 1
 
-    print(
-        f"Output-surgery audit passed: {len(findings)} ratcheted call(s) across "
-        f"{len(grouped_counts(findings))} file(s)."
-    )
+    print(format_pass_summary(findings, failures))
     return 0
 
 

--- a/scripts/emit/test_output_surgery_audit.py
+++ b/scripts/emit/test_output_surgery_audit.py
@@ -113,6 +113,25 @@ class OutputSurgeryAuditTests(unittest.TestCase):
             ],
         )
 
+    def test_pass_summary_names_clean_guardrail_counters(self):
+        findings = [
+            self.audit.Finding("a.rs", 1, "replacen", "output = output.replacen(&a, &b, 1);"),
+            self.audit.Finding("b.rs", 2, "replace", "rewritten = rewritten.replace(&a, &b);"),
+        ]
+
+        summary = self.audit.format_pass_summary(findings, [])
+
+        self.assertEqual(
+            summary,
+            "Output-surgery audit passed: "
+            "total_findings=2, "
+            "files_with_findings=2, "
+            "unallowlisted_calls=0, "
+            "over_allowlist_files=0, "
+            "over_allowlist_excess_calls=0, "
+            "stale_allowlist_files=0.",
+        )
+
     def test_write_json_report_creates_parent_and_writes_json(self):
         with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
             report_path = pathlib.Path(temp_dir) / "nested" / "report.json"


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Track 10 launch infrastructure / cheap evidence plumbing.

## Invariant
When the output-surgery audit passes, the console summary should report both the remaining ratcheted call count and the zero failure counters; this PR makes the green audit line harder to misread without changing the guardrail decision.

## Scope
- `scripts/emit/audit-output-surgery.py`
- `scripts/emit/test_output_surgery_audit.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: script-only reporting change; no compiler, benchmark, emit, checker, solver, parser, binder, LSP, WASM, or project-corpus behavior path changed.

## Verification
- `python3 -m unittest scripts.emit.test_output_surgery_audit`
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery-studio-f-evidence.json`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Studio-F owned PR runway was empty before this branch started.
- Open PR overlap checked; this is limited to Studio-F output-surgery evidence plumbing.
- Signed: Studio-F
