### PR TITLE
fix(checker): guard local alias projection recursion

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain.rs
@@ -1303,59 +1303,6 @@ impl<'a> CheckerState<'a> {
         true
     }
 
-    fn source_file_local_type_alias_application_is_projection_lowerable<'b>(
-        arena: &'b NodeArena,
-        binder: &'b BinderState,
-        symbol: &Symbol,
-        arg_count: usize,
-        proof: &SourceFileAliasProofContext<'b>,
-    ) -> bool {
-        let disallowed = symbol_flags::VALUE
-            | symbol_flags::CLASS
-            | symbol_flags::INTERFACE
-            | symbol_flags::VALUE_MODULE
-            | symbol_flags::NAMESPACE_MODULE;
-        if symbol.flags & symbol_flags::TYPE_ALIAS == 0
-            || symbol.flags & disallowed != 0
-            || symbol.declarations.len() != 1
-        {
-            return false;
-        }
-
-        let decl_idx = symbol.declarations[0];
-        let Some(decl_node) = arena.get(decl_idx) else {
-            return false;
-        };
-        let Some(type_alias) = arena.get_type_alias(decl_node) else {
-            return false;
-        };
-        let mut seen = Vec::new();
-        let Some(target_param_names) =
-            Self::source_file_type_alias_application_param_names_are_lowerable(
-                arena, binder, type_alias, arg_count, &mut seen, proof,
-            )
-        else {
-            return false;
-        };
-        if target_param_names.is_empty()
-            || Self::source_file_type_node_contains_disallowed_type_query(
-                arena,
-                binder,
-                type_alias.type_node,
-            )
-        {
-            return false;
-        }
-        Self::source_file_type_node_is_generic_local_alias_application_lowerable_with_seen(
-            arena,
-            binder,
-            type_alias.type_node,
-            &target_param_names,
-            &mut seen,
-            proof,
-        )
-    }
-
     pub(super) fn source_file_import_alias_target_for_lowering<'b>(
         &'b self,
         source_file_idx: usize,
@@ -1935,4 +1882,5 @@ impl<'a> CheckerState<'a> {
 }
 
 include!("cross_file_direct_alias_chain/subtractive_guard_methods.rs");
+include!("cross_file_direct_alias_chain/projection_guard_methods.rs");
 include!("cross_file_direct_alias_chain/type_literal_methods.rs");

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain.rs
@@ -204,6 +204,12 @@ impl<'a> CheckerState<'a> {
                     resolved.arena,
                     symbol,
                     arg_count,
+                ) || Self::source_file_local_type_alias_application_is_projection_lowerable(
+                    resolved.arena,
+                    resolved.binder,
+                    symbol,
+                    arg_count,
+                    &proof.for_file(resolved.file_idx),
                 )
             })
     }
@@ -1295,6 +1301,59 @@ impl<'a> CheckerState<'a> {
         }
 
         true
