### PR TITLE
fix(bench): let active runs finish

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -18,12 +18,10 @@ on:
         default: false
         type: boolean
 
-# Do not use workflow-level concurrency here. A queued workflow run would start
-# after the active benchmark finishes and benchmark an old "next" commit. The
-# gate below skips duplicate current-target runs, but cancels obsolete active
-# runs before letting the current main benchmark proceed. Release-only daily
-# runs are allowed to publish the latest artifact without waiting behind
-# benchmark shards.
+# Do not use workflow-level concurrency here. Let one active benchmark finish
+# even if `main` moves while it is running; benchmark freshness is about
+# avoiding very old public data, not forcing exact-head timing. The gate below
+# skips duplicate active runs and rejects genuinely old targets.
 
 permissions:
   contents: write
@@ -37,6 +35,7 @@ env:
   BENCH_PGO: "1"
   BENCH_REQUIRE_PGO: "1"
   HYPERFINE_VER: "1.18.0"
+  BENCH_MAX_TARGET_AGE_HOURS: "48"
   GITHUB_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
   BENCH_TARGET_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
   CARGO_HOME: ${{ github.workspace }}/.ci-cache/cargo-home
@@ -85,10 +84,18 @@ jobs:
             release_only=true
           fi
 
+          max_target_age_hours="${BENCH_MAX_TARGET_AGE_HOURS:-48}"
+          if ! [[ "$max_target_age_hours" =~ ^[0-9]+$ ]]; then
+            max_target_age_hours=48
+          fi
           if [[ "$release_only" != "true" ]]; then
-            main_sha="$(gh api "repos/${{ github.repository }}/git/ref/heads/main" --jq '.object.sha' 2>/dev/null || true)"
-            if [[ -n "$main_sha" && "$target_sha" != "$main_sha" ]]; then
-              echo "Benchmark target ${target_sha} is stale; current main is ${main_sha}. Skipping obsolete run."
+            target_date="$(gh api "repos/${{ github.repository }}/commits/${target_sha}" --jq '.commit.committer.date' 2>/dev/null || true)"
+            target_epoch="$(date -u -d "${target_date}" +%s 2>/dev/null || true)"
+            now_epoch="$(date -u +%s)"
+            max_target_age_seconds=$((max_target_age_hours * 3600))
+            if [[ "$target_epoch" =~ ^[0-9]+$ &&
+                  $((now_epoch - target_epoch)) -gt "$max_target_age_seconds" ]]; then
+              echo "Benchmark target ${target_sha} is older than ${max_target_age_hours}h (${target_date}); skipping genuinely stale run."
               should_run=false
             fi
           fi
@@ -105,22 +112,12 @@ jobs:
               } | sort -u
             )"
             active_runs=""
-            obsolete_runs=""
             while IFS=$'\t' read -r run_id run_sha run_url; do
               [[ -n "${run_id:-}" ]] || continue
-              if [[ -n "${run_sha:-}" && "${run_sha}" != "${target_sha}" ]]; then
-                obsolete_runs+="${run_id}"$'\t'"${run_sha}"$'\t'"${run_url}"$'\n'
-                gh run cancel "$run_id" --repo "${{ github.repository }}" >/dev/null 2>&1 || true
-                continue
-              fi
               active_runs+="${run_id}"$'\t'"${run_sha}"$'\t'"${run_url}"$'\n'
             done <<< "$active_runs_raw"
-            if [[ -n "$obsolete_runs" ]]; then
-              echo "Cancelling obsolete Bench run(s) before benchmarking ${target_sha}."
-              printf '%s\n' "$obsolete_runs"
-            fi
             if [[ -n "$active_runs" ]]; then
-              echo "Another Bench run for ${target_sha} is already active; skipping duplicate run instead of queuing."
+              echo "Another Bench run is already active; letting it finish even if main has moved, and skipping this duplicate run."
               printf '%s\n' "$active_runs"
               should_run=false
             fi
