### PR TITLE
chore(arch): add FILE_LINE_LIMIT ratchets for uncovered oversized crate files

### DIFF
--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -306,6 +306,85 @@ FILE_LINE_LIMIT_CHECKS = [
         / "async_es5_ir.rs",
         5150,
     ),
+    # Config monolith: tsconfig/compiler-options parser. Issue #8280 tracks
+    # splitting into option-domain submodules. Ratchet down as domains land.
+    (
+        "Core boundary: tsconfig/config monolith size ratchet (#8280)",
+        ROOT / "crates" / "tsz-core" / "src" / "config" / "mod.rs",
+        8206,
+    ),
+    # LSP signature-help: carries TypeData and direct lookup() baseline debt
+    # (see arch_guard_policy.toml exclusions). Ratchet down per §19 splitting
+    # and arch-debt burn-down in Track 10.
+    (
+        "LSP boundary: signature_help monolith size ratchet",
+        ROOT / "crates" / "tsz-lsp" / "src" / "signature_help.rs",
+        4808,
+    ),
+    # Scanner main loop: issue #9431 tracks splitting by token family.
+    (
+        "Scanner boundary: scanner_impl monolith size ratchet (#9431)",
+        ROOT / "crates" / "tsz-scanner" / "src" / "scanner_impl.rs",
+        4173,
+    ),
+    # CLI driver resolution: source/module-resolution and program build setup.
+    # Ratchet down as resolution phases are extracted per §19.
+    (
+        "CLI boundary: driver/resolution monolith size ratchet",
+        ROOT / "crates" / "tsz-cli" / "src" / "driver" / "resolution.rs",
+        4109,
+    ),
+    # Emitter class declarations: split by emit feature family per §19.
+    (
+        "Emitter boundary: class declaration emitter size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-emitter"
+        / "src"
+        / "emitter"
+        / "declarations"
+        / "class"
+        / "emit_es6.rs",
+        4105,
+    ),
+    # CLI driver check-utils: ProgramData construction. Issue #9412 tracks
+    # extracting the source-resolution phase.
+    (
+        "CLI boundary: driver/check_utils monolith size ratchet (#9412)",
+        ROOT / "crates" / "tsz-cli" / "src" / "driver" / "check_utils.rs",
+        3949,
+    ),
+    # LSP module-specifier resolution: split by resolution family per §19.
+    (
+        "LSP boundary: module_specifiers monolith size ratchet",
+        ROOT / "crates" / "tsz-lsp" / "src" / "project" / "module_specifiers.rs",
+        3669,
+    ),
+    # LSP import candidate collection: issue #9420 tracks splitting collection
+    # from ranking and rendering.
+    (
+        "LSP boundary: project/imports monolith size ratchet (#9420)",
+        ROOT / "crates" / "tsz-lsp" / "src" / "project" / "imports.rs",
+        3384,
+    ),
+    # Binder declaration binding: split by declaration family per §19.
+    (
+        "Binder boundary: binder/declaration monolith size ratchet",
+        ROOT / "crates" / "tsz-binder" / "src" / "binding" / "declaration.rs",
+        3038,
+    ),
+    # Emitter class ES5 AST-to-IR: issue #10638 tracks splitting alongside
+    # async_es5_ir.rs.
+    (
+        "Emitter boundary: class ES5 AST-to-IR engine size ratchet (#10638)",
+        ROOT
+        / "crates"
+        / "tsz-emitter"
+        / "src"
+        / "transforms"
+        / "class_es5_ast_to_ir.rs",
+        2985,
+    ),
 ]
 
 # Pin field counts on giant coordination structs so workstream-4 (Checker

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -307,7 +307,7 @@ FILE_LINE_LIMIT_CHECKS = [
         5150,
     ),
     # Config monolith: tsconfig/compiler-options parser. Issue #8280 tracks
