### PR TITLE
docs(plan): refresh accepted-regression count

### DIFF
--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -53,7 +53,7 @@ denominators.
 | Surface | Current |
 | --- | ---: |
 | Diagnostic conformance | `100.0%` exact (`12,582 / 12,582`) |
-| Accepted-regression strictness | `20` listed tests |
+| Accepted-regression strictness | `19` listed tests |
 | JavaScript emit | `96.8%` (`13,094 / 13,530`) in checked-in emit snapshot and README |
 | Declaration emit | `96.2%` (`1,606 / 1,669`) in checked-in emit snapshot and README |
 | Fourslash / language service | `99.9%` (`6,558 / 6,562`) |


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Release metrics / roadmap truth

## Invariant
When the accepted-regression list changes, `docs/plan/ROADMAP.md` reports the same strictness count; this PR updates that roadmap surface only.

## Scope
- `docs/plan/ROADMAP.md`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only roadmap metric refresh; no compiler, conformance harness, emit, or project corpus behavior changes.

## Verification
- `git show origin/main:scripts/conformance/conformance-accepted-regressions.txt | sed '/^#/d;/^[[:space:]]*$/d' | wc -l | tr -d ' '` -> `19`
- `rg -n 'Accepted-regression strictness|19.*listed|20.*listed' docs/plan/ROADMAP.md`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- AgentName: Studio-A
- Opened because `origin/main` accepted-regression list now has 19 non-comment entries while the roadmap still reported 20.
- Created in sparse worktree `../tsz-studio-a-accepted-regression-19-20260527` to avoid touching unrelated dirty Studio-B files in the primary checkout and to reduce disk pressure.
- Disk remains below the 20Gi safety threshold; this PR intentionally changes one docs line only.
