### PR TITLE
fix(bench): restore Cloud Build logging mode

### DIFF
--- a/scripts/ci/test-cloudbuild-config-paths.mjs
+++ b/scripts/ci/test-cloudbuild-config-paths.mjs
@@ -85,13 +85,13 @@ for (const [name, config] of [
 ]) {
   assert.match(
     config,
-    /logging:\s+GCS_ONLY/,
-    `${name} Cloud Build config should write logs to GCS for GitHub artifact capture`,
+    /logging:\s+CLOUD_LOGGING_ONLY/,
+    `${name} Cloud Build config should keep submit-compatible Cloud Logging mode`,
   );
-  assert.match(
+  assert.doesNotMatch(
     config,
-    /logsBucket:\s+gs:\/\/tsz-ci_cloudbuild\/cloudbuild-logs/,
-    `${name} Cloud Build config should use the benchmark bucket for readable logs`,
+    /logsBucket:/,
+    `${name} Cloud Build config should not set a logs bucket the runtime service account cannot access`,
   );
 }
 

--- a/scripts/cloudbuild/cloudbuild-bench-prepare.yaml
+++ b/scripts/cloudbuild/cloudbuild-bench-prepare.yaml
@@ -144,8 +144,6 @@ substitutions:
 options:
   pool:
     name: projects/tsz-ci/locations/us-central1/workerPools/tsz-ci-build-pool
-  logging: GCS_ONLY
-
-logsBucket: gs://tsz-ci_cloudbuild/cloudbuild-logs
+  logging: CLOUD_LOGGING_ONLY
 
 timeout: 7200s

--- a/scripts/cloudbuild/cloudbuild-bench-shard.yaml
+++ b/scripts/cloudbuild/cloudbuild-bench-shard.yaml
@@ -168,8 +168,6 @@ substitutions:
 options:
   pool:
     name: projects/tsz-ci/locations/us-central1/workerPools/tsz-ci-build-pool
-  logging: GCS_ONLY
-
-logsBucket: gs://tsz-ci_cloudbuild/cloudbuild-logs
+  logging: CLOUD_LOGGING_ONLY
 
 timeout: 7200s


### PR DESCRIPTION
## Agent
AgentName: Studio-A
Runner: Codex-Bench-Fresh

## Track
Benchmark blocker: Bench Cloud Build submit path and website benchmark freshness.

## Invariant
When Bench submits prepare/shard builds to Cloud Build, the config must not require a logs bucket that the Cloud Build runtime service account cannot access; log visibility improvements must not break build submission.

## Scope
- `scripts/cloudbuild/cloudbuild-bench-prepare.yaml`: restore `logging: CLOUD_LOGGING_ONLY` and remove the inaccessible `logsBucket`.
- `scripts/cloudbuild/cloudbuild-bench-shard.yaml`: same restore for shard builds.
- `scripts/ci/test-cloudbuild-config-paths.mjs`: guard that benchmark Cloud Build configs keep submit-compatible logging and do not set `logsBucket`.

## Project Corpus Impact
- Row: n/a
- Bug family: benchmark Cloud Build submit configuration
- Evidence: workflow/config-only fix; no compiler, fixture, project row, or benchmark timing semantics changed.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `git diff --check`
- Failed Bench evidence: run `26531233410` failed in `bench-prepare-cloudbuild` with `FAILED_PRECONDITION: invalid bucket "tsz-ci_cloudbuild"; service account 638133053272-compute@developer.gserviceaccount.com does not have access to the bucket`.

## Coordination Notes
- This preserves the source-provided prep artifact shard fix from #10597 and only reverts the log-bucket addition that broke Cloud Build submit.
- After merge, rerun Bench on current `main` and verify public benchmark data freshness.