### PR TITLE
fix(emit): strip parenthesized types in annotation positions in DTS emit

### DIFF
--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -81,6 +81,10 @@ path = "tests/recursive_defaulted_template_accumulator_tests.rs"
 name = "recursive_const_arrow_dts_emit_tests"
 path = "tests/recursive_const_arrow_dts_emit_tests.rs"
 
+[[test]]
+name = "parenthesized_type_dts_emit_tests"
+path = "tests/parenthesized_type_dts_emit_tests.rs"
+
 [dev-dependencies]
 tempfile = { workspace = true }
 

--- a/crates/tsz-cli/tests/parenthesized_type_dts_emit_tests.rs
+++ b/crates/tsz-cli/tests/parenthesized_type_dts_emit_tests.rs
@@ -1,4 +1,4 @@
-//! DTS emit for `ParenthesizedType` nodes (issue #10556 / `declFileTypeAnnotationParenType`).
+//! DTS emit for `ParenthesizedType` nodes (`declFileTypeAnnotationParenType`).
 //!
 //! When a `ParenthesizedType` appears in an annotation position (variable
 //! type, parameter type, return type, property type), tsc strips the outer

--- a/crates/tsz-cli/tests/parenthesized_type_dts_emit_tests.rs
+++ b/crates/tsz-cli/tests/parenthesized_type_dts_emit_tests.rs
@@ -1,0 +1,306 @@
+//! DTS emit for `ParenthesizedType` nodes (issue #10556 / `declFileTypeAnnotationParenType`).
+//!
+//! When a `ParenthesizedType` appears in an annotation position (variable
+//! type, parameter type, return type, property type), tsc strips the outer
+//! parens.  tsz was emitting them verbatim, producing illegal output such as
+//! `declare var x: (string)`.
+//!
+//! In structural positions (array element, union member, intersection arm,
+//! conditional check/extends), the surrounding context re-adds parens only
+//! when operator precedence requires it, and type-argument positions preserve
+//! source-written parens verbatim to avoid `>>` ambiguity.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(name: &str) -> std::io::Result<Self> {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("tsz_paren_dts_{name}_{nanos}"));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+fn emit_dts(name: &str, source: &str) -> Option<String> {
+    let tsz_bin = find_tsz_binary()?;
+    let temp = TempDir::new(name).expect("temp dir");
+    let src_path = temp.path.join("repro.ts");
+    std::fs::write(&src_path, source).expect("write repro file");
+
+    let output = Command::new(tsz_bin)
+        .args([
+            "repro.ts",
+            "--declaration",
+            "--emitDeclarationOnly",
+            "--target",
+            "es2015",
+            "--lib",
+            "es6",
+            "--pretty",
+            "false",
+        ])
+        .current_dir(&temp.path)
+        .output()
+        .expect("run tsz declaration emit");
+
+    let dts = std::fs::read_to_string(temp.path.join("repro.d.ts")).unwrap_or_else(|_| {
+        panic!(
+            "expected repro.d.ts to be emitted.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    Some(dts)
+}
+
+/// Primary repro: parenthesized primitive in a variable annotation must be stripped.
+/// Adjacent case: different primitive types prove the rule is not spelling-dependent.
+#[test]
+fn parenthesized_primitive_annotation_is_stripped() {
+    let Some(dts) = emit_dts(
+        "primitive",
+        r#"
+export var x: (string);
+export var count: (number);
+export var flag: (boolean);
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("x: string"),
+        "expected (string) annotation parens stripped:\n{dts}"
+    );
+    assert!(
+        dts.contains("count: number"),
+        "expected (number) annotation parens stripped:\n{dts}"
+    );
+    assert!(
+        dts.contains("flag: boolean"),
+        "expected (boolean) annotation parens stripped:\n{dts}"
+    );
+    assert!(
+        !dts.contains("x: (string)") && !dts.contains("count: (number)"),
+        "no annotation parens should survive in output:\n{dts}"
+    );
+}
+
+/// Union type in annotation position: parens stripped.
+/// Adjacent case: different union shapes (2-member, 3-member, with null/undefined).
+#[test]
+fn parenthesized_union_annotation_is_stripped() {
+    let Some(dts) = emit_dts(
+        "union",
+        r#"
+export var a: (string | number);
+export var b: (boolean | null | undefined);
+export var c: (string | number | boolean);
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("a: string | number"),
+        "expected 2-member union parens stripped:\n{dts}"
+    );
+    assert!(
+        dts.contains("b: boolean | null | undefined"),
+        "expected 3-member union parens stripped:\n{dts}"
+    );
+    assert!(
+        !dts.contains("a: (string | number)"),
+        "no parenthesized union annotation should survive:\n{dts}"
+    );
+}
+
+/// Function parameter and return type annotations: parens stripped in both positions.
+/// Adjacent case: multiple parameters, each with parenthesized type.
+#[test]
+fn parenthesized_annotation_stripped_in_function_signature() {
+    let Some(dts) = emit_dts(
+        "function_sig",
+        r#"
+export declare function f(x: (string | number), y: (boolean)): (null | undefined);
+export declare function g(a: (string)): (number);
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("x: string | number"),
+        "expected param parens stripped:\n{dts}"
+    );
+    assert!(
+        dts.contains("y: boolean"),
+        "expected param parens stripped:\n{dts}"
+    );
+    assert!(
+        dts.contains("): null | undefined"),
+        "expected return type parens stripped:\n{dts}"
+    );
+    assert!(
+        dts.contains("a: string"),
+        "expected second function param parens stripped:\n{dts}"
+    );
+}
+
+/// Array element: parens are stripped from the element type but re-added when
+/// the structural inner type requires them for precedence (union, function, conditional).
+#[test]
+fn parenthesized_array_element_gets_structural_parens() {
+    let Some(dts) = emit_dts(
+        "array_element",
+        r#"
+export var a: (string | number)[];
+export var b: (string extends number ? true : false)[];
+export var c: ((x: string) => void)[];
+export var d: (string)[];
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    // Union and conditional need parens in array element position.
+    assert!(
+        dts.contains("a: (string | number)[]"),
+        "union in array element keeps parens:\n{dts}"
+    );
+    assert!(
+        dts.contains("b: (string extends number ? true : false)[]"),
+        "conditional in array element keeps parens:\n{dts}"
+    );
+    assert!(
+        dts.contains("c: ((x: string) => void)[]"),
+        "function type in array element keeps parens:\n{dts}"
+    );
+    // Plain string needs no parens in array element.
+    assert!(
+        dts.contains("d: string[]"),
+        "primitive type in array element has no parens:\n{dts}"
+    );
+    assert!(
+        !dts.contains("((string | number))"),
+        "no double parens on union array element:\n{dts}"
+    );
+}
+
+/// Union members: function types need parens; simple types do not.
+/// Adjacent case: different precedence types within the union.
+#[test]
+fn parenthesized_union_member_gets_structural_parens_for_function() {
+    let Some(dts) = emit_dts(
+        "union_member",
+        r#"
+export var a: ((x: string) => void) | number;
+export var b: ((new (x: string) => void)) | number;
+export var c: (string | number) | boolean;
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("((x: string) => void) | number"),
+        "function type in union member needs parens:\n{dts}"
+    );
+    assert!(
+        dts.contains("((new (x: string) => void)) | number")
+            || dts.contains("(new (x: string) => void) | number"),
+        "constructor type in union member needs parens:\n{dts}"
+    );
+    // Already-flat union member does not get extra parens.
+    assert!(!dts.contains("((("), "no triple parens anywhere:\n{dts}");
+}
+
+/// Intersection arms: union types need parens; simple types do not.
+#[test]
+fn parenthesized_intersection_arm_gets_structural_parens_for_union() {
+    let Some(dts) = emit_dts(
+        "intersection_arm",
+        r#"
+export var a: (string | number) & object;
+export var b: (string extends number ? true : false) & object;
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("(string | number) & object"),
+        "union in intersection arm keeps parens:\n{dts}"
+    );
+    assert!(
+        dts.contains("(string extends number ? true : false) & object"),
+        "conditional in intersection arm keeps parens:\n{dts}"
+    );
+}
+
+/// Conditional type positions: conditional in extends-type keeps parens;
+/// function type in check-type keeps parens; simple types do not.
+#[test]
+fn parenthesized_conditional_type_structural_positions() {
+    let Some(dts) = emit_dts(
+        "conditional",
+        r#"
+export type A<T, U, V> = T extends (U extends V ? string : number) ? true : false;
+export type B = (<T>() => T) extends number ? true : false;
+export type C = string extends (number | boolean) ? true : false;
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("T extends (U extends V ? string : number) ? true : false"),
+        "conditional in extends-type position keeps parens:\n{dts}"
+    );
+    assert!(
+        dts.contains("(<T>() => T) extends number ? true : false"),
+        "function type in check-type position keeps parens:\n{dts}"
+    );
+    // Union in check_type position — union needs parens there too.
+    assert!(
+        dts.contains("string extends (number | boolean) ? true : false")
+            || dts.contains("string extends number | boolean ? true : false"),
+        "union in extends-type or check-type position:\n{dts}"
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/tests/class_features.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/class_features.rs
@@ -109,7 +109,7 @@ fn test_optional_parameter_property_emits_undefined_in_constructor_and_property(
 }
 
 #[test]
-fn test_optional_parenthesized_parameter_property_preserves_explicit_undefined() {
+fn test_optional_parenthesized_parameter_property_strips_annotation_parens() {
     let output = emit_dts(
         r#"
     export class C {
@@ -118,14 +118,14 @@ fn test_optional_parenthesized_parameter_property_preserves_explicit_undefined()
     "#,
     );
 
-    // tsc 6.0.2 preserves user-written parens verbatim in .d.ts output.
+    // tsc strips user-written parens from annotation positions.
     assert!(
-        output.contains("x?: (string | undefined);"),
-        "Expected optional parameter property to preserve source parens: {output}"
+        output.contains("x?: string | undefined;"),
+        "Expected optional parameter property annotation parens stripped: {output}"
     );
     assert!(
-        output.contains("constructor(x?: (string | undefined));"),
-        "Expected constructor parameter to preserve source parens: {output}"
+        output.contains("constructor(x?: string | undefined);"),
+        "Expected constructor parameter annotation parens stripped: {output}"
     );
     assert!(
         !output.contains("(string | undefined) | undefined"),

--- a/crates/tsz-emitter/src/declaration_emitter/tests/type_formatting.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/type_formatting.rs
@@ -1761,38 +1761,48 @@ fn test_typeof_type() {
 // Parenthesized type preservation
 // =============================================================================
 
-/// tsc preserves user-written parentheses on type annotations verbatim in
-/// the generated `.d.ts`.  Check the most common positions.
+/// tsc strips user-written parentheses from type annotations in the generated
+/// `.d.ts`. Parentheses are transparent in annotation positions (variable
+/// types, parameter types, return types); surrounding contexts re-add them
+/// only when operator precedence requires it.
 
 #[test]
-fn parenthesized_simple_type_annotation_preserved() {
-    // Simple parenthesized primitive — e.g. `var x: (string)`
+fn parenthesized_simple_type_annotation_stripped() {
+    // Simple parenthesized primitive — e.g. `var x: (string)` → `string`
     let output = emit_dts("export declare var x: (string);");
     assert!(
-        output.contains("(string)"),
-        "Expected source parens preserved: {output}"
+        output.contains("x: string"),
+        "Expected source parens stripped: {output}"
     );
-    // Renamed variable — prove the fix is not spelling-dependent
+    assert!(
+        !output.contains("(string)"),
+        "Expected no bare annotation parens in output: {output}"
+    );
+    // Renamed variable — prove the rule is not spelling-dependent
     let output2 = emit_dts("export declare var value: (number);");
     assert!(
-        output2.contains("(number)"),
-        "Expected source parens preserved for number: {output2}"
+        output2.contains("value: number"),
+        "Expected source parens stripped for number: {output2}"
     );
 }
 
 #[test]
-fn parenthesized_union_type_annotation_preserved() {
-    // `(string | number)` as a variable annotation
+fn parenthesized_union_type_annotation_stripped() {
+    // `(string | number)` as a variable annotation — parens stripped
     let out = emit_dts("export declare var x: (string | number);");
     assert!(
-        out.contains("(string | number)"),
-        "Expected parenthesized union preserved: {out}"
+        out.contains("x: string | number"),
+        "Expected parenthesized union parens stripped: {out}"
     );
-    // Same shape with different type names
+    assert!(
+        !out.contains("x: (string | number)"),
+        "Expected no annotation parens in union variable: {out}"
+    );
+    // Same rule with different type names
     let out2 = emit_dts("export declare var y: (boolean | null);");
     assert!(
-        out2.contains("(boolean | null)"),
-        "Expected parenthesized union preserved for boolean|null: {out2}"
+        out2.contains("y: boolean | null"),
+        "Expected parenthesized union parens stripped for boolean|null: {out2}"
     );
 }
 
@@ -1856,15 +1866,25 @@ fn parenthesized_intersection_arm_no_double_parens() {
 }
 
 #[test]
-fn parenthesized_function_param_and_return_type_preserved() {
+fn parenthesized_function_param_and_return_type_stripped() {
+    // Parens on parameter and return type annotations are in annotation
+    // positions — tsc strips them; they carry no semantic meaning there.
     let out = emit_dts("export declare function f(x: (string | number)): (boolean | null);");
     assert!(
-        out.contains("(string | number)"),
-        "Expected parens on param type: {out}"
+        out.contains("x: string | number"),
+        "Expected parens stripped from param type: {out}"
     );
     assert!(
-        out.contains("(boolean | null)"),
-        "Expected parens on return type: {out}"
+        out.contains("): boolean | null"),
+        "Expected parens stripped from return type: {out}"
+    );
+    assert!(
+        !out.contains("(string | number)"),
+        "Expected no bare annotation parens on param: {out}"
+    );
+    assert!(
+        !out.contains("(boolean | null)"),
+        "Expected no bare annotation parens on return: {out}"
     );
 }
 

--- a/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
@@ -137,25 +137,20 @@ impl<'a> DeclarationEmitter<'a> {
             // Array type
             k if k == syntax_kind_ext::ARRAY_TYPE => {
                 if let Some(arr) = self.arena.get_array_type(type_node) {
-                    let already_has_parens = self
-                        .arena
-                        .get(arr.element_type)
-                        .is_some_and(|n| n.kind == syntax_kind_ext::PARENTHESIZED_TYPE);
                     let inner = self.peel_paren(arr.element_type);
-                    let needs_parens = !already_has_parens
-                        && self.arena.get(inner).is_some_and(|n| {
-                            n.kind == syntax_kind_ext::FUNCTION_TYPE
-                                || n.kind == syntax_kind_ext::CONSTRUCTOR_TYPE
-                                || n.kind == syntax_kind_ext::UNION_TYPE
-                                || n.kind == syntax_kind_ext::INTERSECTION_TYPE
-                                || n.kind == syntax_kind_ext::CONDITIONAL_TYPE
-                                || n.kind == syntax_kind_ext::TYPE_OPERATOR
-                                || n.kind == syntax_kind_ext::INFER_TYPE
-                        });
+                    let needs_parens = self.arena.get(inner).is_some_and(|n| {
+                        n.kind == syntax_kind_ext::FUNCTION_TYPE
+                            || n.kind == syntax_kind_ext::CONSTRUCTOR_TYPE
+                            || n.kind == syntax_kind_ext::UNION_TYPE
+                            || n.kind == syntax_kind_ext::INTERSECTION_TYPE
+                            || n.kind == syntax_kind_ext::CONDITIONAL_TYPE
+                            || n.kind == syntax_kind_ext::TYPE_OPERATOR
+                            || n.kind == syntax_kind_ext::INFER_TYPE
+                    });
                     if needs_parens {
                         self.write("(");
                     }
-                    self.emit_type(arr.element_type);
+                    self.emit_type(inner);
                     if needs_parens {
                         self.write(")");
                     }
@@ -182,21 +177,16 @@ impl<'a> DeclarationEmitter<'a> {
                             self.emit_named_tuple_type_multiline(type_idx);
                             continue;
                         }
-                        let already_has_parens = self
-                            .arena
-                            .get(type_idx)
-                            .is_some_and(|n| n.kind == syntax_kind_ext::PARENTHESIZED_TYPE);
                         let inner = self.peel_paren(type_idx);
-                        let needs_parens = !already_has_parens
-                            && self.arena.get(inner).is_some_and(|n| {
-                                n.kind == syntax_kind_ext::FUNCTION_TYPE
-                                    || n.kind == syntax_kind_ext::CONSTRUCTOR_TYPE
-                                    || n.kind == syntax_kind_ext::CONDITIONAL_TYPE
-                            });
+                        let needs_parens = self.arena.get(inner).is_some_and(|n| {
+                            n.kind == syntax_kind_ext::FUNCTION_TYPE
+                                || n.kind == syntax_kind_ext::CONSTRUCTOR_TYPE
+                                || n.kind == syntax_kind_ext::CONDITIONAL_TYPE
+                        });
                         if needs_parens {
                             self.write("(");
                         }
-                        self.emit_type(type_idx);
+                        self.emit_type(inner);
                         if needs_parens {
                             self.write(")");
                         }
@@ -252,22 +242,17 @@ impl<'a> DeclarationEmitter<'a> {
                         // to preserve operator precedence:
                         // `(A | B) & C` is different from `A | B & C`.
                         // `(A extends B ? C : D) & E` is different from `A extends B ? C : D & E`.
-                        let already_has_parens = self
-                            .arena
-                            .get(type_idx)
-                            .is_some_and(|n| n.kind == syntax_kind_ext::PARENTHESIZED_TYPE);
                         let inner = self.peel_paren(type_idx);
-                        let needs_parens = !already_has_parens
-                            && self.arena.get(inner).is_some_and(|n| {
-                                n.kind == syntax_kind_ext::FUNCTION_TYPE
-                                    || n.kind == syntax_kind_ext::CONSTRUCTOR_TYPE
-                                    || n.kind == syntax_kind_ext::UNION_TYPE
-                                    || n.kind == syntax_kind_ext::CONDITIONAL_TYPE
-                            });
+                        let needs_parens = self.arena.get(inner).is_some_and(|n| {
+                            n.kind == syntax_kind_ext::FUNCTION_TYPE
+                                || n.kind == syntax_kind_ext::CONSTRUCTOR_TYPE
+                                || n.kind == syntax_kind_ext::UNION_TYPE
+                                || n.kind == syntax_kind_ext::CONDITIONAL_TYPE
+                        });
                         if needs_parens {
                             self.write("(");
                         }
-                        self.emit_type(type_idx);
+                        self.emit_type(inner);
                         if needs_parens {
                             self.write(")");
                         }
@@ -431,16 +416,15 @@ impl<'a> DeclarationEmitter<'a> {
                 }
             }
 
-            // Parenthesized type — tsc preserves source parens verbatim in
-            // the generated .d.ts.  Contexts that call `peel_paren` before
-            // computing `needs_parens` must guard with `!already_has_parens`
-            // so they don't emit a second pair of parens around a node that
-            // already carries its own.
+            // Parenthesized type — strip outer parens and emit the inner
+            // type directly. The surrounding context (array element,
+            // union/intersection arm) adds parens only when the structural
+            // inner type requires them for operator precedence. tsc does not
+            // preserve source parens verbatim; emitting them unconditionally
+            // produces illegal `.d.ts` output such as `declare var x: (string)`.
             k if k == syntax_kind_ext::PARENTHESIZED_TYPE => {
                 if let Some(paren) = self.arena.get_wrapped_type(type_node) {
-                    self.write("(");
                     self.emit_type(paren.type_node);
-                    self.write(")");
                 }
             }
 
@@ -667,24 +651,19 @@ impl<'a> DeclarationEmitter<'a> {
                     // greedily consumes the `extends` keyword:
                     // `new () => T extends U ? X : Y` parses as
                     // `new () => (T extends U ? X : Y)` without parens.
-                    let check_already_has_parens = self
-                        .arena
-                        .get(conditional.check_type)
-                        .is_some_and(|n| n.kind == syntax_kind_ext::PARENTHESIZED_TYPE);
                     let check_inner = self.peel_paren(conditional.check_type);
-                    let check_needs_parens = !check_already_has_parens
-                        && self.arena.get(check_inner).is_some_and(|node| {
-                            node.kind == syntax_kind_ext::CONDITIONAL_TYPE
-                                || node.kind == syntax_kind_ext::FUNCTION_TYPE
-                                || node.kind == syntax_kind_ext::CONSTRUCTOR_TYPE
-                                || node.kind == syntax_kind_ext::UNION_TYPE
-                                || node.kind == syntax_kind_ext::INTERSECTION_TYPE
-                        });
+                    let check_needs_parens = self.arena.get(check_inner).is_some_and(|node| {
+                        node.kind == syntax_kind_ext::CONDITIONAL_TYPE
+                            || node.kind == syntax_kind_ext::FUNCTION_TYPE
+                            || node.kind == syntax_kind_ext::CONSTRUCTOR_TYPE
+                            || node.kind == syntax_kind_ext::UNION_TYPE
+                            || node.kind == syntax_kind_ext::INTERSECTION_TYPE
+                    });
 
                     if check_needs_parens {
                         self.write("(");
                     }
-                    self.emit_type(conditional.check_type);
+                    self.emit_type(check_inner);
                     if check_needs_parens {
                         self.write(")");
                     }
@@ -694,21 +673,16 @@ impl<'a> DeclarationEmitter<'a> {
                     // tsc parenthesizes a conditional type in the extends position,
                     // but does not wrap function/constructor types just because their
                     // return type is conditional.
-                    let extends_already_has_parens = self
-                        .arena
-                        .get(conditional.extends_type)
-                        .is_some_and(|n| n.kind == syntax_kind_ext::PARENTHESIZED_TYPE);
                     let extends_inner = self.peel_paren(conditional.extends_type);
-                    let extends_needs_parens = !extends_already_has_parens
-                        && self
-                            .arena
-                            .get(extends_inner)
-                            .is_some_and(|node| node.kind == syntax_kind_ext::CONDITIONAL_TYPE);
+                    let extends_needs_parens = self
+                        .arena
+                        .get(extends_inner)
+                        .is_some_and(|node| node.kind == syntax_kind_ext::CONDITIONAL_TYPE);
 
                     if extends_needs_parens {
                         self.write("(");
                     }
-                    self.emit_type(conditional.extends_type);
+                    self.emit_type(extends_inner);
                     if extends_needs_parens {
                         self.write(")");
                     }
@@ -741,23 +715,18 @@ impl<'a> DeclarationEmitter<'a> {
                         return;
                     }
                     // Parenthesize complex types before `?` to avoid ambiguity
-                    let already_has_parens = self
-                        .arena
-                        .get(wrapped.type_node)
-                        .is_some_and(|n| n.kind == syntax_kind_ext::PARENTHESIZED_TYPE);
                     let opt_inner = self.peel_paren(wrapped.type_node);
-                    let needs_parens = !already_has_parens
-                        && self.arena.get(opt_inner).is_some_and(|inner| {
-                            inner.kind == syntax_kind_ext::UNION_TYPE
-                                || inner.kind == syntax_kind_ext::INTERSECTION_TYPE
-                                || inner.kind == syntax_kind_ext::FUNCTION_TYPE
-                                || inner.kind == syntax_kind_ext::CONSTRUCTOR_TYPE
-                                || inner.kind == syntax_kind_ext::CONDITIONAL_TYPE
-                        });
+                    let needs_parens = self.arena.get(opt_inner).is_some_and(|inner| {
+                        inner.kind == syntax_kind_ext::UNION_TYPE
+                            || inner.kind == syntax_kind_ext::INTERSECTION_TYPE
+                            || inner.kind == syntax_kind_ext::FUNCTION_TYPE
+                            || inner.kind == syntax_kind_ext::CONSTRUCTOR_TYPE
+                            || inner.kind == syntax_kind_ext::CONDITIONAL_TYPE
+                    });
                     if needs_parens {
                         self.write("(");
                     }
-                    self.emit_type(wrapped.type_node);
+                    self.emit_type(opt_inner);
                     if needs_parens {
                         self.write(")");
                     }
@@ -989,21 +958,27 @@ impl<'a> DeclarationEmitter<'a> {
                 self.write(", ");
             }
             if self.first_type_argument_needs_parentheses(arg_idx, index == 0) {
-                let already_has_parens = self
-                    .arena
-                    .get(arg_idx)
-                    .is_some_and(|n| n.kind == syntax_kind_ext::PARENTHESIZED_TYPE);
-                if !already_has_parens {
-                    self.write("(");
-                }
-                self.emit_type(arg_idx);
-                if !already_has_parens {
-                    self.write(")");
-                }
+                let inner = self.peel_paren(arg_idx);
+                self.write("(");
+                self.emit_type(inner);
+                self.write(")");
                 continue;
             }
             if self.type_argument_tuple_should_preserve_multiline(arg_idx) {
                 self.emit_tuple_type_multiline(arg_idx);
+                continue;
+            }
+            // Preserve source-written parens verbatim on type arguments: tsc does
+            // not strip them (e.g. `InstanceType<(typeof F<T>)>` stays parenthesized).
+            let source_has_parens = self
+                .arena
+                .get(arg_idx)
+                .is_some_and(|n| n.kind == syntax_kind_ext::PARENTHESIZED_TYPE);
+            if source_has_parens {
+                let inner = self.peel_paren(arg_idx);
+                self.write("(");
+                self.emit_type(inner);
+                self.write(")");
                 continue;
             }
             self.emit_type(arg_idx);


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Track 9 — Emit / DTS parity recovery.

## Invariant
When a `ParenthesizedType` node appears in a declaration type annotation position, `tsc` strips the outer source parens; when the peeled inner type is placed in a structural context such as an array element, union member, intersection arm, conditional check/extends, or type argument, the surrounding declaration emitter decides whether parens are required from the inner type's structure and precedence.

## Structural Rule
Annotation positions strip source-written parenthesized type wrappers. Structural child positions peel those wrappers for classification, then re-add parens only when precedence requires them. Type-argument positions preserve source-written parens where `tsc` keeps them, such as avoiding `>>` ambiguity.

## Owner Layer
DTS type emission / direct syntax printing. This is not checker validation, solver inference, or output-string surgery; the change adjusts how the declaration emitter handles `ParenthesizedType` syntax nodes while emitting type text.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/type_emission.rs`: peel parenthesized types in annotation emission, classify peeled inner types for structural parens, and preserve source parens in type-argument contexts where required.
- `crates/tsz-emitter/src/declaration_emitter/tests/type_formatting.rs`: focused declaration-emitter coverage for primitive/union annotations, array elements, union members, intersection arms, and function parameter/return annotations.
- `crates/tsz-emitter/src/declaration_emitter/tests/class_features.rs`: parameter-property coverage for parenthesized annotations.
- `crates/tsz-cli/Cargo.toml` and `crates/tsz-cli/tests/parenthesized_type_dts_emit_tests.rs`: CLI integration coverage for adjacent declaration-output shapes.
- 2026-05-27 follow-up `21d7c6c854`: removed the incorrect unrelated issue breadcrumb from the CLI test header.

## Adjacent Matrix
- Primitive annotation: `var x: (string)` emits `x: string`.
- Union annotation: `var x: (string | number)` emits `x: string | number`.
- Function parameter and return annotations strip parens in both positions.
- Array element contexts re-add parens for union, conditional, and function element types when precedence requires them.
- Union member contexts re-add parens for function/constructor types but avoid duplicate wrappers.
- Intersection arm contexts re-add parens for union/conditional arms when precedence requires them.
- Type-argument contexts preserve source-written parens where `tsc` preserves them.

## Project Corpus Impact
- Row: DTS emit parity
- Bug family: Parenthesized declaration type annotation emission
- Evidence: checked-in DTS failure list includes `declFileTypeAnnotationParenType`, `declFileTypeAnnotationUnionType`, `checkJsdocSatisfiesTag15`, and `definiteAssignmentAssertionsWithObjectShortHand` with extra parenthesized annotation output. Exact-head draft-light CI is green for head `21d7c6c854d55c18b408fa3a2c64e7e29a5db890`.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p tsz-emitter`
- `cargo nextest run -p tsz-emitter parenthesized` (34 passed)
- `cargo nextest run -p tsz-cli --test parenthesized_type_dts_emit_tests` was attempted locally and failed before running this PR's test because the pre-existing standalone bin `crates/tsz-cli/src/bin/tsz_lsp_request_handlers.rs` does not compile outside its intended module context.
- Draft-light CI for exact head `21d7c6c854d55c18b408fa3a2c64e7e29a5db890` is green, including `CI Light Summary`, `dist-binaries`, `lint`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, and `GitGuardian Security Checks`.

## Coordination Notes
- AgentName: Studio-D
- Original generated runner name: dazzling-johnson; ownership is canonicalized to `agent:Studio-D`.
- Reviewer hygiene comment addressed: PR body now uses the standard `## Agent` / `AgentName: Studio-D` shape, the incorrect `#10556` breadcrumb was removed from the CLI test, and verification wording uses repo-preferred `cargo nextest` where local execution is possible.
- No duplicate open PRs found for this parenthesized-DTS family during Studio-D owned-work intake.
- Marked ready on 2026-05-27 after exact-head draft-light CI completed green for `21d7c6c854d55c18b408fa3a2c64e7e29a5db890`. Auto-merge and merge queue remain off; heavy ready CI is the next broad validation.
