### PR TITLE
refactor(checker): source relation flags from typed solver bits

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -621,26 +621,29 @@ impl RelationRequest {
 // Existing boundary helpers
 // ---------------------------------------------------------------------------
 
-/// Boundary-safe flag constants for relation cache keys.
+/// Boundary-safe flag constants for relation policy.
 ///
-/// Wraps the flag constants from `tsz_solver::RelationCacheKey` without exposing
-/// the internal `RelationCacheKey` struct itself. Checker code should use these
-/// constants when constructing relation policy flags (e.g., in `pack_relation_flags`).
+/// Mirrors the solver's typed `RelationFlags` bit surface while keeping the
+/// checker-facing packed `u16` protocol quarantined to this boundary. Checker
+/// code should use these constants when constructing relation policy flags
+/// (e.g., in `pack_relation_flags`).
 pub(crate) struct RelationFlags;
 
 impl RelationFlags {
-    pub const STRICT_NULL_CHECKS: u16 = tsz_solver::RelationCacheKey::FLAG_STRICT_NULL_CHECKS;
-    pub const STRICT_FUNCTION_TYPES: u16 = tsz_solver::RelationCacheKey::FLAG_STRICT_FUNCTION_TYPES;
+    pub const STRICT_NULL_CHECKS: u16 = tsz_solver::RelationFlags::STRICT_NULL_CHECKS.bits() as u16;
+    pub const STRICT_FUNCTION_TYPES: u16 =
+        tsz_solver::RelationFlags::STRICT_FUNCTION_TYPES.bits() as u16;
     pub const EXACT_OPTIONAL_PROPERTY_TYPES: u16 =
-        tsz_solver::RelationCacheKey::FLAG_EXACT_OPTIONAL_PROPERTY_TYPES;
+        tsz_solver::RelationFlags::EXACT_OPTIONAL_PROPERTY_TYPES.bits() as u16;
     pub const NO_UNCHECKED_INDEXED_ACCESS: u16 =
-        tsz_solver::RelationCacheKey::FLAG_NO_UNCHECKED_INDEXED_ACCESS;
-    pub const NO_ERASE_GENERICS: u16 = tsz_solver::RelationCacheKey::FLAG_NO_ERASE_GENERICS;
-    pub const ALLOW_BIVARIANT_REST: u16 = tsz_solver::RelationCacheKey::FLAG_ALLOW_BIVARIANT_REST;
+        tsz_solver::RelationFlags::NO_UNCHECKED_INDEXED_ACCESS.bits() as u16;
+    pub const NO_ERASE_GENERICS: u16 = tsz_solver::RelationFlags::NO_ERASE_GENERICS.bits() as u16;
+    pub const ALLOW_BIVARIANT_REST: u16 =
+        tsz_solver::RelationFlags::ALLOW_BIVARIANT_REST.bits() as u16;
     pub const ALLOW_ERASED_GENERIC_SIGNATURE_RETRY: u16 =
-        tsz_solver::RelationCacheKey::FLAG_ALLOW_ERASED_GENERIC_SIGNATURE_RETRY;
+        tsz_solver::RelationFlags::ALLOW_ERASED_GENERIC_SIGNATURE_RETRY.bits() as u16;
     pub const DISABLE_METHOD_BIVARIANCE: u16 =
-        tsz_solver::RelationCacheKey::FLAG_DISABLE_METHOD_BIVARIANCE;
+        tsz_solver::RelationFlags::DISABLE_METHOD_BIVARIANCE.bits() as u16;
 }
 
 /// Re-export of the solver's relation cache key type.

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_01.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_01.rs
@@ -1723,6 +1723,23 @@ fn test_relation_flags_surface_covers_checker_policy_bits() {
     }
 }
 
+/// The checker boundary's flag wrapper should mirror the solver's typed
+/// `RelationFlags` bit surface, not the legacy cache-key `FLAG_*` protocol.
+#[test]
+fn test_relation_flags_surface_uses_solver_typed_flags() {
+    let source = fs::read_to_string("src/query_boundaries/assignability.rs")
+        .expect("failed to read query_boundaries/assignability.rs");
+
+    assert!(
+        source.contains("tsz_solver::RelationFlags::STRICT_NULL_CHECKS"),
+        "RelationFlags wrapper must derive checker policy bits from solver typed flags"
+    );
+    assert!(
+        !source.contains("tsz_solver::RelationCacheKey::FLAG_"),
+        "RelationFlags wrapper must not depend on legacy RelationCacheKey FLAG_* constants"
+    );
+}
+
 /// Checker compiler-option packing must stay on the boundary-owned
 /// `RelationFlags` wrapper rather than reaching into solver internals.
 #[test]


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
M4-B relation policy/cache-key protocol cleanup (#8207), refactor-only boundary slice.

## Invariant
When checker code needs to encode relation policy bits, the checker query boundary mirrors the solver's typed `RelationFlags` bit surface; this PR removes the boundary's dependency on legacy `RelationCacheKey::FLAG_*` constants without changing the packed checker-facing `u16` protocol.

## Scope
- `crates/tsz-checker/src/query_boundaries/assignability.rs`
- `crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_01.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only checker boundary flag-source cleanup; relation bit values remain sourced from the same solver `RelationFlags` bit assignments and existing checker `u16` callers are unchanged.

## Verification
- RED: `cargo nextest run -p tsz-checker -E 'test(architecture_contract_tests_src::test_relation_flags_surface_uses_solver_typed_flags)'` failed before the production change with `RelationFlags wrapper must derive checker policy bits from solver typed flags`.
- GREEN: `cargo nextest run -p tsz-checker -E 'test(architecture_contract_tests_src::test_relation_flags_surface_uses_solver_typed_flags)'` passed after the boundary change.
- `cargo nextest run -p tsz-checker -E 'test(relation_flags)'` passed: 6 tests.
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- Ready-review CI passed on exact head `bb12e9cdd899daa0989b10ccd4e4e3a1168ac84f`, including `CI Summary`, conformance aggregate/shards, fourslash aggregate/shards, emit, WASM, LSP e2e, project compile guard/canary, project corpus PR body, and light gates.

## Coordination Notes
- Follow-up to merged #10629 and #10617.
- Tracks #8207 by shrinking legacy packed flag protocol usage at the checker/query-boundary edge.
- Disk note: the first checker test run exhausted local disk while linking; cache-preserving cleanup plus removal of clean merged M4-B worktrees #10578, #10617, and #10594 restored `/Users/mohsen/code` to a healthy disk state before final verification.
- `merge-queue` label added after exact-head PR-head checks passed; awaiting queue-owned `Queue Tested` status.
