### PR TITLE
fix(bench): upload prep artifacts explicitly

### DIFF
--- a/scripts/ci/test-cloudbuild-config-paths.mjs
+++ b/scripts/ci/test-cloudbuild-config-paths.mjs
@@ -70,6 +70,11 @@ assert.match(
   /literal_scoped_dir='bench-prep\/\$\{_BENCH_TARGET_SHA\}'[\s\S]+cp bench-prep\.tar bench-prep\.env "\$\{literal_scoped_dir\}\/"/,
   "benchmark prep should mirror artifacts to the literal target path for Cloud Build artifact glob compatibility",
 );
+assert.match(
+  benchPrepareConfig,
+  /metadata\.google\.internal\/computeMetadata\/v1\/instance\/service-accounts\/default\/token[\s\S]+upload_gcs_object bench-prep\.tar "bench-prep\/\$\{_BENCH_TARGET_SHA\}\/bench-prep\.tar"[\s\S]+upload_gcs_object bench-prep\.env "bench-prep\/latest\/bench-prep\.env"/,
+  "benchmark prep should explicitly upload verified env/tar artifacts to SHA-scoped and latest GCS paths",
+);
 
 for (const workflow of workflowFiles) {
   const configs = workflowConfigs.get(workflow) ?? [];

--- a/scripts/cloudbuild/cloudbuild-bench-prepare.yaml
+++ b/scripts/cloudbuild/cloudbuild-bench-prepare.yaml
@@ -99,6 +99,36 @@ steps:
       cp bench-prep.tar bench-prep.env "${literal_scoped_dir}/"
       cp bench-prep.tar bench-prep.env bench-prep/latest/
 
+      gcs_access_token="$(
+        curl -fsSL \
+          -H 'Metadata-Flavor: Google' \
+          'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token' |
+          jq -r '.access_token'
+      )"
+      if [[ -z "${gcs_access_token}" || "${gcs_access_token}" == "null" ]]; then
+        echo "Cloud Build metadata server did not return a GCS access token." >&2
+        exit 1
+      fi
+
+      upload_gcs_object() {
+        local source_file="$1"
+        local object_name="$2"
+        local encoded_object
+        encoded_object="$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "${object_name}")"
+        curl --retry 3 --retry-delay 2 -fsS \
+          -X POST \
+          -H "Authorization: Bearer ${gcs_access_token}" \
+          -H "Content-Type: application/octet-stream" \
+          --data-binary "@${source_file}" \
+          "https://storage.googleapis.com/upload/storage/v1/b/tsz-ci_cloudbuild/o?uploadType=media&name=${encoded_object}" \
+          >/dev/null
+      }
+
+      upload_gcs_object bench-prep.tar "bench-prep/${_BENCH_TARGET_SHA}/bench-prep.tar"
+      upload_gcs_object bench-prep.env "bench-prep/${_BENCH_TARGET_SHA}/bench-prep.env"
+      upload_gcs_object bench-prep.tar "bench-prep/latest/bench-prep.tar"
+      upload_gcs_object bench-prep.env "bench-prep/latest/bench-prep.env"
+
 artifacts:
   objects:
     location: gs://tsz-ci_cloudbuild/


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Benchmark publication / website freshness.

## Invariant
Cloud Build benchmark prep must publish the exact env/tar pair that was validated after PGO preparation, and the GitHub workflow must only consume artifacts whose env metadata matches the workflow target SHA and PGO marker.

## Scope
- Upload verified `bench-prep.tar` and `bench-prep.env` directly from the Cloud Build script to SHA-scoped and latest GCS objects using the Cloud Build metadata-server token.
- Keep the existing Cloud Build artifacts block as a secondary compatibility path.
- Extend the Cloud Build config guard test to require explicit GCS upload coverage.

## Project Corpus Impact
- Row: n/a
- Bug family: benchmark publication artifact handoff
- Evidence: Bench run 26527124117 found a stale readable tar without `.target-bench/dist/.bench-pgo-optimized`; direct upload avoids relying on Cloud Build artifact glob publishing for the verified tar/env pair.

## Verification
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `git diff --check`

## Coordination Notes
- AgentName: Studio-A refreshed the PR body on 2026-05-27 after `project-corpus-pr-body` failed on run 26529054046. The guard requires canonical body metadata on ready semantic/benchmark PRs.
- This follows PRs #10574 and #10584. #10584 proved the workflow can reach a readable fallback artifact, but that object was stale. This PR moves publication of the verified prep artifacts into the Cloud Build step itself so the GCS paths consumed by `bench.yml` are updated atomically after local validation.
