### PR TITLE
fix(bench): run shard prep fetch under sh

### DIFF
--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -149,7 +149,7 @@ assert.match(
 
 assert.match(
   shardCloudbuild,
-  /if \[\[ -f bench-prep\.env && -f bench-prep\.tar \]\]; then[\s\S]+Using benchmark prep artifact from the Cloud Build source archive\.[\s\S]+else[\s\S]+gcloud storage cp[\s\S]+bench-prep\/\$\{_BENCH_TARGET_SHA\}\/bench-prep\.env/,
+  /if \[ -f bench-prep\.env \] && \[ -f bench-prep\.tar \]; then[\s\S]+Using benchmark prep artifact from the Cloud Build source archive\.[\s\S]+else[\s\S]+gcloud storage cp[\s\S]+bench-prep\/\$\{_BENCH_TARGET_SHA\}\/bench-prep\.env/,
   "Cloud Build shard prep should prefer source-provided prep artifacts before falling back to GCS",
 );
 

--- a/scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
@@ -46,8 +46,8 @@ assert.match(
 
 assert.match(
   shardCloudbuild,
-  /\} > bench-prep-fetch\.log 2>&1[\s\S]+BENCH_PREP_FETCH_STATUS=%s[\s\S]+exit 0/,
-  "Cloud Build prep-fetch step should record status and never fail the build before shard status artifacts can be written",
+  /#!\/bin\/sh[\s\S]+\) > bench-prep-fetch\.log 2>&1[\s\S]+BENCH_PREP_FETCH_STATUS=%s[\s\S]+exit 0/,
+  "Cloud Build prep-fetch step should use the shell available in cloud-sdk:slim, record status, and never fail the build before shard status artifacts can be written",
 );
 
 assert.match(

--- a/scripts/cloudbuild/cloudbuild-bench-shard.yaml
+++ b/scripts/cloudbuild/cloudbuild-bench-shard.yaml
@@ -5,13 +5,13 @@ steps:
   - id: download-bench-prep
     name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
     script: |
-      #!/usr/bin/env bash
+      #!/bin/sh
       set +e
 
-      {
-        set -euo pipefail
+      (
+        set -eu
 
-        if [[ -f bench-prep.env && -f bench-prep.tar ]]; then
+        if [ -f bench-prep.env ] && [ -f bench-prep.tar ]; then
           echo "Using benchmark prep artifact from the Cloud Build source archive."
         else
           gcloud storage cp \
@@ -25,16 +25,16 @@ steps:
         tar -tf bench-prep.tar .target-bench/dist/tsz >/dev/null
         tar -tf bench-prep.tar .target-bench/dist/.bench-pgo-optimized >/dev/null
         # shellcheck disable=SC1091
-        source bench-prep.env
-        if [[ "${BENCH_TARGET_SHA:-}" != "${_BENCH_TARGET_SHA}" ]]; then
+        . ./bench-prep.env
+        if [ "${BENCH_TARGET_SHA:-}" != "${_BENCH_TARGET_SHA}" ]; then
           echo "Bench prep artifact is for ${BENCH_TARGET_SHA:-unknown}; expected ${_BENCH_TARGET_SHA}."
           exit 1
         fi
-        if [[ "${BENCH_PGO_OPTIMIZED:-}" != "1" ]]; then
+        if [ "${BENCH_PGO_OPTIMIZED:-}" != "1" ]; then
           echo "Bench prep artifact is not marked PGO optimized."
           exit 1
         fi
-      } > bench-prep-fetch.log 2>&1
+      ) > bench-prep-fetch.log 2>&1
       fetch_status=$?
       cat bench-prep-fetch.log
       {


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 1 benchmark blocker: Bench CI flow and website benchmark freshness.

## Invariant
Cloud Build shard jobs must always reach the shard status/log publication step, even when prep-fetch setup fails, so GitHub can diagnose the failure and avoid blind benchmark red jobs.

## Scope
- `scripts/cloudbuild/cloudbuild-bench-shard.yaml`: run the `download-bench-prep` wrapper under `/bin/sh`, using POSIX syntax compatible with `cloud-sdk:slim`, while preserving the tolerant status-recording behavior.
- `scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`: update the source-artifact fallback assertion for POSIX shell syntax.
- `scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`: assert the prep-fetch step uses the available shell and exits 0 after recording status.

## Project Corpus Impact
- Row: n/a
- Bug family: benchmark freshness / Cloud Build shard setup
- Evidence: CI workflow/config-only fix. The failed manual Bench run `26538802475` showed all shards failing before `bench-shard` because Cloud Build step `download-bench-prep` exited 1 before status artifacts could be published.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `git diff --check`

## Coordination Notes
- Follows #10612/#10625/#10627. The manual-dispatch flow now reaches prep and shard fanout; this fixes the shard setup step so the run can continue into benchmark execution and publish fresh-enough website data.
