### PR TITLE
fix(emit): normalize CR/CRLF to LF in JSX string content

### DIFF
--- a/crates/tsz-emitter/src/emitter/jsx/mod.rs
+++ b/crates/tsz-emitter/src/emitter/jsx/mod.rs
@@ -203,11 +203,20 @@ pub(super) fn process_jsx_text(text: &str) -> String {
 /// `quote` is the surrounding quote char (' or ") so we know which to escape.
 pub(super) fn escape_jsx_text_for_js_with_quote(s: &str, quote: char) -> String {
     let mut result = String::with_capacity(s.len());
-    for c in s.chars() {
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
         match c {
             '\\' => result.push_str("\\\\"),
+            // tsc rebuilds JSX string content as a fresh JS string literal with
+            // line terminators normalized to LF, so a raw `CRLF` or lone `CR` in
+            // a JSX attribute value (or text child) is emitted as `\n`, never `\r`.
+            '\r' => {
+                if chars.peek() == Some(&'\n') {
+                    chars.next();
+                }
+                result.push_str("\\n");
+            }
             '\n' => result.push_str("\\n"),
-            '\r' => result.push_str("\\r"),
             '\t' => result.push_str("\\t"),
             c if c == quote => {
                 result.push('\\');
@@ -565,7 +574,7 @@ pub(super) fn needs_quoting(name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::process_jsx_text;
+    use super::{escape_jsx_text_for_js_with_quote, process_jsx_text};
     use crate::context::emit::EmitContext;
     use crate::emitter::{JsxEmit, Printer as EmitPrinter, PrinterOptions};
     use crate::lowering::LoweringPass;
@@ -767,6 +776,67 @@ x = <foo>x</foo>, x = <foo/>;
     #[test]
     fn process_jsx_text_normalizes_mixed_cr_and_lf() {
         assert_eq!(process_jsx_text("a\rb\nc"), "a b c");
+    }
+
+    #[test]
+    fn escape_jsx_string_normalizes_crlf_to_lf() {
+        // tsc rebuilds a JSX attribute value as a JS string literal with line
+        // terminators normalized to LF, so a raw CRLF must become a single `\n`.
+        assert_eq!(
+            escape_jsx_text_for_js_with_quote("\r\nfoo: 23\r\n", '"'),
+            "\\nfoo: 23\\n"
+        );
+    }
+
+    #[test]
+    fn escape_jsx_string_normalizes_lone_cr_to_lf() {
+        // Classic-Mac line endings (lone CR) normalize the same as CRLF/LF.
+        assert_eq!(escape_jsx_text_for_js_with_quote("a\rb", '"'), "a\\nb");
+    }
+
+    #[test]
+    fn escape_jsx_string_preserves_literal_backslash_n() {
+        // JSX attribute strings do not process escape sequences, so a source
+        // backslash-n is two characters and stays escaped (`\\n`), while the
+        // surrounding raw CRLF terminators normalize to `\n`.
+        assert_eq!(
+            escape_jsx_text_for_js_with_quote("\r\nfoo: 23\\n\r\n", '\''),
+            "\\nfoo: 23\\\\n\\n"
+        );
+    }
+
+    #[test]
+    fn escape_jsx_string_without_line_breaks_is_unchanged() {
+        assert_eq!(
+            escape_jsx_text_for_js_with_quote("plain value", '"'),
+            "plain value"
+        );
+    }
+
+    #[test]
+    fn react_emit_normalizes_crlf_in_double_quoted_attr_value() {
+        let source = "const a = <input value=\"\r\nfoo: 23\r\n\"></input>;";
+        let output = emit_jsx_react(source);
+        assert!(
+            output.contains("{ value: \"\\nfoo: 23\\n\" }"),
+            "CRLF in a JSX attribute value should normalize to \\n.\nOutput: {output}"
+        );
+        assert!(
+            !output.contains("\\r"),
+            "No raw CR should survive into emitted JSX string content.\nOutput: {output}"
+        );
+    }
+
+    #[test]
+    fn react_emit_normalizes_crlf_in_single_quoted_attr_value() {
+        // Preserves the single-quote style while normalizing line endings, and
+        // keeps a literal backslash-n unprocessed (JSX strings are not cooked).
+        let source = "const c = <input value='\r\nfoo: 23\\n\r\n'></input>;";
+        let output = emit_jsx_react(source);
+        assert!(
+            output.contains("{ value: '\\nfoo: 23\\\\n\\n' }"),
+            "Single-quoted multiline JSX attribute value mismatch.\nOutput: {output}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
AgentName: Studio-C
Runner metadata: cloud-opus47-1m-confident-thompson

## Track
Track 9 — JavaScript emit parity (JSX/react emit family, issue #8512)

## Invariant (structural rule)
> When tsz emits the JS string literal for JSX string content (a JSX string-literal **attribute value**, or a JSX **text child**), raw line terminators `CRLF` and lone `CR` are normalized to `\n` — tsc rebuilds the value as a fresh JS string with normalized line endings, so no raw `\r` survives into emitted JSX string content.

tsz previously emitted `'\r' => "\\r"`, so a fixture committed with `CRLF` produced `"\r\nfoo: 23\r\n"` where tsc emits `"\nfoo: 23\n"`.

## Owner layer
Emitter (`crates/tsz-emitter/src/emitter/jsx/mod.rs`). The fix lives at the single chokepoint that turns JSX string content into a JS string literal, `escape_jsx_text_for_js_with_quote`. JSX text children already normalize line breaks earlier via `process_jsx_text`, so in practice the attribute-value path was the gap; placing the rule at the shared escape function keeps it uniform and not attribute-specific.

## Scope
- One match arm: `'\r'` now consumes a following `'\n'` (CRLF) and emits a single `\n`; lone `CR` also becomes `\n`.
- No-op for any content without `\r` (LF-only fixtures are byte-identical), so no other JSX baseline can regress.
- Keys on line-terminator characters only — independent of quote style (`"`/`'`), `--jsx`/`--target`, and surrounding content.

## Witness
`tests/cases/compiler/jsxMultilineAttributeValuesReact.tsx` (committed with `CRLF`). After the fix, tsz output is byte-exact with the tsc baseline for all three cases:
```js
const a = React.createElement("input", { value: "\nfoo: 23\n" });
const b = React.createElement("input", { value: '\nfoo: 23\n' });
const c = React.createElement("input", { value: '\nfoo: 23\\n\n' });
```

## Adjacent-case test matrix (unit tests in `jsx/mod.rs`)
1. Reported repro — CRLF in a double-quoted attr value (`escape_jsx_string_normalizes_crlf_to_lf`, `react_emit_normalizes_crlf_in_double_quoted_attr_value`).
2. Lone CR (classic-Mac endings) → `\n` (`escape_jsx_string_normalizes_lone_cr_to_lf`).
3. Single-quote variant preserving quote style + literal backslash-n unprocessed (`escape_jsx_string_preserves_literal_backslash_n`, `react_emit_normalizes_crlf_in_single_quoted_attr_value`).
4. Negative/regression — content without line breaks is unchanged (`escape_jsx_string_without_line_breaks_is_unchanged`).

## Verification
- `cargo test -p tsz-emitter --lib jsx` → 58 passed, 0 failed (includes 6 new tests).
- `cargo clippy -p tsz-emitter --lib --all-features` → clean.
- End-to-end: built `tsz` and confirmed byte-exact match vs the `jsxMultilineAttributeValuesReact` baseline.
- Review (`/simplify`) run 3 times — no findings.
- A pre-existing, unrelated stack overflow in `declaration_emitter::tests::...shadowed_helper...` reproduces on a clean tree (changes stashed); it is a debug-stack-size quirk in this sandbox, not introduced here.

## Project Corpus Impact
- Row: `jsxMultilineAttributeValuesReact` (JS emit) — flips fail → pass.
- Bug family: JSX/react emit (#8512), line-ending normalization sub-rule.
- Evidence: byte-exact local diff vs `TypeScript/tests/baselines/reference/jsxMultilineAttributeValuesReact.js`; ready-review CI emit suite will confirm corpus movement.

## Coordination Notes
Narrow, behavior-preserving slice of the JSX emit family (#8512). The namespace-prefix and unicode-escape sub-families noted on that issue are separate structural rules (parser error-recovery and cooked-vs-raw identifier text) and are intentionally **not** bundled here.
