### PR TITLE
fix(dts): avoid this-type output surgery

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_object_args.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_object_args.rs
@@ -340,7 +340,6 @@ impl<'a> DeclarationEmitter<'a> {
             else {
                 continue;
             };
-            let searchable = Self::type_text_without_this_type_markers(&member_type_text);
             for type_param_name in type_param_names {
                 if !Self::type_node_exposes_direct_type_param(
                     source_arena,
@@ -352,12 +351,14 @@ impl<'a> DeclarationEmitter<'a> {
                 ) {
                     continue;
                 }
-                let mentions_param =
-                    Self::contains_whole_word_in_text(&searchable, type_param_name)
-                        || aliases.iter().any(|(alias, mapped)| {
-                            mapped == type_param_name
-                                && Self::contains_whole_word_in_text(&searchable, alias)
-                        });
+                let mentions_param = Self::type_node_mentions_mapped_name_outside_this_type(
+                    source_arena,
+                    signature.type_annotation,
+                    type_param_name,
+                    type_param_names,
+                    aliases,
+                    0,
+                );
                 if !mentions_param
                     || substitutions
                         .iter()
@@ -367,7 +368,7 @@ impl<'a> DeclarationEmitter<'a> {
                 }
                 if let Some(value_text) = self.object_member_public_type_text_for_annotation(
                     arg_member_idx,
-                    &searchable,
+                    &member_type_text,
                     Some(arg_idx),
                     substitutions,
                 ) {
@@ -449,6 +450,119 @@ impl<'a> DeclarationEmitter<'a> {
                         })
                     })
             }
+            _ => false,
+        }
+    }
+
+    fn type_node_mentions_mapped_name_outside_this_type(
+        source_arena: &NodeArena,
+        type_idx: NodeIndex,
+        type_param_name: &str,
+        type_param_names: &[String],
+        aliases: &[(String, String)],
+        depth: u8,
+    ) -> bool {
+        if depth > 16 {
+            return false;
+        }
+        let Some(type_node) = source_arena.get(type_idx) else {
+            return false;
+        };
+        match type_node.kind {
+            k if k == SyntaxKind::Identifier as u16 => {
+                identifier_text(source_arena, type_idx)
+                    .and_then(|name| Self::mapped_type_param_name(&name, type_param_names, aliases))
+                    .as_deref()
+                    == Some(type_param_name)
+            }
+            k if k == syntax_kind_ext::TYPE_REFERENCE => {
+                let Some(type_ref) = source_arena.get_type_ref(type_node) else {
+                    return false;
+                };
+                let Some(type_name) = identifier_text(source_arena, type_ref.type_name) else {
+                    return false;
+                };
+                if type_name == "ThisType" {
+                    return false;
+                }
+                if Self::mapped_type_param_name(&type_name, type_param_names, aliases).as_deref()
+                    == Some(type_param_name)
+                {
+                    return true;
+                }
+                type_ref.type_arguments.as_ref().is_some_and(|type_args| {
+                    type_args.nodes.iter().copied().any(|arg_idx| {
+                        Self::type_node_mentions_mapped_name_outside_this_type(
+                            source_arena,
+                            arg_idx,
+                            type_param_name,
+                            type_param_names,
+                            aliases,
+                            depth + 1,
+                        )
+                    })
+                })
+            }
+            k if k == syntax_kind_ext::PARENTHESIZED_TYPE => source_arena
+                .get_wrapped_type(type_node)
+                .is_some_and(|wrapped| {
+                    Self::type_node_mentions_mapped_name_outside_this_type(
+                        source_arena,
+                        wrapped.type_node,
+                        type_param_name,
+                        type_param_names,
+                        aliases,
+                        depth + 1,
+                    )
+                }),
+            k if k == syntax_kind_ext::INTERSECTION_TYPE || k == syntax_kind_ext::UNION_TYPE => {
+                source_arena
+                    .get_composite_type(type_node)
+                    .is_some_and(|composite| {
+                        composite.types.nodes.iter().copied().any(|part_idx| {
+                            Self::type_node_mentions_mapped_name_outside_this_type(
+                                source_arena,
+                                part_idx,
+                                type_param_name,
+                                type_param_names,
+                                aliases,
+                                depth + 1,
+                            )
+                        })
+                    })
+            }
+            k if k == syntax_kind_ext::TYPE_LITERAL => source_arena
+                .get_type_literal(type_node)
+                .is_some_and(|literal| {
+                    literal.members.nodes.iter().copied().any(|member_idx| {
+                        let Some(member_node) = source_arena.get(member_idx) else {
+                            return false;
+                        };
+                        let Some(signature) = source_arena.get_signature(member_node) else {
+                            return false;
+                        };
+                        Self::type_node_mentions_mapped_name_outside_this_type(
+                            source_arena,
+                            signature.type_annotation,
+                            type_param_name,
+                            type_param_names,
+                            aliases,
+                            depth + 1,
+                        )
+                    })
+                }),
+            k if k == syntax_kind_ext::MAPPED_TYPE => source_arena
+                .get_mapped_type(type_node)
+                .is_some_and(|mapped| {
+                    Self::type_node_mentions_mapped_name_outside_this_type(
+                        source_arena,
+                        mapped.type_node,
+                        type_param_name,
+                        type_param_names,
+                        aliases,
+                        depth + 1,
+                    )
+                }),
             _ => false,
         }
     }
