### PR TITLE
fix(bench): dispatch catch-up after stale publish

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1197,6 +1197,9 @@ jobs:
 
           if [[ -n "${MAIN_SHA}" && "${TARGET_SHA}" != "${MAIN_SHA}" ]]; then
             echo "Bench target ${TARGET_SHA} is behind current main ${MAIN_SHA}; publishing because active benchmark runs are intentionally allowed to finish."
+            echo "catchup_main_sha=${MAIN_SHA}" >> "$GITHUB_OUTPUT"
+          else
+            echo "catchup_main_sha=" >> "$GITHUB_OUTPUT"
           fi
 
           gsutil -q cp "$GITHUB_WORKSPACE/bench-results.json" \
@@ -1330,3 +1333,18 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/gh-pages.yml/dispatches" \
             -d '{"ref":"main"}'
+
+      - name: Trigger benchmark catch-up
+        if: steps.publish.outputs.should_redeploy == 'true' && steps.publish.outputs.catchup_main_sha != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "Benchmark target ${BENCH_TARGET_SHA:-${GITHUB_SHA}} was behind current main ${{ steps.publish.outputs.catchup_main_sha }}; dispatching a catch-up benchmark."
+          curl -fsSL \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/bench.yml/dispatches" \
+            -d '{"ref":"main","inputs":{"publish_latest_pgo":"false"}}'

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -103,4 +103,16 @@ assert.match(
   "latest prep artifact fallback must validate the downloaded artifact target SHA and PGO marker",
 );
 
+assert.match(
+  workflow,
+  /TARGET_SHA="\$\{BENCH_TARGET_SHA:-\$\{GITHUB_SHA\}\}"[\s\S]+if \[\[ -n "\$\{MAIN_SHA\}" && "\$\{TARGET_SHA\}" != "\$\{MAIN_SHA\}" \]\]; then[\s\S]+echo "catchup_main_sha=\$\{MAIN_SHA\}" >> "\$GITHUB_OUTPUT"/,
+  "benchmark publish should expose the current main SHA when a finished run publishes an older target",
+);
+
+assert.match(
+  workflow,
+  /- name: Trigger benchmark catch-up[\s\S]+steps\.publish\.outputs\.catchup_main_sha != ''[\s\S]+actions\/workflows\/bench\.yml\/dispatches[\s\S]+-d '\{"ref":"main","inputs":\{"publish_latest_pgo":"false"\}\}'/,
+  "stale benchmark publishes should dispatch a catch-up benchmark for current main",
+);
+
 console.log("bench workflow Cloud Build prep artifact tests passed");


### PR DESCRIPTION
## Agent
AgentName: Studio-A
Runner: Codex-Bench-Fresh

## Track
Benchmark blocker: website benchmark freshness and Bench workflow publication strategy.

## Invariant
When a long Bench run publishes after `main` has advanced, the workflow must not leave the newer main SHA permanently skipped behind the completed stale run; it should schedule a fresh main benchmark catch-up after publication.

## Scope
- `.github/workflows/bench.yml`: expose `catchup_main_sha` from `bench-publish` when `TARGET_SHA` is behind current `main`, then dispatch `bench.yml` on `main` after the website redeploy trigger.
- `scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`: smoke-test the stale-publish catch-up contract.

## Project Corpus Impact
- Row: n/a
- Bug family: benchmark publication freshness / skipped-main catch-up
- Evidence: workflow-only change; no fixture, compiler, project row, or benchmark timing semantics changed.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `git diff --check`

## Coordination Notes
- Current in-flight manual Bench run `26529235644` started on `10301e129e7b0a92c231e2c55b0d99a7b9de6c30`; remote `main` has since advanced to `d4717e9d403dec76fb3dab1b34583953a4247f85`.
- This PR prevents that stale-active-run pattern from stranding newer main benchmark runs after the active run finishes.
- It does not change the Cloud Build artifact handoff fix being validated by the in-flight run.
