### PR TITLE
fix(checker): relate class members against full overloaded interface method

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1551,6 +1551,10 @@ name = "class_implements_predicate_inference_tests"
 path = "tests/class_implements_predicate_inference_tests.rs"
 
 [[test]]
+name = "class_implements_overloaded_method_ts2416_tests"
+path = "tests/class_implements_overloaded_method_ts2416_tests.rs"
+
+[[test]]
 name = "dynamic_names_ts2720_tests"
 path = "tests/dynamic_names_ts2720_tests.rs"
 

--- a/crates/tsz-checker/src/classes/class_implements_checker/core.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/core.rs
@@ -160,6 +160,14 @@ impl<'a> CheckerState<'a> {
             (Vec::new(), false)
         };
 
+        // Track interface method-signature names already rebuilt from the AST in
+        // this loop. The first declaration of a name replaces the object-shape
+        // property (which only stores the return type for methods); subsequent
+        // declarations of the same name are overload signatures and must be
+        // *combined* into one callable rather than overwriting each other.
+        let mut method_sig_rebuilt: rustc_hash::FxHashSet<tsz_common::interner::Atom> =
+            rustc_hash::FxHashSet::default();
+
         for &decl_idx in interface_declarations {
             let Some(decl_node) = self.ctx.arena.get(decl_idx) else {
                 continue;
@@ -237,9 +245,67 @@ impl<'a> CheckerState<'a> {
                     single_quoted_name: false,
                 };
                 if let Some(existing) = properties.iter_mut().find(|p| p.name == member_atom) {
-                    *existing = property_info;
+                    if member_node.kind == syntax_kind_ext::METHOD_SIGNATURE
+                        && existing.is_method
+                        && method_sig_rebuilt.contains(&member_atom)
+                    {
+                        // Overloaded interface method: this is a second (or later)
+                        // overload of an already-rebuilt method. Combine the
+                        // accumulated signature(s) with this declaration's
+                        // signature(s) into one callable so the implements-compat
+                        // check relates the class member against the FULL overload
+                        // set. tsc's `signaturesRelatedTo` erases type parameters
+                        // for the multi-signature (N×M) case; comparing the class
+                        // member against a single overload in isolation produces a
+                        // false TS2416 when the overload's return type depends on
+                        // the method type parameter.
+                        let mut sigs = crate::query_boundaries::class::member_call_signatures(
+                            self.ctx.types,
+                            existing.type_id,
+                        );
+                        sigs.extend(crate::query_boundaries::class::member_call_signatures(
+                            self.ctx.types,
+                            member_type,
+                        ));
+                        if sigs.is_empty() {
+                            // Defensive: if neither declaration yielded a call
+                            // signature, an empty callable would print as `{}` and
+                            // accept anything. Fall back to the single-declaration
+                            // type rather than silently dropping the check.
+                            *existing = property_info;
+                        } else {
+                            // Relate the overload set as a plain call-signature list
+                            // (`is_method = false`). tsc compares a class member
+                            // against an overloaded target with contravariant
+                            // parameters and type-parameter erasure (the N×M
+                            // `signaturesRelatedTo` path), not the bivariant
+                            // single-method parameter rule. Keeping `is_method =
+                            // true` would over-accept — e.g. a narrower impl
+                            // parameter would pass bivariantly — and miss real
+                            // TS2416s.
+                            for sig in &mut sigs {
+                                sig.is_method = false;
+                            }
+                            let combined =
+                                self.ctx
+                                    .types
+                                    .factory()
+                                    .callable(tsz_solver::CallableShape {
+                                        call_signatures: sigs,
+                                        ..tsz_solver::CallableShape::default()
+                                    });
+                            existing.type_id = combined;
+                            existing.write_type = combined;
+                            existing.is_method = false;
+                        }
+                    } else {
+                        *existing = property_info;
+                    }
                 } else {
                     properties.push(property_info);
+                }
+                if member_node.kind == syntax_kind_ext::METHOD_SIGNATURE {
+                    method_sig_rebuilt.insert(member_atom);
                 }
             }
         }

--- a/crates/tsz-checker/src/query_boundaries/class.rs
+++ b/crates/tsz-checker/src/query_boundaries/class.rs
@@ -19,6 +19,30 @@ pub(crate) fn maybe_substitute_this_type(
     }
 }
 
