### PR TITLE
fix(solver): gate ReadonlyArray narrowing by identity

### DIFF
--- a/crates/tsz-checker/tests/array_isarray_mutual_subtype_narrowing_tests.rs
+++ b/crates/tsz-checker/tests/array_isarray_mutual_subtype_narrowing_tests.rs
@@ -426,6 +426,31 @@ function f(x: ReadonlyArray<number> | number) {
     );
 }
 
+/// A local alias named `ReadonlyArray` is not the lib `ReadonlyArray`
+/// protocol. `Array.isArray` may intersect it with the predicate array type,
+/// but it must not preserve the alias member solely because of the spelling.
+#[test]
+fn array_isarray_shadowed_readonlyarray_alias_does_not_use_lib_identity() {
+    let source = r#"
+export {};
+type ReadonlyArray<T> = { value: T };
+declare const x: ReadonlyArray<number> | number;
+if (Array.isArray(x)) {
+    x.value;
+}
+"#;
+    let diags = check_strict_es5(source);
+    let property_errors: Vec<_> = diags
+        .iter()
+        .filter(|(c, m)| matches!(*c, 2339 | 2551) && m.contains("value"))
+        .collect();
+    assert_eq!(
+        property_errors.len(),
+        1,
+        "shadowed ReadonlyArray alias must not retain `.value` after Array.isArray: {diags:?}"
+    );
+}
+
 /// `ArrayLike<T>` from the lib (alongside the built-in `Array`) is handled
 /// correctly when lib is loaded.
 #[test]

--- a/crates/tsz-solver/src/narrowing/compound.rs
+++ b/crates/tsz-solver/src/narrowing/compound.rs
@@ -931,7 +931,7 @@ impl<'a> NarrowingContext<'a> {
             return None;
         };
         let app = self.db.type_application(app_id);
-        if app.args.len() == 1 && self.application_base_name_is(app.base, "ReadonlyArray") {
+        if app.args.len() == 1 && self.application_base_is_readonly_array(app.base) {
             Some(app.args[0])
         } else {
             None
@@ -956,25 +956,5 @@ impl<'a> NarrowingContext<'a> {
         }
 
         false
-    }
-
-    fn application_base_name_is(&self, base: TypeId, expected: &str) -> bool {
-        if expected == "ReadonlyArray" && self.application_base_is_readonly_array(base) {
-            return true;
-        }
-
-        match self.db.lookup(base) {
-            Some(TypeData::Lazy(def_id)) => self
-                .resolver
-                .and_then(|resolver| resolver.get_def_name(def_id))
-                .is_some_and(|name| self.db.resolve_atom_ref(name).as_ref() == expected),
-            Some(TypeData::UnresolvedTypeName(name)) => {
-                self.db.resolve_atom_ref(name).as_ref() == expected
-            }
-            _ => self
-                .db
-                .get_display_alias(base)
-                .is_some_and(|alias| self.application_base_name_is(alias, expected)),
-        }
     }
 }


### PR DESCRIPTION
## Agent
AgentName: M4-D

## Track
Semantic identity cleanup / `Array.isArray` readonly-array identity ratchet.

## Invariant
When `Array.isArray(x)` narrows an application type, only the canonical lib/registered `ReadonlyArray` identity should count as the readonly-array protocol. A local alias or interface that happens to be named `ReadonlyArray` must not retain its own members solely because of that spelling.

## Scope
- Change solver narrowing so `ReadonlyArray<T>` application recognition uses `application_base_is_readonly_array` identity instead of a fallback base-name/display-alias comparison.
- Add a checker regression where a module-local `type ReadonlyArray<T> = { value: T }` does not keep `.value` after `Array.isArray` narrowing.

## Project Corpus Impact
- Row: n/a
- Bug family: name-based `ReadonlyArray` identity debt in solver narrowing
- Evidence: targeted checker and solver tests only; this is an identity ratchet and does not target a known project-corpus row.

## Verification
- `node TypeScript/lib/_tsc.js --strict --noEmit --target es2015 --lib es5 <shadowed ReadonlyArray alias repro>` rejects `x.value` with TS2551.
- RED before implementation: `cargo nextest run -p tsz-checker --test array_isarray_mutual_subtype_narrowing_tests array_isarray_shadowed_readonlyarray_alias_does_not_use_lib_identity` failed with no diagnostics (`[]`).
- GREEN after implementation: `cargo nextest run -p tsz-checker --test array_isarray_mutual_subtype_narrowing_tests array_isarray_shadowed_readonlyarray_alias_does_not_use_lib_identity`
- `cargo nextest run -p tsz-checker --test array_isarray_mutual_subtype_narrowing_tests`
- `cargo nextest run -p tsz-solver array_isarray_narrows_readonly_array_application`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`

- Draft exact-head CI (`73ba71c9389ac54d5044dc7de76bb50faad91526`): `CI Light Summary`, `dist-binaries`, `unit`, `unit-cloudbuild`, `lint`, `cargo-shear`, `cargo-deny`, `project-row-drift`, `gate`, and `GitGuardian Security Checks` passed on 2026-05-28.

- Ready-review exact-head CI (`73ba71c9389ac54d5044dc7de76bb50faad91526`) passed on 2026-05-28: `CI Summary`, `GitGuardian Security Checks`, conformance aggregate/shards, fourslash aggregate/shards, emit, LSP, WASM, project compile gates, dist, lint, unit, snapshot, and project-corpus body gates.

## Coordination Notes
- AgentName: M4-D
- Base: `main`; this PR is independent of #10641, #10686, #10727, #10731, and #10745.
- Adjacent-case matrix: local alias named `ReadonlyArray` is rejected; lib `ReadonlyArray<number>` still narrows; solver registered readonly-array base still narrows; numeric-index array-like tests remain green.
- Ready for heavy CI after exact-head draft light CI passed.
- Exact-head ready-review CI is green; `merge-queue` added so the repo-local queue can run `Queue Tested` on latest `main`.