### PR TITLE
perf(checker): skip scoped type params in missing-name walk

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -322,6 +322,10 @@ name = "ts2304_tests"
 path = "tests/ts2304_tests.rs"
 
 [[test]]
+name = "missing_name_type_parameter_reference_tests"
+path = "tests/missing_name_type_parameter_reference_tests.rs"
+
+[[test]]
 name = "jsx_component_attribute_tests"
 path = "tests/jsx_component_attribute_tests.rs"
 

--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -6,6 +6,31 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 impl<'a> CheckerState<'a> {
+    fn missing_name_type_ref_is_bare_scoped_type_parameter(&self, type_idx: NodeIndex) -> bool {
+        let Some(node) = self.ctx.arena.get(type_idx) else {
+            return false;
+        };
+        let Some(type_ref) = self.ctx.arena.get_type_ref(node) else {
+            return false;
+        };
+        if type_ref
+            .type_arguments
+            .as_ref()
+            .is_some_and(|args| !args.nodes.is_empty())
+        {
+            return false;
+        }
+        let Some(name_node) = self.ctx.arena.get(type_ref.type_name) else {
+            return false;
+        };
+        let Some(ident) = self.ctx.arena.get_identifier(name_node) else {
+            return false;
+        };
+        self.ctx
+            .type_parameter_scope
+            .contains_key(ident.escaped_text.as_str())
+    }
+
     pub(crate) fn check_async_modifier_on_declaration(
         &mut self,
         modifiers: &Option<tsz_parser::parser::NodeList>,
@@ -396,6 +421,9 @@ impl<'a> CheckerState<'a> {
 
         match node.kind {
             k if k == syntax_kind_ext::TYPE_REFERENCE => {
+                if self.missing_name_type_ref_is_bare_scoped_type_parameter(type_idx) {
+                    return;
+                }
                 if !self.ctx.symbol_resolution_set.is_empty()
                     && let Some(type_ref) = self.ctx.arena.get_type_ref(node)
                     && let Some(sym_id) = self

--- a/crates/tsz-checker/tests/missing_name_type_parameter_reference_tests.rs
+++ b/crates/tsz-checker/tests/missing_name_type_parameter_reference_tests.rs
@@ -1,0 +1,30 @@
+use tsz_checker::test_utils::check_source_code_messages;
+
+#[test]
+fn bare_scoped_type_parameters_do_not_emit_missing_name_diagnostics() {
+    let diagnostics = check_source_code_messages(
+        r#"
+type Pair<Alpha, Beta> = Alpha | Beta | { left: Alpha; right: Beta };
+type Other<X, Y> = { first: X; second: Y } | X | Y;
+"#,
+    );
+
+    assert!(
+        !diagnostics.iter().any(|(code, _)| *code == 2304),
+        "Expected scoped type parameters to avoid TS2304, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn scoped_type_parameter_reference_with_type_arguments_still_validates() {
+    let diagnostics = check_source_code_messages(
+        r#"
+type Bad<T, U> = T<U>;
+"#,
+    );
+
+    assert!(
+        diagnostics.iter().any(|(code, _)| *code == 2315),
+        "Expected TS2315 for generic use of a type parameter, got {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Performance / checker diagnostic fast path for the `ts-essentials-project` green-row gap.

## Invariant
When the missing-name diagnostic walk reaches a bare identifier type reference already bound in the current lexical type-parameter scope and the reference has no type arguments, the name is already resolved for missing-name purposes; references with explicit type arguments still take the full path so genericity diagnostics such as TS2315 are preserved.

## Scope
- `crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs`
- `crates/tsz-checker/tests/missing_name_type_parameter_reference_tests.rs`
- `crates/tsz-checker/Cargo.toml`

## Project Corpus Impact
- Row: `ts-essentials-project`
- Bug family: utility types plus recursive JSON shapes
- Evidence: Attribution on `/private/tmp/studio-b-ts-essentials-missing-name-attribution-rebased-20260527.json` kept diagnostics at 0 and showed `xor/index.ts` at 301.9965ms after the fast path, slightly below the prior same-branch-at-start attribution of about 305.9557ms. Narrow quick timing remained noisy and the 2x target gap is not closed: `/private/tmp/studio-b-ts-essentials-missing-name-timing-20260527.tsgo-winners.json` reported `tsz_ms=112.57`, `tsgo_ms=81.24`, `target_gap_factor=2.7713`; `/private/tmp/studio-b-ts-essentials-missing-name-timing2-20260527.tsgo-winners.json` reported a noisy rerun with `tsz_ms=197.54`, `tsgo_ms=162.26`, `target_gap_factor=2.4349`.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --test missing_name_type_parameter_reference_tests`
- `cargo build -p tsz-cli --features perf-tools --bin tsz`
- `TSZ_PERF_COUNTERS=1 .target/debug/tsz --extendedDiagnostics --perf-counters-json /private/tmp/studio-b-ts-essentials-missing-name-attribution-rebased-20260527.json --noEmit -p .target-bench/external/ts-essentials/tsconfig.flat.json`
- `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^ts-essentials-project$' --json-file /private/tmp/studio-b-ts-essentials-missing-name-timing-20260527.json`
- `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^ts-essentials-project$' --json-file /private/tmp/studio-b-ts-essentials-missing-name-timing2-20260527.json`

## Coordination Notes
- No open Studio-B PRs existed before starting; prior Studio-B PR #10530 was merged first per user request.
- This does not touch M1-B relation-routing work or M4 cache policy work.
- This PR is complete for manager review but not a full Studio-B goal completion: `ts-essentials-project` remains below the 2x target.
