### PR TITLE
fix(checker): widen literal source type in TS2418 computed-property message

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
@@ -158,9 +158,12 @@ impl<'a> CheckerState<'a> {
             {
                 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
 
-                let source_type = self
+                // TS2418 widens literal source types (e.g. `"str"` → `string`,
+                // `42` → `number`) unconditionally, matching tsc behavior.
+                let raw_source = self
                     .literal_type_from_initializer(prop_value_idx)
                     .unwrap_or(source_prop.type_id);
+                let source_type = self.widen_literal_type(raw_source);
                 let source_str = self.format_type_for_assignability_message(source_type);
                 let target_str = self.format_type_for_assignability_message(target_value_type);
                 let message = format_message(

--- a/crates/tsz-checker/tests/symbol_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/symbol_index_signature_tests.rs
@@ -1128,6 +1128,80 @@ const o: { foo: string } = { ["foo"]: 42 };
     );
 }
 
+// TS2418 message widens literal value types (issue #9685).
+// tsc always reports the widened type (`string`, `number`) in the TS2418
+// message, not the literal (`"str"`, `42`).
+
+#[test]
+fn ts2418_message_widens_string_literal_value() {
+    let messages = check_source_code_messages(
+        r#"
+interface I { [k: symbol]: number; }
+const s = Symbol();
+const i: I = { [s]: "str" };
+"#,
+    );
+    let ts2418 = messages
+        .iter()
+        .find(|(code, _)| *code == diagnostic_codes::TYPE_OF_COMPUTED_PROPERTYS_VALUE_IS_WHICH_IS_NOT_ASSIGNABLE_TO_TYPE);
+    assert!(ts2418.is_some(), "expected TS2418, got {messages:?}");
+    let msg = &ts2418.unwrap().1;
+    assert!(
+        msg.contains("'string'"),
+        "expected widened 'string' in TS2418 message, got: {msg}"
+    );
+    assert!(
+        !msg.contains("\"str\""),
+        "should not contain string literal in TS2418 message, got: {msg}"
+    );
+}
+
+#[test]
+fn ts2418_message_widens_number_literal_value() {
+    let messages = check_source_code_messages(
+        r#"
+interface I { [k: symbol]: string; }
+const s = Symbol();
+const i: I = { [s]: 42 };
+"#,
+    );
+    let ts2418 = messages
+        .iter()
+        .find(|(code, _)| *code == diagnostic_codes::TYPE_OF_COMPUTED_PROPERTYS_VALUE_IS_WHICH_IS_NOT_ASSIGNABLE_TO_TYPE);
+    assert!(ts2418.is_some(), "expected TS2418, got {messages:?}");
+    let msg = &ts2418.unwrap().1;
+    assert!(
+        msg.contains("'number'"),
+        "expected widened 'number' in TS2418 message, got: {msg}"
+    );
+    assert!(
+        !msg.contains("'42'"),
+        "should not contain numeric literal in TS2418 message, got: {msg}"
+    );
+}
+
+#[test]
+fn ts2418_message_widens_string_literal_with_renamed_symbol() {
+    // Same structural rule with a different symbol variable name — confirms
+    // the fix is not name-bound.
+    let messages = check_source_code_messages(
+        r#"
+interface J { [k: symbol]: boolean; }
+const myKey = Symbol();
+const j: J = { [myKey]: "hello" };
+"#,
+    );
+    let ts2418 = messages
+        .iter()
+        .find(|(code, _)| *code == diagnostic_codes::TYPE_OF_COMPUTED_PROPERTYS_VALUE_IS_WHICH_IS_NOT_ASSIGNABLE_TO_TYPE);
+    assert!(ts2418.is_some(), "expected TS2418, got {messages:?}");
+    let msg = &ts2418.unwrap().1;
+    assert!(
+        msg.contains("'string'"),
+        "expected widened 'string' in TS2418 message with renamed key, got: {msg}"
+    );
+}
+
 // Negative: a computed key against a real index signature must still use TS2418.
 #[test]
 fn computed_key_against_real_number_index_signature_keeps_ts2418() {


### PR DESCRIPTION
## Agent
AgentName: Studio-E

## Track
Track 1 (checker parity) / TS2418 union-index-signature diagnostic message display

## Invariant
For the `try_union_index_signature_value_check` TS2418 path only, `tsc` widens the source literal type before formatting the computed-property index-signature mismatch message (`"str"` -> `string`, `42` -> `number`). This PR makes that union-index-signature diagnostic path format the widened primitive source type without changing unrelated TS2418 elaboration paths.

## Scope
- `crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs`: apply `widen_literal_type` to `raw_source` before formatting the TS2418 source-type display string in the union-index-signature computed-property path.
- `crates/tsz-checker/tests/symbol_index_signature_tests.rs`: three unit tests covering string-literal widening, number-literal widening, and a renamed-symbol variant (proves the fix is name-independent).

## Root Cause
`try_union_index_signature_value_check` called `literal_type_from_initializer(prop_value_idx)` directly to get the display type for TS2418. This returned the raw literal TypeId (`"str"`, `42`), which was then passed to `format_type_for_assignability_message`, producing `'"str"'` in the message instead of `'string'` for this union-index-signature diagnostic path.

Structural rule: when `try_union_index_signature_value_check` formats the TS2418 source-type string for a computed-property index-signature mismatch, the source type for that diagnostic path must be widened to its primitive (`widen_literal_type`) before display.

## Adjacent cases covered by tests
1. String literal `"str"` against `[k: symbol]: number` -> message shows `'string'`
2. Number literal `42` against `[k: symbol]: string` -> message shows `'number'`
3. Same shapes with renamed symbol variable (`myKey` vs `s`) -> rule is name-independent

## Verification
```bash
cargo nextest run -p tsz-checker -E 'test(ts2418_message)'
# test ts2418_message_widens_string_literal_value ... ok
# test ts2418_message_widens_number_literal_value ... ok
# test ts2418_message_widens_string_literal_with_renamed_symbol ... ok
```

Pre-existing failures on HEAD (before this PR): `well_known_symbol_index_signature_reports_computed_property_value_mismatch`, `jsdoc_symbol_index_signature_reports_computed_property_value_mismatch`, and `object_literal_well_known_symbol_property_access_key_still_resolves_named_member` — confirmed via `git stash` baseline test. This PR does not introduce or change those failures.

## Project Corpus Impact
- Row: n/a
- Bug family: TS2418 diagnostic message display / union-index-signature literal widening
- Evidence: unit tests in `symbol_index_signature_tests.rs`; checker-only diagnostic display change with no conformance snapshot impact expected for diagnostic presence.

## Coordination Notes
- AgentName: Studio-E (claude-sonnet-4-6, session `claude/dazzling-johnson-YN8jg`)
- Fallback state: #10419 (M1-C) now has current head `f13ccf82dcb8a8bbc2e3280ebfce8f3480825ab5` and matches this PR's narrow union-index-signature diagnostic path while restoring the accepted-regression entries that made its prior `27ddddd9ba226ca8780fd441272d689658667c75` head fail `conformance-aggregate`. #10419 is still open and its new head is in CI, so this PR remains a draft fallback.
- If #10419 completes exact-head CI cleanly and lands, close #10541 as superseded with links to #10419 and the preserved evidence comments. If #10419 fails or is abandoned in a way that preserves the need for this narrower slice, refresh this PR against current `main`, re-verify, and re-promote only after exact-head CI and coordination notes are current.
- No merge-queue label should be added while this PR is in fallback draft state.
- No overlap with other active PRs (M1-B relation-routing, M4-A solver, Studio-C/D emit, PR #10531 LSP stack-overflow).
- This PR is independent of PR #10531 and can land in any order if reactivated.
- Fixes issue #9685 only if it becomes the landing PR instead of #10419.