### PR TITLE
perf(solver): fast path type parameter intersections

### DIFF
--- a/crates/tsz-solver/src/intern/core/interner_tests.rs
+++ b/crates/tsz-solver/src/intern/core/interner_tests.rs
@@ -46,3 +46,58 @@ fn estimated_size_accounts_for_retained_predicate_caches() {
         "retained TypeInterner predicate cache entries must be visible to residency estimates",
     );
 }
+
+#[test]
+fn all_type_parameter_intersections_preserve_ordered_members() {
+    let interner = TypeInterner::new();
+    let alpha = interner.type_param(TypeParamInfo::simple(interner.intern_string("Alpha")));
+    let beta = interner.type_param(TypeParamInfo::simple(interner.intern_string("Beta")));
+    let gamma = interner.type_param(TypeParamInfo::simple(interner.intern_string("Gamma")));
+
+    let result = interner.intersection(vec![alpha, beta, gamma, beta]);
+    let Some(TypeData::Intersection(list_id)) = interner.lookup(result) else {
+        panic!("expected all-type-parameter intersection, got {result:?}");
+    };
+
+    assert_eq!(&*interner.type_list(list_id), &[alpha, beta, gamma]);
+}
+
+#[test]
+fn same_name_type_parameter_intersection_collapses_to_constrained_member() {
+    let interner = TypeInterner::new();
+    let name = interner.intern_string("T");
+    let unconstrained = interner.type_param(TypeParamInfo::simple(name));
+    let constrained = interner.type_param(TypeParamInfo {
+        name,
+        constraint: Some(TypeId::STRING),
+        default: None,
+        is_const: false,
+    });
+
+    assert_eq!(
+        interner.intersection(vec![unconstrained, constrained]),
+        constrained
+    );
+}
+
+#[test]
+fn same_name_type_parameter_replacement_dedups_non_adjacent_members() {
+    let interner = TypeInterner::new();
+    let t_name = interner.intern_string("T");
+    let u_name = interner.intern_string("U");
+    let unconstrained_t = interner.type_param(TypeParamInfo::simple(t_name));
+    let constrained_t = interner.type_param(TypeParamInfo {
+        name: t_name,
+        constraint: Some(TypeId::STRING),
+        default: None,
+        is_const: false,
+    });
+    let u = interner.type_param(TypeParamInfo::simple(u_name));
+
+    let result = interner.intersection(vec![unconstrained_t, u, constrained_t]);
+    let Some(TypeData::Intersection(list_id)) = interner.lookup(result) else {
+        panic!("expected all-type-parameter intersection, got {result:?}");
+    };
+
+    assert_eq!(&*interner.type_list(list_id), &[constrained_t, u]);
+}

--- a/crates/tsz-solver/src/intern/intersection.rs
+++ b/crates/tsz-solver/src/intern/intersection.rs
@@ -288,6 +288,26 @@ impl TypeInterner {
         // Also check inside union members for constrained type parameters.
         self.merge_same_name_type_params(&mut flat);
 
+        // Re-check length after same-name type-parameter replacement. The merge
+        // may collapse `T & T` where one side carried the constraint.
+        if flat.is_empty() {
+            return TypeId::UNKNOWN;
+        }
+        if flat.len() == 1 {
+            return flat[0];
+        }
+
+        // Intersections made only of type parameters cannot merge concrete
+        // object/callable structure or distribute over unions at declaration
+        // lowering time. Preserve the ordered, deduped form directly.
+        if flat
+            .iter()
+            .all(|&id| matches!(self.lookup(id), Some(TypeData::TypeParameter(_))))
+        {
+            let list_id = self.intern_type_list_from_slice(&flat);
+            return self.intern(TypeData::Intersection(list_id));
+        }
+
         // TS2590: Cross-product union size check for intersections containing unions.
         // When an intersection has union members (e.g., `(A|B) & (C|D) & ...`), the
         // cross-product can grow exponentially.  tsc's checkCrossProductUnion in

--- a/crates/tsz-solver/src/intern/normalize.rs
+++ b/crates/tsz-solver/src/intern/normalize.rs
@@ -356,9 +356,11 @@ impl TypeInterner {
             }
         }
 
-        // Dedup after replacement (may have introduced duplicates).
+        // Order-preserving dedup after replacement (may have introduced
+        // non-adjacent duplicates).
         if changed {
-            flat.dedup();
+            let mut seen = FxHashSet::default();
+            flat.retain(|id| seen.insert(*id));
         }
     }
 


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 green-row speed / Track 1/2/5 utility-type key-space performance PR.

## Invariant
When an intersection's normalized members are all solver `TypeData::TypeParameter` values after existing sentinel, deduplication, and same-name type-parameter handling, the solver can preserve the ordered intersection directly. There is no concrete object/callable structure to merge, no union member to distribute, and subtype reduction is intentionally skipped for type-parameter intersections.

## Scope
- `crates/tsz-solver/src/intern/intersection.rs`
- `crates/tsz-solver/src/intern/core/interner_tests.rs`

## Project Corpus Impact
- Row: `ts-essentials-project`
- Bug family: utility-type mapped/conditional/key-space workload with recursive JSON-like shapes, tracked by #7378.
- Correctness status: green before and after (`exit success`, 0 diagnostics in the latest attribution artifact).
- Evidence: before timing companion `/private/tmp/studio-b-ts-essentials-missing-name-timing-20260527.tsgo-winners.json` had `tsz_ms=112.57`, `tsgo_ms=81.24`, `factor=1.39`, `rows_below_target=1`. After this PR, `/private/tmp/studio-b-type-param-intersection-fastpath-20260527.tsgo-winners.json` has `tsz_ms=102.51`, `tsgo_ms=77.86`, `factor=1.32`, `target_gap_factor=2.6331877729257642`, `rows_below_target=1`.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-solver -E 'test(all_type_parameter_intersections_preserve_ordered_members) | test(same_name_type_parameter)'`
- `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^ts-essentials-project$' --json-file /private/tmp/studio-b-type-param-intersection-fastpath-20260527.json`
- `node scripts/bench/tsgo-winner-report.mjs /private/tmp/studio-b-type-param-intersection-fastpath-20260527.json /private/tmp/studio-b-type-param-intersection-fastpath-20260527.tsgo-winners.json`

## Coordination Notes
- Intake found no open PRs owned by `agent:Studio-B`; #7378 remains the active Studio-B issue.
- Open M4-B cache-policy work is non-overlapping; this PR changes only solver intersection normalization for an all-type-parameter shape.
- The 2x target is not closed yet; this narrows the current `ts-essentials-project` gap and leaves the lane active.
- Ready for CI/manager review. I did not add `merge-queue`; queue labeling should wait for exact-head PR checks.
- Review finding from `Reviewer` addressed on head `b1089cb2edf940fbbb99ea2faad1403783c43fc9`: same-name type-parameter merging now re-runs singleton normalization before the all-type-parameter fast path, and replacement dedup is order-preserving for non-adjacent duplicates.