### PR TITLE
fix(checker): detect cross-file circular type aliases (TS2456)

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -852,11 +852,18 @@ impl<'a> CheckerState<'a> {
 
             // Cross-file circular type-alias detection (TS2456): if resolving
             // this alias re-enters an alias already on the delegation path, mark
-            // the whole cycle circular and stop (see `cross_file_alias_cycle`).
+            // every member of the cycle circular so each file's
+            // `check_cross_file_circular_type_aliases` post-pass emits its own
+            // TS2456 (see `cross_file_alias_cycle`). We deliberately do NOT
+            // short-circuit resolution here: the cross-arena depth guard below
+            // terminates the recursion exactly as it does without this marking,
+            // so a legitimately self-referential (non-circular per tsc, e.g. a
+            // recursive lib alias resolved through deferral) type keeps
+            // resolving to the same type main produces instead of collapsing
+            // early to ERROR and cascading spurious assignability errors.
             let alias_cycle_def_id = self.cross_arena_alias_def_id(sym_id);
-            if alias_cycle_def_id.is_some_and(|def_id| self.mark_cross_arena_alias_cycle(def_id)) {
-                self.ctx.symbol_types.insert(sym_id, TypeId::ERROR);
-                return Some((TypeId::ERROR, Vec::new()));
+            if let Some(def_id) = alias_cycle_def_id {
+                self.mark_cross_arena_alias_cycle(def_id);
             }
 
             // Guard against deep cross-arena recursion to prevent stack overflow.

--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -399,33 +399,11 @@ impl<'a> CheckerState<'a> {
                 sym_found.is_some_and(|s| s.has_any_flags(symbol_flags::TYPE_ALIAS));
             if has_type_alias {
                 let symbol = sym_found.expect("has_type_alias guard ensures sym_found is Some");
-                tracing::debug!(
-                    sym_id = sym_id.0,
-                    name = %symbol.escaped_name,
-                    num_decls = symbol.declarations.len(),
-                    arena_len = self.ctx.arena.len(),
-                    "delegate_cross_arena: checking TYPE_ALIAS in current arena"
-                );
-                let has_type_alias_in_current_arena = symbol.declarations.iter().any(|&d| {
-                    self.ctx
-                        .arena
-                        .get(d)
-                        .and_then(|n| {
-                            if n.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION {
-                                // Verify the name matches to prevent NodeIndex collisions:
-                                // A lib NodeIndex may accidentally map to a different
-                                // TYPE_ALIAS_DECLARATION in the user arena.
-                                let type_alias = self.ctx.arena.get_type_alias(n)?;
-                                let name_node = self.ctx.arena.get(type_alias.name)?;
-                                let ident = self.ctx.arena.get_identifier(name_node)?;
-                                let name = self.ctx.arena.resolve_identifier_text(ident);
-                                Some(name == symbol.escaped_name.as_str())
-                            } else {
-                                Some(false)
-                            }
-                        })
-                        .unwrap_or(false)
-                });
+                // A cross-file alias can collide with an identically-shaped local
+                // alias on raw SymbolId/NodeIndex; the helper confirms genuine
+                // current-file ownership before we resolve it locally.
+                let has_type_alias_in_current_arena =
+                    self.symbol_has_local_type_alias_declaration(symbol, sym_id);
                 tracing::debug!(
                     sym_id = sym_id.0,
                     name = %symbol.escaped_name,
@@ -872,6 +850,15 @@ impl<'a> CheckerState<'a> {
                 miss_target_source_file.map(|source_file| source_file.file_name.as_str()),
             );
 
+            // Cross-file circular type-alias detection (TS2456): if resolving
+            // this alias re-enters an alias already on the delegation path, mark
+            // the whole cycle circular and stop (see `cross_file_alias_cycle`).
+            let alias_cycle_def_id = self.cross_arena_alias_def_id(sym_id);
+            if alias_cycle_def_id.is_some_and(|def_id| self.mark_cross_arena_alias_cycle(def_id)) {
+                self.ctx.symbol_types.insert(sym_id, TypeId::ERROR);
+                return Some((TypeId::ERROR, Vec::new()));
+            }
+
             // Guard against deep cross-arena recursion to prevent stack overflow.
             // Uses shared thread-local counter across all delegation points.
             if !Self::enter_cross_arena_delegation() {
@@ -988,8 +975,16 @@ impl<'a> CheckerState<'a> {
             // so inner DefId→TypeId mappings survive child-checker teardown.
             checker.ctx.ensure_both_envs_have_definition_store();
 
-            // Use get_type_of_symbol to ensure proper cycle detection.
-            let result = checker.get_type_of_symbol(sym_id);
+            // Track this alias on the cross-arena resolution stack so a nested
+            // delegation that comes back to it is recognized as a cross-file
+            // cycle (see the detection above). The guard pops on drop —
+            // including on panic unwind — so a reused worker thread never
+            // inherits a stale entry.
+            let result = {
+                let _alias_guard = alias_cycle_def_id.map(Self::enter_cross_arena_alias);
+                // Use get_type_of_symbol to ensure proper cycle detection.
+                checker.get_type_of_symbol(sym_id)
+            };
             let result_params = checker
                 .ctx
                 .get_existing_def_id(sym_id)

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_alias_cycle.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_alias_cycle.rs
@@ -1,0 +1,120 @@
+//! Cross-file circular type-alias detection (TS2456).
+//!
+//! Cross-file alias bodies are resolved by delegating to a per-file child
+//! checker (see [`super::cross_file`]). A cycle such as `type A = B` in one
+//! module and `type B = A` in another would otherwise ping-pong between arenas
+//! until the cross-arena depth guard collapses the type to `ERROR`, leaving no
+//! alias flagged. This module tracks the aliases currently being resolved on a
+//! delegation path (keyed by canonical `DefId`, since raw `SymbolId`s are
+//! file-local) and, on re-entry, marks every alias in the cycle circular in the
+//! shared `DefinitionStore`. Each file's `check_cross_file_circular_type_aliases`
+//! post-pass then emits the TS2456 for its own member, applying the same
+//! deferral/suppression rules tsc uses for same-file cycles.
+
+use crate::state::CheckerState;
+use tsz_binder::{Symbol, SymbolId, symbol_flags};
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_solver::def::DefId;
+
+thread_local! {
+    /// Stack of type-alias `DefId`s currently being resolved through cross-arena
+    /// delegation, in entry order. Thread-local because each file is checked on
+    /// a single worker thread and the delegation recursion stays on that thread.
+    static CROSS_ARENA_ALIAS_STACK: std::cell::RefCell<Vec<DefId>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// RAII guard returned by [`CheckerState::enter_cross_arena_alias`]. Pops the
+/// pushed alias `DefId` on drop — including on panic unwind — so a stale entry
+/// cannot poison later resolutions on a reused worker thread.
+pub(crate) struct CrossArenaAliasGuard;
+
+impl Drop for CrossArenaAliasGuard {
+    fn drop(&mut self) {
+        CROSS_ARENA_ALIAS_STACK.with(|stack| {
+            stack.borrow_mut().pop();
+        });
+    }
+}
+
+impl<'a> CheckerState<'a> {
+    /// Push a type-alias `DefId` onto the cross-arena alias-resolution stack for
+    /// the duration of a cross-file delegation; the returned guard pops it on
+    /// drop.
+    pub(crate) fn enter_cross_arena_alias(def_id: DefId) -> CrossArenaAliasGuard {
+        CROSS_ARENA_ALIAS_STACK.with(|stack| stack.borrow_mut().push(def_id));
+        CrossArenaAliasGuard
+    }
+
+    /// Canonical `DefId` for `sym_id` when it is a delegatable cross-file type
+    /// alias (not a class/interface, whose recursion is structurally valid), or
+    /// `None` otherwise. The `DefId` is stable per declaring file + symbol, so
+    /// it identifies the alias across child checker contexts.
+    pub(crate) fn cross_arena_alias_def_id(&self, sym_id: SymbolId) -> Option<DefId> {
+        self.get_cross_file_symbol(sym_id)
+            .filter(|symbol| {
+                symbol.has_any_flags(symbol_flags::TYPE_ALIAS)
+                    && !symbol.has_any_flags(symbol_flags::CLASS | symbol_flags::INTERFACE)
+            })
+            .map(|_| self.ctx.get_or_create_def_id(sym_id))
+            .filter(|def_id| *def_id != DefId::INVALID)
+    }
+
+    /// If `def_id` is already on the active cross-arena alias stack, the alias
+    /// chain is circular: mark every member of the cycle (from that entry to the
+    /// top of the stack) circular in the shared `DefinitionStore` and return
+    /// `true`. Returns `false` when there is no cycle.
+    pub(crate) fn mark_cross_arena_alias_cycle(&mut self, def_id: DefId) -> bool {
+        let cycle_members = CROSS_ARENA_ALIAS_STACK.with(|stack| {
+            let stack = stack.borrow();
+            stack
+                .iter()
+                .position(|&d| d == def_id)
+                .map(|idx| stack[idx..].to_vec())
+        });
+        match cycle_members {
+            Some(members) => {
+                for member in members {
+                    self.ctx.definition_store.mark_circular_def(member);
+                }
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// True when one of `symbol`'s declarations is a type-alias declaration that
+    /// genuinely belongs to `sym_id` in the current file. Raw `SymbolId`s and
+    /// `NodeIndex`es are file-local, so a cross-file alias can collide with an
+    /// identically-positioned, identically-named alias in this arena (e.g. two
+    /// modules with the same `export type T` shape). Ownership is confirmed
+    /// through the current binder's node->symbol map; a name match alone is not
+    /// enough to claim the declaration as local — that would suppress the
+    /// cross-arena delegation a cross-file alias requires.
+    pub(crate) fn symbol_has_local_type_alias_declaration(
+        &self,
+        symbol: &Symbol,
+        sym_id: SymbolId,
+    ) -> bool {
+        symbol.declarations.iter().any(|&decl| {
+            if self.ctx.binder.get_node_symbol(decl) != Some(sym_id) {
+                return false;
+            }
+            self.ctx
+                .arena
+                .get(decl)
+                .and_then(|node| {
+                    if node.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION {
+                        let type_alias = self.ctx.arena.get_type_alias(node)?;
+                        let name_node = self.ctx.arena.get(type_alias.name)?;
+                        let ident = self.ctx.arena.get_identifier(name_node)?;
+                        let name = self.ctx.arena.resolve_identifier_text(ident);
+                        Some(name == symbol.escaped_name.as_str())
+                    } else {
+                        Some(false)
+                    }
+                })
+                .unwrap_or(false)
+        })
+    }
+}

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_alias_cycle.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_alias_cycle.rs
@@ -62,9 +62,11 @@ impl<'a> CheckerState<'a> {
 
     /// If `def_id` is already on the active cross-arena alias stack, the alias
     /// chain is circular: mark every member of the cycle (from that entry to the
-    /// top of the stack) circular in the shared `DefinitionStore` and return
-    /// `true`. Returns `false` when there is no cycle.
-    pub(crate) fn mark_cross_arena_alias_cycle(&mut self, def_id: DefId) -> bool {
+    /// top of the stack) circular in the shared `DefinitionStore`. A no-op when
+    /// there is no cycle. Marking only enables the per-file TS2456 post-pass; it
+    /// does not change type resolution, so a legitimately recursive (non-cyclic
+    /// per tsc) alias is unaffected — its own file never owns a circular member.
+    pub(crate) fn mark_cross_arena_alias_cycle(&mut self, def_id: DefId) {
         let cycle_members = CROSS_ARENA_ALIAS_STACK.with(|stack| {
             let stack = stack.borrow();
             stack
@@ -72,14 +74,10 @@ impl<'a> CheckerState<'a> {
                 .position(|&d| d == def_id)
                 .map(|idx| stack[idx..].to_vec())
         });
-        match cycle_members {
-            Some(members) => {
-                for member in members {
-                    self.ctx.definition_store.mark_circular_def(member);
-                }
-                true
+        if let Some(members) = cycle_members {
+            for member in members {
+                self.ctx.definition_store.mark_circular_def(member);
             }
-            None => false,
         }
     }
 

--- a/crates/tsz-checker/src/state/type_analysis/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/mod.rs
@@ -12,6 +12,7 @@ mod computed_loops;
 mod core;
 mod core_type_query;
 pub(crate) mod cross_file;
+mod cross_file_alias_cycle;
 mod cross_file_cache;
 pub(crate) mod cross_file_direct;
 mod cross_file_direct_actual_lib;

--- a/crates/tsz-cli/src/driver/core.rs
+++ b/crates/tsz-cli/src/driver/core.rs
@@ -3150,6 +3150,10 @@ use plan::{
 mod tests;
 
 #[cfg(test)]
+#[path = "cross_file_circular_alias_tests.rs"]
+mod cross_file_circular_alias_tests;
+
+#[cfg(test)]
 mod explain_files_reason_tests {
     use super::*;
 

--- a/crates/tsz-cli/src/driver/cross_file_circular_alias_tests.rs
+++ b/crates/tsz-cli/src/driver/cross_file_circular_alias_tests.rs
@@ -1,0 +1,213 @@
+//! Project-mode coverage for cross-file circular type aliases (TS2456).
+//!
+//! A type alias whose body refers back to itself through one or more aliases in
+//! *other* modules is circular, and tsc reports one `TS2456` per participating
+//! alias at its declaration name. tsz resolves cross-file alias bodies by
+//! delegating to child checkers per file; without cross-arena cycle detection
+//! the delegation ping-pongs between arenas until the depth guard collapses the
+//! type to `error`, so no participant is flagged. These tests run the full
+//! project driver (shared `DefinitionStore`, every file checked) so both sides
+//! of a cycle are observed, mirroring the conformance fixtures
+//! `externalModules/typeOnly/circular2.ts` and `circular4.ts`.
+
+use super::compile;
+use crate::args::CliArgs;
+use clap::Parser;
+use std::fs;
+use tsz_common::diagnostics::Diagnostic;
+
+const TS2456: u32 = 2456;
+
+/// Write `files` plus a strict `noEmit` tsconfig into a fresh temp dir and run
+/// the project-mode compile. Returns every emitted diagnostic.
+fn compile_project(files: &[(&str, &str)]) -> Vec<Diagnostic> {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let names: Vec<String> = files
+        .iter()
+        .map(|(name, _)| format!("\"{name}\""))
+        .collect();
+    let tsconfig = format!(
+        r#"{{ "compilerOptions": {{ "strict": true, "target": "es2015", "noEmit": true }}, "files": [{}] }}"#,
+        names.join(", ")
+    );
+    fs::write(dir.path().join("tsconfig.json"), tsconfig).expect("write tsconfig");
+    for (name, source) in files {
+        fs::write(dir.path().join(name), source).expect("write source");
+    }
+
+    let project = dir.path().to_string_lossy().to_string();
+    let args = CliArgs::try_parse_from([
+        "tsz",
+        "--project",
+        project.as_str(),
+        "--noEmit",
+        "--pretty",
+        "false",
+    ])
+    .expect("project args");
+    compile(&args, dir.path())
+        .expect("compile succeeds")
+        .diagnostics
+}
+
+/// Names of aliases flagged TS2456 in the file whose path ends with `suffix`.
+fn ts2456_alias_names(diags: &[Diagnostic], suffix: &str) -> Vec<String> {
+    diags
+        .iter()
+        .filter(|d| d.code == TS2456 && d.file.ends_with(suffix))
+        .map(|d| d.message_text.clone())
+        .collect()
+}
+
+fn count_ts2456(diags: &[Diagnostic]) -> usize {
+    diags.iter().filter(|d| d.code == TS2456).count()
+}
+
+#[test]
+fn two_file_alias_cycle_reports_ts2456_in_each_file() {
+    // Mirrors conformance circular2.ts.
+    let diags = compile_project(&[
+        (
+            "a.ts",
+            "import type { B } from './b';\nexport type A = B;\n",
+        ),
+        (
+            "b.ts",
+            "import type { A } from './a';\nexport type B = A;\n",
+        ),
+    ]);
+    assert_eq!(
+        count_ts2456(&diags),
+        2,
+        "expected exactly two TS2456 (one per file), got: {diags:?}"
+    );
+    let a = ts2456_alias_names(&diags, "a.ts");
+    let b = ts2456_alias_names(&diags, "b.ts");
+    assert!(
+        a.iter().any(|m| m.contains("'A'")),
+        "expected TS2456 for alias 'A' in a.ts, got: {a:?}"
+    );
+    assert!(
+        b.iter().any(|m| m.contains("'B'")),
+        "expected TS2456 for alias 'B' in b.ts, got: {b:?}"
+    );
+}
+
+#[test]
+fn two_file_alias_cycle_is_not_name_specific() {
+    // Same shape as above with different identifiers — proves the fix keys on
+    // the alias cycle structure, not on the spelling `A`/`B`.
+    let diags = compile_project(&[
+        (
+            "a.ts",
+            "import type { Second } from './b';\nexport type First = Second;\n",
+        ),
+        (
+            "b.ts",
+            "import type { First } from './a';\nexport type Second = First;\n",
+        ),
+    ]);
+    assert_eq!(count_ts2456(&diags), 2, "got: {diags:?}");
+    assert!(
+        ts2456_alias_names(&diags, "a.ts")
+            .iter()
+            .any(|m| m.contains("'First'"))
+    );
+    assert!(
+        ts2456_alias_names(&diags, "b.ts")
+            .iter()
+            .any(|m| m.contains("'Second'"))
+    );
+}
+
+#[test]
+fn three_file_alias_cycle_reports_ts2456_in_each_file() {
+    let diags = compile_project(&[
+        (
+            "a.ts",
+            "import type { Y } from './b';\nexport type X = Y;\n",
+        ),
+        (
+            "b.ts",
+            "import type { Z } from './c';\nexport type Y = Z;\n",
+        ),
+        (
+            "c.ts",
+            "import type { X } from './a';\nexport type Z = X;\n",
+        ),
+    ]);
+    assert_eq!(
+        count_ts2456(&diags),
+        3,
+        "expected one TS2456 per file in a 3-file cycle, got: {diags:?}"
+    );
+}
+
+#[test]
+fn namespace_nested_qualified_alias_cycle_reports_ts2456() {
+    // Mirrors conformance circular4.ts: the cycle runs through qualified names
+    // (`ns2.nested.T`) across modules, and the colliding NodeIndex/name shape of
+    // the two files must not be mistaken for a local declaration.
+    let diags = compile_project(&[
+        (
+            "a.ts",
+            "import type { ns2 } from './b';\nexport namespace ns1 {\n  export namespace nested {\n    export type T = ns2.nested.T;\n  }\n}\n",
+        ),
+        (
+            "b.ts",
+            "import type { ns1 } from './a';\nexport namespace ns2 {\n  export namespace nested {\n    export type T = ns1.nested.T;\n  }\n}\n",
+        ),
+    ]);
+    assert_eq!(
+        count_ts2456(&diags),
+        2,
+        "expected one TS2456 per file for the namespace-nested cycle, got: {diags:?}"
+    );
+    assert!(
+        ts2456_alias_names(&diags, "a.ts")
+            .iter()
+            .any(|m| m.contains("'T'"))
+    );
+    assert!(
+        ts2456_alias_names(&diags, "b.ts")
+            .iter()
+            .any(|m| m.contains("'T'"))
+    );
+}
+
+#[test]
+fn deferred_cross_file_alias_cycle_is_not_circular() {
+    // `A = B[]` / `B = A` is `B = B[]` — a legal recursive alias deferred behind
+    // an array, exactly as tsc treats it. No TS2456.
+    let diags = compile_project(&[
+        (
+            "a.ts",
+            "import type { B } from './b';\nexport type A = B[];\n",
+        ),
+        (
+            "b.ts",
+            "import type { A } from './a';\nexport type B = A;\n",
+        ),
+    ]);
+    assert_eq!(
+        count_ts2456(&diags),
+        0,
+        "deferred (array-wrapped) cross-file cycle must not be TS2456, got: {diags:?}"
+    );
+}
+
+#[test]
+fn non_cyclic_cross_file_alias_has_no_ts2456() {
+    let diags = compile_project(&[
+        (
+            "a.ts",
+            "import type { B } from './b';\nexport type A = B;\nexport const v: A = 1;\n",
+        ),
+        ("b.ts", "export type B = number;\n"),
+    ]);
+    assert_eq!(
+        count_ts2456(&diags),
+        0,
+        "non-cyclic cross-file alias must not report TS2456, got: {diags:?}"
+    );
+}

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -8,8 +8,6 @@ TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElabora
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 TypeScript/tests/cases/compiler/reorderProperties.ts
-TypeScript/tests/cases/conformance/externalModules/typeOnly/circular2.ts
-TypeScript/tests/cases/conformance/externalModules/typeOnly/circular4.ts
 TypeScript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts


### PR DESCRIPTION
## Agent
AgentName: opus47-confident-thompson (remote execution / claude/confident-thompson-dkQWO)

Closes #5303.

## Track
Conformance / diagnostic parity — cross-file circular type-only external modules.

## Structural rule
> When resolving a type alias requires resolving itself through one or more **other** type aliases reachable across module boundaries (with no structural deferral point in the cycle), tsc reports one `TS2456` ("Type alias 'X' circularly references itself") per participating alias at its declaration name; this change makes tsz do the same.

## Invariant
Every type alias that participates in a cross-file circular chain receives its own `TS2456` at its declaration name. Deferred cycles (`type A = B[]` / `type B = A`) and non-cyclic cross-file aliases must stay silent, and same-file behavior, import-alias cycles (`TS2303`), and class/interface recursion are unchanged.

## Root cause
Cross-file alias bodies resolve by delegating to a per-file child checker (`delegate_cross_arena_symbol_resolution`). For `type A = B` in module *a* and `type B = A` in module *b*, the delegation ping-ponged `A → B → A → B …` between arenas — each level removed the symbol from the resolution set, so no cycle was detected — until the cross-arena depth guard collapsed the type to `error`. Nothing was ever marked circular, so neither the inline nor the post-pass `TS2456` check fired (tsz emitted **zero** of the expected two diagnostics).

The namespace-nested qualified form (`ns1.nested.T = ns2.nested.T`, conformance `circular4`) had a second root cause: because the two files are structurally identical, the cross-file alias `T` collided with the local `T` on raw `SymbolId`/`NodeIndex`, so `has_type_alias_in_current_arena` (which only checked the name) treated the foreign alias as local and never delegated at all.

## Scope / owner layer
Type-system identity logic, so it lives in the checker's cross-file resolution layer, not in a feature branch:
- New `crates/tsz-checker/src/state/type_analysis/cross_file_alias_cycle.rs`: a thread-local stack of the alias `DefId`s on the active delegation path (keyed by **canonical `DefId`** because raw `SymbolId`s are file-local), a panic-safe RAII guard, the cycle-marking helper (marks every cycle member circular in the **shared `DefinitionStore`**), and the ownership-confirming `symbol_has_local_type_alias_declaration` helper.
- `cross_file.rs`: on delegating a type alias, detect re-entry and mark the cycle; confirm declaration ownership via the current binder before treating an alias as local; guard the child resolution with the RAII push/pop. (Net result: the file dropped from 1989 → 1984 lines by extracting the new logic.)
- Emission is left to each file's existing `check_cross_file_circular_type_aliases` post-pass, which already encodes tsc's deferral/suppression rules — so deferred cycles stay silent for free.

## Adjacent-case test matrix
`crates/tsz-cli/src/driver/cross_file_circular_alias_tests.rs` (full project driver, shared `DefinitionStore`):
1. Reported repro — two-file `A = B` / `B = A` → one `TS2456` per file (`circular2`).
2. Renamed identifiers (`First`/`Second`) → proves the rule is structural, not name-based.
3. Three-file cycle `X → Y → Z → X` → one `TS2456` per file.
4. Namespace-nested qualified cycle (`circular4`) → one `TS2456` per file.
5. Negative — deferred cycle `A = B[]` / `B = A` → no `TS2456` (legal recursive alias).
6. Negative — non-cyclic cross-file alias → no `TS2456`.

## Unsupported shapes / fallback
Cycles whose members include a structural deferral point (array/tuple/object/function/generic application) are intentionally not flagged — they fall through to the normal resolution path and match tsc. Only `TYPE_ALIAS` symbols participate; classes/interfaces are excluded so their valid recursion is untouched.

## Project Corpus Impact
- Row: n/a (conformance-only)
- Bug family: cross-file circular type-only external-module aliases (`TS2456`)
- Evidence: conformance `externalModules/typeOnly/circular2.ts` and `circular4.ts` removed from `scripts/conformance/conformance-accepted-regressions.txt`; verified locally that a fresh build emits exactly the two `TS2456` per file at the tsc-cache positions (`a.ts(2,13)`/`b.ts(2,13)` and `a.ts(4,17)`/`b.ts(4,17)`). `circular1`/`circular3` (`TS2303` import-alias cycles) are unaffected.

## Verification
- Reconstructed the exact fixtures from the pinned TS submodule SHA and ran a fresh `tsz` build: circular2 and circular4 now match tsc exactly; deferred and non-cyclic cross-file aliases stay clean; single-file circular still emits 2× `TS2456`.
- `cargo test -p tsz-cli --lib cross_file_circular_alias` → 6 passed.
- `cargo test -p tsz-checker --lib circular` → 20 passed.
- Targeted at-risk suites (cross_file / alias / merged_symbol / namespace / import / lib_identity / type_alias) → 781 passed; the only failures are 9 pre-existing environment-dependent tests that fail identically on clean `main` (confirmed by stash + rebuild baseline).
- `cargo clippy -p tsz-checker -p tsz-cli` clean; `cargo fmt --check` clean; `python3 scripts/arch/arch_guard.py` passes (cross_file.rs back under the 2000-line cap).
- Rebased on `origin/main` @ `4eda83d`; no file overlap, clean rebase.
- Full conformance / emit / fourslash / WASM left to ready-review CI per §19.5.

## Coordination Notes
- AgentName: opus47-confident-thompson. Picked #5303 via RNG from the eligible non-WIP bug pool; added `WIP` + a signed claim comment while implementing. Kept the existing `agent:M1-D` owner label and offered handoff.
- Independent root cause #10661/#10634 (cross-file class **instance vs constructor** identity) is in flight on PRs #10686/#10641 and touches different code paths (class instance resolution); this PR only touches type-alias cycle detection and the alias-local-ownership check — no shared edits.
- `/simplify` run as part of review: an independent reviewer flagged a real panic-unwind stack-leak in the first draft; fixed with the RAII guard before this PR.

---
_AgentName: opus47-confident-thompson_

---
_Generated by [Claude Code](https://claude.ai/code/session_017ygyEPrvR9V7EtxUNKG7Vh)_