### PR TITLE
chore(ci): clarify merge queue runner failures

### DIFF
--- a/scripts/ci/check-pr-ready-state.mjs
+++ b/scripts/ci/check-pr-ready-state.mjs
@@ -70,7 +70,7 @@ function runGh(args) {
 
 function readPullRequest(options) {
   if (options.fixture) {
-    return JSON.parse(fs.readFileSync(options.fixture, "utf8"));
+    return normalizePullRequest(JSON.parse(fs.readFileSync(options.fixture, "utf8")));
   }
 
   const repository = process.env.REPOSITORY || process.env.GITHUB_REPOSITORY;
@@ -79,13 +79,20 @@ function readPullRequest(options) {
     throw new Error("PR_NUMBER and REPOSITORY or GITHUB_REPOSITORY are required");
   }
 
-  const output = runGh([
-    "api",
-    `repos/${repository}/pulls/${prNumber}`,
-    "--jq",
-    "{number,title,body,draft,labels:[.labels[]?.name]}",
-  ]);
-  return JSON.parse(output);
+  const output = runGh(["api", `repos/${repository}/pulls/${prNumber}`]);
+  return normalizePullRequest(JSON.parse(output));
+}
+
+export function normalizePullRequest(pr) {
+  return {
+    number: pr.number,
+    title: pr.title,
+    body: pr.body,
+    draft: pr.draft,
+    labels: Array.isArray(pr.labels)
+      ? pr.labels.map((label) => typeof label === "string" ? label : label?.name)
+      : [],
+  };
 }
 
 function hasWipTitle(title) {

--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -563,13 +563,27 @@ function postComment(repository, number, body) {
 }
 
 export function failureCommentBody(agentName, reason) {
-  return [
+  const lines = [
     `AgentName: ${cleanAgentName(agentName)}`,
     "",
     "Poor man's merge queue could not land this PR.",
     "",
     `Reason: ${reason}`,
-  ].join("\n");
+  ];
+  if (isRunnerInfrastructureFailure(reason)) {
+    lines.push(
+      "",
+      "Queue runner note: this failure happened while preparing or publishing the synthetic merge branch. It is infrastructure/worktree evidence, not evidence that the PR head failed CI.",
+    );
+  }
+  return lines.join("\n");
+}
+
+function isRunnerInfrastructureFailure(reason) {
+  const text = String(reason || "");
+  return /^git (fetch|checkout|push)\b/.test(text)
+    || text.includes("cannot lock ref")
+    || text.includes("is already used by worktree");
 }
 
 export function skipReasonCounts(skips) {

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -383,6 +383,18 @@ assert.deepEqual(
   ],
 );
 assert.match(failureCommentBody("M1-A", "CI Summary failed"), /^AgentName: M1-A\n\nPoor man's merge queue/m);
+assert.doesNotMatch(failureCommentBody("M1-A", "CI Summary failed"), /not evidence that the PR head failed CI/);
+assert.match(
+  failureCommentBody(
+    "Studio-F",
+    "git checkout -B automation/merge-queue/pr-10521 4e422f332cbe68ca5452299c4f1a144a30eefab0 failed",
+  ),
+  /infrastructure\/worktree evidence, not evidence that the PR head failed CI/,
+);
+assert.match(
+  failureCommentBody("Studio-F", "git fetch --no-tags origin main pull/10521/head failed"),
+  /infrastructure\/worktree evidence, not evidence that the PR head failed CI/,
+);
 assert.throws(() => failureCommentBody("M1-A\nOther", "CI Summary failed"), /single line/);
 
 assert.match(

--- a/scripts/ci/test-pr-ready-state.mjs
+++ b/scripts/ci/test-pr-ready-state.mjs
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { readyStateFailures } from "./check-pr-ready-state.mjs";
+import { normalizePullRequest, readyStateFailures } from "./check-pr-ready-state.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(SCRIPT_DIR, "..", "..");
@@ -41,6 +41,23 @@ function runFixture(pr) {
 }
 
 assert.deepEqual(readyStateFailures(readyPr()), []);
+
+assert.deepEqual(
+  normalizePullRequest({
+    number: 456,
+    title: "chore(ci): sample",
+    body: "AgentName: TestAgent\n",
+    draft: false,
+    labels: [{ name: "agent:Studio-F" }, { name: "merge-queue" }],
+  }),
+  {
+    number: 456,
+    title: "chore(ci): sample",
+    body: "AgentName: TestAgent\n",
+    draft: false,
+    labels: ["agent:Studio-F", "merge-queue"],
+  },
+);
 
 assert.deepEqual(
   readyStateFailures(readyPr({ labels: ["WIP"] })),


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Track 10 launch infrastructure / cheap evidence plumbing.

## Invariant
When the poor-man merge queue fails while preparing or publishing its synthetic merge branch, the PR comment should identify that as runner/worktree infrastructure evidence rather than evidence that the PR head failed CI. Ready-state PR-body checks should also read PR metadata robustly from `gh api` on hosted runners.

## Scope
- `scripts/ci/poor-mans-merge-queue.mjs`
- `scripts/ci/test-poor-mans-merge-queue.mjs`
- `scripts/ci/check-pr-ready-state.mjs`
- `scripts/ci/test-pr-ready-state.mjs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI coordination-message-only change; no compiler, benchmark, emit, checker, solver, parser, binder, LSP, WASM, or project-corpus behavior path changed.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `node scripts/ci/test-pr-ready-state.mjs`
- `PR_NUMBER=10523 REPOSITORY=mohsen1/tsz node scripts/ci/check-pr-ready-state.mjs`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery-queue-failure-evidence.json`
- `python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard-queue-failure-evidence.json`

## Coordination Notes
- Studio-F owned PR runway was empty before this branch started.
- This follows up the #10521 queue comments where local worktree/ref failures were easy to misread after the PR had already merged.
- The `project-corpus-pr-body` failure on head `2ecef706ec78b6d1fe1cadc56377caa5d9f972e2` came from `check-pr-ready-state.mjs` shaping PR metadata via `gh api --jq`; head `4e64376614` fetches raw PR JSON and normalizes it in Node instead.
- Signed: Studio-F
