### PR TITLE
fix(solver): honor typed relation policy bits

### DIFF
--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -132,11 +132,11 @@ impl RelationPolicy {
         let erase_generics = !flags.contains(RelationFlags::NO_ERASE_GENERICS);
         Self {
             flags,
-            strict_subtype_checking: false,
-            strict_any_propagation: false,
+            strict_subtype_checking: flags.contains(RelationFlags::STRICT_SUBTYPE_CHECKING),
+            strict_any_propagation: flags.contains(RelationFlags::STRICT_ANY_PROPAGATION),
             any_propagation_mode: AnyPropagationMode::All,
             assume_related_on_cycle: true,
-            skip_weak_type_checks: false,
+            skip_weak_type_checks: flags.contains(RelationFlags::SKIP_WEAK_TYPE_CHECKS),
             erase_generics,
         }
     }

--- a/crates/tsz-solver/tests/relation_cache_config_tests/cache_agreement.rs
+++ b/crates/tsz-solver/tests/relation_cache_config_tests/cache_agreement.rs
@@ -397,6 +397,157 @@ fn assignability_cache_strict_any_policy_matches_uncached_relation_query() {
 }
 
 #[test]
+fn typed_strict_any_flag_configures_behavior_and_cache_key() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let value = interner.intern_string("value");
+    let source = interner.object(vec![PropertyInfo::new(value, TypeId::ANY)]);
+    let target = interner.object(vec![PropertyInfo::new(value, TypeId::NUMBER)]);
+    let policy = RelationPolicy::from_relation_flags(RelationFlags::STRICT_ANY_PROPAGATION);
+    let key = RelationCacheKey::for_assignability(source, target, policy.cache_config());
+
+    assert!(
+        policy
+            .cache_config()
+            .flags
+            .contains(RelationFlags::STRICT_ANY_PROPAGATION),
+        "typed strict-any flag must be visible in the cache config",
+    );
+
+    let uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        policy,
+        RelationContext::default(),
+    )
+    .is_related();
+    let cached = db.is_assignable_to_with_policy(source, target, policy);
+
+    assert_eq!(
+        cached, uncached,
+        "typed strict-any flag must drive the same behavior with and without cache",
+    );
+    assert!(
+        !cached,
+        "typed strict-any flag must not only partition the cache; it must also enable strict-any behavior",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(key),
+        Some(cached),
+        "typed strict-any result must be stored under the strict-any cache key",
+    );
+}
+
+#[test]
+fn typed_skip_weak_flag_configures_behavior_and_cache_key() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let optional = interner.intern_string("optional");
+    let unrelated = interner.intern_string("unrelated");
+    let source = interner.object(vec![PropertyInfo::new(unrelated, TypeId::BOOLEAN)]);
+    let target = interner.object(vec![PropertyInfo::opt(optional, TypeId::NUMBER)]);
+    let policy = RelationPolicy::from_relation_flags(RelationFlags::SKIP_WEAK_TYPE_CHECKS);
+    let key = RelationCacheKey::for_assignability(source, target, policy.cache_config());
+
+    assert!(
+        policy
+            .cache_config()
+            .flags
+            .contains(RelationFlags::SKIP_WEAK_TYPE_CHECKS),
+        "typed skip-weak flag must be visible in the cache config",
+    );
+
+    let uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        policy,
+        RelationContext::default(),
+    )
+    .is_related();
+    let cached = db.is_assignable_to_with_policy(source, target, policy);
+
+    assert_eq!(
+        cached, uncached,
+        "typed skip-weak flag must drive the same behavior with and without cache",
+    );
+    assert!(
+        cached,
+        "typed skip-weak flag must not only partition the cache; it must also suppress weak-type rejection",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(key),
+        Some(cached),
+        "typed skip-weak result must be stored under the skip-weak cache key",
+    );
+}
+
+#[test]
+fn typed_strict_subtype_flag_configures_behavior_and_cache_key() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let run = interner.intern_string("run");
+    let name = interner.intern_string("name");
+    let breed = interner.intern_string("breed");
+
+    let animal = interner.object(vec![PropertyInfo::new(name, TypeId::STRING)]);
+    let dog = interner.object(vec![
+        PropertyInfo::new(name, TypeId::STRING),
+        PropertyInfo::new(breed, TypeId::STRING),
+    ]);
+    let dog_method = interner.function(FunctionShape::new(
+        vec![ParamInfo::unnamed(dog)],
+        TypeId::VOID,
+    ));
+    let animal_method = interner.function(FunctionShape::new(
+        vec![ParamInfo::unnamed(animal)],
+        TypeId::VOID,
+    ));
+    let source = interner.object(vec![PropertyInfo::method(run, dog_method)]);
+    let target = interner.object(vec![PropertyInfo::method(run, animal_method)]);
+    let policy = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_FUNCTION_TYPES | RelationFlags::STRICT_SUBTYPE_CHECKING,
+    );
+    let key = RelationCacheKey::for_assignability(source, target, policy.cache_config());
+
+    assert!(
+        policy
+            .cache_config()
+            .flags
+            .contains(RelationFlags::STRICT_SUBTYPE_CHECKING),
+        "typed strict-subtype flag must be visible in the cache config",
+    );
+
+    let uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        policy,
+        RelationContext::default(),
+    )
+    .is_related();
+    let cached = db.is_assignable_to_with_policy(source, target, policy);
+
+    assert_eq!(
+        cached, uncached,
+        "typed strict-subtype flag must drive the same behavior with and without cache",
+    );
+    assert!(
+        !cached,
+        "typed strict-subtype flag must not only partition the cache; it must also disable method bivariance",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(key),
+        Some(cached),
+        "typed strict-subtype result must be stored under the strict-subtype cache key",
+    );
+}
+
+#[test]
 fn subtype_cache_top_level_only_any_mode_matches_uncached_policy() {
     let interner = TypeInterner::new();
     let db = QueryCache::new(&interner);


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 4 solver relation policy/cache-key cleanup for #8207.

## Invariant
When typed `RelationFlags` carries behavior bits that already have engine-facing `RelationPolicy` booleans, `RelationPolicy::from_relation_flags` must configure both the cache key and the behavior booleans. This PR keeps typed callers from creating strict or skip cache slots while running non-strict or non-skip relation behavior.

## Scope
- `crates/tsz-solver/src/relations/relation_queries.rs`
- `crates/tsz-solver/tests/relation_cache_config_tests/cache_agreement.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: solver relation-policy/cache-key unit coverage only; no project corpus row or emit behavior changed.

## Verification
- RED: `cargo nextest run -p tsz-solver -E 'test(typed_strict_any_flag_configures_behavior_and_cache_key) | test(typed_skip_weak_flag_configures_behavior_and_cache_key) | test(typed_strict_subtype_flag_configures_behavior_and_cache_key)'` failed before the fix because typed strict-any, skip-weak, and strict-subtype bits only partitioned cache keys.
- GREEN: `cargo nextest run -p tsz-solver -E 'test(typed_strict_any_flag_configures_behavior_and_cache_key) | test(typed_skip_weak_flag_configures_behavior_and_cache_key) | test(typed_strict_subtype_flag_configures_behavior_and_cache_key)'` passed: 3 passed, 6340 skipped.
- GREEN after rebase to `eaea3eef224`: `cargo nextest run -p tsz-solver -E 'test(relation_cache_config_tests)'` passed: 50 passed, 6293 skipped.
- GREEN after rebase to `eaea3eef224`: `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'` passed: 7 passed, 6336 skipped.
- GREEN after rebase to `eaea3eef224`: `cargo fmt --check`.
- GREEN after rebase to `eaea3eef224`: `git diff --check HEAD~1..HEAD`.
- GREEN after rebase to `eaea3eef224`: `python3 scripts/arch/arch_guard.py`.
- GREEN draft-light CI on head `d12e9924fc4fc6fce2f7d16ed4fdb5df7cf12251`: `CI Light Summary`, `lint`, `unit`, `dist-binaries`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, and `project-row-drift` passed in https://github.com/mohsen1/tsz/actions/runs/26536370575.

## Coordination Notes
- Coordinates with #8207.
- I checked open PRs before publishing; this stays in solver policy/cache-key construction and does not overlap with M1-B checker relation-routing work in #10537.
- Ready for review after green draft-light CI on the exact head.
- No `WIP` label, no auto-merge, and no `merge-queue` label while ready-review CI is pending.
