### PR TITLE
refactor(solver): shard mapped keyof constraint evaluation

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -4,6 +4,7 @@
 
 mod display_order;
 mod key_types;
+mod keyof_constraint;
 
 use crate::construction::TypeDatabase;
 use crate::instantiation::instantiate::{
@@ -1238,117 +1239,6 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             }
             _ => None,
         }
-    }
-
-    /// Evaluate a keyof or constraint type for mapped type iteration.
-    ///
-    /// Wrapped with `stacker::maybe_grow()` to handle deeply nested union/intersection
-    /// constraint chains without overflowing the default thread stack.
-    ///
-    /// All intermediate types in the evaluation chain remain entered in the
-    /// `keyof_constraint_guard` until the chain terminates. This ensures that
-    /// a cycle like `Lazy(A) → Lazy(B) → Lazy(A)` is detected when `A` is
-    /// re-entered while it is still in the guard's visited set. The depth cap
-    /// (`TypeEvaluation` profile: depth 100) also limits the chain length.
-    fn evaluate_keyof_or_constraint(&mut self, constraint: TypeId) -> TypeId {
-        let mut current = constraint;
-        let mut entered: Vec<TypeId> = Vec::new();
-
-        let result = loop {
-            match self.keyof_constraint_guard.enter(current) {
-                crate::recursion::RecursionResult::Entered => {
-                    entered.push(current);
-                }
-                _ => break current,
-            }
-
-            let step = stacker::maybe_grow(256 * 1024, 2 * 1024 * 1024, || {
-                self.evaluate_keyof_or_constraint_inner(current)
-            });
-
-            if step != current
-                && matches!(
-                    self.interner().lookup(step),
-                    Some(
-                        TypeData::Union(_)
-                            | TypeData::Intersection(_)
-                            | TypeData::KeyOf(_)
-                            | TypeData::Conditional(_)
-                            | TypeData::Lazy(_)
-                            | TypeData::Application(_)
-                    )
-                )
-            {
-                current = step;
-                continue;
-            }
-            break step;
-        };
-
-        for &id in entered.iter().rev() {
-            self.keyof_constraint_guard.leave(id);
-        }
-        result
-    }
-
-    fn evaluate_keyof_or_constraint_inner(&mut self, constraint: TypeId) -> TypeId {
-        // PERF: Single lookup handles all cases instead of 4 separate DashMap lookups.
-        let members = match self.interner().lookup(constraint) {
-            Some(TypeData::Conditional(cond_id)) => {
-                let cond = self.interner().get_conditional(cond_id);
-                return self.evaluate_conditional(&cond);
-            }
-            Some(TypeData::Literal(LiteralValue::String(_))) => {
-                return constraint;
-            }
-            Some(TypeData::KeyOf(operand)) => {
-                return self.evaluate_keyof(operand);
-            }
-            Some(TypeData::Union(members)) => Some(members),
-            _ => None,
-        };
-
-        // Union: recursively evaluate each member. This handles the distributed form
-        // where `(keyof T & keyof U)` after T is inferred becomes
-        // `Union(Intersection("x", keyof U), Intersection("y", keyof U))` due to
-        // the interner's intersection-over-union distribution. Each Union member
-        // (which may be an Intersection) gets recursively simplified.
-        if let Some(members) = members {
-            let member_list = self.interner().type_list(members);
-            let mut evaluated_members = Vec::with_capacity(member_list.len());
-            let mut any_changed = false;
-            for &member in member_list.iter() {
-                let evaluated = self.evaluate_keyof_or_constraint(member);
-                if evaluated != member {
-                    any_changed = true;
-                }
-                evaluated_members.push(evaluated);
-            }
-            if any_changed {
-                return self.interner().union(evaluated_members);
-            }
-            return constraint;
-        }
-
-        // Intersection: evaluate each member to get its key set, then compute
-        // their intersection. Handles both pre-distribution `keyof T & keyof U`
-        // and post-distribution `"x" & keyof U` forms.
-        if let Some(TypeData::Intersection(members)) = self.interner().lookup(constraint) {
-            let member_list = self.interner().type_list(members);
-            let mut key_sets = Vec::with_capacity(member_list.len());
-            for &member in member_list.iter() {
-                key_sets.push(self.evaluate_keyof_or_constraint(member));
-            }
-            if let Some(result) = self.intersect_keyof_sets(&key_sets) {
-                return result;
-            }
-            // If intersection computation failed, fall through to general evaluation
-        }
-
-        // Evaluate the constraint to resolve type aliases (Lazy), Applications, etc.
-        // For example, `type Keys = "a" | "b"; { [P in Keys]: T }` has a Lazy(DefId)
-        // constraint that must be evaluated to get the concrete union `"a" | "b"`.
-        self.evaluate(constraint)
     }
 
     /// Build a `MappedKey` from a literal `TypeId`. Returns `None` if the

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped/keyof_constraint.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped/keyof_constraint.rs
@@ -1,0 +1,118 @@
+//! `keyof` constraint reduction for mapped type iteration.
+
+use crate::evaluation::evaluate::TypeEvaluator;
+use crate::relations::subtype::TypeResolver;
+use crate::types::{LiteralValue, TypeData, TypeId};
+
+impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
+    /// Evaluate a keyof or constraint type for mapped type iteration.
+    ///
+    /// Wrapped with `stacker::maybe_grow()` to handle deeply nested union/intersection
+    /// constraint chains without overflowing the default thread stack.
+    ///
+    /// All intermediate types in the evaluation chain remain entered in the
+    /// `keyof_constraint_guard` until the chain terminates. This ensures that
+    /// a cycle like `Lazy(A) → Lazy(B) → Lazy(A)` is detected when `A` is
+    /// re-entered while it is still in the guard's visited set. The depth cap
+    /// (`TypeEvaluation` profile: depth 100) also limits the chain length.
+    pub(super) fn evaluate_keyof_or_constraint(&mut self, constraint: TypeId) -> TypeId {
+        let mut current = constraint;
+        let mut entered: Vec<TypeId> = Vec::new();
+
+        let result = loop {
+            match self.keyof_constraint_guard.enter(current) {
+                crate::recursion::RecursionResult::Entered => {
+                    entered.push(current);
+                }
+                _ => break current,
+            }
+
+            let step = stacker::maybe_grow(256 * 1024, 2 * 1024 * 1024, || {
+                self.evaluate_keyof_or_constraint_inner(current)
+            });
+
+            if step != current
+                && matches!(
+                    self.interner().lookup(step),
+                    Some(
+                        TypeData::Union(_)
+                            | TypeData::Intersection(_)
+                            | TypeData::KeyOf(_)
+                            | TypeData::Conditional(_)
+                            | TypeData::Lazy(_)
+                            | TypeData::Application(_)
+                    )
+                )
+            {
+                current = step;
+                continue;
+            }
+            break step;
+        };
+
+        for &id in entered.iter().rev() {
+            self.keyof_constraint_guard.leave(id);
+        }
+        result
+    }
+
+    fn evaluate_keyof_or_constraint_inner(&mut self, constraint: TypeId) -> TypeId {
+        // PERF: Single lookup handles all cases instead of 4 separate DashMap lookups.
+        let members = match self.interner().lookup(constraint) {
+            Some(TypeData::Conditional(cond_id)) => {
+                let cond = self.interner().get_conditional(cond_id);
+                return self.evaluate_conditional(&cond);
+            }
+            Some(TypeData::Literal(LiteralValue::String(_))) => {
+                return constraint;
+            }
+            Some(TypeData::KeyOf(operand)) => {
+                return self.evaluate_keyof(operand);
+            }
+            Some(TypeData::Union(members)) => Some(members),
+            _ => None,
+        };
+
+        // Union: recursively evaluate each member. This handles the distributed form
+        // where `(keyof T & keyof U)` after T is inferred becomes
+        // `Union(Intersection("x", keyof U), Intersection("y", keyof U))` due to
+        // the interner's intersection-over-union distribution. Each Union member
+        // (which may be an Intersection) gets recursively simplified.
+        if let Some(members) = members {
+            let member_list = self.interner().type_list(members);
+            let mut evaluated_members = Vec::with_capacity(member_list.len());
+            let mut any_changed = false;
+            for &member in member_list.iter() {
+                let evaluated = self.evaluate_keyof_or_constraint(member);
+                if evaluated != member {
+                    any_changed = true;
+                }
+                evaluated_members.push(evaluated);
+            }
+            if any_changed {
+                return self.interner().union(evaluated_members);
+            }
+            return constraint;
+        }
+
+        // Intersection: evaluate each member to get its key set, then compute
+        // their intersection. Handles both pre-distribution `keyof T & keyof U`
+        // and post-distribution `"x" & keyof U` forms.
+        if let Some(TypeData::Intersection(members)) = self.interner().lookup(constraint) {
+            let member_list = self.interner().type_list(members);
+            let mut key_sets = Vec::with_capacity(member_list.len());
+            for &member in member_list.iter() {
+                key_sets.push(self.evaluate_keyof_or_constraint(member));
+            }
+            if let Some(result) = self.intersect_keyof_sets(&key_sets) {
+                return result;
+            }
+            // If intersection computation failed, fall through to general evaluation
+        }
+
+        // Evaluate the constraint to resolve type aliases (Lazy), Applications, etc.
+        // For example, `type Keys = "a" | "b"; { [P in Keys]: T }` has a Lazy(DefId)
+        // constraint that must be evaluated to get the concrete union `"a" | "b"`.
+        self.evaluate(constraint)
+    }
+}


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Track 2 semantic substrate refactor only.

