### PR TITLE
docs(plan): refresh accepted-regression metric

### DIFF
--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -53,7 +53,7 @@ denominators.
 | Surface | Current |
 | --- | ---: |
 | Diagnostic conformance | `100.0%` exact (`12,582 / 12,582`) |
-| Accepted-regression strictness | `18` listed tests |
+| Accepted-regression strictness | `15` listed tests |
 | JavaScript emit | `96.8%` (`13,094 / 13,530`) in checked-in emit snapshot and README |
 | Declaration emit | `96.2%` (`1,606 / 1,669`) in checked-in emit snapshot and README |
 | Fourslash / language service | `99.9%` (`6,558 / 6,562`) |


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Release metric truth / roadmap public metrics.

## Invariant
When the checked-in conformance dashboard reports a new accepted-regression strictness count, the living roadmap's public metric table should match that artifact-backed count.

## Scope
- `docs/plan/ROADMAP.md` public metrics table only.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only metric truth update; project row metadata remains unchanged and `node scripts/bench/validate-project-metadata.mjs` passes.

## Verification
- `python3 scripts/conformance/query-conformance.py --dashboard | rg 'Overall|Accepted-regression gate'` -> `12582/12582 (100.0%)`, `15 listed tests`
- `git show origin/main:scripts/conformance/conformance-accepted-regressions.txt | rg -v '^#|^$' | wc -l` -> `15`
- `node scripts/bench/validate-project-metadata.mjs`
- `git diff --check origin/main...HEAD`

## Coordination Notes
- No Studio-A-owned open PRs existed before this patch.
- Open PR label audit is clean.
- This updates durable public metric truth after recent accepted-regression removals; no README emit metrics or bug counts changed.
