### PR TITLE
fix(emitter): order __runInitializers before __esDecorate by decorated-method presence

### DIFF
--- a/crates/tsz-emitter/src/lowering/decorator_helpers.rs
+++ b/crates/tsz-emitter/src/lowering/decorator_helpers.rs
@@ -31,9 +31,8 @@ impl<'a> LoweringPass<'a> {
     pub(super) fn mark_tc39_decorator_helpers(&mut self, class_data: &ClassData) {
         let needs_prop_key = self.class_has_computed_decorated_member(class_data);
         let needs_set_function_name = self.class_has_private_decorated_member(class_data);
-        let has_decorated_member = self.class_has_decorated_member(class_data);
-        let has_decorated_field_and_auto_accessor =
-            self.class_has_decorated_field_and_auto_accessor(class_data);
+        let has_decorated_method_or_accessor =
+            self.class_has_decorated_method_or_accessor(class_data);
         let private_helper_needs = self.decorated_static_private_member_helper_needs(class_data);
         let has_class_decorators = class_data.modifiers.as_ref().is_some_and(|mods| {
             mods.nodes.iter().any(|&mod_idx| {
@@ -53,8 +52,14 @@ impl<'a> LoweringPass<'a> {
         let helpers = self.transforms.helpers_mut();
         helpers.es_decorate = true;
         helpers.run_initializers = true;
-        if has_decorated_member && (!has_decorated_field_and_auto_accessor || has_class_decorators)
-        {
+        // tsc emits `__runInitializers` before `__esDecorate` (both priority 2,
+        // so request order decides) exactly when the class has a decorated
+        // method, getter, or setter: those request the method extra-initializers
+        // `__runInitializers` while the class element is processed, before the
+        // class-level `__esDecorate` call is built. Decorated fields,
+        // auto-accessors, and bare class decorators do not, so they keep
+        // `__esDecorate` first.
+        if has_decorated_method_or_accessor {
             helpers.run_initializers_before_es_decorate = true;
         }
         if needs_prop_key {
@@ -80,45 +85,22 @@ impl<'a> LoweringPass<'a> {
         }
     }
 
-    fn class_has_decorated_member(&self, class_data: &ClassData) -> bool {
+    /// True when the class has a decorated method, getter, or setter (but not
+    /// an auto-accessor, which is a `PROPERTY_DECLARATION` with the `accessor`
+    /// modifier). These members request the method extra-initializers
+    /// `__runInitializers` helper before the class-level `__esDecorate`, which
+    /// is what makes tsc emit `__runInitializers` first.
+    fn class_has_decorated_method_or_accessor(&self, class_data: &ClassData) -> bool {
         class_data.members.nodes.iter().any(|&member_idx| {
             let Some(member_node) = self.arena.get(member_idx) else {
                 return false;
             };
-            self.member_has_decorator(member_node)
+            let kind = member_node.kind;
+            (kind == syntax_kind_ext::METHOD_DECLARATION
+                || kind == syntax_kind_ext::GET_ACCESSOR
+                || kind == syntax_kind_ext::SET_ACCESSOR)
+                && self.member_has_decorator(member_node)
         })
-    }
-
-    fn class_has_decorated_field_and_auto_accessor(&self, class_data: &ClassData) -> bool {
-        let mut has_decorated_field = false;
-        let mut has_decorated_auto_accessor = false;
-
-        for &member_idx in &class_data.members.nodes {
-            let Some(member_node) = self.arena.get(member_idx) else {
-                continue;
-            };
-            if member_node.kind != syntax_kind_ext::PROPERTY_DECLARATION
-                || !self.member_has_decorator(member_node)
-            {
-                continue;
-            }
-            let Some(property) = self.arena.get_property_decl(member_node) else {
-                continue;
-            };
-            if self
-                .arena
-                .has_modifier(&property.modifiers, SyntaxKind::AccessorKeyword)
-            {
-                has_decorated_auto_accessor = true;
-            } else {
-                has_decorated_field = true;
-            }
-            if has_decorated_field && has_decorated_auto_accessor {
-                return true;
-            }
-        }
-
-        false
     }
 
     fn member_has_decorator(&self, member_node: &tsz_parser::parser::node::Node) -> bool {

--- a/crates/tsz-emitter/tests/lowering_helpers.rs
+++ b/crates/tsz-emitter/tests/lowering_helpers.rs
@@ -993,3 +993,74 @@ fn test_first_private_op_compound_assign_is_not_write_only() {
         "Compound assignment should not flag write-only first op"
     );
 }
+
+// =============================================================================
+// run_initializers_before_es_decorate (TC39 decorator helper emission order)
+// =============================================================================
+
+fn run_initializers_before_es_decorate(source: &str) -> bool {
+    let (arena, root) = parse(source);
+    let mut ctx = EmitContext::default();
+    ctx.set_target(ScriptTarget::ES2022);
+    let transforms = LoweringPass::new(&arena, &ctx).run(root);
+    let helpers = transforms.helpers();
+    assert!(
+        helpers.es_decorate,
+        "expected __esDecorate helper for a TC39-decorated class"
+    );
+    helpers.run_initializers_before_es_decorate
+}
+
+#[test]
+fn test_run_initializers_first_for_decorated_method() {
+    // A decorated method requests the method extra-initializers
+    // `__runInitializers` while the element is processed, before the
+    // class-level `__esDecorate`, so tsc emits `__runInitializers` first.
+    assert!(
+        run_initializers_before_es_decorate("declare let dec: any;\nclass C { @dec m() {} }"),
+        "decorated method should put __runInitializers before __esDecorate"
+    );
+}
+
+#[test]
+fn test_run_initializers_first_for_decorated_method_renamed_identifiers() {
+    // Same rule must hold regardless of the chosen decorator/member spelling.
+    assert!(
+        run_initializers_before_es_decorate(
+            "declare let observe: any;\nclass Widget { @observe render() {} }"
+        ),
+        "rule must not be keyed on identifier names"
+    );
+}
+
+#[test]
+fn test_run_initializers_first_for_decorated_getter() {
+    // Getters/setters also contribute method extra-initializers.
+    assert!(
+        run_initializers_before_es_decorate(
+            "declare let dec: any;\nclass C { @dec get value() { return 1; } }"
+        ),
+        "decorated getter should put __runInitializers before __esDecorate"
+    );
+}
+
+#[test]
+fn test_es_decorate_first_for_decorated_auto_accessor_only() {
+    // Auto-accessors do not contribute method extra-initializers, so tsc keeps
+    // `__esDecorate` first. (Witness: staticAutoAccessorsWithDecorators.)
+    assert!(
+        !run_initializers_before_es_decorate(
+            "declare let dec: any;\nclass C { @dec accessor x = 1; }"
+        ),
+        "auto-accessor-only class should keep __esDecorate before __runInitializers"
+    );
+}
+
+#[test]
+fn test_es_decorate_first_for_decorated_field_only() {
+    // A decorated field alone likewise keeps `__esDecorate` first.
+    assert!(
+        !run_initializers_before_es_decorate("declare let dec: any;\nclass C { @dec field = 1; }"),
+        "field-only decorated class should keep __esDecorate before __runInitializers"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-C

Fixes part of #8750 (esDecorators JS emit family). Branch: `claude/confident-thompson-xnezN`.

## Track
Track 9 — JavaScript emit parity (TC39 decorator helper scheduling).

## Invariant / Structural rule
TC39 emit helpers `__runInitializers` and `__esDecorate` both have priority 2, so `tsc` emits their definitions in **first-request order**. A decorated **method, getter, or setter** requests the method extra-initializers `__runInitializers` while the class element is processed, *before* the class-level `__esDecorate` call is built — so `tsc` emits `__runInitializers` first. Decorated **fields**, **auto-accessors**, and bare **class decorators** do not request method extra-initializers, so `__esDecorate` stays first.

> When a TC39-decorated class has a decorated method/getter/setter, `tsc` emits `__runInitializers` before `__esDecorate`; this change makes tsz do the same — independent of identifier spelling, target, and other member kinds.

The previous heuristic (`has_decorated_member && (!has_decorated_field_and_auto_accessor || has_class_decorators)`) wrongly returned run-first for classes whose only decorated members are auto-accessors (e.g. `@dec accessor x = 1`), producing `__runInitializers` before `__esDecorate` where tsc does the opposite.

## Scope
- `crates/tsz-emitter/src/lowering/decorator_helpers.rs`: replace the heuristic in `mark_tc39_decorator_helpers` with a direct `class_has_decorated_method_or_accessor` check (METHOD/GET_ACCESSOR/SET_ACCESSOR with a decorator). Removes two now-unused predicates.
- `crates/tsz-emitter/tests/lowering_helpers.rs`: adjacent-case unit tests (method, renamed-identifier method, getter → run-first; auto-accessor-only, field-only → esDecorate-first).

No change to `emit_helpers` ordering logic itself; only the request-order flag that feeds it.

## Project Corpus Impact
- Row: n/a (emit-parity / test-harness only; no project-corpus row changes)
- Bug family: TC39 decorator emit-helper emission order
- Evidence: local emit harness, full JS suite — `13382 → 13385` passing, **zero regressions**. Newly passing: `staticAutoAccessorsWithDecorators` (es2017, es2022), `parameterDecoratorsEmitCrash`.

## Adjacent-case matrix (covered by unit tests)
1. Decorated method → run-first (witness: `esDecoratorsMetadata1/2/4/5`).
2. Decorated method with renamed decorator/member identifiers → run-first (proves not name-keyed).
3. Decorated getter → run-first.
4. Decorated auto-accessor only → esDecorate-first (witness: `staticAutoAccessorsWithDecorators`).
5. Decorated field only → esDecorate-first (negative case).

## Verification
- `scripts/emit/run.sh --js-only` (full suite): 13382 → 13385, no new failures; decorator family clean except 5 pre-existing unrelated failures (legacy decorators / sourcemap In-ordering / dts), none touched by this change.
- `cargo test -p tsz-emitter --lib` new ordering tests: 5/5 pass.
- `cargo clippy -p tsz-emitter --all-targets`: clean.
- Rebased cleanly onto current `origin/main`.

## Coordination Notes
- AgentName: Studio-C
- Original runner/session: `cloud-opus47-1m-confident-thompson-xnezN`
- Narrow, behavior-preserving slice of #8750. The remaining esDecorators-sourceMap failures (es2022 `__classPrivateFieldIn` request-order, `__setFunctionName` ordering) are a separate request-order concern and intentionally out of scope here.

https://claude.ai/code/session_01PztixDru5dxQQEqyfbTbBS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PztixDru5dxQQEqyfbTbBS)_
