### PR TITLE
fix(emit): preserve decorated computed temp reservations

### DIFF
--- a/crates/tsz-emitter/src/emitter/class_temp_reservations.rs
+++ b/crates/tsz-emitter/src/emitter/class_temp_reservations.rs
@@ -91,8 +91,6 @@ impl<'a> Printer<'a> {
         if let Some(names) = self.file_level_class_temp_reservations.get_mut(&class_idx)
             && let Some(name) = names.pop_front()
         {
-            self.hoisted_file_level_class_temps
-                .retain(|temp| temp != &name);
             return name;
         }
 


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
JavaScript emit recovery / legacy decorator computed-property temp planning.

## Invariant
When legacy-decorated classes contain computed property fields, `tsc` reserves class field and class-expression wrapper temps in a file-level declaration before decorator key temps; this PR keeps consumed reserved class temps in that file-level declaration slot instead of reordering them into the general hoist list.

## Structural Rule
For ES2015 legacy decorator output, non-constant computed class field temps and class-expression wrapper temps are reserved ahead of member decorator key temps across class declarations and class expressions. Consuming a reserved class temp for field initialization or comma-wrapper emission must not remove the earlier file-level declaration position.

## Owner Layer
Emitter temp reservation and JS output planning in `crates/tsz-emitter/src/emitter/class_temp_reservations.rs`. The change preserves syntax-driven temp declaration order; it does not add checker/solver semantic validation and does not patch emitted text after printing.

## Adjacent Case Matrix
- Class declaration with undecorated computed field temps before decorated computed field keys.
- Class expression with static/computed wrapper temp before decorated computed field keys.
- Decorated computed methods still reuse their decorator key temps and consume pending field side effects.
- Private/static member assignment and async captured-super work remain separate and non-overlapping.

## Scope
- Preserve file-level class temp reservations after `make_class_static_temp_name` consumes a reserved temp name.
- Leave fallback unreserved class temp allocation unchanged.
- Use existing focused emitter unit coverage plus the exact `decoratorsOnComputedProperties` JS baseline filter.

## Project Corpus Impact
- Row: emit conformance `decoratorsOnComputedProperties`
- Bug family: class/private/accessor/decorator lowering; legacy decorator computed-property temp ordering
- Evidence: exact JS emit filter `decoratorsOnComputedProperties` passes locally after rebasing; focused owning-crate unit coverage passes.

## Verification
- `cargo nextest run -p tsz-emitter legacy_decorated_computed_class_expressions_match_tsc_temp_order legacy_decorated_computed_members_reuse_planned_key_temps`
- `scripts/emit/run.sh --filter=decoratorsOnComputedProperties --js-only --verbose --json-out=/tmp/studio-c-10623-decorators-on-computed-properties-post-fdfd235.json`
- `cargo fmt --all --check`
- `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`
- Previous ready-review CI on `e5c9f43081b4978ca24310fca2f2a0dff4f81157`: draft-light checks passed before marking ready.
- Current rebase check on `006903e803d691d0454bdd1de37688d11653010b`: `git diff --check HEAD~1..HEAD`, `cargo fmt --all --check`.

## Known Unsupported Shapes / Follow-Up
This PR fixes the current `decoratorsOnComputedProperties` JS emit mismatch. Broader `esDecorators` and class/private/accessor/decorator failures remain outside this one-commit slice.

## Coordination Notes
- Rebased and force-with-lease pushed onto current `origin/main` at `df089e4e924afb8f0bbe3b90194356eac7f86b29` after #10644 merged.
- Current head: `006903e803d691d0454bdd1de37688d11653010b`.
- Ready-review CI should rerun on the new exact head; merge queue remains off until PR-head checks are green.
