### PR TITLE
refactor(solver): drop root judge convenience export

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -7,11 +7,11 @@ use tsz_solver::{
 #[allow(unused_imports)]
 pub(crate) use tsz_solver::construction::TypeInterner;
 pub(crate) use tsz_solver::construction::{QueryDatabase, TypeDatabase};
-pub(crate) use tsz_solver::judge::{DefaultJudge, Judge, JudgeConfig};
 pub(crate) use tsz_solver::narrowing::OptionalPropertyChainKey;
 pub(crate) use tsz_solver::objects::{IndexKind, IndexSignatureResolver};
 pub(crate) use tsz_solver::operations::property::PropertyAccessResult;
 pub(crate) use tsz_solver::operations::{AssignabilityChecker, CallResult};
+pub(crate) use tsz_solver::relations::judge::{DefaultJudge, Judge, JudgeConfig};
 pub(crate) use tsz_solver::relations::subtype::{TypeEnvironment, TypeResolver};
 pub(crate) use tsz_solver::type_queries::{
     RemappedMappedIndexAccessResult, TypeTraversalKind, constraint_allows_mutable_array_like,

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -38,10 +38,6 @@ mod flow_analysis;
 mod inference;
 mod instantiation;
 mod intern;
-pub mod judge {
-    //! Re-exports from `relations::judge` for convenience.
-    pub use crate::relations::judge::*;
-}
 pub mod narrowing;
 pub mod objects;
 pub mod operations;

--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -789,7 +789,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
     ///
     /// This is used to configure the `CompatChecker` with settings from
     /// the `CompilerOptions` (passed through `JudgeConfig`).
-    pub fn apply_config(&mut self, config: &crate::judge::JudgeConfig) {
+    pub fn apply_config(&mut self, config: &crate::relations::judge::JudgeConfig) {
         self.strict_function_types = config.strict_function_types;
         self.strict_null_checks = config.strict_null_checks;
         self.exact_optional_property_types = config.exact_optional_property_types;

--- a/crates/tsz-solver/src/relations/mod.rs
+++ b/crates/tsz-solver/src/relations/mod.rs
@@ -1,7 +1,7 @@
 pub mod compat;
 pub(crate) mod compat_overrides;
 pub mod freshness;
-pub(crate) mod judge;
+pub mod judge;
 pub mod lawyer;
 pub mod relation_queries;
 pub mod subtype;

--- a/crates/tsz-solver/src/sound_prototype.rs
+++ b/crates/tsz-solver/src/sound_prototype.rs
@@ -5,7 +5,7 @@
 //! experimentation so they do not imply shipped Sound Mode semantics.
 
 use crate::construction::TypeDatabase;
-use crate::judge::JudgeConfig;
+use crate::relations::judge::JudgeConfig;
 use crate::relations::subtype::{SubtypeChecker, TypeEnvironment};
 use crate::types::{TypeData, TypeId};
 

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -344,6 +344,12 @@ REGEX_LINE_COUNT_CHECKS = [
         0,
     ),
     (
+        "Solver API boundary: root judge convenience re-export (#8204)",
+        [ROOT / "crates" / "tsz-solver" / "src" / "lib.rs"],
+        re.compile(r"^\s*pub\s+mod\s+judge\s*\{"),
+        0,
+    ),
+    (
         "Solver relation boundary: legacy relation flag bridge surface (#8207)",
         [ROOT / "crates" / "tsz-solver" / "src"],
         re.compile(

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -253,8 +253,6 @@ LINE_LIMIT_CHECKS = [
             "crates/tsz-checker/src/state/variable_checking/destructuring.rs",
             "crates/tsz-checker/src/types/class_type/constructor.rs",
             "crates/tsz-checker/src/types/property_access_type/resolve.rs",
-            "crates/tsz-checker/src/types/queries/core.rs",
-            "crates/tsz-checker/src/types/queries/lib.rs",
             "crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs",
             "crates/tsz-checker/src/types/type_checking/duplicate_identifiers_helpers.rs",
             "crates/tsz-checker/src/types/utilities/core.rs",
@@ -656,6 +654,12 @@ REGEX_LINE_COUNT_CHECKS = [
         "Solver API boundary: flat root wildcard compatibility re-exports (#8204)",
         [ROOT / "crates" / "tsz-solver" / "src" / "lib.rs"],
         re.compile(r"^pub use (?:[A-Za-z_][A-Za-z0-9_]*::)+\*;"),
+        0,
+    ),
+    (
+        "Solver API boundary: root judge convenience re-export (#8204)",
+        [ROOT / "crates" / "tsz-solver" / "src" / "lib.rs"],
+        re.compile(r"^\s*pub\s+mod\s+judge\s*\{"),
         0,
     ),
     (

--- a/scripts/arch/test_arch_guard_policy.py
+++ b/scripts/arch/test_arch_guard_policy.py
@@ -333,6 +333,25 @@ class ArchGuardRegexLineCountTests(unittest.TestCase):
         self.assertEqual(len(hits), 2, f"unexpected hits: {hits!r}")
         self.assertIn("lib.rs:1", hits[0])
 
+    def test_flags_root_solver_judge_convenience_reexport(self):
+        pattern, _max_lines = self._check_by_name("root judge convenience")
+        root = self._make_tree(
+            {
+                "crates/tsz-solver/src/lib.rs": (
+                    "pub mod judge {\n"
+                    "    pub use crate::relations::judge::*;\n"
+                    "}\n"
+                    "pub mod query {\n"
+                    "    pub use crate::visitors::visitor::*;\n"
+                    "}\n"
+                ),
+            }
+        )
+        hits = self.arch_guard.scan_regex_line_count([root], pattern, 0)
+        self.assertEqual(len(hits), 2, f"unexpected hits: {hits!r}")
+        self.assertIn("lib.rs:1", hits[0])
+        self.assertIn("total matching lines: 1", hits[1])
+
     def test_flags_legacy_relation_flag_bridge_surface(self):
         pattern, _max_lines = self._check_by_name("legacy relation flag bridge surface")
         root = self._make_tree(

--- a/scripts/arch/test_arch_guard_project.py
+++ b/scripts/arch/test_arch_guard_project.py
@@ -927,6 +927,25 @@ class ArchGuardRegexLineCountTests(unittest.TestCase):
         self.assertEqual(len(hits), 2, f"unexpected hits: {hits!r}")
         self.assertIn("lib.rs:1", hits[0])
 
+    def test_flags_root_solver_judge_convenience_reexport(self):
+        pattern, _max_lines = self._check_by_name("root judge convenience")
+        root = self._make_tree(
+            {
+                "crates/tsz-solver/src/lib.rs": (
+                    "pub mod judge {\n"
+                    "    pub use crate::relations::judge::*;\n"
+                    "}\n"
+                    "pub mod query {\n"
+                    "    pub use crate::visitors::visitor::*;\n"
+                    "}\n"
+                ),
+            }
+        )
+        hits = self.arch_guard.scan_regex_line_count([root], pattern, 0)
+        self.assertEqual(len(hits), 2, f"unexpected hits: {hits!r}")
+        self.assertIn("lib.rs:1", hits[0])
+        self.assertIn("total matching lines: 1", hits[1])
+
     def test_flags_legacy_relation_flag_bridge_surface(self):
         pattern, _max_lines = self._check_by_name("legacy relation flag bridge surface")
         root = self._make_tree(


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 4 solver API boundary cleanup for #8204; producer-side architecture ratchet.

## Invariant
When consumers need solver judge APIs, the public path should name the owning module (`tsz_solver::relations::judge`) instead of a root convenience module that hides the solver boundary. This PR removes the root `tsz_solver::judge` alias while preserving the same owner API and adds a guard against reintroducing the alias.

## Scope
- Make `tsz_solver::relations::judge` the public owner path for `DefaultJudge`, `Judge`, and `JudgeConfig`.
- Remove the root `pub mod judge { pub use crate::relations::judge::*; }` convenience export.
- Route repo callers from `tsz_solver::judge` / `crate::judge` to `relations::judge`.
- Add architecture guard coverage for the removed root judge convenience export.
- Remove two stale checker line-limit exemptions found by the arch smoke suite (`types/queries/core.rs`, `types/queries/lib.rs`).

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: API-boundary/architecture-guard-only change; no checker semantics, emit output, conformance baseline, or project corpus behavior changed.

## Verification
- RED: `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard_project.ArchGuardRegexLineCountTests.test_flags_root_solver_judge_convenience_reexport` failed before the guard with missing `REGEX_LINE_COUNT_CHECKS` entry.
- GREEN: `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard_project.ArchGuardRegexLineCountTests.test_flags_root_solver_judge_convenience_reexport scripts.arch.test_arch_guard_policy.ArchGuardRegexLineCountTests.test_flags_root_solver_judge_convenience_reexport`
- `python3 scripts/arch/arch_guard.py`
- `set -euo pipefail; python3 -m py_compile scripts/arch/*.py; while IFS= read -r test_file; do python3 "$test_file"; done < <(find scripts/arch -maxdepth 1 -type f -name 'test_*.py' | sort)`
- `cargo check -p tsz-solver -p tsz-checker`
- `cargo fmt --check`
- `git diff --check`
- Post-rebase on `origin/main` at `9f66da0476`: focused guard tests, `python3 scripts/arch/arch_guard.py`, `cargo check -p tsz-solver -p tsz-checker`, `cargo fmt --check`, and `git diff --check`.
- Post-rebase on `origin/main` at `759c163923`: focused guard tests, `python3 scripts/arch/arch_guard.py`, `cargo check -p tsz-solver -p tsz-checker`, `cargo fmt --check`, and `git diff --check`.
- Post-rebase on `origin/main` at `0ebefb9322`: focused guard tests, `python3 scripts/arch/arch_guard.py`, `cargo check -p tsz-solver -p tsz-checker`, `cargo fmt --check`, and `git diff --check`.
- Exact-head draft CI on `ea9cefdcdf`: `CI Light Summary`, `gate`, `GitGuardian Security Checks`, `lint`, `unit`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `unit-cloudbuild`, and `project-row-drift` passed in run `26532491184`.
- Exact-head ready-review CI on `ea9cefdcdf`: `CI Summary`, `gate`, `GitGuardian Security Checks`, `lint`, `unit`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `unit-cloudbuild`, `conformance-*` and aggregate, `emit`, `fourslash-*` and aggregate, `wasm`, `wasm-web`, `lsp-e2e`, `project-compile-guard`, `project-compile-canary`, `project-corpus-pr-body`, `project-row-drift`, and `conformance-snapshot-gate` passed in run `26533175247`.

## Coordination Notes
- Follows #8204's current root-export cleanup direction after #9232/#9233 merged.
- #10580 merged earlier in this M4-B cycle; this branch is rebased onto `main` at `0ebefb9322` with head `ea9cefdcdf`.
- Current `origin/main` advanced to `7b1fa3acea` after exact-head ready-review CI passed; leaving the green head unchanged for queue-owner review rather than resetting CI for unrelated main churn.
- #10608 is stacked on this branch and depends on this PR landing before retargeting to `main`.
- No overlap with M1-B checker relation routing or M4-A/M4-C solver semantics; this only changes solver API surface routing and architecture guards.
- No auto-merge or `merge-queue` label was added by M4-B.
- AgentName: M4-B
