### PR TITLE
test(solver): cover erased generic retry relation cache

### DIFF
--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -935,3 +935,121 @@ fn assignability_cache_erase_generics_matches_uncached_relation_policy() {
         "strict generic slot must remain intact after the erased lookup",
     );
 }
+
+#[test]
+fn assignability_cache_erased_generic_retry_matches_uncached_relation_policy() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let source_s = TypeParamInfo {
+        name: interner.intern_string("Source"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let source_s_type = interner.type_param(source_s);
+    let source = interner.function(FunctionShape {
+        type_params: vec![source_s],
+        params: vec![ParamInfo::unnamed(source_s_type)],
+        this_type: None,
+        return_type: source_s_type,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+
+    let target_t = TypeParamInfo {
+        name: interner.intern_string("TargetT"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let target_u = TypeParamInfo {
+        name: interner.intern_string("TargetU"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let target_t_type = interner.type_param(target_t);
+    let target_u_type = interner.type_param(target_u);
+    let target = interner.function(FunctionShape {
+        type_params: vec![target_t, target_u],
+        params: vec![ParamInfo::unnamed(target_t_type)],
+        this_type: None,
+        return_type: target_u_type,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+
+    let no_retry = RelationPolicy::default();
+    let retry =
+        RelationPolicy::from_relation_flags(RelationFlags::ALLOW_ERASED_GENERIC_SIGNATURE_RETRY);
+    let no_retry_key = RelationCacheKey::for_assignability(source, target, no_retry.cache_config());
+    let retry_key = RelationCacheKey::for_assignability(source, target, retry.cache_config());
+
+    assert_ne!(
+        no_retry_key, retry_key,
+        "erased generic retry policy must occupy a distinct assignability cache slot",
+    );
+
+    let no_retry_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        no_retry,
+        RelationContext::default(),
+    )
+    .is_related();
+    let retry_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        retry,
+        RelationContext::default(),
+    )
+    .is_related();
+
+    assert!(
+        !no_retry_uncached,
+        "contextual inference should reject the unequal-arity generic signatures before retry",
+    );
+    assert!(
+        retry_uncached,
+        "erased generic retry should allow the unequal-arity signatures",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, no_retry),
+        no_retry_uncached,
+        "cached no-retry policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(no_retry_key),
+        Some(no_retry_uncached),
+        "no-retry result must be stored in the no-retry assignability slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(retry_key),
+        None,
+        "retry lookup must not hit the no-retry slot",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, retry),
+        retry_uncached,
+        "cached retry policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(retry_key),
+        Some(retry_uncached),
+        "retry result must be stored in its own assignability slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(no_retry_key),
+        Some(no_retry_uncached),
+        "no-retry slot must remain intact after the retry lookup",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 10 relation policy/cache-key tech debt (#8207), solver policy/cache agreement test ratchet.

## Invariant
When relation policy enables `ALLOW_ERASED_GENERIC_SIGNATURE_RETRY`, unequal-arity generic signature assignability can change; the cached assignability path must agree with uncached `query_relation` and use a distinct policy-shaped cache key.

## Scope
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: solver test-only ratchet for relation policy/cache agreement; no project corpus behavior change targeted.

## Verification
- RED `cargo nextest run -p tsz-solver -E 'test(assignability_cache_erased_generic_retry_matches_uncached_relation_policy)'` failed before the test existed with `error: no tests to run`.
- `cargo nextest run -p tsz-solver -E 'test(assignability_cache_erased_generic_retry_matches_uncached_relation_policy)'`: 1 passed.
- `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'`: 12 passed.
- `cargo fmt --check`.
- `git diff --check`.
- `git diff --check HEAD~1..HEAD`.
- File-size guard: `wc -l crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs` -> 1055 lines, below the 2000-line cap.
- After #10700 merged, rebased onto `origin/main` `4f679845fc8` and reran focused verification on head `6b08decb07f`.
- After #10705 merged, rebased onto current `origin/main` `6e0c642f30c` and reran `cargo nextest run -p tsz-solver -E 'test(assignability_cache_erased_generic_retry_matches_uncached_relation_policy)'`: 1 passed.
- After #10705 merged, reran `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'`: 12 passed.
- After #10705 merged, reran `cargo fmt --check`, `git diff --check origin/main..HEAD`, and the file-size guard on head `8757a071280`.
- Draft-light GitHub Actions CI passed on exact head `8757a0712805f9861116e7ed447d5b9aac058b6b`: https://github.com/mohsen1/tsz/actions/runs/26551560379.
- Ready-review GitHub Actions CI passed on exact head `8757a0712805f9861116e7ed447d5b9aac058b6b`: https://github.com/mohsen1/tsz/actions/runs/26558820202.

## Coordination Notes
- #10700 merged through the repo-local queue at `2026-05-28T02:42:31Z`; this PR was rebased onto `main` after that merge and retargeted from the stacked base to `main`.
- #10705 then advanced `main`; this PR was rebased again onto current `origin/main` and force-pushed to head `8757a0712805f9861116e7ed447d5b9aac058b6b`.
- Non-overlap: this slice covers only `ALLOW_ERASED_GENERIC_SIGNATURE_RETRY`; it does not touch checker relation routing owned by M1-B, nor M4-A/M4-C evaluation/inference lanes.
- Ready-review CI passed on exact head `8757a0712805f9861116e7ed447d5b9aac058b6b`; adding `merge-queue`. The queue owns the synthetic latest-`main` `Queue Tested` status.
- No `WIP` or auto-merge state set.

