### PR TITLE
fix(bench): gate stale shard fanout

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -936,10 +936,36 @@ jobs:
           if-no-files-found: error
           compression-level: 1
 
-  bench:
-    name: bench-${{ matrix.label }}
+  bench-target-fresh:
+    name: bench-target-fresh
     needs: bench-prep-artifact
     if: always() && needs.bench-prep-artifact.result == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.fresh.outputs.should_run }}
+    steps:
+      - id: fresh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          should_run=true
+          target_sha="${{ env.BENCH_TARGET_SHA }}"
+          main_sha="$(gh api "repos/${{ github.repository }}/git/ref/heads/main" --jq '.object.sha' 2>/dev/null || true)"
+          if [[ -n "$main_sha" && "$target_sha" != "$main_sha" ]]; then
+            echo "Benchmark target ${target_sha} became stale after prep; current main is ${main_sha}. Skipping shard fanout."
+            should_run=false
+          fi
+          echo "should_run=${should_run}" >> "$GITHUB_OUTPUT"
+
+  bench:
+    name: bench-${{ matrix.label }}
+    needs: [bench-prep-artifact, bench-target-fresh]
+    if: >-
+      always() &&
+      needs.bench-prep-artifact.result == 'success' &&
+      needs.bench-target-fresh.outputs.should_run == 'true'
     runs-on: [self-hosted, tsz-cloud-run]
     timeout-minutes: ${{ matrix.timeout }}
     strategy:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1069,6 +1069,7 @@ jobs:
             storage_cp "${prefix}/bench-results-${{ matrix.label }}.json" "bench-results-${{ matrix.label }}.json" || true
             storage_cp "${prefix}/bench-run-${{ matrix.label }}.log" "bench-run-${{ matrix.label }}.log" || true
             storage_cp "${prefix}/bench-postmortem-${{ matrix.label }}.log" "bench-postmortem-${{ matrix.label }}.log" || true
+            storage_cp "${prefix}/bench-prep-fetch-${{ matrix.label }}.log" "bench-prep-fetch-${{ matrix.label }}.log" || true
           }
 
           deadline=$((SECONDS + ${{ matrix.timeout }} * 60))
@@ -1119,6 +1120,7 @@ jobs:
             bench-results-${{ matrix.label }}.json
             bench-run-${{ matrix.label }}.log
             bench-postmortem-${{ matrix.label }}.log
+            bench-prep-fetch-${{ matrix.label }}.log
             bench-cloudbuild-${{ matrix.label }}.log
           retention-days: 7
           if-no-files-found: warn

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -140,6 +140,12 @@ assert.match(
   "bench gate should distinguish obsolete active runs from duplicate current-target runs",
 );
 
