### PR TITLE
refactor(solver): expose application-eval cache on TypeDatabase for interner reads

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/state/type_environment.rs
+++ b/crates/tsz-checker/src/query_boundaries/state/type_environment.rs
@@ -378,8 +378,12 @@ pub(crate) fn evaluate_type_with_cache<R: tsz_solver::relations::subtype::TypeRe
     seed: impl Iterator<Item = (TypeId, TypeId)>,
     has_seed: bool,
     expand_application_display_alias_args: bool,
+    query_db: Option<&dyn QueryDatabase>,
 ) -> EvalWithCacheResult {
     let mut evaluator = tsz_solver::computation::TypeEvaluator::with_resolver(db, resolver);
+    if let Some(query_db) = query_db {
+        evaluator = evaluator.with_query_db(query_db);
+    }
     if expand_application_display_alias_args {
         evaluator = evaluator.with_expanded_application_display_alias_args();
     }

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -224,6 +224,12 @@ impl<'a> CheckerState<'a> {
                 seed_iter.into_iter(),
                 has_seed,
                 self.ctx.is_declaration_file() || self.ctx.emit_declarations(),
+                // First pass uses the limited `TypeEnvironment` resolver, which
+                // can leave residue (unresolved Lazy/IndexAccess/Mapped). Do NOT
+                // let it populate the resolver-independent application-eval cache,
+                // or sibling reads would observe under-resolved results. Writes
+                // are reserved for the authoritative full-resolver second pass.
+                None,
             );
             if eval_result.depth_exceeded {
                 depth_exceeded = true;
@@ -298,6 +304,10 @@ impl<'a> CheckerState<'a> {
                 seed_iter.into_iter(),
                 use_cache,
                 self.ctx.is_declaration_file() || self.ctx.emit_declarations(),
+                // Second pass uses the authoritative full `CheckerContext`
+                // resolver, so its application expansions are safe to memoize in
+                // the per-file application-eval cache.
+                Some(self.ctx.types),
             );
             if eval_result.depth_exceeded {
                 depth_exceeded = true;

--- a/crates/tsz-checker/src/types/type_node_advanced.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced.rs
@@ -138,6 +138,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             std::iter::empty(),
             false,
             self.ctx.is_declaration_file() || self.ctx.emit_declarations(),
+            Some(self.ctx.types),
         )
         .result;
         if evaluated != TypeId::ERROR && evaluated != application {

--- a/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
@@ -92,6 +92,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                         std::iter::empty(),
                         false,
                         self.ctx.is_declaration_file() || self.ctx.emit_declarations(),
+                        Some(self.ctx.types),
                     ),
                 )
             } else {
@@ -569,6 +570,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             std::iter::empty(),
             false,
             self.ctx.is_declaration_file() || self.ctx.emit_declarations(),
+            Some(self.ctx.types),
         )
         .result;
 

--- a/crates/tsz-checker/src/types/type_node_query_members.rs
+++ b/crates/tsz-checker/src/types/type_node_query_members.rs
@@ -42,6 +42,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                 std::iter::empty(),
                 false,
                 self.ctx.is_declaration_file() || self.ctx.emit_declarations(),
+                Some(self.ctx.types),
             )
             .result;
         let base_type = if evaluated_base != TypeId::ERROR {

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -201,12 +201,50 @@ pub trait TypeCompilerOptions {
     }
 }
 
