### PR TITLE
test(solver): share evaluator type-param fixtures

### DIFF
--- a/crates/tsz-solver/src/tests/solver_file_size_ceiling_tests.rs
+++ b/crates/tsz-solver/src/tests/solver_file_size_ceiling_tests.rs
@@ -216,6 +216,21 @@ fn include_paths(text: &str) -> Vec<&str> {
         .collect()
 }
 
+fn contains_simple_type_param_wrapper(text: &str, wrapper: &str) -> bool {
+    let mut remaining = text;
+    while let Some(offset) = remaining.find(wrapper) {
+        let window = &remaining[offset..remaining.len().min(offset + 320)];
+        if window.contains("constraint: None")
+            && window.contains("default: None")
+            && window.contains("is_const: false")
+        {
+            return true;
+        }
+        remaining = &remaining[offset + wrapper.len()..];
+    }
+    false
+}
+
 /// Ratchet guard: keep generated evaluator test shards named after evaluator
 /// feature families. Anonymous numeric chunks make failures and regeneration
 /// diffs harder to review even when they satisfy the file-size ceiling.
@@ -254,6 +269,48 @@ fn evaluate_tests_use_feature_family_shards() {
         assert!(
             includes.iter().any(|path| path.contains(family)),
             "evaluator test shard list is missing a {family} shard: {includes:?}"
+        );
+    }
+}
+
+/// Ratchet guard: generated evaluator shards should use the shared fixture
+/// helpers for unconstrained type and infer parameters instead of repeating the
+/// same `TypeParamInfo` setup in each case.
+#[test]
+fn evaluate_tests_use_shared_type_param_helpers() {
+    let solver_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let evaluate_tests = solver_dir.join("tests/evaluate_tests.rs");
+    let text = fs::read_to_string(&evaluate_tests)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", evaluate_tests.display()));
+
+    assert!(
+        text.contains("fn test_type_param("),
+        "{} should define a shared type-parameter fixture helper",
+        evaluate_tests.display()
+    );
+    assert!(
+        text.contains("fn test_infer_param("),
+        "{} should define a shared infer-parameter fixture helper",
+        evaluate_tests.display()
+    );
+
+    for include in include_paths(&text) {
+        let shard = solver_dir.join("tests").join(include);
+        let shard_text = fs::read_to_string(&shard)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", shard.display()));
+
+        assert!(
+            !contains_simple_type_param_wrapper(
+                &shard_text,
+                "TypeData::TypeParameter(TypeParamInfo {",
+            ),
+            "{} should use test_type_param for generated type parameters",
+            shard.display()
+        );
+        assert!(
+            !contains_simple_type_param_wrapper(&shard_text, "TypeData::Infer(TypeParamInfo {"),
+            "{} should use test_infer_param for generated infer parameters",
+            shard.display()
         );
     }
 }

--- a/crates/tsz-solver/tests/evaluate_tests.rs
+++ b/crates/tsz-solver/tests/evaluate_tests.rs
@@ -4,6 +4,24 @@ use crate::def::DefId;
 use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::relations::subtype::SubtypeChecker;
 
+fn test_type_param(interner: &TypeInterner, name: &str) -> (Atom, TypeId) {
+    let name = interner.intern_string(name);
+    (name, test_type_param_from_name(interner, name))
+}
+
+fn test_infer_param(interner: &TypeInterner, name: &str) -> (Atom, TypeId) {
+    let name = interner.intern_string(name);
+    (name, test_infer_param_from_name(interner, name))
+}
+
+fn test_type_param_from_name(interner: &TypeInterner, name: Atom) -> TypeId {
+    interner.intern(TypeData::TypeParameter(TypeParamInfo::simple(name)))
+}
+
+fn test_infer_param_from_name(interner: &TypeInterner, name: Atom) -> TypeId {
+    interner.intern(TypeData::Infer(TypeParamInfo::simple(name)))
+}
+
 // Split into under-cap shards by evaluator family while preserving test order.
 include!("evaluate_tests_parts/conditional_infer_core.rs");
 include!("evaluate_tests_parts/conditional_infer_arrays.rs");

