### PR TITLE
test(checker): ratchet contextual builder chain inference

### DIFF
--- a/crates/tsz-checker/tests/generic_call_inference_tests_parts/part_02.rs
+++ b/crates/tsz-checker/tests/generic_call_inference_tests_parts/part_02.rs
@@ -1240,3 +1240,40 @@ branch({
         "primitive literal covariant evidence should be probed as the literal, not widened past its union constraint. Got: {diags:#?}"
     );
 }
+
+#[test]
+fn contextual_generic_builder_chain_preserves_indexed_selection() {
+    // Kysely-style builder reduction from #8773: each chained method call must
+    // keep the selected schema/table instantiation while indexing into `S[K]`.
+    let source = r#"
+type Schema = {
+    user: { id: number; name: string };
+    post: { id: number; userId: number };
+};
+
+declare function build<S, K extends keyof S>(
+    key: K,
+): {
+    select<P extends keyof S[K]>(prop: P): S[K][P];
+};
+
+const userId = build<Schema, "user">("user").select("id");
+const userName = build<Schema, "user">("user").select("name");
+const postUserId = build<Schema, "post">("post").select("userId");
+
+const _userId: number = userId;
+const _userName: string = userName;
+const _postUserId: number = postUserId;
+const bad: string = postUserId;
+"#;
+    let diags = relevant_diagnostics(source);
+    assert_eq!(
+        diagnostic_count(&diags, 2322),
+        1,
+        "post.userId should be number, so only the final string assignment should fail. Got: {diags:#?}"
+    );
+    assert!(
+        lacks_any_diagnostic_code(&diags, &[2339, 2344, 2345, 7006]),
+        "builder-chain contextual instantiation should not lose table keys or callback context. Got: {diags:#?}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-C

## Track
M4-C inference/session semantic campaign; test-only project blocker ratchet for #8773.

## Invariant
When a generic builder call selects a key from a schema type parameter and a chained method indexes into `S[K]`, tsz should preserve the per-call contextual instantiation so selected properties retain their `S[K][P]` type. This PR adds a focused checker regression witness without changing compiler behavior.

## Scope
- `crates/tsz-checker/tests/generic_call_inference_tests_parts/part_02.rs`

## Project Corpus Impact
- Row: Kysely
- Bug family: contextual generic builder-chain instantiation through indexed access
- Evidence: crate-local ratchet for #8773; no project-corpus row status is claimed by this test-only PR.

## Verification
- Base: `origin/main` at `6e0c642f30c101279e52e0a71ca3207bd7d77d27`
- Head: `6a2be1e71c5419161ebdc7b143c26b045694235e`
- `git diff --check`
- `cargo fmt --check`
- `cargo nextest run -p tsz-checker --test generic_call_inference_tests contextual_generic_builder_chain_preserves_indexed_selection` (1 passed, 198 skipped)
- Line count: `crates/tsz-checker/tests/generic_call_inference_tests_parts/part_02.rs` is 1279 lines.

## Coordination Notes
- Opened after owned PRs #10532 and #10567 were enqueued with `merge-queue` on green exact-head checks.
- #8773 has prior M4-C notes that the old root reduction path is absent from current `main`; this PR keeps the witness in the current crate-local checker test layout.
- No roadmap update is needed; this is a routine test-only ratchet.