### PR TITLE
refactor(checker): route uniform indexed constraint relations

### DIFF
--- a/crates/tsz-checker/src/error_reporter/generics.rs
+++ b/crates/tsz-checker/src/error_reporter/generics.rs
@@ -747,10 +747,16 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
             let prop_value = self.evaluate_type_for_assignability(prop.type_id);
-            if !self.diagnostic_relation_boolean_guard(prop_value, resolved_constraint)
-                && !self.diagnostic_relation_boolean_guard(prop.type_id, constraint)
-                && !self.diagnostic_relation_boolean_guard(prop_value, constraint)
-                && !self.diagnostic_relation_boolean_guard(prop.type_id, resolved_constraint)
+            if !self
+                .assign_relation_outcome(prop_value, resolved_constraint)
+                .related
+                && !self
+                    .assign_relation_outcome(prop.type_id, constraint)
+                    .related
+                && !self.assign_relation_outcome(prop_value, constraint).related
+                && !self
+                    .assign_relation_outcome(prop.type_id, resolved_constraint)
+                    .related
             {
                 return false;
             }

--- a/crates/tsz-checker/src/tests/jsx_element_type_constraint_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_element_type_constraint_tests.rs
@@ -352,6 +352,29 @@ fn jsx_element_type_constraint_suppression_does_not_read_rendered_type_strings()
     );
 }
 
+#[test]
+fn uniform_indexed_access_constraint_uses_relation_outcome_boundary() {
+    let generics_src = include_str!("../error_reporter/generics.rs");
+    let function_start = generics_src
+        .find("pub(crate) fn indexed_access_into_object_uniformly_satisfies_constraint")
+        .expect("find indexed-access uniform constraint helper");
+    let rest = &generics_src[function_start..];
+    let function_end = rest
+        .find("\n    /// Report TS2635")
+        .expect("find next diagnostic helper");
+    let function = &rest[..function_end];
+
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "uniform indexed-access constraint checks must use the shared relation outcome boundary"
+    );
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        4,
+        "property-value constraint checks should route through RelationOutcome"
+    );
+}
+
 /// Return compatibility alone is not enough: a source callable that requires
 /// more parameters than the `ElementType` callable arm is not a valid JSX
 /// component.


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track: checker relation diagnostic/query-boundary routing refactor

## Invariant
When the generic TS2344 reporter suppresses an indexed-access `M[K]` constraint error because every finite object property value satisfies the target constraint, `tsc` treats each property compatibility check as an assignability relation; this PR keeps checker-owned diagnostic suppression while routing those relation decisions through `RelationOutcome` via `CheckerState::assign_relation_outcome`.

## Scope
- `crates/tsz-checker/src/error_reporter/generics.rs`
- `crates/tsz-checker/src/tests/jsx_element_type_constraint_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation-routing architecture cleanup
- Evidence: behavior-preserving migration from raw boolean diagnostic guards to the existing assignability relation outcome boundary; no project row behavior change intended.

## Verification
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `cargo nextest run -p tsz-checker --lib uniform_indexed_access_constraint_uses_relation_outcome_boundary`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Draft PR for M1-B relation-routing cleanup.
- Exact open-PR file overlap checked before publishing: no open PR touched either changed file.
- Branch was rebased onto current `origin/main`; local divergence before push was `0 1`.
- No `WIP` label and no merge queue/auto-merge requested.