### PR TITLE
fix(checker): resolve lib type aliases to their interface body, not {}

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -379,6 +379,10 @@ name = "lib_merge_indexed_access_no_cascade_tests"
 path = "tests/lib_merge_indexed_access_no_cascade_tests.rs"
 
 [[test]]
+name = "lib_type_alias_to_interface_resolution_tests"
+path = "tests/lib_type_alias_to_interface_resolution_tests.rs"
+
+[[test]]
 name = "readonly_tuple_source_display_tests"
 path = "tests/readonly_tuple_source_display_tests.rs"
 

--- a/crates/tsz-checker/src/types/queries/lib.rs
+++ b/crates/tsz-checker/src/types/queries/lib.rs
@@ -192,49 +192,63 @@ impl<'a> CheckerState<'a> {
                 };
 
                 if !symbol.declarations.is_empty() {
-                    // Use lower_merged_interface_declarations for proper multi-arena support
-                    let (ty, params) =
-                        lowering.lower_merged_interface_declarations(&decls_with_arenas);
+                    // Type aliases (e.g. `type ElementTagNameMap = HTMLElementTagNameMap & ...`,
+                    // `type SVGMatrix = DOMMatrix`) must NOT go through interface lowering:
+                    // `lower_merged_interface_declarations` treats a type-alias declaration node
+                    // as an interface with no members and returns a non-ERROR empty object `{}`,
+                    // which then shadows the real alias body. `resolve_lib_type_by_name` already
+                    // guards this the same way; keep both lib resolution paths consistent.
+                    let is_type_alias = symbol.has_any_flags(symbol_flags::TYPE_ALIAS);
 
-                    // If interface lowering succeeded (not ERROR), use the result
-                    if ty != TypeId::ERROR {
-                        // For the first definition, record canonical type parameter TypeIds
-                        if first_params.is_none() && !params.is_empty() {
-                            first_params = Some(params.clone());
-                            // Compute TypeIds for these canonical params (reuse outer factory)
-                            canonical_param_type_ids =
-                                params.iter().map(|p| factory.type_param(*p)).collect();
+                    if !is_type_alias {
+                        // Use lower_merged_interface_declarations for proper multi-arena support
+                        let (ty, params) =
+                            lowering.lower_merged_interface_declarations(&decls_with_arenas);
 
-                            // Cache type parameters for Application expansion.
-                            // Use the canonical (merged-binder) SymbolId so the DefId
-                            // matches what type reference resolution produces.
-                            self.ctx
-                                .cache_canonical_lib_type_params(name, sym_id, params.clone());
+                        // If interface lowering succeeded (not ERROR), use the result
+                        if ty != TypeId::ERROR {
+                            // For the first definition, record canonical type parameter TypeIds
+                            if first_params.is_none() && !params.is_empty() {
+                                first_params = Some(params.clone());
+                                // Compute TypeIds for these canonical params (reuse outer factory)
+                                canonical_param_type_ids =
+                                    params.iter().map(|p| factory.type_param(*p)).collect();
 
-                            lib_types.push(ty);
-                        } else if !params.is_empty() && !canonical_param_type_ids.is_empty() {
-                            // For subsequent definitions with type params, substitute them
-                            // with the canonical TypeIds to ensure consistency.
-                            // This fixes the Array<T1> & Array<T2> problem where T1 != T2.
-                            let mut subst = TypeSubstitution::new();
-                            for (i, p) in params.iter().enumerate() {
-                                if i < canonical_param_type_ids.len() {
-                                    subst.insert(p.name, canonical_param_type_ids[i]);
+                                // Cache type parameters for Application expansion.
+                                // Use the canonical (merged-binder) SymbolId so the DefId
+                                // matches what type reference resolution produces.
+                                self.ctx.cache_canonical_lib_type_params(
+                                    name,
+                                    sym_id,
+                                    params.clone(),
+                                );
+
+                                lib_types.push(ty);
+                            } else if !params.is_empty() && !canonical_param_type_ids.is_empty() {
+                                // For subsequent definitions with type params, substitute them
+                                // with the canonical TypeIds to ensure consistency.
+                                // This fixes the Array<T1> & Array<T2> problem where T1 != T2.
+                                let mut subst = TypeSubstitution::new();
+                                for (i, p) in params.iter().enumerate() {
+                                    if i < canonical_param_type_ids.len() {
+                                        subst.insert(p.name, canonical_param_type_ids[i]);
+                                    }
                                 }
-                            }
-                            if !subst.is_empty() {
-                                let substituted_ty = instantiate_type(self.ctx.types, ty, &subst);
-                                lib_types.push(substituted_ty);
+                                if !subst.is_empty() {
+                                    let substituted_ty =
+                                        instantiate_type(self.ctx.types, ty, &subst);
+                                    lib_types.push(substituted_ty);
+                                } else {
+                                    lib_types.push(ty);
+                                }
                             } else {
                                 lib_types.push(ty);
                             }
-                        } else {
-                            lib_types.push(ty);
+                            continue;
                         }
-                        continue;
                     }
 
-                    // Interface lowering returned ERROR - try as type alias
+                    // Type alias, or interface lowering returned ERROR - lower as type alias
                     for (decl_idx, decl_arena) in &decls_with_arenas {
                         if let Some(node) = decl_arena.get(*decl_idx)
                             && let Some(alias) = decl_arena.get_type_alias(node)

--- a/crates/tsz-checker/tests/lib_type_alias_to_interface_resolution_tests.rs
+++ b/crates/tsz-checker/tests/lib_type_alias_to_interface_resolution_tests.rs
@@ -1,0 +1,82 @@
+//! Regression tests: a builtin-lib `type X = SomeInterface` alias must resolve to
+//! the referenced interface, not collapse to the empty object `{}`.
+//!
+//! `resolve_lib_type_with_params` previously fed type-alias declaration nodes
+//! through `lower_merged_interface_declarations`, which treats a type-alias node
+//! as an interface with no members and returns a *non-ERROR* empty object. That
+//! empty object then shadowed the real alias body, so `keyof`/indexed-access/
+//! property lookups over lib aliases such as `SVGMatrix = DOMMatrix`,
+//! `WindowProxy = Window`, or `ElementTagNameMap = HTMLElementTagNameMap & …`
+//! all saw `{}`. The sibling resolver `resolve_lib_type_by_name` already guarded
+//! this with an `is_type_alias` check; the fix brings both paths in line.
+//!
+//! The rule is structural ("a lib type-alias symbol lowers via the type-alias
+//! path, never interface lowering") so it must hold regardless of the alias body
+//! shape — a plain reference, an intersection, or a `Pick`/`Exclude` composite.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::{check_source_with_libs, load_lib_files};
+
+fn check_with_dom(source: &str) -> Vec<Diagnostic> {
+    let libs = load_lib_files(&["es5.d.ts", "es2015.d.ts", "dom.d.ts"]);
+    assert!(!libs.is_empty(), "DOM lib files should be available");
+    check_source_with_libs(source, "test.ts", CheckerOptions::default(), &libs)
+}
+
+/// `type SVGMatrix = DOMMatrix` — a plain alias to an interface. Accessing a
+/// member that lives directly on `DOMMatrix` must succeed (no TS2339 on `{}`).
+#[test]
+fn lib_alias_to_plain_interface_exposes_members() {
+    let diags = check_with_dom("declare const m: SVGMatrix; const x = m.a;");
+    assert!(
+        !diags.iter().any(|d| d.code == 2339),
+        "SVGMatrix (= DOMMatrix) must expose DOMMatrix members, got: {diags:#?}"
+    );
+}
+
+/// `type WindowProxy = Window` — a different alias/interface pair, proving the
+/// fix is not keyed to one spelling.
+#[test]
+fn lib_alias_to_window_interface_exposes_members() {
+    let diags = check_with_dom("declare const w: WindowProxy; const d = w.document;");
+    assert!(
+        !diags.iter().any(|d| d.code == 2339),
+        "WindowProxy (= Window) must expose Window members, got: {diags:#?}"
+    );
+}
+
+/// `type ElementTagNameMap = HTMLElementTagNameMap & Pick<…>` — an intersection
+/// alias. `keyof` over it must be a non-empty key space (so a known tag key is
+/// accepted), proving the alias did not collapse to `{}` (whose `keyof` is
+/// `never`).
+#[test]
+fn lib_intersection_alias_keyof_is_not_never() {
+    // If `keyof ElementTagNameMap` were `never` (the `{}` bug), `K` would be
+    // `never` and the `"div"` literal would be unassignable. With the alias
+    // resolved correctly, `"div"` is a valid key and the assignment type-checks.
+    let source = r#"
+type K = keyof ElementTagNameMap;
+const k: K = "div";
+"#;
+    let diags = check_with_dom(source);
+    assert!(
+        !diags.iter().any(|d| d.code == 2322 || d.code == 2339),
+        "keyof ElementTagNameMap must be a real key union, got: {diags:#?}"
+    );
+}
+
+/// Indexed access over the intersection alias resolves to the element type, so
+/// a member of that element (`HTMLDivElement.align`) is reachable.
+#[test]
+fn lib_intersection_alias_indexed_access_resolves_element() {
+    let source = r#"
+declare const el: ElementTagNameMap["div"];
+const a = el.align;
+"#;
+    let diags = check_with_dom(source);
+    assert!(
+        !diags.iter().any(|d| d.code == 2339),
+        "ElementTagNameMap[\"div\"] must resolve to HTMLDivElement, got: {diags:#?}"
+    );
+}

--- a/crates/tsz-checker/tests/lib_type_alias_to_interface_resolution_tests.rs
+++ b/crates/tsz-checker/tests/lib_type_alias_to_interface_resolution_tests.rs
@@ -20,17 +20,27 @@ use tsz_checker::test_utils::{check_source_with_libs, load_lib_files};
 
 fn check_with_dom(source: &str) -> Vec<Diagnostic> {
     let libs = load_lib_files(&["es5.d.ts", "es2015.d.ts", "dom.d.ts"]);
-    assert!(!libs.is_empty(), "DOM lib files should be available");
+    // `load_lib_files` silently skips missing files. A partial load (e.g. only
+    // `es5.d.ts`) would leave DOM globals like `SVGMatrix`/`Window` undefined,
+    // and assertions of the form `!any(d.code == 2339)` would pass on
+    // `TS2304: Cannot find name` instead — green-lighting a broken test. Require
+    // every requested lib file is present so the test actually exercises DOM.
+    assert_eq!(
+        libs.len(),
+        3,
+        "all three lib files must be loaded for DOM tests"
+    );
     check_source_with_libs(source, "test.ts", CheckerOptions::default(), &libs)
 }
 
 /// `type SVGMatrix = DOMMatrix` — a plain alias to an interface. Accessing a
-/// member that lives directly on `DOMMatrix` must succeed (no TS2339 on `{}`).
+/// member that lives directly on `DOMMatrix` must succeed (no `TS2339` on `{}`).
 #[test]
 fn lib_alias_to_plain_interface_exposes_members() {
+    // Snippet is type-correct under tsc: every diagnostic is a regression.
     let diags = check_with_dom("declare const m: SVGMatrix; const x = m.a;");
     assert!(
-        !diags.iter().any(|d| d.code == 2339),
+        diags.is_empty(),
         "SVGMatrix (= DOMMatrix) must expose DOMMatrix members, got: {diags:#?}"
     );
 }
@@ -41,7 +51,7 @@ fn lib_alias_to_plain_interface_exposes_members() {
 fn lib_alias_to_window_interface_exposes_members() {
     let diags = check_with_dom("declare const w: WindowProxy; const d = w.document;");
     assert!(
-        !diags.iter().any(|d| d.code == 2339),
+        diags.is_empty(),
         "WindowProxy (= Window) must expose Window members, got: {diags:#?}"
     );
 }
@@ -49,34 +59,62 @@ fn lib_alias_to_window_interface_exposes_members() {
 /// `type ElementTagNameMap = HTMLElementTagNameMap & Pick<…>` — an intersection
 /// alias. `keyof` over it must be a non-empty key space (so a known tag key is
 /// accepted), proving the alias did not collapse to `{}` (whose `keyof` is
-/// `never`).
+/// `never`). A wrong key must still be rejected so the test fails on a regression
+/// that flips the alias to `any` rather than reporting `{}`.
 #[test]
 fn lib_intersection_alias_keyof_is_not_never() {
     // If `keyof ElementTagNameMap` were `never` (the `{}` bug), `K` would be
     // `never` and the `"div"` literal would be unassignable. With the alias
-    // resolved correctly, `"div"` is a valid key and the assignment type-checks.
+    // resolved correctly, `"div"` is a valid key and the assignment type-checks;
+    // the bogus key `"definitely-not-a-real-tag"` must still be rejected, which
+    // is the lock against a regression that masks the alias as `any`.
     let source = r#"
 type K = keyof ElementTagNameMap;
 const k: K = "div";
+const bad: K = "definitely-not-a-real-tag";
 "#;
     let diags = check_with_dom(source);
-    assert!(
-        !diags.iter().any(|d| d.code == 2322 || d.code == 2339),
-        "keyof ElementTagNameMap must be a real key union, got: {diags:#?}"
+    let codes: Vec<u32> = diags.iter().map(|d| d.code).collect();
+    assert_eq!(
+        codes,
+        vec![2322],
+        "exactly one TS2322 for the bogus tag key (alias must expose a real key union, not `never` or `any`), got: {diags:#?}"
     );
 }
 
 /// Indexed access over the intersection alias resolves to the element type, so
-/// a member of that element (`HTMLDivElement.align`) is reachable.
+/// a member of that element (`HTMLDivElement.align`) is reachable, and a member
+/// that is NOT on the element must still be rejected — proving the alias did
+/// not collapse to `any` (which would silently admit `.notReal`).
 #[test]
 fn lib_intersection_alias_indexed_access_resolves_element() {
     let source = r#"
 declare const el: ElementTagNameMap["div"];
 const a = el.align;
+const b = el.notReal;
 "#;
     let diags = check_with_dom(source);
+    // `.align` (a real HTMLDivElement member) must succeed; `.notReal` must be
+    // rejected with a missing-property diagnostic. tsc emits TS2339; tsz can
+    // emit either TS2339 or TS2812 (which adds a 'try including the dom lib'
+    // hint) depending on whether the lib option lists "dom" explicitly. Accept
+    // either, but require exactly one diagnostic on the bad access and none on
+    // the good one.
+    assert_eq!(
+        diags.len(),
+        1,
+        "exactly one diagnostic expected, got: {diags:#?}"
+    );
+    let d = &diags[0];
     assert!(
-        !diags.iter().any(|d| d.code == 2339),
-        "ElementTagNameMap[\"div\"] must resolve to HTMLDivElement, got: {diags:#?}"
+        d.code == 2339 || d.code == 2812,
+        "`.notReal` must be rejected as a missing property (TS2339 or TS2812), got code {} message {:?}",
+        d.code,
+        d.message_text
+    );
+    assert!(
+        d.message_text.contains("notReal"),
+        "the rejection must be about the `.notReal` access, not `.align`; message = {:?}",
+        d.message_text
     );
 }

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -400,6 +400,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // Helper macro to cache a definitive subtype result, but only when the
         // computation did not depend on a `Lazy` whose body was unresolved
         // (which would make the result undetermined and poison the cache).
+        //
+        // This is best-effort and intentionally conservative: the snapshot is
+        // process-wide (thread-local), so *any* unresolved-`Lazy` event anywhere
+        // in this top-level call's subtree — even in a branch whose result did
+        // not feed the final answer — suppresses the write. That only ever skips
+        // a cache write (correctness-preserving: the result is recomputed later,
+        // when the body is registered), never produces a wrong answer. Captures
+        // `lazy_failures_at_entry` from the enclosing scope by name.
         macro_rules! cache_definitive {
             ($db:expr, $key:expr, $result:expr) => {
                 if lazy_resolve_failure_count() == lazy_failures_at_entry {

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -33,6 +33,26 @@ use crate::visitor::{
 // (2 per check_subtype call instead of 4). Layout: high 32 bits = fuel, low 32 bits = depth.
 thread_local! {
     static GLOBAL_SUBTYPE_STATE: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    // Monotonic counter bumped whenever a `Lazy(DefId)` could not be resolved
+    // (its body is not yet registered — typically a re-entrant lib-resolution
+    // window). A subtype result computed while this counter changed depended on
+    // an undetermined type and must NOT be cached as definitive, or it poisons
+    // every later structural check that shares the same member type.
+    static LAZY_RESOLVE_FAILURES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+/// Record that a `Lazy(DefId)` failed to resolve during a relation check.
+#[inline]
+pub(crate) fn note_lazy_resolve_failure() {
+    LAZY_RESOLVE_FAILURES.with(|c| c.set(c.get().wrapping_add(1)));
+}
+
+/// Current value of the unresolved-`Lazy` counter; compare a snapshot taken
+/// before computing a result with the value after to detect whether the
+/// computation depended on an unresolved `Lazy`.
+#[inline]
+pub(crate) fn lazy_resolve_failure_count() -> u64 {
+    LAZY_RESOLVE_FAILURES.with(std::cell::Cell::get)
 }
 
 /// Pack depth (low 32) and fuel (high 32) into a single u64.
@@ -355,6 +375,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             (depth, fuel)
         });
 
+        // Snapshot the unresolved-`Lazy` counter. If it changes while computing
+        // this pair's result, the result depended on a `Lazy` whose body was not
+        // yet registered, so a `False` is undetermined and must not be cached.
+        let lazy_failures_at_entry = lazy_resolve_failure_count();
+
         // Helper macro to decrement global depth and optionally reset fuel on early returns.
         macro_rules! leave_global {
             () => {
@@ -368,6 +393,21 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                         s.set(pack_depth_fuel(depth, unpack_fuel(prev)));
                     }
                 });
+            };
+        }
+
+        // Helper macro to cache a definitive subtype result, but only when the
+        // computation did not depend on a `Lazy` whose body was unresolved
+        // (which would make the result undetermined and poison the cache).
+        macro_rules! cache_definitive {
+            ($db:expr, $key:expr, $result:expr) => {
+                if lazy_resolve_failure_count() == lazy_failures_at_entry {
+                    match $result {
+                        SubtypeResult::True => $db.insert_subtype_cache($key, true),
+                        SubtypeResult::False => $db.insert_subtype_cache($key, false),
+                        SubtypeResult::CycleDetected | SubtypeResult::DepthExceeded => {}
+                    }
+                }
             };
         }
 
@@ -730,11 +770,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 self.guard.leave(pair);
                 if !has_this_type && let Some(db) = self.query_db {
                     let key = self.make_cache_key(source, target);
-                    match result {
-                        SubtypeResult::True => db.insert_subtype_cache(key, true),
-                        SubtypeResult::False => db.insert_subtype_cache(key, false),
-                        _ => {}
-                    }
+                    cache_definitive!(db, key, result);
                 }
                 leave_global!();
                 return result;
@@ -793,11 +829,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             self.guard.leave(pair);
             if !has_this_type && let Some(db) = self.query_db {
                 let key = self.make_cache_key(source, target);
-                match result {
-                    SubtypeResult::True => db.insert_subtype_cache(key, true),
-                    SubtypeResult::False => db.insert_subtype_cache(key, false),
-                    SubtypeResult::CycleDetected | SubtypeResult::DepthExceeded => {}
-                }
+                cache_definitive!(db, key, result);
             }
             leave_global!();
             return result;
@@ -818,11 +850,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             self.guard.leave(pair);
             if !has_this_type && let Some(db) = self.query_db {
                 let key = self.make_cache_key(source, target);
-                match result {
-                    SubtypeResult::True => db.insert_subtype_cache(key, true),
-                    SubtypeResult::False => db.insert_subtype_cache(key, false),
-                    SubtypeResult::CycleDetected | SubtypeResult::DepthExceeded => {}
-                }
+                cache_definitive!(db, key, result);
             }
             leave_global!();
             return result;
@@ -902,11 +930,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // Skip ThisType: results are context-dependent (see lookup guard above).
         if !has_this_type && let Some(db) = self.query_db {
             let key = self.make_cache_key(source, target);
-            match result {
-                SubtypeResult::True => db.insert_subtype_cache(key, true),
-                SubtypeResult::False => db.insert_subtype_cache(key, false),
-                SubtypeResult::CycleDetected | SubtypeResult::DepthExceeded => {}
-            }
+            cache_definitive!(db, key, result);
         }
 
         // Decrement global depth; reset fuel when outermost call completes.

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -73,11 +73,12 @@ const fn unpack_fuel(state: u64) -> u32 {
     (state >> 32) as u32
 }
 
-/// Reset subtype depth and fuel counters.
+/// Reset subtype depth, fuel, and unresolved-`Lazy`-failure counters.
 /// Called between compilation sessions to prevent stale state from a previous
 /// compilation (e.g., if it panicked and left counters dirty).
 pub fn reset_subtype_thread_local_state() {
     GLOBAL_SUBTYPE_STATE.with(|s| s.set(0));
+    LAZY_RESOLVE_FAILURES.with(|c| c.set(0));
 }
 
 // Maximum number of non-trivial subtype checks per top-level call chain.

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -1016,6 +1016,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return false;
         }
         let Some(body) = self.resolver.resolve_lazy(def_id, self.interner) else {
+            // Same undetermined-result event as `resolve_lazy_type`: the
+            // conditional-alias-base decision derived from an unresolvable
+            // `Lazy` must not poison the subtype cache in the enclosing call.
+            note_lazy_resolve_failure();
             return false;
         };
         if matches!(self.interner.lookup(body), Some(TypeData::Conditional(_))) {

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -586,6 +586,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     // The def body is not registered yet (re-entrant lib
                     // resolution). Any False derived from comparing the
                     // still-Lazy ref is undetermined and must not be cached.
+                    tracing::trace!(
+                        def_id = def_id.0,
+                        "resolve_lazy_type: body unregistered, recording undetermined-result event"
+                    );
                     super::cache::note_lazy_resolve_failure();
                     type_id
                 }

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -580,10 +580,16 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
     pub(crate) fn resolve_lazy_type(&self, type_id: TypeId) -> TypeId {
         if let Some(def_id) = lazy_def_id(self.interner, type_id) {
-            self.resolver
-                .resolve_lazy(def_id, self.interner)
-                .map(|resolved| self.bind_polymorphic_this(type_id, resolved))
-                .unwrap_or(type_id)
+            match self.resolver.resolve_lazy(def_id, self.interner) {
+                Some(resolved) => self.bind_polymorphic_this(type_id, resolved),
+                None => {
+                    // The def body is not registered yet (re-entrant lib
+                    // resolution). Any False derived from comparing the
+                    // still-Lazy ref is undetermined and must not be cached.
+                    super::cache::note_lazy_resolve_failure();
+                    type_id
+                }
+            }
         } else {
             type_id
         }

--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -995,7 +995,18 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
         let def_id = self.application_base_def_id(app.base)?;
         let type_params = self.resolver.get_lazy_type_params(def_id)?;
-        let resolved_body = self.resolver.resolve_lazy(def_id, self.interner)?;
+        let resolved_body = match self.resolver.resolve_lazy(def_id, self.interner) {
+            Some(body) => body,
+            None => {
+                // Re-entrant lib resolution: the application's base def has
+                // no body registered yet. The caller propagates `None` into a
+                // structural fallback that can produce a cacheable False —
+                // record the undetermined-result event so the enclosing
+                // `check_subtype` call skips caching for this pair.
+                crate::relations::subtype::cache::note_lazy_resolve_failure();
+                return None;
+            }
+        };
         let effective_body = if matches!(
             self.resolver.get_def_kind(def_id),
             Some(crate::def::DefKind::Class)
@@ -1758,7 +1769,18 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
         let def_id = self.application_base_def_id(app.base)?;
         let type_params = self.resolver.get_lazy_type_params(def_id)?;
-        let resolved_body = self.resolver.resolve_lazy(def_id, self.interner)?;
+        let resolved_body = match self.resolver.resolve_lazy(def_id, self.interner) {
+            Some(body) => body,
+            None => {
+                // Re-entrant lib resolution: the application's base def has
+                // no body registered yet. The caller propagates `None` into a
+                // structural fallback that can produce a cacheable False —
+                // record the undetermined-result event so the enclosing
+                // `check_subtype` call skips caching for this pair.
+                crate::relations::subtype::cache::note_lazy_resolve_failure();
+                return None;
+            }
+        };
         let effective_body = if matches!(
             self.resolver.get_def_kind(def_id),
             Some(crate::def::DefKind::Class)

--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -283,9 +283,19 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             }
         }
 
-        // Resolve DefIds to their structural forms
+        // Resolve DefIds to their structural forms. A `None` here means the
+        // body is not yet registered (re-entrant lib resolution); record an
+        // undetermined-result event so the enclosing `check_subtype`'s
+        // cache write is skipped instead of caching a False that depended on
+        // a transiently-unresolvable ref.
         let s_resolved = self.resolver.resolve_lazy(s_def, self.interner);
+        if s_resolved.is_none() {
+            crate::relations::subtype::cache::note_lazy_resolve_failure();
+        }
         let t_resolved = self.resolver.resolve_lazy(t_def, self.interner);
+        if t_resolved.is_none() {
+            crate::relations::subtype::cache::note_lazy_resolve_failure();
+        }
 
         // Detect self-referencing Lazy types (namespace circular references).
         // When a namespace's DefId resolves back to Lazy(same_DefId), it means


### PR DESCRIPTION
AgentName: cloud-opus47-1m-confident-thompson

Relates to #10349 (large-union / relation-depth family).

## Summary

A builtin-lib `type X = SomeInterface` alias resolved to the empty object
`{}` instead of the referenced type. `resolve_lib_type_with_params`
(`crates/tsz-checker/src/types/queries/lib.rs`) fed type-alias declaration
nodes through `lower_merged_interface_declarations`, which treats a
type-alias node as a member-less interface and returns a **non-ERROR** `{}`
that shadowed the real alias body. The sibling resolver
`resolve_lib_type_by_name` already guarded this with an `is_type_alias`
check; this brings both lib-resolution paths in line so the alias body lowers
via the type-alias path.

## Structural rule

> When a lib symbol carries the `TYPE_ALIAS` flag, its type lowers via the
> type-alias path, never via interface-declaration lowering — because lowering
> a type-alias declaration node as an interface yields a non-ERROR empty
> object `{}` that masks the alias body.

This is independent of the alias body shape — a plain reference
(`SVGMatrix = DOMMatrix`), an alias to a large interface
(`WindowProxy = Window`), or a `Pick`/`Exclude` composite
(`ElementTagNameMap = HTMLElementTagNameMap & Pick<…>`). Before the fix,
`keyof`/indexed-access/property lookups over any of these saw `{}` (whose
`keyof` is `never`).

## Owner layer & why

`tsz-checker` lib type resolution (`types/queries/lib.rs`). The empty-object
masking happened in the checker's lib-resolution dispatch; the fix is the
type-alias-vs-interface dispatch decision, mirroring the existing guard in
the sibling resolver. No solver type algorithm changed for the alias body.

## Secondary change — relation-cache hardening

Resolving these aliases expands large DOM unions, which **re-enters** lib
resolution while member refs (`Node`, `Element`, event-listener types) are
still in progress. A transient `Lazy(DefId)`-resolution failure during that
window could cache an *undetermined* subtype result and poison later
structural checks that share the member type.

The subtype checker now records an unresolved-`Lazy` event
(`note_lazy_resolve_failure`) whenever `resolver.resolve_lazy` returns `None`
in the subtype crate, and `check_subtype` skips caching any result computed
across one (the new `cache_definitive!` macro snapshots the counter at entry
and compares at the write site). Results are still returned correctly for the
in-flight query; only the *cache write* is suppressed so the relation
re-evaluates once the body is registered. `DepthExceeded`-style coinductive
semantics already treat this as non-cached, so this is consistent with the
existing overflow philosophy.

Hardening sites covered: `core.rs::resolve_lazy_type`,
`cache.rs::is_conditional_alias_base_inline`, and three sites in
`rules/generics.rs`.

## Known remaining tail (NOT fixed here)

`#10349`'s two retained conformance paths
(`intersectionsOfLargeUnions.ts`, `intersectionsOfLargeUnions2.ts`) expect
ordinary `TS2536` index errors. With this fix the `TS2536`s now fire
correctly, but the large-union generic **type-predicate** relation can still
report a transient false `TS2677` in the narrow
`x is T where T extends keyof ElementTagNameMap` pattern — a deep
re-entrant resolution-ordering issue (`ArrayBufferTypes` and event-listener
defs returning `None` at predicate-check time). That is a separate, deeper
fix and is **out of scope** here; the relation-cache hardening reduces but
does not eliminate it. **The accepted-regression entries for those two paths
are intentionally left in place** — this PR does not claim to close #10349.

## Scope

- `crates/tsz-checker/src/types/queries/lib.rs` — `is_type_alias` guard.
- `crates/tsz-solver/src/relations/subtype/{cache.rs,core.rs,rules/generics.rs}`
  — unresolved-`Lazy` event + cache-skip.
- `crates/tsz-checker/tests/lib_type_alias_to_interface_resolution_tests.rs`
  (+ `Cargo.toml` registration) — new regression tests.

## Adjacent-case test matrix

- Reported shape: lib alias to interface (`SVGMatrix = DOMMatrix`).
- Equivalent shapes proving the rule (not a spelling): `WindowProxy = Window`,
  and the `ElementTagNameMap` intersection alias.
- `keyof` over the alias is a real key union (not `never`), with a negative
  probe (a bogus tag key must still be rejected — guards against the alias
  regressing to `any`).
- Indexed access over the alias resolves to the element type, with a negative
  probe (`.notReal` must still be rejected).

## Project Corpus Impact

- Row: n/a (no single project-corpus row attributed; broad lib-resolution fix)
- Bug family: lib type-alias resolution to `{}` (affects DOM-heavy corpora — `kysely-project`, `zod-project`, and any project using lib `type X = Interface` aliases)
- Evidence: local CLI repro (`SVGMatrix`/`WindowProxy`/`ElementTagNameMap` property access now succeeds), 4 new owning-crate unit tests, and the `intersectionsOfLargeUnions` `TS2536` fixtures now emitting the expected codes. Full conformance/emit/fourslash impact is delegated to ready-for-review CI (cannot run the full suites locally per §19.5).

## Verification

- `cargo build -p tsz-cli` — clean.
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets` — clean.
- `cargo test -p tsz-checker --test lib_type_alias_to_interface_resolution_tests`
  — 4/4 pass.
- `cargo test -p tsz-solver --lib` — no new failures (21 pre-existing
  failures match clean `main`).
- Manual CLI: lib alias property access / `keyof` / indexed-access repros
  resolve correctly; `intersectionsOfLargeUnions` emits 2× `TS2536`.
- Rebased onto latest `main`; builds clean post-rebase.

## Coordination Notes

3 rounds of multi-angle code review (`/simplify`) applied: tightened test
assertions (exact code/message + negative probes), reset all subtype TLS
counters, added observability tracing, and broadened the unresolved-`Lazy`
event coverage to every in-crate `resolve_lazy` site that feeds a cacheable
result. The deeper large-union predicate re-entrancy is left as a documented
follow-up for the #10349 owner; accepted-regression entries untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_013N17FwgXZ8aN45UXUZykRS)_