### PR TITLE
fix(bench): always publish project row step summary

### DIFF
--- a/scripts/bench/project-row-summary.mjs
+++ b/scripts/bench/project-row-summary.mjs
@@ -277,6 +277,11 @@ export function formatPlainText(coverage) {
   return lines.join("\n");
 }
 
+export function appendStepSummary(coverage, stepSummaryPath) {
+  if (!stepSummaryPath) return;
+  fs.appendFileSync(stepSummaryPath, `${formatMarkdown(coverage)}\n`);
+}
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const args = process.argv.slice(2);
   const markdown = args.includes("--markdown");
@@ -294,10 +299,7 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
 
   // When running in GitHub Actions, also append the markdown table to the
   // step summary so it's visible in the PR checks UI without a second run.
-  const stepSummary = process.env.GITHUB_STEP_SUMMARY;
-  if (!markdown && stepSummary) {
-    fs.appendFileSync(stepSummary, `${formatMarkdown(coverage)}\n`);
-  }
+  appendStepSummary(coverage, process.env.GITHUB_STEP_SUMMARY);
 
   if (coverage.drift.length > 0) {
     process.exit(1);

--- a/scripts/bench/test-project-row-summary.mjs
+++ b/scripts/bench/test-project-row-summary.mjs
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import {
   BENCH_RUNNER_EXCLUDED_ROWS,
   COMPILE_GUARD_EXCLUDED_ROWS,
+  appendStepSummary,
   computeCoverage,
   extractBenchRunnerRows,
   extractCompileGuardFallbackRows,
@@ -244,6 +248,18 @@ function baseSurfaces() {
   const cleanSummary = `All ${PROJECT_ROW_DEFINITIONS.length} rows consistent`;
   assert.ok(text.includes("Project Row Coverage"), "plain text missing heading");
   assert.ok(text.includes(cleanSummary), "plain text missing clean summary");
+}
+
+// Step summary appends markdown regardless of the selected stdout format.
+{
+  const coverage = computeCoverage(baseSurfaces());
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "project-row-summary-"));
+  const summaryPath = path.join(dir, "summary.md");
+  appendStepSummary(coverage, summaryPath);
+  const summary = fs.readFileSync(summaryPath, "utf8");
+  assert.ok(summary.includes("## Project Row Coverage"), "step summary missing markdown heading");
+  assert.ok(summary.includes(`All ${PROJECT_ROW_DEFINITIONS.length} rows consistent`), "step summary missing clean summary");
+  fs.rmSync(dir, { recursive: true, force: true });
 }
 
 // Extractor: bench runner rows from shell snippet.


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 1 benchmark blocker / project-corpus metric truth.

## Invariant
When `project-row-summary.mjs` runs with `GITHUB_STEP_SUMMARY` set, the GitHub Actions step summary receives the markdown project-row coverage table regardless of the selected stdout format; this PR changes the benchmark reporting helper and its focused script test.

## Scope
- `scripts/bench/project-row-summary.mjs`: route step-summary writes through a shared helper and call it for both plain-text and `--markdown` output modes.
- `scripts/bench/test-project-row-summary.mjs`: cover markdown step-summary appending.

## Project Corpus Impact
- Row: n/a
- Bug family: project-row metric reporting visibility
- Evidence: script-only reporting fix; no project row definitions, fixtures, compiler behavior, compatibility corpus semantics, or benchmark timing semantics changed.

## Verification
- `node scripts/bench/test-project-row-summary.mjs`
- `node scripts/bench/project-row-summary.mjs --markdown`
- `node scripts/bench/validate-project-metadata.mjs`
- `GITHUB_STEP_SUMMARY=$(mktemp) node scripts/bench/project-row-summary.mjs --markdown >/tmp/project-row-summary.out` with summary file checked for the project-row heading and clean summary
- `git diff --check origin/main..HEAD`
- PR-head CI run `26538255683` on `4d3517967b`: `CI Summary`, `GitGuardian Security Checks`, `lint`, `cargo-deny`, `cargo-shear`, `project-corpus-pr-body`, and `project-row-drift` passed.

## Coordination Notes
- Studio-A had no open owned PRs at intake; #10618 was already merged into `main`.
- Open PR/issue overlap and canonical agent labels were checked before editing; no overlap found for this reporting-helper fix.
- Rebased onto `7319b38513` after #10625 merged; focused local verification was rerun on head `4d3517967b`.
- Exact-head PR CI is green; ready for repo-local merge queue.
