### PR TITLE
fix(emit): respect shadowed private static receivers

### DIFF
--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -847,6 +847,7 @@ pub struct Printer<'a> {
     pub(crate) private_members_to_skip: FxHashSet<String>,
 
     pub(crate) private_static_class_alias: Option<(String, String)>,
+    pub(crate) private_static_class_alias_shadow_depth: u32,
 
     /// When true, class emitter defers static block IIFEs.
     pub(crate) defer_class_static_blocks: bool,

--- a/crates/tsz-emitter/src/emitter/core_setup.rs
+++ b/crates/tsz-emitter/src/emitter/core_setup.rs
@@ -389,6 +389,7 @@ impl<'a> Printer<'a> {
             pending_private_accessor_defs: Vec::new(),
             private_members_to_skip: FxHashSet::default(),
             private_static_class_alias: None,
+            private_static_class_alias_shadow_depth: 0,
             defer_class_static_blocks: false,
             deferred_class_static_blocks: Vec::new(),
             jsx_dev_file_name: None,

--- a/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
@@ -82,9 +82,94 @@ impl<'a> Printer<'a> {
         if !node.is_identifier() {
             return None;
         }
+        if self.private_static_class_alias_shadow_depth > 0 {
+            return None;
+        }
         let (cls_name, alias) = self.private_static_class_alias.as_ref()?;
         let ident = self.arena.get_identifier(node)?;
         (ident.escaped_text == *cls_name).then_some(alias.as_str())
+    }
+
+    pub(in crate::emitter) fn block_shadows_private_static_class_alias(
+        &self,
+        statements: &[NodeIndex],
+        include_function_params: bool,
+    ) -> bool {
+        let Some((class_name, _)) = self.private_static_class_alias.as_ref() else {
+            return false;
+        };
+
+        if include_function_params {
+            for &param_idx in &self.pending_function_body_parameters {
+                let Some(param) = self.arena.get_parameter_at(param_idx) else {
+                    continue;
+                };
+                if self.binding_name_matches(param.name, class_name) {
+                    return true;
+                }
+            }
+        }
+
+        statements.iter().copied().any(|stmt_idx| {
+            self.statement_declares_private_static_class_alias_name(stmt_idx, class_name)
+        })
+    }
+
+    fn binding_name_matches(&self, name_idx: NodeIndex, needle: &str) -> bool {
+        let mut names = Vec::new();
+        self.collect_binding_names(name_idx, &mut names);
+        names.iter().any(|name| name == needle)
+    }
+
+    fn declaration_name_matches(&self, name_idx: NodeIndex, needle: &str) -> bool {
+        self.arena
+            .get(name_idx)
+            .and_then(|node| self.arena.get_identifier(node))
+            .is_some_and(|ident| ident.escaped_text == needle)
+    }
+
+    fn statement_declares_private_static_class_alias_name(
+        &self,
+        stmt_idx: NodeIndex,
+        class_name: &str,
+    ) -> bool {
+        let Some(stmt_node) = self.arena.get(stmt_idx) else {
+            return false;
+        };
+
+        match stmt_node.kind {
+            k if k == syntax_kind_ext::VARIABLE_STATEMENT => {
+                let Some(var_stmt) = self.arena.get_variable(stmt_node) else {
+                    return false;
+                };
+                var_stmt.declarations.nodes.iter().copied().any(|list_idx| {
+                    let Some(list_node) = self.arena.get(list_idx) else {
+                        return false;
+                    };
+                    if let Some(decl) = self.arena.get_variable_declaration(list_node) {
+                        return self.binding_name_matches(decl.name, class_name);
+                    }
+                    let Some(list) = self.arena.get_variable(list_node) else {
+                        return false;
+                    };
+                    list.declarations.nodes.iter().copied().any(|decl_idx| {
+                        self.arena
+                            .get(decl_idx)
+                            .and_then(|decl_node| self.arena.get_variable_declaration(decl_node))
+                            .is_some_and(|decl| self.binding_name_matches(decl.name, class_name))
+                    })
+                })
+            }
+            k if k == syntax_kind_ext::FUNCTION_DECLARATION => self
+                .arena
+                .get_function(stmt_node)
+                .is_some_and(|func| self.declaration_name_matches(func.name, class_name)),
+            k if k == syntax_kind_ext::CLASS_DECLARATION => self
+                .arena
+                .get_class(stmt_node)
+                .is_some_and(|class| self.declaration_name_matches(class.name, class_name)),
+            _ => false,
+        }
     }
 
     /// Check if a receiver expression is simple enough that it doesn't need

--- a/crates/tsz-emitter/src/emitter/literals/core.rs
+++ b/crates/tsz-emitter/src/emitter/literals/core.rs
@@ -29,6 +29,7 @@ impl<'a> Printer<'a> {
         }
 
         if !self.suppress_ns_qualification
+            && self.private_static_class_alias_shadow_depth == 0
             && let Some((class_name, class_alias)) = self.scoped_class_expression_self_alias.clone()
             && original_text == class_name.as_ref()
         {

--- a/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
@@ -193,6 +193,44 @@ class A3 {
 }
 
 #[test]
+fn static_private_method_receiver_respects_local_class_name_shadow() {
+    let source = r#"
+class X {
+    static #m() {
+        const X = {};
+        X.#m();
+    }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains("__classPrivateFieldGet(X, _a, \"m\", _X_m).call(X);"),
+        "Local class-name bindings should be used as the receiver while the private state still uses the class alias.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn static_private_method_receiver_reuses_alias_after_nested_shadow_block() {
+    let source = r#"
+class X {
+    static #m() {
+        {
+            const X = {};
+        }
+        X.#m();
+    }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains("__classPrivateFieldGet(_a, _a, \"m\", _X_m).call(_a);"),
+        "Nested block shadows should not suppress class-alias receivers after the block exits.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn static_private_field_destructuring_uses_simple_receivers_directly() {
     let source = r#"
 class A {

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -179,6 +179,13 @@ impl<'a> Printer<'a> {
             && self.pending_object_rest_param_defaults.is_empty();
 
         if should_emit_single_line {
+            let private_static_shadow = self.block_shadows_private_static_class_alias(
+                &block.statements.nodes,
+                is_function_body_block,
+            );
+            if private_static_shadow {
+                self.private_static_class_alias_shadow_depth += 1;
+            }
             if is_function_body_block {
                 self.ctx.block_scope_state.enter_function_scope();
                 self.register_pending_function_body_parameters();
@@ -212,10 +219,20 @@ impl<'a> Printer<'a> {
             self.map_closing_brace(node);
             self.write(" }");
             self.ctx.block_scope_state.exit_scope();
+            if private_static_shadow {
+                self.private_static_class_alias_shadow_depth -= 1;
+            }
             // Trailing comments are handled by the calling context
             return;
         }
 
+        let private_static_shadow = self.block_shadows_private_static_class_alias(
+            &block.statements.nodes,
+            is_function_body_block,
+        );
+        if private_static_shadow {
+            self.private_static_class_alias_shadow_depth += 1;
+        }
         if is_function_body_block {
             self.ctx.block_scope_state.enter_function_scope();
             self.register_pending_function_body_parameters();
@@ -637,6 +654,9 @@ impl<'a> Printer<'a> {
         self.map_closing_brace(node);
         self.write_with_end_marker("}");
         self.ctx.block_scope_state.exit_scope();
+        if private_static_shadow {
+            self.private_static_class_alias_shadow_depth -= 1;
+        }
         // Restore declared_namespace_names for non-function blocks to prevent
         // block-scoped let declarations from leaking to sibling blocks.
         if let Some(prev) = prev_declared_ns {


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Emit/DTS parity: JavaScript private-name emit slice for class/private/accessor/decorator lowering.

## Invariant
When a private static member receiver is written with the class name inside a block that locally declares the same name, `tsc` keeps the local receiver expression but still uses the synthetic class alias as the private state argument. This PR makes tsz apply private static class aliases only while the class name is not shadowed in the current function/block scope.

## Scope
- `crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs`
- `crates/tsz-emitter/src/emitter/literals/core.rs`
- `crates/tsz-emitter/src/emitter/statements/core.rs`
- `crates/tsz-emitter/src/emitter/core.rs`
- `crates/tsz-emitter/src/emitter/core_setup.rs`
- `crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs`

## Owner Layer
Output layer: private-field receiver lowering plus identifier self-alias substitution. The fix uses syntactic block/function binding facts available to the emitter; it does not add checker imports, semantic validation, or output-string surgery.

## Adjacent-Case Matrix
- Local `const X` in the extracted private method body: receiver stays `X`, private state stays the class alias.
- Nested block `const X` followed by an outer `X.#m()` call: alias substitution resumes after the nested block exits.
- Existing private tagged-template/call/destructuring tests remain covered by the focused `private_tagged_template_tests` unit filter.

## Project Corpus Impact
- Row: n/a
- Bug family: class/private/accessor/decorator lowering
- Evidence: JS emit baseline `privateStaticNameShadowing` now passes; no project-corpus row was run because this is a focused JS emit parity fix.

## Verification
- `cargo nextest run -p tsz-emitter static_private_method_receiver`
- `cargo nextest run -p tsz-emitter private_tagged_template_tests`
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/emit/run.sh --filter=privateStaticNameShadowing --js-only --verbose --timeout=15000 --json-out=/tmp/studio-c-privateStaticNameShadowing-after.json`
- `scripts/emit/run.sh --filter=private --js-only --timeout=15000 --json-out=/tmp/studio-c-private-shadow-family-after.json` (287/310; expected remaining failures include sibling pending PR slices such as `privateIndexer2` and `privateNameMethodInStaticFieldInit`)

## Coordination Notes
- This is a non-overlapping Studio-C slice after #10701 and #10704. It does not include either pending PR's changes.
- Current head: `a9b3a5c26498100adc77d32a4604bd8dbf50328a`.
- Ready for review after labels/body verification; ready-state CI should provide heavy emit/conformance/fourslash coverage.
