### PR TITLE
fix(bench): pass target sha to shard prep

### DIFF
--- a/scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
@@ -52,8 +52,8 @@ assert.match(
 
 assert.match(
   shardCloudbuild,
-  /#!\/bin\/sh[\s\S]+\) > bench-prep-fetch\.log 2>&1[\s\S]+BENCH_PREP_FETCH_STATUS=%s[\s\S]+exit 0/,
-  "Cloud Build prep-fetch step should use the shell available in cloud-sdk:slim, record status, and never fail the build before shard status artifacts can be written",
+  /id: download-bench-prep[\s\S]+env:\s*\n\s*- '_BENCH_TARGET_SHA=\$\{_BENCH_TARGET_SHA\}'[\s\S]+#!\/bin\/sh[\s\S]+\) > bench-prep-fetch\.log 2>&1[\s\S]+BENCH_PREP_FETCH_STATUS=%s[\s\S]+exit 0/,
+  "Cloud Build prep-fetch step should receive the benchmark target SHA, use the shell available in cloud-sdk:slim, record status, and never fail the build before shard status artifacts can be written",
 );
 
 assert.match(

--- a/scripts/cloudbuild/cloudbuild-bench-shard.yaml
+++ b/scripts/cloudbuild/cloudbuild-bench-shard.yaml
@@ -4,6 +4,8 @@
 steps:
   - id: download-bench-prep
     name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    env:
+      - '_BENCH_TARGET_SHA=${_BENCH_TARGET_SHA}'
     script: |
       #!/bin/sh
       set +e


### PR DESCRIPTION
AgentName: Studio-A

Track: bench CI / benchmark dashboard freshness

Invariant: Bench shard Cloud Build prep validation must prove the prep artifact belongs to BENCH_TARGET_SHA before timing work starts, and shard failures must still publish status/log artifacts for GitHub to consume.

Scope:
- Add _BENCH_TARGET_SHA to the download-bench-prep Cloud Build step environment.
- Extend the shard workflow guard test so this env wiring stays present.

Project Corpus Impact:
Row: benchmark dashboard / projects shard
Bug family: Cloud Build shard prep validation could fail before project benchmark work because _BENCH_TARGET_SHA was unavailable in the prep-fetch step.
Evidence: manual Bench run 26542449911, projects shard status BENCH_SHARD_STATUS=2 with bench-run-projects.log: `_BENCH_TARGET_SHA: parameter not set`.

Verification:
- node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
- node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
- node scripts/ci/test-cloudbuild-config-paths.mjs
- git diff --check

Coordination Notes:
Manual Bench run 26542449911 is allowed to finish but is expected to fail on this old workflow revision. After merge, trigger a fresh manual Bench run on main and verify public benchmark-data/latest.json updates.
