### PR TITLE
fix(checker): parse jsdoc Promise typedef names

### DIFF
--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -1685,11 +1685,9 @@ impl<'a> CheckerState<'a> {
 
     fn jsdoc_comment_declares_promise_typedef(comment: &str) -> bool {
         comment.contains("@typedef")
-            && comment.split_whitespace().any(|token| {
-                token.trim_matches(|c: char| {
-                    matches!(c, '*' | '/' | '{' | '}' | '(' | ')' | '[' | ']' | ',')
-                }) == "Promise"
-            })
+            && Self::parse_jsdoc_typedefs(comment)
+                .iter()
+                .any(|(name, _)| name == "Promise")
     }
 
     fn jsdoc_return_type_is_exact_promise_reference(trimmed: &str) -> bool {

--- a/crates/tsz-checker/tests/async_return_promise_identity_tests.rs
+++ b/crates/tsz-checker/tests/async_return_promise_identity_tests.rs
@@ -19,6 +19,25 @@ fn check_with_promise_lib(source: &str) -> Vec<u32> {
     .collect()
 }
 
+fn check_js_with_promise_lib(source: &str) -> Vec<u32> {
+    let lib_files = load_compiled_lib_files(&["lib.es5.d.ts", "lib.es2015.promise.d.ts"]);
+    check_source_with_libs(
+        source,
+        "test.js",
+        CheckerOptions {
+            allow_js: true,
+            check_js: true,
+            target: ScriptTarget::ES2015,
+            module: ModuleKind::CommonJS,
+            ..CheckerOptions::default()
+        },
+        &lib_files,
+    )
+    .into_iter()
+    .map(|diagnostic| diagnostic.code)
+    .collect()
+}
+
 #[test]
 fn async_return_completeness_does_not_trust_module_local_promise_spelling() {
     let codes = check_with_promise_lib(
@@ -41,5 +60,24 @@ async function localPromise(): Promise<number> {
     assert!(
         codes.contains(&2355),
         "Expected TS2355 because module-local Promise must not suppress return completeness by spelling, got: {codes:?}"
+    );
+}
+
+#[test]
+fn jsdoc_async_return_ignores_typedef_body_promise_mentions() {
+    let codes = check_js_with_promise_lib(
+        r#"
+/** @typedef {Promise} Box */
+
+/** @type {function(): Promise<number>} */
+const f = async function() {
+    return 1;
+};
+"#,
+    );
+
+    assert!(
+        !codes.contains(&1064),
+        "JSDoc typedef bodies that mention Promise must not shadow the global Promise return protocol; got {codes:?}"
     );
 }


### PR DESCRIPTION
## Agent
AgentName: M4-D

## Track
Semantic identity cleanup / JSDoc async Promise return identity ratchet.

## Invariant
When a checked-JS async function receives its declared return type from `@type {function(): R}`, a prior JSDoc `@typedef` shadows global `Promise` only when the typedef's declared alias name is `Promise`. A typedef body that merely mentions `Promise` must not make tsz reject the real global `Promise<T>` return protocol.

## Scope
- Replace the JSDoc async-return Promise typedef shadow check's whitespace-token scan with the existing `parse_jsdoc_typedefs` parser.
- Add a checked-JS regression where `@typedef {Promise} Box` no longer triggers TS1064 for a later `function(): Promise<number>` async return annotation.

## Project Corpus Impact
- Row: n/a
- Bug family: name-based JSDoc Promise identity debt
- Evidence: architecture cleanup only; this removes an imprecise JSDoc text scan and does not target a known project-row issue.

## Verification
- `node TypeScript/lib/_tsc.js --allowJs --checkJs --noEmit --target es2015 --lib es5,es2015.promise <jsdoc typedef body Promise repro>` produced no TS1064 for the async return protocol.
- RED before implementation: `cargo nextest run -p tsz-checker --test async_return_promise_identity_tests jsdoc_async_return_ignores_typedef_body_promise_mentions` failed with `got [1064]`.
- GREEN after implementation: `cargo nextest run -p tsz-checker --test async_return_promise_identity_tests jsdoc_async_return_ignores_typedef_body_promise_mentions`
- `cargo nextest run -p tsz-checker --test async_return_promise_identity_tests`
- `cargo fmt --check`
- `git diff --check codex/m4-d-async-return-promise-identity-20260528...HEAD`
- `python3 scripts/arch/arch_guard.py`

- Previous exact-head CI (`8437a15c11d6d09c7a19e600c62e1dfc2e308aaa`): `CI Light Summary`, `dist-binaries`, `unit`, `unit-cloudbuild`, `lint`, `cargo-shear`, `cargo-deny`, `project-row-drift`, `gate`, and `GitGuardian Security Checks` passed on 2026-05-28.

## Coordination Notes
- AgentName: M4-D
- Stack: #10731 merged on 2026-05-28; retargeted this PR to `main` for the current merge-runway sweep.
- Non-overlap: #10731 is merged into `main`; #10686 remains a separate cross-file class-instance-ref lane.
- Structural owner: checker JSDoc orchestration uses the existing JSDoc typedef parser to identify alias declarations; no new solver internals, raw type-shape matching, or name allowlist widening is introduced.



