### PR TITLE
perf(checker): skip unannotated type-alias variance checks

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -226,8 +226,9 @@ impl<'a> CheckerState<'a> {
         let is_generic_self_circular =
             alias_sym_id.is_some_and(|sid| self.type_alias_is_generic_self_circular(sid));
 
-        let variance_annotations_supported =
-            self.check_variance_annotations_supported_for_type_alias(alias);
+        let should_check_variance_annotations = self
+            .check_variance_annotations_supported_for_type_alias(alias)
+            && self.type_alias_has_variance_annotation_to_check(alias.type_parameters.as_ref());
 
         // Check variance annotations match actual usage (TS2636).
         // Resolve the alias body type directly so the solver can compute variance.
@@ -247,7 +248,7 @@ impl<'a> CheckerState<'a> {
             } else {
                 self.get_type_from_type_node(alias.type_node)
             };
-            if variance_annotations_supported {
+            if should_check_variance_annotations {
                 self.check_variance_annotations_with_body(
                     node_idx,
                     &alias.type_parameters,
@@ -598,6 +599,39 @@ impl<'a> CheckerState<'a> {
         }
 
         !emitted_unsupported_variance_diagnostic
+    }
+
+    fn type_alias_has_variance_annotation_to_check(
+        &self,
+        type_parameters: Option<&tsz_parser::parser::base::NodeList>,
+    ) -> bool {
+        let Some(type_params) = type_parameters else {
+            return false;
+        };
+
+        type_params.nodes.iter().copied().any(|param_idx| {
+            let Some(param_node) = self.ctx.arena.get(param_idx) else {
+                return false;
+            };
+            let Some(param) = self.ctx.arena.get_type_parameter(param_node) else {
+                return false;
+            };
+            let Some(modifiers) = &param.modifiers else {
+                return false;
+            };
+
+            let mut declared_in = false;
+            let mut declared_out = false;
+            for modifier_idx in modifiers.nodes.iter().copied() {
+                let Some(modifier_node) = self.ctx.arena.get(modifier_idx) else {
+                    continue;
+                };
+                declared_in |= modifier_node.kind == SyntaxKind::InKeyword as u16;
+                declared_out |= modifier_node.kind == SyntaxKind::OutKeyword as u16;
+            }
+
+            declared_in != declared_out
+        })
     }
 
     fn type_alias_body_supports_variance_annotations(


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 green-row performance and residency; checker micro-optimization for `ts-essentials-project` utility-type pressure.

## Structural Rule
When a type alias has no single-direction `in` or `out` type-parameter variance annotation, TS2636 variance validation has no diagnostic to emit. This change makes tsz skip only that unnecessary validation visitor while preserving normal alias body construction and modifier diagnostics.

## Owner Layer
Checker orchestration. The checker decides whether a declaration has a variance annotation to validate; the solver still owns variance computation when validation is actually required.

## Invariant
Unsupported variance annotations on unsupported type-alias body shapes still produce their existing diagnostics, `in out` invariant annotations still need no TS2636 relation check, and aliases without variance annotations keep the same body type and use-site relation behavior.

## Scope
- Gate type-alias variance validation on actual single-direction variance modifiers.
- Preserve unsupported variance annotation diagnostics for unsupported alias body shapes.
- Leave solver type construction, relation behavior, and alias body validation unchanged.

## Adjacent-Case Test Matrix
- Reported/equivalent project shape: generic utility type aliases in `ts-essentials-project` without variance annotations avoid the no-op declaration-time variance visitor.
- Positive validation shape: `out` type-alias annotation still runs TS2636 validation (`test_declared_out_variance_controls_application_assignability_even_when_invalid`).
- Unsupported-body shape: unsupported variance annotations still report the unsupported-alias-body diagnostic without also running TS2636 (`test_variance_annotations_require_direct_supported_type_alias_bodies`).
- Modifier context shape: invalid type-parameter modifiers remain covered by `type_param_modifier_diagnostics_tests`.
- Fallback: class/interface variance validation and unannotated alias use-site assignability stay on the existing paths.

## Known Unsupported Shapes / Fallback
- This PR does not change computed variance, relation variance, or type-alias instantiation semantics.
- If a type alias has a single-direction `in` or `out` annotation, it still falls through to the existing solver-backed validation path.
- If a type alias body cannot support variance annotations, the existing unsupported-body diagnostic path runs before this gate can suppress validation.

## Project Corpus Impact
- Row: `ts-essentials-project`
- Bug family: utility-type mapped/conditional/key-space workload with recursive JSON-like shapes
- Evidence: fresh quick benchmark remains green and still a target gap. Baseline `/tmp/studio-b-ts-essentials-latest-main-20260527210141.json`: `tsz=104.06ms`, `tsgo=81.81ms`, gap factor `2.54`. After `/tmp/studio-b-type-alias-variance-gate-after-20260527211938.json`: `tsz=103.49ms`, `tsgo=83.81ms`, gap factor `2.47`. Attribution-mode slowest file moved `xor/index.ts` `161.87ms -> 159.53ms`; structural counters are otherwise flat, so this PR makes only a micro-performance claim.

## Performance Notes
- Repeated operation: declaration-time variance visitor over type-alias bodies even when no parameter has a single-direction variance annotation.
- Intended complexity improvement: avoid walking large generic alias bodies solely to prove a non-existent TS2636 diagnostic.
- This is a structural gate keyed on AST variance modifiers, not fixture names or alias names.
- No cache is introduced; there are no cache key, invalidation, cycle, or fuel changes.

## Verification
- `cargo nextest run -p tsz-checker --test conformance_issues_types test_variance_annotations_require_direct_supported_type_alias_bodies -- --exact`
- `cargo nextest run -p tsz-checker --test conformance_issues_types test_declared_out_variance_controls_application_assignability_even_when_invalid -- --exact`
- `cargo nextest run -p tsz-checker --test type_param_modifier_diagnostics_tests`
- `cargo fmt --check`
- `git diff --check`
- After rebase to `origin/main` at `4bc500a7b5`: `cargo fmt --check`
- After rebase to `origin/main` at `4bc500a7b5`: `git diff --check origin/main...HEAD`
- `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^ts-essentials-project$' --json-file /tmp/studio-b-type-alias-variance-gate-after-20260527211938.json`
- `TSZ_PERF_COUNTERS=1 cargo run -q -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json /tmp/studio-b-type-alias-variance-gate-after-20260527211938.perf.json --noEmit -p .target-bench/external/ts-essentials/tsconfig.flat.json`

## Coordination Notes
- No active Studio-B PR existed before this branch; #10585 and #10586 were merged first.
- Related open performance PR #10605 works in source-file direct alias lowering, not type-alias declaration variance validation.
- Rebased and force-pushed onto current `origin/main` after #10607 landed; current head is `540b3cf94cfddc260a14afb249aa16e2e439da5a`.
- The first attempted multi-filter `cargo nextest run -p tsz-checker ...` was interrupted after it selected too much and stayed quiet; the exact filtered commands above passed.
- No roadmap update is needed for this routine micro-optimization. The remaining `ts-essentials-project` target gap stays owned by Studio-B.
