### PR TITLE
fix(bench): supersede stale active runs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -20,9 +20,10 @@ on:
 
 # Do not use workflow-level concurrency here. A queued workflow run would start
 # after the active benchmark finishes and benchmark an old "next" commit. The
-# gate below skips new non-release runs while another Bench run is active
-# instead. Release-only daily runs are allowed to publish the latest artifact
-# without waiting behind benchmark shards.
+# gate below skips duplicate current-target runs, but cancels obsolete active
+# runs before letting the current main benchmark proceed. Release-only daily
+# runs are allowed to publish the latest artifact without waiting behind
+# benchmark shards.
 
 permissions:
   contents: write
@@ -104,12 +105,22 @@ jobs:
               } | sort -u
             )"
             active_runs=""
+            obsolete_runs=""
             while IFS=$'\t' read -r run_id run_sha run_url; do
               [[ -n "${run_id:-}" ]] || continue
+              if [[ -n "${run_sha:-}" && "${run_sha}" != "${target_sha}" ]]; then
+                obsolete_runs+="${run_id}"$'\t'"${run_sha}"$'\t'"${run_url}"$'\n'
+                gh run cancel "$run_id" --repo "${{ github.repository }}" >/dev/null 2>&1 || true
+                continue
+              fi
               active_runs+="${run_id}"$'\t'"${run_sha}"$'\t'"${run_url}"$'\n'
             done <<< "$active_runs_raw"
+            if [[ -n "$obsolete_runs" ]]; then
+              echo "Cancelling obsolete Bench run(s) before benchmarking ${target_sha}."
+              printf '%s\n' "$obsolete_runs"
+            fi
             if [[ -n "$active_runs" ]]; then
-              echo "Another Bench run is already active; skipping ${target_sha} instead of cancelling or queuing."
+              echo "Another Bench run for ${target_sha} is already active; skipping duplicate run instead of queuing."
               printf '%s\n' "$active_runs"
               should_run=false
             fi

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -122,6 +122,18 @@ assert.match(
   "stale benchmark publishes should dispatch a catch-up benchmark for current main",
 );
 
+assert.match(
+  workflow,
+  /if \[\[ -n "\$\{run_sha:-\}" && "\$\{run_sha\}" != "\$\{target_sha\}" \]\]; then[\s\S]+obsolete_runs\+="\$\{run_id\}"\$'\\t'"\$\{run_sha\}"\$'\\t'"\$\{run_url\}"\$'\\n'[\s\S]+gh run cancel "\$run_id" --repo "\$\{\{ github\.repository \}\}" >\/dev\/null 2>&1 \|\| true[\s\S]+continue[\s\S]+fi[\s\S]+active_runs\+="\$\{run_id\}"\$'\\t'"\$\{run_sha\}"\$'\\t'"\$\{run_url\}"\$'\\n'/,
+  "bench gate should cancel obsolete active runs instead of letting stale SHA runs block current main",
+);
+
+assert.match(
+  workflow,
+  /Cancelling obsolete Bench run\(s\) before benchmarking \$\{target_sha\}\.[\s\S]+Another Bench run for \$\{target_sha\} is already active; skipping duplicate run instead of queuing\./,
+  "bench gate should distinguish obsolete active runs from duplicate current-target runs",
+);
+
 const benchJob = workflow.match(/  bench:[\s\S]+?  publish:/)?.[0] ?? "";
 assert.match(
   benchJob,


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Benchmark blocker / project-corpus metric truth

## Invariant
When a current-main Bench run checks for active Bench work, only active runs for the same or unknown target SHA should block it; obsolete active runs should be cancellation-requested so current release metric artifacts can proceed through the Bench workflow gate.

## Scope
- `.github/workflows/bench.yml`
- `scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`

## Project Corpus Impact
- Row: all benchmark/project-corpus rows
- Bug family: benchmark artifact freshness / stale active-run gating
- Evidence: stale workflow_dispatch run `26531813325` on `732e8c34005a42f86ab827f21995a8145ab164be` remained active after cancellation and caused current-main run `26532044269` on `759c1639239691b5999866b8d5f201bd6c949ec9` to skip with `Another Bench run is already active`; this PR keeps duplicate current-target protection while superseding obsolete target runs.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- AgentName: Studio-A
- Rebased onto current `origin/main` before publishing.
- No open Studio-A PRs existed before this branch; this PR follows the merged #10597/#10599 Bench harness recovery work.
- The old stale run was cancellation-requested manually; this PR makes future current-main dispatches recover automatically when obsolete active runs linger.
