### PR TITLE
fix(solver): resolve recursive-call-return placeholders to call return type

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -371,6 +371,10 @@ name = "recursive_typeof_param_display_tests"
 path = "tests/recursive_typeof_param_display_tests.rs"
 
 [[test]]
+name = "recursive_value_call_return_tests"
+path = "tests/recursive_value_call_return_tests.rs"
+
+[[test]]
 name = "interface_call_signature_typeof_param_tests"
 path = "tests/interface_call_signature_typeof_param_tests.rs"
 

--- a/crates/tsz-checker/tests/recursive_value_call_return_tests.rs
+++ b/crates/tsz-checker/tests/recursive_value_call_return_tests.rs
@@ -1,0 +1,173 @@
+//! Property access on the result of a self-referential generic call.
+//!
+//! A generic value function whose body returns an object that recursively
+//! calls the same function (`const f = <T>(p: T) => ({ deeper: <U>(c: U) =>
+//! f<T & U>(...) })`) has its inner call typed, during return-type inference,
+//! as a deferred placeholder `Application(Lazy(f), [T & U])` — `f` being the
+//! value symbol, the recursion target. When such a call result is later used
+//! (property access, assignment), the placeholder must resolve to the call
+//! signature's RETURN type instantiated with the type arguments — the object
+//! the call returns — not to the instantiated function value. `tsc` resolves
+//! the recursive object lazily (bottoming out to `any` only at its display
+//! depth limit), so member access at any finite depth succeeds.
+//!
+//! Before the fix the placeholder evaluated to the instantiated function, so
+//! `f(...).deeper(...).result` reported a spurious TS2339. These tests pin the
+//! parity and cover renamed type parameters, the function-declaration form,
+//! deeper nesting, the non-recursive control, and the negative case where a
+//! genuinely-absent property must still report TS2339.
+
+use tsz_checker::context::CheckerOptions;
+
+fn diagnostics_for(source: &str) -> Vec<tsz_checker::diagnostics::Diagnostic> {
+    tsz_checker::test_utils::check_source(source, "test.ts", CheckerOptions::default())
+}
+
+fn ts2339_messages(source: &str) -> Vec<String> {
+    diagnostics_for(source)
+        .into_iter()
+        .filter(|d| d.code == 2339)
+        .map(|d| d.message_text)
+        .collect()
+}
+
+#[test]
+fn recursive_generic_call_return_resolves_to_object() {
+    let ts2339 = ts2339_messages(
+        r#"
+const f = <T extends object>(parent: T) => {
+    return {
+        result: parent,
+        deeper: <U extends object>(child: U) => f<T & U>({ ...parent, ...child })
+    };
+};
+let p1 = f({ one: '1' });
+let p2 = p1.deeper({ two: '2' });
+const a = p2.result;
+const b = p2.deeper;
+"#,
+    );
+    assert!(
+        ts2339.is_empty(),
+        "recursive generic call result should resolve to its return object, \
+         so property access must not report TS2339; got: {ts2339:?}"
+    );
+}
+
+#[test]
+fn recursive_generic_call_return_renamed_type_params() {
+    // Renaming the bound type parameters (`T`->`A`, `U`->`B`) must not change
+    // the behavior: the fix keys on structure, never on identifier spelling.
+    let ts2339 = ts2339_messages(
+        r#"
+const g = <A extends object>(parent: A) => {
+    return {
+        result: parent,
+        deeper: <B extends object>(child: B) => g<A & B>({ ...parent, ...child })
+    };
+};
+let q1 = g({ one: '1' });
+let q2 = q1.deeper({ two: '2' });
+const a = q2.result;
+const b = q2.deeper;
+"#,
+    );
+    assert!(
+        ts2339.is_empty(),
+        "renamed type parameters must behave identically; got: {ts2339:?}"
+    );
+}
+
+#[test]
+fn recursive_generic_call_return_function_declaration() {
+    // The same recursion through a `function` declaration (not a const arrow)
+    // must also resolve to the returned object.
+    let ts2339 = ts2339_messages(
+        r#"
+function rec<T extends object>(parent: T) {
+    return {
+        value: parent,
+        next: <U extends object>(child: U) => rec<T & U>({ ...parent, ...child })
+    };
+}
+let r1 = rec({ a: 1 });
+let r2 = r1.next({ b: 2 });
+const v = r2.value;
+const n = r2.next;
+"#,
+    );
+    assert!(
+        ts2339.is_empty(),
+        "function-declaration recursion should resolve to its return object; got: {ts2339:?}"
+    );
+}
+
+#[test]
+fn recursive_generic_call_return_deeper_nesting() {
+    // Accessing members two levels into the recursion must still succeed.
+    let ts2339 = ts2339_messages(
+        r#"
+const f = <T extends object>(parent: T) => {
+    return {
+        result: parent,
+        deeper: <U extends object>(child: U) => f<T & U>({ ...parent, ...child })
+    };
+};
+let p1 = f({ one: '1' });
+let p2 = p1.deeper({ two: '2' });
+let p3 = p2.deeper({ three: '3' });
+const a = p3.result;
+const b = p3.deeper;
+"#,
+    );
+    assert!(
+        ts2339.is_empty(),
+        "deeper recursion levels must still resolve to objects; got: {ts2339:?}"
+    );
+}
+
+#[test]
+fn non_recursive_generic_call_unaffected() {
+    // A non-recursive generic value function never produces the placeholder;
+    // its call result is the ordinary object and stays accessible.
+    let ts2339 = ts2339_messages(
+        r#"
+const id = <T>(x: T) => ({ wrapped: x });
+let a = id<number>(5);
+const w = a.wrapped;
+"#,
+    );
+    assert!(
+        ts2339.is_empty(),
+        "non-recursive generic calls must be unaffected; got: {ts2339:?}"
+    );
+}
+
+#[test]
+fn recursive_generic_call_return_missing_property_still_errors() {
+    // The resolved return object exposes exactly `result` and `deeper`; a
+    // genuinely-absent property must still report TS2339 (the fix resolves the
+    // placeholder, it does not blanket-suppress property errors).
+    let ts2339 = ts2339_messages(
+        r#"
+const h = <T extends object>(parent: T) => {
+    return {
+        result: parent,
+        deeper: <U extends object>(child: U) => h<T & U>({ ...parent, ...child })
+    };
+};
+let n1 = h({ one: '1' });
+let n2 = n1.deeper({ two: '2' });
+const bad = n2.nonexistent;
+"#,
+    );
+    assert_eq!(
+        ts2339.len(),
+        1,
+        "a genuinely-missing property on the resolved object must still report TS2339; got: {ts2339:?}"
+    );
+    assert!(
+        ts2339[0].contains("nonexistent"),
+        "the TS2339 should name the missing property; got: {ts2339:?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -859,6 +859,25 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         args: &[TypeId],
         ctx: &ApplicationEvalContext,
     ) -> ApplicationEvalOutcome {
+        // Recursive-call-return placeholder: an `Application(Lazy(value_def),
+        // type_args)` whose `value_def` is a value-space symbol (a function or
+        // `const`/`let`/`var` initialized to a function) with a callable type
+        // denotes the RETURN type of a self-referential generic call
+        // `f<type_args>(...)` whose return type was still being inferred when
+        // the placeholder was built (see the checker's circular-call path).
+        // It must evaluate to the matching call signature's return type
+        // instantiated with `type_args`, not to the instantiated function
+        // value, so property access, assignability, and display observe the
+        // object the call returns. Instantiation expressions (`f<T>` /
+        // `typeof f<T>`) never reach here as a `Lazy`-based application — they
+        // are instantiated eagerly and `typeof f<T>` carries a `TypeQuery`
+        // base — so this shape is unambiguous.
+        if !ctx.base_is_type_query
+            && let Some(resolved) = ctx.resolved
+            && let Some(call_return) = self.value_call_return_application(def_id, resolved, args)
+        {
+            return ApplicationEvalOutcome::Computed(call_return);
+        }
         if let Some(type_params) = ctx.type_params.as_ref() {
             let Some(resolved) = ctx.resolved else {
                 return ApplicationEvalOutcome::Computed(original_type_id);
@@ -1312,6 +1331,72 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         match shape.construct_signatures.first() {
             Some(construct_sig) => construct_sig.return_type,
             None => resolved,
+        }
+    }
+
+    /// Resolve a recursive-call-return placeholder `Application(Lazy(value_def),
+    /// type_args)` to the call signature's return type, instantiated with
+    /// `type_args`.
+    ///
+    /// Returns `Some` only when `def_id` is a value-space symbol
+    /// (`DefKind::Variable`/`DefKind::Function`) and `resolved` is a callable
+    /// with a generic call signature whose arity matches `type_args`. The
+    /// returned type is instantiated one level and left otherwise un-evaluated:
+    /// nested self-referential returns stay deferred (they carry the inner
+    /// signature's free type parameter) and expand lazily on demand, matching
+    /// `tsc`'s recursive object type — never eagerly expanding into an
+    /// excessively deep instantiation.
+    ///
+    /// `None` keeps the normal generic-instantiation path, so type aliases,
+    /// classes, interfaces, and non-generic value functions are unaffected.
+    fn value_call_return_application(
+        &self,
+        def_id: DefId,
+        resolved: TypeId,
+        type_args: &[TypeId],
+    ) -> Option<TypeId> {
+        if type_args.is_empty() {
+            return None;
+        }
+        if !matches!(
+            self.resolver.get_def_kind(def_id),
+            Some(crate::def::DefKind::Variable | crate::def::DefKind::Function)
+        ) {
+            return None;
+        }
+        // The resolved value type is either a single-signature `Function` or a
+        // multi-signature `Callable`; in both cases pick the generic call
+        // signature whose type-parameter arity matches the supplied
+        // `type_args` and instantiate its return type.
+        match self.interner.lookup(resolved)? {
+            TypeData::Function(fs_id) => {
+                let shape = self.interner.function_shape(fs_id);
+                if shape.is_constructor
+                    || shape.type_params.is_empty()
+                    || shape.type_params.len() != type_args.len()
+                {
+                    return None;
+                }
+                Some(instantiate_generic(
+                    self.interner,
+                    shape.return_type,
+                    &shape.type_params,
+                    type_args,
+                ))
+            }
+            TypeData::Callable(cs_id) => {
+                let shape = self.interner.callable_shape(cs_id);
+                let signature = shape.call_signatures.iter().find(|sig| {
+                    !sig.type_params.is_empty() && sig.type_params.len() == type_args.len()
+                })?;
+                Some(instantiate_generic(
+                    self.interner,
+                    signature.return_type,
+                    &signature.type_params,
+                    type_args,
+                ))
+            }
+            _ => None,
         }
     }
 

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -2,7 +2,6 @@
 # Add a test path here (one per line) to allow it to fail in CI without
 # blocking the aggregate gate. Remove the entry once the regression is fixed.
 # Format: TypeScript/tests/cases/<subpath>.ts (one path per line, comments with #)
-TypeScript/tests/cases/compiler/declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts


### PR DESCRIPTION
## Agent

AgentName: `opus47-confident-thompson` (remote / Claude Code session)

Closes #10655.

## Track

Conformance — accepted-regression burn-down. Removes
`declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts` from the
accepted-regression list via a structural solver fix (not a list edit).

## Invariant / Structural rule

> When an `Application(Lazy(value_def), type_args)` has `value_def` a value-space
> symbol (`DefKind::Variable`/`DefKind::Function`) whose resolved type is a
> callable, the application is the **recursive-call-return placeholder** built
> for a self-referential generic call `f<type_args>(...)` whose return type was
> still being inferred. tsc resolves such a call to the call signature's
> **return type** (the object the call returns), expanding the recursion lazily
> and bottoming out only at its display-depth limit. tsz must do the same —
> never resolve it to the instantiated function value.

Before this change the placeholder evaluated to the instantiated *function*, so
`f(...).deeper(...).result` reported a spurious **TS2339** ("Property 'result'
does not exist on type 'f<…>'"). tsc reports no error.

## Scope

- `crates/tsz-solver/src/evaluation/evaluate.rs`: short-circuit in
  `evaluate_application_body` plus a `value_call_return_application` helper
  (parallel to the existing `extract_class_instance_body`). Excludes
  `typeof f<T>` instantiation expressions (`TypeQuery` base) and all non-value
  defs, so type aliases, classes, interfaces, and non-generic value functions
  are unaffected. The returned type is instantiated one level and left
  un-evaluated, so nested self-referential returns stay deferred and expand
  lazily — matching the declaration emitter's existing depth-limited expansion
  (`print_recursive_function_application`, capped at 10 then `/*elided*/ any`).
- `scripts/conformance/conformance-accepted-regressions.txt`: drop the now-passing
  witness.
- `crates/tsz-checker/tests/recursive_value_call_return_tests.rs` (+ Cargo.toml):
  owning-crate coverage.

The logic lives in the solver because that is the single place that resolves
applications, so property access, assignability, and display all observe the
returned object — rather than special-casing the checker.

## Adjacent-case test matrix (§26)

- Reported witness shape (const arrow, object spread recursion).
- **Renamed** bound type params (`T`/`U` → `A`/`B`) — proves the rule is
  structural, not name-keyed.
- **Function-declaration** form (not just `const` arrow).
- **Deeper nesting** (two levels into the recursion).
- **Non-recursive** generic call — control, must stay unaffected.
- **Negative**: a genuinely-absent property on the resolved object must still
  report TS2339 (the fix resolves the placeholder; it does not blanket-suppress).

## Project Corpus Impact

- Row: n/a (conformance accepted-regression removal; not a project-corpus row).
- Bug family: false-positive TS2339 on the result of a self-referential generic
  call (recursive return-type inference).
- Evidence: witness `declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts`
  now emits 0 diagnostics under `--target es2015 --lib es6` (tsc baseline: 0
  errors). Declaration emit for the same source is byte-identical to before
  (depth-limited expansion to `/*elided*/ any` preserved).

## Verification

- New unit tests: 6/6 pass (`recursive_value_call_return_tests`).
- Witness + minimized repros: TS2339 gone (exit 0); renamed/fndecl/deeper/non-rec
  all clean; negative case still reports TS2339.
- `cargo test -p tsz-solver --lib`: no new failures (21 pre-existing failures in
  `conditional_comprehensive_tests` `Equal<any, …>` are unrelated, present on the
  base branch, and tracked by the in-flight #10716).
- `cargo clippy -p tsz-solver`: clean.
- Declaration emit unchanged.

## Coordination Notes

- Picked at random from non-WIP bugs; issue marked WIP while in progress.
- Independent finding (not a blocker): the checker unit test
  `assignment_checker_typebox_tests::renamed_static_schema_array_return_diagnostics_use_structural_display`
  is extremely slow / non-terminating under the local `dev-fast` (opt-level 2)
  profile. Verified it hangs **identically on the base branch without this
  change** (this PR's helper never fires for it — 0 invocations), so it is a
  pre-existing issue, not a regression from this PR. Flagging for separate
  follow-up.

AgentName: `opus47-confident-thompson`


---
_Generated by [Claude Code](https://claude.ai/code/session_01BToPyScfpkf7YtTNEwspky)_