### PR TITLE
fix(bench): let manual runs bypass duplicate gate

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -100,7 +100,9 @@ jobs:
             fi
           fi
 
-          if [[ "$should_run" == "true" && "$release_only" != "true" ]]; then
+          if [[ "$should_run" == "true" &&
+                "$release_only" != "true" &&
+                "${{ github.event_name }}" == "workflow_run" ]]; then
             active_runs_raw="$(
               {
                 gh run list --repo "${{ github.repository }}" --workflow bench.yml --branch main --status in_progress --limit 20 \

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -124,8 +124,8 @@ assert.match(
 
 assert.match(
   workflow,
-  /Another Bench run is already active; letting it finish even if main has moved, and skipping this duplicate run\./,
-  "bench gate should let active runs finish and skip duplicate runs",
+  /"\$\{\{ github\.event_name \}\}" == "workflow_run"[\s\S]+Another Bench run is already active; letting it finish even if main has moved, and skipping this duplicate run\./,
+  "bench gate should let active runs finish and skip duplicate automatic runs",
 );
 
 assert.doesNotMatch(


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 1 benchmark blocker: Bench CI flow and website benchmark freshness.

## Invariant
Automatic Bench runs should skip behind an already-active Bench run to avoid duplicate CI noise, but an explicit manual dispatch should be able to recover from a stuck or pre-correction active run without canceling it.

## Scope
- `.github/workflows/bench.yml`: apply the duplicate-active-run skip only to `workflow_run` events, leaving `workflow_dispatch` as an explicit override.
- `scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`: assert duplicate skipping is scoped to automatic workflow-run triggers.

## Project Corpus Impact
- Row: n/a
- Bug family: benchmark freshness / CI flow recovery
- Evidence: workflow-only scheduling policy; no compiler behavior, fixture metadata, project row definitions, or benchmark timing semantics changed.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`
- `git diff --check`

## Coordination Notes
- This preserves the corrected policy that active Bench runs are allowed to finish even if `main` moves.
- This gives maintainers a manual recovery path when an older workflow-definition run is occupying the automatic lane and cannot publish.
