### PR TITLE
docs(plan): refresh live bug metric

### DIFF
--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -57,7 +57,7 @@ denominators.
 | JavaScript emit | `96.8%` (`13,094 / 13,530`) in checked-in emit snapshot and README |
 | Declaration emit | `96.2%` (`1,606 / 1,669`) in checked-in emit snapshot and README |
 | Fourslash / language service | `99.9%` (`6,558 / 6,562`) |
-| Open bug issues | `18` open `bug` issues in live GitHub orientation |
+| Open bug issues | `20` open `bug` issues in live GitHub orientation |
 | Output-surgery audit | red: `1` unallowlisted call, `0` stale allowlist entries (`#10575`) |
 
 Conformance remains a hard regression gate. It is no longer the sole readiness


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Release metric truth / roadmap public metric refresh.

## Invariant
When the roadmap cites live GitHub release metrics, the copied count should match the current live query; this PR updates the public open bug issue count from the live `bug` label query.

## Scope
- `docs/plan/ROADMAP.md` public metrics table only.

## Project Corpus Impact
- Row: n/a
- Bug family: release metric accounting
- Evidence: docs-only metric refresh; project-row surfaces unchanged and `node scripts/bench/project-row-summary.mjs --markdown` reported all 12 rows consistent.

## Verification
- `gh issue list --state open --label bug --limit 200 --json number --jq 'length'` -> `20`
- `git diff --check`
- `python3 scripts/conformance/query-conformance.py --dashboard`
- `python3 scripts/emit/query-emit.py --families`
- `node scripts/bench/project-row-summary.mjs --markdown`
- `node scripts/bench/check-artifact-readiness.mjs crates/tsz-website/bench-snapshot.json`
- `node scripts/bench/validate-project-metadata.mjs`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- No open Studio-A PRs existed before this branch.
- Benchmark artifact freshness remains tracked in #10649; manual Bench run `26543703555` is still in progress with no artifacts at the last check.
- This is a docs-only public metric correction and does not claim a project-corpus behavior change.
