### PR TITLE
test(solver): cover bivariant rest relation cache

### DIFF
--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -558,3 +558,107 @@ fn assignability_cache_strict_subtype_checking_matches_uncached_method_policy() 
         "ordinary assignability slot must remain intact after the strict lookup",
     );
 }
+
+#[test]
+fn assignability_cache_allow_bivariant_rest_matches_uncached_relation_policy() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let source = interner.function(FunctionShape::new(
+        vec![
+            ParamInfo::unnamed(TypeId::STRING),
+            ParamInfo::unnamed(TypeId::NUMBER),
+        ],
+        TypeId::VOID,
+    ));
+    let rest_any = interner.array(TypeId::ANY);
+    let target = interner.function(FunctionShape::new(
+        vec![ParamInfo {
+            name: None,
+            type_id: rest_any,
+            optional: false,
+            rest: true,
+        }],
+        TypeId::VOID,
+    ));
+
+    let ordinary = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_FUNCTION_TYPES | RelationFlags::STRICT_NULL_CHECKS,
+    )
+    .with_strict_any_propagation(true)
+    .with_any_propagation_mode(AnyPropagationMode::TopLevelOnly);
+    let bivariant_rest = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_FUNCTION_TYPES
+            | RelationFlags::STRICT_NULL_CHECKS
+            | RelationFlags::ALLOW_BIVARIANT_REST,
+    )
+    .with_strict_any_propagation(true)
+    .with_any_propagation_mode(AnyPropagationMode::TopLevelOnly);
+    let ordinary_key = RelationCacheKey::for_assignability(source, target, ordinary.cache_config());
+    let bivariant_rest_key =
+        RelationCacheKey::for_assignability(source, target, bivariant_rest.cache_config());
+
+    assert_ne!(
+        ordinary_key, bivariant_rest_key,
+        "ordinary and bivariant-rest policies must occupy distinct assignability cache slots",
+    );
+
+    let ordinary_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        ordinary,
+        RelationContext::default(),
+    )
+    .is_related();
+    let bivariant_rest_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        bivariant_rest,
+        RelationContext::default(),
+    )
+    .is_related();
+
+    assert!(
+        !ordinary_uncached,
+        "ordinary strict-any assignability should compare extra parameters normally",
+    );
+    assert!(
+        bivariant_rest_uncached,
+        "bivariant-rest assignability should accept fixed arguments against a rest-`any` target",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, ordinary),
+        ordinary_uncached,
+        "cached ordinary rest policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(ordinary_key),
+        Some(ordinary_uncached),
+        "ordinary rest result must be stored in the ordinary assignability slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(bivariant_rest_key),
+        None,
+        "bivariant-rest lookup must not hit the ordinary slot",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, bivariant_rest),
+        bivariant_rest_uncached,
+        "cached bivariant-rest policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(bivariant_rest_key),
+        Some(bivariant_rest_uncached),
+        "bivariant-rest result must be stored in the bivariant-rest assignability slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(ordinary_key),
+        Some(ordinary_uncached),
+        "ordinary rest slot must remain intact after the bivariant-rest lookup",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 10 relation policy/cache-key tech debt (#8207), solver policy/cache agreement test ratchet.

## Invariant
When relation policy enables `ALLOW_BIVARIANT_REST`, assignability of fixed parameters against a rest-`any` target can change; the cached assignability path must agree with the uncached `query_relation` facade and use a distinct policy-shaped cache key.

## Scope
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: solver test-only ratchet for relation policy/cache agreement; no project corpus behavior change targeted.

## Verification
- RED `cargo nextest run -p tsz-solver -E 'test(assignability_cache_allow_bivariant_rest_matches_uncached_relation_policy)'` failed before the test existed with `error: no tests to run`.
- `cargo nextest run -p tsz-solver -E 'test(assignability_cache_allow_bivariant_rest_matches_uncached_relation_policy)'`
- `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'`
- `cargo fmt --check`
- `git diff --check`
- Draft-light GitHub Actions CI passed on exact head `7ff99a1fa532ff2bbc016e621dda32832685262e`: https://github.com/mohsen1/tsz/actions/runs/26548118919
- Ready-review GitHub Actions CI passed on exact head `7ff99a1fa532ff2bbc016e621dda32832685262e`: https://github.com/mohsen1/tsz/actions/runs/26548613225

## Coordination Notes
- Non-overlap: #10691 merged through the repo-local queue at `2026-05-28T01:17:40Z`; this PR remains mergeable and is a separate test-only #8207 ratchet.
- Does not touch checker relation routing owned by M1-B, nor M4-A/M4-C evaluation/inference lanes.
- Ready-review CI is green on head `7ff99a1fa532ff2bbc016e621dda32832685262e`; adding `merge-queue` for the repo-local queue.
- `Queue Tested` is queue-owned and may remain pending until the synthetic latest-main merge lands.
