### PR TITLE
fix(emit): preserve ES5 statement body comments

### DIFF
--- a/crates/tsz-emitter/src/emitter/es5/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers.rs
@@ -550,12 +550,8 @@ impl<'a> Printer<'a> {
                         if block.statements.nodes.is_empty() {
                             if needs_param_prologue {
                                 self.emit_block_with_param_prologue(func.body, &param_transforms);
-                            } else if self.is_single_line(block_node) {
-                                self.write("{ }");
                             } else {
-                                self.write("{");
-                                self.write_line();
-                                self.write("}");
+                                self.emit(func.body);
                             }
                             self.emitting_function_body_block = prev_emitting_function_body_block;
                             self.pop_temp_scope();

--- a/crates/tsz-emitter/src/transforms/class_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir.rs
@@ -819,7 +819,28 @@ impl<'a> ES5ClassTransformer<'a> {
         }
         let result = converter.convert_statement(idx);
         self.collect_from_converter(&converter);
-        result
+        if matches!(result, IRNode::ASTRef(_) | IRNode::Raw(_))
+            && let Some(operand) = self.recovered_throw_operand_text(idx)
+        {
+            IRNode::ThrowStatement(Box::new(IRNode::Raw(operand.into())))
+        } else {
+            result
+        }
+    }
+
+    fn recovered_throw_operand_text(&self, idx: NodeIndex) -> Option<String> {
+        let node = self.arena.get(idx)?;
+        if node.kind != syntax_kind_ext::THROW_STATEMENT {
+            return None;
+        }
+
+        let source_text = self.source_text?;
+        let start = (node.pos as usize).min(source_text.len());
+        let end = (node.end as usize).min(source_text.len());
+        let statement = source_text[start..end].trim();
+        let operand = statement.strip_prefix("throw")?.trim();
+        let operand = operand.trim_end_matches(';').trim_end();
+        operand.ends_with('.').then(|| operand.to_string())
     }
 
     /// Collect hoisted temps from a converter and update our temp counter
@@ -1263,11 +1284,15 @@ impl<'a> ES5ClassTransformer<'a> {
                 )
             } else {
                 let mut converted = Vec::new();
+                let mut prev_stmt_end = block_node.pos;
                 for &stmt_idx in &block.statements.nodes {
-                    if let Some(stmt_node) = self.arena.get(stmt_idx)
-                        && let Some(comment) = self.extract_leading_comment(stmt_node)
-                    {
-                        converted.push(IRNode::Raw(comment.into()));
+                    if let Some(stmt_node) = self.arena.get(stmt_idx) {
+                        self.emit_leading_statement_comments(
+                            &mut converted,
+                            prev_stmt_end,
+                            stmt_node.pos,
+                        );
+                        prev_stmt_end = stmt_node.end;
                     }
                     converted.push(self.convert_statement_with_context(
                         stmt_idx,

--- a/crates/tsz-emitter/src/transforms/ir_printer.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer.rs
@@ -1237,7 +1237,13 @@ impl<'a> IRPrinter<'a> {
             IRNode::ThrowStatement(expr) => {
                 self.write("throw ");
                 self.emit_node(expr);
-                self.write(";");
+                if self.is_recovered_empty_property_access(expr) {
+                    self.write_line();
+                    self.write_indent();
+                    self.write(";");
+                } else {
+                    self.write(";");
+                }
             }
             IRNode::BreakStatement(label) => {
                 self.write("break");
@@ -1855,6 +1861,81 @@ impl<'a> IRPrinter<'a> {
                 self.write(";");
             }
         }
+    }
+
+    fn is_recovered_empty_property_access(&self, node: &IRNode) -> bool {
+        match node {
+            IRNode::PropertyAccess { property, .. } => property.is_empty(),
+            IRNode::Raw(text) => text.trim_end().ends_with('.'),
+            IRNode::ASTRef(idx) => self.arena.is_some_and(|arena| {
+                arena.get(*idx).is_some_and(|node| {
+                    if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                        && arena.get_access_expr(node).is_some_and(|access| {
+                            arena.is_missing_recovery_identifier(access.name_or_argument)
+                        })
+                    {
+                        return true;
+                    }
+
+                    self.source_text.is_some_and(|source_text| {
+                        let start = (node.pos as usize).min(source_text.len());
+                        let end = (node.end as usize).min(source_text.len());
+                        if start < end {
+                            let span = &source_text[start..end];
+                            span.trim_end().ends_with('.')
+                                || Self::source_span_has_recovered_property_boundary(span)
+                                || Self::source_has_recovered_property_boundary(source_text, end)
+                        } else {
+                            Self::source_has_recovered_property_boundary(source_text, end)
+                        }
+                    })
+                })
+            }),
+            _ => false,
+        }
+    }
+
+    fn source_has_recovered_property_boundary(source_text: &str, end: usize) -> bool {
+        let bytes = source_text.as_bytes();
+        if bytes.get(end) != Some(&b'.') {
+            return false;
+        }
+
+        let mut i = end + 1;
+        while let Some(byte) = bytes.get(i) {
+            match byte {
+                b' ' | b'\t' | b'\r' => i += 1,
+                b'\n' | b';' | b'}' => return true,
+                _ => return false,
+            }
+        }
+        true
+    }
+
+    fn source_span_has_recovered_property_boundary(span: &str) -> bool {
+        let bytes = span.as_bytes();
+        for dot in bytes
+            .iter()
+            .enumerate()
+            .filter_map(|(i, byte)| (*byte == b'.').then_some(i))
+        {
+            let mut i = dot + 1;
+            while let Some(byte) = bytes.get(i) {
+                match byte {
+                    b' ' | b'\t' | b'\r' => i += 1,
+                    b'\n' => {
+                        i += 1;
+                        while matches!(bytes.get(i), Some(b' ' | b'\t' | b'\r' | b'\n')) {
+                            i += 1;
+                        }
+                        return bytes.get(i).is_none_or(|byte| matches!(byte, b';' | b'}'));
+                    }
+                    b';' | b'}' => return true,
+                    _ => break,
+                }
+            }
+        }
+        false
     }
 }
 

--- a/crates/tsz-emitter/tests/statements.rs
+++ b/crates/tsz-emitter/tests/statements.rs
@@ -149,6 +149,32 @@ fn es5_property_access_preserves_raw_astral_identifier_name() {
 }
 
 #[test]
+fn es5_arrow_empty_block_preserves_inner_line_comment() {
+    let source = "const f: () => undefined = () => {\n    // keep\n};\n";
+    let output = parse_and_emit_strict_target(source, "arrow.ts", ScriptTarget::ES5);
+
+    assert!(
+        output.contains("var f = function () {\n    // keep\n};"),
+        "ES5 arrow block lowering should preserve comment-only bodies.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("};\n// keep"),
+        "Comment-only arrow body comments must not drift after the function expression.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es5_accessor_recovered_throw_preserves_comment_chain_and_semicolon_line() {
+    let source = "class C {\n    get value() {\n        // first\n        // second\n        throw null;\n        throw undefined.\n    }\n}\n";
+    let output = parse_and_emit_strict_target(source, "accessor.ts", ScriptTarget::ES5);
+
+    assert!(
+        output.contains("get: function () {\n            // first\n            // second\n            throw null;\n            throw undefined.\n            ;\n        }"),
+        "ES5 accessor lowering should keep leading comment chains and recovered throw semicolon layout.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn es5_braced_astral_class_member_tail_emits_as_outer_statements() {
     let source = r#"
 class Foo {


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Emit/DTS parity - JavaScript emit statements / ES5 lowering

## Invariant
When ES5 lowering rewrites arrow/accessor bodies, `tsc` keeps source-owned statement-body comments inside the generated function body and prints recovered dangling property throws with the inserted semicolon on the following indented line; this PR makes tsz do that through the ES5 direct printer and class IR/printer boundary.

## Scope
- Reuse normal block emission for empty ES5 arrow block bodies so comment-only bodies stay inside the generated function.
- Preserve full leading comment chains between statements when ES5 class body lowering converts accessor/method bodies to IR.
- Normalize recovered throw fallback operands in class body IR and let the IR printer place the semicolon on the following indented line for dangling property recovery.
- Add focused tsz-emitter tests for the arrow comment-only block and recovered accessor throw cases.

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit statements / ES5 lowering
- Evidence: `scripts/emit/run.sh --skip-build --filter=statements --js-only --verbose --json-out=/tmp/studio-c-statements-after.json` passes 107/107 after the focused fix.

## Verification
- `cargo check -p tsz-emitter`
- `cargo nextest run -p tsz-emitter es5_arrow_empty_block_preserves_inner_line_comment es5_accessor_recovered_throw_preserves_comment_chain_and_semicolon_line`
- `scripts/emit/run.sh --filter=functionsMissingReturnStatementsAndExpressions --js-only --verbose --json-out=/tmp/studio-c-functions-missing-return-after.json`
- `scripts/emit/run.sh --skip-build --filter=statements --js-only --verbose --json-out=/tmp/studio-c-statements-after.json`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`

## Coordination Notes
AgentName: Studio-C. This branch was restored on current `origin/main` after the earlier local Studio-C worktree disappeared; the final commit is based on `474f7ecb64` and contains only the reconstructed four-file emitter/test slice. No checker/solver semantics, no roadmap update, and no full local conformance/emit/fourslash run.

