### PR TITLE
test(solver): cover strict-any relation cache

### DIFF
--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -99,6 +99,87 @@ fn subtype_cache_any_propagation_mode_matches_uncached_nested_any() {
 }
 
 #[test]
+fn assignability_cache_strict_any_matches_uncached_relation_policy() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let value = interner.intern_string("value");
+
+    let source = interner.object(vec![PropertyInfo::new(value, TypeId::ANY)]);
+    let target = interner.object(vec![PropertyInfo::new(value, TypeId::NUMBER)]);
+
+    let ordinary = RelationPolicy::default().with_strict_any_propagation(false);
+    let strict_any = RelationPolicy::default().with_strict_any_propagation(true);
+    let ordinary_key = RelationCacheKey::for_assignability(source, target, ordinary.cache_config());
+    let strict_any_key =
+        RelationCacheKey::for_assignability(source, target, strict_any.cache_config());
+
+    assert_ne!(
+        ordinary_key, strict_any_key,
+        "ordinary and strict-any policies must occupy distinct assignability cache slots",
+    );
+
+    let ordinary_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        ordinary,
+        RelationContext::default(),
+    )
+    .is_related();
+    let strict_any_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        strict_any,
+        RelationContext::default(),
+    )
+    .is_related();
+
+    assert!(
+        ordinary_uncached,
+        "ordinary assignability should allow nested `any` to satisfy a number property",
+    );
+    assert!(
+        !strict_any_uncached,
+        "strict-any assignability must not let nested `any` silence the property mismatch",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, ordinary),
+        ordinary_uncached,
+        "cached ordinary any policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(ordinary_key),
+        Some(ordinary_uncached),
+        "ordinary any result must be stored in the ordinary assignability slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(strict_any_key),
+        None,
+        "strict-any lookup must not hit the ordinary any slot",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, strict_any),
+        strict_any_uncached,
+        "cached strict-any policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(strict_any_key),
+        Some(strict_any_uncached),
+        "strict-any result must be stored in its own assignability slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(ordinary_key),
+        Some(ordinary_uncached),
+        "ordinary any slot must remain intact after the strict-any lookup",
+    );
+}
+
+#[test]
 fn assignability_cache_strict_function_types_matches_uncached_function_variance() {
     let interner = TypeInterner::new();
     let db = QueryCache::new(&interner);


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 10 relation policy/cache-key tech debt (#8207), solver relation policy/cache agreement test ratchet.

## Invariant
Strict-`any` relation policy must be part of the assignability cache key: cached assignability must agree with uncached `query_relation` when `any` propagation mode changes whether a structural mismatch is accepted.

## Scope
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: solver test-only ratchet for relation policy/cache agreement; no project corpus behavior change targeted.

## Verification
- RED `cargo nextest run -p tsz-solver -E 'test(assignability_cache_strict_any_matches_uncached_relation_policy)'` failed before the test existed with `error: no tests to run`.
- Earlier focused verification passed on original heads `c73644201abdd77964e60c3c891174b6c545f9eb` and `f36aba00b012dae580f2dbecdcad26283e0691db`.
- After refreshing onto current `origin/main` (`d7a32c10f204a1a4c2d6fff3083b5c80088c20e2`), exact head is `0977e0ca4a7c88da2ad7be39cfb78ff2a11c6e31`.
- `cargo nextest run -p tsz-solver -E 'test(assignability_cache_strict_any_matches_uncached_relation_policy)'`: 1 passed on `0977e0ca4a7c88da2ad7be39cfb78ff2a11c6e31`.
- `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'`: 14 passed on `0977e0ca4a7c88da2ad7be39cfb78ff2a11c6e31`.
- `cargo fmt --check`.
- `git diff --check origin/main..HEAD`.
- Stack diff check: `git diff --stat origin/main..HEAD` -> one file, 81 insertions.
- File-size guard: `wc -l crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs` -> 1234 lines, below the 2000-line cap.
- Ready-review GitHub Actions are rerunning on exact head `0977e0ca4a7c88da2ad7be39cfb78ff2a11c6e31`; `merge-queue` remains intentionally unset until exact-head PR-head checks complete successfully.

## Coordination Notes
- This PR is based directly on current `main` with one solver test commit.
- Previous ready-review CI on `f36aba00b012dae580f2dbecdcad26283e0691db` passed lint, unit, dist-binaries, wasm, emit, fourslash aggregate, project compile guard/canary, and conformance shards, but failed `conformance-aggregate` from accepted-regression drift: observed `12575/12585`, expected `12582/12585`; unlisted `TypeScript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolIndexer5.ts`; resolved accepted regressions `TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts` and `TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts`.
- The previous conformance drift is tracked by #11254; #10781 has now landed on `main`, and this PR was refreshed onto current `main` before rerunning focused solver verification.
- Downstream #10735 remains draft/stacked on this branch until this PR lands or is otherwise retargeted.
- Non-overlap: this slice covers strict-`any` relation cache agreement only; it does not touch checker relation routing owned by M1-B, nor M4-A/M4-C evaluation/inference lanes.
- No `WIP`, auto-merge, or `merge-queue` state set.
