### PR TITLE
refactor(solver): use typed cache agreement flags

### DIFF
--- a/crates/tsz-solver/tests/relation_cache_config_tests/cache_agreement.rs
+++ b/crates/tsz-solver/tests/relation_cache_config_tests/cache_agreement.rs
@@ -15,9 +15,9 @@ fn assignability_cache_strict_function_types_matches_uncached_policy() {
         TypeId::VOID,
     ));
 
-    let legacy_bivariant = RelationPolicy::from_flags(0);
+    let legacy_bivariant = RelationPolicy::unflagged_compatibility();
     let strict_contravariant =
-        RelationPolicy::from_flags(RelationCacheKey::FLAG_STRICT_FUNCTION_TYPES);
+        RelationPolicy::from_relation_flags(RelationFlags::STRICT_FUNCTION_TYPES);
     let legacy_key =
         RelationCacheKey::for_assignability(source, target, legacy_bivariant.cache_config());
     let strict_key =
@@ -491,8 +491,8 @@ fn subtype_cache_top_level_only_any_mode_matches_uncached_policy() {
 fn assignability_policy_flip_matches_uncached_relation_query() {
     let interner = TypeInterner::new();
     let db = QueryCache::new(&interner);
-    let strict = RelationPolicy::from_flags(RelationCacheKey::FLAG_STRICT_NULL_CHECKS);
-    let loose = RelationPolicy::from_flags(0);
+    let strict = RelationPolicy::from_relation_flags(RelationFlags::STRICT_NULL_CHECKS);
+    let loose = RelationPolicy::unflagged_compatibility();
 
     let strict_uncached = query_relation(
         &interner,
@@ -792,15 +792,15 @@ fn assignability_cache_allow_bivariant_rest_matches_uncached_policy() {
         }],
         TypeId::VOID,
     ));
-    let strict_without_rest = RelationPolicy::from_flags(
-        RelationCacheKey::FLAG_STRICT_FUNCTION_TYPES | RelationCacheKey::FLAG_STRICT_NULL_CHECKS,
+    let strict_without_rest = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_FUNCTION_TYPES | RelationFlags::STRICT_NULL_CHECKS,
     )
     .with_strict_any_propagation(true)
     .with_any_propagation_mode(AnyPropagationMode::TopLevelOnly);
-    let strict_with_rest = RelationPolicy::from_flags(
-        RelationCacheKey::FLAG_STRICT_FUNCTION_TYPES
-            | RelationCacheKey::FLAG_STRICT_NULL_CHECKS
-            | RelationCacheKey::FLAG_ALLOW_BIVARIANT_REST,
+    let strict_with_rest = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_FUNCTION_TYPES
+            | RelationFlags::STRICT_NULL_CHECKS
+            | RelationFlags::ALLOW_BIVARIANT_REST,
     )
     .with_strict_any_propagation(true)
     .with_any_propagation_mode(AnyPropagationMode::TopLevelOnly);
@@ -883,8 +883,8 @@ fn assignability_cache_top_rest_any_rejects_never_source_param() {
         vec![ParamInfo::unnamed(TypeId::NEVER)],
         TypeId::VOID,
     ));
-    let compiler_like_policy = RelationPolicy::from_flags(
-        RelationCacheKey::FLAG_STRICT_FUNCTION_TYPES | RelationCacheKey::FLAG_STRICT_NULL_CHECKS,
+    let compiler_like_policy = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_FUNCTION_TYPES | RelationFlags::STRICT_NULL_CHECKS,
     );
 
     let zero_arg_uncached = query_relation(
@@ -942,9 +942,9 @@ fn assignability_cache_allow_bivariant_param_count_matches_uncached_policy() {
         vec![ParamInfo::unnamed(TypeId::STRING)],
         TypeId::VOID,
     ));
-    let strict_count_policy = RelationPolicy::from_flags(0);
+    let strict_count_policy = RelationPolicy::unflagged_compatibility();
     let bivariant_count_policy =
-        RelationPolicy::from_flags(RelationCacheKey::FLAG_ALLOW_BIVARIANT_PARAM_COUNT);
+        RelationPolicy::from_relation_flags(RelationFlags::ALLOW_BIVARIANT_PARAM_COUNT);
 
     let strict_count_uncached = query_relation(
         &interner,
@@ -1024,14 +1024,13 @@ fn assignability_cache_bivariant_param_count_respects_disabled_method_bivariance
     target_shape.is_method = true;
     let target = interner.function(target_shape);
 
-    let bivariant_method_policy = RelationPolicy::from_flags(
-        RelationCacheKey::FLAG_STRICT_FUNCTION_TYPES
-            | RelationCacheKey::FLAG_ALLOW_BIVARIANT_PARAM_COUNT,
+    let bivariant_method_policy = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_FUNCTION_TYPES | RelationFlags::ALLOW_BIVARIANT_PARAM_COUNT,
     );
-    let disabled_method_policy = RelationPolicy::from_flags(
-        RelationCacheKey::FLAG_STRICT_FUNCTION_TYPES
-            | RelationCacheKey::FLAG_ALLOW_BIVARIANT_PARAM_COUNT
-            | RelationCacheKey::FLAG_DISABLE_METHOD_BIVARIANCE,
+    let disabled_method_policy = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_FUNCTION_TYPES
+            | RelationFlags::ALLOW_BIVARIANT_PARAM_COUNT
+            | RelationFlags::DISABLE_METHOD_BIVARIANCE,
     );
 
     let bivariant_method_uncached = query_relation(


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Solver relation policy/cache-key cleanup for #8207.

## Invariant
Relation cache agreement tests should express behavior-affecting policy modes through typed `RelationFlags` and `RelationPolicy::unflagged_compatibility()` when they are not explicitly testing the legacy packed-mask boundary.

## Scope
- Replaced strict-function-types, strict-null, bivariant rest, bivariant parameter count, and method-bivariance cache-agreement policy setup in `relation_cache_config_tests/cache_agreement.rs` with typed policy constructors.
- Preserved packed-mask tests that explicitly cover legacy `RelationPolicy::from_flags(...)` decoding and packed-only retry paths.
- No solver behavior changes.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: test-only solver relation-cache policy refactor; no checker, emitter, parser, binder, or project-corpus behavior surface changed.

## Verification
- `cargo nextest run -p tsz-solver -E 'test(cache_agreement::assignability_cache_strict_function_types_matches_uncached_policy) | test(cache_agreement::assignability_policy_flip_matches_uncached_relation_query) | test(cache_agreement::assignability_cache_allow_bivariant_rest_matches_uncached_policy) | test(cache_agreement::assignability_cache_top_rest_any_rejects_never_source_param) | test(cache_agreement::assignability_cache_allow_bivariant_param_count_matches_uncached_policy) | test(cache_agreement::assignability_cache_bivariant_param_count_respects_disabled_method_bivariance)'`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`

## Coordination Notes
AgentName: M4-B

Checked owned work and open PR overlap before starting. #10550 is already in the repo-local merge queue with `Queue Tested` success. This PR touches only `relation_cache_config_tests/cache_agreement.rs`, does not overlap Studio-A test-sharding PRs, M1-B checker relation-routing work, M4-A/M4-C solver/checker slices, or DTS/emit tracks. Local focused verification is complete; ready for review/CI.