+/// Per-file cache hooks for evaluated generic applications.
+///
+/// The cache is keyed by the resolver-independent `(DefId, args,
+/// no_unchecked_indexed_access)` triple, so reads are safe for any evaluator
+/// regardless of how it was spawned. Writes remain gated by callers to
+/// authoritative full-resolver contexts. Keeping these hooks separate from
+/// [`TypeDatabase`] makes application-eval cache access a narrow cache
+/// capability instead of growing the general type storage interface.
+pub trait TypeApplicationEvalCache {
+    /// Look up a shared cache entry for evaluated generic applications.
+    ///
+    /// The default returns `None` so raw `TypeInterner` backends and tests opt
+    /// out.
+    fn lookup_application_eval_cache(
+        &self,
+        _def_id: DefId,
+        _args: &[TypeId],
+        _no_unchecked_indexed_access: bool,
+    ) -> Option<TypeId> {
+        None
+    }
+
+    /// Store an evaluated generic application result in the shared per-file
+    /// cache. The default is a no-op so non-cache backends opt out.
+    fn insert_application_eval_cache(
+        &self,
+        _def_id: DefId,
+        _args: &[TypeId],
+        _no_unchecked_indexed_access: bool,
+        _result: TypeId,
+    ) {
+    }
+}
+
 /// Query interface for the solver.
 ///
 /// This keeps solver components generic and prevents them from reaching
 /// into concrete storage structures directly.
 pub trait TypeDatabase:
-    TypePredicateCache + TypeTupleLimitSignal + TypeDisplayProvenance + TypeCompilerOptions
+    TypePredicateCache
+    + TypeTupleLimitSignal
+    + TypeDisplayProvenance
+    + TypeCompilerOptions
+    + TypeApplicationEvalCache
 {
     fn intern(&self, key: TypeData) -> TypeId;
     fn lookup(&self, id: TypeId) -> Option<TypeData>;
@@ -487,6 +525,8 @@ impl TypeCompilerOptions for TypeInterner {
         TypeInterner::exact_optional_property_types(self)
     }
 }
