### PR TITLE
fix(checker): accept cross-file generic interface method overrides

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -431,6 +431,10 @@ name = "ts2430_tests"
 path = "tests/ts2430_tests.rs"
 
 [[test]]
+name = "ts2430_cross_file_generic_heritage_tests"
+path = "tests/ts2430_cross_file_generic_heritage_tests.rs"
+
+[[test]]
 name = "ts2540_readonly_tests"
 path = "tests/ts2540_readonly_tests.rs"
 

--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -405,6 +405,39 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        // For overloaded methods, the type-alias fallback path below (used when a
+        // base interface's declarations live in another file and could not be
+        // resolved into `base_iface_indices`) compares each derived overload
+        // individually against the base member's *combined* overload set. The
+        // strict relation rejects that even for valid specializations, so
+        // precompute a combined derived callable per overloaded method name and
+        // let that path retry the override as a whole.
+        let mut derived_overload_callables: rustc_hash::FxHashMap<String, TypeId> =
+            rustc_hash::FxHashMap::default();
+        {
+            let mut fns_by_name: rustc_hash::FxHashMap<String, Vec<TypeId>> =
+                rustc_hash::FxHashMap::default();
+            for (name, member_type, _, kind, _, _) in &derived_members {
+                if *kind == METHOD_SIGNATURE
+                    && derived_method_counts.get(name).copied().unwrap_or(0) > 1
+                {
+                    let fn_ty = crate::query_boundaries::common::find_property_by_str(
+                        self.ctx.types,
+                        *member_type,
+                        name,
+                    )
+                    .map(|p| p.type_id)
+                    .unwrap_or(*member_type);
+                    fns_by_name.entry(name.clone()).or_default().push(fn_ty);
+                }
+            }
+            for (name, fns) in fns_by_name {
+                if let Some(callable) = self.build_overload_callable(&fns) {
+                    derived_overload_callables.insert(name, callable);
+                }
+            }
+        }
+
         let mut derived_string_index_type: Option<(TypeId, NodeIndex)> = None;
         let mut derived_number_index_type: Option<(TypeId, NodeIndex)> = None;
         for &decl_idx in &all_iface_decls {
@@ -1413,6 +1446,41 @@ impl<'a> CheckerState<'a> {
                         self.get_type_of_symbol(base_sym_id)
                     };
 
+                    // Substitution from the base's type parameters to the heritage
+                    // type arguments, used to instantiate base member types that the
+                    // Application evaluator left referencing the base's own parameters.
+                    let base_member_substitution: Option<TypeSubstitution> = type_arguments
+                        .and_then(|args| {
+                            let mut arg_ids: Vec<TypeId> = args
+                                .nodes
+                                .iter()
+                                .map(|&arg_idx| self.get_type_from_type_node(arg_idx))
+                                .collect();
+                            if arg_ids.is_empty() {
+                                return None;
+                            }
+                            let base_params = self.get_type_params_for_symbol(base_sym_id);
+                            if base_params.is_empty() {
+                                return None;
+                            }
+                            if arg_ids.len() < base_params.len() {
+                                for param in base_params.iter().skip(arg_ids.len()) {
+                                    arg_ids.push(
+                                        param
+                                            .default
+                                            .or(param.constraint)
+                                            .unwrap_or(TypeId::UNKNOWN),
+                                    );
+                                }
+                            }
+                            arg_ids.truncate(base_params.len());
+                            Some(TypeSubstitution::from_args(
+                                self.ctx.types,
+                                &base_params,
+                                &arg_ids,
+                            ))
+                        });
+
                     if base_type != TypeId::ERROR {
                         // Check numeric index signature compatibility. A base
                         // numeric index signature does not constrain every
@@ -1503,6 +1571,24 @@ impl<'a> CheckerState<'a> {
                             };
 
                             if let Some(base_prop_type_id) = base_prop_type {
+                                // The Application evaluator does not always deeply
+                                // instantiate a base interface member's nested generic
+                                // return type, so the member can still reference the
+                                // base's own type parameter (e.g. `AliasedExpression<T, A>`
+                                // for `AliasableExpression<T>` extended with `O`). Apply
+                                // the base→heritage substitution explicitly, mirroring the
+                                // in-arena interface path; it is a no-op on members that
+                                // are already instantiated.
+                                let base_prop_type_id = base_member_substitution
+                                    .as_ref()
+                                    .map(|substitution| {
+                                        instantiate_type(
+                                            self.ctx.types,
+                                            base_prop_type_id,
+                                            substitution,
+                                        )
+                                    })
+                                    .unwrap_or(base_prop_type_id);
                                 // Extract the derived property's raw type from its ObjectShape
                                 // (get_type_of_interface_member returns ObjectShape { name: type },
                                 // but we need the raw property type for comparison with base)
@@ -1515,11 +1601,21 @@ impl<'a> CheckerState<'a> {
                                     .map(|p| p.type_id)
                                     .unwrap_or(*member_type);
 
+                                // For overloaded methods, compare the combined
+                                // derived overload set (not a single overload)
+                                // against the base member.
+                                let generic_override_source = derived_overload_callables
+                                    .get(member_name)
+                                    .copied()
+                                    .unwrap_or(derived_prop_type);
                                 if should_report_member_type_mismatch(
                                     self,
                                     derived_prop_type,
                                     base_prop_type_id,
                                     *derived_member_idx,
+                                ) && !self.generic_method_override_is_valid_specialization(
+                                    generic_override_source,
+                                    base_prop_type_id,
                                 ) {
                                     let diagnostic_base_name = self
                                         .array_or_tuple_alias_target_text_for_name(&base_name)

--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -412,31 +412,8 @@ impl<'a> CheckerState<'a> {
         // strict relation rejects that even for valid specializations, so
         // precompute a combined derived callable per overloaded method name and
         // let that path retry the override as a whole.
-        let mut derived_overload_callables: rustc_hash::FxHashMap<String, TypeId> =
-            rustc_hash::FxHashMap::default();
-        {
-            let mut fns_by_name: rustc_hash::FxHashMap<String, Vec<TypeId>> =
-                rustc_hash::FxHashMap::default();
-            for (name, member_type, _, kind, _, _) in &derived_members {
-                if *kind == METHOD_SIGNATURE
-                    && derived_method_counts.get(name).copied().unwrap_or(0) > 1
-                {
-                    let fn_ty = crate::query_boundaries::common::find_property_by_str(
-                        self.ctx.types,
-                        *member_type,
-                        name,
-                    )
-                    .map(|p| p.type_id)
-                    .unwrap_or(*member_type);
-                    fns_by_name.entry(name.clone()).or_default().push(fn_ty);
-                }
-            }
-            for (name, fns) in fns_by_name {
-                if let Some(callable) = self.build_overload_callable(&fns) {
-                    derived_overload_callables.insert(name, callable);
-                }
-            }
-        }
+        let derived_overload_callables = self
+            .collect_overloaded_derived_method_callables(&derived_members, &derived_method_counts);
 
         let mut derived_string_index_type: Option<(TypeId, NodeIndex)> = None;
         let mut derived_number_index_type: Option<(TypeId, NodeIndex)> = None;
@@ -1446,40 +1423,11 @@ impl<'a> CheckerState<'a> {
                         self.get_type_of_symbol(base_sym_id)
                     };
 
-                    // Substitution from the base's type parameters to the heritage
-                    // type arguments, used to instantiate base member types that the
-                    // Application evaluator left referencing the base's own parameters.
-                    let base_member_substitution: Option<TypeSubstitution> = type_arguments
-                        .and_then(|args| {
-                            let mut arg_ids: Vec<TypeId> = args
-                                .nodes
-                                .iter()
-                                .map(|&arg_idx| self.get_type_from_type_node(arg_idx))
-                                .collect();
-                            if arg_ids.is_empty() {
-                                return None;
-                            }
-                            let base_params = self.get_type_params_for_symbol(base_sym_id);
-                            if base_params.is_empty() {
-                                return None;
-                            }
-                            if arg_ids.len() < base_params.len() {
-                                for param in base_params.iter().skip(arg_ids.len()) {
-                                    arg_ids.push(
-                                        param
-                                            .default
-                                            .or(param.constraint)
-                                            .unwrap_or(TypeId::UNKNOWN),
-                                    );
-                                }
-                            }
-                            arg_ids.truncate(base_params.len());
-                            Some(TypeSubstitution::from_args(
-                                self.ctx.types,
-                                &base_params,
-                                &arg_ids,
-                            ))
-                        });
+                    // Base type parameters + heritage type arguments, used to
+                    // instantiate base member types that the Application evaluator
+                    // left referencing the base's own parameters.
+                    let base_heritage_subst =
+                        self.base_heritage_params_and_args(base_sym_id, type_arguments);
 
                     if base_type != TypeId::ERROR {
                         // Check numeric index signature compatibility. A base
@@ -1579,16 +1527,20 @@ impl<'a> CheckerState<'a> {
                                 // the base→heritage substitution explicitly, mirroring the
                                 // in-arena interface path; it is a no-op on members that
                                 // are already instantiated.
-                                let base_prop_type_id = base_member_substitution
-                                    .as_ref()
-                                    .map(|substitution| {
-                                        instantiate_type(
+                                let base_prop_type_id = if let Some((
+                                    ref base_params,
+                                    ref heritage_args,
+                                )) = base_heritage_subst
+                                {
+                                    crate::query_boundaries::class::instantiate_member_with_heritage_args(
                                             self.ctx.types,
                                             base_prop_type_id,
-                                            substitution,
+                                            base_params,
+                                            heritage_args,
                                         )
-                                    })
-                                    .unwrap_or(base_prop_type_id);
+                                } else {
+                                    base_prop_type_id
+                                };
                                 // Extract the derived property's raw type from its ObjectShape
                                 // (get_type_of_interface_member returns ObjectShape { name: type },
                                 // but we need the raw property type for comparison with base)

--- a/crates/tsz-checker/src/classes/interface_heritage_index_compat.rs
+++ b/crates/tsz-checker/src/classes/interface_heritage_index_compat.rs
@@ -7,6 +7,33 @@ use tsz_parser::parser::node::NodeArena;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
+use tsz_solver::construction::TypeDatabase;
+
+/// Classify a member type as callable and report whether any of its call
+/// signatures carry method-local type parameters.
+///
+/// Returns `None` when the type is not callable (so callers fall back to the
+/// strict relation). Handles both the bare `Function` representation (a derived
+/// member computed from its AST) and the `Callable` representation (a base
+/// member resolved from a lowered interface type), which the raw
+/// `get_call_signatures` query does not unify.
+fn callable_generic_flag(db: &dyn TypeDatabase, type_id: TypeId) -> Option<bool> {
+    if let Some(shape) = crate::query_boundaries::common::function_shape_for_type(db, type_id) {
+        return Some(!shape.type_params.is_empty());
+    }
+    if let Some(shape) = crate::query_boundaries::common::callable_shape_for_type(db, type_id) {
+        if shape.call_signatures.is_empty() {
+            return None;
+        }
+        return Some(
+            shape
+                .call_signatures
+                .iter()
+                .any(|sig| !sig.type_params.is_empty()),
+        );
+    }
+    None
+}
 
 impl<'a> CheckerState<'a> {
     pub(super) fn is_direct_this_type(&self, type_id: TypeId) -> bool {
@@ -49,6 +76,79 @@ impl<'a> CheckerState<'a> {
         }
 
         self.type_base_def_id(source_return) == Some(current_iface_def_id)
+    }
+
+    /// Combine several single-signature method types (one per overload) into a
+    /// single `Callable` carrying all of their call signatures. Returns `None`
+    /// unless at least two signatures were gathered, so callers only use the
+    /// combined form for genuinely overloaded members.
+    pub(super) fn build_overload_callable(&self, fn_types: &[TypeId]) -> Option<TypeId> {
+        use tsz_solver::types::{CallSignature, CallableShape};
+        let mut call_signatures: Vec<CallSignature> = Vec::new();
+        for &ty in fn_types {
+            if let Some(shape) =
+                crate::query_boundaries::common::function_shape_for_type(self.ctx.types, ty)
+            {
+                call_signatures.push(CallSignature {
+                    type_params: shape.type_params.clone(),
+                    params: shape.params.clone(),
+                    this_type: shape.this_type,
+                    return_type: shape.return_type,
+                    type_predicate: shape.type_predicate,
+                    is_method: shape.is_method,
+                });
+            } else if let Some(shape) =
+                crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, ty)
+            {
+                call_signatures.extend(shape.call_signatures.iter().cloned());
+            } else {
+                return None;
+            }
+        }
+        if call_signatures.len() < 2 {
+            return None;
+        }
+        Some(self.ctx.types.factory().callable(CallableShape {
+            call_signatures,
+            construct_signatures: Vec::new(),
+            properties: Vec::new(),
+            string_index: None,
+            number_index: None,
+            symbol: None,
+            is_abstract: false,
+        }))
+    }
+
+    /// For interface heritage (TS2430), the strict no-erase-generics relation
+    /// can reject alpha-equivalent generic method signatures whose method-local
+    /// type parameters are represented with different `TypeId`s on each side —
+    /// e.g. a base member resolved from a lowered interface type (cross-file
+    /// `get_type_of_symbol`, which yields a `Callable` shape) vs a derived member
+    /// computed directly from its AST (a `Function` shape). When both members are
+    /// callables and at least one carries method-local type parameters, and the
+    /// derived signature is assignable to the base signature under fresh
+    /// method-local generic instantiation (the standard relation), the override
+    /// is a valid specialization and tsc does not report TS2430 (matching
+    /// `compareSignaturesRelated`). This is keyed on the structural shape of the
+    /// signatures, not on any identifier name, so renaming the method-local type
+    /// parameter does not change the decision. Non-generic members are excluded
+    /// so the strict relation continues to govern ordinary property/method
+    /// overrides.
+    pub(super) fn generic_method_override_is_valid_specialization(
+        &mut self,
+        derived: TypeId,
+        base: TypeId,
+    ) -> bool {
+        let Some(derived_generic) = callable_generic_flag(self.ctx.types, derived) else {
+            return false;
+        };
+        let Some(base_generic) = callable_generic_flag(self.ctx.types, base) else {
+            return false;
+        };
+        if !derived_generic && !base_generic {
+            return false;
+        }
+        self.diagnostic_relation_boolean_guard(derived, base)
     }
 
     pub(super) fn type_base_def_id(&self, type_id: TypeId) -> Option<tsz_solver::def::DefId> {

--- a/crates/tsz-checker/src/classes/interface_heritage_index_compat.rs
+++ b/crates/tsz-checker/src/classes/interface_heritage_index_compat.rs
@@ -7,33 +7,7 @@ use tsz_parser::parser::node::NodeArena;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
-use tsz_solver::construction::TypeDatabase;
-
-/// Classify a member type as callable and report whether any of its call
-/// signatures carry method-local type parameters.
-///
-/// Returns `None` when the type is not callable (so callers fall back to the
-/// strict relation). Handles both the bare `Function` representation (a derived
-/// member computed from its AST) and the `Callable` representation (a base
-/// member resolved from a lowered interface type), which the raw
-/// `get_call_signatures` query does not unify.
-fn callable_generic_flag(db: &dyn TypeDatabase, type_id: TypeId) -> Option<bool> {
-    if let Some(shape) = crate::query_boundaries::common::function_shape_for_type(db, type_id) {
-        return Some(!shape.type_params.is_empty());
-    }
-    if let Some(shape) = crate::query_boundaries::common::callable_shape_for_type(db, type_id) {
-        if shape.call_signatures.is_empty() {
-            return None;
-        }
-        return Some(
-            shape
-                .call_signatures
-                .iter()
-                .any(|sig| !sig.type_params.is_empty()),
-        );
-    }
-    None
-}
+use tsz_solver::TypeParamInfo;
 
 impl<'a> CheckerState<'a> {
     pub(super) fn is_direct_this_type(&self, type_id: TypeId) -> bool {
@@ -78,45 +52,75 @@ impl<'a> CheckerState<'a> {
         self.type_base_def_id(source_return) == Some(current_iface_def_id)
     }
 
-    /// Combine several single-signature method types (one per overload) into a
-    /// single `Callable` carrying all of their call signatures. Returns `None`
-    /// unless at least two signatures were gathered, so callers only use the
-    /// combined form for genuinely overloaded members.
-    pub(super) fn build_overload_callable(&self, fn_types: &[TypeId]) -> Option<TypeId> {
-        use tsz_solver::types::{CallSignature, CallableShape};
-        let mut call_signatures: Vec<CallSignature> = Vec::new();
-        for &ty in fn_types {
-            if let Some(shape) =
-                crate::query_boundaries::common::function_shape_for_type(self.ctx.types, ty)
+    /// Build a combined callable per overloaded derived method name so the
+    /// cross-file interface heritage path can compare an overloaded override as
+    /// a whole rather than signature-by-signature (the strict relation rejects a
+    /// single derived overload against the base's combined overload set even for
+    /// valid specializations). Names with a single signature are skipped.
+    pub(super) fn collect_overloaded_derived_method_callables(
+        &self,
+        derived_members: &[(String, TypeId, NodeIndex, u16, bool, bool)],
+        derived_method_counts: &rustc_hash::FxHashMap<String, usize>,
+    ) -> rustc_hash::FxHashMap<String, TypeId> {
+        let mut by_name: rustc_hash::FxHashMap<String, Vec<TypeId>> =
+            rustc_hash::FxHashMap::default();
+        for (name, member_type, _, kind, _, _) in derived_members {
+            if *kind == syntax_kind_ext::METHOD_SIGNATURE
+                && derived_method_counts.get(name).copied().unwrap_or(0) > 1
             {
-                call_signatures.push(CallSignature {
-                    type_params: shape.type_params.clone(),
-                    params: shape.params.clone(),
-                    this_type: shape.this_type,
-                    return_type: shape.return_type,
-                    type_predicate: shape.type_predicate,
-                    is_method: shape.is_method,
-                });
-            } else if let Some(shape) =
-                crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, ty)
-            {
-                call_signatures.extend(shape.call_signatures.iter().cloned());
-            } else {
-                return None;
+                by_name.entry(name.clone()).or_default().push(*member_type);
             }
         }
-        if call_signatures.len() < 2 {
+        let mut result: rustc_hash::FxHashMap<String, TypeId> = rustc_hash::FxHashMap::default();
+        for (name, object_types) in by_name {
+            if let Some(callable) =
+                crate::query_boundaries::class::combine_overloaded_method_callable(
+                    self.ctx.types,
+                    &object_types,
+                    &name,
+                )
+            {
+                result.insert(name, callable);
+            }
+        }
+        result
+    }
+
+    /// Resolve the base interface's type parameters and the heritage clause's
+    /// type arguments, padding with defaults/constraints to the base arity. The
+    /// cross-file interface heritage path uses these to instantiate base member
+    /// types that still reference the base's own parameters. Returns `None` when
+    /// there are no type arguments or the base is non-generic.
+    pub(super) fn base_heritage_params_and_args(
+        &mut self,
+        base_sym_id: SymbolId,
+        type_arguments: Option<&tsz_parser::parser::base::NodeList>,
+    ) -> Option<(Vec<TypeParamInfo>, Vec<TypeId>)> {
+        let args = type_arguments?;
+        let mut arg_ids: Vec<TypeId> = args
+            .nodes
+            .iter()
+            .map(|&arg_idx| self.get_type_from_type_node(arg_idx))
+            .collect();
+        if arg_ids.is_empty() {
             return None;
         }
-        Some(self.ctx.types.factory().callable(CallableShape {
-            call_signatures,
-            construct_signatures: Vec::new(),
-            properties: Vec::new(),
-            string_index: None,
-            number_index: None,
-            symbol: None,
-            is_abstract: false,
-        }))
+        let base_params = self.get_type_params_for_symbol(base_sym_id);
+        if base_params.is_empty() {
+            return None;
+        }
+        if arg_ids.len() < base_params.len() {
+            for param in base_params.iter().skip(arg_ids.len()) {
+                arg_ids.push(
+                    param
+                        .default
+                        .or(param.constraint)
+                        .unwrap_or(TypeId::UNKNOWN),
+                );
+            }
+        }
+        arg_ids.truncate(base_params.len());
+        Some((base_params, arg_ids))
     }
 
     /// For interface heritage (TS2430), the strict no-erase-generics relation
@@ -139,10 +143,14 @@ impl<'a> CheckerState<'a> {
         derived: TypeId,
         base: TypeId,
     ) -> bool {
-        let Some(derived_generic) = callable_generic_flag(self.ctx.types, derived) else {
+        let Some(derived_generic) =
+            crate::query_boundaries::class::callable_signature_is_generic(self.ctx.types, derived)
+        else {
             return false;
         };
-        let Some(base_generic) = callable_generic_flag(self.ctx.types, base) else {
+        let Some(base_generic) =
+            crate::query_boundaries::class::callable_signature_is_generic(self.ctx.types, base)
+        else {
             return false;
         };
         if !derived_generic && !base_generic {

--- a/crates/tsz-checker/src/query_boundaries/class.rs
+++ b/crates/tsz-checker/src/query_boundaries/class.rs
@@ -706,3 +706,96 @@ pub(crate) fn is_valid_base_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool
 pub(crate) fn is_valid_interface_base_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     tsz_solver::type_queries::data::is_valid_interface_base_type(db, type_id)
 }
+
+/// True if `type_id` is callable (function or callable shape) and any of its
+/// call signatures carries method-local type parameters. `None` when not
+/// callable, so callers fall back to the strict relation.
+pub(crate) fn callable_signature_is_generic(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<bool> {
+    if let Some(shape) = crate::query_boundaries::common::function_shape_for_type(db, type_id) {
+        return Some(!shape.type_params.is_empty());
+    }
+    if let Some(shape) = crate::query_boundaries::common::callable_shape_for_type(db, type_id) {
+        if shape.call_signatures.is_empty() {
+            return None;
+        }
+        return Some(
+            shape
+                .call_signatures
+                .iter()
+                .any(|sig| !sig.type_params.is_empty()),
+        );
+    }
+    None
+}
+
+/// Combine several object-wrapped single-signature method members (one per
+/// overload of `name`) into one `Callable` carrying all of their call
+/// signatures. Returns `None` unless at least two signatures were gathered, so
+/// callers only use the combined form for genuinely overloaded members.
+pub(crate) fn combine_overloaded_method_callable(
+    db: &dyn QueryDatabase,
+    member_object_types: &[TypeId],
+    name: &str,
+) -> Option<TypeId> {
+    use tsz_solver::types::{CallSignature, CallableShape};
+    let tdb = db.as_type_database();
+    let mut call_signatures: Vec<CallSignature> = Vec::new();
+    for &object_ty in member_object_types {
+        let fn_ty = crate::query_boundaries::common::find_property_by_str(tdb, object_ty, name)
+            .map(|p| p.type_id)
+            .unwrap_or(object_ty);
+        if let Some(shape) = crate::query_boundaries::common::function_shape_for_type(tdb, fn_ty) {
+            call_signatures.push(CallSignature {
+                type_params: shape.type_params.clone(),
+                params: shape.params.clone(),
+                this_type: shape.this_type,
+                return_type: shape.return_type,
+                type_predicate: shape.type_predicate,
+                is_method: shape.is_method,
+            });
+        } else if let Some(shape) =
+            crate::query_boundaries::common::callable_shape_for_type(tdb, fn_ty)
+        {
+            call_signatures.extend(shape.call_signatures.iter().cloned());
+        } else {
+            return None;
+        }
+    }
+    if call_signatures.len() < 2 {
+        return None;
+    }
+    Some(db.factory().callable(CallableShape {
+        call_signatures,
+        construct_signatures: Vec::new(),
+        properties: Vec::new(),
+        string_index: None,
+        number_index: None,
+        symbol: None,
+        is_abstract: false,
+    }))
+}
+
+/// Instantiate a base interface member type by substituting the base's type
+/// parameters with the heritage type arguments. A no-op when `base_params` is
+/// empty or the member contains none of those parameters. The cross-file
+/// interface heritage path relies on this because the lowered base member can
+/// still reference the base's own parameter (e.g. `AliasedExpression<T, A>`).
+pub(crate) fn instantiate_member_with_heritage_args(
+    db: &dyn QueryDatabase,
+    member_type: TypeId,
+    base_params: &[tsz_solver::TypeParamInfo],
+    heritage_args: &[TypeId],
+) -> TypeId {
+    if base_params.is_empty() {
+        return member_type;
+    }
+    let substitution = crate::query_boundaries::common::TypeSubstitution::from_args(
+        db.as_type_database(),
+        base_params,
+        heritage_args,
+    );
+    crate::query_boundaries::common::instantiate_type(db, member_type, &substitution)
+}

--- a/crates/tsz-checker/tests/ts2430_cross_file_generic_heritage_tests.rs
+++ b/crates/tsz-checker/tests/ts2430_cross_file_generic_heritage_tests.rs
@@ -1,0 +1,187 @@
+//! TS2430 ("interface incorrectly extends interface") cross-file generic
+//! method heritage.
+//!
+//! When a base interface lives in another file, its declarations are not
+//! resolved into the in-arena interface path, so `check_interface_extension_compatibility`
+//! falls back to comparing each derived member against the base's *resolved*
+//! type. That fallback used the strict no-erase-generics relation, which
+//! rejects alpha-equivalent generic method signatures (the base member is a
+//! `Callable` lowered from the interface type while the derived member is a
+//! fresh AST `Function`) and never substituted the base interface's type
+//! parameters with the heritage arguments. Both produced false TS2430 reports
+//! on valid generic-method overrides (observed in the Kysely row:
+//! `SelectQueryBuilder`/`RawBuilder`).
+//!
+//! The fix recognises a generic method override that is assignable under fresh
+//! method-local generic instantiation (single or overloaded), and substitutes
+//! the base interface's type parameters before comparison. These tests guard
+//! the rule across renamed type parameters, overload sets, base-parameter
+//! return types, and the negative cases that must still report.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_multi_file;
+
+fn cross_file_codes(files: &[(&str, &str)], entry: &str) -> Vec<u32> {
+    check_multi_file(files, entry, CheckerOptions::default())
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn has_2430(files: &[(&str, &str)], entry: &str) -> bool {
+    cross_file_codes(files, entry).contains(&2430)
+}
+
+/// Reported repro: a generic method whose return type does not mention the
+/// base interface's type parameter, overridden across a file boundary with a
+/// renamed method-local type parameter, must not report TS2430.
+#[test]
+fn cross_file_generic_method_renamed_type_param_no_false_ts2430() {
+    let base = r#"
+export type Fmt = 'a' | 'b';
+export interface Explainable {
+  explain<O extends Record<string, unknown> = Record<string, unknown>>(fmt?: Fmt): Promise<O[]>;
+}
+"#;
+    let derived = r#"
+import type { Explainable, Fmt } from './base.js';
+export interface Builder<DB, O> extends Explainable {
+  explain<ER extends Record<string, unknown> = Record<string, unknown>>(fmt?: Fmt): Promise<ER[]>;
+}
+"#;
+    assert!(
+        !has_2430(
+            &[("./base.ts", base), ("./derived.ts", derived)],
+            "./derived.ts"
+        ),
+        "alpha-equivalent generic method override across files must not report TS2430"
+    );
+}
+
+/// The same rule must hold regardless of the method-local type parameter name
+/// the derived side happens to choose (`K` here instead of `ER`).
+#[test]
+fn cross_file_generic_method_alt_name_no_false_ts2430() {
+    let base = r#"
+export interface Source<T> {
+  pick<P extends keyof T>(key: P): Source<T>;
+}
+"#;
+    let derived = r#"
+import type { Source } from './base.js';
+export interface View<T> extends Source<T> {
+  pick<K extends keyof T>(key: K): View<T>;
+}
+"#;
+    assert!(
+        !has_2430(
+            &[("./base.ts", base), ("./derived.ts", derived)],
+            "./derived.ts"
+        ),
+        "renamed method-local type parameter must not change the decision"
+    );
+}
+
+/// Overloaded generic method override across files: each derived overload is
+/// compared against the base's combined overload set, so the override must be
+/// evaluated as a whole, not signature-by-signature.
+#[test]
+fn cross_file_overloaded_generic_method_no_false_ts2430() {
+    let base = r#"
+export interface WhereInterface<DB, TB extends keyof DB> {
+  where<K extends keyof DB>(key: K, value: DB[K]): WhereInterface<DB, TB>;
+  where(raw: string): WhereInterface<DB, TB>;
+}
+"#;
+    let derived = r#"
+import type { WhereInterface } from './base.js';
+export interface SelectQueryBuilder<DB, TB extends keyof DB, O> extends WhereInterface<DB, TB> {
+  where<K extends keyof DB>(key: K, value: DB[K]): SelectQueryBuilder<DB, TB, O>;
+  where(raw: string): SelectQueryBuilder<DB, TB, O>;
+}
+"#;
+    assert!(
+        !has_2430(
+            &[("./base.ts", base), ("./derived.ts", derived)],
+            "./derived.ts"
+        ),
+        "overloaded generic method override across files must not report TS2430"
+    );
+}
+
+/// Base member return type mentions the base interface's own type parameter
+/// (`AliasedExpression<T, A>`). The heritage argument must be substituted into
+/// the base member before comparison; the derived override returns a subtype
+/// (`AliasedRawBuilder<O, A>`), which is a valid specialization.
+#[test]
+fn cross_file_base_param_return_type_no_false_ts2430() {
+    let base = r#"
+export interface AliasedExpression<T, A extends string> { readonly alias: A; readonly expr: T; }
+export interface AliasableExpression<T> {
+  as<A extends string>(alias: A): AliasedExpression<T, A>;
+  as<A extends string>(alias: number): AliasedExpression<T, A>;
+}
+"#;
+    let derived = r#"
+import type { AliasableExpression, AliasedExpression } from './base.js';
+export interface AliasedRawBuilder<O, A extends string> extends AliasedExpression<O, A> {
+  readonly raw: true;
+}
+export interface RawBuilder<O> extends AliasableExpression<O> {
+  as<A extends string>(alias: A): AliasedRawBuilder<O, A>;
+  as<A extends string>(alias: number): AliasedRawBuilder<O, A>;
+}
+"#;
+    assert!(
+        !has_2430(
+            &[("./base.ts", base), ("./derived.ts", derived)],
+            "./derived.ts"
+        ),
+        "base interface type parameter must be substituted before comparison"
+    );
+}
+
+/// Negative: a genuinely incompatible generic method override (the derived
+/// return type is not assignable to the base's) must still report TS2430.
+#[test]
+fn cross_file_generic_method_incompatible_return_still_ts2430() {
+    let base = r#"
+export interface Source<T> {
+  wrap<A extends string>(key: A): ReadonlyArray<T>;
+}
+"#;
+    let derived = r#"
+import type { Source } from './base.js';
+export interface View<T> extends Source<T> {
+  wrap<A extends string>(key: A): T;
+}
+"#;
+    assert!(
+        has_2430(
+            &[("./base.ts", base), ("./derived.ts", derived)],
+            "./derived.ts"
+        ),
+        "an incompatible generic method override must still report TS2430"
+    );
+}
+
+/// Negative: a non-generic property override with an incompatible type must
+/// still report TS2430 across files (the relaxation is gated on generic
+/// callables only).
+#[test]
+fn cross_file_non_generic_incompatible_still_ts2430() {
+    let base = r#"
+export interface Base { value: number; }
+"#;
+    let derived = r#"
+import type { Base } from './base.js';
+export interface Derived extends Base { value: string; }
+"#;
+    assert!(
+        has_2430(
+            &[("./base.ts", base), ("./derived.ts", derived)],
+            "./derived.ts"
+        ),
+        "an incompatible non-generic property override must still report TS2430"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Opus47-web

## Track
Conformance / false-positive reduction (checker, TS2430).

## Invariant
When a derived interface member is a generic method (single or overloaded)
whose signature is **assignable to the base member's signature under fresh
method-local generic instantiation**, `tsc` accepts the heritage; this PR makes
tsz accept it too (no TS2430) through the interface-heritage compatibility path
in the checker (`check_interface_extension_compatibility` and the
`interface_heritage_index_compat` boundary helpers).

## Scope
Fixes false `TS2430` ("interface incorrectly extends interface") for **cross-file**
generic-method overrides. When a base interface lives in another file, its
declarations are not resolved into the in-arena heritage path, so the checker
falls back to comparing each derived member against the base's resolved
(lowered) type. That fallback produced false positives because:

1. the strict no-erase-generics relation rejects alpha-equivalent generic
   method signatures — the base member is a lowered `Callable` while the
   derived member is a fresh AST `Function`; and
2. the base interface's type parameters were never substituted with the
   heritage type arguments, so a base member return type still referenced the
   base's own parameter (e.g. `AliasedExpression<T, A>` instead of
   `AliasedExpression<O, A>` for `RawBuilder<O> extends AliasableExpression<O>`).

The fix:
- substitutes the base interface's type parameters into base member types
  (via `get_type_params_for_symbol`), mirroring the in-arena path;
- for generic callables, retries the override under the standard relation
  (`generic_method_override_is_valid_specialization`), combining overload
  signatures so an overloaded override is compared **as a whole** rather than
  signature-by-signature.

It is keyed on signature **shape**, not identifier names or file names, and the
strict relation continues to govern non-generic overrides.

### Adjacent-case test matrix (`ts2430_cross_file_generic_heritage_tests.rs`)
1. Reported shape: cross-file generic method, renamed method-local type param
   (`explain<ER>` over `explain<O>`) → no TS2430.
2. Different bound-variable name (`pick<K>` over `pick<P>`) → no TS2430.
3. Overloaded generic method (`where<...>` + raw overload) → no TS2430.
4. Base-parameter return type (`as<A>(): AliasedRawBuilder<O,A>` over
   `AliasedExpression<T,A>`), exercising the substitution → no TS2430.
5. Negative: incompatible generic return → still TS2430.
6. Negative: incompatible non-generic property → still TS2430.

## Project Corpus Impact
- Row: kysely-project (#10663)
- Bug family: false TS2430 generic interface heritage (`SelectQueryBuilder`,
  `RawBuilder`)
- Evidence: fresh dist-fast `tsz` on `.target-bench/external/kysely` (guard
  config) goes from **5 → 0** TS2430 errors (total project errors 281 → 274;
  the removed TS2430s also un-cascaded a couple of downstream errors). tsc is
  clean under that config, so each removed diagnostic was a tsz false positive.

## Verification
- `cargo build --profile dist-fast -p tsz-cli` then `tsz --noEmit -p` on the
  kysely guard config: TS2430 count 0 (was 5).
- New unit tests: `cargo test -p tsz-checker --test
  ts2430_cross_file_generic_heritage_tests` → 6 passed.
- Existing `cargo test -p tsz-checker --test ts2430_tests` → 40 passed
  (no regressions; negatives still report).
- `cargo clippy -p tsz-checker --all-targets --all-features -- -D warnings`
  clean.
- Minimal single-file repros and cross-file repros confirmed clean; non-generic
  and genuinely-incompatible overrides still report TS2430.
- Heavy suites (conformance/emit/fourslash/WASM) left to ready-for-review CI.

## Coordination Notes
- Closes #10671. Issue was labelled `agent:Studio-A` with no active PR; picked
  it up and added a signed claim comment. Left the canonical lane label intact.
- Root cause shares the cross-file-heritage origin noted in #10663 / #10661.
  This PR addresses the generic-method-override slice; remaining kysely rows
  (other diagnostic families) are out of scope here.

https://claude.ai/code/session_01VNboDYdiEsF94tcL4oSqvM

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNboDYdiEsF94tcL4oSqvM)_