### PR TITLE
test(solver): cover strict-null relation cache

### DIFF
--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -262,6 +262,86 @@ fn assignability_cache_skip_weak_type_checks_matches_uncached_relation_policy() 
 }
 
 #[test]
+fn assignability_cache_strict_null_checks_matches_uncached_relation_policy() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let source = TypeId::UNDEFINED;
+    let target = TypeId::NUMBER;
+
+    let loose = RelationPolicy::unflagged_compatibility();
+    let strict_null = RelationPolicy::from_relation_flags(RelationFlags::STRICT_NULL_CHECKS);
+    let loose_key = RelationCacheKey::for_assignability(source, target, loose.cache_config());
+    let strict_null_key =
+        RelationCacheKey::for_assignability(source, target, strict_null.cache_config());
+
+    assert_ne!(
+        loose_key, strict_null_key,
+        "loose and strict-null policies must occupy distinct assignability cache slots",
+    );
+
+    let loose_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        loose,
+        RelationContext::default(),
+    )
+    .is_related();
+    let strict_null_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        strict_null,
+        RelationContext::default(),
+    )
+    .is_related();
+
+    assert!(
+        loose_uncached,
+        "loose nullability should allow `undefined` to satisfy a number target",
+    );
+    assert!(
+        !strict_null_uncached,
+        "strict null checks should reject `undefined` for a number target",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, loose),
+        loose_uncached,
+        "cached loose nullability policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(loose_key),
+        Some(loose_uncached),
+        "loose nullability result must be stored in the loose assignability slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(strict_null_key),
+        None,
+        "strict-null lookup must not hit the loose nullability slot",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, strict_null),
+        strict_null_uncached,
+        "cached strict-null policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(strict_null_key),
+        Some(strict_null_uncached),
+        "strict-null result must be stored in its own assignability slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(loose_key),
+        Some(loose_uncached),
+        "loose nullability slot must remain intact after the strict-null lookup",
+    );
+}
+
+#[test]
 fn assignability_cache_strict_function_types_matches_uncached_function_variance() {
     let interner = TypeInterner::new();
     let db = QueryCache::new(&interner);


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 10 relation policy/cache-key tech debt (#8207), solver policy/cache agreement test ratchet.

## Invariant
When strict null checks are enabled, `undefined` must stop satisfying ordinary non-nullable targets; the cached assignability path must agree with uncached `query_relation` and use a distinct policy-shaped cache key from loose nullability.

## Scope
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: solver test-only ratchet for relation policy/cache agreement; no project corpus behavior change targeted.

## Verification
- RED `cargo nextest run -p tsz-solver -E 'test(assignability_cache_strict_null_checks_matches_uncached_relation_policy)'` failed before the test existed with `error: no tests to run`.
- After #10735 landed on `main`, this branch was rebased onto current `origin/main` at `6df463fdef13` and retargeted to `main` with exact head `2282932ec7`.
- `cargo nextest run -p tsz-solver -E 'test(assignability_cache_strict_null_checks_matches_uncached_relation_policy)'`: 1 passed on `2282932ec7`.
- `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'`: 16 passed on `2282932ec7`.
- `cargo fmt --check`: passed on `2282932ec7`.
- `git diff --check origin/main..HEAD`: passed on `2282932ec7`.
- Stack diff check: `git diff --stat origin/main..HEAD` -> one file, 80 insertions.
- File-size guard: `wc -l crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs` -> 1396 lines, below the 2000-line cap.
- Exact-head draft-light GitHub Actions on `2282932ec7`: `CI Light Summary`, `GitGuardian Security Checks`, unit, lint, dist-binaries, cargo-deny, cargo-shear, project-row-drift, queue-one-pr, and gate passed on 2026-05-29.

## Coordination Notes
- #10735 landed on `main` as merge commit `d42dde6f8b`; this PR now targets `main` directly and is no longer stacked on #10735.
- This branch is refreshed so the PR diff is only the strict-null slice: one commit, one solver test file, 80 insertions.
- Downstream M4-B stack: #10989 remains stacked on this branch; #11658 remains stacked on #10989.
- Non-overlap: this slice covers only `STRICT_NULL_CHECKS` cache agreement; it does not touch checker relation routing owned by M1-B, nor M4-A/M4-C evaluation/inference lanes.
- Exact-head draft-light checks passed; this PR is ready for heavy ready-review CI on 2026-05-29.
- No `WIP`, auto-merge, or `merge-queue` state set.