+    }
+
+    fn source_file_local_type_alias_application_is_projection_lowerable<'b>(
+        arena: &'b NodeArena,
+        binder: &'b BinderState,
+        symbol: &Symbol,
+        arg_count: usize,
+        proof: &SourceFileAliasProofContext<'b>,
+    ) -> bool {
+        let disallowed = symbol_flags::VALUE
+            | symbol_flags::CLASS
+            | symbol_flags::INTERFACE
+            | symbol_flags::VALUE_MODULE
+            | symbol_flags::NAMESPACE_MODULE;
+        if symbol.flags & symbol_flags::TYPE_ALIAS == 0
+            || symbol.flags & disallowed != 0
+            || symbol.declarations.len() != 1
+        {
+            return false;
+        }
+
+        let decl_idx = symbol.declarations[0];
+        let Some(decl_node) = arena.get(decl_idx) else {
+            return false;
+        };
+        let Some(type_alias) = arena.get_type_alias(decl_node) else {
+            return false;
+        };
+        let mut seen = Vec::new();
+        let Some(target_param_names) =
+            Self::source_file_type_alias_application_param_names_are_lowerable(
+                arena, binder, type_alias, arg_count, &mut seen, proof,
+            )
+        else {
+            return false;
+        };
+        if target_param_names.is_empty()
+            || Self::source_file_type_node_contains_disallowed_type_query(
+                arena,
+                binder,
+                type_alias.type_node,
+            )
+        {
+            return false;
+        }
+        Self::source_file_type_node_is_generic_local_alias_application_lowerable_with_seen(
+            arena,
+            binder,
+            type_alias.type_node,
+            &target_param_names,
+            &mut seen,
+            proof,
+        )
     }
 
     pub(super) fn source_file_import_alias_target_for_lowering<'b>(

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain/projection_guard_methods.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain/projection_guard_methods.rs
@@ -1,0 +1,103 @@
+impl<'a> CheckerState<'a> {
+    pub(super) fn source_file_local_type_alias_application_is_projection_lowerable<'b>(
+        arena: &'b NodeArena,
+        binder: &'b BinderState,
+        symbol: &Symbol,
+        arg_count: usize,
+        proof: &SourceFileAliasProofContext<'b>,
+    ) -> bool {
+        let disallowed = symbol_flags::VALUE
+            | symbol_flags::CLASS
+            | symbol_flags::INTERFACE
+            | symbol_flags::VALUE_MODULE
+            | symbol_flags::NAMESPACE_MODULE;
+        if symbol.flags & symbol_flags::TYPE_ALIAS == 0
+            || symbol.flags & disallowed != 0
+            || symbol.declarations.len() != 1
+        {
+            return false;
+        }
+
+        let decl_idx = symbol.declarations[0];
+        let Some(decl_node) = arena.get(decl_idx) else {
+            return false;
+        };
+        let Some(type_alias) = arena.get_type_alias(decl_node) else {
+            return false;
+        };
+        let mut seen = Vec::new();
+        let Some(target_param_names) =
+            Self::source_file_type_alias_application_param_names_are_lowerable(
+                arena, binder, type_alias, arg_count, &mut seen, proof,
+            )
+        else {
+            return false;
+        };
+        if target_param_names.is_empty()
+            || target_param_names.len() != arg_count
+            || Self::source_file_type_node_contains_disallowed_type_query(
+                arena,
+                binder,
+                type_alias.type_node,
+            )
+        {
+            return false;
+        }
+
+        Self::source_file_type_alias_body_is_projection_transparent(
+            arena,
+            type_alias.type_node,
+            &target_param_names,
+        )
+    }
+
+    fn source_file_type_alias_body_is_projection_transparent(
+        arena: &NodeArena,
+        node_idx: NodeIndex,
+        type_param_names: &[String],
+    ) -> bool {
+        if Self::source_file_type_node_is_generic_scope_independent(
+            arena,
+            node_idx,
+            type_param_names,
+        ) {
+            return true;
+        }
+        let Some(node) = arena.get(node_idx) else {
+            return false;
+        };
+        match node.kind {
+            k if k == syntax_kind_ext::TYPE_LITERAL => {
+                Self::source_file_type_literal_has_generic_scope_independent_properties(
+                    arena,
+                    node,
+                    type_param_names,
+                )
+            }
+            k if k == syntax_kind_ext::UNION_TYPE || k == syntax_kind_ext::INTERSECTION_TYPE => {
+                arena.get_composite_type(node).is_some_and(|composite| {
+                    composite.types.nodes.iter().copied().all(|member| {
+                        Self::source_file_type_alias_body_is_projection_transparent(
+                            arena,
+                            member,
+                            type_param_names,
+                        )
+                    })
+                })
+            }
+            k if k == syntax_kind_ext::PARENTHESIZED_TYPE
+                || k == syntax_kind_ext::OPTIONAL_TYPE
+                || k == syntax_kind_ext::REST_TYPE =>
+            {
+                arena.get_wrapped_type(node).is_some_and(|wrapped| {
+                    Self::source_file_type_alias_body_is_projection_transparent(
+                        arena,
+                        wrapped.type_node,
+                        type_param_names,
+                    )
+                })
+            }
+            _ => false,
+        }
+    }
+}

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain_concrete_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain_concrete_tests.rs
@@ -104,3 +104,62 @@ fn direct_source_file_type_alias_rejects_concrete_conditional_flow_type_query() 
         },
     );
 }