-    # splitting into option-domain submodules. Ratchet down as domains land.
+    # splitting into option-domain submodules. Ratchet down as each domain lands.
     (
         "Core boundary: tsconfig/config monolith size ratchet (#8280)",
         ROOT / "crates" / "tsz-core" / "src" / "config" / "mod.rs",

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -345,7 +345,7 @@ FILE_LINE_LIMIT_CHECKS = [
         / "declarations"
         / "class"
         / "emit_es6.rs",
-        4105,
+        4110,
     ),
     # CLI driver check-utils: ProgramData construction. Issue #9412 tracks
     # extracting the source-resolution phase.

--- a/scripts/arch/test_arch_guard.py
+++ b/scripts/arch/test_arch_guard.py
@@ -1078,5 +1078,32 @@ class ArchGuardCheckerContextLifetimeManifestTests(unittest.TestCase):
 
 
 
+class ArchGuardAllFileLimitChecksPassTests(unittest.TestCase):
+    """Generic guard: every FILE_LINE_LIMIT_CHECKS entry must exist on disk
+    and must not exceed its pinned cap.  This catches entries (like
+    async_es5_ir.rs) that have no dedicated per-entry test class."""
+
+    def setUp(self):
+        self.arch_guard = load_arch_guard_module()
+
+    def test_all_file_limit_paths_exist(self):
+        for name, path, _limit in self.arch_guard.FILE_LINE_LIMIT_CHECKS:
+            self.assertTrue(
+                path.exists(),
+                f"FILE_LINE_LIMIT_CHECKS entry '{name}': path {path} does not exist. "
+                "Remove the entry or fix the path.",
+            )
+
+    def test_all_file_limit_caps_are_not_exceeded(self):
+        for name, path, limit in self.arch_guard.FILE_LINE_LIMIT_CHECKS:
+            hits = self.arch_guard.scan_file_line_limit(path, limit)
+            self.assertEqual(
+                hits,
+                [],
+                f"FILE_LINE_LIMIT_CHECKS entry '{name}': cap {limit} is too tight "
+                f"for the live file ({hits}). Bump the cap or split the file.",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
AgentName: Studio-F

## Track

Track 10 — Launch infrastructure / architecture guardrails

## Invariant

`python3 scripts/arch/arch_guard.py` passes before and after this change. All 469 arch guard tests pass locally.

## Scope

Add 10 `FILE_LINE_LIMIT_CHECKS` entries to `scripts/arch/arch_guard_shared.py` for non-checker crate files that are well above the §19 hard 2000-line cap but had no LOC ratchet. Each entry pins the file at its current line count, making future growth a visible, deliberate arch-guard failure rather than silent accumulation.

Also adds `ArchGuardAllFileLimitChecksPassTests` to `test_arch_guard.py` — a generic test class that verifies **every** `FILE_LINE_LIMIT_CHECKS` entry (1) has a path that exists on disk and (2) passes its pinned cap. This closes the coverage gap for the `async_es5_ir.rs` entry (added earlier with no dedicated test) and all future entries.

### Files newly ratcheted

| File | Lines | Companion issue |
|---|---:|---|
| `crates/tsz-core/src/config/mod.rs` | 8206 | #8280 |
| `crates/tsz-lsp/src/signature_help.rs` | 4808 | #10708 (filed this PR) |
| `crates/tsz-scanner/src/scanner_impl.rs` | 4173 | #9431 |
| `crates/tsz-cli/src/driver/resolution.rs` | 4109 | #10709 (filed this PR) |
| `crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs` | 4110 | — |
| `crates/tsz-cli/src/driver/check_utils.rs` | 3949 | #9412 |
| `crates/tsz-lsp/src/project/module_specifiers.rs` | 3669 | — |
| `crates/tsz-lsp/src/project/imports.rs` | 3384 | #9420 |
| `crates/tsz-binder/src/binding/declaration.rs` | 3038 | — |
| `crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs` | 2985 | #10638 |

Prior to this PR, only 4 files had `FILE_LINE_LIMIT_CHECKS` entries (`lib.rs`, `query_boundaries/common.rs`, `generic_call/resolve.rs`, `async_es5_ir.rs`). After this PR, all 14 known oversized files above ~2900 lines have a freeze cap.

`signature_help.rs` (#10708) also carries two arch-guard baseline-debt exclusions (TypeData inspection + direct `lookup()` on solver interner) — the LOC ratchet here is a pre-condition for the structural cleanup tracked in that issue.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: arch-guard-only / metric ratcheting; no compiler source changes

## Verification

```
python3 scripts/arch/arch_guard.py
# → Architecture guardrails passed.

cd scripts/arch && python3 -m unittest discover -p "test_arch_guard*.py"
# → Ran 469 tests in 44s OK
```

## Coordination Notes

- Ratchet caps are set at the live line count on `main` as of 2026-05-28. The `emit_es6.rs` cap was updated to 4110 to match main after sibling PRs landed.
- Companion issues #10708 and #10709 are new. Issues #8280, #9431, #9412, #9420, #10638 are pre-existing.
- No behavior changes. Emit, conformance, fourslash, and WASM suites are unaffected.
