### PR TITLE
fix(bench): require attribution-mode sidecars

### DIFF
--- a/scripts/bench/test-tsgo-winner-report.mjs
+++ b/scripts/bench/test-tsgo-winner-report.mjs
@@ -481,6 +481,59 @@ withTempDir((dir) => {
   assert.match(report.target_gaps[0].attribution_status.generated_at, /^\d{4}-\d{2}-\d{2}T/);
 });
 
+withTempDir((dir) => {
+  const input = path.join(dir, "bench.json");
+  const output = path.join(dir, "report.json");
+  const perfPath = path.join(dir, "bench.perf.json");
+  writeJson(input, {
+    results: [
+      {
+        name: "ts-essentials-project",
+        winner: "tsz",
+        factor: 1.1,
+        tsz_ms: 100,
+        tsgo_ms: 110,
+        compatibility: {
+          state: "green",
+          exit_class: "exit success",
+          phase: "check",
+          last_successful_phase: "check",
+          diagnostic_status: "none",
+        },
+      },
+    ],
+  });
+  writeJson(perfPath, {
+    mode: "timing",
+    delegate: { misses: 0 },
+    checker: { with_parent_cache_constructed: 2 },
+    slow_check_file_timings: [
+      { file: "ts-essentials/lib/xor/index.ts", elapsed_ms: 150, diagnostics: 0 },
+    ],
+  });
+
+  const result = spawnSync(process.execPath, [SCRIPT, input, output], {
+    cwd: ROOT,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /2x target gaps with attribution: 0\/1/);
+
+  const report = JSON.parse(fs.readFileSync(output, "utf8"));
+  assert.equal(report.two_x_target.rows_below_target, 1);
+  assert.equal(report.two_x_target.rows_with_attribution, 0);
+  assert.deepEqual(report.two_x_target.missing_attribution_rows, ["ts-essentials-project"]);
+  assert.deepEqual(report.target_gaps[0].attribution_status, {
+    present: true,
+    path: path.relative(ROOT, perfPath).split(path.sep).join("/"),
+    url: null,
+    generated_at: report.target_gaps[0].attribution_status.generated_at,
+    mode: "timing",
+    dominant_subsystem: null,
+    warning: "sidecar perf snapshot mode is not attribution",
+  });
+});
+
 const benchWorkflow = fs.readFileSync(BENCH_WORKFLOW, "utf8");
 assert.match(
   benchWorkflow,

--- a/scripts/bench/tsgo-winner-report.mjs
+++ b/scripts/bench/tsgo-winner-report.mjs
@@ -169,14 +169,19 @@ function singleRowSidecarAttribution(rows, inputPath) {
 
   const row = rows[0];
   const relativePath = toPortablePath(path.relative(process.cwd(), perfPath));
+  const mode = snapshot.mode ?? null;
+  const isAttributionMode = mode === "attribution";
   return new Map([
     [
       row.name,
       {
         path: relativePath,
         generated_at: fs.statSync(perfPath).mtime.toISOString(),
-        mode: snapshot.mode ?? null,
-        dominant_subsystem: inferDominantSubsystemFromPerfSnapshot(snapshot),
+        mode,
+        dominant_subsystem: isAttributionMode
+          ? inferDominantSubsystemFromPerfSnapshot(snapshot)
+          : null,
+        warning: isAttributionMode ? null : "sidecar perf snapshot mode is not attribution",
       },
     ],
   ]);
@@ -224,6 +229,7 @@ function attributionStatusForRow(row, fallbackArtifact = null) {
   const pathValue = artifact.path ?? artifact.file ?? artifact.artifact ?? null;
   const urlValue = artifact.url ?? null;
   const dominantSubsystem = artifact.dominant_subsystem ?? artifact.dominantSubsystem ?? null;
+  const warningValue = artifact.warning ?? null;
   return {
     present: true,
     path: pathValue,
@@ -231,12 +237,12 @@ function attributionStatusForRow(row, fallbackArtifact = null) {
     generated_at: artifact.generated_at ?? artifact.generatedAt ?? null,
     mode: artifact.mode ?? null,
     dominant_subsystem: dominantSubsystem,
-    warning: dominantSubsystem ? null : "attribution dominant_subsystem missing",
+    warning: warningValue ?? (dominantSubsystem ? null : "attribution dominant_subsystem missing"),
   };
 }
 
 function hasCompleteAttribution(status) {
-  return Boolean(status?.present && status?.dominant_subsystem);
+  return Boolean(status?.present && status?.dominant_subsystem && !status?.warning);
 }
 
 function targetGapFactor(speedup) {


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Performance / benchmark attribution tooling

## Invariant
Single-row benchmark sidecar perf snapshots count as complete target-gap attribution only when the sibling `.perf.json` declares `mode: "attribution"`; timing-mode sidecars may be surfaced as present evidence but must not satisfy the 2x target-gap attribution ledger.

## Scope
- Require attribution-mode sidecars before inferring a dominant subsystem for fallback attribution.
- Preserve explicit warning text from attribution artifacts and require warning-free status for complete attribution.
- Add a regression test proving a `mode: "timing"` sidecar remains in `missing_attribution_rows`.

## Project Corpus Impact
- Row: ts-essentials-project
- Bug family: benchmark target-gap attribution ledger accuracy for utility-type mapped/conditional/key-space workloads.
- Evidence: `node scripts/bench/test-tsgo-winner-report.mjs` covers the merged #10616 sidecar path and the new non-attribution-mode regression case.

## Verification
- `node scripts/bench/test-tsgo-winner-report.mjs`
- `git diff --check`
- `wc -l scripts/bench/tsgo-winner-report.mjs scripts/bench/test-tsgo-winner-report.mjs` (453 and 631 lines)

## Coordination Notes
- Fix-forward for reviewer finding on merged PR #10616.
- #10616 landed before the ready-state blocker could stop the queue; this PR closes that exact gap.
- No compiler semantics, conformance, emit, or project fixture behavior changes.