### PR TITLE
fix(dts): prefer inferred predicate alias surfaces

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
@@ -993,7 +993,13 @@ impl<'a> DeclarationEmitter<'a> {
                     );
                     return;
                 }
-                if let Some(return_type_id) = type_queries::get_return_type(*interner, func_type_id)
+                if func_body.is_some()
+                    && let Some(predicate_text) = self.function_source_type_predicate_text(func)
+                {
+                    self.write(": ");
+                    self.write(&predicate_text);
+                } else if let Some(return_type_id) =
+                    type_queries::get_return_type(*interner, func_type_id)
                 {
                     let effective_return_type_id = if func_body.is_some() {
                         self.refine_invokable_return_type_from_identifier(func_body, return_type_id)
@@ -1297,6 +1303,12 @@ impl<'a> DeclarationEmitter<'a> {
         func_body: NodeIndex,
         func_name: NodeIndex,
     ) -> bool {
+        if let Some(predicate_text) = self.function_source_type_predicate_text(func) {
+            self.write(": ");
+            self.write(&predicate_text);
+            return true;
+        }
+
         if self.body_returns_void(func_body) {
             self.write(": void");
             return true;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
@@ -934,6 +934,9 @@ impl<'a> DeclarationEmitter<'a> {
                 if let Some(type_text) = self.flat_map_array_subclass_return_type_text(expr_idx) {
                     return Some(type_text);
                 }
+                if let Some(type_text) = self.array_map_callback_return_type_text(expr_idx) {
+                    return Some(type_text);
+                }
                 if let Some(type_text) = self.array_filter_typeof_type_text(expr_idx) {
                     return Some(type_text);
                 }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
@@ -1013,6 +1013,7 @@ impl<'a> DeclarationEmitter<'a> {
                 .or_else(|| self.conditional_unique_symbol_union_type_text(expr_idx)),
             k if k == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION => self
                 .array_literal_element_access_type_text(expr_idx)
+                .or_else(|| self.element_access_array_element_type_text(expr_idx))
                 .or_else(|| self.template_index_signature_element_access_type_text(expr_idx))
                 .or_else(|| self.class_static_computed_index_access_type_text(expr_idx)),
             k if k == syntax_kind_ext::CLASS_EXPRESSION => {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
@@ -934,6 +934,9 @@ impl<'a> DeclarationEmitter<'a> {
                 if let Some(type_text) = self.flat_map_array_subclass_return_type_text(expr_idx) {
                     return Some(type_text);
                 }
+                if let Some(type_text) = self.array_filter_typeof_type_text(expr_idx) {
+                    return Some(type_text);
+                }
                 // Synthesise the source-side intersection text for a
                 // generic mixin call like `Mix(A, B)` whose declared
                 // return is `T1 & … & Tn` or `T & X`. tsz's inference

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_guards.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_guards.rs
@@ -3,6 +3,7 @@
 use super::super::DeclarationEmitter;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
 
 impl<'a> DeclarationEmitter<'a> {
     pub(in crate::declaration_emitter) fn array_element_type_text(
@@ -27,6 +28,58 @@ impl<'a> DeclarationEmitter<'a> {
             }
         }
         None
+    }
+
+    pub(in crate::declaration_emitter) fn element_access_array_element_type_text(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        let expr_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(expr_idx);
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind != syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION {
+            return None;
+        }
+        let access = self.arena.get_access_expr(expr_node)?;
+        let key_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(access.name_or_argument);
+        let key_node = self.arena.get(key_idx)?;
+        if key_node.kind != SyntaxKind::NumericLiteral as u16 {
+            return None;
+        }
+
+        let receiver_text = self
+            .preferred_expression_type_text(access.expression)
+            .or_else(|| self.reference_declared_type_annotation_text(access.expression))?;
+        let element_text = Self::array_element_type_text(&receiver_text)?;
+        Some(
+            Self::strip_parenthesized_union_element_type_text(&element_text)
+                .unwrap_or(element_text),
+        )
+    }
+
+    fn strip_parenthesized_union_element_type_text(type_text: &str) -> Option<String> {
+        let trimmed = type_text.trim();
+        if !trimmed.starts_with('(') || !trimmed.ends_with(')') || !trimmed.contains('|') {
+            return None;
+        }
+
+        let mut depth = 0usize;
+        for (idx, ch) in trimmed.char_indices() {
+            match ch {
+                '(' => depth += 1,
+                ')' => {
+                    depth = depth.checked_sub(1)?;
+                    if depth == 0 && idx != trimmed.len() - ch.len_utf8() {
+                        return None;
+                    }
+                }
+                _ => {}
+            }
+        }
+        (depth == 0).then(|| trimmed[1..trimmed.len() - 1].trim().to_string())
     }
 
     /// Returns `true` when `func_body` is a block whose sole non-trivial

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_guards.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_guards.rs
@@ -2,6 +2,7 @@
 
 use super::super::DeclarationEmitter;
 use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::FunctionData;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
@@ -94,6 +95,58 @@ impl<'a> DeclarationEmitter<'a> {
         Some(format!("{primitive}[]"))
     }
 
+    pub(in crate::declaration_emitter) fn array_map_callback_return_type_text(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        let expr_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(expr_idx);
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind != syntax_kind_ext::CALL_EXPRESSION {
+            return None;
+        }
+        let call = self.arena.get_call_expr(expr_node)?;
+        let callee_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(call.expression);
+        let callee_node = self.arena.get(callee_idx)?;
+        if callee_node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            return None;
+        }
+        let access = self.arena.get_access_expr(callee_node)?;
+        if self.get_identifier_text(access.name_or_argument).as_deref() != Some("map") {
+            return None;
+        }
+
+        let callback_idx = call.arguments.as_ref()?.nodes.first().copied()?;
+        let return_expr = self.function_like_single_return_expression(callback_idx)?;
+        let return_type = self
+            .preferred_expression_type_text(return_expr)
+            .or_else(|| self.json_parse_call_type_text(return_expr))
+            .or_else(|| {
+                self.get_node_type_or_names(&[return_expr])
+                    .filter(|type_id| *type_id != tsz_solver::types::TypeId::ERROR)
+                    .map(|type_id| self.print_type_id(type_id))
+            })
+            .filter(|type_text| !type_text.is_empty())?;
+        Some(format!(
+            "{}[]",
+            Self::parenthesize_type_text_in_union_position(&return_type)
+        ))
+    }
+
+    pub(in crate::declaration_emitter) fn function_source_type_predicate_text(
+        &self,
+        func: &FunctionData,
+    ) -> Option<String> {
+        let (param_name, param_type_text) = self.first_named_parameter_type_text(func)?;
+        let predicate_expr = self.callback_predicate_expression(func.body)?;
+        let predicate_type =
+            self.source_type_predicate_type_text(predicate_expr, &param_name, &param_type_text)?;
+        Some(format!("{param_name} is {predicate_type}"))
+    }
+
     fn array_element_type_includes_typeof_primitive(element_text: &str, primitive: &str) -> bool {
         let element_text = Self::strip_parenthesized_union_element_type_text(element_text)
             .unwrap_or_else(|| element_text.trim().to_string());
@@ -102,7 +155,211 @@ impl<'a> DeclarationEmitter<'a> {
             .any(|part| matches!(part.as_str(), "any" | "unknown") || part == primitive)
     }
 
+    fn first_named_parameter_type_text(&self, func: &FunctionData) -> Option<(String, String)> {
+        let param_idx = func.parameters.nodes.first().copied()?;
+        let param_node = self.arena.get(param_idx)?;
+        let param = self.arena.get_parameter(param_node)?;
+        let param_name = self.get_identifier_text(param.name)?;
+        let param_type_text = self.emit_type_node_text(param.type_annotation)?;
+        Some((param_name, param_type_text))
+    }
+
+    fn source_type_predicate_type_text(
+        &self,
+        expr_idx: NodeIndex,
+        param_name: &str,
+        param_type_text: &str,
+    ) -> Option<String> {
+        let expr_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(expr_idx);
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind == syntax_kind_ext::BINARY_EXPRESSION {
+            let binary = self.arena.get_binary_expr(expr_node)?;
+            if binary.operator_token == SyntaxKind::BarBarToken as u16 {
+                return self.typeof_or_truthy_param_predicate_type_text(
+                    binary.left,
+                    binary.right,
+                    param_name,
+                    param_type_text,
+                );
+            }
+        }
+        if expr_node.kind == syntax_kind_ext::PREFIX_UNARY_EXPRESSION {
+            let unary = self.arena.get_unary_expr(expr_node)?;
+            if unary.operator == SyntaxKind::ExclamationToken as u16 {
+                return self.negated_local_predicate_call_type_text(
+                    unary.operand,
+                    param_name,
+                    param_type_text,
+                );
+            }
+        }
+        None
+    }
+
+    fn typeof_or_truthy_param_predicate_type_text(
+        &self,
+        left: NodeIndex,
+        right: NodeIndex,
+        param_name: &str,
+        param_type_text: &str,
+    ) -> Option<String> {
+        if let (Some(primitive), Some(truthy_text)) = (
+            self.typeof_equality_primitive(left, param_name),
+            self.truthy_boolean_param_type_text(right, param_name, param_type_text),
+        ) {
+            return Some(format!("{primitive} | {truthy_text}"));
+        }
+        if let (Some(truthy_text), Some(primitive)) = (
+            self.truthy_boolean_param_type_text(left, param_name, param_type_text),
+            self.typeof_equality_primitive(right, param_name),
+        ) {
+            return Some(format!("{truthy_text} | {primitive}"));
+        }
+        None
+    }
+
+    fn truthy_boolean_param_type_text(
+        &self,
+        expr_idx: NodeIndex,
+        param_name: &str,
+        param_type_text: &str,
+    ) -> Option<&'static str> {
+        let expr_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(expr_idx);
+        if self.get_identifier_text(expr_idx).as_deref() != Some(param_name) {
+            return None;
+        }
+        Self::split_top_level_union_type_parts(param_type_text)
+            .iter()
+            .any(|part| part == "boolean")
+            .then_some("true")
+    }
+
+    fn negated_local_predicate_call_type_text(
+        &self,
+        expr_idx: NodeIndex,
+        param_name: &str,
+        param_type_text: &str,
+    ) -> Option<String> {
+        let expr_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(expr_idx);
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind != syntax_kind_ext::CALL_EXPRESSION {
+            return None;
+        }
+        let call = self.arena.get_call_expr(expr_node)?;
+        let [arg_idx] = call.arguments.as_ref()?.nodes.as_slice() else {
+            return None;
+        };
+        let arg_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(*arg_idx);
+        if self.get_identifier_text(arg_idx).as_deref() != Some(param_name) {
+            return None;
+        }
+        let callee_name = self.get_identifier_text(call.expression)?;
+        let callee_func = self.local_function_declaration_by_name(&callee_name)?;
+        let (_predicate_param, predicate_type_text) =
+            self.function_declared_type_predicate_text(callee_func)?;
+        self.complement_union_type_text(param_type_text, &predicate_type_text)
+    }
+
+    fn json_parse_call_type_text(&self, expr_idx: NodeIndex) -> Option<String> {
+        let expr_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(expr_idx);
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind != syntax_kind_ext::CALL_EXPRESSION {
+            return None;
+        }
+        let call = self.arena.get_call_expr(expr_node)?;
+        let callee_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(call.expression);
+        let callee_node = self.arena.get(callee_idx)?;
+        if callee_node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            return None;
+        }
+        let access = self.arena.get_access_expr(callee_node)?;
+        if self.get_identifier_text(access.expression).as_deref() == Some("JSON")
+            && self.get_identifier_text(access.name_or_argument).as_deref() == Some("parse")
+        {
+            return Some("any".to_string());
+        }
+        None
+    }
+
+    fn local_function_declaration_by_name(&self, name: &str) -> Option<&FunctionData> {
+        if let Some(source_file) = self
+            .current_source_file_idx
+            .and_then(|idx| self.arena.get(idx))
+            .and_then(|node| self.arena.get_source_file(node))
+        {
+            for &stmt_idx in &source_file.statements.nodes {
+                let stmt_node = self.arena.get(stmt_idx)?;
+                let Some(func) = self.arena.get_function(stmt_node) else {
+                    continue;
+                };
+                if self.get_identifier_text(func.name).as_deref() == Some(name) {
+                    return Some(func);
+                }
+            }
+        }
+
+        let binder = self.binder?;
+        let symbol = binder
+            .file_locals
+            .get(name)
+            .or_else(|| binder.current_scope.get(name))?;
+        let declaration = binder.symbols.get(symbol)?.declarations.first().copied()?;
+        let declaration_node = self.arena.get(declaration)?;
+        self.arena.get_function(declaration_node)
+    }
+
+    fn function_declared_type_predicate_text(
+        &self,
+        func: &FunctionData,
+    ) -> Option<(String, String)> {
+        let type_node = self.arena.get(func.type_annotation)?;
+        let predicate = self.arena.get_type_predicate(type_node)?;
+        let target = self.get_identifier_text(predicate.parameter_name)?;
+        let type_text = self.emit_type_node_text(predicate.type_node)?;
+        Some((target, type_text))
+    }
+
+    fn complement_union_type_text(
+        &self,
+        param_type_text: &str,
+        excluded_type_text: &str,
+    ) -> Option<String> {
+        let union_text = self
+            .find_local_type_alias_type_node(param_type_text.trim())
+            .and_then(|type_node| self.emit_type_node_text(type_node))
+            .unwrap_or_else(|| param_type_text.trim().to_string());
+        let excluded = excluded_type_text.trim();
+        let union_parts = Self::split_top_level_union_type_parts(&union_text);
+        let remaining: Vec<_> = union_parts
+            .iter()
+            .filter(|part| part.trim() != excluded)
+            .cloned()
+            .collect();
+        if remaining.is_empty() || remaining.len() == union_parts.len() {
+            return None;
+        }
+        Some(remaining.join(" | "))
+    }
+
     fn typeof_filter_callback_primitive(&self, callback_idx: NodeIndex) -> Option<&'static str> {
+        let condition_idx = self.function_like_single_return_expression(callback_idx)?;
+        let param_name = self.function_like_first_parameter_name(callback_idx)?;
+        self.typeof_equality_primitive(condition_idx, &param_name)
+    }
+
+    fn function_like_single_return_expression(&self, callback_idx: NodeIndex) -> Option<NodeIndex> {
         let callback_idx = self
             .arena
             .skip_parenthesized_and_assertions_and_comma(callback_idx);
@@ -113,12 +370,19 @@ impl<'a> DeclarationEmitter<'a> {
             return None;
         }
         let callback = self.arena.get_function(callback_node)?;
+        self.callback_predicate_expression(callback.body)
+    }
+
+    fn function_like_first_parameter_name(&self, callback_idx: NodeIndex) -> Option<String> {
+        let callback_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(callback_idx);
+        let callback_node = self.arena.get(callback_idx)?;
+        let callback = self.arena.get_function(callback_node)?;
         let param_idx = callback.parameters.nodes.first().copied()?;
         let param_node = self.arena.get(param_idx)?;
         let param = self.arena.get_parameter(param_node)?;
-        let param_name = self.get_identifier_text(param.name)?;
-        let condition_idx = self.callback_predicate_expression(callback.body)?;
-        self.typeof_equality_primitive(condition_idx, &param_name)
+        self.get_identifier_text(param.name)
     }
 
     fn callback_predicate_expression(&self, body_idx: NodeIndex) -> Option<NodeIndex> {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_guards.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_guards.rs
@@ -60,6 +60,146 @@ impl<'a> DeclarationEmitter<'a> {
         )
     }
 
+    pub(in crate::declaration_emitter) fn array_filter_typeof_type_text(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        let expr_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(expr_idx);
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind != syntax_kind_ext::CALL_EXPRESSION {
+            return None;
+        }
+        let call = self.arena.get_call_expr(expr_node)?;
+        let callee_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(call.expression);
+        let callee_node = self.arena.get(callee_idx)?;
+        if callee_node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            return None;
+        }
+        let access = self.arena.get_access_expr(callee_node)?;
+        if self.get_identifier_text(access.name_or_argument).as_deref() != Some("filter") {
+            return None;
+        }
+
+        let receiver_text = self.preferred_expression_type_text(access.expression)?;
+        let element_text = Self::array_element_type_text(&receiver_text)?;
+        let callback_idx = call.arguments.as_ref()?.nodes.first().copied()?;
+        let primitive = self.typeof_filter_callback_primitive(callback_idx)?;
+        if !Self::array_element_type_includes_typeof_primitive(&element_text, primitive) {
+            return None;
+        }
+        Some(format!("{primitive}[]"))
+    }
+
+    fn array_element_type_includes_typeof_primitive(element_text: &str, primitive: &str) -> bool {
+        let element_text = Self::strip_parenthesized_union_element_type_text(element_text)
+            .unwrap_or_else(|| element_text.trim().to_string());
+        Self::split_top_level_union_type_parts(&element_text)
+            .iter()
+            .any(|part| matches!(part.as_str(), "any" | "unknown") || part == primitive)
+    }
+
+    fn typeof_filter_callback_primitive(&self, callback_idx: NodeIndex) -> Option<&'static str> {
+        let callback_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(callback_idx);
+        let callback_node = self.arena.get(callback_idx)?;
+        if callback_node.kind != syntax_kind_ext::ARROW_FUNCTION
+            && callback_node.kind != syntax_kind_ext::FUNCTION_EXPRESSION
+        {
+            return None;
+        }
+        let callback = self.arena.get_function(callback_node)?;
+        let param_idx = callback.parameters.nodes.first().copied()?;
+        let param_node = self.arena.get(param_idx)?;
+        let param = self.arena.get_parameter(param_node)?;
+        let param_name = self.get_identifier_text(param.name)?;
+        let condition_idx = self.callback_predicate_expression(callback.body)?;
+        self.typeof_equality_primitive(condition_idx, &param_name)
+    }
+
+    fn callback_predicate_expression(&self, body_idx: NodeIndex) -> Option<NodeIndex> {
+        let body_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(body_idx);
+        let body_node = self.arena.get(body_idx)?;
+        if body_node.kind != syntax_kind_ext::BLOCK {
+            return Some(body_idx);
+        }
+
+        let block = self.arena.get_block(body_node)?;
+        let [stmt_idx] = block.statements.nodes.as_slice() else {
+            return None;
+        };
+        let stmt_node = self.arena.get(*stmt_idx)?;
+        let ret = self.arena.get_return_statement(stmt_node)?;
+        self.skip_parenthesized_expression(ret.expression)
+    }
+
+    fn typeof_equality_primitive(
+        &self,
+        condition_idx: NodeIndex,
+        param_name: &str,
+    ) -> Option<&'static str> {
+        let condition_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(condition_idx);
+        let condition_node = self.arena.get(condition_idx)?;
+        if condition_node.kind != syntax_kind_ext::BINARY_EXPRESSION {
+            return None;
+        }
+        let binary = self.arena.get_binary_expr(condition_node)?;
+        if binary.operator_token != SyntaxKind::EqualsEqualsEqualsToken as u16 {
+            return None;
+        }
+
+        self.typeof_primitive_pair(binary.left, binary.right, param_name)
+            .or_else(|| self.typeof_primitive_pair(binary.right, binary.left, param_name))
+    }
+
+    fn typeof_primitive_pair(
+        &self,
+        typeof_idx: NodeIndex,
+        literal_idx: NodeIndex,
+        param_name: &str,
+    ) -> Option<&'static str> {
+        let typeof_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(typeof_idx);
+        let typeof_node = self.arena.get(typeof_idx)?;
+        if typeof_node.kind != syntax_kind_ext::PREFIX_UNARY_EXPRESSION {
+            return None;
+        }
+        let unary = self.arena.get_unary_expr(typeof_node)?;
+        if unary.operator != SyntaxKind::TypeOfKeyword as u16 {
+            return None;
+        }
+        if self.get_identifier_text(unary.operand).as_deref() != Some(param_name) {
+            return None;
+        }
+
+        let literal_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(literal_idx);
+        let literal_node = self.arena.get(literal_idx)?;
+        if literal_node.kind != SyntaxKind::StringLiteral as u16 {
+            return None;
+        }
+        let literal = self.get_source_slice(literal_node.pos, literal_node.end)?;
+        match literal.trim().trim_matches(['"', '\'']) {
+            "string" => Some("string"),
+            "number" => Some("number"),
+            "boolean" => Some("boolean"),
+            "bigint" => Some("bigint"),
+            "symbol" => Some("symbol"),
+            "undefined" => Some("undefined"),
+            _ => None,
+        }
+    }
+
     fn strip_parenthesized_union_element_type_text(type_text: &str) -> Option<String> {
         let trimmed = type_text.trim();
         if !trimmed.starts_with('(') || !trimmed.ends_with(')') || !trimmed.contains('|') {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_predicate_text.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_predicate_text.rs
@@ -62,7 +62,8 @@ impl<'a> DeclarationEmitter<'a> {
         let predicate_surface = self.evaluate_type_for_predicate_alias(predicate_type);
         let param_surface = self.evaluate_type_for_predicate_alias(param_type);
         let interner = self.type_interner?;
-        let union_members = tsz_solver::type_queries::get_union_members(interner, param_surface)?;
+        let union_members = tsz_solver::type_queries::get_union_members(interner, param_type)
+            .or_else(|| tsz_solver::type_queries::get_union_members(interner, param_surface))?;
 
         union_members
             .iter()
@@ -87,7 +88,8 @@ impl<'a> DeclarationEmitter<'a> {
             return Some(self.print_type_id_for_inferred_predicate_declaration(type_id));
         }
 
-        self.nameable_alias_text_for_predicate_surface(type_id)
+        let surface = self.evaluate_type_for_predicate_alias(type_id);
+        self.nameable_alias_text_for_predicate_surface(surface, type_id)
     }
 
     fn predicate_alias_candidate_is_nameable_type(
@@ -112,6 +114,7 @@ impl<'a> DeclarationEmitter<'a> {
     fn nameable_alias_text_for_predicate_surface(
         &self,
         type_id: tsz_solver::types::TypeId,
+        source_surface: tsz_solver::types::TypeId,
     ) -> Option<String> {
         let (Some(interner), Some(cache)) = (self.type_interner, self.type_cache.as_ref()) else {
             return None;
@@ -124,15 +127,29 @@ impl<'a> DeclarationEmitter<'a> {
         // Inferred predicate narrowing can return the structural union member
         // after alias identity is lost. Re-anchor it to a public alias body
         // before printing so declaration emit keeps the source API surface.
+        // Prefer aliases still reachable from the source union member; otherwise
+        // only re-anchor when the structural body has a single public alias.
         let resolver = super::DtsStructuralResolver { cache };
-        let mut matches: Vec<_> = cache
-            .def_types
+        let source_defs = tsz_solver::visitor::collect_lazy_def_ids(interner, source_surface);
+        let search_defs: Vec<_> = if source_defs.is_empty() {
+            cache
+                .def_types
+                .keys()
+                .copied()
+                .map(tsz_solver::DefId)
+                .collect()
+        } else {
+            source_defs
+        };
+
+        let mut matches: Vec<_> = search_defs
             .iter()
-            .filter_map(|(&raw_def_id, &body)| {
-                let def_id = tsz_solver::DefId(raw_def_id);
+            .copied()
+            .filter_map(|def_id| {
                 if !self.predicate_alias_def_is_nameable(def_id) {
                     return None;
                 }
+                let body = cache.def_types.get(&def_id.0).copied()?;
                 (body == type_id
                     || tsz_solver::computation::are_types_structurally_identical(
                         interner, &resolver, body, type_id,
@@ -142,12 +159,10 @@ impl<'a> DeclarationEmitter<'a> {
             .collect();
         matches.sort_by_key(|def_id| def_id.0);
 
-        matches
-            .into_iter()
-            .map(|def_id| {
-                self.print_type_id_for_inferred_predicate_declaration(interner.lazy(def_id))
-            })
-            .next()
+        let [def_id] = matches.as_slice() else {
+            return None;
+        };
+        Some(self.print_type_id_for_inferred_predicate_declaration(interner.lazy(*def_id)))
     }
 
     fn predicate_alias_def_is_nameable(&self, def_id: tsz_solver::DefId) -> bool {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_predicate_text.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_predicate_text.rs
@@ -26,17 +26,164 @@ impl<'a> DeclarationEmitter<'a> {
             text.push_str(" is ");
             let type_text = self
                 .type_parameter_strict_null_predicate_text(type_id, outer_type_params)
+                .or_else(|| self.predicate_parameter_union_alias_text(&signature, type_id))
                 .unwrap_or_else(|| {
                     outer_type_params
                         .filter(|type_params| !type_params.nodes.is_empty())
                         .map(|type_params| {
                             self.print_type_id_with_outer_type_params(type_id, type_params)
                         })
-                        .unwrap_or_else(|| self.print_type_id_for_inferred_declaration(type_id))
+                        .unwrap_or_else(|| {
+                            self.print_type_id_for_inferred_predicate_declaration(type_id)
+                        })
                 });
             text.push_str(&type_text);
         }
         Some(text)
+    }
+
+    fn predicate_parameter_union_alias_text(
+        &self,
+        signature: &tsz_solver::type_queries::flow::ExtractedPredicateSignature,
+        predicate_type: tsz_solver::types::TypeId,
+    ) -> Option<String> {
+        let param_index =
+            signature
+                .predicate
+                .parameter_index
+                .or_else(|| match signature.predicate.target {
+                    tsz_solver::types::TypePredicateTarget::Identifier(target) => signature
+                        .params
+                        .iter()
+                        .position(|param| param.name == Some(target)),
+                    tsz_solver::types::TypePredicateTarget::This => None,
+                })?;
+        let param_type = signature.params.get(param_index)?.type_id;
+        let predicate_surface = self.evaluate_type_for_predicate_alias(predicate_type);
+        let param_surface = self.evaluate_type_for_predicate_alias(param_type);
+        let interner = self.type_interner?;
+        let union_members = tsz_solver::type_queries::get_union_members(interner, param_surface)?;
+
+        union_members
+            .iter()
+            .copied()
+            .filter(|member| {
+                *member != tsz_solver::types::TypeId::NULL
+                    && *member != tsz_solver::types::TypeId::UNDEFINED
+            })
+            .find_map(|member| {
+                let member_surface = self.evaluate_type_for_predicate_alias(member);
+                let structural_match =
+                    self.predicate_alias_candidate_matches(member, predicate_type);
+                (member_surface == predicate_surface || structural_match)
+                    .then(|| self.predicate_alias_candidate_text(member))
+                    .flatten()
+            })
+    }
+
+    fn predicate_alias_candidate_text(&self, type_id: tsz_solver::types::TypeId) -> Option<String> {
+        let text = self.print_type_id_for_inferred_predicate_declaration(type_id);
+        if Self::predicate_alias_candidate_text_is_nameable(&text) {
+            return Some(text);
+        }
+
+        self.nameable_alias_text_for_predicate_surface(type_id)
+    }
+
+    fn predicate_alias_candidate_text_is_nameable(text: &str) -> bool {
+        let trimmed = text.trim_start();
+        !text.is_empty()
+            && text != "any"
+            && !trimmed.starts_with('{')
+            && !trimmed.starts_with("import(")
+    }
+
+    fn nameable_alias_text_for_predicate_surface(
+        &self,
+        type_id: tsz_solver::types::TypeId,
+    ) -> Option<String> {
+        let (Some(interner), Some(cache)) = (self.type_interner, self.type_cache.as_ref()) else {
+            return None;
+        };
+        if type_id.is_intrinsic() || tsz_solver::visitor::literal_value(interner, type_id).is_some()
+        {
+            return None;
+        }
+
+        // Inferred predicate narrowing can return the structural union member
+        // after alias identity is lost. Re-anchor it to a public alias body
+        // before printing so declaration emit keeps the source API surface.
+        let resolver = super::DtsStructuralResolver { cache };
+        let mut matches: Vec<_> = cache
+            .def_types
+            .iter()
+            .filter_map(|(&raw_def_id, &body)| {
+                let def_id = tsz_solver::DefId(raw_def_id);
+                if !self.predicate_alias_def_is_nameable(def_id) {
+                    return None;
+                }
+                (body == type_id
+                    || tsz_solver::computation::are_types_structurally_identical(
+                        interner, &resolver, body, type_id,
+                    ))
+                .then_some(def_id)
+            })
+            .collect();
+        matches.sort_by_key(|def_id| def_id.0);
+
+        matches.into_iter().find_map(|def_id| {
+            let text = self.print_type_id_for_inferred_predicate_declaration(interner.lazy(def_id));
+            Self::predicate_alias_candidate_text_is_nameable(&text).then_some(text)
+        })
+    }
+
+    fn predicate_alias_def_is_nameable(&self, def_id: tsz_solver::DefId) -> bool {
+        let Some(cache) = self.type_cache.as_ref() else {
+            return false;
+        };
+        cache
+            .def_to_symbol
+            .get(&def_id)
+            .copied()
+            .is_some_and(|sym_id| self.symbol_is_nameable_type_for_emit(sym_id))
+            || cache.def_to_name.contains_key(&def_id)
+    }
+
+    fn predicate_alias_candidate_matches(
+        &self,
+        candidate: tsz_solver::types::TypeId,
+        predicate_type: tsz_solver::types::TypeId,
+    ) -> bool {
+        let (Some(interner), Some(cache)) = (self.type_interner, &self.type_cache) else {
+            return false;
+        };
+        let resolver = super::DtsCacheResolver { cache };
+        tsz_solver::computation::are_types_structurally_identical(
+            interner,
+            &resolver,
+            candidate,
+            predicate_type,
+        )
+    }
+
+    fn evaluate_type_for_predicate_alias(
+        &self,
+        type_id: tsz_solver::types::TypeId,
+    ) -> tsz_solver::types::TypeId {
+        let Some(interner) = self.type_interner else {
+            return type_id;
+        };
+        if let Some(cache) = &self.type_cache {
+            let resolver = super::DtsCacheResolver { cache };
+            let mut evaluator =
+                tsz_solver::computation::TypeEvaluator::with_resolver(interner, &resolver);
+            evaluator.set_max_mapped_keys(1_024);
+            evaluator.evaluate(type_id)
+        } else {
+            let mut evaluator = tsz_solver::computation::TypeEvaluator::new(interner);
+            evaluator.set_max_mapped_keys(1_024);
+            evaluator.evaluate(type_id)
+        }
     }
 
     fn type_parameter_strict_null_predicate_text(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_predicate_text.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_predicate_text.rs
@@ -82,20 +82,31 @@ impl<'a> DeclarationEmitter<'a> {
     }
 
     fn predicate_alias_candidate_text(&self, type_id: tsz_solver::types::TypeId) -> Option<String> {
-        let text = self.print_type_id_for_inferred_predicate_declaration(type_id);
-        if Self::predicate_alias_candidate_text_is_nameable(&text) {
-            return Some(text);
+        let interner = self.type_interner?;
+        if self.predicate_alias_candidate_is_nameable_type(type_id, interner) {
+            return Some(self.print_type_id_for_inferred_predicate_declaration(type_id));
         }
 
         self.nameable_alias_text_for_predicate_surface(type_id)
     }
 
-    fn predicate_alias_candidate_text_is_nameable(text: &str) -> bool {
-        let trimmed = text.trim_start();
-        !text.is_empty()
-            && text != "any"
-            && !trimmed.starts_with('{')
-            && !trimmed.starts_with("import(")
+    fn predicate_alias_candidate_is_nameable_type(
+        &self,
+        type_id: tsz_solver::types::TypeId,
+        interner: &tsz_solver::construction::TypeInterner,
+    ) -> bool {
+        if type_id.is_intrinsic() || tsz_solver::visitor::literal_value(interner, type_id).is_some()
+        {
+            return true;
+        }
+        if self.should_preserve_named_type_reference_for_emit(type_id, interner) {
+            return true;
+        }
+        let shape_id = tsz_solver::visitor::object_shape_id(interner, type_id)
+            .or_else(|| tsz_solver::visitor::object_with_index_shape_id(interner, type_id));
+        shape_id
+            .and_then(|shape_id| interner.object_shape(shape_id).symbol)
+            .is_some_and(|sym_id| self.symbol_is_nameable_type_for_emit(sym_id))
     }
 
     fn nameable_alias_text_for_predicate_surface(
@@ -131,10 +142,12 @@ impl<'a> DeclarationEmitter<'a> {
             .collect();
         matches.sort_by_key(|def_id| def_id.0);
 
-        matches.into_iter().find_map(|def_id| {
-            let text = self.print_type_id_for_inferred_predicate_declaration(interner.lazy(def_id));
-            Self::predicate_alias_candidate_text_is_nameable(&text).then_some(text)
-        })
+        matches
+            .into_iter()
+            .map(|def_id| {
+                self.print_type_id_for_inferred_predicate_declaration(interner.lazy(def_id))
+            })
+            .next()
     }
 
     fn predicate_alias_def_is_nameable(&self, def_id: tsz_solver::DefId) -> bool {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs
@@ -36,7 +36,10 @@ pub(crate) struct ResolvedDeclarationTypeText {
 }
 
 impl<'a> DeclarationEmitter<'a> {
-    fn symbol_is_nameable_type_for_emit(&self, sym_id: SymbolId) -> bool {
+    pub(in crate::declaration_emitter) fn symbol_is_nameable_type_for_emit(
+        &self,
+        sym_id: SymbolId,
+    ) -> bool {
         self.binder
             .and_then(|binder| binder.symbols.get(sym_id))
             .is_none_or(|symbol| {
@@ -103,6 +106,33 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         false
+    }
+
+    fn should_preserve_named_type_reference_for_emit(
+        &self,
+        type_id: tsz_solver::types::TypeId,
+        interner: &tsz_solver::construction::TypeInterner,
+    ) -> bool {
+        if self.should_preserve_named_application_for_emit(type_id, interner) {
+            return true;
+        }
+
+        if let Some(sym_ref) = tsz_solver::visitor::type_query_symbol(interner, type_id) {
+            return self.symbol_is_nameable_type_for_emit(SymbolId(sym_ref.0));
+        }
+
+        let Some(def_id) = tsz_solver::visitor::lazy_def_id(interner, type_id) else {
+            return false;
+        };
+        let Some(cache) = self.type_cache.as_ref() else {
+            return true;
+        };
+        cache
+            .def_to_symbol
+            .get(&def_id)
+            .copied()
+            .is_some_and(|sym_id| self.symbol_is_nameable_type_for_emit(sym_id))
+            || cache.def_to_name.contains_key(&def_id)
     }
 
     pub(in crate::declaration_emitter) fn should_preserve_named_application_for_inferred_emit(
@@ -807,6 +837,48 @@ impl<'a> DeclarationEmitter<'a> {
         let printed = self.print_type_id_with_policy(
             type_id,
             Self::should_preserve_named_application_for_inferred_emit,
+        );
+        let printed = if elided_alias_names.is_empty() {
+            printed
+        } else {
+            Self::elide_type_reference_names(&printed, &elided_alias_names)
+        };
+        let printed =
+            Self::simplify_inexact_optional_mapped_intersection_text(&printed).unwrap_or(printed);
+        let printed = self
+            .expand_imported_indexed_access_type_text(&printed)
+            .unwrap_or(printed);
+        if Self::contains_portable_mapped_object_text(&printed)
+            && let Some(expanded) =
+                self.expand_portable_intersection_type_text(self.arena, &printed)
+        {
+            expanded
+        } else {
+            printed
+        }
+    }
+
+    pub(in crate::declaration_emitter) fn print_type_id_for_inferred_predicate_declaration(
+        &self,
+        type_id: tsz_solver::types::TypeId,
+    ) -> String {
+        let elided_alias_names = self.function_local_type_alias_application_names(type_id);
+        let type_id = if let Some(interner) = self.type_interner {
+            let type_id = self
+                .inferred_declaration_mapped_constraint_surface(type_id)
+                .unwrap_or(type_id);
+            self.display_alias_for_policy(
+                type_id,
+                interner,
+                Self::should_preserve_named_type_reference_for_emit,
+            )
+        } else {
+            type_id
+        };
+        let type_id = self.reduce_conditional_aliases_for_inferred_emit(type_id, 0);
+        let printed = self.print_type_id_with_policy(
+            type_id,
+            Self::should_preserve_named_type_reference_for_emit,
         );
         let printed = if elided_alias_names.is_empty() {
             printed

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs
@@ -108,7 +108,7 @@ impl<'a> DeclarationEmitter<'a> {
         false
     }
 
-    fn should_preserve_named_type_reference_for_emit(
+    pub(in crate::declaration_emitter) fn should_preserve_named_type_reference_for_emit(
         &self,
         type_id: tsz_solver::types::TypeId,
         interner: &tsz_solver::construction::TypeInterner,

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -739,6 +739,21 @@ impl<'a> DeclarationEmitter<'a> {
             {
                 self.write(": ");
                 self.write(&type_text);
+            } else if has_initializer
+                && self.arena.get(initializer).is_some_and(|node| {
+                    node.kind == syntax_kind_ext::ARROW_FUNCTION
+                        || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
+                })
+                && let Some(func) = self
+                    .arena
+                    .get(initializer)
+                    .and_then(|node| self.arena.get_function(node))
+                && self.function_source_type_predicate_text(func).is_some()
+                && {
+                    self.maybe_emit_non_portable_function_return_diagnostic(decl_name, initializer);
+                    self.emit_function_initializer_type_annotation(decl_idx, decl_name, initializer)
+                }
+            {
             } else if !has_initializer
                 && keyword == "let"
                 && self

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl_function_initializers.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl_function_initializers.rs
@@ -94,6 +94,13 @@ impl<'a> DeclarationEmitter<'a> {
             None
         };
 
+        if func.body.is_some()
+            && let Some(predicate_text) = self.function_source_type_predicate_text(func)
+        {
+            self.write(&predicate_text);
+            return true;
+        }
+
         if let (Some(interner), Some(cache)) = (&self.type_interner, &self.type_cache) {
             let func_type_id = cache
                 .node_types

--- a/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs
@@ -457,7 +457,7 @@ type Bar = Foo & {
         properties: Vec::new(),
         string_index: None,
         number_index: None,
-        symbol: Some(bar_sym),
+        symbol: None,
     });
     let param_type = interner.union(vec![foo_surface, bar_surface, TypeId::NULL]);
 

--- a/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs
@@ -527,6 +527,30 @@ const fooOrBar = list[0];
     );
 }
 
+#[test]
+fn fix_array_filter_typeof_decl_uses_narrowed_primitive_array() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+const strings = [1, "foo", 2, "bar"].filter(x => typeof x === "string");
+const numbers = ["a", 1, "b", 2].filter(x => "number" === typeof x);
+const impossible = [1, 2].filter(x => typeof x === "string");
+"#,
+    );
+
+    assert!(
+        output.contains("declare const strings: string[];"),
+        "typeof string filter should print string[]: {output}"
+    );
+    assert!(
+        output.contains("declare const numbers: number[];"),
+        "reversed typeof number filter should print number[]: {output}"
+    );
+    assert!(
+        !output.contains("declare const impossible: string[];"),
+        "impossible typeof string filter should not be overstated as string[]: {output}"
+    );
+}
+
 // Tests for returned-function-expression recursive unrolling (issue #8683)
 
 #[test]

--- a/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs
@@ -506,6 +506,92 @@ type Bar = Foo & {
 }
 
 #[test]
+fn fix_inferred_predicate_return_does_not_pick_unrelated_duplicate_alias() {
+    use crate::type_cache_view::TypeCacheView;
+    use tsz_solver::construction::TypeInterner;
+    use tsz_solver::{
+        FunctionShape, ParamInfo, TypeId,
+        types::{ObjectFlags, ObjectShape, TypePredicate, TypePredicateTarget},
+    };
+
+    let mut parser = tsz_parser::ParserState::new(
+        "test.ts".to_string(),
+        r#"
+type Unrelated = {
+    value: string;
+};
+type Bar = {
+    value: string;
+};
+"#
+        .to_string(),
+    );
+    let root = parser.parse_source_file();
+    let mut binder = tsz_binder::BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+    let unrelated_sym = binder
+        .file_locals
+        .get("Unrelated")
+        .expect("missing Unrelated symbol");
+    let bar_sym = binder.file_locals.get("Bar").expect("missing Bar symbol");
+
+    let interner = TypeInterner::new();
+    let unrelated_def = tsz_solver::DefId(94_500);
+    let bar_def = tsz_solver::DefId(94_501);
+    let shared_surface = interner.object_with_index(ObjectShape {
+        flags: ObjectFlags::default(),
+        properties: Vec::new(),
+        string_index: None,
+        number_index: None,
+        symbol: None,
+    });
+    let param_type = interner.union(vec![shared_surface, TypeId::NULL]);
+
+    let x_atom = interner.intern_string("x");
+    let func_type = interner.function(FunctionShape {
+        type_params: Vec::new(),
+        params: vec![ParamInfo {
+            name: Some(x_atom),
+            type_id: param_type,
+            optional: false,
+            rest: false,
+        }],
+        this_type: None,
+        return_type: TypeId::BOOLEAN,
+        type_predicate: Some(TypePredicate {
+            asserts: false,
+            target: TypePredicateTarget::Identifier(x_atom),
+            type_id: Some(shared_surface),
+            parameter_index: None,
+        }),
+        is_constructor: false,
+        is_method: false,
+    });
+
+    let mut type_cache = TypeCacheView::default();
+    type_cache
+        .def_to_symbol
+        .insert(unrelated_def, unrelated_sym);
+    type_cache.def_to_symbol.insert(bar_def, bar_sym);
+    type_cache.def_types.insert(unrelated_def.0, shared_surface);
+    type_cache.def_types.insert(bar_def.0, shared_surface);
+    let emitter = crate::declaration_emitter::DeclarationEmitter::with_type_info(
+        &parser.arena,
+        type_cache,
+        &interner,
+        &binder,
+    );
+    let output = emitter
+        .function_type_predicate_text(func_type, None)
+        .unwrap_or_default();
+
+    assert!(
+        !output.contains("Unrelated") && !output.contains("Bar"),
+        "ambiguous structural aliases must not select an arbitrary public alias: {output}"
+    );
+}
+
+#[test]
 fn fix_element_access_decl_uses_source_array_element_type() {
     let output = emit_dts_with_usage_analysis(
         r#"

--- a/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs
@@ -417,6 +417,94 @@ fn fix_predicate_pattern2_does_not_rewrite_unrelated_union_shapes() {
     );
 }
 
+#[test]
+fn fix_inferred_predicate_return_prefers_nameable_alias() {
+    use crate::type_cache_view::TypeCacheView;
+    use tsz_solver::construction::TypeInterner;
+    use tsz_solver::{
+        FunctionShape, ParamInfo, TypeId,
+        types::{ObjectFlags, ObjectShape, TypePredicate, TypePredicateTarget},
+    };
+
+    let mut parser = tsz_parser::ParserState::new(
+        "test.ts".to_string(),
+        r#"
+type Foo = {
+    foo: string;
+};
+type Bar = Foo & {
+    bar: string;
+};
+"#
+        .to_string(),
+    );
+    let root = parser.parse_source_file();
+    let mut binder = tsz_binder::BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+    let bar_sym = binder.file_locals.get("Bar").expect("missing Bar symbol");
+
+    let interner = TypeInterner::new();
+    let bar_def = tsz_solver::DefId(94_501);
+    let foo_surface = interner.object_with_index(ObjectShape {
+        flags: ObjectFlags::default(),
+        properties: Vec::new(),
+        string_index: None,
+        number_index: None,
+        symbol: None,
+    });
+    let bar_surface = interner.object_with_index(ObjectShape {
+        flags: ObjectFlags::default(),
+        properties: Vec::new(),
+        string_index: None,
+        number_index: None,
+        symbol: Some(bar_sym),
+    });
+    let param_type = interner.union(vec![foo_surface, bar_surface, TypeId::NULL]);
+
+    let x_atom = interner.intern_string("x");
+    let func_type = interner.function(FunctionShape {
+        type_params: Vec::new(),
+        params: vec![ParamInfo {
+            name: Some(x_atom),
+            type_id: param_type,
+            optional: false,
+            rest: false,
+        }],
+        this_type: None,
+        return_type: TypeId::BOOLEAN,
+        type_predicate: Some(TypePredicate {
+            asserts: false,
+            target: TypePredicateTarget::Identifier(x_atom),
+            type_id: Some(bar_surface),
+            parameter_index: None,
+        }),
+        is_constructor: false,
+        is_method: false,
+    });
+
+    let mut type_cache = TypeCacheView::default();
+    type_cache.def_to_symbol.insert(bar_def, bar_sym);
+    type_cache.def_types.insert(bar_def.0, bar_surface);
+    let emitter = crate::declaration_emitter::DeclarationEmitter::with_type_info(
+        &parser.arena,
+        type_cache,
+        &interner,
+        &binder,
+    );
+    let output = emitter
+        .function_type_predicate_text(func_type, None)
+        .unwrap_or_default();
+
+    assert!(
+        output == "x is Bar",
+        "expected inferred predicate return to preserve the public alias: {output}"
+    );
+    assert!(
+        !output.contains("x is {"),
+        "predicate return should not expand the nameable alias structurally: {output}"
+    );
+}
+
 // Tests for returned-function-expression recursive unrolling (issue #8683)
 
 #[test]

--- a/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs
@@ -505,6 +505,28 @@ type Bar = Foo & {
     );
 }
 
+#[test]
+fn fix_element_access_decl_uses_source_array_element_type() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+type Foo = {
+    foo: string;
+};
+type Bar = Foo & {
+    bar: string;
+};
+
+const list: (Foo | Bar)[] = [];
+const fooOrBar = list[0];
+"#,
+    );
+
+    assert!(
+        output.contains("declare const fooOrBar: Foo | Bar;"),
+        "element access over a source array annotation should print the element type: {output}"
+    );
+}
+
 // Tests for returned-function-expression recursive unrolling (issue #8683)
 
 #[test]

--- a/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs
@@ -551,6 +551,60 @@ const impossible = [1, 2].filter(x => typeof x === "string");
     );
 }
 
+#[test]
+fn fix_array_map_callback_decl_uses_return_array_surface() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+type MyObj = { data?: string };
+type MyArray = { list?: MyObj[] }[];
+const myArray: MyArray = [];
+
+const result = myArray
+  .map((arr) => arr.list)
+  .filter((arr) => arr && arr.length)
+  .map((arr) => arr
+    .filter((obj) => obj && obj.data)
+    .map(obj => JSON.parse(obj.data))
+  );
+"#,
+    );
+
+    assert!(
+        output.contains("declare const result: any[][];"),
+        "map callback return arrays should compose into the declaration type: {output}"
+    );
+}
+
+#[test]
+fn fix_source_predicate_decl_uses_truthy_union_and_negated_local_guard() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+const numOrBoolean = (x: number | boolean) => typeof x === "number" || x;
+
+type Animal = { breath: true };
+type Rock = { breath: false };
+type Something = Animal | Rock;
+
+function isAnimal(something: Something): something is Animal {
+  return something.breath;
+}
+
+function negative(t: Something) {
+  return !isAnimal(t);
+}
+"#,
+    );
+
+    assert!(
+        output.contains("declare const numOrBoolean: (x: number | boolean) => x is number | true;"),
+        "truthy boolean plus typeof guard should print the inferred predicate: {output}"
+    );
+    assert!(
+        output.contains("declare function negative(t: Something): t is Rock;"),
+        "negated local predicate over a union alias should print the complement arm: {output}"
+    );
+}
+
 // Tests for returned-function-expression recursive unrolling (issue #8683)
 
 #[test]


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Declaration emit / public API summary boundary.

## Invariant
When inferred predicate declaration emit has a source-visible public surface, `tsc` preserves that surface in `.d.ts` output. This PR keeps predicate alias/nameability, source-array element access, `typeof` array filters, array-map callback return arrays, truthy boolean/`typeof` predicate unions, and negated local predicate complements on declaration/public API summary paths rather than changing checker diagnostics or solver relation semantics.

## Scope
- Inferred predicate declaration return printing in `type_predicate_text`.
- Predicate-specific inferred type printing policy in `type_printing`.
- Source-array numeric element access fallback in inferred declaration type text.
- Source-array `.filter(x => typeof x === "<primitive>")` fallback when the receiver element surface admits that primitive.
- Source `.map` callback return-array fallback for declaration pipeline surfaces such as `JSON.parse` maps.
- Source predicate fallback for `typeof x === "<primitive>" || x` when the parameter union includes `boolean`, preserving the `true` branch that `tsc` emits.
- Source predicate fallback for `!localPredicate(param)` over a local union alias when the local predicate has an explicit type-predicate annotation, preserving the complement alias arm.
- Focused unit coverage for alias identity, source-array element access declarations, `typeof` filter declarations, map callback array declarations, and conservative source predicate declarations.

## Project Corpus Impact
- Row: `inferTypePredicates`
- Bug family: DTS inferred predicate alias/nameability surfaces, source-array declaration summary surfaces, array pipeline public surfaces, and source-visible predicate complements
- Evidence: `scripts/safe-run.sh scripts/emit/run.sh --filter=inferTypePredicates --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-inferTypePredicates-rebased-80c4b596-20260528.json` passes 1/1 at head `5f085303cf` on base `80c4b59623cfa1282c8e3ed52c40267d830fcc85`.

## Verification
- Current head `5f085303cf` rebased onto `origin/main` `80c4b59623cfa1282c8e3ed52c40267d830fcc85`.
- `cargo fmt --all --check`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `cargo nextest run -p tsz-emitter -E 'test(fix_array_map_callback_decl_uses_return_array_surface) or test(fix_source_predicate_decl_uses_truthy_union_and_negated_local_guard) or test(fix_array_filter_typeof_decl_uses_narrowed_primitive_array)'`
- `cargo nextest run -p tsz-emitter -E 'test(fix_inferred_predicate_return_prefers_nameable_alias) or test(fix_inferred_predicate_return_does_not_pick_unrelated_duplicate_alias)'`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=inferTypePredicates --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-inferTypePredicates-rebased-80c4b596-20260528.json` (passes 1/1)
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-emitter --all-targets -- -D warnings`
- Touched files remain under the 2000-line limit.

## Coordination Notes
- AgentName: Studio-D
- Owner layer: declaration emit nameability/public API/source declaration surface. This does not change checker diagnostics or solver relation semantics.
- The predicate alias fallback uses existing `TypeCacheView` declaration metadata and structural identity to recover a public alias when narrowing lost alias identity; it does not use rendered DTS fragments to decide whether a candidate is nameable.
- The element-access fallback is intentionally narrow: numeric element access whose receiver has a source-visible array declaration surface. Unsupported shapes fall back to the existing normal path.
- The `typeof` filter fallback is intentionally narrow: direct `.filter` callbacks with a primitive `typeof` equality, and only when the receiver element surface is `any`, `unknown`, the same primitive, or a top-level union containing that primitive. Unsupported shapes fall back to the existing normal path.
- The map fallback is intentionally declaration-surface-only: direct `.map` calls with a single source-visible callback return expression. Unsupported callback shapes fall back to the existing normal path.
- The source predicate fallback is intentionally narrow: same-parameter `typeof || truthy boolean` and negated calls to a local explicitly annotated predicate over a union alias. Unsupported boolean formulas fall back to the existing solver/type-printer path.
- Avoids overlap with M1-D #10281 checker predicate boundary refactor and Studio-E #10637 JSDoc DTS work; this PR remains limited to emitter declaration surfaces.
- #10310 has merged and is included in current `origin/main`; this branch is rebased over it.
- 2026-05-28 Studio-D refresh: rebased over `origin/main` `80c4b59623cfa1282c8e3ed52c40267d830fcc85`, resolving the element-access declaration fallback to keep immediate array-literal element access before declared/source array element access. Local focused verification above passed at head `5f085303cf`.
- PR is ready for review once the remote body is verified; merge queue remains off until exact-head PR checks are green and a queue owner enqueues it.

- 2026-05-28 ReviewHelper blocker fix: predicate alias re-anchoring now prefers aliases reachable from the matching source union member and refuses ambiguous global structural matches instead of choosing the lowest raw `DefId`; added duplicate-alias coverage. Merge queue remains off until fresh exact-head CI for `5f085303cf` is green.

