### PR TITLE
refactor(checker): gate return-context utility wrappers by identity

### DIFF
--- a/crates/tsz-checker/src/checkers/call_context.rs
+++ b/crates/tsz-checker/src/checkers/call_context.rs
@@ -790,8 +790,7 @@ impl<'a> CheckerState<'a> {
         }
         if let Some((base, args)) = common::application_info(self.ctx.types, source)
             && args.len() == 1
-            && self
-                .return_context_application_base_has_name(base, &["Readonly", "NoInfer", "Awaited"])
+            && self.return_context_application_base_is_lib_utility_wrapper(base)
         {
             return self.contextual_return_type_specializes_wrapped_params(
                 args[0],
@@ -956,11 +955,10 @@ impl<'a> CheckerState<'a> {
         self.is_promise_type(base)
     }
 
-    pub(crate) fn return_context_application_base_has_name(
+    fn return_context_application_base_symbol(
         &self,
         base: TypeId,
-        names: &[&str],
-    ) -> bool {
+    ) -> Option<(tsz_binder::SymbolId, &tsz_binder::Symbol)> {
         self.ctx
             .resolve_type_to_symbol_id(base)
             .or_else(|| {
@@ -971,8 +969,27 @@ impl<'a> CheckerState<'a> {
                 common::type_query_symbol(self.ctx.types, base)
                     .map(|symbol_ref| tsz_binder::SymbolId(symbol_ref.0))
             })
-            .and_then(|symbol_id| self.ctx.binder.get_symbol(symbol_id))
-            .is_some_and(|symbol| names.contains(&symbol.escaped_name.as_str()))
+            .and_then(|symbol_id| {
+                self.ctx
+                    .binder
+                    .get_symbol(symbol_id)
+                    .map(|symbol| (symbol_id, symbol))
+            })
+    }
+
+    pub(crate) fn return_context_application_base_is_lib_utility_wrapper(
+        &self,
+        base: TypeId,
+    ) -> bool {
+        let Some((symbol_id, symbol)) = self.return_context_application_base_symbol(base) else {
+            return false;
+        };
+
+        match symbol.escaped_name.as_str() {
+            "Readonly" | "NoInfer" => self.symbol_has_standard_lib_origin(symbol_id),
+            "Awaited" => self.is_standard_or_conditional_awaited_alias(symbol_id, symbol),
+            _ => false,
+        }
     }
 
     pub(crate) fn sensitive_callback_placeholder_should_skip_round1_inference(

--- a/crates/tsz-checker/src/checkers/promise_checker.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker.rs
@@ -241,7 +241,11 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    fn is_standard_or_conditional_awaited_alias(&self, sym_id: SymbolId, symbol: &Symbol) -> bool {
+    pub(crate) fn is_standard_or_conditional_awaited_alias(
+        &self,
+        sym_id: SymbolId,
+        symbol: &Symbol,
+    ) -> bool {
         if self.symbol_has_standard_lib_origin(sym_id) {
             return true;
         }

--- a/crates/tsz-checker/src/tests/contextual_return_wrapper_tests.rs
+++ b/crates/tsz-checker/src/tests/contextual_return_wrapper_tests.rs
@@ -128,6 +128,37 @@ function outer<U>(value: U) {
 }
 
 #[test]
+fn return_context_does_not_unwrap_user_readonly_alias_by_name() {
+    let diags = check_source_diagnostics(
+        r#"
+type Readonly<T> = { value: T };
+declare function make<T>(callback: () => T): Readonly<T>;
+
+const n: number = make(() => "text");
+"#,
+    );
+
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert!(
+        !ts2322.is_empty(),
+        "Expected TS2322 because a user-defined Readonly<T> alias is not the lib wrapper, got: {:?}",
+        diagnostic_messages(&ts2322)
+    );
+}
+
+#[test]
+fn return_context_wrapper_detection_uses_identity_helpers() {
+    let source = include_str!("../checkers/call_context.rs");
+
+    assert!(
+        !source.contains(
+            "return_context_application_base_has_name(base, &[\"Readonly\", \"NoInfer\", \"Awaited\"])"
+        ),
+        "return-context wrapper detection must not treat utility wrappers as a name allowlist"
+    );
+}
+
+#[test]
 fn generic_wrapper_recheck_clears_stale_implicit_any_on_callback_body_use() {
     let diags = check_source_diagnostics(
         r#"


### PR DESCRIPTION
## Agent
AgentName: M4-D

## Track
Semantic identity cleanup / checker return-context utility-wrapper identity ratchet.

## Invariant
When return-context inference sees a generic application whose base is spelled like a utility wrapper, tsz should only peel it as a special wrapper when the base resolves to a standard-lib/cloned-lib utility identity, or to the existing conditional `Awaited` alias compatibility shape. User aliases that merely reuse names such as `Readonly` must keep normal alias semantics.

## Scope
- Replace the return-context `Readonly`/`NoInfer`/`Awaited` name-list helper with a symbol-resolution helper and lib/conditional identity predicates.
- Reuse the existing `Awaited` standard-or-conditional alias predicate from the Promise checker path.
- Add focused return-context tests for user `Readonly` alias behavior and the source-level identity guard.

## Project Corpus Impact
- Row: n/a
- Bug family: name-based utility-wrapper identity debt
- Evidence: architecture cleanup only; this ratchets one return-context name-list decision without changing a known project-row blocker.

## Verification
- `cargo nextest run -p tsz-checker --lib -E 'test(return_context_does_not_unwrap_user_readonly_alias_by_name) | test(return_context_wrapper_detection_uses_identity_helpers) | test(return_context_promise_wrapper_detection_uses_lib_identity_helper)'`
- `cargo nextest run -p tsz-checker --lib contextual_return_wrapper_tests`
- `cargo nextest run -p tsz-checker --lib return_context_promise_identity_tests`
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `python3 scripts/arch/arch_guard.py`
- Draft exact-head CI for `4fadb124c621c1fa06d696f91af4c01b2e7b3c7e`: `CI Light Summary`, `unit`, `unit-cloudbuild`, `lint`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `project-row-drift`, and `GitGuardian Security Checks` passed.
- Ready exact-head CI for `4fadb124c621c1fa06d696f91af4c01b2e7b3c7e`: `CI Summary`, `GitGuardian Security Checks`, conformance, emit, fourslash, WASM, unit, lint, dist, and project guard jobs passed.

## Coordination Notes
- AgentName: M4-D
- Non-overlap: #10641 remains queued with `merge-queue`; #10686 remains draft/stacked on #10641. This PR is a separate return-context identity-ratchet slice from `docs/architecture/WELL_KNOWN_NAME_REFERENCES.md`.
- Structural owner: checker orchestration resolves the application base symbol, while semantic shape extraction still flows through query-boundary helpers and existing solver-backed wrapper predicates.
- Adjacent cases covered: user `Readonly<T>` alias is not peeled by spelling; return-context source guard rejects the utility wrapper name-list; existing Promise identity guard remains green.
- `merge-queue` was added after ready exact-head `CI Summary` and `GitGuardian Security Checks` passed; waiting for queue-owned `Queue Tested`.
