### PR TITLE
refactor(solver): trace relation cache config any mode

### DIFF
--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -816,15 +816,10 @@ impl<'a> QueryCache<'a> {
 
         let trace_enabled = query_trace::enabled();
         let trace_op = relation.trace_op();
+        let cache_config = policy.cache_config();
         let trace_query_id = trace_enabled.then(|| {
             let query_id = query_trace::next_query_id();
-            query_trace::relation_start(
-                query_id,
-                trace_op,
-                source,
-                target,
-                policy.cache_config().flags,
-            );
+            query_trace::relation_start(query_id, trace_op, source, target, cache_config);
             query_id
         });
         let key = relation.cache_key(source, target, policy);

--- a/crates/tsz-solver/src/caches/query_trace.rs
+++ b/crates/tsz-solver/src/caches/query_trace.rs
@@ -6,7 +6,7 @@
 //! Environment:
 //! - `TSZ_QUERY_RUN_ID`: optional run identifier attached to every event.
 
-use crate::types::{RelationFlags, TypeId};
+use crate::types::{CachedAnyMode, RelationCacheConfig, TypeId};
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tracing::{Level, trace};
@@ -74,8 +74,9 @@ pub(crate) fn relation_start(
     op: &'static str,
     source: TypeId,
     target: TypeId,
-    flags: RelationFlags,
+    config: RelationCacheConfig,
 ) {
+    let fields = relation_cache_config_trace_fields(config);
     trace!(
         target: "tsz::query_json",
         event = "query",
@@ -85,8 +86,30 @@ pub(crate) fn relation_start(
         op,
         source_type_id = source.0,
         target_type_id = target.0,
-        flags = flags.bits()
+        flags = fields.flags,
+        any_mode = fields.any_mode
     );
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct RelationCacheConfigTraceFields {
+    flags: u32,
+    any_mode: &'static str,
+}
+
+#[inline]
+const fn relation_cache_config_trace_fields(
+    config: RelationCacheConfig,
+) -> RelationCacheConfigTraceFields {
+    let any_mode = match config.any_mode {
+        CachedAnyMode::All => "all",
+        CachedAnyMode::TopLevelOnlyAtTop => "top_level_only_at_top",
+        CachedAnyMode::TopLevelOnlyNested => "top_level_only_nested",
+    };
+    RelationCacheConfigTraceFields {
+        flags: config.flags.bits(),
+        any_mode,
+    }
 }
 
 #[inline]
@@ -175,6 +198,22 @@ mod tests {
             id >= 1,
             "first non-fetched query id should be >= 1, got {id}"
         );
+    }
+
+    #[test]
+    fn relation_cache_config_trace_fields_include_any_mode() {
+        let config = crate::types::RelationCacheConfig::new(
+            crate::types::RelationFlags::STRICT_NULL_CHECKS,
+            crate::types::CachedAnyMode::TopLevelOnlyNested,
+        );
+
+        let fields = relation_cache_config_trace_fields(config);
+
+        assert_eq!(
+            fields.flags,
+            crate::types::RelationFlags::STRICT_NULL_CHECKS.bits()
+        );
+        assert_eq!(fields.any_mode, "top_level_only_nested");
     }
 
     #[test]


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 10 relation policy/cache-key tech debt (#8207), refactor only.

## Invariant
When relation cache behavior differs by `RelationCacheConfig`, solver query traces should expose the same behavior-shaping config fields that partition the cache. This PR makes relation query start events include effective any-propagation cache mode alongside relation flags.

## Scope
- `crates/tsz-solver/src/caches/query_trace.rs`
- `crates/tsz-solver/src/caches/query_cache.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: trace-only solver refactor; no relation semantics or project corpus behavior changed.

## Verification
- RED: `cargo nextest list -p tsz-solver | rg "relation_cache_config_trace_fields"` failed with missing `relation_cache_config_trace_fields` before implementation.
- `cargo nextest run -p tsz-solver -E 'test(relation_cache_config_trace_fields_include_any_mode)'`
- `cargo nextest run -p tsz-solver -E 'test(query_trace)'`
- `cargo nextest run -p tsz-solver -E 'test(relation_cache_config)'`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- Draft-light CI passed on exact head `0707cc2f3385924803cebb2cadc0e1a2292802d1` before marking ready.
- Ready-review GitHub Actions CI completed successfully on exact head `0707cc2f3385924803cebb2cadc0e1a2292802d1` before enqueue.

## Coordination Notes
- Non-overlap: #10650 covers the checker-facing typed relation flag wrapper; this PR is solver-only query trace explainability for #8207.
- Ready-review CI is green on head `0707cc2f3385924803cebb2cadc0e1a2292802d1`.
- Added `merge-queue`; waiting for repo-local queue to produce `Queue Tested` and land the PR.
