### PR TITLE
fix(bench): validate latest prep artifact fallback

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -660,6 +660,25 @@ jobs:
             [[ -n "${manifest_env:-}" && -n "${manifest_tar:-}" ]] || return 1
             storage_cp "$manifest_env" bench-prep.env && storage_cp "$manifest_tar" bench-prep.tar
           }
+          validate_downloaded_prep_artifact() {
+            tar -tf bench-prep.tar .target-bench/dist/tsz >/dev/null || return 1
+            tar -tf bench-prep.tar .target-bench/dist/.bench-pgo-optimized >/dev/null || return 1
+            manifest_target_sha="$(manifest_value BENCH_TARGET_SHA)"
+            manifest_pgo_optimized="$(manifest_value BENCH_PGO_OPTIMIZED)"
+            [[ "${manifest_target_sha}" == "${target_sha}" &&
+              "${manifest_pgo_optimized}" == "1" ]]
+          }
+          copy_from_latest_prep_artifact() {
+            rm -f latest-bench-prep.env bench-prep.env bench-prep.tar
+            storage_cp \
+              "gs://tsz-ci_cloudbuild/bench-prep/latest/bench-prep.env" \
+              latest-bench-prep.env || return 1
+            storage_cp \
+              "gs://tsz-ci_cloudbuild/bench-prep/latest/bench-prep.tar" \
+              bench-prep.tar || return 1
+            mv latest-bench-prep.env bench-prep.env
+            validate_downloaded_prep_artifact
+          }
           cloudbuild_status() {
             local build_id="$1"
             [[ -n "$build_id" ]] || return 0
@@ -679,12 +698,7 @@ jobs:
               storage_cp \
                 "gs://tsz-ci_cloudbuild/bench-prep/${target_sha}/bench-prep.tar" \
                 bench-prep.tar; then
-              tar -tf bench-prep.tar .target-bench/dist/tsz >/dev/null
-              tar -tf bench-prep.tar .target-bench/dist/.bench-pgo-optimized >/dev/null
-              manifest_target_sha="$(manifest_value BENCH_TARGET_SHA)"
-              manifest_pgo_optimized="$(manifest_value BENCH_PGO_OPTIMIZED)"
-              if [[ "${manifest_target_sha}" == "${target_sha}" &&
-                    "${manifest_pgo_optimized}" == "1" ]]; then
+              if validate_downloaded_prep_artifact; then
                 exit 0
               fi
               echo "Cloud Build prep artifact is for ${manifest_target_sha:-unknown} / PGO=${manifest_pgo_optimized:-0}; waiting for ${target_sha}."
@@ -692,19 +706,17 @@ jobs:
 
             status="$(cloudbuild_status "$cloudbuild_id")"
             if [[ "$status" == "SUCCESS" ]]; then
+              if copy_from_latest_prep_artifact; then
+                exit 0
+              fi
               if copy_from_cloudbuild_manifest "$target_sha"; then
-                tar -tf bench-prep.tar .target-bench/dist/tsz >/dev/null
-                tar -tf bench-prep.tar .target-bench/dist/.bench-pgo-optimized >/dev/null
-                manifest_target_sha="$(manifest_value BENCH_TARGET_SHA)"
-                manifest_pgo_optimized="$(manifest_value BENCH_PGO_OPTIMIZED)"
-                if [[ "${manifest_target_sha}" == "${target_sha}" &&
-                      "${manifest_pgo_optimized}" == "1" ]]; then
+                if validate_downloaded_prep_artifact; then
                   exit 0
                 fi
                 echo "Cloud Build benchmark prep ${cloudbuild_id} succeeded, but its manifest artifact is for ${manifest_target_sha:-unknown} / PGO=${manifest_pgo_optimized:-0}; expected ${target_sha} / PGO=1."
                 exit 1
               fi
-              echo "Cloud Build benchmark prep ${cloudbuild_id} succeeded, but its artifact manifest did not expose bench-prep env/tar for ${target_sha}."
+              echo "Cloud Build benchmark prep ${cloudbuild_id} succeeded, but neither SHA-scoped, latest, nor manifest artifacts exposed valid bench-prep env/tar for ${target_sha}."
               exit 1
             fi
             case "$status" in
@@ -820,6 +832,25 @@ jobs:
             [[ -n "${manifest_env:-}" && -n "${manifest_tar:-}" ]] || return 1
             storage_cp "$manifest_env" bench-prep.env && storage_cp "$manifest_tar" bench-prep.tar
           }
