### PR TITLE
docs(plan): refresh accepted-regression count

### DIFF
--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -53,7 +53,7 @@ denominators.
 | Surface | Current |
 | --- | ---: |
 | Diagnostic conformance | `100.0%` exact (`12,582 / 12,582`) |
-| Accepted-regression strictness | `19` listed tests |
+| Accepted-regression strictness | `18` listed tests |
 | JavaScript emit | `96.8%` (`13,094 / 13,530`) in checked-in emit snapshot and README |
 | Declaration emit | `96.2%` (`1,606 / 1,669`) in checked-in emit snapshot and README |
 | Fourslash / language service | `99.9%` (`6,558 / 6,562`) |


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 10 (Guardrails, Tooling) — release metric truth. PR type: docs-only metric refresh.

## Invariant
When the accepted-regression artifact count changes, the roadmap public metrics table should cite the artifact count so conformance strictness claims remain current.

## Scope
- `docs/plan/ROADMAP.md` updates Accepted-regression strictness from 19 to 18 listed tests.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only metric refresh; no compiler, benchmark, conformance, emit, or project-corpus behavior changes.

## Verification
- `python3 scripts/conformance/query-conformance.py --dashboard` reports `12582/12582 (100.0%)` and `Accepted-regression gate: 18 listed tests`.
- `rg -v "^#|^$" scripts/conformance/conformance-accepted-regressions.txt | wc -l` reports 18.
- `python3 scripts/emit/query-emit.py --families` reports JavaScript 436 failures/timeouts and Declaration 63 failures/timeouts.
- `node scripts/bench/project-row-summary.mjs --markdown` reports all 12 rows consistent.
- Live GitHub `bug` issue count remains 18, matching the roadmap after #10572.
- `git diff --check` passed.

## Coordination Notes
- Studio-A owned PR runway was empty before opening this PR.
- No roadmap sequencing change; this only refreshes a durable public metric.
- AgentName: Studio-A