### PR TITLE
fix(emit): bind private member invocation receivers

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -2922,33 +2922,14 @@ impl<'a> Printer<'a> {
                     if !first {
                         self.write(", ");
                     }
-                    self.write(var_name);
-                    self.write(" = function ");
-                    self.write(var_name);
-                    self.write("(");
-                    for (i, &param_idx) in params.iter().enumerate() {
-                        if i > 0 {
-                            self.write(", ");
-                        }
-                        if let Some(param_node) = self.arena.get(param_idx)
-                            && let Some(param_data) = self.arena.get_parameter(param_node)
-                        {
-                            self.emit(param_data.name);
-                        }
-                    }
-                    self.write(") ");
-                    let prev_self_alias = self.scoped_class_expression_self_alias.clone();
-                    if private_member_def_needs_class_alias
-                        && let Some(alias) = class_value_alias.as_ref()
-                        && !class_name.is_empty()
-                    {
-                        self.scoped_class_expression_self_alias = Some((
-                            Arc::<str>::from(class_name.as_str()),
-                            Arc::<str>::from(alias.as_str()),
-                        ));
-                    }
-                    self.emit_single_line_block(*body_idx);
-                    self.scoped_class_expression_self_alias = prev_self_alias;
+                    self.emit_private_method_function_def(
+                        var_name,
+                        *body_idx,
+                        params,
+                        private_member_def_needs_class_alias,
+                        class_value_alias.as_deref(),
+                        &class_name,
+                    );
                     first = false;
                 }
                 for def in &accessor_defs {
@@ -3726,34 +3707,14 @@ impl<'a> Printer<'a> {
                 if !first {
                     self.write(", ");
                 }
-                self.write(var_name);
-                self.write(" = function ");
-                self.write(var_name);
-                self.write("(");
-                for (i, &param_idx) in params.iter().enumerate() {
-                    if i > 0 {
-                        self.write(", ");
-                    }
-                    // Emit parameter name (identifier or pattern)
-                    if let Some(param_node) = self.arena.get(param_idx)
-                        && let Some(param_data) = self.arena.get_parameter(param_node)
-                    {
-                        self.emit(param_data.name);
-                    }
-                }
-                self.write(") ");
-                let prev_self_alias = self.scoped_class_expression_self_alias.clone();
-                if private_member_def_needs_class_alias
-                    && let Some(alias) = class_value_alias.as_ref()
-                    && !class_name.is_empty()
-                {
-                    self.scoped_class_expression_self_alias = Some((
-                        Arc::<str>::from(class_name.as_str()),
-                        Arc::<str>::from(alias.as_str()),
-                    ));
-                }
-                self.emit_single_line_block(*body_idx);
-                self.scoped_class_expression_self_alias = prev_self_alias;
+                self.emit_private_method_function_def(
+                    var_name,
+                    *body_idx,
+                    params,
+                    private_member_def_needs_class_alias,
+                    class_value_alias.as_deref(),
+                    &class_name,
+                );
                 first = false;
             }
 

--- a/crates/tsz-emitter/src/emitter/declarations/class/mod.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/mod.rs
@@ -4,6 +4,7 @@ mod decorators;
 mod emit_declaration;
 mod emit_es6;
 mod helpers;
+mod private_method_defs;
 
 use super::super::core::PropertyNameEmit;
 use tsz_parser::parser::NodeIndex;

--- a/crates/tsz-emitter/src/emitter/declarations/class/private_method_defs.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/private_method_defs.rs
@@ -1,0 +1,33 @@
+use super::super::super::Printer;
+use std::sync::Arc;
+use tsz_parser::parser::NodeIndex;
+
+impl<'a> Printer<'a> {
+    pub(in crate::emitter) fn emit_private_method_function_def(
+        &mut self,
+        var_name: &str,
+        body_idx: NodeIndex,
+        params: &[NodeIndex],
+        private_member_def_needs_class_alias: bool,
+        class_value_alias: Option<&str>,
+        class_name: &str,
+    ) {
+        self.write(var_name);
+        self.write(" = function ");
+        self.write(var_name);
+        self.write("(");
+        self.emit_function_parameters_js(params);
+        self.write(") ");
+
+        let prev_self_alias = self.scoped_class_expression_self_alias.clone();
+        if private_member_def_needs_class_alias
+            && let Some(alias) = class_value_alias
+            && !class_name.is_empty()
+        {
+            self.scoped_class_expression_self_alias =
+                Some((Arc::<str>::from(class_name), Arc::<str>::from(alias)));
+        }
+        self.emit_single_line_block(body_idx);
+        self.scoped_class_expression_self_alias = prev_self_alias;
+    }
+}

--- a/crates/tsz-emitter/src/emitter/es5/templates.rs
+++ b/crates/tsz-emitter/src/emitter/es5/templates.rs
@@ -55,7 +55,9 @@ impl<'a> Printer<'a> {
             return;
         };
 
-        self.emit_expression(tagged.tag);
+        if !self.emit_private_field_tagged_template_tag(tagged.tag) {
+            self.emit_expression(tagged.tag);
+        }
         self.write("(");
 
         if self.ctx.file_is_module {

--- a/crates/tsz-emitter/src/emitter/expressions/call.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/call.rs
@@ -225,10 +225,14 @@ impl<'a> Printer<'a> {
                 self.write_helper("__classPrivateFieldGet");
                 self.write("(");
                 if let Some(temp) = receiver_temp_str {
+                    self.write("(");
                     self.write(temp);
                     self.write(" = ");
+                    self.emit_private_receiver(expression, &clean_name);
+                    self.write(")");
+                } else {
+                    self.emit_private_receiver(expression, &clean_name);
                 }
-                self.emit_private_receiver(expression, &clean_name);
                 self.write(", ");
                 if let Some(info) = self.private_member_info.get(&clean_name).cloned() {
                     if let Some(ref state_var) = info.state_var {

--- a/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
@@ -496,6 +496,21 @@ impl<'a> Printer<'a> {
         }
     }
 
+    fn emit_private_field_get_close(&mut self, clean_name: &str) {
+        let info = self.private_member_info.get(clean_name).cloned();
+        let kind = info.as_ref().map_or("f", |i| i.kind);
+        self.write(", \"");
+        self.write(kind);
+        self.write("\"");
+        if let Some(ref i) = info
+            && let Some(ref fn_ref) = i.fn_ref
+        {
+            self.write(", ");
+            self.write(fn_ref);
+        }
+        self.write(")");
+    }
+
     /// Emit either `expr` directly or `_a = expr` for temp assignment.
     fn emit_receiver_or_temp_assign(&mut self, expression: NodeIndex, receiver_temp: Option<&str>) {
         if let Some(temp) = receiver_temp {
@@ -531,17 +546,46 @@ impl<'a> Printer<'a> {
         } else {
             self.write(weakmap_name);
         }
-        let kind = info.as_ref().map_or("f", |i| i.kind);
-        self.write(", \"");
-        self.write(kind);
-        self.write("\"");
-        if let Some(ref i) = info
-            && let Some(ref fn_ref) = i.fn_ref
-        {
-            self.write(", ");
-            self.write(fn_ref);
+        self.emit_private_field_get_close(clean_name);
+    }
+
+    pub(in crate::emitter) fn emit_private_field_tagged_template_tag(
+        &mut self,
+        tag: NodeIndex,
+    ) -> bool {
+        let Some(access) = self.try_extract_private_field_access(tag) else {
+            return false;
+        };
+
+        let receiver_temp = if self.private_call_receiver_is_simple(access.expression) {
+            None
+        } else {
+            Some(self.make_unique_name_hoisted())
+        };
+        let receiver_temp = receiver_temp.as_deref();
+
+        self.write_helper("__classPrivateFieldGet");
+        self.write("(");
+        if let Some(temp) = receiver_temp {
+            self.write("(");
+            self.write(temp);
+            self.write(" = ");
+            self.emit_private_receiver(access.expression, &access.clean_name);
+            self.write(")");
+        } else {
+            self.emit_private_receiver(access.expression, &access.clean_name);
+        }
+        self.write(", ");
+        self.emit_private_state_var(&access.weakmap_name, &access.clean_name);
+        self.emit_private_field_get_close(&access.clean_name);
+        self.write(".bind(");
+        if let Some(temp) = receiver_temp {
+            self.write(temp);
+        } else {
+            self.emit_private_receiver(access.expression, &access.clean_name);
         }
         self.write(")");
+        true
     }
 
     pub(in crate::emitter) fn emit_binary_expression(&mut self, node: &Node) {

--- a/crates/tsz-emitter/src/emitter/literals/template.rs
+++ b/crates/tsz-emitter/src/emitter/literals/template.rs
@@ -124,7 +124,9 @@ impl<'a> Printer<'a> {
             None
         };
 
-        if let Some(subst) = cjs_subst {
+        if self.emit_private_field_tagged_template_tag(tagged.tag) {
+            // private tag emitted with its required receiver binding
+        } else if let Some(subst) = cjs_subst {
             self.write("(0, ");
             self.write(&subst);
             self.write(")");

--- a/crates/tsz-emitter/src/emitter/source_file/mod.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/mod.rs
@@ -22,6 +22,8 @@ mod es5_object_rest_tests;
 mod legacy_decorator_computed_tests;
 #[cfg(test)]
 mod private_field_helper_order_tests;
+#[cfg(test)]
+mod private_tagged_template_tests;
 
 #[cfg(test)]
 mod es5_emit_tests;

--- a/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
@@ -1,0 +1,74 @@
+use crate::context::emit::EmitContext;
+use crate::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use crate::lowering::LoweringPass;
+use tsz_common::ScriptTarget;
+use tsz_parser::ParserState;
+
+fn emit(source: &str, target: ScriptTarget) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        target,
+        use_define_for_class_fields: false,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+#[test]
+fn instance_private_accessor_tag_binds_original_receiver() {
+    let source = r#"
+class Box {
+    get #tag() { return function() {}; }
+    make() { return new Box(); }
+    run() {
+        this.#tag`a`;
+        this.make().#tag`b`;
+    }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains(
+            "__classPrivateFieldGet(this, _Box_instances, \"a\", _Box_tag_get).bind(this) `a`"
+        ),
+        "Simple private accessor tags should bind to `this`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("__classPrivateFieldGet((_a = this.make()), _Box_instances, \"a\", _Box_tag_get).bind(_a) `b`"),
+        "Side-effecting private accessor tag receivers should be captured once.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn static_private_method_tag_binds_class_alias_receiver() {
+    let source = r#"
+class Widget {
+    static #tag() {}
+    static factory() { return Widget; }
+    run() {
+        Widget.#tag`a`;
+        Widget.factory().#tag`b`;
+    }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains("__classPrivateFieldGet(_a, _a, \"m\", _Widget_tag).bind(_a) `a`"),
+        "Static private method tags should bind to the class alias receiver.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "__classPrivateFieldGet((_b = _a.factory()), _a, \"m\", _Widget_tag).bind(_b) `b`"
+        ),
+        "Side-effecting static private method tag receivers should be captured once.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
@@ -72,3 +72,28 @@ class Widget {
         "Side-effecting static private method tag receivers should be captured once.\nOutput:\n{output}"
     );
 }
+
+#[test]
+fn static_private_method_call_captures_receiver_and_preserves_rest_param() {
+    let source = r#"
+class Widget {
+    static #run(a, ...b) {}
+    static factory() { return Widget; }
+    run(items) {
+        Widget.factory().#run(0, ...items, 3);
+    }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains(
+            "__classPrivateFieldGet((_b = _a.factory()), _a, \"m\", _Widget_run).call(_b, 0, ...items, 3)"
+        ),
+        "Side-effecting static private method call receivers should be captured once.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_Widget_run = function _Widget_run(a, ...b) { }"),
+        "Extracted private method definitions should preserve rest parameters.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
JavaScript emit recovery / class-private invocation emit parity.

## Invariant
When downleveled private field, accessor, or method access is invoked through a call or tagged template, `tsc` uses one receiver value for both `__classPrivateFieldGet` and the subsequent `.call(...)`/`.bind(...)`; extracted private method helper functions also preserve the original JS parameter surface, including rest parameters.

## Structural Rule
Private member invocation emit is owned by expression/template printing and class private-method helper emission. If a private member receiver is side-effecting, emit the receiver assignment as the first helper argument and reuse that temp for `.call(...)` or `.bind(...)`. Extracted private method definitions print parameters through the normal JS parameter printer instead of hand-emitting names.

## Owner Layer
Emitter output code in `crates/tsz-emitter/src/emitter/`, not checker/solver validation and not output surgery. The helper paths consume AST/lowering facts that already exist; they do not add semantic validation.

## Adjacent Case Matrix
- Instance private accessor tag with simple `this` receiver: `this.#tag\`a\`` binds to `this`.
- Instance private accessor tag with side-effecting receiver: `this.make().#tag\`b\`` captures the receiver once and binds the temp.
- Static private method tag with class-name alias receiver: `Widget.#tag\`a\`` binds to the static class alias.
- Static private method tag with side-effecting static receiver: `Widget.factory().#tag\`b\`` captures the receiver once and binds the temp.
- Static private method call with side-effecting static receiver: `Widget.factory().#run(...)` captures the receiver once and calls the temp.
- Extracted private method helpers preserve rest parameters: `static #run(a, ...b) {}` emits `function _Widget_run(a, ...b)`.

## Scope
- Add `emit_private_field_tagged_template_tag` beside existing private-field get/set helpers.
- Route native tagged-template emit and ES5 tagged-template downlevel emit through the private tag helper when the tag is a private access.
- Parenthesize side-effecting private-call receiver assignment helper arguments and reuse the temp for `.call(...)`.
- Split extracted private method helper-definition printing out of `emit_es6.rs` and route its parameter list through `emit_function_parameters_js`.
- Add focused emitter unit tests for private tagged-template binding, private method call receiver binding, and extracted private method rest parameters.

## Project Corpus Impact
- Row: emit conformance `privateNameAccessorsCallExpression`, `privateNameStaticAccessorsCallExpression`, `privateNameStaticMethodCallExpression`
- Bug family: class/private/accessor/static invocation receiver binding and private method helper parameter printing
- Evidence: the three exact JS emit filters passed locally after rebasing onto current `origin/main`; the narrow `privateNameStatic` sweep is 26/31.

## Verification
- `cargo nextest run -p tsz-emitter private_tagged_template_tests`
- `scripts/emit/run.sh --filter=privateNameAccessorsCallExpression --js-only --verbose --json-out=/tmp/studio-c-private-accessors-call-post-main-rebase.json`
- `scripts/emit/run.sh --skip-build --filter=privateNameStaticAccessorsCallExpression --js-only --verbose --json-out=/tmp/studio-c-private-static-accessors-call-post-main-rebase.json`
- `scripts/emit/run.sh --skip-build --filter=privateNameStaticMethodCallExpression --js-only --verbose --json-out=/tmp/studio-c-private-static-method-call-post-main-rebase.json`
- `scripts/emit/run.sh --skip-build --filter=privateNameStatic --js-only --verbose --json-out=/tmp/studio-c-private-name-static-post-main-rebase.json` (26/31; remaining failures are separate families)
- `cargo fmt --all --check`
- `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`
- `git diff --check`

## Known Unsupported Shapes / Follow-Up
This PR does not fix private static optional-call recovery (`(_b = _a.)`), private destructuring temp minimization, class-expression `__setFunctionName` scheduling, static private method assignment receiver/temp parity, or async/generator private method helper forms.

## Coordination Notes
- #10591 merged through the repo-local queue at 2026-05-27T18:30:50Z.
- This branch was rebased onto current `origin/main`; current head is ready for heavy CI.
- Remaining private-static failures are tracked as follow-up structural families, not blockers for this receiver-binding slice.
