### PR TITLE
chore(conformance): drop stale accepted-regression entries

### DIFF
--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -2,16 +2,8 @@
 # Add a test path here (one per line) to allow it to fail in CI without
 # blocking the aggregate gate. Remove the entry once the regression is fixed.
 # Format: TypeScript/tests/cases/<subpath>.ts (one path per line, comments with #)
-TypeScript/tests/cases/compiler/declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts
+# Retained: perf/relation-depth-sensitive tests whose runway guards against CI
+# timeout variance (deeplyNestedMappedTypes #10452, intersectionsOfLargeUnions #10349).
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
-TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
-TypeScript/tests/cases/compiler/reorderProperties.ts
-TypeScript/tests/cases/conformance/externalModules/typeOnly/circular2.ts
-TypeScript/tests/cases/conformance/externalModules/typeOnly/circular4.ts
-TypeScript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.ts
-TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
-TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
-TypeScript/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts
-TypeScript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference1.ts


### PR DESCRIPTION
AgentName: M5Opus

## Track
Conformance hygiene (resolves #10654, #10655, #10350, #10443; trims aggregate #10306).

## Invariant
`conformance-accepted-regressions.txt` is a temporary runway for *failing* tests. Entries whose tests now pass are stale and must be removed (documented "stale-accepted" workflow in `scripts/conformance/link-regression-issues.py`).

## Scope
Remove 10 stale entries that `link-regression-issues.py` classifies as "stale: accepted-regression entry no longer fails" (each is `PASS` in `conformance-baseline.txt`; current snapshot `conformance-detail.json` = 12582/12582, 0 failures, 0 known failures):
declarationsWithRecursiveInternalTypesProduceUniqueTypeParams, errorInfoForRelatedIndexTypesNoConstraintElaboration, reorderProperties, circular2, circular4, declarationFileForHtmlImport, keyofAndIndexedAccess, keyofAndIndexedAccessErrors, mappedTypeRelationships, unionAndIntersectionInference1.

Retained the 3 perf/relation-depth-sensitive entries (deeplyNestedMappedTypes, intersectionsOfLargeUnions, intersectionsOfLargeUnions2) whose runway guards against CI timeout variance — left for a separate perf-focused removal rather than risk timeout flake here.

Since conformance has no deficit (12582 ≥ floor), the allowlist is not consulted by the aggregate gate, so removing passing entries is safe; the ready-CI full conformance suite verifies it.

## Project Corpus Impact
- Row: n/a
- Bug family: conformance accepted-regression staleness (entries that no longer fail)
- Evidence: `link-regression-issues.py` stale-accepted classification + `conformance-detail.json` 12582/12582.

## Verification
- `python3 scripts/conformance/link-regression-issues.py` reports all removed entries as "stale: accepted-regression entry no longer fails".
- Ready-CI conformance suite is the authoritative gate.

## Coordination Notes
Signed M5Opus. Resolves #10654, #10655, #10350, #10443. Complements the recent jsxComplexSignatureHasApplicabilityError removal on main.