### PR TITLE
fix(bench): skip stale prep artifact waits

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -561,11 +561,43 @@ jobs:
           bash scripts/install.sh --version latest --dir "${install_dir}"
           "${install_dir}/tsz" --version
 
-  bench-prep-artifact:
-    name: bench-prep-artifact
+  bench-prep-target-fresh:
+    name: bench-prep-target-fresh
     needs: [bench-prepare, bench-prepare-cloudbuild]
     if: >-
       always() &&
+      (needs.bench-prepare.outputs.should_run == 'true' ||
+       (!(github.event_name == 'workflow_dispatch' && inputs.publish_latest_pgo) &&
+        !(github.event_name == 'schedule' && github.event.schedule == '0 3 * * *') &&
+        !(github.event_name == 'schedule' && github.event.schedule == '0 5 * * *') &&
+        needs.bench-prepare-cloudbuild.outputs.should_run == 'true')) &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.fresh.outputs.should_run }}
+    steps:
+      - id: fresh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          should_run=true
+          target_sha="${{ env.BENCH_TARGET_SHA }}"
+          main_sha="$(gh api "repos/${{ github.repository }}/git/ref/heads/main" --jq '.object.sha' 2>/dev/null || true)"
+          if [[ -n "$main_sha" && "$target_sha" != "$main_sha" ]]; then
+            echo "Benchmark target ${target_sha} became stale before prep artifact download; current main is ${main_sha}. Skipping self-hosted prep wait."
+            should_run=false
+          fi
+          echo "should_run=${should_run}" >> "$GITHUB_OUTPUT"
+
+  bench-prep-artifact:
+    name: bench-prep-artifact
+    needs: [bench-prepare, bench-prepare-cloudbuild, bench-prep-target-fresh]
+    if: >-
+      always() &&
+      needs.bench-prep-target-fresh.outputs.should_run == 'true' &&
       (needs.bench-prepare.outputs.should_run == 'true' ||
        (!(github.event_name == 'workflow_dispatch' && inputs.publish_latest_pgo) &&
         !(github.event_name == 'schedule' && github.event.schedule == '0 3 * * *') &&

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -142,6 +142,12 @@ assert.match(
 
 assert.match(
   workflow,
+  /bench-prep-target-fresh:[\s\S]+needs: \[bench-prepare, bench-prepare-cloudbuild\][\s\S]+target_sha="\$\{\{ env\.BENCH_TARGET_SHA \}\}"[\s\S]+main_sha="\$\(gh api "repos\/\$\{\{ github\.repository \}\}\/git\/ref\/heads\/main" --jq '\.object\.sha' 2>\/dev\/null \|\| true\)"[\s\S]+Benchmark target \$\{target_sha\} became stale before prep artifact download; current main is \$\{main_sha\}\. Skipping self-hosted prep wait\.[\s\S]+echo "should_run=\$\{should_run\}" >> "\$GITHUB_OUTPUT"[\s\S]+bench-prep-artifact:[\s\S]+needs: \[bench-prepare, bench-prepare-cloudbuild, bench-prep-target-fresh\][\s\S]+needs\.bench-prep-target-fresh\.outputs\.should_run == 'true'/,
+  "bench prep artifact polling should re-check target freshness before occupying a self-hosted runner",
+);
+
+assert.match(
+  workflow,
   /bench-target-fresh:[\s\S]+needs: bench-prep-artifact[\s\S]+target_sha="\$\{\{ env\.BENCH_TARGET_SHA \}\}"[\s\S]+main_sha="\$\(gh api "repos\/\$\{\{ github\.repository \}\}\/git\/ref\/heads\/main" --jq '\.object\.sha' 2>\/dev\/null \|\| true\)"[\s\S]+Benchmark target \$\{target_sha\} became stale after prep; current main is \$\{main_sha\}\. Skipping shard fanout\.[\s\S]+echo "should_run=\$\{should_run\}" >> "\$GITHUB_OUTPUT"[\s\S]+bench:[\s\S]+needs: \[bench-prep-artifact, bench-target-fresh\][\s\S]+needs\.bench-target-fresh\.outputs\.should_run == 'true'/,
   "bench shards should re-check target freshness after prep so obsolete runs cannot fan out while a current-main run is active",
 );


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 1 benchmark blocker: Bench artifact freshness and project-corpus metric truth.

## Invariant
When a Bench target becomes stale after prep submission but before the self-hosted prep artifact polling job starts, the workflow should skip the long prep wait instead of occupying a runner for an obsolete target; this PR changes the Bench workflow gate surface.

## Scope
- `.github/workflows/bench.yml`: add `bench-prep-target-fresh` before `bench-prep-artifact` and gate the self-hosted prep artifact job on that freshness result.
- `scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`: assert stale targets are checked before prep artifact polling and still checked after prep before shard fanout.

## Project Corpus Impact
- Row: n/a
- Bug family: benchmark freshness / stale prep artifact wait
- Evidence: workflow-only guard; no compiler behavior, fixture metadata, project row definitions, or benchmark timing semantics changed.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Observed stale manual Bench run `26536196704` on `304a17039061d876561ea656f10d413e165b99b6` remain in `bench-prep-artifact` after current `main` advanced to `eaea3eef224507bd463b50e65520b897d3048569`; cancellation was requested, but the run continued to occupy the prep artifact wait.
- Existing post-prep `bench-target-fresh` is preserved so shard fanout is still guarded if `main` advances during prep.
- Rebased onto `0b15795787` after #10616 merged; focused workflow tests still pass.