### PR TITLE
fix(bench): parse shard status safely

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1132,6 +1132,13 @@ jobs:
             fi
             copy_from_cloudbuild_manifest
           }
+          shard_status_value() {
+            local key="$1"
+            awk -v key="$key" '
+              index($0, key "=") == 1 { value = substr($0, length(key) + 2) }
+              END { print value }
+            ' "bench-status-${{ matrix.label }}.env"
+          }
 
           deadline=$((SECONDS + ${{ matrix.timeout }} * 60))
           while true; do
@@ -1142,15 +1149,21 @@ jobs:
                 capture_cloudbuild_log
                 exit 1
               fi
-              # shellcheck disable=SC1091
-              source "bench-status-${{ matrix.label }}.env"
-              if [[ "${BENCH_TARGET_SHA:-}" != "${{ env.BENCH_TARGET_SHA }}" ||
-                    "${BENCH_SHARD_LABEL:-}" != "${{ matrix.label }}" ]]; then
+              status_target_sha="$(shard_status_value BENCH_TARGET_SHA)"
+              status_shard_label="$(shard_status_value BENCH_SHARD_LABEL)"
+              status_exit="$(shard_status_value BENCH_SHARD_STATUS)"
+              if [[ "${status_target_sha}" != "${{ env.BENCH_TARGET_SHA }}" ||
+                    "${status_shard_label}" != "${{ matrix.label }}" ]]; then
                 echo "Cloud Build shard status metadata did not match this shard."
                 cat "bench-status-${{ matrix.label }}.env"
                 exit 1
               fi
-              exit "${BENCH_SHARD_STATUS:-1}"
+              if ! [[ "${status_exit}" =~ ^[0-9]+$ ]]; then
+                echo "Cloud Build shard status did not include numeric BENCH_SHARD_STATUS."
+                cat "bench-status-${{ matrix.label }}.env"
+                exit 1
+              fi
+              exit "${status_exit}"
             fi
             case "$status" in
               FAILURE|INTERNAL_ERROR|TIMEOUT|CANCELLED|EXPIRED)

--- a/scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
@@ -51,6 +51,18 @@ assert.match(
 );
 
 assert.match(
+  workflow,
+  /shard_status_value\(\)[\s\S]+index\(\$0, key "="\) == 1[\s\S]+status_target_sha="\$\(shard_status_value BENCH_TARGET_SHA\)"[\s\S]+status_shard_label="\$\(shard_status_value BENCH_SHARD_LABEL\)"[\s\S]+status_exit="\$\(shard_status_value BENCH_SHARD_STATUS\)"[\s\S]+exit "\$\{status_exit\}"/,
+  "bench shard waits should parse status env files without sourcing unquoted filter values",
+);
+
+assert.doesNotMatch(
+  workflow,
+  /source "bench-status-\$\{\{ matrix\.label \}\}\.env"/,
+  "bench shard waits must not source status env files because BENCH_SHARD_FILTER can contain spaces or shell metacharacters",
+);
+
+assert.match(
   shardCloudbuild,
   /id: download-bench-prep[\s\S]+env:\s*\n\s*- '_BENCH_TARGET_SHA=\$\{_BENCH_TARGET_SHA\}'[\s\S]+#!\/bin\/sh[\s\S]+\) > bench-prep-fetch\.log 2>&1[\s\S]+BENCH_PREP_FETCH_STATUS=%s[\s\S]+exit 0/,
   "Cloud Build prep-fetch step should receive the benchmark target SHA, use the shell available in cloud-sdk:slim, record status, and never fail the build before shard status artifacts can be written",


### PR DESCRIPTION
AgentName: Studio-A

Track: bench CI / benchmark dashboard freshness

Invariant: GitHub shard wait jobs must consume Cloud Build shard status files without executing status-file values as shell code.

Scope:
- Replace `source bench-status-*.env` in the Bench shard wait step with key-specific parsing for BENCH_TARGET_SHA, BENCH_SHARD_LABEL, and BENCH_SHARD_STATUS.
- Add a workflow guard test that rejects sourcing shard status files because BENCH_SHARD_FILTER may contain spaces or shell metacharacters.

Project Corpus Impact:
Row: benchmark dashboard / algorithmic shard fanout
Bug family: GitHub wait step failed successful Cloud Build shards by sourcing unquoted BENCH_SHARD_FILTER values.
Evidence: manual Bench run 26544890116, algorithmic-bct and algorithmic-mapped Cloud Builds had BENCH_SHARD_STATUS=0 but GitHub wait step failed after sourcing filters like `Mapped complex template keys`.

Verification:
- node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
- node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
- node scripts/ci/test-cloudbuild-config-paths.mjs
- git diff --check

Coordination Notes:
After merge, trigger a fresh manual Bench run on current main and verify public benchmark-data/latest.json updates. The previous run proved prep validation and hyperfine installation are now past their old blockers.
