### PR TITLE
refactor(solver): centralize evaluator defaults

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -155,10 +155,16 @@ impl<'a> TypeEvaluator<'a, NoopResolver> {
     /// Create a new evaluator without a resolver.
     pub fn new(interner: &'a dyn TypeDatabase) -> Self {
         static NOOP: NoopResolver = NoopResolver;
+        Self::with_resolver_and_defaults(interner, &NOOP)
+    }
+}
+
+impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
+    fn with_resolver_and_defaults(interner: &'a dyn TypeDatabase, resolver: &'a R) -> Self {
         TypeEvaluator {
             interner,
             query_db: None,
-            resolver: &NOOP,
+            resolver,
             no_unchecked_indexed_access: false,
             cache: FxHashMap::default(),
             guard: crate::recursion::RecursionGuard::with_profile(
@@ -180,9 +186,7 @@ impl<'a> TypeEvaluator<'a, NoopResolver> {
             detection_growth_runs: FxHashMap::default(),
         }
     }
-}
 
-impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// Return entry and size accounting for this evaluator's operation-local caches.
     #[must_use]
     pub fn cache_statistics(&self) -> TypeEvaluatorCacheStatistics {
@@ -267,30 +271,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
     /// Create a new evaluator with a custom resolver.
     pub fn with_resolver(interner: &'a dyn TypeDatabase, resolver: &'a R) -> Self {
-        TypeEvaluator {
-            interner,
-            query_db: None,
-            resolver,
-            no_unchecked_indexed_access: false,
-            cache: FxHashMap::default(),
-            guard: crate::recursion::RecursionGuard::with_profile(
-                crate::recursion::RecursionProfile::TypeEvaluation,
-            ),
-            keyof_constraint_guard: crate::recursion::RecursionGuard::with_profile(
-                crate::recursion::RecursionProfile::TypeEvaluation,
-            ),
-            def_depth: FxHashMap::default(),
-            real_instantiation_depth_count: 0,
-            suppress_this_binding: false,
-            conditional_subtype_cache: FxHashMap::default(),
-            contains_infer_cache: FxHashMap::default(),
-            max_mapped_keys: DEFAULT_MAX_MAPPED_KEYS,
-            flag_depth_on_app_cycle: false,
-            expand_application_display_alias_args: false,
-            apparent_conditional_branch: None,
-            silent_depth_bailed: false,
-            detection_growth_runs: FxHashMap::default(),
-        }
+        Self::with_resolver_and_defaults(interner, resolver)
     }
 
     /// Set the query database for Salsa-backed memoization.

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -230,6 +230,12 @@ fn evaluation_engine_keeps_request_stage_boundary() {
         "evaluation/evaluate.rs must consume typed request/result stages instead of owning loose shell setup"
     );
     assert!(
+        evaluate_rs.contains("fn with_resolver_and_defaults(")
+            && evaluate_rs.matches("TypeEvaluator {").count() == 1
+            && evaluate_rs.matches("with_resolver_and_defaults").count() >= 3,
+        "TypeEvaluator construction must keep request-local cache/guard defaults in one path"
+    );
+    assert!(
         query_cache_rs
             .contains("use crate::evaluation::request::{EvaluationCacheKey, EvaluationRequest};")
             && query_cache_rs.contains("request.cache_key()")


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Solver architecture boundary cleanup for #8203 / #8209.

## Invariant
When `TypeEvaluator` constructs request-local recursion guards, memo tables, and evaluation defaults, both noop and resolver-aware evaluators should use one solver-owned initialization path; this PR centralizes those defaults without changing evaluation semantics.

## Scope
- Route `TypeEvaluator::new` and `TypeEvaluator::with_resolver` through one private initializer.
- Extend the staged evaluation engine architecture guard so duplicate constructor literals do not return silently.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: behavior-preserving solver architecture refactor; no checker diagnostics, emit output, parser, binder, or benchmark row behavior changed.

## Verification
- RED: `cargo nextest run -p tsz-solver --lib evaluation_engine_keeps_request_stage_boundary` failed before the initializer extraction with `TypeEvaluator construction must keep request-local cache/guard defaults in one path`.
- GREEN: `cargo nextest run -p tsz-solver --lib evaluation_engine_keeps_request_stage_boundary`
- `cargo nextest run -p tsz-solver --lib -E 'test(file_size_ceiling)'`
- `cargo fmt --check`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`

## Coordination Notes
- AgentName: M4-A.
- Open M4-A PR runway was empty before starting; #10547 had merged.
- Checked open PR overlap and avoided M4-B relation/cache policy work, M4-C contextual/object-literal request work, M1-C accepted-regression work, and Studio emit/DTS lanes.
- No roadmap update: this is a small behavior-preserving #8203/#8209 architecture slice, not a durable roadmap direction change.