### PR TITLE
refactor(solver): use typed subtype cache policies

### DIFF
--- a/crates/tsz-solver/tests/subtype_cache_tests.rs
+++ b/crates/tsz-solver/tests/subtype_cache_tests.rs
@@ -388,11 +388,11 @@ fn cache_key_includes_flags() {
     );
     let entries_default = db.relation_cache_stats().subtype_entries;
 
-    // Check with strict null checks flag (1)
+    // Check with strict null checks policy.
     db.is_subtype_of_with_policy(
         hello,
         TypeId::STRING,
-        RelationPolicy::from_flags(RelationCacheKey::FLAG_STRICT_NULL_CHECKS),
+        RelationPolicy::from_relation_flags(RelationFlags::STRICT_NULL_CHECKS),
     );
     let entries_strict = db.relation_cache_stats().subtype_entries;
 
@@ -566,7 +566,7 @@ fn probe_returns_hit_after_check() {
     let key = RelationCacheKey::for_subtype(
         hello,
         TypeId::STRING,
-        RelationPolicy::from_flags(0).cache_config(),
+        RelationPolicy::unflagged_compatibility().cache_config(),
     );
     assert_eq!(db.probe_subtype_cache(key), RelationCacheProbe::Hit(true));
 }
@@ -581,7 +581,7 @@ fn probe_negative_hit_after_failed_check() {
     let key = RelationCacheKey::for_subtype(
         TypeId::STRING,
         TypeId::NUMBER,
-        RelationPolicy::from_flags(0).cache_config(),
+        RelationPolicy::unflagged_compatibility().cache_config(),
     );
     assert_eq!(db.probe_subtype_cache(key), RelationCacheProbe::Hit(false));
 }


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Solver relation policy/cache-key cleanup for #8207.

## Invariant
Subtype cache tests should use typed relation policy constructors when they are asserting typed cache behavior or unflagged compatibility behavior. Packed `RelationPolicy::from_flags(...)` construction should stay reserved for tests that explicitly exercise legacy packed flag decoding.

## Scope
- Replaced the strict-null cache population check in `subtype_cache_tests.rs` with `RelationPolicy::from_relation_flags(RelationFlags::STRICT_NULL_CHECKS)`.
- Replaced two probe cache-key setup sites with `RelationPolicy::unflagged_compatibility()`.
- No solver behavior changes.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: test-only solver subtype-cache policy refactor; no checker, emitter, parser, binder, or project-corpus behavior surface changed.

## Verification
- `cargo nextest run -p tsz-solver -E 'test(subtype_cache_tests::cache_key_includes_flags) | test(subtype_cache_tests::probe_returns_hit_after_check) | test(subtype_cache_tests::probe_negative_hit_after_failed_check)'`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- `rg -n "RelationPolicy::from_flags\\(|RelationCacheKey::FLAG_" crates/tsz-solver/tests/subtype_cache_tests.rs` returned no matches.

## Coordination Notes
AgentName: M4-B

Checked owned work before starting. This is independent from #10525 and avoids the files touched there; it also avoids M1-B checker relation-routing work, M4-A conditional library application work, and M4-D defineProperty identity work. Local focused verification is complete; ready for review/CI.
