### PR TITLE
perf(checker): lower index signature alias access directly

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain.rs
@@ -1958,6 +1958,24 @@ impl<'a> CheckerState<'a> {
                 let Some(member_node) = arena.get(member_idx) else {
                     return false;
                 };
+                if member_node.kind == syntax_kind_ext::INDEX_SIGNATURE {
+                    let Some(index_signature) = arena.get_index_signature(member_node) else {
+                        return false;
+                    };
+                    let Some(param_idx) = index_signature.parameters.nodes.first().copied() else {
+                        return false;
+                    };
+                    let Some(param_node) = arena.get(param_idx) else {
+                        return false;
+                    };
+                    let Some(param) = arena.get_parameter(param_node) else {
+                        return false;
+                    };
+                    return Self::source_file_type_node_is_scope_independent(
+                        arena,
+                        param.type_annotation,
+                    ) && value_is_lowerable(index_signature.type_annotation);
+                }
                 if member_node.kind != syntax_kind_ext::PROPERTY_SIGNATURE {
                     return false;
                 }

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain_tests.rs
@@ -674,6 +674,28 @@ fn direct_source_file_type_alias_lowers_type_literal_property_local_alias_applic
 }
 
 #[test]
+fn direct_source_file_type_alias_lowers_index_signature_type_literal_access() {
+    with_two_file_state(
+        "type Box<Value> = { value: Value };\nexport type DictionaryValue<Item> = { [key: string]: Box<Item> }[string];",
+        "import { DictionaryValue } from './target';",
+        |state, target_binder| {
+            let dictionary_value_sym = target_binder
+                .file_locals
+                .get("DictionaryValue")
+                .expect("DictionaryValue");
+            let (ty, params) = state
+                .direct_source_file_type_alias_result(dictionary_value_sym, Some(1), true)
+                .expect(
+                    "index-signature type literals with lowerable values should lower directly",
+                );
+            assert_ne!(ty, TypeId::UNKNOWN);
+            assert_ne!(ty, TypeId::ERROR);
+            assert_eq!(params.len(), 1, "DictionaryValue should expose Item");
+        },
+    );
+}
+
+#[test]
 fn direct_source_file_type_alias_rejects_type_literal_with_computed_name() {
     with_two_file_state(
         "declare const key: unique symbol;\nexport type Box<T> = { [key]: T };",
@@ -702,6 +724,26 @@ fn direct_source_file_type_alias_rejects_type_literal_property_typeof_alias_appl
                     .direct_source_file_type_alias_result(select_sym, Some(1), true)
                     .is_none(),
                 "flow-sensitive local alias applications in type-literal properties must stay on the child-checker path",
+            );
+        },
+    );
+}
+
+#[test]
+fn direct_source_file_type_alias_rejects_index_signature_typeof_alias_application() {
+    with_two_file_state(
+        "const value = 1;\ntype Box<X> = X | typeof value;\nexport type DictionaryValue<Item> = { [key: string]: Box<Item> }[string];",
+        "import { DictionaryValue } from './target';",
+        |state, target_binder| {
+            let dictionary_value_sym = target_binder
+                .file_locals
+                .get("DictionaryValue")
+                .expect("DictionaryValue");
+            assert!(
+                state
+                    .direct_source_file_type_alias_result(dictionary_value_sym, Some(1), true)
+                    .is_none(),
+                "flow-sensitive local alias applications in index-signature values must stay on the child-checker path",
             );
         },
     );

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain_tests.rs
@@ -696,6 +696,26 @@ fn direct_source_file_type_alias_lowers_index_signature_type_literal_access() {
 }
 
 #[test]
+fn direct_source_file_type_alias_lowers_renamed_numeric_index_signature_type_literal_access() {
+    with_two_file_state(
+        "type Cell<Data> = { item: Data };\nexport type TableEntry<Row> = { [slot: number]: Cell<Row> }[number];",
+        "import { TableEntry } from './target';",
+        |state, target_binder| {
+            let table_entry_sym = target_binder
+                .file_locals
+                .get("TableEntry")
+                .expect("TableEntry");
+            let (ty, params) = state
+                .direct_source_file_type_alias_result(table_entry_sym, Some(1), true)
+                .expect("renamed numeric index-signature type literals should lower directly");
+            assert_ne!(ty, TypeId::UNKNOWN);
+            assert_ne!(ty, TypeId::ERROR);
+            assert_eq!(params.len(), 1, "TableEntry should expose Row");
+        },
+    );
+}
+
+#[test]
 fn direct_source_file_type_alias_rejects_type_literal_with_computed_name() {
     with_two_file_state(
         "declare const key: unique symbol;\nexport type Box<T> = { [key]: T };",


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
M4-A recursive conditional/mapped/template/infer/indexed-access evaluation and performance pressure.

## Structural Rule
When a source-file type alias indexes into a type-literal object whose members are index signatures with scope-independent key annotations and values that satisfy the existing source-file alias lowerability proof, the checker direct-lowering proof can admit that object shape and reuse the normal syntax-to-solver lowering path.

## Owner Layer
Checker proof/orchestration. The change does not compute new type semantics in checker code; it only decides that an index-signature type-literal shape is safe to pass through the existing lowering path. Solver-owned type construction and relation behavior remain unchanged.

## Invariant
Preserve tsc parity and checker/solver boundaries. Unsupported member kinds, missing index-signature annotations, non-scope-independent key annotations, and flow-sensitive value paths still fall back to the child-checker path.

## Scope
- Allow source-file direct alias proof to accept type-literal index signatures when the key annotation is scope independent and the value annotation satisfies the existing lowerability proof.
- Add positive direct-lowering unit tests for string and number index signatures.
- Add a negative unit test proving `typeof`-dependent index-signature values still fall back.

## Adjacent-Case Test Matrix
- Reported/equivalent shape: `{ [key: string]: Box<Item> }[string]` with a lowerable local alias value.
- Renamed/numeric equivalent: `{ [slot: number]: Cell<Row> }[number]` using different type-parameter and index-parameter names.
- Alias/wrapper coverage: both positive cases wrap the indexed value through a local generic alias before direct lowering.
- Negative/fallback coverage: `{ [key: string]: Box<Item> }[string]` where `Box` contains a local `typeof` value remains on the child-checker path.

## Known Unsupported Shapes / Fallback
- Computed property names, unsupported type-literal members, missing index parameter/type annotations, flow-sensitive `typeof` value dependencies, and non-scope-independent index key annotations are not admitted by this fast path.
- Those shapes continue to use the existing child-checker path instead of being silently accepted.

## Project Corpus Impact
- Row: ts-toolbelt-project
- Bug family: recursive/source-file alias direct-lowering pressure for indexed-access aliases over type-literal index signatures
- Evidence: targeted checker unit tests cover the direct-lowering admission and fallback behavior. No local benchmark timing claim is made in this PR.

## Performance Notes
- Intended complexity improvement: avoid invoking the child checker for lowerable indexed-access aliases whose object side is a type literal made of proven-safe index signatures.
- Performance numbers: not measured locally for this small proof slice; the PR makes no timing claim and relies on focused unit coverage plus CI/project-row follow-up for benchmark evidence.

## Verification
- RED: `cargo nextest run -p tsz-checker --lib direct_source_file_type_alias_lowers_index_signature_type_literal_access` failed before the implementation with `direct_source_file_type_alias_result(...).expect(...)` returning `None`.
- PASS: `cargo nextest run -p tsz-checker --lib direct_source_file_type_alias_lowers_index_signature_type_literal_access`
- PASS: `cargo nextest run -p tsz-checker --lib direct_source_file_type_alias_rejects_index_signature_typeof_alias_application`
- PASS: `cargo nextest run -p tsz-checker --lib direct_source_file_type_alias`
- PASS: `cargo fmt --check`
- PASS: `git diff --check`
- PASS: `python3 scripts/arch/arch_guard.py`

## Coordination Notes
- Refs #8356 as a small green-row direct-lowering/performance-pressure slice.
- No open M4-A PR existed at start of this cycle; existing M4-A PRs were merged first.
- Updated after push `fdee5634bf` to satisfy the stricter generalization gate with renamed/numeric coverage.
