### PR TITLE
fix(bench): read shard artifacts from manifest

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1036,13 +1036,101 @@ jobs:
               --region=us-central1 \
               > "bench-cloudbuild-${{ matrix.label }}.log" 2>&1 || true
           }
+          copy_from_cloudbuild_manifest() {
+            local manifest_file=cloudbuild-artifacts.json
+            local manifest_paths=cloudbuild-artifacts.env
+
+            storage_cp \
+              "gs://tsz-ci_cloudbuild/artifacts-${{ steps.cloudbuild-submit.outputs.build_id }}.json" \
+              "$manifest_file" || return 1
+            if ! node - "$manifest_file" "${{ matrix.label }}" > "$manifest_paths" <<'NODE'
+          const fs = require("node:fs");
+
+          const [manifestPath, label] = process.argv.slice(2);
+          const rawManifest = fs.readFileSync(manifestPath, "utf8").trim();
+          const parseManifest = (raw) => {
+            if (!raw) return [];
+            try {
+              return JSON.parse(raw);
+            } catch (jsonError) {
+              return raw.split(/\r?\n/)
+                .map((line) => line.trim())
+                .filter(Boolean)
+                .map((line, index) => {
+                  try {
+                    return JSON.parse(line);
+                  } catch (lineError) {
+                    lineError.message = `Could not parse Cloud Build artifact manifest line ${index + 1}: ${lineError.message}`;
+                    throw lineError;
+                  }
+                });
+            }
+          };
+          const collectEntries = (manifest) => {
+            const queue = Array.isArray(manifest) ? [...manifest] : [manifest];
+            const entries = [];
+            for (const entry of queue) {
+              if (!entry || typeof entry !== "object") continue;
+              if (entry.location) entries.push(entry);
+              for (const key of ["artifacts", "results", "objects", "files"]) {
+                if (Array.isArray(entry[key])) queue.push(...entry[key]);
+              }
+            }
+            return entries;
+          };
+          const entries = collectEntries(parseManifest(rawManifest));
+          const locationOf = (entry) => String(entry.location || "").split("#", 1)[0];
+          const findLocation = (basename) => {
+            for (const entry of entries) {
+              const location = locationOf(entry);
+              if (location.endsWith(`/${basename}`) || location.endsWith(basename)) {
+                return location;
+              }
+            }
+            return "";
+          };
+          const files = {
+            status: `bench-status-${label}.env`,
+            results: `bench-results-${label}.json`,
+            run: `bench-run-${label}.log`,
+            postmortem: `bench-postmortem-${label}.log`,
+            prep_fetch: `bench-prep-fetch-${label}.log`,
+          };
+          const locations = Object.fromEntries(
+            Object.entries(files).map(([key, basename]) => [key, findLocation(basename)]),
+          );
+          if (!locations.status) {
+            console.error(`Cloud Build artifact manifest did not include bench status for ${label}.`);
+            process.exit(1);
+          }
+          for (const [key, location] of Object.entries(locations)) {
+            if (location) {
+              console.log(`manifest_${key}=${JSON.stringify(location)}`);
+            }
+          }
+          NODE
+            then
+              return 1
+            fi
+            # shellcheck disable=SC1090
+            source "$manifest_paths"
+            [[ -n "${manifest_status:-}" ]] || return 1
+            storage_cp "$manifest_status" "bench-status-${{ matrix.label }}.env" || return 1
+            [[ -z "${manifest_results:-}" ]] || storage_cp "$manifest_results" "bench-results-${{ matrix.label }}.json" || true
+            [[ -z "${manifest_run:-}" ]] || storage_cp "$manifest_run" "bench-run-${{ matrix.label }}.log" || true
+            [[ -z "${manifest_postmortem:-}" ]] || storage_cp "$manifest_postmortem" "bench-postmortem-${{ matrix.label }}.log" || true
+            [[ -z "${manifest_prep_fetch:-}" ]] || storage_cp "$manifest_prep_fetch" "bench-prep-fetch-${{ matrix.label }}.log" || true
+          }
           download_shard_artifacts() {
             local prefix="gs://tsz-ci_cloudbuild/bench-shards/${BENCH_TARGET_SHA}/${{ matrix.label }}"
-            storage_cp "${prefix}/bench-status-${{ matrix.label }}.env" "bench-status-${{ matrix.label }}.env" || return 1
-            storage_cp "${prefix}/bench-results-${{ matrix.label }}.json" "bench-results-${{ matrix.label }}.json" || true
-            storage_cp "${prefix}/bench-run-${{ matrix.label }}.log" "bench-run-${{ matrix.label }}.log" || true
-            storage_cp "${prefix}/bench-postmortem-${{ matrix.label }}.log" "bench-postmortem-${{ matrix.label }}.log" || true
-            storage_cp "${prefix}/bench-prep-fetch-${{ matrix.label }}.log" "bench-prep-fetch-${{ matrix.label }}.log" || true
+            if storage_cp "${prefix}/bench-status-${{ matrix.label }}.env" "bench-status-${{ matrix.label }}.env"; then
+              storage_cp "${prefix}/bench-results-${{ matrix.label }}.json" "bench-results-${{ matrix.label }}.json" || true
+              storage_cp "${prefix}/bench-run-${{ matrix.label }}.log" "bench-run-${{ matrix.label }}.log" || true
+              storage_cp "${prefix}/bench-postmortem-${{ matrix.label }}.log" "bench-postmortem-${{ matrix.label }}.log" || true
+              storage_cp "${prefix}/bench-prep-fetch-${{ matrix.label }}.log" "bench-prep-fetch-${{ matrix.label }}.log" || true
+              return 0
+            fi
+            copy_from_cloudbuild_manifest
           }
 
           deadline=$((SECONDS + ${{ matrix.timeout }} * 60))

