### PR TITLE
fix(bench): install hyperfine in shards

### DIFF
--- a/scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
@@ -58,8 +58,8 @@ assert.match(
 
 assert.match(
   shardCloudbuild,
-  /output_dir="bench-shards\/\$\{_BENCH_TARGET_SHA\}\/\$\{_BENCH_SHARD_LABEL\}"[\s\S]+mkdir -p "\$output_dir"[\s\S]+run_shard\(\)[\s\S]+apt-get update/,
-  "Cloud Build shard status directory should be prepared before setup commands that can fail",
+  /output_dir="bench-shards\/\$\{_BENCH_TARGET_SHA\}\/\$\{_BENCH_SHARD_LABEL\}"[\s\S]+mkdir -p "\$output_dir"[\s\S]+run_shard\(\)[\s\S]+apt-get update[\s\S]+hyperfine[\s\S]+pnpm config set store-dir/,
+  "Cloud Build shard status directory should be prepared before setup commands that can fail, and shard images should install benchmark runtime tools",
 );
 
 assert.ok(

--- a/scripts/cloudbuild/cloudbuild-bench-shard.yaml
+++ b/scripts/cloudbuild/cloudbuild-bench-shard.yaml
@@ -103,6 +103,7 @@ steps:
           ca-certificates \
           curl \
           git \
+          hyperfine \
           jq \
           pkg-config \
           xz-utils


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Benchmark blocker / benchmark dashboard freshness.

## Invariant
Benchmark shard containers must include the runtime tools required by `scripts/bench/bench-vs-tsgo.sh`; this PR installs `hyperfine` in the Cloud Build shard image before shard benchmarks run.

## Scope
- `scripts/cloudbuild/cloudbuild-bench-shard.yaml`: install `hyperfine` with the shard runtime dependencies.
- `scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`: keep a guard that shard images install benchmark runtime tools.

## Project Corpus Impact
- Row: benchmark dashboard / algorithmic shard fanout
- Bug family: Cloud Build shard runtime image missing `hyperfine`, causing benchmark shards to exit before writing results.
- Evidence: manual Bench run `26543703555`; failed shard logs for `algorithmic-constraint`, `synthetic`, and `large-ts-repo` all end at the `bench-vs-tsgo.sh` prerequisite check with `hyperfine not found`.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `git diff --check`

## Coordination Notes
- Manual Bench run `26543703555` proved the target-SHA prep validation fix works, then exposed this missing shard runtime dependency.
- After this PR lands, trigger a fresh manual Bench run on current `main` and verify the public benchmark artifact refresh path.
- #10649 remains the Studio-A tracking issue for public benchmark artifact freshness.
