### PR TITLE
refactor(lsp): split lifecycle dispatch helpers

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_lsp.rs
+++ b/crates/tsz-cli/src/bin/tsz_lsp.rs
@@ -71,6 +71,8 @@ use tsz::lsp::{
 
 #[path = "tsz_lsp/tsz_lsp_dispatch.rs"]
 mod tsz_lsp_dispatch;
+#[path = "tsz_lsp/tsz_lsp_notification_handlers.rs"]
+mod tsz_lsp_notification_handlers;
 #[path = "tsz_lsp/tsz_lsp_request_handlers.rs"]
 mod tsz_lsp_request_handlers;
 

--- a/crates/tsz-cli/src/bin/tsz_lsp.rs
+++ b/crates/tsz-cli/src/bin/tsz_lsp.rs
@@ -75,6 +75,8 @@ mod tsz_lsp_dispatch;
 mod tsz_lsp_notification_handlers;
 #[path = "tsz_lsp/tsz_lsp_request_handlers.rs"]
 mod tsz_lsp_request_handlers;
+#[path = "tsz_lsp/tsz_lsp_response_helpers.rs"]
+mod tsz_lsp_response_helpers;
 
 /// TSZ Language Server
 #[derive(Parser, Debug)]
@@ -279,46 +281,6 @@ impl LspServer {
                 "message": message,
             }),
         });
-    }
-
-    // ─── Response helpers ───────────────────────────────────────────────
-
-    fn success_response(&self, id: Option<Value>, result: Value) -> JsonRpcResponse {
-        JsonRpcResponse {
-            jsonrpc: "2.0".to_string(),
-            id: id.unwrap_or(Value::Null),
-            result: Some(result),
-            error: None,
-        }
-    }
-
-    fn make_response(&self, id: Option<Value>, result: Result<Value>) -> JsonRpcResponse {
-        match result {
-            Ok(value) => self.success_response(id, value),
-            Err(e) => JsonRpcResponse {
-                jsonrpc: "2.0".to_string(),
-                id: id.unwrap_or(Value::Null),
-                result: None,
-                error: Some(JsonRpcError {
-                    code: -32603,
-                    message: e.to_string(),
-                    data: None,
-                }),
-            },
-        }
-    }
-
-    fn error_response(&self, id: Option<Value>, code: i32, message: String) -> JsonRpcResponse {
-        JsonRpcResponse {
-            jsonrpc: "2.0".to_string(),
-            id: id.unwrap_or(Value::Null),
-            result: None,
-            error: Some(JsonRpcError {
-                code,
-                message,
-                data: None,
-            }),
-        }
     }
 
     // ─── Param extraction helpers ───────────────────────────────────────

