### PR TITLE
perf(checker): skip unconstrained generic arg validation

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mod.rs
@@ -969,6 +969,9 @@ impl<'a> CheckerState<'a> {
         // A syntactic check cannot reliably distinguish these cases and produces
         // false positives.  TS4109 should be emitted from the solver's type
         // resolution path once cycle detection is implemented there.
+        if type_params.iter().all(|param| param.constraint.is_none()) {
+            return false;
+        }
         self.validate_type_args_against_params(type_params, type_args_list);
         false
     }

--- a/crates/tsz-checker/tests/ts2304_tests.rs
+++ b/crates/tsz-checker/tests/ts2304_tests.rs
@@ -601,6 +601,23 @@ function A(): (x: B) => C {
 }
 
 #[test]
+fn unconstrained_generic_type_arg_still_reports_missing_name() {
+    let source = r#"
+type Box<T> = T;
+type Alias = Box<MissingType>;
+"#;
+    let diagnostics = check_without_lib(source);
+    let ts2304_errors: Vec<_> = diagnostics.iter().filter(|d| d.code == 2304).collect();
+
+    assert!(
+        ts2304_errors
+            .iter()
+            .any(|d| diagnostic_contains(d, "'MissingType'")),
+        "Expected TS2304 for MissingType inside unconstrained type argument, got: {ts2304_errors:?}",
+    );
+}
+
+#[test]
 fn test_no_ts2591_for_private_name_access_base() {
     let source = r#"exports.#nope = 1;"#;
     let diagnostics = check_without_lib(source);

--- a/crates/tsz-checker/tests/type_arg_count_mismatch_tests.rs
+++ b/crates/tsz-checker/tests/type_arg_count_mismatch_tests.rs
@@ -116,6 +116,21 @@ var r1 = create<number>(1, "hello");
     );
 }
 
+#[test]
+fn unconstrained_outer_type_ref_still_checks_nested_type_arg_arity() {
+    let source = r#"
+type Box<T> = T;
+type Pair<T, U> = T | U;
+type Alias = Box<Pair<string>>;
+"#;
+    let codes = check_source_codes(source);
+
+    assert!(
+        codes.contains(&2314),
+        "Expected TS2314 for nested Pair<string>, got: {codes:?}"
+    );
+}
+
 /// Calling a non-generic function with type arguments should emit TS2558
 /// but NOT emit spurious argument-related errors.
 #[test]


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Performance: green-row tsgo winner reduction for ts-essentials / utility type workload.

## Invariant
When a generic type reference has the correct arity and every referenced type parameter is unconstrained, checker constraint validation must not re-lower and re-check the argument list solely for TS2344. Nested argument diagnostics still come from normal argument lowering and type-node checks.

## Scope
- `crates/tsz-checker/src/checkers/generic_checker/mod.rs`
- `crates/tsz-checker/tests/ts2304_tests.rs`
- `crates/tsz-checker/tests/type_arg_count_mismatch_tests.rs`

## Project Corpus Impact
- Row: `ts-essentials-project`
- Bug family: unconstrained utility-type generic applications in the XOR workload.
- Evidence: `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^ts-essentials-project$' --json-file /private/tmp/studio-b-unconstrained-baseline-main-474f7ec-20260527.json` measured `tsz=106.81 ms`, `tsgo=78.47 ms`; patched `/private/tmp/studio-b-unconstrained-after-main-474f7ec-20260527.json` measured `tsz=90.28 ms`, `tsgo=75.73 ms`. Winner reports remain one target gap: `/private/tmp/studio-b-unconstrained-baseline-main-474f7ec-20260527.tsgo-winners.json` and `/private/tmp/studio-b-unconstrained-after-main-474f7ec-20260527.tsgo-winners.json`.

## Verification
- `cargo fmt --check`
- `cargo check -p tsz-checker`
- `cargo nextest run -p tsz-checker --test ts2304_tests unconstrained_generic_type_arg_still_reports_missing_name`
- `cargo nextest run -p tsz-checker --test type_arg_count_mismatch_tests unconstrained_outer_type_ref_still_checks_nested_type_arg_arity`
- `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^ts-essentials-project$' --json-file /private/tmp/studio-b-unconstrained-baseline-main-474f7ec-20260527.json`
- `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^ts-essentials-project$' --json-file /private/tmp/studio-b-unconstrained-after-main-474f7ec-20260527.json`

## Coordination Notes
- No open Studio-B PRs existed before this work; #10556 was already merged.
- Worktree used for final patch: `/Users/mohsen/code/tsz-studio-b-unconstrained-20260527`.
- The benchmark remains a green tsgo winner and still has a 2x target gap; this PR is a small improvement, not goal completion.
