### PR TITLE
fix(bench): include prep env in shard artifact

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -929,7 +929,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: bench-prep-ready
-          path: bench-prep.tar
+          path: |
+            bench-prep.env
+            bench-prep.tar
           retention-days: 1
           if-no-files-found: error
           compression-level: 1

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -111,6 +111,12 @@ assert.match(
 );
 
 assert.match(
+  prepArtifactJob,
+  /name: bench-prep-ready[\s\S]+path:\s+\|[\s\S]+bench-prep\.env[\s\S]+bench-prep\.tar/,
+  "bench-prep-ready artifact should include both the prep manifest and tarball consumed by shard jobs",
+);
+
+assert.match(
   workflow,
   /TARGET_SHA="\$\{BENCH_TARGET_SHA:-\$\{GITHUB_SHA\}\}"[\s\S]+if \[\[ -n "\$\{MAIN_SHA\}" && "\$\{TARGET_SHA\}" != "\$\{MAIN_SHA\}" \]\]; then[\s\S]+echo "catchup_main_sha=\$\{MAIN_SHA\}" >> "\$GITHUB_OUTPUT"/,
   "benchmark publish should expose the current main SHA when a finished run publishes an older target",


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Benchmark blocker: Bench shard artifact handoff and website benchmark freshness.

## Invariant
When benchmark shards download `bench-prep-ready`, the artifact must include both `bench-prep.env` and `bench-prep.tar`; shard validation and Cloud Build source upload require the manifest as well as the tarball.

## Scope
- `.github/workflows/bench.yml`: include `bench-prep.env` in the `bench-prep-ready` artifact alongside `bench-prep.tar`.
- `scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`: guard that `bench-prep-ready` contains both files.

## Project Corpus Impact
- Row: n/a
- Bug family: benchmark prep artifact handoff
- Evidence: workflow-only artifact packaging fix; no compiler, fixture, project row, or benchmark timing semantics changed.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `git diff --check`
- Failed Bench evidence: run `26531813325` reached shard fanout, downloaded `bench-prep-ready`, then all shard jobs failed in `Validate source benchmark prep artifact` because the artifact contained `bench-prep.tar` but not `bench-prep.env`.

## Coordination Notes
- Builds on #10597 and #10599. This keeps the source-provided prep path and only fixes the missing manifest file in the GitHub artifact.
- `Codex-Bench-Fresh` was the contributor identity on creation; canonical queue ownership is now `Studio-A` via body AgentName and `agent:Studio-A` label.
- After merge, rerun Bench on current `main` and verify public benchmark data freshness.