### PR TITLE
fix(bench): attribute single-row target gap sidecars

### DIFF
--- a/scripts/bench/test-tsgo-winner-report.mjs
+++ b/scripts/bench/test-tsgo-winner-report.mjs
@@ -162,6 +162,8 @@ withTempDir((dir) => {
     rows_meeting_target: 1,
     rows_below_target: 3,
     project_rows_below_target: 2,
+    rows_with_attribution: 1,
+    missing_attribution_rows: ["single-file-loss", "vite-vanilla-ts-app"],
     worst_gap: report.target_gaps[0],
   });
   assert.deepEqual(
@@ -276,6 +278,11 @@ withTempDir((dir) => {
     ["BCT candidates=200", "200 classes"],
   );
   assert.equal(report.two_x_target.rows_below_target, 2);
+  assert.equal(report.two_x_target.rows_with_attribution, 0);
+  assert.deepEqual(report.two_x_target.missing_attribution_rows, [
+    "200 classes",
+    "BCT candidates=200",
+  ]);
 });
 
 // Duplicate known project rows make the green-tsgo-winner summary non-authoritative.
@@ -368,6 +375,8 @@ withTempDir((dir) => {
   assert.deepEqual(report.totals.missing_attribution_rows, ["complete-project", "single-file-win"]);
   assert.equal(report.two_x_target.eligible_green_rows, 2);
   assert.equal(report.two_x_target.rows_below_target, 2);
+  assert.equal(report.two_x_target.rows_with_attribution, 0);
+  assert.deepEqual(report.two_x_target.missing_attribution_rows, ["complete-project", "single-file-win"]);
   assert.deepEqual(
     report.target_gaps.map((row) => row.name),
     ["complete-project", "single-file-win"],
@@ -406,6 +415,8 @@ withTempDir((dir) => {
   const report = JSON.parse(fs.readFileSync(output, "utf8"));
   assert.equal(report.two_x_target.rows_meeting_target, 1);
   assert.equal(report.two_x_target.rows_below_target, 2);
+  assert.equal(report.two_x_target.rows_with_attribution, 0);
+  assert.deepEqual(report.two_x_target.missing_attribution_rows, ["target-short", "tsgo-win"]);
   assert.deepEqual(
     report.target_gaps.map((row) => [row.name, row.tsz_speedup_vs_tsgo]),
     [
@@ -413,6 +424,61 @@ withTempDir((dir) => {
       ["target-short", 15 / 10],
     ],
   );
+});
+
+withTempDir((dir) => {
+  const input = path.join(dir, "bench.json");
+  const output = path.join(dir, "report.json");
+  const perfPath = path.join(dir, "bench.perf.json");
+  writeJson(input, {
+    results: [
+      {
+        name: "ts-essentials-project",
+        winner: "tsz",
+        factor: 1.1,
+        tsz_ms: 100,
+        tsgo_ms: 110,
+        compatibility: {
+          state: "green",
+          exit_class: "exit success",
+          phase: "check",
+          last_successful_phase: "check",
+          diagnostic_status: "none",
+          semantic_owner_family: "utility types plus recursive JSON shapes",
+        },
+      },
+    ],
+  });
+  writeJson(perfPath, {
+    mode: "attribution",
+    delegate: { misses: 0 },
+    checker: { with_parent_cache_constructed: 2 },
+    slow_check_file_timings: [
+      { file: "ts-essentials/lib/xor/index.ts", elapsed_ms: 150, diagnostics: 0 },
+    ],
+  });
+
+  const result = spawnSync(process.execPath, [SCRIPT, input, output], {
+    cwd: ROOT,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /2x target gaps with attribution: 1\/1/);
+
+  const report = JSON.parse(fs.readFileSync(output, "utf8"));
+  assert.equal(report.two_x_target.rows_below_target, 1);
+  assert.equal(report.two_x_target.rows_with_attribution, 1);
+  assert.deepEqual(report.two_x_target.missing_attribution_rows, []);
+  assert.deepEqual(report.target_gaps[0].attribution_status, {
+    present: true,
+    path: path.relative(ROOT, perfPath).split(path.sep).join("/"),
+    url: null,
+    generated_at: report.target_gaps[0].attribution_status.generated_at,
+    mode: "attribution",
+    dominant_subsystem: "checker:semantic-check",
+    warning: null,
+  });
+  assert.match(report.target_gaps[0].attribution_status.generated_at, /^\d{4}-\d{2}-\d{2}T/);
 });
 
 const benchWorkflow = fs.readFileSync(BENCH_WORKFLOW, "utf8");

--- a/scripts/bench/tsgo-winner-report.mjs
+++ b/scripts/bench/tsgo-winner-report.mjs
@@ -11,6 +11,10 @@ function readJson(file) {
   return JSON.parse(fs.readFileSync(file, "utf8"));
 }
 
+function toPortablePath(file) {
+  return file.split(path.sep).join("/");
+}
+
 function asNumber(value) {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
@@ -126,7 +130,59 @@ function measurementProfileStatus(input) {
   };
 }
 
-function pickAttributionArtifact(row) {
+function inferDominantSubsystemFromPerfSnapshot(snapshot) {
+  const delegateMisses = asNumber(snapshot?.delegate?.misses) ?? 0;
+  const parentCache = asNumber(snapshot?.checker?.with_parent_cache_constructed) ?? 0;
+  if (delegateMisses > 0 || parentCache > 10) {
+    return "checker:cross-arena-delegation";
+  }
+
+  if (Array.isArray(snapshot?.slow_check_file_timings) && snapshot.slow_check_file_timings.length > 0) {
+    return "checker:semantic-check";
+  }
+
+  const internerCalls = asNumber(snapshot?.interner?.intern_calls) ?? 0;
+  if (internerCalls > 0) {
+    return "solver:type-interning";
+  }
+
+  return null;
+}
+
+function sidecarPerfPath(inputPath) {
+  if (typeof inputPath !== "string" || !inputPath.endsWith(".json")) return null;
+  return inputPath.replace(/\.json$/, ".perf.json");
+}
+
+function singleRowSidecarAttribution(rows, inputPath) {
+  if (rows.length !== 1) return new Map();
+
+  const perfPath = sidecarPerfPath(inputPath);
+  if (!perfPath || !fs.existsSync(perfPath)) return new Map();
+
+  let snapshot;
+  try {
+    snapshot = readJson(perfPath);
+  } catch {
+    return new Map();
+  }
+
+  const row = rows[0];
+  const relativePath = toPortablePath(path.relative(process.cwd(), perfPath));
+  return new Map([
+    [
+      row.name,
+      {
+        path: relativePath,
+        generated_at: fs.statSync(perfPath).mtime.toISOString(),
+        mode: snapshot.mode ?? null,
+        dominant_subsystem: inferDominantSubsystemFromPerfSnapshot(snapshot),
+      },
+    ],
+  ]);
+}
+
+function pickAttributionArtifact(row, fallbackArtifact = null) {
   return (
     row?.attribution_artifact ??
     row?.performance_attribution ??
@@ -134,12 +190,13 @@ function pickAttributionArtifact(row) {
     row?.compatibility?.attribution_artifact ??
     row?.compatibility?.performance_attribution ??
     row?.compatibility?.attribution ??
+    fallbackArtifact ??
     null
   );
 }
 
-function attributionStatusForRow(row) {
-  const artifact = pickAttributionArtifact(row);
+function attributionStatusForRow(row, fallbackArtifact = null) {
+  const artifact = pickAttributionArtifact(row, fallbackArtifact);
   if (!artifact) {
     return {
       present: false,
@@ -235,6 +292,7 @@ function duplicateProjectRows(rows) {
 
 export function createTsgoWinnerReport(input, inputPath) {
   const rows = Array.isArray(input.results) ? input.results : [];
+  const sidecarAttribution = singleRowSidecarAttribution(rows, inputPath);
   const duplicateRows = duplicateProjectRows(rows);
   const duplicateNames = new Set(duplicateRows.map((row) => row.name));
   const incompleteCompatExcluded = rows.filter(isIncompleteCompat).length;
@@ -259,12 +317,16 @@ export function createTsgoWinnerReport(input, inputPath) {
         exit_class: row.compatibility?.exit_class ?? null,
         semantic_owner_family: row.compatibility?.semantic_owner_family ?? null,
         loss_closure: lossClosureForRow(row),
-        attribution_status: attributionStatusForRow(row),
+        attribution_status: attributionStatusForRow(row, sidecarAttribution.get(row.name)),
       };
     });
   const targetGapRows = eligibleRows
     .filter((row) => row.tsz_speedup_vs_tsgo == null || row.tsz_speedup_vs_tsgo < TARGET_TSZ_SPEEDUP)
     .sort(compareTargetGaps);
+  const missingTargetGapAttributionRows = targetGapRows
+    .filter((row) => !hasCompleteAttribution(row.attribution_status))
+    .map((row) => row.name)
+    .sort();
 
   const winners = rows
     .filter((row) => row?.winner === "tsgo" && isGreen(row) && !duplicateNames.has(row?.name))
@@ -281,7 +343,7 @@ export function createTsgoWinnerReport(input, inputPath) {
       exit_class: row.compatibility?.exit_class ?? null,
       semantic_owner_family: row.compatibility?.semantic_owner_family ?? null,
       loss_closure: lossClosureForRow(row),
-      attribution_status: attributionStatusForRow(row),
+      attribution_status: attributionStatusForRow(row, sidecarAttribution.get(row.name)),
     }))
     .sort(compareWinnersByFactorDesc);
 
@@ -335,6 +397,8 @@ export function createTsgoWinnerReport(input, inputPath) {
       rows_meeting_target: eligibleRows.length - targetGapRows.length,
       rows_below_target: targetGapRows.length,
       project_rows_below_target: targetGapRows.filter((row) => row.semantic_owner_family).length,
+      rows_with_attribution: targetGapRows.length - missingTargetGapAttributionRows.length,
+      missing_attribution_rows: missingTargetGapAttributionRows,
       worst_gap: targetGapRows[0] ?? null,
     },
     measurement_profile: measurementProfileStatus(input),
@@ -367,6 +431,7 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
       `green tsgo winners: ${report.totals.green_tsgo_winners}`,
       `project green tsgo winners: ${report.totals.project_green_tsgo_winners}`,
       `2x target gaps: ${report.two_x_target.rows_below_target}/${report.two_x_target.eligible_green_rows}`,
+      `2x target gaps with attribution: ${report.two_x_target.rows_with_attribution}/${report.two_x_target.rows_below_target}`,
       `report: ${path.relative(process.cwd(), outputPath).split(path.sep).join("/")}`,
     ].join("\n"),
   );


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 green-row performance measurement/tooling for the 2x target gate.

## Invariant
When a focused single-row benchmark has a sibling attribution-mode perf-counter sidecar (`<artifact>.perf.json`), the `tsgo-winner-report` should count that row as attributed in the 2x target-gap ledger and surface the dominant subsystem from the sidecar instead of reporting attribution as missing.

## Scope
- Teach `scripts/bench/tsgo-winner-report.mjs` to read a single-row sidecar perf artifact.
- Add 2x target-gap attribution counts and missing-attribution rows to the report.
- Extend `scripts/bench/test-tsgo-winner-report.mjs` coverage for sidecar attribution and target-gap attribution fields.

## Project Corpus Impact
- Row: `ts-essentials-project`
- Bug family: utility-type mapped/conditional/key-space workload with recursive JSON-like shapes
- Evidence: fresh focused timing artifact `/tmp/studio-b-ts-essentials-main-20260527215926.json` is green (`tsc=0`, `tsz=0`, `tsgo=0`) but below the 2x gate: `tsz_ms=162.07`, `tsgo_ms=176.86`, `tsz_speedup_vs_tsgo=1.09`, target gap factor `1.83`. Attribution sidecar `/tmp/studio-b-ts-essentials-main-20260527215926.perf.json` identifies the dominant subsystem as `checker:semantic-check` with `xor/index.ts` the slowest semantic file and cross-arena misses at zero.

## Verification
- `node scripts/bench/test-tsgo-winner-report.mjs`
- `git diff --check origin/main...HEAD`
- `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^ts-essentials-project$' --json-file /tmp/studio-b-ts-essentials-main-20260527215926.json`
- `TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh cargo run -q -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json /tmp/studio-b-ts-essentials-main-20260527215926.perf.json --noEmit -p .target-bench/external/ts-essentials/tsconfig.flat.json`
- `node scripts/bench/tsgo-winner-report.mjs /tmp/studio-b-ts-essentials-main-20260527215926.json /tmp/studio-b-ts-essentials-main-20260527215926.tsgo-winners.after-rebase.json`

## Coordination Notes
- Opened after Studio-B PR #10609 merged and `agent:Studio-B` had no open PRs.
- This is measurement/tooling only; it does not claim to improve row speed or change compiler semantics.
- Current `ts-essentials-project` target gap remains open. This PR makes the next semantic optimization target clearer by linking the single-row timing artifact to the matching attribution sidecar.
- Overlap checked against open PRs and recent merged PRs; no active PR owns this `tsgo-winner-report` sidecar attribution surface.
