### PR TITLE
fix(checker): recognize type parameters constrained to async-iterables in for-await-of

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -35,6 +35,10 @@ name = "union_protected_intersection_property_tests"
 path = "tests/union_protected_intersection_property_tests.rs"
 
 [[test]]
+name = "for_await_type_parameter_iterability_tests"
+path = "tests/for_await_type_parameter_iterability_tests.rs"
+
+[[test]]
 name = "array_element_naked_inference_tests"
 path = "tests/array_element_naked_inference_tests.rs"
 

--- a/crates/tsz-checker/src/checkers/iterable_checker.rs
+++ b/crates/tsz-checker/src/checkers/iterable_checker.rs
@@ -336,6 +336,21 @@ impl<'a> CheckerState<'a> {
             AsyncIterableTypeKind::Union(members) => {
                 members.iter().all(|&m| self.is_async_iterable_type(m))
             }
+            AsyncIterableTypeKind::Intersection(members) => {
+                // An intersection is async iterable if at least one member is,
+                // mirroring the sync `is_iterable_type` intersection rule.
+                members.iter().any(|&m| self.is_async_iterable_type(m))
+            }
+            AsyncIterableTypeKind::TypeParameter { constraint } => {
+                // `for await ... of` resolves a type parameter to its apparent
+                // type (the constraint). Recurse into the constraint instead of
+                // probing `[Symbol.asyncIterator]` on the bare parameter, which
+                // cannot see through a generic `Application` constraint such as
+                // `AsyncIterableIterator<T>`. An unconstrained parameter is not
+                // async iterable here; the caller still falls back to the sync
+                // iterable check before reporting TS2504.
+                constraint.is_some_and(|c| self.is_async_iterable_type(c))
+            }
             AsyncIterableTypeKind::Object(shape_id) => {
                 // Check if object has a [Symbol.asyncIterator] method or callable property.
                 // Both `{ [Symbol.asyncIterator]() { ... } }` (method) and

--- a/crates/tsz-checker/tests/for_await_type_parameter_iterability_tests.rs
+++ b/crates/tsz-checker/tests/for_await_type_parameter_iterability_tests.rs
@@ -1,0 +1,166 @@
+//! `for await ... of` over a **type parameter** must resolve the parameter to
+//! its apparent type (constraint) when deciding async-iterability, exactly like
+//! the sync `for ... of` path. Regression coverage for the false `TS2504`
+//! emitted when the operand's type is a type parameter whose constraint is a
+//! generic `AsyncIterableIterator<...>` / `AsyncIterable<...>` application.
+//!
+//! These run against the full default lib bundle (which includes
+//! `es2018.asynciterable` / `es2018.asyncgenerator`) so `AsyncIterableIterator`
+//! and friends are real global types, not stubs.
+
+use std::sync::Arc;
+use tsz_binder::lib_loader::LibFile;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs_code_messages, load_default_lib_files};
+use tsz_common::common::ScriptTarget;
+
+const TS2504: u32 = 2504;
+
+fn check(source: &str, libs: &[Arc<LibFile>]) -> Vec<(u32, String)> {
+    check_source_with_libs_code_messages(
+        source,
+        "test.ts",
+        CheckerOptions {
+            target: ScriptTarget::ES2018,
+            ..CheckerOptions::default()
+        },
+        libs,
+    )
+}
+
+fn assert_no_ts2504(source: &str, libs: &[Arc<LibFile>], context: &str) {
+    let diags = check(source, libs);
+    assert!(
+        !diags.iter().any(|(code, _)| *code == TS2504),
+        "{context}: expected no TS2504, got: {diags:#?}"
+    );
+}
+
+fn assert_has_ts2504(source: &str, libs: &[Arc<LibFile>], context: &str) {
+    let diags = check(source, libs);
+    assert!(
+        diags.iter().any(|(code, _)| *code == TS2504),
+        "{context}: expected TS2504, got: {diags:#?}"
+    );
+}
+
+#[test]
+fn type_param_constrained_to_async_iterable_iterator_is_async_iterable() {
+    let libs = load_default_lib_files();
+    assert!(!libs.is_empty(), "default lib files must be available");
+    assert_no_ts2504(
+        r#"
+async function f<T extends AsyncIterableIterator<number>>(t: T) {
+    for await (const x of t) { void x; }
+}
+"#,
+        &libs,
+        "T extends AsyncIterableIterator<number>",
+    );
+}
+
+#[test]
+fn type_param_constrained_to_async_iterable_is_async_iterable() {
+    let libs = load_default_lib_files();
+    assert_no_ts2504(
+        r#"
+async function f<S extends AsyncIterable<string>>(s: S) {
+    for await (const x of s) { void x; }
+}
+"#,
+        &libs,
+        "S extends AsyncIterable<string>",
+    );
+}
+
+#[test]
+fn type_param_constrained_to_async_generator_is_async_iterable() {
+    let libs = load_default_lib_files();
+    assert_no_ts2504(
+        r#"
+async function f<G extends AsyncGenerator<boolean>>(g: G) {
+    for await (const x of g) { void x; }
+}
+"#,
+        &libs,
+        "G extends AsyncGenerator<boolean>",
+    );
+}
+
+#[test]
+fn nested_type_param_constrained_to_async_iterable_is_async_iterable() {
+    // The constraint is itself a type parameter, so resolution must be
+    // transitive. Renamed bound variables (`Outer`/`Inner`) prove the fix is
+    // structural rather than keyed on a `T`/`U` spelling.
+    let libs = load_default_lib_files();
+    assert_no_ts2504(
+        r#"
+async function f<Outer extends AsyncIterableIterator<number>, Inner extends Outer>(t: Inner) {
+    for await (const x of t) { void x; }
+}
+"#,
+        &libs,
+        "Inner extends Outer extends AsyncIterableIterator<number>",
+    );
+}
+
+#[test]
+fn type_param_constrained_to_intersection_with_async_iterable_is_async_iterable() {
+    let libs = load_default_lib_files();
+    assert_no_ts2504(
+        r#"
+async function f<T extends AsyncIterableIterator<number> & { extra: string }>(t: T) {
+    for await (const x of t) { void x; }
+}
+"#,
+        &libs,
+        "T extends AsyncIterableIterator<number> & { extra }",
+    );
+}
+
+#[test]
+fn direct_async_iterable_iterator_remains_async_iterable() {
+    // Regression guard: the non-type-parameter case already worked and must
+    // keep working.
+    let libs = load_default_lib_files();
+    assert_no_ts2504(
+        r#"
+async function f(t: AsyncIterableIterator<number>) {
+    for await (const x of t) { void x; }
+}
+"#,
+        &libs,
+        "direct AsyncIterableIterator<number>",
+    );
+}
+
+#[test]
+fn type_param_constrained_to_non_iterable_object_still_reports_ts2504() {
+    // Negative case: an object-shaped constraint without [Symbol.asyncIterator]
+    // is not async iterable, so tsc (and tsz) still report TS2504.
+    let libs = load_default_lib_files();
+    assert_has_ts2504(
+        r#"
+async function f<T extends { foo: number }>(t: T) {
+    for await (const x of t) { void x; }
+}
+"#,
+        &libs,
+        "T extends { foo: number }",
+    );
+}
+
+#[test]
+fn type_param_constrained_to_number_still_reports_ts2504() {
+    // Negative case: a primitive constraint is neither async- nor sync-iterable.
+    let libs = load_default_lib_files();
+    assert_has_ts2504(
+        r#"
+async function f<T extends number>(t: T) {
+    for await (const x of t) { void x; }
+}
+"#,
+        &libs,
+        "T extends number",
+    );
+}

--- a/crates/tsz-solver/src/type_queries/iterable.rs
+++ b/crates/tsz-solver/src/type_queries/iterable.rs
@@ -112,8 +112,12 @@ pub fn classify_full_iterable_type(db: &dyn TypeDatabase, type_id: TypeId) -> Fu
 pub enum AsyncIterableTypeKind {
     /// Union type - all members must be async iterable
     Union(Vec<TypeId>),
+    /// Intersection type - at least one member must be async iterable
+    Intersection(Vec<TypeId>),
     /// Object type - check for [Symbol.asyncIterator] method
     Object(crate::types::ObjectShapeId),
+    /// Type parameter - check constraint (apparent type) if present
+    TypeParameter { constraint: Option<TypeId> },
     /// Readonly wrapper - check inner type
     Readonly(TypeId),
     /// Not async iterable
@@ -121,6 +125,14 @@ pub enum AsyncIterableTypeKind {
 }
 
 /// Classify a type for async iterable checking.
+///
+/// Mirrors [`classify_full_iterable_type`] for the structural arms that need
+/// recursion in the checker (union, intersection, type parameter, readonly).
+/// `for await ... of` accepts a type parameter when its apparent type (the
+/// constraint, transitively) is async iterable, exactly like the sync
+/// `for ... of` path — so the `TypeParameter` arm carries the constraint
+/// instead of falling back to `[Symbol.asyncIterator]` property access on the
+/// bare parameter (which cannot see through a generic `Application` constraint).
 pub fn classify_async_iterable_type(
     db: &dyn TypeDatabase,
     type_id: TypeId,
@@ -137,8 +149,17 @@ pub fn classify_async_iterable_type(
             let members = db.type_list(members_id);
             AsyncIterableTypeKind::Union(members.to_vec())
         }
+        TypeData::Intersection(members_id) => {
+            let members = db.type_list(members_id);
+            AsyncIterableTypeKind::Intersection(members.to_vec())
+        }
         TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => {
             AsyncIterableTypeKind::Object(shape_id)
+        }
+        TypeData::TypeParameter(info) | TypeData::Infer(info) => {
+            AsyncIterableTypeKind::TypeParameter {
+                constraint: info.constraint,
+            }
         }
         TypeData::ReadonlyType(inner) => AsyncIterableTypeKind::Readonly(inner),
         _ => AsyncIterableTypeKind::NotAsyncIterable,

--- a/crates/tsz-solver/tests/iterable_classifier_tests.rs
+++ b/crates/tsz-solver/tests/iterable_classifier_tests.rs
@@ -459,6 +459,67 @@ fn async_iterable_object_returns_object_shape() {
 }
 
 #[test]
+fn async_iterable_type_parameter_carries_constraint() {
+    // `for await ... of` over a type parameter resolves to the parameter's
+    // apparent type (its constraint). The classifier must surface the
+    // constraint so the checker can recurse into it, mirroring the sync path.
+    let interner = TypeInterner::new();
+    let constraint = interner.lazy(DefId(7));
+    let tp = interner.type_param(TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: Some(constraint),
+        default: None,
+        is_const: false,
+    });
+    match classify_async_iterable_type(&interner, tp) {
+        AsyncIterableTypeKind::TypeParameter { constraint: c } => assert_eq!(c, Some(constraint)),
+        other => panic!("expected TypeParameter, got {other:?}"),
+    }
+}
+
+#[test]
+fn async_iterable_type_parameter_without_constraint_yields_none() {
+    // Renamed bound variable (`Elem`) proves the arm is structural, not keyed
+    // on a particular type-parameter spelling.
+    let interner = TypeInterner::new();
+    let tp = interner.type_param(TypeParamInfo {
+        name: interner.intern_string("Elem"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    });
+    match classify_async_iterable_type(&interner, tp) {
+        AsyncIterableTypeKind::TypeParameter { constraint } => assert_eq!(constraint, None),
+        other => panic!("expected TypeParameter, got {other:?}"),
+    }
+}
+
+#[test]
+fn async_iterable_intersection_returns_intersection_members() {
+    let interner = TypeInterner::new();
+    let tp_a = interner.type_param(TypeParamInfo {
+        name: interner.intern_string("A"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    });
+    let tp_b = interner.type_param(TypeParamInfo {
+        name: interner.intern_string("B"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    });
+    let isect = interner.intersection(vec![tp_a, tp_b]);
+    match classify_async_iterable_type(&interner, isect) {
+        AsyncIterableTypeKind::Intersection(members) => {
+            assert!(members.contains(&tp_a));
+            assert!(members.contains(&tp_b));
+        }
+        other => panic!("expected Intersection, got {other:?}"),
+    }
+}
+
+#[test]
 fn async_iterable_readonly_returns_inner() {
     let interner = TypeInterner::new();
     let inner = interner.array(TypeId::NUMBER);


### PR DESCRIPTION
AgentName: Studio-A
Track: Conformance / checker parity (TS2504 async-iterable family)
Refs: #10667

## Structural rule

> When the operand of `for await ... of` is a type parameter, `tsc` checks
> async-iterability against the parameter's apparent type (its constraint,
> transitively); tsz must classify the constraint for async-iterability —
> mirroring what it already does for the sync `for ... of` path.

## Invariant

`for await ... of` accepts an operand iff its apparent type is async- **or**
sync-iterable, for type parameters identically to concrete types. Unconstrained
and non-iterable constraints still report `TS2504`, matching `tsc`.

## Root cause

The **sync** iterable classifier (`classify_full_iterable_type`) has a
`TypeParameter { constraint }` arm and the checker recurses into the constraint.
The **async** classifier (`classify_async_iterable_type`) did not — type
parameters fell through to the `NotAsyncIterable` fallback, which probes
`[Symbol.asyncIterator]` via property access on the **bare** parameter. That
cannot see through a generic `Application` constraint like
`AsyncIterableIterator<T>`, so `for await` over a type parameter constrained to
an async-iterable was wrongly rejected with `TS2504` (tsc accepts it).

Minimal divergence (tsc clean, tsz `TS2504` before this PR):
```ts
async function f<T extends AsyncIterableIterator<number>>(t: T) { for await (const x of t) {} }
async function g<T extends AsyncIterable<string>>(t: T)         { for await (const x of t) {} }
async function h<T extends AsyncGenerator<boolean>>(t: T)       { for await (const x of t) {} }
async function k<U extends AsyncIterableIterator<number>, T extends U>(t: T) { for await (const x of t) {} }
```

## Scope

- `crates/tsz-solver/src/type_queries/iterable.rs`: add `TypeParameter`/`Infer`
  and `Intersection` arms to `AsyncIterableTypeKind` + `classify_async_iterable_type`
  (mirrors the sync classifier).
- `crates/tsz-checker/src/checkers/iterable_checker.rs`:
  `is_async_iterable_type_classified` recurses into a type parameter's
  constraint and treats an intersection as async-iterable if any member is.

Purely additive recognition that generalizes the classifier — no special-casing,
no removed guards. Loop-variable element-type precision for iterated type
parameters (the binding resolves to `any` rather than the precise element type)
is **pre-existing and shared with the sync path** (it is not a false positive)
and is intentionally out of scope here.

## Adjacent-case test matrix

`crates/tsz-checker/tests/for_await_type_parameter_iterability_tests.rs` (full
default libs, ES2018):
1. `T extends AsyncIterableIterator<number>` — reported family (no TS2504).
2. `S extends AsyncIterable<string>` — alias shape (no TS2504).
3. `G extends AsyncGenerator<boolean>` — generator interface (no TS2504).
4. `Inner extends Outer extends AsyncIterableIterator<number>` — nested/renamed
   params prove the rule is structural, not a `T`/`U` spelling.
5. `T extends AsyncIterableIterator<number> & { extra }` — intersection constraint.
6. Direct `AsyncIterableIterator<number>` — regression guard (already worked).
7. Negative: `T extends { foo: number }` — still TS2504.
8. Negative: `T extends number` — still TS2504.

Plus solver classifier unit tests in `iterable_classifier_tests.rs`
(`TypeParameter` carries constraint / `None`; `Intersection` returns members).

## Verification

- `cargo test -p tsz-solver --lib async_iterable` → 12 passed.
- `cargo test -p tsz-checker --test for_await_type_parameter_iterability_tests` → 8 passed.
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets --all-features -- -D warnings` → clean.
- CLI parity vs `tsc 6.0.2` on a 9-case matrix: identical output (TS2504 only
  on the two genuinely-non-iterable constraints).

## Project Corpus Impact

- Row: kysely-project (#10663)
- Bug family: false TS2504 async-iterable (for-await over async-iterable-constrained type parameters)
- Evidence: local `cargo test` (solver + checker), clippy clean, and `tsz`-vs-`tsc 6.0.2` CLI parity on a 9-case matrix. This PR fixes the type-parameter sub-family of #10667. Kysely's two `AsyncIterableIterator<QueryResult<unknown>>` sites (`runtime-driver.ts`, `query-executor-base.ts`) remain: with a fixed local release build those still report TS2504, but only in the full multi-file context — a distinct cross-file property-resolution root cause (shares the `resolve_property_access_with_env` mechanism with the sync path; likely overlaps #10661) that resisted faithful minimization. #10667 is left open with these findings. Net-positive, regression-free.

## Coordination Notes

Signed: Studio-A. Issue #10667 has the agent ownership and root-cause comment.
This is a broad-but-scoped fix for the type-parameter class; the kysely cross-file
`Application` case is documented for a follow-up (related to #10661). No overlap
with the active #10661 / #10686 lane (that lane is class instance/constructor
resolution, not async-iterability).