### PR TITLE
fix(checker): merge heritage members for namespaced lib interfaces

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct/actual_lib_methods.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct/actual_lib_methods.rs
@@ -9,6 +9,50 @@ impl<'a> CheckerState<'a> {
             .is_some_and(|export_sym_id| export_sym_id == sym_id)
     }
 
+    /// Namespace-qualifier of a lib interface symbol (e.g. `Temporal`), derived
+    /// from the enclosing `module`/`namespace` declarations of its declarations.
+    fn lib_symbol_namespace_prefix(
+        &self,
+        sym_id: SymbolId,
+        symbol: &tsz_binder::Symbol,
+    ) -> Option<String> {
+        symbol.declarations.iter().find_map(|&decl_idx| {
+            self.ctx
+                .binder
+                .declaration_arenas
+                .get(&(sym_id, decl_idx))
+                .and_then(|arenas| {
+                    arenas.iter().find_map(|arena| {
+                        Self::lib_interface_namespace_prefix(&[(decl_idx, arena.as_ref())])
+                    })
+                })
+        })
+    }
+
+    /// Whether any declaration of a lib interface symbol has an `extends` clause.
+    fn lib_interface_declarations_have_heritage(
+        &self,
+        sym_id: SymbolId,
+        symbol: &tsz_binder::Symbol,
+    ) -> bool {
+        symbol.declarations.iter().any(|&decl_idx| {
+            self.ctx
+                .binder
+                .declaration_arenas
+                .get(&(sym_id, decl_idx))
+                .is_some_and(|arenas| {
+                    arenas.iter().any(|arena| {
+                        let arena = arena.as_ref();
+                        arena
+                            .get(decl_idx)
+                            .and_then(|node| arena.get_interface(node))
+                            .and_then(|interface| interface.heritage_clauses.as_ref())
+                            .is_some_and(|clauses| !clauses.nodes.is_empty())
+                    })
+                })
+        })
+    }
+
     fn symbol_is_proven_direct_actual_lib_value_interface(
         &self,
         sym_id: SymbolId,
@@ -469,6 +513,20 @@ impl<'a> CheckerState<'a> {
         if !symbol.has_any_flags(symbol_flags::TYPE) {
             return None;
         }
+
+        // Namespaced lib interfaces (e.g. `Temporal.RoundingOptionsWithLargestUnit`,
+        // `Intl.*`) that `extends` a base interface declared in the same namespace
+        // need their inherited members merged in. The lightweight direct lowerings
+        // below emit only an interface's own body, so the qualified name is
+        // computed here and used to run the namespace-aware heritage merge on the
+        // lowered body before returning (see the end of this method).
+        let heritage_merge_name = (symbol.has_any_flags(symbol_flags::INTERFACE)
+            && !symbol.has_any_flags(symbol_flags::TYPE_ALIAS)
+            && self.lib_interface_declarations_have_heritage(sym_id, &symbol))
+        .then(|| self.lib_symbol_namespace_prefix(sym_id, &symbol))
+        .flatten()
+        .filter(|prefix| self.symbol_is_actual_lib_namespace_export(prefix, &name, sym_id))
+        .map(|prefix| format!("{prefix}.{name}"));
         let proven_value_interface =
             self.symbol_is_proven_direct_actual_lib_value_interface(sym_id, &symbol, &name);
         let protocol_method_interface =
@@ -598,6 +656,17 @@ impl<'a> CheckerState<'a> {
         if let Some(outcome) = intl_success_outcome {
             record_direct_actual_lib_intl_interface_outcome(outcome);
         }
+        // Merge inherited members for a namespaced interface that `extends` a
+        // base declared in the same namespace. The body-only lowerings above
+        // drop them; this runs the namespace-aware heritage merge keyed by the
+        // qualified name so the base interface members are instantiated in.
+        let (direct_type, params) = match heritage_merge_name {
+            Some(merge_name) => {
+                let merged = self.merge_lib_interface_heritage(direct_type, &merge_name);
+                (merged, params)
+            }
+            None => (direct_type, params),
+        };
         self.ctx.symbol_types.insert(sym_id, direct_type);
         self.ctx
             .lib_delegation_cache

--- a/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
+++ b/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
@@ -1643,9 +1643,17 @@ impl<'a> CheckerState<'a> {
                 let mut merged =
                     self.merge_interface_heritage_types(&symbol.declarations, interface_type);
                 // If standard merge didn't propagate lib-arena heritage, fall
-                // back to the lib-aware heritage merge.
+                // back to the lib-aware heritage merge. Namespaced lib interfaces
+                // (e.g. `Temporal.RoundingOptionsWithLargestUnit`) resolve their
+                // own symbol and their base interfaces through the enclosing
+                // namespace, so the lib-aware merge needs the qualified name; the
+                // bare name fails to resolve the namespaced symbol and drops every
+                // inherited member.
                 if merged == interface_type {
-                    let name = symbol.escaped_name.clone();
+                    let name = match &namespace_prefix {
+                        Some(prefix) => format!("{prefix}.{}", symbol.escaped_name),
+                        None => symbol.escaped_name.clone(),
+                    };
                     merged = self.merge_lib_interface_heritage(merged, &name);
                 }
                 self.pop_type_parameters(updates);

--- a/crates/tsz-checker/src/test_utils.rs
+++ b/crates/tsz-checker/src/test_utils.rs
@@ -1543,18 +1543,17 @@ class C {}
         let source = format!(
             "declare namespace NS {{\n\
                  type Unit = \"x\" | \"y\";\n\
-                 type Plural<{P} extends Unit> = {P} | {{ x: \"xs\"; y: \"ys\" }}[{P}];\n\
-                 interface RoundOpts<{P} extends Unit> {{\n\
-                     small?: Plural<{P}> | undefined;\n\
+                 type Plural<{param_name} extends Unit> = {param_name} | {{ x: \"xs\"; y: \"ys\" }}[{param_name}];\n\
+                 interface RoundOpts<{param_name} extends Unit> {{\n\
+                     small?: Plural<{param_name}> | undefined;\n\
                      mode?: \"a\" | \"b\" | undefined;\n\
                  }}\n\
-                 interface RoundOptsLargest<{P} extends Unit> extends RoundOpts<{P}> {{\n\
-                     large?: \"auto\" | Plural<{P}> | undefined;\n\
+                 interface RoundOptsLargest<{param_name} extends Unit> extends RoundOpts<{param_name}> {{\n\
+                     large?: \"auto\" | Plural<{param_name}> | undefined;\n\
                  }}\n\
                  interface RelativeOpts {{ relative?: string | undefined; }}\n\
                  interface DurationOpts extends RelativeOpts, RoundOptsLargest<Unit> {{}}\n\
-             }}\n",
-            P = param_name
+             }}\n"
         );
         vec![Arc::new(LibFile::from_source(
             "lib.es2099.synthetic.d.ts".to_string(),

--- a/crates/tsz-checker/src/test_utils.rs
+++ b/crates/tsz-checker/src/test_utils.rs
@@ -1533,6 +1533,124 @@ class C {}
         );
     }
 
+    /// Synthetic `lib.*.d.ts` exercising namespaced lib interfaces whose
+    /// `extends` clause names a base interface declared in the same namespace.
+    /// Mirrors the shape of `Temporal.RoundingOptionsWithLargestUnit` /
+    /// `Temporal.DurationRoundingOptions` without depending on the full lib.
+    /// `param_name` varies the bound type-parameter spelling so the fix cannot
+    /// be hardcoded to a particular identifier.
+    fn namespaced_heritage_lib(param_name: &str) -> Vec<Arc<LibFile>> {
+        let source = format!(
+            "declare namespace NS {{\n\
+                 type Unit = \"x\" | \"y\";\n\
+                 type Plural<{P} extends Unit> = {P} | {{ x: \"xs\"; y: \"ys\" }}[{P}];\n\
+                 interface RoundOpts<{P} extends Unit> {{\n\
+                     small?: Plural<{P}> | undefined;\n\
+                     mode?: \"a\" | \"b\" | undefined;\n\
+                 }}\n\
+                 interface RoundOptsLargest<{P} extends Unit> extends RoundOpts<{P}> {{\n\
+                     large?: \"auto\" | Plural<{P}> | undefined;\n\
+                 }}\n\
+                 interface RelativeOpts {{ relative?: string | undefined; }}\n\
+                 interface DurationOpts extends RelativeOpts, RoundOptsLargest<Unit> {{}}\n\
+             }}\n",
+            P = param_name
+        );
+        vec![Arc::new(LibFile::from_source(
+            "lib.es2099.synthetic.d.ts".to_string(),
+            source,
+        ))]
+    }
+
+    #[test]
+    fn namespaced_lib_interface_inherits_base_members() {
+        // A namespaced interface that `extends` another namespaced interface
+        // must expose the base's members (single inheritance level).
+        for param in ["U", "T", "K"] {
+            let libs = namespaced_heritage_lib(param);
+            let codes: Vec<u32> = check_source_with_libs(
+                "declare const o: NS.RoundOptsLargest<NS.Unit>;\n\
+                 const a = o.small;\n\
+                 const b = o.large;\n\
+                 const c = o.mode;\n",
+                "test.ts",
+                CheckerOptions::default(),
+                &libs,
+            )
+            .iter()
+            .map(|d| d.code)
+            .collect();
+            assert!(
+                !codes.contains(&2339),
+                "inherited member access on NS.RoundOptsLargest (param {param}) must not emit TS2339, got: {codes:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn namespaced_lib_interface_excess_property_uses_inherited_members() {
+        // Inherited optional members must count as known properties so the
+        // object literal is not flagged with a spurious TS2353, while a truly
+        // unknown property still is.
+        let libs = namespaced_heritage_lib("U");
+        let ok_codes: Vec<u32> = check_source_with_libs(
+            "declare function f(o?: NS.RoundOptsLargest<NS.Unit>): void;\n\
+             f({ large: \"x\", small: \"x\" });\n",
+            "test.ts",
+            CheckerOptions::default(),
+            &libs,
+        )
+        .iter()
+        .map(|d| d.code)
+        .collect();
+        assert!(
+            !ok_codes.contains(&2353),
+            "object literal using inherited `small` must not emit TS2353, got: {ok_codes:?}"
+        );
+
+        let bad_codes: Vec<u32> = check_source_with_libs(
+            "declare function f(o?: NS.RoundOptsLargest<NS.Unit>): void;\n\
+             f({ large: \"x\", bogus: 1 });\n",
+            "test.ts",
+            CheckerOptions::default(),
+            &libs,
+        )
+        .iter()
+        .map(|d| d.code)
+        .collect();
+        assert!(
+            bad_codes.contains(&2353),
+            "a genuinely unknown property must still emit TS2353, got: {bad_codes:?}"
+        );
+    }
+
+    #[test]
+    fn namespaced_lib_interface_inherits_transitive_members_after_base_resolved() {
+        // `DurationOpts extends RelativeOpts, RoundOptsLargest<Unit>` inherits
+        // `small` transitively (RoundOptsLargest -> RoundOpts). Resolving the
+        // intermediate `RoundOptsLargest` first must not poison the cache and
+        // strip the transitive member from `DurationOpts`.
+        let libs = namespaced_heritage_lib("U");
+        let codes: Vec<u32> = check_source_with_libs(
+            "declare const m: NS.RoundOptsLargest<NS.Unit>;\n\
+             const pre = m.small;\n\
+             declare const d: NS.DurationOpts;\n\
+             const a = d.small;\n\
+             const b = d.large;\n\
+             const c = d.relative;\n",
+            "test.ts",
+            CheckerOptions::default(),
+            &libs,
+        )
+        .iter()
+        .map(|d| d.code)
+        .collect();
+        assert!(
+            !codes.contains(&2339),
+            "transitively inherited members on NS.DurationOpts must resolve even after the intermediate base is resolved first, got: {codes:?}"
+        );
+    }
+
     #[test]
     fn check_source_with_libs_code_messages_projects_diagnostics() {
         let pairs = check_source_with_libs_code_messages(

--- a/crates/tsz-checker/src/types/queries/lib_namespace_direct.rs
+++ b/crates/tsz-checker/src/types/queries/lib_namespace_direct.rs
@@ -310,4 +310,43 @@ impl<'a> CheckerState<'a> {
                 })
         })
     }
+
+    /// Compute the namespace-qualifier (e.g. `Temporal` for
+    /// `Temporal.RoundingOptionsWithLargestUnit`) for a lib interface from its
+    /// declarations by walking enclosing `module`/`namespace` declarations.
+    ///
+    /// Heritage merging resolves both the interface's own symbol and its base
+    /// interfaces through this namespace, so callers that only have the bare
+    /// interface name must qualify it before delegating to
+    /// `merge_lib_interface_heritage`; otherwise the namespaced symbol cannot be
+    /// found and every inherited member is dropped.
+    pub(crate) fn lib_interface_namespace_prefix(
+        decls_with_arenas: &[(NodeIndex, &NodeArena)],
+    ) -> Option<String> {
+        decls_with_arenas.iter().find_map(|(decl_idx, arena)| {
+            let node = arena.get(*decl_idx)?;
+            arena.get_interface(node)?;
+
+            let mut parent = arena
+                .get_extended(*decl_idx)
+                .map_or(NodeIndex::NONE, |info| info.parent);
+            let mut prefixes = Vec::new();
+            while parent.is_some() {
+                let parent_node = arena.get(parent)?;
+                if parent_node.kind == syntax_kind_ext::MODULE_DECLARATION
+                    && let Some(module) = arena.get_module(parent_node)
+                    && let Some(name_node) = arena.get(module.name)
+                    && name_node.kind == SyntaxKind::Identifier as u16
+                    && let Some(name_ident) = arena.get_identifier(name_node)
+                {
+                    prefixes.push(name_ident.escaped_text.clone());
+                }
+                parent = arena
+                    .get_extended(parent)
+                    .map_or(NodeIndex::NONE, |info| info.parent);
+            }
+
+            (!prefixes.is_empty()).then(|| prefixes.into_iter().rev().collect::<Vec<_>>().join("."))
+        })
+    }
 }

--- a/crates/tsz-checker/src/types/queries/lib_resolution.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution.rs
@@ -463,45 +463,6 @@ impl<'a> CheckerState<'a> {
     /// }
     /// // lib Window type is merged with augmentation
     /// ```
-    /// Compute the namespace-qualifier (e.g. `Temporal` for
-    /// `Temporal.RoundingOptionsWithLargestUnit`) for a lib interface from its
-    /// declarations by walking enclosing `module`/`namespace` declarations.
-    ///
-    /// Heritage merging resolves both the interface's own symbol and its base
-    /// interfaces through this namespace, so callers that only have the bare
-    /// interface name must qualify it before delegating to
-    /// `merge_lib_interface_heritage`; otherwise the namespaced symbol cannot be
-    /// found and every inherited member is dropped.
-    pub(crate) fn lib_interface_namespace_prefix(
-        decls_with_arenas: &[(NodeIndex, &NodeArena)],
-    ) -> Option<String> {
-        decls_with_arenas.iter().find_map(|(decl_idx, arena)| {
-            let node = arena.get(*decl_idx)?;
-            arena.get_interface(node)?;
-
-            let mut parent = arena
-                .get_extended(*decl_idx)
-                .map_or(NodeIndex::NONE, |info| info.parent);
-            let mut prefixes = Vec::new();
-            while parent.is_some() {
-                let parent_node = arena.get(parent)?;
-                if parent_node.kind == syntax_kind_ext::MODULE_DECLARATION
-                    && let Some(module) = arena.get_module(parent_node)
-                    && let Some(name_node) = arena.get(module.name)
-                    && name_node.kind == SyntaxKind::Identifier as u16
-                    && let Some(name_ident) = arena.get_identifier(name_node)
-                {
-                    prefixes.push(name_ident.escaped_text.clone());
-                }
-                parent = arena
-                    .get_extended(parent)
-                    .map_or(NodeIndex::NONE, |info| info.parent);
-            }
-
-            (!prefixes.is_empty()).then(|| prefixes.into_iter().rev().collect::<Vec<_>>().join("."))
-        })
-    }
-
     /// Merge base interface members into a lib interface type by walking
     /// heritage (`extends`) clauses in declaration-specific arenas.
     ///

--- a/crates/tsz-checker/src/types/queries/lib_resolution.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution.rs
@@ -463,6 +463,45 @@ impl<'a> CheckerState<'a> {
     /// }
     /// // lib Window type is merged with augmentation
     /// ```
+    /// Compute the namespace-qualifier (e.g. `Temporal` for
+    /// `Temporal.RoundingOptionsWithLargestUnit`) for a lib interface from its
+    /// declarations by walking enclosing `module`/`namespace` declarations.
+    ///
+    /// Heritage merging resolves both the interface's own symbol and its base
+    /// interfaces through this namespace, so callers that only have the bare
+    /// interface name must qualify it before delegating to
+    /// `merge_lib_interface_heritage`; otherwise the namespaced symbol cannot be
+    /// found and every inherited member is dropped.
+    pub(crate) fn lib_interface_namespace_prefix(
+        decls_with_arenas: &[(NodeIndex, &NodeArena)],
+    ) -> Option<String> {
+        decls_with_arenas.iter().find_map(|(decl_idx, arena)| {
+            let node = arena.get(*decl_idx)?;
+            arena.get_interface(node)?;
+
+            let mut parent = arena
+                .get_extended(*decl_idx)
+                .map_or(NodeIndex::NONE, |info| info.parent);
+            let mut prefixes = Vec::new();
+            while parent.is_some() {
+                let parent_node = arena.get(parent)?;
+                if parent_node.kind == syntax_kind_ext::MODULE_DECLARATION
+                    && let Some(module) = arena.get_module(parent_node)
+                    && let Some(name_node) = arena.get(module.name)
+                    && name_node.kind == SyntaxKind::Identifier as u16
+                    && let Some(name_ident) = arena.get_identifier(name_node)
+                {
+                    prefixes.push(name_ident.escaped_text.clone());
+                }
+                parent = arena
+                    .get_extended(parent)
+                    .map_or(NodeIndex::NONE, |info| info.parent);
+            }
+
+            (!prefixes.is_empty()).then(|| prefixes.into_iter().rev().collect::<Vec<_>>().join("."))
+        })
+    }
+
     /// Merge base interface members into a lib interface type by walking
     /// heritage (`extends`) clauses in declaration-specific arenas.
     ///
@@ -1116,8 +1155,6 @@ impl<'a> CheckerState<'a> {
             lib_type_id = Some(merged);
         }
 
-        // Merge heritage (extends) from lib interface declarations.
-        // This propagates base interface members (e.g., Iterator.next() into ArrayIterator).
         // Merge heritage (extends) from lib interface declarations.
         // This propagates base interface members (e.g., Iterator.next() into ArrayIterator).
         if let Some(ty) = lib_type_id {

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -9,7 +9,6 @@ TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 TypeScript/tests/cases/compiler/jsxComplexSignatureHasApplicabilityError.tsx
 TypeScript/tests/cases/compiler/reorderProperties.ts
-TypeScript/tests/cases/compiler/temporal.ts
 TypeScript/tests/cases/conformance/es2019/globalThisAmbientModules.ts
 TypeScript/tests/cases/conformance/es2024/sharedMemory.ts
 TypeScript/tests/cases/conformance/externalModules/typeOnly/circular2.ts


### PR DESCRIPTION
## Agent
AgentName: M1-C

Fixes #10457.

## Track
Track 1 (Diagnostic Conformance). PR type: checker bug fix + accepted-regression retire.

## Structural rule
> When a namespaced lib interface (e.g. `Temporal.RoundingOptionsWithLargestUnit`) `extends` a base interface declared in the same namespace, `tsc` exposes the base's members on the derived type; tsz must merge those inherited members too, resolving the base through the enclosing namespace — regardless of which lib-resolution path materializes the interface.

Previously tsz dropped every inherited member of a namespaced lib interface: the standard heritage merge (`merge_interface_heritage_types`) reads the user arena, not lib arenas, and the lib-aware fallback (`merge_lib_interface_heritage`) was only ever handed the **bare** interface name, so it could neither resolve the namespaced symbol nor its same-namespace base. The interface kept only its own body.

This produced the extra diagnostics on `compiler/temporal.ts`:
- **TS2353** — `smallestUnit` reported as not existing in `RoundingOptionsWithLargestUnit<…>` (it is inherited from `RoundingOptions<…>`).
- **TS2769** — `Duration.round`/`Duration.total` overloads rejected because `DurationRoundingOptions` (which `extends … , RoundingOptionsWithLargestUnit<…>`) was missing its transitively-inherited members.

## Scope
- `compute_type_of_symbol` (checker `symbol_types`): qualifies the interface name with its namespace prefix before the lib-aware heritage merge fallback.
- `direct_actual_lib_symbol_type` (cross-arena/delegate path that previously special-cased only `Intl`): generally detects a namespaced interface with heritage and runs the namespace-aware merge on the lowered body before returning. Covers both generic (`RoundingOptionsWithLargestUnit<U>`) and non-generic (`DurationRoundingOptions`) cases, including the resolution-ordering cache twist that stripped transitively-inherited members.
- New shared helper `lib_interface_namespace_prefix` (in `lib_namespace_direct.rs`) derives the namespace qualifier from a declaration's enclosing `module`/`namespace` nodes.
- `scripts/conformance/conformance-accepted-regressions.txt`: retire `compiler/temporal.ts`.

`extends Pick<…>`-style heritage (the `ToString*` options family) is unaffected: it flows through the same robust `merge_lib_interface_heritage` rather than the body-only direct lowerings, so its members are preserved (verified — no new diagnostics).

## Owner layer
Type-shape construction for lib interfaces is checker-side lib resolution; the merge itself reuses the existing `merge_lib_interface_heritage` boundary. No solver internals are touched.

## Adjacent-case test matrix
New `tsz-checker` unit tests over a synthetic `lib.*.d.ts` namespace (in `test_utils.rs`):
1. Single-level inheritance member access — run for type-parameter spellings `U`, `T`, `K` (proves the fix is not keyed to an identifier).
2. Excess-property check uses inherited members (no spurious TS2353) **and** a genuinely unknown property still emits TS2353 (negative case).
3. Transitive inheritance (`DurationOpts extends RelativeOpts, RoundOptsLargest<Unit>`) resolves correctly **even after** the intermediate base is resolved first (the ordering/cache case).

All three fail without the fix and pass with it.

## Project Corpus Impact
- Row: `compiler/temporal.ts` (conformance accepted-regression, issue #10457).
- Bug family: namespaced lib interface heritage member loss (extra TS2353 excess-property + TS2769 overload divergences).
- Evidence: local CLI `tsz --noEmit --strict --target es2020 --lib es2015,es2021.intl,esnext.date,esnext.intl,esnext.temporal,dom temporal.ts` now emits only the expected `TS2339` codes (the extra `TS2353`×7 and `TS2769`×4 are gone); 3 new owning-crate unit tests; `cargo clippy -p tsz-checker --all-targets` clean. Full conformance is validated by heavy CI on this PR.

## Verification
- `cargo nextest run -p tsz_checker -E 'test(namespaced_lib_interface)'` → 3 passed (and 3 failed when the fix is reverted, confirming they guard the change).
- `cargo clippy -p tsz-checker --all-targets` → clean.
- File-size hygiene: the namespace-prefix helper was rerouted from `lib_resolution.rs` into the under-cap `lib_namespace_direct.rs`, keeping every touched source file under the §19 2000-line cap (`lib_resolution.rs` is 1972 lines on the current head).
- Minimized repros for both the TS2353 and TS2769 sites (including the resolution-ordering case) now type-check cleanly.
- Rebased onto latest `origin/main`; no conflicts.

## Coordination Notes
Issue #10457 was unclaimed (M1-C lane label, no prior claim comment); claimed with `WIP` + signed comment. Not overlapping the active #10306 aggregate stack — this is a single retained path with a self-contained checker fix. Canonical `agent:M1-C` ownership applied (thanks to ReviewHelper).