### PR TITLE
fix(solver): allow deferred IndexAccess as spread operand

### DIFF
--- a/crates/tsz-checker/tests/spread_rest_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/spread_rest_diagnostics_tests.rs
@@ -690,6 +690,28 @@ function f<T>(x: keyof T) {
 }
 
 #[test]
+fn test_no_ts2698_for_spread_of_deferred_conditional() {
+    // tsc treats a deferred `T extends … ? … : …` as `InstantiableNonPrimitive`
+    // when no useful base constraint can be computed. tsz already accepts
+    // these through the catch-all arm in `is_valid_spread_type_impl`; this
+    // test pins that behavior so it doesn't drift while the IndexAccess
+    // and KeyOf arms move around.
+    let source = r#"
+function f<T>(x: T extends string ? { s: string } : { n: number }) {
+    return { ...x };
+}
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let ts2698 = diagnostic_count(&diagnostics, 2698);
+    assert_eq!(
+        ts2698,
+        0,
+        "TS2698 must not fire for spread of a deferred conditional; got: {:?}",
+        diagnostic_messages_with_code(&diagnostics, 2698)
+    );
+}
+
+#[test]
 fn test_ts2698_still_fires_for_spread_of_t_extends_string() {
     // Negative case: `T extends string` reduces to a primitive constraint,
     // which is not spreadable.

--- a/crates/tsz-checker/tests/spread_rest_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/spread_rest_diagnostics_tests.rs
@@ -607,6 +607,106 @@ const d = [...n];
     );
 }
 
