### PR TITLE
fix(emit): order TC39 decorator helpers before private helpers

### DIFF
--- a/crates/tsz-emitter/src/transforms/helpers.rs
+++ b/crates/tsz-emitter/src/transforms/helpers.rs
@@ -591,11 +591,14 @@ impl HelpersNeeded {
         if self.dispose_resources {
             names.push("__disposeResources");
         }
-        self.push_unprioritized_names(&mut names);
         if self.prop_key {
             names.push("__propKey");
         }
-        if self.set_function_name {
+        if self.es_decorate && self.set_function_name {
+            names.push("__setFunctionName");
+        }
+        self.push_unprioritized_names(&mut names);
+        if !self.es_decorate && self.set_function_name {
             names.push("__setFunctionName");
         }
         if self.rewrite_relative_import_extension {
@@ -749,8 +752,12 @@ pub fn emit_helpers(helpers: &HelpersNeeded) -> String {
         output.push('\n');
     }
     let mut emitted_unprioritized = Vec::new();
+    if helpers.es_decorate && helpers.set_function_name {
+        output.push_str(SET_FUNCTION_NAME_HELPER);
+        output.push('\n');
+    }
     emit_class_private_helpers(helpers, &mut output, &mut emitted_unprioritized);
-    if helpers.set_function_name {
+    if !helpers.es_decorate && helpers.set_function_name {
         output.push_str(SET_FUNCTION_NAME_HELPER);
         output.push('\n');
     }
@@ -792,6 +799,18 @@ fn emit_class_private_helpers(
     output: &mut String,
     emitted: &mut Vec<HelperEmitOrder>,
 ) {
+    if helpers.es_decorate && !helpers.unprioritized_order.is_empty() {
+        for &helper in &helpers.unprioritized_order {
+            if is_class_private_helper(helper) {
+                emit_unprioritized_helper(helper, helpers, output, emitted);
+            }
+        }
+        for helper in fallback_class_private_order(helpers) {
+            emit_unprioritized_helper(helper, helpers, output, emitted);
+        }
+        return;
+    }
+
     let (first, second) = if helpers.class_private_field_set_before_get {
         (
             HelperEmitOrder::ClassPrivateFieldSet,
@@ -811,6 +830,31 @@ fn emit_class_private_helpers(
         output,
         emitted,
     );
+}
+
+const fn is_class_private_helper(helper: HelperEmitOrder) -> bool {
+    matches!(
+        helper,
+        HelperEmitOrder::ClassPrivateFieldGet
+            | HelperEmitOrder::ClassPrivateFieldSet
+            | HelperEmitOrder::ClassPrivateFieldIn
+    )
+}
+
+const fn fallback_class_private_order(helpers: &HelpersNeeded) -> [HelperEmitOrder; 3] {
+    [
+        if helpers.class_private_field_set_before_get {
+            HelperEmitOrder::ClassPrivateFieldSet
+        } else {
+            HelperEmitOrder::ClassPrivateFieldGet
+        },
+        if helpers.class_private_field_set_before_get {
+            HelperEmitOrder::ClassPrivateFieldGet
+        } else {
+            HelperEmitOrder::ClassPrivateFieldSet
+        },
+        HelperEmitOrder::ClassPrivateFieldIn,
+    ]
 }
 
 const fn fallback_unprioritized_order(helpers: &HelpersNeeded) -> [HelperEmitOrder; 12] {
@@ -1074,6 +1118,8 @@ mod tests {
                 "__generator",
                 "__addDisposableResource",
                 "__disposeResources",
+                "__propKey",
+                "__setFunctionName",
                 "__await",
                 "__asyncGenerator",
                 "__asyncDelegator",
@@ -1086,8 +1132,6 @@ mod tests {
                 "__classPrivateFieldGet",
                 "__classPrivateFieldSet",
                 "__classPrivateFieldIn",
-                "__propKey",
-                "__setFunctionName",
                 "__rewriteRelativeImportExtension",
             ],
         );
@@ -1262,6 +1306,30 @@ mod tests {
 
         assert!(i_get < i_set_name);
         assert!(i_set_name < i_await);
+    }
+
+    #[test]
+    fn emit_helpers_order_tc39_set_function_name_before_private_helpers() {
+        let mut helpers = HelpersNeeded {
+            es_decorate: true,
+            set_function_name: true,
+            ..HelpersNeeded::default()
+        };
+        helpers.mark_class_private_field_in();
+        helpers.mark_class_private_field_get();
+        helpers.mark_class_private_field_set();
+
+        let output = emit_helpers(&helpers);
+        let i_es_decorate = find_helper(&output, "__esDecorate");
+        let i_set_name = find_helper(&output, "__setFunctionName");
+        let i_in = find_helper(&output, "__classPrivateFieldIn");
+        let i_get = find_helper(&output, "__classPrivateFieldGet");
+        let i_set = find_helper(&output, "__classPrivateFieldSet");
+
+        assert!(i_es_decorate < i_set_name);
+        assert!(i_set_name < i_in);
+        assert!(i_in < i_get);
+        assert!(i_get < i_set);
     }
 
     #[test]


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
JavaScript emit recovery / TC39 decorator helper ordering.

## Invariant
TC39-decorated classes that also need private-field helpers must emit runtime helpers in `tsc` order: decorator helpers first, `__setFunctionName` before private helper declarations, and private helper declarations following their recorded first-use order when decorators request private access helpers.

## Structural Rule
For TC39 decorator emit (`__esDecorate`), `__setFunctionName` belongs to the decorator helper cluster before unprioritized private helpers. Private-field helpers still use the existing get/set ordering outside that decorator path, but decorator access objects can request `__classPrivateFieldIn` before get/set and that first-use order must be preserved.

## Owner Layer
Emitter helper scheduling in `crates/tsz-emitter/src/transforms/helpers.rs`. This is output planning only: no checker/solver semantic validation and no output surgery.

## Adjacent Case Matrix
- TC39 class decorators with private fields/accessors requiring `__setFunctionName` and private helper declarations.
- Decorator access objects where the `has` accessor requests `__classPrivateFieldIn` before get/set helpers.
- Non-TC39/private-only helper scheduling remains covered by existing get/set ordering tests.
- Import-helper name ordering remains covered through `needed_names` priority tests.

## Scope
- Move `__setFunctionName` ahead of unprioritized helper declarations when `es_decorate` is active.
- Preserve recorded first-use order for class-private helpers under TC39 decorator helper scheduling.
- Keep the existing non-decorator private helper ordering behavior and its unit coverage.
- Add helper-order unit coverage for the TC39 decorator/private-helper combination.

## Project Corpus Impact
- Row: emit conformance `esDecorators-classDeclaration-sourceMap`
- Bug family: class/private/accessor/decorator lowering; helper declaration ordering
- Evidence: exact JS emit filter `esDecorators-classDeclaration-sourceMap` passes locally after this change.

## Verification
- `cargo check -p tsz-emitter`
- `cargo nextest run -p tsz-emitter transforms::helpers::tests`
- `scripts/emit/run.sh --filter=esDecorators-classDeclaration-sourceMap --js-only --verbose --timeout=30000 --json-out=/tmp/studio-c-esdecorators-sourcemap-helper-order-after-10653.json`
- `git diff --check origin/main..HEAD`
- `cargo fmt --all --check`
- File-size check: `crates/tsz-emitter/src/transforms/helpers.rs` 1770 lines.

## Coordination Notes
- Non-overlapping with Studio-C PR #10685 (async imported Promise constructor retention).
- Rebased onto current `origin/main` after #10653 merged; current head `fb3459e2c3`.
- Draft-light CI passed on head `fb3459e2c3`: `CI Light Summary`, lint, unit, dist-binaries, unit-cloudbuild, cargo-deny, cargo-shear, project-row-drift, gate, and GitGuardian Security Checks. Marked ready so heavy ready-review CI can run.
- Related issue context: #8750.

