### PR TITLE
fix(emit): lower private optional field calls

### DIFF
--- a/crates/tsz-emitter/src/emitter/expressions/call.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/call.rs
@@ -175,6 +175,12 @@ impl<'a> Printer<'a> {
 
             let has_optional_call_token =
                 self.has_optional_call_token(node, call.expression, call.arguments.as_ref());
+            if has_optional_call_token
+                && self
+                    .emit_optional_private_field_call_expression(call.expression, &call.arguments)
+            {
+                return;
+            }
             if let Some(call_expr) = self.arena.get(call.expression)
                 && (call_expr.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
                     || call_expr.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION)

--- a/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
@@ -588,6 +588,61 @@ impl<'a> Printer<'a> {
         true
     }
 
+    pub(in crate::emitter) fn emit_optional_private_field_call_expression(
+        &mut self,
+        callee: NodeIndex,
+        args: &Option<NodeList>,
+    ) -> bool {
+        let Some(access) = self.try_extract_private_field_access(callee) else {
+            return false;
+        };
+
+        let receiver_temp = if self.private_call_receiver_is_simple(access.expression) {
+            None
+        } else {
+            Some(self.make_unique_name_hoisted())
+        };
+        let receiver_temp = receiver_temp.as_deref();
+        let func_temp = self.make_unique_name_hoisted_value();
+
+        self.write("(");
+        self.write(&func_temp);
+        self.write(" = ");
+        self.write_helper("__classPrivateFieldGet");
+        self.write("(");
+        if let Some(temp) = receiver_temp {
+            self.write("(");
+            self.write(temp);
+            self.write(" = ");
+            self.emit_private_receiver(access.expression, &access.clean_name);
+            self.write(")");
+        } else {
+            self.emit_private_receiver(access.expression, &access.clean_name);
+        }
+        self.write(", ");
+        self.emit_private_state_var(&access.weakmap_name, &access.clean_name);
+        self.emit_private_field_get_close(&access.clean_name);
+        self.write(")");
+        self.write(" === null || ");
+        self.write(&func_temp);
+        self.write(" === void 0 ? void 0 : ");
+        self.write(&func_temp);
+        self.write(".call(");
+        if let Some(temp) = receiver_temp {
+            self.write(temp);
+        } else {
+            self.emit_private_receiver(access.expression, &access.clean_name);
+        }
+        if let Some(args) = args
+            && !args.nodes.is_empty()
+        {
+            self.write(", ");
+            self.emit_comma_separated(&args.nodes);
+        }
+        self.write(")");
+        true
+    }
+
     pub(in crate::emitter) fn emit_binary_expression(&mut self, node: &Node) {
         let Some(binary) = self.arena.get_binary_expr(node) else {
             return;

--- a/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
@@ -99,6 +99,42 @@ class Widget {
 }
 
 #[test]
+fn optional_private_field_call_uses_lowered_get_as_callee() {
+    let source = r#"
+class Widget {
+    static #run = function(a, ...b) {};
+    #tap = function() {};
+    static factory() { return Widget; }
+    test(items) {
+        Widget.#run?.(0, ...items, 3);
+        Widget.factory().#run?.();
+        this.#tap?.();
+    }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains(
+            "(_b = __classPrivateFieldGet(_a, _a, \"f\", _Widget_run)) === null || _b === void 0 ? void 0 : _b.call(_a, 0, ...items, 3)"
+        ),
+        "Static private field optional calls should null-check the lowered private get and call with the class alias receiver.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "(_d = __classPrivateFieldGet((_c = _a.factory()), _a, \"f\", _Widget_run)) === null || _d === void 0 ? void 0 : _d.call(_c)"
+        ),
+        "Side-effecting private field optional call receivers should be captured once and reused for `.call()`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "(_e = __classPrivateFieldGet(this, _Widget_tap, \"f\")) === null || _e === void 0 ? void 0 : _e.call(this)"
+        ),
+        "Instance private field optional calls should call with the original receiver.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn static_private_async_generator_helpers_preserve_function_kind() {
     let source = r#"
 const Widget = class {


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
JavaScript emit recovery / class-private optional-call parity.

## Invariant
When an optional call targets a downleveled private field value, `tsc` null-checks the lowered `__classPrivateFieldGet(...)` result and calls it with the same receiver used for the private read; this PR routes private optional calls through private-field lowering before generic optional method-call printing.

## Structural Rule
For `receiver.#field?.(args)`, emit `(_temp = __classPrivateFieldGet(receiver, state, "f", storage)) === null || _temp === void 0 ? void 0 : _temp.call(receiver, args)`. If the receiver is side-effecting, capture it once inside the private get and reuse that temp for `.call(...)`.

## Owner Layer
Emitter private-field expression printing in `crates/tsz-emitter/src/emitter/`. This consumes private-member lowering facts and optional-call syntax; it does not add checker/solver semantic validation and does not patch output text after emission.

## Adjacent Case Matrix
- Static private field optional call: `Widget.#run?.(0, ...items, 3)` null-checks the lowered get and calls with the class alias receiver.
- Side-effecting static receiver: `Widget.factory().#run?.()` captures the receiver once and reuses it for `.call(...)`.
- Instance private field optional call: `this.#tap?.()` calls with `this`.
- Existing private tagged-template and private method call receiver binding coverage remains intact.

## Scope
- Add `emit_optional_private_field_call_expression` beside private-field lowering helpers.
- Let optional-call emission ask the private helper before falling back to generic property/element optional-call lowering.
- Add a focused unit test covering static, side-effecting static, and instance private field optional calls.

## Project Corpus Impact
- Row: emit conformance `privateNameStaticFieldCallExpression`
- Bug family: class/private/static optional-call lowering
- Evidence: exact JS emit filter `privateNameStaticFieldCallExpression` passes on the rebased head; narrow `privateNameStatic` sweep is 28/31 with only separate known private-static failures remaining.

## Verification
- `cargo nextest run -p tsz-emitter private_tagged_template_tests`
- `scripts/emit/run.sh --filter=privateNameStaticFieldCallExpression --js-only --verbose --json-out=/tmp/studio-c-private-static-field-call-post-main.json`
- `scripts/emit/run.sh --skip-build --filter=privateNameFieldCallExpression --js-only --verbose --json-out=/tmp/studio-c-private-field-call-post-main-adjacent.json`
- `scripts/emit/run.sh --skip-build --filter=privateNameStatic --js-only --verbose --json-out=/tmp/studio-c-private-name-static-post-main-optional.json` (28/31; remaining failures are separate class-expression naming, destructured static field assignment planning, and static private method assignment receiver/temp parity)
- `cargo fmt --all --check`
- `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`
- `git diff --check`

## Known Unsupported Shapes / Follow-Up
This PR does not fix private static field class-expression `__setFunctionName` scheduling, private destructuring temp minimization, or static private method assignment receiver/temp parity.

## Coordination Notes
- #10601 landed and this branch was rebased onto `main` at head `4203c190a2`.
- Ready for CI/manager review after the post-main focused verification above.
- #10610 remains stacked on this branch for the private static field class-expression naming follow-up.