+
+#[test]
+fn direct_source_file_type_alias_lowers_local_alias_projection_conditional_recursion() {
+    with_two_file_state(
+        "type Box<Item> = { value: Item };\nexport type UnboxDeep<Input> = Input extends Box<infer Item> ? UnboxDeep<Item> : Input;",
+        "import { UnboxDeep } from './target';",
+        |state, target_binder| {
+            let unbox_sym = target_binder
+                .file_locals
+                .get("UnboxDeep")
+                .expect("UnboxDeep");
+            let (ty, params) = state
+                .direct_source_file_type_alias_result(unbox_sym, Some(1), true)
+                .expect(
+                    "local alias projections should guard recursion through inferred components",
+                );
+
+            assert_ne!(ty, TypeId::UNKNOWN);
+            assert_ne!(ty, TypeId::ERROR);
+            assert_eq!(params.len(), 1, "UnboxDeep should expose Input");
+        },
+    );
+}
+
+#[test]
+fn direct_source_file_type_alias_lowers_renamed_pair_alias_projection_recursion() {
+    with_two_file_state(
+        "type PairBox<First, Rest> = { first: First; rest: Rest };\nexport type LastTail<Subject> = Subject extends PairBox<infer Head, infer Tail> ? LastTail<Tail> : Subject;",
+        "import { LastTail } from './target';",
+        |state, target_binder| {
+            let last_tail_sym = target_binder.file_locals.get("LastTail").expect("LastTail");
+            let (ty, params) = state
+                .direct_source_file_type_alias_result(last_tail_sym, Some(1), true)
+                .expect("renamed multi-argument alias projections should guard consumed recursion");
+
+            assert_ne!(ty, TypeId::UNKNOWN);
+            assert_ne!(ty, TypeId::ERROR);
+            assert_eq!(params.len(), 1, "LastTail should expose Subject");
+        },
+    );
+}
+
+#[test]
+fn direct_source_file_type_alias_rejects_local_alias_projection_original_arg_recursion() {
+    with_two_file_state(
+        "type Box<Item> = { value: Item };\nexport type Loop<Input> = Input extends Box<infer Item> ? Loop<Input> : Input;",
+        "import { Loop } from './target';",
+        |state, target_binder| {
+            let loop_sym = target_binder.file_locals.get("Loop").expect("Loop");
+
+            assert!(
+                state
+                    .direct_source_file_type_alias_result(loop_sym, Some(1), true)
+                    .is_none(),
+                "local alias projections only guard recursive calls that consume inferred components",
+            );
+        },
+    );
+}

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain_concrete_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain_concrete_tests.rs
@@ -1,3 +1,4 @@
+use super::cross_file_direct_alias_chain::SourceFileAliasProofContext;
 use crate::context::{CheckerContext, CheckerOptions};
 use crate::query_boundaries::common::TypeInterner;
 use crate::state::CheckerState;
@@ -159,6 +160,41 @@ fn direct_source_file_type_alias_rejects_local_alias_projection_original_arg_rec
                     .direct_source_file_type_alias_result(loop_sym, Some(1), true)
                     .is_none(),
                 "local alias projections only guard recursive calls that consume inferred components",