@@ -561,43 +558,11 @@ jobs:
           bash scripts/install.sh --version latest --dir "${install_dir}"
           "${install_dir}/tsz" --version
 
-  bench-prep-target-fresh:
-    name: bench-prep-target-fresh
+  bench-prep-artifact:
+    name: bench-prep-artifact
     needs: [bench-prepare, bench-prepare-cloudbuild]
     if: >-
       always() &&
-      (needs.bench-prepare.outputs.should_run == 'true' ||
-       (!(github.event_name == 'workflow_dispatch' && inputs.publish_latest_pgo) &&
-        !(github.event_name == 'schedule' && github.event.schedule == '0 3 * * *') &&
-        !(github.event_name == 'schedule' && github.event.schedule == '0 5 * * *') &&
-        needs.bench-prepare-cloudbuild.outputs.should_run == 'true')) &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled')
-    runs-on: ubuntu-latest
-    outputs:
-      should_run: ${{ steps.fresh.outputs.should_run }}
-    steps:
-      - id: fresh
-        env:
-          GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          should_run=true
-          target_sha="${{ env.BENCH_TARGET_SHA }}"
-          main_sha="$(gh api "repos/${{ github.repository }}/git/ref/heads/main" --jq '.object.sha' 2>/dev/null || true)"
-          if [[ -n "$main_sha" && "$target_sha" != "$main_sha" ]]; then
-            echo "Benchmark target ${target_sha} became stale before prep artifact download; current main is ${main_sha}. Skipping self-hosted prep wait."
-            should_run=false
-          fi
-          echo "should_run=${should_run}" >> "$GITHUB_OUTPUT"
-
-  bench-prep-artifact:
-    name: bench-prep-artifact
-    needs: [bench-prepare, bench-prepare-cloudbuild, bench-prep-target-fresh]
-    if: >-
-      always() &&
-      needs.bench-prep-target-fresh.outputs.should_run == 'true' &&
       (needs.bench-prepare.outputs.should_run == 'true' ||
        (!(github.event_name == 'workflow_dispatch' && inputs.publish_latest_pgo) &&
         !(github.event_name == 'schedule' && github.event.schedule == '0 3 * * *') &&
@@ -968,36 +933,10 @@ jobs:
           if-no-files-found: error
           compression-level: 1
 
-  bench-target-fresh:
-    name: bench-target-fresh
-    needs: bench-prep-artifact
-    if: always() && needs.bench-prep-artifact.result == 'success'
-    runs-on: ubuntu-latest
-    outputs:
-      should_run: ${{ steps.fresh.outputs.should_run }}
-    steps:
-      - id: fresh
-        env:
-          GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          should_run=true
-          target_sha="${{ env.BENCH_TARGET_SHA }}"
-          main_sha="$(gh api "repos/${{ github.repository }}/git/ref/heads/main" --jq '.object.sha' 2>/dev/null || true)"
-          if [[ -n "$main_sha" && "$target_sha" != "$main_sha" ]]; then
-            echo "Benchmark target ${target_sha} became stale after prep; current main is ${main_sha}. Skipping shard fanout."
-            should_run=false
-          fi
-          echo "should_run=${should_run}" >> "$GITHUB_OUTPUT"
-
   bench:
     name: bench-${{ matrix.label }}
-    needs: [bench-prep-artifact, bench-target-fresh]
-    if: >-
-      always() &&
-      needs.bench-prep-artifact.result == 'success' &&
-      needs.bench-target-fresh.outputs.should_run == 'true'
+    needs: bench-prep-artifact
+    if: always() && needs.bench-prep-artifact.result == 'success'
     runs-on: [self-hosted, tsz-cloud-run]
     timeout-minutes: ${{ matrix.timeout }}
     strategy:
@@ -1287,9 +1226,6 @@ jobs:
 
           if [[ -n "${MAIN_SHA}" && "${TARGET_SHA}" != "${MAIN_SHA}" ]]; then
             echo "Bench target ${TARGET_SHA} is behind current main ${MAIN_SHA}; publishing because active benchmark runs are intentionally allowed to finish."
-            echo "catchup_main_sha=${MAIN_SHA}" >> "$GITHUB_OUTPUT"
-          else
-            echo "catchup_main_sha=" >> "$GITHUB_OUTPUT"
           fi
 
           gsutil -q cp "$GITHUB_WORKSPACE/bench-results.json" \
@@ -1423,18 +1359,3 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/gh-pages.yml/dispatches" \
             -d '{"ref":"main"}'
-
-      - name: Trigger benchmark catch-up
-        if: steps.publish.outputs.should_redeploy == 'true' && steps.publish.outputs.catchup_main_sha != ''
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          echo "Benchmark target ${BENCH_TARGET_SHA:-${GITHUB_SHA}} was behind current main ${{ steps.publish.outputs.catchup_main_sha }}; dispatching a catch-up benchmark."
-          curl -fsSL \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/bench.yml/dispatches" \
-            -d '{"ref":"main","inputs":{"publish_latest_pgo":"false"}}'

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -118,38 +118,26 @@ assert.match(
 
 assert.match(
   workflow,
-  /TARGET_SHA="\$\{BENCH_TARGET_SHA:-\$\{GITHUB_SHA\}\}"[\s\S]+if \[\[ -n "\$\{MAIN_SHA\}" && "\$\{TARGET_SHA\}" != "\$\{MAIN_SHA\}" \]\]; then[\s\S]+echo "catchup_main_sha=\$\{MAIN_SHA\}" >> "\$GITHUB_OUTPUT"/,
-  "benchmark publish should expose the current main SHA when a finished run publishes an older target",
+  /BENCH_MAX_TARGET_AGE_HOURS: "48"[\s\S]+target_date="\$\(gh api "repos\/\$\{\{ github\.repository \}\}\/commits\/\$\{target_sha\}" --jq '\.commit\.committer\.date' 2>\/dev\/null \|\| true\)"[\s\S]+Benchmark target \$\{target_sha\} is older than \$\{max_target_age_hours\}h/,
+  "bench gate should reject genuinely old targets by age instead of exact-main mismatch",
 );
 
 assert.match(
   workflow,
-  /- name: Trigger benchmark catch-up[\s\S]+steps\.publish\.outputs\.catchup_main_sha != ''[\s\S]+actions\/workflows\/bench\.yml\/dispatches[\s\S]+-d '\{"ref":"main","inputs":\{"publish_latest_pgo":"false"\}\}'/,
-  "stale benchmark publishes should dispatch a catch-up benchmark for current main",
+  /Another Bench run is already active; letting it finish even if main has moved, and skipping this duplicate run\./,
+  "bench gate should let active runs finish and skip duplicate runs",
 );
 
-assert.match(
+assert.doesNotMatch(
   workflow,
-  /if \[\[ -n "\$\{run_sha:-\}" && "\$\{run_sha\}" != "\$\{target_sha\}" \]\]; then[\s\S]+obsolete_runs\+="\$\{run_id\}"\$'\\t'"\$\{run_sha\}"\$'\\t'"\$\{run_url\}"\$'\\n'[\s\S]+gh run cancel "\$run_id" --repo "\$\{\{ github\.repository \}\}" >\/dev\/null 2>&1 \|\| true[\s\S]+continue[\s\S]+fi[\s\S]+active_runs\+="\$\{run_id\}"\$'\\t'"\$\{run_sha\}"\$'\\t'"\$\{run_url\}"\$'\\n'/,
-  "bench gate should cancel obsolete active runs instead of letting stale SHA runs block current main",
+  /gh run cancel/,
+  "bench gate must not cancel active benchmark runs just because main moved",
 );
 
-assert.match(
+assert.doesNotMatch(
   workflow,
-  /Cancelling obsolete Bench run\(s\) before benchmarking \$\{target_sha\}\.[\s\S]+Another Bench run for \$\{target_sha\} is already active; skipping duplicate run instead of queuing\./,
-  "bench gate should distinguish obsolete active runs from duplicate current-target runs",
-);
-
-assert.match(
-  workflow,
-  /bench-prep-target-fresh:[\s\S]+needs: \[bench-prepare, bench-prepare-cloudbuild\][\s\S]+target_sha="\$\{\{ env\.BENCH_TARGET_SHA \}\}"[\s\S]+main_sha="\$\(gh api "repos\/\$\{\{ github\.repository \}\}\/git\/ref\/heads\/main" --jq '\.object\.sha' 2>\/dev\/null \|\| true\)"[\s\S]+Benchmark target \$\{target_sha\} became stale before prep artifact download; current main is \$\{main_sha\}\. Skipping self-hosted prep wait\.[\s\S]+echo "should_run=\$\{should_run\}" >> "\$GITHUB_OUTPUT"[\s\S]+bench-prep-artifact:[\s\S]+needs: \[bench-prepare, bench-prepare-cloudbuild, bench-prep-target-fresh\][\s\S]+needs\.bench-prep-target-fresh\.outputs\.should_run == 'true'/,
-  "bench prep artifact polling should re-check target freshness before occupying a self-hosted runner",
-);
-
-assert.match(
-  workflow,
-  /bench-target-fresh:[\s\S]+needs: bench-prep-artifact[\s\S]+target_sha="\$\{\{ env\.BENCH_TARGET_SHA \}\}"[\s\S]+main_sha="\$\(gh api "repos\/\$\{\{ github\.repository \}\}\/git\/ref\/heads\/main" --jq '\.object\.sha' 2>\/dev\/null \|\| true\)"[\s\S]+Benchmark target \$\{target_sha\} became stale after prep; current main is \$\{main_sha\}\. Skipping shard fanout\.[\s\S]+echo "should_run=\$\{should_run\}" >> "\$GITHUB_OUTPUT"[\s\S]+bench:[\s\S]+needs: \[bench-prep-artifact, bench-target-fresh\][\s\S]+needs\.bench-target-fresh\.outputs\.should_run == 'true'/,
-  "bench shards should re-check target freshness after prep so obsolete runs cannot fan out while a current-main run is active",
+  /bench-prep-target-fresh:|bench-target-fresh:|catchup_main_sha|Trigger benchmark catch-up/,
+  "benchmark workflow should not kill or chase in-flight runs when main moves a few commits",
 );
 
 const benchJob = workflow.match(/  bench:[\s\S]+?  publish:/)?.[0] ?? "";


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 1 benchmark blocker: Bench artifact freshness and project-corpus metric truth.

## Invariant
When a Bench run has already started for a recent main commit, later movement on `main` must not cancel or skip that in-flight run; tsz.dev freshness is allowed to be a few commits behind, while genuinely old targets should still be rejected before consuming runner time.

## Scope
- `.github/workflows/bench.yml`: replace exact-main stale checks with a 48-hour target-age guard.
- `.github/workflows/bench.yml`: stop canceling active Bench runs and stop post-prep/shard freshness rechecks against moving `main`.
- `.github/workflows/bench.yml`: remove automatic catch-up dispatch after publishing a behind-main run.
- `scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`: assert age-based stale rejection, duplicate-run skipping, and no active-run cancellation/chasing.

## Project Corpus Impact
- Row: n/a
- Bug family: benchmark freshness / active run churn
- Evidence: workflow-only benchmark scheduling policy; no compiler behavior, fixture metadata, project row definitions, or benchmark timing semantics changed.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `git diff --check`

## Coordination Notes
- This corrects the over-strict exact-main behavior from #10612/#10618. A few commits behind is acceptable; 10-day-old public benchmark data is not.
- Active Bench runs should be allowed to complete and publish. New duplicate runs should skip while one is active instead of canceling the active run.
