### PR TITLE
docs(readme): fix compatibility heading typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ curl -fsSL https://tsz.dev/install | sh
 irm https://tsz.dev/install.ps1 | iex
 ```
 
-## TypeScript compatiblity 
+## TypeScript compatibility
 <!-- TS_VERSION_START -->
 Currently targeting `TypeScript`@`6.0.3`
 <!-- TS_VERSION_END -->


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Docs-only public release-metric surface hygiene.

## Invariant
When README headings describe the TypeScript compatibility section, the wording should be spelled correctly; this PR fixes a public-doc typo without changing metric values or compiler behavior.

## Scope
- README.md heading spelling only.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only typo fix; no benchmark, compile-guard, conformance, emit, checker, solver, parser, binder, LSP, WASM, or CI behavior changed.

## Verification
- git diff --check

## Coordination Notes
- Opened after Studio-A owned PR runway was empty.
- No overlap with active benchmark, conformance, emit, or project-corpus PRs.
