### PR TITLE
fix(agents): audit issue ownership labels

### DIFF
--- a/scripts/agents/ensure-agent-labels.sh
+++ b/scripts/agents/ensure-agent-labels.sh
@@ -19,10 +19,11 @@ usage: scripts/agents/ensure-agent-labels.sh [--audit]
 
 Create or refresh the GitHub labels used by multi-agent sessions.
 
-With --audit, list noncanonical agent ownership labels and open PRs whose
-agent ownership labels are missing, duplicated, or noncanonical. Open PRs whose
-body explicitly says no canonical agent lane was assigned are reported
-separately. The audit does not edit labels.
+With --audit, list noncanonical agent ownership labels; open PRs whose
+agent ownership labels are missing, duplicated, or noncanonical; and open
+release-triage issues whose agent ownership labels are missing, duplicated, or
+noncanonical. Open PRs whose body explicitly says no canonical agent lane was
+assigned are reported separately. The audit does not edit labels.
 USAGE
 }
 
@@ -58,16 +59,26 @@ existing="$(gh label list --limit 300 --json name --jq '.[].name')"
 
 if [[ "$AUDIT" == true ]]; then
   prs_json="$(gh pr list --state open --limit 500 --json number,title,labels,body,url)"
+  issues_json="$(gh issue list --state open --limit 500 --json number,title,labels,url)"
   agents_json="$(
     printf '%s\n' "${AGENTS[@]}" | node -e '
       const fs = require("fs");
       process.stdout.write(JSON.stringify(fs.readFileSync(0, "utf8").trim().split(/\n/).filter(Boolean)));
     '
   )"
-  AGENTS_JSON="$agents_json" LABELS_TEXT="$existing" PRS_JSON="$prs_json" node <<'NODE'
+  AGENTS_JSON="$agents_json" LABELS_TEXT="$existing" PRS_JSON="$prs_json" ISSUES_JSON="$issues_json" node <<'NODE'
 const canonical = new Set(JSON.parse(process.env.AGENTS_JSON).map((agent) => `agent:${agent}`));
 const labels = process.env.LABELS_TEXT.split(/\n/).filter(Boolean);
 const prs = JSON.parse(process.env.PRS_JSON);
+const issues = JSON.parse(process.env.ISSUES_JSON);
+const releaseTriageIssueLabels = new Set([
+  "accepted-regression",
+  "bug",
+  "false-negative",
+  "false-positive",
+  "urgent",
+  "WIP",
+]);
 
 const ownershipLabel = (label) => label.startsWith("agent:") || label.startsWith("agnet:");
 const noncanonicalLabels = labels
@@ -79,6 +90,9 @@ const missingPrs = [];
 const intentionallyUnassignedPrs = [];
 const multiplePrs = [];
 const noncanonicalPrs = [];
