### PR TITLE
fix(checker): resolve intersection constraint members for TS7053 indexability

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1587,6 +1587,10 @@ name = "ts7053_unconstrained_type_param_index_tests"
 path = "tests/ts7053_unconstrained_type_param_index_tests.rs"
 
 [[test]]
+name = "ts7053_intersection_constraint_index_tests"
+path = "tests/ts7053_intersection_constraint_index_tests.rs"
+
+[[test]]
 name = "tuple_union_contextual_typing_tests"
 path = "tests/tuple_union_contextual_typing_tests.rs"
 

--- a/crates/tsz-checker/src/types/utilities/core.rs
+++ b/crates/tsz-checker/src/types/utilities/core.rs
@@ -2581,6 +2581,31 @@ impl<'a> CheckerState<'a> {
             return true;
         }
 
+        // When the constraint is an intersection, evaluate each member through the
+        // checker's type resolver before checking indexability. Intersection members
+        // may be `Application`/`Lazy` types (e.g. `Record<string, V>`) that
+        // `classify_element_indexable` cannot expand without a resolver — the
+        // solver-level `evaluate_type` it uses has no access to the `TypeEnvironment`.
+        // Structural rule: if any intersection member, when resolved through the
+        // checker's resolver, has a string or number index signature that covers
+        // the key, tsc allows the access and tsz must agree.
+        if let Some(members) =
+            crate::query_boundaries::common::intersection_members(self.ctx.types, unwrapped_type)
+        {
+            let any_member_indexable = members.iter().any(|&member| {
+                let resolved =
+                    crate::query_boundaries::state::type_environment::evaluate_type_with_resolver(
+                        self.ctx.types,
+                        &self.ctx,
+                        member,
+                    );
+                self.is_element_indexable(resolved, wants_string, wants_number)
+            });
+            if any_member_indexable {
+                return false;
+            }
+        }
+
         !self.is_element_indexable(unwrapped_type, wants_string, wants_number)
     }
 

