### PR TITLE
refactor(solver): drop relation policy packed accessor

### DIFF
--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -171,15 +171,6 @@ impl RelationPolicy {
         self
     }
 
-    /// Return the packed legacy flags represented by this policy.
-    ///
-    /// This accessor is for compatibility edges and trace payloads that still
-    /// need the historical bit layout. Relation engines and cache keys should
-    /// prefer the typed accessors and [`RelationPolicy::cache_config`].
-    pub const fn legacy_packed_flags(self) -> u16 {
-        self.flags.bits() as u16
-    }
-
     /// Whether `null` and `undefined` are distinct types.
     pub const fn strict_null_checks(self) -> bool {
         self.flags.contains(RelationFlags::STRICT_NULL_CHECKS)

--- a/crates/tsz-solver/tests/relation_cache_config_tests/cache_agreement.rs
+++ b/crates/tsz-solver/tests/relation_cache_config_tests/cache_agreement.rs
@@ -189,11 +189,6 @@ fn relation_policy_from_relation_flags_preserves_typed_bits() {
             .contains(RelationFlags::IN_CALLBACK_PARAM_CHECK),
         "typed constructor should preserve transient callback relation mode",
     );
-    assert_eq!(
-        typed.legacy_packed_flags(),
-        typed_flags.bits() as u16,
-        "compatibility edges should still be able to observe the packed bit layout",
-    );
 }
 
 #[test]
@@ -233,20 +228,6 @@ fn relation_policy_typed_accessors_preserve_packed_relation_bits() {
     assert!(!disabled.allow_bivariant_param_count());
     assert!(!disabled.allow_erased_generic_signature_retry());
     assert!(!disabled.strict_readonly_identity());
-}
-
-#[test]
-fn relation_policy_legacy_packed_flags_accessor_preserves_input_bits() {
-    let packed = RelationCacheKey::FLAG_STRICT_NULL_CHECKS
-        | RelationCacheKey::FLAG_ALLOW_VOID_RETURN
-        | RelationFlags::STRICT_READONLY_IDENTITY.bits() as u16;
-    let policy = RelationPolicy::from_flags(packed);
-
-    assert_eq!(
-        policy.legacy_packed_flags(),
-        packed,
-        "compatibility edges should observe the exact legacy bit layout",
-    );
 }
 
 #[test]


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 4 solver relation/cache-key architecture cleanup; refactor only.

## Invariant
When legacy packed `u16` flags enter solver relation policy, tsz should decode them at the compatibility boundary and keep typed `RelationFlags`/`RelationPolicy` as the solver-facing representation; this PR removes the unused reverse packed accessor.

## Scope
- Remove `RelationPolicy::legacy_packed_flags`.
- Remove tests that existed only to preserve the reverse packed-output accessor.
- Keep forward `RelationPolicy::from_flags(...)` compatibility tests.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only solver API cleanup; no relation semantics or project corpus behavior changed.

## Verification
- `cargo nextest run -p tsz-solver -E 'test(cache_agreement::relation_policy_from_relation_flags_preserves_typed_bits) | test(cache_agreement::relation_policy_typed_accessors_preserve_packed_relation_bits) | test(legacy_flag_constructor_stores_typed_relation_flags) | test(strict_function_types_does_not_imply_strict_any_propagation)'`
- `cargo fmt --check`
- `git diff --check origin/main`
- `python3 scripts/arch/arch_guard.py`

## Coordination Notes
- Addresses a small slice of #8207 by removing an unused reverse packed-protocol API after #10559 quarantined the forward decoder.
- No overlap with M1-B checker routing or M4-A/M4-C active solver slices; only tsz-solver relation policy/test files are touched.
- AgentName: M4-B
