### PR TITLE
fix(bench): recover Cloud Build prep artifacts

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -636,10 +636,14 @@ jobs:
           const env = findLocation([
             `/bench-prep/${targetSha}/bench-prep.env`,
             `bench-prep/${targetSha}/bench-prep.env`,
+            "/bench-prep/${_BENCH_TARGET_SHA}/bench-prep.env",
+            "bench-prep/${_BENCH_TARGET_SHA}/bench-prep.env",
           ]);
           const tar = findLocation([
             `/bench-prep/${targetSha}/bench-prep.tar`,
             `bench-prep/${targetSha}/bench-prep.tar`,
+            "/bench-prep/${_BENCH_TARGET_SHA}/bench-prep.tar",
+            "bench-prep/${_BENCH_TARGET_SHA}/bench-prep.tar",
           ]);
           if (!env || !tar) {
             console.error(`Cloud Build artifact manifest did not include bench prep env/tar for ${targetSha}.`);
@@ -687,16 +691,20 @@ jobs:
             fi
 
             status="$(cloudbuild_status "$cloudbuild_id")"
-            if [[ "$status" == "SUCCESS" ]] && copy_from_cloudbuild_manifest "$target_sha"; then
-              tar -tf bench-prep.tar .target-bench/dist/tsz >/dev/null
-              tar -tf bench-prep.tar .target-bench/dist/.bench-pgo-optimized >/dev/null
-              manifest_target_sha="$(manifest_value BENCH_TARGET_SHA)"
-              manifest_pgo_optimized="$(manifest_value BENCH_PGO_OPTIMIZED)"
-              if [[ "${manifest_target_sha}" == "${target_sha}" &&
-                    "${manifest_pgo_optimized}" == "1" ]]; then
-                exit 0
+            if [[ "$status" == "SUCCESS" ]]; then
+              if copy_from_cloudbuild_manifest "$target_sha"; then
+                tar -tf bench-prep.tar .target-bench/dist/tsz >/dev/null
+                tar -tf bench-prep.tar .target-bench/dist/.bench-pgo-optimized >/dev/null
+                manifest_target_sha="$(manifest_value BENCH_TARGET_SHA)"
+                manifest_pgo_optimized="$(manifest_value BENCH_PGO_OPTIMIZED)"
+                if [[ "${manifest_target_sha}" == "${target_sha}" &&
+                      "${manifest_pgo_optimized}" == "1" ]]; then
+                  exit 0
+                fi
+                echo "Cloud Build benchmark prep ${cloudbuild_id} succeeded, but its manifest artifact is for ${manifest_target_sha:-unknown} / PGO=${manifest_pgo_optimized:-0}; expected ${target_sha} / PGO=1."
+                exit 1
               fi
-              echo "Cloud Build benchmark prep ${cloudbuild_id} succeeded, but its manifest artifact is for ${manifest_target_sha:-unknown} / PGO=${manifest_pgo_optimized:-0}; expected ${target_sha} / PGO=1."
+              echo "Cloud Build benchmark prep ${cloudbuild_id} succeeded, but its artifact manifest did not expose bench-prep env/tar for ${target_sha}."
               exit 1
             fi
             case "$status" in
@@ -788,10 +796,14 @@ jobs:
           const env = findLocation([
             `/bench-prep/${targetSha}/bench-prep.env`,
             `bench-prep/${targetSha}/bench-prep.env`,
+            "/bench-prep/${_BENCH_TARGET_SHA}/bench-prep.env",
+            "bench-prep/${_BENCH_TARGET_SHA}/bench-prep.env",
           ]);
           const tar = findLocation([
             `/bench-prep/${targetSha}/bench-prep.tar`,
             `bench-prep/${targetSha}/bench-prep.tar`,
+            "/bench-prep/${_BENCH_TARGET_SHA}/bench-prep.tar",
+            "bench-prep/${_BENCH_TARGET_SHA}/bench-prep.tar",
           ]);
           if (!env || !tar) {
             console.error(`Cloud Build artifact manifest did not include bench prep env/tar for ${targetSha}.`);
@@ -839,16 +851,20 @@ jobs:
             fi
 
             status="$(cloudbuild_status "$cloudbuild_id")"
-            if [[ "$status" == "SUCCESS" ]] && copy_from_cloudbuild_manifest "${target_sha}"; then
-              tar -tf bench-prep.tar .target-bench/dist/tsz >/dev/null
-              tar -tf bench-prep.tar .target-bench/dist/.bench-pgo-optimized >/dev/null
-              manifest_target_sha="$(manifest_value BENCH_TARGET_SHA)"
-              manifest_pgo_optimized="$(manifest_value BENCH_PGO_OPTIMIZED)"
-              if [[ "${manifest_target_sha}" == "${target_sha}" &&
-                    "${manifest_pgo_optimized}" == "1" ]]; then
-                exit 0
+            if [[ "$status" == "SUCCESS" ]]; then
+              if copy_from_cloudbuild_manifest "${target_sha}"; then
+                tar -tf bench-prep.tar .target-bench/dist/tsz >/dev/null
+                tar -tf bench-prep.tar .target-bench/dist/.bench-pgo-optimized >/dev/null
+                manifest_target_sha="$(manifest_value BENCH_TARGET_SHA)"
+                manifest_pgo_optimized="$(manifest_value BENCH_PGO_OPTIMIZED)"
+                if [[ "${manifest_target_sha}" == "${target_sha}" &&
+                      "${manifest_pgo_optimized}" == "1" ]]; then
+                  exit 0
+                fi
+                echo "Cloud Build benchmark prep ${cloudbuild_id} succeeded, but its manifest artifact is for ${manifest_target_sha:-unknown} / PGO=${manifest_pgo_optimized:-0}; expected ${target_sha} / PGO=1."
+                exit 1
               fi
-              echo "Cloud Build benchmark prep ${cloudbuild_id} succeeded, but its manifest artifact is for ${manifest_target_sha:-unknown} / PGO=${manifest_pgo_optimized:-0}; expected ${target_sha} / PGO=1."
+              echo "Cloud Build benchmark prep ${cloudbuild_id} succeeded, but its artifact manifest did not expose bench-prep env/tar for ${target_sha}."
               exit 1
             fi
             case "$status" in

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -25,6 +25,21 @@ assert.doesNotMatch(
   "successful Cloud Build prep with a stale manifest artifact must not wait until the 150 minute deadline",
 );
 
+const unusableManifestMessages = workflow.match(
+  /Cloud Build benchmark prep \$\{cloudbuild_id\} succeeded, but its artifact manifest did not expose bench-prep env\/tar for/g,
+) ?? [];
+assert.equal(
+  unusableManifestMessages.length,
+  2,
+  "both Cloud Build prep artifact paths should fail fast when a successful build exposes no usable prep artifacts",
+);
+
+assert.match(
+  workflow,
+  /"\/bench-prep\/\$\{_BENCH_TARGET_SHA\}\/bench-prep\.env"[\s\S]+"bench-prep\/\$\{_BENCH_TARGET_SHA\}\/bench-prep\.tar"/,
+  "Cloud Build manifest parsing should accept literal unsubstituted target path entries from the exact build manifest",
+);
+
 assert.match(
   workflow,
   /expected \$\{target_sha\} \/ PGO=1\."\s*\n\s+exit 1/,

--- a/scripts/ci/test-cloudbuild-config-paths.mjs
+++ b/scripts/ci/test-cloudbuild-config-paths.mjs
@@ -61,6 +61,16 @@ for (const config of expectedConfigs) {
   );
 }
 
+const benchPrepareConfig = fs.readFileSync(
+  path.join(ROOT, "scripts", "cloudbuild", "cloudbuild-bench-prepare.yaml"),
+  "utf8",
+);
+assert.match(
+  benchPrepareConfig,
+  /literal_scoped_dir='bench-prep\/\$\{_BENCH_TARGET_SHA\}'[\s\S]+cp bench-prep\.tar bench-prep\.env "\$\{literal_scoped_dir\}\/"/,
+  "benchmark prep should mirror artifacts to the literal target path for Cloud Build artifact glob compatibility",
+);
+
 for (const workflow of workflowFiles) {
   const configs = workflowConfigs.get(workflow) ?? [];
   const workflowText = fs.readFileSync(path.join(ROOT, workflow), "utf8");

--- a/scripts/cloudbuild/cloudbuild-bench-prepare.yaml
+++ b/scripts/cloudbuild/cloudbuild-bench-prepare.yaml
@@ -89,8 +89,14 @@ steps:
         printf 'BENCH_BUILD_DATE=%s\n' "$(date -u +%F)"
         printf 'BENCH_PGO_OPTIMIZED=1\n'
       } > bench-prep.env
-      mkdir -p "bench-prep/${_BENCH_TARGET_SHA}" bench-prep/latest
+      # Cloud Build has historically been inconsistent about substituting
+      # custom variables inside artifact path globs. Keep the real SHA-scoped
+      # path for direct GCS consumers, and mirror it to the literal path that
+      # matches an unsubstituted artifact glob.
+      literal_scoped_dir='bench-prep/${_BENCH_TARGET_SHA}'
+      mkdir -p "bench-prep/${_BENCH_TARGET_SHA}" "${literal_scoped_dir}" bench-prep/latest
       cp bench-prep.tar bench-prep.env "bench-prep/${_BENCH_TARGET_SHA}/"
+      cp bench-prep.tar bench-prep.env "${literal_scoped_dir}/"
       cp bench-prep.tar bench-prep.env bench-prep/latest/
 
 artifacts:


### PR DESCRIPTION
AgentName: Studio-B

## Track
Track 1 / benchmark dashboard and website freshness

## Invariant
A successful Cloud Build benchmark prep must hand a valid, target-SHA benchmark prep artifact back to `bench.yml`, and a successful Cloud Build prep must not leave GitHub Actions waiting until the 150 minute timeout when the artifact manifest is unusable.

## Scope
- Mirror benchmark prep artifacts into the literal `${_BENCH_TARGET_SHA}` path as a compatibility fallback for Cloud Build artifact path substitution behavior.
- Teach the exact-build manifest lookup to accept that literal path while still validating `BENCH_TARGET_SHA` and `BENCH_PGO_OPTIMIZED` from `bench-prep.env` before publishing.
- Fail fast when Cloud Build reports `SUCCESS` but the artifact manifest does not expose usable prep env/tar entries.
- Add workflow/config smoke assertions so the handoff cannot silently regress.

## Project Corpus Impact
- Row: n/a
- Bug family: benchmark website artifact publication
- Evidence: workflow-only handoff fix; no compiler/project corpus behavior changes. The public `https://tsz.dev/benchmark-data/latest.json` is currently stale at `generated_at=2026-05-17T01:23:02.991Z`; recent `Bench` runs skip or fail before producing `bench-results-merged`.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `git diff --check`

## Coordination Notes
- AgentName: Studio-B
- This follows merged PR #10293, which correctly stopped Bench-triggered website redeploys when no `bench-results-merged` artifact exists. This PR fixes the deeper Cloud Build prep handoff so a fresh benchmark run can actually produce a publishable artifact.
- Evidence from run `26510293858`: `bench-prepare-cloudbuild` submitted build `f00b3e8f-a4d8-4186-bad0-dedb443f5138`; Cloud Build reached `SUCCESS`, but `bench-prep-artifact` waited 150 minutes because it could not find SHA-scoped `bench-prep.env`/`bench-prep.tar` in either the stable bucket path or the manifest parser.
