### PR TITLE
refactor(checker): share strict Object global helper

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/core.rs
@@ -1534,28 +1534,14 @@ impl<'a> CheckerState<'a> {
                         .get(call.expression)
                         .and_then(|callee| self.ctx.arena.get_access_expr(callee))
                         .is_some_and(|access| {
-                            self.object_assign_receiver_is_lib_object(access.expression)
-                                && self.ctx.arena.get_identifier_text(access.name_or_argument)
-                                    == Some("assign")
+                            self.identifier_resolves_to_proven_lib_global(
+                                access.expression,
+                                "Object",
+                            ) && self.ctx.arena.get_identifier_text(access.name_or_argument)
+                                == Some("assign")
                         })
                 })
         })
-    }
-
-    fn object_assign_receiver_is_lib_object(&self, idx: NodeIndex) -> bool {
-        let Some(base_ident) = self.ctx.arena.get_identifier_at(idx) else {
-            return false;
-        };
-        if base_ident.escaped_text != "Object" {
-            return false;
-        }
-        let Some(sym_id) = self.resolve_identifier_symbol_without_tracking(idx) else {
-            return false;
-        };
-        if self.known_global_value_has_local_shadow(idx, "Object") {
-            return false;
-        }
-        self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id) || self.ctx.symbol_is_from_lib(sym_id)
     }
 
     pub(crate) fn first_non_portable_object_assign_object_literal_reference(

--- a/crates/tsz-checker/src/tests/object_define_property_identity_tests.rs
+++ b/crates/tsz-checker/src/tests/object_define_property_identity_tests.rs
@@ -71,17 +71,23 @@ new C();
 #[test]
 fn object_define_property_descriptor_gate_uses_global_identity() {
     let source = include_str!("../types/computation/object_literal/mod.rs");
+    let known_globals_source = include_str!("../types/property_access_type/known_globals.rs");
     assert!(
         source.contains("object_define_property_base_is_global_object"),
         "Object.defineProperty descriptor detection must prove the base is the global/lib Object value"
     );
     assert!(
-        !source.contains("object_ident.escaped_text != \"Object\""),
-        "Object.defineProperty descriptor detection must not rely on the raw Object spelling"
+        source.contains("identifier_resolves_to_proven_lib_global"),
+        "Object.defineProperty descriptor detection must route global Object proof through the shared helper"
     );
     assert!(
-        source.contains("symbol_is_from_actual_or_cloned_lib(sym_id)"),
-        "Object.defineProperty descriptor detection must admit only proven actual/cloned lib identity"
+        !source.contains("symbol_is_from_actual_or_cloned_lib(sym_id)"),
+        "Object.defineProperty descriptor detection must not duplicate proven-lib identity checks"
+    );
+    assert!(
+        known_globals_source.contains("symbol_is_from_actual_or_cloned_lib(sym_id)")
+            && known_globals_source.contains("symbol_is_from_lib(sym_id)"),
+        "the shared proven-lib global identity helper must admit only proven actual/cloned lib identity"
     );
 }
 

--- a/crates/tsz-checker/src/tests/object_global_identity_helper_tests.rs
+++ b/crates/tsz-checker/src/tests/object_global_identity_helper_tests.rs
@@ -10,3 +10,28 @@ fn prototype_define_property_uses_global_identity_helper() {
         "`Object.defineProperty` prototype detection must not duplicate Object lib-symbol matching"
     );
 }
