### PR TITLE
fix(dts): preserve mapped type operand parens

### DIFF
--- a/crates/tsz-cli/tests/parenthesized_type_dts_emit_tests.rs
+++ b/crates/tsz-cli/tests/parenthesized_type_dts_emit_tests.rs
@@ -304,3 +304,45 @@ export type C = string extends (number | boolean) ? true : false;
         "union in extends-type or check-type position:\n{dts}"
     );
 }
+
+#[test]
+fn parenthesized_conditional_mapped_type_operands_keep_parens() {
+    let Some(dts) = emit_dts(
+        "conditional_mapped",
+        r#"
+export type T0<T> = ({ [K in keyof T]: ; }) extends ({ [P in keyof T]: T[P]; }) ? number : never;
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("({\n    [K in keyof T]: ;\n}) extends ({\n    [P in keyof T]: T[P];\n}) ? number : never"),
+        "mapped type operands in conditional positions need parens:\n{dts}"
+    );
+}
+
+#[test]
+fn mapped_type_indexed_access_value_keeps_object_operand_parens() {
+    let Some(dts) = emit_dts(
+        "mapped_indexed_access",
+        r#"
+export type Clone<T> = {
+    [P in keyof (T & {})]: (T & {})[P];
+};
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("[P in keyof (T & {})]: (T & {})[P];"),
+        "indexed access object operand in mapped type value needs parens:\n{dts}"
+    );
+    assert!(
+        !dts.contains("T & {}[P]"),
+        "indexed access must not collapse into an unparenthesized intersection:\n{dts}"
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
@@ -646,11 +646,16 @@ impl<'a> DeclarationEmitter<'a> {
             // Conditional type (T extends U ? X : Y)
             k if k == syntax_kind_ext::CONDITIONAL_TYPE => {
                 if let Some(conditional) = self.arena.get_conditional_type(type_node) {
-                    // check_type needs parens for conditional/function/constructor/union/intersection.
+                    // check_type needs parens for conditional/function/constructor/union/
+                    // intersection/mapped operands.
                     // Constructor types need parens because their return type parsing
                     // greedily consumes the `extends` keyword:
                     // `new () => T extends U ? X : Y` parses as
                     // `new () => (T extends U ? X : Y)` without parens.
+                    let check_source_was_parenthesized = self
+                        .arena
+                        .get(conditional.check_type)
+                        .is_some_and(|node| node.kind == syntax_kind_ext::PARENTHESIZED_TYPE);
                     let check_inner = self.peel_paren(conditional.check_type);
                     let check_needs_parens = self.arena.get(check_inner).is_some_and(|node| {
                         node.kind == syntax_kind_ext::CONDITIONAL_TYPE
@@ -658,6 +663,8 @@ impl<'a> DeclarationEmitter<'a> {
                             || node.kind == syntax_kind_ext::CONSTRUCTOR_TYPE
                             || node.kind == syntax_kind_ext::UNION_TYPE
                             || node.kind == syntax_kind_ext::INTERSECTION_TYPE
+                            || (check_source_was_parenthesized
+                                && node.kind == syntax_kind_ext::MAPPED_TYPE)
                     });
 
                     if check_needs_parens {
@@ -670,14 +677,20 @@ impl<'a> DeclarationEmitter<'a> {
 
                     self.write(" extends ");
 
-                    // tsc parenthesizes a conditional type in the extends position,
-                    // but does not wrap function/constructor types just because their
-                    // return type is conditional.
-                    let extends_inner = self.peel_paren(conditional.extends_type);
-                    let extends_needs_parens = self
+                    // Extends-type operands need parens when the operand syntax would
+                    // otherwise bind across the surrounding conditional type.
+                    let extends_source_was_parenthesized = self
                         .arena
-                        .get(extends_inner)
-                        .is_some_and(|node| node.kind == syntax_kind_ext::CONDITIONAL_TYPE);
+                        .get(conditional.extends_type)
+                        .is_some_and(|node| node.kind == syntax_kind_ext::PARENTHESIZED_TYPE);
+                    let extends_inner = self.peel_paren(conditional.extends_type);
+                    let extends_needs_parens = self.arena.get(extends_inner).is_some_and(|node| {
+                        node.kind == syntax_kind_ext::CONDITIONAL_TYPE
+                            || (extends_source_was_parenthesized
+                                && (node.kind == syntax_kind_ext::FUNCTION_TYPE
+                                    || node.kind == syntax_kind_ext::CONSTRUCTOR_TYPE
+                                    || node.kind == syntax_kind_ext::MAPPED_TYPE))
+                    });
 
                     if extends_needs_parens {
                         self.write("(");
@@ -1370,7 +1383,21 @@ impl<'a> DeclarationEmitter<'a> {
         if type_node.kind == syntax_kind_ext::INDEXED_ACCESS_TYPE
             && let Some(indexed_access) = self.arena.get_indexed_access_type(type_node)
         {
-            self.emit_type(indexed_access.object_type);
+            let obj_peeled = self.peel_paren(indexed_access.object_type);
+            let needs_parens = self.arena.get(obj_peeled).is_some_and(|n| {
+                n.kind == syntax_kind_ext::UNION_TYPE
+                    || n.kind == syntax_kind_ext::INTERSECTION_TYPE
+                    || n.kind == syntax_kind_ext::FUNCTION_TYPE
+                    || n.kind == syntax_kind_ext::CONDITIONAL_TYPE
+                    || n.kind == syntax_kind_ext::TYPE_QUERY
+            });
+            if needs_parens {
+                self.write("(");
+            }
+            self.emit_type(obj_peeled);
+            if needs_parens {
+                self.write(")");
+            }
             self.write("[");
             self.emit_indexed_access_index_type(indexed_access.index_type, true);
             self.write("]");


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Declaration emit parity / mapped-type direct printer precedence

## Invariant
When DTS prints mapped types or function types as conditional operands, `tsc` preserves required parentheses only where the operand syntax would otherwise bind across the surrounding conditional type; when DTS prints an indexed access as a mapped-type value, the object operand keeps precedence parentheses such as `(T & {})[P]`.

## Owner Layer
Emitter direct type printer. This PR changes declaration type-syntax emission only; it does not add checker or solver semantic validation, fresh type evaluation during printing, or output surgery.

## Scope
- Parenthesize source-parenthesized mapped-type operands in conditional check/extends positions without adding parens around ordinary unparenthesized mapped types.
- Preserve source-parenthesized function/constructor operands in conditional extends positions.
- Reuse indexed-access object precedence inside mapped-type value printing so intersection operands do not collapse into `T & {}[P]`.
- Add focused CLI DTS tests for mapped conditional operands and mapped indexed-access values.

## Project Corpus Impact
- Row: `mappedType`
- Bug family: DTS mapped-type printer precedence / mapped indexed-access value parentheses
- Evidence: `scripts/safe-run.sh scripts/emit/run.sh --filter=mappedType --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-mappedType-final-main-1d43-20260527.json` moves live current-main mapped-type DTS from 25/29 to 27/29; `mappedTypeAsClauses` and `mappedTypeNoTypeNoCrash` now pass, while unrelated `mappedTypes4` substitution and `mappedTypesArraysTuples` mapped-object expansion gaps remain.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main..HEAD`
- `cargo check -p tsz-emitter`
- `cargo nextest run -p tsz-cli parenthesized_conditional_mapped_type_operands_keep_parens mapped_type_indexed_access_value_keeps_object_operand_parens parenthesized_conditional_type_structural_positions` (3 passed)
- `scripts/safe-run.sh scripts/emit/run.sh --filter=mappedType --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-mappedType-final-main-1d43-20260527.json` (27/29 passed)

## Coordination Notes
- AgentName: Studio-D
- Reused existing worktree `/Users/mohsen/code/tsz-studui-import-type-bundled`; the previous branch in that worktree belonged to merged PR #10346.
- The checked-in emit snapshot is stale for several DTS rows; this PR uses live narrow-filter evidence from current `origin/main`.
- Remaining live mapped-type DTS failures are intentionally out of scope: `mappedTypes4` still needs generic mapped return substitution for `Boxified<T>`, and `mappedTypesArraysTuples` still needs mapped-object expansion cleanup.
- PR is ready after local verification and previous draft-light CI.
- 2026-05-27 Studio-D refresh: replayed the same patch onto current `origin/main` `4bc500a7b500e88df6714223c0c2a8e69486c20c` and pushed head `4741eaff07923d140351c8c785ae1ac8e9dd1812`; `git diff --check origin/main..HEAD` is clean. Local build-heavy checks were not rerun because the machine is below the disk guard. PR-head CI is restarted for the refreshed head. Merge queue remains off.



