### PR TITLE
fix(parser): recover object private indexer emit tail

### DIFF
--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -1948,6 +1948,10 @@ impl ParserState {
                     self.suppress_object_literal_comma_once = true;
                 }
                 name // Use property name as fallback for error recovery
+            } else if let Some(recovered) =
+                self.recover_object_literal_computed_indexer_tail(name, expr)
+            {
+                recovered
             } else {
                 expr
             };
@@ -2006,6 +2010,57 @@ impl ParserState {
                 },
             )
         }
+    }
+
+    fn recover_object_literal_computed_indexer_tail(
+        &mut self,
+        name: NodeIndex,
+        left: NodeIndex,
+    ) -> Option<NodeIndex> {
+        let name_node = self.arena.get(name)?;
+        let name_end = name_node.end;
+        if name_node.kind != syntax_kind_ext::COMPUTED_PROPERTY_NAME
+            || !self.is_token(SyntaxKind::CloseBracketToken)
+        {
+            return None;
+        }
+
+        let snapshot = self.scanner.save_state();
+        let current = self.current_token;
+        self.next_token();
+        let has_colon_after_bracket = self.is_token(SyntaxKind::ColonToken);
+        self.scanner.restore_state(snapshot);
+        self.current_token = current;
+        if !has_colon_after_bracket {
+            return None;
+        }
+
+        self.parse_error_at_current_token("',' expected.", diagnostic_codes::EXPECTED);
+        self.next_token();
+        self.parse_error_at_current_token(
+            "Property assignment expected.",
+            diagnostic_codes::PROPERTY_ASSIGNMENT_EXPECTED,
+        );
+        self.next_token();
+        let right = self.parse_assignment_expression();
+        if right.is_none() {
+            return Some(left);
+        }
+        let left_start = self.arena.get(left).map_or(name_end, |node| node.pos);
+        let end_pos = self
+            .arena
+            .get(right)
+            .map_or(self.token_end(), |node| node.end);
+        Some(self.arena.add_binary_expr(
+            syntax_kind_ext::BINARY_EXPRESSION,
+            left_start,
+            end_pos,
+            crate::parser::node::BinaryExprData {
+                left,
+                operator_token: SyntaxKind::CommaToken as u16,
+                right,
+            },
+        ))
     }
 
     /// Look ahead to check if get/set/async is a method vs property name

--- a/crates/tsz-parser/tests/parser_unit_tests_parts/part_01.rs
+++ b/crates/tsz-parser/tests/parser_unit_tests_parts/part_01.rs
@@ -828,6 +828,40 @@ fn expr_object_literal() {
 }
 
 #[test]
+fn object_literal_private_indexer_tail_recovers_as_comma_initializer() {
+    let source = "const x = { private [x: string]: string; };";
+    let (parser, root) = parse_source(source);
+    let arena = parser.get_arena();
+    let init = get_var_initializer(arena, root);
+    let object = arena.get(init).expect("object literal");
+    let object_data = arena
+        .get_literal_expr(object)
+        .expect("object literal expression");
+    assert_eq!(
+        object_data.elements.nodes.len(),
+        1,
+        "malformed indexer tail should stay on one object property"
+    );
+
+    let prop = arena
+        .get(object_data.elements.nodes[0])
+        .expect("property assignment");
+    let assignment = arena
+        .get_property_assignment(prop)
+        .expect("property assignment data");
+    let (_, op, _) = get_binary(arena, assignment.initializer);
+    assert_eq!(op, SyntaxKind::CommaToken as u16);
+
+    let codes: Vec<u32> = parser
+        .get_diagnostics()
+        .iter()
+        .map(|diag| diag.code)
+        .collect();
+    assert!(codes.contains(&diagnostic_codes::EXPECTED));
+    assert!(codes.contains(&diagnostic_codes::PROPERTY_ASSIGNMENT_EXPECTED));
+}
+
+#[test]
 fn expr_yield() {
     // `function* gen() { yield 1; yield* other(); }`
     let (parser, _) = parse_source("function* gen() { yield 1; yield* other(); }");
@@ -1772,4 +1806,3 @@ fn no_substitution_template_records_raw_token_text() {
         );
     }
 }
-


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
emit(js) / parser recovery

## Invariant
When an object literal parses a computed property name and then sees an index-signature-like tail `[expr: Type]: Value`, `tsc` keeps the malformed tail in a single recovered property initializer as comma-expression output while reporting recovery diagnostics at the structural recovery tokens; this PR makes tsz do the same through parser recovery facts consumed by normal JS emit.

## Scope
- Recover object literal computed-property tails shaped like `[expr: Type]: Value` as a single computed property initializer comma expression.
- Preserve TS1005-style comma recovery at the closing `]` and TS1136 property-assignment recovery at the following `:`.
- Add parser coverage for the malformed private-indexer object-literal shape without adding emitter source-text surgery or checker/solver semantic validation.

## Owner Layer
Parser recovery owns this behavior. The emitter should print the recovered AST it is given; it should not inspect checker facts, validate private-indexer semantics, or patch already-emitted JavaScript text.

## Adjacent-Case Matrix
- Reported witness: object-literal private indexer recovery in `privateIndexer2` now emits `[x]: string, string` as one property.
- Renamed computed key: the parser unit test asserts the rule through AST shape and diagnostics, not a specific identifier spelling.
- Fallback behavior: only computed property names followed by `]` then `:` use this tail recovery; ordinary property assignments and supported computed-property initializers continue through the normal object-literal parser path.

## Project Corpus Impact
- Row: n/a
- Bug family: private-name/object-literal malformed indexer JS emit recovery
- Evidence: exact emit filter `privateIndexer2` now passes; `Private` emit slice improves from 286/310 to 287/310 with remaining failures unchanged/pre-existing.

## Verification
- `cargo nextest run -p tsz-parser object_literal_private_indexer_tail_recovers_as_comma_initializer`
- `scripts/emit/run.sh --filter=privateIndexer2 --js-only --verbose --timeout=15000 --json-out=/tmp/studio-c-private-indexer2-final.json`
- `./scripts/conformance/conformance.sh run --filter privateIndexer2 --verbose`
- `scripts/emit/run.sh --filter=Private --js-only --timeout=15000 --json-out=/tmp/studio-c-current-private-after.json`
- `cargo fmt --all --check`
- `git diff --check`

## Coordination Notes
- Studio-C reused the existing `/Users/mohsen/code/tsz` worktree after the previous `tsz-studio-c` worktree was removed by cache-preserving cleanup during disk-full recovery.
- Branch name is stale from an earlier sampled module slice; this PR's actual scope is the private-indexer object-literal recovery above.
- Open PR overlap check on 2026-05-28 found no active parser/emit recovery PR covering this recovery shape.
- PR #10695 is already merged on `main`; this branch includes that merged helper-order fix.
- Current head is synced with `origin/main` on 2026-05-28 (`0` behind, `1` ahead).
