### PR TITLE
fix(emitter): eliminate generator-state/class-alias collision in ES5 async

### DIFF
--- a/crates/tsz-emitter/src/emitter/class_temp_reservations.rs
+++ b/crates/tsz-emitter/src/emitter/class_temp_reservations.rs
@@ -94,6 +94,12 @@ impl<'a> Printer<'a> {
             return name;
         }
 
+        // Honour pre-allocated names reserved by reserve_es5_computed_key_inner_class_temps
+        // so that the class alias gets the same slot that was counted before the key temp.
+        if let Some(name) = self.preallocated_temp_names.pop_front() {
+            return name;
+        }
+
         self.make_unique_name_reserved_for_nested()
     }
 

--- a/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
@@ -39,17 +39,6 @@ impl Es5StaticClassExpressionElement {
     }
 }
 
-fn avoid_generator_state_collision(segment: &str, class_temp: &str) -> String {
-    if class_temp != "_a" || !segment.contains("function (_a)") {
-        return segment.to_string();
-    }
-
-    segment
-        .replace("function (_a)", "function (_b)")
-        .replace("_a.label", "_b.label")
-        .replace("_a.sent()", "_b.sent()")
-}
-
 impl<'a> Printer<'a> {
     fn next_arguments_capture_name(&mut self) -> String {
         loop {
@@ -290,11 +279,11 @@ impl<'a> Printer<'a> {
         let temp = class_value_temp.map_or_else(
             || {
                 if self.class_expression_is_in_loop_body(class_node) {
-                    let temp = self.make_unique_name();
+                    let temp = self.make_class_static_temp_name(class_node);
                     self.block_scoped_private_temps.push(temp.clone());
                     temp
                 } else {
-                    self.make_unique_name_hoisted()
+                    self.make_class_static_temp_name_hoisted(class_node)
                 }
             },
             str::to_string,
@@ -362,15 +351,6 @@ impl<'a> Printer<'a> {
                         let full = self.writer.get_output().to_string();
                         let segment = &full[before..after];
                         let replaced = replace_identifier(segment, class_name, &temp);
-                        let replaced = avoid_generator_state_collision(&replaced, &temp);
-                        if replaced != segment {
-                            self.writer.truncate(before);
-                            self.write(&replaced);
-                        }
-                    } else {
-                        let full = self.writer.get_output().to_string();
-                        let segment = &full[before..after];
-                        let replaced = avoid_generator_state_collision(segment, &temp);
                         if replaced != segment {
                             self.writer.truncate(before);
                             self.write(&replaced);
@@ -664,6 +644,10 @@ impl<'a> Printer<'a> {
             let blocked_disposable_names = self.blocked_disposable_names_for_transform();
             async_emitter
                 .set_disposable_env_context(self.next_disposable_env_id, blocked_disposable_names);
+            if let Some((_, alias)) = &self.scoped_class_expression_self_alias {
+                async_emitter
+                    .set_outer_reserved_for_generator_state(vec![alias.as_ref().to_string()]);
+            }
 
             let body_has_await = async_emitter.body_contains_await(body);
             let body_is_single_line = self.arena.get(body).is_some_and(|n| self.is_single_line(n));
@@ -1402,6 +1386,9 @@ impl<'a> Printer<'a> {
             es5_emitter.set_tslib_import_binding(self.commonjs_tslib_import_binding.clone());
         }
         es5_emitter.set_use_define_for_class_fields(self.ctx.options.use_define_for_class_fields);
+        if let Some((_, alias)) = &self.scoped_class_expression_self_alias {
+            es5_emitter.set_outer_reserved_for_generator_state(vec![alias.as_ref().to_string()]);
+        }
         if self.es5_class_expression_extends_this_captured {
             es5_emitter.set_extends_this_captured(true);
         }
@@ -1494,11 +1481,11 @@ impl<'a> Printer<'a> {
                 }
             }
             let class_temp = if in_loop {
-                let t = self.make_unique_name();
+                let t = self.make_class_static_temp_name(class_node);
                 self.block_scoped_private_temps.push(t.clone());
                 t
             } else {
-                self.make_unique_name_hoisted()
+                self.make_class_static_temp_name_hoisted(class_node)
             };
 
             let comma_static_elements = if use_static_comma {

--- a/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
@@ -845,6 +845,71 @@ fn es5_nested_static_class_expression_non_null_wrapper_still_hoists_alias() {
     );
 }
 
+// When B holds alias `_a` and then allocates alias `_b` for its nested class E,
+// E's static field F has an async method that references E.  The generator state
+// inside F.func must pick `_c` (not `_b`) to avoid shadowing E's alias.
+#[test]
+fn es5_class_expression_generator_state_avoids_alias_b() {
+    // B→_a (depth 1).  While B's comma expression runs, E gets _b (depth 2).
+    // F is a static-field value of E, so replace_identifier("E","_b") runs on
+    // F's output.  Without the fix the generator state in F.func would be `_b`.
+    let source = "class A {\n    static B = class B {\n        static E = class E {\n            static F = class F {\n                static async func() { await E.help(); }\n            };\n            static help() { return 1; }\n        };\n    };\n}\n";
+
+    let (parser, root) = parse_test_source(source);
+    let options = PrinterOptions {
+        target: ScriptTarget::ES5,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert!(
+        output.contains("_b.help()"),
+        "E class-name reference should be replaced with the `_b` alias.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("function (_b)"),
+        "Generator state must not collide with the `_b` class-expression alias.\nOutput:\n{output}"
+    );
+}
+
+// Three-deep nesting: B→_a, E→_b, G→_c.  G's static field H has an async
+// method referencing G.  Generator state in H.func must pick `_d`, not `_c`.
+#[test]
+fn es5_class_expression_generator_state_avoids_alias_c() {
+    // B→_a, E→_b, G→_c (each allocated while the outer alias is still live).
+    // H is a static-field value of G, so replace_identifier("G","_c") runs
+    // on H's output.  Without the fix the generator state in H.func is `_c`.
+    let source = "class A {\n    static B = class B {\n        static E = class E {\n            static G = class G {\n                static H = class H {\n                    static async func() { await G.help(); }\n                };\n                static help() { return 1; }\n            };\n        };\n    };\n}\n";
+
+    let (parser, root) = parse_test_source(source);
+    let options = PrinterOptions {
+        target: ScriptTarget::ES5,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert!(
+        output.contains("_c.help()"),
+        "G class-name reference should be replaced with the `_c` alias.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("function (_c)"),
+        "Generator state must not collide with the `_c` class-expression alias.\nOutput:\n{output}"
+    );
+}
+
 #[test]
 fn class_expression_static_comma_temp_follows_computed_name_temps() {
     let source = "async function* test(x) {\n    return class {\n        [await x] = await x;\n        static [await x] = await x;\n        [yield 1] = yield 2;\n        static [yield 3] = yield 4;\n    };\n}\n";

--- a/crates/tsz-emitter/src/transforms/async_es5.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5.rs
@@ -90,6 +90,11 @@ pub struct AsyncES5Emitter<'a> {
     mappings: Vec<Mapping>,
     this_capture_depth: u32,
     class_name: Option<String>,
+    /// Outer names (e.g. a class-expression alias) that must not be chosen as
+    /// the generator state variable.  When non-empty they are treated as
+    /// already-allocated hoisted vars for the purpose of `generator_state_name_for_hoisted`,
+    /// so the state-name picker skips past them.
+    outer_reserved_for_generator_state: Vec<String>,
     /// When true, prefix runtime helper calls with `tslib_1.` (for CJS importHelpers).
     tslib_prefix: bool,
     tslib_import_binding: String,
@@ -107,6 +112,7 @@ impl<'a> AsyncES5Emitter<'a> {
             mappings: Vec::new(),
             this_capture_depth: 0,
             class_name: None,
+            outer_reserved_for_generator_state: Vec::new(),
             tslib_prefix: false,
             tslib_import_binding: "tslib_1".to_string(),
             system_import_meta: false,
@@ -182,6 +188,12 @@ impl<'a> AsyncES5Emitter<'a> {
     /// Set the class name for private field access transformations
     pub fn set_class_name(&mut self, name: &str) {
         self.class_name = Some(name.to_string());
+    }
+
+    /// Declare outer names (e.g. a class-expression alias) that must not be
+    /// chosen as the `__generator` state variable.
+    pub fn set_outer_reserved_for_generator_state(&mut self, names: Vec<String>) {
+        self.outer_reserved_for_generator_state = names;
     }
 
     pub const fn set_source_map_context(&mut self, source_text: &'a str, source_index: u32) {
@@ -304,8 +316,18 @@ impl<'a> AsyncES5Emitter<'a> {
             .iter()
             .flat_map(|group| group.iter().map(String::as_str))
             .collect();
-        printer
-            .set_generator_state_name(IRPrinter::generator_state_name_for_hoisted(&hoisted_names));
+        let state_name = if self.outer_reserved_for_generator_state.is_empty() {
+            IRPrinter::generator_state_name_for_hoisted(&hoisted_names)
+        } else {
+            let mut combined: Vec<&str> = hoisted_names.clone();
+            combined.extend(
+                self.outer_reserved_for_generator_state
+                    .iter()
+                    .map(String::as_str),
+            );
+            IRPrinter::generator_state_name_for_hoisted(&combined)
+        };
+        printer.set_generator_state_name(state_name);
         printer.emit(&ir);
         (
             printer.take_output(),

--- a/crates/tsz-emitter/src/transforms/class_es5.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5.rs
@@ -88,6 +88,9 @@ pub struct ClassES5Emitter<'a> {
     externally_hoisted_decls: rustc_hash::FxHashSet<String>,
     block_scope_shadowed_names: Vec<String>,
     block_scope_reserved_names: Vec<String>,
+    /// Outer names (e.g. a class-expression alias) excluded from generator state
+    /// variable selection inside `__awaiter`/`__generator` method bodies.
+    outer_reserved_for_generator_state: Vec<String>,
 }
 
 impl<'a> ClassES5Emitter<'a> {
@@ -110,6 +113,7 @@ impl<'a> ClassES5Emitter<'a> {
             externally_hoisted_decls: rustc_hash::FxHashSet::default(),
             block_scope_shadowed_names: Vec::new(),
             block_scope_reserved_names: Vec::new(),
+            outer_reserved_for_generator_state: Vec::new(),
             tc39_wrap_output: true,
         }
     }
@@ -144,6 +148,12 @@ impl<'a> ClassES5Emitter<'a> {
             .extend(printer.block_scope_reserved_names());
         self.block_scope_reserved_names.sort();
         self.block_scope_reserved_names.dedup();
+    }
+
+    /// Set names that must not be chosen as the `__generator` state variable in
+    /// any async method body emitted by this class emitter.
+    pub fn set_outer_reserved_for_generator_state(&mut self, names: Vec<String>) {
+        self.outer_reserved_for_generator_state = names;
     }
 
     pub fn set_outer_rename_map(&mut self, map: rustc_hash::FxHashMap<String, String>) {
@@ -507,6 +517,11 @@ impl<'a> ClassES5Emitter<'a> {
         }
         printer.set_block_scope_shadowed_names(self.block_scope_shadowed_names.clone());
         printer.set_block_scope_reserved_names(self.block_scope_reserved_names.clone());
+        if !self.outer_reserved_for_generator_state.is_empty() {
+            printer.set_outer_reserved_for_generator_state(
+                self.outer_reserved_for_generator_state.clone(),
+            );
+        }
         printer
     }
 

--- a/crates/tsz-emitter/src/transforms/ir_printer.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer.rs
@@ -79,6 +79,10 @@ pub struct IRPrinter<'a> {
     system_import_meta: bool,
     pub(crate) base_printer_options: Option<PrinterOptions>,
     generator_state_name: &'static str,
+    /// Outer names (e.g. a class-expression alias) excluded from generator state
+    /// variable selection.  Treated as already-allocated hoisted vars so the
+    /// state-name picker skips past them.
+    outer_reserved_for_generator_state: Vec<String>,
     namespace_ast_name: Option<String>,
     namespace_ast_exported_names: rustc_hash::FxHashSet<String>,
     block_scope_shadowed_names: Vec<String>,
@@ -310,6 +314,7 @@ impl<'a> IRPrinter<'a> {
             system_import_meta: false,
             base_printer_options: None,
             generator_state_name: "_a",
+            outer_reserved_for_generator_state: Vec::new(),
             namespace_ast_name: None,
             namespace_ast_exported_names: rustc_hash::FxHashSet::default(),
             block_scope_shadowed_names: Vec::new(),
@@ -340,6 +345,7 @@ impl<'a> IRPrinter<'a> {
             system_import_meta: false,
             base_printer_options: None,
             generator_state_name: "_a",
+            outer_reserved_for_generator_state: Vec::new(),
             namespace_ast_name: None,
             namespace_ast_exported_names: rustc_hash::FxHashSet::default(),
             block_scope_shadowed_names: Vec::new(),
@@ -370,6 +376,7 @@ impl<'a> IRPrinter<'a> {
             system_import_meta: false,
             base_printer_options: None,
             generator_state_name: "_a",
+            outer_reserved_for_generator_state: Vec::new(),
             namespace_ast_name: None,
             namespace_ast_exported_names: rustc_hash::FxHashSet::default(),
             block_scope_shadowed_names: Vec::new(),
@@ -488,6 +495,11 @@ impl<'a> IRPrinter<'a> {
 
     pub const fn set_generator_state_name(&mut self, name: &'static str) {
         self.generator_state_name = name;
+    }
+
+    /// Set names that must not be chosen as the `__generator` state variable.
+    pub fn set_outer_reserved_for_generator_state(&mut self, names: Vec<String>) {
+        self.outer_reserved_for_generator_state = names;
     }
 
     /// When true, suppress comment annotations like `/** @class */` in output.

--- a/crates/tsz-emitter/src/transforms/ir_printer_class_emit.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer_class_emit.rs
@@ -412,7 +412,17 @@ impl<'a> IRPrinter<'a> {
             .iter()
             .flat_map(|group| group.iter().map(String::as_str))
             .collect();
-        self.generator_state_name = Self::generator_state_name_for_hoisted(&hoisted_vars);
+        self.generator_state_name = if self.outer_reserved_for_generator_state.is_empty() {
+            Self::generator_state_name_for_hoisted(&hoisted_vars)
+        } else {
+            let mut combined: Vec<&str> = hoisted_vars.clone();
+            combined.extend(
+                self.outer_reserved_for_generator_state
+                    .iter()
+                    .map(String::as_str),
+            );
+            Self::generator_state_name_for_hoisted(&combined)
+        };
         self.write("return __awaiter(");
         self.emit_node(this_arg);
         if let Some(ctor) = promise_constructor {

--- a/scripts/emit/output-surgery-allowlist.txt
+++ b/scripts/emit/output-surgery-allowlist.txt
@@ -8,6 +8,5 @@ crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs|dts-output-
 crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_imported_calls.rs|dts-output-surgery|1|imported-call inferred text indentation patch; migrate to structured type display formatting
 crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs|dts-output-surgery|4|object member inferred text rewrites; migrate to declaration summary member facts
 crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs|dts-output-surgery|3|return type text normalization rewrites; migrate to structured return declaration display
-crates/tsz-emitter/src/emitter/es5/helpers_async.rs|legacy-es5-output-surgery|3|legacy ES5 async helper text patch; quarantine under legacy target lane
 crates/tsz-emitter/src/emitter/source_file/top_level_using.rs|resource-region-output-surgery|16|top-level using region rewrites emitted strings; migrate to disposable-region plan
 crates/tsz-emitter/src/transforms/ir_printer.rs|ir-output-surgery|1|IR printer patches emitted class wrapper text; migrate to structured IR node/chunk


### PR DESCRIPTION
AgentName: claude-sonnet-4-6 (dazzling-johnson)

## Track
emit — ES5 async output correctness

## Invariant
When tsc emits ES5 async code for a method inside a class expression that is assigned to a static field of an outer class, the `__generator` state variable must not collide with the outer class expression's alias temp.

**Structural rule:** When an async method body is lowered inside a class expression that uses a temp alias (e.g. `_a` as the comma-expression alias for `class B`), the `__generator` state variable must be chosen from a name that does not appear in `outer_reserved_for_generator_state`, which lists all alias temps live around the async body.

## Scope

### Root cause
Two independent bugs conspired:

1. **Generator-state name selection ignored live class-expression aliases.**
   `emit_awaiter_call_node` picked the generator state variable by scanning only `hoisted_vars` inside the async body. When a class-expression alias (e.g. `_a` for an outer `class B { static X = class B { ... } }`) happened to be the first available name, it was chosen as the state variable. Then `replace_identifier("B", "_a")` in the comma expression loop overwrote the state variable's occurrences (`function (_a)`, `_a.label`, `_a.sent()`), corrupting the emitted JS.

2. **`make_class_static_temp_name` bypassed `preallocated_temp_names`.**
   `reserve_es5_computed_key_inner_class_temps` pre-allocates one slot in `preallocated_temp_names` so the class alias temp gets the right ordering relative to the key computation temp. The refactored code called `make_unique_name_reserved_for_nested()` directly (via `generate_fresh_temp_name`), skipping that queue and picking a later counter slot. The pre-allocated slot was then consumed by the first `make_unique_name()` caller it encountered (the destructuring default temp), producing wrong variable names in the output.

### Fix
- Thread `outer_reserved_for_generator_state: Vec<String>` through `Printer → ClassES5Emitter → IRPrinter`. When `scoped_class_expression_self_alias` is set, the alias is added to this list before calling into `ClassES5Emitter` or `AsyncES5Emitter`.
- In `emit_awaiter_call_node`, combine `hoisted_vars` with `outer_reserved_for_generator_state` before calling `generator_state_name_for_hoisted`, so the state variable is chosen to avoid all live outer aliases.
- In `make_class_static_temp_name`, drain `preallocated_temp_names` before falling through to `make_unique_name_reserved_for_nested()`, preserving the pre-allocation ordering contract.
- Remove `avoid_generator_state_collision` (the old post-emit text patch) and its three call sites; this reduces the output-surgery allowlist count by 3.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: no project-corpus fixture exercises nested ES5 async + class expression alias collision; fix is purely emit-correctness for that ES5 corner case. Two new unit tests (`es5_class_expression_generator_state_avoids_alias_b`, `es5_class_expression_generator_state_avoids_alias_c`) cover 2-deep and 3-deep alias nesting; both pass locally after the fix.

## Verification
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` → exit 0
- `cargo test -p tsz-emitter --lib -- es5` → 594 passed, 12 pre-existing failures (all in `async_es5_ir::tests` for do-while/try-catch variants, confirmed pre-existing on base branch)
- New tests pass: `es5_class_expression_generator_state_avoids_alias_b` and `es5_class_expression_generator_state_avoids_alias_c`
- Previously broken test passes: `static_field_class_expression_in_binding_key_uses_es5_comma_alias`

## Coordination Notes
- No overlap with any open PR found in PR list review.
- The `outer_reserved_for_generator_state` mechanism is additive — it only affects name selection when a live alias is present.
- The `make_class_static_temp_name` fix is mechanical; it simply honours the preallocated queue that `reserve_es5_computed_key_inner_class_temps` sets up.
- The 12 pre-existing `async_es5_ir::tests` failures (do-while, try-catch variants) are unrelated to this change and were present before any of our modifications.