### PR TITLE
refactor(solver): decode relation flags from typed bits

### DIFF
--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -271,59 +271,11 @@ impl RelationPolicy {
 /// typed [`RelationPolicy`](super::RelationPolicy) /
 /// [`RelationFlags`](crate::types::RelationFlags) values after this boundary.
 mod legacy_policy_flags {
-    use crate::types::{RelationCacheKey, RelationFlags};
+    use crate::types::RelationFlags;
 
     pub(super) const fn decode(flags: u16) -> RelationFlags {
-        let mut bits = RelationFlags::empty();
-        if flags & RelationCacheKey::FLAG_STRICT_NULL_CHECKS != 0 {
-            bits = bits.union(RelationFlags::STRICT_NULL_CHECKS);
-        }
-        if flags & RelationCacheKey::FLAG_STRICT_FUNCTION_TYPES != 0 {
-            bits = bits.union(RelationFlags::STRICT_FUNCTION_TYPES);
-        }
-        if flags & RelationCacheKey::FLAG_EXACT_OPTIONAL_PROPERTY_TYPES != 0 {
-            bits = bits.union(RelationFlags::EXACT_OPTIONAL_PROPERTY_TYPES);
-        }
-        if flags & RelationCacheKey::FLAG_NO_UNCHECKED_INDEXED_ACCESS != 0 {
-            bits = bits.union(RelationFlags::NO_UNCHECKED_INDEXED_ACCESS);
-        }
-        if flags & RelationCacheKey::FLAG_DISABLE_METHOD_BIVARIANCE != 0 {
-            bits = bits.union(RelationFlags::DISABLE_METHOD_BIVARIANCE);
-        }
-        if flags & RelationCacheKey::FLAG_ALLOW_VOID_RETURN != 0 {
-            bits = bits.union(RelationFlags::ALLOW_VOID_RETURN);
-        }
-        if flags & RelationCacheKey::FLAG_ALLOW_BIVARIANT_REST != 0 {
-            bits = bits.union(RelationFlags::ALLOW_BIVARIANT_REST);
-        }
-        if flags & RelationCacheKey::FLAG_ALLOW_BIVARIANT_PARAM_COUNT != 0 {
-            bits = bits.union(RelationFlags::ALLOW_BIVARIANT_PARAM_COUNT);
-        }
-        if flags & RelationCacheKey::FLAG_NO_ERASE_GENERICS != 0 {
-            bits = bits.union(RelationFlags::NO_ERASE_GENERICS);
-        }
-        if flags & RelationCacheKey::FLAG_ALLOW_ERASED_GENERIC_SIGNATURE_RETRY != 0 {
-            bits = bits.union(RelationFlags::ALLOW_ERASED_GENERIC_SIGNATURE_RETRY);
-        }
-        if flags & RelationFlags::STRICT_SUBTYPE_CHECKING.bits() as u16 != 0 {
-            bits = bits.union(RelationFlags::STRICT_SUBTYPE_CHECKING);
-        }
-        if flags & RelationFlags::STRICT_ANY_PROPAGATION.bits() as u16 != 0 {
-            bits = bits.union(RelationFlags::STRICT_ANY_PROPAGATION);
-        }
-        if flags & RelationFlags::SKIP_WEAK_TYPE_CHECKS.bits() as u16 != 0 {
-            bits = bits.union(RelationFlags::SKIP_WEAK_TYPE_CHECKS);
-        }
-        if flags & RelationFlags::ASSUME_RELATED_ON_CYCLE.bits() as u16 != 0 {
-            bits = bits.union(RelationFlags::ASSUME_RELATED_ON_CYCLE);
-        }
-        if flags & RelationFlags::IN_CALLBACK_PARAM_CHECK.bits() as u16 != 0 {
-            bits = bits.union(RelationFlags::IN_CALLBACK_PARAM_CHECK);
-        }
-        if flags & RelationFlags::STRICT_READONLY_IDENTITY.bits() as u16 != 0 {
-            bits = bits.union(RelationFlags::STRICT_READONLY_IDENTITY);
-        }
-        bits
+        let known_bits = flags as u32 & RelationFlags::all().bits();
+        RelationFlags::from_bits_retain(known_bits)
     }
 }
 

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -778,6 +778,12 @@ REGEX_LINE_COUNT_CHECKS = [
         0,
     ),
     (
+        "Solver relation boundary: legacy flag decoder avoids cache-key constants (#8207)",
+        [ROOT / "crates" / "tsz-solver" / "src" / "relations" / "relation_queries.rs"],
+        re.compile(r"\bRelationCacheKey::FLAG_[A-Z0-9_]+\b"),
+        0,
+    ),
+    (
         "Solver relation boundary: legacy RelationPolicy::from_flags calls stay at boundary (#8207)",
         [ROOT / "crates" / "tsz-solver" / "src"],
         re.compile(

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -759,6 +759,12 @@ REGEX_LINE_COUNT_CHECKS = [
         0,
     ),
     (
+        "Solver relation boundary: legacy flag decoder avoids cache-key constants (#8207)",
+        [ROOT / "crates" / "tsz-solver" / "src" / "relations" / "relation_queries.rs"],
+        re.compile(r"\bRelationCacheKey::FLAG_[A-Z0-9_]+\b"),
+        0,
+    ),
+    (
         "Solver relation boundary: legacy RelationPolicy::from_flags calls stay at boundary (#8207)",
         [ROOT / "crates" / "tsz-solver" / "src"],
         re.compile(

--- a/scripts/arch/test_arch_guard_policy.py
+++ b/scripts/arch/test_arch_guard_policy.py
@@ -227,6 +227,24 @@ class ArchGuardRegexLineCountTests(unittest.TestCase):
         self.assertIn("query_cache.rs:1", hits[0])
         self.assertIn("total matching lines: 1", hits[1])
 
+    def test_legacy_flag_decoder_avoids_cache_key_constants(self):
+        pattern, _max_lines = self._check_by_name("decoder avoids cache-key constants")
+        root = self._make_tree(
+            {
+                "crates/tsz-solver/src/relations/relation_queries.rs": (
+                    "if flags & RelationCacheKey::FLAG_STRICT_NULL_CHECKS != 0 {}\n"
+                    "if flags & RelationFlags::STRICT_NULL_CHECKS.bits() as u16 != 0 {}\n"
+                    "/// RelationCacheKey::FLAG_STRICT_NULL_CHECKS is discussed here.\n"
+                    'let text = "RelationCacheKey::FLAG_STRICT_NULL_CHECKS";\n'
+                ),
+            }
+        )
+        hits = self.arch_guard.scan_regex_line_count([root], pattern, 0)
+        self.assertEqual(len(hits), 3, f"unexpected hits: {hits!r}")
+        self.assertIn("relation_queries.rs:1", hits[0])
+        self.assertIn("relation_queries.rs:4", hits[1])
+        self.assertIn("total matching lines: 2", hits[2])
+
     def test_query_cache_relation_facade_guard(self):
         pattern, _max_lines = self._check_by_name("query cache uses relation facade")
         root = self._make_tree(

--- a/scripts/arch/test_arch_guard_project.py
+++ b/scripts/arch/test_arch_guard_project.py
@@ -821,6 +821,24 @@ class ArchGuardRegexLineCountTests(unittest.TestCase):
         self.assertIn("query_cache.rs:1", hits[0])
         self.assertIn("total matching lines: 1", hits[1])
 
+    def test_legacy_flag_decoder_avoids_cache_key_constants(self):
+        pattern, _max_lines = self._check_by_name("decoder avoids cache-key constants")
+        root = self._make_tree(
+            {
+                "crates/tsz-solver/src/relations/relation_queries.rs": (
+                    "if flags & RelationCacheKey::FLAG_STRICT_NULL_CHECKS != 0 {}\n"
+                    "if flags & RelationFlags::STRICT_NULL_CHECKS.bits() as u16 != 0 {}\n"
+                    "/// RelationCacheKey::FLAG_STRICT_NULL_CHECKS is discussed here.\n"
+                    'let text = "RelationCacheKey::FLAG_STRICT_NULL_CHECKS";\n'
+                ),
+            }
+        )
+        hits = self.arch_guard.scan_regex_line_count([root], pattern, 0)
+        self.assertEqual(len(hits), 3, f"unexpected hits: {hits!r}")
+        self.assertIn("relation_queries.rs:1", hits[0])
+        self.assertIn("relation_queries.rs:4", hits[1])
+        self.assertIn("total matching lines: 2", hits[2])
+
     def test_query_cache_relation_facade_guard(self):
         pattern, _max_lines = self._check_by_name("query cache uses relation facade")
         root = self._make_tree(


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 4 solver relation policy/cache-key cleanup for #8207. Follow-up to merged #10617.

## Invariant
When the legacy packed `u16` relation boundary decodes relation behavior, the source of truth must be typed `RelationFlags`, not `RelationCacheKey::FLAG_*` cache-key constants. This PR keeps cache-key constants as external compatibility aliases while preventing solver relation policy decoding from depending on them.

## Scope
- `crates/tsz-solver/src/relations/relation_queries.rs`
- `scripts/arch/arch_guard_shared.py`
- `scripts/arch/arch_guard_config.py`
- `scripts/arch/test_arch_guard_policy.py`
- `scripts/arch/test_arch_guard_project.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: architecture guard and solver relation-cache unit coverage only; no project corpus row or emit behavior changed.

## Verification
- RED: `python3 scripts/arch/arch_guard.py` failed on 10 live `RelationCacheKey::FLAG_*` decoder lines in `relation_queries.rs` after adding the guard.
- GREEN: `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard_policy.ArchGuardRegexLineCountTests.test_legacy_flag_decoder_avoids_cache_key_constants scripts.arch.test_arch_guard_project.ArchGuardRegexLineCountTests.test_legacy_flag_decoder_avoids_cache_key_constants` passed: 2 tests.
- GREEN: `python3 scripts/arch/arch_guard.py` passed before initial publish.
- GREEN: `cargo nextest run -p tsz-solver -E 'test(relation_cache_config_tests)'` passed before initial publish: 50 passed, 6293 skipped.
- GREEN: `cargo fmt --check` passed before initial publish.
- GREEN: full arch smoke passed before initial publish via `python3 -m py_compile scripts/arch/*.py` and each `scripts/arch/test_*.py` file: 223, 28, and 62 tests.
- GREEN: `git diff --check` passed before initial publish.
- GREEN draft-light CI on old stacked head `b1da8b8d2a025d65061c7b79206edc1969602744`: `CI Light Summary`, `lint`, `unit`, `dist-binaries`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, and `project-row-drift` passed in https://github.com/mohsen1/tsz/actions/runs/26538864638.
- GREEN after rebase onto merged #10617 / `origin/main` at `216f57ce5e8`: `git diff --check origin/main...HEAD`.
- GREEN after rebase onto merged #10617 / `origin/main` at `216f57ce5e8`: `python3 scripts/arch/arch_guard.py`.
- GREEN after rebase onto merged #10617 / `origin/main` at `216f57ce5e8`: `cargo fmt --check`.
- GREEN after rebase onto merged #10617 / `origin/main` at `216f57ce5e8`: `cargo nextest run -p tsz-solver -E 'test(relation_cache_config_tests)'` passed: 50 passed, 6293 skipped.

## Coordination Notes
- #10617 merged via queue at `216f57ce5e8190c1c79bcf9a2f267427ce03f279`; this PR is now rebased to one cleanup commit on top of `main` and retargeted from the stacked base to `main`.
- Coordinates with #8207.
- I checked open PRs before publishing; this stays in solver relation-policy decoding and arch guard coverage, with no checker routing changes and no overlap with M1-B #10537.
- Ready for merge queue after exact-head `CI Summary` and `GitGuardian Security Checks` passed on head `954f2b88104`.
- No `WIP` label; `merge-queue` may be applied by ReviewHelper after exact-head checks.