+          validate_downloaded_prep_artifact() {
+            tar -tf bench-prep.tar .target-bench/dist/tsz >/dev/null || return 1
+            tar -tf bench-prep.tar .target-bench/dist/.bench-pgo-optimized >/dev/null || return 1
+            manifest_target_sha="$(manifest_value BENCH_TARGET_SHA)"
+            manifest_pgo_optimized="$(manifest_value BENCH_PGO_OPTIMIZED)"
+            [[ "${manifest_target_sha}" == "${target_sha}" &&
+              "${manifest_pgo_optimized}" == "1" ]]
+          }
+          copy_from_latest_prep_artifact() {
+            rm -f latest-bench-prep.env bench-prep.env bench-prep.tar
+            storage_cp \
+              "gs://tsz-ci_cloudbuild/bench-prep/latest/bench-prep.env" \
+              latest-bench-prep.env || return 1
+            storage_cp \
+              "gs://tsz-ci_cloudbuild/bench-prep/latest/bench-prep.tar" \
+              bench-prep.tar || return 1
+            mv latest-bench-prep.env bench-prep.env
+            validate_downloaded_prep_artifact
+          }
           cloudbuild_status() {
             local build_id="$1"
             [[ -n "$build_id" ]] || return 0
@@ -839,12 +870,7 @@ jobs:
               storage_cp \
                 "gs://tsz-ci_cloudbuild/bench-prep/${target_sha}/bench-prep.tar" \
                 bench-prep.tar; then
-              tar -tf bench-prep.tar .target-bench/dist/tsz >/dev/null
-              tar -tf bench-prep.tar .target-bench/dist/.bench-pgo-optimized >/dev/null
-              manifest_target_sha="$(manifest_value BENCH_TARGET_SHA)"
-              manifest_pgo_optimized="$(manifest_value BENCH_PGO_OPTIMIZED)"
-              if [[ "${manifest_target_sha}" == "${target_sha}" &&
-                    "${manifest_pgo_optimized}" == "1" ]]; then
+              if validate_downloaded_prep_artifact; then
                 exit 0
               fi
               echo "Cloud Build prep artifact is for ${manifest_target_sha:-unknown} / PGO=${manifest_pgo_optimized:-0}; waiting for ${target_sha}."
@@ -852,19 +878,17 @@ jobs:
 
             status="$(cloudbuild_status "$cloudbuild_id")"
             if [[ "$status" == "SUCCESS" ]]; then
+              if copy_from_latest_prep_artifact; then
+                exit 0
+              fi
               if copy_from_cloudbuild_manifest "${target_sha}"; then
-                tar -tf bench-prep.tar .target-bench/dist/tsz >/dev/null
-                tar -tf bench-prep.tar .target-bench/dist/.bench-pgo-optimized >/dev/null
-                manifest_target_sha="$(manifest_value BENCH_TARGET_SHA)"
-                manifest_pgo_optimized="$(manifest_value BENCH_PGO_OPTIMIZED)"
-                if [[ "${manifest_target_sha}" == "${target_sha}" &&
-                      "${manifest_pgo_optimized}" == "1" ]]; then
+                if validate_downloaded_prep_artifact; then
                   exit 0
                 fi
                 echo "Cloud Build benchmark prep ${cloudbuild_id} succeeded, but its manifest artifact is for ${manifest_target_sha:-unknown} / PGO=${manifest_pgo_optimized:-0}; expected ${target_sha} / PGO=1."
                 exit 1
               fi
-              echo "Cloud Build benchmark prep ${cloudbuild_id} succeeded, but its artifact manifest did not expose bench-prep env/tar for ${target_sha}."
+              echo "Cloud Build benchmark prep ${cloudbuild_id} succeeded, but neither SHA-scoped, latest, nor manifest artifacts exposed valid bench-prep env/tar for ${target_sha}."
               exit 1
             fi
             case "$status" in

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -25,11 +25,11 @@ assert.doesNotMatch(
   "successful Cloud Build prep with a stale manifest artifact must not wait until the 150 minute deadline",
 );
 
-const unusableManifestMessages = workflow.match(
-  /Cloud Build benchmark prep \$\{cloudbuild_id\} succeeded, but its artifact manifest did not expose bench-prep env\/tar for/g,
+const unusableArtifactMessages = workflow.match(
+  /Cloud Build benchmark prep \$\{cloudbuild_id\} succeeded, but neither SHA-scoped, latest, nor manifest artifacts exposed valid bench-prep env\/tar for/g,
 ) ?? [];
 assert.equal(
-  unusableManifestMessages.length,
+  unusableArtifactMessages.length,
   2,
   "both Cloud Build prep artifact paths should fail fast when a successful build exposes no usable prep artifacts",
 );
@@ -84,8 +84,23 @@ const prepArtifactJob = workflow.match(
 )?.[0] ?? "";
 assert.doesNotMatch(
   prepArtifactJob,
-  /bench-prep\/latest\/bench-prep\.(?:env|tar)|^\s*["']\/?bench-prep\.(?:env|tar)["'],?$/m,
-  "bench-prep-artifact must only trust SHA-scoped manifest paths; latest/root fallbacks can publish stale artifacts",
+  /^\s*["']\/?bench-prep\.(?:env|tar)["'],?$/m,
+  "bench-prep-artifact must not trust root-level Cloud Build artifact paths",
+);
+
+const latestFallbacks = prepArtifactJob.match(
+  /copy_from_latest_prep_artifact\(\) \{[\s\S]+?bench-prep\/latest\/bench-prep\.env[\s\S]+?bench-prep\/latest\/bench-prep\.tar[\s\S]+?validate_downloaded_prep_artifact[\s\S]+?\}/g,
+) ?? [];
+assert.equal(
+  latestFallbacks.length,
+  2,
+  "both Cloud Build prep artifact paths should recover validated latest prep artifacts",
+);
+
+assert.match(
+  prepArtifactJob,
+  /validate_downloaded_prep_artifact\(\) \{[\s\S]+manifest_target_sha="\$\(manifest_value BENCH_TARGET_SHA\)"[\s\S]+manifest_pgo_optimized="\$\(manifest_value BENCH_PGO_OPTIMIZED\)"[\s\S]+\$\{manifest_target_sha\}" == "\$\{target_sha\}" &&[\s\S]+\$\{manifest_pgo_optimized\}" == "1"/,
+  "latest prep artifact fallback must validate the downloaded artifact target SHA and PGO marker",
 );
 
 console.log("bench workflow Cloud Build prep artifact tests passed");


### PR DESCRIPTION
AgentName: Studio-B

Track: benchmark publication / website freshness

Invariant: Benchmark prep artifacts must only be accepted after validating the downloaded env/tar pair belongs to the workflow target SHA and is PGO optimized.

Scope:
- Add a validated `bench-prep/latest` fallback to both Cloud Build prep artifact download paths.
- Reuse the same target/PGO validation for SHA-scoped, latest, and manifest-recovered artifacts.
- Update the workflow guard test so latest is allowed only through validated artifact recovery, while root-level artifact paths remain forbidden.

Project Corpus Impact:
Row: n/a
Bug family: benchmark publication artifact handoff
Evidence: workflow-only recovery after Bench run 26524734398 failed because Cloud Build succeeded but did not expose SHA-scoped/manifest prep artifacts.

Verification:
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `git diff --check`

Coordination Notes:
This follows PR #10574. The failed run proved the fail-fast status path works, but Cloud Build still did not expose the SHA-scoped or manifest-listed prep artifacts. The config already publishes `bench-prep/latest`; this PR lets the Bench workflow recover it only when `BENCH_TARGET_SHA` and `BENCH_PGO_OPTIMIZED=1` match the workflow target.
