### PR TITLE
docs(plan): refresh live bug metric

### DIFF
--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -57,7 +57,7 @@ denominators.
 | JavaScript emit | `96.8%` (`13,094 / 13,530`) in checked-in emit snapshot and README |
 | Declaration emit | `96.2%` (`1,606 / 1,669`) in checked-in emit snapshot and README |
 | Fourslash / language service | `99.9%` (`6,558 / 6,562`) |
-| Open bug issues | `23` open `bug` issues in live GitHub orientation |
+| Open bug issues | `40` open `bug` issues in live GitHub orientation |
 | Output-surgery audit | red: `1` unallowlisted call, `0` stale allowlist entries (`#10575`) |
 
 Conformance remains a hard regression gate. It is no longer the sole readiness


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 10 / metric truth PR.

## Invariant
When live GitHub bug triage splits add or remove open `bug` issues, the roadmap public metric should reflect the current live orientation count instead of the previous snapshot.

## Scope
- `docs/plan/ROADMAP.md`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only public metric refresh; no compiler, benchmark runner, fixture, or project-row behavior changed.

## Verification
- `git fetch origin main`
- `scripts/agents/show-goal.sh Studio-A`
- `scripts/agents/disk-preflight.sh Studio-A`
- `scripts/agents/list-owned-work.sh Studio-A`
- `python3 scripts/conformance/query-conformance.py --dashboard`
- `python3 scripts/emit/query-emit.py --families`
- `node scripts/bench/project-row-summary.mjs --markdown`
- `gh issue list --state open --label bug --limit 300 --json number,title | node -e ...` -> `40`
- `node scripts/bench/validate-project-metadata.mjs`
- `git diff --check`

## Coordination Notes
- AgentName: Studio-A
- Follow-up to merged #10666. After #10666 moved the metric to `23`, the Kysely issue-family split expanded the live open `bug` count to `40`.
- No overlapping Studio-A metric PR was open before publishing this follow-up.
- This PR only updates the durable public bug metric.
