### PR TITLE
test(solver): cover noUncheckedIndexedAccess relation cache

### DIFF
--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -311,6 +311,88 @@ fn assignability_cache_exact_optional_matches_uncached_property_policy() {
 }
 
 #[test]
+fn assignability_cache_no_unchecked_indexed_access_matches_uncached_index_policy() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let source = interner.index_access(interner.array(TypeId::STRING), TypeId::NUMBER);
+    let target = TypeId::STRING;
+    let checked_policy = RelationPolicy::from_relation_flags(RelationFlags::STRICT_NULL_CHECKS);
+    let unchecked_policy = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_NULL_CHECKS | RelationFlags::NO_UNCHECKED_INDEXED_ACCESS,
+    );
+    let checked_key =
+        RelationCacheKey::for_assignability(source, target, checked_policy.cache_config());
+    let unchecked_key =
+        RelationCacheKey::for_assignability(source, target, unchecked_policy.cache_config());
+
+    assert_ne!(
+        checked_key, unchecked_key,
+        "no-unchecked-indexed-access must occupy a distinct assignability cache slot",
+    );
+
+    let checked_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        checked_policy,
+        RelationContext::default(),
+    )
+    .is_related();
+    let unchecked_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        unchecked_policy,
+        RelationContext::default(),
+    )
+    .is_related();
+
+    assert!(
+        checked_uncached,
+        "plain array indexed access should produce the element type",
+    );
+    assert!(
+        !unchecked_uncached,
+        "no-unchecked-indexed-access should include undefined under strict null checks",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, checked_policy),
+        checked_uncached,
+        "cached checked indexed-access policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(checked_key),
+        Some(checked_uncached),
+        "checked indexed-access result must be stored in the checked assignability slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(unchecked_key),
+        None,
+        "unchecked lookup must not hit the checked slot",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, unchecked_policy),
+        unchecked_uncached,
+        "cached no-unchecked-indexed-access policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(unchecked_key),
+        Some(unchecked_uncached),
+        "unchecked indexed-access result must be stored in the unchecked assignability slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(checked_key),
+        Some(checked_uncached),
+        "checked assignability slot must remain intact after the unchecked lookup",
+    );
+}
+
+#[test]
 fn subtype_cache_strict_readonly_identity_matches_uncached_property_policy() {
     let interner = TypeInterner::new();
     let db = QueryCache::new(&interner);


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 10 relation policy/cache-key tech debt (#8207), solver policy/cache agreement test ratchet.

## Invariant
When relation policy enables `NO_UNCHECKED_INDEXED_ACCESS` under strict null checks, indexed access relations must include `undefined`; the cached assignability path must agree with the uncached `query_relation` facade and use a distinct policy-shaped cache key.

## Scope
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: solver test-only ratchet for relation policy/cache agreement; no project corpus behavior change targeted.

## Verification
- `cargo nextest run -p tsz-solver -E 'test(assignability_cache_no_unchecked_indexed_access_matches_uncached_index_policy)'`
- `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'`
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- Draft-light GitHub Actions CI passed on exact head `11473eff766f55ec1bcc1b4212c1acbd7c3449ae`: https://github.com/mohsen1/tsz/actions/runs/26547115955
- Ready-review GitHub Actions CI completed successfully on exact head `11473eff766f55ec1bcc1b4212c1acbd7c3449ae`: https://github.com/mohsen1/tsz/actions/runs/26547528926

## Coordination Notes
- Non-overlap: #10665 has merged; this PR is a test-only follow-up for another relation policy/cache bit in #8207.
- Does not touch checker relation routing owned by M1-B, nor M4-A/M4-C evaluation/inference lanes.
- Ready-review heavy CI is green on exact head `11473eff766f55ec1bcc1b4212c1acbd7c3449ae`; adding `merge-queue` for the repo-local queue.
- `Queue Tested` is queue-owned and may remain pending until the synthetic latest-main merge lands.
