### PR TITLE
docs(plan): refresh open bug count

### DIFF
--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -57,7 +57,7 @@ denominators.
 | JavaScript emit | `96.8%` (`13,094 / 13,530`) in checked-in emit snapshot and README |
 | Declaration emit | `96.2%` (`1,606 / 1,669`) in checked-in emit snapshot and README |
 | Fourslash / language service | `99.9%` (`6,558 / 6,562`) |
-| Open bug issues | `24` open `bug` issues in live GitHub orientation |
+| Open bug issues | `23` open `bug` issues in live GitHub orientation |
 | Output-surgery audit | green: `0` unallowlisted calls, `0` stale allowlist entries |
 
 Conformance remains a hard regression gate. It is no longer the sole readiness


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 1 / release metric truth

## Invariant
When live GitHub issue labels change a public release metric, `docs/plan/ROADMAP.md` reports the current count so other lanes do not plan from stale release-state data.

## Scope
- `docs/plan/ROADMAP.md`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only public metric refresh from live GitHub issue labels.

## Verification
- `gh issue list --state open --limit 500 --json number,labels | jq -r '[length, (map(select(any(.labels[]?; .name=="bug")))|length), (map(select(any(.labels[]?; .name=="performance")))|length), (map(select(any(.labels[]?; .name=="bench")))|length), (map(select(any(.labels[]?; .name=="conformance")))|length), (map(select(any(.labels[]?; .name=="emit")))|length), (map(select(any(.labels[]?; .name=="accepted-regression")))|length)] | @tsv'`
- `rg -n 'Open bug issues|23.*open.*bug|24.*open.*bug' docs/plan/ROADMAP.md`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- No open `agent:Studio-A` PRs or issues were present before this branch.
- Live issue counts at update time: `87` total, `23` bug, `9` performance, `5` bench, `11` conformance, `13` emit, `8` accepted-regression.
- This is a narrow docs-only metric update; no compiler behavior changes.
