### PR TITLE
fix(solver): treat any as identical only to any in conditional extends identity

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/rules/conditionals.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/conditionals.rs
@@ -29,6 +29,18 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     ///   `MutableKeys` built on top of it) able to distinguish properties
     ///   by mutability.
     fn conditional_extends_types_equivalent(&mut self, left: TypeId, right: TypeId) -> bool {
+        // For extends-clause identity (tsc's `isTypeIdenticalTo`) `any` is
+        // identical only to `any`. The bidirectional check below runs with
+        // `TopLevelOnly` any-propagation, so a top-level `any` would otherwise
+        // relate to every type and wrongly equate `T extends any` with
+        // `T extends string` (breaking the higher-order `Equal<X, Y>` trick).
+        // Resolving one `Lazy(DefId)` level keeps `type A = any` recognised.
+        if (self.resolve_lazy_type(left) == TypeId::ANY)
+            != (self.resolve_lazy_type(right) == TypeId::ANY)
+        {
+            return false;
+        }
+
         if !self.identity_fallback_property_modifiers_match(left, right) {
             return false;
         }

--- a/crates/tsz-solver/tests/conditional_comprehensive_tests_parts/part_01.rs
+++ b/crates/tsz-solver/tests/conditional_comprehensive_tests_parts/part_01.rs
@@ -807,6 +807,22 @@ fn test_equal_never_any_is_false() {
     );
 }
 
+/// `Equal<any, boolean>` — `any` is not identity-equivalent to `boolean`.
+/// Pairs with `test_equal_any_any_is_true` (the only `any` case that is
+/// `true`) to pin the extends-clause identity rule to `any ≡ any` exactly,
+/// independent of which concrete type sits opposite the `any`.
+#[test]
+fn test_equal_any_boolean_is_false() {
+    let interner = TypeInterner::new();
+    let result = make_equal_outer(&interner, TypeId::ANY, TypeId::BOOLEAN);
+    assert_eq!(
+        result,
+        TypeId::BOOLEAN_FALSE,
+        "Equal<any, boolean> must evaluate to false, got {:?}",
+        interner.lookup(result)
+    );
+}
+
 /// `Equal<string, string>` — identical concrete types remain `true` even after
 /// `Equal<any, X>` evaluations (regression gate for issue #6742 cache corruption).
 #[test]


### PR DESCRIPTION
## Agent
AgentName: x86-4c-opus47

## Summary

Conditional extends-clause identity (tsc's `isTypeIdenticalTo`) must treat
`any` as identical only to `any`. `conditional_extends_types_equivalent`
decides whether two conditional types' `extends` clauses are the *same*
type by running a bidirectional subtype check in `TopLevelOnly`
any-propagation mode. In that mode a top-level `any` is still treated as
top/bottom, so it related to **every** type in both directions and wrongly
equated distinct conditionals such as `T extends any ? X : Y` and
`T extends string ? X : Y`.

That broke the higher-order `Equal<X, Y>` identity trick
(`` (<T>() => T extends X ? 1 : 2) extends (<T>() => T extends Y ? 1 : 2) ? true : false ``):
`` Equal<any, string> ``, `` Equal<any, 1> ``, `` Equal<any, unknown> ``
(and the reversed forms) all evaluated to `true` instead of `false`.

**Structural rule:** when exactly one `extends` clause is `any`, the two
conditionals are not identity-equivalent; `any` is equivalent only to
`any`. The guard resolves one `Lazy(DefId)` level so a `type A = any`
alias is still recognised as `any`, and does not fire when neither side
definitively resolves to `any` (existing structural checks run unchanged).

## Track
Conformance / checker-solver correctness (conditional-type identity).

## Invariant
When two conditional types' `extends` clauses are compared for identity,
`tsc` treats `any` as identical only to `any`; this PR makes tsz do the
same through the solver's `conditional_extends_types_equivalent` guard.

## Scope
One solver function: `conditional_extends_types_equivalent` in
`crates/tsz-solver/src/relations/subtype/rules/conditionals.rs`. No public
API change.

## Project Corpus Impact
- Row: `ts-toolbelt-project`, `type-challenges-solutions-project`, `type-fest-project` — these corpora rely heavily on the `Equal` / `IfEquals` identity trick, where `any` operands previously mis-collapsed.
- Bug family: conditional-type identity / `any` propagation in extends-clause equivalence.
- Evidence: the 10 `conditional_comprehensive_tests::test_equal_any_*` / `test_outer_equal_*` solver unit tests covering the `Equal<any, X>` family go from failing to passing locally; the rest of the `tsz-solver` suite is unchanged (no new failures).

## Verification
- `cargo nextest run -p tsz-solver -E 'test(test_equal) + test(test_outer_equal)'` → 19 passed (previously 10 of these failed).
- Full `cargo nextest run -p tsz-solver` shows no new failures introduced by this change.
- `cargo clippy -p tsz-solver --lib` clean.

## Coordination Notes
Discovered while investigating #10670 (kysely false `TS2394` on generic
`returning`/`set` overloads). That issue's root cause is a separate
problem: comparing the deeply-nested generic `Selection<DB, TB, any>`
mapped type during the overload-vs-implementation return-type relation is
extremely expensive (self-comparison alone runs for minutes and exhausts
the relation fuel budget, yielding a false negative). That is a
performance/canonicalization issue in the deeply-nested-mapped-type family
(see #10452) and is out of scope here. This PR lands the orthogonal,
unconditionally-correct `any`-identity fix found along the way; a status
note is left on #10670.

https://claude.ai/code/session_014pchdcPCyjeg3SdvFCDz6t