### PR TITLE
[WIP] fix(checker): cross-module self-referential override false TS2416 (#10634)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -550,6 +550,9 @@ mod cross_file_interface_property_access_tests;
 #[path = "../tests/cross_file_type_params_cache_tests.rs"]
 mod cross_file_type_params_cache_tests;
 #[cfg(test)]
+#[path = "tests/cross_module_self_ref_override_ts2416_tests.rs"]
+mod cross_module_self_ref_override_ts2416_tests;
+#[cfg(test)]
 #[path = "tests/destructured_discriminant_source_narrowing_tests.rs"]
 mod destructured_discriminant_source_narrowing_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/cross_module_self_ref_override_ts2416_tests.rs
+++ b/crates/tsz-checker/src/tests/cross_module_self_ref_override_ts2416_tests.rs
@@ -1,0 +1,75 @@
+//! Regression coverage for issue #10634: a class imported from another module
+//! that is extended with a covariant member return/field referring to the
+//! class itself produces a false `TS2416`.
+//!
+//! Root cause: tsz uses per-file arenas, so the cross-file base class node is
+//! not in the consuming file's arena. `base_instance_type_from_expression`
+//! falls back to constructor synthesis, whose self-referential members are
+//! typed as the *constructor* (Callable) instead of the *instance* type, so the
+//! override check `Derived <: Base` compares against the constructor and fails.
+//! Single-file (AST path) is correct.
+//!
+//! Harness note: the self-referential *field* form reproduces in this
+//! `check_multi_file` harness; the self-returning *method* form additionally
+//! manifests in full project/CLI mode (`tsz --noEmit -p`, `moduleResolution:
+//! bundler`) — see #10634 for the CLI repro. The field test below is parked
+//! (`#[ignore]`) until the fix lands. The negative test is an active guard
+//! against the over-suppression failure mode documented in #10634 (the naive
+//! "replace the whole base instance" fix regressed it to clean).
+
+use crate::context::CheckerOptions;
+use crate::test_utils::check_multi_file;
+
+fn strict_bundler() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn ts2416_count(files: &[(&str, &str)]) -> usize {
+    check_multi_file(files, "derived.ts", strict_bundler())
+        .iter()
+        .filter(|d| d.code == 2416)
+        .count()
+}
+
+#[test]
+#[ignore = "blocked on #10634: cross-module self-referential override false TS2416"]
+fn cross_module_self_referential_field_no_false_ts2416() {
+    // Covariant self-referential field override across modules. tsc: clean.
+    let files = &[
+        ("base.ts", "export class Base { next!: Base; }\n"),
+        (
+            "derived.ts",
+            "import { Base } from \"./base\";\nexport class Derived extends Base { next!: Derived; }\n",
+        ),
+    ];
+    assert_eq!(
+        ts2416_count(files),
+        0,
+        "covariant self-referential field override should not emit TS2416"
+    );
+}
+
+#[test]
+fn cross_module_incompatible_override_still_errors_ts2416() {
+    // Genuinely incompatible override across modules. tsc: TS2416. The fix for
+    // #10634 must keep reporting this — the discarded naive fix (replacing the
+    // whole base instance) regressed it to clean (false negative).
+    let files = &[
+        (
+            "base.ts",
+            "export abstract class Base { abstract val(): string; }\n",
+        ),
+        (
+            "derived.ts",
+            "import { Base } from \"./base\";\nexport class Derived extends Base { val(): number { return 1; } }\n",
+        ),
+    ];
+    assert_eq!(
+        ts2416_count(files),
+        1,
+        "incompatible return-type override must still emit TS2416"
+    );
+}


### PR DESCRIPTION
AgentName: M4-D

**AgentName:** M5Opus

**Track:** Benchmark blocker (project-corpus compile campaign — kysely row)

**Invariant:** tsc parity for `TS2416` override checks; must not over-suppress (genuine incompatible overrides must still error). Conformance floor preserved.

## Status: WIP (draft)
This PR currently lands only the **failing repro + an active over-suppression guard** for issue #10634. The fix implementation is the next step (see plan below). Parking the repro keeps the root-cause work from being lost and gives the fix a ready test harness.

## Scope
- `crates/tsz-checker/src/tests/cross_module_self_ref_override_ts2416_tests.rs` (new):
  - `cross_module_self_referential_field_no_false_ts2416` — parked `#[ignore]`; reproduces the false `TS2416` in the `check_multi_file` harness (confirmed FAILS today).
  - `cross_module_incompatible_override_still_errors_ts2416` — **active** guard; a genuinely incompatible cross-module override must still emit `TS2416` (passes today; guards the regression that sank the naive fix).
- `crates/tsz-checker/src/lib.rs` — register the test module.

## Root cause (issue #10634)
tsz uses per-file arenas, so a cross-file base class node is not in the consuming file's arena. `base_instance_type_from_expression` falls back to constructor synthesis, whose **self-referential** member return/field types are typed as the **constructor (Callable)** instead of the **instance** type. The override check `Derived <: Base` then compares an instance against the constructor and fails → false `TS2416`. Single-file (AST path) is correct, and plain cross-module assignment (`const b: Base = d`) is correct.

**Structural rule:** when a cross-module base class member's type refers to the class itself, it must resolve to the **instance** type, not the constructor/static type (matching tsc).

## Fix plan (next commit on this branch)
Add a cycle-safe deep type substitution (solver query) that rebuilds object/callable shapes preserving flags/symbols/index-sigs, and apply it narrowly in `base_instance_type_from_expression` to map the base **constructor** type → base **instance** type **only on self-references** in the synthesized cross-file base instance. The solver's symbol-level coinductive cycle detection then closes the recursion. A discarded naive approach (replacing the whole base instance with the canonical lazy instance) cleared the false positive but regressed the negative case — hence the active guard test.

## Project Corpus Impact
- Row: `kysely-project` (canary). Bug family: false `TS2416` on cross-module self-referential class overrides (13 of kysely's 280 current false positives; same shape also appears in zod/other libs).
- Evidence: reproduced on a fresh `dist-fast` build of `main`; minimal 2-file repro + tsc-parity confirmation via the bench `tsc`; full analysis in #10634.

## Verification
- `cargo nextest run -p tsz-checker -E 'test(cross_module_self_ref)'`: active guard passes (1 passed); field repro skipped (ignored).
- `--run-ignored all`: field repro FAILS as expected (captures the bug), negative passes.

## Coordination Notes
WIP — fix not yet implemented; do not merge. Picking this up under AgentName M5Opus. Linked issue: #10634. No overlap with open PRs #10624 (bench summary) / #10310 (dts).
