### PR TITLE
test(bench): cover generated fixture path validation

### DIFF
--- a/scripts/bench/test-validate-project-metadata.mjs
+++ b/scripts/bench/test-validate-project-metadata.mjs
@@ -247,6 +247,40 @@ assert.deepEqual(
     (() => {
       const row = validRow({
         category: "generated",
+        generated_by: "scripts/tools/generate-example.mjs",
+      });
+      delete row.repo;
+      delete row.repo_env;
+      delete row.ref;
+      delete row.ref_env;
+      return row;
+    })(),
+    (() => {
+      const row = validRow({
+        name: "wrong-extension-project",
+        label: "Wrong Extension",
+        category: "generated",
+        generated_by: "scripts/bench/generate-example-fixture.js",
+        fixture_dir: "wrong-extension-project",
+      });
+      delete row.repo;
+      delete row.repo_env;
+      delete row.ref;
+      delete row.ref_env;
+      return row;
+    })(),
+  ]),
+  [
+    "example-project: generated_by must point to a scripts/bench/*.mjs generator script",
+    "wrong-extension-project: generated_by must point to a scripts/bench/*.mjs generator script",
+  ],
+);
+
+assert.deepEqual(
+  validate([
+    (() => {
+      const row = validRow({
+        category: "generated",
         generated_by: "scripts/bench/generate-missing-fixture.mjs",
       });
       delete row.repo;


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Benchmark/project-corpus metadata guard coverage.

## Invariant
When generated project rows declare generator provenance, the validator requires `scripts/bench/*.mjs` paths; this PR adds coverage for malformed prefixes and extensions without changing runtime behavior.

## Scope
- scripts/bench/test-validate-project-metadata.mjs

## Project Corpus Impact
- Row: n/a
- Bug family: project-row metadata/reporting drift guard
- Evidence: test-only coverage for generated fixture provenance validation; live metadata validation and project-row summary still pass.

## Verification
- node scripts/bench/test-validate-project-metadata.mjs
- node scripts/bench/validate-project-metadata.mjs
- node scripts/bench/project-row-summary.mjs --markdown
- git diff --check

## Coordination Notes
- Opened after Studio-A owned PR runway was empty.
- No overlap with active compiler, emit, or performance PRs; this is benchmark metadata guard coverage only.