--- a/crates/tsz-solver/tests/evaluate_tests_parts/application_conditionals.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/application_conditionals.rs
@@ -300,13 +300,7 @@ fn test_conditional_infer_extract_state_pattern() {
     // Simulates: type ExtractState<R> = R extends Reducer<infer S, AnyAction> ? S : never;
     // Where Reducer<S, A> is represented as a function type: (state: S | undefined, action: A) => S
 
-    let infer_s_name = interner.intern_string("S");
-    let infer_s = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_s_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_s_name, infer_s) = test_infer_param(&interner, "S");
 
     // AnyAction = { type: string }
     let any_action = interner.object(vec![PropertyInfo::new(
@@ -389,13 +383,7 @@ fn test_conditional_infer_extract_action_pattern() {
 
     // Simulates: type ExtractAction<R> = R extends Reducer<any, infer A> ? A : never;
 
-    let infer_a_name = interner.intern_string("A");
-    let infer_a = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_a_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_a_name, infer_a) = test_infer_param(&interner, "A");
 
     // Pattern: Reducer<any, infer A> - function (state: any | undefined, action: A) => any
     let state_param = interner.union(vec![TypeId::ANY, TypeId::UNDEFINED]);
@@ -481,13 +469,7 @@ fn test_conditional_infer_extract_state_non_matching() {
 
     // Test that ExtractState returns never when given a non-Reducer type
 
-    let infer_s_name = interner.intern_string("S");
-    let infer_s = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_s_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_s_name, infer_s) = test_infer_param(&interner, "S");
 
     // AnyAction = { type: string }
     let any_action = interner.object(vec![PropertyInfo::new(
@@ -545,21 +527,9 @@ fn test_conditional_infer_extract_state_union_distributive() {
     // Test distributive ExtractState over a union of reducers:
     // ExtractState<Reducer<number, A> | Reducer<string, A>> should give number | string
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_s_name = interner.intern_string("S");
-    let infer_s = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_s_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_s_name, infer_s) = test_infer_param(&interner, "S");
 
     // Simple function pattern for testing: (x: infer S) => S
     let extends_fn = interner.function(FunctionShape {

--- a/crates/tsz-solver/tests/evaluate_tests_parts/application_template_literal.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/application_template_literal.rs
@@ -1203,18 +1203,8 @@ fn test_conditional_infer_tuple_multiple_positions() {
     // Create infer placeholders for A and B
     let a_name = interner.intern_string("A");
     let b_name = interner.intern_string("B");
-    let infer_a = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: a_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_b = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: b_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let infer_a = test_infer_param_from_name(&interner, a_name);
+    let infer_b = test_infer_param_from_name(&interner, b_name);
 
     // Create extends pattern: [infer A, infer B]
     let pattern = interner.tuple(vec![
@@ -1437,21 +1427,9 @@ fn test_template_literal_hyphen_prefix_extraction() {
     // Pattern: T extends `hello-${infer R}` ? R : never
     // Input: "hello-world" => R = "world"
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends `hello-${infer R}` ? R : never
     let extends_template = interner.template_literal(vec![
@@ -1485,26 +1463,10 @@ fn test_template_literal_hyphen_two_part_extraction() {
     // Pattern: T extends `${infer First}-${infer Rest}` ? [First, Rest] : never
     // Input: "foo-bar-baz" => First = "foo", Rest = "bar-baz"
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_first = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: interner.intern_string("First"),
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_rest = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: interner.intern_string("Rest"),
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let infer_first = test_infer_param(&interner, "First").1;
+    let infer_rest = test_infer_param(&interner, "Rest").1;
 
     // T extends `${infer First}-${infer Rest}` ? [First, Rest] : never
     let extends_template = interner.template_literal(vec![
@@ -1568,21 +1530,9 @@ fn test_template_literal_hyphen_suffix_pattern() {
     // Pattern: T extends `${infer R}-handler` ? R : never
     // Input: "click-handler" => R = "click"
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends `${infer R}-handler` ? R : never
     let extends_template = interner.template_literal(vec![
@@ -1616,21 +1566,9 @@ fn test_template_literal_hyphen_distributive_union() {
     // Pattern: T extends `event-${infer R}` ? R : never (distributive)
     // Input: "event-click" | "event-load" => "click" | "load"
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends `event-${infer R}` ? R : never
     let extends_template = interner.template_literal(vec![
@@ -1669,21 +1607,9 @@ fn test_template_literal_hyphen_no_match_returns_never() {
     // Pattern: T extends `prefix-${infer R}` ? R : never
     // Input: "other-value" (doesn't start with "prefix-") => never
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends `prefix-${infer R}` ? R : never
     let extends_template = interner.template_literal(vec![
@@ -1717,21 +1643,9 @@ fn test_template_literal_prefix_infer_suffix_extraction() {
     // Pattern: T extends `start-${infer M}-end` ? M : never
     // Input: "start-middle-end" => M = "middle"
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("M");
-    let infer_m = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_m) = test_infer_param(&interner, "M");
 
     // T extends `start-${infer M}-end` ? M : never
     let extends_template = interner.template_literal(vec![

--- a/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_arrays.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_arrays.rs
@@ -2,21 +2,9 @@
 fn test_conditional_infer_template_literal_non_distributive_template_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [`foo${infer R}`] ? R : never, with T = `foo${string}` | `bar${string}` (no distribution).
     let extends_template = interner.template_literal(vec![
@@ -63,13 +51,7 @@ fn test_conditional_infer_template_literal_non_distributive_template_union_input
 fn test_conditional_infer_template_literal_with_constrained_infer_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_name = interner.intern_string("R");
     let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -122,13 +104,7 @@ fn test_conditional_infer_template_literal_with_constrained_infer_non_distributi
 fn test_conditional_infer_template_literal_with_constrained_infer_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_name = interner.intern_string("R");
     let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -177,21 +153,9 @@ fn test_conditional_infer_template_literal_with_constrained_infer_non_distributi
 fn test_conditional_infer_template_literal_with_middle_infer_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [`foo${infer R}bar`] ? R : never, with T = "foobazbar" | "foobuzbar" (no distribution).
     let extends_template = interner.template_literal(vec![
@@ -237,21 +201,9 @@ fn test_conditional_infer_template_literal_with_middle_infer_non_distributive_un
 fn test_conditional_infer_template_literal_with_middle_infer_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [`foo${infer R}bar`] ? R : never, with T = "foobazbar" | "bar" (no distribution).
     let extends_template = interner.template_literal(vec![
@@ -293,13 +245,7 @@ fn test_conditional_infer_template_literal_with_middle_infer_non_distributive_un
 fn test_conditional_infer_template_literal_with_middle_constrained_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_name = interner.intern_string("R");
     let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -354,13 +300,7 @@ fn test_conditional_infer_template_literal_with_middle_constrained_non_distribut
 fn test_conditional_infer_template_literal_with_middle_constrained_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_name = interner.intern_string("R");
     let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -412,21 +352,9 @@ fn test_conditional_infer_template_literal_with_middle_non_distributive_non_matc
 {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [`foo${infer R}bar`] ? R : never, with T = "foobazbar" | "bar" (no distribution).
     let extends_template = interner.template_literal(vec![
@@ -468,21 +396,9 @@ fn test_conditional_infer_template_literal_with_middle_non_distributive_non_matc
 fn test_conditional_infer_template_literal_with_middle_non_distributive_non_string_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [`foo${infer R}bar`] ? R : never, with T = "foobazbar" | number (no distribution).
     let extends_template = interner.template_literal(vec![
@@ -524,21 +440,9 @@ fn test_conditional_infer_template_literal_with_middle_non_distributive_non_stri
  {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [`foo${infer R}bar`] ? R : never, with T = `foo${string}bar` | number (no distribution).
     let extends_template = interner.template_literal(vec![
@@ -586,28 +490,10 @@ fn test_conditional_infer_template_literal_with_middle_non_distributive_non_stri
 fn test_conditional_infer_template_literal_two_infers_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_a_name = interner.intern_string("A");
-    let infer_a = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_a_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_b_name = interner.intern_string("B");
-    let infer_b = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_b_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_a_name, infer_a) = test_infer_param(&interner, "A");
+    let (_infer_b_name, infer_b) = test_infer_param(&interner, "B");
 
     // [T] extends [`${infer A}-${infer B}`] ? A | B : never, with T = "foo-bar" | "baz-qux" (no distribution).
     let extends_template = interner.template_literal(vec![
@@ -655,28 +541,10 @@ fn test_conditional_infer_template_literal_two_infers_non_distributive_union_inp
 fn test_conditional_infer_template_literal_two_infers_non_distributive_non_matching_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_a_name = interner.intern_string("A");
-    let infer_a = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_a_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_b_name = interner.intern_string("B");
-    let infer_b = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_b_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_a_name, infer_a) = test_infer_param(&interner, "A");
+    let (_infer_b_name, infer_b) = test_infer_param(&interner, "B");
 
     // [T] extends [`${infer A}-${infer B}`] ? A | B : never, with T = "foo-bar" | "baz" (no distribution).
     let extends_template = interner.template_literal(vec![
@@ -718,28 +586,10 @@ fn test_conditional_infer_template_literal_two_infers_non_distributive_non_match
 fn test_conditional_infer_template_literal_two_infers_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_a_name = interner.intern_string("A");
-    let infer_a = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_a_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_b_name = interner.intern_string("B");
-    let infer_b = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_b_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_a_name, infer_a) = test_infer_param(&interner, "A");
+    let (_infer_b_name, infer_b) = test_infer_param(&interner, "B");
 
     // [T] extends [`${infer A}-${infer B}`] ? A | B : never, with T = "foo-bar" | number (no distribution).
     let extends_template = interner.template_literal(vec![
@@ -780,21 +630,9 @@ fn test_conditional_infer_template_literal_two_infers_non_distributive_union_bra
 fn test_conditional_infer_template_literal_with_suffix_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [`${infer R}bar`] ? R : never, with T = "foobar" | "bazbar" (no distribution).
     let extends_template = interner.template_literal(vec![
@@ -839,21 +677,9 @@ fn test_conditional_infer_template_literal_with_suffix_non_distributive_union_in
 fn test_conditional_infer_template_literal_with_suffix_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [`${infer R}bar`] ? R : never, with T = "foobar" | "baz" (no distribution).
     let extends_template = interner.template_literal(vec![
@@ -895,21 +721,9 @@ fn test_conditional_infer_template_literal_with_suffix_non_distributive_non_matc
 {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [`${infer R}bar`] ? R : never, with T = "foobar" | "baz" (no distribution).
     let extends_template = interner.template_literal(vec![
@@ -950,21 +764,9 @@ fn test_conditional_infer_template_literal_with_suffix_non_distributive_non_matc
 fn test_conditional_infer_template_literal_with_suffix_non_distributive_non_string_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [`${infer R}bar`] ? R : never, with T = "foobar" | number (no distribution).
     let extends_template = interner.template_literal(vec![
@@ -1005,21 +807,9 @@ fn test_conditional_infer_template_literal_with_suffix_non_distributive_non_stri
  {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [`${infer R}bar`] ? R : never, with T = `${string}bar` | number (no distribution).
     let extends_template = interner.template_literal(vec![
@@ -1065,13 +855,7 @@ fn test_conditional_infer_template_literal_with_suffix_non_distributive_non_stri
 fn test_conditional_infer_template_literal_with_suffix_constrained_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_name = interner.intern_string("R");
     let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -1124,13 +908,7 @@ fn test_conditional_infer_template_literal_with_suffix_constrained_non_distribut
 fn test_conditional_infer_template_literal_with_suffix_constrained_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_name = interner.intern_string("R");
     let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -1179,21 +957,9 @@ fn test_conditional_infer_template_literal_with_suffix_constrained_non_distribut
 fn test_conditional_infer_template_literal_with_prefix_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [`foo${infer R}`] ? R : never, with T = "foo1" | "foo2" (no distribution).
     let extends_template = interner.template_literal(vec![
@@ -1238,21 +1004,9 @@ fn test_conditional_infer_template_literal_with_prefix_non_distributive_union_in
 fn test_conditional_infer_template_literal_with_prefix_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [`foo${infer R}`] ? R : never, with T = "foo1" | "bar" (no distribution).
     let extends_template = interner.template_literal(vec![
@@ -1294,21 +1048,9 @@ fn test_conditional_infer_template_literal_with_prefix_non_distributive_non_matc
 {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [`foo${infer R}`] ? R : never, with T = "foo1" | "bar" (no distribution).
     let extends_template = interner.template_literal(vec![
@@ -1349,21 +1091,9 @@ fn test_conditional_infer_template_literal_with_prefix_non_distributive_non_matc
 fn test_conditional_infer_template_literal_with_prefix_non_distributive_non_string_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [`foo${infer R}`] ? R : never, with T = "foo1" | number (no distribution).
     let extends_template = interner.template_literal(vec![
@@ -1403,13 +1133,7 @@ fn test_conditional_infer_template_literal_with_prefix_non_distributive_non_stri
 fn test_conditional_infer_template_literal_with_prefix_constrained_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_name = interner.intern_string("R");
     let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -1462,13 +1186,7 @@ fn test_conditional_infer_template_literal_with_prefix_constrained_non_distribut
 fn test_conditional_infer_template_literal_with_prefix_constrained_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_name = interner.intern_string("R");
     let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -1518,13 +1236,7 @@ fn test_conditional_infer_template_literal_two_infers_with_constraint_non_distri
 {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_a_name = interner.intern_string("A");
     let infer_a = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -1589,13 +1301,7 @@ fn test_conditional_infer_template_literal_two_infers_with_constraint_non_distri
  {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_a_name = interner.intern_string("A");
     let infer_a = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -1654,13 +1360,7 @@ fn test_conditional_infer_template_literal_two_infers_with_constraint_non_distri
  {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_a_name = interner.intern_string("A");
     let infer_a = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -1717,21 +1417,9 @@ fn test_conditional_infer_template_literal_two_infers_with_constraint_non_distri
 fn test_conditional_infer_template_literal_union_input_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends `foo${infer R}` ? R : never, with T = `foo${string}` | `bar${string}`.
     let extends_template = interner.template_literal(vec![

--- a/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_core.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_core.rs
@@ -175,13 +175,7 @@ fn test_rest_unknown_bivariant_conditional_evaluate_strict() {
 fn test_conditional_instantiated_param_distributes() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let string_or_number = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
     let lit_true = interner.literal_boolean(true);
@@ -211,13 +205,7 @@ fn test_conditional_instantiated_param_distributes() {
 fn test_conditional_instantiated_param_distributes_branch_substitution() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     // T extends string ? T : never, with T = string | number
     // Distributes to: (string extends string ? string : never) |
@@ -245,13 +233,7 @@ fn test_conditional_instantiated_param_distributes_branch_substitution() {
 fn test_conditional_distributive_nested_extends() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     // T extends string ? (T extends "a" ? 1 : 2) : 3, with T = "a" | "b"
     // Distributes to 1 | 2.
@@ -292,13 +274,7 @@ fn test_conditional_distributive_nested_extends() {
 fn test_conditional_distributive_infer_extends_nested() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_name = interner.intern_string("R");
     let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -400,21 +376,9 @@ fn test_conditional_infer_false_branch_substitution() {
 fn test_conditional_infer_array_element_extraction() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends (infer R)[] ? R : never, with T = string[] | number[].
     let extends_array = interner.array(infer_r);
@@ -447,21 +411,9 @@ fn test_conditional_infer_array_element_extraction() {
 fn test_conditional_infer_array_element_non_array_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends (infer R)[] ? R : never, with T = string[] | number.
     let extends_array = interner.array(infer_r);
@@ -490,21 +442,9 @@ fn test_conditional_infer_array_element_non_array_union_branch() {
 fn test_conditional_infer_array_element_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends (infer R)[] ? R : never, with T = string[] | number[] (no distribution).
     let extends_array = interner.array(infer_r);
@@ -537,21 +477,9 @@ fn test_conditional_infer_array_element_non_distributive_union_input() {
 fn test_conditional_infer_array_element_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends (infer R)[] ? R : never, with T = string[] | number (no distribution).
     let extends_array = interner.array(infer_r);
@@ -580,21 +508,9 @@ fn test_conditional_infer_array_element_non_distributive_union_branch() {
 fn test_conditional_infer_array_element_from_tuple_rest() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends (infer R)[] ? R : never, with T = [string, ...number[]].
     let extends_array = interner.array(infer_r);
@@ -636,21 +552,9 @@ fn test_conditional_infer_array_element_from_tuple_rest() {
 fn test_conditional_infer_array_element_from_tuple_rest_tuple() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends (infer R)[] ? R : never, with T = [string, ...[number, boolean]].
     let extends_array = interner.array(infer_r);
@@ -705,21 +609,9 @@ fn test_conditional_infer_array_element_from_tuple_rest_tuple() {
 fn test_conditional_infer_array_element_from_optional_tuple_element() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends (infer R)[] ? R : never, with T = [string?].
     let extends_array = interner.array(infer_r);
@@ -752,13 +644,7 @@ fn test_conditional_infer_array_element_from_optional_tuple_element() {
 fn test_conditional_infer_array_element_with_constraint() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_name = interner.intern_string("R");
     let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -801,13 +687,7 @@ fn test_conditional_infer_array_element_with_constraint() {
 fn test_conditional_infer_array_element_with_object_constraint() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_name = interner.intern_string("R");
     let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -845,13 +725,7 @@ fn test_conditional_infer_array_element_with_object_constraint() {
 fn test_conditional_infer_array_element_rejects_non_array_application() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_name = interner.intern_string("R");
     let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -889,21 +763,9 @@ fn test_conditional_infer_array_element_rejects_non_array_application() {
 fn test_conditional_infer_array_element_non_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // (T[]) extends (infer R)[] ? R : never, with T = string | number (no distribution).
     let check_array = interner.array(t_param);
@@ -931,21 +793,9 @@ fn test_conditional_infer_array_element_non_distributive() {
 fn test_conditional_infer_array_element_non_distributive_tuple_wrapper() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [(infer R)[]] ? R : never, with T = string[] | number[].
     let check_tuple = interner.tuple(vec![TupleElement {
@@ -989,21 +839,9 @@ fn test_conditional_infer_array_element_non_distributive_tuple_wrapper() {
 fn test_conditional_infer_object_property_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { a: infer R } ? R : never, with T = { a: string } | { a: number } | { b: boolean }.
     let extends_obj = interner.object(vec![PropertyInfo::new(
@@ -1045,13 +883,7 @@ fn test_conditional_infer_object_property_distributive() {
 fn test_conditional_infer_object_property_with_constraint() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_name = interner.intern_string("R");
     let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -1096,21 +928,9 @@ fn test_conditional_infer_object_property_with_constraint() {
 fn test_conditional_infer_object_property_readonly() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { readonly a: infer R } ? R : never, with T = { a: string } | { readonly a: number }.
     let extends_obj = interner.object(vec![PropertyInfo::readonly(
@@ -1148,21 +968,9 @@ fn test_conditional_infer_object_property_readonly() {
 fn test_conditional_infer_object_property_readonly_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { readonly a: infer R } ? R : never, with T = { readonly a: string } | { a: number } (no distribution).
     let extends_obj = interner.object(vec![PropertyInfo::readonly(
@@ -1200,21 +1008,9 @@ fn test_conditional_infer_object_property_readonly_non_distributive_union_input(
 fn test_conditional_infer_object_property_readonly_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { readonly a: infer R } ? R : never, with T = { readonly a: string } | number (no distribution).
     let extends_obj = interner.object(vec![PropertyInfo::readonly(
@@ -1247,21 +1043,9 @@ fn test_conditional_infer_object_property_readonly_non_distributive_union_branch
 fn test_conditional_infer_object_property_readonly_wrapper_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends Readonly<{ a: infer R }> ? R : never,
     // with T = Readonly<{ a: string }> | { a: number } (no distribution).
@@ -1302,21 +1086,9 @@ fn test_conditional_infer_object_property_readonly_wrapper_non_distributive_unio
 fn test_conditional_infer_object_property_readonly_wrapper_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends Readonly<{ a: infer R }> ? R : never,
     // with T = Readonly<{ a: string }> | number (no distribution).
@@ -1352,21 +1124,9 @@ fn test_conditional_infer_object_property_readonly_wrapper_non_distributive_unio
 fn test_conditional_infer_object_property_function_return_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { a: () => infer R } ? R : never, with T = { a: () => string } | { a: () => number }.
     let extends_fn = interner.function(FunctionShape {
@@ -1431,21 +1191,9 @@ fn test_conditional_infer_object_property_function_return_distributive() {
 fn test_conditional_infer_template_literal_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends `${infer R}` ? R : never, with T = "foo" | "bar".
     let extends_template = interner.template_literal(vec![TemplateSpan::Type(infer_r)]);
@@ -1474,21 +1222,9 @@ fn test_conditional_infer_template_literal_distributive() {
 fn test_conditional_infer_template_literal_with_prefix_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends `foo${infer R}` ? R : never, with T = "foo1" | "bar".
     let extends_template = interner.template_literal(vec![
@@ -1520,21 +1256,9 @@ fn test_conditional_infer_template_literal_with_prefix_distributive() {
 fn test_conditional_infer_template_literal_with_suffix_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends `${infer R}bar` ? R : never, with T = "foobar" | "baz".
     let extends_template = interner.template_literal(vec![
@@ -1576,13 +1300,7 @@ fn eval_single_placeholder_infer(
     constraint: Option<TypeId>,
     source: TypeId,
 ) -> TypeId {
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(interner, "T");
 
     let infer_name = interner.intern_string(infer_var);
     let infer_v = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -1663,21 +1381,9 @@ fn test_single_placeholder_infer_extends_boolean_takes_false_branch() {
 fn test_conditional_infer_template_literal_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [`foo${infer R}`] ? R : never, with T = "foo1" | "foo2" (no distribution).
     let extends_template = interner.template_literal(vec![
@@ -1722,21 +1428,9 @@ fn test_conditional_infer_template_literal_non_distributive_union_input() {
 fn test_conditional_infer_template_literal_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [`foo${infer R}`] ? R : never, with T = "foo1" | "bar" (no distribution).
     let extends_template = interner.template_literal(vec![

--- a/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_functions.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_functions.rs
@@ -2,21 +2,9 @@
 fn test_conditional_infer_object_call_signature_optional_param_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { (x?: infer R): void } ? R : never, with T = { (x?: string): void }
     // | { (x?: number): void }.
@@ -109,21 +97,9 @@ fn test_conditional_infer_object_call_signature_optional_param_distributive() {
 fn test_conditional_infer_object_call_signature_optional_param_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [{ (x?: infer R): void }] ? R : never, with T = { (x?: string): void }
     // | { (x?: number): void }.
@@ -227,21 +203,9 @@ fn test_conditional_infer_object_call_signature_optional_param_non_distributive_
 fn test_conditional_infer_object_call_signature_rest_param_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { (...args: infer R): void } ? R : never, with T = { (...args: string[]): void }
     // | { (...args: number[]): void }.
@@ -337,21 +301,9 @@ fn test_conditional_infer_object_call_signature_rest_param_distributive() {
 fn test_conditional_infer_object_call_signature_rest_param_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [{ (...args: infer R): void }] ? R : never, with T = { (...args: string[]): void }
     // | { (...args: number[]): void }.
@@ -458,21 +410,9 @@ fn test_conditional_infer_object_call_signature_rest_param_non_distributive_unio
 fn test_conditional_infer_object_call_signature_non_callable_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { (x: infer R): void } ? R : never, with T = { (x: string): void } | number.
     let extends_callable = interner.callable(CallableShape {
@@ -532,21 +472,9 @@ fn test_conditional_infer_object_call_signature_non_callable_union_branch() {
 fn test_conditional_infer_object_call_signature_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [{ (x: infer R): void }] ? R : never, with T = { (x: string): void } | number.
     let extends_callable = interner.callable(CallableShape {
@@ -616,21 +544,9 @@ fn test_conditional_infer_object_call_signature_non_distributive_union_branch() 
 fn test_conditional_infer_object_call_signature_overload_source_non_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [{ (x: infer R): void }] ? R : never, with T = { (x: string): void; (x: number): void }.
     let extends_callable = interner.callable(CallableShape {
@@ -707,21 +623,9 @@ fn test_conditional_infer_object_call_signature_overload_source_non_distributive
 fn test_conditional_infer_object_property_non_distributive_union_all_match() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [{ a: infer R }] ? R : never, with T = { a: string } | { a: number }.
     let extends_obj = interner.object(vec![PropertyInfo::new(
@@ -769,21 +673,9 @@ fn test_conditional_infer_object_property_non_distributive_union_all_match() {
 fn test_conditional_infer_object_property_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [{ a: infer R }] ? R : never, with T = { a: string } | number.
     let extends_obj = interner.object(vec![PropertyInfo::new(
@@ -826,21 +718,9 @@ fn test_conditional_infer_object_property_non_distributive_union_branch() {
 fn test_conditional_infer_tuple_element_extraction() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends [infer R] ? R : never, with T = [string] | [number].
     let extends_tuple = interner.tuple(vec![TupleElement {
@@ -888,21 +768,9 @@ fn test_conditional_infer_tuple_element_extraction() {
 fn test_conditional_infer_tuple_optional_element_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends [infer R?] ? R : never, with T = [string] | [].
     let extends_tuple = interner.tuple(vec![TupleElement {
@@ -941,21 +809,9 @@ fn test_conditional_infer_tuple_optional_element_distributive() {
 fn test_conditional_infer_tuple_optional_element_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends [infer R?] ? R : never, with T = [string] | [] (no distribution).
     let extends_tuple = interner.tuple(vec![TupleElement {
@@ -994,21 +850,9 @@ fn test_conditional_infer_tuple_optional_element_non_distributive_union_input() 
 fn test_conditional_infer_tuple_optional_element_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends [infer R?] ? R : never, with T = [string] | number (no distribution).
     let extends_tuple = interner.tuple(vec![TupleElement {
@@ -1045,21 +889,9 @@ fn test_conditional_infer_tuple_optional_element_non_distributive_union_branch()
 fn test_conditional_infer_tuple_element_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends [infer R] ? R : never, with T = [string] | [number] (no distribution).
     let extends_tuple = interner.tuple(vec![TupleElement {
@@ -1107,21 +939,9 @@ fn test_conditional_infer_tuple_element_non_distributive_union_input() {
 fn test_conditional_infer_tuple_element_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends [infer R] ? R : never, with T = [string] | number (no distribution).
     let extends_tuple = interner.tuple(vec![TupleElement {
@@ -1158,21 +978,9 @@ fn test_conditional_infer_tuple_element_non_distributive_union_branch() {
 fn test_conditional_infer_tuple_element_non_tuple_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends [infer R] ? R : never, with T = [string] | number.
     let extends_tuple = interner.tuple(vec![TupleElement {
@@ -1209,13 +1017,7 @@ fn test_conditional_infer_tuple_element_non_tuple_union_branch() {
 fn test_conditional_infer_tuple_element_with_constraint() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_name = interner.intern_string("R");
     let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -1270,13 +1072,7 @@ fn test_conditional_infer_tuple_element_with_constraint() {
 fn test_conditional_infer_optional_tuple_element_with_constraint() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_name = interner.intern_string("R");
     let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -1331,21 +1127,9 @@ fn test_conditional_infer_optional_tuple_element_with_constraint() {
 fn test_conditional_infer_tuple_rest_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends [string, ...infer R] ? R : never, with T = [string, number] | [string].
     let extends_tuple = interner.tuple(vec![
@@ -1417,28 +1201,10 @@ fn test_conditional_infer_tuple_rest_distributive() {
 fn test_conditional_infer_tuple_rest_with_head_infer_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_h_name = interner.intern_string("H");
-    let infer_h = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_h_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_r_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_r_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_h_name, infer_h) = test_infer_param(&interner, "H");
+    let (_infer_r_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends [infer H, ...infer R] ? R : never, with T = [string, number] | [boolean].
     let extends_tuple = interner.tuple(vec![
@@ -1510,21 +1276,9 @@ fn test_conditional_infer_tuple_rest_with_head_infer_distributive() {
 fn test_conditional_infer_union_true_branch_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends string ? R | number : never, with T = string | boolean.
     // Infer appears only in the true branch; ensure it is preserved.
@@ -1553,21 +1307,9 @@ fn test_conditional_infer_union_true_branch_distributive() {
 fn test_conditional_infer_union_false_branch_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends string ? never : R | number, with T = string | boolean.
     // Infer appears only in the false branch; ensure it is preserved.
@@ -1596,13 +1338,7 @@ fn test_conditional_infer_union_false_branch_distributive() {
 fn test_conditional_infer_any_check_type_distributive() {
     let interner = TypeInterner::new();
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // any extends string ? infer R : never
     // any produces union of branches; infer should survive in true branch.
@@ -1622,21 +1358,9 @@ fn test_conditional_infer_any_check_type_distributive() {
 fn test_conditional_infer_readonly_array_element_extraction() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends readonly (infer R)[] ? R : never, with T = readonly string[] | readonly number[].
     let extends_array = interner.intern(TypeData::ReadonlyType(interner.array(infer_r)));
@@ -1670,21 +1394,9 @@ fn test_conditional_infer_readonly_array_element_extraction() {
 fn test_conditional_infer_readonly_array_element_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends readonly (infer R)[] ? R : never, with T = readonly string[] | readonly number[] (no distribution).
     let extends_array = interner.intern(TypeData::ReadonlyType(interner.array(infer_r)));
@@ -1718,21 +1430,9 @@ fn test_conditional_infer_readonly_array_element_non_distributive_union_input() 
 fn test_conditional_infer_readonly_array_element_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends readonly (infer R)[] ? R : never, with T = readonly string[] | number (no distribution).
     let extends_array = interner.intern(TypeData::ReadonlyType(interner.array(infer_r)));

--- a/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_objects.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_objects.rs
@@ -2,21 +2,9 @@
 fn test_conditional_infer_template_literal_from_string_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends `${infer R}` ? R : never, with T = string.
     // tsc: primitive `string` does NOT extend a template literal pattern → never.
@@ -43,21 +31,9 @@ fn test_conditional_infer_template_literal_from_string_input() {
 fn test_conditional_infer_template_literal_from_template_string_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends `${infer R}` ? R : never, with T = `${string}`.
     // `${string}` spans the full string domain and collapses to `string`, and
@@ -90,21 +66,9 @@ fn test_conditional_infer_template_literal_from_template_string_input() {
 fn test_conditional_infer_template_literal_with_middle_infer_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends `foo${infer R}bar` ? R : never, with T = "foobazbar" | "bar".
     let extends_template = interner.template_literal(vec![
@@ -137,28 +101,10 @@ fn test_conditional_infer_template_literal_with_middle_infer_distributive() {
 fn test_conditional_infer_template_literal_two_infers_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_a_name = interner.intern_string("A");
-    let infer_a = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_a_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_b_name = interner.intern_string("B");
-    let infer_b = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_b_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_a_name, infer_a) = test_infer_param(&interner, "A");
+    let (_infer_b_name, infer_b) = test_infer_param(&interner, "B");
 
     // T extends `${infer A}-${infer B}` ? A | B : never, with T = "foo-bar" | "baz-qux".
     let extends_template = interner.template_literal(vec![
@@ -196,13 +142,7 @@ fn test_conditional_infer_template_literal_two_infers_distributive() {
 fn test_conditional_infer_template_literal_with_constrained_infer_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_name = interner.intern_string("R");
     let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -250,13 +190,7 @@ fn test_conditional_primitive_string_does_not_match_template_infer_pattern() {
     let interner = TypeInterner::new();
 
     // Infer variable name R (test: rule holds regardless of name choice)
-    let infer_name_r = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name_r,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name_r, infer_r) = test_infer_param(&interner, "R");
 
     // `string extends \`${infer R}\` ? true : false` — non-distributive direct check
     let extends_template = interner.template_literal(vec![TemplateSpan::Type(infer_r)]);
@@ -283,13 +217,7 @@ fn test_conditional_primitive_string_does_not_match_template_infer_pattern() {
 fn test_conditional_primitive_string_does_not_match_template_infer_pattern_any_name() {
     let interner = TypeInterner::new();
 
-    let infer_name_x = interner.intern_string("X");
-    let infer_x = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name_x,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name_x, infer_x) = test_infer_param(&interner, "X");
 
     let extends_template = interner.template_literal(vec![TemplateSpan::Type(infer_x)]);
     let cond = ConditionalType {
@@ -310,13 +238,7 @@ fn test_conditional_primitive_string_does_not_match_template_infer_pattern_any_n
 fn test_conditional_primitive_string_prefixed_template_stays_false() {
     let interner = TypeInterner::new();
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     let prefix = interner.intern_string("prefix_");
     let extends_template = interner.template_literal(vec![
@@ -341,13 +263,7 @@ fn test_conditional_primitive_string_prefixed_template_stays_false() {
 fn test_conditional_string_literal_still_matches_template_infer_pattern() {
     let interner = TypeInterner::new();
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     let extends_template = interner.template_literal(vec![TemplateSpan::Type(infer_r)]);
     let cond = ConditionalType {
@@ -371,13 +287,7 @@ fn test_conditional_string_literal_still_matches_template_infer_pattern() {
 fn test_conditional_template_literal_source_still_matches_template_infer_pattern() {
     let interner = TypeInterner::new();
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     let prefix = interner.intern_string("x");
     let source_template = interner.template_literal(vec![
@@ -404,21 +314,9 @@ fn test_conditional_template_literal_source_still_matches_template_infer_pattern
 fn test_conditional_infer_nested_object_property_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { a: { b: infer R } } ? R : never, with T = { a: { b: string } } | { a: { b: number } }.
     let extends_inner = interner.object(vec![PropertyInfo::new(
@@ -468,21 +366,9 @@ fn test_conditional_infer_nested_object_property_distributive() {
 fn test_conditional_infer_nested_object_property_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { a: { b: infer R } } ? R : never, with T = { a: { b: string } } | { a: { b: number } } (no distribution).
     let extends_inner = interner.object(vec![PropertyInfo::new(
@@ -532,21 +418,9 @@ fn test_conditional_infer_nested_object_property_non_distributive_union_input() 
 fn test_conditional_infer_nested_object_property_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { a: { b: infer R } } ? R : never, with T = { a: { b: string } } | number (no distribution).
     let extends_inner = interner.object(vec![PropertyInfo::new(
@@ -587,13 +461,7 @@ fn test_conditional_infer_nested_object_property_non_distributive_union_branch()
 fn test_conditional_infer_nested_object_property_with_constraint() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_name = interner.intern_string("R");
     let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -650,21 +518,9 @@ fn test_conditional_infer_nested_object_property_with_constraint() {
 fn test_conditional_infer_nested_object_property_readonly() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { readonly a: { b: infer R } } ? R : never, with T = { readonly a: { b: string } } | { a: { b: number } }.
     let extends_inner = interner.object(vec![PropertyInfo::new(
@@ -714,21 +570,9 @@ fn test_conditional_infer_nested_object_property_readonly() {
 fn test_conditional_infer_nested_object_property_readonly_wrapper() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { a: Readonly<{ b: infer R }> } ? R : never,
     // with T = { a: Readonly<{ b: string }> } | { a: { b: number } }.
@@ -781,21 +625,9 @@ fn test_conditional_infer_nested_object_property_readonly_wrapper() {
 fn test_conditional_infer_nested_object_property_readonly_wrapper_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { a: Readonly<{ b: infer R }> } ? R : never,
     // with T = { a: Readonly<{ b: string }> } | { a: { b: number } } (no distribution).
@@ -848,21 +680,9 @@ fn test_conditional_infer_nested_object_property_readonly_wrapper_non_distributi
 fn test_conditional_infer_nested_object_property_readonly_wrapper_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { a: Readonly<{ b: infer R }> } ? R : never,
     // with T = { a: Readonly<{ b: string }> } | number (no distribution).
@@ -906,21 +726,9 @@ fn test_conditional_infer_nested_object_property_readonly_wrapper_non_distributi
 fn test_conditional_infer_nested_object_property_non_matching_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { a: { b: infer R } } ? R : never, with T = { a: { b: string } } | { a: { c: number } }.
     let extends_inner = interner.object(vec![PropertyInfo::new(
@@ -971,21 +779,9 @@ fn test_conditional_infer_nested_object_property_non_matching_branch() {
 fn test_conditional_infer_nested_object_property_union_value() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { a: { b: infer R } } ? R : never, with T = { a: { b: string | number } }.
     let extends_inner = interner.object(vec![PropertyInfo::new(
@@ -1024,21 +820,9 @@ fn test_conditional_infer_nested_object_property_union_value() {
 fn test_conditional_infer_object_property_non_object_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { a: infer R } ? R : never, with T = { a: string } | number.
     let extends_obj = interner.object(vec![PropertyInfo::new(
@@ -1073,21 +857,9 @@ fn test_conditional_infer_object_property_non_object_union_branch() {
 fn test_conditional_infer_object_property_non_distributive_non_object_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [{ a: infer R }] ? R : never, with T = { a: string } | number (no distribution).
     let extends_obj = interner.object(vec![PropertyInfo::new(
@@ -1130,21 +902,9 @@ fn test_conditional_infer_object_property_non_distributive_non_object_union_bran
 fn test_conditional_infer_object_index_signature_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { [key: string]: infer R } ? R : never, with T = { a: string } | { b: number }.
     let extends_obj = interner.object_with_index(ObjectShape {
@@ -1190,21 +950,9 @@ fn test_conditional_infer_object_index_signature_distributive() {
 fn test_conditional_infer_number_index_signature_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { [key: number]: infer R } ? R : never, with T = { 0: string } | { 1: number }.
     let extends_obj = interner.object_with_index(ObjectShape {
@@ -1250,21 +998,9 @@ fn test_conditional_infer_number_index_signature_distributive() {
 fn test_conditional_infer_number_index_signature_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { [key: number]: infer R } ? R : never, with T = { 0: string } | { 1: number } (no distribution).
     let extends_obj = interner.object_with_index(ObjectShape {
@@ -1310,21 +1046,9 @@ fn test_conditional_infer_number_index_signature_non_distributive_union_input() 
 fn test_conditional_infer_number_index_signature_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { [key: number]: infer R } ? R : never, with T = { 0: string } | number (no distribution).
     let extends_obj = interner.object_with_index(ObjectShape {
@@ -1365,21 +1089,9 @@ fn test_conditional_infer_number_index_signature_non_distributive_union_branch()
 fn test_conditional_infer_object_index_signature_non_object_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { [key: string]: infer R } ? R : never, with T = { a: string } | number.
     let extends_obj = interner.object_with_index(ObjectShape {
@@ -1420,21 +1132,9 @@ fn test_conditional_infer_object_index_signature_non_object_union_branch() {
 fn test_conditional_infer_object_index_signature_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { [key: string]: infer R } ? R : never, with T = { a: string } | { b: number } (no distribution).
     let extends_obj = interner.object_with_index(ObjectShape {
@@ -1480,21 +1180,9 @@ fn test_conditional_infer_object_index_signature_non_distributive_union_input() 
 fn test_conditional_infer_object_index_signature_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { [key: string]: infer R } ? R : never, with T = { a: string } | number (no distribution).
     let extends_obj = interner.object_with_index(ObjectShape {
@@ -1535,21 +1223,9 @@ fn test_conditional_infer_object_index_signature_non_distributive_union_branch()
 fn test_conditional_infer_optional_property_missing_object() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { a?: infer R } ? R : never, with T = {}.
     let extends_obj = interner.object(vec![PropertyInfo::opt(
@@ -1579,21 +1255,9 @@ fn test_conditional_infer_optional_property_missing_object() {
 fn test_conditional_infer_optional_property_present_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { a?: infer R } ? R : never, with T = { a?: string } | { a?: number }.
     let extends_obj = interner.object(vec![PropertyInfo::opt(
@@ -1631,13 +1295,7 @@ fn test_conditional_infer_optional_property_present_distributive() {
 fn test_conditional_infer_optional_property_with_constraint() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_name = interner.intern_string("R");
     let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -1682,21 +1340,9 @@ fn test_conditional_infer_optional_property_with_constraint() {
 fn test_conditional_infer_optional_property_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [{ a?: infer R }] ? R : never, with T = { a: string } | {} (no distribution).
     let extends_obj = interner.object(vec![PropertyInfo::opt(
@@ -1741,21 +1387,9 @@ fn test_conditional_infer_optional_property_non_distributive_union_input() {
 fn test_conditional_infer_optional_property_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [{ a?: infer R }] ? R : never, with T = { a: string } | number (no distribution).
     let extends_obj = interner.object(vec![PropertyInfo::opt(

--- a/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_templates.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_templates.rs
@@ -2,21 +2,9 @@
 fn test_conditional_infer_object_property_intersection_check() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { a: infer R } ? R : never, with T = { a: string } & { b: number }.
     let extends_obj = interner.object(vec![PropertyInfo::new(
@@ -54,21 +42,9 @@ fn test_conditional_infer_object_property_intersection_check() {
 fn test_conditional_infer_function_param_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends (arg: infer R) => void ? R : never, with T = ((arg: string) => void)
     // | ((arg: number) => void).
@@ -122,21 +98,9 @@ fn test_conditional_infer_function_param_distributive() {
 fn test_conditional_infer_function_optional_param_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends (arg?: infer R) => void ? R : never, with T = ((arg?: string) => void)
     // | ((arg?: number) => void).
@@ -205,21 +169,9 @@ fn test_conditional_infer_function_optional_param_distributive() {
 fn test_conditional_infer_function_optional_param_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [(arg?: infer R) => void] ? R : never, with T = ((arg?: string) => void)
     // | ((arg?: number) => void).
@@ -300,21 +252,9 @@ fn test_conditional_infer_function_optional_param_non_distributive_union_input()
 fn test_conditional_infer_function_param_non_function_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends (arg: infer R) => void ? R : never, with T = ((arg: string) => void) | number.
     let extends_fn = interner.function(FunctionShape {
@@ -357,21 +297,9 @@ fn test_conditional_infer_function_param_non_function_union_branch() {
 fn test_conditional_infer_function_param_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [(arg: infer R) => void] ? R : never, with T = ((arg: string) => void)
     // | ((arg: number) => void).
@@ -438,21 +366,9 @@ fn test_conditional_infer_function_param_non_distributive_union_input() {
 fn test_conditional_infer_function_param_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [(arg: infer R) => void] ? R : never, with T = ((arg: string) => void) | number.
     let extends_fn = interner.function(FunctionShape {
@@ -505,21 +421,9 @@ fn test_conditional_infer_function_param_non_distributive_union_branch() {
 fn test_conditional_infer_function_rest_param_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends (...args: infer R) => void ? R : never, with T = ((...args: string[]) => void)
     // | ((...args: number[]) => void).
@@ -591,21 +495,9 @@ fn test_conditional_infer_function_rest_param_distributive() {
 fn test_conditional_infer_function_rest_param_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [(...args: infer R) => void] ? R : never, with T = ((...args: string[]) => void)
     // | ((...args: number[]) => void).
@@ -689,21 +581,9 @@ fn test_conditional_infer_function_rest_param_non_distributive_union_input() {
 fn test_conditional_infer_function_rest_param_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [(...args: infer R) => void] ? R : never, with T = ((...args: string[]) => void)
     // | number.
@@ -767,21 +647,9 @@ fn test_conditional_infer_function_rest_param_non_distributive_union_branch() {
 fn test_conditional_infer_function_this_param_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends (this: infer R) => void ? R : never, with T = ((this: string) => void)
     // | ((this: number) => void).
@@ -835,21 +703,9 @@ fn test_conditional_infer_function_this_param_distributive() {
 fn test_conditional_infer_function_this_param_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [(this: infer R) => void] ? R : never, with T = ((this: string) => void)
     // | ((this: number) => void).
@@ -913,21 +769,9 @@ fn test_conditional_infer_function_this_param_non_distributive_union_input() {
 fn test_conditional_infer_function_this_param_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [(this: infer R) => void] ? R : never, with T = ((this: string) => void)
     // | number.
@@ -981,21 +825,9 @@ fn test_conditional_infer_function_this_param_non_distributive_union_branch() {
 fn test_conditional_infer_function_return_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends () => infer R ? R : never, with T = (() => string) | (() => number).
     let extends_fn = interner.function(FunctionShape {
@@ -1048,21 +880,9 @@ fn test_conditional_infer_function_return_distributive() {
 fn test_conditional_infer_function_return_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [() => infer R] ? R : never, with T = (() => string) | (() => number).
     let extends_fn = interner.function(FunctionShape {
@@ -1125,29 +945,11 @@ fn test_conditional_infer_function_return_non_distributive_union_input() {
 fn test_conditional_infer_function_param_and_return_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let p_name = interner.intern_string("P");
-    let infer_p = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: p_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_p_name, infer_p) = test_infer_param(&interner, "P");
 
-    let r_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: r_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_r_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends (arg: infer P) => infer R ? [P, R] : never, with T = ((arg: string) => number)
     // | ((arg: boolean) => string).
@@ -1246,21 +1048,9 @@ fn test_conditional_infer_function_param_and_return_distributive() {
 fn test_conditional_infer_function_return_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [() => infer R] ? R : never, with T = (() => string) | number.
     let extends_fn = interner.function(FunctionShape {
@@ -1313,29 +1103,11 @@ fn test_conditional_infer_function_return_non_distributive_union_branch() {
 fn test_conditional_infer_function_param_and_return_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let p_name = interner.intern_string("P");
-    let infer_p = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: p_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_p_name, infer_p) = test_infer_param(&interner, "P");
 
-    let r_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: r_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_r_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [(arg: infer P) => infer R] ? [P, R] : never, with T = ((arg: string) => number)
     // | ((arg: boolean) => string).
@@ -1433,21 +1205,9 @@ fn test_conditional_infer_function_param_and_return_non_distributive_union_input
 fn test_conditional_infer_object_call_signature_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { (x: infer R): void } ? R : never, with T = { (x: string): void }
     // | { (x: number): void }.
@@ -1525,21 +1285,9 @@ fn test_conditional_infer_object_call_signature_distributive() {
 fn test_conditional_infer_call_signature_param_from_function_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { (x: infer R): void } ? R : never, with T = ((x: string) => void)
     // | ((x: number) => void).
@@ -1600,21 +1348,9 @@ fn test_conditional_infer_call_signature_param_from_function_distributive() {
 fn test_conditional_infer_call_signature_return_from_function_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends { (): infer R } ? R : never, with T = (() => string) | (() => number).
     let extends_callable = interner.callable(CallableShape {
@@ -1674,21 +1410,9 @@ fn test_conditional_infer_call_signature_return_from_function_distributive() {
 fn test_conditional_infer_object_call_signature_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // [T] extends [{ (x: infer R): void }] ? R : never, with T = { (x: string): void }
     // | { (x: number): void }.

--- a/crates/tsz-solver/tests/evaluate_tests_parts/distributive_conditionals.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/distributive_conditionals.rs
@@ -6,21 +6,9 @@ fn test_distributive_with_infer_in_true_branch() {
     // Result: string | number
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("V");
-    let infer_v = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_v) = test_infer_param(&interner, "V");
 
     let value_atom = interner.intern_string("value");
     let other_atom = interner.intern_string("other");
@@ -61,13 +49,7 @@ fn test_distributive_exclude_utility() {
     // Exclude<"a" | "b" | "c", "a"> = "b" | "c"
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_a = interner.literal_string("a");
     let lit_b = interner.literal_string("b");
@@ -100,13 +82,7 @@ fn test_distributive_extract_utility() {
     // Extract<"a" | 1 | "b" | 2, string> = "a" | "b"
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_a = interner.literal_string("a");
     let lit_b = interner.literal_string("b");
@@ -140,13 +116,7 @@ fn test_distributive_non_nullable_utility() {
     // NonNullable<string | null | undefined | number> = string | number
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let null_or_undefined = interner.union(vec![TypeId::NULL, TypeId::UNDEFINED]);
 
@@ -187,13 +157,7 @@ fn test_distributive_deeply_nested_union() {
     // Result: "s" | "n" | "b" | "x"
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_s = interner.literal_string("s");
     let lit_n = interner.literal_string("n");
@@ -255,13 +219,7 @@ fn test_distributive_with_never_input() {
     // Distribution over never: never
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_fallback = interner.literal_string("fallback");
 
@@ -290,13 +248,7 @@ fn test_distributive_with_any_input() {
     // any distributes to both branches, result is 1 | 2
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_1 = interner.literal_number(1.0);
     let lit_2 = interner.literal_number(2.0);
@@ -327,13 +279,7 @@ fn test_distributive_single_member_union() {
     // Result: "a"
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_a = interner.literal_string("a");
 
@@ -363,13 +309,7 @@ fn test_distributive_with_duplicate_results() {
     // Result: 1 | 2 (deduplicated)
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_a = interner.literal_string("a");
     let lit_1 = interner.literal_number(1.0);
@@ -411,21 +351,9 @@ fn test_distributive_preserves_tuple_structure() {
     // Result: string | number
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     let extends_tuple = interner.tuple(vec![TupleElement {
         type_id: infer_r,
@@ -474,13 +402,7 @@ fn test_distributive_with_constrained_infer() {
     // Result: string
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_name = interner.intern_string("R");
     let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -525,13 +447,7 @@ fn test_distributive_intrinsic_union() {
     // Result: "obj" | "prim"
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_obj = interner.literal_string("obj");
     let lit_prim = interner.literal_string("prim");
@@ -689,13 +605,7 @@ fn test_distributive_function_types() {
     // Result: "func" | "other"
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_func = interner.literal_string("func");
     let lit_other = interner.literal_string("other");
@@ -765,21 +675,9 @@ fn test_distributive_readonly_array() {
     // Result: string | number
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     let extends_array = interner.intern(TypeData::ReadonlyType(interner.array(infer_r)));
 
@@ -822,13 +720,7 @@ fn test_distributive_literal_union_exhaustive() {
     // Result: 0 | 1 | 2 | 3
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_a = interner.literal_string("a");
     let lit_b = interner.literal_string("b");
@@ -886,21 +778,9 @@ fn test_distributive_multiple_arrays() {
     // Result: string | number
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // R[][] = Array<Array<R>>
     let extends_nested_array = interner.array(interner.array(infer_r));
@@ -941,13 +821,7 @@ fn test_distributive_keyof_filter() {
     // Result: "a" | "b" | 1 | symbol (all are valid keyof types)
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_a = interner.literal_string("a");
     let lit_b = interner.literal_string("b");
@@ -988,13 +862,7 @@ fn test_distributive_mixed_primitive_union() {
     // Result: "primitive" | "other"
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_primitive = interner.literal_string("primitive");
     let lit_other = interner.literal_string("other");
@@ -1041,13 +909,7 @@ fn test_distributive_very_large_union() {
     // T extends string ? "yes" : "no", with T = mix of 25 strings and 25 numbers
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_yes = interner.literal_string("yes");
     let lit_no = interner.literal_string("no");
@@ -1091,13 +953,7 @@ fn test_distributive_all_to_same_result() {
     // Result: "primitive" (single value, not union)
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_primitive = interner.literal_string("primitive");
     let lit_other = interner.literal_string("other");
@@ -1133,13 +989,7 @@ fn test_distributive_identity_preservation() {
     // Result: "a" | 1 | true
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_a = interner.literal_string("a");
     let lit_1 = interner.literal_number(1.0);
@@ -1172,29 +1022,11 @@ fn test_distributive_two_infers_different_positions() {
     // Result: [string, number] | [boolean, symbol]
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_a_name = interner.intern_string("A");
-    let infer_a = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_a_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_a_name, infer_a) = test_infer_param(&interner, "A");
 
-    let infer_b_name = interner.intern_string("B");
-    let infer_b = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_b_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_b_name, infer_b) = test_infer_param(&interner, "B");
 
     let prop_a = interner.intern_string("a");
     let prop_b = interner.intern_string("b");
@@ -1285,21 +1117,9 @@ fn test_distributive_infer_return_type() {
     // Expected result is string | number (extracted from function return types)
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     let pattern_fn = interner.function(FunctionShape {
         params: Vec::new(),
@@ -1361,13 +1181,7 @@ fn test_distributive_union_of_unions() {
     // Result: 1 | 2
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_1 = interner.literal_number(1.0);
     let lit_2 = interner.literal_number(2.0);
@@ -1408,13 +1222,7 @@ fn test_distributive_boolean_literals() {
     // Result: "yes" | "no" | "other"
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_true = interner.literal_boolean(true);
     let lit_false = interner.literal_boolean(false);
@@ -1461,13 +1269,7 @@ fn test_distributive_with_unknown() {
     // Everything extends unknown, so result = string | number | null
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let cond = ConditionalType {
         check_type: t_param,
@@ -1496,13 +1298,7 @@ fn test_distributive_partial_object_match() {
     // Result: string | "no-x" | boolean
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let x_atom = interner.intern_string("x");
     let y_atom = interner.intern_string("y");
@@ -1546,13 +1342,7 @@ fn test_distributive_hundred_member_union() {
     // Stress test with 100 union members
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_match = interner.literal_string("match");
     let lit_no_match = interner.literal_string("no-match");
@@ -1596,13 +1386,7 @@ fn test_distributive_triple_nested_conditional() {
     // Result: 0 | 1 | 2 | 3 | 4
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_a = interner.literal_string("a");
     let lit_b = interner.literal_string("b");
@@ -1670,13 +1454,7 @@ fn test_distributive_no_false_branch_matches() {
     // Result: never
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let cond = ConditionalType {
         check_type: t_param,
@@ -1708,13 +1486,7 @@ fn test_distributive_empty_object_match() {
     // In TypeScript, string and number extend {}, but null doesn't
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_object_like = interner.literal_string("object-like");
     let lit_primitive = interner.literal_string("primitive");
@@ -1758,13 +1530,7 @@ fn test_distributive_literal_type_filter() {
     // Result: "a" | "b" | "c"
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_a = interner.literal_string("a");
     let lit_b = interner.literal_string("b");

--- a/crates/tsz-solver/tests/evaluate_tests_parts/indexed_access_conditionals.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/indexed_access_conditionals.rs
@@ -2,21 +2,9 @@
 fn test_conditional_infer_readonly_array_element_non_array_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends readonly (infer R)[] ? R : never, with T = readonly string[] | number.
     let extends_array = interner.intern(TypeData::ReadonlyType(interner.array(infer_r)));
@@ -47,21 +35,9 @@ fn test_conditional_infer_readonly_array_element_non_array_union_branch() {
 fn test_conditional_infer_readonly_tuple_element_extraction() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends readonly [infer R] ? R : never, with T = readonly [string] | readonly [number].
     let extends_tuple =
@@ -111,21 +87,9 @@ fn test_conditional_infer_readonly_tuple_element_extraction() {
 fn test_conditional_infer_readonly_tuple_element_non_distributive_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends readonly [infer R] ? R : never, with T = readonly [string] | readonly [number] (no distribution).
     let extends_tuple =
@@ -175,21 +139,9 @@ fn test_conditional_infer_readonly_tuple_element_non_distributive_union_input() 
 fn test_conditional_infer_readonly_tuple_element_non_distributive_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends readonly [infer R] ? R : never, with T = readonly [string] | number (no distribution).
     let extends_tuple =
@@ -231,21 +183,9 @@ fn test_conditional_infer_readonly_tuple_element_non_distributive_union_branch()
 fn test_conditional_infer_readonly_tuple_element_non_tuple_union_branch() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends readonly [infer R] ? R : never, with T = readonly [string] | number.
     let extends_tuple =
@@ -287,21 +227,9 @@ fn test_conditional_infer_readonly_tuple_element_non_tuple_union_branch() {
 fn test_conditional_infer_readonly_array_mixed_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends readonly (infer R)[] ? R : never, with T = readonly string[] | number[].
     let extends_array = interner.intern(TypeData::ReadonlyType(interner.array(infer_r)));
@@ -334,13 +262,7 @@ fn test_conditional_infer_readonly_array_mixed_input() {
 fn test_conditional_instantiated_param_tuple_wrapper_no_distribution() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let string_or_number = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
     let lit_true = interner.literal_boolean(true);
@@ -439,12 +361,7 @@ fn test_conditional_deferred_type_parameter() {
 
     // T extends string ? number : boolean
     // Should remain deferred when T is an unsubstituted type parameter
-    let type_param_t = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: interner.intern_string("T"),
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let type_param_t = test_type_param(&interner, "T").1;
 
     let cond = ConditionalType {
         check_type: type_param_t,
@@ -528,13 +445,7 @@ fn test_conditional_deferred_type_parameter_constraint_not_satisfying() {
 fn test_conditional_infer_direct_match() {
     let interner = TypeInterner::new();
 
-    let r_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: r_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_r_name, infer_r) = test_infer_param(&interner, "R");
 
     // string extends infer R ? R : never -> string
     let cond = ConditionalType {
@@ -579,21 +490,9 @@ fn test_conditional_infer_constraint_mismatch() {
 fn test_conditional_distributive_infer_array_extends() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let r_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: r_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_r_name, infer_r) = test_infer_param(&interner, "R");
 
     // T extends Array<infer R> ? R : never
     let cond = ConditionalType {
@@ -623,21 +522,9 @@ fn test_conditional_distributive_infer_array_extends() {
 fn test_conditional_nested_distributive_infer() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let r_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: r_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_r_name, infer_r) = test_infer_param(&interner, "R");
 
     let yes = interner.literal_string("yes");
     let no = interner.literal_string("no");
@@ -677,13 +564,7 @@ fn test_conditional_nested_distributive_infer() {
 fn test_conditional_infer_object_property() {
     let interner = TypeInterner::new();
 
-    let r_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: r_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_r_name, infer_r) = test_infer_param(&interner, "R");
 
     let prop_name = interner.intern_string("a");
     let source = interner.object(vec![PropertyInfo::new(prop_name, TypeId::STRING)]);
@@ -706,13 +587,7 @@ fn test_conditional_infer_object_property() {
 fn test_conditional_infer_object_string_index_signature() {
     let interner = TypeInterner::new();
 
-    let r_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: r_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_r_name, infer_r) = test_infer_param(&interner, "R");
 
     let source = interner.object_with_index(ObjectShape {
         symbol: None,
@@ -1236,12 +1111,7 @@ fn test_index_access_type_param_constraint() {
 fn test_index_access_type_param_no_constraint_deferred() {
     let interner = TypeInterner::new();
 
-    let type_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: interner.intern_string("T"),
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let type_param = test_type_param(&interner, "T").1;
 
     let key_x = interner.literal_string("x");
     let result = evaluate_index_access(&interner, type_param, key_x);

--- a/crates/tsz-solver/tests/evaluate_tests_parts/indexed_access_template_recursive.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/indexed_access_template_recursive.rs
@@ -888,21 +888,9 @@ fn test_keyof_union_of_template_literals() {
 fn test_conditional_infer_template_with_keyof_result() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("K");
-    let infer_k = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_k) = test_infer_param(&interner, "K");
 
     // Pattern: `get${infer K}Done`
     let pattern = interner.template_literal(vec![
@@ -975,29 +963,11 @@ fn test_template_literal_with_uppercase_intrinsic_pattern() {
 fn test_nested_conditional_template_literal_infer() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_r_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_r_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_r_name, infer_r) = test_infer_param(&interner, "R");
 
-    let infer_s_name = interner.intern_string("S");
-    let infer_s = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_s_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_s_name, infer_s) = test_infer_param(&interner, "S");
 
     // Outer pattern: `prefix${infer R}`
     let outer_pattern = interner.template_literal(vec![
@@ -1062,20 +1032,8 @@ fn test_recursive_template_literal_application_with_string_intrinsics() {
     };
     let s_param = interner.intern(TypeData::TypeParameter(s_param_info));
 
-    let l_name = interner.intern_string("L");
-    let infer_l = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: l_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let r_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: r_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_l_name, infer_l) = test_infer_param(&interner, "L");
+    let (_r_name, infer_r) = test_infer_param(&interner, "R");
 
     let pattern = interner.template_literal(vec![
         TemplateSpan::Type(infer_l),
@@ -1120,13 +1078,7 @@ fn test_recursive_template_literal_application_with_string_intrinsics() {
 fn test_template_literal_conditional_extends_template() {
     let interner = TypeInterner::new();
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // Pattern: `prefix${infer R}`
     let pattern = interner.template_literal(vec![
@@ -1186,13 +1138,7 @@ fn test_template_literal_escape_sequences() {
 fn test_template_literal_infer_with_special_chars() {
     let interner = TypeInterner::new();
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // Pattern with special character
     let pattern = interner.template_literal(vec![
@@ -1222,21 +1168,9 @@ fn test_template_literal_infer_with_special_chars() {
 fn test_complex_keyof_template_infer_composition() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_k_name = interner.intern_string("K");
-    let infer_k = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_k_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_k_name, infer_k) = test_infer_param(&interner, "K");
 
     // Pattern: `get${infer K}`
     let pattern = interner.template_literal(vec![
@@ -1305,29 +1239,11 @@ fn test_template_literal_with_number_interpolation() {
 fn test_template_literal_two_infers_union_input() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_a_name = interner.intern_string("A");
-    let infer_a = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_a_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_a_name, infer_a) = test_infer_param(&interner, "A");
 
-    let infer_b_name = interner.intern_string("B");
-    let infer_b = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_b_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_b_name, infer_b) = test_infer_param(&interner, "B");
 
     // Pattern: `${infer A}-${infer B}`
     let pattern = interner.template_literal(vec![
@@ -1377,13 +1293,7 @@ fn test_template_literal_two_infers_union_input() {
 fn test_template_literal_constrained_infer() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let infer_name = interner.intern_string("R");
     let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
@@ -1527,13 +1437,7 @@ fn test_template_literal_only_type_interpolation() {
 fn test_distributive_conditional_template_union() {
     let interner = TypeInterner::new();
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // Pattern: `${infer R}x`
     let pattern = interner.template_literal(vec![
@@ -1572,13 +1476,7 @@ fn test_distributive_conditional_template_union() {
 fn test_non_distributive_conditional_template_union() {
     let interner = TypeInterner::new();
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // Pattern: `${infer R}x`
     let pattern = interner.template_literal(vec![
@@ -1692,13 +1590,7 @@ fn test_template_literal_index_access_scenario() {
 fn test_template_literal_mapped_type_pattern() {
     let interner = TypeInterner::new();
 
-    let infer_s_name = interner.intern_string("S");
-    let infer_s = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_s_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_s_name, infer_s) = test_infer_param(&interner, "S");
 
     // Create a template literal pattern like `get${infer S}`
     let pattern_template = interner.template_literal(vec![
@@ -1721,29 +1613,11 @@ fn test_template_literal_mapped_type_pattern() {
 fn test_template_literal_multiple_infers_complex_pattern() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_a_name = interner.intern_string("A");
-    let infer_a = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_a_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_a_name, infer_a) = test_infer_param(&interner, "A");
 
-    let infer_b_name = interner.intern_string("B");
-    let infer_b = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_b_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_b_name, infer_b) = test_infer_param(&interner, "B");
 
     // Pattern: `start${infer A}-middle${infer B}-end`
     let pattern = interner.template_literal(vec![

--- a/crates/tsz-solver/tests/evaluate_tests_parts/infer_utility_core.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/infer_utility_core.rs
@@ -3,21 +3,9 @@ fn test_array_covariance_element_extraction() {
     // Test: T extends Array<infer E> ? E : never
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("E");
-    let infer_e = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_e) = test_infer_param(&interner, "E");
 
     // Pattern: Array<infer E> - using array type
     let extends_array = interner.array(infer_e);
@@ -49,21 +37,9 @@ fn test_array_covariance_union_element() {
     // Test: Array with union element type
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("E");
-    let infer_e = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_e) = test_infer_param(&interner, "E");
 
     // Pattern: Array<infer E>
     let extends_array = interner.array(infer_e);
@@ -96,21 +72,9 @@ fn test_array_covariance_readonly() {
     // Test: Readonly array covariance
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("E");
-    let infer_e = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_e) = test_infer_param(&interner, "E");
 
     // Pattern: readonly E[] represented as array
     let extends_array = interner.array(infer_e);
@@ -142,21 +106,9 @@ fn test_array_covariance_nested() {
     // T extends Array<Array<infer E>> ? E : never
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("E");
-    let infer_e = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_e) = test_infer_param(&interner, "E");
 
     // Pattern: Array<Array<infer E>>
     let inner_array = interner.array(infer_e);
@@ -190,21 +142,9 @@ fn test_array_covariance_non_array() {
     // Test: Non-array doesn't match array pattern
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("E");
-    let infer_e = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_e) = test_infer_param(&interner, "E");
 
     // Pattern: Array<infer E>
     let extends_array = interner.array(infer_e);
@@ -243,13 +183,7 @@ fn test_array_covariance_non_array() {
 fn test_return_type_generic_function() {
     let interner = TypeInterner::new();
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // Pattern: (...args: any[]) => infer R
     let extends_fn = interner.function(FunctionShape {
@@ -268,13 +202,7 @@ fn test_return_type_generic_function() {
     });
 
     // Source: generic function <U>(x: U) => U
-    let u_name = interner.intern_string("U");
-    let u_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: u_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (u_name, u_param) = test_type_param(&interner, "U");
     let generic_fn = interner.function(FunctionShape {
         type_params: vec![TypeParamInfo {
             name: u_name,
@@ -314,13 +242,7 @@ fn test_return_type_generic_function() {
 fn test_return_type_overloaded_function() {
     let interner = TypeInterner::new();
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // Pattern: (...args: any[]) => infer R
     let extends_fn = interner.function(FunctionShape {
@@ -396,13 +318,7 @@ fn test_return_type_overloaded_function() {
 fn test_return_type_type_predicate_function() {
     let interner = TypeInterner::new();
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // Pattern: (...args: any[]) => infer R
     let extends_fn = interner.function(FunctionShape {
@@ -457,13 +373,7 @@ fn test_return_type_type_predicate_function() {
 fn test_parameters_rest_param_function() {
     let interner = TypeInterner::new();
 
-    let infer_name = interner.intern_string("P");
-    let infer_p = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_p) = test_infer_param(&interner, "P");
 
     // Pattern for Parameters: T extends (...args: infer P) => any ? P : never
     let extends_fn = interner.function(FunctionShape {
@@ -518,13 +428,7 @@ fn test_parameters_rest_param_function() {
 fn test_parameters_optional_and_rest_combination() {
     let interner = TypeInterner::new();
 
-    let infer_name = interner.intern_string("P");
-    let infer_p = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_p) = test_infer_param(&interner, "P");
 
     // Pattern: (...args: infer P) => any
     let extends_fn = interner.function(FunctionShape {
@@ -604,13 +508,7 @@ fn test_parameters_optional_and_rest_combination() {
 fn test_parameters_generic_function_extracts_parameter_tuple() {
     let interner = TypeInterner::new();
 
-    let infer_name = interner.intern_string("P");
-    let infer_p = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_p) = test_infer_param(&interner, "P");
 
     let extends_fn = interner.function(FunctionShape {
         params: vec![ParamInfo {
@@ -629,18 +527,8 @@ fn test_parameters_generic_function_extracts_parameter_tuple() {
 
     let t_name = interner.intern_string("T");
     let u_name = interner.intern_string("U");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let u_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: u_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
+    let u_param = test_type_param_from_name(&interner, u_name);
 
     let source_fn = interner.function(FunctionShape {
         type_params: vec![
@@ -702,13 +590,7 @@ fn test_parameters_generic_function_extracts_parameter_tuple() {
 fn test_constructor_parameters_basic() {
     let interner = TypeInterner::new();
 
-    let infer_name = interner.intern_string("P");
-    let infer_p = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_p) = test_infer_param(&interner, "P");
 
     // Pattern for ConstructorParameters: T extends new (...args: infer P) => any ? P : never
     let extends_ctor = interner.function(FunctionShape {
@@ -776,13 +658,7 @@ fn test_constructor_parameters_basic() {
 fn test_constructor_parameters_callable_construct_signature() {
     let interner = TypeInterner::new();
 
-    let infer_name = interner.intern_string("P");
-    let infer_p = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_p) = test_infer_param(&interner, "P");
 
     // Pattern: new (...args: infer P) => any
     let extends_ctor = interner.function(FunctionShape {
@@ -849,13 +725,7 @@ fn test_constructor_parameters_callable_construct_signature() {
 fn test_constructor_parameters_callable_construct_signature_with_properties() {
     let interner = TypeInterner::new();
 
-    let infer_name = interner.intern_string("P");
-    let infer_p = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_p) = test_infer_param(&interner, "P");
 
     let extends_ctor = interner.function(FunctionShape {
         params: vec![ParamInfo {
@@ -923,21 +793,9 @@ fn test_constructor_parameters_callable_construct_signature_with_properties() {
 fn test_return_type_union_distributive() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // Pattern: T extends (...args: any[]) => infer R ? R : never
     let extends_fn = interner.function(FunctionShape {
@@ -1183,18 +1041,8 @@ fn test_infer_tuple_swap_pattern() {
     let infer_a_name = interner.intern_string("A");
     let infer_b_name = interner.intern_string("B");
 
-    let infer_a = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_a_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_b = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_b_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let infer_a = test_infer_param_from_name(&interner, infer_a_name);
+    let infer_b = test_infer_param_from_name(&interner, infer_b_name);
 
     // Pattern: [infer A, infer B]
     let pattern = interner.tuple(vec![
@@ -1251,18 +1099,8 @@ fn test_infer_tuple_swap_second_position() {
     let infer_a_name = interner.intern_string("A");
     let infer_b_name = interner.intern_string("B");
 
-    let infer_a = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_a_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_b = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_b_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let infer_a = test_infer_param_from_name(&interner, infer_a_name);
+    let infer_b = test_infer_param_from_name(&interner, infer_b_name);
 
     // Pattern: [infer A, infer B]
     let pattern = interner.tuple(vec![
@@ -1319,18 +1157,8 @@ fn test_infer_function_signature_param_and_return() {
     let infer_p_name = interner.intern_string("P");
     let infer_r_name = interner.intern_string("R");
 
-    let infer_p = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_p_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_r_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let infer_p = test_infer_param_from_name(&interner, infer_p_name);
+    let infer_r = test_infer_param_from_name(&interner, infer_r_name);
 
     // Pattern: (x: infer P) => infer R
     let pattern_fn = interner.function(FunctionShape {
@@ -1395,18 +1223,8 @@ fn test_infer_function_multiple_params() {
     let infer_a_name = interner.intern_string("A");
     let infer_b_name = interner.intern_string("B");
 
-    let infer_a = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_a_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_b = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_b_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let infer_a = test_infer_param_from_name(&interner, infer_a_name);
+    let infer_b = test_infer_param_from_name(&interner, infer_b_name);
 
     // Pattern: (a: infer A, b: infer B) => any
     let pattern_fn = interner.function(FunctionShape {
@@ -1649,13 +1467,7 @@ fn test_infer_contravariant_single_param() {
     // Function parameter positions are contravariant
     let interner = TypeInterner::new();
 
-    let infer_p_name = interner.intern_string("P");
-    let infer_p = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_p_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_p_name, infer_p) = test_infer_param(&interner, "P");
 
     // Pattern: (x: infer P) => any
     let pattern_fn = interner.function(FunctionShape {
@@ -1710,13 +1522,7 @@ fn test_infer_contravariant_intersection_from_multiple_candidates() {
     // This tests the contravariant inference behavior
     let interner = TypeInterner::new();
 
-    let infer_t_name = interner.intern_string("T");
-    let infer_t = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_t_name, infer_t) = test_infer_param(&interner, "T");
 
     // Pattern: (a: infer T, b: infer T) => any
     // Same infer variable in two contravariant positions

--- a/crates/tsz-solver/tests/evaluate_tests_parts/infer_utility_iterables.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/infer_utility_iterables.rs
@@ -4,13 +4,7 @@ fn test_infer_contravariant_callback_param() {
     // Extracting the parameter type from a callback
     let interner = TypeInterner::new();
 
-    let infer_t_name = interner.intern_string("T");
-    let infer_t = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_t_name, infer_t) = test_infer_param(&interner, "T");
 
     // Inner callback pattern: (x: infer T) => void
     let callback_pattern = interner.function(FunctionShape {
@@ -102,18 +96,8 @@ fn test_tuple_spread_infer_first_rest() {
     let infer_f_name = interner.intern_string("F");
     let infer_r_name = interner.intern_string("R");
 
-    let infer_f = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_f_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_r_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let infer_f = test_infer_param_from_name(&interner, infer_f_name);
+    let infer_r = test_infer_param_from_name(&interner, infer_r_name);
 
     // Pattern: [infer F, ...infer R]
     let pattern = interner.tuple(vec![
@@ -236,13 +220,7 @@ fn test_tuple_spread_length_check() {
     // Testing tuple length extraction pattern
     let interner = TypeInterner::new();
 
-    let infer_l_name = interner.intern_string("L");
-    let infer_l = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_l_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_l_name, infer_l) = test_infer_param(&interner, "L");
 
     // Pattern: { length: infer L }
     let pattern = interner.object(vec![PropertyInfo::new(
@@ -517,13 +495,7 @@ fn test_readonly_nested_object_top_level_only() {
     // Readonly: { readonly [K in keyof T]: T[K] }
     let keyof_outer = interner.intern(TypeData::KeyOf(outer_obj));
 
-    let k_name = interner.intern_string("K");
-    let k_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: k_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (k_name, k_param) = test_type_param(&interner, "K");
 
     let mapped = MappedType {
         type_param: TypeParamInfo {
@@ -585,13 +557,7 @@ fn test_readonly_multiple_properties_nested() {
 
     // Readonly mapped type
     let keyof_outer = interner.intern(TypeData::KeyOf(outer));
-    let k_name = interner.intern_string("K");
-    let k_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: k_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (k_name, k_param) = test_type_param(&interner, "K");
 
     let mapped = MappedType {
         type_param: TypeParamInfo {
@@ -650,13 +616,7 @@ fn test_deep_readonly_pattern_structure() {
 
     // Apply Readonly (single level) - simulating DeepReadonly on leaf
     let keyof_obj = interner.intern(TypeData::KeyOf(simple_obj));
-    let k_name = interner.intern_string("K");
-    let k_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: k_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (k_name, k_param) = test_type_param(&interner, "K");
 
     let mapped = MappedType {
         type_param: TypeParamInfo {
@@ -703,13 +663,7 @@ fn test_deep_readonly_manual_nested_application() {
 
     // Apply Readonly to inner
     let keyof_inner = interner.intern(TypeData::KeyOf(inner));
-    let k_name = interner.intern_string("K");
-    let k_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: k_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (k_name, k_param) = test_type_param(&interner, "K");
 
     let inner_mapped = MappedType {
         type_param: TypeParamInfo {
@@ -735,13 +689,7 @@ fn test_deep_readonly_manual_nested_application() {
 
     // Apply Readonly to outer
     let keyof_outer = interner.intern(TypeData::KeyOf(outer_with_readonly_inner));
-    let k2_name = interner.intern_string("K2");
-    let k2_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: k2_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (k2_name, k2_param) = test_type_param(&interner, "K2");
 
     let outer_mapped = MappedType {
         type_param: TypeParamInfo {
@@ -797,13 +745,7 @@ fn test_deep_readonly_with_array_property() {
 
     // Apply Readonly
     let keyof_obj = interner.intern(TypeData::KeyOf(obj));
-    let k_name = interner.intern_string("K");
-    let k_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: k_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (k_name, k_param) = test_type_param(&interner, "K");
 
     let mapped = MappedType {
         type_param: TypeParamInfo {
@@ -854,13 +796,7 @@ fn test_awaited_simple_promise() {
     let promise_string = interner.object(vec![PropertyInfo::readonly(then_name, TypeId::STRING)]);
 
     // Awaited pattern: T extends { then: infer R } ? R : T
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // Pattern: { then: infer R }
     let pattern = interner.object(vec![PropertyInfo::readonly(then_name, infer_r)]);
@@ -894,13 +830,7 @@ fn test_awaited_nested_promise_one_level() {
     let outer_promise = interner.object(vec![PropertyInfo::readonly(then_name, inner_promise)]);
 
     // Awaited pattern: T extends { then: infer R } ? R : T
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     let pattern = interner.object(vec![PropertyInfo::readonly(then_name, infer_r)]);
 
@@ -950,13 +880,7 @@ fn test_awaited_union_of_promises() {
     let union_promises = interner.union(vec![promise_string, promise_number]);
 
     // Awaited pattern with distributive conditional
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     let pattern = interner.object(vec![PropertyInfo::readonly(then_name, infer_r)]);
 
@@ -985,13 +909,7 @@ fn test_awaited_non_promise_passthrough() {
     let then_name = interner.intern_string("then");
 
     // Awaited pattern: T extends { then: infer R } ? R : T
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     let pattern = interner.object(vec![PropertyInfo::readonly(then_name, infer_r)]);
 
@@ -1024,13 +942,7 @@ fn test_awaited_mixed_union() {
     let mixed_union = interner.union(vec![promise_boolean, TypeId::NUMBER]);
 
     // Awaited pattern with distributive conditional
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     let pattern = interner.object(vec![PropertyInfo::readonly(then_name, infer_r)]);
 
@@ -1063,13 +975,7 @@ fn test_infer_mapped_type_value_extraction() {
     // Extracting value types from mapped type
     let interner = TypeInterner::new();
 
-    let infer_v_name = interner.intern_string("V");
-    let infer_v = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_v_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_v_name, infer_v) = test_infer_param(&interner, "V");
 
     // Pattern: object with infer V as value type
     // { x: infer V, y: infer V }
@@ -1102,13 +1008,7 @@ fn test_infer_mapped_type_mixed_values() {
     // When values differ, should infer union
     let interner = TypeInterner::new();
 
-    let infer_v_name = interner.intern_string("V");
-    let infer_v = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_v_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_v_name, infer_v) = test_infer_param(&interner, "V");
 
     // Pattern: { a: infer V, b: infer V }
     let pattern = interner.object(vec![
@@ -1147,13 +1047,7 @@ fn test_infer_mapped_type_key_and_value() {
     // Extract value type from object with specific key
     let interner = TypeInterner::new();
 
-    let infer_v_name = interner.intern_string("V");
-    let infer_v = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_v_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_v_name, infer_v) = test_infer_param(&interner, "V");
 
     // Pattern with infer in value position
     let pattern = interner.object(vec![PropertyInfo::new(
@@ -1306,13 +1200,7 @@ fn test_infer_multiple_same_name_covariant() {
     // Same infer variable in covariant position (return type)
     let interner = TypeInterner::new();
 
-    let infer_r_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_r_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_r_name, infer_r) = test_infer_param(&interner, "R");
 
     // Getter method returning infer R
     let getter = interner.function(FunctionShape {
@@ -1369,13 +1257,7 @@ fn test_infer_template_literal_prefix() {
     // T extends `prefix${infer Rest}` ? Rest : never
     let interner = TypeInterner::new();
 
-    let infer_rest_name = interner.intern_string("Rest");
-    let infer_rest = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_rest_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_rest_name, infer_rest) = test_infer_param(&interner, "Rest");
 
     // Pattern: `prefix${infer Rest}`
     let pattern = interner.template_literal(vec![
@@ -1406,13 +1288,7 @@ fn test_infer_template_literal_suffix() {
     // T extends `${infer Prefix}Suffix` ? Prefix : never
     let interner = TypeInterner::new();
 
-    let infer_prefix_name = interner.intern_string("Prefix");
-    let infer_prefix = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_prefix_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_prefix_name, infer_prefix) = test_infer_param(&interner, "Prefix");
 
     // Pattern: `${infer Prefix}Suffix`
     let pattern = interner.template_literal(vec![
@@ -1442,13 +1318,7 @@ fn test_infer_template_literal_middle() {
     // T extends `start${infer Middle}end` ? Middle : never
     let interner = TypeInterner::new();
 
-    let infer_middle_name = interner.intern_string("Middle");
-    let infer_middle = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_middle_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_middle_name, infer_middle) = test_infer_param(&interner, "Middle");
 
     // Pattern: `start${infer Middle}end`
     let pattern = interner.template_literal(vec![
@@ -1480,13 +1350,7 @@ fn test_infer_template_literal_no_match() {
     // When input doesn't match prefix
     let interner = TypeInterner::new();
 
-    let infer_rest_name = interner.intern_string("Rest");
-    let infer_rest = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_rest_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_rest_name, infer_rest) = test_infer_param(&interner, "Rest");
 
     // Pattern: `prefix${infer Rest}`
     let pattern = interner.template_literal(vec![

--- a/crates/tsz-solver/tests/evaluate_tests_parts/keyof_indexed_access.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/keyof_indexed_access.rs
@@ -294,12 +294,7 @@ fn test_base_constraint_assignability_evaluate_keyof() {
 fn test_keyof_type_param_no_constraint_deferred() {
     let interner = TypeInterner::new();
 
-    let type_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: interner.intern_string("T"),
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let type_param = test_type_param(&interner, "T").1;
 
     let result = evaluate_keyof(&interner, type_param);
     match interner.lookup(result) {
@@ -315,12 +310,7 @@ fn test_keyof_type_param_with_type_param_constraint_not_collapsed() {
     // keyof B ⊇ keyof A — they are distinct types.
     let interner = TypeInterner::new();
 
-    let a_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: interner.intern_string("A"),
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let a_param = test_type_param(&interner, "A").1;
 
     let b_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
         name: interner.intern_string("B"),

--- a/crates/tsz-solver/tests/evaluate_tests_parts/literal_satisfies_intrinsics.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/literal_satisfies_intrinsics.rs
@@ -317,12 +317,7 @@ fn test_satisfies_with_generic_function() {
     let t_name = interner.intern_string("T");
     let x_name = interner.intern_string("x");
 
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
 
     let source_func = interner.function(FunctionShape {
         type_params: vec![TypeParamInfo {
@@ -432,12 +427,7 @@ fn test_noinfer_blocks_inference_in_target() {
     let t_name = interner.intern_string("T");
 
     let var_t = ctx.fresh_type_param(t_name, false);
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
 
     let hello_lit = interner.literal_string("hello");
     let noinfer_t = interner.intern(TypeData::NoInfer(t_param));
@@ -550,14 +540,7 @@ fn test_noinfer_contains_type_param() {
     }
 
     let interner = TypeInterner::new();
-    let t_name = interner.intern_string("T");
-
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let noinfer_t = interner.intern(TypeData::NoInfer(t_param));
 

--- a/crates/tsz-solver/tests/evaluate_tests_parts/mapped_core.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/mapped_core.rs
@@ -445,12 +445,7 @@ fn test_mapped_type_with_template_substitution() {
     let keys = interner.union(vec![key_x, key_y]);
 
     // Template is the type parameter K itself
-    let type_param_k = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: interner.intern_string("K"),
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let type_param_k = test_type_param(&interner, "K").1;
 
     let mapped = MappedType {
         type_param: TypeParamInfo {
@@ -541,12 +536,7 @@ fn test_mapped_type_deferred() {
 
     // { [K in T]: number } where T is a type parameter
     // Should remain as mapped type (deferred)
-    let type_param_t = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: interner.intern_string("T"),
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let type_param_t = test_type_param(&interner, "T").1;
 
     let mapped = MappedType {
         type_param: TypeParamInfo {

--- a/crates/tsz-solver/tests/evaluate_tests_parts/mapped_keyof_template.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/mapped_keyof_template.rs
@@ -425,18 +425,8 @@ fn test_callable_param_infer_union_of_signatures() {
 
     let t_name = interner.intern_string("T");
     let p_name = interner.intern_string("P");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_p = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: p_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
+    let infer_p = test_infer_param_from_name(&interner, p_name);
 
     // Pattern: (x: infer P) => any
     let pattern_fn = interner.function(FunctionShape {
@@ -500,18 +490,8 @@ fn test_callable_param_infer_overloaded_callable() {
 
     let t_name = interner.intern_string("T");
     let p_name = interner.intern_string("P");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_p = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: p_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
+    let infer_p = test_infer_param_from_name(&interner, p_name);
 
     // Pattern: { (x: infer P): any }
     let pattern_callable = interner.callable(CallableShape {
@@ -591,18 +571,8 @@ fn test_callable_param_infer_mixed_union() {
 
     let t_name = interner.intern_string("T");
     let p_name = interner.intern_string("P");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_p = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: p_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
+    let infer_p = test_infer_param_from_name(&interner, p_name);
 
     let pattern_fn = interner.function(FunctionShape {
         params: vec![ParamInfo::unnamed(infer_p)],
@@ -655,24 +625,9 @@ fn test_callable_return_and_param_infer_separately() {
     let t_name = interner.intern_string("T");
     let p_name = interner.intern_string("P");
     let r_name = interner.intern_string("R");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_p = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: p_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: r_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
+    let infer_p = test_infer_param_from_name(&interner, p_name);
+    let infer_r = test_infer_param_from_name(&interner, r_name);
 
     let pattern_fn = interner.function(FunctionShape {
         params: vec![ParamInfo::unnamed(infer_p)],
@@ -753,24 +708,9 @@ fn test_callable_multiple_params_infer() {
     let t_name = interner.intern_string("T");
     let a_name = interner.intern_string("A");
     let b_name = interner.intern_string("B");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_a = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: a_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_b = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: b_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
+    let infer_a = test_infer_param_from_name(&interner, a_name);
+    let infer_b = test_infer_param_from_name(&interner, b_name);
 
     let pattern_fn = interner.function(FunctionShape {
         params: vec![ParamInfo::unnamed(infer_a), ParamInfo::unnamed(infer_b)],
@@ -1354,18 +1294,8 @@ fn test_infer_return_void_vs_undefined() {
 
     let t_name = interner.intern_string("T");
     let r_name = interner.intern_string("R");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: r_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
+    let infer_r = test_infer_param_from_name(&interner, r_name);
 
     let pattern_fn = interner.function(FunctionShape {
         params: Vec::new(),
@@ -1415,18 +1345,8 @@ fn test_infer_return_promise_like() {
 
     let t_name = interner.intern_string("T");
     let r_name = interner.intern_string("R");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: r_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
+    let infer_r = test_infer_param_from_name(&interner, r_name);
 
     let pattern_fn = interner.function(FunctionShape {
         params: Vec::new(),
@@ -1494,18 +1414,8 @@ fn test_infer_return_union() {
 
     let t_name = interner.intern_string("T");
     let r_name = interner.intern_string("R");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: r_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
+    let infer_r = test_infer_param_from_name(&interner, r_name);
 
     let pattern_fn = interner.function(FunctionShape {
         params: Vec::new(),
@@ -1558,18 +1468,8 @@ fn test_infer_return_never() {
 
     let t_name = interner.intern_string("T");
     let r_name = interner.intern_string("R");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: r_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
+    let infer_r = test_infer_param_from_name(&interner, r_name);
 
     let pattern_fn = interner.function(FunctionShape {
         params: Vec::new(),

--- a/crates/tsz-solver/tests/evaluate_tests_parts/mapped_utility_distribution.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/mapped_utility_distribution.rs
@@ -1267,13 +1267,7 @@ fn test_short_circuit_unknown_extends_unknown() {
 fn test_deferred_unresolved_type_param_check() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_true = interner.literal_string("true");
     let lit_false = interner.literal_string("false");
@@ -1298,13 +1292,7 @@ fn test_deferred_unresolved_type_param_check() {
 fn test_deferred_unresolved_type_param_extends() {
     let interner = TypeInterner::new();
 
-    let u_name = interner.intern_string("U");
-    let u_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: u_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_u_name, u_param) = test_type_param(&interner, "U");
 
     let lit_true = interner.literal_string("true");
     let lit_false = interner.literal_string("false");
@@ -1360,21 +1348,9 @@ fn test_deferred_constrained_type_param() {
 fn test_deferred_nested_type_params() {
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_t_name, t_param) = test_type_param(&interner, "T");
 
-    let u_name = interner.intern_string("U");
-    let u_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: u_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_u_name, u_param) = test_type_param(&interner, "U");
 
     let lit_1 = interner.literal_number(1.0);
     let lit_2 = interner.literal_number(2.0);
@@ -1408,13 +1384,7 @@ fn test_deferred_nested_type_params() {
 fn test_partially_deferred_outer_resolves() {
     let interner = TypeInterner::new();
 
-    let u_name = interner.intern_string("U");
-    let u_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: u_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_u_name, u_param) = test_type_param(&interner, "U");
 
     let lit_1 = interner.literal_number(1.0);
     let lit_2 = interner.literal_number(2.0);
@@ -1484,13 +1454,7 @@ fn test_distributive_large_union_basic() {
     // Result: true | false
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_true = interner.literal_boolean(true);
     let lit_false = interner.literal_boolean(false);
@@ -1532,13 +1496,7 @@ fn test_distributive_large_union_all_match() {
     // Result: union of all input strings
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let cond = ConditionalType {
         check_type: t_param,
@@ -1572,13 +1530,7 @@ fn test_distributive_large_union_none_match() {
     // Result: never
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let cond = ConditionalType {
         check_type: t_param,
@@ -1610,13 +1562,7 @@ fn test_distributive_nested_conditional() {
     // Result: 1 | 2 | 3
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_a = interner.literal_string("a");
     let lit_b = interner.literal_string("b");
@@ -1665,21 +1611,9 @@ fn test_distributive_with_infer_filter() {
     // Result: string | number
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     let extends_array = interner.array(infer_r);
 
@@ -1717,13 +1651,7 @@ fn test_distributive_with_mapped_branches() {
     // Result: "a" | "num" | "other"
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_a = interner.literal_string("a");
     let lit_num = interner.literal_string("num");

--- a/crates/tsz-solver/tests/evaluate_tests_parts/recursive_infer_awaited.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/recursive_infer_awaited.rs
@@ -9,13 +9,7 @@ fn test_awaited_basic_promise() {
     let promise_string = interner.object(vec![PropertyInfo::readonly(then_name, TypeId::STRING)]);
 
     // Using infer pattern: T extends { then: infer U } ? U : T
-    let infer_name = interner.intern_string("U");
-    let infer_u = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_u) = test_infer_param(&interner, "U");
 
     let pattern = interner.object(vec![PropertyInfo::readonly(then_name, infer_u)]);
 
@@ -41,13 +35,7 @@ fn test_awaited_promise_number() {
 
     let promise_number = interner.object(vec![PropertyInfo::readonly(then_name, TypeId::NUMBER)]);
 
-    let infer_name = interner.intern_string("U");
-    let infer_u = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_u) = test_infer_param(&interner, "U");
 
     let pattern = interner.object(vec![PropertyInfo::readonly(then_name, infer_u)]);
 
@@ -89,18 +77,8 @@ fn test_awaited_thenable_matches_optional_onfulfilled_parameter() {
     });
     let source_thenable = interner.object(vec![PropertyInfo::readonly(then_name, source_then)]);
 
-    let infer_f = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_f_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_rest = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_rest_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let infer_f = test_infer_param_from_name(&interner, infer_f_name);
+    let infer_rest = test_infer_param_from_name(&interner, infer_rest_name);
     let pattern_then = interner.function(FunctionShape {
         params: vec![
             ParamInfo::required(onfulfilled_name, infer_f),
@@ -141,13 +119,7 @@ fn test_awaited_nested_promise() {
     let outer_promise = interner.object(vec![PropertyInfo::readonly(then_name, inner_promise)]);
 
     // First unwrap: extracts Promise<string>
-    let infer_name = interner.intern_string("U");
-    let infer_u = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_u) = test_infer_param(&interner, "U");
 
     let pattern = interner.object(vec![PropertyInfo::readonly(then_name, infer_u)]);
 
@@ -183,13 +155,7 @@ fn test_awaited_string_passthrough() {
 
     let then_name = interner.intern_string("then");
 
-    let infer_name = interner.intern_string("U");
-    let infer_u = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_u) = test_infer_param(&interner, "U");
 
     let pattern = interner.object(vec![PropertyInfo::readonly(then_name, infer_u)]);
 
@@ -214,13 +180,7 @@ fn test_awaited_number_passthrough() {
 
     let then_name = interner.intern_string("then");
 
-    let infer_name = interner.intern_string("U");
-    let infer_u = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_u) = test_infer_param(&interner, "U");
 
     let pattern = interner.object(vec![PropertyInfo::readonly(then_name, infer_u)]);
 
@@ -243,13 +203,7 @@ fn test_awaited_null_undefined_passthrough() {
 
     let then_name = interner.intern_string("then");
 
-    let infer_name = interner.intern_string("U");
-    let infer_u = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_u) = test_infer_param(&interner, "U");
 
     let pattern = interner.object(vec![PropertyInfo::readonly(then_name, infer_u)]);
 
@@ -288,13 +242,7 @@ fn test_awaited_promise_union_distributive() {
 
     let promise_number = interner.object(vec![PropertyInfo::readonly(then_name, TypeId::NUMBER)]);
 
-    let infer_name = interner.intern_string("U");
-    let infer_u = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_u) = test_infer_param(&interner, "U");
 
     let pattern = interner.object(vec![PropertyInfo::readonly(then_name, infer_u)]);
 
@@ -339,13 +287,7 @@ fn test_awaited_mixed_promise_union() {
 
     let promise_string = interner.object(vec![PropertyInfo::readonly(then_name, TypeId::STRING)]);
 
-    let infer_name = interner.intern_string("U");
-    let infer_u = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_u) = test_infer_param(&interner, "U");
 
     let pattern = interner.object(vec![PropertyInfo::readonly(then_name, infer_u)]);
 
@@ -391,13 +333,7 @@ fn test_awaited_promise_void() {
 
     let promise_void = interner.object(vec![PropertyInfo::readonly(then_name, TypeId::VOID)]);
 
-    let infer_name = interner.intern_string("U");
-    let infer_u = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_u) = test_infer_param(&interner, "U");
 
     let pattern = interner.object(vec![PropertyInfo::readonly(then_name, infer_u)]);
 
@@ -422,13 +358,7 @@ fn test_awaited_promise_never() {
 
     let promise_never = interner.object(vec![PropertyInfo::readonly(then_name, TypeId::NEVER)]);
 
-    let infer_name = interner.intern_string("U");
-    let infer_u = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_u) = test_infer_param(&interner, "U");
 
     let pattern = interner.object(vec![PropertyInfo::readonly(then_name, infer_u)]);
 
@@ -453,13 +383,7 @@ fn test_awaited_promise_any() {
 
     let promise_any = interner.object(vec![PropertyInfo::readonly(then_name, TypeId::ANY)]);
 
-    let infer_name = interner.intern_string("U");
-    let infer_u = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_u) = test_infer_param(&interner, "U");
 
     let pattern = interner.object(vec![PropertyInfo::readonly(then_name, infer_u)]);
 
@@ -487,13 +411,7 @@ fn test_awaited_promise_object() {
 
     let promise_obj = interner.object(vec![PropertyInfo::readonly(then_name, inner_obj)]);
 
-    let infer_name = interner.intern_string("U");
-    let infer_u = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_u) = test_infer_param(&interner, "U");
 
     let pattern = interner.object(vec![PropertyInfo::readonly(then_name, infer_u)]);
 
@@ -519,13 +437,7 @@ fn test_awaited_promise_array() {
 
     let promise_array = interner.object(vec![PropertyInfo::readonly(then_name, string_array)]);
 
-    let infer_name = interner.intern_string("U");
-    let infer_u = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_u) = test_infer_param(&interner, "U");
 
     let pattern = interner.object(vec![PropertyInfo::readonly(then_name, infer_u)]);
 
@@ -557,13 +469,7 @@ fn test_awaited_triple_nested() {
     // Level 3: Promise<Promise<Promise<boolean>>>
     let level3 = interner.object(vec![PropertyInfo::readonly(then_name, level2)]);
 
-    let infer_name = interner.intern_string("U");
-    let infer_u = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_u) = test_infer_param(&interner, "U");
 
     let pattern = interner.object(vec![PropertyInfo::readonly(then_name, infer_u)]);
 
@@ -1450,13 +1356,7 @@ fn test_infer_optional_property_present() {
     // Input: { prop: string } -> P = string
     let interner = TypeInterner::new();
 
-    let infer_p_name = interner.intern_string("P");
-    let infer_p = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_p_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_p_name, infer_p) = test_infer_param(&interner, "P");
 
     // Pattern: { prop?: infer P }
     let pattern = interner.object(vec![PropertyInfo::opt(
@@ -1489,13 +1389,7 @@ fn test_infer_optional_property_missing() {
     // Input: {} (no prop) -> P = undefined
     let interner = TypeInterner::new();
 
-    let infer_p_name = interner.intern_string("P");
-    let infer_p = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_p_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_p_name, infer_p) = test_infer_param(&interner, "P");
 
     // Pattern: { prop?: infer P }
     let pattern = interner.object(vec![PropertyInfo::opt(
@@ -1525,13 +1419,7 @@ fn test_infer_optional_property_with_undefined() {
     // Input: { prop: string | undefined } -> P = string | undefined
     let interner = TypeInterner::new();
 
-    let infer_p_name = interner.intern_string("P");
-    let infer_p = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_p_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_p_name, infer_p) = test_infer_param(&interner, "P");
 
     // Pattern: { prop?: infer P }
     let pattern = interner.object(vec![PropertyInfo::opt(
@@ -1686,13 +1574,7 @@ fn test_infer_discriminated_union_kind() {
     // Input: { kind: "circle" } | { kind: "square" }
     let interner = TypeInterner::new();
 
-    let infer_k_name = interner.intern_string("K");
-    let infer_k = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_k_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_k_name, infer_k) = test_infer_param(&interner, "K");
 
     // Pattern: { kind: infer K }
     let pattern = interner.object(vec![PropertyInfo::new(
@@ -1734,21 +1616,9 @@ fn test_infer_discriminated_union_with_extra_props() {
     // T extends { type: infer T, data: infer D } ? [T, D] : never
     let interner = TypeInterner::new();
 
-    let infer_t_name = interner.intern_string("T");
-    let infer_t = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_t_name, infer_t) = test_infer_param(&interner, "T");
 
-    let infer_d_name = interner.intern_string("D");
-    let infer_d = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_d_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_d_name, infer_d) = test_infer_param(&interner, "D");
 
     // Pattern: { type: infer T, data: infer D }
     let pattern = interner.object(vec![

--- a/crates/tsz-solver/tests/evaluate_tests_parts/template_literal_indexed_access.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/template_literal_indexed_access.rs
@@ -6,21 +6,9 @@ fn test_template_literal_prefix_infer_suffix_multiple_hyphens() {
     // Input: "api-user-profile-handler" => Route = "user-profile"
     // The infer captures everything between "api-" and "-handler"
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("Route");
-    let infer_route = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_route) = test_infer_param(&interner, "Route");
 
     // T extends `api-${infer Route}-handler` ? Route : never
     let extends_template = interner.template_literal(vec![
@@ -56,21 +44,9 @@ fn test_template_literal_prefix_infer_suffix_distributive() {
     // Pattern: T extends `on-${infer E}-event` ? E : never (distributive)
     // Input: "on-click-event" | "on-load-event" => "click" | "load"
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("E");
-    let infer_e = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_e) = test_infer_param(&interner, "E");
 
     // T extends `on-${infer E}-event` ? E : never
     let extends_template = interner.template_literal(vec![
@@ -116,21 +92,9 @@ fn test_template_literal_extract_numeric_id() {
     // Input: "user-42" => Id = "42"
     // Common pattern for extracting numeric IDs from string keys
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("Id");
-    let infer_id = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_id) = test_infer_param(&interner, "Id");
 
     // T extends `user-${infer Id}` ? Id : never
     let extends_template = interner.template_literal(vec![
@@ -166,26 +130,10 @@ fn test_template_literal_extract_version_numbers() {
     // Input: "v1.2" => [Major, Minor] = ["1", "2"]
     // Common pattern for parsing version strings
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_major = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: interner.intern_string("Major"),
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_minor = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: interner.intern_string("Minor"),
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let infer_major = test_infer_param(&interner, "Major").1;
+    let infer_minor = test_infer_param(&interner, "Minor").1;
 
     // T extends `v${infer Major}.${infer Minor}` ? [Major, Minor] : never
     let extends_template = interner.template_literal(vec![
@@ -251,21 +199,9 @@ fn test_template_literal_extract_index_from_array_key() {
     // Input: "item[0]" | "item[1]" | "item[2]" => "0" | "1" | "2"
     // Common pattern for extracting array indices from bracket notation
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("Index");
-    let infer_index = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_index) = test_infer_param(&interner, "Index");
 
     // T extends `item[${infer Index}]` ? Index : never
     let extends_template = interner.template_literal(vec![
@@ -309,21 +245,9 @@ fn test_template_literal_extract_port_number() {
     // Input: "localhost:3000" => Port = "3000"
     // Common pattern for extracting port numbers from host strings
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("Port");
-    let infer_port = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_port) = test_infer_param(&interner, "Port");
 
     // T extends `localhost:${infer Port}` ? Port : never
     let extends_template = interner.template_literal(vec![
@@ -358,26 +282,10 @@ fn test_template_literal_extract_coordinates() {
     // Input: "(10,20)" => [X, Y] = ["10", "20"]
     // Common pattern for parsing coordinate pairs
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_x = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: interner.intern_string("X"),
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let infer_y = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: interner.intern_string("Y"),
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let infer_x = test_infer_param(&interner, "X").1;
+    let infer_y = test_infer_param(&interner, "Y").1;
 
     // T extends `(${infer X},${infer Y})` ? [X, Y] : never
     let extends_template = interner.template_literal(vec![
@@ -509,19 +417,9 @@ fn test_variadic_tuple_infer_rest_elements() {
     let t_name = interner.intern_string("T");
     let rest_name = interner.intern_string("Rest");
 
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
 
-    let infer_rest = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: rest_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let infer_rest = test_infer_param_from_name(&interner, rest_name);
 
     // Pattern: [string, ...infer Rest]
     let extends_tuple = interner.tuple(vec![
@@ -604,26 +502,11 @@ fn test_variadic_tuple_infer_first_element() {
     let first_name = interner.intern_string("First");
     let rest_name = interner.intern_string("Rest");
 
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
 
-    let infer_first = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: first_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let infer_first = test_infer_param_from_name(&interner, first_name);
 
-    let infer_rest = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: rest_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let infer_rest = test_infer_param_from_name(&interner, rest_name);
 
     // Pattern: [infer First, ...infer Rest]
     let extends_tuple = interner.tuple(vec![
@@ -691,19 +574,9 @@ fn test_variadic_tuple_empty_rest() {
     let t_name = interner.intern_string("T");
     let r_name = interner.intern_string("R");
 
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
 
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: r_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let infer_r = test_infer_param_from_name(&interner, r_name);
 
     // Pattern: [string, ...infer R]
     let extends_tuple = interner.tuple(vec![
@@ -1169,21 +1042,9 @@ fn test_generator_function_return_type_extraction() {
     // T extends () => infer R ? R : never
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // Pattern: () => infer R
     let extends_fn = interner.function(FunctionShape {
@@ -1232,21 +1093,9 @@ fn test_generator_function_yield_type_simulation() {
     // Generator<T, TReturn, TNext> - extract T
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("Y");
-    let infer_y = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_y) = test_infer_param(&interner, "Y");
 
     // Pattern function returning: { value: infer Y; done: boolean }
     let value_prop = interner.intern_string("value");
@@ -1287,21 +1136,9 @@ fn test_generator_function_async_return() {
     // T extends () => Promise<infer R> ? R : never (simulated with object)
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // Pattern: { then: (resolve: (value: infer R) => void) => void }
     let then_prop = interner.intern_string("then");
@@ -1363,21 +1200,9 @@ fn test_generator_function_next_param_type() {
     // T extends (arg: infer A) => any ? A : never
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("A");
-    let infer_a = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_a) = test_infer_param(&interner, "A");
 
     // Pattern: (arg: infer A) => any
     let arg_name = interner.intern_string("arg");
@@ -1428,21 +1253,9 @@ fn test_generator_function_multiple_params() {
     // T extends (...args: infer P) => any ? P : never
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("P");
-    let infer_p = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_p) = test_infer_param(&interner, "P");
 
     // Pattern: (...args: infer P) => any
     let args_name = interner.intern_string("args");
@@ -1510,13 +1323,7 @@ fn test_module_augmentation_object_merge() {
     // interface A { x: string } merged with interface A { y: number }
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     // First object: { x: string }
     let x_prop = interner.intern_string("x");
@@ -1560,21 +1367,9 @@ fn test_module_augmentation_function_overload() {
     // Test: Merged function signatures (callable with multiple overloads)
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // Pattern: () => infer R
     let extends_fn = interner.function(FunctionShape {
@@ -1664,13 +1459,7 @@ fn test_module_augmentation_class_extension() {
     // Test: Class with augmented static members
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     // Class static: { new (): Instance }
     let instance_type = interner.object(vec![]);
@@ -1726,21 +1515,9 @@ fn test_module_augmentation_global_interface() {
     // Test: Global interface augmentation (like adding to Array prototype)
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
-    let infer_name = interner.intern_string("E");
-    let infer_e = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_e) = test_infer_param(&interner, "E");
 
     // Pattern: Array-like with custom method
     // { myMethod: () => infer E }

--- a/crates/tsz-solver/tests/evaluate_tests_parts/template_literal_infer_distribution.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/template_literal_infer_distribution.rs
@@ -18,13 +18,7 @@ fn test_nonnullable_type() {
     // NonNullable<T> = T extends null | undefined ? never : T
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_t_name, t_param) = test_type_param(&interner, "T");
 
     let null_or_undefined = interner.union(vec![TypeId::NULL, TypeId::UNDEFINED]);
 
@@ -296,13 +290,7 @@ fn test_non_distributive_wrapped_type_param() {
     // Wrapping in tuple prevents distribution
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_t_name, t_param) = test_type_param(&interner, "T");
 
     let wrapped_t = interner.tuple(vec![TupleElement {
         type_id: t_param,
@@ -409,13 +397,7 @@ fn test_distributive_infer_in_extends() {
     // Distribution with inference
     let interner = TypeInterner::new();
 
-    let u_name = interner.intern_string("U");
-    let infer_u = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: u_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_u_name, infer_u) = test_infer_param(&interner, "U");
 
     let array_pattern = interner.array(infer_u);
 
@@ -445,12 +427,7 @@ fn test_distributive_multiple_type_params() {
     let t_name = interner.intern_string("T");
     let u_name = interner.intern_string("U");
 
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
 
     let u_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
         name: u_name,
@@ -616,21 +593,9 @@ fn test_distributive_function_type_union() {
 fn test_infer_variadic_tuple_head() {
     let interner = TypeInterner::new();
 
-    let infer_h_name = interner.intern_string("H");
-    let infer_h = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_h_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_h_name, infer_h) = test_infer_param(&interner, "H");
 
-    let infer_t_name = interner.intern_string("T");
-    let infer_t = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_t_name, infer_t) = test_infer_param(&interner, "T");
 
     // Pattern: [infer H, ...infer T]
     let pattern = interner.tuple(vec![
@@ -688,21 +653,9 @@ fn test_infer_variadic_tuple_head() {
 fn test_infer_variadic_tuple_tail() {
     let interner = TypeInterner::new();
 
-    let infer_h_name = interner.intern_string("H");
-    let infer_h = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_h_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_h_name, infer_h) = test_infer_param(&interner, "H");
 
-    let infer_l_name = interner.intern_string("L");
-    let infer_l = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_l_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_l_name, infer_l) = test_infer_param(&interner, "L");
 
     // Pattern: [...infer H, infer L]
     let pattern = interner.tuple(vec![
@@ -760,29 +713,11 @@ fn test_infer_variadic_tuple_tail() {
 fn test_infer_variadic_tuple_middle() {
     let interner = TypeInterner::new();
 
-    let infer_f_name = interner.intern_string("F");
-    let infer_f = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_f_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_f_name, infer_f) = test_infer_param(&interner, "F");
 
-    let infer_m_name = interner.intern_string("M");
-    let infer_m = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_m_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_m_name, infer_m) = test_infer_param(&interner, "M");
 
-    let infer_l_name = interner.intern_string("L");
-    let infer_l = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_l_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_l_name, infer_l) = test_infer_param(&interner, "L");
 
     // Pattern: [infer F, ...infer M, infer L]
     let pattern = interner.tuple(vec![
@@ -856,13 +791,7 @@ fn test_infer_variadic_tuple_middle() {
 fn test_infer_from_overloaded_callable() {
     let interner = TypeInterner::new();
 
-    let infer_r_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_r_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_r_name, infer_r) = test_infer_param(&interner, "R");
 
     // Pattern: (...args: any[]) => infer R
     let pattern = interner.function(FunctionShape {
@@ -937,13 +866,7 @@ fn test_infer_from_overloaded_callable() {
 fn test_infer_from_construct_signature() {
     let interner = TypeInterner::new();
 
-    let infer_t_name = interner.intern_string("T");
-    let infer_t = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_t_name, infer_t) = test_infer_param(&interner, "T");
 
     // Pattern: { new (): infer T }
     let pattern = interner.callable(CallableShape {
@@ -1003,13 +926,7 @@ fn test_infer_from_construct_signature() {
 fn test_infer_with_index_access_result() {
     let interner = TypeInterner::new();
 
-    let infer_p_name = interner.intern_string("P");
-    let infer_p = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_p_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_p_name, infer_p) = test_infer_param(&interner, "P");
 
     // Pattern: { prop: infer P }
     let pattern = interner.object(vec![PropertyInfo::new(
@@ -1047,13 +964,7 @@ fn test_infer_with_index_access_result() {
 fn test_infer_from_index_signature_value() {
     let interner = TypeInterner::new();
 
-    let infer_v_name = interner.intern_string("V");
-    let infer_v = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_v_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_v_name, infer_v) = test_infer_param(&interner, "V");
 
     // Pattern: { [k: string]: infer V }
     let pattern = interner.object_with_index(ObjectShape {
@@ -1105,13 +1016,7 @@ fn test_infer_from_index_signature_value() {
 fn test_infer_promise_like_unwrap() {
     let interner = TypeInterner::new();
 
-    let infer_t_name = interner.intern_string("T");
-    let infer_t = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_t_name, infer_t) = test_infer_param(&interner, "T");
 
     // Pattern: { then: (onfulfilled: (value: infer T) => any) => any }
     let callback_param = interner.function(FunctionShape {
@@ -1207,13 +1112,7 @@ fn test_infer_promise_like_unwrap() {
 fn test_infer_from_mapped_type_output() {
     let interner = TypeInterner::new();
 
-    let infer_v_name = interner.intern_string("V");
-    let infer_v = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_v_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_v_name, infer_v) = test_infer_param(&interner, "V");
 
     // Pattern: { a: infer V; b: infer V }
     let pattern = interner.object(vec![
@@ -1245,13 +1144,7 @@ fn test_infer_from_mapped_type_output() {
 fn test_infer_same_name_different_values() {
     let interner = TypeInterner::new();
 
-    let infer_v_name = interner.intern_string("V");
-    let infer_v = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_v_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_v_name, infer_v) = test_infer_param(&interner, "V");
 
     // Pattern: { a: infer V; b: infer V }
     let pattern = interner.object(vec![
@@ -1345,13 +1238,7 @@ fn test_infer_with_keyof_constraint() {
 fn test_infer_from_branded_intersection() {
     let interner = TypeInterner::new();
 
-    let infer_b_name = interner.intern_string("B");
-    let infer_b = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_b_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_b_name, infer_b) = test_infer_param(&interner, "B");
 
     // Pattern: { __brand: infer B }
     let brand_pattern = interner.object(vec![PropertyInfo::new(
@@ -1389,13 +1276,7 @@ fn test_infer_from_branded_intersection() {
 fn test_infer_ignores_readonly() {
     let interner = TypeInterner::new();
 
-    let infer_t_name = interner.intern_string("T");
-    let infer_t = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_t_name, infer_t) = test_infer_param(&interner, "T");
 
     // Pattern: { readonly prop: infer T }
     let pattern = interner.object(vec![PropertyInfo {
@@ -1438,21 +1319,9 @@ fn test_infer_ignores_readonly() {
 fn test_infer_optional_tuple_element() {
     let interner = TypeInterner::new();
 
-    let infer_a_name = interner.intern_string("A");
-    let infer_a = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_a_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_a_name, infer_a) = test_infer_param(&interner, "A");
 
-    let infer_b_name = interner.intern_string("B");
-    let infer_b = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_b_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_b_name, infer_b) = test_infer_param(&interner, "B");
 
     // Pattern: [infer A, infer B?]
     let pattern = interner.tuple(vec![

--- a/crates/tsz-solver/tests/evaluate_tests_parts/template_literal_intrinsics.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/template_literal_intrinsics.rs
@@ -1095,13 +1095,7 @@ fn test_string_template_infer_prefix_pattern() {
 
     let input = interner.literal_string("prefix-value");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     let pattern = interner.template_literal(vec![
         TemplateSpan::Text(interner.intern_string("prefix-")),
@@ -1128,13 +1122,7 @@ fn test_string_template_infer_suffix_pattern() {
 
     let input = interner.literal_string("value-suffix");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     let pattern = interner.template_literal(vec![
         TemplateSpan::Type(infer_r),
@@ -1161,13 +1149,7 @@ fn test_string_template_infer_middle_pattern() {
 
     let input = interner.literal_string("start-middle-end");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     let pattern = interner.template_literal(vec![
         TemplateSpan::Text(interner.intern_string("start-")),
@@ -1195,13 +1177,7 @@ fn test_string_template_infer_no_match_pattern() {
 
     let input = interner.literal_string("different");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     let pattern = interner.template_literal(vec![
         TemplateSpan::Text(interner.intern_string("prefix-")),
@@ -1227,21 +1203,9 @@ fn test_template_infer_two_parts() {
 
     let input = interner.literal_string("first_second");
 
-    let infer_a_name = interner.intern_string("A");
-    let infer_a = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_a_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_a_name, infer_a) = test_infer_param(&interner, "A");
 
-    let infer_b_name = interner.intern_string("B");
-    let infer_b = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_b_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_b_name, infer_b) = test_infer_param(&interner, "B");
 
     let pattern = interner.template_literal(vec![
         TemplateSpan::Type(infer_a),
@@ -1282,13 +1246,7 @@ fn test_template_infer_union_distributive() {
     let input_a = interner.literal_string("get-foo");
     let input_b = interner.literal_string("get-bar");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     let pattern = interner.template_literal(vec![
         TemplateSpan::Text(interner.intern_string("get-")),
@@ -1338,13 +1296,7 @@ fn test_template_multi_segment_extraction() {
     // `item-${infer N}-end` should match "item-123-end" and extract "123"
     let input = interner.literal_string("item-123-end");
 
-    let infer_name = interner.intern_string("N");
-    let infer_n = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_n) = test_infer_param(&interner, "N");
 
     let pattern = interner.template_literal(vec![
         TemplateSpan::Text(interner.intern_string("item-")),
@@ -1517,13 +1469,7 @@ fn test_literal_matches_template_via_infer() {
 
     let literal = interner.literal_string("prefix-value");
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     let template = interner.template_literal(vec![
         TemplateSpan::Text(interner.intern_string("prefix-")),

--- a/crates/tsz-solver/tests/evaluate_tests_parts/template_literal_utility.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/template_literal_utility.rs
@@ -105,13 +105,7 @@ fn test_template_infer_prefix_extraction() {
     // Input: "prefixSuffix" -> Rest = "Suffix"
     let interner = TypeInterner::new();
 
-    let infer_rest_name = interner.intern_string("Rest");
-    let infer_rest = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_rest_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_rest_name, infer_rest) = test_infer_param(&interner, "Rest");
 
     // Pattern: `prefix${infer Rest}`
     let pattern = interner.template_literal(vec![
@@ -140,13 +134,7 @@ fn test_template_infer_suffix_extraction() {
     // Input: "PrefixSuffix" where suffix is "Suffix" -> Start = "Prefix"
     let interner = TypeInterner::new();
 
-    let infer_start_name = interner.intern_string("Start");
-    let infer_start = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_start_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_start_name, infer_start) = test_infer_param(&interner, "Start");
 
     // Pattern: `${infer Start}Suffix`
     let pattern = interner.template_literal(vec![
@@ -174,13 +162,7 @@ fn test_template_infer_middle_extraction() {
     // T extends `start${infer Middle}end` ? Middle : never
     let interner = TypeInterner::new();
 
-    let infer_middle_name = interner.intern_string("Middle");
-    let infer_middle = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_middle_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_middle_name, infer_middle) = test_infer_param(&interner, "Middle");
 
     // Pattern: `start${infer Middle}end`
     let pattern = interner.template_literal(vec![
@@ -210,13 +192,7 @@ fn test_template_infer_no_match() {
     // Input: "wrongStart" doesn't match -> never
     let interner = TypeInterner::new();
 
-    let infer_rest_name = interner.intern_string("Rest");
-    let infer_rest = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_rest_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_rest_name, infer_rest) = test_infer_param(&interner, "Rest");
 
     // Pattern: `prefix${infer Rest}`
     let pattern = interner.template_literal(vec![
@@ -244,21 +220,9 @@ fn test_template_multiple_infers() {
     // Input: "hello-world" -> [A="hello", B="world"]
     let interner = TypeInterner::new();
 
-    let infer_a_name = interner.intern_string("A");
-    let infer_a = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_a_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_a_name, infer_a) = test_infer_param(&interner, "A");
 
-    let infer_b_name = interner.intern_string("B");
-    let infer_b = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_b_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_b_name, infer_b) = test_infer_param(&interner, "B");
 
     // Pattern: `${infer A}-${infer B}`
     let pattern = interner.template_literal(vec![
@@ -304,29 +268,11 @@ fn test_template_three_infers() {
     // Input: "a/b/c" -> ["a", "b", "c"]
     let interner = TypeInterner::new();
 
-    let infer_a_name = interner.intern_string("A");
-    let infer_a = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_a_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_a_name, infer_a) = test_infer_param(&interner, "A");
 
-    let infer_b_name = interner.intern_string("B");
-    let infer_b = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_b_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_b_name, infer_b) = test_infer_param(&interner, "B");
 
-    let infer_c_name = interner.intern_string("C");
-    let infer_c = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_c_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_c_name, infer_c) = test_infer_param(&interner, "C");
 
     // Pattern: `${infer A}/${infer B}/${infer C}`
     let pattern = interner.template_literal(vec![
@@ -377,13 +323,7 @@ fn test_template_union_distribution_simple() {
     // T extends `${infer X}` ? X : never  (distributive over "a" | "b")
     let interner = TypeInterner::new();
 
-    let infer_x_name = interner.intern_string("X");
-    let infer_x = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_x_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_x_name, infer_x) = test_infer_param(&interner, "X");
 
     // Pattern: just `${infer X}` (matches any string)
     let pattern = interner.template_literal(vec![TemplateSpan::Type(infer_x)]);
@@ -411,13 +351,7 @@ fn test_template_union_prefix_distribution() {
     // Distributive over "getName" | "getValue" | "other"
     let interner = TypeInterner::new();
 
-    let infer_name = interner.intern_string("Name");
-    let infer_name_type = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_name_type) = test_infer_param(&interner, "Name");
 
     // Pattern: `get${infer Name}`
     let pattern = interner.template_literal(vec![
@@ -449,13 +383,7 @@ fn test_template_union_all_match() {
     // Distributive over "onClick" | "onHover" | "onFocus"
     let interner = TypeInterner::new();
 
-    let infer_event_name = interner.intern_string("Event");
-    let infer_event = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_event_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_event_name, infer_event) = test_infer_param(&interner, "Event");
 
     // Pattern: `on${infer Event}`
     let pattern = interner.template_literal(vec![
@@ -717,14 +645,7 @@ fn test_omit_this_preserves_generics() {
     let interner = TypeInterner::new();
 
     let t_name = interner.intern_string("T");
-    let u_name = interner.intern_string("U");
-
-    let u_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: u_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (u_name, u_param) = test_type_param(&interner, "U");
 
     // After OmitThisParameter, type params remain
     let fn_result = interner.function(FunctionShape {
@@ -1105,13 +1026,7 @@ fn test_instance_type_with_generics() {
     // InstanceType<new <T>(x: T) => Container<T>> = Container<T>
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let container = interner.object(vec![PropertyInfo::new(
         interner.intern_string("value"),
@@ -1300,13 +1215,7 @@ fn test_distributive_large_union_15_members() {
     let large_union = interner.union(members);
 
     // Type parameter T for check type
-    let t_name = interner.intern_string("T");
-    let _t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_t_name, _t_param) = test_type_param(&interner, "T");
 
     let cond = ConditionalType {
         check_type: large_union,
@@ -1462,13 +1371,7 @@ fn test_nested_distributive_with_infer() {
     // T extends { a: infer A } ? (A extends string ? A : never) : never
     let interner = TypeInterner::new();
 
-    let infer_a_name = interner.intern_string("A");
-    let infer_a = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_a_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_a_name, infer_a) = test_infer_param(&interner, "A");
 
     // Pattern: { a: infer A }
     let pattern = interner.object(vec![PropertyInfo::new(
@@ -1674,13 +1577,7 @@ fn test_never_filtering_exclude_pattern() {
     let union_abc = interner.union(vec![lit_a, lit_b, lit_c]);
 
     // T param for distributive check
-    let t_name = interner.intern_string("T");
-    let _t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_t_name, _t_param) = test_type_param(&interner, "T");
 
     let cond = ConditionalType {
         check_type: union_abc,

--- a/crates/tsz-solver/tests/evaluate_tests_parts/tuple_keyof_indexed_access.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/tuple_keyof_indexed_access.rs
@@ -42,13 +42,7 @@ fn test_template_literal_nested_union_interpolation() {
 fn test_template_literal_matches_template_literal() {
     let interner = TypeInterner::new();
 
-    let infer_name = interner.intern_string("R");
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: infer_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_infer_name, infer_r) = test_infer_param(&interner, "R");
 
     // Pattern: `foo${infer R}`
     let pattern = interner.template_literal(vec![
@@ -1312,18 +1306,8 @@ fn test_tuple_spread_generic_union_is_not_distributed() {
     let l0 = interner.literal_number(0.0);
     let t_name = interner.intern_string("T");
     let u_name = interner.intern_string("U");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
-    let u_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: u_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
+    let u_param = test_type_param_from_name(&interner, u_name);
     let union = interner.union(vec![t_param, u_param]);
 
     let src = interner.tuple(vec![fixed_elem(l0), rest_elem(union)]);

--- a/crates/tsz-solver/tests/evaluate_tests_parts/utility_mapped_infer.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/utility_mapped_infer.rs
@@ -42,13 +42,7 @@ fn test_exclude_basic_union() {
     let _union = interner.union(vec![TypeId::STRING, TypeId::NUMBER, TypeId::BOOLEAN]);
 
     // Exclude pattern: T extends string ? never : T
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_t_name, t_param) = test_type_param(&interner, "T");
 
     let cond = ConditionalType {
         check_type: t_param,
@@ -108,13 +102,7 @@ fn test_extract_basic_union() {
     // Extract<T, U> = T extends U ? T : never
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_t_name, t_param) = test_type_param(&interner, "T");
 
     let string_or_number = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
 
@@ -285,13 +273,7 @@ fn test_distributive_conditional_with_type_param() {
     // Distributive: T extends U ? X : Y distributes when T is type param
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_t_name, t_param) = test_type_param(&interner, "T");
 
     // T extends string ? "yes" : "no"
     let yes = interner.literal_string("yes");
@@ -315,13 +297,7 @@ fn test_non_distributive_conditional() {
     // [T] extends [U] ? X : Y is non-distributive (wrapped in tuple)
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_t_name, t_param) = test_type_param(&interner, "T");
 
     // Wrap in tuple to make non-distributive
     let tuple_t = interner.tuple(vec![TupleElement {
@@ -629,12 +605,7 @@ fn test_noinfer_in_function_param_position() {
 
     let var_t = ctx.fresh_type_param(t_name, false);
 
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
 
     let hello_lit = interner.literal_string("hello");
     let number_type = TypeId::NUMBER;
@@ -668,12 +639,7 @@ fn test_noinfer_inference_priority() {
 
     let var_t = ctx.fresh_type_param(t_name, false);
 
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
 
     let lit_hello = interner.literal_string("hello");
     let lit_123 = interner.literal_number(123.0);
@@ -897,19 +863,9 @@ fn test_noinfer_multiple_type_params() {
     let t_name = interner.intern_string("T");
     let u_name = interner.intern_string("U");
 
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
 
-    let u_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: u_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let u_param = test_type_param_from_name(&interner, u_name);
 
     let result_tuple = interner.tuple(vec![
         TupleElement {
@@ -997,13 +953,7 @@ fn test_noinfer_in_return_position() {
     // Return type NoInfer<T> = T, but doesn't contribute to inference from return
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let func = interner.function(FunctionShape {
         type_params: vec![TypeParamInfo {
@@ -1040,13 +990,7 @@ fn test_noinfer_conditional_true_branch() {
     // In true branch, NoInfer<T> = T
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_t_name, t_param) = test_type_param(&interner, "T");
 
     // When check passes, return NoInfer<T> = T
     let cond = ConditionalType {
@@ -1072,13 +1016,7 @@ fn test_noinfer_with_infer_keyword() {
     // T extends NoInfer<infer U> ? U : never
     let interner = TypeInterner::new();
 
-    let u_name = interner.intern_string("U");
-    let infer_u = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: u_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_u_name, infer_u) = test_infer_param(&interner, "U");
 
     // Pattern: NoInfer<infer U> = infer U for matching purposes
     // Test that infer still works within NoInfer context

--- a/crates/tsz-solver/tests/evaluate_tests_parts/utility_return_parameters.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/utility_return_parameters.rs
@@ -5,13 +5,7 @@ fn test_distributive_numeric_literal_filter() {
     // Result: "low" | "mid" | "high"
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_low = interner.literal_string("low");
     let lit_mid = interner.literal_string("mid");
@@ -71,13 +65,7 @@ fn test_distributive_with_void() {
     // with T = void | string | undefined
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_void = interner.literal_string("void");
     let lit_not_void = interner.literal_string("not-void");
@@ -115,13 +103,7 @@ fn test_distributive_chained_conditionals() {
     // Tests: multiple conditional evaluation in sequence
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_str = interner.literal_string("str");
     let lit_num = interner.literal_string("num");
@@ -166,13 +148,7 @@ fn test_distributive_with_intersection_check() {
     // T extends { a: string } & { b: number } ? "match" : "no-match"
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let a_prop = interner.intern_string("a");
     let b_prop = interner.intern_string("b");
@@ -218,13 +194,7 @@ fn test_distributive_with_bigint_literals() {
     // T extends bigint ? "bigint" : "not-bigint"
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_bigint = interner.literal_string("bigint");
     let lit_not = interner.literal_string("not-bigint");
@@ -257,13 +227,7 @@ fn test_distributive_filter_nullables() {
     // NonNullable<T> = T extends null | undefined ? never : T
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let nullish = interner.union(vec![TypeId::NULL, TypeId::UNDEFINED]);
 
@@ -300,13 +264,7 @@ fn test_distributive_with_symbol() {
     // T extends symbol ? "symbol" : "not-symbol"
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_sym = interner.literal_string("symbol");
     let lit_not = interner.literal_string("not-symbol");
@@ -335,13 +293,7 @@ fn test_distributive_with_object_keyword() {
     // T extends object ? "object" : "primitive"
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_obj = interner.literal_string("object");
     let lit_prim = interner.literal_string("primitive");
@@ -384,19 +336,9 @@ fn test_distributive_infer_with_fallback() {
     let t_name = interner.intern_string("T");
     let v_name = interner.intern_string("V");
 
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
 
-    let v_infer = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: v_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let v_infer = test_infer_param_from_name(&interner, v_name);
 
     let value_prop = interner.intern_string("value");
     let extends_obj = interner.object(vec![PropertyInfo::new(value_prop, v_infer)]);
@@ -434,26 +376,11 @@ fn test_distributive_tuple_check() {
     let first_name = interner.intern_string("First");
     let rest_name = interner.intern_string("Rest");
 
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
 
-    let first_infer = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: first_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let first_infer = test_infer_param_from_name(&interner, first_name);
 
-    let rest_infer = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: rest_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let rest_infer = test_infer_param_from_name(&interner, rest_name);
 
     let extends_tuple = interner.tuple(vec![
         TupleElement {
@@ -520,13 +447,7 @@ fn test_distributive_with_literal_numbers() {
     // T extends 1 | 2 | 3 ? "low" : "high"
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let one = interner.literal_number(1.0);
     let two = interner.literal_number(2.0);
@@ -563,13 +484,7 @@ fn test_distributive_with_boolean_literal_union() {
     // T extends true ? "yes" : "no"
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let lit_true = interner.literal_boolean(true);
     let lit_false = interner.literal_boolean(false);
@@ -605,19 +520,9 @@ fn test_distributive_readonly_array_unwrap() {
     let t_name = interner.intern_string("T");
     let u_name = interner.intern_string("U");
 
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
 
-    let u_infer = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: u_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let u_infer = test_infer_param_from_name(&interner, u_name);
 
     let readonly_array = interner.intern(TypeData::ReadonlyType(interner.array(u_infer)));
 
@@ -659,19 +564,9 @@ fn test_distributive_promise_like_unwrap() {
     let t_name = interner.intern_string("T");
     let v_name = interner.intern_string("V");
 
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
 
-    let v_infer = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: v_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let v_infer = test_infer_param_from_name(&interner, v_name);
 
     // Callback type: (value: V) => any
     let callback = interner.function(FunctionShape {
@@ -898,13 +793,7 @@ fn test_return_type_conditional_return() {
     // type F<T> = (x: T) => T extends string ? number : boolean
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let cond_return = interner.conditional(ConditionalType {
         check_type: t_param,
@@ -1193,19 +1082,9 @@ fn test_return_type_with_infer_in_conditional() {
     let t_name = interner.intern_string("T");
     let r_name = interner.intern_string("R");
 
-    let _t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let _t_param = test_type_param_from_name(&interner, t_name);
 
-    let infer_r = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: r_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let infer_r = test_infer_param_from_name(&interner, r_name);
 
     let _any_array = interner.array(TypeId::ANY);
     let func_pattern = interner.function(FunctionShape {
@@ -1254,14 +1133,7 @@ fn test_parameters_with_infer_in_conditional() {
     // type Parameters<T> = T extends (...args: infer P) => any ? P : never
     let interner = TypeInterner::new();
 
-    let p_name = interner.intern_string("P");
-
-    let infer_p = interner.intern(TypeData::Infer(TypeParamInfo {
-        name: p_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (_p_name, infer_p) = test_infer_param(&interner, "P");
 
     let func_pattern = interner.function(FunctionShape {
         type_params: vec![],
@@ -1508,12 +1380,7 @@ fn test_return_type_mapped_type_method() {
     let t_name = interner.intern_string("T");
     let k_name = interner.intern_string("K");
 
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let t_param = test_type_param_from_name(&interner, t_name);
 
     let keyof_t = interner.intern(TypeData::KeyOf(t_param));
     let k_param_info = TypeParamInfo {
@@ -1693,13 +1560,7 @@ fn test_constructor_parameters_with_generics() {
     // ConstructorParameters<new <T>(value: T) => Container<T>>
     let interner = TypeInterner::new();
 
-    let t_name = interner.intern_string("T");
-    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
-        name: t_name,
-        constraint: None,
-        default: None,
-        is_const: false,
-    }));
+    let (t_name, t_param) = test_type_param(&interner, "T");
 
     let container = interner.object(vec![PropertyInfo::new(
         interner.intern_string("value"),


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Solver evaluation test-harness refactor for the M4-A recursive conditional / mapped / template-literal / `infer` / indexed-access lane.

## Invariant
When generated evaluator cases construct simple unconstrained type parameters or `infer` parameters, the case uses shared fixture helpers while preserving the same names, `TypeId` shapes, and evaluated expectations. This PR changes only the solver evaluator test harness and its file-size ratchets.

## Scope
- Add shared `test_type_param*` and `test_infer_param*` fixture helpers in `crates/tsz-solver/tests/evaluate_tests.rs`.
- Mechanically rewrite generated evaluator shards under `crates/tsz-solver/tests/evaluate_tests_parts/` to use those helpers for simple unconstrained type/infer params.
- Add a ratchet in `crates/tsz-solver/src/tests/solver_file_size_ceiling_tests.rs` so future generated shards keep simple type/infer params behind the helpers.
- Fix the CI lint follow-up by avoiding a redundant borrow inside the helper-shaped `eval_single_placeholder_infer` case.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: test-harness-only refactor; no checker, solver evaluation, parser, binder, emitter, LSP, WASM, benchmark, or project-corpus runtime behavior changes.

## Verification
- RED before helper rewrite: `cargo nextest run -p tsz-solver --lib evaluate_tests_use_shared_type_param_helpers` exited with no matching test before the ratchet was added.
- Initial branch proof: `git diff --check`, `cargo fmt --check`, `python3 scripts/arch/arch_guard.py`, and `cargo nextest run -p tsz-solver --lib -E 'test(evaluate_tests_use_shared_type_param_helpers) or test(evaluate_tests_use_feature_family_shards) or test(test_solver_file_size_ceiling) or test(test_solver_oversized_file_size_ceilings) or test(test_conditional_infer_readonly_array_element_non_array_union_branch) or test(test_distributive_with_infer_in_true_branch) or test(test_tuple_spread_generic_union_is_not_distributed)'`.
- CI lint failure root cause on prior head `6fc5463067ee266768a228941a48735c257552cd`: `clippy::needless_borrow` at `crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_core.rs:1303`.
- Rebased onto current `origin/main` at head `0290d5dab4ea6ee0c1633af673543067084b7563` and reran: `git diff --check HEAD~1..HEAD`, `cargo fmt --check`, `cargo clippy -p tsz-solver --lib --tests -- -D warnings`, `python3 scripts/arch/arch_guard.py`, and the focused `cargo nextest run` command above.

## Coordination Notes
- AgentName: M4-A
- Builds on merged PR #10570 (`test(solver): name evaluator test shards`) by completing the helper-extraction follow-up for simple evaluator type/infer parameter fixtures.
- Advances issue #9391 without taking over M1-C mapped/recursive accepted-regression work or M4-D property-access follow-ups.
- Related M4-A umbrella: #8203.
- Ready for PR-head CI on exact head `0290d5dab4ea6ee0c1633af673543067084b7563`; do not add `merge-queue` until required exact-head checks pass.
