### PR TITLE
test(arch): guard solver policy flag decoding

### DIFF
--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -778,6 +778,15 @@ REGEX_LINE_COUNT_CHECKS = [
         0,
     ),
     (
+        "Solver relation boundary: legacy RelationPolicy::from_flags calls stay at boundary (#8207)",
+        [ROOT / "crates" / "tsz-solver" / "src"],
+        re.compile(
+            r'^\s*(?!//)(?:[^"\n]|"[^"\n]*")*?'
+            r"\bRelationPolicy::from_flags\s*\("
+        ),
+        0,
+    ),
+    (
         "Solver relation boundary: query cache uses relation facade (#8207)",
         [ROOT / "crates" / "tsz-solver" / "src" / "caches" / "query_cache.rs"],
         re.compile(r"\b(?:configured_compat_checker|configured_subtype_checker)\s*\("),

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -759,6 +759,15 @@ REGEX_LINE_COUNT_CHECKS = [
         0,
     ),
     (
+        "Solver relation boundary: legacy RelationPolicy::from_flags calls stay at boundary (#8207)",
+        [ROOT / "crates" / "tsz-solver" / "src"],
+        re.compile(
+            r'^\s*(?!//)(?:[^"\n]|"[^"\n]*")*?'
+            r"\bRelationPolicy::from_flags\s*\("
+        ),
+        0,
+    ),
+    (
         "Solver relation boundary: query cache uses relation facade (#8207)",
         [ROOT / "crates" / "tsz-solver" / "src" / "caches" / "query_cache.rs"],
         re.compile(r"\b(?:configured_compat_checker|configured_subtype_checker)\s*\("),

--- a/scripts/arch/test_arch_guard_policy.py
+++ b/scripts/arch/test_arch_guard_policy.py
@@ -210,6 +210,23 @@ class ArchGuardRegexLineCountTests(unittest.TestCase):
         self.assertIn("core.rs:1", hits[2])
         self.assertIn("total matching lines: 3", hits[3])
 
+    def test_solver_internals_do_not_decode_legacy_relation_flags(self):
+        pattern, _max_lines = self._check_by_name("legacy RelationPolicy::from_flags calls")
+        root = self._make_tree(
+            {
+                "crates/tsz-solver/src/caches/query_cache.rs": (
+                    "let policy = RelationPolicy::from_flags(flags);\n"
+                    "let typed = RelationPolicy::from_relation_flags(flags);\n"
+                    "/// RelationPolicy::from_flags(flags) is discussed here.\n"
+                    'let text = "RelationPolicy::from_flags(flags)";\n'
+                ),
+            }
+        )
+        hits = self.arch_guard.scan_regex_line_count([root], pattern, 0)
+        self.assertEqual(len(hits), 2, f"unexpected hits: {hits!r}")
+        self.assertIn("query_cache.rs:1", hits[0])
+        self.assertIn("total matching lines: 1", hits[1])
+
     def test_query_cache_relation_facade_guard(self):
         pattern, _max_lines = self._check_by_name("query cache uses relation facade")
         root = self._make_tree(

--- a/scripts/arch/test_arch_guard_project.py
+++ b/scripts/arch/test_arch_guard_project.py
@@ -804,6 +804,23 @@ class ArchGuardRegexLineCountTests(unittest.TestCase):
         self.assertIn("core.rs:1", hits[2])
         self.assertIn("total matching lines: 3", hits[3])
 
+    def test_solver_internals_do_not_decode_legacy_relation_flags(self):
+        pattern, _max_lines = self._check_by_name("legacy RelationPolicy::from_flags calls")
+        root = self._make_tree(
+            {
+                "crates/tsz-solver/src/caches/query_cache.rs": (
+                    "let policy = RelationPolicy::from_flags(flags);\n"
+                    "let typed = RelationPolicy::from_relation_flags(flags);\n"
+                    "/// RelationPolicy::from_flags(flags) is discussed here.\n"
+                    'let text = "RelationPolicy::from_flags(flags)";\n'
+                ),
+            }
+        )
+        hits = self.arch_guard.scan_regex_line_count([root], pattern, 0)
+        self.assertEqual(len(hits), 2, f"unexpected hits: {hits!r}")
+        self.assertIn("query_cache.rs:1", hits[0])
+        self.assertIn("total matching lines: 1", hits[1])
+
     def test_query_cache_relation_facade_guard(self):
         pattern, _max_lines = self._check_by_name("query cache uses relation facade")
         root = self._make_tree(


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 4 solver relation policy/cache-key cleanup for #8207; architecture guard ratchet after #10594.

## Invariant
When solver internals need relation behavior, they should receive typed `RelationPolicy` / `RelationFlags`; this PR prevents new solver-internal runtime calls to `RelationPolicy::from_flags(...)` so legacy packed `u16` decoding stays isolated at the relation-query compatibility boundary.

## Scope
- Add a shared architecture guard for `RelationPolicy::from_flags(...)` call sites under `crates/tsz-solver/src`.
- Cover the guard in both project and policy arch test suites.
- Keep documentation and quoted explanatory strings out of the guard so only runtime-style calls are flagged.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: architecture-guard-only change; no checker semantics, solver relation behavior, emit output, conformance baseline, or project corpus behavior changed.

## Verification
- RED: `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard_project.ArchGuardRegexLineCountTests.test_solver_internals_do_not_decode_legacy_relation_flags scripts.arch.test_arch_guard_policy.ArchGuardRegexLineCountTests.test_solver_internals_do_not_decode_legacy_relation_flags` failed before the guard with missing `REGEX_LINE_COUNT_CHECKS` entries.
- GREEN on rebased head `3b71024279`: `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard_project.ArchGuardRegexLineCountTests.test_solver_internals_do_not_decode_legacy_relation_flags scripts.arch.test_arch_guard_policy.ArchGuardRegexLineCountTests.test_solver_internals_do_not_decode_legacy_relation_flags`
- GREEN on rebased head `3b71024279`: `python3 scripts/arch/arch_guard.py`
- GREEN on rebased head `3b71024279`: `set -euo pipefail; python3 -m py_compile scripts/arch/*.py; for test_file in $(find scripts/arch -maxdepth 1 -type f -name 'test_*.py' | sort); do python3 "$test_file"; done` (222 + 28 + 61 tests)
- GREEN on rebased head `3b71024279`: `git diff --check HEAD~1..HEAD`
- Exact-head draft CI on `3b71024279`: `CI Light Summary`, `arch-tool-smoke`, `gate`, and `GitGuardian Security Checks` passed in run `26535465122`.
- Exact-head ready-review CI on `3b71024279`: `CI Summary`, `arch-tool-smoke`, `project-corpus-pr-body`, `gate`, and `GitGuardian Security Checks` passed in run `26535554063`.

## Coordination Notes
- #10594 landed on `main` at `f706bc2488f`; this PR was rebased past it and then refreshed onto `origin/main` at `0b86e6f226b1` before ready-review CI.
- This PR is based on `main`, verified locally, green in exact-head ready-review CI, and queued through the repo-local merge queue.
- No overlap with M1-B RelationRequest adoption; this only ratchets solver-side legacy packed policy decoding.
- No WIP label, no auto-merge; `merge-queue` label is used as the repo-local merge gate after exact-head ready-review checks passed.
- AgentName: M4-B