--- a/crates/tsz-checker/tests/ts7053_intersection_constraint_index_tests.rs
+++ b/crates/tsz-checker/tests/ts7053_intersection_constraint_index_tests.rs
@@ -1,0 +1,185 @@
+//! TS7053 — indexing a type parameter constrained to an intersection that
+//! includes a member with an index signature.
+//!
+//! Structural rule: when the indexed object is a type parameter and its
+//! constraint is an intersection type, tsc allows the access if any
+//! intersection member—when resolved through the checker's type resolver—has
+//! a string or number index signature that covers the key. tsz must evaluate
+//! each intersection member through the resolver before deciding the
+//! intersection is unindexable.
+//!
+//! Issue: <https://github.com/mohsen1/tsz/issues/10726>
+//!
+//! Complementary to #10728 (direct `T extends Record<K,V>` constraint), which
+//! fixes the same resolver gap for the non-intersection path.
+
+use tsz_checker::context::{CheckerOptions, ScriptTarget};
+use tsz_checker::test_utils::check_source;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            target: ScriptTarget::ES2022,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+// ── Positive cases: TS7053 must NOT fire ─────────────────────────────────────
+
+/// 1. Reported repro: Record<string,V> as second intersection member, indexed
+///    by `string`.
+#[test]
+fn intersection_record_second_member_no_ts7053() {
+    let result = codes(
+        r#"
+function f<T extends { a: number } & Record<string, unknown>>(obj: T, key: string): unknown {
+    return obj[key];
+}
+"#,
+    );
+    assert!(
+        !result.contains(&7053),
+        "expected no TS7053 for T extends {{a:number}} & Record<string,unknown>, got: {result:?}"
+    );
+}
+
+/// 2. Renamed type parameter — rule is structural, not name-based.
+#[test]
+fn intersection_record_renamed_param_no_ts7053() {
+    let result = codes(
+        r#"
+function g<Row extends { id: number } & Record<string, unknown>>(row: Row, key: string): unknown {
+    return row[key];
+}
+"#,
+    );
+    assert!(
+        !result.contains(&7053),
+        "expected no TS7053 with renamed param (Row), got: {result:?}"
+    );
+}
+
+/// 3. Record as first intersection member (order-independence).
+#[test]
+fn intersection_record_first_member_no_ts7053() {
+    let result = codes(
+        r#"
+function h<T extends Record<string, unknown> & { a: number }>(obj: T, key: string): unknown {
+    return obj[key];
+}
+"#,
+    );
+    assert!(
+        !result.contains(&7053),
+        "expected no TS7053 for T extends Record<string,unknown> & {{a:number}}, got: {result:?}"
+    );
+}
+
+/// 4. Concrete value type variant: `Record<string, number>`.
+#[test]
+fn intersection_record_concrete_value_type_no_ts7053() {
+    let result = codes(
+        r#"
+function i<T extends Record<string, number> & { b: boolean }>(obj: T, key: string): number {
+    return obj[key];
+}
+"#,
+    );
+    assert!(
+        !result.contains(&7053),
+        "expected no TS7053 for T extends Record<string,number> & {{b:boolean}}, got: {result:?}"
+    );
+}
+
+/// 5. Inline index signature in intersection (structural, not via Application).
+///    This case already worked; verify it continues to work.
+#[test]
+fn intersection_inline_index_sig_no_ts7053() {
+    let result = codes(
+        r#"
+function j<T extends { readonly [key: string]: unknown } & { a: number }>(
+    obj: T,
+    key: string,
+): unknown {
+    return obj[key];
+}
+"#,
+    );
+    assert!(
+        !result.contains(&7053),
+        "expected no TS7053 for inline string index in intersection, got: {result:?}"
+    );
+}
+
+/// 6. Number index: `Record<number, string>` member in intersection indexed by
+///    a `number` key.
+#[test]
+fn intersection_record_number_index_no_ts7053() {
+    let result = codes(
+        r#"
+function k<T extends { length: number } & Record<number, string>>(obj: T, i: number): string {
+    return obj[i];
+}
+"#,
+    );
+    assert!(
+        !result.contains(&7053),
+        "expected no TS7053 for number index in T extends {{length:number}} & Record<number,string>, got: {result:?}"
+    );
+}
+
+// ── Negative cases: TS7053 MUST still fire ───────────────────────────────────
+
+/// 7. Intersection with no index signature in any member → TS7053 fires.
+#[test]
+fn intersection_without_index_sig_emits_ts7053() {
+    let result = codes(
+        r#"
+function m<T extends { a: number } & { b: boolean }>(obj: T, key: string): unknown {
+    return obj[key as any];
+}
+"#,
+    );
+    assert!(
+        result.contains(&7053),
+        "expected TS7053 for T extends {{a:number}} & {{b:boolean}} (no index sig), got: {result:?}"
+    );
+}
+
+/// 8. Unconstrained type parameter → TS7053 fires (base constraint is `unknown`).
+#[test]
+fn unconstrained_param_emits_ts7053() {
+    let result2 = codes(r#"function q<T>(obj: T) { return obj["x"]; }"#);
+    assert!(
+        result2.contains(&7053),
+        "expected TS7053 for unconstrained T indexed by \"x\", got: {result2:?}"
+    );
+}
+
+/// 9. Constraint with still-generic Record (`T extends Record<K, V>` where K and
+///    V are type params) — `contains_type_parameters` returns true, so no
+///    TS7053 is emitted (deferred to instantiation). Verify no false positive.
+#[test]
+fn intersection_generic_record_no_ts7053_deferred() {
+    let result = codes(
+        r#"
+function r<T extends { a: number } & Record<K, V>, K extends string, V>(
+    obj: T,
+    key: K,
+): V {
+    return obj[key];
+}
+"#,
+    );
+    assert!(
+        !result.contains(&7053),
+        "expected no TS7053 when Record type args are generic, got: {result:?}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: claude-sonnet-4-6 (dazzling-johnson)

## Track
Track 5 — Key-Space, Indexed Access, and Property Semantics  
PR type: semantic campaign / false-positive elimination

## Invariant
When the indexed object is a type parameter and its constraint is an intersection type, `tsc` allows the element access if any intersection member—when resolved through the checker's type resolver—has a string or number index signature that covers the key. This PR makes tsz evaluate each intersection member via `evaluate_type_with_resolver` before deciding the intersection is unindexable.

## Scope
- `crates/tsz-checker/src/types/utilities/core.rs` — one logic arm added in `should_report_no_index_signature`, before the final `!is_element_indexable` call
- `crates/tsz-checker/tests/ts7053_intersection_constraint_index_tests.rs` — new 9-test regression suite
- `crates/tsz-checker/Cargo.toml` — register the new integration test

## Root Cause
`should_report_no_index_signature` fed the intersection type directly to `is_element_indexable`, which calls the solver-level `classify_element_indexable`. That classifier uses `evaluate_type` (no `TypeResolver`), so `Application`/`Lazy` members like `Record<string, V>` remained unresolved and fell through to `Other` → false-positive TS7053.

The fix checks whether the unwrapped `check_type` is an intersection; if so, evaluates each member through `evaluate_type_with_resolver` (which has access to the `TypeEnvironment`) and returns `false` (no diagnostic) when any member is element-indexable.

## Adjacent-case test matrix
1. Reported repro: `T extends { a: number } & Record<string, unknown>` indexed by `string` → no TS7053
2. Renamed type parameter (`Row`, `U`) — rule is structural, not name-based → no TS7053
3. Record as **first** intersection member (order-independence) → no TS7053
4. Concrete value type: `Record<string, number> & { b: boolean }` → no TS7053
5. Inline index signature `{ readonly [key: string]: unknown } & { a: number }` (already worked; regression guard) → no TS7053
6. Number index: `{ length: number } & Record<number, string>` indexed by `number` → no TS7053
7. **Negative**: intersection with no index signature in any member → TS7053 still fires
8. **Negative**: unconstrained `T` → TS7053 still fires
9. **Negative**: `T extends { a: number } & Record<K, V>` (K/V generic) → `contains_type_parameters` guard → no TS7053 (deferred to instantiation, correct behavior)

## Project Corpus Impact
Row: kysely-project  
Bug family: false-positive TS7053 implicit-any-index on type-parameter constrained by an intersection including a utility/index type  
Evidence: Closes #10726. Complementary to #10728 (direct `T extends Record<K,V>` path), which was explicitly documented in #10728's Coordination Notes as needing a separate conformance-gated PR.

## Verification
```
cargo test -p tsz-checker --test ts7053_intersection_constraint_index_tests
# → 9 passed; 0 failed

cargo test -p tsz-checker --test ts7053_unconstrained_type_param_index_tests
cargo test -p tsz-checker --test ts7053_template_mapped_tests
# → all pass; no regressions in adjacent suites

cargo clippy -p tsz-checker --lib -- -D warnings
# → clean
```

## Coordination Notes
- Does NOT overlap with #10728 (direct Record constraint path) — the two are complementary: #10728 handles `T extends Record<K,V>` directly; this PR handles `T extends X & Record<K,V>` (intersection constraints).
- Does NOT require changes to `classify_element_indexable` or `is_element_indexable` — the fix is narrowly scoped to the intersection case in `should_report_no_index_signature`, avoiding the "broad blast radius" noted in #10728's Coordination Notes.
- Checked open draft and ready PRs before branching; no overlap found.
- Stack: no dependencies on other in-flight branches.

Signed: claude-sonnet-4-6 (dazzling-johnson)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYs5oVrvsmtZJMhJTBGVGZ)_