+
+#[test]
+fn strict_object_paths_use_proven_global_identity_helper() {
+    let object_literal_source = include_str!("../types/computation/object_literal/mod.rs");
+    assert!(
+        object_literal_source.contains("identifier_resolves_to_proven_lib_global")
+            && object_literal_source.contains("\"Object\""),
+        "`Object.defineProperty` descriptor detection must route through the shared proven-lib global identity helper"
+    );
+    assert!(
+        !object_literal_source.contains("symbol_is_from_actual_or_cloned_lib(sym_id)"),
+        "`Object.defineProperty` descriptor detection must not duplicate Object lib-symbol matching"
+    );
+
+    let object_assign_source = include_str!("../state/variable_checking/variable_helpers/core.rs");
+    assert!(
+        object_assign_source.contains("identifier_resolves_to_proven_lib_global")
+            && object_assign_source.contains("\"Object\""),
+        "`Object.assign` portability detection must route through the shared proven-lib global identity helper"
+    );
+    assert!(
+        !object_assign_source.contains("fn object_assign_receiver_is_lib_object"),
+        "`Object.assign` portability detection must not keep a local Object lib-symbol helper"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/object_literal/mod.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/mod.rs
@@ -74,19 +74,7 @@ impl<'a> CheckerState<'a> {
     }
 
     fn object_define_property_base_is_global_object(&self, idx: NodeIndex) -> bool {
-        let Some(base_ident) = self.ctx.arena.get_identifier_at(idx) else {
-            return false;
-        };
-        if base_ident.escaped_text != "Object" {
-            return false;
-        }
-        let Some(sym_id) = self.resolve_identifier_symbol_without_tracking(idx) else {
-            return false;
-        };
-        if self.known_global_value_has_local_shadow(idx, "Object") {
-            return false;
-        }
-        self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id) || self.ctx.symbol_is_from_lib(sym_id)
+        self.identifier_resolves_to_proven_lib_global(idx, "Object")
     }
 
     fn define_property_descriptor_accessor_type(

--- a/crates/tsz-checker/src/types/property_access_type/known_globals.rs
+++ b/crates/tsz-checker/src/types/property_access_type/known_globals.rs
@@ -42,6 +42,41 @@ impl<'a> CheckerState<'a> {
         self.known_global_identifier_resolves_to_lib_value(idx, name)
     }
 
+    /// Returns `true` if the node at `idx` is an identifier spelled `name` and
+    /// the binder resolves it to a proven lib/global value.
+    ///
+    /// Unlike `identifier_resolves_to_unshadowed_global`, this intentionally
+    /// does not fall back to "unresolved but unshadowed" when symbol resolution
+    /// misses. Use it for paths whose existing behavior requires concrete lib
+    /// identity evidence.
+    pub(crate) fn identifier_resolves_to_proven_lib_global(
+        &self,
+        idx: NodeIndex,
+        name: &str,
+    ) -> bool {
+        let Some(node) = self.ctx.arena.get(idx) else {
+            return false;
+        };
+        let Some(ident) = self.ctx.arena.get_identifier(node) else {
+            return false;
+        };
+        if ident.escaped_text.as_str() != name {
+            return false;
+        }
+        let Some(sym_id) = self.resolve_identifier_symbol_without_tracking(idx) else {
+            return false;
+        };
+        if self.known_global_value_has_local_shadow(idx, name) {
+            return false;
+        }
+        let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
+            return false;
+        };
+        symbol.escaped_name == name
+            && (self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id)
+                || self.ctx.symbol_is_from_lib(sym_id))
+    }
+
     pub(crate) fn known_global_value_has_local_shadow(&self, idx: NodeIndex, name: &str) -> bool {
         if let Some(mut scope_id) = self.ctx.binder.find_enclosing_scope(self.ctx.arena, idx) {
             let mut iterations = 0;


### PR DESCRIPTION
## Agent
AgentName: M4-D

## Track
Semantic identity cleanup / checker refactor.

## Invariant
When checker orchestration needs the built-in `Object` value and the path requires concrete lib identity, it must prove that identity through one shared binder/global helper. This PR moves the strict `Object` proof for `Object.defineProperty` descriptor contextual typing and `Object.assign` declaration-emit portability detection into `identifier_resolves_to_proven_lib_global`.

## Scope
- Adds a strict proven-lib global identifier helper in `known_globals.rs`.
- Routes `Object.defineProperty` descriptor detection through the shared helper.
- Routes `Object.assign` portability detection through the shared helper and removes its local duplicate.
- Updates identity ratchets for the new helper boundary.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: checker identity refactor only; focused Object identity tests preserve local-vs-built-in behavior for `Object.defineProperty` and `Object.assign`.

## Verification
- `cargo nextest run -p tsz-checker --lib object_global_identity_helper_tests`
- `cargo nextest run -p tsz-checker --lib object_define_property_identity_tests`
- `cargo nextest run -p tsz-checker --test object_assign_identity_tests`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`

## Coordination Notes
- #10582 was merged before this branch was created, so this builds on the existing `Object.prototype.defineProperty` helper routing.
- Avoided #10592 / structural `[Symbol.xxx]` key recovery because local M4-A worktree `codex/m4a-symbol-key-structural-20260527` already owns that overlapping slice.
- `scripts/agents/list-owned-work.sh M4-D` reported no owned M4-D PRs or issues before starting.
- Open-PR scan before publishing showed no overlapping M4-D PR.
