### PR TITLE
fix(checker): accept structurally-fitting assertions to constrained type parameter

### DIFF
--- a/crates/tsz-checker/src/assignability/constrained_type_param_assertion.rs
+++ b/crates/tsz-checker/src/assignability/constrained_type_param_assertion.rs
@@ -1,0 +1,126 @@
+use crate::state::CheckerState;
+use tsz_common::{Atom, Visibility};
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// Returns true when `target` is a constrained type parameter `T extends C`
+    /// and `source`'s required members structurally fit `C`, matching `tsc`'s
+    /// deferred assertion overlap rule for `source as T`.
+    pub(crate) fn assertion_source_fits_constrained_type_param(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> bool {
+        let Some(info) = crate::query_boundaries::common::type_param_info(self.ctx.types, target)
+        else {
+            return false;
+        };
+        let Some(raw_constraint) = info.constraint else {
+            return false;
+        };
+        if raw_constraint == TypeId::ANY || raw_constraint == TypeId::UNKNOWN {
+            return false;
+        }
+        if crate::query_boundaries::assignability::contains_type_parameters(
+            self.ctx.types,
+            raw_constraint,
+        ) {
+            return false;
+        }
+
+        let resolved_source = self.evaluate_type_with_resolution(source);
+        let resolved_constraint = self.evaluate_type_with_resolution(raw_constraint);
+
+        let source_props =
+            crate::query_boundaries::common::object_shape_for_type(self.ctx.types, resolved_source)
+                .map(|shape| shape.properties.to_vec())
+                .unwrap_or_default();
+        if source_props.is_empty() {
+            // Empty-object and non-object cases stay on the solver overlap path.
+            return false;
+        }
+        if source_props
+            .iter()
+            .any(|p| p.visibility != Visibility::Public)
+        {
+            return false;
+        }
+
+        let mut saw_required = false;
+        for prop in source_props.iter().filter(|p| !p.optional) {
+            saw_required = true;
+            if !self.constrained_type_param_constraint_provides_member(
+                resolved_constraint,
+                prop.name,
+                prop.type_id,
+                0,
+            ) {
+                return false;
+            }
+        }
+        saw_required
+    }
+
+    fn constrained_type_param_constraint_provides_member(
+        &mut self,
+        constraint: TypeId,
+        name: Atom,
+        source_prop_type: TypeId,
+        depth: u32,
+    ) -> bool {
+        if depth > 10 {
+            return false;
+        }
+        if constraint == TypeId::ANY || constraint == TypeId::UNKNOWN {
+            return true;
+        }
+
+        let constraint = self.evaluate_type_with_resolution(constraint);
+        if let Some(members) =
+            crate::query_boundaries::common::union_members(self.ctx.types, constraint)
+        {
+            return members.iter().any(|&member| {
+                self.constrained_type_param_constraint_provides_member(
+                    member,
+                    name,
+                    source_prop_type,
+                    depth + 1,
+                )
+            });
+        }
+        if let Some(members) =
+            crate::query_boundaries::common::intersection_members(self.ctx.types, constraint)
+        {
+            return members.iter().any(|&member| {
+                self.constrained_type_param_constraint_provides_member(
+                    member,
+                    name,
+                    source_prop_type,
+                    depth + 1,
+                )
+            });
+        }
+        if let Some(prop) = crate::query_boundaries::common::find_property_in_object(
+            self.ctx.types,
+            constraint,
+            name,
+        ) {
+            return crate::query_boundaries::common::types_are_comparable_for_assertion(
+                self.ctx.types,
+                source_prop_type,
+                prop.type_id,
+            );
+        }
+        if let Some(shape) =
+            crate::query_boundaries::common::object_shape_for_type(self.ctx.types, constraint)
+            && let Some(idx) = shape.string_index
+        {
+            return crate::query_boundaries::common::types_are_comparable_for_assertion(
+                self.ctx.types,
+                source_prop_type,
+                idx.value_type,
+            );
+        }
+        false
+    }
+}

