### PR TITLE
perf(lowering): cache type parameter scope text

### DIFF
--- a/crates/tsz-lowering/src/lower/core.rs
+++ b/crates/tsz-lowering/src/lower/core.rs
@@ -9,6 +9,7 @@ use indexmap::IndexMap;
 use std::cell::RefCell;
 use std::path::Path;
 use std::rc::Rc;
+use std::sync::Arc;
 use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeList;
 use tsz_parser::parser::base::NodeIndex;
@@ -33,7 +34,13 @@ pub const MAX_LOWERING_OPERATIONS: u32 = 100_000;
 pub(super) type NodeIndexResolver<'a, T> = dyn Fn(NodeIndex) -> Option<T> + 'a;
 pub(super) type TypeIdResolver<'a> = dyn Fn(&str) -> Option<DefId> + 'a;
 pub(super) type LazyTypeParamsResolver<'a> = dyn Fn(DefId) -> Option<Vec<TypeParamInfo>> + 'a;
-pub(super) type TypeParamScopeStack = RefCell<Vec<Vec<(Atom, TypeId)>>>;
+#[derive(Clone)]
+pub(super) struct TypeParamBinding {
+    type_id: TypeId,
+}
+
+pub(super) type TypeParamScope = IndexMap<Arc<str>, TypeParamBinding>;
+pub(super) type TypeParamScopeStack = RefCell<Vec<TypeParamScope>>;
 pub(super) type TypeofParamScopeStack = RefCell<Vec<Vec<(Atom, TypeId)>>>;
 pub type LoweredInterfaceMemberTypes = (Vec<TypeParamInfo>, Vec<(NodeIndex, TypeId)>);
 