+
+impl TypeApplicationEvalCache for TypeInterner {}
 
 impl TypeDatabase for TypeInterner {
     fn intern(&self, key: TypeData) -> TypeId {
@@ -936,26 +976,6 @@ pub trait QueryDatabase: TypeDatabase + TypeResolver {
 
     fn evaluate_mapped(&self, mapped: &MappedType) -> TypeId {
         crate::evaluation::evaluate::evaluate_mapped(self.as_type_database(), mapped)
-    }
-
-    /// Look up a shared cache entry for evaluated generic applications.
-    fn lookup_application_eval_cache(
-        &self,
-        _def_id: DefId,
-        _args: &[TypeId],
-        _no_unchecked_indexed_access: bool,
-    ) -> Option<TypeId> {
-        None
-    }
-
-    /// Store an evaluated generic application result in the shared cache.
-    fn insert_application_eval_cache(
-        &self,
-        _def_id: DefId,
-        _args: &[TypeId],
-        _no_unchecked_indexed_access: bool,
-        _result: TypeId,
-    ) {
     }
 
     /// Look up a cross-call `instantiate_type` cache entry.

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -204,11 +204,12 @@ pub trait TypeCompilerOptions {
 /// Per-file cache hooks for evaluated generic applications.
 ///
 /// The cache is keyed by the resolver-independent `(DefId, args,
-/// no_unchecked_indexed_access)` triple, so reads are safe for any evaluator
-/// regardless of how it was spawned. Writes remain gated by callers to
-/// authoritative full-resolver contexts. Keeping these hooks separate from
-/// [`TypeDatabase`] makes application-eval cache access a narrow cache
-/// capability instead of growing the general type storage interface.
+/// no_unchecked_indexed_access)` triple. Callers are responsible for using it
+/// only from authoritative full-resolver contexts; limited/noop resolvers can
+/// otherwise skip fallback behavior that is part of recursive and inference
+/// parity. Keeping these hooks separate from [`TypeDatabase`] makes
+/// application-eval cache access a narrow cache capability instead of growing
+/// the general type storage interface.
 pub trait TypeApplicationEvalCache {
     /// Look up a shared cache entry for evaluated generic applications.
     ///

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -5,8 +5,8 @@
 //! database implementation used by the checker at runtime.
 
 use crate::caches::db::{
-    QueryDatabase, TypeCompilerOptions, TypeDatabase, TypeDisplayProvenance, TypePredicateCache,
-    TypeTupleLimitSignal,
+    QueryDatabase, TypeApplicationEvalCache, TypeCompilerOptions, TypeDatabase,
+    TypeDisplayProvenance, TypePredicateCache, TypeTupleLimitSignal,
 };
 use crate::caches::instantiation_cache::{InstantiationCache, InstantiationCacheKey};
 use crate::caches::query_trace;
@@ -1133,6 +1133,39 @@ impl TypeCompilerOptions for QueryCache<'_> {
     }
 }
 
+impl TypeApplicationEvalCache for QueryCache<'_> {
+    fn lookup_application_eval_cache(
+        &self,
+        def_id: DefId,
+        args: &[TypeId],
+        no_unchecked_indexed_access: bool,
+    ) -> Option<TypeId> {
+        self.check_application_eval_cache((
+            def_id,
+            smallvec::SmallVec::from_slice(args),
+            no_unchecked_indexed_access,
+        ))
+    }
+
+    fn insert_application_eval_cache(
+        &self,
+        def_id: DefId,
+        args: &[TypeId],
+        no_unchecked_indexed_access: bool,
+        result: TypeId,
+    ) {
+        QueryCache::insert_application_eval_cache(
+            self,
+            (
+                def_id,
+                smallvec::SmallVec::from_slice(args),
+                no_unchecked_indexed_access,
+            ),
+            result,
+        );
+    }
+}
+
 impl TypeDatabase for QueryCache<'_> {
     fn intern(&self, key: TypeData) -> TypeId {
         self.interner.intern(key)
@@ -1610,36 +1643,6 @@ impl QueryDatabase for QueryCache<'_> {
             query_trace::unary_end(query_id, "evaluate_type_with_options", result, false);
         }
         result
-    }
-
-    fn lookup_application_eval_cache(
-        &self,
-        def_id: DefId,
-        args: &[TypeId],
-        no_unchecked_indexed_access: bool,
-    ) -> Option<TypeId> {
-        self.check_application_eval_cache((
-            def_id,
-            smallvec::SmallVec::from_slice(args),
-            no_unchecked_indexed_access,
-        ))
-    }
-
-    fn insert_application_eval_cache(
-        &self,
-        def_id: DefId,
-        args: &[TypeId],
-        no_unchecked_indexed_access: bool,
-        result: TypeId,
-    ) {
-        self.insert_application_eval_cache(
-            (
-                def_id,
-                smallvec::SmallVec::from_slice(args),
-                no_unchecked_indexed_access,
-            ),
-            result,
-        );
     }
 
     /// Look up a cross-call `instantiate_type` result.

--- a/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
+++ b/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
@@ -1,6 +1,6 @@
 //! Query cache statistics and size-accounting coverage tests.
 
-use crate::caches::db::QueryDatabase;
+use crate::caches::db::{QueryDatabase, TypeApplicationEvalCache};
 use crate::caches::instantiation_cache::{CanonicalSubst, InstantiationCacheKey};
 use crate::caches::query_cache::{QueryCache, QueryCacheStatistics, SharedQueryCache};
 use crate::def::DefId;

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -710,22 +710,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // restore `saved_apparent` — outer caller observes `None`.
         let saved_apparent = self.apparent_conditional_branch.take();
 
-        // Phase 4 — raw-args cache shortcut. Lite resolvers (e.g. inside
-        // `SubtypeChecker`) often return `None` for `get_lazy_type_params`,
-        // so the normal expanded-args lookup never runs. Trying `app.args`
-        // first lets every context benefit from previously computed results.
-        //
-        // The application-eval cache lives on the interner (the per-file
-        // `QueryCache`), so even evaluators that were not handed an explicit
-        // `query_db` can read previously computed, authoritative results. This
-        // is the read-side counterpart to the write-side gating in
-        // `insert_application_eval_cache_if_some`, which still only writes from
-        // an authoritative (full-resolver) `query_db` context.
-        {
+        // Phase 4 — raw-args cache shortcut. Only evaluators with an explicit
+        // `query_db` consume this cache: limited/noop resolvers can otherwise
+        // observe a result computed under stronger resolution assumptions and
+        // skip the fallback behavior that preserves recursive/inference parity.
+        if let Some(db) = self.query_db {
             let no_unchecked = self.no_unchecked_indexed_access;
-            if let Some(cached) =
-                self.interner
-                    .lookup_application_eval_cache(def_id, &app.args, no_unchecked)
+            if let Some(cached) = db.lookup_application_eval_cache(def_id, &app.args, no_unchecked)
             {
                 self.decrement_def_depth(def_id);
                 return cached;
@@ -948,11 +939,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let expanded_args = self.prepare_expanded_args_for_body(resolved, args);
         let no_unchecked_indexed_access = self.no_unchecked_indexed_access;
 
-        if let Some(cached) = self.interner.lookup_application_eval_cache(
-            def_id,
-            &expanded_args,
-            no_unchecked_indexed_access,
-        ) {
+        if let Some(db) = self.query_db
+            && let Some(cached) = db.lookup_application_eval_cache(
+                def_id,
+                &expanded_args,
+                no_unchecked_indexed_access,
+            )
+        {
             return ApplicationEvalOutcome::ShortCircuit(cached);
         }
 
@@ -1034,11 +1027,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let expanded_args = self.expand_type_args(args);
         let no_unchecked_indexed_access = self.no_unchecked_indexed_access;
 
-        if let Some(cached) = self.interner.lookup_application_eval_cache(
-            def_id,
-            &expanded_args,
-            no_unchecked_indexed_access,
-        ) {
+        if let Some(db) = self.query_db
+            && let Some(cached) = db.lookup_application_eval_cache(
+                def_id,
+                &expanded_args,
+                no_unchecked_indexed_access,
+            )
+        {
             return ApplicationEvalOutcome::ShortCircuit(cached);
         }
 
@@ -1275,9 +1270,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// Writes stay gated on an authoritative (full-resolver) `query_db`
     /// context: a limited resolver could otherwise store an under-resolved
     /// result under the resolver-independent `(DefId, args)` key and poison
-    /// sibling reads. Reads, by contrast, go through the interner (see
-    /// `evaluate_application`) so every evaluator can consume these
-    /// authoritative entries.
+    /// sibling reads. Reads use the same explicit `query_db` gate for the same
+    /// reason.
     fn insert_application_eval_cache_if_some(
         &self,
         def_id: DefId,

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -714,9 +714,18 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // `SubtypeChecker`) often return `None` for `get_lazy_type_params`,
         // so the normal expanded-args lookup never runs. Trying `app.args`
         // first lets every context benefit from previously computed results.
-        if let Some(db) = self.query_db {
+        //
+        // The application-eval cache lives on the interner (the per-file
+        // `QueryCache`), so even evaluators that were not handed an explicit
+        // `query_db` can read previously computed, authoritative results. This
+        // is the read-side counterpart to the write-side gating in
+        // `insert_application_eval_cache_if_some`, which still only writes from
+        // an authoritative (full-resolver) `query_db` context.
+        {
             let no_unchecked = self.no_unchecked_indexed_access;
-            if let Some(cached) = db.lookup_application_eval_cache(def_id, &app.args, no_unchecked)
+            if let Some(cached) =
+                self.interner
+                    .lookup_application_eval_cache(def_id, &app.args, no_unchecked)
             {
                 self.decrement_def_depth(def_id);
                 return cached;
@@ -939,13 +948,11 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let expanded_args = self.prepare_expanded_args_for_body(resolved, args);
         let no_unchecked_indexed_access = self.no_unchecked_indexed_access;
 
-        if let Some(db) = self.query_db
-            && let Some(cached) = db.lookup_application_eval_cache(
-                def_id,
-                &expanded_args,
-                no_unchecked_indexed_access,
-            )
-        {
+        if let Some(cached) = self.interner.lookup_application_eval_cache(
+            def_id,
+            &expanded_args,
+            no_unchecked_indexed_access,
+        ) {
             return ApplicationEvalOutcome::ShortCircuit(cached);
         }
 
@@ -1027,13 +1034,11 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let expanded_args = self.expand_type_args(args);
         let no_unchecked_indexed_access = self.no_unchecked_indexed_access;
 
-        if let Some(db) = self.query_db
-            && let Some(cached) = db.lookup_application_eval_cache(
-                def_id,
-                &expanded_args,
-                no_unchecked_indexed_access,
-            )
-        {
+        if let Some(cached) = self.interner.lookup_application_eval_cache(
+            def_id,
+            &expanded_args,
+            no_unchecked_indexed_access,
+        ) {
             return ApplicationEvalOutcome::ShortCircuit(cached);
         }
 
@@ -1266,6 +1271,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// Insert into the application-eval cache iff `query_db` is connected.
     /// Folds the two-line `if let Some(db) = self.query_db { … }` idiom
     /// repeated in every body-aware shortcut and finalize helper.
+    ///
+    /// Writes stay gated on an authoritative (full-resolver) `query_db`
+    /// context: a limited resolver could otherwise store an under-resolved
+    /// result under the resolver-independent `(DefId, args)` key and poison
+    /// sibling reads. Reads, by contrast, go through the interner (see
+    /// `evaluate_application`) so every evaluator can consume these
+    /// authoritative entries.
     fn insert_application_eval_cache_if_some(
         &self,
         def_id: DefId,

--- a/crates/tsz-solver/tests/evaluate_application_orchestrator_tests.rs
+++ b/crates/tsz-solver/tests/evaluate_application_orchestrator_tests.rs
@@ -221,20 +221,19 @@ fn evaluate_application_class_uses_construct_signature_return_type() {
     );
 }
 
-/// Phase 4 — interner-routed application-eval cache read.
+/// Phase 4 — authoritative application-eval cache read.
 ///
-/// The per-file application-eval cache lives on the `QueryCache`, which an
-/// evaluator sees through its interner (`&dyn TypeDatabase`). An evaluator that
-/// was NOT handed an explicit `query_db` (here, `TypeEvaluator::new`, which uses
-/// a `NoopResolver`) must still consume an authoritative cache entry through the
-/// interner rather than recomputing — this is the read-side widening that lets
-/// the otherwise-cacheless expansion paths reuse finished results.
+/// The per-file application-eval cache lives on the `QueryCache`. Evaluators
+/// only consume it when handed an explicit `query_db`; resolver-less evaluators
+/// must not read it through the interner alone because the key does not encode
+/// resolver strength, and limited/noop resolvers need their normal opaque
+/// fallback behavior for recursive and inference parity.
 ///
 /// Structural axis (CLAUDE.md §25/§26): the rule is keyed on the `(DefId, args)`
 /// identity, not on a spelling, so the test varies both the def id and the
-/// argument type to prove the lookup is structural.
+/// argument type to prove the lookup and the `query_db` gate are structural.
 #[test]
-fn evaluate_application_reads_cache_through_interner_without_query_db() {
+fn evaluate_application_reads_cache_only_with_query_db() {
     use crate::caches::db::TypeApplicationEvalCache;
     use crate::caches::query_cache::QueryCache;
 
@@ -259,15 +258,29 @@ fn evaluate_application_reads_cache_through_interner_without_query_db() {
         }
 
         // With an authoritative entry seeded on the per-file cache, the same
-        // resolver-less evaluator must return the cached result via its interner.
+        // resolver-less evaluator still must not read through its interner
+        // alone.
         {
             let qc = QueryCache::new(&interner);
             qc.insert_application_eval_cache(def_id, &[arg], false, cached);
             let mut evaluator = TypeEvaluator::new(&qc);
             assert_eq!(
                 evaluator.evaluate(app),
+                app,
+                "evaluator without query_db must preserve the opaque fallback"
+            );
+        }
+
+        // The cache is reusable once the evaluator is connected to an explicit
+        // query database.
+        {
+            let qc = QueryCache::new(&interner);
+            qc.insert_application_eval_cache(def_id, &[arg], false, cached);
+            let mut evaluator = TypeEvaluator::new(&interner).with_query_db(&qc);
+            assert_eq!(
+                evaluator.evaluate(app),
                 cached,
-                "evaluator without query_db must read the per-file app-eval cache through its interner"
+                "evaluator with query_db should read the per-file app-eval cache"
             );
         }
     }

--- a/crates/tsz-solver/tests/evaluate_application_orchestrator_tests.rs
+++ b/crates/tsz-solver/tests/evaluate_application_orchestrator_tests.rs
@@ -220,3 +220,55 @@ fn evaluate_application_class_uses_construct_signature_return_type() {
         "class application must reduce to the instance type produced by the construct signature"
     );
 }
+
+/// Phase 4 — interner-routed application-eval cache read.
+///
+/// The per-file application-eval cache lives on the `QueryCache`, which an
+/// evaluator sees through its interner (`&dyn TypeDatabase`). An evaluator that
+/// was NOT handed an explicit `query_db` (here, `TypeEvaluator::new`, which uses
+/// a `NoopResolver`) must still consume an authoritative cache entry through the
+/// interner rather than recomputing — this is the read-side widening that lets
+/// the otherwise-cacheless expansion paths reuse finished results.
+///
+/// Structural axis (CLAUDE.md §25/§26): the rule is keyed on the `(DefId, args)`
+/// identity, not on a spelling, so the test varies both the def id and the
+/// argument type to prove the lookup is structural.
+#[test]
+fn evaluate_application_reads_cache_through_interner_without_query_db() {
+    use crate::caches::db::TypeApplicationEvalCache;
+    use crate::caches::query_cache::QueryCache;
+
+    for (def_raw, arg, cached) in [
+        (501u32, TypeId::STRING, TypeId::NUMBER),
+        (777u32, TypeId::BOOLEAN, TypeId::STRING),
+    ] {
+        let interner = TypeInterner::new();
+        let def_id = DefId(def_raw);
+        let app = interner.application(interner.lazy(def_id), vec![arg]);
+
+        // A `NoopResolver` evaluator cannot resolve the alias body, so without a
+        // cache entry the application stays opaque.
+        {
+            let qc = QueryCache::new(&interner);
+            let mut evaluator = TypeEvaluator::new(&qc);
+            assert_eq!(
+                evaluator.evaluate(app),
+                app,
+                "without a cache entry the unresolvable application must stay opaque"
+            );
+        }
+
+        // With an authoritative entry seeded on the per-file cache, the same
+        // resolver-less evaluator must return the cached result via its interner.
+        {
+            let qc = QueryCache::new(&interner);
+            qc.insert_application_eval_cache(def_id, &[arg], false, cached);
+            let mut evaluator = TypeEvaluator::new(&qc);
+            assert_eq!(
+                evaluator.evaluate(app),
+                cached,
+                "evaluator without query_db must read the per-file app-eval cache through its interner"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-B
Runner: cloud-opus47-confident-thompson (remote execution / branch `claude/confident-thompson-Drx7l`)
Coordination: Operating in the `agent:Studio-B` lane per the current canonical owner label; continues #10490 and references #10452.

## Track
Architecture / performance - solver type-evaluation cache reuse. Continues #10490; investigation for #10452.

## Invariant
Behavior-preserving. The application-eval cache is keyed by the resolver-independent `(DefId, args, no_unchecked_indexed_access)` triple, and remains per-file (never promoted to `SharedQueryCache`, preserving the #9507 cross-file isolation). Reads and writes stay gated on an authoritative full-resolver `query_db` context so limited/noop resolvers preserve their opaque fallback behavior and cannot store or consume under-resolved residue.

## Scope
- `crates/tsz-solver/src/caches/db.rs` - expose `lookup_application_eval_cache` / `insert_application_eval_cache` through the narrow `TypeApplicationEvalCache` capability required by `TypeDatabase` (default opt-out). `QueryDatabase` callers still reach them via the supertrait stack; raw `TypeInterner` keeps the no-op default.
- `crates/tsz-solver/src/caches/query_cache.rs` - relocate the `QueryCache` overrides into its `TypeApplicationEvalCache` impl (same backing store).
- `crates/tsz-solver/src/evaluation/evaluate.rs` - keep application-eval cache reads behind the explicit `query_db` gate while preserving the narrow cache capability; resolver-less/cacheless evaluators do not read through the interner alone.
- `crates/tsz-checker/src/.../{type_node_advanced, indexed_access_type, type_node_query_members, lazy.rs}` - thread `query_db` into the authoritative full-`CheckerContext`-resolver evaluation passes so they populate and consume the per-file cache. The limited `TypeEnvironment` first pass in `lazy.rs` deliberately passes `None` (residue safety).
- Unit test: resolver-less evaluators preserve the opaque fallback even when the per-file cache has an entry; evaluators with explicit `query_db` consume the same structural `(DefId, arg)` cache entry.

## Why this layer
The cache is a per-file `QueryCache` capability. Exposing it as a narrow `TypeApplicationEvalCache` supertrait keeps cache access out of the already-wide `TypeDatabase` method body while still allowing authoritative `QueryDatabase` contexts to share the same backing store. CI conformance showed that interner-only reads from limited/noop resolvers regress recursive and reverse-mapped inference cases, so this PR keeps the explicit `query_db` read gate and only broadens the authoritative checker passes that can carry that handle.

## Project Corpus Impact
- Row: `TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts` (accepted-regression, #10452) - retained, not removed. This change is incremental cache-reuse infrastructure and does not by itself eliminate that timeout (see Coordination Notes), so the accepted-regression entry stays.
- Bug family: deeply-nested mapped/conditional/intersection evaluation complexity (TypeBox `Static<>`).
- Evidence: gdb stack sampling + per-call instrumentation on the TypeBox section of the repro; local focused cache tests; checker boundary guard; solver/checker clippy; CI ready suites run on this PR.

## Verification
- `cargo fmt --all --check` - clean.
- `cargo check -p tsz-solver -p tsz-checker` - clean.
- `scripts/arch/check-checker-boundaries.sh` - clean.
- `cargo nextest run -p tsz-solver evaluate_application_reads_cache_only_with_query_db application_eval_cache_is_per_file_isolated application_eval_cache_stats_visible_in_display` - 3 passed.
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver -p tsz-checker --all-targets -- -D warnings` - clean.
- Local targeted conformance note: attempted `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter "recursiveConditionalTypes" --verbose`, but this worktree's shared `TypeScript` symlink is checked out at `f3d3968058b5ee0f1c78dc1484a287d9f33bf638` while this branch requires `050880ce59e30b356b686bd3144efe24f875ebc8`; CI has the correct cached TypeScript tree and remains the conformance authority for this PR.
- Heavy suites (conformance / emit / fourslash / WASM) run on this ready PR via CI.

## Coordination Notes
Root cause of #10452 documented in https://github.com/mohsen1/tsz/issues/10452#issuecomment-4556996913. The remaining timeout is a mutually-recursive evaluate-then-subtype expansion of TypeBox `Static<>` types running in cacheless limited-resolver contexts; the redundant intermediate results are deferred/partial (not ground) so they cannot be safely memoized from a limited resolver. The `tsc`-parity completion is an `isDeeplyNestedType` recursion-identity bailout in the one-sided `check_application_expansion_target` subtype path (the two-sided generic path already has a `def_guard`; the one-sided path has none). That changes relation semantics and must be validated against the full conformance suite in CI before the accepted-regression entry can be removed; that remaining work is tracked on #10452, which keeps the accepted-regression entry. The change here is self-contained and ready for review.

https://claude.ai/code/session_012ZvaGS7ryjMTSCFDvu4jnc
