### PR TITLE
fix(checker): resolve generic-lib application union members before access

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -811,6 +811,9 @@ mod partial_pick_indexed_access_write_tests;
 #[path = "tests/polymorphic_this_relation_routing_arch_tests.rs"]
 mod polymorphic_this_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/predicate_narrowed_lib_union_access_tests.rs"]
+mod predicate_narrowed_lib_union_access_tests;
+#[cfg(test)]
 #[path = "../tests/private_brands.rs"]
 mod private_brands;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -794,11 +794,11 @@ impl<'a> CheckerState<'a> {
     /// application member made progress, so callers can fall through to their
     /// normal resolution path.
     fn resolve_union_application_members(&mut self, type_id: TypeId) -> Option<TypeId> {
-        use tsz_solver::TypeData;
+        use crate::query_boundaries::state::type_environment::is_application_type;
         let members = crate::query_boundaries::common::union_members(self.ctx.types, type_id)?;
         if !members
             .iter()
-            .any(|&m| matches!(self.ctx.types.lookup(m), Some(TypeData::Application(_))))
+            .any(|&m| is_application_type(self.ctx.types, m))
         {
             return None;
         }
@@ -806,10 +806,7 @@ impl<'a> CheckerState<'a> {
         let resolved: Vec<TypeId> = members
             .iter()
             .map(|&member| {
-                if matches!(
-                    self.ctx.types.lookup(member),
-                    Some(TypeData::Application(_))
-                ) {
+                if is_application_type(self.ctx.types, member) {
                     let evaluated = self.evaluate_application_type(member);
                     if evaluated != member {
                         changed = true;

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -788,8 +788,59 @@ impl<'a> CheckerState<'a> {
         self.resolve_lib_type_by_name(name)
     }
 
+    /// When `type_id` is a union with at least one `Application` member, evaluate
+    /// those application members through the type environment and return the
+    /// rebuilt union. Returns `None` when `type_id` is not such a union or no
+    /// application member made progress, so callers can fall through to their
+    /// normal resolution path.
+    fn resolve_union_application_members(&mut self, type_id: TypeId) -> Option<TypeId> {
+        use tsz_solver::TypeData;
+        let members = crate::query_boundaries::common::union_members(self.ctx.types, type_id)?;
+        if !members
+            .iter()
+            .any(|&m| matches!(self.ctx.types.lookup(m), Some(TypeData::Application(_))))
+        {
+            return None;
+        }
+        let mut changed = false;
+        let resolved: Vec<TypeId> = members
+            .iter()
+            .map(|&member| {
+                if matches!(
+                    self.ctx.types.lookup(member),
+                    Some(TypeData::Application(_))
+                ) {
+                    let evaluated = self.evaluate_application_type(member);
+                    if evaluated != member {
+                        changed = true;
+                    }
+                    evaluated
+                } else {
+                    member
+                }
+            })
+            .collect();
+        changed.then(|| self.ctx.types.union(resolved))
+    }
+
     pub(crate) fn resolve_type_for_property_access(&mut self, type_id: TypeId) -> TypeId {
         use rustc_hash::FxHashSet;
+
+        // A union whose members are `Application(Lazy(DefId), …)` instantiations
+        // of generic lib references (e.g. `Int32Array | Uint8Array`) keeps those
+        // members opaque under the solver's environment-free evaluator, hiding
+        // the referenced interface's members and index signatures. Such unions
+        // arise from narrowing or constraint-position substitution, where the
+        // members are interned in their raw application form rather than the
+        // resolved object form a directly-declared union would carry. Resolve
+        // the application members through the type environment first so property
+        // and element access see the interface shape; the recursion then runs
+        // the normal per-member resolution on the resolved union. This precedes
+        // the per-id resolve cache, which can otherwise return a stale identity
+        // entry recorded on an earlier pass before the members were resolvable.
+        if let Some(resolved) = self.resolve_union_application_members(type_id) {
+            return self.resolve_type_for_property_access(resolved);
+        }
 
         if let Some(&cached) = self
             .ctx

--- a/crates/tsz-checker/src/tests/predicate_narrowed_lib_union_access_tests.rs
+++ b/crates/tsz-checker/src/tests/predicate_narrowed_lib_union_access_tests.rs
@@ -1,0 +1,144 @@
+//! Property/element access on a union of generic lib references produced by
+//! narrowing (or constraint-position substitution).
+//!
+//! Structural rule: when a value whose type is a union of generic lib
+//! `Application` references — e.g. `Int32Array | Uint8Array` — reaches a
+//! property or element access, the access must see each member's resolved
+//! interface shape (its members and index signatures). Such unions arise from
+//! narrowing a union operand by a user-defined type guard or from
+//! constraint-position substitution of a generic parameter; their members are
+//! interned as raw `Application(Lazy(DefId), …)` types, which the solver's
+//! environment-free evaluator leaves opaque. Resolving the application members
+//! through the type environment before access makes `arr[1]` resolve to the
+//! numeric-index element type (no TS7053) and `arr.length` resolve to the shared
+//! property (no TS2339), matching `tsc`. A `number` member (no index signature)
+//! still makes the access fail, exactly as in `tsc`.
+
+use std::sync::Arc;
+use tsz_binder::lib_loader::LibFile;
+use tsz_common::options::checker::CheckerOptions;
+
+fn opts() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn libs() -> Vec<Arc<LibFile>> {
+    crate::test_utils::load_lib_files(&["es5.d.ts"])
+}
+
+fn codes(source: &str) -> Vec<u32> {
+    crate::test_utils::check_source_with_libs(source, "test.ts", opts(), &libs())
+        .iter()
+        .map(|diag| diag.code)
+        .collect()
+}
+
+fn count(source: &str, code: u32) -> usize {
+    codes(source).iter().filter(|&&c| c == code).count()
+}
+
+// ---------------------------------------------------------------------------
+// Reported repro (#10500): a generic parameter whose constraint is
+// `number | TypedArray` is substituted to its base constraint at `arr[1]`
+// (constraint-position substitution, #10494). The `isTypedArray` guard narrows
+// the substituted union to `Int32Array | Uint8Array`; indexing that union must
+// resolve through the typed arrays' numeric index signature, not report TS7053.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generic_constraint_typed_array_index_after_guard_has_no_ts7053() {
+    let source = r#"
+type TypedArray = Int32Array | Uint8Array;
+function isTypedArray(a: unknown): a is TypedArray { return true as any; }
+function flatten<T extends number | TypedArray>(arr: T): void {
+    if (isTypedArray(arr)) {
+        const x: number = arr[1];
+    }
+}
+"#;
+    assert_eq!(count(source, 7053), 0, "got {:?}", codes(source));
+    assert_eq!(count(source, 2322), 0, "got {:?}", codes(source));
+}
+
+#[test]
+fn generic_constraint_typed_array_index_after_guard_renamed_params() {
+    // Same rule with P/X instead of T — proves the fix is not name-keyed.
+    let source = r#"
+type TypedArray = Int32Array | Uint8Array;
+function isTypedArray(a: unknown): a is TypedArray { return true as any; }
+function flatten<P extends number | TypedArray>(o: P): void {
+    if (isTypedArray(o)) {
+        const x: number = o[0];
+    }
+}
+"#;
+    assert_eq!(count(source, 7053), 0, "got {:?}", codes(source));
+}
+
+// ---------------------------------------------------------------------------
+// Non-generic union operand narrowed by a user-defined type guard: the same
+// resolution must apply whether the union came from a generic constraint or a
+// directly-declared variable.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn declared_union_index_after_guard_has_no_ts7053() {
+    let source = r#"
+function isI32(a: unknown): a is Int32Array | Uint8Array { return true as any; }
+declare const z: number | Int32Array | Uint8Array;
+if (isI32(z)) {
+    const x: number = z[1];
+}
+"#;
+    assert_eq!(count(source, 7053), 0, "got {:?}", codes(source));
+}
+
+#[test]
+fn declared_union_property_access_after_guard_has_no_ts2339() {
+    // Property access on the narrowed union must also see the shared interface
+    // member: `length` exists on both Int32Array and Uint8Array.
+    let source = r#"
+type TypedArray = Int32Array | Uint8Array;
+function isTypedArray(a: unknown): a is TypedArray { return true as any; }
+declare const z: number | Int32Array | Uint8Array;
+if (isTypedArray(z)) {
+    const n: number = z.length;
+}
+"#;
+    assert_eq!(count(source, 2339), 0, "got {:?}", codes(source));
+}
+
+// ---------------------------------------------------------------------------
+// Negative / fallback cases.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn number_member_without_guard_still_reports_ts7053() {
+    // A `number` member has no index signature, so indexing the un-narrowed
+    // union must still report TS7053, exactly as tsc does.
+    let source = r#"
+function index<T extends number | Int32Array>(r: T): void {
+    r[0];
+}
+"#;
+    assert_eq!(count(source, 7053), 1, "got {:?}", codes(source));
+}
+
+#[test]
+fn else_branch_keeps_number_member() {
+    // The guard's else branch keeps the `number` member; indexing it stays an
+    // error and `number` remains assignable to `number`.
+    let source = r#"
+function isI32(a: unknown): a is Int32Array { return true as any; }
+declare const w: number | Int32Array;
+if (isI32(w)) {
+} else {
+    const b: number = w;
+}
+"#;
+    assert_eq!(count(source, 2322), 0, "got {:?}", codes(source));
+}

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -10,7 +10,6 @@ TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 TypeScript/tests/cases/compiler/jsxComplexSignatureHasApplicabilityError.tsx
 TypeScript/tests/cases/compiler/reorderProperties.ts
 TypeScript/tests/cases/compiler/temporal.ts
-TypeScript/tests/cases/compiler/unionWithIndexSignature.ts
 TypeScript/tests/cases/conformance/es2019/globalThisAmbientModules.ts
 TypeScript/tests/cases/conformance/es2024/sharedMemory.ts
 TypeScript/tests/cases/conformance/externalModules/typeOnly/circular2.ts


### PR DESCRIPTION
Fixes #10500.

## Agent
AgentName: M1-C

(Runner: web-opus47-cvUJE, operating in the M1-C lane.)

## Track
Conformance / checker — index & property access on narrowed generic-lib unions.

## Invariant
When a value whose type is a union of generic lib `Application` references (e.g. `Int32Array | Uint8Array`) reaches a property or element access, the access must see each member's resolved interface shape (members + index signatures), matching `tsc`. A `number` member (no index signature) still makes the access fail.

## Structural rule
> When a property/element access targets a union whose members are environment-unresolved generic-lib references — `Application(Lazy(DefId), …)` instantiations such as the typed arrays — resolve those application members through the checker's `TypeEnvironment` before deciding member/index-signature visibility; `tsc` indexes the resolved (apparent) members, so tsz must too.

## Root cause
`#10494` added constraint-position substitution, which (correctly) turns `arr` in `flatten<T extends number | TypedArray>(arr: T)` into its base constraint `number | TypedArray` at `arr[1]`. A user-defined guard `if (isTypedArray(arr))` then narrows that union — and the narrowing **is** correct (it drops `number`). But the resulting union's members are interned as raw `Application(Lazy(DefId=Int32Array), [ArrayBufferLike])`, not the resolved `ObjectWithIndex` form a directly-declared `Int32Array | Uint8Array` carries.

The solver's environment-free evaluator cannot resolve a `Lazy(DefId)` interface reference, so `resolve_element_access_type` returned `ERROR`/the type was deemed non-indexable → spurious **TS7053** on `arr[1]` and **TS2339** on `arr.length`. `resolve_type_for_property_access` left the union unresolved (its per-id resolve cache can hold a stale identity entry recorded on an earlier pass before the members were resolvable).

The issue's `const p2: 0 = z` probe is what made the reporter believe narrowing was a no-op; in fact narrowing works and the divergence was purely in access-time resolution.

## Scope
- `crates/tsz-checker/src/state/type_environment/lazy.rs`: in `resolve_type_for_property_access`, before the per-id resolve cache, resolve `Application` members of a union object through the type environment (`evaluate_application_type`) and recurse. New helper `resolve_union_application_members` returns `None` for non-union / no-progress inputs so all other shapes fall through unchanged. The application-member test routes through the `query_boundaries::state::type_environment::is_application_type` boundary helper (no raw `TypeData` matching in checker state).
- `crates/tsz-checker/src/tests/predicate_narrowed_lib_union_access_tests.rs` + `lib.rs`: owning-crate unit tests.
- `scripts/conformance/conformance-accepted-regressions.txt`: remove `unionWithIndexSignature.ts` (parked by #10494).

This fixes both element access (TS7053) and property access (TS2339), since both route through `resolve_type_for_property_access`.

## Adjacent-case test matrix
1. Reported repro: generic `flatten<T extends number | TypedArray>` + `isTypedArray` guard, `arr[1]` → no TS7053.
2. Renamed type params (`P` instead of `T`) — proves the fix is not name-keyed.
3. Declared (non-generic) union narrowed by a guard, element access → no TS7053.
4. Declared union narrowed by a guard, **property** access `z.length` → no TS2339.
5. Negative: `number | Int32Array` without a guard → still TS7053 (number has no index signature).
6. Negative: guard `else` branch keeps the `number` member.

## Project Corpus Impact
- Row: `unionWithIndexSignature.ts` (conformance) — moves from accepted-regression back to passing.
- Bug family: index/property access on unions of unresolved generic-lib `Application` references produced by narrowing / constraint-position substitution.
- Evidence: `tsc` (6.0.3 cache) emits no diagnostics for `unionWithIndexSignature.ts`; local `cargo run -p tsz-cli` on the repro family now matches (no TS7053/TS2339), negatives preserved.

## Verification
- New unit tests: `cargo nextest run -p tsz-checker -E 'test(predicate_narrowed_lib_union_access)'` → 6 passed.
- `cargo clippy -p tsz-checker -p tsz-solver --all-targets -- -D warnings` → clean; `scripts/arch/check-checker-boundaries.sh` → passes.
- Manual CLI repros (generic constraint, renamed params, alias/inline unions, declared union, DataView negative, `number | Int32Array` negative) all match tsc.
- Full `cargo nextest run -p tsz-checker` run locally; conformance/emit/fourslash run in CI on ready.

## Coordination Notes
Picked up #10500 under the existing `agent:M1-C` lane (it was only a triage label, no active PR). Ready-review CI is running on the current head; `merge-queue` remains off until exact-head PR checks are green.
