### PR TITLE
fix(bench): run required project rows

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -965,7 +965,7 @@ jobs:
             filter: 'Mapped complex template keys'
           - label: projects
             timeout: 120
-            filter: 'utility-types/|ts-toolbelt/|ts-essentials/|utility-types-project|ts-essentials-project|rxjs-project|type-fest-project|vite-vanilla-ts-app|nextjs-fresh-app|nextjs'
+            filter: 'utility-types/|ts-toolbelt/|ts-essentials/|utility-types-project|ts-toolbelt-project|ts-essentials-project|rxjs-project|type-fest-project|zod-project|kysely-project|vite-vanilla-ts-app|nextjs-fresh-app|nextjs'
           - label: large-ts-repo
             timeout: 120
             filter: '^large-ts-repo$'

--- a/scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
@@ -2,6 +2,8 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 
+import { REQUIRED_PROJECT_ROWS } from "./project-rows.mjs";
+
 const workflow = fs.readFileSync(".github/workflows/bench.yml", "utf8");
 const shardCloudbuild = fs.readFileSync(
   "scripts/cloudbuild/cloudbuild-bench-shard.yaml",
@@ -60,6 +62,16 @@ assert.doesNotMatch(
   workflow,
   /source "bench-status-\$\{\{ matrix\.label \}\}\.env"/,
   "bench shard waits must not source status env files because BENCH_SHARD_FILTER can contain spaces or shell metacharacters",
+);
+
+const shardFilters = [...workflow.matchAll(/^\s+filter: '([^']+)'/gm)]
+  .map((match) => new RegExp(match[1]));
+const missingRequiredProjectRows = REQUIRED_PROJECT_ROWS
+  .filter((row) => !shardFilters.some((filter) => filter.test(row)));
+assert.deepEqual(
+  missingRequiredProjectRows,
+  [],
+  "bench matrix filters should select every required project row so publish does not fail on missing compatibility rows",
 );
 
 assert.match(


### PR DESCRIPTION
## Agent
AgentName: Studio-A
Contributor: m5-pro-48g-gpt5

## Track
Bench / CI project-row coverage.

## Invariant
Bench publish must receive every required project row, so a green shard fanout cannot fail later because the workflow matrix skipped rows that `project-rows.mjs` marks required.

## Scope
- Add `ts-toolbelt-project`, `zod-project`, and `kysely-project` to the Bench `projects` shard filter.
- Add a workflow guard test that checks every `REQUIRED_PROJECT_ROWS` entry matches at least one Bench shard filter.

## Project Corpus Impact
- Row: `ts-toolbelt-project`, `zod-project`, `kysely-project`
- Bug family: benchmark project-row filter drift / publish compatibility validation
- Evidence: Bench run 26546420315 completed all shards but failed `bench-publish` with missing project rows for `ts-toolbelt-project`, `zod-project`, and `kysely-project`.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`
- `node scripts/bench/test-project-rows.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/bench/test-merge-results.mjs`
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `git diff --check`

## Coordination Notes
- Canonical owner normalized by M1-A to `agent:Studio-A` / `AgentName: Studio-A` because this PR changes Bench project-row coverage, which belongs to the project-corpus/release-metric truth lane.
- Original contributor identity preserved as `m5-pro-48g-gpt5`.
- Follow-up to the Bench CI-flow fixes already landed on main.
- After merge, trigger a fresh manual Bench run on main and verify `bench-publish` refreshes the public benchmark artifact.
