### PR TITLE
docs(plan): refresh output-surgery audit metric

### DIFF
--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -58,7 +58,7 @@ denominators.
 | Declaration emit | `96.2%` (`1,606 / 1,669`) in checked-in emit snapshot and README |
 | Fourslash / language service | `99.9%` (`6,558 / 6,562`) |
 | Open bug issues | `18` open `bug` issues in live GitHub orientation |
-| Output-surgery audit | green: `0` unallowlisted calls, `0` stale allowlist entries |
+| Output-surgery audit | red: `1` unallowlisted call, `0` stale allowlist entries (`#10575`) |
 
 Conformance remains a hard regression gate. It is no longer the sole readiness
 signal. The primary readiness signal for this phase is whether tsz can
@@ -119,9 +119,9 @@ changes the picture.
    `1,606 / 1,669` in the checked-in snapshot and public README. DTS still
    needs to move away from late semantic discovery during printing toward a
    precomputed declaration/public-API summary.
-8. Output-surgery audit debt is now ratcheted behind the allowlist: the current
-   audit reports `0` unallowlisted calls and `0` stale allowlist entries. Treat
-   that as a guardrail for Studio-C/D/F emit work.
+8. Output-surgery audit debt is no longer fully behind the allowlist: the
+   current audit reports `1` unallowlisted call and `0` stale allowlist entries,
+   tracked in `#10575`. Treat that as a guardrail for Studio-C/D/F emit work.
 9. Conformance is no longer the dominant progress signal but it remains a hard
    regression gate. The current diagnostic gap is zero tests; broad
    checker/solver changes must preserve that floor while moving project rows


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Studio-A release metric truth / roadmap public metrics.

## Invariant
When the output-surgery audit on current `origin/main` reports unallowlisted calls, the roadmap public metric must not claim the audit is green.

## Scope
- `docs/plan/ROADMAP.md`

## Project Corpus Impact
- Row: n/a
- Bug family: output-surgery audit metric drift
- Evidence: docs-only roadmap metric correction; current `origin/main` audit reports one unallowlisted DTS output-surgery call tracked by #10575.

## Verification
- `git fetch origin main`
- `scripts/agents/show-goal.sh Studio-A`
- `scripts/agents/disk-preflight.sh Studio-A`
- `scripts/agents/list-owned-work.sh Studio-A`
- `python3 scripts/conformance/query-conformance.py --dashboard`
- `python3 scripts/emit/query-emit.py --families`
- `node scripts/bench/project-row-summary.mjs --markdown`
- `node scripts/bench/validate-project-metadata.mjs`
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery-audit-main.json` (expected red evidence: one unallowlisted call)
- `git diff --check`

## Coordination Notes
- Started after confirming Studio-A had no open owned PRs or issues.
- #10575 is the owning Studio-D cleanup issue for the DTS implementation decision.
- This PR updates the scoreboard only; it does not raise the allowlist cap or modify emitter code.