### PR TITLE
fix(solver): subtype-reduce fresh empty {} in conditional unions (TS7053)

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/type_computation/core.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_computation/core.rs
@@ -106,6 +106,21 @@ pub(crate) fn compute_conditional_expression_type(
     )
 }
 
+/// Resolver-aware conditional (ternary) expression type. The resolver lets
+/// subtype reduction of the branch union see through alias/application wrappers
+/// (e.g. `Record<string, unknown>`).
+pub(crate) fn compute_conditional_expression_type_with_resolver<R: TypeResolver>(
+    db: &dyn TypeDatabase,
+    condition: TypeId,
+    true_type: TypeId,
+    false_type: TypeId,
+    resolver: Option<&R>,
+) -> TypeId {
+    tsz_solver::operations::expression_ops::compute_conditional_expression_type_with_resolver(
+        db, condition, true_type, false_type, resolver,
+    )
+}
+
 /// Merge a single object-spread property contribution through the solver-owned
 /// AST-independent spread merge rule.
 pub(crate) fn merge_object_spread_property(

--- a/crates/tsz-checker/src/types/computation/helpers.rs
+++ b/crates/tsz-checker/src/types/computation/helpers.rs
@@ -263,12 +263,15 @@ impl<'a> CheckerState<'a> {
                 .union_preserve_members(vec![when_true, when_false]);
         }
 
-        // Use Solver API for type computation (Solver-First architecture)
-        expr_ops::compute_conditional_expression_type(
+        // Use Solver API for type computation (Solver-First architecture).
+        // Thread the checker's resolver so subtype reduction of the branch union
+        // can see through alias/application wrappers (e.g. `Record<string, unknown>`).
+        expr_ops::compute_conditional_expression_type_with_resolver(
             self.ctx.types,
             condition_type,
             when_true,
             when_false,
+            Some(&self.ctx),
         )
     }
 

--- a/crates/tsz-solver/src/operations/expression_ops.rs
+++ b/crates/tsz-solver/src/operations/expression_ops.rs
@@ -36,6 +36,28 @@ pub fn compute_conditional_expression_type(
     true_type: TypeId,
     false_type: TypeId,
 ) -> TypeId {
+    compute_conditional_expression_type_with_resolver(
+        interner,
+        condition,
+        true_type,
+        false_type,
+        None::<&crate::relations::subtype::NoopResolver>,
+    )
+}
+
+/// Resolver-aware variant of [`compute_conditional_expression_type`].
+///
+/// A resolver lets subtype-reduction of the branch union see through alias /
+/// application / mapped wrappers (e.g. `Record<string, unknown>` interns as a
+/// `TypeData::Application`). Without it, the index signature that drives
+/// `UnionReduction.Subtype` stays hidden behind the wrapper.
+pub fn compute_conditional_expression_type_with_resolver<R: TypeResolver>(
+    interner: &dyn TypeDatabase,
+    condition: TypeId,
+    true_type: TypeId,
+    false_type: TypeId,
+    resolver: Option<&R>,
+) -> TypeId {
     // Handle error propagation
     if condition == TypeId::ERROR {
         return TypeId::ERROR;
@@ -50,6 +72,11 @@ pub fn compute_conditional_expression_type(
     // Handle special type constants
     if condition == TypeId::ANY {
         // any ? A : B -> A | B
+        if let Some(reduced) =
+            reduce_fresh_empty_object_branch(interner, true_type, false_type, resolver)
+        {
+            return reduced;
+        }
         return interner.union2(true_type, false_type);
     }
     if condition == TypeId::NEVER {
@@ -85,7 +112,92 @@ pub fn compute_conditional_expression_type(
         return interner.union_preserve_members(vec![true_type, false_type]);
     }
 
+    if let Some(reduced) =
+        reduce_fresh_empty_object_branch(interner, true_type, false_type, resolver)
+    {
+        return reduced;
+    }
+
     interner.union2(true_type, false_type)
+}
+
+/// tsc computes a conditional expression's type as
+/// `getUnionType([trueType, falseType], UnionReduction.Subtype)`. A *fresh*
+/// empty object literal `{}` is a strict subtype of any object type it is
+/// assignable to (e.g. one with a string/number index signature, or with only
+/// optional members), so subtype reduction drops it: `cond ? {} : rec` where
+/// `rec: Record<string, unknown>` has type `Record<string, unknown>`, not
+/// `{} | Record<string, unknown>`.
+///
+/// The freshness requirement mirrors tsc: a *declared* `{}` is the wide
+/// empty-object supertype and survives reduction, so it is intentionally left
+/// untouched here. A sibling that `{}` is not assignable to (e.g. `{ a: number }`,
+/// which has a required property) is also preserved, because the fresh `{}` is
+/// then the supertype rather than the subtype.
+fn reduce_fresh_empty_object_branch<R: TypeResolver>(
+    interner: &dyn TypeDatabase,
+    true_type: TypeId,
+    false_type: TypeId,
+    resolver: Option<&R>,
+) -> Option<TypeId> {
+    if is_fresh_empty_object_literal(interner, true_type)
+        && !is_fresh_empty_object_literal(interner, false_type)
+        && fresh_empty_is_subtype_of(interner, true_type, false_type, resolver)
+    {
+        return Some(false_type);
+    }
+    if is_fresh_empty_object_literal(interner, false_type)
+        && !is_fresh_empty_object_literal(interner, true_type)
+        && fresh_empty_is_subtype_of(interner, false_type, true_type, resolver)
+    {
+        return Some(true_type);
+    }
+    None
+}
+
+/// Decide whether a fresh empty `{}` is a subtype of `other`. `other` may be an
+/// alias/application/mapped wrapper (e.g. `Record<string, unknown>` interns as a
+/// `TypeData::Application`), so it is evaluated to its structural form first —
+/// otherwise the index signature that makes `{}` a subtype stays hidden behind
+/// the wrapper and the reduction is missed.
+fn fresh_empty_is_subtype_of<R: TypeResolver>(
+    interner: &dyn TypeDatabase,
+    empty: TypeId,
+    other: TypeId,
+    resolver: Option<&R>,
+) -> bool {
+    match resolver {
+        Some(res) => {
+            let resolved =
+                crate::evaluation::evaluate::evaluate_type_with_resolver(interner, res, other);
+            let mut checker = SubtypeChecker::with_resolver(interner, res);
+            checker.is_subtype_of(empty, resolved)
+        }
+        None => {
+            let resolved = crate::evaluation::evaluate::evaluate_type(interner, other);
+            is_subtype_of(interner, empty, resolved)
+        }
+    }
+}
+
+/// A fresh empty object literal is `{}` written inline (carrying
+/// `ObjectFlags::FRESH_LITERAL`) with no members and no index signatures.
+/// Inspects the interned shape in place rather than cloning it, since this runs
+/// for every conditional expression whose branch is a fresh object literal.
+fn is_fresh_empty_object_literal(interner: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    if type_id.is_intrinsic() {
+        return false;
+    }
+    let shape_id = match interner.lookup(type_id) {
+        Some(TypeData::Object(id) | TypeData::ObjectWithIndex(id)) => id,
+        _ => return false,
+    };
+    let shape = interner.object_shape(shape_id);
+    shape.flags.contains(ObjectFlags::FRESH_LITERAL)
+        && shape.properties.is_empty()
+        && shape.string_index.is_none()
+        && shape.number_index.is_none()
+        && shape.symbol.is_none()
 }
 
 fn contains_unique_symbol(interner: &dyn TypeDatabase, type_id: TypeId) -> bool {

--- a/crates/tsz-solver/tests/expression_ops_tests.rs
+++ b/crates/tsz-solver/tests/expression_ops_tests.rs
@@ -191,6 +191,102 @@ fn test_conditional_fresh_object_literals_get_complementary_optional_properties(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Fresh empty object literal subtype reduction in conditional expressions.
+//
+// tsc computes a conditional's type as `getUnionType([t, f], UnionReduction.Subtype)`.
+// A *fresh* empty `{}` literal is a subtype of any type it is assignable to (one
+// with an index signature or only-optional members), so it is reduced away:
+// `cond ? {} : rec` (rec: Record<string, unknown>) has type `Record<...>`, not
+// `{} | Record<...>`. These tests exercise the structural rule with multiple
+// shapes — they must not depend on a particular property/alias spelling.
+// ---------------------------------------------------------------------------
+
+fn string_index_record(interner: &TypeInterner, value: TypeId) -> TypeId {
+    interner.object_with_index(crate::types::ObjectShape {
+        flags: ObjectFlags::empty(),
+        properties: Vec::new(),
+        string_index: Some(crate::types::IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: value,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+        symbol: None,
+    })
+}
+
+#[test]
+fn test_conditional_fresh_empty_object_reduces_into_string_index_sibling() {
+    let interner = TypeInterner::new();
+    let fresh_empty = interner.object_with_flags(Vec::new(), ObjectFlags::FRESH_LITERAL);
+    let record = string_index_record(&interner, TypeId::UNKNOWN);
+
+    // `{} (fresh) | Record<string, unknown>` reduces to the record.
+    assert_eq!(
+        compute_conditional_expression_type(&interner, TypeId::BOOLEAN, fresh_empty, record),
+        record,
+    );
+    // Order independent: the record may be the true branch.
+    assert_eq!(
+        compute_conditional_expression_type(&interner, TypeId::BOOLEAN, record, fresh_empty),
+        record,
+    );
+    // Also holds with a different index value type (not a fixed spelling).
+    let record_num = string_index_record(&interner, TypeId::NUMBER);
+    assert_eq!(
+        compute_conditional_expression_type(&interner, TypeId::BOOLEAN, fresh_empty, record_num),
+        record_num,
+    );
+}
+
+#[test]
+fn test_conditional_fresh_empty_object_reduces_into_optional_only_sibling() {
+    let interner = TypeInterner::new();
+    let a = interner.intern_string("a");
+    let fresh_empty = interner.object_with_flags(Vec::new(), ObjectFlags::FRESH_LITERAL);
+    // `{ a?: number }` has no required members, so `{}` is assignable to it.
+    let optional_only = interner.object(vec![PropertyInfo::opt(a, TypeId::NUMBER)]);
+
+    assert_eq!(
+        compute_conditional_expression_type(&interner, TypeId::BOOLEAN, fresh_empty, optional_only),
+        optional_only,
+    );
+}
+
+#[test]
+fn test_conditional_fresh_empty_object_kept_when_sibling_has_required_property() {
+    let interner = TypeInterner::new();
+    let a = interner.intern_string("a");
+    let fresh_empty = interner.object_with_flags(Vec::new(), ObjectFlags::FRESH_LITERAL);
+    // `{ a: number }` has a required property, so `{}` is NOT assignable to it and
+    // is the supertype — the union is preserved (tsc keeps the error on `{}` here).
+    let required = interner.object(vec![PropertyInfo::new(a, TypeId::NUMBER)]);
+
+    let result =
+        compute_conditional_expression_type(&interner, TypeId::BOOLEAN, fresh_empty, required);
+    assert_ne!(result, fresh_empty);
+    assert_ne!(result, required);
+    assert!(
+        crate::type_queries::get_union_members(&interner, result).is_some(),
+        "fresh {{}} | {{ a: number }} must remain a union",
+    );
+}
+
+#[test]
+fn test_conditional_declared_empty_object_not_reduced_into_record() {
+    let interner = TypeInterner::new();
+    // A *non-fresh* `{}` is the wide empty-object supertype; tsc preserves it in
+    // the union (and still reports the index error), so reduction must not fire.
+    let declared_empty = interner.object(Vec::new());
+    let record = string_index_record(&interner, TypeId::UNKNOWN);
+
+    let result =
+        compute_conditional_expression_type(&interner, TypeId::BOOLEAN, declared_empty, record);
+    assert_ne!(result, record, "declared {{}} must not be reduced away");
+}
+
 #[test]
 fn test_normalize_fresh_object_literal_union_members_preserves_source_order_for_empty_member() {
     // When a fresh-object union has an empty `{}` literal alongside members


### PR DESCRIPTION
## Agent
AgentName: claude-confident-thompson (continuing the `agent:Studio-A` lane on #10674)

## Track
Project corpus benchmark blocker — kysely row TS7053 false-positive family (#10663), completing the remainder of merged PR #10694.

## Invariant / structural rule
> When a conditional expression's branches form an inferred union where one branch is a **fresh** empty object literal `{}` and that `{}` is assignable to the other branch, tsc reduces the union via `getUnionType(..., UnionReduction.Subtype)` and drops the `{}`; this change makes tsz do the same.

`cond ? {} : rec` (where `rec: Record<string, unknown>`) has type `Record<string, unknown>`, **not** `{} | Record<string, unknown>`. tsz previously built the branch union with literal-only reduction, so `x[key]` on the result raised a false `TS7053` under `noImplicitAny`.

The reduction is gated on **freshness** to match tsc exactly:
- a *declared* `{}` is the wide empty-object supertype → preserved (tsc still reports the index error there);
- a sibling with a required property (e.g. `{ a: number }`) → preserved, because `{}` is then the supertype, not the subtype.

The sibling may intern as an alias/application wrapper (`Record<string, unknown>` is a `TypeData::Application`), so the helper threads the checker resolver and evaluates the sibling before the subtype check. The **original** (unevaluated) type is returned, so display stays `Record<string, unknown>`.

## Scope
- `crates/tsz-solver/src/operations/expression_ops.rs` — `compute_conditional_expression_type_with_resolver` + `reduce_fresh_empty_object_branch` / `is_fresh_empty_object_literal` helpers.
- `crates/tsz-checker/src/query_boundaries/type_computation/core.rs` — resolver-aware boundary wrapper.
- `crates/tsz-checker/src/types/computation/helpers.rs` — thread `&self.ctx` resolver into the ternary path.
- `crates/tsz-solver/tests/expression_ops_tests.rs` — adjacent-shape coverage.

## Project Corpus Impact
- Row: `kysely-project`
- Bug family: false `TS7053` on `Record` / open-object indexing (#10674), tracked under #10663.
- Evidence: minimized repros checked against `tsc` 6.0.2 — `cond ? {} : Record<string, unknown>` and the reversed-order form are now clean in both tsz and tsc; declared-`{}` and required-property siblings still error in both (display-only divergence on the error text, no false positive). Display of the reduced type stays `Record<string, unknown>`.

## Verification
- `tsc --strict --noImplicitAny` vs `tsz` on a repro matrix (fresh `{}`|Record reduced; declared `{}`|Record and `{}`|`{a:number}` preserved-and-erroring in both; `Animal|Dog`, array-literal, common ternaries unchanged).
- `cargo test -p tsz-solver --lib expression_ops` → 45 passed.
- Full `tsz-solver` lib tests: 6335 passed / 21 failed, identical 21 pre-existing failures to clean `main` (template/mapped widening, conditional-*type* `any`, file-size ceiling) → **zero regressions introduced**.
- `cargo fmt --check` + `cargo clippy -p tsz-solver -p tsz-checker --all-targets -D warnings` clean.

## Coordination Notes
- AgentName: claude-confident-thompson. Builds on merged PR #10694 (which fixed the mapped/`Record`-alias index-signature lookup, repro 1); this PR fixes the remaining **union** case (`{} | Record` from a ternary, repro 2 in #10674).
- Adjacent case intentionally **out of scope**: control-flow joins (`let x; if(b) x={}; else x=rec;`) build their union via `union_preserve_members` at `flow/control_flow/core.rs`, which is deliberately non-reducing for narrowing correctness; extending reduction there is a separate, riskier change (hot path + freshness-retention uncertainty) and warrants its own conformance-validated PR. Noted for follow-up rather than bundled here.
- Non-overlap: changes only the conditional-expression type path + solver helper; does not touch the index-signature resolver from #10694 or active M4-D cross-file class PRs.

https://claude.ai/code/session_01AKAaM21RRutZEDHFDekQwo

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKAaM21RRutZEDHFDekQwo)_