+const missingIssues = [];
+const multipleIssues = [];
+const noncanonicalIssues = [];
 for (const pr of prs) {
   const agentLabels = pr.labels.map((label) => label.name).filter(ownershipLabel);
   if (agentLabels.length === 0) {
@@ -95,6 +109,22 @@ for (const pr of prs) {
   const generated = agentLabels.filter((label) => !canonical.has(label));
   if (generated.length > 0) {
     noncanonicalPrs.push({ ...pr, agentLabels: generated });
+  }
+}
+
+for (const issue of issues) {
+  const labels = issue.labels.map((label) => label.name);
+  const agentLabels = labels.filter(ownershipLabel);
+  const needsOwner = labels.some((label) => releaseTriageIssueLabels.has(label));
+  if (needsOwner && agentLabels.length === 0) {
+    missingIssues.push(issue);
+  }
+  if (agentLabels.length > 1) {
+    multipleIssues.push({ ...issue, agentLabels });
+  }
+  const generated = agentLabels.filter((label) => !canonical.has(label));
+  if (generated.length > 0) {
+    noncanonicalIssues.push({ ...issue, agentLabels: generated });
   }
 }
 
@@ -117,6 +147,9 @@ console.log(`open_prs_missing_agent_label=${missingPrs.length}`);
 console.log(`open_prs_intentionally_unassigned=${intentionallyUnassignedPrs.length}`);
 console.log(`open_prs_multiple_agent_labels=${multiplePrs.length}`);
 console.log(`open_prs_noncanonical_agent_label=${noncanonicalPrs.length}`);
+console.log(`open_release_issues_missing_agent_label=${missingIssues.length}`);
+console.log(`open_issues_multiple_agent_labels=${multipleIssues.length}`);
+console.log(`open_issues_noncanonical_agent_label=${noncanonicalIssues.length}`);
 
 printRows("Missing Canonical Labels", missingCanonicalLabels, (label) => `- ${label}`);
 printRows("Noncanonical Agent Labels", noncanonicalLabels, (label) => `- ${label}`);
@@ -137,6 +170,17 @@ printRows(
   "Open PRs With Noncanonical Agent Labels",
   noncanonicalPrs,
   (pr) => `- #${pr.number} ${pr.agentLabels.join(", ")} ${pr.title}${pr.url ? ` ${pr.url}` : ""}`,
+);
+printRows("Open Release Issues Missing Agent Label", missingIssues, prRow);
+printRows(
+  "Open Issues With Multiple Agent Labels",
+  multipleIssues,
+  (issue) => `- #${issue.number} ${issue.agentLabels.join(", ")} ${issue.title}${issue.url ? ` ${issue.url}` : ""}`,
+);
+printRows(
+  "Open Issues With Noncanonical Agent Labels",
+  noncanonicalIssues,
+  (issue) => `- #${issue.number} ${issue.agentLabels.join(", ")} ${issue.title}${issue.url ? ` ${issue.url}` : ""}`,
 );
 NODE
   exit 0

--- a/scripts/agents/test_ensure_agent_labels.py
+++ b/scripts/agents/test_ensure_agent_labels.py
@@ -31,7 +31,9 @@ CANONICAL_AGENT_LABELS = [
 
 
 class EnsureAgentLabelsAuditTests(unittest.TestCase):
-    def run_audit_with_prs(self, prs):
+    def run_audit_with_prs(self, prs, issues=None):
+        if issues is None:
+            issues = []
         with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
             fake_gh = pathlib.Path(temp_dir) / "gh"
             fake_gh.write_text(
@@ -54,6 +56,15 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
                       exit 0
                     fi
 
+                    if [[ "${1:-}" == "issue" && "${2:-}" == "list" ]]; then
+                      if [[ "$*" != *"--json number,title,labels,url"* ]]; then
+                        echo "expected issue audit to request url field: $*" >&2
+                        exit 97
+                      fi
+                      printf '%s\n' "${FAKE_GH_ISSUES}"
+                      exit 0
+                    fi
+
                     echo "unexpected gh invocation: $*" >&2
                     exit 99
                     """
@@ -66,6 +77,7 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
                 **os.environ,
                 "FAKE_GH_LABELS": "\n".join(CANONICAL_AGENT_LABELS),
                 "FAKE_GH_PRS": json.dumps(prs),
+                "FAKE_GH_ISSUES": json.dumps(issues),
                 "PATH": f"{temp_dir}{os.pathsep}{os.environ['PATH']}",
             }
 
@@ -124,6 +136,75 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
         self.assertIn("open_prs_intentionally_unassigned=0", output)
         self.assertIn(
             "#3 fix: missing label https://github.com/mohsen1/tsz/pull/3",
+            output,
+        )
+
+    def test_audit_flags_release_issues_missing_agent_labels(self):
+        output = self.run_audit_with_prs(
+            [],
+            issues=[
+                {
+                    "number": 10,
+                    "title": "bug: missing owner",
+                    "labels": [{"name": "bug"}],
+                    "url": "https://github.com/mohsen1/tsz/issues/10",
+                },
+                {
+                    "number": 11,
+                    "title": "perf: intake context",
+                    "labels": [{"name": "performance"}],
+                    "url": "https://github.com/mohsen1/tsz/issues/11",
+                },
+                {
+                    "number": 12,
+                    "title": "accepted regression owned",
+                    "labels": [
+                        {"name": "accepted-regression"},
+                        {"name": "agent:M1-C"},
+                    ],
+                    "url": "https://github.com/mohsen1/tsz/issues/12",
+                },
+            ],
+        )
+
+        self.assertIn("open_release_issues_missing_agent_label=1", output)
+        self.assertIn("Open Release Issues Missing Agent Label", output)
+        self.assertIn(
+            "#10 bug: missing owner https://github.com/mohsen1/tsz/issues/10",
+            output,
+        )
+        self.assertNotIn("perf: intake context", output)
+
+    def test_audit_flags_issue_agent_label_hygiene(self):
+        output = self.run_audit_with_prs(
+            [],
+            issues=[
+                {
+                    "number": 20,
+                    "title": "issue with too many owners",
+                    "labels": [
+                        {"name": "agent:M1-A"},
+                        {"name": "agent:M1-B"},
+                    ],
+                    "url": "https://github.com/mohsen1/tsz/issues/20",
+                },
+                {
+                    "number": 21,
+                    "title": "issue with generated owner",
+                    "labels": [{"name": "agent:claude-sonnet"}],
+                    "url": "https://github.com/mohsen1/tsz/issues/21",
+                },
+            ],
+        )
+
+        self.assertIn("open_issues_multiple_agent_labels=1", output)
+        self.assertIn("open_issues_noncanonical_agent_label=1", output)
+        self.assertIn(
+            "#20 agent:M1-A, agent:M1-B issue with too many owners https://github.com/mohsen1/tsz/issues/20",
+            output,
+        )
+        self.assertIn(
+            "#21 agent:claude-sonnet issue with generated owner https://github.com/mohsen1/tsz/issues/21",
             output,
         )
 


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 1 release metric and bug-family ownership guardrail.

## Invariant
When an open release-triage issue carries `bug`, `false-positive`, `false-negative`, `accepted-regression`, `urgent`, or `WIP`, the agent label audit reports missing, duplicate, or noncanonical `agent:*` ownership instead of only checking PR ownership; this keeps bug-family ownership visible before metric claims rely on issue state.

## Scope
- `scripts/agents/ensure-agent-labels.sh`
- `scripts/agents/test_ensure_agent_labels.py`

## Project Corpus Impact
- Row: n/a
- Bug family: release issue ownership / metric coordination hygiene
- Evidence: audit-only guardrail; live `scripts/agents/ensure-agent-labels.sh --audit` reports zero PR and issue ownership-label violations.

## Verification
- `python3 scripts/agents/test_ensure_agent_labels.py`
- `scripts/agents/ensure-agent-labels.sh --audit`
- `git diff --check`

## Coordination Notes
- Existing Studio-A PR #10645 was merged first and local `main` was synced before this branch.
- Open PR overlap check showed active compiler and emit lanes only; this PR is script-level coordination hygiene for issue metrics.
