### PR TITLE
fix(checker): resolve Record-constrained type param apparent type for TS7053

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1583,6 +1583,10 @@ name = "ts7053_template_mapped_tests"
 path = "tests/ts7053_template_mapped_tests.rs"
 
 [[test]]
+name = "ts7053_record_constrained_type_param_index_tests"
+path = "tests/ts7053_record_constrained_type_param_index_tests.rs"
+
+[[test]]
 name = "ts7053_unconstrained_type_param_index_tests"
 path = "tests/ts7053_unconstrained_type_param_index_tests.rs"
 

--- a/crates/tsz-checker/src/types/utilities/core.rs
+++ b/crates/tsz-checker/src/types/utilities/core.rs
@@ -2531,7 +2531,21 @@ impl<'a> CheckerState<'a> {
                     {
                         return false;
                     }
-                    Some(constraint) => constraint,
+                    // A concrete constraint may still be an unevaluated wrapper
+                    // (e.g. `T extends Record<string, V>`, where the constraint
+                    // is an `Application` of a mapped type). Resolve it to its
+                    // apparent type through the checker environment so the
+                    // index-signature queries below inspect the structural shape
+                    // (`{ [k: string]: V }`) rather than an opaque application
+                    // node — otherwise a resolver-less evaluation leaves the
+                    // wrapper intact and the constraint looks unindexable.
+                    Some(constraint) => {
+                        crate::query_boundaries::dispatch::evaluate_type_with_resolver(
+                            self.ctx.types,
+                            &self.ctx,
+                            constraint,
+                        )
+                    }
                     // Unconstrained: the base constraint is `unknown`, which has
                     // no index signatures, so a concrete key can't index it.
                     None => TypeId::UNKNOWN,

--- a/crates/tsz-checker/tests/ts7053_record_constrained_type_param_index_tests.rs
+++ b/crates/tsz-checker/tests/ts7053_record_constrained_type_param_index_tests.rs
@@ -1,0 +1,161 @@
+//! TS7053 — indexing a type parameter whose constraint resolves, through a
+//! wrapper, to a type that has an applicable index signature.
+//!
+//! Structural rule: when the indexed object is a type parameter, indexability is
+//! governed by its *base constraint*. That constraint may still be an
+//! unevaluated wrapper — `T extends Record<string, V>` stores the constraint as
+//! an `Application` of a mapped type. tsz must resolve the constraint to its
+//! apparent type (`{ [k: string]: V }`) before deciding the parameter is
+//! unindexable; otherwise a resolver-less evaluation leaves the wrapper intact
+//! and a `string` key looks unusable, producing a false TS7053. tsc allows the
+//! access because the constraint's string index signature covers a `string` key.
+//!
+//! Issue: <https://github.com/mohsen1/tsz/issues/10674>
+use tsz_checker::context::{CheckerOptions, ScriptTarget};
+use tsz_checker::test_utils::check_source;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            target: ScriptTarget::ES2022,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+// 1. Reported repro: `Record<string, unknown>` constraint indexed by `string`.
+#[test]
+fn record_string_unknown_constraint_string_key_no_ts7053() {
+    let result =
+        codes(r#"function f<T extends Record<string, unknown>>(o: T, k: string) { return o[k]; }"#);
+    assert!(
+        !result.contains(&7053),
+        "expected no TS7053 for Record<string, unknown>-constrained param, got: {result:?}"
+    );
+}
+
+// 2. Renamed type parameter — proves the rule is structural, not name-based.
+#[test]
+fn record_constraint_renamed_param_is_structural() {
+    let renamed = codes(
+        r#"function g<U extends Record<string, unknown>>(p: U, key: string) { return p[key]; }"#,
+    );
+    assert!(
+        !renamed.contains(&7053),
+        "expected no TS7053 with renamed param/key, got: {renamed:?}"
+    );
+    let multi = codes(
+        r#"function h<Row extends Record<string, number>>(value: Row, field: string) { return value[field]; }"#,
+    );
+    assert!(
+        !multi.contains(&7053),
+        "expected no TS7053 with multi-char param name, got: {multi:?}"
+    );
+}
+
+// 3. Value-type variant: the rule does not depend on the index value type.
+#[test]
+fn record_string_number_constraint_string_key_no_ts7053() {
+    let result =
+        codes(r#"function f<T extends Record<string, number>>(o: T, k: string) { return o[k]; }"#);
+    assert!(
+        !result.contains(&7053),
+        "expected no TS7053 for Record<string, number>-constrained param, got: {result:?}"
+    );
+}
+
+// 4. Nested wrapper: `Partial<Record<...>>` must also resolve to an indexable shape.
+#[test]
+fn partial_record_constraint_string_key_no_ts7053() {
+    let result = codes(
+        r#"function f<T extends Partial<Record<string, number>>>(o: T, k: string) { return o[k]; }"#,
+    );
+    assert!(
+        !result.contains(&7053),
+        "expected no TS7053 for Partial<Record<...>>-constrained param, got: {result:?}"
+    );
+}
+
+// 4b. `Readonly<Record<...>>` wrapper constraint.
+#[test]
+fn readonly_record_constraint_string_key_no_ts7053() {
+    let result = codes(
+        r#"function f<T extends Readonly<Record<string, number>>>(o: T, k: string) { return o[k]; }"#,
+    );
+    assert!(
+        !result.contains(&7053),
+        "expected no TS7053 for Readonly<Record<...>>-constrained param, got: {result:?}"
+    );
+}
+
+// 5. User-defined mapped-type alias as the constraint (renamed iteration var too).
+#[test]
+fn user_mapped_alias_constraint_string_key_no_ts7053() {
+    let result = codes(
+        r#"
+type MyRec<V> = { [P in string]: V };
+function f<T extends MyRec<number>>(o: T, k: string) { return o[k]; }
+"#,
+    );
+    assert!(
+        !result.contains(&7053),
+        "expected no TS7053 for user mapped-alias-constrained param, got: {result:?}"
+    );
+}
+
+// 5b. Plain alias to `Record` as the constraint.
+#[test]
+fn alias_to_record_constraint_string_key_no_ts7053() {
+    let result = codes(
+        r#"
+type RowLike = Record<string, unknown>;
+function f<T extends RowLike>(o: T, k: string) { return o[k]; }
+"#,
+    );
+    assert!(
+        !result.contains(&7053),
+        "expected no TS7053 for alias-to-Record-constrained param, got: {result:?}"
+    );
+}
+
+// 6. Negative control: a wrapper constraint that resolves to a shape WITHOUT a
+//    string index signature must still report TS7053 (the fix only resolves the
+//    apparent type — it does not invent index signatures).
+#[test]
+fn object_constraint_missing_index_still_emits_ts7053() {
+    let result =
+        codes(r#"function bad<T extends { a: number }>(o: T, k: string) { return o[k]; }"#);
+    assert!(
+        result.contains(&7053),
+        "expected TS7053 for object constraint lacking a string index, got: {result:?}"
+    );
+}
+
+// 6b. Negative control: an unconstrained parameter still reports TS7053.
+#[test]
+fn unconstrained_param_string_key_still_emits_ts7053() {
+    let result = codes(r#"function f<T>(o: T, k: string) { return o[k]; }"#);
+    assert!(
+        result.contains(&7053),
+        "expected TS7053 for unconstrained param, got: {result:?}"
+    );
+}
+
+// 6c. Negative control: a still-generic constraint (`Record<K, V>`) defers to
+//     instantiation and stays clean (no TS7053, no premature acceptance error).
+#[test]
+fn generic_record_constraint_defers_no_ts7053() {
+    let result = codes(
+        r#"function f<K extends string, T extends Record<K, number>>(o: T, k: K) { return o[k]; }"#,
+    );
+    assert!(
+        !result.contains(&7053),
+        "expected no TS7053 for generically-constrained param, got: {result:?}"
+    );
+}


### PR DESCRIPTION
AgentName: xeon-4c-16g-web
Track: Conformance / checker false-positive (kysely row #10663)
Closes: #10674

## Invariant
When indexing a type parameter, indexability is governed by its base
constraint resolved to its apparent type (tsc's `getReducedApparentType`). A
concrete key that the resolved constraint's index signature covers must not
report TS7053.

> Structural rule: when the indexed object is a type parameter and its
> constraint resolves — through an application/lazy/mapped wrapper — to a type
> with an applicable index signature, tsc allows the access; tsz must resolve
> the constraint's apparent type before deciding the parameter is unindexable.

## Scope
`should_report_no_index_signature` (the noImplicitAny TS7053 gate) resolved a
type parameter to its base constraint but used the raw constraint. A
`T extends Record<string, V>` constraint is stored as an unevaluated
`Application` of a mapped type; the downstream indexability query
(`classify_element_indexable`) evaluates with a resolver-less pass that cannot
expand the application, so the constraint looked unindexable and tsz emitted a
false TS7053. The fix evaluates the constraint to its apparent type through
the checker environment (`evaluate_type_with_resolver` with `&self.ctx`) before
the index-signature queries run.

One logic-arm change in `crates/tsz-checker/src/types/utilities/core.rs`, plus a
new registered regression test file. `is_element_indexable` and the solver
classifier are intentionally untouched (broad blast radius — see Coordination
Notes).

## Generalization (matrix in the test file)
- Reported repro: `T extends Record<string, unknown>` indexed by `string` -> clean.
- Renamed param (`U`, `Row`) -> clean (rule is structural, not name-based).
- Value-type variant `Record<string, number>` -> clean.
- Nested wrappers `Partial<Record<...>>`, `Readonly<Record<...>>` -> clean.
- User mapped alias `type MyRec<V> = { [P in string]: V }` -> clean.
- Plain alias to `Record` -> clean.
- Negatives preserved: unconstrained `T`, `T extends { a: number }`,
  still-generic `T extends Record<K, V>`, and the genuine `{} | Record<...>`
  union TS7053 (real tsc 6.0.2 reports it too).

## Project Corpus Impact
- Row: kysely-project (#10663)
- Bug family: false TS7053 implicit-any-index on utility/alias/constrained types
- Evidence: differential testing against real `tsc` 6.0.2
  (`--noImplicitAny --strict`): the reproduced false positives
  (`T extends Record<string, V>` indexed by `string`) are now clean in tsz and
  match tsc; genuine negatives still match tsc. Full kysely row re-measure runs
  in CI.

## Verification
- `cargo test -p tsz-checker --test ts7053_record_constrained_type_param_index_tests` -> 10/10 pass.
- No regressions in related suites:
  `ts7053_unconstrained_type_param_index_tests`, `ts7053_template_mapped_tests`,
  `symbol_index_signature_tests`, `class_implements_index_signature_tests`,
  `union_index_access_function_application_param_tests`,
  `element_access_structural_codes_tests`,
  `indexed_access_unconstrained_param_tests`,
  `indexed_access_resolved_union_property_tests`,
  `homomorphic_indexed_access_tests`, `index_signature_argument_assignability_tests`.
- `cargo clippy -p tsz-checker --tests` clean.
- Differential vs real `tsc` 6.0.2 on ~30 index-access shapes; confirmed the
  3 `enum_indexed_access_tests` failures are pre-existing on the baseline
  (reproduced with the fix stashed), unrelated to this change.

## Coordination Notes
- Builds on merged PR #10694 (direct `Record`/`UnknownRow` receivers); this
  covers the remaining type-parameter-constraint path.
- Filed #10726 for a pre-existing, separate false positive: type params
  constrained to an intersection with a `Record` member
  (`T extends { a: number } & Record<string, number>`). A full fix needs a
  resolver-aware `is_element_indexable`/`classify_element_indexable`, which has a
  broad blast radius across `indexed_access.rs` / `error_reporter` and warrants
  its own conformance-gated PR.

Signed: xeon-4c-16g-web