### PR TITLE
fix(dts): prefer source indexed helper returns

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
@@ -16,6 +16,7 @@ impl<'a> DeclarationEmitter<'a> {
             .or_else(|| self.call_expression_returned_local_class_constructor_text(expr_idx, false))
             .or_else(|| {
                 self.super_method_call_return_type_text(expr_idx)
+                    .or_else(|| self.generic_call_reverse_mapped_handler_type_text(expr_idx))
                     .or_else(|| self.generic_call_literal_type_text(expr_idx))
                     .or_else(|| self.generic_call_pick_mapped_type_text(expr_idx))
                     .or_else(|| self.generic_call_constrained_mapped_return_type_text(expr_idx))

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_mapped_inference.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_mapped_inference.rs
@@ -8,6 +8,28 @@ use tsz_parser::parser::{NodeIndex, NodeList};
 use tsz_scanner::SyntaxKind;
 
 impl<'a> DeclarationEmitter<'a> {
+    pub(in crate::declaration_emitter) fn generic_call_reverse_mapped_handler_type_text(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        let expr_node = self.arena.get(expr_idx)?;
+        let call = self.arena.get_call_expr(expr_node)?;
+        let arguments = call.arguments.as_ref()?;
+        let sym_id = self.value_reference_symbol(call.expression)?;
+        let binder = self.binder?;
+        let sym_id = self
+            .resolve_portability_import_alias(sym_id, binder)
+            .unwrap_or_else(|| self.resolve_portability_symbol(sym_id, binder));
+        self.with_symbol_declarations(sym_id, |source_arena, decl_idx| {
+            let func = callable_function_from_symbol_decl(source_arena, decl_idx)?;
+            self.generic_call_reverse_mapped_handler_type_text_for_function(
+                source_arena,
+                func,
+                arguments,
+            )
+        })
+    }
+
     pub(in crate::declaration_emitter) fn generic_call_pick_mapped_type_text(
         &self,
         expr_idx: NodeIndex,
@@ -61,6 +83,131 @@ impl<'a> DeclarationEmitter<'a> {
                 func,
             )
         })
+    }
+
+    fn generic_call_reverse_mapped_handler_type_text_for_function(
+        &self,
+        source_arena: &NodeArena,
+        func: &FunctionData,
+        arguments: &NodeList,
+    ) -> Option<String> {
+        let return_type_param = type_reference_identifier_name(source_arena, func.type_annotation)?;
+        if !function_declares_type_parameter(source_arena, func, &return_type_param) {
+            return None;
+        }
+
+        func.parameters
+            .nodes
+            .iter()
+            .copied()
+            .zip(arguments.nodes.iter().copied())
+            .find_map(|(param_idx, arg_idx)| {
+                let param_node = source_arena.get(param_idx)?;
+                let param = source_arena.get_parameter(param_node)?;
+                let type_node = source_arena.get(param.type_annotation)?;
+                if type_node.kind != syntax_kind_ext::TYPE_REFERENCE {
+                    return None;
+                }
+                let type_ref = source_arena.get_type_ref(type_node)?;
+                let type_args = type_ref.type_arguments.as_ref()?;
+                let [type_arg_idx] = type_args.nodes.as_slice() else {
+                    return None;
+                };
+                if type_reference_identifier_name(source_arena, *type_arg_idx).as_deref()
+                    != Some(return_type_param.as_str())
+                {
+                    return None;
+                }
+                let alias_sym =
+                    self.type_reference_symbol_from_arena(source_arena, type_ref.type_name)?;
+                self.with_symbol_declarations(alias_sym, |alias_arena, alias_decl_idx| {
+                    let alias_node = alias_arena.get(alias_decl_idx)?;
+                    let alias = alias_arena.get_type_alias(alias_node)?;
+                    reverse_mapped_handler_alias_source_param(alias_arena, alias)?;
+                    self.object_literal_reverse_mapped_handler_type_text(arg_idx, 0)
+                })
+            })
+    }
+
+    fn object_literal_reverse_mapped_handler_type_text(
+        &self,
+        object_idx: NodeIndex,
+        depth: u32,
+    ) -> Option<String> {
+        let object_idx = self.skip_parenthesized_expression(object_idx)?;
+        let object_node = self.arena.get(object_idx)?;
+        if object_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            return None;
+        }
+        let object = self.arena.get_literal_expr(object_node)?;
+        let mut members = Vec::new();
+
+        for &member_idx in &object.elements.nodes {
+            let member_node = self.arena.get(member_idx)?;
+            if member_node.kind == syntax_kind_ext::SPREAD_ASSIGNMENT {
+                return None;
+            }
+            let name_idx = self.object_literal_member_name_idx(member_node)?;
+            let name = self.object_literal_member_name_text(name_idx)?;
+            if name.is_empty() || name == ":" {
+                return None;
+            }
+            let type_text = self.reverse_mapped_handler_member_type_text(member_node)?;
+            members.push(Self::format_object_member_type_text(
+                &name,
+                &type_text,
+                depth + 1,
+            ));
+        }
+
+        if members.is_empty() {
+            return None;
+        }
+        let member_indent = "    ".repeat((depth + 1) as usize);
+        let closing_indent = "    ".repeat(depth as usize);
+        let formatted_members = members
+            .iter()
+            .map(|member| Self::format_object_member_entry(&member_indent, member))
+            .collect::<Vec<_>>()
+            .join("\n");
+        Some(format!("{{\n{formatted_members}\n{closing_indent}}}"))
+    }
+
+    fn reverse_mapped_handler_member_type_text(
+        &self,
+        member_node: &tsz_parser::parser::node::Node,
+    ) -> Option<String> {
+        if let Some(method) = self.arena.get_method_decl(member_node) {
+            return self.first_handler_parameter_type_text(&method.parameters);
+        }
+
+        let initializer = self.object_literal_member_initializer(member_node)?;
+        let initializer = self.skip_parenthesized_expression(initializer)?;
+        let node = self.arena.get(initializer)?;
+        if node.kind != syntax_kind_ext::ARROW_FUNCTION
+            && node.kind != syntax_kind_ext::FUNCTION_EXPRESSION
+        {
+            return None;
+        }
+        let func = self.arena.get_function(node)?;
+        self.first_handler_parameter_type_text(&func.parameters)
+    }
+
+    fn first_handler_parameter_type_text(&self, parameters: &NodeList) -> Option<String> {
+        let Some(param_idx) = parameters.nodes.first().copied() else {
+            return Some("unknown".to_string());
+        };
+        let param = self
+            .arena
+            .get(param_idx)
+            .and_then(|node| self.arena.get_parameter(node))?;
+        let Some(type_annotation) = param.type_annotation.into_option() else {
+            return Some("unknown".to_string());
+        };
+        self.source_slice_from_arena(self.arena, type_annotation)
+            .or_else(|| self.emit_type_node_text_from_arena(self.arena, type_annotation))
+            .map(|text| text.trim().to_string())
+            .filter(|text| !text.is_empty())
     }
 
     fn generic_call_pick_mapped_type_text_for_function(
@@ -679,6 +826,71 @@ fn type_alias_is_pick_like(source_arena: &NodeArena, alias: &TypeAliasData) -> b
         == Some(object_param_name.as_str())
         && type_reference_identifier_name(source_arena, indexed.index_type).as_deref()
             == Some(mapped_param_name.as_str())
+}
+
+fn reverse_mapped_handler_alias_source_param(
+    source_arena: &NodeArena,
+    alias: &TypeAliasData,
+) -> Option<String> {
+    let [source_param_idx] = alias.type_parameters.as_ref()?.nodes.as_slice() else {
+        return None;
+    };
+    let source_param_name = type_parameter_name(source_arena, *source_param_idx)?;
+    let mapped = mapped_type_from_annotation(source_arena, alias.type_node)?;
+    if mapped.name_type.is_some()
+        || mapped.question_token.is_some()
+        || mapped
+            .members
+            .as_ref()
+            .is_some_and(|members| !members.nodes.is_empty())
+    {
+        return None;
+    }
+    let mapped_param = source_arena
+        .get(mapped.type_parameter)
+        .and_then(|node| source_arena.get_type_parameter(node))?;
+    let mapped_param_name = identifier_text(source_arena, mapped_param.name)?;
+    let constraint_node = source_arena.get(mapped_param.constraint)?;
+    let constraint = source_arena.get_type_operator(constraint_node)?;
+    if constraint.operator != SyntaxKind::KeyOfKeyword as u16
+        || type_reference_identifier_name(source_arena, constraint.type_node).as_deref()
+            != Some(source_param_name.as_str())
+    {
+        return None;
+    }
+
+    let function_node = source_arena.get(mapped.type_node)?;
+    if function_node.kind != syntax_kind_ext::FUNCTION_TYPE {
+        return None;
+    }
+    let function = source_arena.get_function_type(function_node)?;
+    let first_param_idx = function.parameters.nodes.first().copied()?;
+    let first_param = source_arena
+        .get(first_param_idx)
+        .and_then(|node| source_arena.get_parameter(node))?;
+    let indexed_node = source_arena.get(first_param.type_annotation)?;
+    let indexed = source_arena.get_indexed_access_type(indexed_node)?;
+    if type_reference_identifier_name(source_arena, indexed.object_type).as_deref()
+        == Some(source_param_name.as_str())
+        && type_reference_identifier_name(source_arena, indexed.index_type).as_deref()
+            == Some(mapped_param_name.as_str())
+    {
+        Some(source_param_name)
+    } else {
+        None
+    }
+}
+
+fn function_declares_type_parameter(
+    source_arena: &NodeArena,
+    func: &FunctionData,
+    type_param_name: &str,
+) -> bool {
+    func.type_parameters.as_ref().is_some_and(|type_params| {
+        type_params.nodes.iter().copied().any(|param_idx| {
+            type_parameter_name(source_arena, param_idx).as_deref() == Some(type_param_name)
+        })
+    })
 }
 
 fn type_parameter_name(source_arena: &NodeArena, type_param_idx: NodeIndex) -> Option<String> {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
@@ -29,6 +29,14 @@ impl<'a> DeclarationEmitter<'a> {
         }
         if let Some(return_expr) = self.function_body_single_return_expression(body_idx)
             && let Some(type_text) = self
+                .source_indexed_access_return_type_text(return_expr)
+                .or_else(|| self.source_indexed_access_call_return_type_text(return_expr))
+                .filter(|text| !text.is_empty())
+        {
+            return Some(type_text);
+        }
+        if let Some(return_expr) = self.function_body_single_return_expression(body_idx)
+            && let Some(type_text) = self
                 .declaration_summary_primitive_expression_type_text(return_expr, 0)
                 .filter(|text| !text.is_empty() && text != "any")
         {
@@ -1786,7 +1794,11 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         let mut substitutions = Vec::new();
-        if call.type_arguments.is_some() {
+        if call
+            .type_arguments
+            .as_ref()
+            .is_some_and(|type_args| !type_args.nodes.is_empty())
+        {
             let explicit_type_args =
                 self.type_argument_list_source_text(call.type_arguments.as_ref());
             for (name, value) in type_param_names.iter().zip(explicit_type_args.iter()) {
@@ -1801,8 +1813,10 @@ impl<'a> DeclarationEmitter<'a> {
                     continue;
                 };
                 let Some(param_type_text) = self
-                    .emit_type_node_text_from_arena(source_arena, param.type_annotation)
-                    .or_else(|| self.source_slice_from_arena(source_arena, param.type_annotation))
+                    .source_slice_from_arena(source_arena, param.type_annotation)
+                    .or_else(|| {
+                        self.emit_type_node_text_from_arena(source_arena, param.type_annotation)
+                    })
                     .map(|text| text.trim().to_string())
                 else {
                     continue;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
@@ -683,6 +683,36 @@ let y = complete(value);
 }
 
 #[test]
+fn call_reused_type_inverts_reverse_mapped_handler_parameters() {
+    let source = r#"
+type Callbacks<Shape> = { [Field in keyof Shape]: (value: Shape[Field]) => void };
+declare function listen<Shape>(handlers: Callbacks<Shape>): Shape;
+let result = listen({ ready: () => {}, flag: (value: boolean) => {} });
+"#;
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+    let interner = TypeInterner::new();
+    let type_cache = crate::type_cache_view::TypeCacheView::default();
+    let emitter = DeclarationEmitter::with_type_info(&parser.arena, type_cache, &interner, &binder);
+    let call_idx = parser
+        .arena
+        .nodes
+        .iter()
+        .enumerate()
+        .find_map(|(idx, node)| {
+            (node.kind == syntax_kind_ext::CALL_EXPRESSION).then_some(NodeIndex(idx as u32))
+        })
+        .expect("missing call expression");
+
+    assert_eq!(
+        emitter.call_expression_reused_type_text(call_idx),
+        Some("{\n    ready: unknown;\n    flag: boolean;\n}".to_string())
+    );
+}
+
+#[test]
 fn declared_call_return_does_not_treat_shadowed_partial_name_as_builtin() {
     let source = r#"
 type Partial<T> = T;


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Declaration emit / DTS parity recovery.

## Invariant
When declaration emit needs a public surface for a generic call that returns the same type parameter inferred from source-indexed helper calls or reverse-mapped handler objects, it should recover the `tsc`-compatible source-backed declaration surface. For `getProperty(this, "parts")`, the declaration surface is `this["parts"]`, not the helper's unresolved generic `T[K]` return. For a mapped handler alias such as `{ [Field in keyof Shape]: (value: Shape[Field]) => void }`, the returned object surface is inferred from each handler's first parameter type, using `unknown` when no typed first parameter exists.

## Scope
- Reorders method/function body preferred-return inference so source indexed-access calls are considered before generic expression summaries.
- Treats parser-created empty type-argument lists as absent for indexed helper-call substitution, so value arguments can drive the public return surface.
- Prefers source-slice parameter type text for the substitution match used by this emitter-only helper.
- Adds a declaration-summary helper for reverse-mapped handler aliases whose mapped member value is a callback parameter typed as `Source[Key]`.
- Wires that helper before the broad generic literal fallback so handler objects emit `{ property: inferredParameterType }` instead of callback function types.

## Structural Rule
- For DTS indexed helper calls, when a generic helper returns `Obj[Key]` and the call arguments identify `this` plus a literal key, recover the public indexed-access surface from the source call arguments.
- For generic calls returning type parameter `Shape` from an argument typed as a mapped handler alias `{ [Field in keyof Shape]: (value: Shape[Field]) => void }`, infer each returned object property from the corresponding object-literal handler's first parameter annotation; if the handler has no typed first parameter, emit `unknown`.

## Owner Layer
Emitter declaration summary / public-surface inference only. This PR does not change checker relation logic, solver inference, semantic assignability, diagnostics, or emitter output surgery.

## Adjacent Case Matrix
- Reported witness: `keyofAndIndexedAccess` indexed helper call and reverse-mapped handler object.
- Renamed binder witness: unit test uses `Callbacks<Shape>` / `Field` rather than `Handlers<T>` / `K`.
- Handler shapes: no first parameter emits `unknown`; typed first parameter emits the annotation type.
- Fallback: unsupported non-object handler arguments, spreads, non-callback members, optional/remapped mapped aliases, and aliases whose callback parameter is not `Source[Key]` fall through to existing generic-call declaration emit paths.

## Project Corpus Impact
- Row: `keyofAndIndexedAccess`
- Bug family: DTS indexed helper-call return surfaces and reverse-mapped handler object inference
- Evidence: `scripts/safe-run.sh scripts/emit/run.sh --filter=keyofAndIndexedAccess --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-keyofAndIndexedAccess-main-05f133-20260527.json` passes 1/1 at head `9f4a85879b7b3d736b4a4cf8773bcb99bd7a84ae`; the previous `OtherPerson.getParts(): T[K]` and `hashOfEmpty1` / `hashOfEmpty2` mismatches are removed.

## Verification
- Current head `9f4a85879b7b3d736b4a4cf8773bcb99bd7a84ae` rebased onto latest `origin/main` (`05f13346e3a9877081553a3e11a4c49b5cac2dc5`): `cargo fmt --all --check`
- Current head: `git diff --check origin/main..HEAD`
- Current head: `cargo check -p tsz-emitter`
- Current head: `cargo nextest run -p tsz-emitter test_unannotated_method_returning_indexed_helper_call_preserves_this_surface test_unannotated_method_returning_inherited_this_indexed_method_call_preserves_surface call_reused_type_inverts_reverse_mapped_handler_parameters` (3 passed)
- Current head: `scripts/safe-run.sh scripts/emit/run.sh --filter=keyofAndIndexedAccess --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-keyofAndIndexedAccess-main-05f133-20260527.json` (passes 1/1)
- Line counts after the reverse-mapped handler helper: `generic_call_mapped_inference.rs` 966, `generic_call_literal.rs` 1940, `type_inference_return_normalization.rs` 1985, `type_inference_tests.rs` 744.

## Coordination Notes
- AgentName: Studio-D
- Pushed synced head `9f4a85879b7b3d736b4a4cf8773bcb99bd7a84ae` on 2026-05-27 after replaying the two PR commits onto latest `origin/main`.
- Marked ready for review after exact-head draft-light CI passed for `9f4a85879b7b3d736b4a4cf8773bcb99bd7a84ae`; heavy ready CI is the next broad validation. Merge queue remains off until a manager/queue owner chooses to enqueue it.
- No roadmap update: this is routine Studio-D DTS parity work under the existing declaration emit track.

