### PR TITLE
fix(emit): initialize private state before static reads

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -743,6 +743,9 @@ impl<'a> Printer<'a> {
             && static_initializer_alias_source_nodes
                 .iter()
                 .any(|idx| self.node_text_contains_identifier(*idx, &class_name));
+        let static_initializer_directly_uses_private_name = static_initializer_alias_source_nodes
+            .iter()
+            .any(|idx| self.expression_directly_contains_private_identifier(*idx));
         let static_initializer_needs_class_alias = static_initializer_contains_class_name
             && (static_initializer_needs_this_alias
                 || has_static_privates
@@ -2865,7 +2868,9 @@ impl<'a> Printer<'a> {
         // For class declarations: use separate statements `ClassName.field = value;`
         let emit_private_inits_before_static_elements = !needs_private_comma_expr
             && has_any_private_lowering
-            && (static_initializer_class_alias.is_some() || has_static_privates)
+            && (static_initializer_class_alias.is_some()
+                || has_static_privates
+                || static_initializer_directly_uses_private_name)
             && (!static_field_inits.is_empty() || !deferred_static_blocks.is_empty());
         let mut emitted_private_auto_accessors_pre_static = false;
         if emit_private_inits_before_static_elements {

--- a/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
@@ -2,7 +2,7 @@ use super::super::super::Printer;
 use super::AutoAccessorEmitOptions;
 use crate::transforms::private_fields_es5::get_private_field_name;
 use tsz_parser::parser::NodeIndex;
-use tsz_parser::parser::node::Node;
+use tsz_parser::parser::node::{Node, NodeAccess};
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
@@ -162,6 +162,30 @@ impl<'a> Printer<'a> {
             && let Some(paren) = self.arena.get_parenthesized(expr_node)
         {
             return self.is_computed_name_expr_side_effect_free(paren.expression);
+        }
+        false
+    }
+
+    pub(in crate::emitter) fn expression_directly_contains_private_identifier(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> bool {
+        let mut stack = vec![expr_idx];
+        while let Some(current) = stack.pop() {
+            let Some(node) = self.arena.get(current) else {
+                continue;
+            };
+            if node.kind == SyntaxKind::PrivateIdentifier as u16 {
+                return true;
+            }
+            if current != expr_idx
+                && (node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
+                    || node.kind == syntax_kind_ext::ARROW_FUNCTION
+                    || node.kind == syntax_kind_ext::CLASS_EXPRESSION)
+            {
+                continue;
+            }
+            stack.extend(self.arena.get_children(current));
         }
         false
     }

--- a/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
@@ -99,6 +99,34 @@ class Widget {
 }
 
 #[test]
+fn private_state_initializes_before_static_fields_that_read_private_names() {
+    let source = r#"
+class Widget {
+    static fromMethod = new Widget().#run();
+    static fromGetter = new Widget().#value;
+    #run() { return 1; }
+    get #value() { return 2; }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    let private_state_pos = output
+        .find("_Widget_instances = new WeakSet(), _Widget_run = function _Widget_run()")
+        .expect("expected private method/accessor setup");
+    let static_method_pos = output
+        .find("Widget.fromMethod = __classPrivateFieldGet")
+        .expect("expected lowered static method-read field");
+    let static_getter_pos = output
+        .find("Widget.fromGetter = __classPrivateFieldGet")
+        .expect("expected lowered static getter-read field");
+
+    assert!(
+        private_state_pos < static_method_pos && private_state_pos < static_getter_pos,
+        "Private state setup should precede static field initializers that directly evaluate private names.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn optional_private_field_call_uses_lowered_get_as_callee() {
     let source = r#"
 class Widget {


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
emit(js) / class-private lowering

## Invariant
When a lowered static field initializer directly evaluates a private-name access, `tsc` emits the private WeakMap/WeakSet/method/accessor setup before the static field assignment; this PR makes tsz do the same through the class emit scheduling layer.

## Scope
- Detect static field initializers whose evaluated expression tree directly contains a private identifier, stopping at nested function and class expression boundaries.
- Include that structural fact in the existing pre-static private-state scheduling gate.
- Add focused emitter coverage for static fields that read an instance private method and an instance private accessor.

## Owner Layer
The owner is JS emit class-private scheduling. The fix does not add checker or solver semantic validation and does not patch already-emitted JavaScript text.

## Adjacent-Case Matrix
- Reported witness: `privateNameMethodInStaticFieldInit` now emits `_C_instances` and `_C_method` before `C.s`.
- Adjacent method shape: a static field that calls `new Widget().#run()` now schedules private method setup first.
- Adjacent accessor shape: a static field that reads `new Widget().#value` now schedules private accessor setup first.
- Fallback behavior: private identifiers inside nested function or class expressions do not trigger this pre-static scheduling gate, so non-immediately-evaluated nested bodies stay on the existing path.

## Project Corpus Impact
- Row: n/a
- Bug family: class/private/accessor/decorator lowering
- Evidence: exact JS emit filter `privateNameMethodInStaticFieldInit` now passes; live `private` JS slice improves from 286/310 to 287/310 on this branch. `privateIndexer2` remains a separate already-open parser recovery PR (#10701).

## Verification
- `cargo nextest run -p tsz-emitter private_state_initializes_before_static_fields_that_read_private_names`
- `scripts/emit/run.sh --filter=privateNameMethodInStaticFieldInit --js-only --verbose --timeout=15000 --json-out=/tmp/studio-c-privateNameMethodInStaticFieldInit-after.json`
- `scripts/emit/run.sh --filter=private --js-only --timeout=15000 --json-out=/tmp/studio-c-private-live-after.json`
- post-rebase: `scripts/emit/run.sh --filter=privateNameMethodInStaticFieldInit --js-only --verbose --timeout=15000 --json-out=/tmp/studio-c-privateNameMethodInStaticFieldInit-rebased.json`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

## Coordination Notes
- Studio-C first promoted #10701 to ready and left a signed status comment; #10701 ready CI was still waiting on `dist-binaries` when this PR was opened, so it was not enqueueable yet.
- Open PR overlap check on 2026-05-28 found no active PR covering static-field/private-state scheduling.
- Branch is rebased on `origin/main` at `b5cab6d387` and is `0` behind, `1` ahead.
