### PR TITLE
fix(solver): keep generic alias applications opaque while body is self-lazy

### DIFF
--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
@@ -532,6 +532,87 @@ interface Window {
         resolved
     }
 
+    /// A cross-file alias whose body nests a homomorphic utility type over an
+    /// imported type (`Omit<Partial<X>, "k">`) must resolve to the real object
+    /// shape, even when the consumer reaches the alias first through a property
+    /// access (so the alias is first evaluated in a nested context).
+    ///
+    /// Regression for #10682 (kysely): while computing `keyof T` for the
+    /// enclosing `Omit`, `Partial`'s structural body has not been registered
+    /// yet, so the resolver hands back `Partial`'s own self-lazy wrapper.
+    /// Substituting the argument into that wrapper dropped it, collapsing
+    /// `Partial<X>` to bare `Partial` and the whole alias to `{}`; a fresh
+    /// object literal with a valid optional subset then failed with a false
+    /// `TS2345`, and the cached degenerate result poisoned later uses. The fix
+    /// keeps the application opaque until the body is ready.
+    ///
+    /// The helper runs two unrelated name/key choices so a fix keyed to a
+    /// single spelling (the interface name, property names, or the omitted
+    /// key) would not satisfy it.
+    #[test]
+    fn cross_file_omit_partial_alias_param_resolves_via_property_access() {
+        // `iface` gains a required `omit_key: string` plus optional number
+        // members `props`; the alias drops `omit_key` via `Omit<Partial<_>, _>`.
+        fn run(case: &str, iface: &str, omit_key: &str, props: &[&str], good: &str) {
+            let lib_files = tsz::checker::test_utils::load_lib_files(&["es5.d.ts"]);
+            assert!(
+                !lib_files.is_empty(),
+                "[{case}] es5.d.ts must be available for this regression"
+            );
+            let members = props
+                .iter()
+                .map(|p| format!("  readonly {p}?: number;\n"))
+                .collect::<String>();
+            let wrong_prop = props[0];
+            let defs = format!(
+                "export interface {iface} {{\n  readonly {omit_key}: string;\n{members}}}\n\
+                 export type Props = Omit<Partial<{iface}>, \"{omit_key}\">;\n\
+                 // type/value name collision, as in kysely's frozen node factories.\n\
+                 export declare const {iface}: {{ with(p: Props): {iface} }};\n"
+            );
+            // Consumer file listed first so the alias is first evaluated through
+            // the nested property-access path (the order that triggered #10682).
+            let use_src = format!(
+                "import {{ {iface} }} from \"./defs.js\";\n\
+                 export const okMulti = {iface}.with({{ {good} }});\n\
+                 export const okEmpty = {iface}.with({{}});\n\
+                 export const wrong = {iface}.with({{ {wrong_prop}: \"not-a-number\" }});\n\
+                 export const excess = {iface}.with({{ definitelyNotAKey: 1 }});\n"
+            );
+            let files = [("/p/use.ts", use_src.as_str()), ("/p/defs.ts", defs.as_str())];
+            let diagnostics = collect_test_diagnostics_with_lib_files(&files, &lib_files);
+
+            // The fix: the nested-utility alias no longer collapses to `{}`, so
+            // valid optional-subset literals (and `{}`) produce no false TS2345.
+            assert!(
+                !diagnostics.iter().any(|d| d.code == 2345),
+                "[{case}] valid optional-subset literals must be assignable to \
+                 Omit<Partial<{iface}>, \"{omit_key}\"> resolved through property \
+                 access; no TS2345 expected. Diagnostics: {diagnostics:?}"
+            );
+
+            // The alias must still resolve to a real object (not `any`/`{}`):
+            // an unknown property and a wrong-typed value are still rejected.
+            assert!(
+                diagnostics
+                    .iter()
+                    .any(|d| d.code == 2353 && d.message_text.contains("definitelyNotAKey")),
+                "[{case}] an unknown property must still be rejected (TS2353), \
+                 proving the alias resolved to a structural object. \
+                 Diagnostics: {diagnostics:?}"
+            );
+            assert!(
+                diagnostics.iter().any(|d| d.code == 2322),
+                "[{case}] a wrong-typed property must still be rejected (TS2322). \
+                 Diagnostics: {diagnostics:?}"
+            );
+        }
+
+        // Two unrelated spellings prove the fix is structural, not name-keyed.
+        run("widget", "Widget", "kind", &["w", "label"], "w: 1, label: 2");
+        run("record", "RecordNode", "tag", &["alpha", "beta"], "alpha: 2");
+    }
+
     #[test]
     fn readonly_alias_annotation_survives_consumer_first_program_check() {
         let lib_files = tsz::checker::test_utils::load_lib_files(&["es5.d.ts"]);

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -874,6 +874,33 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             if resolved == TypeId::UNKNOWN {
                 return ApplicationEvalOutcome::Computed(original_type_id);
             }
+
+            // The same situation arises when the body resolves to the alias's
+            // own self-lazy wrapper `Lazy(def_id)`: the structural body (e.g. a
+            // mapped type registered on demand in the type environment) is not
+            // available on this query, so substituting `Args` into
+            // `Lazy(def_id)` yields bare `Lazy(def_id)` — dropping the type
+            // arguments. Caching that degenerate result poisons every later
+            // use: a nested `Partial<X>` first evaluated while `Partial`'s body
+            // is still self-lazy makes the enclosing `Omit<Partial<X>, K>`
+            // collapse to `{}`, producing a false `TS2345` against a fresh
+            // object literal with a valid optional subset (see #10682). Keep
+            // the application opaque so a later pass (with the populated body)
+            // expands it correctly.
+            //
+            // Gate on the outermost (non-recursive) expansion of this def:
+            // `increment_def_depth` has already run for this entry, so depth 1
+            // is the first expansion. For a genuinely recursive alias the
+            // self-lazy wrapper is the legitimate cycle breaker at deeper
+            // entries, where bailing must not interfere.
+            if self.def_depth.get(&def_id).copied().unwrap_or(0) <= 1
+                && matches!(
+                    self.interner.lookup(resolved),
+                    Some(TypeData::Lazy(body_def_id)) if body_def_id == def_id
+                )
+            {
+                return ApplicationEvalOutcome::Computed(original_type_id);
+            }
             self.evaluate_application_with_known_params(
                 def_id,
                 original_type_id,


### PR DESCRIPTION
AgentName: opus47-web
Track: Conformance / project-corpus false-positive cleanup (kysely)
Closes: #10682

## Structural rule

> When `evaluate_application` resolves a generic type alias's body to the alias's own self-lazy wrapper `Lazy(def_id)` (the structural body is not yet registered), substituting the application arguments into that wrapper yields bare `Lazy(def_id)` and drops the arguments; `tsc` never lets a utility-type application collapse to its argless base, so this change keeps the application opaque until a later pass can expand it with the populated body.

## Invariant

A generic alias application (`Partial<X>`, `Omit<...>`, `Pick<...>`, ...) must never evaluate to its bare base `Lazy(def_id)` with the type arguments silently dropped. When the body is momentarily unavailable (resolves to the self-lazy wrapper), the application stays opaque so a later evaluation with the real body produces the correct object — exactly as the existing `resolved == UNKNOWN` guard already does for the not-yet-registered case.

## Root cause (#10682)

In the kysely corpus, `Omit<Partial<UniqueConstraintNode>, 'kind'>` (a cross-file alias accessed via a property on the frozen-factory value that shares the interface's name) produced a false `TS2345` on `cloneWith({ deferrable: true })`.

Minimized to a 2-file repro and traced: when the alias is first evaluated in a nested context (computing `keyof T` for the enclosing `Omit`), `Partial`'s structural mapped body has not been registered in the type environment yet, so `resolve_lazy(Partial)` returns `Partial`'s own self-lazy wrapper. Substituting `X` into that wrapper drops the argument, collapsing `Partial<X>` to bare `Partial`; the enclosing `Omit<Partial<X>, K>` then collapses to `{}`, and the degenerate result is cached, so a fresh object literal with a valid optional subset is rejected. The bug requires the first evaluation to happen on the nested path (consumer-first / property-access ordering); referencing the alias directly first makes the correct body win and the error disappears.

## Scope

- Solver evaluation (`crates/tsz-solver/src/evaluation/evaluate.rs`): extend the pre-existing body-not-ready bail (`resolved == UNKNOWN`) to the self-lazy-wrapper case, gated to the outermost (non-recursive) expansion of the def via `def_depth`, so a genuinely recursive alias (`Id2<T> = { [K in keyof T]: Id2<Id2<T[K]>> }`, recursive schema validators) keeps using the self-lazy wrapper as its legitimate cycle breaker.
- Adjacent-case test in `tsz-cli` check tests: `cross_file_omit_partial_alias_param_resolves_via_property_access` runs two unrelated name/key choices (`Widget`/`kind`/`w`,`label` and `RecordNode`/`tag`/`alpha`,`beta`) so a fix keyed to a spelling would fail. Each asserts: valid optional-subset literals (and `{}`) produce no false `TS2345`; an unknown property is still rejected (`TS2353`, proving the alias resolved to a structural object, not `any`/`{}`); a wrong-typed property is still rejected (`TS2322`).

## Project Corpus Impact

- Row: kysely-project (tracker #10663)
- Bug family: false TS2345 from cross-file nested utility-type composition `Omit<Partial<X>, K>` collapsing to `{}`
- Evidence: on a fresh dist-fast build, `src/schema/unique-constraint-builder.ts` goes from 5 false `TS2345` to 0; the 2-file minimized repro flips from false `TS2345` to clean while `kind` exclusion and wrong-type checks still fire. Related root causes #10661/#10686 (cross-file class instance resolution) are now merged but do not fix this interface+const / utility-composition case — verified the repro still fails on `main` (642b298) without this change.

## Verification

- `cargo build -p tsz-cli` (clean); `cargo clippy -p tsz-solver --lib` clean.
- New test passes: `cargo test -p tsz-cli --lib cross_file_omit_partial_alias_param_resolves_via_property_access`.
- `cargo test -p tsz-solver --lib`: identical results before/after this change (no new failures relative to the branch base on this checkout).
- Minimized repro + kysely `unique-constraint-builder.ts` verified clean with the fix and still failing without it on current `main`.
- Heavy suites (conformance/emit/fourslash/WASM) deferred to CI per §19.5.

## Coordination Notes

- AgentName: opus47-web. Sibling root-cause work #10661/#10686/#10641 (cross-file class instance vs constructor) merged into `main`; this PR is the distinct interface+const / nested-utility facet of the same kysely false-positive family and is rebased on top of those merges with no conflicts.
- A residual deeper facet remains out of scope: in some multi-alias / frozen-value cross-file shapes the `Omit` key exclusion is not always recomputed in time (excess-property apparent-type falls back to `Partial<X>`); that is the cross-file lazy body-registration ordering tracked by #10661 and is improved, not regressed, here.

https://claude.ai/code/session_01DSXpBAazPw7jq8RctqEiPq