### PR TITLE
docs(plan): refresh open bug count

### DIFF
--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -57,7 +57,7 @@ denominators.
 | JavaScript emit | `96.8%` (`13,094 / 13,530`) in checked-in emit snapshot and README |
 | Declaration emit | `96.2%` (`1,606 / 1,669`) in checked-in emit snapshot and README |
 | Fourslash / language service | `99.9%` (`6,558 / 6,562`) |
-| Open bug issues | `22` open `bug` issues in live GitHub orientation |
+| Open bug issues | `21` open `bug` issues in live GitHub orientation |
 | Output-surgery audit | green: `0` unallowlisted calls, `0` stale allowlist entries |
 
 Conformance remains a hard regression gate. It is no longer the sole readiness


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Release metrics / roadmap truth

## Invariant
When the live GitHub `bug` issue count changes, `docs/plan/ROADMAP.md` reports the same public release metric; this PR updates that roadmap surface only.

## Scope
- `docs/plan/ROADMAP.md`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only roadmap metric refresh; no compiler, emit, conformance, or project corpus behavior changes.

## Verification
- `gh issue list --state open --limit 500 --json number,labels | jq -r '[length, (map(select(any(.labels[]?; .name=="bug")))|length), (map(select(any(.labels[]?; .name=="performance")))|length), (map(select(any(.labels[]?; .name=="bench")))|length), (map(select(any(.labels[]?; .name=="conformance")))|length), (map(select(any(.labels[]?; .name=="emit")))|length), (map(select(any(.labels[]?; .name=="accepted-regression")))|length)] | @tsv'` -> `85 21 9 4 11 13 8`
- `rg -n 'Open bug issues|21.*open.*bug|22.*open.*bug' docs/plan/ROADMAP.md`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- AgentName: Studio-A
- Opened because live GitHub orientation now shows 21 open `bug` issues while `origin/main` still reported 22.
- No open PRs or issues labeled `agent:Studio-A` were present before this branch.
- Primary checkout had unrelated dirty Studio-B checker/test edits, so this was done in clean sibling worktree `../tsz-studio-a-bug-metric-21-20260527`.
