### PR TITLE
fix(checker): resolve cross-module class self-references to the instance

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -550,6 +550,9 @@ mod cross_file_interface_property_access_tests;
 #[path = "../tests/cross_file_type_params_cache_tests.rs"]
 mod cross_file_type_params_cache_tests;
 #[cfg(test)]
+#[path = "tests/cross_module_self_ref_override_ts2416_tests.rs"]
+mod cross_module_self_ref_override_ts2416_tests;
+#[cfg(test)]
 #[path = "tests/destructured_discriminant_source_narrowing_tests.rs"]
 mod destructured_discriminant_source_narrowing_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -1481,6 +1481,21 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// The class **instance** type recorded for `def_id` in the solver type
+    /// environment, if any. Only classes register `class_instance_types`
+    /// entries, so a hit is unambiguously the instance (type-position) form. A
+    /// self-`Lazy(def_id)` wrapper is rejected so callers don't return the very
+    /// reference they are trying to resolve.
+    fn registered_class_instance_for_def(&self, def_id: tsz_solver::DefId) -> Option<TypeId> {
+        let instance_type = self
+            .ctx
+            .type_env
+            .try_borrow()
+            .ok()
+            .and_then(|env| env.get_class_instance_type(def_id))?;
+        (lazy_def_id(self.ctx.types, instance_type) != Some(def_id)).then_some(instance_type)
+    }
+
     /// Resolve a `DefId` to a concrete type and insert a `DefId` mapping into the type environment.
     ///
     /// Returns the resolved type when a symbol bridge exists; returns `None` when the `DefId`
@@ -1501,6 +1516,24 @@ impl<'a> CheckerState<'a> {
                 return Some(resolved);
             }
             return Some(self.ctx.types.lazy(def_id));
+        }
+
+        // A `Lazy(DefId)` in type position resolves to the class **instance**, not
+        // its constructor. When a base class was resolved cross-arena, its
+        // canonical instance is recorded in the solver type environment's
+        // `class_instance_types` (see
+        // `register_self_referential_base_class_instance`). Honour that mapping
+        // before the symbol-based fallback, which yields the class
+        // **constructor** and makes a self-referential covariant override compare
+        // against the static side, emitting a false `TS2416` (issue #10634). This
+        // also covers cross-arena classes whose `def_symbol_identity` is not
+        // resolvable in the current context (the `?` below would otherwise bail).
+        // Inserting the instance as the def body mirrors the in-file class path
+        // (symbol → `symbol_instance_types` → `try_insert_def_in_type_env`), so
+        // callers relying on the def-registration side effect keep working.
+        if let Some(instance_type) = self.registered_class_instance_for_def(def_id) {
+            self.try_insert_def_in_type_env(def_id, instance_type);
+            return Some(instance_type);
         }
 
         let (sym_id, owner_file_idx) = self.ctx.def_symbol_identity(def_id)?;

