### PR TITLE
fix(emit): scope class static aliases

### DIFF
--- a/crates/tsz-emitter/src/emitter/class_temp_reservations.rs
+++ b/crates/tsz-emitter/src/emitter/class_temp_reservations.rs
@@ -91,6 +91,8 @@ impl<'a> Printer<'a> {
         if let Some(names) = self.file_level_class_temp_reservations.get_mut(&class_idx)
             && let Some(name) = names.pop_front()
         {
+            self.hoisted_file_level_class_temps
+                .retain(|temp| temp != &name);
             return name;
         }
 
@@ -131,6 +133,15 @@ impl<'a> Printer<'a> {
         class: &ClassData,
     ) -> usize {
         if (self.ctx.options.target as u32) >= (ScriptTarget::ES2022 as u32) {
+            return 0;
+        }
+
+        if (self.ctx.options.target as u32) < (ScriptTarget::ES2015 as u32)
+            && self
+                .arena
+                .get(class_idx)
+                .is_some_and(|node| node.kind == super::syntax_kind_ext::CLASS_DECLARATION)
+        {
             return 0;
         }
 

--- a/crates/tsz-emitter/src/emitter/source_file/class_static_alias_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/class_static_alias_tests.rs
@@ -1,0 +1,76 @@
+use crate::context::emit::EmitContext;
+use crate::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use crate::lowering::LoweringPass;
+use tsz_common::ScriptTarget;
+use tsz_parser::ParserState;
+
+fn emit(source: &str, target: ScriptTarget) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        target,
+        use_define_for_class_fields: false,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+#[test]
+fn es2015_static_async_arrow_declares_class_alias_once() {
+    let source = "class Test {\n    static member = async (x: string) => { };\n}\n";
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert_eq!(
+        output.matches("var _a;").count(),
+        1,
+        "ES2015 static async arrow class alias should be declared once.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a = Test;\nTest.member = (x) => __awaiter(void 0"),
+        "Static async arrow should keep `void 0` as the awaiter receiver.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es5_static_async_arrow_uses_local_class_alias_as_generator_this() {
+    let source = "class Test {\n    static member = async (x: string) => { };\n}\n";
+    let output = emit(source, ScriptTarget::ES5);
+
+    assert!(
+        !output.starts_with("var _a;\n"),
+        "ES5 class declarations should not emit an outer class-alias temp.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("var _a;\n    _a = Test;"),
+        "ES5 class IIFE should own the static initializer class alias.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("__awaiter(void 0, void 0, void 0, function () { return __generator(_a"),
+        "Static async arrow should pass the class alias to `__generator`, not `__awaiter`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es5_static_block_reuses_surrounding_class_alias() {
+    let source = "class Test {\n    static value = this.name;\n    static { this.value; }\n}\n";
+    let output = emit(source, ScriptTarget::ES5);
+
+    assert!(
+        output.contains("var _a;\n    _a = Test;"),
+        "ES5 class IIFE should establish one static class alias.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("var _a = this;"),
+        "Lowered static blocks should not shadow the class alias with a local receiver capture.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("(function () {\n        _a.value;\n    })();"),
+        "Static block `this` references should use the surrounding class alias.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/source_file/mod.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/mod.rs
@@ -11,6 +11,8 @@ mod class_es5_field_initializer_tests;
 #[cfg(test)]
 mod class_expression_decorator_tests;
 #[cfg(test)]
+mod class_static_alias_tests;
+#[cfg(test)]
 mod decorator_metadata_tests;
 #[cfg(test)]
 mod derived_constructor_tests;

--- a/crates/tsz-emitter/src/transforms/class_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir.rs
@@ -1024,6 +1024,18 @@ impl<'a> ES5ClassTransformer<'a> {
         idx: NodeIndex,
         class_alias: &str,
     ) -> IRNode {
+        if self
+            .arena
+            .get(idx)
+            .and_then(|node| self.arena.get_function(node))
+            .is_some_and(|function| function.is_async && function.equals_greater_than_token)
+        {
+            return IRNode::ASTRefWithGeneratorThis {
+                node: idx,
+                generator_this: class_alias.to_string().into(),
+            };
+        }
+
         let converter = self
             .make_converter()
             .with_static(true)
@@ -1329,8 +1341,11 @@ impl<'a> ES5ClassTransformer<'a> {
             stmts.insert(0, IRNode::VarDeclList(var_decls));
         }
 
-        // If we have a class_alias, prepend the alias declaration: `var <alias> = this;`
-        if let Some(alias) = class_alias {
+        // Non-static alias contexts capture the current receiver. Static blocks
+        // already use the class alias from the surrounding class IIFE.
+        if let Some(alias) = class_alias
+            && !is_static
+        {
             stmts.insert(
                 0,
                 IRNode::VarDecl {


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Emit/DTS parity: JavaScript emit class-static temp/alias planning.

## Invariant
When static class initializers or lowered static blocks need a class-value alias, `tsc` emits one alias in the owner scope; this PR makes tsz consume class-temp reservations without duplicate file-level declarations and keeps ES5 class declarations owned by the class IIFE.

## Scope
- `crates/tsz-emitter/src/emitter/class_temp_reservations.rs`
- `crates/tsz-emitter/src/transforms/class_es5_ir.rs`
- Focused source-file emitter regression tests for class static aliases

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit class/static initializer temp scoping
- Evidence: emit-only class baseline filters; no project corpus row behavior expected beyond JS output parity.

## Verification
- `cargo check -p tsz-emitter`
- `cargo nextest run -p tsz-emitter class_static_alias_tests`
- `cargo nextest run -p tsz-emitter class_static_alias_tests es5_static_this_aliases_advance_across_classes`
- `scripts/emit/run.sh --filter=asyncArrowInClassES5 --js-only --verbose --json-out=/tmp/studio-c-async-arrow-class-rebased.json`
- `scripts/emit/run.sh --skip-build --filter=asyncArrowInClassES5 --js-only --verbose --json-out=/tmp/studio-c-async-arrow-class-final2.json`
- `scripts/emit/run.sh --skip-build --filter=classStaticBlock5 --js-only --verbose --json-out=/tmp/studio-c-class-static-block5-final.json`
- `scripts/emit/run.sh --skip-build --filter=classStaticBlock6 --js-only --verbose --json-out=/tmp/studio-c-class-static-block6-rebased.json`
- `scripts/emit/run.sh --skip-build --filter=classNameReferencesInStaticElements --js-only --verbose --json-out=/tmp/studio-c-class-name-static-rebased.json`
- `scripts/emit/run.sh --skip-build --filter=thisInOuterClassBody --js-only --verbose --json-out=/tmp/studio-c-this-outer-class-after.json`
- `scripts/emit/run.sh --skip-build --filter=class --js-only --json-out=/tmp/studio-c-class-live-after.json` (`1455/1479`, up from `1447/1479` in the live class slice before this patch)
- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`

## Coordination Notes
- No overlapping open PR found for the class-static alias/temp slice before coding.
- Keeps the remaining class failures (private-name/static property conflict clusters) for follow-up PRs.
- Previous Studio-C PR #10583 merged before this PR was opened; this branch is rebased over current `origin/main`.
