### PR TITLE
fix(solver): resolve mapped index signatures

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -1866,6 +1866,16 @@ pub fn evaluate_type(interner: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
     evaluate_type_with_request(interner, EvaluationRequest::new(type_id))
 }
 
+/// Convenience function for full type evaluation with an explicit resolver.
+pub fn evaluate_type_with_resolver(
+    interner: &dyn TypeDatabase,
+    resolver: &impl TypeResolver,
+    type_id: TypeId,
+) -> TypeId {
+    let mut evaluator = TypeEvaluator::with_resolver(interner, resolver);
+    evaluator.evaluate(type_id)
+}
+
 /// Convenience function for full type evaluation with explicit request options.
 pub fn evaluate_type_with_request(
     interner: &dyn TypeDatabase,

--- a/crates/tsz-solver/src/objects/index_signatures.rs
+++ b/crates/tsz-solver/src/objects/index_signatures.rs
@@ -29,6 +29,7 @@
 
 use crate::TypeId;
 use crate::construction::TypeDatabase;
+use crate::relations::subtype::{NoopResolver, TypeResolver};
 use crate::types::{
     CallableShapeId, IndexInfo, IndexSignature, MappedTypeId, ObjectShapeId, TypeApplicationId,
     TypeData,
@@ -50,11 +51,12 @@ pub enum IndexKind {
 // =============================================================================
 
 /// Visitor for resolving string index signatures.
-struct StringIndexResolver<'a> {
+struct StringIndexResolver<'a, R: TypeResolver> {
     db: &'a dyn TypeDatabase,
+    resolver: &'a R,
 }
 
-impl<'a> TypeVisitor for StringIndexResolver<'a> {
+impl<R: TypeResolver> TypeVisitor for StringIndexResolver<'_, R> {
     type Output = Option<TypeId>;
 
     fn visit_intrinsic(&mut self, _kind: crate::types::IntrinsicKind) -> Self::Output {
@@ -111,7 +113,11 @@ impl<'a> TypeVisitor for StringIndexResolver<'a> {
     fn visit_application(&mut self, app_id: u32) -> Self::Output {
         let app = self.db.type_application(TypeApplicationId(app_id));
         let type_id = self.db.application(app.base, app.args.clone());
-        let evaluated = crate::evaluation::evaluate::evaluate_type(self.db, type_id);
+        let evaluated = crate::evaluation::evaluate::evaluate_type_with_resolver(
+            self.db,
+            self.resolver,
+            type_id,
+        );
         (evaluated != type_id)
             .then(|| self.visit_type(self.db, evaluated))
             .flatten()
@@ -131,11 +137,12 @@ impl<'a> TypeVisitor for StringIndexResolver<'a> {
 }
 
 /// Visitor for resolving number index signatures.
-struct NumberIndexResolver<'a> {
+struct NumberIndexResolver<'a, R: TypeResolver> {
     db: &'a dyn TypeDatabase,
+    resolver: &'a R,
 }
 
-impl<'a> TypeVisitor for NumberIndexResolver<'a> {
+impl<R: TypeResolver> TypeVisitor for NumberIndexResolver<'_, R> {
     type Output = Option<TypeId>;
 
     fn visit_intrinsic(&mut self, _kind: crate::types::IntrinsicKind) -> Self::Output {
@@ -181,7 +188,11 @@ impl<'a> TypeVisitor for NumberIndexResolver<'a> {
     fn visit_application(&mut self, app_id: u32) -> Self::Output {
         let app = self.db.type_application(TypeApplicationId(app_id));
         let type_id = self.db.application(app.base, app.args.clone());
-        let evaluated = crate::evaluation::evaluate::evaluate_type(self.db, type_id);
+        let evaluated = crate::evaluation::evaluate::evaluate_type_with_resolver(
+            self.db,
+            self.resolver,
+            type_id,
+        );
         (evaluated != type_id)
             .then(|| self.visit_type(self.db, evaluated))
             .flatten()
@@ -415,14 +426,26 @@ impl<'a> TypeVisitor for IndexInfoCollector<'a> {
 ///
 /// This struct provides a unified interface for querying index signatures
 /// across different type representations (`ObjectWithIndex`, Union, etc.).
-pub struct IndexSignatureResolver<'a> {
+pub struct IndexSignatureResolver<'a, R: TypeResolver = NoopResolver> {
     db: &'a dyn TypeDatabase,
+    resolver: &'a R,
 }
 
-impl<'a> IndexSignatureResolver<'a> {
+impl<'a> IndexSignatureResolver<'a, NoopResolver> {
     /// Create a new index signature resolver.
     pub fn new(db: &'a dyn TypeDatabase) -> Self {
-        Self { db }
+        static NOOP: NoopResolver = NoopResolver;
+        Self {
+            db,
+            resolver: &NOOP,
+        }
+    }
+}
+
+impl<'a, R: TypeResolver> IndexSignatureResolver<'a, R> {
+    /// Create a new index signature resolver with a lazy/application resolver.
+    pub fn with_resolver(db: &'a dyn TypeDatabase, resolver: &'a R) -> Self {
+        Self { db, resolver }
     }
 
     /// Resolve the string index signature type from an object type.
@@ -436,7 +459,10 @@ impl<'a> IndexSignatureResolver<'a> {
     /// - `{ [key: string]: string }` → `Some(TypeId::STRING)`
     /// - `{ a: number }` → `None`
     pub fn resolve_string_index(&self, obj: TypeId) -> Option<TypeId> {
-        let mut visitor = StringIndexResolver { db: self.db };
+        let mut visitor = StringIndexResolver {
+            db: self.db,
+            resolver: self.resolver,
+        };
         visitor.visit_type(self.db, obj)
     }
 
@@ -453,7 +479,10 @@ impl<'a> IndexSignatureResolver<'a> {
     ///
     /// Note: Array and tuple types have implicit numeric index signatures.
     pub fn resolve_number_index(&self, obj: TypeId) -> Option<TypeId> {
-        let mut visitor = NumberIndexResolver { db: self.db };
+        let mut visitor = NumberIndexResolver {
+            db: self.db,
+            resolver: self.resolver,
+        };
         visitor.visit_type(self.db, obj)
     }
 

--- a/crates/tsz-solver/src/objects/index_signatures.rs
+++ b/crates/tsz-solver/src/objects/index_signatures.rs
@@ -29,7 +29,10 @@
 
 use crate::TypeId;
 use crate::construction::TypeDatabase;
-use crate::types::{CallableShapeId, IndexInfo, IndexSignature, ObjectShapeId, TypeData};
+use crate::types::{
+    CallableShapeId, IndexInfo, IndexSignature, MappedTypeId, ObjectShapeId, TypeApplicationId,
+    TypeData,
+};
 use crate::utils;
 use crate::visitor::TypeVisitor;
 
@@ -105,6 +108,23 @@ impl<'a> TypeVisitor for StringIndexResolver<'a> {
         self.visit_type(self.db, inner_type)
     }
 
+    fn visit_application(&mut self, app_id: u32) -> Self::Output {
+        let app = self.db.type_application(TypeApplicationId(app_id));
+        let type_id = self.db.application(app.base, app.args.clone());
+        let evaluated = crate::evaluation::evaluate::evaluate_type(self.db, type_id);
+        (evaluated != type_id)
+            .then(|| self.visit_type(self.db, evaluated))
+            .flatten()
+    }
+
+    fn visit_mapped(&mut self, mapped_id: u32) -> Self::Output {
+        let type_id = self.db.mapped(self.db.get_mapped(MappedTypeId(mapped_id)));
+        let evaluated = crate::evaluation::evaluate::evaluate_type(self.db, type_id);
+        (evaluated != type_id)
+            .then(|| self.visit_type(self.db, evaluated))
+            .flatten()
+    }
+
     fn default_output() -> Self::Output {
         None
     }
@@ -156,6 +176,23 @@ impl<'a> TypeVisitor for NumberIndexResolver<'a> {
 
     fn visit_readonly_type(&mut self, inner_type: TypeId) -> Self::Output {
         self.visit_type(self.db, inner_type)
+    }
+
+    fn visit_application(&mut self, app_id: u32) -> Self::Output {
+        let app = self.db.type_application(TypeApplicationId(app_id));
+        let type_id = self.db.application(app.base, app.args.clone());
+        let evaluated = crate::evaluation::evaluate::evaluate_type(self.db, type_id);
+        (evaluated != type_id)
+            .then(|| self.visit_type(self.db, evaluated))
+            .flatten()
+    }
+
+    fn visit_mapped(&mut self, mapped_id: u32) -> Self::Output {
+        let type_id = self.db.mapped(self.db.get_mapped(MappedTypeId(mapped_id)));
+        let evaluated = crate::evaluation::evaluate::evaluate_type(self.db, type_id);
+        (evaluated != type_id)
+            .then(|| self.visit_type(self.db, evaluated))
+            .flatten()
     }
 
     fn default_output() -> Self::Output {

--- a/crates/tsz-solver/tests/index_signatures_tests.rs
+++ b/crates/tsz-solver/tests/index_signatures_tests.rs
@@ -1,5 +1,7 @@
 use super::*;
+use crate::DefId;
 use crate::intern::TypeInterner;
+use crate::relations::subtype::TypeResolver;
 use crate::types::{
     CallableShape, MappedType, ObjectFlags, ObjectShape, TupleElement, TypeParamInfo,
 };
@@ -93,6 +95,70 @@ fn test_resolve_number_index_from_mapped_record() {
         Some(TypeId::STRING),
         "Record<number, string>-shaped mapped types should expose their number index"
     );
+}
+
+#[test]
+fn test_resolve_string_index_from_application_mapped_record() {
+    struct AliasResolver {
+        def_id: DefId,
+        body: TypeId,
+        params: Vec<TypeParamInfo>,
+    }
+
+    impl TypeResolver for AliasResolver {
+        fn resolve_ref(
+            &self,
+            _symbol: crate::types::SymbolRef,
+            _interner: &dyn crate::construction::TypeDatabase,
+        ) -> Option<TypeId> {
+            None
+        }
+
+        fn resolve_lazy(
+            &self,
+            def_id: DefId,
+            _interner: &dyn crate::construction::TypeDatabase,
+        ) -> Option<TypeId> {
+            (def_id == self.def_id).then_some(self.body)
+        }
+
+        fn get_lazy_type_params(&self, def_id: DefId) -> Option<Vec<TypeParamInfo>> {
+            (def_id == self.def_id).then(|| self.params.clone())
+        }
+    }
+
+    let db = TypeInterner::new();
+    let key_param = TypeParamInfo {
+        name: db.intern_string("Key"),
+        constraint: Some(TypeId::STRING),
+        default: None,
+        is_const: false,
+    };
+    let value_param = TypeParamInfo {
+        name: db.intern_string("Value"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let key_type = db.type_param(key_param);
+    let value_type = db.type_param(value_param);
+    let body = mapped_record(&db, key_type, value_type);
+    let def_id = DefId(94);
+    let alias = db.lazy(def_id);
+    let applied_record = db.application(alias, vec![TypeId::STRING, TypeId::UNKNOWN]);
+    let alias_resolver = AliasResolver {
+        def_id,
+        body,
+        params: vec![key_param, value_param],
+    };
+
+    let resolver = IndexSignatureResolver::with_resolver(&db, &alias_resolver);
+    assert_eq!(
+        resolver.resolve_string_index(applied_record),
+        Some(TypeId::UNKNOWN),
+        "application-wrapped Record<string, unknown> aliases should expose their string index"
+    );
+    assert_eq!(resolver.resolve_number_index(applied_record), None);
 }
 
 #[test]

--- a/crates/tsz-solver/tests/index_signatures_tests.rs
+++ b/crates/tsz-solver/tests/index_signatures_tests.rs
@@ -1,6 +1,9 @@
 use super::*;
 use crate::intern::TypeInterner;
-use crate::types::{CallableShape, ObjectFlags, ObjectShape, TupleElement};
+use crate::types::{
+    CallableShape, MappedType, ObjectFlags, ObjectShape, TupleElement, TypeParamInfo,
+};
+use tsz_common::interner::Atom;
 
 #[test]
 fn test_resolve_string_index() {
@@ -46,6 +49,50 @@ fn test_resolve_number_index() {
     let resolver = IndexSignatureResolver::new(&db);
     assert_eq!(resolver.resolve_string_index(obj), None);
     assert_eq!(resolver.resolve_number_index(obj), Some(TypeId::STRING));
+}
+
+fn mapped_record(db: &TypeInterner, key_type: TypeId, value_type: TypeId) -> TypeId {
+    db.mapped(MappedType {
+        type_param: TypeParamInfo {
+            name: Atom::NONE,
+            constraint: Some(key_type),
+            default: None,
+            is_const: false,
+        },
+        constraint: key_type,
+        name_type: None,
+        template: value_type,
+        readonly_modifier: None,
+        optional_modifier: None,
+    })
+}
+
+#[test]
+fn test_resolve_string_index_from_mapped_record() {
+    let db = TypeInterner::new();
+    let record = mapped_record(&db, TypeId::STRING, TypeId::UNKNOWN);
+
+    let resolver = IndexSignatureResolver::new(&db);
+    assert_eq!(
+        resolver.resolve_string_index(record),
+        Some(TypeId::UNKNOWN),
+        "Record<string, unknown>-shaped mapped types should expose their string index"
+    );
+    assert_eq!(resolver.resolve_number_index(record), None);
+}
+
+#[test]
+fn test_resolve_number_index_from_mapped_record() {
+    let db = TypeInterner::new();
+    let record = mapped_record(&db, TypeId::NUMBER, TypeId::STRING);
+
+    let resolver = IndexSignatureResolver::new(&db);
+    assert_eq!(resolver.resolve_string_index(record), None);
+    assert_eq!(
+        resolver.resolve_number_index(record),
+        Some(TypeId::STRING),
+        "Record<number, string>-shaped mapped types should expose their number index"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Project corpus benchmark blocker / semantic solver helper

## Invariant
When a mapped type has evaluated to a `Record<K, V>`-style index-signature shape, index-signature queries must see that string or number index before checker TS7053 reporting decides the receiver has no index signature. This PR makes the solver index-signature resolver evaluate mapped/application wrappers before answering.

## Scope
- `crates/tsz-solver/src/objects/index_signatures.rs`
- `crates/tsz-solver/tests/index_signatures_tests.rs`

## Project Corpus Impact
- Row: `kysely-project`
- Bug family: TS7053 false positive on `Record<string, unknown>` / open-object indexing (#10674), tracked under Kysely row map #10663.
- Evidence: focused solver coverage for mapped `Record<string, unknown>` and `Record<number, string>` index-signature resolution; project row metadata remains consistent. Full Kysely guard re-measure is deferred because this machine hit a low-disk condition and the row is canary with multiple active blockers.

## Verification
- `CARGO_BUILD_JOBS=2 cargo check -p tsz-solver`
- `cargo nextest run -p tsz-solver index_signatures`
- `cargo fmt --check`
- `git diff --check`
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`
- `node scripts/bench/validate-project-metadata.mjs`
- `node scripts/bench/project-row-summary.mjs --markdown`

## Coordination Notes
- AgentName: Studio-A
- Issue focus: #10674; row tracker: #10663.
- Non-overlap: avoids active M4-D cross-file class/heritage PRs and changes only solver index-signature query behavior plus tests.
- Disk note: preflight found low disk; cache-preserving cleanup was insufficient, so failed current-checkout Rust debug deps/incremental artifacts were removed after a no-space compile failure. Sibling worktree caches were preserved.
- Benchmark truth: fresh manual Bench run `26547179325` is in progress on current `main` for #10649.
- Review-blocker follow-up on head `8b8145418c`: added application-wrapper index-signature resolver coverage and ran `cargo nextest run -p tsz-solver index_signatures`, `cargo fmt --check`, `python3 scripts/arch/arch_guard.py`, and `git diff --check`.