--- a/crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_dispatch.rs
+++ b/crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_dispatch.rs
@@ -7,9 +7,9 @@ impl LspServer {
         let method = msg.method.as_deref();
         let id = msg.id.clone();
 
-        // Handle cancellation notification
-        if method == Some("$/cancelRequest") {
-            self.handle_cancel_request(msg.params);
+        if let Some(method) = method
+            && self.handle_notification_method(method, msg.params.clone())
+        {
             return None;
         }
 
@@ -35,35 +35,9 @@ impl LspServer {
                 let result = self.handle_initialize(msg.params.as_ref());
                 Some(self.success_response(id, result))
             }
-            Some("initialized") => {
-                self.initialized = true;
-                self.handle_initialized();
-                None
-            }
             Some("shutdown") => {
                 self.shutdown_requested = true;
                 Some(self.success_response(id, Value::Null))
-            }
-            Some("exit") => {
-                std::process::exit(i32::from(!self.shutdown_requested));
-            }
-
-            // ── Document lifecycle ──────────────────────────────────────
-            Some("textDocument/didOpen") => {
-                self.handle_did_open(msg.params);
-                None
-            }
-            Some("textDocument/didChange") => {
-                self.handle_did_change(msg.params);
-                None
-            }
-            Some("textDocument/didClose") => {
-                self.handle_did_close(msg.params);
-                None
-            }
-            Some("textDocument/didSave") => {
-                self.handle_did_save(msg.params);
-                None
             }
 
             // ── Language features ───────────────────────────────────────
@@ -212,20 +186,6 @@ impl LspServer {
                 Some(self.make_response(id, r))
             }
 
-            // ── Workspace notifications ───────────────────────────────
-            Some("workspace/didChangeConfiguration") => {
-                self.handle_did_change_configuration(msg.params);
-                None
-            }
-            Some("workspace/didChangeWatchedFiles") => {
-                self.handle_did_change_watched_files(msg.params);
-                None
-            }
-            Some("workspace/didChangeWorkspaceFolders") => {
-                self.handle_did_change_workspace_folders(msg.params);
-                None
-            }
-
             // ── Execute command ────────────────────────────────────────
             Some("workspace/executeCommand") => {
                 let r = self.handle_execute_command(msg.params);
@@ -247,25 +207,13 @@ impl LspServer {
                 let r = self.handle_will_rename_files(msg.params);
                 Some(self.make_response(id, r))
             }
-            Some("workspace/didRenameFiles") => {
-                self.handle_did_rename_files(msg.params);
-                None
-            }
             Some("workspace/willCreateFiles") => {
                 // Acknowledge but no edits needed for file creation
                 Some(self.success_response(id, Value::Null))
             }
-            Some("workspace/didCreateFiles") => {
-                self.handle_did_create_files(msg.params);
-                None
-            }
             Some("workspace/willDeleteFiles") => {
                 // Acknowledge but no edits needed for file deletion
                 Some(self.success_response(id, Value::Null))
-            }
-            Some("workspace/didDeleteFiles") => {
-                self.handle_did_delete_files(msg.params);
-                None
             }
 
             // Unknown request → method not found

--- a/crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_notification_handlers.rs
+++ b/crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_notification_handlers.rs
@@ -1,0 +1,65 @@
+use super::*;
+
+impl LspServer {
+    pub(super) fn handle_notification_method(
+        &mut self,
+        method: &str,
+        params: Option<Value>,
+    ) -> bool {
+        match method {
+            "$/cancelRequest" => {
+                self.handle_cancel_request(params);
+                true
+            }
+            "initialized" => {
+                self.initialized = true;
+                self.handle_initialized();
+                true
+            }
+            "exit" => {
+                std::process::exit(i32::from(!self.shutdown_requested));
+            }
+            "textDocument/didOpen" => {
+                self.handle_did_open(params);
+                true
+            }
+            "textDocument/didChange" => {
+                self.handle_did_change(params);
+                true
+            }
+            "textDocument/didClose" => {
+                self.handle_did_close(params);
+                true
+            }
+            "textDocument/didSave" => {
+                self.handle_did_save(params);
+                true
+            }
+            "workspace/didChangeConfiguration" => {
+                self.handle_did_change_configuration(params);
+                true
+            }
+            "workspace/didChangeWatchedFiles" => {
+                self.handle_did_change_watched_files(params);
+                true
+            }
+            "workspace/didChangeWorkspaceFolders" => {
+                self.handle_did_change_workspace_folders(params);
+                true
+            }
+            "workspace/didRenameFiles" => {
+                self.handle_did_rename_files(params);
+                true
+            }
+            "workspace/didCreateFiles" => {
+                self.handle_did_create_files(params);
+                true
+            }
+            "workspace/didDeleteFiles" => {
+                self.handle_did_delete_files(params);
+                true
+            }
+            _ => false,
+        }
+    }
+}

--- a/crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_response_helpers.rs
+++ b/crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_response_helpers.rs
@@ -1,0 +1,50 @@
+use super::*;
+
+impl LspServer {
+    pub(super) fn success_response(&self, id: Option<Value>, result: Value) -> JsonRpcResponse {
+        JsonRpcResponse {
+            jsonrpc: "2.0".to_string(),
+            id: id.unwrap_or(Value::Null),
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    pub(super) fn make_response(
+        &self,
+        id: Option<Value>,
+        result: Result<Value>,
+    ) -> JsonRpcResponse {
+        match result {
+            Ok(value) => self.success_response(id, value),
+            Err(e) => JsonRpcResponse {
+                jsonrpc: "2.0".to_string(),
+                id: id.unwrap_or(Value::Null),
+                result: None,
+                error: Some(JsonRpcError {
+                    code: -32603,
+                    message: e.to_string(),
+                    data: None,
+                }),
+            },
+        }
+    }
+
+    pub(super) fn error_response(
+        &self,
+        id: Option<Value>,
+        code: i32,
+        message: String,
+    ) -> JsonRpcResponse {
+        JsonRpcResponse {
+            jsonrpc: "2.0".to_string(),
+            id: id.unwrap_or(Value::Null),
+            result: None,
+            error: Some(JsonRpcError {
+                code,
+                message,
+                data: None,
+            }),
+        }
+    }
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-E

## Track
Track LSP/WASM consumer boundary / refactor only

## Invariant
When `tsz-lsp` receives a JSON-RPC lifecycle message, dispatch should route notification-like methods and JSON-RPC response construction through named binary-local helpers. This PR changes only LSP binary orchestration; it does not change JSON-RPC behavior, compiler-service ownership, diagnostics, or semantic computation.

## Scope
- `crates/tsz-cli/src/bin/tsz_lsp.rs`: declare notification, request, dispatch, and response-helper modules beside the main binary state.
- `crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_dispatch.rs`: delegate notification-like methods to `handle_notification_method` before request cancellation/response dispatch.
- `crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_notification_handlers.rs`: host cancellation, initialized/exit, document lifecycle, workspace notification, and file-operation notification dispatch.
- `crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_response_helpers.rs`: host JSON-RPC success, error, and `Result<Value>` response conversion helpers.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only LSP binary module split; no checker, solver, emitter, or project corpus behavior changed.

## Verification
Prior local verification before rebasing onto the latest main:
```bash
git diff --check origin/main..HEAD
cargo fmt --all --check
scripts/check-crate-root-files.sh
wc -l crates/tsz-cli/src/bin/tsz_lsp.rs crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_dispatch.rs crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_notification_handlers.rs crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_request_handlers.rs crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_response_helpers.rs
CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo check -p tsz-cli --bins
```

Line counts after split:
```text
1686 crates/tsz-cli/src/bin/tsz_lsp.rs
 226 crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_dispatch.rs
  65 crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_notification_handlers.rs
1124 crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_request_handlers.rs
  50 crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_response_helpers.rs
3151 total
```

After rebasing onto current `origin/main` (`b5cab6d3`), exact-head local verification passed on head `663e8ec542`:
```bash
git diff --check refs/remotes/origin/main..HEAD
cargo fmt --all --check
scripts/check-crate-root-files.sh
wc -l crates/tsz-cli/src/bin/tsz_lsp.rs crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_dispatch.rs crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_notification_handlers.rs crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_request_handlers.rs crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_response_helpers.rs
CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo check -p tsz-cli --bins
```

Exact-head CI restarted for `663e8ec542`; `merge-queue` remains off while required PR-head checks are pending.

## Coordination Notes
- AgentName: Studio-E
- Refs #9422. This follows merged #10553 and continues the same lifecycle split by extracting notification dispatch and response conversion helpers; it still does not claim to close the full issue.
- #10557 is closed; current open LSP PR scan found no same-scope notification/response dispatch PR.
- Branch was rebased onto `origin/main` at `b5cab6d3`; current head is `663e8ec542`.
- Kept the main checkout untouched; implementation lives in `/Users/mohsen/code/tsz-studio-e-lsp-notifications`.
- `merge-queue` remains off until all required PR-head checks are green for `663e8ec542`; `Queue Tested` is pending as expected before queue enrollment.

