### PR TITLE
fix(solver): bound cross-evaluator infer-match expansion to stop Zod non-termination

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1743,6 +1743,10 @@ name = "deeply_nested_conditional_mapped_recursion_tests"
 path = "tests/deeply_nested_conditional_mapped_recursion_tests.rs"
 
 [[test]]
+name = "infer_match_recursive_wrapper_termination_tests"
+path = "tests/infer_match_recursive_wrapper_termination_tests.rs"
+
+[[test]]
 name = "type_parameter_canonical_typeid_tests"
 path = "tests/type_parameter_canonical_typeid_tests.rs"
 

--- a/crates/tsz-checker/tests/infer_match_recursive_wrapper_termination_tests.rs
+++ b/crates/tsz-checker/tests/infer_match_recursive_wrapper_termination_tests.rs
@@ -1,0 +1,149 @@
+//! Termination guards for #10662: `tsz` must always terminate when
+//! infer-pattern matching expands a recursive generic-wrapper application.
+//!
+//! Background: when a conditional's `extends` clause is (or expands to) an
+//! object pattern containing `infer`, and the check type is an `Application` of
+//! a generic wrapper, matching expands the source application in a *fresh*
+//! sub-evaluator (the matching helpers only hold `&self`). Each fresh evaluator
+//! resets its own recursion guard, depth counter, and per-`DefId` depth, so a
+//! recursive wrapper can re-enter that expansion at ever-deeper nesting through
+//! a brand-new evaluator each level — none of the per-evaluator guards fire
+//! because they all live on a single evaluator. On the real Zod fixture this
+//! hung past 240s with zero output. The cross-evaluator infer-match expansion
+//! budget (`MAX_INFER_MATCH_EXPANSION_DEPTH` in `tsz-solver`) cuts the recursion
+//! off so the compile always terminates; the guard primitive itself is unit
+//! tested in `tsz-solver`.
+//!
+//! These checker tests exercise the recursive-wrapper infer-extraction family
+//! and assert it terminates and stays free of spurious depth diagnostics. The
+//! authoritative non-termination reproduction is the Zod project-corpus row
+//! (`benchmark_set: required`), which CI runs against the full fixture.
+
+use tsz_checker::test_utils::check_source_codes;
+
+/// A self-referential wrapper whose `_output` member is computed by the very
+/// same `infer`-extracting conditional that is matching it. Expanding the
+/// source application to read `_output` re-enters the conditional, which
+/// expands the source again — through a fresh sub-evaluator each level.
+#[test]
+fn self_referential_output_infer_extraction_terminates() {
+    let source = r#"
+interface Schema<Output> {
+  _output: Output;
+}
+
+interface Lazy<T extends Schema<any>> extends Schema<InferOutput<Lazy<T>>> {
+  inner: T;
+}
+
+type InferOutput<T> = T extends Schema<infer O> ? O : never;
+
+declare const s: Lazy<Schema<number>>;
+type Out = InferOutput<typeof s>;
+declare const out: Out;
+
+export {};
+"#;
+    // The assertion that matters is that this returns at all. A hang times out
+    // the entire test binary.
+    let _codes = check_source_codes(source);
+}
+
+/// Same structural rule with every user-chosen name changed (wrapper, inner
+/// field, type parameters, iteration variable) to prove the fix keys on the
+/// type *shape*, not on a spelling.
+#[test]
+fn self_referential_output_infer_extraction_renamed_terminates() {
+    let source = r#"
+interface Carrier<Payload> {
+  carried: Payload;
+}
+
+interface Deferred<Inner extends Carrier<any>> extends Carrier<Extract2<Deferred<Inner>>> {
+  child: Inner;
+}
+
+type Extract2<X> = X extends Carrier<infer P> ? P : never;
+
+declare const d: Deferred<Carrier<string>>;
+type Result = Extract2<typeof d>;
+declare const result: Result;
+
+export {};
+"#;
+    let _codes = check_source_codes(source);
+}
+
+/// Zod-shaped recursive schema: `ZodObject`/`ZodOptional` wrappers whose
+/// `_output` is computed through mapped types, conditionals, and `infer`, with
+/// a self-referential lazy schema that makes the output evaluation unbounded —
+/// the structure that hung the Zod benchmark row.
+#[test]
+fn zod_shaped_recursive_schema_infer_terminates() {
+    let source = r#"
+interface ZodTypeDef {}
+
+interface ZodType<Output = any, Def extends ZodTypeDef = ZodTypeDef> {
+  _output: Output;
+  _def: Def;
+}
+
+interface ZodLazyDef<T extends ZodType = ZodType> extends ZodTypeDef {
+  getter: () => T;
+}
+
+interface ZodLazy<T extends ZodType = ZodType>
+  extends ZodType<InferOutput<ZodLazy<T>>, ZodLazyDef<T>> {
+  schema: T;
+}
+
+type baseObjectOutputType<Shape extends Record<string, ZodType>> = {
+  [k in keyof Shape]: InferOutput<Shape[k]>;
+};
+
+interface ZodObjectDef<
+  T extends Record<string, ZodType> = Record<string, ZodType>
+> extends ZodTypeDef {
+  shape: () => T;
+}
+
+interface ZodObject<
+  T extends Record<string, ZodType> = Record<string, ZodType>
+> extends ZodType<baseObjectOutputType<T>, ZodObjectDef<T>> {
+  shape: T;
+}
+
+type InferOutput<T> = T extends ZodType<infer O> ? O : never;
+
+declare const schema: ZodObject<{ a: ZodLazy<ZodType<number>> }>;
+type Out = InferOutput<typeof schema>;
+declare const out: Out;
+
+export {};
+"#;
+    let _codes = check_source_codes(source);
+}
+
+/// A deep but finite recursive wrapper must still terminate and must not emit a
+/// spurious TS2589 — the bound only fires on genuinely unbounded nesting.
+#[test]
+fn deep_finite_wrapper_infer_no_ts2589() {
+    let source = r#"
+interface Box<T> {
+  value: T;
+}
+
+type Unbox<T> = T extends Box<infer U> ? Unbox<U> : T;
+
+declare const b: Box<Box<Box<Box<Box<number>>>>>;
+type R = Unbox<typeof b>;
+declare const r: R = 0;
+
+export {};
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        !codes.contains(&2589),
+        "finite Box nesting must not produce TS2589. Got: {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -22,6 +22,7 @@ use tsz_common::interner::Atom;
 
 use super::super::evaluate::TypeEvaluator;
 use super::infer_substitutor::InferSubstitutor;
+use std::cell::Cell;
 
 /// Selects how co-located `infer T` candidates are merged when the same name
 /// gets distinct bindings from multiple structurally adjacent positions.
@@ -31,6 +32,58 @@ enum CoLocatedMerge {
     Union,
     /// Function/callable parameters — contravariant.
     Intersection,
+}
+
+thread_local! {
+    /// Cross-evaluator nesting depth for infer-pattern matching that expands an
+    /// `Application`/`Mapped` source or pattern in a *fresh* sub-evaluator.
+    ///
+    /// Infer matching cannot call `evaluate` on the current `&self` evaluator
+    /// (those methods take `&self`), so it spins up a brand-new `TypeEvaluator`
+    /// whose per-instance recursion guard, depth counter, and fuel all start at
+    /// zero. A recursive generic-wrapper application — Zod's
+    /// `ZodObject`/`ZodOptional`/`ZodArray` chains, `DeepPartial`-style helpers,
+    /// etc. — makes that expansion re-enter conditional/infer evaluation at a
+    /// deeper nesting through a *new* evaluator each level, so no per-evaluator
+    /// guard ever fires and the compile hangs. This thread-global counter bounds
+    /// that cross-evaluator nesting. See [`TypeEvaluator::evaluate_for_infer_match`].
+    static INFER_MATCH_EXPANSION_DEPTH: Cell<u32> = const { Cell::new(0) };
+}
+
+/// Maximum cross-evaluator nesting for infer-match sub-evaluator expansions.
+///
+/// Mirrors tsc's `instantiationDepth` cutoff (100): beyond this nesting, tsc
+/// abandons the instantiation, so tsz stops expanding too rather than recurse
+/// forever. Legitimate structural expansion of an application source during
+/// infer matching never nests anywhere near this deep; only unbounded recursive
+/// wrappers do.
+const MAX_INFER_MATCH_EXPANSION_DEPTH: u32 = 100;
+
+/// RAII guard for [`INFER_MATCH_EXPANSION_DEPTH`].
+///
+/// `enter` returns `None` when the budget is exhausted (the caller must then
+/// skip the expansion); otherwise it increments the counter and decrements it
+/// on drop, so the bound is restored even if evaluation unwinds via panic.
+struct InferMatchExpansionGuard;
+
+impl InferMatchExpansionGuard {
+    fn enter() -> Option<Self> {
+        INFER_MATCH_EXPANSION_DEPTH.with(|depth| {
+            let current = depth.get();
+            if current >= MAX_INFER_MATCH_EXPANSION_DEPTH {
+                None
+            } else {
+                depth.set(current + 1);
+                Some(Self)
+            }
+        })
+    }
+}
+
+impl Drop for InferMatchExpansionGuard {
+    fn drop(&mut self) {
+        INFER_MATCH_EXPANSION_DEPTH.with(|depth| depth.set(depth.get().saturating_sub(1)));
+    }
 }
 
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
@@ -1273,6 +1326,34 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         Some(true)
     }
 
