### PR TITLE
perf(tools): attribute slow semantic statements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,6 +1480,7 @@ dependencies = [
  "tsz-parser",
  "tsz-scanner",
  "tsz-solver",
+ "web-time",
 ]
 
 [[package]]

--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -27,6 +27,7 @@ smallvec = { workspace = true }
 serde_json = { workspace = true }
 globset = { workspace = true }
 dashmap = { workspace = true }
+web-time = { workspace = true }
 stacker = "0.1.23"
 
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -383,7 +383,14 @@ impl<'a> CheckerState<'a> {
         }
 
         let mut seen_dts_ambient_violation = false;
+        let statement_timing_enabled = tsz_common::perf_counters::enabled_fast();
         for &stmt_idx in &sf.statements.nodes {
+            let stmt_timing_start = statement_timing_enabled.then(web_time::Instant::now);
+            let stmt_timing_node = self
+                .ctx
+                .arena
+                .get(stmt_idx)
+                .map(|node| (node.kind, node.pos, node.end));
             if !is_dts
                 && !suppress_grammar
                 && let Some(stmt_node) = self.ctx.arena.get(stmt_idx)
@@ -404,6 +411,15 @@ impl<'a> CheckerState<'a> {
             self.check_statement(stmt_idx);
             if !self.statement_falls_through(stmt_idx) {
                 self.ctx.is_unreachable = true;
+            }
+            if let (Some(start), Some((kind, pos, end))) = (stmt_timing_start, stmt_timing_node) {
+                tsz_common::perf_counters::record_slow_check_statement_timing(
+                    &sf.file_name,
+                    kind,
+                    pos,
+                    end,
+                    start.elapsed().as_nanos() as u64,
+                );
             }
         }
         self.ctx.is_unreachable = prev_unreachable;

--- a/crates/tsz-common/src/perf_counters/definitions.rs
+++ b/crates/tsz-common/src/perf_counters/definitions.rs
@@ -914,6 +914,7 @@ pub const DELEGATE_DECLARATION_FILE_MISS_RESIDUE_LIMIT: usize = 128;
 pub const DELEGATE_SOURCE_FILE_MISS_RESIDUE_LIMIT: usize = 128;
 pub const DIRECT_SOURCE_FILE_TYPE_ALIAS_BODY_REJECTION_RESIDUE_LIMIT: usize = 128;
 pub const SLOW_CHECK_FILE_TIMING_LIMIT: usize = 32;
+pub const SLOW_CHECK_STATEMENT_TIMING_LIMIT: usize = 64;
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct DelegateDeclarationFileMissResidue {
@@ -954,6 +955,15 @@ pub struct SlowCheckFileTiming {
     pub diagnostics: u64,
 }
 
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SlowCheckStatementTiming {
+    pub file: String,
+    pub kind: u16,
+    pub pos: u32,
+    pub end: u32,
+    pub elapsed_ms: f64,
+}
+
 #[derive(Debug, Copy, Clone)]
 pub struct DirectSourceFileTypeAliasBodyRejectionResidueInput<'a> {
     pub name: &'a str,
@@ -978,6 +988,8 @@ static DIRECT_SOURCE_FILE_TYPE_ALIAS_BODY_REJECTION_RESIDUES: OnceLock<
     Mutex<Vec<DirectSourceFileTypeAliasBodyRejectionResidue>>,
 > = OnceLock::new();
 static SLOW_CHECK_FILE_TIMINGS: OnceLock<Mutex<Vec<SlowCheckFileTiming>>> = OnceLock::new();
+static SLOW_CHECK_STATEMENT_TIMINGS: OnceLock<Mutex<Vec<SlowCheckStatementTiming>>> =
+    OnceLock::new();
 
 fn delegate_declaration_file_miss_residues(
 ) -> &'static Mutex<Vec<DelegateDeclarationFileMissResidue>> {
@@ -995,6 +1007,10 @@ fn direct_source_file_type_alias_body_rejection_residues(
 
 fn slow_check_file_timings() -> &'static Mutex<Vec<SlowCheckFileTiming>> {
     SLOW_CHECK_FILE_TIMINGS.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+fn slow_check_statement_timings() -> &'static Mutex<Vec<SlowCheckStatementTiming>> {
+    SLOW_CHECK_STATEMENT_TIMINGS.get_or_init(|| Mutex::new(Vec::new()))
 }
 
 pub const COMPUTE_TYPE_OF_SYMBOL_INTERFACE_SIMPLE_OBJECT_TYPE_REFERENCE_REJECT_RESIDUE_LIMIT:

--- a/crates/tsz-common/src/perf_counters/dump.rs
+++ b/crates/tsz-common/src/perf_counters/dump.rs
@@ -144,6 +144,7 @@ impl PerfCounters {
                 &snap.delegate_source_file_miss_residues,
             )
             + &Self::dump_source_file_symbol_arena_cache_eligibility_outcomes()
+            + &Self::dump_slow_check_timings(&snap)
             + &Self::dump_by_reason()
     }
 
@@ -688,6 +689,35 @@ impl PerfCounters {
             let count = load(&c.source_file_symbol_arena_cache_eligibility_outcome[idx]);
             if count > 0 {
                 out.push_str(&format!("  {name:<32} {count:>12}\n"));
+            }
+        }
+        out
+    }
+
+    fn dump_slow_check_timings(snap: &PerfCounterSnapshot) -> String {
+        if snap.slow_check_file_timings.is_empty()
+            && snap.slow_check_statement_timings.is_empty()
+        {
+            return String::new();
+        }
+
+        let mut out = String::new();
+        if !snap.slow_check_file_timings.is_empty() {
+            out.push_str("\nSlowest semantic check files:\n");
+            for row in snap.slow_check_file_timings.iter().take(10) {
+                out.push_str(&format!(
+                    "  {:>8.2} ms  diags={:>4}  {}\n",
+                    row.elapsed_ms, row.diagnostics, row.file
+                ));
+            }
+        }
+        if !snap.slow_check_statement_timings.is_empty() {
+            out.push_str("\nSlowest semantic check statements:\n");
+            for row in snap.slow_check_statement_timings.iter().take(10) {
+                out.push_str(&format!(
+                    "  {:>8.2} ms  kind={:>4}  span={:>8}..{:<8}  {}\n",
+                    row.elapsed_ms, row.kind, row.pos, row.end, row.file
+                ));
             }
         }
         out

--- a/crates/tsz-common/src/perf_counters/runtime.rs
+++ b/crates/tsz-common/src/perf_counters/runtime.rs
@@ -1492,6 +1492,43 @@ pub fn record_slow_check_file_timing(file: &str, elapsed_ns: u64, diagnostics: u
     rows.truncate(SLOW_CHECK_FILE_TIMING_LIMIT);
 }
 
+/// Record one top-level statement duration inside semantic `check_source_file`.
+///
+/// This is attribution-only: callers gate `Instant::now()` behind
+/// [`enabled_fast`], so timing-mode runs do not pay for clock reads. The rows
+/// intentionally store syntax coordinates rather than source snippets so the
+/// counter stays structural and cheap.
+pub fn record_slow_check_statement_timing(
+    file: &str,
+    kind: u16,
+    pos: u32,
+    end: u32,
+    elapsed_ns: u64,
+) {
+    if !enabled_fast() {
+        return;
+    }
+    let mut rows = slow_check_statement_timings()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    rows.push(SlowCheckStatementTiming {
+        file: file.to_owned(),
+        kind,
+        pos,
+        end,
+        elapsed_ms: elapsed_ns as f64 / 1_000_000.0,
+    });
+    rows.sort_by(|a, b| {
+        b.elapsed_ms
+            .total_cmp(&a.elapsed_ms)
+            .then_with(|| a.file.cmp(&b.file))
+            .then_with(|| a.pos.cmp(&b.pos))
+            .then_with(|| a.end.cmp(&b.end))
+            .then_with(|| a.kind.cmp(&b.kind))
+    });
+    rows.truncate(SLOW_CHECK_STATEMENT_TIMING_LIMIT);
+}
+
 /// Record a raw `SymbolId`-shaped `DefId` redirect inside
 /// `TypeEnvironment::resolve_lazy`.
 ///

--- a/crates/tsz-common/src/perf_counters/snapshot.rs
+++ b/crates/tsz-common/src/perf_counters/snapshot.rs
@@ -1,6 +1,6 @@
 /// Stable schema version for `PerfCounterSnapshot`. Bump when the JSON
 /// shape changes in a way the bench harness must adapt to.
-pub const PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION: u32 = 3;
+pub const PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION: u32 = 4;
 
 /// Frozen value-object view of the counter state. Built by
 /// [`PerfCounters::snapshot`]; serializable to JSON via serde.
@@ -245,6 +245,12 @@ pub struct PerfCounterSnapshot {
     /// elapsed time. It is empty when `TSZ_PERF_COUNTERS` is unset or no file
     /// ran semantic checking.
     pub slow_check_file_timings: Vec<SlowCheckFileTiming>,
+    /// Top top-level statement durations observed inside semantic checking.
+    ///
+    /// This is a bounded list sorted by descending elapsed time. Rows use syntax
+    /// kind and byte offsets rather than source snippets so attribution remains
+    /// structural and cheap.
+    pub slow_check_statement_timings: Vec<SlowCheckStatementTiming>,
 }
 
 /// Per-bucket "is this wired up to its producer?" flag. Lets the bench
@@ -692,6 +698,7 @@ impl PerfCounters {
                 })
                 .collect(),
             slow_check_file_timings: Self::snapshot_slow_check_file_timings(),
