### PR TITLE
fix(checker): gate TS4112 on whether extends target is a class

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -947,6 +947,10 @@ name = "ts2344_literal_type_message"
 path = "tests/ts2344_literal_type_message.rs"
 
 [[test]]
+name = "ts4112_cross_file_override_heritage_tests"
+path = "tests/ts4112_cross_file_override_heritage_tests.rs"
+
+[[test]]
 name = "ts2344_keyof_bare_tparam_defer_tests"
 path = "tests/ts2344_keyof_bare_tparam_defer_tests.rs"
 

--- a/crates/tsz-checker/src/classes/class_checker.rs
+++ b/crates/tsz-checker/src/classes/class_checker.rs
@@ -342,12 +342,10 @@ impl<'a> CheckerState<'a> {
                 .get_expr_type_args(checker.ctx.arena.get(type_idx)?)
                 .and_then(|expr_type_args| expr_type_args.type_arguments.as_ref())
         };
-        // Track the base class symbol for namespace-merged static type check (TS2417).
-        // Set when the heritage clause resolves to a class symbol. The actual TS2417
-        // check only fires when the *derived* class has a merged namespace.
-        let mut base_sym_for_ns_static_check: Option<tsz_binder::SymbolId> = None;
-        // The symbol the `extends` target resolves to, used to gate TS4112 when no
-        // base type could be resolved structurally (e.g. cross-file generic base).
+        // The symbol the `extends` target resolves to. Drives the namespace-merged
+        // static type check (TS2417) and gates TS4112 when no base type could be
+        // resolved structurally (e.g. a cross-file generic base). The TS2417 check
+        // only fires when the *derived* class has a merged namespace.
         let mut base_heritage_sym: Option<tsz_binder::SymbolId> = None;
 
         for &clause_idx in &heritage_clauses.nodes {
@@ -446,7 +444,6 @@ impl<'a> CheckerState<'a> {
                         // *base* had a namespace, but tsc also reports TS2417 when the
                         // derived class's namespace introduces conflicting static members
                         // even if the base class has no namespace at all.
-                        base_sym_for_ns_static_check = Some(sym_id);
                         base_heritage_sym = Some(sym_id);
                         // Resolve to an in-arena class declaration when possible.
                         // Cross-file/module heritage often resolves to symbols whose
@@ -1312,7 +1309,7 @@ impl<'a> CheckerState<'a> {
         // flag), since a derived class without any namespace cannot have conflicting
         // namespace exports. This avoids false positives for classes that simply
         // don't replicate namespace exports from their base class.
-        if !class_extends_error_reported && let Some(base_sym) = base_sym_for_ns_static_check {
+        if !class_extends_error_reported && let Some(base_sym) = base_heritage_sym {
             let derived_sym = self.ctx.binder.get_node_symbol(class_idx);
             if let Some(derived_sym) = derived_sym {
                 let derived_symbol_flags = self

--- a/crates/tsz-checker/src/classes/class_checker.rs
+++ b/crates/tsz-checker/src/classes/class_checker.rs
@@ -346,6 +346,9 @@ impl<'a> CheckerState<'a> {
         // Set when the heritage clause resolves to a class symbol. The actual TS2417
         // check only fires when the *derived* class has a merged namespace.
         let mut base_sym_for_ns_static_check: Option<tsz_binder::SymbolId> = None;
+        // The symbol the `extends` target resolves to, used to gate TS4112 when no
+        // base type could be resolved structurally (e.g. cross-file generic base).
+        let mut base_heritage_sym: Option<tsz_binder::SymbolId> = None;
 
         for &clause_idx in &heritage_clauses.nodes {
             let Some(clause_node) = self.ctx.arena.get(clause_idx) else {
@@ -444,6 +447,7 @@ impl<'a> CheckerState<'a> {
                         // derived class's namespace introduces conflicting static members
                         // even if the base class has no namespace at all.
                         base_sym_for_ns_static_check = Some(sym_id);
+                        base_heritage_sym = Some(sym_id);
                         // Resolve to an in-arena class declaration when possible.
                         // Cross-file/module heritage often resolves to symbols whose
                         // declaration nodes live in another arena; returning `None`
@@ -556,12 +560,23 @@ impl<'a> CheckerState<'a> {
                 }
             }
 
-            // True fallback: no extends clause resolved at all — emit TS4112
-            self.report_overrides_without_base(
-                class_data,
-                &derived_class_name,
-                no_implicit_override,
-            );
+            // True fallback: no base type could be resolved structurally. Emit
+            // TS4112 only when the class does not actually extend another class.
+            // A present `extends` clause whose target resolves to a real class —
+            // even one whose full instance type tsz could not resolve here, e.g.
+            // a cross-file generic base — still means the class extends another
+            // class, so TS4112 must not fire. This matches tsc, which reports
+            // TS4112 only when there is no class base at all (no `extends`
+            // clause, an interface base, or an unresolved name).
+            let extends_a_class = base_heritage_sym
+                .is_some_and(|sym| self.ctx.heritage_symbol_resolves_to_class(sym));
+            if !extends_a_class {
+                self.report_overrides_without_base(
+                    class_data,
+                    &derived_class_name,
+                    no_implicit_override,
+                );
+            }
 
             return;
         };

--- a/crates/tsz-checker/src/context/cross_file_query.rs
+++ b/crates/tsz-checker/src/context/cross_file_query.rs
@@ -161,6 +161,40 @@ impl<'a> CheckerContext<'a> {
         None
     }
 
+    /// Whether `sym_id` ultimately denotes a class declaration, following
+    /// import-alias / re-export hops across files.
+    ///
+    /// This gates TS4112 ("...does not extend another class"): a class whose
+    /// `extends` target resolves to a real class *does* extend another class,
+    /// even when tsz cannot resolve that base's full instance type at the use
+    /// site (for example a cross-file generic base). tsc reports TS4112 only
+    /// when there is no class base at all (no `extends` clause, an `extends`
+    /// target that is an interface, or an unresolved name), so the gate must
+    /// key off whether the target is a class rather than off whether the base
+    /// type happened to resolve.
+    pub fn heritage_symbol_resolves_to_class(&self, sym_id: SymbolId) -> bool {
+        let mut current = sym_id;
+        for _ in 0..16 {
+            let Some(symbol) = self.cross_file_cache_symbol(current) else {
+                return false;
+            };
+            if symbol.has_any_flags(symbol_flags::CLASS) {
+                return true;
+            }
+            if !symbol.has_any_flags(symbol_flags::ALIAS) {
+                return false;
+            }
+            let Some(next) = self.resolve_import_alias_and_register(current) else {
+                return false;
+            };
+            if next == current {
+                return false;
+            }
+            current = next;
+        }
+        false
+    }
+
     const fn source_file_symbol_type_requester_key(requester_file_idx: u32) -> u32 {
         requester_file_idx.saturating_add(1)
     }

--- a/crates/tsz-checker/tests/class_member_closure_tests.rs
+++ b/crates/tsz-checker/tests/class_member_closure_tests.rs
@@ -330,6 +330,69 @@ fn override_valid_no_error() {
 }
 
 #[test]
+fn override_extends_interface_still_ts4112() {
+    // TS4112 must still fire when the `extends` target is an interface — an
+    // interface is not a class, so the class does not extend another class.
+    // tsc emits TS4112 (and TS2689) here.
+    let source = r#"
+        interface I { z: number }
+        class C extends I {
+            override z: number = 0;
+        }
+    "#;
+    let diags = check_default(source);
+    assert!(
+        has_code(&diags, 4112),
+        "Expected TS4112 when extending an interface, got: {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn override_implements_only_still_ts4112() {
+    // TS4112 must still fire when the class only `implements` an interface and
+    // has no `extends` clause — implementing an interface is not extending a
+    // class.
+    let source = r#"
+        interface I { z: number }
+        class C implements I {
+            override z: number = 0;
+        }
+    "#;
+    let diags = check_default(source);
+    assert!(
+        has_code(&diags, 4112),
+        "Expected TS4112 for implements-only class, got: {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn override_generic_base_no_ts4112() {
+    // A generic class base resolves to a real class, so override members on the
+    // derived generic class must not emit TS4112 regardless of the type
+    // parameter name chosen (the rule is structural, not name-based).
+    for (base_param, derived_param) in [("T", "U"), ("DB", "X")] {
+        let source = format!(
+            r#"
+            class Base<{base_param}> {{
+                greet(): string {{ return "hi"; }}
+            }}
+            class Derived<{derived_param}> extends Base<{derived_param}> {{
+                override greet(): string {{ return "yo"; }}
+            }}
+            "#
+        );
+        let diags = check_default(&source);
+        assert!(
+            !has_code(&diags, 4112),
+            "Generic base should not emit TS4112 (params {base_param}/{derived_param}), got: {:?}",
+            codes(&diags)
+        );
+    }
+}
+
+#[test]
 fn no_implicit_override_missing_ts4114() {
     // TS4114: member overrides base without 'override' keyword
     let source = r#"

--- a/crates/tsz-checker/tests/ts4112_cross_file_override_heritage_tests.rs
+++ b/crates/tsz-checker/tests/ts4112_cross_file_override_heritage_tests.rs
@@ -11,74 +11,10 @@
 //! keys off whether the `extends` target resolves to a class, not off whether
 //! the base type happened to resolve.
 
-use std::sync::Arc;
-
-use tsz_binder::BinderState;
-use tsz_binder::lib_loader::LibFile;
-use tsz_checker::context::{CheckerOptions, LibContext};
-use tsz_checker::state::CheckerState;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_multi_file;
 use tsz_common::common::ModuleKind;
-use tsz_parser::parser::ParserState;
-use tsz_solver::construction::TypeInterner;
-
-fn check_multi_file(
-    files: &[(&str, &str)],
-    entry_file: &str,
-    options: CheckerOptions,
-    lib_files: &[Arc<LibFile>],
-) -> Vec<tsz_checker::diagnostics::Diagnostic> {
-    let mut arenas = Vec::with_capacity(files.len());
-    let mut binders = Vec::with_capacity(files.len());
-    let mut roots = Vec::with_capacity(files.len());
-    let file_names: Vec<String> = files.iter().map(|(name, _)| (*name).to_string()).collect();
-
-    for (name, source) in files {
-        let mut parser = ParserState::new((*name).to_string(), (*source).to_string());
-        let root = parser.parse_source_file();
-        let mut binder = BinderState::new();
-        binder.bind_source_file_with_libs(parser.get_arena(), root, lib_files);
-        arenas.push(Arc::new(parser.get_arena().clone()));
-        binders.push(Arc::new(binder));
-        roots.push(root);
-    }
-
-    let entry_idx = file_names
-        .iter()
-        .position(|name| name == entry_file)
-        .unwrap_or_else(|| panic!("entry_file {entry_file:?} not found in files"));
-    let (resolved_module_paths, resolved_modules) =
-        tsz_checker::module_resolution::build_module_resolution_maps(&file_names);
-
-    let all_arenas = Arc::new(arenas);
-    let all_binders = Arc::new(binders);
-    let types = TypeInterner::new();
-    let mut checker = CheckerState::new(
-        all_arenas[entry_idx].as_ref(),
-        all_binders[entry_idx].as_ref(),
-        &types,
-        file_names[entry_idx].clone(),
-        options,
-    );
-    checker.ctx.set_all_arenas(Arc::clone(&all_arenas));
-    checker.ctx.set_all_binders(Arc::clone(&all_binders));
-    checker.ctx.set_current_file_idx(entry_idx);
-    let lib_contexts: Vec<LibContext> = lib_files
-        .iter()
-        .map(|lib| LibContext {
-            arena: Arc::clone(&lib.arena),
-            binder: Arc::clone(&lib.binder),
-        })
-        .collect();
-    checker.ctx.set_lib_contexts(lib_contexts);
-    checker.ctx.set_actual_lib_file_count(lib_files.len());
-    checker
-        .ctx
-        .set_resolved_module_paths(Arc::new(resolved_module_paths));
-    checker.ctx.set_resolved_modules(resolved_modules);
-
-    checker.check_source_file(roots[entry_idx]);
-    checker.ctx.diagnostics.clone()
-}
 
 fn opts() -> CheckerOptions {
     CheckerOptions {
@@ -88,11 +24,11 @@ fn opts() -> CheckerOptions {
     }
 }
 
-fn has_code(diags: &[tsz_checker::diagnostics::Diagnostic], code: u32) -> bool {
+fn has_code(diags: &[Diagnostic], code: u32) -> bool {
     diags.iter().any(|d| d.code == code)
 }
 
-fn codes(diags: &[tsz_checker::diagnostics::Diagnostic]) -> Vec<u32> {
+fn codes(diags: &[Diagnostic]) -> Vec<u32> {
     diags.iter().map(|d| d.code).collect()
 }
 
@@ -126,7 +62,6 @@ export class Kysely<DB> extends QueryCreator<DB> {
         ],
         "./kysely.ts",
         opts(),
-        &[],
     );
 
     assert!(
@@ -163,7 +98,6 @@ export class CachedRepo<Entity> extends Repo<Entity> {
         ],
         "./derived.ts",
         opts(),
-        &[],
     );
 
     assert!(
@@ -198,7 +132,6 @@ export class Circle extends Shape {
         ],
         "./circle.ts",
         opts(),
-        &[],
     );
 
     assert!(

--- a/crates/tsz-checker/tests/ts4112_cross_file_override_heritage_tests.rs
+++ b/crates/tsz-checker/tests/ts4112_cross_file_override_heritage_tests.rs
@@ -1,0 +1,209 @@
+//! Regression tests for TS4112 ("This member cannot have an 'override'
+//! modifier because its containing class does not extend another class") on
+//! cross-file class heritage.
+//!
+//! When a class extends a class imported from another module, the base's full
+//! instance type may not be resolvable at the derived class's use site (for
+//! example a heavily generic base, as in the Kysely benchmark row). tsz must
+//! not conclude from a failed base-type resolution that the class "does not
+//! extend another class": TS4112 fires only when there is no class base at all
+//! (no `extends` clause, an interface base, or an unresolved name). The gate
+//! keys off whether the `extends` target resolves to a class, not off whether
+//! the base type happened to resolve.
+
+use std::sync::Arc;
+
+use tsz_binder::BinderState;
+use tsz_binder::lib_loader::LibFile;
+use tsz_checker::context::{CheckerOptions, LibContext};
+use tsz_checker::state::CheckerState;
+use tsz_common::common::ModuleKind;
+use tsz_parser::parser::ParserState;
+use tsz_solver::construction::TypeInterner;
+
+fn check_multi_file(
+    files: &[(&str, &str)],
+    entry_file: &str,
+    options: CheckerOptions,
+    lib_files: &[Arc<LibFile>],
+) -> Vec<tsz_checker::diagnostics::Diagnostic> {
+    let mut arenas = Vec::with_capacity(files.len());
+    let mut binders = Vec::with_capacity(files.len());
+    let mut roots = Vec::with_capacity(files.len());
+    let file_names: Vec<String> = files.iter().map(|(name, _)| (*name).to_string()).collect();
+
+    for (name, source) in files {
+        let mut parser = ParserState::new((*name).to_string(), (*source).to_string());
+        let root = parser.parse_source_file();
+        let mut binder = BinderState::new();
+        binder.bind_source_file_with_libs(parser.get_arena(), root, lib_files);
+        arenas.push(Arc::new(parser.get_arena().clone()));
+        binders.push(Arc::new(binder));
+        roots.push(root);
+    }
+
+    let entry_idx = file_names
+        .iter()
+        .position(|name| name == entry_file)
+        .unwrap_or_else(|| panic!("entry_file {entry_file:?} not found in files"));
+    let (resolved_module_paths, resolved_modules) =
+        tsz_checker::module_resolution::build_module_resolution_maps(&file_names);
+
+    let all_arenas = Arc::new(arenas);
+    let all_binders = Arc::new(binders);
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        all_arenas[entry_idx].as_ref(),
+        all_binders[entry_idx].as_ref(),
+        &types,
+        file_names[entry_idx].clone(),
+        options,
+    );
+    checker.ctx.set_all_arenas(Arc::clone(&all_arenas));
+    checker.ctx.set_all_binders(Arc::clone(&all_binders));
+    checker.ctx.set_current_file_idx(entry_idx);
+    let lib_contexts: Vec<LibContext> = lib_files
+        .iter()
+        .map(|lib| LibContext {
+            arena: Arc::clone(&lib.arena),
+            binder: Arc::clone(&lib.binder),
+        })
+        .collect();
+    checker.ctx.set_lib_contexts(lib_contexts);
+    checker.ctx.set_actual_lib_file_count(lib_files.len());
+    checker
+        .ctx
+        .set_resolved_module_paths(Arc::new(resolved_module_paths));
+    checker.ctx.set_resolved_modules(resolved_modules);
+
+    checker.check_source_file(roots[entry_idx]);
+    checker.ctx.diagnostics.clone()
+}
+
+fn opts() -> CheckerOptions {
+    CheckerOptions {
+        module: ModuleKind::ESNext,
+        strict: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn has_code(diags: &[tsz_checker::diagnostics::Diagnostic], code: u32) -> bool {
+    diags.iter().any(|d| d.code == code)
+}
+
+fn codes(diags: &[tsz_checker::diagnostics::Diagnostic]) -> Vec<u32> {
+    diags.iter().map(|d| d.code).collect()
+}
+
+/// A derived class that extends a generic class imported from another module
+/// must not emit TS4112 on its `override` members, even if the base's full
+/// instance type cannot be resolved at the use site. Kysely repro shape.
+#[test]
+fn cross_file_generic_base_override_no_ts4112() {
+    let diags = check_multi_file(
+        &[
+            (
+                "./query-creator.ts",
+                r#"
+export interface KyselyPlugin { name: string }
+export class QueryCreator<DB> {
+  withPlugin(plugin: KyselyPlugin): QueryCreator<DB> { return this; }
+  withoutPlugins(): QueryCreator<DB> { return this; }
+}
+"#,
+            ),
+            (
+                "./kysely.ts",
+                r#"
+import { QueryCreator, type KyselyPlugin } from "./query-creator.ts";
+export class Kysely<DB> extends QueryCreator<DB> {
+  override withPlugin(plugin: KyselyPlugin): Kysely<DB> { return this; }
+  override withoutPlugins(): Kysely<DB> { return this; }
+}
+"#,
+            ),
+        ],
+        "./kysely.ts",
+        opts(),
+        &[],
+    );
+
+    assert!(
+        !has_code(&diags, 4112),
+        "cross-file generic base override must not emit TS4112, got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// The same rule must hold regardless of the type-parameter name chosen on
+/// either the base or the derived class — the gate is structural, not
+/// name-based.
+#[test]
+fn cross_file_generic_base_override_no_ts4112_renamed_params() {
+    let diags = check_multi_file(
+        &[
+            (
+                "./base.ts",
+                r#"
+export class Repo<Row> {
+  find(): Row | undefined { return undefined; }
+}
+"#,
+            ),
+            (
+                "./derived.ts",
+                r#"
+import { Repo } from "./base.ts";
+export class CachedRepo<Entity> extends Repo<Entity> {
+  override find(): Entity | undefined { return undefined; }
+}
+"#,
+            ),
+        ],
+        "./derived.ts",
+        opts(),
+        &[],
+    );
+
+    assert!(
+        !has_code(&diags, 4112),
+        "renamed-type-parameter cross-file base override must not emit TS4112, got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// Importing an interface (not a class) and using it as the `extends` target is
+/// not extending a class, so TS4112 must still fire. Guards against the gate
+/// over-suppressing.
+#[test]
+fn cross_file_interface_base_still_ts4112() {
+    let diags = check_multi_file(
+        &[
+            (
+                "./shape.ts",
+                r#"
+export interface Shape { area(): number }
+"#,
+            ),
+            (
+                "./circle.ts",
+                r#"
+import { Shape } from "./shape.ts";
+export class Circle extends Shape {
+  override area(): number { return 0; }
+}
+"#,
+            ),
+        ],
+        "./circle.ts",
+        opts(),
+        &[],
+    );
+
+    assert!(
+        has_code(&diags, 4112),
+        "extending an imported interface must still emit TS4112, got: {:?}",
+        codes(&diags)
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: m3-max-64g-opus47

## Track
Conformance / checker parity (Kysely project row, #10663)

## Invariant
When a class has an `extends` clause whose target resolves to a class (following
import-alias / re-export hops), `tsc` treats the class as extending another
class and never emits TS4112 — even when the base's full instance type cannot be
resolved at the use site. This PR makes tsz do the same by gating TS4112 in the
checker (`class_checker.rs`) on whether the `extends` target is a class symbol,
rather than on whether `base_instance_type_from_expression` happened to resolve.
TS4112 still fires when there is no class base at all (no `extends` clause, an
interface base, or an unresolved name).

## Scope
- `crates/tsz-checker/src/classes/class_checker.rs` — the TS4112 "true fallback"
  now only reports when the `extends` target does not resolve to a class;
  consolidated the duplicate `base_heritage_sym` / `base_sym_for_ns_static_check`
  local into one symbol holder.
- `crates/tsz-checker/src/context/cross_file_query.rs` — new
  `CheckerContext::heritage_symbol_resolves_to_class` (follows import-alias /
  re-export hops, checks the `CLASS` symbol flag cross-file).
- Tests: unit negatives in `class_member_closure_tests.rs` + cross-file
  positives/negative in `ts4112_cross_file_override_heritage_tests.rs`.

## Project Corpus Impact
- Row: kysely-project (#10663)
- Bug family: cross-file/generic class heritage resolution → false override
  diagnostics (TS4112)
- Evidence: pinned Kysely corpus (guard config, ref
  `d4911be21cd568d3694dc7f879f72390635226d7`), built `tsz` before/after:
  - before: 281 errors incl. 3× false TS4112 at `src/kysely.ts(452,12)`,
    `(462,12)`, `(472,12)`.
  - after: 278 errors, **0× TS4112**; the only diff between the two runs is those
    3 removed lines — no new diagnostics, no other changes.

## Verification
- `cargo build -p tsz-cli` → run on real Kysely (above): 3 false TS4112 gone,
  nothing else changed.
- `cargo test -p tsz-checker --lib class_member_closure_tests::override` → 9
  pass, incl. new negatives (interface base / implements-only / no-heritage all
  still emit TS4112) and a generic-base positive that varies the type-parameter
  name (`T`/`U`, `DB`/`X`) to prove the rule is structural, not name-based.
- `cargo test -p tsz-checker --test ts4112_cross_file_override_heritage_tests` →
  3 pass (cross-file generic base + renamed params: no TS4112; cross-file
  interface base: still TS4112).
- Focused regression set (`ts4112 ts4113 ts4114 ts4115 ts2416 ts2417 override
  inheritance heritage class_member`) → 104 pass, 0 fail.
- `cargo clippy -p tsz-checker --all-targets --all-features` → clean.
- Full conformance/emit/fourslash left to ready-for-review CI per §19.5.

## Coordination Notes
- Fixes #10679. Issue is labeled `WIP` and claimed by m3-max-64g-opus47 with a
  signed comment.
- Related: #10661 (cross-file class reference resolves to constructor vs
  instance) — that deeper resolution gap is *why* the base type fails to resolve
  here; this PR fixes the TS4112 false positive without depending on it.
- Out of scope / follow-up: tsz has a separate, opposite-direction divergence
  where extending an **unresolved name** (`class C extends NotDefined {}`)
  resolves the base to `any` and emits **no** TS4112, whereas tsc emits TS4112.
  That lives in a different path (`check_override_members_against_type` with an
  `any` base); will file a follow-up issue rather than widen this PR.

https://claude.ai/code/session_01LNVE8ECpdQbR989D75zNyF