### PR TITLE
chore(checker): split direct alias type literal proof

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain.rs
@@ -1940,61 +1940,6 @@ impl<'a> CheckerState<'a> {
 
         Some(active_type_param_names)
     }
-
-    fn source_file_type_literal_properties_are_lowerable(
-        arena: &NodeArena,
-        node: &tsz_parser::parser::node::Node,
-        mut value_is_lowerable: impl FnMut(NodeIndex) -> bool,
-    ) -> bool {
-        let Some(type_literal) = arena.get_type_literal(node) else {
-            return false;
-        };
-        type_literal
-            .members
-            .nodes
-            .iter()
-            .copied()
-            .all(|member_idx| {
-                let Some(member_node) = arena.get(member_idx) else {
-                    return false;
-                };
-                if member_node.kind == syntax_kind_ext::INDEX_SIGNATURE {
-                    let Some(index_signature) = arena.get_index_signature(member_node) else {
-                        return false;
-                    };
-                    let Some(param_idx) = index_signature.parameters.nodes.first().copied() else {
-                        return false;
-                    };
-                    let Some(param_node) = arena.get(param_idx) else {
-                        return false;
-                    };
-                    let Some(param) = arena.get_parameter(param_node) else {
-                        return false;
-                    };
-                    return Self::source_file_type_node_is_scope_independent(
-                        arena,
-                        param.type_annotation,
-                    ) && value_is_lowerable(index_signature.type_annotation);
-                }
-                if member_node.kind != syntax_kind_ext::PROPERTY_SIGNATURE {
-                    return false;
-                }
-                let Some(signature) = arena.get_signature(member_node) else {
-                    return false;
-                };
-                if signature.type_parameters.is_some()
-                    || signature.parameters.is_some()
-                    || signature.type_annotation.is_none()
-                {
-                    return false;
-                }
-                if arena
-                    .get(signature.name)
-                    .is_some_and(|name| name.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME)
-                {
-                    return false;
-                }
-                value_is_lowerable(signature.type_annotation)
-            })
-    }
 }
+
+include!("cross_file_direct_alias_chain/type_literal_methods.rs");

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain/type_literal_methods.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain/type_literal_methods.rs
@@ -1,0 +1,58 @@
+impl<'a> CheckerState<'a> {
+    fn source_file_type_literal_properties_are_lowerable(
+        arena: &NodeArena,
+        node: &tsz_parser::parser::node::Node,
+        mut value_is_lowerable: impl FnMut(NodeIndex) -> bool,
+    ) -> bool {
+        let Some(type_literal) = arena.get_type_literal(node) else {
+            return false;
+        };
+        type_literal
+            .members
+            .nodes
+            .iter()
+            .copied()
+            .all(|member_idx| {
+                let Some(member_node) = arena.get(member_idx) else {
+                    return false;
+                };
+                if member_node.kind == syntax_kind_ext::INDEX_SIGNATURE {
+                    let Some(index_signature) = arena.get_index_signature(member_node) else {
+                        return false;
+                    };
+                    let Some(param_idx) = index_signature.parameters.nodes.first().copied() else {
+                        return false;
+                    };
+                    let Some(param_node) = arena.get(param_idx) else {
+                        return false;
+                    };
+                    let Some(param) = arena.get_parameter(param_node) else {
+                        return false;
+                    };
+                    return Self::source_file_type_node_is_scope_independent(
+                        arena,
+                        param.type_annotation,
+                    ) && value_is_lowerable(index_signature.type_annotation);
+                }
+                if member_node.kind != syntax_kind_ext::PROPERTY_SIGNATURE {
+                    return false;
+                }
+                let Some(signature) = arena.get_signature(member_node) else {
+                    return false;
+                };
+                if signature.type_parameters.is_some()
+                    || signature.parameters.is_some()
+                    || signature.type_annotation.is_none()
+                {
+                    return false;
+                }
+                if arena
+                    .get(signature.name)
+                    .is_some_and(|name| name.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME)
+                {
+                    return false;
+                }
+                value_is_lowerable(signature.type_annotation)
+            })
+    }
+}


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
M4-A checker maintainability follow-up from #10605.

## Invariant
When a touched checker shard sits at the §19 hard file-size ceiling, move cohesive helper code into a small sibling shard without changing checker behavior or solver boundaries.

## Scope
- Move `source_file_type_literal_properties_are_lowerable` from `cross_file_direct_alias_chain.rs` into `cross_file_direct_alias_chain/type_literal_methods.rs`.
- Include the new shard from the original module so existing private helper access and call sites remain unchanged.
- Leave direct alias lowering semantics untouched.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: maintainability-only split; no intended checker behavior change.

## Verification
- PASS: `wc -l crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain.rs crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain/type_literal_methods.rs crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain_tests.rs` => parent shard 1945 lines, new shard 58 lines, tests 1929 lines.
- PASS: `cargo nextest run -p tsz-checker --lib direct_source_file_type_alias`
- PASS: `cargo fmt --check`
- PASS: `git diff --check`
- PASS: `python3 scripts/arch/arch_guard.py`

## Coordination Notes
- Closes #10614.
- Follow-up to #10605 after `cross_file_direct_alias_chain.rs` landed exactly at 2000 physical lines.
- No overlap with open solver, relation-policy, emit, or contextual-inference PRs.