+            slow_check_statement_timings: Self::snapshot_slow_check_statement_timings(),
         }
     }
 
@@ -832,6 +839,23 @@ impl PerfCounters {
                 .then_with(|| a.file.cmp(&b.file))
         });
         rows.truncate(SLOW_CHECK_FILE_TIMING_LIMIT);
+        rows
+    }
+
+    fn snapshot_slow_check_statement_timings() -> Vec<SlowCheckStatementTiming> {
+        let mut rows = slow_check_statement_timings()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        rows.sort_by(|a, b| {
+            b.elapsed_ms
+                .total_cmp(&a.elapsed_ms)
+                .then_with(|| a.file.cmp(&b.file))
+                .then_with(|| a.pos.cmp(&b.pos))
+                .then_with(|| a.end.cmp(&b.end))
+                .then_with(|| a.kind.cmp(&b.kind))
+        });
+        rows.truncate(SLOW_CHECK_STATEMENT_TIMING_LIMIT);
         rows
     }
 

--- a/crates/tsz-common/src/perf_counters/tests.rs
+++ b/crates/tsz-common/src/perf_counters/tests.rs
@@ -2,10 +2,10 @@ mod json_tests {
     use super::*;
 
     #[test]
-    fn schema_version_is_three() {
+    fn schema_version_is_four() {
         // Bumping schema_version is a breaking change for the bench harness;
         // make the intent explicit.
-        assert_eq!(PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION, 3);
+        assert_eq!(PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION, 4);
     }
 
     #[test]
@@ -49,10 +49,11 @@ mod json_tests {
             "cross_file_cache_miss_causes",
             "source_file_symbol_arena_cache_eligibility_outcomes",
             "slow_check_file_timings",
+            "slow_check_statement_timings",
         ] {
             assert!(json.get(key).is_some(), "missing top-level key: {key}");
         }
-        assert_eq!(json["schema_version"], 3);
+        assert_eq!(json["schema_version"], 4);
     }
 
     #[test]
@@ -88,6 +89,52 @@ mod json_tests {
         );
         assert_eq!(rows[0]["file"], "slow.ts");
         assert_eq!(rows[0]["diagnostics"], 2);
+        assert!(
+            rows[0]["elapsed_ms"].as_f64().unwrap_or_default()
+                >= rows[1]["elapsed_ms"].as_f64().unwrap_or_default(),
+            "rows must be sorted by descending elapsed_ms"
+        );
+    }
+
+    #[test]
+    fn slow_check_statement_timings_keep_slowest_rows_sorted() {
+        {
+            let mut rows = slow_check_statement_timings()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            rows.push(SlowCheckStatementTiming {
+                file: "fast.ts".to_string(),
+                kind: 243,
+                pos: 1,
+                end: 2,
+                elapsed_ms: 1.0,
+            });
+            rows.push(SlowCheckStatementTiming {
+                file: "slow.ts".to_string(),
+                kind: 244,
+                pos: 3,
+                end: 9,
+                elapsed_ms: 12.5,
+            });
+            rows.push(SlowCheckStatementTiming {
+                file: "middle.ts".to_string(),
+                kind: 245,
+                pos: 5,
+                end: 7,
+                elapsed_ms: 4.0,
+            });
+        }
+
+        let json = serde_json::to_value(PerfCounters::snapshot()).expect("serializes");
+        let rows = json["slow_check_statement_timings"]
+            .as_array()
+            .expect("slow_check_statement_timings is array");
+        assert!(
+            rows.len() >= 3,
+            "expected recorded timing rows in snapshot: {rows:?}"
+        );
+        assert_eq!(rows[0]["file"], "slow.ts");
+        assert_eq!(rows[0]["kind"], 244);
         assert!(
             rows[0]["elapsed_ms"].as_f64().unwrap_or_default()
                 >= rows[1]["elapsed_ms"].as_f64().unwrap_or_default(),
@@ -1781,7 +1828,7 @@ mod json_tests {
         let raw = std::fs::read_to_string(&path).expect("read back");
         // Round-trip through serde to confirm structure.
         let value: serde_json::Value = serde_json::from_str(&raw).expect("valid JSON");
-        assert_eq!(value["schema_version"], 3);
+        assert_eq!(value["schema_version"], 4);
         assert!(value["wired"].is_object());
         // The atomic-rename `.json.tmp` should not be left behind.
         let tmp = path.with_extension("json.tmp");

--- a/scripts/perf/query-perf-counters.py
+++ b/scripts/perf/query-perf-counters.py
@@ -141,6 +141,16 @@ def print_summary(snap: dict) -> None:
                 f"    {row['elapsed_ms']:>8.2f} ms  "
                 f"diags={fmt_int(row.get('diagnostics', 0)):>4}  {row['file']}"
             )
+    slow_statements = snap.get("slow_check_statement_timings") or []
+    if slow_statements:
+        print("  slowest semantic check statements:")
+        for row in slow_statements[:10]:
+            print(
+                f"    {row['elapsed_ms']:>8.2f} ms  "
+                f"kind={fmt_int(row.get('kind')):>4}  "
+                f"span={fmt_int(row.get('pos'))}..{fmt_int(row.get('end'))}  "
+                f"{row['file']}"
+            )
     print()
     print("overlay copy:")
     print(
@@ -262,6 +272,22 @@ def print_diff(post: dict, base: dict) -> None:
         if post_slow:
             a = post_slow[0]
             print(f"    current  {a['elapsed_ms']:.2f} ms  {a['file']}")
+    post_stmt = post.get("slow_check_statement_timings") or []
+    base_stmt = base.get("slow_check_statement_timings") or []
+    if post_stmt or base_stmt:
+        print("  slowest semantic check statement:")
+        if base_stmt:
+            b = base_stmt[0]
+            print(
+                f"    baseline {b['elapsed_ms']:.2f} ms  "
+                f"kind={b.get('kind')} span={b.get('pos')}..{b.get('end')} {b['file']}"
+            )
+        if post_stmt:
+            a = post_stmt[0]
+            print(
+                f"    current  {a['elapsed_ms']:.2f} ms  "
+                f"kind={a.get('kind')} span={a.get('pos')}..{a.get('end')} {a['file']}"
+            )
     print()
     post_rows = {r["reason"]: r for r in by_reason_rows(post, optional=True)}
     base_rows = {r["reason"]: r for r in by_reason_rows(base, optional=True)}

--- a/scripts/perf/test_query_perf_counters.py
+++ b/scripts/perf/test_query_perf_counters.py
@@ -11,7 +11,7 @@ SCRIPT = Path(__file__).with_name("query-perf-counters.py")
 
 def sample_snapshot(*, type_environment_core: int = 7, import_type: int = 3):
     return {
-        "schema_version": 3,
+        "schema_version": 4,
         "mode": "attribution",
         "enabled": True,
         "delegate": {
@@ -67,6 +67,10 @@ def sample_snapshot(*, type_environment_core: int = 7, import_type: int = 3):
             {"file": "src/deep.ts", "elapsed_ms": 12.5, "diagnostics": 1},
             {"file": "src/shallow.ts", "elapsed_ms": 2.0, "diagnostics": 0},
         ],
+        "slow_check_statement_timings": [
+            {"file": "src/deep.ts", "kind": 244, "pos": 10, "end": 80, "elapsed_ms": 8.25},
+            {"file": "src/shallow.ts", "kind": 243, "pos": 1, "end": 9, "elapsed_ms": 1.5},
+        ],
     }
 
 
@@ -95,6 +99,8 @@ class QueryPerfCountersTests(unittest.TestCase):
         self.assertIn("delegate (cross-arena symbol resolution):", result.stdout)
         self.assertIn("slowest semantic check files:", result.stdout)
         self.assertIn("src/deep.ts", result.stdout)
+        self.assertIn("slowest semantic check statements:", result.stdout)
+        self.assertIn("kind= 244", result.stdout)
         self.assertIn("Dominant: TypeEnvironmentCore = 7", result.stdout)
         self.assertIn("Top non-baseline T2.2 target: ImportType = 3", result.stdout)
 


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Performance / benchmark attribution tooling

## Invariant
Attribution mode may collect bounded top-N top-level statement timings inside semantic checking; timing mode must not read clocks or change compiler semantics. Rows are structural coordinates only: file, syntax kind, and span. Checker timing uses `web_time::Instant` so WASM-compiled crates do not depend on `std::time::Instant`.

## Scope
- Add `slow_check_statement_timings` to perf counter snapshot schema v4.
- Record bounded slow top-level statement timings from `check_source_file` behind `TSZ_PERF_COUNTERS`.
- Print the new table in extended diagnostics and `scripts/perf/query-perf-counters.py`.
- Cover the new JSON field and query output in focused tests.

## Project Corpus Impact
- Row: `ts-essentials-project`
- Bug family: benchmark 2x target-gap attribution for utility-type mapped/conditional/key-space workloads.
- Evidence: fresh attribution artifact `/tmp/studio-b-slow-statement-attribution-rebased.perf.json` on this rebased head reports `xor/index.ts` as the slowest semantic-check file and statement kind 279 span 679..45175 as the hottest top-level statement.

## Verification
- `cargo fmt --check`
- `python3 scripts/perf/test_query_perf_counters.py`
- `git diff --check`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-common perf_counters`
- `cargo check -p tsz-checker`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-common -p tsz-checker --all-targets -- -D warnings`
- `TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh cargo run -q -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json /tmp/studio-b-slow-statement-attribution-rebased.perf.json --noEmit -p .target-bench/external/ts-essentials/tsconfig.flat.json`

## Coordination Notes
- Measurement-only slice; it does not close the `ts-essentials-project` 2x target gap.
- Avoids M4 relation-cache, solver-policy, and alias-residue overlap; this PR only improves attribution for the current semantic-check bottleneck.
- Draft CI lint failure on head `e6fd427b38` was a WASM architecture guard finding for `std::time::Instant`; head `d9cf7bab82` fixes it with `web_time::Instant` and passed the guard locally.
