### PR TITLE
fix(checker): widen optional private field write target to include undefined

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs
@@ -257,6 +257,7 @@ impl<'a> CheckerState<'a> {
             let Some(prop) = self.ctx.arena.get_property_decl(node) else {
                 continue;
             };
+            let is_optional = prop.question_token;
             let declared_type = if is_write_context {
                 self.class_property_relation_declared_type(decl_idx, prop)
             } else {
@@ -264,22 +265,57 @@ impl<'a> CheckerState<'a> {
             };
             if let Some(type_id) = declared_type {
                 let evaluated = self.evaluate_type_for_assignability(type_id);
-                if evaluated != type_id
+                let base = if evaluated != type_id
                     && crate::query_boundaries::common::object_shape_for_type(
                         self.ctx.types,
                         evaluated,
                     )
                     .is_some_and(|shape| {
                         shape.string_index.is_some() || shape.number_index.is_some()
-                    })
-                {
-                    return Some(evaluated);
-                }
-                return Some(type_id);
+                    }) {
+                    evaluated
+                } else {
+                    type_id
+                };
+                return Some(self.optional_field_write_target_type(
+                    base,
+                    is_optional,
+                    is_write_context,
+                ));
             }
         }
 
         None
+    }
+
+    /// Widen the write target of an optional private field to `T | undefined`.
+    ///
+    /// This annotation-direct path bypasses the solver property query (so it can
+    /// resolve self-referential class members before the full type is built),
+    /// which means it must replicate tsc's optional-property semantics itself.
+    /// Under `strictNullChecks`, the assignment target of an optional field
+    /// (`name?: T`) is `T | undefined`, so `this.#x = undefined` is allowed.
+    /// With `exactOptionalPropertyTypes`, an optional field's write target stays
+    /// `T` (assigning `undefined` is an error), matching tsc. Read context is
+    /// left unchanged.
+    fn optional_field_write_target_type(
+        &self,
+        base: TypeId,
+        is_optional: bool,
+        is_write_context: bool,
+    ) -> TypeId {
+        if is_optional
+            && is_write_context
+            && self.ctx.strict_null_checks()
+            && !self.ctx.exact_optional_property_types()
+            && base != TypeId::ANY
+            && base != TypeId::UNKNOWN
+            && base != TypeId::ERROR
+        {
+            self.ctx.types.factory().union2(base, TypeId::UNDEFINED)
+        } else {
+            base
+        }
     }
 
     pub(crate) fn get_type_of_private_property_access(
@@ -930,5 +966,106 @@ impl<'a> CheckerState<'a> {
         // E.g., inside `if (!this.#x)`, the narrowed type of `this.#x` is `null`,
         // but assigning `this.#x = value` must check against `T | null`.
         self.finalize_property_access_result(idx, result_type, is_write_context, false)
+    }
+}
+
+#[cfg(test)]
+mod optional_private_field_write_tests {
+    use crate::test_utils::{check_source_strict, check_with_options, strict_checker_options};
+    use tsz_common::options::checker::CheckerOptions;
+
+    fn codes(diags: Vec<crate::diagnostics::Diagnostic>) -> Vec<u32> {
+        diags.into_iter().map(|d| d.code).collect()
+    }
+
+    // Under strictNullChecks (no exactOptionalPropertyTypes), an optional field's
+    // write target is `T | undefined`, so assigning `undefined` is allowed. The
+    // private-name (`#x`) path used to drop the `| undefined`, wrongly raising
+    // TS2322. Cover several field names and value types so the fix proves the
+    // structural rule rather than one spelling.
+    #[test]
+    fn assigning_undefined_to_optional_private_field_is_allowed() {
+        let codes = codes(check_source_strict(
+            r#"
+class Mutex {
+    #promise?: Promise<void>
+    #resolve?: () => void
+    #count?: number
+    clear(): void {
+        this.#promise = undefined
+        this.#resolve = undefined
+        this.#count = undefined
+    }
+}
+"#,
+        ));
+        assert!(
+            !codes.contains(&2322),
+            "assigning undefined to an optional private field should not raise TS2322; got {codes:?}"
+        );
+    }
+
+    // Renaming the field and changing its type must not change the outcome.
+    #[test]
+    fn assigning_undefined_to_optional_private_field_is_allowed_renamed() {
+        let codes = codes(check_source_strict(
+            r#"
+class Holder<T> {
+    #slot?: T[]
+    reset(): void {
+        this.#slot = undefined
+    }
+}
+"#,
+        ));
+        assert!(
+            !codes.contains(&2322),
+            "renamed/generic optional private field should accept undefined; got {codes:?}"
+        );
+    }
+
+    // A non-optional private field still rejects `undefined` (negative case).
+    #[test]
+    fn assigning_undefined_to_required_private_field_is_rejected() {
+        let codes = codes(check_source_strict(
+            r#"
+class C {
+    #value: number = 1
+    clear(): void {
+        this.#value = undefined
+    }
+}
+"#,
+        ));
+        assert!(
+            codes.contains(&2322),
+            "assigning undefined to a required private field should raise TS2322; got {codes:?}"
+        );
+    }
+
+    // With exactOptionalPropertyTypes, an optional field's write target stays
+    // `T`, so assigning `undefined` is still an error (TS2322 for private names,
+    // matching tsc — the EOPT-specific TS2412 is only used for public members).
+    #[test]
+    fn assigning_undefined_to_optional_private_field_rejected_under_exact_optional() {
+        let opts = CheckerOptions {
+            exact_optional_property_types: true,
+            ..strict_checker_options()
+        };
+        let codes = codes(check_with_options(
+            r#"
+class C {
+    #value?: number
+    clear(): void {
+        this.#value = undefined
+    }
+}
+"#,
+            opts,
+        ));
+        assert!(
+            codes.contains(&2322),
+            "exactOptionalPropertyTypes should still reject undefined on an optional private field; got {codes:?}"
+        );
     }
 }