--- a/crates/tsz-checker/src/assignability/mod.rs
+++ b/crates/tsz-checker/src/assignability/mod.rs
@@ -15,6 +15,7 @@ pub mod assignment_checker;
 mod awaited_variance_normalization;
 mod callable_union_relation;
 pub(crate) mod compound_assignment;
+mod constrained_type_param_assertion;
 mod index_access_normalization;
 mod nullish_error_targets;
 mod polymorphic_this_diagnostics;

--- a/crates/tsz-checker/src/dispatch/mod.rs
+++ b/crates/tsz-checker/src/dispatch/mod.rs
@@ -1106,6 +1106,17 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                                                 effective_asserted,
                                             );
                                     }
+                                    // Constrained-type-parameter assertion (#10676):
+                                    // `source as T extends C` is comparable when
+                                    // source's required members fit C structurally.
+                                    if !have_overlap {
+                                        have_overlap = self
+                                            .checker
+                                            .assertion_source_fits_constrained_type_param(
+                                                expr_type,
+                                                asserted_type,
+                                            );
+                                    }
                                     if have_overlap
                                         && self
                                             .object_literal_this_property_blocks_assertion_overlap(

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -345,6 +345,9 @@ mod ts2323_tests;
 #[path = "../tests/ts2347_tests.rs"]
 mod ts2347_tests;
 #[cfg(test)]
+#[path = "../tests/ts2352_constrained_type_param_target_tests.rs"]
+mod ts2352_constrained_type_param_target_tests;
+#[cfg(test)]
 #[path = "../tests/ts2352_disjoint_literal_property_tests.rs"]
 mod ts2352_disjoint_literal_property_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/tests/ts2352_constrained_type_param_target_tests.rs
+++ b/crates/tsz-checker/tests/ts2352_constrained_type_param_target_tests.rs
@@ -1,0 +1,281 @@
+//! Tests for TS2352 type-assertion overlap when the assertion target is a
+//! constrained type parameter `T extends C`.
+//!
+//! Reported via #10676 (kysely false-positive `Readonly<X> as T` assertions).
+//!
+//! Structural rule, matching tsc's `checkAssertionDeferred`: the cast
+//! `source as T extends C` is permitted iff source's REQUIRED object members
+//! structurally fit C (allowing primitive↔literal comparable narrowing).
+//! Source's optional members are ignored. If source has any REQUIRED member
+//! not present in C with a comparable type, tsc emits TS2352 with the
+//! "T could be instantiated with a different subtype of constraint"
+//! elaboration.
+//!
+//! The check runs at the checker level so that interface-shaped constraints
+//! (stored as `Lazy(DefId)` references on the type-parameter info) are
+//! resolved before the structural walk — purely solver-level checks see an
+//! opaque constraint and miss the structural overlap that tsc accepts.
+
+use crate::test_utils::check_source_strict_codes as check_strict;
+
+// ---------------------------------------------------------------------------
+// Source structurally fits constraint → no TS2352
+// ---------------------------------------------------------------------------
+
+/// `Readonly<X> as T extends C` where X conforms to C must NOT emit TS2352.
+/// Reduced from kysely's `operation-node-transformer.ts` row.
+#[test]
+fn readonly_concrete_subtype_as_constrained_type_param_no_ts2352() {
+    for (op_name, sn_name, t_name) in [
+        ("OperationNode", "SelectNode", "T"),
+        ("Op", "SN", "U"),
+        ("Base", "Concrete", "K"),
+    ] {
+        let source = format!(
+            r#"
+interface {op_name} {{ readonly kind: string }}
+interface {sn_name} {{ readonly kind: 'SelectNode'; readonly stuff?: string }}
+
+function transform<{t_name} extends {op_name}>(node: Readonly<{sn_name}>): {t_name} {{
+    return node as {t_name};
+}}
+"#
+        );
+        let codes = check_strict(&source);
+        let ts2352: Vec<&u32> = codes.iter().filter(|c| **c == 2352).collect();
+        assert!(
+            ts2352.is_empty(),
+            "[{op_name}/{sn_name}/{t_name}] no TS2352 expected — `Readonly<{sn_name}>` \
+             structurally fits constraint `{op_name}`. Got: {codes:?}"
+        );
+    }
+}
+
+/// Inline object literal with a literal-narrowed property assigned to a
+/// constrained type parameter must NOT emit TS2352 — the literal at the
+/// matching key is comparable to the constraint's primitive at the same key.
+#[test]
+fn inline_literal_property_as_constrained_type_param_no_ts2352() {
+    let source = r#"
+interface Op { kind: string }
+function f<T extends Op>(): T {
+    return { kind: 'foo' } as T;
+}
+function g<U extends { kind: string }>(): U {
+    return { kind: 'bar' } as U;
+}
+"#;
+    let codes = check_strict(source);
+    let ts2352: Vec<&u32> = codes.iter().filter(|c| **c == 2352).collect();
+    assert!(
+        ts2352.is_empty(),
+        "no TS2352 expected — `kind:'foo'`/`kind:'bar'` are comparable to constraint's \
+         `kind:string`. Got: {codes:?}"
+    );
+}
+
+/// A source whose only required member matches the constraint exactly must
+/// NOT emit TS2352, even when the source carries additional OPTIONAL members.
+#[test]
+fn source_with_optional_extras_no_ts2352() {
+    let source = r#"
+interface Op { kind: string }
+function f<T extends Op>(x: { kind: string; extra?: number }): T {
+    return x as T;
+}
+function g<T extends Op>(x: { kind: 'a'; extra?: number }): T {
+    return x as T;
+}
+"#;
+    let codes = check_strict(source);
+    let ts2352: Vec<&u32> = codes.iter().filter(|c| **c == 2352).collect();
+    assert!(
+        ts2352.is_empty(),
+        "no TS2352 expected — `extra` is optional, not a required extra. Got: {codes:?}"
+    );
+}
+
+/// `{}` source against a constrained type parameter whose constraint
+/// contains an object-like member must remain comparable. Anti-regression
+/// for the existing `{}`-special-case rule.
+#[test]
+fn empty_object_as_constrained_type_param_no_ts2352() {
+    let source = r#"
+function yes<T extends object | null | undefined>() {
+    let x = {};
+    x as T;
+}
+"#;
+    let codes = check_strict(source);
+    let ts2352: Vec<&u32> = codes.iter().filter(|c| **c == 2352).collect();
+    assert!(
+        ts2352.is_empty(),
+        "no TS2352 expected — `{{}}` overlaps with `object` member of T's constraint. \
+         Got: {codes:?}"
+    );
+}
+
+/// Source assigned to a constrained type parameter whose constraint is an
+/// intersection of object-likes — ANY intersection member providing a
+/// matching property is sufficient (the intersection exposes all members'
+/// properties).
+#[test]
+fn source_fits_intersection_constraint_no_ts2352() {
+    for (op_name, t_name) in [("Op", "T"), ("Base", "U"), ("Node", "K")] {
+        let source = format!(
+            r#"
+interface {op_name} {{ kind: string }}
+function f<{t_name} extends {op_name} & {{ other: number }}>(x: {{ kind: 'a'; other: 1 }}): {t_name} {{
+    return x as {t_name};
+}}
+"#
+        );
+        let codes = check_strict(&source);
+        let ts2352: Vec<&u32> = codes.iter().filter(|c| **c == 2352).collect();
+        assert!(
+            ts2352.is_empty(),
+            "[{op_name}/{t_name}] no TS2352 expected — both required source members fit \
+             members of the intersection constraint. Got: {codes:?}"
+        );
+    }
+}
+
+/// Source assigned to a constrained type parameter whose constraint is a
+/// union of object-likes — SOME union member must provide the required
+/// property for the cast to be accepted.
+#[test]
+fn source_fits_some_union_member_in_constraint_no_ts2352() {
+    for (op_name, other_name, t_name) in [
+        ("Op", "Other", "T"),
+        ("First", "Second", "U"),
+        ("A", "B", "K"),
+    ] {
+        let source = format!(
+            r#"
+interface {op_name} {{ kind: string }}
+interface {other_name} {{ otherKey: number }}
+function f<{t_name} extends {op_name} | {other_name}>(x: {{ kind: 'a' }}): {t_name} {{
+    return x as {t_name};
+}}
+"#
+        );
+        let codes = check_strict(&source);
+        let ts2352: Vec<&u32> = codes.iter().filter(|c| **c == 2352).collect();
+        assert!(
+            ts2352.is_empty(),
+            "[{op_name}/{other_name}/{t_name}] no TS2352 expected — `kind:'a'` fits the \
+             `{op_name}` member of the constraint union. Got: {codes:?}"
+        );
+    }
+}
+
+/// Anti-regression for the Lazy-wrapped union: when the constraint is named
+/// via a type alias whose body is a union, the structural fit still applies
+/// — the helper must resolve the alias before decomposing the union.
+#[test]
+fn source_fits_lazy_aliased_union_constraint_no_ts2352() {
+    let source = r#"
+interface Op { kind: string }
+interface Other { otherKey: number }
+type OpOrOther = Op | Other;
+function f<T extends OpOrOther>(x: { kind: 'a' }): T {
+    return x as T;
+}
+"#;
+    let codes = check_strict(source);
+    let ts2352: Vec<&u32> = codes.iter().filter(|c| **c == 2352).collect();
+    assert!(
+        ts2352.is_empty(),
+        "no TS2352 expected — alias `OpOrOther` resolves to a union whose `Op` member fits \
+         `kind:'a'`. Got: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Source has REQUIRED extras beyond constraint → TS2352 still fires
+// ---------------------------------------------------------------------------
+
+/// Source class has a required member that does not exist in the constraint.
+/// tsc emits TS2352 with the "different subtype of constraint" elaboration;
+/// tsz must continue to emit TS2352. Mirrors `genericTypeAssertions4.ts`.
+#[test]
+fn subclass_with_required_extras_as_constrained_type_param_emits_ts2352() {
+    for (a_name, b_name) in [("A", "B"), ("Base", "Derived"), ("Animal", "Dog")] {
+        let source = format!(
+            r#"
+class {a_name} {{ foo() {{ return ""; }} }}
+class {b_name} extends {a_name} {{ bar() {{ return 1; }} }}
+declare let b: {b_name};
+function f<T extends {a_name}>() {{
+    let y = b as T;
+}}
+"#
+        );
+        let codes = check_strict(&source);
+        let ts2352: Vec<&u32> = codes.iter().filter(|c| **c == 2352).collect();
+        assert!(
+            !ts2352.is_empty(),
+            "[{a_name}/{b_name}] TS2352 expected — `{b_name}` has REQUIRED `bar` not in \
+             constraint `{a_name}`. Got: {codes:?}"
+        );
+    }
+}
+
+/// Source object literal with a REQUIRED extra property emits TS2352, even
+/// when the matching property fits the constraint.
+#[test]
+fn object_literal_with_required_extra_emits_ts2352() {
+    let source = r#"
+interface Op { kind: string }
+function f<T extends Op>(x: { kind: string; extra: number }): T {
+    return x as T;
+}
+function g<T extends Op>(x: { kind: 'a'; extra: number }): T {
+    return x as T;
+}
+"#;
+    let codes = check_strict(source);
+    let ts2352: Vec<&u32> = codes.iter().filter(|c| **c == 2352).collect();
+    assert!(
+        ts2352.len() >= 2,
+        "TS2352 expected on both casts — `extra` is required and absent from constraint. \
+         Got: {codes:?}"
+    );
+}
+
+/// Source completely unrelated to constraint still emits TS2352. The
+/// constraint-fit rule does not over-permit primitive/object mismatches.
+#[test]
+fn unrelated_shape_emits_ts2352() {
+    let source = r#"
+interface Op { kind: string }
+function a<T extends Op>(x: { foo: number }): T { return x as T; }
+function b<T extends Op>(x: number): T { return x as T; }
+function c<T extends Op>(x: boolean): T { return x as T; }
+"#;
+    let codes = check_strict(source);
+    let ts2352: Vec<&u32> = codes.iter().filter(|c| **c == 2352).collect();
+    assert!(
+        ts2352.len() >= 3,
+        "TS2352 expected on all three casts. Got: {codes:?}"
+    );
+}
+
+/// Source against a constrained type parameter whose constraint is
+/// `null | undefined` (no object-like member) must emit TS2352 even when
+/// source is `{}`. Anti-regression for the empty-object special case.
+#[test]
+fn empty_object_as_typeparam_without_object_in_constraint_emits_ts2352() {
+    let source = r#"
+function f<T extends null | undefined>() {
+    let x = {};
+    x as T;
+}
+"#;
+    let codes = check_strict(source);
+    let ts2352: Vec<&u32> = codes.iter().filter(|c| **c == 2352).collect();
+    assert!(
+        !ts2352.is_empty(),
+        "TS2352 expected — `{{}}` has no overlap with `null | undefined`. Got: {codes:?}"
+    );
+}

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -216,7 +216,16 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         # `intersection_members` + `find_property_by_str` member lookup, all
         # matching the existing direct-call pattern already used throughout this
         # file. The helpers are only exposed via `query_boundaries::common`.
-        3269,
+        #
+        # Bumped by 8 for the TS2352 constrained-type-parameter assertion
+        # rule (#10676) — `assertion_source_fits_constrained_type_param` and
+        # its recursive helper resolve / decompose the constraint via
+        # `query_boundaries::common` helpers (`type_param_info`,
+        # `union_members`, `intersection_members`, `find_property_in_object`,
+        # `object_shape_for_type`, `types_are_comparable_for_assertion`).
+        # All routes are existing request-shaped boundaries — no new
+        # quarantine entry — so the count rises by the expected delta.
+        3277,
     ),
 ]
 

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1140,7 +1140,16 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         # `intersection_members` + `find_property_by_str` member lookup, all
         # matching the existing direct-call pattern already used throughout this
         # file. The helpers are only exposed via `query_boundaries::common`.
-        3269,
+        #
+        # Bumped by 8 for the TS2352 constrained-type-parameter assertion
+        # rule (#10676) — `assertion_source_fits_constrained_type_param` and
+        # its recursive helper resolve / decompose the constraint via
+        # `query_boundaries::common` helpers (`type_param_info`,
+        # `union_members`, `intersection_members`, `find_property_in_object`,
+        # `object_shape_for_type`, `types_are_comparable_for_assertion`).
+        # All routes are existing request-shaped boundaries — no new
+        # quarantine entry — so the count rises by the expected delta.
+        3277,
     ),
 ]
 