+            );
+        },
+    );
+}
+
+#[test]
+fn direct_source_file_type_alias_rejects_recursive_mapped_projection_guard() {
+    with_two_file_state(
+        "type Primitive = string | number | boolean | bigint | symbol | undefined | null;\nexport type DeepReadonly<T> = T extends ((...args: any[]) => any) | Primitive ? T : T extends _DeepReadonlyArray<infer Item> ? _DeepReadonlyArray<Item> : T extends _DeepReadonlyObject<infer Shape> ? _DeepReadonlyObject<Shape> : T;\nexport interface _DeepReadonlyArray<Item> extends ReadonlyArray<DeepReadonly<Item>> {}\nexport type _DeepReadonlyObject<Shape> = { readonly [Key in keyof Shape]: DeepReadonly<Shape[Key]> };\nexport type ReadOnly<Input extends object> = DeepReadonly<Input>;",
+        "import { ReadOnly } from './target';",
+        |state, target_binder| {
+            let object_sym = target_binder
+                .file_locals
+                .get("_DeepReadonlyObject")
+                .expect("_DeepReadonlyObject");
+            let object_symbol = target_binder
+                .get_symbol(object_sym)
+                .expect("_DeepReadonlyObject symbol");
+            let target_arena = state.ctx.get_arena_for_file(1);
+            let global_type_is_lowerable = |_: &BinderState, _: &str| true;
+            let proof = SourceFileAliasProofContext {
+                current_file_idx: Some(1),
+                global_type_is_lowerable: &global_type_is_lowerable,
+                import_alias_target: None,
+            };
+
+            assert!(
+                !CheckerState::source_file_local_type_alias_application_is_projection_lowerable(
+                    target_arena,
+                    target_binder,
+                    object_symbol,
+                    1,
+                    &proof,
+                ),
+                "recursive mapped aliases are not transparent projection guards",
             );
         },
     );


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Semantic campaign / checker direct-lowering performance slice for #8356.

## Invariant
When a conditional type infers through a structurally lowerable local generic type-alias projection, recursive source-file alias proof may treat recursive calls that consume those inferred projection components as guarded; this PR changes checker direct-lowering eligibility only, not solver evaluation or relation policy.

Structural rule: when `Input extends LocalAlias<infer Part>` and `LocalAlias` is a transparent projection over its type parameters, `tsc` can evaluate recursive uses that consume `Part`; tsz should admit that shape through the checker direct-lowering proof while still rejecting recursion on the original `Input` and recursive mapped aliases that are not transparent projections.

Owner layer: checker type-analysis. This proof decides whether cross-file source-file alias lowering can avoid the child-checker path; final type semantics remain with the existing lowering/evaluation paths.

## Scope
- `crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain.rs`
- `crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain/projection_guard_methods.rs`
- `crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain_concrete_tests.rs`

## Project Corpus Impact
- Row: `utility-types-project` and `ts-toolbelt-project`
- Bug family: recursive conditional/infer/source-file alias direct-lowering pressure; transparent vs recursive mapped projection guards
- Evidence: CI head `c070b54d2392e95a60fe864966bb83d10194265b` failed `project-compile-guard` with a `utility-types-project` stack overflow; local filtered guard passes on fixed head `1ca6d48c99bf1208746cbc7c61ad4c7dc273aa43`.

## Adjacent-Case Matrix
- Reported family witness: local single-argument alias projection `Box<infer Item>` guards `UnboxDeep<Item>`.
- Renamed/multi-argument variant: `PairBox<infer Head, infer Tail>` guards `LastTail<Tail>`.
- Negative fallback: `Box<infer Item>` does not guard `Loop<Input>` because the recursive call does not consume the inferred component.
- Project-row negative: recursive mapped alias `_DeepReadonlyObject<infer Shape>` does not count as a transparent projection guard for `DeepReadonly`.
- Existing surrounding regression filter covers shadowed globals, `typeof` fallbacks, unguarded recursion, imported alias chains, tuple/array projection guards, and subtractive recursion guards.

## Verification
- RED before initial implementation: `cargo nextest run -p tsz-checker --lib direct_source_file_type_alias_lowers_local_alias_projection_conditional_recursion`
- CI blocker reproduced on prior head: `TSZ_BIN=/Users/mohsen/code/tsz/.target/dist-fast/tsz TSZ_PROJECT_COMPILE_FILTER='utility-types-project' TSZ_PROJECT_COMPILE_SET=required scripts/safe-run.sh scripts/ci/project-compile-guard.sh` failed with stack overflow on `c070b54d2392e95a60fe864966bb83d10194265b`
- Fixed head: `cargo nextest run -p tsz-checker --lib cross_file_direct_alias_chain_concrete_tests`
- Fixed head: `cargo nextest run -p tsz-checker --lib direct_source_file_type_alias`
- Fixed head: `TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 /Users/mohsen/code/tsz/.target/dist-fast/tsz --noEmit --lib dom,es2017 --strict /tmp/deep-import.ts`
- Fixed head: `TSZ_BIN=/Users/mohsen/code/tsz/.target/dist-fast/tsz TSZ_PROJECT_COMPILE_FILTER='utility-types-project' TSZ_PROJECT_COMPILE_SET=required scripts/safe-run.sh scripts/ci/project-compile-guard.sh`
- Fixed head: `cargo fmt --check`
- Fixed head: `git diff --check origin/main...HEAD`
- Fixed head: `python3 scripts/arch/arch_guard.py`

## Coordination Notes
- M4-A is fixing its existing ready PR before continuing stacked follow-up work, per user request.
- The stacked follow-up worktree remains separate and is not included in this PR.
- Branch: `codex/m4a-local-alias-projection-guard-20260527`
- Head: `1ca6d48c99bf1208746cbc7c61ad4c7dc273aa43`
- Ready for fresh exact-head CI; no `WIP` state and no `merge-queue` label requested until PR-head checks are green.
