### PR TITLE
fix(emit): preserve private async method helpers

### DIFF
--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -57,6 +57,21 @@ pub(crate) struct PrivateAccessorDef {
     pub param: Option<NodeIndex>,
 }
 
+/// Info about a private method function to emit after the class body.
+#[derive(Debug, Clone)]
+pub(crate) struct PrivateMethodDef {
+    /// The variable name (e.g., `_C_method`).
+    pub var_name: String,
+    /// The body node index.
+    pub body: NodeIndex,
+    /// Method parameter node indices.
+    pub params: Vec<NodeIndex>,
+    /// Whether the extracted method function is async.
+    pub is_async: bool,
+    /// Whether the extracted method function is a generator.
+    pub is_generator: bool,
+}
+
 /// How a class property name should be emitted in `ClassName.name = ...` assignments.
 #[derive(Clone)]
 pub(crate) enum PropertyNameEmit {
@@ -820,10 +835,10 @@ pub struct Printer<'a> {
     /// Set when the class has private instance methods or accessors.
     pub(crate) pending_instances_weakset_add: Option<String>,
 
-    /// Private method/accessor function definitions to emit after the class body.
-    /// Each entry is (`var_name`, `body_idx`, params) for `_C_method = function _C_method(params) { ... }`.
+    /// Private method function definitions to emit after the class body.
+    /// Each entry emits `_C_method = function _C_method(params) { ... }`.
     /// These are joined with the WeakMap/WeakSet inits using comma separation.
-    pub(crate) pending_private_method_defs: Vec<(String, NodeIndex, Vec<NodeIndex>)>,
+    pub(crate) pending_private_method_defs: Vec<PrivateMethodDef>,
 
     /// Private accessor function definitions to emit after the class body.
     /// Each entry is (`var_name`, `body_idx`) for `_C_prop_get = function _C_prop_get() { ... }`.

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -2,7 +2,7 @@ use super::super::super::core::PropertyNameEmit;
 use super::super::super::{Printer, ScriptTarget};
 use super::replace_identifier;
 use super::{AutoAccessorEmitOptions, AutoAccessorInfo, StaticFieldInit};
-use crate::emitter::core::PrivateMemberInfo;
+use crate::emitter::core::{PrivateMemberInfo, PrivateMethodDef};
 use crate::transforms::private_fields_es5::{
     PrivateAccessorInfo, PrivateFieldInfo, PrivateMethodInfo,
     collect_enclosing_source_binding_names, collect_private_accessors_with_reserved,
@@ -1055,11 +1055,13 @@ impl<'a> Printer<'a> {
                     continue;
                 }
                 if let Some(body_idx) = method.body {
-                    self.pending_private_method_defs.push((
-                        method.fn_var_name.clone(),
-                        body_idx,
-                        method.parameters.clone(),
-                    ));
+                    self.pending_private_method_defs.push(PrivateMethodDef {
+                        var_name: method.fn_var_name.clone(),
+                        body: body_idx,
+                        params: method.parameters.clone(),
+                        is_async: method.is_async,
+                        is_generator: method.is_generator,
+                    });
                 }
             }
 
@@ -2918,14 +2920,12 @@ impl<'a> Printer<'a> {
                     self.write(init);
                     first = false;
                 }
-                for (var_name, body_idx, params) in &method_defs {
+                for def in &method_defs {
                     if !first {
                         self.write(", ");
                     }
                     self.emit_private_method_function_def(
-                        var_name,
-                        *body_idx,
-                        params,
+                        def,
                         private_member_def_needs_class_alias,
                         class_value_alias.as_deref(),
                         &class_name,
@@ -3501,37 +3501,16 @@ impl<'a> Printer<'a> {
             }
 
             // Private method function definitions
-            for (var_name, body_idx, params) in &method_defs {
+            for def in &method_defs {
                 self.write(",");
                 self.write_line();
                 self.increase_indent();
-                self.write(var_name);
-                self.write(" = function ");
-                self.write(var_name);
-                self.write("(");
-                for (i, &param_idx) in params.iter().enumerate() {
-                    if i > 0 {
-                        self.write(", ");
-                    }
-                    if let Some(param_node) = self.arena.get(param_idx)
-                        && let Some(param_data) = self.arena.get_parameter(param_node)
-                    {
-                        self.emit(param_data.name);
-                    }
-                }
-                self.write(") ");
-                let prev_self_alias = self.scoped_class_expression_self_alias.clone();
-                if private_member_def_needs_class_alias
-                    && let Some(alias) = class_value_alias.as_ref()
-                    && !class_name.is_empty()
-                {
-                    self.scoped_class_expression_self_alias = Some((
-                        Arc::<str>::from(class_name.as_str()),
-                        Arc::<str>::from(alias.as_str()),
-                    ));
-                }
-                self.emit_single_line_block(*body_idx);
-                self.scoped_class_expression_self_alias = prev_self_alias;
+                self.emit_private_method_function_def(
+                    def,
+                    private_member_def_needs_class_alias,
+                    class_value_alias.as_deref(),
+                    &class_name,
+                );
                 self.decrease_indent();
             }
 
@@ -3703,14 +3682,12 @@ impl<'a> Printer<'a> {
 
             // Private method function definitions:
             // _C_method = function _C_method(params) { ... }
-            for (var_name, body_idx, params) in &method_defs {
+            for def in &method_defs {
                 if !first {
                     self.write(", ");
                 }
                 self.emit_private_method_function_def(
-                    var_name,
-                    *body_idx,
-                    params,
+                    def,
                     private_member_def_needs_class_alias,
                     class_value_alias.as_deref(),
                     &class_name,

--- a/crates/tsz-emitter/src/emitter/declarations/class/private_method_defs.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/private_method_defs.rs
@@ -1,22 +1,29 @@
 use super::super::super::Printer;
+use crate::emitter::core::PrivateMethodDef;
 use std::sync::Arc;
-use tsz_parser::parser::NodeIndex;
 
 impl<'a> Printer<'a> {
     pub(in crate::emitter) fn emit_private_method_function_def(
         &mut self,
-        var_name: &str,
-        body_idx: NodeIndex,
-        params: &[NodeIndex],
+        def: &PrivateMethodDef,
         private_member_def_needs_class_alias: bool,
         class_value_alias: Option<&str>,
         class_name: &str,
     ) {
-        self.write(var_name);
-        self.write(" = function ");
-        self.write(var_name);
+        self.write(&def.var_name);
+        self.write(" = ");
+        if def.is_async {
+            self.write("async ");
+        }
+        self.write("function");
+        if def.is_generator {
+            self.write("*");
+        }
+        self.write(" ");
+        self.write(&def.var_name);
         self.write("(");
-        self.emit_function_parameters_js(params);
+        self.function_scope_depth += 1;
+        self.emit_function_parameters_js(&def.params);
         self.write(") ");
 
         let prev_self_alias = self.scoped_class_expression_self_alias.clone();
@@ -27,7 +34,26 @@ impl<'a> Printer<'a> {
             self.scoped_class_expression_self_alias =
                 Some((Arc::<str>::from(class_name), Arc::<str>::from(alias)));
         }
-        self.emit_single_line_block(body_idx);
+        let prev_emitting_function_body_block = self.emitting_function_body_block;
+        self.emitting_function_body_block = true;
+        let prev_pending_function_body_parameters = std::mem::replace(
+            &mut self.pending_function_body_parameters,
+            def.params.clone(),
+        );
+        self.ctx.block_scope_state.enter_scope();
+        self.push_temp_scope();
+        let prev_declared = std::mem::take(&mut self.declared_namespace_names);
+        self.prepare_logical_assignment_value_temps(def.body);
+        let prev_in_generator = self.ctx.flags.in_generator;
+        self.ctx.flags.in_generator = def.is_generator;
+        self.emit(def.body);
+        self.ctx.flags.in_generator = prev_in_generator;
+        self.declared_namespace_names = prev_declared;
+        self.pop_temp_scope();
+        self.ctx.block_scope_state.exit_scope();
+        self.pending_function_body_parameters = prev_pending_function_body_parameters;
+        self.emitting_function_body_block = prev_emitting_function_body_block;
+        self.function_scope_depth -= 1;
         self.scoped_class_expression_self_alias = prev_self_alias;
     }
 }

--- a/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
@@ -97,3 +97,35 @@ class Widget {
         "Extracted private method definitions should preserve rest parameters.\nOutput:\n{output}"
     );
 }
+
+#[test]
+fn static_private_async_generator_helpers_preserve_function_kind() {
+    let source = r#"
+const Widget = class {
+    static async #load() { return await Promise.resolve(1); }
+    static *#values() { yield 1; }
+    static async *#stream() {
+        yield (await Promise.resolve(2));
+    }
+    static run() {
+        this.#load();
+        this.#values();
+        this.#stream();
+    }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2019);
+
+    assert!(
+        output.contains("_Widget_load = async function _Widget_load()"),
+        "Extracted async private methods should stay async functions.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_Widget_values = function* _Widget_values()"),
+        "Extracted generator private methods should stay generator functions.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_Widget_stream = async function* _Widget_stream() {\n        yield (await Promise.resolve(2));\n    }"),
+        "Extracted async generator private methods should preserve function kind and multiline body formatting.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
JavaScript emit recovery / class-private async and generator helper parity.

## Invariant
When a downleveled private method is extracted into a helper function, `tsc` preserves the method's function kind (`async`, generator, or async generator) and emits the helper body using normal function-body formatting; this PR carries the collected method-kind facts into private helper definition emission.

## Structural Rule
Private method extraction already records whether each method is async and/or a generator. The queued helper-definition fact must retain those flags, and the printer must emit `async function`, `function*`, or `async function*` with generator context and source-shaped block formatting for the helper body.

## Owner Layer
Emitter class-private helper definition printing in `crates/tsz-emitter/src/emitter/`. This consumes syntax/lowering facts already collected for private methods; it does not add checker/solver semantic validation and does not patch output text after emission.

## Adjacent Case Matrix
- Static private async method: `static async #load() { ... }` emits `_C_load = async function _C_load(...)`.
- Static private generator method: `static *#values() { ... }` emits `_C_values = function* _C_values(...)` and keeps generator `yield` spacing.
- Static private async generator method: `static async *#stream() { ... }` emits `_C_stream = async function* _C_stream(...)` and preserves multiline body shape.
- Existing private method rest-parameter helper coverage remains intact through the shared helper-definition printer.

## Scope
- Replace the pending private-method helper tuple with a structured `PrivateMethodDef` carrying async/generator flags.
- Route every private method helper-definition site through `emit_private_method_function_def`.
- Emit extracted helper bodies through the normal function-body block path with generator context rather than forcing every body into `emit_single_line_block`.
- Add a focused unit test covering async, generator, and async-generator private helper definitions.

## Project Corpus Impact
- Row: emit conformance `privateNameStaticMethodAsync`
- Bug family: class/private/static async-generator helper definition emit
- Evidence: exact JS emit filter `privateNameStaticMethodAsync` passed locally after rebasing onto `main`; narrow `privateNameStatic` sweep is 27/31 on this PR head.

## Verification
- `cargo nextest run -p tsz-emitter private_tagged_template_tests`
- `scripts/emit/run.sh --filter=privateNameStaticMethodAsync --js-only --verbose --json-out=/tmp/studio-c-private-method-async-rebased-main.json`
- `scripts/emit/run.sh --skip-build --filter=privateNameStatic --js-only --verbose --json-out=/tmp/studio-c-private-name-static-rebased-async.json` (27/31; remaining failures are separate private static field optional-call, class-expression naming, destructuring temp, and method assignment families)
- `cargo fmt --all --check`
- `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`
- `git diff --check`

## Known Unsupported Shapes / Follow-Up
This PR does not fix private static optional-call recovery (`(_b = _a.)`), private static field class-expression `__setFunctionName` scheduling, private destructuring temp minimization, or static private method assignment receiver/temp parity. The optional-call recovery is split into the follow-up branch `codex/studio-c-private-field-optional-call-20260527`.

## Coordination Notes
- #10596 landed on `main`; this PR was rebased onto `origin/main` at head `92ccefdefb` and is no longer stacked on #10596.
- Ready for review/CI after local focused verification above.
