### PR TITLE
fix(solver): honor callback relation policy bit

### DIFF
--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -221,6 +221,11 @@ impl RelationPolicy {
             .contains(RelationFlags::ALLOW_ERASED_GENERIC_SIGNATURE_RETRY)
     }
 
+    /// Whether the next signature comparison is a callback parameter check.
+    pub const fn in_callback_param_check(self) -> bool {
+        self.flags.contains(RelationFlags::IN_CALLBACK_PARAM_CHECK)
+    }
+
     /// Whether readonly must be treated as identity-significant.
     pub const fn strict_readonly_identity(self) -> bool {
         self.flags.contains(RelationFlags::STRICT_READONLY_IDENTITY)
@@ -533,6 +538,7 @@ fn configure_compat_checker_policy_bits<R: TypeResolver>(
     checker.subtype.allow_bivariant_param_count = policy.allow_bivariant_param_count();
     checker.subtype.allow_erased_generic_signature_retry =
         policy.allow_erased_generic_signature_retry();
+    checker.subtype.in_callback_param_check = policy.in_callback_param_check();
 }
 
 const fn configure_subtype_checker_policy_bits<'a, R: TypeResolver>(
@@ -550,6 +556,7 @@ const fn configure_subtype_checker_policy_bits<'a, R: TypeResolver>(
     checker.strict_readonly_identity = policy.strict_readonly_identity();
     checker.erase_generics = policy.erase_generics;
     checker.allow_erased_generic_signature_retry = policy.allow_erased_generic_signature_retry();
+    checker.in_callback_param_check = policy.in_callback_param_check();
     checker
 }
 

--- a/crates/tsz-solver/tests/relation_cache_config_tests/cache_agreement.rs
+++ b/crates/tsz-solver/tests/relation_cache_config_tests/cache_agreement.rs
@@ -1225,3 +1225,101 @@ fn assignability_cache_bivariant_param_count_respects_disabled_method_bivariance
         "disabled-method-bivariance result must use its own cache slot",
     );
 }
+
+#[test]
+fn assignability_cache_in_callback_param_check_matches_uncached_policy() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let name = interner.intern_string("name");
+    let breed = interner.intern_string("breed");
+
+    let animal = interner.object(vec![PropertyInfo::new(name, TypeId::STRING)]);
+    let dog = interner.object(vec![
+        PropertyInfo::new(name, TypeId::STRING),
+        PropertyInfo::new(breed, TypeId::STRING),
+    ]);
+
+    let mut dog_method_shape = FunctionShape::new(vec![ParamInfo::unnamed(dog)], TypeId::VOID);
+    dog_method_shape.is_method = true;
+    let source = interner.function(dog_method_shape);
+
+    let mut animal_method_shape =
+        FunctionShape::new(vec![ParamInfo::unnamed(animal)], TypeId::VOID);
+    animal_method_shape.is_method = true;
+    let target = interner.function(animal_method_shape);
+
+    let ordinary_method_policy =
+        RelationPolicy::from_relation_flags(RelationFlags::STRICT_FUNCTION_TYPES);
+    let callback_policy = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_FUNCTION_TYPES | RelationFlags::IN_CALLBACK_PARAM_CHECK,
+    );
+    let ordinary_key =
+        RelationCacheKey::for_assignability(source, target, ordinary_method_policy.cache_config());
+    let callback_key =
+        RelationCacheKey::for_assignability(source, target, callback_policy.cache_config());
+
+    assert_ne!(
+        ordinary_key, callback_key,
+        "callback parameter mode must occupy a distinct assignability cache slot",
+    );
+
+    let ordinary_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        ordinary_method_policy,
+        RelationContext::default(),
+    )
+    .is_related();
+    let callback_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        callback_policy,
+        RelationContext::default(),
+    )
+    .is_related();
+
+    assert!(
+        ordinary_uncached,
+        "ordinary strict-function method comparison keeps method parameters bivariant",
+    );
+    assert!(
+        !callback_uncached,
+        "callback parameter mode must disable method bivariance for the immediate signature comparison",
+    );
+
+    let ordinary_cached = db.is_assignable_to_with_policy(source, target, ordinary_method_policy);
+    assert_eq!(
+        ordinary_cached, ordinary_uncached,
+        "cached ordinary method policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(ordinary_key),
+        Some(ordinary_cached),
+        "ordinary method result must use its own cache slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(callback_key),
+        None,
+        "callback-mode lookup must not hit the ordinary method slot",
+    );
+
+    let callback_cached = db.is_assignable_to_with_policy(source, target, callback_policy);
+    assert_eq!(
+        callback_cached, callback_uncached,
+        "cached callback-mode policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(callback_key),
+        Some(callback_cached),
+        "callback-mode result must use its own cache slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(ordinary_key),
+        Some(ordinary_cached),
+        "ordinary method slot must remain intact after the callback-mode lookup",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 10 relation policy/cache-key tech debt (#8207), solver policy/cache agreement fix.

## Invariant
When a typed relation policy carries `RelationFlags::IN_CALLBACK_PARAM_CHECK`, solver relation engines must apply callback-parameter mode to the immediate signature comparison and store the answer under the callback-mode cache key. This PR makes the typed policy bit configure both subtype and assignability-backed relation paths.

## Scope
- `crates/tsz-solver/src/relations/relation_queries.rs`
- `crates/tsz-solver/tests/relation_cache_config_tests/cache_agreement.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: solver policy/cache contract fix for an explicit relation mode; no project corpus row targeted.

## Verification
- RED: `cargo nextest run -p tsz-solver -E 'test(assignability_cache_in_callback_param_check_matches_uncached_policy)'` failed before the production change because callback mode still kept method bivariance.
- GREEN: `cargo nextest run -p tsz-solver -E 'test(assignability_cache_in_callback_param_check_matches_uncached_policy)'`
- `cargo nextest run -p tsz-solver -E 'test(relation_cache_config_tests)'` passed: 51 tests.
- `cargo nextest run -p tsz-solver -E 'test(query_relation)'` passed: 5 tests.
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- Draft-light CI passed on exact head `9649a05777eb1d1364ef9d4a06f482e1669192f4`: https://github.com/mohsen1/tsz/actions/runs/26545414740
- Ready-review GitHub Actions CI completed successfully on exact head `9649a05777eb1d1364ef9d4a06f482e1669192f4`: https://github.com/mohsen1/tsz/actions/runs/26545925358

## Coordination Notes
- Non-overlap: #10656 has merged; this PR is the next solver relation policy/cache agreement slice for #8207.
- This PR does not touch checker relation routing owned by M1-B, nor M4-A/M4-C evaluation/inference lanes.
- Ready-review heavy CI is green on head `9649a05777eb1d1364ef9d4a06f482e1669192f4`; adding `merge-queue` for the repo-local queue.
- `Queue Tested` is queue-owned and may remain pending until the synthetic latest-main merge lands.