### PR TITLE
fix(checker): emit TS2322 not TS2719 for unique-symbol mismatches (#9752)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -1944,6 +1944,11 @@ impl<'a> CheckerState<'a> {
                 && !authoritative_names_differ
                 && !pair_is_literal_value
                 && !exact_optional_structural_pair
+                // unique symbols stringify identically but are distinct symbol
+                // identities; tsc reports their mismatch as TS2322, not TS2719.
+                // Detect structurally rather than by display. See #9752.
+                && !crate::query_boundaries::common::is_unique_symbol_type(self.ctx.types, source)
+                && !crate::query_boundaries::common::is_unique_symbol_type(self.ctx.types, target)
             {
                 (
                     format_message(

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -1944,11 +1944,6 @@ impl<'a> CheckerState<'a> {
                 && !authoritative_names_differ
                 && !pair_is_literal_value
                 && !exact_optional_structural_pair
-                // unique symbols stringify identically but are distinct symbol
-                // identities; tsc reports their mismatch as TS2322, not TS2719.
-                // Detect structurally rather than by display. See #9752.
-                && !crate::query_boundaries::common::is_unique_symbol_type(self.ctx.types, source)
-                && !crate::query_boundaries::common::is_unique_symbol_type(self.ctx.types, target)
             {
                 (
                     format_message(

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -1151,8 +1151,8 @@ impl<'a> CheckerState<'a> {
             && !crate::error_reporter::assignability::display_is_literal_value(&source_param_str)
             // unique symbols stringify identically but are distinct identities;
             // tsc uses TS2322, not TS2719. Detect structurally. See #9752.
-            && !crate::query_boundaries::common::is_unique_symbol_type(self.ctx.types, source_param)
-            && !crate::query_boundaries::common::is_unique_symbol_type(self.ctx.types, target_param)
+            && !crate::query_boundaries::type_predicates::is_unique_symbol_type(self.ctx.types, source_param)
+            && !crate::query_boundaries::type_predicates::is_unique_symbol_type(self.ctx.types, target_param)
         {
             (
                 format_message(

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -1149,6 +1149,10 @@ impl<'a> CheckerState<'a> {
         let (inner, inner_code) = if source_param_str == target_param_str
             && !crate::error_reporter::assignability::is_primitive_type_name(&source_param_str)
             && !crate::error_reporter::assignability::display_is_literal_value(&source_param_str)
+            // unique symbols stringify identically but are distinct identities;
+            // tsc uses TS2322, not TS2719. Detect structurally. See #9752.
+            && !crate::query_boundaries::common::is_unique_symbol_type(self.ctx.types, source_param)
+            && !crate::query_boundaries::common::is_unique_symbol_type(self.ctx.types, target_param)
         {
             (
                 format_message(

--- a/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
@@ -530,6 +530,12 @@ impl<'a> CheckerState<'a> {
             // `Type '"foo"' is not assignable to type '"foo"'` is misleading.
             // Fall through to TS2322.
             && !crate::error_reporter::assignability::display_is_literal_value(&source_str)
+            // `unique symbol` types are distinct symbol identities, not two
+            // named nominal types — both stringify as `unique symbol`, but tsc
+            // reports their mismatch as TS2322 (with `typeof`-based names), not
+            // TS2719. Detect them structurally rather than by display. See #9752.
+            && !crate::query_boundaries::common::is_unique_symbol_type(self.ctx.types, source)
+            && !crate::query_boundaries::common::is_unique_symbol_type(self.ctx.types, target)
         {
             let message = format_message(
                 diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE_TWO_DIFFERENT_TYPES_WITH_THIS_NAME_EXIST_BUT_THEY,

--- a/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
@@ -534,8 +534,8 @@ impl<'a> CheckerState<'a> {
             // named nominal types — both stringify as `unique symbol`, but tsc
             // reports their mismatch as TS2322 (with `typeof`-based names), not
             // TS2719. Detect them structurally rather than by display. See #9752.
-            && !crate::query_boundaries::common::is_unique_symbol_type(self.ctx.types, source)
-            && !crate::query_boundaries::common::is_unique_symbol_type(self.ctx.types, target)
+            && !crate::query_boundaries::type_predicates::is_unique_symbol_type(self.ctx.types, source)
+            && !crate::query_boundaries::type_predicates::is_unique_symbol_type(self.ctx.types, target)
         {
             let message = format_message(
                 diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE_TWO_DIFFERENT_TYPES_WITH_THIS_NAME_EXIST_BUT_THEY,

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -934,6 +934,9 @@ mod union_constraint_relation_routing_arch_tests;
 #[path = "tests/union_multi_overload_unified_sig_tests.rs"]
 mod union_multi_overload_unified_sig_tests;
 #[cfg(test)]
+#[path = "tests/unique_symbol_assignment_ts2322_tests.rs"]
+mod unique_symbol_assignment_ts2322_tests;
+#[cfg(test)]
 #[path = "../tests/variadic_tuple_elaboration_tests.rs"]
 mod variadic_tuple_elaboration_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/type_predicates.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_predicates.rs
@@ -67,6 +67,11 @@ pub(crate) fn is_this_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     tsz_solver::type_queries::is_this_type(db, type_id)
 }
 
+/// Whether `type_id` is a `unique symbol` type (`TypeData::UniqueSymbol`).
+pub(crate) fn is_unique_symbol_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    tsz_solver::type_queries::is_unique_symbol_type(db, type_id)
+}
+
 pub(crate) fn is_recursive_type_reference(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     tsz_solver::recursive_index(db, type_id).is_some()
 }

--- a/crates/tsz-checker/src/tests/unique_symbol_assignment_ts2322_tests.rs
+++ b/crates/tsz-checker/src/tests/unique_symbol_assignment_ts2322_tests.rs
@@ -1,0 +1,94 @@
+//! Regression tests for #9752: assigning between two distinct `unique symbol`
+//! types must emit TS2322 (like tsc), not TS2719 ("two different types with
+//! this name"). TS2719 is reserved for distinct *named nominal* types sharing a
+//! name; two `unique symbol` types stringify identically but are separate
+//! symbol identities, so the failure must route through the standard TS2322
+//! path. The fix detects unique-symbol operands structurally, not by display.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::check_source;
+
+fn strict() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn codes(src: &str) -> Vec<u32> {
+    check_source(src, "test.ts", strict())
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+#[test]
+fn assigning_unique_symbol_to_other_unique_symbol_is_ts2322_not_ts2719() {
+    let c = codes(
+        r#"
+declare const s1: unique symbol;
+declare const s2: unique symbol;
+let b: typeof s1;
+b = s2;
+"#,
+    );
+    assert!(c.contains(&2322), "expected TS2322, got {c:?}");
+    assert!(!c.contains(&2719), "must not emit TS2719, got {c:?}");
+}
+
+#[test]
+fn declaration_form_unique_symbol_mismatch_is_ts2322() {
+    let c = codes(
+        r#"
+declare const s1: unique symbol;
+declare const s2: unique symbol;
+const a: typeof s1 = s2;
+"#,
+    );
+    assert!(c.contains(&2322), "expected TS2322, got {c:?}");
+    assert!(!c.contains(&2719), "must not emit TS2719, got {c:?}");
+}
+
+#[test]
+fn renamed_unique_symbols_still_ts2322_not_name_based() {
+    // Different identifier spellings — proves the routing is structural, not
+    // keyed on a shared display name.
+    let c = codes(
+        r#"
+declare const alpha: unique symbol;
+declare const beta: unique symbol;
+let target: typeof alpha;
+target = beta;
+"#,
+    );
+    assert!(c.contains(&2322), "expected TS2322, got {c:?}");
+    assert!(!c.contains(&2719), "must not emit TS2719, got {c:?}");
+}
+
+#[test]
+fn same_unique_symbol_assignment_is_clean() {
+    let c = codes(
+        r#"
+declare const s1: unique symbol;
+let b: typeof s1;
+b = s1;
+"#,
+    );
+    assert!(
+        !c.contains(&2322) && !c.contains(&2719),
+        "same-symbol assignment must be clean, got {c:?}"
+    );
+}
+
+#[test]
+fn unique_symbol_vs_wide_symbol_stays_ts2322() {
+    let c = codes(
+        r#"
+declare const s1: unique symbol;
+declare const w: symbol;
+const x: typeof s1 = w;
+"#,
+    );
+    assert!(c.contains(&2322), "expected TS2322, got {c:?}");
+    assert!(!c.contains(&2719), "must not emit TS2719, got {c:?}");
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B
Contributor: M5Opus

## Track
Conformance / diagnostic parity (closes #9752).

## Invariant
TS2719 ("two different types with this name exist, but they are unrelated") is reserved for distinct **named nominal** types sharing a name. Two `unique symbol` types are separate symbol identities that stringify identically as `unique symbol`; tsc reports their mismatch as **TS2322**. The TS2719 heuristic keys on identical display strings, so it misfired for unique symbols.

## Scope
Guard the TS2719 reporting path with a **structural** unique-symbol check (`query_boundaries::type_predicates::is_unique_symbol_type` on source/target `TypeId`s), not a display-string check (per §25), so unique-symbol operands route through the standard TS2322 path. The current head changes:
- `error_reporter/render_failure/type_mismatch.rs`
- `error_reporter/render_failure.rs`

Residual message text still renders `unique symbol` rather than tsc's `typeof s1`/`typeof s2` — the secondary display divergence noted in #9752 (pre-existing for the unique-vs-wide case), left as follow-up. This PR fixes the diagnostic **code**, the issue's primary ask.

## Project Corpus Impact
- Row: n/a
- Bug family: wrong-diagnostic-code (TS2719 misfire for unique-symbol assignability; should be TS2322)
- Evidence: minimal repro from #9752 now emits TS2322 (was TS2719) on a dist-fast build; 5 new owning-crate unit tests pass.

## Verification
- Repro `b = s2` (two `unique symbol`s): now `TS2322` (was `TS2719`).
- `cargo nextest run -p tsz-checker -E 'test(unique_symbol_assignment)'` → 5/5 pass (repro, declaration form, renamed-symbols structural guard, same-symbol clean, unique-vs-wide TS2322).

## Coordination Notes
Signed M1-B (Contributor: M5Opus). Closes #9752. No overlap with open PRs.