### PR TITLE
fix(checker): resolve project cross-file class instance refs

### DIFF
--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -1525,6 +1525,23 @@ impl<'a> CheckerState<'a> {
                             .primary_declaration()
                             .and_then(|idx| self.ctx.class_instance_type_cache.get(&idx).copied())
                     })
+                    .or_else(|| {
+                        owner_file_idx
+                            .filter(|file_idx| *file_idx != self.ctx.current_file_idx)
+                            .and_then(|file_idx| {
+                                self.ctx
+                                    .cached_cross_file_class_instance_type(sym_id, file_idx as u32)
+                                    .map(|(instance_type, _)| instance_type)
+                            })
+                    })
+                    .or_else(|| {
+                        owner_file_idx
+                            .filter(|file_idx| *file_idx != self.ctx.current_file_idx)
+                            .and_then(|_| {
+                                self.delegate_cross_arena_class_instance_type(sym_id)
+                                    .map(|(instance_type, _)| instance_type)
+                            })
+                    })
                     .unwrap_or_else(|| self.get_type_of_symbol(sym_id))
             } else {
                 self.get_type_of_symbol(sym_id)

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
@@ -88,6 +88,136 @@
         parallel::merge_bind_results(bind_results)
     }
 
+    #[test]
+    fn project_mode_cross_file_class_type_reference_uses_instance_type() {
+        let mut options = ResolvedCompilerOptions::default();
+        options.no_emit = true;
+        options.checker.strict = true;
+        options.checker.module = ModuleKind::ES2015;
+        options.printer.module = ModuleKind::ES2015;
+
+        let diagnostics = collect_test_diagnostics_with_options(
+            &[
+                (
+                    "/p/base.ts",
+                    r#"
+export abstract class Base {
+  abstract self(): Base;
+}
+"#,
+                ),
+                (
+                    "/p/derived.ts",
+                    r#"
+import { Base } from "./base";
+
+export class Derived extends Base {
+  self(): Derived {
+    return this;
+  }
+}
+"#,
+                ),
+            ],
+            &options,
+            Path::new("/p"),
+        );
+
+        assert!(
+            diagnostics.iter().all(|diagnostic| diagnostic.code != 2416),
+            "project mode should resolve imported class type annotations to the instance type, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn project_mode_cross_file_generic_class_self_reference_uses_instance_type() {
+        let mut options = ResolvedCompilerOptions::default();
+        options.no_emit = true;
+        options.checker.strict = true;
+        options.checker.module = ModuleKind::ES2015;
+        options.printer.module = ModuleKind::ES2015;
+
+        let diagnostics = collect_test_diagnostics_with_options(
+            &[
+                (
+                    "/p/base.ts",
+                    r#"
+export abstract class Box<T> {
+  value!: T;
+  abstract self(): Box<T>;
+}
+"#,
+                ),
+                (
+                    "/p/derived.ts",
+                    r#"
+import { Box } from "./base";
+
+export class StringBox extends Box<string> {
+  self(): StringBox {
+    return this;
+  }
+}
+"#,
+                ),
+            ],
+            &options,
+            Path::new("/p"),
+        );
+
+        assert!(
+            diagnostics.iter().all(|diagnostic| diagnostic.code != 2416),
+            "project mode should resolve generic imported class self references to the instance type, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn project_mode_imported_class_annotation_and_typeof_keep_instance_constructor_split() {
+        let mut options = ResolvedCompilerOptions::default();
+        options.no_emit = true;
+        options.checker.strict = true;
+        options.checker.module = ModuleKind::ES2015;
+        options.printer.module = ModuleKind::ES2015;
+
+        let diagnostics = collect_test_diagnostics_with_options(
+            &[
+                (
+                    "/p/base.ts",
+                    r#"
+export class Token {
+  value = 1;
+  static create(): Token {
+    return new Token();
+  }
+}
+"#,
+                ),
+                (
+                    "/p/use.ts",
+                    r#"
+import { Token } from "./base";
+
+let okInstance: Token = Token.create();
+let okCtor: typeof Token = Token;
+let badCtor: typeof Token = Token.create();
+"#,
+                ),
+            ],
+            &options,
+            Path::new("/p"),
+        );
+
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "only the typeof constructor mismatch should be reported, got: {diagnostics:?}"
+        );
+        assert_eq!(
+            diagnostics[0].code, 2739,
+            "typeof Token should remain constructor-shaped, got: {diagnostics:?}"
+        );
+    }
+
     /// Asserts the post-PR-#7521 file-session reuse env policy: OFF unless
     /// the user opts back in via `TSZ_FILE_SESSION_REUSE=1`. Before
     /// PR #7521 the default was ON (set by PRs #6870 / #6893) which


### PR DESCRIPTION
## Agent
AgentName: M4-D

## Track
Semantic identity cleanup / project-mode class instance identity follow-up for #10634 and #10661.

## Invariant
Project-mode cross-file class references in type positions should resolve to the exported class instance type, while value-side `typeof` references must continue to resolve to the constructor/static side. Generic class self references should preserve their application arguments across file boundaries.

## Scope
- Reuse resolved lazy target types when project-mode lazy class references already resolve through the type environment.
- Add project-mode CLI coverage for imported class annotations, generic class self references, and `typeof` constructor splits.

## Project Corpus Impact
- Row: Kysely
- Bug family: cross-file class identity / false constructor-vs-instance resolution
- Evidence: targeted project-mode tests cover the minimized cross-file class instance rule from #10661 and stack on #10641, which covers the self-member override base rule for #10634.

## Verification
- `cargo nextest run -p tsz-cli --lib -E 'test(project_mode_cross_file_class_type_reference_uses_instance_type) | test(project_mode_cross_file_generic_class_self_reference_uses_instance_type) | test(project_mode_imported_class_annotation_and_typeof_keep_instance_constructor_split)'`
- `cargo nextest run -p tsz-checker --lib cross_module_class_self_member_tests`
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `python3 scripts/arch/arch_guard.py`
- Post-parent-merge retarget verification on current head `827f5b2b457c73d8a92e2b5a5a52c5bd94a345d9` passed:
  - `cargo nextest run -p tsz-cli --lib -E 'test(project_mode_cross_file_class_type_reference_uses_instance_type) | test(project_mode_cross_file_generic_class_self_reference_uses_instance_type) | test(project_mode_imported_class_annotation_and_typeof_keep_instance_constructor_split)'`
  - `cargo nextest run -p tsz-checker --lib cross_module_class_self_member_tests`
  - `cargo fmt --check`
  - `git diff --check origin/main...HEAD`
  - `python3 scripts/arch/arch_guard.py`
- Draft exact-head CI for `827f5b2b457c73d8a92e2b5a5a52c5bd94a345d9` passed on 2026-05-28: `CI Light Summary`, `dist-binaries`, `unit`, `unit-cloudbuild`, `lint`, `cargo-shear`, `cargo-deny`, `project-row-drift`, `gate`, and `GitGuardian Security Checks`. Heavy suites were skipped while this PR was draft.

- Ready-review exact-head CI (`827f5b2b457c73d8a92e2b5a5a52c5bd94a345d9`) passed on 2026-05-28: `CI Summary`, `GitGuardian Security Checks`, conformance aggregate/shards, fourslash aggregate/shards, emit, LSP, WASM, project compile gates, dist, lint, unit, snapshot, and project-corpus body gates.

## Coordination Notes
- AgentName: M4-D
- Retargeted to `main` after #10641 merged; marked ready after exact-head draft light CI passed.
- #10641 merged on 2026-05-28; this branch was rebased with `--onto origin/main` to keep only the project-mode follow-up commit.
- Current head is `827f5b2b457c73d8a92e2b5a5a52c5bd94a345d9`.
- Exact-head ready-review CI is green; `merge-queue` added so the repo-local queue can run `Queue Tested` on latest `main`.
- Refs #10661 and #10634. This PR owns the project-mode follow-up evidence and should be the issue-closing PR once its base lands and CI is complete.
- Before an earlier rebase, M4-D recovered disk from ~2 GiB free to ~107 GiB free by removing only clean worktrees whose PRs had already merged (#10665, #10650, #10656, #10629, #10611, #10619). TypeScript and Cargo caches were preserved.