+assert.match(
+  workflow,
+  /bench-target-fresh:[\s\S]+needs: bench-prep-artifact[\s\S]+target_sha="\$\{\{ env\.BENCH_TARGET_SHA \}\}"[\s\S]+main_sha="\$\(gh api "repos\/\$\{\{ github\.repository \}\}\/git\/ref\/heads\/main" --jq '\.object\.sha' 2>\/dev\/null \|\| true\)"[\s\S]+Benchmark target \$\{target_sha\} became stale after prep; current main is \$\{main_sha\}\. Skipping shard fanout\.[\s\S]+echo "should_run=\$\{should_run\}" >> "\$GITHUB_OUTPUT"[\s\S]+bench:[\s\S]+needs: \[bench-prep-artifact, bench-target-fresh\][\s\S]+needs\.bench-target-fresh\.outputs\.should_run == 'true'/,
+  "bench shards should re-check target freshness after prep so obsolete runs cannot fan out while a current-main run is active",
+);
+
 const benchJob = workflow.match(/  bench:[\s\S]+?  publish:/)?.[0] ?? "";
 assert.match(
   benchJob,

--- a/scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
@@ -3,6 +3,10 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 
 const workflow = fs.readFileSync(".github/workflows/bench.yml", "utf8");
+const shardCloudbuild = fs.readFileSync(
+  "scripts/cloudbuild/cloudbuild-bench-shard.yaml",
+  "utf8",
+);
 
 assert.match(
   workflow,
@@ -30,8 +34,35 @@ assert.match(
 
 assert.match(
   workflow,
-  /bench-postmortem-\$\{\{ matrix\.label \}\}\.log\s*\n\s*bench-cloudbuild-\$\{\{ matrix\.label \}\}\.log\s*\n\s*retention-days: 7/,
+  /bench-postmortem-\$\{\{ matrix\.label \}\}\.log\s*\n\s*bench-prep-fetch-\$\{\{ matrix\.label \}\}\.log\s*\n\s*bench-cloudbuild-\$\{\{ matrix\.label \}\}\.log\s*\n\s*retention-days: 7/,
   "bench shard artifacts should include the captured Cloud Build log",
+);
+
+assert.match(
+  workflow,
+  /storage_cp "\$\{prefix\}\/bench-prep-fetch-\$\{\{ matrix\.label \}\}\.log" "bench-prep-fetch-\$\{\{ matrix\.label \}\}\.log" \|\| true/,
+  "bench shard waits should download the prep-fetch log when Cloud Build publishes it",
+);
+
+assert.match(
+  shardCloudbuild,
+  /\} > bench-prep-fetch\.log 2>&1[\s\S]+BENCH_PREP_FETCH_STATUS=%s[\s\S]+exit 0/,
+  "Cloud Build prep-fetch step should record status and never fail the build before shard status artifacts can be written",
+);
+
+assert.match(
+  shardCloudbuild,
+  /output_dir="bench-shards\/\$\{_BENCH_TARGET_SHA\}\/\$\{_BENCH_SHARD_LABEL\}"[\s\S]+mkdir -p "\$output_dir"[\s\S]+run_shard\(\)[\s\S]+apt-get update/,
+  "Cloud Build shard status directory should be prepared before setup commands that can fail",
+);
+
+assert.ok(
+  shardCloudbuild.includes('run_shard 2>&1 | tee "/workspace/${run_log}"') &&
+    shardCloudbuild.includes('shard_status="${PIPESTATUS[0]}"') &&
+    shardCloudbuild.includes("printf 'BENCH_SHARD_STATUS=%s\\n' \"$shard_status\"") &&
+    shardCloudbuild.includes("bench-prep-fetch-${_BENCH_SHARD_LABEL}.log") &&
+    shardCloudbuild.includes("exit 0"),
+  "Cloud Build shard should publish status/log artifacts and exit successfully so GitHub can consume BENCH_SHARD_STATUS",
 );
 
 console.log("test-bench-workflow-cloudbuild-shards: ok");

--- a/scripts/cloudbuild/cloudbuild-bench-shard.yaml
+++ b/scripts/cloudbuild/cloudbuild-bench-shard.yaml
@@ -6,31 +6,42 @@ steps:
     name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
     script: |
       #!/usr/bin/env bash
-      set -euo pipefail
+      set +e
 
-      if [[ -f bench-prep.env && -f bench-prep.tar ]]; then
-        echo "Using benchmark prep artifact from the Cloud Build source archive."
-      else
-        gcloud storage cp \
-          "gs://tsz-ci_cloudbuild/bench-prep/${_BENCH_TARGET_SHA}/bench-prep.env" \
-          bench-prep.env
-        gcloud storage cp \
-          "gs://tsz-ci_cloudbuild/bench-prep/${_BENCH_TARGET_SHA}/bench-prep.tar" \
-          bench-prep.tar
-      fi
+      {
+        set -euo pipefail
 
-      tar -tf bench-prep.tar .target-bench/dist/tsz >/dev/null
-      tar -tf bench-prep.tar .target-bench/dist/.bench-pgo-optimized >/dev/null
-      # shellcheck disable=SC1091
-      source bench-prep.env
-      if [[ "${BENCH_TARGET_SHA:-}" != "${_BENCH_TARGET_SHA}" ]]; then
-        echo "Bench prep artifact is for ${BENCH_TARGET_SHA:-unknown}; expected ${_BENCH_TARGET_SHA}."
-        exit 1
-      fi
-      if [[ "${BENCH_PGO_OPTIMIZED:-}" != "1" ]]; then
-        echo "Bench prep artifact is not marked PGO optimized."
-        exit 1
-      fi
+        if [[ -f bench-prep.env && -f bench-prep.tar ]]; then
+          echo "Using benchmark prep artifact from the Cloud Build source archive."
+        else
+          gcloud storage cp \
+            "gs://tsz-ci_cloudbuild/bench-prep/${_BENCH_TARGET_SHA}/bench-prep.env" \
+            bench-prep.env
+          gcloud storage cp \
+            "gs://tsz-ci_cloudbuild/bench-prep/${_BENCH_TARGET_SHA}/bench-prep.tar" \
+            bench-prep.tar
+        fi
+
+        tar -tf bench-prep.tar .target-bench/dist/tsz >/dev/null
+        tar -tf bench-prep.tar .target-bench/dist/.bench-pgo-optimized >/dev/null
+        # shellcheck disable=SC1091
+        source bench-prep.env
+        if [[ "${BENCH_TARGET_SHA:-}" != "${_BENCH_TARGET_SHA}" ]]; then
+          echo "Bench prep artifact is for ${BENCH_TARGET_SHA:-unknown}; expected ${_BENCH_TARGET_SHA}."
+          exit 1
+        fi
+        if [[ "${BENCH_PGO_OPTIMIZED:-}" != "1" ]]; then
+          echo "Bench prep artifact is not marked PGO optimized."
+          exit 1
+        fi
+      } > bench-prep-fetch.log 2>&1
+      fetch_status=$?
+      cat bench-prep-fetch.log
+      {
+        printf 'BENCH_PREP_FETCH_STATUS=%s\n' "$fetch_status"
+        printf 'BENCH_TARGET_SHA=%s\n' "${_BENCH_TARGET_SHA}"
+      } > bench-prep-fetch.env
+      exit 0
 
   - id: bench-shard
     name: rust:1.95
@@ -60,76 +71,98 @@ steps:
       #!/usr/bin/env bash
       set -euo pipefail
 
-      apt-get update
-      apt-get install -y --no-install-recommends \
-        bc \
-        ca-certificates \
-        curl \
-        git \
-        jq \
-        pkg-config \
-        xz-utils
-      rm -rf /var/lib/apt/lists/*
-
-      node_version="22.13.1"
-      node_arch="x64"
-      curl -fsSL "https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-${node_arch}.tar.xz" \
-        | tar -xJ -C /usr/local --strip-components=1
-
-      if ! command -v pnpm >/dev/null 2>&1; then
-        npm install -g pnpm --silent
-      fi
-      pnpm config set store-dir "${PNPM_STORE_DIR}"
-
-      tar -xf bench-prep.tar
-      test -x .target-bench/dist/tsz
-      test -f .target-bench/dist/.bench-pgo-optimized
-      export PATH="/workspace/.target-bench/tools/bin:${PATH}"
-      touch .target-bench/dist/tsz
-
-      export TSZ="/workspace/.target-bench/dist/tsz"
-      export TSZ_BENCH_SHARD_LABEL="${_BENCH_SHARD_LABEL}"
-      export TSZ_BENCH_SHARD_FILTER="${_BENCH_SHARD_FILTER}"
-      if [[ "${_BENCH_SHARD_LABEL}" == "projects" ]]; then
-        export NEXTJS_BENCHMARK_ENABLED=1
-      fi
-
       output_dir="bench-shards/${_BENCH_TARGET_SHA}/${_BENCH_SHARD_LABEL}"
       mkdir -p "$output_dir"
       result_json="bench-results-${_BENCH_SHARD_LABEL}.json"
       run_log="bench-run-${_BENCH_SHARD_LABEL}.log"
       postmortem_log="bench-postmortem-${_BENCH_SHARD_LABEL}.log"
       status_file="bench-status-${_BENCH_SHARD_LABEL}.env"
+      prep_fetch_log="bench-prep-fetch-${_BENCH_SHARD_LABEL}.log"
 
-      prelude_status=0
-      scripts/ci/bench-shard-prelude.sh prelude --label "${_BENCH_SHARD_LABEL}" \
-        || prelude_status=$?
+      run_shard() {
+        set -euo pipefail
 
-      if [[ "$prelude_status" -ne 0 ]]; then
-        echo "Benchmark shard prelude failed with ${prelude_status}; skipping ${_BENCH_SHARD_LABEL}." \
-          | tee "/workspace/${run_log}"
-        shard_status="$prelude_status"
-      else
+        if [[ -f bench-prep-fetch.env ]]; then
+          # shellcheck disable=SC1091
+          source bench-prep-fetch.env
+          if [[ "${BENCH_PREP_FETCH_STATUS:-1}" != "0" ]]; then
+            echo "Benchmark prep artifact fetch failed with ${BENCH_PREP_FETCH_STATUS:-unknown}."
+            [[ ! -f bench-prep-fetch.log ]] || cat bench-prep-fetch.log
+            return "${BENCH_PREP_FETCH_STATUS:-1}"
+          fi
+        fi
+
+        test -f bench-prep.env
+        test -f bench-prep.tar
+
+        apt-get update
+        apt-get install -y --no-install-recommends \
+          bc \
+          ca-certificates \
+          curl \
+          git \
+          jq \
+          pkg-config \
+          xz-utils
+        rm -rf /var/lib/apt/lists/*
+
+        node_version="22.13.1"
+        node_arch="x64"
+        curl -fsSL "https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-${node_arch}.tar.xz" \
+          | tar -xJ -C /usr/local --strip-components=1
+
+        if ! command -v pnpm >/dev/null 2>&1; then
+          npm install -g pnpm --silent
+        fi
+        pnpm config set store-dir "${PNPM_STORE_DIR}"
+
+        tar -xf bench-prep.tar
+        test -x .target-bench/dist/tsz
+        test -f .target-bench/dist/.bench-pgo-optimized
+        export PATH="/workspace/.target-bench/tools/bin:${PATH}"
+        touch .target-bench/dist/tsz
+
+        export TSZ="/workspace/.target-bench/dist/tsz"
+        export TSZ_BENCH_SHARD_LABEL="${_BENCH_SHARD_LABEL}"
+        export TSZ_BENCH_SHARD_FILTER="${_BENCH_SHARD_FILTER}"
+        if [[ "${_BENCH_SHARD_LABEL}" == "projects" ]]; then
+          export NEXTJS_BENCHMARK_ENABLED=1
+        fi
+
+        prelude_status=0
+        scripts/ci/bench-shard-prelude.sh prelude --label "${_BENCH_SHARD_LABEL}" \
+          || prelude_status=$?
+
+        if [[ "$prelude_status" -ne 0 ]]; then
+          echo "Benchmark shard prelude failed with ${prelude_status}; skipping ${_BENCH_SHARD_LABEL}."
+          return "$prelude_status"
+        fi
+
         set +e
         scripts/safe-run.sh --limit "${TSZ_BENCH_MEMORY_LIMIT:-85%}" --interval 30 -- \
           ./scripts/bench/bench-vs-tsgo.sh \
             --filter "${_BENCH_SHARD_FILTER}" \
             --json \
-            --json-file "/workspace/${result_json}" \
-          2>&1 | tee "/workspace/${run_log}"
-        shard_status="${PIPESTATUS[0]}"
+            --json-file "/workspace/${result_json}"
+        bench_status=$?
         set -e
-      fi
+        return "$bench_status"
+      }
 
-      if [[ "$shard_status" -ne 0 ]]; then
-        scripts/ci/bench-shard-prelude.sh postmortem \
-          --label "${_BENCH_SHARD_LABEL}" \
-          --output "/workspace/${postmortem_log}"
-      fi
+      set +e
+      run_shard 2>&1 | tee "/workspace/${run_log}"
+      shard_status="${PIPESTATUS[0]}"
+      set -e
+
       if [[ "$shard_status" -eq 0 && ! -f "$result_json" ]]; then
         echo "Benchmark shard ${_BENCH_SHARD_LABEL} exited 0 but did not write ${result_json}." \
           | tee -a "$run_log"
         shard_status=1
+      fi
+      if [[ "$shard_status" -ne 0 ]]; then
+        scripts/ci/bench-shard-prelude.sh postmortem \
+          --label "${_BENCH_SHARD_LABEL}" \
+          --output "/workspace/${postmortem_log}" || true
       fi
       if [[ ! -f "$result_json" ]]; then
         printf '{"schema_version":1,"results":[],"error":"benchmark shard did not write results"}\n' \
@@ -150,6 +183,8 @@ steps:
       [[ ! -f "$result_json" ]] || cp "$result_json" "$output_dir/"
       [[ ! -f "$run_log" ]] || cp "$run_log" "$output_dir/"
       [[ ! -f "$postmortem_log" ]] || cp "$postmortem_log" "$output_dir/"
+      [[ ! -f bench-prep-fetch.log ]] || cp bench-prep-fetch.log "$output_dir/${prep_fetch_log}"
+      exit 0
 
 artifacts:
   objects:
@@ -159,6 +194,7 @@ artifacts:
       - bench-shards/${_BENCH_TARGET_SHA}/${_BENCH_SHARD_LABEL}/bench-results-${_BENCH_SHARD_LABEL}.json
       - bench-shards/${_BENCH_TARGET_SHA}/${_BENCH_SHARD_LABEL}/bench-run-${_BENCH_SHARD_LABEL}.log
       - bench-shards/${_BENCH_TARGET_SHA}/${_BENCH_SHARD_LABEL}/bench-postmortem-${_BENCH_SHARD_LABEL}.log
+      - bench-shards/${_BENCH_TARGET_SHA}/${_BENCH_SHARD_LABEL}/bench-prep-fetch-${_BENCH_SHARD_LABEL}.log
 
 substitutions:
   _BENCH_TARGET_SHA: unknown


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 1 benchmark blocker: Bench artifact freshness and project-corpus metric truth.

## Invariant
When a Bench run finishes prep for a target SHA that is no longer current `main`, shard fanout must be skipped before self-hosted runners publish stale benchmark data; this PR changes the Bench workflow gate surface.

When a Cloud Build shard fails during prep download, apt/node setup, tar extraction, or prelude before the benchmark runner starts, it must still publish shard status and setup logs back to GitHub; this PR makes setup failures explicit artifacts instead of opaque Cloud Build `FAILURE` states with unreadable logs.

## Scope
- `.github/workflows/bench.yml`: add a post-prep `bench-target-fresh` job that compares `BENCH_TARGET_SHA` with current `main` and gates the matrix shard jobs.
- `.github/workflows/bench.yml`: download and upload per-shard prep-fetch logs alongside run, postmortem, and Cloud Build logs.
- `scripts/cloudbuild/cloudbuild-bench-shard.yaml`: record prep-fetch status without failing the Cloud Build build early, create shard artifact paths before setup, capture setup/bench output into `bench-run-*`, write `BENCH_SHARD_STATUS`, and exit Cloud Build successfully so GitHub can consume the status artifact.
- `scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`: assert stale post-prep targets cannot fan out to shard jobs.
- `scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`: assert shard setup failures are surfaced through status/log artifacts.

## Project Corpus Impact
- Row: n/a
- Bug family: benchmark freshness / stale shard fanout / opaque Cloud Build shard setup failure
- Evidence: workflow and Cloud Build harness-only guard; no compiler behavior, fixture metadata, project row definitions, or benchmark timing semantics changed.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `git diff --check`

## Coordination Notes
- Observed stale Bench run `26532785409` on `1d43c855784b1dca3b9be686c3f399866371638e` reach shard queue after current-main Bench run `26534030067` on `4bc500a7b500e88df6714223c0c2a8e69486c20c` had started.
- Observed Bench run `26534030067` fail all eight Cloud Build shards before any `bench-status-*`, `bench-run-*`, or `bench-postmortem-*` artifact was available; only `gcloud builds log` permission-denied stubs were uploaded. This PR makes the next shard failure actionable and lets successful shards proceed normally.
- This PR prevents stale fanout even when GitHub cancellation lags after prep artifact completion.
