### PR TITLE
fix(checker): optional private field write type includes | undefined (#10749) [DUPLICATE of #10751]

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1762,5 +1762,9 @@ path = "tests/optional_chain_continuation_undefined_tests.rs"
 name = "structural_dispatch_void_tests"
 path = "tests/structural_dispatch_void_tests.rs"
 
+[[test]]
+name = "optional_private_field_write_tests"
+path = "tests/optional_private_field_write_tests.rs"
+
 [lints]
 workspace = true

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs
@@ -264,18 +264,29 @@ impl<'a> CheckerState<'a> {
             };
             if let Some(type_id) = declared_type {
                 let evaluated = self.evaluate_type_for_assignability(type_id);
-                if evaluated != type_id
+                let base = if evaluated != type_id
                     && crate::query_boundaries::common::object_shape_for_type(
                         self.ctx.types,
                         evaluated,
                     )
                     .is_some_and(|shape| {
                         shape.string_index.is_some() || shape.number_index.is_some()
-                    })
+                    }) {
+                    evaluated
+                } else {
+                    type_id
+                };
+                // Optional private fields (`#x?: T`) in a write context accept
+                // `undefined` unless exactOptionalPropertyTypes is set, matching
+                // the solver's optional_property_write_type behavior for public fields.
+                if is_write_context
+                    && prop.question_token
+                    && self.ctx.strict_null_checks()
+                    && !self.ctx.exact_optional_property_types()
                 {
-                    return Some(evaluated);
+                    return Some(self.ctx.types.factory().union2(base, TypeId::UNDEFINED));
                 }
-                return Some(type_id);
+                return Some(base);
             }
         }
 

