### PR TITLE
fix(bench): pass prep artifact to shard builds

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -963,6 +963,23 @@ jobs:
           ref: ${{ env.BENCH_TARGET_SHA }}
           fetch-depth: 1
 
+      - name: Download benchmark prep artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: bench-prep-ready
+          path: .
+
+      - name: Validate source benchmark prep artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f bench-prep.env
+          test -f bench-prep.tar
+          grep -qx "BENCH_TARGET_SHA=${BENCH_TARGET_SHA}" bench-prep.env
+          grep -qx "BENCH_PGO_OPTIMIZED=1" bench-prep.env
+          tar -tf bench-prep.tar .target-bench/dist/tsz >/dev/null
+          tar -tf bench-prep.tar .target-bench/dist/.bench-pgo-optimized >/dev/null
+
       - id: cloudbuild-submit
         name: Submit benchmark shard to Cloud Build pool
         shell: bash

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -7,8 +7,15 @@ import { fileURLToPath } from "node:url";
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(SCRIPT_DIR, "..", "..");
 const BENCH_WORKFLOW = path.join(ROOT, ".github", "workflows", "bench.yml");
+const BENCH_SHARD_CLOUDBUILD = path.join(
+  ROOT,
+  "scripts",
+  "cloudbuild",
+  "cloudbuild-bench-shard.yaml",
+);
 
 const workflow = fs.readFileSync(BENCH_WORKFLOW, "utf8");
