### PR TITLE
test(arch): guard relation policy packed accessor

### DIFF
--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -207,7 +207,9 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         # Ratcheted down to the live merged count after #10311 and #10359
         # narrowed checker-side direct common references; removal condition
         # remains #8225 narrowing this quarantine.
-        3338,
+        #
+        # Ratcheted down after arch-smoke caught current stacked-branch slack.
+        3266,
     ),
 ]
 
@@ -349,6 +351,12 @@ REGEX_LINE_COUNT_CHECKS = [
             r"subtype_cache_config_from_legacy_flags|"
             r"assignability_cache_config_from_legacy_flags)\b"
         ),
+        0,
+    ),
+    (
+        "Solver relation boundary: RelationPolicy must not expose packed flags (#8207)",
+        [ROOT / "crates" / "tsz-solver" / "src" / "relations" / "relation_queries.rs"],
+        re.compile(r"\bfn\s+legacy_packed_flags\s*\([^)]*\)\s*->\s*u16\b"),
         0,
     ),
     (

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -239,7 +239,6 @@ LINE_LIMIT_CHECKS = [
             # `test_excluded_files_actually_exceed_limit` test will catch
             # any regression.
             "crates/tsz-checker/src/assignability/assignability_diagnostics.rs",
-            "crates/tsz-checker/src/checkers/jsx/tests.rs",
             "crates/tsz-checker/src/declarations/import/declaration.rs",
             "crates/tsz-checker/src/error_reporter/properties.rs",
             "crates/tsz-checker/src/flow/control_flow/core.rs",
@@ -252,7 +251,6 @@ LINE_LIMIT_CHECKS = [
             "crates/tsz-checker/src/state/type_resolution/module.rs",
             "crates/tsz-checker/src/state/variable_checking/core.rs",
             "crates/tsz-checker/src/state/variable_checking/destructuring.rs",
-            "crates/tsz-checker/src/tests/dispatch_tests.rs",
             "crates/tsz-checker/src/types/class_type/constructor.rs",
             "crates/tsz-checker/src/types/property_access_type/resolve.rs",
             "crates/tsz-checker/src/types/queries/core.rs",
@@ -524,7 +522,9 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         #
         # Ratcheted down after current-main guard tests caught slack in the
         # live direct-reference count.
-        3269,
+        #
+        # Ratcheted down after arch-smoke caught current stacked-branch slack.
+        3266,
     ),
 ]
 
@@ -672,6 +672,12 @@ REGEX_LINE_COUNT_CHECKS = [
         "Solver relation boundary: RelationPolicy must store typed flags (#8207)",
         [ROOT / "crates" / "tsz-solver" / "src" / "relations" / "relation_queries.rs"],
         re.compile(r"^\s*(?:pub\s+)?flags\s*:\s*u16\s*,"),
+        0,
+    ),
+    (
+        "Solver relation boundary: RelationPolicy must not expose packed flags (#8207)",
+        [ROOT / "crates" / "tsz-solver" / "src" / "relations" / "relation_queries.rs"],
+        re.compile(r"\bfn\s+legacy_packed_flags\s*\([^)]*\)\s*->\s*u16\b"),
         0,
     ),
     (

--- a/scripts/arch/test_arch_guard_project.py
+++ b/scripts/arch/test_arch_guard_project.py
@@ -967,6 +967,26 @@ class ArchGuardRegexLineCountTests(unittest.TestCase):
         self.assertIn("relation_queries.rs:2", hits[0])
         self.assertIn("total matching lines: 1", hits[1])
 
+    def test_flags_relation_policy_packed_flag_accessor(self):
+        pattern, _max_lines = self._check_by_name(
+            "RelationPolicy must not expose packed flags"
+        )
+        root = self._make_tree(
+            {
+                "crates/tsz-solver/src/relations/relation_queries.rs": (
+                    "impl RelationPolicy {\n"
+                    "    pub const fn legacy_packed_flags(self) -> u16 {\n"
+                    "        self.flags.bits() as u16\n"
+                    "    }\n"
+                    "}\n"
+                ),
+            }
+        )
+        hits = self.arch_guard.scan_regex_line_count([root], pattern, 0)
+        self.assertEqual(len(hits), 2, f"unexpected hits: {hits!r}")
+        self.assertIn("relation_queries.rs:2", hits[0])
+        self.assertIn("total matching lines: 1", hits[1])
+
     def test_scan_regex_line_count_accepts_file_roots(self):
         pattern, _max_lines = self._check_by_name(
             "raw diagnostic assignability predicates"


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 4 solver relation/cache-key architecture cleanup; architecture ratchet.

## Invariant
When `RelationPolicy` has decoded legacy packed `u16` inputs into typed `RelationFlags`, solver APIs should not expose a reverse accessor that turns the typed policy back into packed flags; this PR adds an architecture guard for the removal landed in #10578.

## Scope
- Add a `REGEX_LINE_COUNT_CHECKS` guard for `RelationPolicy::legacy_packed_flags(...) -> u16` in `relation_queries.rs`.
- Add a synthetic arch-guard fixture proving the forbidden accessor is detected.
- Fix arch-smoke ratchet hygiene found by draft CI: remove stale sub-2000-line checker file exclusions and ratchet the live `query_boundaries::common` reference cap to 3266.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: architecture-test-only guard and ratchet cleanup; no compiler semantics, emit output, or project corpus behavior changed.

## Verification
- RED: `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard_project.ArchGuardRegexLineCountTests.test_flags_relation_policy_packed_flag_accessor` failed before the guard with missing `REGEX_LINE_COUNT_CHECKS` entry.
- GREEN: `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard_project.ArchGuardRegexLineCountTests.test_flags_relation_policy_packed_flag_accessor`
- `set -euo pipefail; python3 -m py_compile scripts/arch/*.py; while IFS= read -r test_file; do python3 "$test_file"; done < <(find scripts/arch -maxdepth 1 -type f -name 'test_*.py' | sort)`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check origin/main`

## Coordination Notes
- #10578 (`refactor(solver): drop relation policy packed accessor`) merged; this PR is now rebased onto `main` at `883c81c212` with head `ac4dfcb409`.
- Addresses the guardrail side of #8207 after #10578 removed the reverse packed-protocol API.
- Draft CI initially failed `arch-tool-smoke` because existing ratchets had slack/stale exemptions; head `ac4dfcb409` includes the local arch-smoke fix and reruns CI on `main` base.
- No overlap with M1-B checker routing or M4-A/M4-C solver semantics; this only touches architecture guard files.
- AgentName: M4-B
