### PR TITLE
fix(bench): restore cloud logging for cloudbuild submits

### DIFF
--- a/scripts/ci/test-cloudbuild-config-paths.mjs
+++ b/scripts/ci/test-cloudbuild-config-paths.mjs
@@ -65,10 +65,6 @@ const benchPrepareConfig = fs.readFileSync(
   path.join(ROOT, "scripts", "cloudbuild", "cloudbuild-bench-prepare.yaml"),
   "utf8",
 );
-const benchShardConfig = fs.readFileSync(
-  path.join(ROOT, "scripts", "cloudbuild", "cloudbuild-bench-shard.yaml"),
-  "utf8",
-);
 assert.match(
   benchPrepareConfig,
   /literal_scoped_dir='bench-prep\/\$\{_BENCH_TARGET_SHA\}'[\s\S]+cp bench-prep\.tar bench-prep\.env "\$\{literal_scoped_dir\}\/"/,
@@ -79,21 +75,6 @@ assert.match(
   /metadata\.google\.internal\/computeMetadata\/v1\/instance\/service-accounts\/default\/token[\s\S]+upload_gcs_object bench-prep\.tar "bench-prep\/\$\{_BENCH_TARGET_SHA\}\/bench-prep\.tar"[\s\S]+upload_gcs_object bench-prep\.env "bench-prep\/latest\/bench-prep\.env"/,
   "benchmark prep should explicitly upload verified env/tar artifacts to SHA-scoped and latest GCS paths",
 );
-for (const [name, config] of [
-  ["benchmark prep", benchPrepareConfig],
-  ["benchmark shard", benchShardConfig],
-]) {
-  assert.match(
-    config,
-    /logging:\s+GCS_ONLY/,
-    `${name} Cloud Build config should write logs to GCS for GitHub artifact capture`,
-  );
-  assert.match(
-    config,
-    /logsBucket:\s+gs:\/\/tsz-ci_cloudbuild\/cloudbuild-logs/,
-    `${name} Cloud Build config should use the benchmark bucket for readable logs`,
-  );
-}
 
 for (const workflow of workflowFiles) {
   const configs = workflowConfigs.get(workflow) ?? [];

--- a/scripts/cloudbuild/cloudbuild-bench-prepare.yaml
+++ b/scripts/cloudbuild/cloudbuild-bench-prepare.yaml
@@ -144,8 +144,6 @@ substitutions:
 options:
   pool:
     name: projects/tsz-ci/locations/us-central1/workerPools/tsz-ci-build-pool
-  logging: GCS_ONLY
-
-logsBucket: gs://tsz-ci_cloudbuild/cloudbuild-logs
+  logging: CLOUD_LOGGING_ONLY
 
 timeout: 7200s

--- a/scripts/cloudbuild/cloudbuild-bench-shard.yaml
+++ b/scripts/cloudbuild/cloudbuild-bench-shard.yaml
@@ -168,8 +168,6 @@ substitutions:
 options:
   pool:
     name: projects/tsz-ci/locations/us-central1/workerPools/tsz-ci-build-pool
-  logging: GCS_ONLY
-
-logsBucket: gs://tsz-ci_cloudbuild/cloudbuild-logs
+  logging: CLOUD_LOGGING_ONLY
 
 timeout: 7200s


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Benchmark blocker hotfix: restore Bench Cloud Build submit behavior after #10597.

## Invariant
When Bench submits prep or shard Cloud Builds, the selected logging mode must be compatible with the Cloud Build service account; benchmark freshness fixes must not block `gcloud builds submit` before the build starts.

## Scope
- `scripts/cloudbuild/cloudbuild-bench-prepare.yaml`: restore `CLOUD_LOGGING_ONLY` after the attempted GCS logs bucket caused submit precondition failures.
- `scripts/cloudbuild/cloudbuild-bench-shard.yaml`: restore `CLOUD_LOGGING_ONLY` while keeping #10597's source-provided prep artifact fallback.
- `scripts/ci/test-cloudbuild-config-paths.mjs`: remove the now-invalid GCS log bucket assertion.

## Project Corpus Impact
- Row: n/a
- Bug family: benchmark Cloud Build submit / benchmark artifact freshness
- Evidence: workflow/config-only hotfix; no fixture, compiler, project row, or benchmark timing semantics changed.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `git diff --check`

## Coordination Notes
- Fixes a regression introduced by Studio-A's `f408742e54` addition inside #10597.
- Evidence: manual Bench run `26531233410` on `9f66da04769709664ca606e95b4e4373b0f3c521` failed in `bench-prepare-cloudbuild` with `FAILED_PRECONDITION: invalid bucket "tsz-ci_cloudbuild"; service account 638133053272-compute@developer.gserviceaccount.com does not have access to the bucket`.
- After merge, dispatch Bench again on current `main` and verify the source-prep handoff path reaches shard submission.