+const shardCloudbuild = fs.readFileSync(BENCH_SHARD_CLOUDBUILD, "utf8");
 
 const failFastMessages = workflow.match(
   /Cloud Build benchmark prep \$\{cloudbuild_id\} succeeded, but its manifest artifact is for/g,
@@ -113,6 +120,19 @@ assert.match(
   workflow,
   /- name: Trigger benchmark catch-up[\s\S]+steps\.publish\.outputs\.catchup_main_sha != ''[\s\S]+actions\/workflows\/bench\.yml\/dispatches[\s\S]+-d '\{"ref":"main","inputs":\{"publish_latest_pgo":"false"\}\}'/,
   "stale benchmark publishes should dispatch a catch-up benchmark for current main",
+);
+
+const benchJob = workflow.match(/  bench:[\s\S]+?  publish:/)?.[0] ?? "";
+assert.match(
+  benchJob,
+  /- name: Download benchmark prep artifact[\s\S]+actions\/download-artifact@v4[\s\S]+name: bench-prep-ready[\s\S]+- name: Validate source benchmark prep artifact[\s\S]+tar -tf bench-prep\.tar \.target-bench\/dist\/tsz[\s\S]+- id: cloudbuild-submit/,
+  "benchmark shard jobs should include the validated prep artifact in the Cloud Build source archive before submit",
+);
+
+assert.match(
+  shardCloudbuild,
+  /if \[\[ -f bench-prep\.env && -f bench-prep\.tar \]\]; then[\s\S]+Using benchmark prep artifact from the Cloud Build source archive\.[\s\S]+else[\s\S]+gcloud storage cp[\s\S]+bench-prep\/\$\{_BENCH_TARGET_SHA\}\/bench-prep\.env/,
+  "Cloud Build shard prep should prefer source-provided prep artifacts before falling back to GCS",
 );
 
 console.log("bench workflow Cloud Build prep artifact tests passed");

--- a/scripts/ci/test-cloudbuild-config-paths.mjs
+++ b/scripts/ci/test-cloudbuild-config-paths.mjs
@@ -65,6 +65,10 @@ const benchPrepareConfig = fs.readFileSync(
   path.join(ROOT, "scripts", "cloudbuild", "cloudbuild-bench-prepare.yaml"),
   "utf8",
 );
+const benchShardConfig = fs.readFileSync(
+  path.join(ROOT, "scripts", "cloudbuild", "cloudbuild-bench-shard.yaml"),
+  "utf8",
+);
 assert.match(
   benchPrepareConfig,
   /literal_scoped_dir='bench-prep\/\$\{_BENCH_TARGET_SHA\}'[\s\S]+cp bench-prep\.tar bench-prep\.env "\$\{literal_scoped_dir\}\/"/,
@@ -75,6 +79,21 @@ assert.match(
   /metadata\.google\.internal\/computeMetadata\/v1\/instance\/service-accounts\/default\/token[\s\S]+upload_gcs_object bench-prep\.tar "bench-prep\/\$\{_BENCH_TARGET_SHA\}\/bench-prep\.tar"[\s\S]+upload_gcs_object bench-prep\.env "bench-prep\/latest\/bench-prep\.env"/,
   "benchmark prep should explicitly upload verified env/tar artifacts to SHA-scoped and latest GCS paths",
 );
+for (const [name, config] of [
+  ["benchmark prep", benchPrepareConfig],
+  ["benchmark shard", benchShardConfig],
+]) {
+  assert.match(
+    config,
+    /logging:\s+GCS_ONLY/,
+    `${name} Cloud Build config should write logs to GCS for GitHub artifact capture`,
+  );
+  assert.match(
+    config,
+    /logsBucket:\s+gs:\/\/tsz-ci_cloudbuild\/cloudbuild-logs/,
+    `${name} Cloud Build config should use the benchmark bucket for readable logs`,
+  );
+}
 
 for (const workflow of workflowFiles) {
   const configs = workflowConfigs.get(workflow) ?? [];

--- a/scripts/cloudbuild/cloudbuild-bench-prepare.yaml
+++ b/scripts/cloudbuild/cloudbuild-bench-prepare.yaml
@@ -144,6 +144,8 @@ substitutions:
 options:
   pool:
     name: projects/tsz-ci/locations/us-central1/workerPools/tsz-ci-build-pool
-  logging: CLOUD_LOGGING_ONLY
+  logging: GCS_ONLY
+
+logsBucket: gs://tsz-ci_cloudbuild/cloudbuild-logs
 
 timeout: 7200s

--- a/scripts/cloudbuild/cloudbuild-bench-shard.yaml
+++ b/scripts/cloudbuild/cloudbuild-bench-shard.yaml
@@ -8,12 +8,16 @@ steps:
       #!/usr/bin/env bash
       set -euo pipefail
 
-      gcloud storage cp \
-        "gs://tsz-ci_cloudbuild/bench-prep/${_BENCH_TARGET_SHA}/bench-prep.env" \
-        bench-prep.env
-      gcloud storage cp \
-        "gs://tsz-ci_cloudbuild/bench-prep/${_BENCH_TARGET_SHA}/bench-prep.tar" \
-        bench-prep.tar
+      if [[ -f bench-prep.env && -f bench-prep.tar ]]; then
+        echo "Using benchmark prep artifact from the Cloud Build source archive."
+      else
+        gcloud storage cp \
+          "gs://tsz-ci_cloudbuild/bench-prep/${_BENCH_TARGET_SHA}/bench-prep.env" \
+          bench-prep.env
+        gcloud storage cp \
+          "gs://tsz-ci_cloudbuild/bench-prep/${_BENCH_TARGET_SHA}/bench-prep.tar" \
+          bench-prep.tar
+      fi
 
       tar -tf bench-prep.tar .target-bench/dist/tsz >/dev/null
       tar -tf bench-prep.tar .target-bench/dist/.bench-pgo-optimized >/dev/null

--- a/scripts/cloudbuild/cloudbuild-bench-shard.yaml
+++ b/scripts/cloudbuild/cloudbuild-bench-shard.yaml
@@ -168,6 +168,8 @@ substitutions:
 options:
   pool:
     name: projects/tsz-ci/locations/us-central1/workerPools/tsz-ci-build-pool
-  logging: CLOUD_LOGGING_ONLY
+  logging: GCS_ONLY
+
+logsBucket: gs://tsz-ci_cloudbuild/cloudbuild-logs
 
 timeout: 7200s


### PR DESCRIPTION
## Agent
AgentName: Studio-A
Runner: Codex-Bench-Fresh

## Track
Benchmark blocker: Bench Cloud Build shard handoff, shard diagnostics, and website benchmark freshness.

## Invariant
When `bench-prep-artifact` has produced a validated `bench-prep-ready` artifact, each benchmark shard should submit that artifact with its Cloud Build source and validate it before running; shard success must not depend on Cloud Build being able to read the private prep object directly from GCS. When a Bench Cloud Build fails, the GitHub artifact should contain a readable Cloud Build log instead of a Cloud Logging permission error.

## Scope
- `.github/workflows/bench.yml`: download and validate `bench-prep-ready` in each benchmark shard job before `gcloud builds submit`, so `bench-prep.env` and `bench-prep.tar` are included in the Cloud Build source archive.
- `scripts/cloudbuild/cloudbuild-bench-shard.yaml`: prefer source-provided prep files and keep the SHA-scoped GCS download as fallback.
- `scripts/cloudbuild/cloudbuild-bench-prepare.yaml` and `scripts/cloudbuild/cloudbuild-bench-shard.yaml`: write Cloud Build logs to `gs://tsz-ci_cloudbuild/cloudbuild-logs` with `GCS_ONLY`, so the runner can upload useful failure diagnostics.
- `scripts/bench/test-bench-workflow-cloudbuild-prep.mjs` and `scripts/ci/test-cloudbuild-config-paths.mjs`: smoke-test the source-provided prep path and readable log configuration.

## Project Corpus Impact
- Row: n/a
- Bug family: benchmark shard Cloud Build prep handoff / benchmark artifact diagnosability
- Evidence: workflow/config-only handoff and log-capture change; no fixture, compiler, project row, or benchmark timing semantics changed.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `git diff --check origin/codex/bench-shard-source-prep-20260527..HEAD`
- Failed Bench evidence: run `26529235644` passed `bench-prep-artifact`, then shard Cloud Builds failed before publishing shard status artifacts; uploaded shard diagnostics contained only `gcloud builds log` `PERMISSION_DENIED` output under `CLOUD_LOGGING_ONLY`.

## Coordination Notes
- Builds on merged fixes #10574, #10584, #10590, and #10595.
- Studio-A owns this PR as release-metric / benchmark artifact truth work; `Codex-Bench-Fresh` is retained as runner metadata.
- After merge, dispatch Bench again on current `main` and verify public benchmark JSON/page freshness.
