### PR TITLE
refactor(solver): isolate legacy relation flag decoder

### DIFF
--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -12,9 +12,7 @@ use crate::relations::compat::{
     AssignabilityOverrideProvider, CompatChecker, NoopOverrideProvider,
 };
 use crate::relations::subtype::{AnyPropagationMode, NoopResolver, SubtypeChecker, TypeResolver};
-use crate::types::{
-    CachedAnyMode, RelationCacheConfig, RelationCacheKey, RelationFlags, SymbolRef, TypeId,
-};
+use crate::types::{CachedAnyMode, RelationCacheConfig, RelationFlags, SymbolRef, TypeId};
 
 /// Relation categories supported by the unified query API.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -118,7 +116,7 @@ impl RelationPolicy {
     /// > silently coupled two independent compiler options. See the
     /// > `strict_function_types_does_not_imply_strict_any` regression test.
     pub const fn from_flags(flags: u16) -> Self {
-        let typed_flags = Self::cache_flags_from_packed(flags);
+        let typed_flags = legacy_policy_flags::decode(flags);
         Self::from_relation_flags(typed_flags)
     }
 
@@ -241,8 +239,8 @@ impl RelationPolicy {
     ///
     /// This is the single conversion point from the high-level `RelationPolicy`
     /// bundle to the behavior-complete [`RelationCacheConfig`] used as the
-    /// `config` field of a [`RelationCacheKey`]. Every behavior-affecting field
-    /// on `RelationPolicy` must be reflected here.
+    /// `config` field of a [`crate::types::RelationCacheKey`]. Every
+    /// behavior-affecting field on `RelationPolicy` must be reflected here.
     pub const fn cache_config(self) -> RelationCacheConfig {
         let mut bits = self.flags;
         if self.strict_subtype_checking {
@@ -273,8 +271,18 @@ impl RelationPolicy {
         };
         RelationCacheConfig::new(bits, any_mode)
     }
+}
 
-    const fn cache_flags_from_packed(flags: u16) -> RelationFlags {
+/// Compatibility edge for callers that still receive historical packed `u16`
+/// relation flags.
+///
+/// Keep this module narrow: relation engines and cache keys should consume
+/// typed [`RelationPolicy`](super::RelationPolicy) /
+/// [`RelationFlags`](crate::types::RelationFlags) values after this boundary.
+mod legacy_policy_flags {
+    use crate::types::{RelationCacheKey, RelationFlags};
+
+    pub(super) const fn decode(flags: u16) -> RelationFlags {
         let mut bits = RelationFlags::empty();
         if flags & RelationCacheKey::FLAG_STRICT_NULL_CHECKS != 0 {
             bits = bits.union(RelationFlags::STRICT_NULL_CHECKS);


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 4 solver relation/cache-key architecture cleanup; refactor only.

## Invariant
When a caller still enters through legacy packed `u16` relation flags, tsz decodes those bits exactly once at the solver relation policy boundary, then carries typed `RelationFlags` through policy and cache configuration.

## Scope
- Move the packed-flag decoding helper out of the high-level `RelationPolicy` impl and into a private compatibility module in `crates/tsz-solver/src/relations/relation_queries.rs`.
- Preserve `RelationPolicy::from_flags` as the compatibility edge for existing callers.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only solver policy boundary cleanup; no relation semantics or project corpus behavior changed.

## Verification
- `cargo nextest run -p tsz-solver -E 'test(legacy_flag_constructor_stores_typed_relation_flags) | test(strict_function_types_does_not_imply_strict_any_propagation) | test(strict_function_types_and_strict_any_have_distinct_keys)'`
- `cargo fmt --check`
- `git diff --check origin/main`
- `python3 scripts/arch/arch_guard.py`

## Coordination Notes
- Addresses a small slice of #8207 by quarantining the packed flag decoder.
- Rebased onto current `origin/main` at `5a5b2148da4` after #10558 merged, then re-ran focused local verification on head `9a108257057`.
- AgentName: M4-B
