### PR TITLE
fix(bench): record fixture failure compatibility rows

### DIFF
--- a/scripts/bench/bench-vs-tsgo.sh
+++ b/scripts/bench/bench-vs-tsgo.sh
@@ -1313,11 +1313,44 @@ run_isolated() {
     return 0
 }
 
+is_project_compatibility_row() {
+    local candidate="$1"
+    command -v node >/dev/null 2>&1 || return 1
+
+    PROJECT_ROW_NAME="$candidate" \
+    TSZ_PROJECT_ROWS_MJS="$PROJECT_ROOT/scripts/bench/project-rows.mjs" \
+    node --input-type=module <<'NODE'
+import { pathToFileURL } from "node:url";
+
+const rowModule = await import(pathToFileURL(process.env.TSZ_PROJECT_ROWS_MJS));
+const compatibilityRows = new Set([
+  ...rowModule.REQUIRED_PROJECT_ROWS,
+  ...rowModule.COMPILE_CANARY_PROJECT_ROWS,
+]);
+process.exit(compatibilityRows.has(process.env.PROJECT_ROW_NAME) ? 0 : 1);
+NODE
+}
+
 # Append a degraded row to RESULTS_CSV when a fixture group fails outright
 # (no individual benchmarks were recorded). The schema matches existing error
 # rows: name, lines, kb, tsz_ms, tsgo_ms, tsz_lps, tsgo_lps, winner, ratio, status.
 record_fixture_failure() {
     local label="$1" rc="$2"
+    if is_project_compatibility_row "$label"; then
+        record_project_compatibility \
+            "$label" \
+            "runner error" \
+            "fixture setup" \
+            "fixture failed" \
+            "fixture failed before project benchmark recorded compatibility (rc=${rc})" \
+            "0" \
+            "" \
+            "" \
+            "" \
+            "" \
+            "" \
+            ""
+    fi
     RESULTS_CSV="${RESULTS_CSV}${label},0,0,ERR,ERR,N/A,N/A,error,0,fixture failed (rc=${rc})\n"
 }
 

--- a/scripts/bench/test-project-rows.mjs
+++ b/scripts/bench/test-project-rows.mjs
@@ -200,6 +200,11 @@ const benchRunnerScript = readRepoFile("scripts/bench/bench-vs-tsgo.sh");
 const projectFixturesScript = readRepoFile("scripts/bench/project-fixtures.sh");
 const projectCompileGuardScript = readRepoFile("scripts/ci/project-compile-guard.sh");
 const benchRows = extractBenchRunnerRows(benchRunnerScript);
+assert.match(
+  benchRunnerScript,
+  /is_project_compatibility_row\(\)[\s\S]+REQUIRED_PROJECT_ROWS[\s\S]+COMPILE_CANARY_PROJECT_ROWS[\s\S]+record_fixture_failure\(\)[\s\S]+is_project_compatibility_row "\$label"[\s\S]+record_project_compatibility[\s\S]+fixture failed before project benchmark recorded compatibility/,
+  "bench fixture failures for project rows must record compatibility metadata before publishing degraded rows",
+);
 assert.doesNotMatch(
   benchRunnerScript,
   /\[ "\$name" != "nextjs" \] && \[ "\$name" != "large-ts-repo" \]/,


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Project corpus / benchmark artifact truth.

## Invariant
When a project benchmark fixture exits before its project row records normal compatibility metadata, the benchmark artifact must still publish a degraded project row with structured compatibility metadata instead of failing publish validation or losing row truth.

## Scope
- `scripts/bench/bench-vs-tsgo.sh`: record project compatibility JSONL for early project fixture failures.
- `scripts/bench/test-project-rows.mjs`: guard the fixture-failure compatibility contract.

## Project Corpus Impact
- Row: project corpus benchmark rows, especially required rows that can fail before `run_project_benchmark` records metadata.
- Bug family: benchmark artifact truth / missing project compatibility metadata.
- Evidence: Bench run 26547179325 failed publish validation after missing project rows; this PR preserves red compatibility rows for early fixture failures rather than letting them vanish from artifact truth.

## Verification
- `bash -n scripts/bench/bench-vs-tsgo.sh`
- `node scripts/bench/test-project-rows.mjs`
- `node scripts/bench/test-merge-results.mjs`
- `node scripts/bench/test-project-row-summary.mjs`
- `node scripts/bench/project-row-summary.mjs --markdown`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- AgentName: Studio-A
- Related issue: #10649.
- Current `main` already includes #10697 for the required project-row matrix filter; this PR handles the remaining early fixture-failure path without changing docs or roadmap files.
- No auto-merge enabled by this PR.
