### PR TITLE
fix(checker): route renamed symbol property keys structurally

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -59,7 +59,7 @@ impl<'a> CheckerState<'a> {
         false
     }
 
-    fn resolve_index_signature_key_type_via_env(&self, key_type: TypeId) -> TypeId {
+    pub(crate) fn resolve_index_signature_key_type_via_env(&self, key_type: TypeId) -> TypeId {
         let mut current = key_type;
         for _ in 0..8 {
             let Some(def_id) =

--- a/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
@@ -474,6 +474,14 @@ impl<'a> CheckerState<'a> {
                     .unwrap_or(TypeId::ANY)
             };
 
+            if prop_name_type == TypeId::SYMBOL {
+                self.report_contextual_symbol_index_value_mismatch(
+                    accessor.name,
+                    None,
+                    accessor_type,
+                    contextual_type,
+                );
+            }
             self.route_computed_member_value_to_index_signature(
                 prop_name_type,
                 accessor_type,

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -987,6 +987,14 @@ impl<'a> CheckerState<'a> {
                         value_type = literal_type;
                     }
 
+                    if prop_name_type == TypeId::SYMBOL {
+                        self.report_contextual_symbol_index_value_mismatch(
+                            prop.name,
+                            Some(prop.initializer),
+                            value_type,
+                            contextual_type,
+                        );
+                    }
                     self.route_computed_member_value_to_index_signature(
                         prop_name_type,
                         value_type,
@@ -1738,6 +1746,14 @@ impl<'a> CheckerState<'a> {
                         );
                     }
 
+                    if prop_name_type == TypeId::SYMBOL {
+                        self.report_contextual_symbol_index_value_mismatch(
+                            method.name,
+                            None,
+                            method_type,
+                            contextual_type,
+                        );
+                    }
                     self.route_computed_member_value_to_index_signature(
                         prop_name_type,
                         method_type,

--- a/crates/tsz-checker/src/types/computation/object_literal/symbol_key_routing.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/symbol_key_routing.rs
@@ -110,9 +110,99 @@ impl<'a> CheckerState<'a> {
         let Some(expr_node) = self.ctx.arena.get(computed.expression) else {
             return false;
         };
-        if self.ctx.arena.get_identifier(expr_node).is_none() {
+        let is_supported_wide_symbol_syntax = self.ctx.arena.get_identifier(expr_node).is_some()
+            || matches!(
+                expr_node.kind,
+                k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                    || k == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+            );
+        if !is_supported_wide_symbol_syntax {
+            return false;
+        }
+        if self
+            .declared_unique_symbol_member_property_name(computed.expression)
+            .is_some()
+        {
             return false;
         }
         self.get_type_of_node(computed.expression) == TypeId::SYMBOL
+    }
+
+    pub(super) fn report_contextual_symbol_index_value_mismatch(
+        &mut self,
+        name_idx: NodeIndex,
+        value_idx: Option<NodeIndex>,
+        source_value_type: TypeId,
+        contextual_type: Option<TypeId>,
+    ) -> bool {
+        let Some(target_value_type) = self.contextual_symbol_index_value_type(contextual_type)
+        else {
+            return false;
+        };
+        if self.diagnostic_relation_boolean_guard(source_value_type, target_value_type) {
+            return false;
+        }
+
+        use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+
+        let source_type = value_idx
+            .and_then(|idx| self.literal_type_from_initializer(idx))
+            .unwrap_or(source_value_type);
+        let source_type = self.widen_literal_type(source_type);
+        let source_str = self.format_type_for_assignability_message(source_type);
+        let target_str = self.format_type_for_assignability_message(target_value_type);
+        let message = format_message(
+            diagnostic_messages::TYPE_OF_COMPUTED_PROPERTYS_VALUE_IS_WHICH_IS_NOT_ASSIGNABLE_TO_TYPE,
+            &[&source_str, &target_str],
+        );
+        self.error_at_node(
+            name_idx,
+            &message,
+            diagnostic_codes::TYPE_OF_COMPUTED_PROPERTYS_VALUE_IS_WHICH_IS_NOT_ASSIGNABLE_TO_TYPE,
+        );
+        true
+    }
+
+    fn contextual_symbol_index_value_type(
+        &mut self,
+        contextual_type: Option<TypeId>,
+    ) -> Option<TypeId> {
+        let contextual_type = contextual_type?;
+        let mut value_types = Vec::new();
+        self.collect_contextual_symbol_index_value_types(contextual_type, &mut value_types);
+        if value_types.is_empty() {
+            return None;
+        }
+        Some(tsz_solver::utils::union_or_single(
+            self.ctx.types,
+            value_types,
+        ))
+    }
+
+    fn collect_contextual_symbol_index_value_types(
+        &mut self,
+        type_id: TypeId,
+        value_types: &mut Vec<TypeId>,
+    ) {
+        let evaluated = self.evaluate_type_with_env(type_id);
+        let resolved = self.resolve_lazy_type(evaluated);
+        if let Some(shape) =
+            crate::query_boundaries::state::checking::object_shape(self.ctx.types, resolved)
+        {
+            if let Some(index) = &shape.string_index
+                && self.resolve_index_signature_key_type_via_env(index.key_type) == TypeId::SYMBOL
+            {
+                value_types.push(index.value_type);
+            }
+            return;
+        }
+
+        if let Some(members) =
+            crate::query_boundaries::state::checking::union_members(self.ctx.types, resolved)
+        {
+            for member in members {
+                self.collect_contextual_symbol_index_value_types(member, value_types);
+            }
+        }
     }
 }

--- a/crates/tsz-checker/src/types/queries/core_names.rs
+++ b/crates/tsz-checker/src/types/queries/core_names.rs
@@ -1,6 +1,6 @@
 //! Name, computed-property, and display-name query helpers for `CheckerState`.
 
-use super::core::{get_literal_or_well_known_property_name, get_literal_property_name};
+use super::core::get_literal_property_name;
 use crate::state::CheckerState;
 use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeIndex;
@@ -163,13 +163,11 @@ impl<'a> CheckerState<'a> {
             // computed expression is not a bare identifier (so `resolve_computed_symbol_property_name`
             // returns None) but the prop type widened to plain `symbol` — e.g. when `Symbol` is a
             // user-declared const with `{ readonly iterator: unique symbol }` type annotation.
-            // Text-based matching recovers `"[Symbol.xxx]"` without registering a well-known symbol
-            // mapping, preserving `keyof` behavior for user-declared Symbol shapes.
             if prop_name_type == TypeId::SYMBOL
-                && let Some(well_known) =
-                    get_literal_or_well_known_property_name(self.ctx.arena, name_idx)
+                && let Some(unique_member_name) =
+                    self.declared_unique_symbol_member_property_name(computed.expression)
             {
-                return Some(well_known);
+                return Some(unique_member_name);
             }
             if let Some(symbol_name) =
                 self.symbol_valued_binding_property_name(computed.expression, prop_name_type)
@@ -298,6 +296,9 @@ impl<'a> CheckerState<'a> {
 
     pub(crate) fn computed_property_expression_is_symbol_named(&self, expr_idx: NodeIndex) -> bool {
         self.get_symbol_property_name_from_expr(expr_idx).is_some()
+            || self
+                .declared_unique_symbol_member_property_name(expr_idx)
+                .is_some()
             || self
                 .computed_identifier_unique_symbol_property_ref(expr_idx)
                 .is_some()
@@ -500,6 +501,12 @@ impl<'a> CheckerState<'a> {
         let Some(computed) = self.ctx.arena.get_computed_property(name_node) else {
             return false;
         };
+        if self
+            .declared_unique_symbol_member_property_name(computed.expression)
+            .is_some()
+        {
+            return true;
+        }
 
         let prev_checking = self.ctx.checking_computed_property_name;
         self.ctx.checking_computed_property_name = Some(name_idx);
@@ -588,6 +595,106 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        None
+    }
+
+    pub(crate) fn declared_unique_symbol_member_property_name(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        let (base_expr, member_name) = self.property_access_identifier_parts(expr_idx)?;
+        let local_sym_id = self.resolve_identifier_symbol_without_tracking(base_expr)?;
+        let sym_id = self
+            .ctx
+            .resolve_import_alias_and_register(local_sym_id)
+            .unwrap_or(local_sym_id);
+        let file_idx = self.ctx.resolve_symbol_file_index(sym_id).or_else(|| {
+            self.get_cross_file_symbol(sym_id)
+                .map(|symbol| symbol.decl_file_idx as usize)
+        })?;
+        let symbol = self
+            .ctx
+            .get_binder_for_file(file_idx)
+            .and_then(|binder| binder.get_symbol(sym_id))
+            .or_else(|| self.get_cross_file_symbol(sym_id))?;
+        let value_decl = symbol.value_declaration;
+        if value_decl.is_none() {
+            return None;
+        }
+        let decl_arena = self.ctx.get_arena_for_file(file_idx as u32);
+        let decl_node = decl_arena.get(value_decl)?;
+        let var_decl = decl_arena.get_variable_declaration(decl_node)?;
+        let type_annotation = var_decl.type_annotation;
+        let type_node = crate::types_domain::unique_symbol_arena::unwrap_parenthesized_type(
+            decl_arena,
+            type_annotation,
+        );
+        let type_node = decl_arena.get(type_node)?;
+        if type_node.kind != syntax_kind_ext::TYPE_LITERAL {
+            return None;
+        }
+        let type_lit = decl_arena.get_type_literal(type_node)?;
+        let has_unique_member = type_lit.members.nodes.iter().any(|&member_idx| {
+            let Some(member_node) = decl_arena.get(member_idx) else {
+                return false;
+            };
+            if member_node.kind != syntax_kind_ext::PROPERTY_SIGNATURE {
+                return false;
+            }
+            let Some(sig) = decl_arena.get_signature(member_node) else {
+                return false;
+            };
+            get_literal_property_name(decl_arena, sig.name).is_some_and(|name| {
+                name == member_name
+                    && sig.type_annotation.is_some()
+                    && crate::types_domain::unique_symbol_arena::is_unique_symbol_type_annotation_unwrapped(
+                        decl_arena,
+                        sig.type_annotation,
+                    )
+            })
+        });
+        has_unique_member.then(|| {
+            let base_name = self
+                .ctx
+                .arena
+                .get_identifier_at(base_expr)
+                .map(|ident| ident.escaped_text.as_str())
+                .unwrap_or("Symbol");
+            format!("[{base_name}.{member_name}]")
+        })
+    }
+
+    fn property_access_identifier_parts(
+        &self,
+        mut expr_idx: NodeIndex,
+    ) -> Option<(NodeIndex, String)> {
+        while let Some(node) = self.ctx.arena.get(expr_idx)
+            && node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION
+        {
+            expr_idx = self.ctx.arena.get_parenthesized(node)?.expression;
+        }
+        let node = self.ctx.arena.get(expr_idx)?;
+        if node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            && node.kind != syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+        {
+            return None;
+        }
+        let access = self.ctx.arena.get_access_expr(node)?;
+        let base_node = self.ctx.arena.get(access.expression)?;
+        self.ctx.arena.get_identifier(base_node)?;
+        let name_node = self.ctx.arena.get(access.name_or_argument)?;
+        if let Some(ident) = self.ctx.arena.get_identifier(name_node) {
+            return Some((access.expression, ident.escaped_text.clone()));
+        }
+        if matches!(
+            name_node.kind,
+            k if k == SyntaxKind::StringLiteral as u16
+                || k == SyntaxKind::NoSubstitutionTemplateLiteral as u16
+        ) && let Some(lit) = self.ctx.arena.get_literal(name_node)
+            && !lit.text.is_empty()
+        {
+            return Some((access.expression, lit.text.clone()));
+        }
         None
     }
 

--- a/crates/tsz-checker/tests/symbol_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/symbol_index_signature_tests.rs
@@ -97,6 +97,66 @@ const table: { [k: symbol]: string } = {
 }
 
 #[test]
+fn renamed_unique_symbol_property_access_reports_computed_property_value_mismatch() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const Sym: { readonly foo: unique symbol };
+
+const table: { [k: symbol]: string } = {
+    [Sym.foo]: 123,
+};
+"#,
+    );
+
+    assert!(
+        codes.contains(
+            &diagnostic_codes::TYPE_OF_COMPUTED_PROPERTYS_VALUE_IS_WHICH_IS_NOT_ASSIGNABLE_TO_TYPE
+        ),
+        "expected TS2418 for renamed unique-symbol property access, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "did not expect the object-level TS2322 fallback, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(
+            &diagnostic_codes::OBJECT_LITERAL_MAY_ONLY_SPECIFY_KNOWN_PROPERTIES_AND_DOES_NOT_EXIST_IN_TYPE
+        ),
+        "did not expect TS2353 excess property fallback, got {codes:?}",
+    );
+}
+
+#[test]
+fn plain_symbol_property_access_reports_computed_property_value_mismatch() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const Sym: { readonly foo: symbol };
+
+const table: { [k: symbol]: string } = {
+    [Sym.foo]: 123,
+};
+"#,
+    );
+
+    assert!(
+        codes.contains(
+            &diagnostic_codes::TYPE_OF_COMPUTED_PROPERTYS_VALUE_IS_WHICH_IS_NOT_ASSIGNABLE_TO_TYPE
+        ),
+        "expected TS2418 for plain-symbol property access, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "did not expect the object-level TS2322 fallback, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(
+            &diagnostic_codes::OBJECT_LITERAL_MAY_ONLY_SPECIFY_KNOWN_PROPERTIES_AND_DOES_NOT_EXIST_IN_TYPE
+        ),
+        "did not expect TS2353 excess property fallback, got {codes:?}",
+    );
+}
+
+#[test]
 fn keyof_well_known_symbol_property_preserves_symbol_key_type() {
     let codes = diagnostic_codes_for_ts(
         r#"
@@ -871,11 +931,10 @@ const _v: number = ({} as V);
 
 #[test]
 fn object_literal_well_known_symbol_property_access_key_still_resolves_named_member() {
-    // `Symbol.iterator`-style property-access keys must continue to produce
-    // canonical `[Symbol.xxx]` named members. The wide-symbol bypass is
-    // gated on bare-identifier expressions, so a property access never
-    // triggers it. The target's symbol index signature still rejects the
-    // mismatched value via TS2418 — proving the named-member path is intact.
+    // Unique-symbol property-access keys must continue to produce canonical
+    // named members. Plain-symbol property-access keys can use the symbol-index
+    // path, but a structurally declared `unique symbol` member must keep the
+    // named-member path intact.
     let codes = diagnostic_codes_for_ts(
         r#"
 declare const Symbol: { readonly iterator: unique symbol };


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Semantic campaign / checker key-space parity follow-up for #10592.

## Invariant
When an object literal uses a computed property-access key whose accessed member is structurally declared as `unique symbol`, tsz keeps a named symbol property independent of the base identifier spelling; when the accessed member is plain `symbol`, tsz routes the value through the symbol-index path and emits TS2418 for contextual symbol-index value mismatches.

## Scope
- Replace the `get_property_name_resolved` text fallback for `[Symbol.xxx]` with an AST/binder/type-literal check for declared `unique symbol` members.
- Extend object-literal wide-symbol routing to property-access keys unless the accessed member is structurally `unique symbol`.
- Emit contextual TS2418 for unresolved wide-symbol computed keys against symbol index signatures.
- Add renamed unique-symbol and plain-symbol property-access diagnostic coverage.

## Project Corpus Impact
- Row: n/a
- Bug family: symbol-key/index-signature diagnostic parity
- Evidence: targeted checker tests for symbol index signatures and adjacent object-literal symbol key behavior; no project row run needed for this checker-local parity slice.

## Verification
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `cargo nextest run -p tsz-checker --test symbol_index_signature_tests`
- `cargo nextest run -p tsz-checker --lib -E 'test(well_known_symbol_method_shorthand_indexable) or test(namespace_shadowed_symbol_constructor_member_index_does_not_emit_ts7053) or test(shadowed_symbol_type_member_uses_resolved_literal_key) or test(keyof_method_shorthand_unique_symbol_yields_symbol_key)'`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --test symbol_index_signature_tests -- -D warnings`

## Coordination Notes
- Closes #10592.
- Follows PR #10571 review feedback.
- No open M4-A PR overlap found before starting; open PR audit and `scripts/agents/ensure-agent-labels.sh --audit` were clean.
- Ready for review/CI on head `e82bb403132`; no known blockers.