## Invariant
When mapped-type iteration reduces a `keyof` constraint, tsz should keep the recursion guard and reducer in solver-owned mapped evaluation code; this PR changes only the solver module layout so the near-cap mapped evaluator can accept future semantic fixes without growing the monolith.

## Scope
- Move `evaluate_keyof_or_constraint` and its inner reducer from `mapped.rs` to `mapped/keyof_constraint.rs`.
- Add the mapped evaluator submodule declaration.
- No behavior, cache, relation, checker, or diagnostic-path changes.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only solver module split; no project-corpus behavior surface intentionally changes.

## Verification
- `cargo fmt --check`
- `cargo nextest run -p tsz-solver evaluate_keyof_or_constraint` — 10 passed, 6321 skipped
- `cargo nextest run -p tsz-solver mapped` — 358 passed, 2 failed; both failing tests reproduce on clean `origin/main` with the exact one-test filters, so they are baseline red tests rather than this PR
- `wc -l crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs crates/tsz-solver/src/evaluation/evaluate_rules/mapped/keyof_constraint.rs` — `mapped.rs` 1872 lines, new shard 118 lines

## Coordination Notes
- AgentName: M4-A
- Supports #8203 / #8209 by splitting a mapped-evaluation helper cluster while preserving solver ownership.
- Avoids active M4-B relation/cache-policy work and M4-C checker/request-fact work.
- Branch is based on current `origin/main` after a clean rebase.
