### PR TITLE
fix(checker): detect cross-file circular type aliases structurally

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1087,6 +1087,10 @@ name = "cross_file_type_params_cache_tests"
 path = "tests/cross_file_type_params_cache_tests.rs"
 
 [[test]]
+name = "cross_file_circular_type_alias_tests"
+path = "tests/cross_file_circular_type_alias_tests.rs"
+
+[[test]]
 name = "cross_file_lib_interface_identity_tests"
 path = "tests/cross_file_lib_interface_identity_tests.rs"
 

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_circular.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_circular.rs
@@ -14,6 +14,20 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
+/// The declaration context of a (possibly cross-file) type alias, used by the
+/// structural cross-file circularity walk.
+struct AliasBodyContext<'b> {
+    /// File index that owns the alias declaration.
+    file_idx: usize,
+    arena: &'b tsz_parser::parser::NodeArena,
+    binder: &'b tsz_binder::BinderState,
+    /// The alias's declared body type node.
+    body: NodeIndex,
+    /// Type-parameter names in scope for the body (so they are not mistaken for
+    /// same-named top-level aliases).
+    type_params: Vec<String>,
+}
+
 impl<'a> CheckerState<'a> {
     /// True for bare type refs (`type A = B`), false for wrapped (`type A = { x: B }`).
     pub(crate) fn is_simple_type_reference(&self, type_node: NodeIndex) -> bool {
@@ -1203,6 +1217,243 @@ impl<'a> CheckerState<'a> {
         false
     }
 
+    /// Structural detection of a cross-file type-alias self-cycle.
+    ///
+    /// Cross-file alias resolution runs through child-checker delegation, which
+    /// breaks the `Lazy(DefId)` re-entry by collapsing the cycle to `ERROR`
+    /// instead of leaving a `Lazy` chain or marking the `DefId` circular. That
+    /// makes both `is_cross_file_circular_alias` (which walks a `Lazy` chain)
+    /// and the `shared_circular` mark unreliable for mutually-referential
+    /// type-only imports. This walk reconstructs the cycle directly from the
+    /// alias declarations: starting at `start_sym`, it follows each alias body's
+    /// non-deferred type references across files (resolving import aliases and
+    /// namespace members) and returns `true` if a path returns to `start_sym`.
+    ///
+    /// Deferral matches `tsc`'s rule and `alias_ast_is_deferred`: references
+    /// behind a structural wrapper (array, tuple, object literal, mapped,
+    /// function/constructor, type operator, or a generic application carrying
+    /// type arguments) defer evaluation and break the cycle. Parenthesized,
+    /// union, and intersection types are transparent and are traversed.
+    ///
+    /// Symbol identity is keyed on `(SymbolId, file_idx)`: raw `SymbolId`s are
+    /// not globally unique (different files' binders can share index ranges), so
+    /// the file index disambiguates them when comparing against the start alias
+    /// and when recording visited aliases.
+    pub(crate) fn alias_cross_file_cycles_to_self(&self, start_sym: SymbolId) -> bool {
+        let start = (start_sym, self.symbol_file_idx(start_sym));
+        let mut visited = FxHashSet::default();
+        visited.insert(start);
+        self.alias_body_cycles_to(start_sym, start, &mut visited)
+    }
+
+    /// File index that canonically owns `sym_id`. Used to disambiguate raw
+    /// `SymbolId`s that can collide across files' binders.
+    fn symbol_file_idx(&self, sym_id: SymbolId) -> usize {
+        self.get_cross_file_symbol(sym_id)
+            .map(|s| s.decl_file_idx)
+            .filter(|&f| f != u32::MAX)
+            .map(|f| f as usize)
+            .or_else(|| self.ctx.resolve_symbol_file_index(sym_id))
+            .unwrap_or(self.ctx.current_file_idx)
+    }
+
+    fn alias_body_cycles_to(
+        &self,
+        cur_sym: SymbolId,
+        start: (SymbolId, usize),
+        visited: &mut FxHashSet<(SymbolId, usize)>,
+    ) -> bool {
+        let Some(ctx) = self.alias_body_in_file(cur_sym) else {
+            return false;
+        };
+        self.type_node_cycles_to(&ctx, ctx.body, start, visited)
+    }
+
+    /// Resolve the declaration context (owning file, arena, binder, body type
+    /// node, type-parameter names) for a (possibly cross-file) type-alias
+    /// symbol. The type-parameter names scope the walk: a body reference whose
+    /// name is one of them denotes the parameter, not a same-named top-level
+    /// alias.
+    fn alias_body_in_file(&self, sym_id: SymbolId) -> Option<AliasBodyContext<'_>> {
+        let symbol = self.get_cross_file_symbol(sym_id)?;
+        if symbol.flags & tsz_binder::symbol_flags::TYPE_ALIAS == 0 {
+            return None;
+        }
+        let file_idx = (symbol.decl_file_idx != u32::MAX)
+            .then_some(symbol.decl_file_idx as usize)
+            .or_else(|| self.ctx.resolve_symbol_file_index(sym_id))?;
+        let arena = self.ctx.get_arena_for_file(file_idx as u32);
+        // Pair the binder to the arena we actually use so resolution never runs
+        // a sibling file's AST against the wrong file's `file_locals`.
+        let binder = self
+            .ctx
+            .get_binder_for_arena(arena)
+            .unwrap_or(self.ctx.binder);
+        for &decl_idx in &symbol.declarations {
+            if let Some(node) = arena.get(decl_idx)
+                && node.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION
+                && let Some(ta) = arena.get_type_alias(node)
+            {
+                let name_matches = arena
+                    .get(ta.name)
+                    .and_then(|n| arena.get_identifier(n))
+                    .is_some_and(|ident| {
+                        arena.resolve_identifier_text(ident) == symbol.escaped_name.as_str()
+                    });
+                if name_matches {
+                    return Some(AliasBodyContext {
+                        file_idx,
+                        arena,
+                        binder,
+                        body: ta.type_node,
+                        type_params: Self::type_alias_type_param_names(arena, ta),
+                    });
+                }
+            }
+        }
+        None
+    }
+
+    /// Walk a type node looking for a non-deferred reference path back to the
+    /// `start` alias. Transparent wrappers are traversed; structural wrappers
+    /// defer and stop the walk. `ctx` carries the file/arena/binder and the
+    /// type-parameter names in scope for the alias body being walked.
+    fn type_node_cycles_to(
+        &self,
+        ctx: &AliasBodyContext<'_>,
+        node_idx: NodeIndex,
+        start: (SymbolId, usize),
+        visited: &mut FxHashSet<(SymbolId, usize)>,
+    ) -> bool {
+        let Some(node) = ctx.arena.get(node_idx) else {
+            return false;
+        };
+        let k = node.kind;
+        if k == syntax_kind_ext::PARENTHESIZED_TYPE
+            || k == syntax_kind_ext::UNION_TYPE
+            || k == syntax_kind_ext::INTERSECTION_TYPE
+        {
+            return ctx
+                .arena
+                .get_children(node_idx)
+                .into_iter()
+                .any(|child| self.type_node_cycles_to(ctx, child, start, visited));
+        }
+        if k == syntax_kind_ext::TYPE_REFERENCE {
+            let Some(type_ref) = ctx.arena.get_type_ref(node) else {
+                return false;
+            };
+            // A generic application defers through instantiation, just like
+            // `alias_ast_is_deferred` treats `Foo<...>`.
+            if type_ref
+                .type_arguments
+                .as_ref()
+                .is_some_and(|args| !args.nodes.is_empty())
+            {
+                return false;
+            }
+            let Some(target) = self.resolve_type_name_symbol_in_file(ctx, type_ref.type_name)
+            else {
+                return false;
+            };
+            if target == start {
+                return true;
+            }
+            let target_is_alias = self
+                .get_cross_file_symbol(target.0)
+                .is_some_and(|s| s.flags & tsz_binder::symbol_flags::TYPE_ALIAS != 0);
+            if target_is_alias && visited.insert(target) {
+                return self.alias_body_cycles_to(target.0, start, visited);
+            }
+        }
+        false
+    }
+
+    /// Resolve an entity-name node (`Identifier` or `QualifiedName`) that lives
+    /// in `ctx`'s file to the `(SymbolId, file_idx)` it denotes, following
+    /// cross-file import aliases and namespace member access. A bare name listed
+    /// in `ctx.type_params` denotes a type parameter (not a top-level alias) and
+    /// resolves to nothing.
+    fn resolve_type_name_symbol_in_file(
+        &self,
+        ctx: &AliasBodyContext<'_>,
+        name_node: NodeIndex,
+    ) -> Option<(SymbolId, usize)> {
+        let node = ctx.arena.get(name_node)?;
+        if node.kind == SyntaxKind::Identifier as u16 {
+            let ident = ctx.arena.get_identifier(node)?;
+            let name = ident.escaped_text.as_str();
+            if ctx.type_params.iter().any(|p| p == name) {
+                return None;
+            }
+            let local = ctx.binder.file_locals.get(name)?;
+            return Some(self.canonicalize_resolved(local, ctx.file_idx));
+        }
+        if node.kind == syntax_kind_ext::QUALIFIED_NAME {
+            let qn = ctx.arena.get_qualified_name(node)?;
+            let (left_sym, left_file) = self.resolve_type_name_symbol_in_file(ctx, qn.left)?;
+            let right_node = ctx.arena.get(qn.right)?;
+            let right_name = ctx.arena.get_identifier(right_node)?.escaped_text.as_str();
+            let member = self
+                .get_cross_file_symbol(left_sym)?
+                .exports
+                .as_ref()?
+                .get(right_name)?;
+            return Some(self.canonicalize_resolved(member, left_file));
+        }
+        None
+    }
+
+    /// Follow `sym_id`'s import-alias chain (if any) to its real target and pair
+    /// it with the owning file. A symbol that is not an import alias keeps
+    /// `home_file` — the file whose scope produced it — since that is where it
+    /// is declared.
+    fn canonicalize_resolved(&self, sym_id: SymbolId, home_file: usize) -> (SymbolId, usize) {
+        let followed = self.follow_alias_to_target(sym_id);
+        if followed == sym_id {
+            (sym_id, home_file)
+        } else {
+            (followed, self.symbol_file_idx(followed))
+        }
+    }
+
+    /// Follow an import/export alias chain to its real target symbol across
+    /// files, stopping at the first non-alias symbol. Bounded by a visited set.
+    fn follow_alias_to_target(&self, sym_id: SymbolId) -> SymbolId {
+        let mut current = sym_id;
+        let mut guard = FxHashSet::default();
+        while guard.insert(current) {
+            let Some(symbol) = self.get_cross_file_symbol(current) else {
+                break;
+            };
+            if symbol.flags & tsz_binder::symbol_flags::ALIAS == 0 {
+                break;
+            }
+            let Some(module_name) = symbol.import_module.clone() else {
+                break;
+            };
+            let import_name = symbol
+                .import_name
+                .clone()
+                .unwrap_or_else(|| symbol.escaped_name.clone());
+            let source_file_idx = (symbol.decl_file_idx != u32::MAX)
+                .then_some(symbol.decl_file_idx as usize)
+                .or_else(|| self.ctx.resolve_symbol_file_index(current));
+            let Some(target) = self.resolve_cross_file_export_from_file(
+                &module_name,
+                &import_name,
+                source_file_idx,
+            ) else {
+                break;
+            };
+            if target == current {
+                break;
+            }
+            current = target;
+        }
+        current
+    }
+
     /// Detect cross-file circular type alias cycles via `DefinitionStore` Lazy chain.
     pub(crate) fn is_cross_file_circular_alias(
         &self,
@@ -1319,11 +1570,25 @@ impl<'a> CheckerState<'a> {
                 .get_existing_def_id(sym_id)
                 .is_some_and(|def_id| self.ctx.definition_store.is_circular_def(def_id));
 
-            if !is_lazy && !shared_circular {
+            // Structural cross-file cycle detection: when a sibling file's alias
+            // body resolves back to this alias (a `Lazy(...)` cycle through
+            // type-only imports), the cross-arena resolution path collapses the
+            // cycle to `ERROR` without leaving a `Lazy` chain or a
+            // `shared_circular` mark. Detect the cycle directly from the alias
+            // declarations across files so the diagnostic does not depend on the
+            // fragile resolved-type signals above. Only walk when the cheap
+            // signals have not already decided the alias is circular.
+            let structural_cycle =
+                !is_lazy && !shared_circular && self.alias_cross_file_cycles_to_self(sym_id);
+
+            if !is_lazy && !shared_circular && !structural_cycle {
                 continue;
             }
 
-            if shared_circular || self.is_cross_file_circular_alias(sym_id, resolved) {
+            if shared_circular
+                || structural_cycle
+                || self.is_cross_file_circular_alias(sym_id, resolved)
+            {
                 // Get the symbol name for the diagnostic message.
                 let name = self
                     .ctx

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct/source_shape_methods.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct/source_shape_methods.rs
@@ -554,7 +554,7 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    pub(super) fn type_alias_type_param_names(
+    pub(crate) fn type_alias_type_param_names(
         arena: &NodeArena,
         type_alias: &TypeAliasData,
     ) -> Vec<String> {

--- a/crates/tsz-checker/tests/cross_file_circular_type_alias_tests.rs
+++ b/crates/tsz-checker/tests/cross_file_circular_type_alias_tests.rs
@@ -1,0 +1,155 @@
+//! Cross-file circular type-alias detection (TS2456).
+//!
+//! When two type aliases in different files form a mutual cycle through
+//! type-only imports, `tsc` reports `TS2456 "Type alias 'X' circularly
+//! references itself."` at *each* alias's local declaration. tsz's cross-file
+//! alias resolution runs through child-checker delegation, which collapses the
+//! `Lazy(DefId)` re-entry to `ERROR` — leaving neither a `Lazy` chain nor a
+//! `circular_def` mark — so the post-pass detection reconstructs the cycle
+//! structurally from the alias declarations across files.
+//!
+//! Mirrors the conformance cases `externalModules/typeOnly/circular2.ts`
+//! (simple `type A = B` / `type B = A`) and `circular4.ts` (namespace-nested
+//! `ns1.nested.T = ns2.nested.T`). The structural rule is keyed on the cycle
+//! shape, not on the chosen alias/namespace names, so the renamed variants
+//! below must behave identically.
+
+use tsz_checker::context::CheckerOptions;
+
+fn codes_for(files: &[(&str, &str)], entry: &str) -> Vec<u32> {
+    tsz_checker::test_utils::check_multi_file(files, entry, CheckerOptions::default())
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+/// circular2 shape: `type A = B` / `type B = A` via `import type`. Each file's
+/// local alias must be reported circular when that file is the entry.
+#[test]
+fn simple_two_file_cycle_emits_ts2456_for_each_file() {
+    let a = "import type { B } from './b';\nexport type A = B;\n";
+    let b = "import type { A } from './a';\nexport type B = A;\n";
+    let files = [("a.ts", a), ("b.ts", b)];
+    for entry in ["a.ts", "b.ts"] {
+        let codes = codes_for(&files, entry);
+        assert!(
+            codes.contains(&2456),
+            "entry {entry} should emit TS2456 for the cross-file alias cycle, got: {codes:?}"
+        );
+    }
+}
+
+/// Renamed variant of the simple cycle. The fix must not key on the names
+/// `A`/`B` — any two mutually-referential aliases cycle the same way.
+#[test]
+fn renamed_two_file_cycle_emits_ts2456() {
+    let a = "import type { Bar } from './b';\nexport type Foo = Bar;\n";
+    let b = "import type { Foo } from './a';\nexport type Bar = Foo;\n";
+    let files = [("a.ts", a), ("b.ts", b)];
+    for entry in ["a.ts", "b.ts"] {
+        let codes = codes_for(&files, entry);
+        assert!(
+            codes.contains(&2456),
+            "entry {entry} renamed cycle should emit TS2456, got: {codes:?}"
+        );
+    }
+}
+
+/// circular4 shape: the cycle runs through namespace-qualified members
+/// (`ns1.nested.T` / `ns2.nested.T`) across files, so resolution must follow
+/// namespace exports, not just bare top-level names.
+#[test]
+fn namespace_nested_cross_file_cycle_emits_ts2456() {
+    let a = "import type { ns2 } from './b';\n\
+             export namespace ns1 {\n  export namespace nested {\n    export type T = ns2.nested.T;\n  }\n}\n";
+    let b = "import type { ns1 } from './a';\n\
+             export namespace ns2 {\n  export namespace nested {\n    export type T = ns1.nested.T;\n  }\n}\n";
+    let files = [("a.ts", a), ("b.ts", b)];
+    for entry in ["a.ts", "b.ts"] {
+        let codes = codes_for(&files, entry);
+        assert!(
+            codes.contains(&2456),
+            "entry {entry} namespace-nested cycle should emit TS2456, got: {codes:?}"
+        );
+    }
+}
+
+/// Three-file cycle `a -> b -> c -> a` — the walk must traverse an arbitrary
+/// number of cross-file hops before closing the loop.
+#[test]
+fn three_file_cycle_emits_ts2456() {
+    let a = "import type { B } from './b';\nexport type A = B;\n";
+    let b = "import type { C } from './c';\nexport type B = C;\n";
+    let c = "import type { A } from './a';\nexport type C = A;\n";
+    let files = [("a.ts", a), ("b.ts", b), ("c.ts", c)];
+    for entry in ["a.ts", "b.ts", "c.ts"] {
+        let codes = codes_for(&files, entry);
+        assert!(
+            codes.contains(&2456),
+            "entry {entry} three-file cycle should emit TS2456, got: {codes:?}"
+        );
+    }
+}
+
+/// Negative: a cross-file alias chain that terminates in a concrete type is
+/// not circular and must not report TS2456.
+#[test]
+fn non_circular_cross_file_chain_has_no_ts2456() {
+    let a = "import type { B } from './b';\nexport type A = B;\n";
+    let b = "export type B = number;\n";
+    let files = [("a.ts", a), ("b.ts", b)];
+    let codes = codes_for(&files, "a.ts");
+    assert!(
+        !codes.contains(&2456),
+        "non-circular chain must not emit TS2456, got: {codes:?}"
+    );
+}
+
+/// Negative: a structural wrapper (array) defers the back-reference, so
+/// `type A = B` / `type B = A[]` is a legal recursive type, not a circular
+/// alias — `tsc` reports no TS2456 here.
+#[test]
+fn deferred_cross_file_cycle_through_array_has_no_ts2456() {
+    let a = "import type { B } from './b';\nexport type A = B;\n";
+    let b = "import type { A } from './a';\nexport type B = A[];\n";
+    let files = [("a.ts", a), ("b.ts", b)];
+    for entry in ["a.ts", "b.ts"] {
+        let codes = codes_for(&files, entry);
+        assert!(
+            !codes.contains(&2456),
+            "entry {entry}: array-deferred recursive alias must not emit TS2456, got: {codes:?}"
+        );
+    }
+}
+
+/// Negative: a structural wrapper (object literal) likewise defers the
+/// back-reference; `type B = { next: A }` is a legal recursive type.
+#[test]
+fn deferred_cross_file_cycle_through_object_has_no_ts2456() {
+    let a = "import type { B } from './b';\nexport type A = B;\n";
+    let b = "import type { A } from './a';\nexport type B = { next: A };\n";
+    let files = [("a.ts", a), ("b.ts", b)];
+    for entry in ["a.ts", "b.ts"] {
+        let codes = codes_for(&files, entry);
+        assert!(
+            !codes.contains(&2456),
+            "entry {entry}: object-deferred recursive alias must not emit TS2456, got: {codes:?}"
+        );
+    }
+}
+
+/// Negative: a generic alias whose type-parameter name shadows a top-level
+/// alias name must not be mistaken for a cycle. In `type T = U; type U<T> = T`
+/// the `T` inside `U`'s body is `U`'s parameter, not the alias `T`. `tsc`
+/// reports only TS2314 (missing type argument), never TS2456; the structural
+/// walk must be scope-aware and skip in-scope type-parameter names.
+#[test]
+fn type_parameter_shadowing_alias_name_has_no_ts2456() {
+    let src = "type T = U;\ntype U<T> = T;\nexport {};\n";
+    let files = [("a.ts", src)];
+    let codes = codes_for(&files, "a.ts");
+    assert!(
+        !codes.contains(&2456),
+        "type-parameter shadowing must not emit TS2456 (only TS2314), got: {codes:?}"
+    );
+}

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -8,8 +8,6 @@ TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElabora
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 TypeScript/tests/cases/compiler/reorderProperties.ts
-TypeScript/tests/cases/conformance/externalModules/typeOnly/circular2.ts
-TypeScript/tests/cases/conformance/externalModules/typeOnly/circular4.ts
 TypeScript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts


### PR DESCRIPTION
## Agent
AgentName: cloud-opus47-confident-thompson (remote execution / claude/confident-thompson-MJlyR)

Fixes #5303 (circular type-only external module regression family: `circular2.ts`, `circular4.ts`).

## Track
Checker / cross-file type-alias resolution / TS2456 diagnostics.

## Invariant
When two (or more) type aliases in different files form a mutual cycle through type-only imports — `A`'s body resolves to `B` whose body resolves back to `A` — `tsc` reports `TS2456 "Type alias 'X' circularly references itself."` at **each** alias's local declaration. tsz must mark every alias on the cross-file cycle and emit the diagnostic at each local declaration, regardless of whether the cached resolved type collapsed to `ERROR` (or is still a `Lazy(...)` placeholder), and this must hold for namespace-qualified aliases (`ns.nested.T`), not just bare top-level names.

## Structural rule
> When a type alias's declared body, expanded by following its **non-deferred** type references across files (resolving import aliases and namespace members), returns to the alias itself, `tsc` reports TS2456; this change makes tsz report it too. References behind a structural wrapper (array, tuple, object literal, mapped, function/constructor, type operator, or a generic application carrying type arguments) **defer** and break the cycle; parenthesized/union/intersection are transparent.

## Root cause
Cross-file alias resolution runs through child-checker delegation (`compute_type_of_symbol` → `delegate_cross_arena_symbol_resolution`), which **bypasses** the inline TS2456 detection and collapses the `Lazy(DefId)` re-entry to `ERROR`. The post-pass `check_cross_file_circular_type_aliases` keyed solely on two fragile signals — the cached type still being `Lazy` (`is_cross_file_circular_alias` walks a `Lazy` chain) and a pre-set `circular_def` mark (`shared_circular`). For mutually-referential type-only imports neither holds (both `DefId` bodies are `ERROR`), so tsz emitted **zero** TS2456 where tsc emits two.

## Scope
- New solver-independent structural detector in `crates/tsz-checker/src/state/type_analysis/computed_helpers_circular.rs` (`alias_cross_file_cycles_to_self` + helpers). It walks alias declarations directly, owning-file by owning-file, and is wired into `check_cross_file_circular_type_aliases` as a `structural_cycle` signal, gated behind `!is_lazy && !shared_circular` so existing `Lazy`/`shared_circular` paths are byte-for-byte unchanged (strictly additive for the previously-broken collapsed-`ERROR` case).
- Owner layer: checker post-pass that already owns cross-file circular detection and diagnostic locations; no solver-internal or printer-output keying, no test-name/alias-spelling special-casing.
- Robustness: symbol identity keyed on `(SymbolId, file_idx)` because raw `SymbolId`s can collide across files' binders; in-scope type-parameter names are skipped so a generic alias's parameter shadowing a top-level alias name is not mistaken for a cycle; arena/binder paired via `get_binder_for_arena` so a sibling file's AST never resolves against the wrong file's `file_locals`.
- Widened `type_alias_type_param_names` to `pub(crate)` to reuse it for the scope set.
- Removed `circular2.ts` / `circular4.ts` from `scripts/conformance/conformance-accepted-regressions.txt`.

## Adjacent-case test matrix
`crates/tsz-checker/tests/cross_file_circular_type_alias_tests.rs` (8 tests):
- the reported repro (simple two-file `type A = B` / `type B = A`, both entry files);
- **renamed** aliases (`Foo`/`Bar`) — proves the rule is not keyed on names;
- **namespace-nested** (`ns1.nested.T` / `ns2.nested.T`) — circular4 shape;
- three-file cycle (`a → b → c → a`);
- negative: non-circular chain terminating in a concrete type;
- negative: array-deferred (`type B = A[]`) recursive alias — no TS2456;
- negative: object-deferred (`type B = { next: A }`) recursive alias — no TS2456;
- negative: type-parameter shadowing (`type T = U; type U<T> = T`) — only TS2314, never TS2456.

## Known unsupported shapes / fallback
Conservatively defers (no detection, never a false positive) on cross-file cycles that close only through `keyof`, indexed-access, or conditional check-type positions — consistent with the existing `alias_ast_is_deferred` classification. These are out of scope for circular2/circular4 and broadening them would risk false positives (e.g. `readonly T[]` must still defer); they can be a focused follow-up if a conformance case demands them.

## Project Corpus Impact
- Row: n/a
- Bug family: cross-file circular type-alias (TS2456) false-negative
- Evidence: conformance — un-accepts `externalModules/typeOnly/circular2.ts` and `circular4.ts` (full corpus runs on ready-for-review CI). Local CLI on equivalent multi-file projects matches the tsc cache exactly (`a.ts(2,13)`/`b.ts(2,13)` for circular2; `a.ts(4,17)`/`b.ts(4,17)` for circular4).

## Verification
- `cargo build -p tsz-cli --bin tsz` — clean.
- `cargo clippy -p tsz-checker --lib -- -D warnings` — clean.
- `cargo test -p tsz-checker --test cross_file_circular_type_alias_tests` — 8/8 pass.
- `cargo test -p tsz-checker --lib circular` — 20/20 pass (no regression).
- Local CLI (dist lib dir) reproduced circular2/circular4 → exact tsc parity; negatives and the type-parameter-shadowing case emit no spurious TS2456.
- Full conformance/emit/fourslash run on ready-for-review CI.

## Coordination Notes
- AgentName: cloud-opus47-confident-thompson. Picks up the `help wanted` handoff on #5303; no other open PR touches this family (#10721 is an unrelated LSP highlight test).
- Reviewed via three review passes; findings fixed: type-parameter-shadowing false positive, `(SymbolId, file_idx)` cross-file identity, arena/binder pairing, eager-walk gating, dead checks, redundant fallbacks, and `clippy::type_complexity` (factored into an `AliasBodyContext` struct).
- Auto-merge enabled per request; merge gate remains the repo merge queue on green PR-head checks.

https://claude.ai/code/session_0117arHQiYBMgzhhuLRgP4rj