### PR TITLE
test(solver): share evaluator assertion helpers

### DIFF
--- a/crates/tsz-solver/src/tests/solver_file_size_ceiling_tests.rs
+++ b/crates/tsz-solver/src/tests/solver_file_size_ceiling_tests.rs
@@ -231,6 +231,15 @@ fn contains_simple_type_param_wrapper(text: &str, wrapper: &str) -> bool {
     false
 }
 
+fn contains_direct_evaluate_assert_block(text: &str) -> bool {
+    let lines: Vec<_> = text.lines().map(str::trim).collect();
+    lines.windows(3).any(|window| {
+        window[0] == "let mut evaluator = TypeEvaluator::new(&interner);"
+            && window[1].starts_with("let result = evaluator.evaluate(")
+            && window[2].starts_with("assert_eq!(result,")
+    })
+}
+
 /// Ratchet guard: keep generated evaluator test shards named after evaluator
 /// feature families. Anonymous numeric chunks make failures and regeneration
 /// diffs harder to review even when they satisfy the file-size ceiling.
@@ -269,6 +278,34 @@ fn evaluate_tests_use_feature_family_shards() {
         assert!(
             includes.iter().any(|path| path.contains(family)),
             "evaluator test shard list is missing a {family} shard: {includes:?}"
+        );
+    }
+}
+
+/// Ratchet guard: compact evaluator assertions should flow through the shared
+/// helper instead of rebuilding `TypeEvaluator` in individual generated cases.
+#[test]
+fn evaluate_tests_use_shared_evaluation_assert_helper() {
+    let solver_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let evaluate_tests = solver_dir.join("tests/evaluate_tests.rs");
+    let text = fs::read_to_string(&evaluate_tests)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", evaluate_tests.display()));
+
+    assert!(
+        text.contains("fn assert_evaluates_to("),
+        "{} should define a shared evaluator assertion helper",
+        evaluate_tests.display()
+    );
+
+    for include in include_paths(&text) {
+        let shard = solver_dir.join("tests").join(include);
+        let shard_text = fs::read_to_string(&shard)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", shard.display()));
+
+        assert!(
+            !contains_direct_evaluate_assert_block(&shard_text),
+            "{} should use assert_evaluates_to for direct evaluate assertions",
+            shard.display()
         );
     }
 }

--- a/crates/tsz-solver/tests/evaluate_tests.rs
+++ b/crates/tsz-solver/tests/evaluate_tests.rs
@@ -22,6 +22,11 @@ fn test_infer_param_from_name(interner: &TypeInterner, name: Atom) -> TypeId {
     interner.intern(TypeData::Infer(TypeParamInfo::simple(name)))
 }
 
+fn assert_evaluates_to(interner: &TypeInterner, input: TypeId, expected: TypeId) {
+    let result = evaluate_type(interner, input);
+    assert_eq!(result, expected);
+}
+
 // Split into under-cap shards by evaluator family while preserving test order.
 include!("evaluate_tests_parts/conditional_infer_core.rs");
 include!("evaluate_tests_parts/conditional_infer_arrays.rs");

--- a/crates/tsz-solver/tests/evaluate_tests_parts/distributive_conditionals.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/distributive_conditionals.rs
@@ -36,11 +36,10 @@ fn test_distributive_with_infer_in_true_branch() {
     );
 
     let instantiated = instantiate_type(&interner, cond_type, &subst);
-    let result = evaluate_type(&interner, instantiated);
 
     // Expected: string | number
     let expected = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
-    assert_eq!(result, expected);
+    assert_evaluates_to(&interner, instantiated, expected);
 }
 
 #[test]
@@ -69,11 +68,10 @@ fn test_distributive_exclude_utility() {
     subst.insert(t_name, interner.union(vec![lit_a, lit_b, lit_c]));
 
     let instantiated = instantiate_type(&interner, cond_type, &subst);
-    let result = evaluate_type(&interner, instantiated);
 
     // Expected: "b" | "c"
     let expected = interner.union(vec![lit_b, lit_c]);
-    assert_eq!(result, expected);
+    assert_evaluates_to(&interner, instantiated, expected);
 }
 
 #[test]