+    /// Evaluate `type_id` in a fresh sub-evaluator during infer-pattern
+    /// matching, bounded by a thread-global cross-evaluator recursion budget.
+    ///
+    /// Infer matching expands `Application`/`Mapped` sources and patterns by
+    /// spinning up a new [`TypeEvaluator`] (the matching helpers only hold
+    /// `&self`, so they cannot reuse the current evaluator's `&mut` evaluate
+    /// path). Each fresh evaluator resets its own recursion guard, so a
+    /// recursive generic wrapper can re-enter this expansion at ever-deeper
+    /// nesting without any per-evaluator guard firing — an unbounded hang.
+    ///
+    /// This routes every such expansion through one place that participates in
+    /// [`INFER_MATCH_EXPANSION_DEPTH`]. Once the budget is exhausted the input
+    /// is returned **unchanged**: every caller already treats an unchanged
+    /// result as "could not expand" (the infer match fails / the property is
+    /// not found), which terminates the chain instead of looping. Mirrors tsc's
+    /// global `instantiationDepth` cutoff.
+    pub(crate) fn evaluate_for_infer_match(&self, type_id: TypeId) -> TypeId {
+        let Some(_guard) = InferMatchExpansionGuard::enter() else {
+            return type_id;
+        };
+        let mut evaluator = TypeEvaluator::with_resolver(self.interner(), self.resolver());
+        evaluator.set_no_unchecked_indexed_access(self.no_unchecked_indexed_access());
+        if let Some(query_db) = self.query_db() {
+            evaluator = evaluator.with_query_db(query_db);
+        }
+        evaluator.evaluate(type_id)
+    }
+
     /// Main pattern matching function for infer types.
     ///
     /// Matches a source type against a pattern containing `infer` types,
