### PR TITLE
docs(plan): refresh live bug metric

### DIFF
--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -45,7 +45,7 @@ as campaigns instead of isolated conformance picks.
 ## Current Public Metrics
 
 Sources: checked-in conformance and emit artifacts, live GitHub orientation on
-2026-05-27, `scripts/bench/project-row-summary.mjs`, and public README
+2026-05-28, `scripts/bench/project-row-summary.mjs`, and public README
 metrics. The public README emit block was refreshed from the checked-in emit
 artifact on 2026-05-26; release planning uses exact artifact numerators and
 denominators.
@@ -57,7 +57,7 @@ denominators.
 | JavaScript emit | `96.8%` (`13,094 / 13,530`) in checked-in emit snapshot and README |
 | Declaration emit | `96.2%` (`1,606 / 1,669`) in checked-in emit snapshot and README |
 | Fourslash / language service | `99.9%` (`6,558 / 6,562`) |
-| Open bug issues | `20` open `bug` issues in live GitHub orientation |
+| Open bug issues | `23` open `bug` issues in live GitHub orientation |
 | Output-surgery audit | red: `1` unallowlisted call, `0` stale allowlist entries (`#10575`) |
 
 Conformance remains a hard regression gate. It is no longer the sole readiness


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 10 / metric truth PR.

## Invariant
When the live GitHub `bug` issue count changes, the roadmap public metric should reflect the current live orientation count rather than a stale copied value.

## Scope
- `docs/plan/ROADMAP.md`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only public metric refresh; no compiler, benchmark runner, or fixture behavior changed.

## Verification
- `git fetch origin main`
- `scripts/agents/show-goal.sh Studio-A`
- `scripts/agents/disk-preflight.sh Studio-A`
- `scripts/agents/list-owned-work.sh Studio-A`
- `python3 scripts/conformance/query-conformance.py --dashboard`
- `python3 scripts/emit/query-emit.py --families`
- `node scripts/bench/project-row-summary.mjs --markdown`
- `gh issue list --state open --label bug --limit 200 --json number | node -e 'let s="";process.stdin.on("data",d=>s+=d);process.stdin.on("end",()=>console.log(JSON.parse(s).length))'` -> `23`
- `node scripts/bench/validate-project-metadata.mjs`
- `git diff --check HEAD~1..HEAD`

## Coordination Notes
- AgentName: Studio-A
- No open Studio-A PR existed before publishing.
- No overlapping roadmap/metric PR was found; #10641 is an M4-D checker bug PR and does not refresh roadmap metric truth.
- This PR only updates the durable public bug metric and the live orientation date.