--- a/crates/tsz-checker/src/state/type_resolution/constructors.rs
+++ b/crates/tsz-checker/src/state/type_resolution/constructors.rs
@@ -925,6 +925,7 @@ impl<'a> CheckerState<'a> {
             if let Some((base_instance_type, base_type_params)) =
                 self.class_instance_type_with_params_from_symbol(base_sym_id)
             {
+                self.register_self_referential_base_class_instance(base_sym_id, base_instance_type);
                 let instantiated = self.instantiate_base_instance_type_with_args(
                     base_instance_type,
                     &base_type_params,
@@ -959,6 +960,21 @@ impl<'a> CheckerState<'a> {
         if adds_implicit_any_index && resolved.is_some_and(TypeId::is_any) {
             resolved = Some(self.implicit_any_index_base_instance_type());
         }
+        // When the base class lives in another file's arena, the instance is
+        // synthesized from its constructor's construct-return. Self-referential
+        // members in that synthesized instance are interned as `Lazy(DefId)`
+        // pointing back at the base class. Register the synthesized instance as
+        // the base class's instance type so the solver resolves those
+        // `Lazy(DefId)` self-references to the base **instance**, not the base
+        // **constructor** (issue #10634, false TS2416 on covariant overrides).
+        // Only do this for the un-instantiated base (no heritage type args), so
+        // the registered type is the class's canonical instance.
+        if type_argument_count == 0
+            && let Some(resolved_instance) = resolved
+            && let Some(base_sym_id) = self.resolve_heritage_symbol(expr_idx)
+        {
+            self.register_self_referential_base_class_instance(base_sym_id, resolved_instance);
+        }
         if self.ctx.is_js_file()
             && let Some(synthesized) =
                 self.synthesize_js_constructor_instance_type(expr_idx, ctor_type, &[])
@@ -975,6 +991,54 @@ impl<'a> CheckerState<'a> {
             };
         }
         self.cache_base_instance_result(expr_idx, should_cache, resolved)
+    }
+
+    /// Register a base class's canonical **instance** type against its `DefId`
+    /// in the solver type environments, mirroring the in-file class path.
+    ///
+    /// The solver's `TypeEnvironment::resolve_lazy` resolves a `Lazy(DefId)`
+    /// type reference to the class **instance** when `class_instance_types`
+    /// carries an entry for that `DefId`, otherwise it falls back to the def
+    /// body — which for a class is the **constructor** (static side). When a
+    /// base class is resolved cross-arena (constructor synthesis or the
+    /// symbol path), nothing populates that entry, so a self-referential
+    /// member typed as `Lazy(DefId(base))` resolves to the constructor and a
+    /// covariant override (`self(): Derived` / `next: Derived`) is wrongly
+    /// compared against the base constructor, yielding a false `TS2416`.
+    /// Registering the instance closes that gap (issue #10634).
+    fn register_self_referential_base_class_instance(
+        &mut self,
+        base_sym_id: tsz_binder::SymbolId,
+        canonical_instance: TypeId,
+    ) {
+        if matches!(
+            canonical_instance,
+            TypeId::ERROR | TypeId::ANY | TypeId::UNKNOWN
+        ) {
+            return;
+        }
+        let Some(def_id) = self.ctx.get_existing_def_id(base_sym_id) else {
+            return;
+        };
+        // Don't clobber an already-registered instance (e.g. the in-file
+        // canonical instance) with a synthesized one.
+        let already_registered = self
+            .ctx
+            .type_env
+            .try_borrow()
+            .ok()
+            .is_some_and(|env| env.get_class_instance_type(def_id).is_some());
+        if already_registered {
+            return;
+        }
+        self.ctx
+            .register_class_instance_in_envs(def_id, canonical_instance);
+        // A `Lazy(DefId)` self-reference may already have been evaluated to the
+        // base **constructor** and memoized in the evaluation caches before the
+        // instance mapping existed (heritage processing evaluates the base
+        // reference eagerly). Drop those stale entries so the self-reference
+        // re-resolves to the freshly registered instance type.
+        self.ctx.clear_type_evaluation_caches_for_def(def_id);
     }
 
     fn constructor_type_explicitly_returns_any(&mut self, ctor_type: TypeId) -> bool {

--- a/crates/tsz-checker/src/tests/cross_module_self_ref_override_ts2416_tests.rs
+++ b/crates/tsz-checker/src/tests/cross_module_self_ref_override_ts2416_tests.rs
@@ -1,0 +1,179 @@
+//! Regression coverage for issue #10634: a cross-module derived class that
+//! overrides a base member with a self-referential (covariant) return/field
+//! type must not produce a false `TS2416`, while a genuinely incompatible
+//! cross-module override must still error.
+
+use crate::context::CheckerOptions;
+use crate::diagnostics::{Diagnostic, diagnostic_codes};
+use crate::test_utils::check_multi_file;
+use tsz_common::common::ModuleKind;
+
+fn check(files: &[(&str, &str)], entry: &str) -> Vec<Diagnostic> {
+    check_multi_file(
+        files,
+        entry,
+        CheckerOptions {
+            module: ModuleKind::CommonJS,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn ts2416(diags: &[Diagnostic]) -> Vec<String> {
+    diags
+        .iter()
+        .filter(|d| {
+            d.code == diagnostic_codes::PROPERTY_IN_TYPE_IS_NOT_ASSIGNABLE_TO_THE_SAME_PROPERTY_IN_BASE_TYPE
+        })
+        .map(|d| d.message_text.to_string())
+        .collect()
+}
+
+#[test]
+fn cross_module_self_referential_method_no_false_ts2416() {
+    let diags = check(
+        &[
+            (
+                "./base.ts",
+                r#"export abstract class Base { abstract self(): Base; }"#,
+            ),
+            (
+                "./derived.ts",
+                r#"import { Base } from "./base";
+export class Derived extends Base { self(): Derived { return this; } }"#,
+            ),
+        ],
+        "./derived.ts",
+    );
+    let errs = ts2416(&diags);
+    assert!(errs.is_empty(), "expected no TS2416, got: {errs:?}");
+}
+
+#[test]
+fn cross_module_self_referential_field_no_false_ts2416() {
+    let diags = check(
+        &[
+            ("./base.ts", r#"export class Base { next!: Base; }"#),
+            (
+                "./derived.ts",
+                r#"import { Base } from "./base";
+export class Derived extends Base { next!: Derived; }"#,
+            ),
+        ],
+        "./derived.ts",
+    );
+    let errs = ts2416(&diags);
+    assert!(errs.is_empty(), "expected no TS2416, got: {errs:?}");
+}
+
+#[test]
+fn cross_module_incompatible_override_still_errors_ts2416() {
+    let diags = check(
+        &[
+            (
+                "./base.ts",
+                r#"export class Base { val(): string { return ""; } }"#,
+            ),
+            (
+                "./derived.ts",
+                r#"import { Base } from "./base";
+export class Derived extends Base { val(): number { return 0; } }"#,
+            ),
+        ],
+        "./derived.ts",
+    );
+    let errs = ts2416(&diags);
+    assert!(
+        !errs.is_empty(),
+        "expected TS2416 for number-over-string override"
+    );
+}
+
+#[test]
+fn cross_module_self_referential_method_renamed_type_param_no_false_ts2416() {
+    // The fix must follow the structural self-reference, not a particular
+    // type-parameter spelling. A generic base/derived with differently named
+    // type parameters that both reference the class itself must stay clean.
+    let diags = check(
+        &[
+            (
+                "./base.ts",
+                r#"export abstract class Base<A> { abstract self(): Base<A>; }"#,
+            ),
+            (
+                "./derived.ts",
+                r#"import { Base } from "./base";
+export class Derived<Q> extends Base<Q> { self(): Derived<Q> { return this; } }"#,
+            ),
+        ],
+        "./derived.ts",
+    );
+    let errs = ts2416(&diags);
+    assert!(errs.is_empty(), "expected no TS2416, got: {errs:?}");
+}
+
+#[test]
+fn cross_module_identity_override_no_false_ts2416() {
+    // Overriding a self-referential member with the *same* base type (no
+    // narrowing) must also stay clean cross-module.
+    let diags = check(
+        &[
+            ("./base.ts", r#"export class Base { next!: Base; }"#),
+            (
+                "./derived.ts",
+                r#"import { Base } from "./base";
+export class Derived extends Base { next!: Base; }"#,
+            ),
+        ],
+        "./derived.ts",
+    );
+    let errs = ts2416(&diags);
+    assert!(errs.is_empty(), "expected no TS2416, got: {errs:?}");
+}
+
+#[test]
+fn cross_module_self_referential_getter_no_false_ts2416() {
+    // Accessor members carry the same self-reference shape as fields/methods.
+    let diags = check(
+        &[
+            (
+                "./base.ts",
+                r#"export class Base { get node(): Base { return this; } }"#,
+            ),
+            (
+                "./derived.ts",
+                r#"import { Base } from "./base";
+export class Derived extends Base { get node(): Derived { return this; } }"#,
+            ),
+        ],
+        "./derived.ts",
+    );
+    let errs = ts2416(&diags);
+    assert!(errs.is_empty(), "expected no TS2416, got: {errs:?}");
+}
+
+#[test]
+fn cross_module_incompatible_self_referential_field_still_errors_ts2416() {
+    // Negative guard for the self-referential shape: overriding a self field
+    // (`next: Base`) with a primitive that is not assignable to the base
+    // instance must still error. Proves the fix resolves the self-reference to
+    // the base instance for the relation rather than blanket-suppressing
+    // self-referential overrides.
+    let diags = check(
+        &[
+            ("./base.ts", r#"export class Base { next!: Base; }"#),
+            (
+                "./derived.ts",
+                r#"import { Base } from "./base";
+export class Derived extends Base { next!: number; }"#,
+            ),
+        ],
+        "./derived.ts",
+    );
+    let errs = ts2416(&diags);
+    assert!(
+        !errs.is_empty(),
+        "expected TS2416 for number override of a self-referential class field"
+    );
+}


### PR DESCRIPTION
AgentName: claude-opus47-fRhCv (operating in the agent:M4-D lane)

**Track:** Benchmark unblock (project-corpus compile campaign — kysely row) / cross-module class typing
**Invariant:** `tsc` parity for `TS2416` override checks; a `Lazy(DefId)` type reference to a class resolves to the class **instance**, never its constructor. Must not over-suppress — genuinely incompatible overrides still error. Conformance floor preserved.
**Scope:** `crates/tsz-checker` only — `state/type_resolution/constructors.rs`, `state/type_environment/lazy.rs`, a new `check_multi_file` test module, and its registration in `lib.rs`. No solver/binder/emitter changes.

Fixes #10634.

## Structural rule
> When a `Lazy(DefId)` referencing a **class** is resolved in type position, the result is the class **instance** type, not the class **constructor** (static side) — including when the class lives in another file's arena and its instance was synthesized cross-arena.

## Root cause
tsz uses per-file arenas. For a cross-module base class the declaration node isn't in the consuming file's arena, so `base_instance_type_from_expression` synthesizes the base instance from its constructor's construct-return. Self-referential members in that synthesized instance (`self(): Base`, `next: Base`) are interned as `Lazy(DefId(base))`.

Nothing recorded that base `DefId`'s instance in the solver `TypeEnvironment::class_instance_types`. So when the override relation evaluated the base member, `resolve_and_insert_def_type` / `resolve_lazy` fell through to `get_type_of_symbol`, which returns the class **constructor** (a `Callable` with construct signatures). The override check then compared `Derived`-instance `<:` `Base`-**constructor** and emitted a false `TS2416`. Single-file (AST path) and plain cross-module assignment (`const b: Base = d`) were already correct.

## Fix (owner layer: checker type-resolution / solver type-environment bridge)
1. `base_instance_type_from_expression` registers the synthesized **canonical** base instance against its `DefId` via `register_class_instance_in_envs` (mirrors the in-file class path), and clears stale evaluation-cache entries for that def so an already-memoized `Lazy→constructor` result re-resolves to the instance. Done on both the symbol path and the constructor-synthesis path (un-instantiated base only, so the registered type is canonical).
2. `resolve_and_insert_def_type` honours a registered class instance before the symbol-based constructor fallback — placed before the `def_symbol_identity?` bail so it also covers cross-arena classes whose symbol identity isn't resolvable in the current context. The def-insert side effect is preserved (matches the in-file path), so TS2589 expansion callers are unaffected.

The logic belongs here because it is a type-position resolution rule (`WHAT`), expressed through the existing `class_instance_types` mechanism the solver already consults for in-file classes — not a checker-local diagnostic special case.

## Adjacent-case test matrix
`crates/tsz-checker/src/tests/cross_module_self_ref_override_ts2416_tests.rs`:
- self-referential **method** return (`self(): Derived` ext `self(): Base`) — clean.
- self-referential **field** (`next: Derived` ext `next: Base`) — clean (the reported repro).
- self-referential **getter** accessor — clean.
- **generic** base/derived with **renamed** type parameters (`Base<A>`/`Derived<Q>`) — clean (proves the rule follows the self-reference, not a spelling).
- **identity** override (`next: Base` over `next: Base`) — clean.
- **negative:** `number` over `string` method override — still `TS2416`.
- **negative:** `number` over a self-referential class field — still `TS2416` (proves no blanket suppression).

## Known unsupported shape / fallback
A **generic** cross-file base reached only through the constructor-synthesis fallback (when the cross-arena symbol/delegation path returns `None`) is not registered (we avoid registering an instantiated `Base<number>` as the canonical instance). In real project compiles the symbol/delegation path supplies the canonical generic instance; the generic-method matrix case passes. Non-generic and generic-via-symbol-path shapes are covered.

## Project Corpus Impact
- Row: kysely-project (canary). Bug family: false TS2416 on cross-module self-referential class overrides (13 of kysely's current false positives; same shape recurs in zod/other fluent/builder libs).
- Bug family: false `TS2416` on cross-module self-referential covariant class overrides.
- Evidence: minimal 2-file repro reproduced on `dist-fast`; tsc-parity confirmed in #10634; new owning-crate unit tests (`tsz_checker`, `check_multi_file`) lock the behavior.

## Verification
- `cargo test -p tsz-checker --lib cross_module_self_ref` — 7/7 pass (5 positive + 2 negative).
- `cargo test -p tsz-checker --lib cross_file` — 221 pass; the 3 failures (`*builtin_lib*`, `zod_cross_file_lib_partial_omit*`) are pre-existing on `main` in this container (require the TS lib submodule).
- Heavy suites (conformance/emit/fourslash/WASM) run on ready-CI.

## Coordination Notes
Picked up #10634 (was open and not marked WIP; the earlier test-only PR #10643 is closed-unmerged). Labeled the issue `WIP` while implementing. No overlap with other open PRs.