### PR TITLE
fix(checker): defer JSX generic-spread relation on conditional operands

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1243,6 +1243,10 @@ name = "generic_inference_ordering_tests"
 path = "tests/generic_inference_ordering_tests.rs"
 
 [[test]]
+name = "jsx_generic_spread_deferred_conditional_tests"
+path = "tests/jsx_generic_spread_deferred_conditional_tests.rs"
+
+[[test]]
 name = "jsx_multi_construct_overload_tests"
 path = "tests/jsx_multi_construct_overload_tests.rs"
 

--- a/crates/tsz-checker/src/checkers/jsx/props/generic_spread.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/generic_spread.rs
@@ -44,6 +44,9 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
+        let spread_source_is_deferred = generic_spread_types
+            .iter()
+            .any(|&spread_type| self.jsx_relation_operand_defers(spread_type));
         let explicit_attrs_type = self.build_jsx_provided_attrs_object_type(provided_attrs);
         let mut members = generic_spread_types;
         members.push(explicit_attrs_type);
@@ -63,6 +66,14 @@ impl<'a> CheckerState<'a> {
             let Some(expected_type) = expected_type else {
                 return false;
             };
+            // A deferred conditional on either operand is comparable for `tsc`;
+            // the structural relation cannot soundly disprove it, so it is not a
+            // genuine mismatch.
+            if self.jsx_relation_operand_defers(*actual_type)
+                || self.jsx_relation_operand_defers(expected_type)
+            {
+                return false;
+            }
             !self.diagnostic_relation_boolean_guard(*actual_type, expected_type)
         });
 
