### PR TITLE
fix(checker): lower concrete conditional alias chains

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain.rs
@@ -1024,6 +1024,71 @@ impl<'a> CheckerState<'a> {
                 Self::source_file_alias_proof_seen_pop(seen, key);
                 result
             }
+            k if k == syntax_kind_ext::CONDITIONAL_TYPE => {
+                arena.get_conditional_type(node).is_some_and(|conditional| {
+                    let mut true_branch_names = Vec::new();
+                    Self::collect_infer_type_param_names(
+                        arena,
+                        conditional.extends_type,
+                        &mut true_branch_names,
+                    );
+                    let mut true_inferred_guard_names = inferred_guard_names.to_vec();
+                    Self::collect_tuple_rest_infer_type_param_names(
+                        arena,
+                        conditional.extends_type,
+                        &mut true_inferred_guard_names,
+                    );
+                    Self::collect_array_element_infer_type_param_names(
+                        arena,
+                        conditional.extends_type,
+                        &mut true_inferred_guard_names,
+                    );
+                    Self::collect_generic_projection_infer_type_param_names(
+                        arena,
+                        binder,
+                        conditional.extends_type,
+                        &mut true_inferred_guard_names,
+                        proof,
+                    );
+                    Self::source_file_type_node_is_generic_local_alias_application_lowerable_with_guard(
+                        arena,
+                        binder,
+                        conditional.check_type,
+                        &[],
+                        seen,
+                        proof,
+                        recursion_guarded,
+                        inferred_guard_names,
+                    ) && Self::source_file_type_node_is_generic_local_alias_application_lowerable_with_guard(
+                        arena,
+                        binder,
+                        conditional.extends_type,
+                        &[],
+                        seen,
+                        proof,
+                        recursion_guarded,
+                        inferred_guard_names,
+                    ) && Self::source_file_type_node_is_generic_local_alias_application_lowerable_with_guard(
+                        arena,
+                        binder,
+                        conditional.true_type,
+                        &true_branch_names,
+                        seen,
+                        proof,
+                        recursion_guarded,
+                        &true_inferred_guard_names,
+                    ) && Self::source_file_type_node_is_generic_local_alias_application_lowerable_with_guard(
+                        arena,
+                        binder,
+                        conditional.false_type,
+                        &[],
+                        seen,
+                        proof,
+                        recursion_guarded,
+                        inferred_guard_names,
+                    )
+                })
+            }
             k if k == syntax_kind_ext::UNION_TYPE || k == syntax_kind_ext::INTERSECTION_TYPE => {
                 arena.get_composite_type(node).is_some_and(|composite| {
                     composite.types.nodes.iter().copied().all(|member| {

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain_concrete_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain_concrete_tests.rs
@@ -1,0 +1,106 @@
+use crate::context::{CheckerContext, CheckerOptions};
+use crate::query_boundaries::common::TypeInterner;
+use crate::state::CheckerState;
+use std::sync::Arc;
+use tsz_binder::BinderState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeId;
+
+fn parse_bound_source(
+    source: &str,
+) -> (
+    Arc<tsz_parser::parser::node::NodeArena>,
+    Arc<BinderState>,
+    TypeInterner,
+) {
+    let mut parser = ParserState::new("fixture.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+    (
+        Arc::new(parser.get_arena().clone()),
+        Arc::new(binder),
+        TypeInterner::new(),
+    )
+}
+
+fn with_two_file_state<F, R>(target_source: &str, requester_source: &str, test: F) -> R
+where
+    F: FnOnce(&mut CheckerState<'_>, &Arc<BinderState>) -> R,
+{
+    let (target_arena, target_binder, types) = parse_bound_source(target_source);
+    let (requester_arena, requester_binder, _) = parse_bound_source(requester_source);
+    let ctx = CheckerContext::new(
+        requester_arena.as_ref(),
+        requester_binder.as_ref(),
+        &types,
+        "requester.ts".to_string(),
+        CheckerOptions::default(),
+    );
+    let mut state = CheckerState { ctx };
+    state.ctx.set_all_arenas(Arc::new(vec![
+        Arc::clone(&requester_arena),
+        Arc::clone(&target_arena),
+    ]));
+    state.ctx.set_all_binders(Arc::new(vec![
+        Arc::clone(&requester_binder),
+        Arc::clone(&target_binder),
+    ]));
+    test(&mut state, &target_binder)
+}
+
+#[test]
+fn direct_source_file_type_alias_lowers_concrete_local_conditional_alias_chain() {
+    with_two_file_state(
+        "type Slots = { yes: string; no: number };\ntype PickYes = 'x' extends string ? Slots['yes'] : Slots['no'];\nexport type Result = PickYes;",
+        "import { Result } from './target';",
+        |state, target_binder| {
+            let result_sym = target_binder.file_locals.get("Result").expect("Result");
+            let (ty, params) = state
+                .direct_source_file_type_alias_result(result_sym, Some(1), true)
+                .expect("concrete conditional aliases should lower through local alias chains");
+
+            assert_ne!(ty, TypeId::UNKNOWN);
+            assert_ne!(ty, TypeId::ERROR);
+            assert!(params.is_empty(), "Result should stay non-generic");
+        },
+    );
+}
+
+#[test]
+fn direct_source_file_type_alias_lowers_concrete_conditional_infer_branch() {
+    with_two_file_state(
+        "type TupleItem = readonly ['value'] extends readonly [infer Chosen] ? Chosen : never;\nexport type Result = TupleItem;",
+        "import { Result } from './target';",
+        |state, target_binder| {
+            let result_sym = target_binder.file_locals.get("Result").expect("Result");
+            let (ty, params) = state
+                .direct_source_file_type_alias_result(result_sym, Some(1), true)
+                .expect(
+                    "concrete conditional infer aliases should lower through local alias chains",
+                );
+
+            assert_ne!(ty, TypeId::UNKNOWN);
+            assert_ne!(ty, TypeId::ERROR);
+            assert!(params.is_empty(), "Result should stay non-generic");
+        },
+    );
+}
+
+#[test]
+fn direct_source_file_type_alias_rejects_concrete_conditional_flow_type_query() {
+    with_two_file_state(
+        "declare const liveValue: string;\ntype Unsafe = 'x' extends string ? typeof liveValue : never;\nexport type Result = Unsafe;",
+        "import { Result } from './target';",
+        |state, target_binder| {
+            let result_sym = target_binder.file_locals.get("Result").expect("Result");
+
+            assert!(
+                state
+                    .direct_source_file_type_alias_result(result_sym, Some(1), true)
+                    .is_none(),
+                "flow-sensitive typeof branches must stay on the child-checker path",
+            );
+        },
+    );
+}

--- a/crates/tsz-checker/src/state/type_analysis/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/mod.rs
@@ -17,6 +17,8 @@ pub(crate) mod cross_file_direct;
 mod cross_file_direct_actual_lib;
 mod cross_file_direct_alias_chain;
 #[cfg(test)]
+mod cross_file_direct_alias_chain_concrete_tests;
+#[cfg(test)]
 mod cross_file_direct_alias_chain_tests;
 mod cross_file_direct_declaration_alias;
 mod cross_file_direct_functions;


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Track 10 / semantic performance campaign: ts-toolbelt direct source-file alias lowering residue.

## Invariant
When a non-generic source-file alias chain reaches a concrete conditional type, and the conditional check, extends, true, and false arms are already structurally lowerable by the existing source-file alias proof, tsz can direct-lower the alias through the checker proof gate and normal type lowering instead of forcing a child checker.

## Scope
- `crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain.rs`
- `crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain_concrete_tests.rs`
- `crates/tsz-checker/src/state/type_analysis/mod.rs`

## Project Corpus Impact
- Row: `ts-toolbelt-project`
- Bug family: green-but-slow source-file alias direct-lowering residue (`body_not_direct_lowerable`, conditional-type shaped aliases)
- Evidence: #8356 current residue packet lists `conditional_type=82` among direct source-file alias proof misses. This PR adds a structural proof slice only; no benchmark timing claim is made.

## Structural Rule
When a concrete conditional appears inside a non-generic local alias chain, the proof treats each conditional arm like the generic proof already does: inherited guard names stay in outer arms, `infer` names are scoped to the true branch, and unsafe branches fall back.

## Owner Layer
Owner: checker direct source-file alias proof gate. This is not a semantic type algorithm change; type construction still goes through the existing lowering path after the proof admits only structurally lowerable syntax.

## Adjacent-Case Matrix
- Concrete conditional over local type-literal indexed-access branches lowers directly.
- Concrete conditional with a true-branch `infer` binding lowers directly with the inferred name scoped to the true branch.
- Concrete conditional with a flow-sensitive `typeof` branch is rejected and stays on the child-checker path.

## Known Fallbacks
- Flow-sensitive `typeof` queries, unsupported operands, unsafe alias cycles, and other non-lowerable branch shapes continue to return `false` from the proof and use the existing child-checker path.

## Verification
- RED before implementation: `cargo nextest run -p tsz-checker --lib direct_source_file_type_alias_lowers_concrete_local_conditional_alias_chain` failed with `direct_source_file_type_alias_result(...).expect(...)`.
- `cargo nextest run -p tsz-checker --lib cross_file_direct_alias_chain_concrete_tests`
- `cargo nextest run -p tsz-checker --lib direct_source_file_type_alias`
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `python3 scripts/arch/arch_guard.py`

## Coordination Notes
- Non-overlap: M1-C owns deep recursive mapped accepted-regression work; M4-B owns relation policy/cache flags; M4-C owns contextual/object-literal request state. This PR is a small direct-alias proof slice for #8356 and does not change relation policy, cache keys, or recursive mapped-depth behavior.
- Branch was rebased onto `origin/main` before publish.