### PR DESCRIPTION
AgentName: M1-C

## Track

Conformance / checker false-positive (issue #10676).

## Invariant

Match tsc's `checkAssertionDeferred` for `source as T extends C`: the cast is comparable iff each REQUIRED member of source has a comparable counterpart in `C` (with primitive↔literal narrowing). Source's optional members are ignored. Required extras still emit TS2352 with the "different subtype of constraint" semantic.

## Scope

Closes #10676. Adds a checker-level fallback that runs after `object_properties_are_comparable` bails on type-parameter operands; resolves the constraint through `evaluate_type_with_resolution` so Lazy interface refs and aliased `A | B` constraints decompose correctly.

```ts
interface OperationNode { readonly kind: string }
interface SelectNode { readonly kind: 'SelectNode'; readonly stuff?: string }

function transform<T extends OperationNode>(node: Readonly<SelectNode>): T {
    return node as T;   // before: false TS2352. tsc: clean. now: clean.
}
```

The dispatch path previously keyed the bidirectional overlap on the opaque `T` itself; for a concrete source vs opaque type-parameter target, both directions returned false and TS2352 fired. tsc's rule walks via T's source-type-variable case to `comparable(C, widenedSource)`. The new helper implements that one-directional structural check.

Anti-regression coverage: `B as T extends A` (B has required `bar` not in A) and `{kind:string;extra:number} as T extends {kind:string}` both continue to emit TS2352.

## Project Corpus Impact

- Row: kysely-project
- Bug family: false-positive TS2352 on constrained type-parameter cast targets

Reduced witnesses derived from `src/operation-node/operation-node-transformer.ts`; full row impact awaits a CI bench refresh. Evidence: 11 new unit tests in `crates/tsz-checker/tests/ts2352_constrained_type_param_target_tests.rs` cover the structural rule's positive and negative cases. The full kysely benchmark fixture cannot be reproduced locally per §19.5, so CI will validate row delta.

## Verification

Local (focused, per §19.5):

```
cargo test -p tsz-checker --lib ts2352_constrained_type_param_target_tests:: → 11/11 PASS
cargo test -p tsz-checker --lib ts2352                                       → 76/76 PASS
cargo test -p tsz-checker --lib assertion_overlap                             → 28/28 PASS
python3 scripts/arch/arch_guard.py                                            → PASS
```

Minimal repros run against the built `dist-fast` tsz:

| case | before | after | tsc |
| --- | --- | --- | --- |
| `Readonly<SelectNode> as T extends OperationNode` | TS2352 | clean | clean |
| `{ kind: 'foo' } as T extends Op` | TS2352 | clean | clean |
| `{ kind: string; extra?: number } as T extends Op` | TS2352 | clean | clean |
| `{} as T extends object \| null \| undefined` | clean | clean | clean |
| `{} as T extends null \| undefined` | TS2352 | TS2352 | TS2352 |
| `B as T extends A` (B has required `bar`) | TS2352 | TS2352 | TS2352 |
| `{ kind: string; extra: number } as T extends Op` | TS2352 | TS2352 | TS2352 |
| `Cat as T extends Animal` (Cat has required `meow`) | TS2352 | TS2352 | TS2352 |
| `Op \| Other` aliased as `type OpOrOther`, `{kind:'a'} as T extends OpOrOther` | TS2352 | clean | clean |

Heavy CI (conformance-aggregate, emit, fourslash, WASM) will run with this ready PR.

## Coordination Notes

- Kysely-cluster siblings (#10667 — #10683) signed `M5Opus` are not in scope here. This PR fixes the TS2352 false positive specifically; other kysely false positives need their own structural rules.
- The fix lives in `assignability_diagnostics.rs` rather than the solver because the constraint may be a `Lazy(DefId)` reference that only the checker can resolve. The solver's existing `types_are_comparable_for_assertion` complements this path but skips it (line ~1015 narrows to `{}` source only — a deliberate choice to avoid over-permitting `B as T extends A`).
- Architecture cap (`scripts/arch/arch_guard_config.py` + `arch_guard_shared.py`) bumped by 8 for the new helper's `query_boundaries::common` traversal; all routes are existing request-shaped boundaries.
- Hardcoding/generalization checklist (§25 / §26):
  - Three+ adjacent cases per rule: `Readonly<X>` / inline literal / optional extras / union constraint / Lazy-aliased union / intersection constraint / required-extras emit / unrelated-shape emit.
  - Renamed bound variables (`T`/`U`/`K`, `Op`/`Base`/`Node`) prove the fix is not name-hardcoded.
  - Structural rule stated as: "when target is a constrained type parameter `T extends C`, suppress TS2352 iff each REQUIRED source member has a comparable counterpart in `C`".
  - No regex / printer-output / source-text decisions.

---
_Generated by [Claude Code](https://claude.ai/code)_
