### PR TITLE
fix(emit): route async-captured super writes through captured accessor

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -31,6 +31,10 @@ name = "comment_tests"
 path = "tests/comment_tests.rs"
 
 [[test]]
+name = "async_method_super_write_tests"
+path = "tests/async_method_super_write_tests.rs"
+
+[[test]]
 name = "variable_declaration_emit_tests"
 path = "tests/variable_declaration_emit_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/expressions/static_super.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/static_super.rs
@@ -18,7 +18,7 @@ impl<'a> Printer<'a> {
     /// alias. In that mode reads and writes go directly through the captured
     /// accessor (`_super.x`, `_superIndex("x").value`); the `Reflect`-based
     /// rewrite is only correct for the static-member super alias.
-    pub(in crate::emitter) fn in_async_captured_super(&self) -> bool {
+    pub(in crate::emitter) const fn in_async_captured_super(&self) -> bool {
         self.scoped_static_super_direct_access || self.scoped_static_super_index_alias.is_some()
     }
 

--- a/crates/tsz-emitter/src/emitter/expressions/static_super.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/static_super.rs
@@ -12,12 +12,25 @@ enum StaticSuperMember {
 }
 
 impl<'a> Printer<'a> {
+    /// True when `super` is captured through the async-lowering accessor objects
+    /// (`_super = Object.create(null, { x: { get, set } })` / the `_superIndex`
+    /// value-accessor closure) rather than the static-member `Reflect.get`/`set`
+    /// alias. In that mode reads and writes go directly through the captured
+    /// accessor (`_super.x`, `_superIndex("x").value`); the `Reflect`-based
+    /// rewrite is only correct for the static-member super alias.
+    pub(in crate::emitter) fn in_async_captured_super(&self) -> bool {
+        self.scoped_static_super_direct_access || self.scoped_static_super_index_alias.is_some()
+    }
+
     pub(in crate::emitter) fn emit_scoped_static_super_assignment(
         &mut self,
         left: NodeIndex,
         operator: u16,
         right: NodeIndex,
     ) -> bool {
+        if self.in_async_captured_super() {
+            return false;
+        }
         let Some(member) = self.scoped_static_super_member(left) else {
             return false;
         };
@@ -54,6 +67,9 @@ impl<'a> Printer<'a> {
         operator: u16,
         is_prefix: bool,
     ) -> bool {
+        if self.in_async_captured_super() {
+            return false;
+        }
         let Some(member) = self.scoped_static_super_member(operand) else {
             return false;
         };
@@ -242,6 +258,9 @@ impl<'a> Printer<'a> {
         is_element: bool,
     ) -> bool {
         if !self.scoped_static_super_assignment_target {
+            return false;
+        }
+        if self.in_async_captured_super() {
             return false;
         }
         let Some(base_node) = self.arena.get(access.expression) else {

--- a/crates/tsz-emitter/tests/async_method_super_write_tests.rs
+++ b/crates/tsz-emitter/tests/async_method_super_write_tests.rs
@@ -1,0 +1,167 @@
+//! When `super` is captured for an async method/generator/arrow via the
+//! `_super = Object.create(null, { x: { get, set } })` / `_superIndex`
+//! value-accessor objects, writes to `super.x` / `super["x"]` must go
+//! directly through the captured accessor (`_super.x = v`,
+//! `_superIndex("x").value = v`, and destructuring `({ f: _super.x } = ...)`),
+//! never through the `Reflect.set(_super, "x", v, this)` form. The
+//! `Reflect.get`/`Reflect.set` rewrite is only correct for the static-member
+//! super alias, so it must be preserved there.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_print_named_with_opts;
+
+fn emit_es2015(source: &str) -> String {
+    let opts = PrintOptions {
+        module: ModuleKind::ESNext,
+        target: ScriptTarget::ES2015,
+        ..Default::default()
+    };
+    parse_and_print_named_with_opts("a.ts", source, opts)
+}
+
+/// Property write through the captured `_super` accessor object.
+#[test]
+fn async_method_super_property_write_uses_captured_accessor() {
+    let source = r#"
+class A { x() {} }
+class B extends A {
+    async m() {
+        const f = () => {};
+        super.x();
+        super.x = f;
+    }
+}
+"#;
+    let output = emit_es2015(source);
+    assert!(
+        output.contains("_super.x = f;"),
+        "expected direct `_super.x = f` write. Output:\n{output}"
+    );
+    assert!(
+        !output.contains("Reflect.set"),
+        "must NOT use Reflect.set for async-captured super write. Output:\n{output}"
+    );
+}
+
+/// The rule is about the captured-accessor shape, not the property spelling:
+/// renaming the property keeps the direct-accessor write.
+#[test]
+fn async_method_super_property_write_is_not_name_keyed() {
+    let source = r#"
+class A { renamed() {} }
+class B extends A {
+    async m() {
+        const f = () => {};
+        super.renamed();
+        super.renamed = f;
+    }
+}
+"#;
+    let output = emit_es2015(source);
+    assert!(
+        output.contains("_super.renamed = f;"),
+        "expected direct `_super.renamed = f` write. Output:\n{output}"
+    );
+    assert!(!output.contains("Reflect.set"), "Output:\n{output}");
+}
+
+/// Element write goes through the `_superIndex("x").value` value accessor.
+#[test]
+fn async_method_super_element_write_uses_index_value_accessor() {
+    let source = r#"
+class A { x() {} }
+class B extends A {
+    async m() {
+        const f = () => {};
+        super["x"]();
+        super["x"] = f;
+    }
+}
+"#;
+    let output = emit_es2015(source);
+    assert!(
+        output.contains("_superIndex(\"x\").value = f;"),
+        "expected `_superIndex(\"x\").value = f` write. Output:\n{output}"
+    );
+    assert!(!output.contains("Reflect.set"), "Output:\n{output}");
+}
+
+/// Destructuring assignment target through the captured accessor must stay a
+/// plain reference (`({ f: _super.x } = ...)`), not the synthetic
+/// `({ set value(_a) { Reflect.set(...) } }).value` wrapper.
+#[test]
+fn async_method_super_destructuring_target_uses_captured_accessor() {
+    let source = r#"
+class A { x() {} }
+class B extends A {
+    async m() {
+        const f = () => {};
+        super.x = f;
+        ({ f: super.x } = { f });
+    }
+}
+"#;
+    let output = emit_es2015(source);
+    assert!(
+        output.contains("({ f: _super.x } = { f });"),
+        "expected direct destructuring target through _super.x. Output:\n{output}"
+    );
+    assert!(
+        !output.contains("set value(_a)"),
+        "must NOT synthesize a setter-object wrapper. Output:\n{output}"
+    );
+    assert!(!output.contains("Reflect.set"), "Output:\n{output}");
+}
+
+/// Async-captured super writes inside an async *generator* method use the same
+/// captured accessors.
+#[test]
+fn async_generator_super_write_uses_captured_accessor() {
+    let source = r#"
+class A { x() {} }
+class B extends A {
+    async *m() {
+        const f = () => {};
+        super.x = f;
+        super["x"] = f;
+    }
+}
+"#;
+    let output = emit_es2015(source);
+    assert!(output.contains("_super.x = f;"), "Output:\n{output}");
+    assert!(
+        output.contains("_superIndex(\"x\").value = f;"),
+        "Output:\n{output}"
+    );
+    assert!(!output.contains("Reflect.set"), "Output:\n{output}");
+}
+
+/// Negative / preservation case: static-member super (no async capture) must
+/// still lower writes through `Reflect.set` against the static base alias.
+/// Changing the captured-super write path must not disturb this.
+#[test]
+fn static_member_super_write_still_uses_reflect() {
+    let source = r#"
+class Base { static x = 1; }
+class Derived extends Base {
+    static {
+        super.x = 2;
+    }
+}
+"#;
+    let opts = PrintOptions {
+        module: ModuleKind::ESNext,
+        target: ScriptTarget::ES2015,
+        ..Default::default()
+    };
+    let output = parse_and_print_named_with_opts("a.ts", source, opts);
+    assert!(
+        output.contains("Reflect.set"),
+        "static-member super write must keep Reflect.set. Output:\n{output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-C
Runner AgentName: cloud-opus47-1m-confident-thompson

## Track
Track 9 — JavaScript emit parity (#8510 super/this-capture slice). #8510 stays open for its other subfamilies (sourcemap destructuring, `staticPropertyNameConflicts`, `topLevelAwait`, nested-generator-with-try, etc.).

## Invariant
When `super` is captured for an async method/generator/arrow via the `_super = Object.create(null, { x: { get, set } })` / `_superIndex` value-accessor objects, `tsc` lowers writes to `super.x` / `super["x"]` directly through those captured accessors; this PR makes tsz do the same through the emitter super-expression lowering, instead of the static-member `Reflect.set` rewrite.

## Summary

When `super` is captured for an async method / async generator / async arrow, `tsc`
lowers **writes** to `super.x` / `super["x"]` directly through the captured accessors:

- assignment: `_super.x = v`
- element write: `_superIndex("x").value = v`
- compound / update: `_super.x += v`, `_super.x++`, `_superIndex("x").value *= v`
- destructuring target: `({ f: _super.x } = { f })`

tsz instead emitted the static-member-super form `Reflect.set(_super, "x", v, this)` (and a
synthetic `({ set value(_a) { Reflect.set(...) } }).value` wrapper for destructuring), which
`tsc` never produces in this lowering.

**Root cause:** the read paths already branch on `scoped_static_super_direct_access`, but the
three *write* surfaces (`emit_scoped_static_super_assignment`, `emit_scoped_static_super_update`,
`emit_scoped_static_super_assignment_target`) ignored the capture flags and always took the
static-member `Reflect` rewrite. They now gate on a shared `in_async_captured_super()` predicate
(`scoped_static_super_direct_access || scoped_static_super_index_alias.is_some()`) and fall through
to the normal emit, which already routes through the captured accessors. The `Reflect` path is
preserved for the static-member super alias (those flags are only ever set by the async-capture
paths).

## Scope
- Emitter-only: `crates/tsz-emitter/src/emitter/expressions/static_super.rs` — one shared predicate gating three write surfaces. No checker/solver changes, no name/file/rendered-string special-casing.

## Project Corpus Impact
- Row: asyncMethodWithSuper_es5, asyncMethodWithSuper_es6, asyncMethodWithSuperConflict_es6 (conformance/async)
- Bug family: async super-capture write lowering (Track 9 JS emit)
- Evidence: `scripts/emit/run.sh --filter=asyncMethodWithSuper --js-only` → 5/5 JS pass after the change (was 0/5); broad base-vs-change sweep over super/async/generator/class/decorator/this/await/yield → 3 fixed, 0 regressed.

## Verification
- `asyncMethodWithSuper{,Conflict}` es5/es6/es2017: 5/5 JS pass (was 0/5), rebuilt on rebased `main`.
- Broad base-vs-change emit sweep: 3 fixed, 0 regressed.
- Byte-parity confirmed against installed `tsc` on compound/update/element/nested-arrow super writes.
- New owning-crate test `crates/tsz-emitter/tests/async_method_super_write_tests.rs` (6 tests, all pass): property write, renamed property (proves not name-keyed), element write, destructuring target, async generator, and a negative case asserting static-member super still uses `Reflect.set`.

## Coordination Notes
- AgentName: Studio-C
- Owning lane: `agent:Studio-C` (Track 9 emit; #8510 runway). Contributor identity `cloud-opus47-1m-confident-thompson` retained as provenance.
- Picked #8510 at random after the originally-rolled #8509 turned out already-resolved (closed with evidence).
- Non-overlapping with active #8510 slices: directive-prologue (#9352), `switch` (#9645), and the `for-of`-downlevelIteration + generator rest-parameter slice claimed the same day — none touch the super-capture write path.

https://claude.ai/code/session_017KadqFFD2arULPRWFMwErE