### PR TITLE
fix(dts): cap recursive function fallback inference

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
@@ -287,6 +287,14 @@ impl<'a> DeclarationEmitter<'a> {
         &self,
         expr_idx: NodeIndex,
     ) -> Option<String> {
+        self.function_expression_type_text_from_ast_at(expr_idx, 0)
+    }
+
+    pub(in crate::declaration_emitter) fn function_expression_type_text_from_ast_at(
+        &self,
+        expr_idx: NodeIndex,
+        depth: u32,
+    ) -> Option<String> {
         let expr_node = self.arena.get(expr_idx)?;
         if expr_node.kind != syntax_kind_ext::ARROW_FUNCTION
             && expr_node.kind != syntax_kind_ext::FUNCTION_EXPRESSION
@@ -334,8 +342,7 @@ impl<'a> DeclarationEmitter<'a> {
             scratch.write(&return_type);
         } else if func.body.is_some()
             && let Some(return_type) = scratch
-                .preferred_expression_type_text(func.body)
-                .or_else(|| scratch.infer_fallback_type_text_at(func.body, 0))
+                .function_expression_return_type_text(func, depth + 1)
                 .filter(|text| !text.is_empty() && text != "any")
         {
             scratch.write(&return_type);

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
@@ -125,7 +125,7 @@ impl<'a> DeclarationEmitter<'a> {
             k if k == syntax_kind_ext::ARROW_FUNCTION
                 || k == syntax_kind_ext::FUNCTION_EXPRESSION =>
             {
-                self.function_expression_type_text_from_ast(node_id)
+                self.function_expression_type_text_from_ast_at(node_id, depth + 1)
             }
             k if k == syntax_kind_ext::NEW_EXPRESSION => {
                 self.preferred_expression_type_text(node_id)
@@ -663,7 +663,7 @@ impl<'a> DeclarationEmitter<'a> {
         found
     }
 
-    fn function_expression_return_type_text(
+    pub(in crate::declaration_emitter) fn function_expression_return_type_text(
         &self,
         func: &tsz_parser::parser::node::FunctionData,
         depth: u32,

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_members.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_members.rs
@@ -337,6 +337,14 @@ impl<'a> DeclarationEmitter<'a> {
         {
             return Some(type_text);
         }
+        if self.arena.get(initializer).is_some_and(|node| {
+            node.kind == syntax_kind_ext::ARROW_FUNCTION
+                || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
+        }) {
+            return self
+                .function_expression_type_text_from_ast_at(initializer, depth + 1)
+                .or_else(|| self.infer_fallback_type_text_at(initializer, depth));
+        }
         self.preferred_expression_type_text(initializer)
             .or_else(|| self.infer_fallback_type_text_at(initializer, depth))
     }


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Declaration emit parity / recursive unique type-parameter renaming

## Invariant
When declaration fallback reconstructs a function expression whose body returns a recursive direct call into the same value, `tsc` emits a finite recursive DTS surface; this PR keeps tsz's declaration-summary fallback depth intact through function-expression scratch emitters so the existing recursive DTS expansion limit can bottom out instead of re-entering the source body indefinitely.

## Owner Layer
Declaration emit fallback/source reconstruction. The change stays in declaration summary helpers and expression-literal fallback scheduling; it does not add checker or solver semantic validation, and it does not use output surgery.

## Scope
- Preserve declaration fallback depth when printing function-expression return text through the scratch emitter.
- Reuse the existing `function_expression_return_type_text` declaration-summary helper across expression-literal emission.
- Route function-valued object literal members through the depth-aware helper before falling back to generic expression inference.

## Adjacent Case Matrix
- Reported object-returning recursive const arrow: `testRecFun<T>().deeper<U>()` unrolls and bottoms out with `/*elided*/ any`.
- Renamed equivalent shape: `build<P>().nest<C>()` proves the rule is structural and not keyed to source names.
- Function-returning recursive const arrow still unrolls through the existing recursive expansion path.
- Negative case: a non-recursive generic const arrow returning an object does not emit the elided sentinel.

## Known Fallbacks
Unsupported or non-recursive function-expression shapes still fall back to the existing preferred-expression and fallback inference paths. The guard is the structural fallback depth, not any identifier spelling or output string fragment.

## Project Corpus Impact
- Row: `declarationsWithRecursiveInternalTypesProduceUniqueTypeParams`
- Bug family: recursive unique type-parameter renaming / object-returning recursive const-arrow DTS emit
- Evidence: `scripts/safe-run.sh scripts/emit/run.sh --filter=declarationsWithRecursiveInternalTypesProduceUniqueTypeParams --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-recursive-internal-unique-typeparams-main-d471-20260527.json` passes 1/1 on head `e432d8a88ed041a243231c80a7f0a95cfe65cd5e`.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main..HEAD`
- `cargo check -p tsz-emitter`
- `cargo nextest run -p tsz-cli object_returning_recursive_const_arrow_unrolls_in_dts object_returning_recursion_dts_unroll_is_not_hardcoded_to_names function_returning_recursive_const_arrow_still_unrolls_in_dts non_recursive_generic_const_arrow_does_not_emit_elided_sentinel`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=declarationsWithRecursiveInternalTypesProduceUniqueTypeParams --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-recursive-internal-unique-typeparams-main-d471-20260527.json`

## Coordination Notes
- AgentName: Studio-D
- Root cause was a declaration-emitter fallback recursion loop: `direct_call_primitive_return_type_text` re-entered the same recursive const-arrow body through `function_expression_type_text_from_ast`, whose scratch emitter reset fallback depth to zero.
- This PR stays in DTS source reconstruction and does not change checker, solver relations, diagnostics, or JS emit.
- Marked ready for review after exact-head draft-light CI passed for `e432d8a88ed041a243231c80a7f0a95cfe65cd5e`; heavy ready CI is the next broad validation. Merge queue remains off until a manager/queue owner chooses to enqueue it.
- Remote body refreshed on 2026-05-27 to satisfy the Project Corpus Impact checklist shape after the ready-run body gate flagged the stale unbulleted section.
