### PR TITLE
fix(checker): resolve [Symbol.xxx] property access keys when Symbol is user-declared

### DIFF
--- a/crates/tsz-checker/src/types/queries/core_names.rs
+++ b/crates/tsz-checker/src/types/queries/core_names.rs
@@ -1,6 +1,6 @@
 //! Name, computed-property, and display-name query helpers for `CheckerState`.
 
-use super::core::get_literal_property_name;
+use super::core::{get_literal_or_well_known_property_name, get_literal_property_name};
 use crate::state::CheckerState;
 use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeIndex;
@@ -157,6 +157,18 @@ impl<'a> CheckerState<'a> {
                 {
                     self.register_well_known_symbol_name_mapping(&well_known, symbol_ref);
                 }
+                return Some(well_known);
+            }
+            // Fallback for property access expressions like `[Symbol.iterator]` where the
+            // computed expression is not a bare identifier (so `resolve_computed_symbol_property_name`
+            // returns None) but the prop type widened to plain `symbol` — e.g. when `Symbol` is a
+            // user-declared const with `{ readonly iterator: unique symbol }` type annotation.
+            // Text-based matching recovers `"[Symbol.xxx]"` without registering a well-known symbol
+            // mapping, preserving `keyof` behavior for user-declared Symbol shapes.
+            if prop_name_type == TypeId::SYMBOL
+                && let Some(well_known) =
+                    get_literal_or_well_known_property_name(self.ctx.arena, name_idx)
+            {
                 return Some(well_known);
             }
             if let Some(symbol_name) =


### PR DESCRIPTION
## Summary

AgentName: M1-C
Runner metadata: claude-sonnet-4-6 / dazzling-johnson
**Track:** checker / property-name resolution
**Invariant:** When `[Symbol.xxx]` is used as a computed property key and `Symbol` is user-declared (not the global), the property must still be treated as a named `[Symbol.xxx]` member — not silently routed to the symbol index bucket — so that TS2418 fires correctly for value-type mismatches against `{ [k: symbol]: T }` targets.

## Scope

Single commit, one file changed: 13 insertions / 1 deletion in `crates/tsz-checker/src/types/queries/core_names.rs`.

- Added import of `get_literal_or_well_known_property_name` from `super::core`
- Added 12-line fallback block in `get_property_name_resolved` for the `prop_name_type == TypeId::SYMBOL` + property-access case

No other crates, no solver changes, no conformance snapshot changes.

(The §19 file-split concern raised on earlier heads no longer applies — `main` independently split `core.rs` → `core_names.rs` before this rebase, so both files are under the 2000-line cap without any split work needed here.)

## Root Cause

For `declare const Symbol: { readonly iterator: unique symbol }`, the `unique symbol` annotation inside the type literal widens to plain `symbol` (`TypeId::SYMBOL`) because `has_declared_unique_symbol_owner` walks through `TYPE_LITERAL → VARIABLE_DECLARATION` and returns `true`, causing the type-operator path to return `inner_type = TypeId::SYMBOL` rather than creating a `UniqueSymbol`.

As a result, `Symbol.iterator` resolves to `TypeId::SYMBOL` and `get_property_name_resolved` could not recover `"[Symbol.iterator]"` — `resolve_computed_symbol_property_name` only handles bare identifier expressions, not property access expressions. The property was silently routed to the symbol index bucket rather than named `"[Symbol.iterator]"`, so TS2418 never fired.

## Fix (structural rule)

> When a computed property expression is a `Symbol.xxx` property access and the resolved type widened to plain `symbol` (because `Symbol` is user-declared rather than the global), tsc still treats it as a named `[Symbol.xxx]` property; this change makes tsz do the same by calling `get_literal_or_well_known_property_name` as a text-based fallback.

The fallback deliberately omits `register_well_known_symbol_name_mapping` — preserving `keyof` behaviour for user-declared Symbol shapes (`keyof` falls back to broad `symbol` rather than a specific unique symbol).

## Adjacent cases covered

1. `[Symbol.iterator]` — user-declared `declare const Symbol: { readonly iterator: unique symbol }` (primary case)
2. `[Symbol.observable]` — same structural pattern, different member name
3. `[Symbol["iterator"]]` (element access) — handled by `get_literal_or_well_known_property_name`'s element-access branch
4. Bare identifier `[k]` where `k: symbol` — NOT affected (not a property access; fallback returns `None`)
5. Global `Symbol.iterator` from lib.d.ts — NOT affected (`prop_name_type = UniqueSymbol(ref_N)`, not `TypeId::SYMBOL`; fallback is gated on `prop_name_type == TypeId::SYMBOL`)

## Verification

```
cargo nextest run -p tsz-checker --test symbol_index_signature_tests
test result: ok. 46 passed; 0 failed
```

Previously-failing tests now pass:
- `well_known_symbol_index_signature_reports_computed_property_value_mismatch`
- `jsdoc_symbol_index_signature_reports_computed_property_value_mismatch`
- `object_literal_well_known_symbol_property_access_key_still_resolves_named_member`

Regression guard continues to pass: `keyof_well_known_symbol_property_preserves_symbol_key_type`

Also verified: `keyof_class_unique_symbol_key_tests`, `keyof_well_known_symbol_key_tests`, `static_readonly_unique_symbol_tests`, `non_unique_symbol_late_bound_member_tests`, `ts2490_unique_symbol_iterator_tests`.

`cargo check -p tsz-checker` and `cargo clippy -p tsz-checker --no-deps -- -D warnings` clean.

## Project Corpus Impact

- Row: n/a (no project-corpus fixture for user-declared Symbol shapes)
- Bug family: TS2418 not firing for `[Symbol.xxx]` computed keys when `Symbol` is user-declared
- Evidence: unit tests above; no conformance snapshot changes; structural analysis confirms the fix is gated on `prop_name_type == TypeId::SYMBOL` (not `UniqueSymbol`) so lib.d.ts global Symbol paths are unaffected

## Coordination Notes

- Rebased onto `main` after `main` independently split `core.rs` → `core_names.rs` (earlier heads had a conflict because our branch also modified `core.rs`). Post-rebase the diff is a clean single-file change in `core_names.rs`.
- PR #10541 (overlapping fallback draft) was closed as superseded by #10419 before this PR was opened; #10419 fixed TS2418 message display widening in `union_index_signature_diagnostics.rs` — orthogonal to this fix in `get_property_name_resolved`.
- M1-A's draft conversion note on the conflict has been addressed: branch is now rebased, clean, and ready for review CI.
