### PR TITLE
fix(checker): optional private field reads include `| undefined` (#10668)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -823,6 +823,9 @@ mod predicate_narrowed_lib_union_access_tests;
 #[path = "../tests/private_brands.rs"]
 mod private_brands;
 #[cfg(test)]
+#[path = "tests/private_optional_field_undefined_tests.rs"]
+mod private_optional_field_undefined_tests;
+#[cfg(test)]
 #[path = "tests/promise_like_infer_tests.rs"]
 mod promise_like_infer_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs
@@ -264,18 +264,28 @@ impl<'a> CheckerState<'a> {
             };
             if let Some(type_id) = declared_type {
                 let evaluated = self.evaluate_type_for_assignability(type_id);
-                if evaluated != type_id
+                let result = if evaluated != type_id
                     && crate::query_boundaries::common::object_shape_for_type(
                         self.ctx.types,
                         evaluated,
                     )
                     .is_some_and(|shape| {
                         shape.string_index.is_some() || shape.number_index.is_some()
-                    })
-                {
-                    return Some(evaluated);
+                    }) {
+                    evaluated
+                } else {
+                    type_id
+                };
+                // Reading an optional private field (`this.#p` where `#p?: T`)
+                // yields `T | undefined`, just like public optional property
+                // access (`optional_property_type`). Without this, the field
+                // reads as bare `T`, dropping a soundness check (TS2322) and
+                // misfiring "always defined" truthiness (TS2801). The write path
+                // keeps the relation type unchanged. See #10668.
+                if !is_write_context && prop.question_token {
+                    return Some(self.ctx.types.factory().union2(result, TypeId::UNDEFINED));
                 }
-                return Some(type_id);
+                return Some(result);
             }
         }
 

--- a/crates/tsz-checker/src/tests/private_optional_field_undefined_tests.rs
+++ b/crates/tsz-checker/src/tests/private_optional_field_undefined_tests.rs
@@ -1,0 +1,111 @@
+//! Regression tests for #10668: reading an *optional private* field
+//! (`this.#p` where `#p?: T`) must yield `T | undefined`, like public optional
+//! property access. Previously the private read path
+//! (`private_property_declared_access_type`) returned bare `T`, which both
+//! dropped a soundness check (assigning `this.#p` to `T` wrongly succeeded,
+//! missing TS2322) and misfired the "always defined" awaitable-truthiness
+//! diagnostic (TS2801) on `if (this.#p)`.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::check_source;
+
+fn strict() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn codes(src: &str) -> Vec<u32> {
+    check_source(src, "test.ts", strict())
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+#[test]
+fn optional_private_promise_field_truthiness_no_ts2801() {
+    let c = codes(
+        r#"
+class C {
+  #p?: Promise<void>;
+  m() { if (this.#p) { return; } this.#p = Promise.resolve(); }
+}
+"#,
+    );
+    assert!(
+        !c.contains(&2801),
+        "optional private field is `T | undefined`; truthiness is meaningful, must not emit TS2801, got {c:?}"
+    );
+}
+
+#[test]
+fn reading_optional_private_field_includes_undefined_ts2322() {
+    // Reading `this.#name` (= `string | undefined`) where `string` is required
+    // must error TS2322 — proving the read type now carries `| undefined`, as
+    // for public optional fields and as tsc reports. (Uses a primitive rather
+    // than a lib type so the assignability check is lib-independent.)
+    let c = codes(
+        r#"
+class C {
+  #name?: string;
+  m(): string { return this.#name; }
+}
+"#,
+    );
+    assert!(
+        c.contains(&2322),
+        "reading an optional private field must include `undefined` (TS2322 on narrowing assignment), got {c:?}"
+    );
+}
+
+#[test]
+fn renamed_optional_private_field_is_structural_not_name_based() {
+    let c = codes(
+        r#"
+class Widget {
+  #handle?: number;
+  read(): number { return this.#handle; }
+}
+"#,
+    );
+    assert!(
+        c.contains(&2322),
+        "expected TS2322 for renamed optional private field, got {c:?}"
+    );
+}
+
+#[test]
+fn non_optional_private_promise_field_still_emits_ts2801() {
+    // Regression guard: a genuinely always-defined private Promise field must
+    // still trigger the awaitable-truthiness diagnostic (matches tsc).
+    let c = codes(
+        r#"
+class C {
+  #p: Promise<void> = Promise.resolve();
+  m() { if (this.#p) {} }
+}
+"#,
+    );
+    assert!(
+        c.contains(&2801),
+        "non-optional private Promise field is always defined; TS2801 must still fire, got {c:?}"
+    );
+}
+
+#[test]
+fn public_optional_field_unaffected() {
+    // Public optional fields already included `undefined`; behavior unchanged.
+    let c = codes(
+        r#"
+class C {
+  p?: Promise<void>;
+  m() { if (this.p) {} }
+}
+"#,
+    );
+    assert!(
+        !c.contains(&2801) && !c.contains(&2322),
+        "public optional field truthiness must stay clean, got {c:?}"
+    );
+}


### PR DESCRIPTION
AgentName: M5Opus

## Track
Checker correctness / soundness (closes #10668).

## Invariant
Reading an optional property yields `T | undefined`. This holds for public optional fields via `optional_property_type`; it must also hold for **optional private fields** (`this.#p` where `#p?: T`). Non-optional fields and the write path are unchanged.

## Scope
`private_property_declared_access_type` (in `state/type_analysis/computed_helpers_private.rs`) returned the declared property type directly, skipping the optional->undefined widening. For an optional private field in read context, union the result with `undefined`, mirroring public optional access.

Consequences fixed:
- **Soundness (TS2322):** assigning `this.#p` (now `T | undefined`) to `T` correctly errors again.
- **Truthiness (TS2801):** `if (this.#p)` no longer misfires "this condition will always return true since this Promise is always defined" — the value is genuinely possibly-undefined.

## Project Corpus Impact
- Row: kysely-project (the false TS2801 in `src/driver/runtime-driver.ts` is this bug; see #10668)
- Bug family: optional private field read type missing `| undefined` (false TS2801 + missed TS2322)
- Evidence: minimal repro `class C { #p?: Promise<void>; m(){ if (this.#p) {} } }` no longer emits TS2801 (verified dist-fast); soundness probe now emits TS2322. tsc parity confirmed via bench tsc.

## Verification
- `cargo nextest run -p tsz-checker -E 'test(private_optional_field)'` → 5/5 pass: optional-Promise truthiness no-TS2801, optional read soundness TS2322 (primitive, lib-independent), renamed-field structural guard, **non-optional** Promise still TS2801, public optional unaffected.
- Checker arch boundaries pass.

## Coordination Notes
Signed M5Opus. Closes #10668 (one of the kysely TS2801 false positives from the #10663 family map).