### PR TITLE
fix(checker): gate async Promise return completeness by identity

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -111,6 +111,10 @@ name = "async_return_widening_tests"
 path = "tests/async_return_widening_tests.rs"
 
 [[test]]
+name = "async_return_promise_identity_tests"
+path = "tests/async_return_promise_identity_tests.rs"
+
+[[test]]
 name = "object_literal_getter_widening_tests"
 path = "tests/object_literal_getter_widening_tests.rs"
 

--- a/crates/tsz-checker/src/checkers/promise_checker.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker.rs
@@ -1218,34 +1218,6 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    /// Check if a return type annotation syntactically looks like `Promise<T>` or `PromiseLike<T>`.
-    ///
-    /// Syntactic fallback used when the type can't yet be resolved (e.g. during implicit
-    /// return-type checks). Matches only the two canonical lib names; user-chosen names
-    /// containing "Promise" are intentionally excluded.
-    pub fn return_type_annotation_looks_like_promise(&self, type_annotation: NodeIndex) -> bool {
-        let Some(node) = self.ctx.arena.get(type_annotation) else {
-            return false;
-        };
-
-        if let Some(type_ref) = self.ctx.arena.get_type_ref(node)
-            && let Some(name_node) = self.ctx.arena.get(type_ref.type_name)
-        {
-            if let Some(ident) = self.ctx.arena.get_identifier(name_node) {
-                return matches!(ident.escaped_text.as_str(), "Promise" | "PromiseLike");
-            }
-            // Qualified name like `SomeModule.Promise` — check the rightmost identifier.
-            if let Some(qualified) = self.ctx.arena.get_qualified_name(name_node)
-                && let Some(right_node) = self.ctx.arena.get(qualified.right)
-                && let Some(ident) = self.ctx.arena.get_identifier(right_node)
-            {
-                return matches!(ident.escaped_text.as_str(), "Promise" | "PromiseLike");
-            }
-        }
-
-        false
-    }
-
     /// Check if a type is an Application (generic instantiation) whose base is definitively
     /// NOT the global Promise type.
     ///

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -945,7 +945,7 @@ impl<'a> CheckerState<'a> {
             if is_async
                 && check_return_type == return_type
                 && has_type_annotation
-                && self.return_type_annotation_looks_like_promise(method.type_annotation)
+                && self.return_type_annotation_is_exactly_promise(method.type_annotation)
             {
                 check_return_type = TypeId::VOID;
             }
@@ -1783,7 +1783,7 @@ impl<'a> CheckerState<'a> {
                 if is_async
                     && check_return_type == return_type
                     && has_type_annotation
-                    && self.return_type_annotation_looks_like_promise(accessor.type_annotation)
+                    && self.return_type_annotation_is_exactly_promise(accessor.type_annotation)
                 {
                     check_return_type = TypeId::VOID;
                 }

--- a/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
@@ -1162,13 +1162,13 @@ impl<'a> CheckerState<'a> {
         } else {
             self.return_type_for_implicit_return_check(return_type, is_async, false)
         };
-        // For async functions, if we couldn't unwrap Promise<T> (e.g. lib files not loaded),
-        // fall back to the annotation syntax. If it looks like Promise<...>, suppress TS2355
-        // since we can't verify the inner type anyway.
+        // For async functions, suppress return-completeness diagnostics only
+        // when the annotation resolves to the actual global Promise. A local
+        // or qualified type named Promise still follows normal return checks.
         if is_async
             && check_return_type == return_type
             && has_type_annotation
-            && self.return_type_annotation_looks_like_promise(func.type_annotation)
+            && self.return_type_annotation_is_exactly_promise(func.type_annotation)
         {
             check_return_type = TypeId::VOID;
         }

--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -1810,12 +1810,13 @@ impl<'a> CheckerState<'a> {
             is_async,
             is_generator,
         );
-        // For async functions, if we couldn't unwrap Promise<T> (e.g. lib files not loaded),
-        // fall back to the annotation syntax. If it looks like Promise<...>, suppress TS2355.
+        // For async functions, suppress return-completeness diagnostics only
+        // when the annotation resolves to the actual global Promise. A local
+        // or qualified type named Promise still follows normal return checks.
         if is_async
             && check_return_type == effective_return_type
             && has_type_annotation
-            && self.return_type_annotation_looks_like_promise(type_annotation)
+            && self.return_type_annotation_is_exactly_promise(type_annotation)
         {
             check_return_type = TypeId::VOID;
         }

--- a/crates/tsz-checker/tests/async_return_promise_identity_tests.rs
+++ b/crates/tsz-checker/tests/async_return_promise_identity_tests.rs
@@ -1,0 +1,45 @@
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs, load_compiled_lib_files};
+use tsz_common::common::{ModuleKind, ScriptTarget};
+
+fn check_with_promise_lib(source: &str) -> Vec<u32> {
+    let lib_files = load_compiled_lib_files(&["lib.es5.d.ts", "lib.es2015.promise.d.ts"]);
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            target: ScriptTarget::ES2015,
+            module: ModuleKind::CommonJS,
+            ..CheckerOptions::default()
+        },
+        &lib_files,
+    )
+    .into_iter()
+    .map(|diagnostic| diagnostic.code)
+    .collect()
+}
+
+#[test]
+fn async_return_completeness_does_not_trust_module_local_promise_spelling() {
+    let codes = check_with_promise_lib(
+        r#"
+export {};
+
+interface Promise<T> {
+  shadow: T;
+}
+
+async function localPromise(): Promise<number> {
+}
+"#,
+    );
+
+    assert!(
+        codes.contains(&1064),
+        "Expected TS1064 for module-local Promise annotation, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&2355),
+        "Expected TS2355 because module-local Promise must not suppress return completeness by spelling, got: {codes:?}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-D

## Track
Semantic identity cleanup / async return-completeness Promise identity ratchet.

## Invariant
When async return-completeness checks cannot unwrap the declared return type, tsz should suppress TS2355 only when the annotation resolves to the actual global `Promise` identity. A module-local or qualified type named `Promise` is not the global `Promise<T>` return protocol and must still follow normal return-completeness diagnostics.

## Scope
- Remove the checker helper that suppressed async return-completeness diagnostics from raw `Promise` / `PromiseLike` spelling.
- Route async return-completeness fallback gates through the existing `return_type_annotation_is_exactly_promise` lib-identity helper.
- Add a focused integration regression for a module-local `Promise<T>` annotation that should report both TS1064 and TS2355, matching `tsc`.

## Project Corpus Impact
- Row: n/a
- Bug family: name-based async Promise identity debt
- Evidence: architecture cleanup only; this removes one raw spelling fallback from async return-completeness diagnostics and does not target a known project-row blocker.

## Verification
- `node TypeScript/lib/_tsc.js --target es2015 --lib es5,es2015.promise --noEmit <module-local Promise repro>` produced TS1064 and TS2355.
- RED before implementation: `cargo nextest run -p tsz-checker --test promise_constructor_capability_tests async_return_completeness_does_not_trust_module_local_promise_spelling` failed because TS2355 was missing.
- GREEN after implementation and rebase: `cargo nextest run -p tsz-checker --test async_return_promise_identity_tests`
- `cargo nextest run -p tsz-checker --test promise_constructor_capability_tests -E 'test(ts1064_does_not_fire_for_global_promise_with_indexed_return_type) | test(ts1064_suggestion_wraps_declared_return_type) | test(ts1064_fires_for_async_methods_with_non_promise_return)'`
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `python3 scripts/arch/arch_guard.py`
- Draft exact-head CI for `f83a555251bbaad77bc5891e203b415347793e41`: `CI Light Summary`, `unit`, `unit-cloudbuild`, `lint`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, and `GitGuardian Security Checks` passed.
- Ready exact-head CI for `f83a555251bbaad77bc5891e203b415347793e41`: `CI Summary`, `conformance-aggregate`, `conformance-0` through `conformance-5`, `fourslash-aggregate`, `fourslash-0` through `fourslash-5`, `emit`, `project-compile-canary`, `project-compile-guard`, `lsp-e2e`, `wasm`, `wasm-web`, `unit`, `unit-cloudbuild`, `lint`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `conformance-snapshot-gate`, `project-corpus-pr-body`, `gate`, and `GitGuardian Security Checks` passed.

## Coordination Notes
- AgentName: M4-D
- Fresh worktree: `/Users/mohsen/code/tsz-m4d-async-return-promise-identity-20260528`.
- Non-overlap: #10641 and #10727 remain queued with `merge-queue`; #10686 remains draft/stacked for cross-file class instance refs. This PR is a separate async return-completeness identity ratchet from `docs/architecture/WELL_KNOWN_NAME_REFERENCES.md`.
- Baseline note: the full `promise_constructor_capability_tests` integration target is already red on `main` for `preserves_imported_promise_subclass_type_parameter_in_async_diagnostics`; this slice verified the new focused target plus the adjacent TS1064/global-Promise cases instead of claiming the whole target is green.
- Structural owner: checker orchestration uses resolved type-symbol identity; no new solver internals or raw type-shape matching are introduced.
- Ready exact-head heavy CI passed; `merge-queue` is appropriate for the current head.
