### PR TITLE
refactor(solver): use typed cache agreement policies

### DIFF
--- a/crates/tsz-solver/tests/db_tests.rs
+++ b/crates/tsz-solver/tests/db_tests.rs
@@ -135,12 +135,12 @@ fn relation_cache_stats_track_hits_and_misses() {
     let key = RelationCacheKey::for_subtype(
         hello,
         TypeId::STRING,
-        RelationPolicy::from_flags(0).cache_config(),
+        RelationPolicy::unflagged_compatibility().cache_config(),
     );
     let assignability_key = RelationCacheKey::for_assignability(
         hello,
         TypeId::STRING,
-        RelationPolicy::from_flags(0).cache_config(),
+        RelationPolicy::unflagged_compatibility().cache_config(),
     );
 
     assert_eq!(

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -120,8 +120,8 @@ fn assignability_cache_strict_function_types_matches_uncached_function_variance(
         TypeId::VOID,
     ));
 
-    let strict_policy = RelationPolicy::from_flags(RelationCacheKey::FLAG_STRICT_FUNCTION_TYPES);
-    let loose_policy = RelationPolicy::from_flags(0);
+    let strict_policy = RelationPolicy::from_relation_flags(RelationFlags::STRICT_FUNCTION_TYPES);
+    let loose_policy = RelationPolicy::unflagged_compatibility();
 
     let strict_uncached = query_relation(
         &interner,
@@ -185,8 +185,8 @@ fn subtype_cache_allow_void_return_matches_uncached_function_return_policy() {
     let source = interner.function(FunctionShape::new(vec![], TypeId::STRING));
     let target = interner.function(FunctionShape::new(vec![], TypeId::VOID));
 
-    let strict_policy = RelationPolicy::from_flags(0);
-    let allow_void_policy = RelationPolicy::from_flags(RelationCacheKey::FLAG_ALLOW_VOID_RETURN);
+    let strict_policy = RelationPolicy::unflagged_compatibility();
+    let allow_void_policy = RelationPolicy::from_relation_flags(RelationFlags::ALLOW_VOID_RETURN);
 
     let strict_uncached = query_relation(
         &interner,
@@ -251,10 +251,9 @@ fn assignability_cache_exact_optional_matches_uncached_property_policy() {
     let source = interner.object(vec![PropertyInfo::new(x, TypeId::UNDEFINED)]);
     let target = interner.object(vec![PropertyInfo::opt(x, TypeId::NUMBER)]);
 
-    let inexact_policy = RelationPolicy::from_flags(RelationCacheKey::FLAG_STRICT_NULL_CHECKS);
-    let exact_policy = RelationPolicy::from_flags(
-        RelationCacheKey::FLAG_STRICT_NULL_CHECKS
-            | RelationCacheKey::FLAG_EXACT_OPTIONAL_PROPERTY_TYPES,
+    let inexact_policy = RelationPolicy::from_relation_flags(RelationFlags::STRICT_NULL_CHECKS);
+    let exact_policy = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_NULL_CHECKS | RelationFlags::EXACT_OPTIONAL_PROPERTY_TYPES,
     );
 
     let inexact_uncached = query_relation(
@@ -320,7 +319,7 @@ fn subtype_cache_strict_readonly_identity_matches_uncached_property_policy() {
     let source = interner.object(vec![PropertyInfo::readonly(x, TypeId::NUMBER)]);
     let target = interner.object(vec![PropertyInfo::new(x, TypeId::NUMBER)]);
 
-    let permissive_policy = RelationPolicy::from_flags(0);
+    let permissive_policy = RelationPolicy::unflagged_compatibility();
     let strict_policy =
         RelationPolicy::from_relation_flags(RelationFlags::STRICT_READONLY_IDENTITY);
 
@@ -487,9 +486,9 @@ fn assignability_cache_strict_subtype_checking_matches_uncached_method_policy() 
     let source = interner.object(vec![PropertyInfo::method(run, dog_method)]);
     let target = interner.object(vec![PropertyInfo::method(run, animal_method)]);
 
-    let ordinary = RelationPolicy::from_flags(RelationCacheKey::FLAG_STRICT_FUNCTION_TYPES)
+    let ordinary = RelationPolicy::from_relation_flags(RelationFlags::STRICT_FUNCTION_TYPES)
         .with_strict_subtype_checking(false);
-    let strict = RelationPolicy::from_flags(RelationCacheKey::FLAG_STRICT_FUNCTION_TYPES)
+    let strict = RelationPolicy::from_relation_flags(RelationFlags::STRICT_FUNCTION_TYPES)
         .with_strict_subtype_checking(true);
     let ordinary_key = RelationCacheKey::for_assignability(source, target, ordinary.cache_config());
     let strict_key = RelationCacheKey::for_assignability(source, target, strict.cache_config());


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Solver relation policy/cache-key cleanup for #8207.

## Invariant
Relation cache agreement tests should describe behavior-affecting policy modes through typed `RelationPolicy` constructors, not legacy packed `RelationCacheKey::FLAG_*` masks, unless the test is specifically exercising packed-mask compatibility.

## Scope
- Replaced packed flag construction in `relation_policy_cache_agreement_tests.rs` with `RelationPolicy::from_relation_flags(...)` and `RelationPolicy::unflagged_compatibility()`.
- Replaced no-flags cache-key setup in the cache stats test with `RelationPolicy::unflagged_compatibility()`.
- No solver behavior changes.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: test-only relation policy/cache agreement refactor; no checker, emitter, parser, binder, or project-corpus behavior surface changed.

## Verification
- `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests) | test(relation_cache_stats_track_hits_and_misses)'`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- `rg -n "RelationPolicy::from_flags\\(|RelationCacheKey::FLAG_" crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs crates/tsz-solver/tests/db_tests.rs` returned no matches.

## Coordination Notes
AgentName: M4-B

Checked open PRs before starting. This stays in solver test policy/cache agreement and avoids M1-B checker relation-routing work, M4-A conditional library application work, and M4-D defineProperty identity work. Local focused verification is complete; ready for review/CI.
