### PR TITLE
fix(bench): pass target SHA to shard prep fetch

### DIFF
--- a/scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
@@ -52,7 +52,7 @@ assert.match(
 
 assert.match(
   shardCloudbuild,
-  /#!\/bin\/sh[\s\S]+\) > bench-prep-fetch\.log 2>&1[\s\S]+BENCH_PREP_FETCH_STATUS=%s[\s\S]+exit 0/,
+  /id: download-bench-prep[\s\S]+env:\s*\n\s+- '_BENCH_TARGET_SHA=\$\{_BENCH_TARGET_SHA\}'[\s\S]+#!\/bin\/sh[\s\S]+\) > bench-prep-fetch\.log 2>&1[\s\S]+BENCH_PREP_FETCH_STATUS=%s[\s\S]+exit 0/,
   "Cloud Build prep-fetch step should use the shell available in cloud-sdk:slim, record status, and never fail the build before shard status artifacts can be written",
 );
 

--- a/scripts/cloudbuild/cloudbuild-bench-shard.yaml
+++ b/scripts/cloudbuild/cloudbuild-bench-shard.yaml
@@ -4,6 +4,8 @@
 steps:
   - id: download-bench-prep
     name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    env:
+      - '_BENCH_TARGET_SHA=${_BENCH_TARGET_SHA}'
     script: |
       #!/bin/sh
       set +e


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 1 benchmark blocker / project-corpus artifact truth

## Invariant
When a benchmark shard receives a source-provided `bench-prep.env` and `bench-prep.tar`, the Cloud Build prep-fetch step must still know the intended benchmark target SHA before validating the artifact; this PR maps the `_BENCH_TARGET_SHA` substitution into that first Cloud Build shard step.

## Scope
- `scripts/cloudbuild/cloudbuild-bench-shard.yaml`
- `scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`

## Project Corpus Impact
- Row: project benchmark shards, first observed on `projects`
- Bug family: benchmark artifact freshness / Cloud Build shard prep
- Evidence: Bench run `26542449911` produced `bench-results-projects` with `bench-prep-fetch-projects.log` showing `/cloudbuild/scripts/script-0-6463387778: 22: _BENCH_TARGET_SHA: parameter not set`, preventing a fresh merged benchmark artifact for #10649.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `git diff --check`

## Coordination Notes
- Fixes #10649.
- No overlap with #10647; that PR is Studio-B performance attribution, while this PR is a Bench Cloud Build shard environment fix.
- Latest reviewed head: `baad4bfca5`.
