### PR TITLE
test(solver): cover skip-weak relation cache

### DIFF
--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -180,6 +180,88 @@ fn assignability_cache_strict_any_matches_uncached_relation_policy() {
 }
 
 #[test]
+fn assignability_cache_skip_weak_type_checks_matches_uncached_relation_policy() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let unrelated = interner.intern_string("unrelated");
+    let optional = interner.intern_string("optional");
+
+    let source = interner.object(vec![PropertyInfo::new(unrelated, TypeId::STRING)]);
+    let target = interner.object(vec![PropertyInfo::opt(optional, TypeId::NUMBER)]);
+
+    let ordinary = RelationPolicy::default().with_skip_weak_type_checks(false);
+    let skip_weak = RelationPolicy::default().with_skip_weak_type_checks(true);
+    let ordinary_key = RelationCacheKey::for_assignability(source, target, ordinary.cache_config());
+    let skip_weak_key =
+        RelationCacheKey::for_assignability(source, target, skip_weak.cache_config());
+
+    assert_ne!(
+        ordinary_key, skip_weak_key,
+        "ordinary and skip-weak policies must occupy distinct assignability cache slots",
+    );
+
+    let ordinary_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        ordinary,
+        RelationContext::default(),
+    )
+    .is_related();
+    let skip_weak_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        skip_weak,
+        RelationContext::default(),
+    )
+    .is_related();
+
+    assert!(
+        !ordinary_uncached,
+        "ordinary assignability should reject unrelated object properties against a weak target",
+    );
+    assert!(
+        skip_weak_uncached,
+        "skip-weak assignability should bypass the weak-type no-overlap rejection",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, ordinary),
+        ordinary_uncached,
+        "cached ordinary weak-type policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(ordinary_key),
+        Some(ordinary_uncached),
+        "ordinary weak-type result must be stored in the ordinary assignability slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(skip_weak_key),
+        None,
+        "skip-weak lookup must not hit the ordinary weak-type slot",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, skip_weak),
+        skip_weak_uncached,
+        "cached skip-weak policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(skip_weak_key),
+        Some(skip_weak_uncached),
+        "skip-weak result must be stored in its own assignability slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(ordinary_key),
+        Some(ordinary_uncached),
+        "ordinary weak-type slot must remain intact after the skip-weak lookup",
+    );
+}
+
+#[test]
 fn assignability_cache_strict_function_types_matches_uncached_function_variance() {
     let interner = TypeInterner::new();
     let db = QueryCache::new(&interner);


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 10 relation policy/cache-key tech debt (#8207), solver policy/cache agreement test ratchet.

## Invariant
`skip_weak_type_checks` must be part of the assignability cache key: cached assignability must agree with uncached `query_relation` when weak-type checking changes whether an empty/non-overlapping object assignment is accepted.

## Scope
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: solver test-only ratchet for relation policy/cache agreement; no project corpus behavior change targeted.

## Verification
- RED `cargo nextest run -p tsz-solver -E 'test(assignability_cache_skip_weak_type_checks_matches_uncached_relation_policy)'` failed before the test existed with `error: no tests to run`.
- After #10729 merged to `origin/main` at `e1d43eb8fd8d`, this PR was rebased onto exact base `origin/main` with exact head `9cbbf81c733`.
- `cargo nextest run -p tsz-solver -E 'test(assignability_cache_skip_weak_type_checks_matches_uncached_relation_policy)'`: 1 passed on `9cbbf81c733`.
- `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'`: 15 passed on `9cbbf81c733`.
- `cargo fmt --check`: passed on `9cbbf81c733`.
- `git diff --check origin/main..HEAD`: passed on `9cbbf81c733`.
- Stack diff check: `git diff --stat origin/main..HEAD` -> one file, 82 insertions.
- File-size guard: `wc -l crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs` -> 1316 lines, below the 2000-line cap.
- Ready-review GitHub Actions on `9cbbf81c733`: `CI Summary`, `GitGuardian Security Checks`, conformance aggregate, fourslash aggregate, emit, wasm, unit, lint, project corpus PR body, and project compile gates passed on 2026-05-29.
- Repo-local merge queue landed the PR on `main` as merge commit `d42dde6f8b` on 2026-05-29.

## Coordination Notes
- #10729 landed on `main`; this PR retargeted `main` directly and is no longer stacked on #10729.
- This PR landed through the repo-local merge queue as #10735; no follow-up action remains for this slice.
- Downstream M4-B stack after landing: #10739 (`strict_null_checks`) now targets `main` directly; #10989 remains stacked on #10739; #11658 remains stacked on #10989.
- Non-overlap: this slice covers only `skip_weak_type_checks` relation cache agreement; it does not touch checker relation routing owned by M1-B, nor M4-A/M4-C evaluation/inference lanes.
- No `WIP` or auto-merge state set.