@@ -1574,12 +1655,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 // Fallback: Structural expansion
                 // Expand the pattern Application to its structural form and recurse
                 // This handles cases like: Reducer<infer S> matching a structural function type
-                let mut evaluator = TypeEvaluator::with_resolver(self.interner(), self.resolver());
-                evaluator.set_no_unchecked_indexed_access(self.no_unchecked_indexed_access());
-                if let Some(query_db) = self.query_db() {
-                    evaluator = evaluator.with_query_db(query_db);
-                }
-                let expanded_pattern = evaluator.evaluate(pattern);
+                let expanded_pattern = self.evaluate_for_infer_match(pattern);
 
                 // Only recurse if expansion actually changed the type
                 if expanded_pattern != pattern {
@@ -1667,5 +1743,48 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             }
             _ => checker.is_subtype_of(source, pattern),
         }
+    }
+}
+
+#[cfg(test)]
+mod infer_match_expansion_guard_tests {
+    use super::{
+        INFER_MATCH_EXPANSION_DEPTH, InferMatchExpansionGuard, MAX_INFER_MATCH_EXPANSION_DEPTH,
+    };
+
+    /// The cross-evaluator infer-match expansion guard must (1) allow expansion
+    /// up to the budget, (2) deny it beyond the budget so the caller skips the
+    /// expansion (returns the source unchanged) instead of recursing through a
+    /// fresh evaluator forever, and (3) restore capacity as guards unwind, so
+    /// sequential (non-nested) expansions are never throttled. This is the
+    /// primitive that turns the Zod non-termination (#10662) into a terminating
+    /// compile.
+    #[test]
+    fn guard_bounds_cross_evaluator_expansion_depth() {
+        INFER_MATCH_EXPANSION_DEPTH.with(|depth| depth.set(0));
+
+        let mut held = Vec::new();
+        for expected_prev in 0..MAX_INFER_MATCH_EXPANSION_DEPTH {
+            let guard =
+                InferMatchExpansionGuard::enter().expect("enter within budget must succeed");
+            held.push(guard);
+            assert_eq!(
+                INFER_MATCH_EXPANSION_DEPTH.with(|depth| depth.get()),
+                expected_prev + 1
+            );
+        }
+
+        assert!(
+            InferMatchExpansionGuard::enter().is_none(),
+            "enter at the budget must be denied so the caller stops expanding"
+        );
+
+        held.clear();
+        assert_eq!(INFER_MATCH_EXPANSION_DEPTH.with(|depth| depth.get()), 0);
+        assert!(
+            InferMatchExpansionGuard::enter().is_some(),
+            "after unwinding, a fresh expansion must be allowed again"
+        );
+        INFER_MATCH_EXPANSION_DEPTH.with(|depth| depth.set(0));
     }
 }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_object_match.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_object_match.rs