@@ -73,6 +84,19 @@ impl<'a> CheckerState<'a> {
         if has_excess_property_error
             && !has_explicit_prop_mismatch
             && !has_alias_string_prop_mismatch
+        {
+            return false;
+        }
+
+        // A spread whose source carries a deferred conditional over a type
+        // parameter (e.g. `Omit`/`Overwrite` of an unresolved `T`) is an
+        // instantiable, comparable type for `tsc`; it does not drive a
+        // whole-object TS2322. Without a concrete explicit-attribute mismatch
+        // the structural relation cannot soundly disprove assignability, so
+        // emitting here is a false positive.
+        if !has_explicit_prop_mismatch
+            && !has_alias_string_prop_mismatch
+            && spread_source_is_deferred
         {
             return false;
         }

--- a/crates/tsz-checker/src/checkers/jsx/props/validation.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/validation.rs
@@ -20,6 +20,36 @@ use tsz_solver::computation::TypeSubstitution;
 use tsz_solver::{ObjectShape, TypeId};
 
 impl<'a> CheckerState<'a> {
+    /// Whether a JSX relation operand (a spread source or an attribute value
+    /// type) carries a conditional that is still deferred over a type
+    /// parameter, so a structural assignability answer is unreliable. See
+    /// `query_boundaries::checkers::jsx::jsx_relation_operand_is_deferred_conditional`.
+    ///
+    /// The operand is frequently a not-yet-expanded alias application
+    /// (`SingleProps<W>`); evaluating it surfaces the underlying conditional
+    /// intersection (`Omit<...> & ...`) so detection does not depend on whether
+    /// the type happened to be expanded at the call site.
+    pub(in crate::checkers_domain::jsx) fn jsx_relation_operand_defers(
+        &mut self,
+        type_id: TypeId,
+    ) -> bool {
+        if crate::query_boundaries::checkers::jsx::jsx_relation_operand_is_deferred_conditional(
+            self.ctx.types,
+            &self.ctx.definition_store,
+            type_id,
+        ) {
+            return true;
+        }
+        let evaluated = self.evaluate_application_type(type_id);
+        let evaluated = self.evaluate_type_with_env(evaluated);
+        evaluated != type_id
+            && crate::query_boundaries::checkers::jsx::jsx_relation_operand_is_deferred_conditional(
+                self.ctx.types,
+                &self.ctx.definition_store,
+                evaluated,
+            )
+    }
+
     /// Walk every `{...expr}` spread attribute on a JSX element and emit
     /// TS2698 ("Spread types may only be created from object types") for
     /// each one whose type is not a valid spread source.
@@ -220,12 +250,31 @@ impl<'a> CheckerState<'a> {
             let Some(expected_type) = expected_type else {
                 return false;
             };
+            // A deferred conditional on either operand is comparable for `tsc`;
+            // the structural relation cannot soundly disprove it, so it is not a
+            // genuine mismatch.
+            if self.jsx_relation_operand_defers(*attr_type)
+                || self.jsx_relation_operand_defers(expected_type)
+            {
+                return false;
+            }
             !self.diagnostic_relation_boolean_guard(*attr_type, expected_type)
         });
+        // A spread whose source carries a deferred conditional over a type
+        // parameter (e.g. `Omit`/`Overwrite` of an unresolved `T`) is an
+        // instantiable, comparable type for `tsc`; absent a concrete explicit
+        // mismatch the structural relation cannot soundly disprove the
+        // whole-object assignability, so emitting here is a false positive.
+        let spread_source_is_deferred = generic_spreads
+            .iter()
+            .any(|&spread_type| self.jsx_relation_operand_defers(spread_type));
         let explicit_type = self.build_jsx_provided_attrs_object_type(&explicit_attrs);
         generic_spreads.push(explicit_type);
         let attrs_type = self.ctx.types.factory().intersection(generic_spreads);
         if !has_explicit_mismatch {
+            if spread_source_is_deferred {
+                return;
+            }
             if !crate::query_boundaries::checkers::jsx::contains_mapped_type_with_readonly_modifier(
                 self.ctx.types,
                 props_type,

--- a/crates/tsz-checker/src/query_boundaries/checkers/jsx.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/jsx.rs
@@ -13,6 +13,47 @@ pub(crate) fn contains_index_access_type(db: &dyn TypeDatabase, type_id: TypeId)
     tsz_solver::type_queries::contains_index_access_type(db, type_id)
 }
 
+/// Whether a JSX attribute relation operand carries a conditional type that is
+/// still deferred over a type parameter, making a structural assignability
+/// answer unreliable.
+///
+/// This covers both whole-object spread sources (`{...props}` where `props` is
+/// `Omit`/`Pick`/`Exclude`/`Overwrite`/a user conditional over an unresolved
+/// `T`) and individual attribute operand types (e.g. `value={props.value}`
+/// whose type is `Option<C<T>> | C<T>`). `tsc` treats such instantiable types
+/// as *comparable* and does not emit `TS2322`; `tsz`'s structural relation
+/// cannot soundly decide them and conservatively reports "not assignable",
+/// producing a false positive.
+///
+/// Keyed purely on type structure (a deferred conditional member, or a
+/// conditional surface that still mentions a type parameter) so it is
+/// independent of the conditional helper's spelling or the type-parameter
+/// name.
+pub(crate) fn jsx_relation_operand_is_deferred_conditional(
+    db: &dyn TypeDatabase,
+    def_store: &DefinitionStore,
+    type_id: TypeId,
+) -> bool {
+    fn one(db: &dyn TypeDatabase, def_store: &DefinitionStore, type_id: TypeId) -> bool {
+        if !crate::query_boundaries::common::contains_type_parameters(db, type_id) {
+            return false;
+        }
+        crate::query_boundaries::common::has_deferred_conditional_member(db, type_id)
+            || crate::query_boundaries::common::contains_conditional_type(db, type_id)
+            || crate::query_boundaries::diagnostics::application_base_has_conditional_alias_body(
+                db, def_store, type_id,
+            )
+    }
+
+    if one(db, def_store, type_id) {
+        return true;
+    }
+    // The operand is frequently an intersection (`Omit<T, K> & Extra`);
+    // a conditional-bodied member anywhere in it defers the relation.
+    crate::query_boundaries::common::intersection_members(db, type_id)
+        .is_some_and(|members| members.iter().any(|&m| one(db, def_store, m)))
+}
+
 /// Check whether a type surface contains an explicit-readonly mapped type.
 pub(crate) fn contains_mapped_type_with_readonly_modifier(
     db: &dyn TypeDatabase,

--- a/crates/tsz-checker/tests/jsx_generic_spread_deferred_conditional_tests.rs
+++ b/crates/tsz-checker/tests/jsx_generic_spread_deferred_conditional_tests.rs
@@ -1,0 +1,168 @@
+//! Parity tests for JSX generic-spread whole-object assignability when the
+//! spread source (or an explicit attribute value) carries a conditional type
+//! that is still deferred over a type parameter.
+//!
+//! Structural rule: when a JSX element spreads a generic value whose type is a
+//! deferred conditional over a type parameter (`Omit`/`Pick`/`Exclude`/
+//! `Overwrite`/a user conditional applied to an unresolved `T`), `tsc` treats
+//! the source as an instantiable, *comparable* type and does not emit `TS2322`
+//! from the whole-object check. The same holds for an explicit attribute whose
+//! value type is itself a deferred conditional. `tsz`'s structural relation
+//! cannot soundly decide such operands and used to conservatively report
+//! "not assignable", producing a false positive.
+//!
+//! A concrete (non-deferred) attribute mismatch must still be reported, so the
+//! suppression is scoped to deferred-conditional operands only.
+//!
+//! Regression target: `jsxComplexSignatureHasApplicabilityError.tsx`
+//! (the react-select HOC corpus shape).
+
+use tsz_common::checker_options::{CheckerOptions, JsxMode};
+use tsz_common::diagnostics::diagnostic_codes;
+
+const JSX_PREAMBLE: &str = r#"
+declare namespace JSX {
+    interface Element {}
+    interface IntrinsicElements {}
+    interface ElementAttributesProperty { props: {} }
+    interface ElementChildrenAttribute { children: {} }
+}
+"#;
+
+const COMMON: &str = r#"
+interface SelectProps<T> {
+    multi?: boolean;
+    value?: T;
+    onChange?: (v: T | undefined) => void;
+}
+declare function Select<T>(props: SelectProps<T>): JSX.Element;
+
+type Pull<T> = T extends SelectProps<infer U> ? U : never;
+type Drop<T, K extends keyof any> = T extends any ? Pick<T, Exclude<keyof T, K>> : never;
+type Merge<T, U> = Drop<T, keyof T & keyof U> & U;
+type SingleProps<W extends SelectProps<any>> = Merge<Drop<W, "multi">, { value?: Pull<W> }>;
+"#;
+
+fn jsx_opts() -> CheckerOptions {
+    CheckerOptions {
+        jsx_mode: JsxMode::Preserve,
+        ..Default::default()
+    }
+}
+
+fn jsx_diagnostics(source: &str) -> Vec<(u32, u32, String)> {
+    tsz_checker::test_utils::check_source(source, "test.tsx", jsx_opts())
+        .into_iter()
+        .map(|d| (d.code, d.start, d.message_text))
+        .collect()
+}
+
+fn count_ts2322(source: &str) -> usize {
+    jsx_diagnostics(source)
+        .iter()
+        .filter(|(c, _, _)| *c == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE)
+        .count()
+}
+
+/// Primary regression: a generic component spread with a deferred-conditional
+/// source (`SingleProps<W>` reducing to `Drop<W, "multi"> & ...`) plus an
+/// explicit attribute whose value type is itself deferred (`value={props.value}`
+/// of type `Pull<W>`). `tsc` accepts this; `tsz` must not emit `TS2322`.
+#[test]
+fn generic_spread_deferred_conditional_no_ts2322() {
+    let source = format!(
+        r#"{JSX_PREAMBLE}{COMMON}
+function wrap<W extends SelectProps<any>>(props: SingleProps<W>) {{
+    return <Select<Pull<W>> {{...props}} multi={{false}} value={{props.value}} />;
+}}
+"#
+    );
+    assert_eq!(
+        count_ts2322(&source),
+        0,
+        "valid generic-spread with deferred-conditional source must not emit TS2322; got {:#?}",
+        jsx_diagnostics(&source)
+    );
+}
+
+/// The rule is structural, not name-based: renaming every type parameter and
+/// helper alias must not change the outcome.
+#[test]
+fn generic_spread_deferred_conditional_renamed_no_ts2322() {
+    // Same shape, every user-chosen identifier renamed.
+    let source = format!(
+        r#"{JSX_PREAMBLE}
+interface PropsX<Q> {{
+    multi?: boolean;
+    value?: Q;
+    onChange?: (v: Q | undefined) => void;
+}}
+declare function Widget<Q>(props: PropsX<Q>): JSX.Element;
+
+type Grab<Z> = Z extends PropsX<infer U> ? U : never;
+type Strip<Z, K extends keyof any> = Z extends any ? Pick<Z, Exclude<keyof Z, K>> : never;
+type Combine<Z, U> = Strip<Z, keyof Z & keyof U> & U;
+type OneProps<Z extends PropsX<any>> = Combine<Strip<Z, "multi">, {{ value?: Grab<Z> }}>;
+
+function build<Z extends PropsX<any>>(props: OneProps<Z>) {{
+    return <Widget<Grab<Z>> {{...props}} multi={{false}} value={{props.value}} />;
+}}
+"#
+    );
+    assert_eq!(
+        count_ts2322(&source),
+        0,
+        "renamed generic-spread case must also be clean (rule is structural); got {:#?}",
+        jsx_diagnostics(&source)
+    );
+}
+
+/// Multi-construct class component variant of the same shape (the exact
+/// conformance-witness routing): overload resolution is the sole check and a
+/// valid deferred-conditional spread must produce no TS2322.
+#[test]
+fn multi_construct_generic_spread_deferred_conditional_no_ts2322() {
+    let source = format!(
+        r#"{JSX_PREAMBLE}{COMMON}
+declare class Component<P> {{
+    constructor(props: Readonly<P>);
+    constructor(props: P, context?: any);
+    props: Readonly<P>;
+}}
+declare class SelectClass<T = string> extends Component<SelectProps<T>> {{}}
+
+function wrapClass<W extends SelectProps<any>>(props: SingleProps<W>) {{
+    return <SelectClass<Pull<W>> {{...props}} multi={{false}} value={{props.value}} />;
+}}
+"#
+    );
+    assert_eq!(
+        count_ts2322(&source),
+        0,
+        "multi-construct class component with deferred-conditional spread must not emit TS2322; got {:#?}",
+        jsx_diagnostics(&source)
+    );
+}
+
+/// Negative guard: a *concrete* (non-deferred) attribute mismatch must still be
+/// reported. The deferred-conditional suppression must not hide real errors.
+#[test]
+fn generic_spread_concrete_attr_mismatch_still_reported() {
+    let source = format!(
+        r#"{JSX_PREAMBLE}{COMMON}
+function wrap<W extends SelectProps<any>>(props: SingleProps<W>) {{
+    // `multi` is concretely `boolean`; a string literal is a real mismatch.
+    return <Select<Pull<W>> {{...props}} multi={{"definitely-not-boolean"}} value={{props.value}} />;
+}}
+"#
+    );
+    let diags = jsx_diagnostics(&source);
+    let real_error = diags.iter().any(|(c, _, _)| {
+        *c == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
+            || *c == diagnostic_codes::NO_OVERLOAD_MATCHES_THIS_CALL
+    });
+    assert!(
+        real_error,
+        "a concrete `multi` mismatch must still be reported; got {diags:#?}"
+    );
+}

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -3,7 +3,6 @@
 # blocking the aggregate gate. Remove the entry once the regression is fixed.
 # Format: TypeScript/tests/cases/<subpath>.ts (one path per line, comments with #)
 TypeScript/tests/cases/compiler/declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts
-TypeScript/tests/cases/compiler/jsxComplexSignatureHasApplicabilityError.tsx
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts


### PR DESCRIPTION
## Agent
AgentName: M1-B
Contributor: cloud-opus47-1m-confident-thompson

Fixes #8694.

## Track
Conformance / checker parity (TS2322 false-positive family).

## Invariant
When a JSX attribute relation operand carries a conditional type that is still **deferred over a type parameter** (`Omit`/`Pick`/`Exclude`/`Overwrite`/a user conditional applied to an unresolved `T`), `tsc` treats it as an instantiable, *comparable* type and emits **no** `TS2322`. tsz must reach the same outcome instead of reporting a hard "not assignable" from a structural relation it cannot soundly decide. Concrete (non-deferred) mismatches must still be reported.

## Scope
The conformance witness `jsxComplexSignatureHasApplicabilityError.tsx` (the react-select HOC corpus shape) renders `<ReactSelectClass<ExtractValueType<W>> {...props} multi={false} value={props.value} … />` where the spread is `Overwrite<Omit<W,"multi">, …>` and `value` is typed by a deferred conditional. tsc accepts it (no `.errors.txt` baseline); tsz emitted two false `TS2322`.

Root cause: the explicit JSX type argument on a class component routes props checking through the per-attribute + generic-spread assignability passes (the multi-construct overload route is bypassed because the instantiated class exposes a single construct signature). Those passes ran the structural relation against deferred conditionals and reported failure.

Fix (checker `WHERE`, via a query-boundary helper for the structural fact):
- New boundary predicate `jsx_relation_operand_is_deferred_conditional` (in `query_boundaries::checkers::jsx`) detects, structurally, an operand that defers the relation: an evaluated type with a deferred conditional member, a conditional surface still mentioning a type parameter, or a conditional-bodied alias application — including intersection members. Keyed on structure only (no identifier names, no printer output), so renaming type params/aliases does not change behavior.
- `report_invalid_generic_jsx_spread_assignability` and `check_jsx_generic_spread_attrs_assignability` skip the whole-object `TS2322` when the spread source defers and there is no concrete explicit mismatch.
- Both functions' explicit-attribute mismatch scans no longer count an attribute as mismatched when either operand defers.
- The checker-side `jsx_relation_operand_defers` evaluates the operand first, so detection does not depend on whether the alias happened to be expanded at the call site.

Removed `jsxComplexSignatureHasApplicabilityError.tsx` from `conformance-accepted-regressions.txt`.

## Project Corpus Impact
- Row: react-select / HOC-style generic component libraries (kysely/zod-adjacent generic-spread shapes)
- Bug family: TS2322 false positives on deferred-conditional JSX generic spreads
- Evidence: built `tsz` and reproduced the upstream test (fetched `jsxComplexSignatureHasApplicabilityError.tsx` + `react16.d.ts`) — 2 false TS2322 before, 0 after, matching tsc's empty error baseline. Adjacent renamed and SFC variants also go error→clean; concrete `multi={"…"}` and a concrete bad spread still error.

## Verification
- New owning-crate tests `crates/tsz-checker/tests/jsx_generic_spread_deferred_conditional_tests.rs` (4 tests): deferred-conditional spread (SFC + multi-construct class), a fully **renamed** variant (proves the rule is structural), and a concrete-mismatch negative guard — all pass.
- All registered JSX checker integration tests pass (211+ across the suite); no regressions.
- `cargo clippy -p tsz-checker` clean.
- Branch is non-conflicting with current `main` (no overlapping files); leaving heavy conformance/emit/fourslash to ready-review CI.

## Coordination Notes
AgentName normalized to the canonical `agent:M1-B` lane by M1-A; implemented by contributor `cloud-opus47-1m-confident-thompson`.

Prior attempt #8908 fixed this via multi-construct overload routing; it regressed because the explicit-type-arg-instantiated class component exposes a single construct signature and falls into the generic-spread assignability passes. This PR fixes the underlying relation-deferral rule in those passes rather than the routing, so it also covers the generic-SFC variant. Issue #8694 former work-in-progress label has been cleared; this PR is ready.

https://claude.ai/code/session_01SsqvwV9vexnE1VYCoW1PL7