### PR TITLE
docs(plan): refresh open bug count

### DIFF
--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -57,7 +57,7 @@ denominators.
 | JavaScript emit | `96.8%` (`13,094 / 13,530`) in checked-in emit snapshot and README |
 | Declaration emit | `96.2%` (`1,606 / 1,669`) in checked-in emit snapshot and README |
 | Fourslash / language service | `99.9%` (`6,558 / 6,562`) |
-| Open bug issues | `21` open `bug` issues in live GitHub orientation |
+| Open bug issues | `20` open `bug` issues in live GitHub orientation |
 | Output-surgery audit | green: `0` unallowlisted calls, `0` stale allowlist entries |
 
 Conformance remains a hard regression gate. It is no longer the sole readiness


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 10 (Guardrails, Tooling) — release metric truth. PR type: docs-only metric refresh.

## Invariant
When live GitHub issue orientation reports a different open `bug` issue count than the roadmap public metrics table, the roadmap should cite the live count so release planning uses current evidence.

## Scope
- `docs/plan/ROADMAP.md` updates the Open bug issues metric from 21 to 20.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only metric refresh; no compiler, benchmark, conformance, emit, or project-corpus behavior changes.

## Verification
- `gh issue list --state open --label bug --limit 100 --json number,title,labels,updatedAt,url | jq ...` reported `bug_count=20`.
- `python3 scripts/conformance/query-conformance.py --dashboard` reports `12582/12582 (100.0%)` and accepted-regression strictness 19.
- `python3 scripts/emit/query-emit.py --families` reports JavaScript 436 failures/timeouts and Declaration 63 failures/timeouts.
- `node scripts/bench/project-row-summary.mjs --markdown` reports all 12 rows consistent.
- `python3 scripts/emit/audit-output-surgery.py --json-report <tmp>` reports ok with 0 unallowlisted and 0 stale allowlist entries.
- `git diff --check` passed.

## Coordination Notes
- Studio-A owned PR runway was empty before opening this PR.
- Agent label audit was clean before opening this PR.
- No roadmap sequencing change; this only refreshes a durable public metric.
- AgentName: Studio-A