### PR TITLE
refactor(checker): route Symbol.for identity through helper

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -868,6 +868,9 @@ mod string_literal_union_display_order_tests;
 #[path = "tests/super_call_ts2376_ts17009_priority_tests.rs"]
 mod super_call_ts2376_ts17009_priority_tests;
 #[cfg(test)]
+#[path = "tests/symbol_for_identity_helper_tests.rs"]
+mod symbol_for_identity_helper_tests;
+#[cfg(test)]
 #[path = "../tests/symbol_index_signature_tests.rs"]
 mod symbol_index_signature_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/symbol_for_identity_helper_tests.rs
+++ b/crates/tsz-checker/src/tests/symbol_for_identity_helper_tests.rs
@@ -1,0 +1,12 @@
+#[test]
+fn symbol_for_initializer_uses_global_identity_helper() {
+    let source = include_str!("../types/computation/helpers.rs");
+    assert!(
+        source.contains("identifier_resolves_to_unshadowed_global(access.expression, \"Symbol\")"),
+        "`Symbol.for` initializer detection must route through the shared global identity helper"
+    );
+    assert!(
+        !source.contains("get_identifier_text(access.expression)\n            .is_some_and(|name| name == \"Symbol\")\n            && !self.known_global_value_has_local_shadow(access.expression, \"Symbol\")"),
+        "`Symbol.for` initializer detection must not duplicate a spelling-plus-shadow check"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/helpers.rs
+++ b/crates/tsz-checker/src/types/computation/helpers.rs
@@ -1086,11 +1086,7 @@ impl<'a> CheckerState<'a> {
         let Some(access) = self.ctx.arena.get_access_expr(callee_node) else {
             return false;
         };
-        self.ctx
-            .arena
-            .get_identifier_text(access.expression)
-            .is_some_and(|name| name == "Symbol")
-            && !self.known_global_value_has_local_shadow(access.expression, "Symbol")
+        self.identifier_resolves_to_unshadowed_global(access.expression, "Symbol")
             && self
                 .ctx
                 .arena


### PR DESCRIPTION
## Agent
AgentName: M4-D

## Track
Semantic identity cleanup / checker refactor.

## Invariant
When a const initializer is `Symbol.for(...)`, tsz should treat it as the built-in Symbol factory only when the receiver resolves to the unshadowed global Symbol. This PR routes that decision through the existing checker global-identity helper instead of duplicating a spelling-plus-shadow check.

## Owner Layer
Checker orchestration; the semantic ownership remains the existing binder-backed global identity helper.

## Adjacent-Case Matrix
- Built-in `Symbol.for(...)`: still accepted by the initializer identity path.
- Shadowed local `Symbol`: existing shadowed-Symbol behavior tests remain green.
- Computed `[Symbol.iterator]` classification: existing unshadowed Symbol iterator behavior remains green.

## Scope
- `crates/tsz-checker/src/types/computation/helpers.rs`
- `crates/tsz-checker/src/tests/symbol_for_identity_helper_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Known Unsupported Shapes / Fallback
No new fallback. This is a small ratchet from a local name check to the existing shared identity helper.

## Project Corpus Impact
- Row: n/a
- Bug family: stable built-in/global identity cleanup
- Evidence: checker helper refactor only; no project-row behavior expected.

## Verification
- RED: `cargo nextest run -p tsz-checker --lib symbol_for_initializer_uses_global_identity_helper` failed before the helper change.
- GREEN: `cargo nextest run -p tsz-checker --lib symbol_for_initializer_uses_global_identity_helper`
- GREEN: `cargo nextest run -p tsz-checker --test shadowed_symbol_global_tests`
- GREEN: `cargo fmt --check`
- GREEN: `python3 scripts/arch/arch_guard.py`
- GREEN: `git diff --check HEAD~1..HEAD`

## Coordination Notes
- #10554 and #10477 were verified merged before starting this slice.
- Old merged M4-D worktrees were removed to recover disk after a local linker ENOSPC during the first RED attempt; current worktree retained caches and has about 115 GiB free afterward.
- No overlapping open M4-D PRs found at publish time.