### PR TITLE
perf(tools): attribute type alias check phases

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -46,6 +46,27 @@ fn with_alias_defid_visited<R>(f: impl FnOnce(&mut rustc_hash::FxHashSet<DefId>)
     r
 }
 
+#[inline]
+fn record_type_alias_phase_timing(
+    file: &str,
+    name: Option<&str>,
+    phase: &'static str,
+    pos: u32,
+    end: u32,
+    start: Option<web_time::Instant>,
+) {
+    if let Some(start) = start {
+        tsz_common::perf_counters::record_slow_type_alias_check_timing(
+            file,
+            name,
+            phase,
+            pos,
+            end,
+            start.elapsed().as_nanos() as u64,
+        );
+    }
+}
+
 impl<'a> CheckerState<'a> {
     fn type_node_is_nested_in_type_literal(&self, node_idx: NodeIndex) -> bool {
         let mut current = self
@@ -138,6 +159,9 @@ impl<'a> CheckerState<'a> {
         let Some(alias) = self.ctx.arena.get_type_alias(node) else {
             return;
         };
+        let alias_timing_enabled = tsz_common::perf_counters::enabled_fast();
+        let alias_pos = node.pos;
+        let alias_end = node.end;
 
         // TS1277: 'const' modifier not allowed on type alias type parameters
         self.check_const_type_parameter_on_non_function(alias.type_parameters.as_ref());
@@ -154,6 +178,7 @@ impl<'a> CheckerState<'a> {
             .get(alias.name)
             .and_then(|n| self.ctx.arena.get_identifier(n))
             .map(|id| id.escaped_text.to_string());
+        let parameter_timing_start = alias_timing_enabled.then(web_time::Instant::now);
         // Push type parameters to scope FIRST so that constraints like
         // `type Pair<A extends B, B>` can reference sibling type parameters.
         let updates = self.push_missing_name_type_parameters(&alias.type_parameters);
@@ -209,6 +234,14 @@ impl<'a> CheckerState<'a> {
                     .insert(ident.escaped_text.clone(), constrained_param);
             }
         }
+        record_type_alias_phase_timing(
+            &self.ctx.file_name,
+            alias_name_str.as_deref(),
+            "parameters",
+            alias_pos,
+            alias_end,
+            parameter_timing_start,
+        );
         // Temporarily register this alias in `symbol_resolution_set` before visiting
         // the type body. This is used by TS4110 (tuple type circularity) and other
         // circular-reference detection during type node checking.
@@ -238,6 +271,7 @@ impl<'a> CheckerState<'a> {
                 && self.ctx.symbol_resolution_set.contains(&alias_sid)
                 && self.alias_ast_refs_symbol_or_resolution_chain_alias(alias.type_node, alias_sid)
         });
+        let body_timing_start = alias_timing_enabled.then(web_time::Instant::now);
         let body_type = {
             let _ = self.ctx.types.take_union_too_complex();
             // Clear any stale tuple_too_large flag before constructing the body
@@ -262,6 +296,14 @@ impl<'a> CheckerState<'a> {
                 body_type
             }
         };
+        record_type_alias_phase_timing(
+            &self.ctx.file_name,
+            alias_name_str.as_deref(),
+            "body",
+            alias_pos,
+            alias_end,
+            body_timing_start,
+        );
         let body_construction_too_complex = self.ctx.types.take_union_too_complex();
         let mut body_produced_too_large_tuple = self.alias_body_owns_too_large_tuple(body_type);
         let has_type_params = alias
@@ -273,11 +315,21 @@ impl<'a> CheckerState<'a> {
         let body_evaluation_too_complex = if has_deferred_self_reference || has_type_params {
             false
         } else {
+            let evaluation_timing_start = alias_timing_enabled.then(web_time::Instant::now);
             let _ = self.evaluate_type_with_env_uncached(body_type);
+            record_type_alias_phase_timing(
+                &self.ctx.file_name,
+                alias_name_str.as_deref(),
+                "evaluation",
+                alias_pos,
+                alias_end,
+                evaluation_timing_start,
+            );
             body_produced_too_large_tuple =
                 body_produced_too_large_tuple || self.alias_body_owns_too_large_tuple(body_type);
             self.ctx.types.take_union_too_complex()
         };
+        let registration_timing_start = alias_timing_enabled.then(web_time::Instant::now);
         if body_type != TypeId::ERROR
             && let Some(alias_sid) = alias_sym_id
         {
@@ -301,6 +353,14 @@ impl<'a> CheckerState<'a> {
                 self.ctx.clear_type_evaluation_caches_for_def(alias_def_id);
             }
         }
+        record_type_alias_phase_timing(
+            &self.ctx.file_name,
+            alias_name_str.as_deref(),
+            "registration",
+            alias_pos,
+            alias_end,
+            registration_timing_start,
+        );
         if body_produced_too_large_tuple || self.type_node_produces_too_large_tuple(alias.type_node)
         {
             use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
@@ -333,6 +393,7 @@ impl<'a> CheckerState<'a> {
         // 1. Verifying the body references the alias's own DefId
         // 2. Registering the body temporarily so the evaluator can resolve it
         // 3. Evaluating with a special flag that detects Application cycle = TS2589
+        let recursion_timing_start = alias_timing_enabled.then(web_time::Instant::now);
         if let Some(alias_sid) = alias_sym_id {
             let def_id = self.ctx.get_or_create_def_id(alias_sid);
             // Only check when the body is a conditional type — tsc emits TS2589
@@ -407,6 +468,14 @@ impl<'a> CheckerState<'a> {
                 }
             }
         }
+        record_type_alias_phase_timing(
+            &self.ctx.file_name,
+            alias_name_str.as_deref(),
+            "recursive_depth",
+            alias_pos,
+            alias_end,
+            recursion_timing_start,
+        );
 
         // TS4109: detect circular type arguments when the alias body is directly
         // a TypeReference (e.g. `type X = Foo<X extends {} ? A : B>`).  In TSC
@@ -455,6 +524,7 @@ impl<'a> CheckerState<'a> {
         if is_generic_self_circular {
             self.validate_collapsed_alias_body_reference(alias.type_node);
         }
+        let validation_timing_start = alias_timing_enabled.then(web_time::Instant::now);
         if has_deferred_self_reference {
             if let Some(owner_name) = alias_name_str.as_deref() {
                 self.check_type_literal_self_indexed_property_annotations(
@@ -475,6 +545,14 @@ impl<'a> CheckerState<'a> {
             self.check_type_node(alias.type_node);
             self.check_type_for_missing_names(alias.type_node);
         }
+        record_type_alias_phase_timing(
+            &self.ctx.file_name,
+            alias_name_str.as_deref(),
+            "body_validation",
+            alias_pos,
+            alias_end,
+            validation_timing_start,
+        );
 
         if inserted_for_circular_check && let Some(sid) = alias_sym_id {
             self.ctx.symbol_resolution_set.remove(&sid);
@@ -484,7 +562,16 @@ impl<'a> CheckerState<'a> {
         // control flow (e.g., inside an `if (typeof c === 'string')` block).
         // The results are stored in `node_types` and consumed by `TypeLowering`
         // via the `type_query_override` callback during `ensure_type_alias_resolved`.
+        let flow_timing_start = alias_timing_enabled.then(web_time::Instant::now);
         self.precompute_type_query_flow_types(alias.type_node);
+        record_type_alias_phase_timing(
+            &self.ctx.file_name,
+            alias_name_str.as_deref(),
+            "type_query_flow",
+            alias_pos,
+            alias_end,
+            flow_timing_start,
+        );
         self.pop_type_parameters(updates);
     }
 

--- a/crates/tsz-common/src/perf_counters/definitions.rs
+++ b/crates/tsz-common/src/perf_counters/definitions.rs
@@ -915,6 +915,7 @@ pub const DELEGATE_SOURCE_FILE_MISS_RESIDUE_LIMIT: usize = 128;
 pub const DIRECT_SOURCE_FILE_TYPE_ALIAS_BODY_REJECTION_RESIDUE_LIMIT: usize = 128;
 pub const SLOW_CHECK_FILE_TIMING_LIMIT: usize = 32;
 pub const SLOW_CHECK_STATEMENT_TIMING_LIMIT: usize = 64;
+pub const SLOW_TYPE_ALIAS_CHECK_TIMING_LIMIT: usize = 64;
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct DelegateDeclarationFileMissResidue {
@@ -964,6 +965,16 @@ pub struct SlowCheckStatementTiming {
     pub elapsed_ms: f64,
 }
 
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SlowTypeAliasCheckTiming {
+    pub file: String,
+    pub name: String,
+    pub phase: &'static str,
+    pub pos: u32,
+    pub end: u32,
+    pub elapsed_ms: f64,
+}
+
 #[derive(Debug, Copy, Clone)]
 pub struct DirectSourceFileTypeAliasBodyRejectionResidueInput<'a> {
     pub name: &'a str,
@@ -990,6 +1001,8 @@ static DIRECT_SOURCE_FILE_TYPE_ALIAS_BODY_REJECTION_RESIDUES: OnceLock<
 static SLOW_CHECK_FILE_TIMINGS: OnceLock<Mutex<Vec<SlowCheckFileTiming>>> = OnceLock::new();
 static SLOW_CHECK_STATEMENT_TIMINGS: OnceLock<Mutex<Vec<SlowCheckStatementTiming>>> =
     OnceLock::new();
+static SLOW_TYPE_ALIAS_CHECK_TIMINGS: OnceLock<Mutex<Vec<SlowTypeAliasCheckTiming>>> =
+    OnceLock::new();
 
 fn delegate_declaration_file_miss_residues(
 ) -> &'static Mutex<Vec<DelegateDeclarationFileMissResidue>> {
@@ -1011,6 +1024,10 @@ fn slow_check_file_timings() -> &'static Mutex<Vec<SlowCheckFileTiming>> {
 
 fn slow_check_statement_timings() -> &'static Mutex<Vec<SlowCheckStatementTiming>> {
     SLOW_CHECK_STATEMENT_TIMINGS.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+fn slow_type_alias_check_timings() -> &'static Mutex<Vec<SlowTypeAliasCheckTiming>> {
+    SLOW_TYPE_ALIAS_CHECK_TIMINGS.get_or_init(|| Mutex::new(Vec::new()))
 }
 
 pub const COMPUTE_TYPE_OF_SYMBOL_INTERFACE_SIMPLE_OBJECT_TYPE_REFERENCE_REJECT_RESIDUE_LIMIT:

--- a/crates/tsz-common/src/perf_counters/dump.rs
+++ b/crates/tsz-common/src/perf_counters/dump.rs
@@ -697,6 +697,7 @@ impl PerfCounters {
     fn dump_slow_check_timings(snap: &PerfCounterSnapshot) -> String {
         if snap.slow_check_file_timings.is_empty()
             && snap.slow_check_statement_timings.is_empty()
+            && snap.slow_type_alias_check_timings.is_empty()
         {
             return String::new();
         }
@@ -717,6 +718,15 @@ impl PerfCounters {
                 out.push_str(&format!(
                     "  {:>8.2} ms  kind={:>4}  span={:>8}..{:<8}  {}\n",
                     row.elapsed_ms, row.kind, row.pos, row.end, row.file
+                ));
+            }
+        }
+        if !snap.slow_type_alias_check_timings.is_empty() {
+            out.push_str("\nSlowest type alias check phases:\n");
+            for row in snap.slow_type_alias_check_timings.iter().take(10) {
+                out.push_str(&format!(
+                    "  {:>8.2} ms  phase={:<24} span={:>8}..{:<8}  {}  {}\n",
+                    row.elapsed_ms, row.phase, row.pos, row.end, row.name, row.file
                 ));
             }
         }

--- a/crates/tsz-common/src/perf_counters/runtime.rs
+++ b/crates/tsz-common/src/perf_counters/runtime.rs
@@ -1529,6 +1529,45 @@ pub fn record_slow_check_statement_timing(
     rows.truncate(SLOW_CHECK_STATEMENT_TIMING_LIMIT);
 }
 
+/// Record one type-alias checking phase duration in attribution mode.
+///
+/// Callers gate `Instant::now()` behind [`enabled_fast`], so timing-mode runs
+/// do not pay for clock reads. The alias name is an output label only; it must
+/// never drive compiler behavior.
+pub fn record_slow_type_alias_check_timing(
+    file: &str,
+    name: Option<&str>,
+    phase: &'static str,
+    pos: u32,
+    end: u32,
+    elapsed_ns: u64,
+) {
+    if !enabled_fast() {
+        return;
+    }
+    let mut rows = slow_type_alias_check_timings()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    rows.push(SlowTypeAliasCheckTiming {
+        file: file.to_owned(),
+        name: name.unwrap_or("<anonymous>").to_owned(),
+        phase,
+        pos,
+        end,
+        elapsed_ms: elapsed_ns as f64 / 1_000_000.0,
+    });
+    rows.sort_by(|a, b| {
+        b.elapsed_ms
+            .total_cmp(&a.elapsed_ms)
+            .then_with(|| a.file.cmp(&b.file))
+            .then_with(|| a.name.cmp(&b.name))
+            .then_with(|| a.phase.cmp(b.phase))
+            .then_with(|| a.pos.cmp(&b.pos))
+            .then_with(|| a.end.cmp(&b.end))
+    });
+    rows.truncate(SLOW_TYPE_ALIAS_CHECK_TIMING_LIMIT);
+}
+
 /// Record a raw `SymbolId`-shaped `DefId` redirect inside
 /// `TypeEnvironment::resolve_lazy`.
 ///

--- a/crates/tsz-common/src/perf_counters/snapshot.rs
+++ b/crates/tsz-common/src/perf_counters/snapshot.rs
@@ -1,6 +1,6 @@
 /// Stable schema version for `PerfCounterSnapshot`. Bump when the JSON
 /// shape changes in a way the bench harness must adapt to.
-pub const PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION: u32 = 4;
+pub const PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION: u32 = 5;
 
 /// Frozen value-object view of the counter state. Built by
 /// [`PerfCounters::snapshot`]; serializable to JSON via serde.
@@ -251,6 +251,11 @@ pub struct PerfCounterSnapshot {
     /// kind and byte offsets rather than source snippets so attribution remains
     /// structural and cheap.
     pub slow_check_statement_timings: Vec<SlowCheckStatementTiming>,
+    /// Top type-alias checking phase durations observed in attribution mode.
+    ///
+    /// This bounded list is sorted by descending elapsed time. Alias names are
+    /// labels for humans reading the report, not compiler-policy inputs.
+    pub slow_type_alias_check_timings: Vec<SlowTypeAliasCheckTiming>,
 }
 
 /// Per-bucket "is this wired up to its producer?" flag. Lets the bench
@@ -699,6 +704,7 @@ impl PerfCounters {
                 .collect(),
             slow_check_file_timings: Self::snapshot_slow_check_file_timings(),
             slow_check_statement_timings: Self::snapshot_slow_check_statement_timings(),
+            slow_type_alias_check_timings: Self::snapshot_slow_type_alias_check_timings(),
         }
     }
 
@@ -856,6 +862,24 @@ impl PerfCounters {
                 .then_with(|| a.kind.cmp(&b.kind))
         });
         rows.truncate(SLOW_CHECK_STATEMENT_TIMING_LIMIT);
+        rows
+    }
+
+    fn snapshot_slow_type_alias_check_timings() -> Vec<SlowTypeAliasCheckTiming> {
+        let mut rows = slow_type_alias_check_timings()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        rows.sort_by(|a, b| {
+            b.elapsed_ms
+                .total_cmp(&a.elapsed_ms)
+                .then_with(|| a.file.cmp(&b.file))
+                .then_with(|| a.name.cmp(&b.name))
+                .then_with(|| a.phase.cmp(b.phase))
+                .then_with(|| a.pos.cmp(&b.pos))
+                .then_with(|| a.end.cmp(&b.end))
+        });
+        rows.truncate(SLOW_TYPE_ALIAS_CHECK_TIMING_LIMIT);
         rows
     }
 

--- a/crates/tsz-common/src/perf_counters/tests.rs
+++ b/crates/tsz-common/src/perf_counters/tests.rs
@@ -2,10 +2,10 @@ mod json_tests {
     use super::*;
 
     #[test]
-    fn schema_version_is_four() {
+    fn schema_version_is_five() {
         // Bumping schema_version is a breaking change for the bench harness;
         // make the intent explicit.
-        assert_eq!(PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION, 4);
+        assert_eq!(PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION, 5);
     }
 
     #[test]
@@ -50,10 +50,11 @@ mod json_tests {
             "source_file_symbol_arena_cache_eligibility_outcomes",
             "slow_check_file_timings",
             "slow_check_statement_timings",
+            "slow_type_alias_check_timings",
         ] {
             assert!(json.get(key).is_some(), "missing top-level key: {key}");
         }
-        assert_eq!(json["schema_version"], 4);
+        assert_eq!(json["schema_version"], 5);
     }
 
     #[test]
@@ -140,6 +141,40 @@ mod json_tests {
                 >= rows[1]["elapsed_ms"].as_f64().unwrap_or_default(),
             "rows must be sorted by descending elapsed_ms"
         );
+    }
+
+    #[test]
+    fn slow_type_alias_check_timings_keep_slowest_rows_sorted() {
+        {
+            let mut rows = slow_type_alias_check_timings()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            rows.push(SlowTypeAliasCheckTiming {
+                file: "fast.ts".to_string(),
+                name: "Fast".to_string(),
+                phase: "body",
+                pos: 1,
+                end: 2,
+                elapsed_ms: 1.0,
+            });
+            rows.push(SlowTypeAliasCheckTiming {
+                file: "slow.ts".to_string(),
+                name: "Slow".to_string(),
+                phase: "body_validation",
+                pos: 3,
+                end: 9,
+                elapsed_ms: 12.5,
+            });
+        }
+
+        let json = serde_json::to_value(PerfCounters::snapshot()).expect("serializes");
+        let rows = json["slow_type_alias_check_timings"]
+            .as_array()
+            .expect("slow_type_alias_check_timings is array");
+        assert!(rows.len() >= 2, "expected alias timing rows: {rows:?}");
+        assert_eq!(rows[0]["file"], "slow.ts");
+        assert_eq!(rows[0]["name"], "Slow");
+        assert_eq!(rows[0]["phase"], "body_validation");
     }
 
     #[test]
@@ -1828,7 +1863,10 @@ mod json_tests {
         let raw = std::fs::read_to_string(&path).expect("read back");
         // Round-trip through serde to confirm structure.
         let value: serde_json::Value = serde_json::from_str(&raw).expect("valid JSON");
-        assert_eq!(value["schema_version"], 4);
+        assert_eq!(
+            value["schema_version"],
+            PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION
+        );
         assert!(value["wired"].is_object());
         // The atomic-rename `.json.tmp` should not be left behind.
         let tmp = path.with_extension("json.tmp");

--- a/scripts/perf/query-perf-counters.py
+++ b/scripts/perf/query-perf-counters.py
@@ -151,6 +151,16 @@ def print_summary(snap: dict) -> None:
                 f"span={fmt_int(row.get('pos'))}..{fmt_int(row.get('end'))}  "
                 f"{row['file']}"
             )
+    slow_alias_phases = snap.get("slow_type_alias_check_timings") or []
+    if slow_alias_phases:
+        print("  slowest type alias check phases:")
+        for row in slow_alias_phases[:10]:
+            print(
+                f"    {row['elapsed_ms']:>8.2f} ms  "
+                f"phase={row.get('phase', '<unknown>'):<24}  "
+                f"span={fmt_int(row.get('pos'))}..{fmt_int(row.get('end'))}  "
+                f"{row.get('name', '<anonymous>')}  {row['file']}"
+            )
     print()
     print("overlay copy:")
     print(
@@ -287,6 +297,22 @@ def print_diff(post: dict, base: dict) -> None:
             print(
                 f"    current  {a['elapsed_ms']:.2f} ms  "
                 f"kind={a.get('kind')} span={a.get('pos')}..{a.get('end')} {a['file']}"
+            )
+    post_alias = post.get("slow_type_alias_check_timings") or []
+    base_alias = base.get("slow_type_alias_check_timings") or []
+    if post_alias or base_alias:
+        print("  slowest type alias check phase:")
+        if base_alias:
+            b = base_alias[0]
+            print(
+                f"    baseline {b['elapsed_ms']:.2f} ms  "
+                f"phase={b.get('phase')} {b.get('name')} {b['file']}"
+            )
+        if post_alias:
+            a = post_alias[0]
+            print(
+                f"    current  {a['elapsed_ms']:.2f} ms  "
+                f"phase={a.get('phase')} {a.get('name')} {a['file']}"
             )
     print()
     post_rows = {r["reason"]: r for r in by_reason_rows(post, optional=True)}

--- a/scripts/perf/test_query_perf_counters.py
+++ b/scripts/perf/test_query_perf_counters.py
@@ -11,7 +11,7 @@ SCRIPT = Path(__file__).with_name("query-perf-counters.py")
 
 def sample_snapshot(*, type_environment_core: int = 7, import_type: int = 3):
     return {
-        "schema_version": 4,
+        "schema_version": 5,
         "mode": "attribution",
         "enabled": True,
         "delegate": {
@@ -71,6 +71,16 @@ def sample_snapshot(*, type_environment_core: int = 7, import_type: int = 3):
             {"file": "src/deep.ts", "kind": 244, "pos": 10, "end": 80, "elapsed_ms": 8.25},
             {"file": "src/shallow.ts", "kind": 243, "pos": 1, "end": 9, "elapsed_ms": 1.5},
         ],
+        "slow_type_alias_check_timings": [
+            {
+                "file": "src/deep.ts",
+                "name": "XOR",
+                "phase": "body",
+                "pos": 10,
+                "end": 80,
+                "elapsed_ms": 7.5,
+            },
+        ],
     }
 
 
@@ -101,6 +111,8 @@ class QueryPerfCountersTests(unittest.TestCase):
         self.assertIn("src/deep.ts", result.stdout)
         self.assertIn("slowest semantic check statements:", result.stdout)
         self.assertIn("kind= 244", result.stdout)
+        self.assertIn("slowest type alias check phases:", result.stdout)
+        self.assertIn("phase=body", result.stdout)
         self.assertIn("Dominant: TypeEnvironmentCore = 7", result.stdout)
         self.assertIn("Top non-baseline T2.2 target: ImportType = 3", result.stdout)
 


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 performance measurement/tooling; green-row 2x target-gap attribution for `ts-essentials-project`.

## Invariant
When `TSZ_PERF_COUNTERS` enables attribution mode, perf-counter snapshots expose a bounded top-N list of type-alias checking phase timings. Timing-mode runs keep the clock reads out of the hot path because every `Instant::now()` is gated behind `enabled_fast()`.

## Scope
- Add `slow_type_alias_check_timings` to perf-counter schema v5, text dump, and `scripts/perf/query-perf-counters.py`.
- Record type-alias phases around parameter setup, body construction, evaluation, registration, recursive-depth checks, body validation, and type-query flow precompute.
- Cover schema/output changes in `tsz-common` perf-counter tests and query script tests.

## Project Corpus Impact
- Row: `ts-essentials-project`
- Bug family: green-row `2x` target gap attribution; dominant subsystem was `checker:semantic-check` before this slice.
- Evidence: tooling/attribution only; no semantic policy or project-row timing claim. Prior companion report still showed one target gap for `ts-essentials-project`; this PR makes the next attribution run split the hot export/type-alias statement into checker phases.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/perf/test_query_perf_counters.py`
- `cargo nextest run -p tsz-common perf_counters`
- `cargo check -p tsz-checker`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-common -p tsz-checker --all-targets -- -D warnings`
- Draft/light CI passed on earlier head `cdf8b96367c14de2da79bc27a4f5aed2640e2ab4`; ready-review CI was restarted by rebases. Current head `c0559060ebe26f4dfba268160873c75951410514` is rebased onto `origin/main` `df089e4e92` and ready-review CI restarted after the latest rebase.

## Coordination Notes
- Existing Studio-B PR runway was cleared first: #10609, #10616, #10622, and #10628 are merged.
- Open/recent PRs were inspected; this avoids relation-policy, solver relation-cache, alias-recursion, and emit/DTS lanes.
- Ready for review while CI confirms the rebased head. No `2x` target closure is claimed here.
- Attempted a dev-profile attribution run with `TSZ_PERF_COUNTERS=1 cargo run -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json ... -p .target-bench/external/ts-essentials/tsconfig.json`; interrupted after roughly four minutes with no JSON because disk was down to about 8.4 GiB and the run was attribution-only.