### PR DESCRIPTION
## Agent
AgentName: web-opus47

## Track
Checker / TS2322 parity — class private-field assignability.

## Invariant
When a private class field is optional (`#x?: T`), under `strictNullChecks` and **not** `exactOptionalPropertyTypes`, its assignment-target (write) type is `T | undefined`, so `this.#x = undefined` is allowed — matching tsc and matching how tsz already treats public optional fields. With `exactOptionalPropertyTypes`, the write target stays `T` and assigning `undefined` is correctly `TS2322` (private members use TS2322, not the public TS2412). Read context is unchanged.

## Root cause
Private-field access resolves the member type directly from its declaration annotation via `private_property_declared_access_type` (`crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs`). That path intentionally bypasses the solver property query so it can resolve self-referential members before the full class type is built — but it returned the raw declared type `T`, never applying the optional `?` → `| undefined`. Public fields get `| undefined` from the solver's `PropertyInfo.optional`. So `this.#promise = undefined` on `#promise?: Promise<void>` raised a false `TS2322`.

## Scope
- Add `optional_field_write_target_type` and apply it in the private-field annotation-direct path. It unions `| undefined` only when: optional AND write-context AND `strictNullChecks` AND NOT `exactOptionalPropertyTypes` AND base ∉ {any, unknown, error}.
- Refactor the existing `evaluated`/`type_id` selection into a `base` binding (behavior-preserving) so the optional rule applies to the chosen type.
- Focused unit tests (varied field names + value types, generic field, EOPT, and a required-field negative case).

## Owner Layer
Checker, in the private-field type-resolution path that already owns annotation-direct member typing. No solver internals constructed; the `| undefined` union goes through the public type factory.

## Adjacent-Case Matrix
- Optional private field write (`#promise?`, `#resolve?`, `#count?`) → accepts `undefined` (the reported repro + multiple names/types).
- Generic optional private field (`#slot?: T[]`) → accepts `undefined` (renamed, proves structural rule not spelling).
- Required private field (`#value: number`) write of `undefined` → still `TS2322`.
- Optional private field under `exactOptionalPropertyTypes` → still `TS2322` (private TS2322, not public TS2412).
- Read context → unchanged.

## Project Corpus Impact
- Row: kysely-project (family tracker #10663)
- Bug family: false TS2322 / strict-null write target on class private fields
- Evidence: on the kysely guard config (`scripts/bench/project-fixtures.sh::tsz_write_kysely_config`, tsc-clean), tsz drops from **281 → 275** diagnostics with **0 new** diagnostics. Fixed sites span 4 files: `sqlite-driver.ts`, `postgres-driver.ts`, `driver/runtime-driver.ts`, `driver/single-connection-provider.ts` — confirming the fix is broad, not point-targeted.

## Verification
- `cargo test -p tsz-checker --lib optional_private_field_write` → 4 passed
- `cargo test -p tsz-checker --lib private` → 111 passed, 0 failed
- `cargo fmt --all --check` → clean
- `cargo clippy -p tsz-checker --all-targets --all-features -- -D warnings` → clean
- `python3 scripts/arch/arch_guard.py` → passed
- Manual parity matrix vs `tsc` 6.0.2 (read/write × public/private × EOPT): all match except a pre-existing read-side under-report on private optional fields (out of scope; see below).
- Re-ran tsz on the kysely fixture before/after: 281 → 275, no new diagnostics.

## Coordination Notes
- AgentName: web-opus47. Discovered while triaging the kysely false-positive family (#10663); closes #10749.
- Known follow-up (out of scope): the **read** type of an optional private field also omits `| undefined` (`const x: T = this.#x` should error). Fixing the read side additionally triggers tsc's private-vs-public EOPT divergence (private TS2322 vs public TS2412) and broader narrowing changes, so it is intentionally left for a separate change to keep this fix low-risk and parity-correct.
- Rebased on `origin/main`; the two base files in this diff do not overlap any other open PR.

https://claude.ai/code/session_011Qf9Y5thWFHZ7dnvPhaaGV

---
_Generated by [Claude Code](https://claude.ai/code/session_011Qf9Y5thWFHZ7dnvPhaaGV)_