### PR TITLE
test(bench): cover row summary orphan surfaces

### DIFF
--- a/scripts/bench/test-project-row-summary.mjs
+++ b/scripts/bench/test-project-row-summary.mjs
@@ -139,6 +139,28 @@ function baseSurfaces() {
   );
 }
 
+// Row in fixture source that is not defined in project-rows.mjs.
+{
+  const surfaces = baseSurfaces();
+  surfaces.fixtureSourceRows = [...surfaces.fixtureSourceRows, "fixture-ghost-row"].sort();
+  const coverage = computeCoverage(surfaces);
+  assert.ok(
+    coverage.drift.some((d) => d.includes("fixture-ghost-row") && d.includes("scripts/bench/project-fixtures.sh") && d.includes("not defined")),
+    `Expected fixture source orphan drift for fixture-ghost-row, got: ${coverage.drift.join("; ")}`,
+  );
+}
+
+// Row in compatibility corpus that is not defined in project-rows.mjs.
+{
+  const surfaces = baseSurfaces();
+  surfaces.compatCorpusRows = [...surfaces.compatCorpusRows, "compat-ghost-row"].sort();
+  const coverage = computeCoverage(surfaces);
+  assert.ok(
+    coverage.drift.some((d) => d.includes("compat-ghost-row") && d.includes("COMPATIBILITY_CORPUS_ROWS") && d.includes("not defined")),
+    `Expected compatibility corpus orphan drift for compat-ghost-row, got: ${coverage.drift.join("; ")}`,
+  );
+}
+
 // Row has pinned repo/ref but missing from fixture source.
 {
   const surfaces = baseSurfaces();


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Benchmark/project-corpus metadata guard coverage.

## Invariant
When a project row appears only in fixture-source or compatibility-corpus surfaces, `project-row-summary.mjs` reports it as drift against the centralized row definitions; this PR adds focused coverage for those reporting paths without changing runtime behavior.

## Scope
- `scripts/bench/test-project-row-summary.mjs`

## Project Corpus Impact
- Row: n/a
- Bug family: project-row metadata/reporting drift guard
- Evidence: test-only guard coverage; live `node scripts/bench/project-row-summary.mjs --markdown` still reports all 12 rows consistent.

## Verification
- `node scripts/bench/test-project-row-summary.mjs`
- `node scripts/bench/validate-project-metadata.mjs`
- `node scripts/bench/project-row-summary.mjs --markdown`
- `git diff --check`

## Coordination Notes
- No open Studio-A PRs/issues before this branch.
- Open PR overlap check showed other lanes on checker, solver, emit, and LSP work; this PR is bench-script test coverage only.