--- a/scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
@@ -45,6 +45,12 @@ assert.match(
 );
 
 assert.match(
+  workflow,
+  /copy_from_cloudbuild_manifest\(\)[\s\S]+artifacts-\$\{\{ steps\.cloudbuild-submit\.outputs\.build_id \}\}\.json[\s\S]+manifest_status[\s\S]+download_shard_artifacts\(\)[\s\S]+copy_from_cloudbuild_manifest/,
+  "bench shard waits should fall back to the Cloud Build artifact manifest when object paths are flattened",
+);
+
+assert.match(
   shardCloudbuild,
   /#!\/bin\/sh[\s\S]+\) > bench-prep-fetch\.log 2>&1[\s\S]+BENCH_PREP_FETCH_STATUS=%s[\s\S]+exit 0/,
   "Cloud Build prep-fetch step should use the shell available in cloud-sdk:slim, record status, and never fail the build before shard status artifacts can be written",


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 1 benchmark blocker: Bench CI flow and website benchmark freshness.

## Invariant
When a Cloud Build shard succeeds, GitHub must be able to recover its status and result artifacts whether Cloud Build preserves configured object prefixes or flattens artifact paths and records the real object names in `artifacts-<build>.json`.

## Scope
- `.github/workflows/bench.yml`: add a Cloud Build artifact-manifest fallback for shard result/status downloads after the prefix lookup misses.
- `scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`: assert shard waits use the manifest fallback.

## Project Corpus Impact
- Row: n/a
- Bug family: benchmark freshness / Cloud Build shard artifact handoff
- Evidence: manual Bench run `26540706446` reached shard fanout and all eight Cloud Build shard builds succeeded, but GitHub failed each shard with `Cloud Build shard succeeded but did not publish a status artifact` because Cloud Build flattened artifacts to bucket-root object names listed in `artifacts-<build>.json`.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `git diff --check`

## Coordination Notes
- Follows #10636. This keeps the current “fresh enough” policy intact and fixes the final shard handoff path needed before `bench-publish` can run.