@@ -103,11 +101,10 @@ fn test_distributive_extract_utility() {
     subst.insert(t_name, interner.union(vec![lit_a, lit_1, lit_b, lit_2]));
 
     let instantiated = instantiate_type(&interner, cond_type, &subst);
-    let result = evaluate_type(&interner, instantiated);
 
     // Expected: "a" | "b"
     let expected = interner.union(vec![lit_a, lit_b]);
-    assert_eq!(result, expected);
+    assert_evaluates_to(&interner, instantiated, expected);
 }
 
 #[test]

--- a/crates/tsz-solver/tests/evaluate_tests_parts/tuple_keyof_indexed_access.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/tuple_keyof_indexed_access.rs
@@ -162,9 +162,7 @@ fn test_tail_recursive_conditional() {
 fn test_intersection_reduction_disjoint_primitives() {
     let interner = TypeInterner::new();
     let intersection = interner.intersection(vec![TypeId::STRING, TypeId::NUMBER]);
-    let mut evaluator = TypeEvaluator::new(&interner);
-    let result = evaluator.evaluate(intersection);
-    assert_eq!(result, TypeId::NEVER);
+    assert_evaluates_to(&interner, intersection, TypeId::NEVER);
 }
 
 /// Test intersection reduction with any.
@@ -172,9 +170,7 @@ fn test_intersection_reduction_disjoint_primitives() {
 fn test_intersection_reduction_any() {
     let interner = TypeInterner::new();
     let intersection = interner.intersection(vec![TypeId::STRING, TypeId::ANY]);
-    let mut evaluator = TypeEvaluator::new(&interner);
-    let result = evaluator.evaluate(intersection);
-    assert_eq!(result, TypeId::ANY);
+    assert_evaluates_to(&interner, intersection, TypeId::ANY);
 }
 
 /// Test union reduction for duplicate types.
@@ -182,9 +178,7 @@ fn test_intersection_reduction_any() {
 fn test_union_reduction_duplicates() {
     let interner = TypeInterner::new();
     let union = interner.union(vec![TypeId::STRING, TypeId::STRING]);
-    let mut evaluator = TypeEvaluator::new(&interner);
-    let result = evaluator.evaluate(union);
-    assert_eq!(result, TypeId::STRING);
+    assert_evaluates_to(&interner, union, TypeId::STRING);
 }
 
 /// Test union reduction for literal and base type.
@@ -193,9 +187,7 @@ fn test_union_reduction_literal_into_base() {
     let interner = TypeInterner::new();
     let hello = interner.literal_string("hello");
     let union = interner.union(vec![hello, TypeId::STRING]);
-    let mut evaluator = TypeEvaluator::new(&interner);
-    let result = evaluator.evaluate(union);
-    assert_eq!(result, TypeId::STRING);
+    assert_evaluates_to(&interner, union, TypeId::STRING);
 }
 
 /// Homomorphic mapped type with `keyof` constraint preserves optional modifiers.


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Refactor only: solver evaluation test-harness cleanup for #9391 and M4-A's #8203 architecture-debt lane.

## Invariant
When evaluator tests directly evaluate a `TypeId` and assert an expected `TypeId`, the test should use a shared named assertion helper. This PR changes only solver test harness code and leaves evaluation behavior unchanged.

## Scope
- Add `assert_evaluates_to` beside the shared evaluator fixture helpers.
- Route compact direct evaluator assertions in selected evaluator shards through the helper.
- Add a ratchet guard against reintroducing the repeated direct evaluator/assert block.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: test-harness-only refactor; no checker, solver semantic, emit, benchmark, or project corpus behavior changed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-solver --lib -E 'test(evaluate_tests_use_shared_evaluation_assert_helper) or test(test_intersection_reduction_disjoint_primitives) or test(test_intersection_reduction_any) or test(test_union_reduction_duplicates) or test(test_union_reduction_literal_into_base) or test(test_distributive_with_infer_in_true_branch) or test(test_distributive_exclude_utility) or test(test_distributive_extract_utility)'`
- `cargo clippy -p tsz-solver --lib --tests -- -D warnings`
- `python3 scripts/arch/arch_guard.py`

## Coordination Notes
- #10570 and #10581 are merged; there were no open M4-A PRs before this branch.
- This is the next small #9391 helper-extraction slice and does not close #9391.
- Avoids active overlap with M1-C accepted-regression work, M4-B relation/cache policy work, M4-C instantiation/session work, M4-D checker identity work, and Studio emit/LSP work.