### PR TITLE
refactor(checker): share flow global identity helper

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/type_guards.rs
+++ b/crates/tsz-checker/src/flow/control_flow/type_guards.rs
@@ -12,6 +12,7 @@ use crate::state::MAX_TREE_WALK_ITERATIONS;
 
 use super::FlowAnalyzer;
 use crate::query_boundaries::flow_analysis::{self as flow_query, TypeResolver};
+use crate::types_domain::property_access_type::known_globals;
 
 pub(crate) fn reference_is_in_class_property_initializer(
     arena: &NodeArena,
@@ -578,18 +579,11 @@ impl<'a> FlowAnalyzer<'a> {
                 // The lib.d.ts instance types may be Lazy references that the solver's
                 // is_object_interface/is_function_interface_structural checks don't match.
                 let ctor_expr = self.skip_parens_and_assertions(bin.right);
-                if let Some(ident) = self.arena.get_identifier_at(ctor_expr) {
-                    let name = &ident.escaped_text;
-                    if name == "Object" && self.is_builtin_global_reference(ctor_expr) {
-                        return Some((TypeGuard::Instanceof(TypeId::OBJECT, true), target, false));
-                    }
-                    if name == "Function" && self.is_builtin_global_reference(ctor_expr) {
-                        return Some((
-                            TypeGuard::Instanceof(TypeId::FUNCTION, true),
-                            target,
-                            false,
-                        ));
-                    }
+                if self.identifier_resolves_to_unshadowed_global(ctor_expr, "Object") {
+                    return Some((TypeGuard::Instanceof(TypeId::OBJECT, true), target, false));
+                }
+                if self.identifier_resolves_to_unshadowed_global(ctor_expr, "Function") {
+                    return Some((TypeGuard::Instanceof(TypeId::FUNCTION, true), target, false));
                 }
                 return Some((TypeGuard::Instanceof(instance_type, false), target, false));
             }
@@ -888,10 +882,9 @@ impl<'a> FlowAnalyzer<'a> {
             .and_then(|node| self.arena.get_identifier(node))
             .map(|ident| ident.escaped_text.as_str())?;
 
-        if obj_text != "Array" {
-            return None;
-        }
-        if !self.is_builtin_global_reference(access.expression) {
+        if obj_text != "Array"
+            || !self.identifier_resolves_to_unshadowed_global(access.expression, "Array")
+        {
             return None;
         }
 
@@ -965,10 +958,9 @@ impl<'a> FlowAnalyzer<'a> {
             .get(access.expression)
             .and_then(|node| self.arena.get_identifier(node))
             .map(|ident| ident.escaped_text.as_str())?;
-        if obj_text != "ArrayBuffer" {
-            return None;
-        }
-        if !self.is_builtin_global_reference(access.expression) {
+        if obj_text != "ArrayBuffer"
+            || !self.identifier_resolves_to_unshadowed_global(access.expression, "ArrayBuffer")
+        {
             return None;
         }
 
@@ -1032,10 +1024,28 @@ impl<'a> FlowAnalyzer<'a> {
         ))
     }
 
-    fn is_builtin_global_reference(&self, reference: NodeIndex) -> bool {
-        self.binder
-            .resolve_identifier(self.arena, reference)
-            .is_none_or(|symbol_id| self.binder.lib_symbol_ids.contains(&symbol_id))
+    fn identifier_resolves_to_unshadowed_global(&self, reference: NodeIndex, name: &str) -> bool {
+        if let Some(ctx) = self.checker_context {
+            return known_globals::identifier_resolves_to_unshadowed_global_in_context(
+                ctx,
+                self.arena,
+                self.binder,
+                reference,
+                name,
+            );
+        }
+
+        let Some(node) = self.arena.get(reference) else {
+            return false;
+        };
+        let Some(ident) = self.arena.get_identifier(node) else {
+            return false;
+        };
+        ident.escaped_text == name
+            && self
+                .binder
+                .resolve_identifier(self.arena, reference)
+                .is_none_or(|symbol_id| self.binder.lib_symbol_ids.contains(&symbol_id))
     }
 
     /// Check if a call is `array.every(predicate)` where predicate has a type predicate.

--- a/crates/tsz-checker/src/tests/object_global_identity_helper_tests.rs
+++ b/crates/tsz-checker/src/tests/object_global_identity_helper_tests.rs
@@ -60,3 +60,21 @@ fn arena_global_identity_helper_accepts_target_binder_lib_clones() {
         "arena-aware global identity helper must accept lib clones recorded on the target binder"
     );
 }
+
+#[test]
+fn flow_instanceof_uses_global_identity_helper() {
+    let source = include_str!("../flow/control_flow/type_guards.rs");
+    assert!(
+        source.contains("identifier_resolves_to_unshadowed_global(ctor_expr, \"Object\")")
+            && source.contains("identifier_resolves_to_unshadowed_global(ctor_expr, \"Function\")"),
+        "`instanceof Object/Function` narrowing must route through the shared global identity helper"
+    );
+    assert!(
+        source.contains("known_globals::identifier_resolves_to_unshadowed_global_in_context"),
+        "flow's global identity adapter must delegate to the shared context helper"
+    );
+    assert!(
+        !source.contains("fn is_builtin_global_reference"),
+        "flow guards must not keep a name-agnostic local builtin-global helper"
+    );
+}

--- a/crates/tsz-checker/src/types/property_access_type/known_globals.rs
+++ b/crates/tsz-checker/src/types/property_access_type/known_globals.rs
@@ -1,10 +1,182 @@
 //! Helpers for distinguishing built-in globals from same-named local values.
 
+use crate::context::CheckerContext;
 use crate::state::CheckerState;
-use tsz_binder::BinderState;
+use tsz_binder::{BinderState, SymbolId};
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::node::NodeArena;
+
+pub(crate) fn known_global_identifier_resolves_to_lib_value_in_context(
+    ctx: &CheckerContext<'_>,
+    arena: &NodeArena,
+    binder: &BinderState,
+    idx: NodeIndex,
+    name: &str,
+) -> bool {
+    if let Some(sym_id) = binder.resolve_identifier(arena, idx) {
+        let Some(symbol) = binder
+            .get_symbol(sym_id)
+            .or_else(|| ctx.binder.get_symbol(sym_id))
+        else {
+            return false;
+        };
+        if symbol.escaped_name == name
+            && (ctx.symbol_is_from_actual_or_cloned_lib(sym_id)
+                || binder.lib_symbol_ids.contains(&sym_id)
+                || ctx.symbol_is_from_lib(sym_id))
+        {
+            return true;
+        }
+
+        return !known_global_value_has_local_shadow_in_context(ctx, arena, binder, idx, name);
+    }
+
+    !known_global_value_has_local_shadow_in_context(ctx, arena, binder, idx, name)
+}
+
+pub(crate) fn identifier_resolves_to_unshadowed_global_in_context(
+    ctx: &CheckerContext<'_>,
+    arena: &NodeArena,
+    binder: &BinderState,
+    idx: NodeIndex,
+    name: &str,
+) -> bool {
+    let Some(node) = arena.get(idx) else {
+        return false;
+    };
+    let Some(ident) = arena.get_identifier(node) else {
+        return false;
+    };
+    if ident.escaped_text.as_str() != name {
+        return false;
+    }
+    known_global_identifier_resolves_to_lib_value_in_context(ctx, arena, binder, idx, name)
+}
+
+pub(crate) fn known_global_value_has_local_shadow_in_context(
+    ctx: &CheckerContext<'_>,
+    arena: &NodeArena,
+    binder: &BinderState,
+    idx: NodeIndex,
+    name: &str,
+) -> bool {
+    if let Some(mut scope_id) = binder.find_enclosing_scope(arena, idx) {
+        let mut iterations = 0;
+        while scope_id.is_some() {
+            iterations += 1;
+            if iterations > crate::state::MAX_TREE_WALK_ITERATIONS {
+                break;
+            }
+            let Some(scope) = binder.scopes.get(scope_id.0 as usize) else {
+                break;
+            };
+            if let Some(sym_id) = scope.table.get(name) {
+                if binder.lib_symbol_ids.contains(&sym_id)
+                    || ctx.symbol_is_from_actual_lib(sym_id)
+                    || ctx.symbol_is_from_lib(sym_id)
+                {
+                    scope_id = scope.parent;
+                    continue;
+                }
+                let Some(symbol) = binder
+                    .get_symbol(sym_id)
+                    .or_else(|| ctx.binder.get_symbol(sym_id))
+                else {
+                    return true;
+                };
+                if symbol.escaped_name == name
+                    && symbol.declarations.iter().copied().any(|decl_idx| {
+                        arena_value_declares_name(arena, binder, sym_id, decl_idx, name)
+                    })
+                {
+                    return true;
+                }
+            }
+            scope_id = scope.parent;
+        }
+    }
+
+    let Some(sym_id) = binder.resolve_identifier(arena, idx) else {
+        return false;
+    };
+    let Some(symbol) = binder
+        .get_symbol(sym_id)
+        .or_else(|| ctx.binder.get_symbol(sym_id))
+    else {
+        return false;
+    };
+    if symbol.escaped_name != name {
+        return false;
+    }
+    let mut declarations = symbol.declarations.clone();
+    if symbol.value_declaration.is_some() && !declarations.contains(&symbol.value_declaration) {
+        declarations.push(symbol.value_declaration);
+    }
+
+    if !binder.lib_symbol_ids.contains(&sym_id)
+        && !ctx.symbol_is_from_actual_lib(sym_id)
+        && !ctx.symbol_is_from_lib(sym_id)
+    {
+        return declarations
+            .into_iter()
+            .any(|decl_idx| arena_value_declares_name(arena, binder, sym_id, decl_idx, name));
+    }
+
+    declarations
+        .into_iter()
+        .any(|decl_idx| arena_value_declares_name(arena, binder, sym_id, decl_idx, name))
+}
+
+fn arena_value_declares_name(
+    arena: &NodeArena,
+    binder: &BinderState,
+    sym_id: SymbolId,
+    decl_idx: NodeIndex,
+    name: &str,
+) -> bool {
+    if !decl_idx.is_some() {
+        return false;
+    }
+
+    if let Some(arenas) = binder.declaration_arenas.get(&(sym_id, decl_idx)) {
+        if !arenas
+            .iter()
+            .any(|known| std::ptr::eq(known.as_ref(), arena))
+        {
+            return false;
+        }
+    } else if binder.symbol_arenas.contains_key(&sym_id) {
+        return false;
+    }
+
+    let Some(node) = arena.get(decl_idx) else {
+        return false;
+    };
+
+    if let Some(var_decl) = arena.get_variable_declaration(node) {
+        return arena
+            .get_identifier_text(var_decl.name)
+            .is_some_and(|decl_name| decl_name == name);
+    }
+    if let Some(class_decl) = arena.get_class(node) {
+        return arena
+            .get_identifier_text(class_decl.name)
+            .is_some_and(|decl_name| decl_name == name);
+    }
+    if let Some(function_decl) = arena.get_function(node) {
+        return arena
+            .get_identifier_text(function_decl.name)
+            .is_some_and(|decl_name| decl_name == name);
+    }
+    if let Some(enum_decl) = arena.get_enum(node) {
+        return arena
+            .get_identifier_text(enum_decl.name)
+            .is_some_and(|decl_name| decl_name == name);
+    }
+
+    false
+}
 
 impl<'a> CheckerState<'a> {
     pub(crate) fn known_global_identifier_resolves_to_lib_value(
@@ -12,16 +184,13 @@ impl<'a> CheckerState<'a> {
         idx: NodeIndex,
         name: &str,
     ) -> bool {
-        if let Some(sym_id) = self.resolve_identifier_symbol_without_tracking(idx) {
-            let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
-                return false;
-            };
-            return symbol.escaped_name == name
-                && (self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id)
-                    || self.ctx.symbol_is_from_lib(sym_id));
-        }
-
-        !self.known_global_value_has_local_shadow(idx, name)
+        known_global_identifier_resolves_to_lib_value_in_context(
+            &self.ctx,
+            self.ctx.arena,
+            self.ctx.binder,
+            idx,
+            name,
+        )
     }
 
     pub(crate) fn known_global_identifier_resolves_to_lib_value_in_arena(
@@ -31,25 +200,9 @@ impl<'a> CheckerState<'a> {
         idx: NodeIndex,
         name: &str,
     ) -> bool {
-        if let Some(sym_id) = binder.resolve_identifier(arena, idx) {
-            let Some(symbol) = binder
-                .get_symbol(sym_id)
-                .or_else(|| self.ctx.binder.get_symbol(sym_id))
-            else {
-                return false;
-            };
-            if symbol.escaped_name == name
-                && (self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id)
-                    || binder.lib_symbol_ids.contains(&sym_id)
-                    || self.ctx.symbol_is_from_lib(sym_id))
-            {
-                return true;
-            }
-
-            return !self.known_global_value_has_local_shadow_in_arena(arena, binder, idx, name);
-        }
-
-        !self.known_global_value_has_local_shadow_in_arena(arena, binder, idx, name)
+        known_global_identifier_resolves_to_lib_value_in_context(
+            &self.ctx, arena, binder, idx, name,
+        )
     }
 
     /// Returns `true` if the node at `idx` is an identifier spelled `name` and
@@ -60,16 +213,13 @@ impl<'a> CheckerState<'a> {
         idx: NodeIndex,
         name: &str,
     ) -> bool {
-        let Some(node) = self.ctx.arena.get(idx) else {
-            return false;
-        };
-        let Some(ident) = self.ctx.arena.get_identifier(node) else {
-            return false;
-        };
-        if ident.escaped_text.as_str() != name {
-            return false;
-        }
-        self.known_global_identifier_resolves_to_lib_value(idx, name)
+        identifier_resolves_to_unshadowed_global_in_context(
+            &self.ctx,
+            self.ctx.arena,
+            self.ctx.binder,
+            idx,
+            name,
+        )
     }
 
     /// Arena-aware form of [`Self::identifier_resolves_to_unshadowed_global`]
@@ -81,16 +231,7 @@ impl<'a> CheckerState<'a> {
         idx: NodeIndex,
         name: &str,
     ) -> bool {
-        let Some(node) = arena.get(idx) else {
-            return false;
-        };
-        let Some(ident) = arena.get_identifier(node) else {
-            return false;
-        };
-        if ident.escaped_text.as_str() != name {
-            return false;
-        }
-        self.known_global_identifier_resolves_to_lib_value_in_arena(arena, binder, idx, name)
+        identifier_resolves_to_unshadowed_global_in_context(&self.ctx, arena, binder, idx, name)
     }
 
     /// Returns `true` if the node at `idx` is an identifier spelled `name` and
@@ -129,48 +270,13 @@ impl<'a> CheckerState<'a> {
     }
 
     pub(crate) fn known_global_value_has_local_shadow(&self, idx: NodeIndex, name: &str) -> bool {
-        if let Some(mut scope_id) = self.ctx.binder.find_enclosing_scope(self.ctx.arena, idx) {
-            let mut iterations = 0;
-            while scope_id.is_some() {
-                iterations += 1;
-                if iterations > crate::state::MAX_TREE_WALK_ITERATIONS {
-                    break;
-                }
-                let Some(scope) = self.ctx.binder.scopes.get(scope_id.0 as usize) else {
-                    break;
-                };
-                if let Some(sym_id) = scope.table.get(name)
-                    && !self.ctx.symbol_is_from_actual_lib(sym_id)
-                    && !self.ctx.symbol_is_from_lib(sym_id)
-                {
-                    return true;
-                }
-                scope_id = scope.parent;
-            }
-        }
-
-        let Some(sym_id) = self.resolve_identifier_symbol_without_tracking(idx) else {
-            return false;
-        };
-        let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
-            return false;
-        };
-        if symbol.escaped_name != name {
-            return false;
-        }
-        if !self.ctx.symbol_is_from_actual_lib(sym_id) && !self.ctx.symbol_is_from_lib(sym_id) {
-            return true;
-        }
-
-        let mut declarations = symbol.declarations.clone();
-        if symbol.value_declaration.is_some() && !declarations.contains(&symbol.value_declaration) {
-            declarations.push(symbol.value_declaration);
-        }
-
-        declarations
-            .into_iter()
-            .filter(|decl| decl.is_some())
-            .any(|decl| self.current_arena_value_declares_name(sym_id, decl, name))
+        known_global_value_has_local_shadow_in_context(
+            &self.ctx,
+            self.ctx.arena,
+            self.ctx.binder,
+            idx,
+            name,
+        )
     }
 
     pub(crate) fn known_global_value_has_local_shadow_in_arena(
@@ -180,130 +286,6 @@ impl<'a> CheckerState<'a> {
         idx: NodeIndex,
         name: &str,
     ) -> bool {
-        if let Some(mut scope_id) = binder.find_enclosing_scope(arena, idx) {
-            let mut iterations = 0;
-            while scope_id.is_some() {
-                iterations += 1;
-                if iterations > crate::state::MAX_TREE_WALK_ITERATIONS {
-                    break;
-                }
-                let Some(scope) = binder.scopes.get(scope_id.0 as usize) else {
-                    break;
-                };
-                if let Some(sym_id) = scope.table.get(name) {
-                    if binder.lib_symbol_ids.contains(&sym_id)
-                        || self.ctx.symbol_is_from_actual_lib(sym_id)
-                        || self.ctx.symbol_is_from_lib(sym_id)
-                    {
-                        scope_id = scope.parent;
-                        continue;
-                    }
-                    let Some(symbol) = binder
-                        .get_symbol(sym_id)
-                        .or_else(|| self.ctx.binder.get_symbol(sym_id))
-                    else {
-                        return true;
-                    };
-                    if symbol.escaped_name == name
-                        && symbol.declarations.iter().copied().any(|decl_idx| {
-                            self.arena_value_declares_name(arena, binder, sym_id, decl_idx, name)
-                        })
-                    {
-                        return true;
-                    }
-                }
-                scope_id = scope.parent;
-            }
-        }
-
-        let Some(sym_id) = binder.resolve_identifier(arena, idx) else {
-            return false;
-        };
-        let Some(symbol) = binder
-            .get_symbol(sym_id)
-            .or_else(|| self.ctx.binder.get_symbol(sym_id))
-        else {
-            return false;
-        };
-        if symbol.escaped_name != name {
-            return false;
-        }
-        let mut declarations = symbol.declarations.clone();
-        if symbol.value_declaration.is_some() && !declarations.contains(&symbol.value_declaration) {
-            declarations.push(symbol.value_declaration);
-        }
-
-        if !binder.lib_symbol_ids.contains(&sym_id)
-            && !self.ctx.symbol_is_from_actual_lib(sym_id)
-            && !self.ctx.symbol_is_from_lib(sym_id)
-        {
-            return declarations.into_iter().any(|decl_idx| {
-                self.arena_value_declares_name(arena, binder, sym_id, decl_idx, name)
-            });
-        }
-
-        declarations
-            .into_iter()
-            .any(|decl_idx| self.arena_value_declares_name(arena, binder, sym_id, decl_idx, name))
-    }
-
-    fn current_arena_value_declares_name(
-        &self,
-        sym_id: tsz_binder::SymbolId,
-        decl_idx: NodeIndex,
-        name: &str,
-    ) -> bool {
-        self.arena_value_declares_name(self.ctx.arena, self.ctx.binder, sym_id, decl_idx, name)
-    }
-
-    fn arena_value_declares_name(
-        &self,
-        arena: &NodeArena,
-        binder: &BinderState,
-        sym_id: tsz_binder::SymbolId,
-        decl_idx: NodeIndex,
-        name: &str,
-    ) -> bool {
-        if !decl_idx.is_some() {
-            return false;
-        }
-
-        if let Some(arenas) = binder.declaration_arenas.get(&(sym_id, decl_idx)) {
-            if !arenas
-                .iter()
-                .any(|known| std::ptr::eq(known.as_ref(), arena))
-            {
-                return false;
-            }
-        } else if binder.symbol_arenas.contains_key(&sym_id) {
-            return false;
-        }
-
-        let Some(node) = arena.get(decl_idx) else {
-            return false;
-        };
-
-        if let Some(var_decl) = arena.get_variable_declaration(node) {
-            return arena
-                .get_identifier_text(var_decl.name)
-                .is_some_and(|decl_name| decl_name == name);
-        }
-        if let Some(class_decl) = arena.get_class(node) {
-            return arena
-                .get_identifier_text(class_decl.name)
-                .is_some_and(|decl_name| decl_name == name);
-        }
-        if let Some(function_decl) = arena.get_function(node) {
-            return arena
-                .get_identifier_text(function_decl.name)
-                .is_some_and(|decl_name| decl_name == name);
-        }
-        if let Some(enum_decl) = arena.get_enum(node) {
-            return arena
-                .get_identifier_text(enum_decl.name)
-                .is_some_and(|decl_name| decl_name == name);
-        }
-
-        false
+        known_global_value_has_local_shadow_in_context(&self.ctx, arena, binder, idx, name)
     }
 }

--- a/crates/tsz-checker/src/types/property_access_type/mod.rs
+++ b/crates/tsz-checker/src/types/property_access_type/mod.rs
@@ -4,7 +4,7 @@
 mod class_recovery;
 mod helpers;
 mod imported_array_to_enum;
-mod known_globals;
+pub(crate) mod known_globals;
 mod nullish_access;
 mod optional_chain_cache;
 mod partial_initializer;


### PR DESCRIPTION
## Agent
AgentName: M4-D

## Track
Semantic identity cleanup / refactor-only follow-up to #10611.

## Invariant
When flow narrowing sees `instanceof Object` or `instanceof Function`, tsz should prove the constructor identifier is the built-in global via binder/global identity before using the well-known intrinsic `TypeId`. Same-named local constructors must continue narrowing to their local instance types. This PR routes that proof through the shared global identity helper.

## Scope
- Lift the Object/Function global identity helper logic into a context-level helper usable outside `CheckerState`.
- Keep the existing `CheckerState` helper methods as thin delegates.
- Route flow guard recognition for `instanceof Object` / `instanceof Function`, `Array.isArray`, and `ArrayBuffer.isView` through the shared helper adapter.
- Add a source guard so flow does not keep a name-agnostic builtin-global helper.

## Project Corpus Impact
- Row: n/a
- Bug family: stable semantic identity / well-known globals
- Evidence: refactor-only; targeted flow behavior tests preserve shadowed local Object/Function/Array/ArrayBuffer behavior.

## Verification
- `cargo nextest run -p tsz-checker --lib flow_instanceof_uses_global_identity_helper` (RED before implementation)
- `cargo nextest run -p tsz-checker --lib flow_instanceof_uses_global_identity_helper` (after rebase onto `main`)
- `cargo nextest run -p tsz-checker --lib object_global_identity_helper_tests` (after rebase onto `main`)
- `cargo nextest run -p tsz-checker --test ts2339_union_narrow_display_tests shadowed_object_and_function_instanceof_use_local_constructor_instances` (after rebase onto `main`)
- `cargo nextest run -p tsz-checker --test control_flow_type_guard_tests shadowed_builtin_guard_names_do_not_narrow` (after rebase onto `main`)
- `cargo fmt --check` (after rebase onto `main`)
- `git diff --check origin/main...HEAD` (after rebase onto `main`)
- `python3 scripts/arch/arch_guard.py` (after rebase onto `main`)

## Coordination Notes
- AgentName: M4-D
- #10611 merged into `main` at `afbc28468d7`; this PR is now based directly on `main`.
- Rebased #10619 onto `origin/main`; latest reviewed head is `5ebfc0952fcf0ed587c53249817520ef29faee0a`.
- Ready for review after the stack base landed; no WIP blocker remains.
- Fixed PR body metadata bullets after `project-corpus-pr-body` rejected the non-bulleted `Row` / `Bug family` lines.