+/// Collect a type's call signatures, handling both `CallableShape`
+/// (overloaded / object-with-call-sigs) and the single-signature `FunctionShape`
+/// that an interface method declaration lowers to. `get_call_signatures` alone
+/// misses the `FunctionShape` case and would yield an empty signature list.
+pub(crate) fn member_call_signatures(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Vec<tsz_solver::CallSignature> {
+    if let Some(sigs) = tsz_solver::type_queries::get_call_signatures(db, type_id) {
+        return sigs;
+    }
+    if let Some(fs) = tsz_solver::type_queries::get_function_shape(db, type_id) {
+        return vec![tsz_solver::CallSignature {
+            type_params: fs.type_params.clone(),
+            params: fs.params.clone(),
+            this_type: fs.this_type,
+            return_type: fs.return_type,
+            type_predicate: fs.type_predicate,
+            is_method: fs.is_method,
+        }];
+    }
+    Vec::new()
+}
+
 fn has_own_signature_type_params(checker: &CheckerState<'_>, type_id: TypeId) -> bool {
     if let Some(shape) = tsz_solver::type_queries::get_callable_shape(checker.ctx.types, type_id) {
         return shape

--- a/crates/tsz-checker/tests/class_implements_overloaded_method_ts2416_tests.rs
+++ b/crates/tsz-checker/tests/class_implements_overloaded_method_ts2416_tests.rs
@@ -1,0 +1,196 @@
+//! Regression tests for issue #10681: a class that `implements` an interface
+//! whose method is **overloaded** (multiple call signatures) must be checked
+//! against the *combined* overload set, not a single (last) overload.
+//!
+//! tsc's `signaturesRelatedTo` relates a class member against an overloaded
+//! interface member using the multi-signature (N×M) path: type parameters are
+//! erased to their constraints and parameters are compared contravariantly.
+//! Previously tsz rebuilt each interface method-signature declaration
+//! individually and let the last one overwrite the property, so a non-generic
+//! implementation was compared against a single generic overload whose return
+//! type depends on the method type parameter — producing a false TS2416.
+//!
+//! The reported witness was kysely's `RawBuilderImpl.as` vs `RawBuilder.as`.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+fn ts2416_count(source: &str) -> usize {
+    check_source(source, "test.ts", CheckerOptions::default())
+        .iter()
+        .filter(|d| d.code == 2416)
+        .count()
+}
+
+/// The reported repro shape: an overloaded generic interface method whose
+/// return type depends on the type parameter, implemented by a non-generic
+/// method with a broad parameter that accepts every overload's parameter.
+/// tsc accepts this; tsz must not emit TS2416.
+#[test]
+fn overloaded_interface_method_broad_impl_no_ts2416() {
+    let source = r#"
+interface Expr<T> { readonly t?: T; toNode(): number; }
+interface Box<A extends string> { readonly a?: A; }
+interface Base {
+  as<A extends string>(alias: A): Box<A>;
+  as<A extends string>(alias: Expr<any>): Box<A>;
+}
+class Impl implements Base {
+  as(alias: string | Expr<unknown>): Box<string> {
+    return {};
+  }
+}
+"#;
+    assert_eq!(
+        ts2416_count(source),
+        0,
+        "Non-generic impl that satisfies every overload must not emit TS2416"
+    );
+}
+
+/// Same rule, different bound-variable spellings (`K`/`P` instead of `A`).
+/// If the fix were name-based this would behave differently.
+#[test]
+fn overloaded_interface_method_renamed_type_params_no_ts2416() {
+    let source = r#"
+interface Expr<T> { readonly t?: T; toNode(): number; }
+interface Box<K extends string> { readonly a?: K; }
+interface Base {
+  as<K extends string>(alias: K): Box<K>;
+  as<P extends string>(alias: Expr<any>): Box<P>;
+}
+class Impl implements Base {
+  as(alias: string | Expr<unknown>): Box<string> {
+    return {};
+  }
+}
+"#;
+    assert_eq!(ts2416_count(source), 0);
+}
+
+/// Three overloads, including a concrete (non-generic) one. The broad impl
+/// parameter must accept all three. tsc clean.
+#[test]
+fn overloaded_interface_method_three_overloads_no_ts2416() {
+    let source = r#"
+interface Expr<T> { readonly t?: T; toNode(): number; }
+interface Box<A extends string> { readonly a?: A; }
+interface Base {
+  as<A extends string>(alias: A): Box<A>;
+  as<A extends string>(alias: Expr<any>): Box<A>;
+  as(alias: number): Box<string>;
+}
+class Impl implements Base {
+  as(alias: string | Expr<unknown> | number): Box<string> {
+    return {};
+  }
+}
+"#;
+    assert_eq!(ts2416_count(source), 0);
+}
+
+/// Negative: the impl parameter is too narrow to accept the second overload's
+/// parameter (`Expr<any>`). tsc rejects with TS2416 because, after erasing the
+/// type parameter, `Expr<any>` is not contravariantly assignable to `string`.
+/// The fix must NOT over-accept this.
+#[test]
+fn overloaded_interface_method_narrow_impl_still_ts2416() {
+    let source = r#"
+interface Expr<T> { readonly t?: T; toNode(): number; }
+interface Box<A extends string> { readonly a?: A; }
+interface Base {
+  as<A extends string>(alias: A): Box<A>;
+  as<A extends string>(alias: Expr<any>): Box<A>;
+}
+class Impl implements Base {
+  as(alias: string): Box<string> {
+    return {};
+  }
+}
+"#;
+    assert!(
+        ts2416_count(source) >= 1,
+        "A too-narrow impl parameter must still emit TS2416"
+    );
+}
+
+/// Negative: the impl return type is genuinely incompatible with the overload
+/// return types. The combined-overload comparison must still reject it.
+#[test]
+fn overloaded_interface_method_incompatible_return_still_ts2416() {
+    let source = r#"
+interface Base {
+  as<A extends string>(alias: A): A;
+  as(alias: number): number;
+}
+class Impl implements Base {
+  as(alias: string | number): boolean {
+    return true;
+  }
+}
+"#;
+    assert!(
+        ts2416_count(source) >= 1,
+        "An incompatible impl return type must still emit TS2416"
+    );
+}
+
+/// Negative for overloads specifically: with multiple overloads, tsc compares
+/// parameters *contravariantly* (not bivariantly), so an impl whose parameter
+/// is narrower than an overload's parameter is rejected.
+#[test]
+fn overloaded_interface_method_narrower_param_is_contravariant_ts2416() {
+    let source = r#"
+interface Animal { n: string; }
+interface Dog extends Animal { bark(): void; }
+interface Base {
+  m(x: Animal): void;
+  m(x: number): void;
+}
+class Impl implements Base {
+  m(x: Dog | number): void {}
+}
+"#;
+    assert!(
+        ts2416_count(source) >= 1,
+        "Overloaded-method parameter checks are contravariant; a narrower impl param must emit TS2416"
+    );
+}
+
+/// A *single* (non-overloaded) interface method keeps tsc's bivariant method
+/// parameter rule: a narrower parameter is accepted. The overload fix must not
+/// regress this.
+#[test]
+fn single_method_bivariant_narrower_param_no_ts2416() {
+    let source = r#"
+interface Animal { n: string; }
+interface Dog extends Animal { bark(): void; }
+interface Base {
+  m(x: Animal): void;
+}
+class Impl implements Base {
+  m(x: Dog): void {}
+}
+"#;
+    assert_eq!(
+        ts2416_count(source),
+        0,
+        "Single-method override keeps bivariant parameters (narrower param accepted)"
+    );
+}
+
+/// Control: an overloaded interface method where every overload is satisfied
+/// by a simple union-parameter impl. tsc clean.
+#[test]
+fn overloaded_interface_method_all_compatible_no_ts2416() {
+    let source = r#"
+interface Base {
+  m(x: string): void;
+  m(x: number): void;
+}
+class Impl implements Base {
+  m(x: string | number): void {}
+}
+"#;
+    assert_eq!(ts2416_count(source), 0);
+}


### PR DESCRIPTION
## Agent
AgentName: opus47-confident-thompson

Closes #10681.

## Track
Track 1 — false-positive parity (kysely project row, #10663). Routed under the
existing `agent:Studio-A` lane for the kysely cluster; claimed via signed
comment on #10681. Hand back if Studio-A is mid-investigation.

## Invariant
When a class `implements` an interface whose method is **overloaded** (more than
one call signature), `tsc` relates the class member against the **combined**
overload set, not a single overload. Its `signaturesRelatedTo` uses the
multi-signature (N×M) path: each signature's type parameters are erased to their
constraints and parameters are compared **contravariantly**. This PR makes the
checker build that combined call-signature list so the solver's existing erasure
relation decides, instead of comparing the class member against only the last
interface overload.

## Structural rule
> When an interface member has multiple method-signature declarations of the
> same name, the implements-compat check relates the class member against a
> single `CallableShape` holding all overload signatures (with `is_method =
> false`, i.e. contravariant parameters + type-parameter erasure), not against
> the last-declared overload in isolation.

Single (non-overloaded) interface methods are unchanged and keep `tsc`'s
bivariant method-parameter rule.

## Owner layer & why
Checker (`class_implements_checker`). The bug was purely in how the checker
*constructed* the interface member type for comparison — `implemented_interface_members`
rebuilt each method-signature declaration individually and let the last one
overwrite the property. The solver relation is already correct (a direct
assignment to the same combined call-signature object type relates correctly);
only the checker fed it the wrong (single-overload) target. The signature-list
helper lives in `query_boundaries::class` so it stays a boundary query.

## Scope
- `crates/tsz-checker/src/classes/class_implements_checker/core.rs` —
  in `implemented_interface_members`, combine overload signatures of the same
  method name into one `CallableShape` instead of overwriting; empty-extraction
  guard falls back to the single-declaration type.
- `crates/tsz-checker/src/query_boundaries/class.rs` — new
  `member_call_signatures` helper that reads call signatures from both
  `CallableShape` and the single-signature `FunctionShape` (the latter is what
  an interface method declaration lowers to; `get_call_signatures` alone misses
  it and yields an empty list).
- `crates/tsz-checker/tests/class_implements_overloaded_method_ts2416_tests.rs`
  (+ Cargo.toml registration) — 8 owning-crate tests.

## Adjacent-case test matrix (oracle: tsc 5.7)
- Reported repro: overloaded generic interface method, broad non-generic impl
  param → **no** TS2416.
- Renamed bound variables (`K`/`P` instead of `A`) → no TS2416 (proves the rule
  is structural, not name-based).
- Three overloads incl. a concrete one → no TS2416.
- Negative — impl param too narrow to accept an overload's param → **still**
  TS2416 (parameters are contravariant for overloads).
- Negative — genuinely incompatible impl return → **still** TS2416.
- Negative — `Dog | number` impl vs `Animal`/`number` overloads → **still**
  TS2416 (contravariant, not bivariant, for the N×M case).
- Single non-overloaded method with narrower (`Dog`) param → no TS2416
  (bivariance preserved).
- Control — all-compatible overloads → no TS2416.

All 8 cases match tsc exactly; a 12-row tsc-vs-tsz comparison matrix (including
the above) returns ALL-MATCH.

## Known unsupported / out of scope
Indexed-access of an overloaded interface method type (`I["m"]`) is independently
over-permissive in tsz (it carries `is_method = true` bivariance), but that is a
separate code path with a separate symptom and is not exercised by the
implements-compat check this PR fixes; left as a follow-up.

## Project Corpus Impact
- Row: `kysely-project` (#10663)
- Bug family: false TS2416 on generic-method override/implements variance.
- Evidence: on the pinned kysely fixture (guard config, `KYSELY_REF
  d4911be…`-era), the false `src/raw-builder/raw-builder.ts(158,3)` TS2416 is
  **cleared**; total diagnostics 281 → 280 (net −1), TS2416 13 → 12, and a
  per-line diff shows **no new diagnostics introduced**. The remaining kysely
  TS2416s are a distinct cross-file class-identity root cause (#10661) and are
  intentionally untouched.

## Verification
Local (per §19.5 — narrow, fast feedback only):
- `cargo test -p tsz-checker --test class_implements_overloaded_method_ts2416_tests` → 8 passed.
- Existing regression suites pass: `class_implements_predicate_inference_tests` (5),
  `abstract_method_overload_ts2416_tests` (10), `accessor_pair_override_ts2416_tests` (12),
  `class_implements_index_signature_tests` (10).
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings` clean; clippy on the new test clean.
- `cargo fmt --check -p tsz-checker` clean.
- `python3 scripts/arch/arch_guard.py` → exit 0 (no net increase to the #8225
  `query_boundaries::common` quarantine — the helper lives in `query_boundaries::class`).
- 12-row tsc(5.7)-vs-tsz parity matrix → ALL-MATCH.
- Rebased on `origin/main` (`4eda83d`); clean rebase, no conflicts; re-verified after rebase.

CI to confirm: conformance, emit, fourslash, WASM, snapshot.

## Coordination Notes
- `/simplify` run 3 times before opening: pass 1 added the empty-extraction
  defensive guard; passes 2–3 found no further issues.
- The fix is solver-first in spirit (the relation was already correct); the
  checker change only corrects the target type it builds.

---
_AgentName: opus47-confident-thompson_

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmKPqNtWhYWVqv7RftFyt9)_