+// =============================================================================
+// Deferred IndexAccess in object spread — tsc `InstantiableNonPrimitive` rule
+//
+// `{ ...x }` where the operand `x: T[K]` is a deferred indexed access on
+// generic type parameters must NOT emit TS2698. tsc's `isValidSpreadType`
+// passes deferred IndexAccess via the `InstantiableNonPrimitive` flag
+// when no useful base constraint can be computed; tsz must mirror that
+// behavior at the solver query layer (not by spelling/file/identifier
+// heuristics).
+// =============================================================================
+
+#[test]
+fn test_no_ts2698_for_spread_of_unconstrained_index_access() {
+    let source = r#"
+function f<T, K>(x: T[K]) {
+    return { ...x };
+}
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let ts2698 = diagnostic_count(&diagnostics, 2698);
+    assert_eq!(
+        ts2698,
+        0,
+        "TS2698 must not fire for `{{ ...x }}` where x is a deferred T[K]; got: {:?}",
+        diagnostic_messages_with_code(&diagnostics, 2698)
+    );
+}
+
+#[test]
+fn test_no_ts2698_for_spread_of_renamed_index_access() {
+    // Same structural rule with renamed type parameters — pins that the fix
+    // does not depend on the spelling `T`/`K`.
+    let source = r#"
+function f<Alpha, Beta>(x: Alpha[Beta]) {
+    return { ...x };
+}
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let ts2698 = diagnostic_count(&diagnostics, 2698);
+    assert_eq!(
+        ts2698,
+        0,
+        "TS2698 must not fire for renamed generic indexed access spread; got: {:?}",
+        diagnostic_messages_with_code(&diagnostics, 2698)
+    );
+}
+
+#[test]
+fn test_no_ts2698_for_spread_of_index_access_with_object_constraint() {
+    let source = r#"
+function f<T extends object, K extends keyof T>(x: T[K]) {
+    return { ...x };
+}
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let ts2698 = diagnostic_count(&diagnostics, 2698);
+    assert_eq!(
+        ts2698,
+        0,
+        "TS2698 must not fire for spread of T[K] where T extends object; got: {:?}",
+        diagnostic_messages_with_code(&diagnostics, 2698)
+    );
+}
+
+#[test]
+fn test_ts2698_still_fires_for_spread_of_keyof_t() {
+    // Negative case: `keyof T` is structurally a property-key primitive,
+    // even when deferred. Spread must still error.
+    let source = r#"
+function f<T>(x: keyof T) {
+    return { ...x };
+}
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let ts2698 = diagnostic_count(&diagnostics, 2698);
+    assert!(
+        ts2698 >= 1,
+        "TS2698 should still fire for spread of `keyof T`; got: {:?}",
+        diagnostic_codes(&diagnostics)
+    );
+}
+
+#[test]
+fn test_ts2698_still_fires_for_spread_of_t_extends_string() {
+    // Negative case: `T extends string` reduces to a primitive constraint,
+    // which is not spreadable.
+    let source = r#"
+function f<T extends string>(x: T) {
+    return { ...x };
+}
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let ts2698 = diagnostic_count(&diagnostics, 2698);
+    assert!(
+        ts2698 >= 1,
+        "TS2698 should still fire for spread of T extends string; got: {:?}",
+        diagnostic_codes(&diagnostics)
+    );
+}
+
 #[test]
 fn test_destructuring_index_signature_only_emits_ts2488_in_es2015() {
     // Pinned by `destructuringArrayBindingPatternAndAssignment2.ts`. tsc emits

--- a/crates/tsz-solver/src/tests/type_queries_spread_tests.rs
+++ b/crates/tsz-solver/src/tests/type_queries_spread_tests.rs
@@ -555,6 +555,41 @@ fn spread_intersection_with_undefined_is_invalid_on_its_own() {
 // property-key primitive even when deferred.
 // =============================================================================
 
+/// Build a type parameter with the standard `default=None, is_const=false`
+/// defaults so the new IndexAccess-spread coverage reads as the *shape* under
+/// test instead of `TypeParamInfo` boilerplate.
+fn tp(db: &TypeInterner, name: &str, constraint: Option<TypeId>) -> TypeId {
+    db.type_param(TypeParamInfo {
+        name: db.intern_string(name),
+        constraint,
+        default: None,
+        is_const: false,
+    })
+}
+
+/// Build a single-property object with `Public` visibility for use as a
+/// generic constraint. The new spread tests only vary by the property's
+/// value type, so the rest of the `PropertyInfo` flags stay at their
+/// minimal defaults.
+fn obj_with_prop(db: &TypeInterner, name: &str, type_id: TypeId) -> TypeId {
+    let prop_name = db.intern_string(name);
+    db.object(vec![PropertyInfo {
+        name: prop_name,
+        type_id,
+        write_type: type_id,
+        optional: false,
+        readonly: false,
+        is_method: false,
+        is_class_prototype: false,
+        visibility: Visibility::Public,
+        parent_id: None,
+        declaration_order: 0,
+        is_string_named: false,
+        is_symbol_named: false,
+        single_quoted_name: false,
+    }])
+}
+
 #[test]
 fn spread_deferred_index_access_unconstrained_both_sides_is_valid() {
     // `<T, K>(x: T[K]) { ...{ ...x } }` — both type parameters unconstrained.
@@ -562,19 +597,7 @@ fn spread_deferred_index_access_unconstrained_both_sides_is_valid() {
     // base-constraint lookup yields nothing useful, so the flag-check arm
     // accepts the spread.
     let db = TypeInterner::new();
-    let t = db.type_param(TypeParamInfo {
-        name: db.intern_string("T"),
-        constraint: None,
-        default: None,
-        is_const: false,
-    });
-    let k = db.type_param(TypeParamInfo {
-        name: db.intern_string("K"),
-        constraint: None,
-        default: None,
-        is_const: false,
-    });
-    let access = db.index_access(t, k);
+    let access = db.index_access(tp(&db, "T", None), tp(&db, "K", None));
     assert!(is_valid_spread_type(&db, access));
 }
 
@@ -583,19 +606,7 @@ fn spread_deferred_index_access_renamed_params_is_valid() {
     // Same structural rule as above with renamed type parameters — confirms
     // the fix is keyed on the structural shape, not the parameter spelling.
     let db = TypeInterner::new();
-    let alpha = db.type_param(TypeParamInfo {
-        name: db.intern_string("Alpha"),
-        constraint: None,
-        default: None,
-        is_const: false,
-    });
-    let beta = db.type_param(TypeParamInfo {
-        name: db.intern_string("Beta"),
-        constraint: None,
-        default: None,
-        is_const: false,
-    });
-    let access = db.index_access(alpha, beta);
+    let access = db.index_access(tp(&db, "Alpha", None), tp(&db, "Beta", None));
     assert!(is_valid_spread_type(&db, access));
 }
 
@@ -605,20 +616,8 @@ fn spread_deferred_index_access_object_constraint_generic_key_is_valid() {
     // The object's constraint is an object type and the key's constraint
     // is `keyof T`. tsc accepts the spread.
     let db = TypeInterner::new();
-    let obj_constraint = db.object(vec![]);
-    let t = db.type_param(TypeParamInfo {
-        name: db.intern_string("T"),
-        constraint: Some(obj_constraint),
-        default: None,
-        is_const: false,
-    });
-    let keyof_t = db.keyof(t);
-    let k = db.type_param(TypeParamInfo {
-        name: db.intern_string("K"),
-        constraint: Some(keyof_t),
-        default: None,
-        is_const: false,
-    });
+    let t = tp(&db, "T", Some(db.object(vec![])));
+    let k = tp(&db, "K", Some(db.keyof(t)));
     let access = db.index_access(t, k);
     assert!(is_valid_spread_type(&db, access));
 }
@@ -631,36 +630,9 @@ fn spread_deferred_index_access_into_record_value_is_valid() {
     // property since we cannot synthesize `Record<…>` at the solver-internal
     // layer without a binder.
     let db = TypeInterner::new();
-    let prop = db.intern_string("prop");
     let inner_obj = db.object(vec![]);
-    let constraint = db.object(vec![PropertyInfo {
-        name: prop,
-        type_id: inner_obj,
-        write_type: inner_obj,
-        optional: false,
-        readonly: false,
-        is_method: false,
-        is_class_prototype: false,
-        visibility: Visibility::Public,
-        parent_id: None,
-        declaration_order: 0,
-        is_string_named: false,
-        is_symbol_named: false,
-        single_quoted_name: false,
-    }]);
-    let t = db.type_param(TypeParamInfo {
-        name: db.intern_string("T"),
-        constraint: Some(constraint),
-        default: None,
-        is_const: false,
-    });
-    let keyof_t = db.keyof(t);
-    let k = db.type_param(TypeParamInfo {
-        name: db.intern_string("K"),
-        constraint: Some(keyof_t),
-        default: None,
-        is_const: false,
-    });
+    let t = tp(&db, "T", Some(obj_with_prop(&db, "prop", inner_obj)));
+    let k = tp(&db, "K", Some(db.keyof(t)));
     let access = db.index_access(t, k);
     assert!(is_valid_spread_type(&db, access));
 }
@@ -672,35 +644,8 @@ fn spread_deferred_index_access_into_primitive_record_is_invalid() {
     // primitives (`{prop: number}`), `T[K]` with `K extends keyof T` would
     // index into `number`. tsc rejects the spread. tsz must still reject.
     let db = TypeInterner::new();
-    let prop = db.intern_string("prop");
-    let constraint = db.object(vec![PropertyInfo {
-        name: prop,
-        type_id: TypeId::NUMBER,
-        write_type: TypeId::NUMBER,
-        optional: false,
-        readonly: false,
-        is_method: false,
-        is_class_prototype: false,
-        visibility: Visibility::Public,
-        parent_id: None,
-        declaration_order: 0,
-        is_string_named: false,
-        is_symbol_named: false,
-        single_quoted_name: false,
-    }]);
-    let t = db.type_param(TypeParamInfo {
-        name: db.intern_string("T"),
-        constraint: Some(constraint),
-        default: None,
-        is_const: false,
-    });
-    let keyof_t = db.keyof(t);
-    let k = db.type_param(TypeParamInfo {
-        name: db.intern_string("K"),
-        constraint: Some(keyof_t),
-        default: None,
-        is_const: false,
-    });
+    let t = tp(&db, "T", Some(obj_with_prop(&db, "prop", TypeId::NUMBER)));
+    let k = tp(&db, "K", Some(db.keyof(t)));
     let access = db.index_access(t, k);
     assert!(!is_valid_spread_type(&db, access));
 }
@@ -713,13 +658,18 @@ fn spread_keyof_deferred_remains_invalid() {
     // Primitive flag does NOT cover `KeyOf` semantically (tsc treats keyof
     // results as primitive `string | number | symbol` keys).
     let db = TypeInterner::new();
-    let t = db.type_param(TypeParamInfo {
-        name: db.intern_string("T"),
-        constraint: None,
-        default: None,
-        is_const: false,
-    });
-    let keyof_t = db.keyof(t);
+    let keyof_t = db.keyof(tp(&db, "T", None));
+    assert!(!is_valid_spread_type(&db, keyof_t));
+}
+
+#[test]
+fn spread_keyof_object_constrained_remains_invalid() {
+    // The deferred `keyof T` rejection must hold regardless of `T`'s
+    // constraint — a future change accidentally treating constrained
+    // `keyof T` as object-like would silently accept primitive property
+    // keys as spread sources.
+    let db = TypeInterner::new();
+    let keyof_t = db.keyof(tp(&db, "T", Some(db.object(vec![]))));
     assert!(!is_valid_spread_type(&db, keyof_t));
 }
 
@@ -729,19 +679,7 @@ fn spread_union_member_deferred_index_access_is_valid() {
     // Each non-falsy member must pass; the deferred IndexAccess member is
     // the only difference from the existing union tests.
     let db = TypeInterner::new();
-    let t = db.type_param(TypeParamInfo {
-        name: db.intern_string("T"),
-        constraint: None,
-        default: None,
-        is_const: false,
-    });
-    let k = db.type_param(TypeParamInfo {
-        name: db.intern_string("K"),
-        constraint: None,
-        default: None,
-        is_const: false,
-    });
-    let access = db.index_access(t, k);
+    let access = db.index_access(tp(&db, "T", None), tp(&db, "K", None));
     let obj = db.object(vec![]);
     let union = db.union(vec![access, obj]);
     assert!(is_valid_spread_type(&db, union));

--- a/crates/tsz-solver/src/tests/type_queries_spread_tests.rs
+++ b/crates/tsz-solver/src/tests/type_queries_spread_tests.rs
@@ -536,6 +536,217 @@ fn spread_intersection_with_undefined_is_invalid_on_its_own() {
     assert!(!is_valid_spread_type(&db, intersection));
 }
 
+// =============================================================================
+// Deferred IndexAccess — tsc's InstantiableNonPrimitive rule
+//
+// tsc's `isValidSpreadType`:
+//   if (type.flags & TypeFlags.Instantiable) {
+//       const constraint = getBaseConstraintOfType(type);
+//       if (constraint !== undefined) return isValidSpreadType(constraint);
+//   }
+//   return !!(type.flags & (Any | NonPrimitive | Object | InstantiableNonPrimitive) | …);
+//
+// `TypeFlags.InstantiableNonPrimitive` covers `IndexedAccess`. When the
+// indexed-access expression cannot be reduced (no usable base constraint),
+// the flag check itself accepts the spread — tsc treats deferred `T[K]` as
+// "could be an object at runtime, allow `{ ...x }`".
+//
+// tsz must mirror this. `keyof T` stays invalid: it is semantically a
+// property-key primitive even when deferred.
+// =============================================================================
+
+#[test]
+fn spread_deferred_index_access_unconstrained_both_sides_is_valid() {
+    // `<T, K>(x: T[K]) { ...{ ...x } }` — both type parameters unconstrained.
+    // tsc: deferred IndexAccess has `InstantiableNonPrimitive` flag and the
+    // base-constraint lookup yields nothing useful, so the flag-check arm
+    // accepts the spread.
+    let db = TypeInterner::new();
+    let t = db.type_param(TypeParamInfo {
+        name: db.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    });
+    let k = db.type_param(TypeParamInfo {
+        name: db.intern_string("K"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    });
+    let access = db.index_access(t, k);
+    assert!(is_valid_spread_type(&db, access));
+}
+
+#[test]
+fn spread_deferred_index_access_renamed_params_is_valid() {
+    // Same structural rule as above with renamed type parameters — confirms
+    // the fix is keyed on the structural shape, not the parameter spelling.
+    let db = TypeInterner::new();
+    let alpha = db.type_param(TypeParamInfo {
+        name: db.intern_string("Alpha"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    });
+    let beta = db.type_param(TypeParamInfo {
+        name: db.intern_string("Beta"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    });
+    let access = db.index_access(alpha, beta);
+    assert!(is_valid_spread_type(&db, access));
+}
+
+#[test]
+fn spread_deferred_index_access_object_constraint_generic_key_is_valid() {
+    // `<T extends Obj, K extends keyof T>(x: T[K]) { ...{ ...x } }`
+    // The object's constraint is an object type and the key's constraint
+    // is `keyof T`. tsc accepts the spread.
+    let db = TypeInterner::new();
+    let obj_constraint = db.object(vec![]);
+    let t = db.type_param(TypeParamInfo {
+        name: db.intern_string("T"),
+        constraint: Some(obj_constraint),
+        default: None,
+        is_const: false,
+    });
+    let keyof_t = db.keyof(t);
+    let k = db.type_param(TypeParamInfo {
+        name: db.intern_string("K"),
+        constraint: Some(keyof_t),
+        default: None,
+        is_const: false,
+    });
+    let access = db.index_access(t, k);
+    assert!(is_valid_spread_type(&db, access));
+}
+
+#[test]
+fn spread_deferred_index_access_into_record_value_is_valid() {
+    // `<T extends Record<string, { x: number }>, K extends keyof T>(x: T[K])`
+    // — the indexed value is structurally an object; tsc accepts the spread.
+    // Modeled directly with an object constraint having an object-typed
+    // property since we cannot synthesize `Record<…>` at the solver-internal
+    // layer without a binder.
+    let db = TypeInterner::new();
+    let prop = db.intern_string("prop");
+    let inner_obj = db.object(vec![]);
+    let constraint = db.object(vec![PropertyInfo {
+        name: prop,
+        type_id: inner_obj,
+        write_type: inner_obj,
+        optional: false,
+        readonly: false,
+        is_method: false,
+        is_class_prototype: false,
+        visibility: Visibility::Public,
+        parent_id: None,
+        declaration_order: 0,
+        is_string_named: false,
+        is_symbol_named: false,
+        single_quoted_name: false,
+    }]);
+    let t = db.type_param(TypeParamInfo {
+        name: db.intern_string("T"),
+        constraint: Some(constraint),
+        default: None,
+        is_const: false,
+    });
+    let keyof_t = db.keyof(t);
+    let k = db.type_param(TypeParamInfo {
+        name: db.intern_string("K"),
+        constraint: Some(keyof_t),
+        default: None,
+        is_const: false,
+    });
+    let access = db.index_access(t, k);
+    assert!(is_valid_spread_type(&db, access));
+}
+
+#[test]
+fn spread_deferred_index_access_into_primitive_record_is_invalid() {
+    // Negative case proving the fix is not "deferred IndexAccess is always
+    // valid". When T's constraint is an object whose property values are
+    // primitives (`{prop: number}`), `T[K]` with `K extends keyof T` would
+    // index into `number`. tsc rejects the spread. tsz must still reject.
+    let db = TypeInterner::new();
+    let prop = db.intern_string("prop");
+    let constraint = db.object(vec![PropertyInfo {
+        name: prop,
+        type_id: TypeId::NUMBER,
+        write_type: TypeId::NUMBER,
+        optional: false,
+        readonly: false,
+        is_method: false,
+        is_class_prototype: false,
+        visibility: Visibility::Public,
+        parent_id: None,
+        declaration_order: 0,
+        is_string_named: false,
+        is_symbol_named: false,
+        single_quoted_name: false,
+    }]);
+    let t = db.type_param(TypeParamInfo {
+        name: db.intern_string("T"),
+        constraint: Some(constraint),
+        default: None,
+        is_const: false,
+    });
+    let keyof_t = db.keyof(t);
+    let k = db.type_param(TypeParamInfo {
+        name: db.intern_string("K"),
+        constraint: Some(keyof_t),
+        default: None,
+        is_const: false,
+    });
+    let access = db.index_access(t, k);
+    assert!(!is_valid_spread_type(&db, access));
+}
+
+#[test]
+fn spread_keyof_deferred_remains_invalid() {
+    // Regression guard for the negative side of the IndexAccess fix:
+    // `keyof T` for an unconstrained `T` is a deferred property-key
+    // primitive. It must still be rejected for spread — the InstantiableNon-
+    // Primitive flag does NOT cover `KeyOf` semantically (tsc treats keyof
+    // results as primitive `string | number | symbol` keys).
+    let db = TypeInterner::new();
+    let t = db.type_param(TypeParamInfo {
+        name: db.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    });
+    let keyof_t = db.keyof(t);
+    assert!(!is_valid_spread_type(&db, keyof_t));
+}
+
+#[test]
+fn spread_union_member_deferred_index_access_is_valid() {
+    // Union of `T[K]` (deferred, unconstrained) and `{}` should be valid.
+    // Each non-falsy member must pass; the deferred IndexAccess member is
+    // the only difference from the existing union tests.
+    let db = TypeInterner::new();
+    let t = db.type_param(TypeParamInfo {
+        name: db.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    });
+    let k = db.type_param(TypeParamInfo {
+        name: db.intern_string("K"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    });
+    let access = db.index_access(t, k);
+    let obj = db.object(vec![]);
+    let union = db.union(vec![access, obj]);
+    assert!(is_valid_spread_type(&db, union));
+}
+
 #[test]
 fn object_spread_dts_projection_matches_falsy_spread_rules() {
     let db = TypeInterner::new();

--- a/crates/tsz-solver/src/type_queries/core.rs
+++ b/crates/tsz-solver/src/type_queries/core.rs
@@ -884,7 +884,9 @@ fn is_valid_spread_type_impl(db: &dyn TypeDatabase, type_id: TypeId, depth: u32)
     }
 
     match db.lookup(resolved) {
-        // Primitives, null/undefined/void, literals, template literals, string intrinsics:
+        // Primitives, null/undefined/void, literals, template literals, string
+        // intrinsics, and `keyof T` (which is structurally a property-key
+        // primitive `string | number | symbol` whether evaluated or deferred):
         // not spreadable on their own.
         // (Definitely-falsy members are filtered out in the union branch instead.)
         Some(
@@ -902,7 +904,8 @@ fn is_valid_spread_type_impl(db: &dyn TypeDatabase, type_id: TypeId, depth: u32)
             | TypeData::Literal(_)
             | TypeData::TemplateLiteral(_)
             | TypeData::StringIntrinsic { .. }
-            | TypeData::Enum(_, _),
+            | TypeData::Enum(_, _)
+            | TypeData::KeyOf(_),
         ) => false,
         // Union: remove definitely-falsy members, then check remaining.
         // Matches tsc's removeDefinitelyFalsyTypes before checking.
@@ -931,16 +934,26 @@ fn is_valid_spread_type_impl(db: &dyn TypeDatabase, type_id: TypeId, depth: u32)
                 .all(|&m| is_valid_spread_type_impl(db, m, depth + 1))
         }
         Some(TypeData::ReadonlyType(inner)) => is_valid_spread_type_impl(db, inner, depth + 1),
-        // tsc applies `getBaseConstraintOrType` before checking spread flags.
-        // For type operators that can evaluate against a concrete constraint
-        // (for example `T["x"]` where `T extends { x: Obj }`), validate the
-        // evaluated constraint. If evaluation cannot reduce the operator, do
-        // not assume it is object-like. For `keyof T`, evaluation yields
-        // property-key primitives, which the recursive primitive handling
-        // rejects.
-        Some(TypeData::IndexAccess(_, _) | TypeData::KeyOf(_)) => {
+        // Mirrors tsc's `isValidSpreadType`:
+        //   if (type.flags & Instantiable) {
+        //       const constraint = getBaseConstraintOfType(type);
+        //       if (constraint !== undefined) return isValidSpreadType(constraint);
+        //   }
+        //   return !!(type.flags & (Any | NonPrimitive | Object | InstantiableNonPrimitive) | …);
+        //
+        // For an `IndexAccess` we first try to reduce through any usable
+        // constraint by asking the evaluator. If reduction succeeds the
+        // result is validated like any other type. If it does not, the
+        // deferred form is itself `InstantiableNonPrimitive` (an indexed
+        // access could be an object at runtime), so the flag-check arm
+        // accepts the spread.
+        Some(TypeData::IndexAccess(_, _)) => {
             let evaluated = evaluate_type(db, resolved);
-            evaluated != resolved && is_valid_spread_type_impl(db, evaluated, depth + 1)
+            if evaluated != resolved {
+                is_valid_spread_type_impl(db, evaluated, depth + 1)
+            } else {
+                true
+            }
         }
         // Everything else is spreadable: object types, arrays, tuples, functions,
         // callables, mapped types, type parameters (unconstrained ones reach here

--- a/crates/tsz-solver/src/type_queries/core.rs
+++ b/crates/tsz-solver/src/type_queries/core.rs
@@ -941,19 +941,16 @@ fn is_valid_spread_type_impl(db: &dyn TypeDatabase, type_id: TypeId, depth: u32)
         //   }
         //   return !!(type.flags & (Any | NonPrimitive | Object | InstantiableNonPrimitive) | …);
         //
-        // For an `IndexAccess` we first try to reduce through any usable
-        // constraint by asking the evaluator. If reduction succeeds the
-        // result is validated like any other type. If it does not, the
-        // deferred form is itself `InstantiableNonPrimitive` (an indexed
-        // access could be an object at runtime), so the flag-check arm
-        // accepts the spread.
+        // For an `IndexAccess` we first ask the evaluator to reduce through
+        // any usable constraint. If reduction succeeds the result is
+        // validated like any other type. If it does not, the deferred form
+        // itself carries `InstantiableNonPrimitive` (an indexed access could
+        // be an object at runtime), so the flag-check arm accepts the
+        // spread without recursing — the unchanged `resolved` carries no new
+        // information for a recursive call.
         Some(TypeData::IndexAccess(_, _)) => {
             let evaluated = evaluate_type(db, resolved);
-            if evaluated != resolved {
-                is_valid_spread_type_impl(db, evaluated, depth + 1)
-            } else {
-                true
-            }
+            evaluated == resolved || is_valid_spread_type_impl(db, evaluated, depth + 1)
         }
         // Everything else is spreadable: object types, arrays, tuples, functions,
         // callables, mapped types, type parameters (unconstrained ones reach here


### PR DESCRIPTION
## Agent
AgentName: opus47-vibrant-lovelace (remote execution / vibrant-lovelace-WL78C)

Closes #10673.

## Track
Track 1 — false-positive parity / kysely project-row blockers. Routed under the
existing `agent:Studio-A` lane for the kysely cluster; M5Opus / Studio-A: WIP
claim signed on the issue thread, hand back via signed comment if anyone is
mid-investigation.

## Invariant

When `{ ...x }` is an object spread whose operand resolves to an `IndexAccess`
type `T[K]` that the evaluator cannot reduce to a concrete shape, `tsc` accepts
the spread via the `InstantiableNonPrimitive` arm of `isValidSpreadType`
(deferred indexed access "could be an object at runtime"); this PR makes tsz
do the same through `tsz_solver::type_queries::core::is_valid_spread_type_impl`
without any checker-side spelling, file-path, or rendered-display hook.

## Scope

- `crates/tsz-solver/src/type_queries/core.rs`
  - Split the previous combined `IndexAccess | KeyOf` arm. `KeyOf` joins the
    primitive `=> false` arm because it is structurally a property-key
    primitive (`string | number | symbol`) in both evaluated and deferred
    form. `IndexAccess` keeps the evaluator-first path and, when the
    evaluator returns the same type id (deferred), accepts the spread:
    ```rust
    Some(TypeData::IndexAccess(_, _)) => {
        let evaluated = evaluate_type(db, resolved);
        evaluated == resolved || is_valid_spread_type_impl(db, evaluated, depth + 1)
    }
    ```
- `crates/tsz-solver/src/tests/type_queries_spread_tests.rs`
  - New owning-crate coverage:
    `spread_deferred_index_access_unconstrained_both_sides_is_valid`,
    `spread_deferred_index_access_renamed_params_is_valid`,
    `spread_deferred_index_access_object_constraint_generic_key_is_valid`,
    `spread_deferred_index_access_into_record_value_is_valid`,
    `spread_deferred_index_access_into_primitive_record_is_invalid` (negative),
    `spread_keyof_deferred_remains_invalid`,
    `spread_keyof_object_constrained_remains_invalid`,
    `spread_union_member_deferred_index_access_is_valid`.
  - Small `tp()` / `obj_with_prop()` helpers so each test reads as the shape
    under test rather than `TypeParamInfo` / `PropertyInfo` boilerplate.
- `crates/tsz-checker/tests/spread_rest_diagnostics_tests.rs`
  - End-to-end checker coverage through `check_source_diagnostics`:
    `test_no_ts2698_for_spread_of_unconstrained_index_access`,
    `test_no_ts2698_for_spread_of_renamed_index_access`,
    `test_no_ts2698_for_spread_of_index_access_with_object_constraint`,
    `test_no_ts2698_for_spread_of_deferred_conditional` (locks in the
    existing `_ => true` catch-all),
    `test_ts2698_still_fires_for_spread_of_keyof_t`,
    `test_ts2698_still_fires_for_spread_of_t_extends_string`.

No checker-side decisions, no `format_type_diagnostic` reads, no
identifier-name or file-path hooks — anti-hardcoding §25 compliant. The rule
is keyed on `TypeData::IndexAccess(_, _)` / `TypeData::KeyOf(_)`, not on
spelling, alias, or rendered display.

## Project Corpus Impact

- Row: `kysely-project`
- Bug family: false TS2698 ("Spread types may only be created from object
  types") on generic-shaped operands. The reported witness is
  `src/plugin/handle-empty-in-lists/handle-empty-in-lists.ts(84,9)` (1 direct
  diagnostic against the kysely-project guard config); the broader pattern is
  the spread-of-generic-indexed-access family the issue lists as "common —
  likely affects other rows".
- Evidence: structural reproduction in `tsz-solver` and `tsz-checker` unit
  layers (see Verification). The reported kysely site itself requires the
  full kysely fixture; ready-review CI's conformance + project-corpus runs
  cover that surface.

## Verification

Local (per §19.5 — narrow, fast feedback only):

- `cargo test -p tsz-solver --lib spread` → 98 passed / 0 failed (added 8 new;
  net +8). Pre-existing 21 unrelated suite failures on `cargo test -p
  tsz-solver --lib` are unchanged between `origin/main` and this branch
  (confirmed via `git stash` baseline).
- `cargo test -p tsz-checker --test spread_rest_diagnostics_tests` → 23
  passed / 0 failed (added 6 new).
- `cargo test -p tsz-checker --test jsx_component_attribute_tests` → 211
  passed / 0 failed (regression check on the other TS2698 emission site).
- `cargo clippy -p tsz-solver --lib --all-features -- -D warnings` clean.
- `cargo check --workspace --all-targets` clean.

CI to confirm: lint, unit, conformance, emit, fourslash, WASM, snapshot.

## Coordination Notes

- Claimed via WIP on #10673 (signed `opus47-vibrant-lovelace`). Random-roll
  pick from the eligible bug pool; no active PR addresses this issue and
  Studio-A (canonical owner of the kysely cluster) has no in-flight PR on
  #10673.
- Related but disjoint root causes already in flight:
  - #10661 / PR #10686 (cross-file class instance refs) — class identity,
    not spread guard.
  - #10634 / PR #10641 (cross-module self member overrides) — override
    fallback, not spread guard.
  None of these PRs touch `is_valid_spread_type_impl`; this PR sequences
  freely alongside them and shares no files.
- /simplify ran three times before opening this PR; all three iterations
  returned no findings against this diff.

---
_AgentName: opus47-vibrant-lovelace_

---
_Generated by [Claude Code](https://claude.ai/code/session_01SERc34AFuuEu9Z9UCjpDVZ)_