@@ -1107,32 +1221,6 @@ impl<'a> DeclarationEmitter<'a> {
         }
         None
     }
-
-    fn type_text_without_this_type_markers(type_text: &str) -> String {
-        let mut text = type_text.to_string();
-        while let Some(start) = text.find("ThisType<") {
-            let mut depth = 0usize;
-            let mut end = None;
-            for (offset, ch) in text[start + "ThisType".len()..].char_indices() {
-                match ch {
-                    '<' => depth += 1,
-                    '>' => {
-                        depth = depth.saturating_sub(1);
-                        if depth == 0 {
-                            end = Some(start + "ThisType".len() + offset + ch.len_utf8());
-                            break;
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            let Some(end) = end else {
-                break;
-            };
-            text.replace_range(start..end, "");
-        }
-        text
-    }
 }
 
 fn identifier_text(source_arena: &NodeArena, idx: NodeIndex) -> Option<String> {
@@ -1268,6 +1356,67 @@ let arg = {
                 "{\n    a: number;\n    b: string;\n    f(): number;\n    d: number;\n    e: string;\n}"
                     .to_string()
             )
+        );
+    }
+
+    #[test]
+    fn this_type_context_marker_is_not_a_value_map_inference_mention() {
+        let mut parser = ParserState::new(
+            "this-type-context-marker.ts".to_string(),
+            r#"
+type ContextOnly<Model> = ThisType<Model>;
+type ValueAndContext<Model> = Model & ThisType<{ current: Model }>;
+type AliasAndContext<Model> = ValueAlias & ThisType<Model>;
+"#
+            .to_string(),
+        );
+        parser.parse_source_file();
+        let arena = parser.get_arena();
+        let emitter = DeclarationEmitter::new(arena);
+        let context_only_type = emitter
+            .find_type_alias_type_node_in_arena(arena, "ContextOnly")
+            .expect("context-only alias type");
+        let value_and_context_type = emitter
+            .find_type_alias_type_node_in_arena(arena, "ValueAndContext")
+            .expect("value-and-context alias type");
+        let alias_and_context_type = emitter
+            .find_type_alias_type_node_in_arena(arena, "AliasAndContext")
+            .expect("alias-and-context alias type");
+        let type_params = ["Model".to_string()];
+        let aliases = [("ValueAlias".to_string(), "Model".to_string())];
+
+        assert!(
+            !DeclarationEmitter::type_node_mentions_mapped_name_outside_this_type(
+                arena,
+                context_only_type,
+                "Model",
+                &type_params,
+                &aliases,
+                0,
+            ),
+            "`ThisType<Model>` is only contextual and must not infer Model"
+        );
+        assert!(
+            DeclarationEmitter::type_node_mentions_mapped_name_outside_this_type(
+                arena,
+                value_and_context_type,
+                "Model",
+                &type_params,
+                &aliases,
+                0,
+            ),
+            "Model outside `ThisType` should still infer"
+        );
+        assert!(
+            DeclarationEmitter::type_node_mentions_mapped_name_outside_this_type(
+                arena,
+                alias_and_context_type,
+                "Model",
+                &type_params,
+                &aliases,
+                0,
+            ),
+            "aliases outside `ThisType` should still infer"
         );
     }
 


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Emit/DTS parity guardrail: output-surgery audit restoration.

## Invariant
When a DTS source-object member annotation mentions a type parameter only through contextual `ThisType<...>`, that context marker must not drive public value-map inference; real member type mentions still can. This PR makes tsz decide that from the parsed type node instead of deleting `ThisType` text after type display.

## Scope
- Replace the `ThisType<...>` text-stripping helper in `type_inference_source_object_args.rs` with a bounded AST walk that skips `ThisType` references.
- Add focused unit coverage for context-only, direct, and alias mentions.

## Project Corpus Impact
- Row: n/a
- Bug family: dts-output-surgery guardrail
- Evidence: restores `scripts/emit/audit-output-surgery.py` to `0` unallowlisted calls for issue #10575; no project corpus row behavior is targeted.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard-studio-f.json`
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery-studio-f.json`
- Prior PR-head CI for `8848f572ddb6275b9e7b69c67554674941b40c67`: light gates green and most ready-review heavy suites green before `origin/main` advanced.
- Prior PR-head CI for `827d2eae96456c836ced868414de7a196e087f71`: light gates were still in progress when `origin/main` advanced again.
- Prior PR-head CI for `2c79af39089cf4653e53a2e244bf94f0b4891080`: light gates were still in progress when `origin/main` advanced again.
- Prior PR-head CI for `52f882ffb3397359088f4973742759b86606aa61`: light gates were still in progress when `origin/main` advanced again.
- Prior PR-head CI for `5b08cc151261e0940be8e00e1c2c6f02bcde5d22`: light gates green and heavy suite in progress when `origin/main` advanced again.
- Prior head before latest clean rebase: `cargo nextest run -p tsz-emitter -E 'test(this_type_context_marker_is_not_a_value_map_inference_mention) or test(test_generic_call_this_type_descriptor_intersections_preserve_source_surfaces) or test(mapped_accessor_object_argument_infers_public_value_map)'`
- Prior head before latest clean rebase: `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`

## Coordination Notes
- Fixes #10575 from the Studio-F guardrail lane after Studio-F owned PR runway was clear.
- Rebased on current `origin/main` and force-with-lease pushed head `9f85451602a46583c3b50464a7f2c94c63dd54de`.
- Ready for PR-head CI and manager review; no `merge-queue` label until exact-head PR checks pass.
- Disk guard is currently OK: `disk_status=ok` with 49 GiB free; this worktree's Cargo artifacts remain pruned, so latest-head local verification was kept to cheap guardrails.\n\nTemporary debt note for queue readiness: the current AST-walk guard still identifies the contextual `ThisType<T>` marker by the parsed type-reference spelling. Reviewer accepted queueing only if this shortcut is explicitly documented as temporary debt. Removal criteria: replace the spelling check with binder/global builtin identity for the contextual `ThisType` marker, or move the decision to a structured declaration-summary/boundary fact so shadowed/user-defined `ThisType` aliases cannot be mistaken for the lib marker. This debt is limited to the output-surgery guardrail path and does not reintroduce emitted-text surgery.