### PR TITLE
perf(checker): skip duplicate alias missing-name walks

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/mod.rs
+++ b/crates/tsz-checker/src/types/type_checking/mod.rs
@@ -28,4 +28,5 @@ mod indexed_access;
 mod property_init;
 mod type_alias_checking;
 mod type_alias_depth_helpers;
+mod type_alias_missing_name_coverage;
 mod unused;

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -543,7 +543,9 @@ impl<'a> CheckerState<'a> {
             }
         } else {
             self.check_type_node(alias.type_node);
-            self.check_type_for_missing_names(alias.type_node);
+            if !self.type_alias_body_missing_names_covered_by_type_node_checking(alias.type_node) {
+                self.check_type_for_missing_names(alias.type_node);
+            }
         }
         record_type_alias_phase_timing(
             &self.ctx.file_name,

--- a/crates/tsz-checker/src/types/type_checking/type_alias_missing_name_coverage.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_missing_name_coverage.rs
@@ -1,0 +1,63 @@
+//! Coverage checks for duplicate type-alias missing-name validation.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
+
+impl<'a> CheckerState<'a> {
+    pub(crate) fn type_alias_body_missing_names_covered_by_type_node_checking(
+        &self,
+        root: NodeIndex,
+    ) -> bool {
+        let mut stack = vec![root];
+        while let Some(node_idx) = stack.pop() {
+            if node_idx == NodeIndex::NONE {
+                continue;
+            }
+            let Some(node) = self.ctx.arena.get(node_idx) else {
+                return false;
+            };
+            match node.kind {
+                k if k == syntax_kind_ext::TYPE_REFERENCE => {
+                    let Some(type_ref) = self.ctx.arena.get_type_ref(node) else {
+                        return false;
+                    };
+                    if let Some(args) = &type_ref.type_arguments {
+                        stack.extend(args.nodes.iter().copied());
+                    }
+                }
+                k if k == syntax_kind_ext::UNION_TYPE
+                    || k == syntax_kind_ext::INTERSECTION_TYPE =>
+                {
+                    let Some(composite) = self.ctx.arena.get_composite_type(node) else {
+                        return false;
+                    };
+                    stack.extend(composite.types.nodes.iter().copied());
+                }
+                k if k == syntax_kind_ext::ARRAY_TYPE => {
+                    let Some(array) = self.ctx.arena.get_array_type(node) else {
+                        return false;
+                    };
+                    stack.push(array.element_type);
+                }
+                k if k == syntax_kind_ext::OPTIONAL_TYPE
+                    || k == syntax_kind_ext::REST_TYPE
+                    || k == syntax_kind_ext::PARENTHESIZED_TYPE =>
+                {
+                    let Some(wrapped) = self.ctx.arena.get_wrapped_type(node) else {
+                        return false;
+                    };
+                    stack.push(wrapped.type_node);
+                }
+                k if k == syntax_kind_ext::INDEXED_ACCESS_TYPE => {
+                    let Some(indexed) = self.ctx.arena.get_indexed_access_type(node) else {
+                        return false;
+                    };
+                    stack.push(indexed.object_type);
+                    stack.push(indexed.index_type);
+                }
+                _ => return false,
+            }
+        }
+        true
+    }
+}

--- a/crates/tsz-checker/tests/ts2304_tests.rs
+++ b/crates/tsz-checker/tests/ts2304_tests.rs
@@ -138,6 +138,37 @@ fn check_js_without_lib(source: &str) -> Vec<Diagnostic> {
 }
 
 #[test]
+fn type_alias_reference_algebra_still_reports_nested_missing_name() {
+    let codes = tsz_checker::test_utils::check_source_codes(
+        "type Wrap<T> = T;\ntype Alias<T> = Wrap<T | MissingAlpha>;",
+    );
+
+    assert!(codes.contains(&2304), "expected TS2304, got {codes:?}");
+}
+
+#[test]
+fn type_alias_indexed_reference_algebra_still_reports_missing_name() {
+    let codes = tsz_checker::test_utils::check_source_codes(
+        "type Wrap<T> = T;\ntype Alias<U> = Wrap<U & MissingBeta['field']>;",
+    );
+
+    assert!(codes.contains(&2304), "expected TS2304, got {codes:?}");
+}
+
+#[test]
+fn type_alias_conditional_fallback_still_checks_missing_names() {
+    let codes = tsz_checker::test_utils::check_source_codes(
+        "type Alias<T> = T extends MissingGamma ? T : MissingDelta;",
+    );
+    let missing_name_count = codes.iter().filter(|&&code| code == 2304).count();
+
+    assert!(
+        missing_name_count >= 2,
+        "expected both conditional branches to report TS2304, got {codes:?}"
+    );
+}
+
+#[test]
 fn local_ambient_value_shadows_dom_interface_in_value_position() {
     let diagnostics = check_with_lib(
         r#"


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 performance micro-slice: green-row `ts-essentials-project` checker hot path.

## Invariant
When a type-alias body is composed only of type references plus union/intersection, array, wrapper, and indexed-access type nodes, `check_type_node` already visits every nested type reference needed for TS2304 missing-name reporting. This PR skips only the duplicate missing-name walk for that covered shape; every unsupported shape falls back to the existing `check_type_for_missing_names` path.

## Scope
- Add a structural coverage helper for type-alias missing-name validation.
- Skip duplicate alias-body missing-name walks only when the helper proves coverage.
- Add TS2304 tests for two covered reference-algebra shapes and one conditional fallback shape.

## Project Corpus Impact
- Row: `ts-essentials-project`
- Bug family: utility-type alias/reference algebra in the remaining 2x target gap (#7378)
- Evidence: exact-head attribution mode on `.target-bench/external/ts-essentials/lib/xor/index.ts` reports the hot `XOR` `body_validation` phase at 3.26 ms in `/private/tmp/studio-b-type-alias-coverage-xor-exact-20260528023946.perf.json`; earlier comparable Studio-B attribution before this slice had the same phase at 3.99 ms in `/private/tmp/studio-b-type-alias-phases-xor-20260528020747.perf.json`. This does not close the 2x target; a quick timing sanity artifact still showed one target gap in `/private/tmp/studio-b-type-alias-coverage-ts-essentials-20260528022755.tsgo-winners.json`.

## Verification
- `cargo fmt --all`
- `cargo test -p tsz-checker --test ts2304_tests type_alias_ -- --nocapture`
- `scripts/safe-run.sh env CARGO_TARGET_DIR=.target-bench/perf-tools CARGO_INCREMENTAL=0 RUSTFLAGS='-Ctarget-cpu=native' cargo build --profile dist -p tsz-cli --bin tsz --features perf-tools`
- `TSZ_PERF_COUNTERS=1 scripts/safe-run.sh .target-bench/perf-tools/dist/tsz --extendedDiagnostics --perf-counters-json /private/tmp/studio-b-type-alias-coverage-xor-exact-20260528023946.perf.json --noEmit --strict .target-bench/external/ts-essentials/lib/xor/index.ts`

## Coordination Notes
- No open `agent:Studio-B` PRs existed before this PR.
- Open overlap check found other lanes active on checker/solver/emit work; no PR claimed this type-alias missing-name duplication slice.
- `cargo nextest` was attempted first for the focused tests, but the runner hung after compilation even for `nextest list`; the direct integration-test binary command above is the recorded fallback.
- Disk dropped to 116 MB free during local optimized builds; ran `scripts/setup/disk-worktree-guard.sh --auto-prune` and `scripts/setup/clean.sh --quiet`, recovering about 7.3 GiB while preserving `.target`, `.target-bench`, and `target` caches.