--- a/crates/tsz-checker/tests/optional_private_field_write_tests.rs
+++ b/crates/tsz-checker/tests/optional_private_field_write_tests.rs
@@ -1,0 +1,151 @@
+//! Tests for optional private field write-context type (#10749).
+//!
+//! When `#x?: T`, assigning `undefined` must be accepted under strictNullChecks
+//! (matching public optional field behavior), and rejected under
+//! exactOptionalPropertyTypes.
+
+use tsz_binder::BinderState;
+use tsz_checker::{context::CheckerOptions, state::CheckerState};
+use tsz_common::common::ScriptTarget;
+use tsz_parser::parser::ParserState;
+use tsz_solver::construction::TypeInterner;
+
+fn check(source: &str, opts: CheckerOptions) -> Vec<u32> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        opts,
+    );
+    checker.check_source_file(root);
+    checker.ctx.diagnostics.iter().map(|d| d.code).collect()
+}
+
+fn strict_opts() -> CheckerOptions {
+    CheckerOptions {
+        target: ScriptTarget::ES2022,
+        strict: true,
+        ..Default::default()
+    }
+}
+
+fn exact_optional_opts() -> CheckerOptions {
+    CheckerOptions {
+        target: ScriptTarget::ES2022,
+        strict: true,
+        exact_optional_property_types: true,
+        ..Default::default()
+    }
+}
+
+// Structural rule: When a private field is optional (`#x?: T`), under
+// strictNullChecks and not exactOptionalPropertyTypes, its write type is
+// `T | undefined`, so assigning undefined must not produce TS2322.
+#[test]
+fn optional_private_field_accepts_undefined_write() {
+    let codes = check(
+        r#"
+class Mutex {
+    #promise?: Promise<void>;
+    #resolve?: () => void;
+    unlock(): void {
+        this.#promise = undefined;
+        this.#resolve = undefined;
+    }
+}
+"#,
+        strict_opts(),
+    );
+    assert!(
+        !codes.contains(&2322),
+        "should not produce TS2322 for optional private field write; got codes: {codes:?}"
+    );
+}
+
+// Name-independence: different type-parameter name (V) produces the same result.
+#[test]
+fn optional_private_field_undefined_write_name_independent() {
+    let codes = check(
+        r#"
+class Container<V> {
+    #value?: V;
+    clear(): void {
+        this.#value = undefined;
+    }
+}
+"#,
+        strict_opts(),
+    );
+    assert!(
+        !codes.contains(&2322),
+        "optional private field write should accept undefined regardless of type-param name; got: {codes:?}"
+    );
+}
+
+// Non-optional private field must still reject undefined.
+#[test]
+fn non_optional_private_field_rejects_undefined_write() {
+    let codes = check(
+        r#"
+class C {
+    #x: number;
+    constructor() { this.#x = 0; }
+    clear(): void {
+        this.#x = undefined;
+    }
+}
+"#,
+        strict_opts(),
+    );
+    assert!(
+        codes.contains(&2322),
+        "non-optional private field write must still reject undefined; got: {codes:?}"
+    );
+}
+
+// Under exactOptionalPropertyTypes, assigning undefined to an optional private
+// field must be rejected (matching public field behavior).
+#[test]
+fn optional_private_field_rejects_undefined_with_exact_optional() {
+    let codes = check(
+        r#"
+class D {
+    #data?: string;
+    reset(): void {
+        this.#data = undefined;
+    }
+}
+"#,
+        exact_optional_opts(),
+    );
+    assert!(
+        codes.contains(&2322),
+        "optional private field write should be rejected under exactOptionalPropertyTypes; got: {codes:?}"
+    );
+}
+
+// Public optional field (already working): parity check.
+#[test]
+fn optional_public_field_parity_accepts_undefined() {
+    let codes = check(
+        r#"
+class E {
+    pub?: string;
+    reset(): void {
+        this.pub = undefined;
+    }
+}
+"#,
+        strict_opts(),
+    );
+    assert!(
+        !codes.contains(&2322),
+        "optional public field write should accept undefined (parity baseline); got: {codes:?}"
+    );
+}


### PR DESCRIPTION
## Summary

**AgentName**: claude-sonnet-4-6

**Track**: Checker / Diagnostics (TS2322 correctness)

**Invariant**: When `#x?: T` is declared in a class, assigning `undefined` to that field in a write context must NOT produce TS2322 under `strictNullChecks` (matching the public optional field behavior). Under `exactOptionalPropertyTypes`, TS2322 must be produced (mirroring public field behavior).

**Structural rule**: When a private class field declaration has a `question_token` (is optional), and the access is in a write context, and `strictNullChecks` is enabled, and `exactOptionalPropertyTypes` is NOT set, the declared access type must include `| undefined`. This matches what the solver's `optional_property_write_type` already does for public optional properties.

## Scope

**Root cause**: `private_property_declared_access_type` in `crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs` returned the declared type as-is for write contexts, never widening to `T | undefined` for optional private fields. Public optional fields correctly get `| undefined` in write contexts via the solver's `optional_property_write_type` (in `crates/tsz-solver/src/operations/property_helpers.rs`). Private fields bypassed that code path and hit the checker's own `private_property_declared_access_type` instead.

**Fix**: After computing `base` type in the write-context branch, check `prop.question_token && strict_null_checks && !exact_optional_property_types`. If true, return `union2(base, TypeId::UNDEFINED)`. This mirrors exactly what the solver does for public fields.

**Adjacent cases covered by the same rule**:
1. `#promise?: Promise<void>` + `#resolve?: () => void` (function type) — both accept `undefined`
2. `#value?: V` (generic type param `V`) — name-independence
3. `#x: number` (non-optional) — still rejects `undefined`
4. `#data?: string` under `exactOptionalPropertyTypes` — still rejects `undefined`
5. `pub?: string` public optional — parity baseline unchanged

## Files Changed

- `crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs`: Added `| undefined` widening for optional private fields in write context.
- `crates/tsz-checker/tests/optional_private_field_write_tests.rs`: 5 unit tests covering the fix's behavior.
- `crates/tsz-checker/Cargo.toml`: Registered the new test target.

## Project Corpus Impact

Row: n/a (no project corpus row is directly affected by this isolated checker fix)
Bug family: TS2322 false positive for optional private field writes
Evidence: 5 unit tests pass locally (`cargo test -p tsz-checker --test optional_private_field_write_tests`); no conformance regressions expected since this only widens the write type for optional private fields, matching `tsc` behavior.

## Verification

```
running 5 tests
test optional_private_field_rejects_undefined_with_exact_optional ... ok
test non_optional_private_field_rejects_undefined_write ... ok
test optional_private_field_undefined_write_name_independent ... ok
test optional_private_field_accepts_undefined_write ... ok
test optional_public_field_parity_accepts_undefined ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```

## Coordination Notes

- **Complements PR #10741**: PR #10741 fixes optional private field _reads_; this PR fixes the _write_ context. The function `private_property_declared_access_type` branches on `is_write_context`, so the two fixes are non-overlapping.
- No changes to solver, binder, emitter, or LSP. Pure checker fix.
- Does not touch conformance baselines or snapshot files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AD2CUWjPEjQk3LxUrbVRUS)_