### PR TITLE
refactor(checker): route Object prototype identity through helper

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -787,6 +787,9 @@ mod nullish_target_relation_routing_arch_tests;
 #[path = "tests/object_define_property_identity_tests.rs"]
 mod object_define_property_identity_tests;
 #[cfg(test)]
+#[path = "tests/object_global_identity_helper_tests.rs"]
+mod object_global_identity_helper_tests;
+#[cfg(test)]
 #[path = "tests/object_literal_computed_symbol_member_tests.rs"]
 mod object_literal_computed_symbol_member_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/object_global_identity_helper_tests.rs
+++ b/crates/tsz-checker/src/tests/object_global_identity_helper_tests.rs
@@ -1,0 +1,12 @@
+#[test]
+fn prototype_define_property_uses_global_identity_helper() {
+    let source = include_str!("../types/computation/complex_constructors.rs");
+    assert!(
+        source.contains("self.identifier_resolves_to_unshadowed_global(idx, \"Object\")"),
+        "`Object.defineProperty` prototype detection must route through the shared global identity helper"
+    );
+    assert!(
+        !source.contains("let is_object_lib_symbol = |sym_id|"),
+        "`Object.defineProperty` prototype detection must not duplicate Object lib-symbol matching"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/complex_constructors.rs
+++ b/crates/tsz-checker/src/types/computation/complex_constructors.rs
@@ -1317,25 +1317,7 @@ impl<'a> CheckerState<'a> {
     }
 
     fn prototype_define_property_base_is_global_object(&self, idx: NodeIndex) -> bool {
-        let Some(base_ident) = self.ctx.arena.get_identifier_at(idx) else {
-            return false;
-        };
-        if base_ident.escaped_text != "Object" {
-            return false;
-        }
-        let is_object_lib_symbol = |sym_id| {
-            self.ctx
-                .binder
-                .get_symbol(sym_id)
-                .is_some_and(|symbol| symbol.escaped_name == "Object")
-                && (self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id)
-                    || self.ctx.symbol_is_from_lib(sym_id))
-        };
-
-        if let Some(sym_id) = self.resolve_identifier_symbol_without_tracking(idx) {
-            return is_object_lib_symbol(sym_id);
-        }
-        !self.known_global_value_has_local_shadow(idx, "Object")
+        self.identifier_resolves_to_unshadowed_global(idx, "Object")
     }
 
     /// Resolve a self-referencing class constructor in a static initializer.


### PR DESCRIPTION
## Agent
AgentName: M4-D

## Track
Semantic identity cleanup / checker refactor.

## Invariant
When checker code recognizes `Object.defineProperty(...)` on a function prototype, tsz should prove the receiver is the unshadowed built-in global `Object` through the shared binder-backed global identity helper instead of duplicating local lib-symbol matching.

## Owner Layer
Checker orchestration; semantic identity remains owned by the existing global identity helper over binder/lib symbol facts.

## Adjacent-Case Matrix
- Built-in `Object.defineProperty(...)` prototype detection: still accepted by the existing constructor/prototype path.
- Local `Object` shadowing: existing Object.defineProperty identity tests remain green.
- Unresolved/no-lib `Object`: existing no-lib Object.defineProperty identity test remains green.

## Scope
- `crates/tsz-checker/src/types/computation/complex_constructors.rs`
- `crates/tsz-checker/src/tests/object_global_identity_helper_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Known Unsupported Shapes / Fallback
No new fallback. This is a behavior-preserving ratchet from a duplicated local name/lib-symbol check to the existing shared identity helper.

## Project Corpus Impact
- Row: n/a
- Bug family: stable built-in/global identity cleanup
- Evidence: checker helper refactor only; no project-row behavior expected.

## Verification
- RED: `cargo nextest run -p tsz-checker --lib prototype_define_property_uses_global_identity_helper` failed before the helper change.
- GREEN: `cargo nextest run -p tsz-checker --lib prototype_define_property_uses_global_identity_helper`
- GREEN: `cargo nextest run -p tsz-checker --lib object_define_property_identity_tests`
- GREEN: `cargo fmt --check`
- GREEN: `python3 scripts/arch/arch_guard.py`
- GREEN: `git diff --check`
- GREEN: `git diff --cached --check`

## Coordination Notes
- #10565 merged before this branch was created.
- Open PR scan showed #10571 owns the nearby `[Symbol.xxx]` computed-property path, so this PR stays on the separate `Object.defineProperty` prototype helper ratchet.
- No overlapping open M4-D PRs existed before publish.
