### PR TITLE
fix(bench): scope project row case-arm extraction

### DIFF
--- a/scripts/bench/project-row-summary.mjs
+++ b/scripts/bench/project-row-summary.mjs
@@ -38,8 +38,14 @@ export const COMPILE_GUARD_EXCLUDED_ROWS = new Set([
 ]);
 
 function extractCaseArmRows(scriptText) {
-  return [...scriptText.matchAll(/^\s{4}([a-z0-9-]+(?:\|[a-z0-9-]+)*)\)\s*$/gm)]
+  return [...scriptText.matchAll(/^[ \t]+([a-z0-9-]+(?:\|[a-z0-9-]+)*)\)\s*$/gm)]
     .flatMap((m) => m[1].split("|"));
+}
+
+function extractShellFunctionBody(scriptText, functionName) {
+  const escapedName = functionName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = scriptText.match(new RegExp(`^[ \\t]*${escapedName}\\(\\)[ \\t]*\\{\\n([\\s\\S]*?)^\\}`, "m"));
+  return match ? match[1] : scriptText;
 }
 
 export function extractBenchRunnerRows(scriptText) {
@@ -49,10 +55,11 @@ export function extractBenchRunnerRows(scriptText) {
 }
 
 export function extractCompileGuardRows(scriptText) {
+  const projectRowFunction = extractShellFunctionBody(scriptText, "run_project_row");
   const literalRows = [...scriptText.matchAll(/check_project\s+"([^"]+)"/g)]
     .map((m) => m[1])
     .filter((r) => r !== "$name");
-  return [...new Set([...literalRows, ...extractCaseArmRows(scriptText)])].sort();
+  return [...new Set([...literalRows, ...extractCaseArmRows(projectRowFunction)])].sort();
 }
 
 function extractShellArrayRows(scriptText, arrayName) {
@@ -70,7 +77,7 @@ export function extractCompileGuardFallbackRows(scriptText) {
 }
 
 export function extractFixtureSourceRows(scriptText) {
-  return [...new Set(extractCaseArmRows(scriptText))].sort();
+  return [...new Set(extractCaseArmRows(extractShellFunctionBody(scriptText, "tsz_project_fixture_sources")))].sort();
 }
 
 export function readSurfaceData() {

--- a/scripts/bench/test-project-row-summary.mjs
+++ b/scripts/bench/test-project-row-summary.mjs
@@ -276,16 +276,28 @@ run_project_benchmark "alpha" "$tsconfig" "$src"
 // Extractor: compile guard rows from shell snippet — both literal and case-arm forms.
 {
   const snippet = `
-check_project "alpha" "$tsconfig" "$src"
-check_project "beta" "$tsconfig" "$src"
-    gamma|delta)
+check_project "alpha-project" "$tsconfig" "$src"
+check_project "beta-project" "$tsconfig" "$src"
+  124|137)
+  required)
+run_project_row() {
+  case "$name" in
+    gamma-project|delta-project)
 check_project "$name" "$tsconfig" "$src"
+  epsilon-project)
+\tzeta-project)
+  esac
+}
 `;
   const rows = extractCompileGuardRows(snippet);
-  assert.ok(rows.includes("alpha"), "missing alpha");
-  assert.ok(rows.includes("beta"), "missing beta");
-  assert.ok(rows.includes("gamma"), "missing gamma from case arm");
-  assert.ok(rows.includes("delta"), "missing delta from case arm");
+  assert.ok(rows.includes("alpha-project"), "missing alpha-project");
+  assert.ok(rows.includes("beta-project"), "missing beta-project");
+  assert.ok(rows.includes("gamma-project"), "missing gamma-project from case arm");
+  assert.ok(rows.includes("delta-project"), "missing delta-project from case arm");
+  assert.ok(rows.includes("epsilon-project"), "missing epsilon-project from two-space case arm");
+  assert.ok(rows.includes("zeta-project"), "missing zeta-project from tab-indented case arm");
+  assert.ok(!rows.includes("124"), "numeric case arms must not be treated as project rows");
+  assert.ok(!rows.includes("required"), "mode case arms must not be treated as project rows");
   assert.ok(!rows.includes("$name"), "$name must be filtered out");
 }
 
@@ -309,15 +321,19 @@ TSZ_COMPILE_GUARD_CANARY_ROWS=(
 // Extractor: fixture source rows from project-fixtures.sh case-arm format.
 {
   const snippet = `
-    alpha|beta)
+tsz_project_fixture_sources() {
+  case "$1" in
+    alpha-project|beta-project)
       setup_alpha
     ;;
-    gamma)
+    gamma-project)
       setup_gamma
     ;;
+  esac
+}
 `;
   const rows = extractFixtureSourceRows(snippet);
-  assert.deepEqual(rows, ["alpha", "beta", "gamma"]);
+  assert.deepEqual(rows, ["alpha-project", "beta-project", "gamma-project"]);
 }
 
 console.log("test-project-row-summary: all tests passed");


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Benchmark/project-corpus metric guard.

## Invariant
When project-row coverage extracts shell case arms, only the project-row mapping functions should contribute rows; this PR makes the extractor tolerate case-arm indentation inside those functions without counting unrelated shell case arms.

## Scope
- scripts/bench/project-row-summary.mjs
- scripts/bench/test-project-row-summary.mjs

## Project Corpus Impact
- Row: n/a
- Bug family: project-row metadata/reporting drift guard
- Evidence: `node scripts/bench/project-row-summary.mjs --markdown` reports all 12 rows consistent; metadata validation still passes.

## Verification
- node scripts/bench/test-project-row-summary.mjs
- node scripts/bench/project-row-summary.mjs --markdown
- node scripts/bench/validate-project-metadata.mjs
- git diff --check

## Coordination Notes
- Opened after Studio-A owned PR runway was empty.
- No overlap with active compiler, emit, or performance PRs; this is reporting-script guard coverage only.
