### PR TITLE
test(solver): cover bivariant param count relation cache

### DIFF
--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -744,3 +744,92 @@ fn assignability_cache_allow_bivariant_rest_matches_uncached_relation_policy() {
         "ordinary rest slot must remain intact after the bivariant-rest lookup",
     );
 }
+
+#[test]
+fn assignability_cache_allow_bivariant_param_count_matches_uncached_relation_policy() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let source = interner.function(FunctionShape::new(
+        vec![
+            ParamInfo::unnamed(TypeId::STRING),
+            ParamInfo::unnamed(TypeId::NUMBER),
+        ],
+        TypeId::VOID,
+    ));
+    let target = interner.function(FunctionShape::new(
+        vec![ParamInfo::unnamed(TypeId::STRING)],
+        TypeId::VOID,
+    ));
+
+    let ordinary = RelationPolicy::unflagged_compatibility();
+    let bivariant_count =
+        RelationPolicy::from_relation_flags(RelationFlags::ALLOW_BIVARIANT_PARAM_COUNT);
+    let ordinary_key = RelationCacheKey::for_assignability(source, target, ordinary.cache_config());
+    let bivariant_count_key =
+        RelationCacheKey::for_assignability(source, target, bivariant_count.cache_config());
+
+    assert_ne!(
+        ordinary_key, bivariant_count_key,
+        "ordinary and bivariant-param-count policies must occupy distinct assignability cache slots",
+    );
+
+    let ordinary_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        ordinary,
+        RelationContext::default(),
+    )
+    .is_related();
+    let bivariant_count_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        bivariant_count,
+        RelationContext::default(),
+    )
+    .is_related();
+
+    assert!(
+        !ordinary_uncached,
+        "ordinary assignability should reject extra required source parameters",
+    );
+    assert!(
+        bivariant_count_uncached,
+        "bivariant parameter-count assignability should allow extra required source parameters",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, ordinary),
+        ordinary_uncached,
+        "cached ordinary parameter-count policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(ordinary_key),
+        Some(ordinary_uncached),
+        "ordinary parameter-count result must be stored in the ordinary assignability slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(bivariant_count_key),
+        None,
+        "bivariant-param-count lookup must not hit the ordinary slot",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, bivariant_count),
+        bivariant_count_uncached,
+        "cached bivariant-param-count policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(bivariant_count_key),
+        Some(bivariant_count_uncached),
+        "bivariant-param-count result must be stored in its own assignability slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(ordinary_key),
+        Some(ordinary_uncached),
+        "ordinary parameter-count slot must remain intact after the bivariant-param-count lookup",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 10 relation policy/cache-key tech debt (#8207), solver policy/cache agreement test ratchet.

## Invariant
When relation policy enables `ALLOW_BIVARIANT_PARAM_COUNT`, assignability of a source function with extra required parameters can change; the cached assignability path must agree with the uncached `query_relation` facade and use a distinct policy-shaped cache key.

## Scope
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: solver test-only ratchet for relation policy/cache agreement; no project corpus behavior change targeted.

## Verification
- RED `cargo nextest run -p tsz-solver -E 'test(assignability_cache_allow_bivariant_param_count_matches_uncached_relation_policy)'` failed before the test existed with `error: no tests to run`.
- `cargo nextest run -p tsz-solver -E 'test(assignability_cache_allow_bivariant_param_count_matches_uncached_relation_policy)'`
- `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'`
- `cargo fmt --check`
- `git diff --check`
- After #10696 merged, rebased onto `origin/main` `b66def7d21b` and reran `cargo nextest run -p tsz-solver -E 'test(assignability_cache_allow_bivariant_param_count_matches_uncached_relation_policy)'`.
- After #10696 merged, `git diff --check origin/main..HEAD` passed.
- Ready-review GitHub Actions CI passed on exact head `6c5161c03a0a67babc9f273946484fb66587e8c4`: https://github.com/mohsen1/tsz/actions/runs/26549545232

## Coordination Notes
- #10696 merged through the repo-local queue at `2026-05-28T01:41:07Z`; this PR is now rebased onto `main` and retargeted from the former stacked base to `main`.
- Non-overlap: this is the next #8207 test-only ratchet for `ALLOW_BIVARIANT_PARAM_COUNT`; it does not touch checker relation routing owned by M1-B, nor M4-A/M4-C evaluation/inference lanes.
- Ready-review CI passed on exact head `6c5161c03a0a67babc9f273946484fb66587e8c4`; adding `merge-queue` for the repo-local queue.
- `Queue Tested` is queue-owned and may remain pending until the synthetic latest-main merge lands.