@@ -195,12 +195,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 true
             }
             Some(TypeData::Application(_)) => {
-                let mut evaluator = TypeEvaluator::with_resolver(self.interner(), self.resolver());
-                evaluator.set_no_unchecked_indexed_access(self.no_unchecked_indexed_access());
-                if let Some(query_db) = self.query_db() {
-                    evaluator = evaluator.with_query_db(query_db);
-                }
-                let evaluated = evaluator.evaluate(source);
+                let evaluated = self.evaluate_for_infer_match(source);
                 if evaluated == source {
                     return false;
                 }
@@ -404,17 +399,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     ) -> Option<TypeId> {
         let evaluated = match self.interner().lookup(type_id) {
             Some(TypeData::Application(_)) | Some(TypeData::Mapped(_)) => {
-                let mut evaluator = TypeEvaluator::with_resolver(self.interner(), self.resolver());
-                evaluator.set_no_unchecked_indexed_access(self.no_unchecked_indexed_access());
-                if let Some(query_db) = self.query_db() {
-                    evaluator = evaluator.with_query_db(query_db);
-                }
-                let evaluated = evaluator.evaluate(type_id);
-                if evaluated == type_id {
-                    type_id
-                } else {
-                    evaluated
-                }
+                self.evaluate_for_infer_match(type_id)
             }
             _ => type_id,
         };
@@ -615,12 +600,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 true
             }
             Some(TypeData::Application(_)) => {
-                let mut evaluator = TypeEvaluator::with_resolver(self.interner(), self.resolver());
-                evaluator.set_no_unchecked_indexed_access(self.no_unchecked_indexed_access());
-                if let Some(query_db) = self.query_db() {
-                    evaluator = evaluator.with_query_db(query_db);
-                }
-                let evaluated = evaluator.evaluate(source);
+                let evaluated = self.evaluate_for_infer_match(source);
                 if evaluated == source {
                     return false;
                 }


### PR DESCRIPTION
AgentName: M4-A (claude/confident-thompson-u37U5)

## Summary

Fixes #10662 — `tsz --noEmit` on the **Zod** benchmark fixture did not terminate
(ran past 240s, exit 124, zero output), which held back the Zod project-corpus row.

### Structural rule

> When infer-pattern matching expands an `Application`/`Mapped` source or pattern
> in a fresh sub-evaluator and that expansion re-enters infer matching beyond a
> fixed nesting budget, tsc abandons the instantiation (`instantiationDepth`); tsz
> must stop expanding too (treat it as "could not expand") instead of recursing
> through a brand-new evaluator forever.

### Root cause

The infer-pattern matching helpers hold only `&self`, so to evaluate an
`Application`/`Mapped` source/pattern they spin up a brand-new `TypeEvaluator`
(`TypeEvaluator::with_resolver(...)`). Each fresh evaluator resets its own
recursion guard, per-`DefId` depth counter, and global-eval-depth participation
(the `evaluate()` cross-evaluator `GLOBAL_EVAL_DEPTH` guard only arms once a
single evaluator's local depth >= 10, which never happens here). A recursive
generic-wrapper application (Zod's `ZodObject`/`ZodOptional`/`ZodArray` chains)
makes that expansion re-enter conditional/infer evaluation at ever-deeper
nesting through a *new* evaluator each level, so **none** of the per-evaluator
guards ever fire and the compile hangs. The loop matches the trace recorded in
the issue:
`evaluate_conditional -> match_infer_pattern -> match_infer_object_pattern -> evaluate(source Application) -> evaluate_application -> evaluate_conditional`.

### Fix (owner layer: solver)

Route all four sub-evaluator expansion sites
(`match_infer_object_pattern`, `match_infer_object_with_index_pattern`,
`find_property_type_in_structural`, and the pattern-expansion fallback in
`match_infer_pattern`) through one helper, `evaluate_for_infer_match`, that
participates in a thread-global nesting budget (`MAX_INFER_MATCH_EXPANSION_DEPTH
= 100`, mirroring tsc's `instantiationDepth`). When the budget is exhausted the
input is returned **unchanged** — every call site already treats an unchanged
result as "could not expand" (the infer match fails / the property is not
found), which terminates the chain. The guard is RAII so the bound is restored
on unwind, and it is per-thread (recursion is per-thread). Below the budget,
behavior is byte-for-byte identical to before (the helper is a behavior-
preserving de-duplication of the four copy-pasted evaluator-construction
blocks).

## Track

Track 2 — recursive conditionals / generic-identity evaluation termination
(`docs/plan/ROADMAP.md` Phase 1, Zod row).

## Invariant

Type evaluation always terminates: cross-evaluator infer-match expansion is
bounded, so no input can drive unbounded fresh-evaluator nesting. Semantics
below the budget are unchanged.

## Scope

- `crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs` — new
  thread-local budget, `InferMatchExpansionGuard`, `evaluate_for_infer_match`
  helper, and a direct unit test of the bounding primitive.
- `crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_object_match.rs`
  — three expansion sites now call the helper.
- `crates/tsz-checker/tests/infer_match_recursive_wrapper_termination_tests.rs`
  (+ `Cargo.toml` target) — checker-level termination guards for the
  recursive-wrapper infer family.

## Project Corpus Impact

- Row: zod-project (`benchmark_set: required`).
- Bug family: recursive conditionals / generic identity (non-termination).
- Evidence: built the release `tsz` against the pinned fixture
  (`colinhacks/zod` @ `93b0b68`) with the guard config from
  `scripts/bench/project-fixtures.sh`. Before the bound (budget disabled):
  exit 124 at 120s, zero output (reproduces the hang). After the bound
  (budget = 100): exit 2 in ~8s with ~80 diagnostics — a terminating compile.
  The remaining diagnostic deltas are the separate false-positive family tracked
  in #10663; this PR only restores termination, which #10662 calls the
  prerequisite for any further Zod-row progress.

## Verification

- New solver unit test `guard_bounds_cross_evaluator_expansion_depth` — passes.
- New checker tests (`infer_match_recursive_wrapper_termination_tests`, 4) —
  pass.
- Full `tsz-solver --lib` suite: 6332 passed / 21 failed, identical 21
  failures to the pre-change baseline (6331 / 21); the +1 is the new guard
  test. The 21 are pre-existing local-environment failures (the `any`-widening /
  `Equal<any>` family), unrelated to this change.
- Targeted recursion/infer suites (`deeply_nested_conditional_mapped_recursion`,
  `recursive_intersection_assignability`, `tuple_infer_mapped_recursive`,
  `reverse_mapped_inference`, `curry_recursive_conditional_infer`) — pass.
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets --all-features -D
  warnings` — clean.

## Coordination Notes

Picked up the M4-A investigation in #10662 (matches the recorded trace and the
"redesign the expansion boundary" framing). The fix is a bounded cutoff rather
than a full boundary redesign — intentional: it generalizes across the whole
cross-evaluator infer-match family (all four spawn sites, any type shape) and
guarantees termination, which is the stated prerequisite. — M4-A

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuvvJa2yacQpm3AVQs8cJn)_