### PR TITLE
fix(emit): complete private static member assignments

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/constructor_temp_estimation.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/constructor_temp_estimation.rs
@@ -113,12 +113,94 @@ impl<'a> Printer<'a> {
                             | syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
                     ) {
                         self.estimate_destructuring_pattern_temps(left_node, right_is_simple)
+                            + self.estimate_private_destructuring_receiver_temps(binary.left)
                     } else {
                         0
                     }
                 } else {
                     0
                 }
+            }
+            _ => 0,
+        }
+    }
+
+    fn estimate_private_destructuring_receiver_temps(&self, node_idx: NodeIndex) -> usize {
+        if node_idx.is_none() {
+            return 0;
+        }
+        if self.private_destructuring_receiver_needs_temp(node_idx) {
+            return 1;
+        }
+
+        let Some(node) = self.arena.get(node_idx) else {
+            return 0;
+        };
+        match node.kind {
+            kind if kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION => {
+                let Some(paren) = self.arena.get_parenthesized(node) else {
+                    return 0;
+                };
+                self.estimate_private_destructuring_receiver_temps(paren.expression)
+            }
+            kind if kind == syntax_kind_ext::TYPE_ASSERTION
+                || kind == syntax_kind_ext::AS_EXPRESSION
+                || kind == syntax_kind_ext::SATISFIES_EXPRESSION =>
+            {
+                let Some(assertion) = self.arena.get_type_assertion(node) else {
+                    return 0;
+                };
+                self.estimate_private_destructuring_receiver_temps(assertion.expression)
+            }
+            kind if kind == syntax_kind_ext::BINARY_EXPRESSION => {
+                let Some(binary) = self.arena.get_binary_expr(node) else {
+                    return 0;
+                };
+                if binary.operator_token == SyntaxKind::EqualsToken as u16 {
+                    self.estimate_private_destructuring_receiver_temps(binary.left)
+                } else {
+                    0
+                }
+            }
+            kind if kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                || kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION =>
+            {
+                let Some(literal) = self.arena.get_literal_expr(node) else {
+                    return 0;
+                };
+                literal
+                    .elements
+                    .nodes
+                    .iter()
+                    .map(|&element| self.estimate_private_destructuring_receiver_temps(element))
+                    .sum()
+            }
+            kind if kind == syntax_kind_ext::OBJECT_BINDING_PATTERN
+                || kind == syntax_kind_ext::ARRAY_BINDING_PATTERN =>
+            {
+                let Some(pattern) = self.arena.get_binding_pattern(node) else {
+                    return 0;
+                };
+                pattern
+                    .elements
+                    .nodes
+                    .iter()
+                    .map(|&element| self.estimate_private_destructuring_receiver_temps(element))
+                    .sum()
+            }
+            kind if kind == syntax_kind_ext::PROPERTY_ASSIGNMENT => {
+                let Some(prop) = self.arena.get_property_assignment(node) else {
+                    return 0;
+                };
+                self.estimate_private_destructuring_receiver_temps(prop.initializer)
+            }
+            kind if kind == syntax_kind_ext::SPREAD_ELEMENT
+                || kind == syntax_kind_ext::SPREAD_ASSIGNMENT =>
+            {
+                let Some(spread) = self.arena.get_spread(node) else {
+                    return 0;
+                };
+                self.estimate_private_destructuring_receiver_temps(spread.expression)
             }
             _ => 0,
         }

--- a/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
@@ -17,7 +17,7 @@ struct PrivateFieldAccess {
 struct PrivateDestructuringTarget {
     target: NodeIndex,
     access: PrivateFieldAccess,
-    receiver_temp: String,
+    receiver_temp: Option<String>,
     setter_value: String,
 }
 
@@ -118,6 +118,38 @@ impl<'a> Printer<'a> {
             || node.is_identifier()
     }
 
+    fn receiver_is_static_class_alias(&self, idx: NodeIndex) -> bool {
+        self.arena
+            .get(idx)
+            .and_then(|node| self.static_class_alias_for_node(node))
+            .is_some()
+    }
+
+    fn peek_fresh_temp_name(&self) -> String {
+        let mut counter = self.ctx.destructuring_state.temp_var_counter;
+        loop {
+            let current = counter;
+            counter += 1;
+
+            if current < 26 && (current == 8 || current == 13) {
+                continue;
+            }
+
+            let name = if current < 26 {
+                format!("_{}", (b'a' + current as u8) as char)
+            } else {
+                format!("_{}", current - 26)
+            };
+
+            if !self.file_identifiers.contains(&name)
+                && !self.generated_temp_names.contains(&name)
+                && !self.reserved_nested_temp_names.contains(&name)
+            {
+                return name;
+            }
+        }
+    }
+
     fn emit_private_field_set_close(&mut self, clean_name: &str) {
         let info = self.private_member_info.get(clean_name).cloned();
         let kind = info.as_ref().map_or("f", |i| i.kind);
@@ -215,7 +247,11 @@ impl<'a> Printer<'a> {
         self.write(") { ");
         self.write_helper("__classPrivateFieldSet");
         self.write("(");
-        self.write(&target.receiver_temp);
+        if let Some(receiver_temp) = &target.receiver_temp {
+            self.write(receiver_temp);
+        } else {
+            self.emit_private_receiver(target.access.expression, &target.access.clean_name);
+        }
         self.write(", ");
         self.emit_private_state_var(&target.access.weakmap_name, &target.access.clean_name);
         self.write(", ");
@@ -344,17 +380,20 @@ impl<'a> Printer<'a> {
             .into_iter()
             .map(|(target, access)| PrivateDestructuringTarget {
                 target,
+                receiver_temp: (!self.receiver_is_static_class_alias(access.expression))
+                    .then(|| self.make_unique_name_hoisted_assignment()),
+                setter_value: self.peek_fresh_temp_name(),
                 access,
-                receiver_temp: self.make_unique_name_hoisted_assignment(),
-                setter_value: self.make_unique_name_fresh(),
             })
             .collect::<Vec<_>>();
 
         for target in &targets {
-            self.write(&target.receiver_temp);
-            self.write(" = ");
-            self.emit_private_receiver(target.access.expression, &target.access.clean_name);
-            self.write(", ");
+            if let Some(receiver_temp) = &target.receiver_temp {
+                self.write(receiver_temp);
+                self.write(" = ");
+                self.emit_private_receiver(target.access.expression, &target.access.clean_name);
+                self.write(", ");
+            }
         }
         self.emit_private_destructuring_pattern(left, &targets);
         self.write(" = ");
@@ -373,7 +412,12 @@ impl<'a> Printer<'a> {
         is_prefix: bool,
         is_statement: bool,
     ) {
-        let needs_receiver_temp = !self.receiver_is_simple(pfa.expression);
+        let member_kind = self
+            .private_member_info
+            .get(&pfa.clean_name)
+            .map(|info| info.kind);
+        let needs_receiver_temp =
+            member_kind == Some("m") || !self.receiver_is_simple(pfa.expression);
         let op_text = get_operator_text(operator);
         let expression = pfa.expression;
         let weakmap_name = pfa.weakmap_name.clone();
@@ -516,9 +560,9 @@ impl<'a> Printer<'a> {
         if let Some(temp) = receiver_temp {
             self.write(temp);
             self.write(" = ");
-            self.emit(expression);
+            self.emit_private_receiver(expression, "");
         } else {
-            self.emit(expression);
+            self.emit_private_receiver(expression, "");
         }
     }
 

--- a/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
@@ -118,11 +118,25 @@ impl<'a> Printer<'a> {
             || node.is_identifier()
     }
 
-    fn receiver_is_static_class_alias(&self, idx: NodeIndex) -> bool {
-        self.arena
-            .get(idx)
-            .and_then(|node| self.static_class_alias_for_node(node))
-            .is_some()
+    pub(in crate::emitter) fn private_destructuring_receiver_needs_temp(
+        &self,
+        idx: NodeIndex,
+    ) -> bool {
+        self.try_extract_private_field_access(idx)
+            .is_some_and(|access| {
+                !self.private_member_is_static(&access.clean_name)
+                    || !self.private_call_receiver_is_simple(access.expression)
+            })
+    }
+
+    fn private_member_is_static(&self, clean_name: &str) -> bool {
+        let Some((_, class_alias)) = self.private_static_class_alias.as_ref() else {
+            return false;
+        };
+        self.private_member_info
+            .get(clean_name)
+            .and_then(|info| info.state_var.as_deref())
+            == Some(class_alias.as_str())
     }
 
     fn peek_fresh_temp_name(&self) -> String {
@@ -376,16 +390,24 @@ impl<'a> Printer<'a> {
             return false;
         }
 
-        let targets = raw_targets
+        let mut targets = raw_targets
             .into_iter()
-            .map(|(target, access)| PrivateDestructuringTarget {
-                target,
-                receiver_temp: (!self.receiver_is_static_class_alias(access.expression))
-                    .then(|| self.make_unique_name_hoisted_assignment()),
-                setter_value: self.peek_fresh_temp_name(),
-                access,
+            .map(|(target, access)| {
+                let receiver_temp = (!self.private_member_is_static(&access.clean_name)
+                    || !self.private_call_receiver_is_simple(access.expression))
+                .then(|| self.make_unique_name_hoisted_assignment());
+                PrivateDestructuringTarget {
+                    target,
+                    receiver_temp,
+                    setter_value: String::new(),
+                    access,
+                }
             })
             .collect::<Vec<_>>();
+        let setter_value = self.peek_fresh_temp_name();
+        for target in &mut targets {
+            target.setter_value.clone_from(&setter_value);
+        }
 
         for target in &targets {
             if let Some(receiver_temp) = &target.receiver_temp {

--- a/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
@@ -193,6 +193,43 @@ class A3 {
 }
 
 #[test]
+fn static_private_field_destructuring_uses_simple_receivers_directly() {
+    let source = r#"
+class A {
+    static #field = 1;
+    otherClass = A;
+    constructor() {
+        ({ x: A.#field } = { x: 1 });
+        [this.otherClass.#field = 2] = [];
+    }
+    static test(other) {
+        [other.#field] = [2];
+    }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains(
+            "({ x: ({ set value(_c) { __classPrivateFieldSet(_a, _a, _c, \"f\", _A_field); } }).value } = { x: 1 });"
+        ),
+        "Static class private field destructuring should write through the class alias and keep setter params after reserved receiver temps.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "_b = this.otherClass, [({ set value(_c) { __classPrivateFieldSet(_b, _a, _c, \"f\", _A_field); } }).value = 2] = [];"
+        ),
+        "Complex private destructuring receivers should still be captured once.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "static test(other) {\n        [({ set value(_b) { __classPrivateFieldSet(other, _a, _b, \"f\", _A_field); } }).value] = [2];\n    }"
+        ),
+        "Simple identifier private destructuring receivers should not allocate an extra receiver temp.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn static_private_async_generator_helpers_preserve_function_kind() {
     let source = r#"
 const Widget = class {

--- a/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
@@ -162,6 +162,37 @@ class Widget {
 }
 
 #[test]
+fn static_private_method_assignment_uses_alias_and_update_receiver_temp() {
+    let source = r#"
+class A3 {
+    static #method() { };
+    constructor(a, b) {
+        A3.#method = () => {};
+        a.#method = () => {};
+        b.#method = () => {};
+        ({ x: A3.#method } = { x: () => {}});
+        let x = A3.#method;
+        b.#method++;
+    }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains(
+            "({ x: ({ set value(_b) { __classPrivateFieldSet(_a, _a, _b, \"m\"); } }).value } = { x: () => { } });"
+        ),
+        "Static class private method destructuring targets should write through the class alias without an extra receiver temp.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "__classPrivateFieldSet(_b = b, _a, (_c = __classPrivateFieldGet(_b, _a, \"m\", _A3_method), _c++, _c), \"m\")"
+        ),
+        "Private method update expressions should capture the receiver shared by get and set.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn static_private_async_generator_helpers_preserve_function_kind() {
     let source = r#"
 const Widget = class {


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
JavaScript emit recovery / class-private static member assignment parity.

## Invariant
When a static private member appears in an assignment target, `tsc` preserves the same receiver/temp discipline used by its private helper writes; this PR fixes private static method update receivers and private static field destructuring receiver/temp planning without adding checker or solver semantic validation.

## Structural Rule
For `{ x: C.#method } = rhs`, the setter proxy writes through the class alias receiver directly. For `obj.#method++`, the update captures the receiver once and uses that temp for both `__classPrivateFieldSet` and the nested `__classPrivateFieldGet`. For destructuring writes to static private fields, simple receivers such as the class alias or identifiers are emitted directly, while complex receivers are reserved as function-body temps before local setter parameter names are chosen. Instance private fields continue to reserve a setter receiver temp, matching `tsc` constructor destructuring output.

## Owner Layer
Emitter private-field expression printing and constructor temp preplanning in `crates/tsz-emitter/src/emitter/`. The change adjusts syntax-driven receiver/temp planning for private-member output and keeps the helper call structure direct; it does not inspect types or patch already-emitted text.

## Adjacent Case Matrix
- Static private method destructuring target: `{ x: A.#method } = rhs` writes through the class alias without an extra receiver temp.
- Static private method unary update: `b.#method++` captures `b` once for the paired throwing set/get path.
- Static private field destructuring target with class alias: `{ x: A.#field } = rhs` writes through the class alias directly.
- Static private field destructuring target with simple identifier: `[other.#field] = rhs` writes through the identifier directly.
- Static private field destructuring target with complex receiver: `[this.otherClass.#field = value] = rhs` reserves and reuses a receiver temp.
- Instance private field destructuring target: `{ key: this.#field } = rhs` still reserves the receiver temp in constructor output.

## Scope
- Allow static private destructuring setter targets to omit receiver temps for simple receivers.
- Reserve constructor private-destructuring receiver temps before setter proxy parameter names are picked.
- Use one local setter parameter name per private destructuring assignment shape without consuming the outer temp sequence.
- Force receiver capture for private method unary update expressions.
- Add focused emitter unit coverage for static private method assignment and static private field destructuring receiver/temp planning.

## Project Corpus Impact
- Row: emit conformance `privateNameStatic`
- Bug family: class/private/static member assignment receiver and temp planning
- Evidence: narrow `privateNameStatic` JS sweep is 31/31 locally after rebasing onto current `main` at head `1b0fcdc020`; adjacent constructor private-field destructuring filter also passes.

## Verification
- `cargo nextest run -p tsz-emitter es2015_private_field_destructuring_assignment_uses_setter_target static_private_method_assignment_uses_alias_and_update_receiver_temp static_private_field_destructuring_uses_simple_receivers_directly`
- `scripts/emit/run.sh --filter=constructorWithParameterPropertiesAndPrivateFields --js-only --verbose --json-out=/tmp/studio-c-10613-constructor-param-private-main-sync.json`
- `scripts/emit/run.sh --skip-build --filter=privateNameStatic --js-only --verbose --json-out=/tmp/studio-c-10613-private-name-static-main-sync.json` (31/31)
- `cargo fmt --all --check`
- `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`
- `git diff --check`

## Known Unsupported Shapes / Follow-Up
This PR finishes the current `privateNameStatic` JS emit filter locally. Broader checked-in `class/private/accessor/decorator lowering` failures remain outside this focused slice.

## Coordination Notes
- #10610 has landed on `main`; this PR is retargeted to `main`.
- Synced with current `origin/main` after #10616; current ready head: `1b0fcdc020`.
- Ready for review/CI after the fresh-main verification above.
