### PR TITLE
perf(checker): avoid alias resolving set rebuilds

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -100,13 +100,7 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        let resolving_defs: rustc_hash::FxHashSet<_> = self
-            .ctx
-            .symbol_resolution_set
-            .iter()
-            .filter_map(|sid| self.ctx.get_existing_def_id(*sid))
-            .collect();
-        if resolving_defs.is_empty() {
+        if self.ctx.symbol_resolution_set.is_empty() {
             return false;
         }
 
@@ -121,7 +115,12 @@ impl<'a> CheckerState<'a> {
                 if !visited.insert(def_id) {
                     continue;
                 }
-                if resolving_defs.contains(&def_id) {
+                if self
+                    .ctx
+                    .symbol_resolution_set
+                    .iter()
+                    .any(|sid| self.ctx.get_existing_def_id(*sid) == Some(def_id))
+                {
                     return true;
                 }
                 let Some(body) = self.ctx.definition_store.get_body(def_id) else {


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 performance micro-slice for green-row `ts-essentials-project` alias validation.

## Invariant
When checking whether a referenced type alias reaches the currently resolving alias, tsz returns the same DefId reachability answer but compares against the live resolving symbol set directly instead of rebuilding a resolving-DefId set for every type-reference validation.

## Scope
- `crates/tsz-checker/src/types/type_checking/type_alias_checking.rs`

## Project Corpus Impact
- Row: `ts-essentials-project`
- Bug family: green-row type-alias validation overhead in recursive utility-type aliases
- Evidence: before companion `/private/tmp/studio-b-type-alias-coverage-ts-essentials-20260528022755.tsgo-winners.json` had one target gap for `ts-essentials-project` (`tsz_ms=98.30`, `tsgo_ms=80.13`, `target_gap_factor=2.4535`). Exact-head attribution `/private/tmp/studio-b-type-alias-coverage-xor-exact-20260528023946.perf.json` showed `XOR` `body_validation=3.26 ms` in the reduced `xor` path. After this PR, `/private/tmp/studio-b-alias-resolving-ts-essentials-after-20260528.tsgo-winners.json` still has one target gap (`tsz_ms=88.72`, `tsgo_ms=74.87`, `target_gap_factor=2.3700`). Fresh attribution `/private/tmp/studio-b-alias-resolving-ts-essentials-after-20260528.perf.json` keeps the row green (`Errors: 0`) with no delegate misses and no parent-cache constructions; remaining hot phases are type-alias `body_validation` (`XOR=3.17 ms`, `DeepReadonly=2.25 ms`, `DeepRequired=2.21 ms`). This PR does not close #7378.

## Verification
- `cargo fmt --all`
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo check -p tsz-checker`
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo nextest run -p tsz-checker --test ts2304_tests -- type_alias_`
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo nextest run -p tsz-checker --lib recursive_alias`
- `git diff --check`
- `BENCH_PGO=0 TSC_NPM_SPEC=6.0.3 scripts/safe-run.sh --limit 75% -- scripts/bench/bench-vs-tsgo.sh --quick --filter '^ts-essentials-project$' --json-file /private/tmp/studio-b-alias-resolving-ts-essentials-after-20260528.json`
- `node scripts/bench/tsgo-winner-report.mjs /private/tmp/studio-b-alias-resolving-ts-essentials-after-20260528.json /private/tmp/studio-b-alias-resolving-ts-essentials-after-20260528.tsgo-winners.json`
- `scripts/safe-run.sh --limit 75% -- env CARGO_TARGET_DIR=.target-bench/perf-tools CARGO_INCREMENTAL=0 RUSTFLAGS='-Ctarget-cpu=native' cargo build --profile dist -p tsz-cli --bin tsz --features perf-tools`
- `TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh --limit 75% -- .target-bench/perf-tools/dist/tsz --extendedDiagnostics --perf-counters-json /private/tmp/studio-b-alias-resolving-ts-essentials-after-20260528.perf.json --noEmit -p .target-bench/external/ts-essentials/tsconfig.flat.json > /private/tmp/studio-b-alias-resolving-ts-essentials-after-20260528.extended.txt`

## Coordination Notes
- Ready for CI as a narrow allocation/removal slice; it does not claim to solve the 2x target.
- A package-wide `cargo nextest list -p tsz-checker type_alias` attempt was abandoned after linking many checker test binaries and filling disk (`ld: write() failed, errno=28`). I recovered space with targeted deletion of generated debug test executables under `/Users/mohsen/code/tsz/.target/debug/deps`, preserving rlibs and incremental caches.
- No open Studio-B PRs existed before this branch; #7378 remains the owning issue and the 2x target gap remains open.