@@ -743,7 +750,16 @@ impl<'a> TypeLowering<'a> {
     /// These are added to a new scope that persists for the lifetime of the `TypeLowering`.
     pub fn with_type_param_bindings(self, bindings: Vec<(Atom, TypeId)>) -> Self {
         if !bindings.is_empty() {
-            *self.type_param_scopes.borrow_mut() = vec![bindings];
+            let scope = bindings
+                .into_iter()
+                .map(|(name, type_id)| {
+                    (
+                        self.interner.resolve_atom_ref(name),
+                        TypeParamBinding { type_id },
+                    )
+                })
+                .collect();
+            *self.type_param_scopes.borrow_mut() = vec![scope];
         }
         self
     }
@@ -976,7 +992,7 @@ impl<'a> TypeLowering<'a> {
     }
 
     pub(super) fn push_type_param_scope(&self) {
-        self.type_param_scopes.borrow_mut().push(Vec::new());
+        self.type_param_scopes.borrow_mut().push(IndexMap::new());
     }
 
     pub(super) fn pop_type_param_scope(&self) {
@@ -985,18 +1001,26 @@ impl<'a> TypeLowering<'a> {
 
     pub(super) fn add_type_param_binding(&self, name: Atom, type_id: TypeId) {
         if let Some(scope) = self.type_param_scopes.borrow_mut().last_mut() {
-            scope.push((name, type_id));
+            scope.insert(
+                self.interner.resolve_atom_ref(name),
+                TypeParamBinding { type_id },
+            );
+        }
+    }
+
+    pub(super) fn update_type_param_binding(&self, name: Atom, type_id: TypeId) {
+        if let Some(scope) = self.type_param_scopes.borrow_mut().last_mut()
+            && let Some(existing) = scope.get_mut(self.interner.resolve_atom_ref(name).as_ref())
+        {
+            existing.type_id = type_id;
         }
     }
 
     pub(super) fn lookup_type_param(&self, name: &str) -> Option<TypeId> {
-        let atom = self.interner.intern_string(name);
         let scopes = self.type_param_scopes.borrow();
         for scope in scopes.iter().rev() {
-            for (scope_name, type_id) in scope.iter().rev() {
-                if *scope_name == atom {
-                    return Some(*type_id);
-                }
+            if let Some(binding) = scope.get(name) {
+                return Some(binding.type_id);
             }
         }
         None
@@ -1383,7 +1407,7 @@ impl<'a> TypeLowering<'a> {
                 info.name = name;
                 info.is_const = is_const;
                 let type_id = self.interner.type_param(info);
-                self.add_type_param_binding(info.name, type_id);
+                self.update_type_param_binding(info.name, type_id);
                 params.push(info);
             }
         }

--- a/crates/tsz-lowering/src/lower/core/constructor_parity_tests.rs
+++ b/crates/tsz-lowering/src/lower/core/constructor_parity_tests.rs
@@ -87,3 +87,27 @@ fn with_hybrid_resolver_initializes_invariant_defaults() {
     assert!(lowering.def_id_resolver.is_some());
     assert!(lowering.value_resolver.is_some());
 }
+
+#[test]
+fn type_param_scope_update_replaces_placeholder_binding() {
+    let arena = NodeArena::new();
+    let interner = TypeInterner::new();
+    let lowering = TypeLowering::new(&arena, &interner);
+    let name = interner.intern_string("T");
+
+    lowering.push_type_param_scope();
+    lowering.add_type_param_binding(name, TypeId::STRING);
+    lowering.update_type_param_binding(name, TypeId::NUMBER);
+
+    let scopes = lowering.type_param_scopes.borrow();
+    assert_eq!(scopes.len(), 1);
+    assert_eq!(scopes[0].len(), 1);
+    let (stored_name, binding) = scopes[0].iter().next().expect("binding");
+    assert_eq!(stored_name.as_ref(), "T");
+    assert_eq!(binding.type_id, TypeId::NUMBER);
+    drop(scopes);
+
+    assert_eq!(lowering.lookup_type_param("T"), Some(TypeId::NUMBER));
+    assert_eq!(lowering.lookup_type_param("U"), None);
+    lowering.pop_type_param_scope();
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 performance micro-allocation / green-row attribution follow-up for `ts-essentials-project` (#7378).

## Invariant
When lowering generic type scopes, local type-parameter lookup should preserve TypeScript lexical scope behavior while avoiding repeated type-interner string insertion for each identifier reference. This PR keeps the placeholder binding window for self-referential constraints/defaults, then updates the same binding with the final `TypeId` and stores scope entries by interned text.

## Scope
- Change `TypeLowering` type-parameter scopes from linear `(Atom, TypeId)` vectors to `IndexMap<Arc<str>, TypeParamBinding>` maps.
- Replace placeholder type-parameter bindings in place after lowering constraints/defaults instead of appending duplicate bindings.
- Add a focused lowering unit test for placeholder replacement and lookup behavior.

## Project Corpus Impact
- Row: `ts-essentials-project`
- Bug family: green-row utility-type mapped/conditional/key-space workload (#7378)
- Evidence: attribution before `/private/tmp/studio-b-ts-essentials-perf-20260527135726.json` reported `string_intern_calls=268,226` for the project and `xor/index.ts` as the slowest semantic check file (`292.86ms`). After this PR, `/private/tmp/studio-b-ts-essentials-project-after-scope-map.json` reports `string_intern_calls=119,012` and `xor/index.ts=278.33ms` in attribution mode. Timing mode still has one 2x target gap: `/private/tmp/studio-b-ts-essentials-after-scope-map-timing.tsgo-winners.json` reports `tsz_ms=103.04`, `tsgo_ms=77.05`, target gap factor `2.6746`; no row win is claimed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo check -p tsz-lowering`
- `cargo nextest run -p tsz-lowering type_param_scope_update_replaces_placeholder_binding`
- `cargo build -p tsz-cli --features perf-tools --bin tsz`
- Attribution: `TSZ_PERF_COUNTERS=1 .target/debug/tsz --extendedDiagnostics --perf-counters-json /private/tmp/studio-b-ts-essentials-project-after-scope-map.json --noEmit -p .target-bench/external/ts-essentials/tsconfig.flat.json`
- Timing: `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^ts-essentials-project$' --json-file /private/tmp/studio-b-ts-essentials-after-scope-map-timing.json`
- Winner report: `node scripts/bench/tsgo-winner-report.mjs /private/tmp/studio-b-ts-essentials-after-scope-map-timing.json /private/tmp/studio-b-ts-essentials-after-scope-map-timing.tsgo-winners.json`

## Coordination Notes
- Ready for review as a small focused perf/allocation reduction; this PR intentionally does not claim the `ts-essentials-project` row target is solved.
- No open Studio-B PRs existed before this branch; open PR overlap was checked and belongs to other lanes.
- Next Studio-B work after this lands should target the remaining `ts-essentials-project` runtime gap, with current profiling pointing at repeated checker missing-name traversal in `xor/index.ts`.
