### PR TITLE
chore(emit): label output surgery budget status

### DIFF
--- a/scripts/emit/audit-output-surgery.py
+++ b/scripts/emit/audit-output-surgery.py
@@ -66,6 +66,7 @@ class BudgetSummary:
     allowlist_cap: int = 0
     remaining_allowlist_capacity: int = 0
     allowlisted_files: int = 0
+    budget_status: str = "no_allowlist"
 
 
 def iter_rust_files(base: pathlib.Path = SOURCE_ROOT):
@@ -290,6 +291,26 @@ def summarize_budget(file_summaries: list[dict[str, object]]) -> BudgetSummary:
         allowlist_cap=allowlist_cap,
         remaining_allowlist_capacity=max(0, allowlist_cap - allowlisted_calls),
         allowlisted_files=allowlisted_files,
+        budget_status=classify_budget_status(allowlisted_calls, allowlist_cap),
+    )
+
+
+def classify_budget_status(allowlisted_calls: int, allowlist_cap: int) -> str:
+    if allowlist_cap == 0:
+        return "no_allowlist"
+    if allowlisted_calls > allowlist_cap:
+        return "over_cap"
+    if allowlisted_calls == allowlist_cap:
+        return "exhausted"
+    return "available"
+
+
+def format_budget_metrics(budget: BudgetSummary) -> str:
+    return (
+        f"allowlisted_calls={budget.allowlisted_calls}, "
+        f"allowlist_cap={budget.allowlist_cap}, "
+        f"remaining_allowlist_capacity={budget.remaining_allowlist_capacity}, "
+        f"allowlist_budget_status={budget.budget_status}"
     )
 
 
@@ -356,9 +377,7 @@ def format_pass_summary(
         "Output-surgery audit passed: "
         f"total_findings={len(findings)}, "
         f"files_with_findings={len(grouped_counts(findings))}, "
-        f"allowlisted_calls={budget.allowlisted_calls}, "
-        f"allowlist_cap={budget.allowlist_cap}, "
-        f"remaining_allowlist_capacity={budget.remaining_allowlist_capacity}, "
+        f"{format_budget_metrics(budget)}, "
         f"unallowlisted_calls={summary.unallowlisted}, "
         f"over_allowlist_files={summary.over_allowlist_files}, "
         f"over_allowlist_excess_calls={summary.over_allowlist_excess_calls}, "
@@ -388,8 +407,10 @@ def main(argv: list[str] | None = None) -> int:
 
     if failures:
         summary = summarize_failures(failures)
+        budget = summarize_budget(build_file_summaries(grouped_counts(findings), allowlist))
         print(
             "\nOutput-surgery audit summary: "
+            f"{format_budget_metrics(budget)}, "
             f"unallowlisted_calls={summary.unallowlisted}, "
             f"unallowlisted_files={summary.unallowlisted_files}, "
             f"over_allowlist_files={summary.over_allowlist_files}, "

--- a/scripts/emit/test_output_surgery_audit.py
+++ b/scripts/emit/test_output_surgery_audit.py
@@ -90,6 +90,7 @@ class OutputSurgeryAuditTests(unittest.TestCase):
                 "allowlist_cap": 2,
                 "remaining_allowlist_capacity": 1,
                 "allowlisted_files": 2,
+                "budget_status": "available",
             },
         )
         self.assertEqual(
@@ -142,11 +143,18 @@ class OutputSurgeryAuditTests(unittest.TestCase):
             "allowlisted_calls=2, "
             "allowlist_cap=2, "
             "remaining_allowlist_capacity=0, "
+            "allowlist_budget_status=exhausted, "
             "unallowlisted_calls=0, "
             "over_allowlist_files=0, "
             "over_allowlist_excess_calls=0, "
             "stale_allowlist_files=0.",
         )
+
+    def test_budget_status_classifies_budget_edges(self):
+        self.assertEqual(self.audit.classify_budget_status(0, 0), "no_allowlist")
+        self.assertEqual(self.audit.classify_budget_status(1, 2), "available")
+        self.assertEqual(self.audit.classify_budget_status(2, 2), "exhausted")
+        self.assertEqual(self.audit.classify_budget_status(3, 2), "over_cap")
 
     def test_write_json_report_creates_parent_and_writes_json(self):
         with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Track 10 launch infrastructure / output-surgery evidence plumbing.

## Invariant
When the output-surgery audit reports a green allowlist budget, the artifact should state whether the budget still has capacity, is exhausted, or is over cap; this PR makes that state explicit in the audit JSON and console summaries.

## Scope
- `scripts/emit/audit-output-surgery.py`
- `scripts/emit/test_output_surgery_audit.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: script-only evidence plumbing; no compiler behavior, benchmark fixture, parser/checker/solver, or emitter output path changes.

## Verification
- `python3 scripts/emit/test_output_surgery_audit.py`
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery-budget-status.json`
- `python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard-budget-status.json`
- `git diff --check HEAD~1..HEAD`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- AgentName: Studio-F
- Owned Studio-F PR runway was empty before this branch.
- Open PR overlap checked; this stays in Studio-F audit evidence plumbing and does not touch active checker, solver, LSP, or emit parity implementation lanes.
- The current live output-surgery audit reports `allowlisted_calls=31`, `allowlist_cap=31`, `remaining_allowlist_capacity=0`, and now `allowlist_budget_status=exhausted` so a green audit cannot be mistaken for spare budget.
