### PR TITLE
test(solver): cover erase generics relation cache

### DIFF
--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -9,7 +9,7 @@ use crate::relations::relation_queries::{
 };
 use crate::relations::subtype::AnyPropagationMode;
 use crate::types::{
-    FunctionShape, ParamInfo, PropertyInfo, RelationCacheKey, RelationFlags, TypeId,
+    FunctionShape, ParamInfo, PropertyInfo, RelationCacheKey, RelationFlags, TypeId, TypeParamInfo,
 };
 
 #[test]
@@ -831,5 +831,107 @@ fn assignability_cache_allow_bivariant_param_count_matches_uncached_relation_pol
         db.lookup_assignability_cache(ordinary_key),
         Some(ordinary_uncached),
         "ordinary parameter-count slot must remain intact after the bivariant-param-count lookup",
+    );
+}
+
+#[test]
+fn assignability_cache_erase_generics_matches_uncached_relation_policy() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let target_t = TypeParamInfo {
+        name: interner.intern_string("Target"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let target_t_type = interner.type_param(target_t);
+    let source = interner.function(FunctionShape {
+        type_params: vec![],
+        params: vec![],
+        this_type: None,
+        return_type: target_t_type,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+    let target = interner.function(FunctionShape {
+        type_params: vec![target_t],
+        params: vec![],
+        this_type: None,
+        return_type: target_t_type,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+
+    let erased = RelationPolicy::default().with_erase_generics(true);
+    let strict = RelationPolicy::default().with_erase_generics(false);
+    let erased_key = RelationCacheKey::for_assignability(source, target, erased.cache_config());
+    let strict_key = RelationCacheKey::for_assignability(source, target, strict.cache_config());
+
+    assert_ne!(
+        erased_key, strict_key,
+        "erased and strict generic-signature policies must occupy distinct assignability cache slots",
+    );
+
+    let erased_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        erased,
+        RelationContext::default(),
+    )
+    .is_related();
+    let strict_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        strict,
+        RelationContext::default(),
+    )
+    .is_related();
+
+    assert!(
+        erased_uncached,
+        "erased generic-signature compatibility should allow the relation",
+    );
+    assert!(
+        !strict_uncached,
+        "strict generic-signature compatibility must not promote an outer type parameter into a generic signature",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, strict),
+        strict_uncached,
+        "cached strict generic policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(strict_key),
+        Some(strict_uncached),
+        "strict generic result must be stored in the strict assignability slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(erased_key),
+        None,
+        "erased-generic lookup must not hit the strict slot",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, erased),
+        erased_uncached,
+        "cached erased generic policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(erased_key),
+        Some(erased_uncached),
+        "erased generic result must be stored in the erased assignability slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(strict_key),
+        Some(strict_uncached),
+        "strict generic slot must remain intact after the erased lookup",
     );
 }


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 10 relation policy/cache-key tech debt (#8207), solver policy/cache agreement test ratchet.

## Invariant
When relation policy disables generic erasure (`erase_generics=false` / `NO_ERASE_GENERICS`), generic-signature assignability can change; the cached assignability path must agree with uncached `query_relation` and use a distinct policy-shaped cache key.

## Scope
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: solver test-only ratchet for relation policy/cache agreement; no project corpus behavior change targeted.

## Verification
- RED `cargo nextest run -p tsz-solver -E 'test(assignability_cache_erase_generics_matches_uncached_relation_policy)'` failed before the test existed with `error: no tests to run`.
- `cargo nextest run -p tsz-solver -E 'test(assignability_cache_erase_generics_matches_uncached_relation_policy)'`
- `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'`
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- After #10698 merged, rebased onto then-current `origin/main` `2d9b262852c` and reran `cargo nextest run -p tsz-solver -E 'test(assignability_cache_erase_generics_matches_uncached_relation_policy)'`.
- After #10698 merged, reran `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'`: 11 passed.
- After #10698 merged, reran `cargo fmt --check` and `git diff --check origin/main..HEAD` on head `7a8eecb26fc3c1c66703181476dae97e41116d4b`.
- Ready-review GitHub Actions CI passed on exact head `7a8eecb26fc3c1c66703181476dae97e41116d4b`: https://github.com/mohsen1/tsz/actions/runs/26550591776

## Coordination Notes
- Non-overlap: this is the next #8207 test-only ratchet for `erase_generics`; it does not touch checker relation routing owned by M1-B, nor M4-A/M4-C evaluation/inference lanes.
- #10698 merged through the repo-local queue at `2026-05-28T02:15:07Z`; this PR was rebased after that merge and force-pushed to head `7a8eecb26fc3c1c66703181476dae97e41116d4b`.
- Ready-review CI passed on exact head `7a8eecb26fc3c1c66703181476dae97e41116d4b`: https://github.com/mohsen1/tsz/actions/runs/26550591776
- Adding `merge-queue`; `Queue Tested` is queue-owned and may remain pending until the synthetic latest-main merge lands.
- Stacked follow-up #10706 remains draft on `codex/m4-b-erased-retry-cache-20260528` until this PR lands or is retargeted.
