### PR TITLE
test(checker): ratchet property access recovery boundary

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/property_access.rs
+++ b/crates/tsz-checker/src/state/state_checking/property_access.rs
@@ -299,7 +299,7 @@ impl<'a> CheckerState<'a> {
             // concrete `Success` whose type is not `any`, a type parameter, or
             // `this`. That keeps this strictly a rescue of the degenerate `any` —
             // a still-generic or `this`-bearing member is left for the
-            // post-query/AST-recovery paths that instantiate it.
+            // post-query instantiation paths.
             let resolver_result =
                 crate::query_boundaries::common::is_lazy_type(self.ctx.types, original_object_type)
                     .then(|| {
@@ -315,11 +315,10 @@ impl<'a> CheckerState<'a> {
                     tsz_solver::operations::property::PropertyAccessResult::PropertyNotFound { .. }
                 )
             ) {
-                // Both the solver (with the checker's `TypeResolver`) and the
-                // AST heritage recovery agree the member is absent on the
-                // resolved interface. Surface that absence instead of masking it
-                // with the noop path's `any`, so a genuinely missing cross-file
-                // member still reports TS2339 (the masking this ratchet targets).
+                // The solver, with the checker's `TypeResolver`, resolved the
+                // interface and found no member. Surface that absence instead
+                // of masking it with the noop path's `any`, so a genuinely
+                // missing cross-file member still reports TS2339.
                 result = resolver_result.expect("matched Some above");
             }
         }

--- a/crates/tsz-checker/tests/property_access_boundaries.rs
+++ b/crates/tsz-checker/tests/property_access_boundaries.rs
@@ -219,6 +219,8 @@ fn checker_property_access_has_no_ast_interface_recovery_backstop() {
         "resolve_heritage_sym_in_arena",
         "find_named_member_in_iface_decl",
         "resolve_cross_file_type_arg",
+        "AST-recovery",
+        "AST heritage recovery",
     ] {
         assert!(
             !source.contains(retired_helper),


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Track 5 / solver-boundary architecture ratchet for #8535.

## Invariant
When checker property access handles lazy/interface member lookup, the semantic answer should stay on the solver-backed property-access resolver boundary; this PR changes checker tests/comments to keep retired AST heritage recovery language and helper names from re-entering the path.

## Scope
- `crates/tsz-checker/tests/property_access_boundaries.rs`
- `crates/tsz-checker/src/state/state_checking/property_access.rs` comments only

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: architecture-ratchet/comment-only guard; no compiler behavior change.

## Verification
- RED: `cargo nextest run -p tsz-checker --lib checker_property_access_has_no_ast_interface_recovery_backstop` failed on stale `AST-recovery` wording.
- GREEN: `cargo nextest run -p tsz-checker --lib checker_property_access_has_no_ast_interface_recovery_backstop`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`

## Coordination Notes
- AgentName: M4-A
- Follow-up to merged #10503 and #10547 for #8535.
- No overlap with M4-B relation/cache-policy PRs or Studio-B solver performance work.
- Opened as draft for light CI; ready after remote body verification and draft checks.