### PR TITLE
fix(emit): name private field class expressions

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
@@ -1,5 +1,6 @@
 use super::super::super::Printer;
 use super::AutoAccessorEmitOptions;
+use crate::transforms::private_fields_es5::get_private_field_name;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::Node;
 use tsz_parser::parser::syntax_kind_ext;
@@ -64,6 +65,13 @@ impl<'a> Printer<'a> {
                     }
                     return self.identifier_binding_name(param.name);
                 }
+                syntax_kind_ext::PROPERTY_DECLARATION => {
+                    let property = self.arena.get_property_decl(parent_node)?;
+                    if property.initializer != current {
+                        return None;
+                    }
+                    return self.property_declaration_binding_name(property.name);
+                }
                 syntax_kind_ext::BINARY_EXPRESSION => {
                     let binary = self.arena.get_binary_expr(parent_node)?;
                     if binary.right != current
@@ -88,6 +96,15 @@ impl<'a> Printer<'a> {
 
         let name = self.get_identifier_text_idx(name_idx);
         (!name.is_empty()).then_some(name)
+    }
+
+    fn property_declaration_binding_name(&self, name_idx: NodeIndex) -> Option<String> {
+        let name_node = self.arena.get(name_idx)?;
+        if name_node.kind == SyntaxKind::PrivateIdentifier as u16 {
+            get_private_field_name(self.arena, name_idx)
+        } else {
+            self.get_property_key_text(name_idx)
+        }
     }
 
     pub(in crate::emitter) fn emit_class_expr_set_function_name_comma_item(

--- a/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
@@ -135,6 +135,33 @@ class Widget {
 }
 
 #[test]
+fn static_private_field_class_expression_gets_private_name() {
+    let source = r#"
+class Widget {
+    static #Anon = class {
+        static value = 1;
+    };
+    static #Named = class Named {
+        static value = 2;
+    };
+    read() {
+        return Widget.#Anon.value + Widget.#Named.value;
+    }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains("__setFunctionName(_b, \"#Anon\")"),
+        "Anonymous class expressions assigned to private static fields should use the private name for named evaluation.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("__setFunctionName(_c, \"#Named\")"),
+        "Named class expressions assigned to private static fields should keep their class name and skip named-evaluation helpers.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn static_private_async_generator_helpers_preserve_function_kind() {
     let source = r#"
 const Widget = class {

--- a/crates/tsz-emitter/src/lowering/helpers.rs
+++ b/crates/tsz-emitter/src/lowering/helpers.rs
@@ -943,6 +943,13 @@ impl<'a> LoweringPass<'a> {
                         .get_identifier_text_ref(param.name)
                         .filter(|name| !name.is_empty());
                 }
+                syntax_kind_ext::PROPERTY_DECLARATION => {
+                    let property = self.arena.get_property_decl(parent_node)?;
+                    if property.initializer != current {
+                        return None;
+                    }
+                    return self.property_declaration_binding_name_ref(property.name);
+                }
                 syntax_kind_ext::BINARY_EXPRESSION => {
                     let binary = self.arena.get_binary_expr(parent_node)?;
                     if binary.right != current
@@ -958,6 +965,38 @@ impl<'a> LoweringPass<'a> {
             }
         }
 
+        None
+    }
+
+    fn property_declaration_binding_name_ref(&self, name_idx: NodeIndex) -> Option<&str> {
+        let name_node = self.arena.get(name_idx)?;
+        if name_node.kind == SyntaxKind::Identifier as u16
+            || name_node.kind == SyntaxKind::PrivateIdentifier as u16
+        {
+            return self
+                .arena
+                .get_identifier(name_node)
+                .map(|ident| ident.escaped_text.as_str())
+                .filter(|name| !name.is_empty());
+        }
+        if name_node.kind == SyntaxKind::StringLiteral as u16
+            || name_node.kind == SyntaxKind::NumericLiteral as u16
+        {
+            return self
+                .arena
+                .get_literal(name_node)
+                .map(|literal| literal.text.as_str())
+                .filter(|name| !name.is_empty());
+        }
+        if name_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+            let computed = self.arena.get_computed_property(name_node)?;
+            let expr_node = self.arena.get(computed.expression)?;
+            return self
+                .arena
+                .get_literal(expr_node)
+                .map(|literal| literal.text.as_str())
+                .filter(|name| !name.is_empty());
+        }
         None
     }
 

--- a/crates/tsz-emitter/src/transforms/helpers.rs
+++ b/crates/tsz-emitter/src/transforms/helpers.rs
@@ -748,6 +748,8 @@ pub fn emit_helpers(helpers: &HelpersNeeded) -> String {
         output.push_str(GENERATOR_HELPER);
         output.push('\n');
     }
+    let mut emitted_unprioritized = Vec::new();
+    emit_class_private_helpers(helpers, &mut output, &mut emitted_unprioritized);
     if helpers.set_function_name {
         output.push_str(SET_FUNCTION_NAME_HELPER);
         output.push('\n');
@@ -760,27 +762,55 @@ pub fn emit_helpers(helpers: &HelpersNeeded) -> String {
         output.push_str(DISPOSE_RESOURCES_HELPER);
         output.push('\n');
     }
-    emit_unprioritized_helpers(helpers, &mut output);
+    emit_unprioritized_helpers(helpers, &mut output, &mut emitted_unprioritized);
 
     output
 }
 
-fn emit_unprioritized_helpers(helpers: &HelpersNeeded, output: &mut String) {
-    let mut emitted = Vec::new();
-
+fn emit_unprioritized_helpers(
+    helpers: &HelpersNeeded,
+    output: &mut String,
+    emitted: &mut Vec<HelperEmitOrder>,
+) {
     if helpers.unprioritized_order.is_empty() {
         for helper in fallback_unprioritized_order(helpers) {
-            emit_unprioritized_helper(helper, helpers, output, &mut emitted);
+            emit_unprioritized_helper(helper, helpers, output, emitted);
         }
         return;
     }
 
     for &helper in &helpers.unprioritized_order {
-        emit_unprioritized_helper(helper, helpers, output, &mut emitted);
+        emit_unprioritized_helper(helper, helpers, output, emitted);
     }
     for helper in fallback_unprioritized_order(helpers) {
-        emit_unprioritized_helper(helper, helpers, output, &mut emitted);
+        emit_unprioritized_helper(helper, helpers, output, emitted);
     }
+}
+
+fn emit_class_private_helpers(
+    helpers: &HelpersNeeded,
+    output: &mut String,
+    emitted: &mut Vec<HelperEmitOrder>,
+) {
+    let (first, second) = if helpers.class_private_field_set_before_get {
+        (
+            HelperEmitOrder::ClassPrivateFieldSet,
+            HelperEmitOrder::ClassPrivateFieldGet,
+        )
+    } else {
+        (
+            HelperEmitOrder::ClassPrivateFieldGet,
+            HelperEmitOrder::ClassPrivateFieldSet,
+        )
+    };
+    emit_unprioritized_helper(first, helpers, output, emitted);
+    emit_unprioritized_helper(second, helpers, output, emitted);
+    emit_unprioritized_helper(
+        HelperEmitOrder::ClassPrivateFieldIn,
+        helpers,
+        output,
+        emitted,
+    );
 }
 
 const fn fallback_unprioritized_order(helpers: &HelpersNeeded) -> [HelperEmitOrder; 12] {
@@ -1214,6 +1244,24 @@ mod tests {
         assert!(i_generator < i_set_name);
         assert!(i_set_name < i_await);
         assert!(i_await < i_async_generator);
+    }
+
+    #[test]
+    fn emit_helpers_order_class_private_before_set_function_name() {
+        let mut helpers = HelpersNeeded {
+            set_function_name: true,
+            await_helper: true,
+            ..HelpersNeeded::default()
+        };
+        helpers.mark_class_private_field_get();
+
+        let output = emit_helpers(&helpers);
+        let i_get = find_helper(&output, "__classPrivateFieldGet");
+        let i_set_name = find_helper(&output, "__setFunctionName");
+        let i_await = find_helper(&output, "__await");
+
+        assert!(i_get < i_set_name);
+        assert!(i_set_name < i_await);
     }
 
     #[test]


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
JavaScript emit recovery / class-private class-expression named evaluation.

## Invariant
When an anonymous class expression is assigned to a class property that emits through a comma initializer, `tsc` uses the property name for named evaluation; this PR makes private static fields participate in that same property-declaration name resolution and plans the required helper before printing.

## Structural Rule
For `static #name = class { ... static field ... }`, emit the class-expression comma item `__setFunctionName(temp, "#name")` after the private-field helper is available. Named class expressions, such as `static #name = class Named { ... }`, keep their inner class name and do not emit a named-evaluation helper.

## Owner Layer
Emitter/lowering output planning for class-expression comma initializers in `crates/tsz-emitter/src/lowering/` and `crates/tsz-emitter/src/emitter/declarations/class/`. This consumes syntax-level property names and helper needs; it does not add checker/solver semantic validation and does not patch emitted text after the fact.

## Adjacent Case Matrix
- Anonymous private static field class expression: `static #Anon = class { static value = 1; }` emits `__setFunctionName(temp, "#Anon")`.
- Named private static field class expression: `static #Named = class Named { static value = 2; }` skips `__setFunctionName`.
- Helper ordering with both `__classPrivateFieldGet` and `__setFunctionName` keeps the private-field helper before named-evaluation helper while preserving existing decorator/async helper order.
- Existing private optional-call and async/generator private-method helper coverage remains intact through merged #10604.

## Scope
- Extend class-expression contextual-name resolution to property declarations, including private identifiers.
- Mirror the same property-declaration recognition in lowering helper discovery so `__setFunctionName` is emitted before the class body references it.
- Emit class-private helpers before `__setFunctionName` in inline helper output while leaving the remaining unprioritized helper block after `__setFunctionName`.
- Add focused unit coverage for private static field class-expression naming and helper ordering.

## Project Corpus Impact
- Row: emit conformance `privateNameStaticFieldClassExpression`
- Bug family: class/private/static field class-expression named evaluation and helper ordering
- Evidence: exact JS emit filter `privateNameStaticFieldClassExpression` passes locally after rebasing onto `main`; narrow `privateNameStatic` sweep is 29/31 with the two remaining private-static failures owned by stacked #10613.

## Verification
- `cargo nextest run -p tsz-emitter static_private_field_class_expression_gets_private_name emit_helpers_order_class_private_before_set_function_name emit_helpers_order_decorators_and_async_helpers`
- `scripts/emit/run.sh --filter=privateNameStaticFieldClassExpression --js-only --verbose --json-out=/tmp/studio-c-10610-private-static-field-class-expression-main.json`
- `scripts/emit/run.sh --skip-build --filter=privateNameStatic --js-only --verbose --json-out=/tmp/studio-c-10610-private-name-static-main.json` (29/31; remaining failures are private static field destructuring and static private method assignment receiver/temp parity, fixed in stacked #10613)
- `cargo fmt --all --check`
- `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`
- `git diff --check`

## Known Unsupported Shapes / Follow-Up
This PR does not fix private static field destructuring temp minimization or static private method assignment receiver/temp parity; those are fixed in stacked #10613.

## Coordination Notes
- #10604 landed and this branch is rebased onto `main` at head `0479aed8cd`.
- Ready for CI/manager review after the focused post-main verification above.
- #10613 remains stacked on this branch for the remaining private static member assignment/destructuring follow-up.
