### PR TITLE
fix(ci): accept because in WIP comments

### DIFF
--- a/scripts/ci/check-wip-state-comments.mjs
+++ b/scripts/ci/check-wip-state-comments.mjs
@@ -321,7 +321,7 @@ function commentHasAgentName(comment) {
 function commentIsExplanatory(comment) {
   const body = commentBody(comment);
   return commentHasAgentName(comment)
-    && /\b(reason|why)\b/i.test(body)
+    && /\b(reason|why|because)\b/i.test(body)
     && /\b(blocker|blocked|current work|currently|next work)\b/i.test(body)
     && /\b(next owner|next action|next step|owner|action)\b/i.test(body);
 }

--- a/scripts/ci/test-wip-state-comments.mjs
+++ b/scripts/ci/test-wip-state-comments.mjs
@@ -99,6 +99,31 @@ assert.deepEqual(wipStateFindings([{
   comments: [signedComment()],
 }]), []);
 
+assert.deepEqual(wipStateFindings([{
+  number: 10310,
+  title: "fix(dts): project object literal union surfaces",
+  isDraft: true,
+  labels: { nodes: [] },
+  timelineItems: {
+    nodes: [{
+      __typename: "ConvertToDraftEvent",
+      createdAt: "2026-05-27T22:45:03Z",
+      actor: { login: "mohsen1" },
+    }],
+  },
+  comments: {
+    nodes: [signedComment({
+      created_at: "2026-05-27T22:45:04Z",
+      body: [
+        "AgentName: M1-A",
+        "Converted this PR back to draft because the current ready head is blocked.",
+        "Blockers: CI Summary is red and the latest review still flags output surgery.",
+        "Next owner/action: Studio-D should keep merge-queue off and fix the blocker.",
+      ].join("\n"),
+    })],
+  },
+}]), []);
+
 assert.deepEqual(
   wipStateFindings([pr()]),
   [{


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Coordination tooling / WIP-state hygiene.

## Invariant
When a signed WIP-state comment explains a draft conversion with ordinary because-language and includes blockers plus next owner/action, the WIP-state advisory should treat it as explanatory rather than reporting a false gap.

## Scope
- scripts/ci/check-wip-state-comments.mjs
- scripts/ci/test-wip-state-comments.mjs

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI coordination tooling only; no compiler, emitter, benchmark, or project corpus behavior changes.

## Verification
- node scripts/ci/test-wip-state-comments.mjs
- REPOSITORY=mohsen1/tsz node scripts/ci/check-wip-state-comments.mjs
- git diff --check

## Coordination Notes
- AgentName: M1-A
- This repairs the false positive seen for #10310 after the existing M1-A draft-conversion comment used “because” while already naming blockers and next owner/action.
- No WIP state, merge-queue labels, or ownership labels were changed on #10310.
- Merge queue remains off until PR-head checks are clean for this exact head.