### PR TITLE
docs(plan): refresh accepted regression metric

### DIFF
--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -53,7 +53,7 @@ denominators.
 | Surface | Current |
 | --- | ---: |
 | Diagnostic conformance | `100.0%` exact (`12,582 / 12,582`) |
-| Accepted-regression strictness | `15` listed tests |
+| Accepted-regression strictness | `14` listed tests |
 | JavaScript emit | `96.8%` (`13,094 / 13,530`) in checked-in emit snapshot and README |
 | Declaration emit | `96.2%` (`1,606 / 1,669`) in checked-in emit snapshot and README |
 | Fourslash / language service | `99.9%` (`6,558 / 6,562`) |


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 1 release metric truth / roadmap metric refresh.

## Invariant
When the checked-in accepted-regression gate has 14 active entries, the roadmap public metric should say 14 listed tests; this PR changes only the living roadmap metric row.

## Scope
- `docs/plan/ROADMAP.md`: refresh Accepted-regression strictness from `15` to `14` listed tests.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only public metric refresh; no compiler behavior, project fixtures, benchmark timing, conformance artifacts, or emit artifacts changed.

## Verification
- `python3 scripts/conformance/query-conformance.py --dashboard | sed -n '1,12p'` shows `Accepted-regression gate: 14 listed tests`.
- Counted non-comment entries in `scripts/conformance/conformance-accepted-regressions.txt`: `accepted_entries=14`.
- `git diff --check`
- Draft CI light run `26539101536`: `CI Light Summary`, `gate`, and `GitGuardian Security Checks` passed on `309ea7e29253c4f59fcdabef11f091634d08ac2a`.
- PR-head CI run `26539147555`: `CI Summary`, `project-corpus-pr-body`, `gate`, and `GitGuardian Security Checks` passed on `309ea7e29253c4f59fcdabef11f091634d08ac2a`.

## Coordination Notes
- Studio-A had no open owned PRs at intake.
- Canonical agent-label audit passed before publishing.
- M1-C draft #10265 may change the accepted-regression list again; this PR only keeps the current public roadmap metric aligned with current `main`.
- Exact-head PR CI is green; ready for repo-local merge queue.
