### PR TITLE
fix(checker): resolve cross-module self member overrides

### DIFF
--- a/crates/tsz-checker/src/classes/class_member_info.rs
+++ b/crates/tsz-checker/src/classes/class_member_info.rs
@@ -392,7 +392,12 @@ impl<'a> CheckerState<'a> {
                         && base_type != TypeId::ANY
                     {
                         let resolved_member_type = self.resolve_type_query_type(member_type);
+                        let resolved_member_type = self.resolve_lazy_type(resolved_member_type);
+                        let resolved_member_type =
+                            self.evaluate_type_with_env(resolved_member_type);
                         let resolved_base_type = self.resolve_type_query_type(base_type);
+                        let resolved_base_type = self.resolve_lazy_type(resolved_base_type);
+                        let resolved_base_type = self.evaluate_type_with_env(resolved_base_type);
 
                         let should_report = if info.is_method || info.is_static {
                             should_report_member_type_mismatch_bivariant(

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -136,6 +136,9 @@ mod control_flow_tests;
 #[path = "../tests/control_flow_type_guard_tests.rs"]
 mod control_flow_type_guard_tests;
 #[cfg(test)]
+#[path = "tests/cross_module_class_self_member_tests.rs"]
+mod cross_module_class_self_member_tests;
+#[cfg(test)]
 #[path = "tests/decorator_return_relation_routing_arch_tests.rs"]
 mod decorator_return_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/cross_module_class_self_member_tests.rs
+++ b/crates/tsz-checker/src/tests/cross_module_class_self_member_tests.rs
@@ -1,0 +1,187 @@
+use crate::diagnostics::diagnostic_codes;
+use crate::test_utils::check_multi_file;
+
+fn strict_options() -> tsz_common::CheckerOptions {
+    tsz_common::CheckerOptions {
+        module: tsz_common::common::ModuleKind::CommonJS,
+        strict: true,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn cross_module_self_return_override_uses_base_instance_type() {
+    let diagnostics = check_multi_file(
+        &[
+            (
+                "base.ts",
+                r#"
+export abstract class Base {
+    abstract self(): Base;
+}
+"#,
+            ),
+            (
+                "derived.ts",
+                r#"
+import { Base } from "./base";
+
+export class Derived extends Base {
+    self(): Derived {
+        return this;
+    }
+}
+"#,
+            ),
+        ],
+        "derived.ts",
+        strict_options(),
+    );
+
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|diag| diag.code == diagnostic_codes::PROPERTY_IN_TYPE_IS_NOT_ASSIGNABLE_TO_THE_SAME_PROPERTY_IN_BASE_TYPE),
+        "expected no TS2416 for covariant self return across modules, got {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn cross_module_self_field_override_uses_base_instance_type() {
+    let diagnostics = check_multi_file(
+        &[
+            (
+                "base.ts",
+                r#"
+export class Base {
+    next!: Base;
+}
+"#,
+            ),
+            (
+                "derived.ts",
+                r#"
+import { Base } from "./base";
+
+export class Derived extends Base {
+    next!: Derived;
+}
+"#,
+            ),
+        ],
+        "derived.ts",
+        strict_options(),
+    );
+
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|diag| diag.code == diagnostic_codes::PROPERTY_IN_TYPE_IS_NOT_ASSIGNABLE_TO_THE_SAME_PROPERTY_IN_BASE_TYPE),
+        "expected no TS2416 for covariant self field across modules, got {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn cross_module_generic_self_field_override_uses_base_instance_type() {
+    let diagnostics = check_multi_file(
+        &[
+            (
+                "base.ts",
+                r#"
+export class Box<T> {
+    next!: Box<T>;
+}
+"#,
+            ),
+            (
+                "derived.ts",
+                r#"
+import { Box } from "./base";
+
+export class FancyBox<Item> extends Box<Item> {
+    next!: FancyBox<Item>;
+}
+"#,
+            ),
+        ],
+        "derived.ts",
+        strict_options(),
+    );
+
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|diag| diag.code == diagnostic_codes::PROPERTY_IN_TYPE_IS_NOT_ASSIGNABLE_TO_THE_SAME_PROPERTY_IN_BASE_TYPE),
+        "expected no TS2416 for generic covariant self field across modules, got {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn cross_module_genuine_field_override_mismatch_still_reports_ts2416() {
+    let diagnostics = check_multi_file(
+        &[
+            (
+                "base.ts",
+                r#"
+export class Base {
+    value!: string;
+}
+"#,
+            ),
+            (
+                "derived.ts",
+                r#"
+import { Base } from "./base";
+
+export class Derived extends Base {
+    value!: number;
+}
+"#,
+            ),
+        ],
+        "derived.ts",
+        strict_options(),
+    );
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diag| diag.code == diagnostic_codes::PROPERTY_IN_TYPE_IS_NOT_ASSIGNABLE_TO_THE_SAME_PROPERTY_IN_BASE_TYPE),
+        "expected TS2416 for genuine cross-module field mismatch, got {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn cross_module_typeof_constructor_field_override_still_reports_ts2416() {
+    let diagnostics = check_multi_file(
+        &[
+            (
+                "base.ts",
+                r#"
+export class Base {
+    ctor!: typeof Base;
+}
+"#,
+            ),
+            (
+                "derived.ts",
+                r#"
+import { Base } from "./base";
+
+export class Derived extends Base {
+    ctor!: Derived;
+}
+"#,
+            ),
+        ],
+        "derived.ts",
+        strict_options(),
+    );
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diag| diag.code == diagnostic_codes::PROPERTY_IN_TYPE_IS_NOT_ASSIGNABLE_TO_THE_SAME_PROPERTY_IN_BASE_TYPE),
+        "expected TS2416 when overriding constructor-typed field with instance type, got {diagnostics:#?}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-D

## Track
Semantic identity cleanup / benchmark issue base for #10634.

## Invariant
When the cross-module class override fallback compares a derived instance member against a base member whose annotation refers to the base class, tsz should resolve lazy/application class references to the base instance type before relation checking. `typeof Base` constructor annotations and genuine incompatible members must still report TS2416.

## Scope
- Normalize type-level override fallback member types through type-query, lazy, and environment evaluation before asking the relation boundary.
- Add multi-file checker tests for cross-module self-return and self-field overrides, generic self fields, and negative TS2416 cases.

## Project Corpus Impact
- Row: Kysely
- Bug family: cross-module class identity / false TS2416
- Evidence: unit-harness base for #10634. This PR covers the minimized structural rule and negative cases locally; stacked PR #10686 carries the project-mode/Kysely follow-up evidence and should own the issue-closing claim.

## Verification
- `cargo nextest run -p tsz-checker --lib cross_module_self_field_override_uses_base_instance_type` (RED before implementation)
- `cargo nextest run -p tsz-checker --lib cross_module_class_self_member_tests`
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `python3 scripts/arch/arch_guard.py`
- Post-rebase local verification on current head `798ef4daf521f65a44c82349411823d5b603390d` passed:
  - `cargo nextest run -p tsz-checker --lib cross_module_class_self_member_tests`
  - `cargo fmt --check`
  - `git diff --check origin/main...HEAD`
  - `python3 scripts/arch/arch_guard.py`
- Exact-head ready-review CI for `798ef4daf521f65a44c82349411823d5b603390d` passed on base `6e0c642f30c101279e52e0a71ca3207bd7d77d27`:
  - `CI Summary`
  - `GitGuardian Security Checks`
  - conformance, emit, fourslash, WASM, lint, unit, project guards, snapshot gate

## Coordination Notes
- AgentName: M4-D
- Refs #10634. This PR is the harness/unit base and intentionally does not close #10634; stacked PR #10686 owns the project-mode follow-up and issue-closing evidence.
- Branch is rebased on `origin/main` at `6e0c642f30c101279e52e0a71ca3207bd7d77d27`.
- Current head is `798ef4daf521f65a44c82349411823d5b603390d`; stacked draft #10686 is refreshed on this base at head `5245f8fd71883575926d162ab30f6b082d7c44db`.
- Before an earlier rebase, M4-D recovered disk from ~2 GiB free to ~107 GiB free by removing only clean worktrees whose PRs had already merged (#10665, #10650, #10656, #10629, #10611, #10619). TypeScript and Cargo caches were preserved.
- Exact-head PR checks are green and `merge-queue` has been added. Queue-owned `Queue Tested` may now run on the synthetic latest-main merge before landing.
