### PR TITLE
fix(emit): preserve conditional operand comments

### DIFF
--- a/crates/tsz-emitter/src/emitter/expressions/core/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/core/helpers.rs
@@ -403,7 +403,12 @@ impl<'a> Printer<'a> {
         let close_paren_end = self.find_token_end_before_trivia(node.pos, node.end);
         let trailing_comment_end =
             self.parenthesized_same_line_trailing_comment_end(close_paren_end);
-        self.emit_parenthesized_same_line_trailing_comments(close_paren_end, trailing_comment_end);
+        if self.parenthesized_trailing_comment_precedes_source_semicolon(trailing_comment_end) {
+            self.emit_parenthesized_same_line_trailing_comments(
+                close_paren_end,
+                trailing_comment_end,
+            );
+        }
     }
 
     fn parenthesized_inner_is_decorated_class_expression(&self, idx: NodeIndex) -> bool {
@@ -463,6 +468,18 @@ impl<'a> Printer<'a> {
         }
 
         end as u32
+    }
+
+    fn parenthesized_trailing_comment_precedes_source_semicolon(&self, end: u32) -> bool {
+        let Some(text) = self.source_text else {
+            return false;
+        };
+        let bytes = text.as_bytes();
+        let mut pos = std::cmp::min(end as usize, bytes.len());
+        while pos < bytes.len() && matches!(bytes[pos], b' ' | b'\t') {
+            pos += 1;
+        }
+        bytes.get(pos).is_some_and(|byte| *byte == b';')
     }
 
     fn emit_parenthesized_same_line_trailing_comments(&mut self, start: u32, end: u32) {
@@ -736,12 +753,25 @@ impl<'a> Printer<'a> {
         // because the ternary operator has very low precedence.
         self.ctx.flags.in_binary_operand = false;
 
+        let (question_pos, colon_pos) =
+            self.conditional_operator_positions(cond.condition, cond.when_true, cond.when_false);
+
         if newline_before_question {
             // Check if `?` is on the condition line (Case A) or the next line (Case B).
             // Case A: `a ?\n    b` → `?` before newline → emit `a ?` then newline + indent
             // Case B: `a\n    ? b` → `?` after newline → emit `a` then newline + indent + `?`
             let question_on_condition_line =
                 self.question_on_condition_line(cond.condition, cond.when_true);
+            let question_comment_starts_new_line = !question_on_condition_line
+                && self.conditional_comments_before_question_start_new_line(
+                    cond.condition,
+                    question_pos,
+                );
+            if question_comment_starts_new_line {
+                self.increase_indent();
+            }
+            let question_comment_emitted_line =
+                self.emit_conditional_comments_before_question(cond.condition, question_pos);
             if question_on_condition_line {
                 // Case A: `?` trails on condition line — e.g.:
                 //   var v = a ?
@@ -774,12 +804,20 @@ impl<'a> Printer<'a> {
                 //   var v = a
                 //       ? b
                 //       : c;
-                self.write_line();
-                self.increase_indent();
+                if !question_comment_emitted_line {
+                    self.write_line();
+                }
+                if !question_comment_starts_new_line {
+                    self.increase_indent();
+                }
                 self.write("? ");
                 self.emit(cond.when_true);
                 if newline_before_colon {
-                    self.write_line();
+                    let colon_comment_emitted_line =
+                        self.emit_conditional_comments_before_colon(cond.when_true, colon_pos);
+                    if !colon_comment_emitted_line {
+                        self.write_line();
+                    }
                     self.write(": ");
                 } else {
                     self.write(" : ");
@@ -797,24 +835,31 @@ impl<'a> Printer<'a> {
                 self.ctx
                     .flags
                     .recovered_jsx_missing_false_tail_break_pending = true;
-            } else if !self.colon_on_true_line(cond.when_true, cond.when_false) {
-                // Newline before `:` — e.g.:
-                //   var v = a ? b
-                //       : c;
-                self.write_line();
-                self.increase_indent();
-                self.write(": ");
-                self.emit(cond.when_false);
-                self.decrease_indent();
             } else {
-                // `:` trailing on same line, alternate on next — e.g.:
-                //   var v = a ? b :
-                //       c;
-                self.write(" :");
-                self.write_line();
-                self.increase_indent();
-                self.emit(cond.when_false);
-                self.decrease_indent();
+                let colon_on_new_line = !self.colon_on_true_line(cond.when_true, cond.when_false);
+                let colon_comment_emitted_line =
+                    self.emit_conditional_comments_before_colon(cond.when_true, colon_pos);
+                if colon_on_new_line {
+                    // Newline before `:` — e.g.:
+                    //   var v = a ? b
+                    //       : c;
+                    if !colon_comment_emitted_line {
+                        self.write_line();
+                    }
+                    self.increase_indent();
+                    self.write(": ");
+                    self.emit(cond.when_false);
+                    self.decrease_indent();
+                } else {
+                    // `:` trailing on same line, alternate on next — e.g.:
+                    //   var v = a ? b :
+                    //       c;
+                    self.write(" :");
+                    self.write_line();
+                    self.increase_indent();
+                    self.emit(cond.when_false);
+                    self.decrease_indent();
+                }
             }
         } else {
             self.write(" ? ");
@@ -824,6 +869,126 @@ impl<'a> Printer<'a> {
         }
 
         self.ctx.flags.in_binary_operand = prev;
+    }
+
+    fn conditional_comments_before_question_start_new_line(
+        &self,
+        condition: NodeIndex,
+        question_pos: Option<u32>,
+    ) -> bool {
+        let (Some(question_pos), Some(condition_node)) = (question_pos, self.arena.get(condition))
+        else {
+            return false;
+        };
+        let condition_end = self.find_token_end_before_trivia(condition_node.pos, question_pos);
+        self.conditional_comments_between_start_new_line(condition_end, question_pos)
+    }
+
+    fn conditional_comments_between_start_new_line(&self, from_pos: u32, to_pos: u32) -> bool {
+        if self.ctx.options.remove_comments {
+            return false;
+        }
+        self.all_comments
+            .iter()
+            .skip(self.comment_emit_idx)
+            .find(|comment| comment.pos >= from_pos && comment.end <= to_pos)
+            .is_some_and(|comment| self.source_range_has_newline(from_pos, comment.pos))
+    }
+
+    fn conditional_operator_positions(
+        &self,
+        condition: NodeIndex,
+        when_true: NodeIndex,
+        when_false: NodeIndex,
+    ) -> (Option<u32>, Option<u32>) {
+        let Some(text) = self.source_text else {
+            return (None, None);
+        };
+        let (Some(condition_node), Some(true_node), Some(false_node)) = (
+            self.arena.get(condition),
+            self.arena.get(when_true),
+            self.arena.get(when_false),
+        ) else {
+            return (None, None);
+        };
+
+        let bytes = text.as_bytes();
+        let question_pos = self.find_byte_backward(
+            bytes,
+            condition_node.pos as usize,
+            true_node.pos as usize,
+            b'?',
+        );
+        let colon_pos =
+            self.find_byte_backward(bytes, true_node.pos as usize, false_node.pos as usize, b':');
+
+        (question_pos, colon_pos)
+    }
+
+    fn find_byte_backward(
+        &self,
+        bytes: &[u8],
+        start: usize,
+        end: usize,
+        needle: u8,
+    ) -> Option<u32> {
+        let start = start.min(bytes.len());
+        let mut cursor = end.min(bytes.len());
+        while cursor > start {
+            cursor -= 1;
+            if bytes[cursor] == needle {
+                return Some(cursor as u32);
+            }
+        }
+        None
+    }
+
+    fn emit_conditional_comments_before_question(
+        &mut self,
+        condition: NodeIndex,
+        question_pos: Option<u32>,
+    ) -> bool {
+        let (Some(question_pos), Some(condition_node)) = (question_pos, self.arena.get(condition))
+        else {
+            return false;
+        };
+        let condition_end = self.find_token_end_before_trivia(condition_node.pos, question_pos);
+        self.emit_conditional_comments_between(condition_end, question_pos)
+    }
+
+    fn emit_conditional_comments_before_colon(
+        &mut self,
+        when_true: NodeIndex,
+        colon_pos: Option<u32>,
+    ) -> bool {
+        let (Some(colon_pos), Some(true_node)) = (colon_pos, self.arena.get(when_true)) else {
+            return false;
+        };
+        let true_end = self.find_token_end_before_trivia(true_node.pos, colon_pos);
+        self.emit_conditional_comments_between(true_end, colon_pos)
+    }
+
+    fn emit_conditional_comments_between(&mut self, from_pos: u32, to_pos: u32) -> bool {
+        if self.ctx.options.remove_comments {
+            return false;
+        }
+
+        let Some(first_comment_pos) = self
+            .all_comments
+            .iter()
+            .skip(self.comment_emit_idx)
+            .find(|comment| comment.pos >= from_pos && comment.end <= to_pos)
+            .map(|comment| comment.pos)
+        else {
+            return false;
+        };
+
+        if self.source_range_has_newline(from_pos, first_comment_pos) {
+            self.write_line();
+        } else {
+            self.write_space();
+        }
+        self.emit_unemitted_comments_between(from_pos, to_pos)
     }
 
     /// Detect whether the source text has newlines between the parts of a

--- a/crates/tsz-emitter/src/emitter/expressions/core/mod.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/core/mod.rs
@@ -417,6 +417,77 @@ mod tests {
     }
 
     #[test]
+    fn conditional_preserves_operand_comments_before_question_and_colon() {
+        let source = r#"function f(x: string | number | boolean) {
+    return typeof x !== "string"
+        && (typeof x !== "number" // number | boolean
+        ? x // boolean
+        : x === 10);
+}
+"#;
+
+        let (parser, root) = parse_test_source(source);
+
+        let mut printer = Printer::new(&parser.arena, PrintOptions::default());
+        printer.set_source_text(source);
+        printer.print(root);
+        let output = printer.finish().code;
+
+        assert!(
+            output.contains("typeof x !== \"number\" // number | boolean\n            ? x // boolean\n            : x === 10"),
+            "Conditional operand comments should stay before `?` and `:`.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn conditional_comment_line_before_question_keeps_continuation_indent() {
+        let source = r#"function f(x: string | number | boolean) {
+    return typeof x !== "string"
+        && (typeof x === "number"
+        // change value
+        ? ((x = 10) && x.toString())
+        : x);
+}
+"#;
+
+        let (parser, root) = parse_test_source(source);
+
+        let mut printer = Printer::new(&parser.arena, PrintOptions::default());
+        printer.set_source_text(source);
+        printer.print(root);
+        let output = printer.finish().code;
+
+        assert!(
+            output.contains(
+                "typeof x === \"number\"\n            // change value\n            ? ((x = 10)"
+            ),
+            "Comment-only lines before `?` should align with the continuation operator.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn parenthesized_return_comment_waits_for_inserted_semicolon() {
+        let source = r#"function f(x: string | number | boolean) {
+    return (typeof x !== "number"
+        ? x
+        : x === 10) // number
+}
+"#;
+
+        let (parser, root) = parse_test_source(source);
+
+        let mut printer = Printer::new(&parser.arena, PrintOptions::default());
+        printer.set_source_text(source);
+        printer.print(root);
+        let output = printer.finish().code;
+
+        assert!(
+            output.contains(": x === 10); // number"),
+            "Inserted return semicolon should precede the trailing line comment.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
     fn binary_continuation_operator_preserves_left_line_comment() {
         let source = r#"function foo(x: string | number | boolean) {
     return typeof x !== "string" // string | number | boolean


### PR DESCRIPTION

## Agent
AgentName: Studio-C

## Track
Emit/DTS parity: JavaScript emit comment/layout parity for type-guard conditional expressions.

## Invariant
When a conditional expression has source comments between the condition and `?`, between the true branch and `:`, or after a parenthesized return expression without an explicit semicolon, `tsc` preserves those comments around the emitted conditional operators and places the inserted return semicolon before the trailing comment. This PR changes the direct expression printer only.

## Scope
- `crates/tsz-emitter/src/emitter/expressions/core/helpers.rs`
- `crates/tsz-emitter/src/emitter/expressions/core/mod.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: JavaScript emit type-guard/comment layout parity
- Evidence: emit-only printer formatting change; targeted JS emit filter `typeGuard` improves from live 96/98 to 98/98 with no checker/solver behavior change.

## Verification
- `cargo nextest run -p tsz-emitter conditional_preserves_operand_comments_before_question_and_colon conditional_comment_line_before_question_keeps_continuation_indent parenthesized_return_comment_waits_for_inserted_semicolon`
- `scripts/emit/run.sh --filter=typeGuardsInRightOperand --js-only --verbose --json-out=/tmp/studio-c-typeguard-rebased.json`
- `scripts/emit/run.sh --filter=typeGuard --js-only --verbose --json-out=/tmp/studio-c-typeguard-family-rebased.json`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`
- `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`

## Coordination Notes
- No overlap with active Studio-D DTS work or the blocked Studio-C class/decorator draft.
- Touched files are under the 2000-line cap after the patch: `helpers.rs` 1171 lines, `mod.rs` 970 lines.
- Created from the existing `tsz-studio-c` worktree and rebased onto `origin/main` before push; conflict resolution preserved main's recovered-JSX missing-false tail break and this PR's conditional colon-comment emission.