### PR TITLE
test(solver): cover callback relation cache

### DIFF
--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -1053,3 +1053,101 @@ fn assignability_cache_erased_generic_retry_matches_uncached_relation_policy() {
         "no-retry slot must remain intact after the retry lookup",
     );
 }
+
+#[test]
+fn assignability_cache_in_callback_param_check_matches_uncached_relation_policy() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let name = interner.intern_string("name");
+    let breed = interner.intern_string("breed");
+
+    let animal = interner.object(vec![PropertyInfo::new(name, TypeId::STRING)]);
+    let dog = interner.object(vec![
+        PropertyInfo::new(name, TypeId::STRING),
+        PropertyInfo::new(breed, TypeId::STRING),
+    ]);
+
+    let mut dog_method_shape = FunctionShape::new(vec![ParamInfo::unnamed(dog)], TypeId::VOID);
+    dog_method_shape.is_method = true;
+    let source = interner.function(dog_method_shape);
+
+    let mut animal_method_shape =
+        FunctionShape::new(vec![ParamInfo::unnamed(animal)], TypeId::VOID);
+    animal_method_shape.is_method = true;
+    let target = interner.function(animal_method_shape);
+
+    let ordinary_method_policy =
+        RelationPolicy::from_relation_flags(RelationFlags::STRICT_FUNCTION_TYPES);
+    let callback_policy = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_FUNCTION_TYPES | RelationFlags::IN_CALLBACK_PARAM_CHECK,
+    );
+    let ordinary_key =
+        RelationCacheKey::for_assignability(source, target, ordinary_method_policy.cache_config());
+    let callback_key =
+        RelationCacheKey::for_assignability(source, target, callback_policy.cache_config());
+
+    assert_ne!(
+        ordinary_key, callback_key,
+        "callback parameter mode must occupy a distinct assignability cache slot",
+    );
+
+    let ordinary_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        ordinary_method_policy,
+        RelationContext::default(),
+    )
+    .is_related();
+    let callback_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        callback_policy,
+        RelationContext::default(),
+    )
+    .is_related();
+
+    assert!(
+        ordinary_uncached,
+        "ordinary strict-function method comparison keeps method parameters bivariant",
+    );
+    assert!(
+        !callback_uncached,
+        "callback parameter mode must disable method bivariance for the immediate signature comparison",
+    );
+
+    let ordinary_cached = db.is_assignable_to_with_policy(source, target, ordinary_method_policy);
+    assert_eq!(
+        ordinary_cached, ordinary_uncached,
+        "cached ordinary method policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(ordinary_key),
+        Some(ordinary_cached),
+        "ordinary method result must use its own cache slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(callback_key),
+        None,
+        "callback-mode lookup must not hit the ordinary method slot",
+    );
+
+    let callback_cached = db.is_assignable_to_with_policy(source, target, callback_policy);
+    assert_eq!(
+        callback_cached, callback_uncached,
+        "cached callback-mode policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(callback_key),
+        Some(callback_cached),
+        "callback-mode result must use its own cache slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(ordinary_key),
+        Some(ordinary_cached),
+        "ordinary method slot must remain intact after the callback-mode lookup",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 10 relation policy/cache-key tech debt (#8207), solver policy/cache agreement test ratchet.

## Invariant
When relation policy enables `IN_CALLBACK_PARAM_CHECK`, a method-like signature comparison entered as a callback parameter check must use strict immediate parameter variance; the cached assignability path must agree with uncached `query_relation` and use a distinct policy-shaped cache key.

## Scope
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: solver test-only ratchet for relation policy/cache agreement; no project corpus behavior change targeted.

## Verification
- RED `cargo nextest run -p tsz-solver -E 'test(assignability_cache_in_callback_param_check_matches_uncached_relation_policy)'` failed before the test existed with `error: no tests to run`.
- Pre-stack verification on old head `b2d75cff779192cb50c9c2193a432d8cc4962c72`: `cargo nextest run -p tsz-solver -E 'test(assignability_cache_in_callback_param_check_matches_uncached_relation_policy)'`: 1 passed.
- Pre-stack verification on old head `b2d75cff779192cb50c9c2193a432d8cc4962c72`: `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'`: 13 passed.
- After #10706 merged, rebased onto `origin/main` and pushed exact head `3fd84e72186189deff79022064db77424b32140a`.
- `cargo nextest run -p tsz-solver -E 'test(assignability_cache_in_callback_param_check_matches_uncached_relation_policy)'`: 1 passed on rebased head `3fd84e72186189deff79022064db77424b32140a`.
- `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'`: 13 passed on rebased head `3fd84e72186189deff79022064db77424b32140a`.
- `cargo fmt --check`.
- `git diff --check`.
- `git diff --check origin/main..HEAD`.
- File-size guard: `wc -l crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs` -> 1153 lines, below the 2000-line cap.
- Ready-review GitHub Actions are expected to run after this PR is marked ready; no `merge-queue` label set.

## Coordination Notes
- #10706 merged on 2026-05-28; this PR has been retargeted from `codex/m4-b-erased-retry-cache-20260528` to `main` and rebased cleanly.
- Non-overlap: this slice covers only `IN_CALLBACK_PARAM_CHECK`; it does not touch checker relation routing owned by M1-B, nor M4-A/M4-C evaluation/inference lanes.
- Downstream stack remains draft: #10729 is based on this branch and should be retargeted only after this PR lands.
- No `WIP`, auto-merge, or `merge-queue` state set.