### PR TITLE
test(checker): add kysely-shape regression coverage for cross-file class identity

### DIFF
--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
@@ -218,6 +218,336 @@ let badCtor: typeof Token = Token.create();
         );
     }
 
+    // Kysely-shape regression coverage for the cross-file class instance-type
+    // resolution fixed by #10686. These tests pin down adjacent shapes from
+    // issue #10672 (Readonly mapped-type members, PromiseLike conformance via
+    // a `then` method, merged interface + const value, private class fields)
+    // that share the cross-file class identity root cause but were not yet
+    // covered by the three project_mode_* tests #10686 added.
+    //
+    // Structural rule under test:
+    //   In project mode, a cross-file class reference used in a type position
+    //   (including as the argument of a mapped/utility type, as the
+    //   constraint of a PromiseLike conformance check, or as a private-field
+    //   annotation) must resolve to the class's instance type, not the
+    //   constructor (static) type.
+    //
+    // Renamed identifiers (different class names, different property names,
+    // different generic parameter names) are used across the matrix to prove
+    // the rule is structural and not name-keyed.
+
+    fn project_mode_es2015_strict_options() -> ResolvedCompilerOptions {
+        let mut options = ResolvedCompilerOptions::default();
+        options.no_emit = true;
+        options.checker.strict = true;
+        options.checker.module = ModuleKind::ES2015;
+        options.printer.module = ModuleKind::ES2015;
+        options
+    }
+
+    #[test]
+    fn project_mode_readonly_imported_class_preserves_instance_members() {
+        let lib_files = tsz::checker::test_utils::load_lib_files(&["es5.d.ts"]);
+        assert!(
+            !lib_files.is_empty(),
+            "es5.d.ts must be available to provide Readonly<T>"
+        );
+        let options = project_mode_es2015_strict_options();
+
+        let diagnostics = collect_test_diagnostics_with_lib_files_and_options(
+            &[
+                (
+                    "/p/node.ts",
+                    r#"
+export class AlterNode {
+  readonly kind: 'AlterNode' = 'AlterNode';
+  cloneWithProps(props: unknown): AlterNode {
+    return this;
+  }
+  cloneWithAlt(alt: unknown): AlterNode {
+    return this;
+  }
+}
+"#,
+                ),
+                (
+                    "/p/builder.ts",
+                    r#"
+import { AlterNode } from "./node";
+
+export class Builder {
+  // Cross-file class as the argument of Readonly<T>: the mapped instantiation
+  // must preserve the instance methods declared on AlterNode.
+  readonly node: Readonly<AlterNode>;
+
+  constructor(node: Readonly<AlterNode>) {
+    this.node = node;
+  }
+
+  // Reading members through Readonly<X> must see X's instance methods.
+  clone(): Builder {
+    const next = this.node.cloneWithProps({});
+    return new Builder(next);
+  }
+
+  // Readonly<X> assignable to X (instance) is the structural rule under test.
+  unwrap(): AlterNode {
+    return this.node;
+  }
+}
+"#,
+                ),
+            ],
+            &lib_files,
+            &options,
+        );
+
+        let blocking: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| matches!(d.code, 2322 | 2339 | 2345 | 2739))
+            .collect();
+        assert!(
+            blocking.is_empty(),
+            "Readonly<ImportedClass> must preserve instance members; cross-file class identity in mapped-type position must resolve to the instance type. Blocking diagnostics: {blocking:?}. All: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn project_mode_imported_class_with_then_method_is_promise_like() {
+        let lib_files = tsz::checker::test_utils::load_lib_files(&["es5.d.ts", "es2015.d.ts"]);
+        assert!(
+            lib_files.len() >= 2,
+            "es5.d.ts + es2015.d.ts must be available to provide PromiseLike and Promise"
+        );
+        let options = project_mode_es2015_strict_options();
+
+        let diagnostics = collect_test_diagnostics_with_lib_files_and_options(
+            &[
+                (
+                    "/p/builder.ts",
+                    r#"
+export class SchemaBuilder<O> {
+  then<TResult1 = O, TResult2 = never>(
+    onfulfilled?: ((value: O) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return Promise.resolve(undefined as unknown as O).then(onfulfilled, onrejected);
+  }
+}
+"#,
+                ),
+                (
+                    "/p/consumer.ts",
+                    r#"
+import { SchemaBuilder } from "./builder";
+
+declare function expectPromiseLike<U>(p: PromiseLike<U>): void;
+
+declare const b: SchemaBuilder<number>;
+
+// Cross-file class is used in PromiseLike<U> argument position; the relation
+// must see the class's instance `then` method to accept the conformance.
+expectPromiseLike(b);
+"#,
+                ),
+            ],
+            &lib_files,
+            &options,
+        );
+
+        let blocking: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| matches!(d.code, 2322 | 2345 | 2739))
+            .collect();
+        assert!(
+            blocking.is_empty(),
+            "Cross-file class with a structural `then` method must be recognized as PromiseLike. Blocking diagnostics: {blocking:?}. All: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn project_mode_imported_class_with_private_field_assignable_across_files() {
+        let lib_files = tsz::checker::test_utils::load_lib_files(&["es5.d.ts"]);
+        assert!(
+            !lib_files.is_empty(),
+            "es5.d.ts must be available to provide Array<T>"
+        );
+        let options = project_mode_es2015_strict_options();
+
+        let diagnostics = collect_test_diagnostics_with_lib_files_and_options(
+            &[
+                (
+                    "/p/store.ts",
+                    r#"
+export class Store<V> {
+  #items: V[] = [];
+  push(value: V): void {
+    this.#items.push(value);
+  }
+  size(): number {
+    return this.#items.length;
+  }
+}
+"#,
+                ),
+                (
+                    "/p/consumer.ts",
+                    r#"
+import { Store } from "./store";
+
+declare function consume(s: Store<number>): void;
+
+const s: Store<number> = new Store<number>();
+s.push(1);
+consume(s);
+"#,
+                ),
+            ],
+            &lib_files,
+            &options,
+        );
+
+        let blocking: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| matches!(d.code, 2322 | 2345 | 2339 | 2739))
+            .collect();
+        assert!(
+            blocking.is_empty(),
+            "Cross-file class with a private (#) field must remain assignable through type annotations. Blocking diagnostics: {blocking:?}. All: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn project_mode_cross_file_kysely_shape_negative_still_reports_genuine_mismatch() {
+        // The cross-file class instance-type fix must not silence genuine
+        // mismatches. Each kysely-shape pattern below still surfaces its
+        // ordinary diagnostic when the source/target really differ.
+        let lib_files = tsz::checker::test_utils::load_lib_files(&["es5.d.ts", "es2015.d.ts"]);
+        assert!(
+            lib_files.len() >= 2,
+            "es5.d.ts + es2015.d.ts must be available for negative coverage"
+        );
+        let options = project_mode_es2015_strict_options();
+
+        let diagnostics = collect_test_diagnostics_with_lib_files_and_options(
+            &[
+                (
+                    "/p/lib.ts",
+                    r#"
+export class NodeA {
+  readonly kind: 'A' = 'A';
+  alpha(): number {
+    return 1;
+  }
+}
+
+export class NodeB {
+  readonly kind: 'B' = 'B';
+  beta(): string {
+    return "b";
+  }
+}
+
+export class NotAwaitable {
+  describe(): string {
+    return "no then here";
+  }
+}
+"#,
+                ),
+                (
+                    "/p/use.ts",
+                    r#"
+import { NodeA, NodeB, NotAwaitable } from "./lib";
+
+// Cross-file class identity preserved on the negative direction:
+// NodeA and NodeB are distinct cross-file classes, so assigning one to
+// Readonly<the other> must still report TS2322.
+declare const a: NodeA;
+const wrong: Readonly<NodeB> = a;
+
+// Cross-file class without a `then` method is not PromiseLike: assigning it
+// to PromiseLike<unknown> must still report TS2322.
+declare const na: NotAwaitable;
+const notPL: PromiseLike<unknown> = na;
+"#,
+                ),
+            ],
+            &lib_files,
+            &options,
+        );
+
+        // tsc emits TS2741 (missing required property) for these specific
+        // missing-member assignability failures. The fix must still produce a
+        // mismatch diagnostic — accept TS2322 or TS2741, which both represent
+        // a real cross-file assignability failure preserved by the fix.
+        let mismatches = diagnostics
+            .iter()
+            .filter(|d| matches!(d.code, 2322 | 2741))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            mismatches.len(),
+            2,
+            "genuine cross-file Readonly mismatch and missing-then PromiseLike mismatch must still emit a mismatch diagnostic. Got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn project_mode_merged_interface_and_const_value_keep_distinct_shapes_across_files() {
+        let options = project_mode_es2015_strict_options();
+
+        // Kysely-shape: an interface `Op` declares the data shape;
+        // a const `Op` carries static-like helpers (`is` / `create`). Cross-file
+        // consumers must see the interface (no helpers) when `Op` is in a type
+        // position, and the const (with helpers) when it is in a value position.
+        let diagnostics = collect_test_diagnostics_with_options(
+            &[
+                (
+                    "/p/op.ts",
+                    r#"
+export interface Op {
+  readonly kind: string;
+}
+
+export const Op = {
+  is(value: unknown): value is Op {
+    return typeof value === "object" && value !== null && "kind" in value;
+  },
+  create(kind: string): Op {
+    return { kind };
+  },
+};
+"#,
+                ),
+                (
+                    "/p/use.ts",
+                    r#"
+import { Op } from "./op";
+
+// `Op` in a type position is the interface (no helpers).
+declare const item: Op;
+const k: string = item.kind;
+
+// `Op` in a value position is the const (helpers available).
+const made: Op = Op.create("X");
+const checked: boolean = Op.is(made);
+"#,
+                ),
+            ],
+            &options,
+            Path::new("/p"),
+        );
+
+        let blocking: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| matches!(d.code, 2322 | 2345 | 2339 | 2739 | 2306))
+            .collect();
+        assert!(
+            blocking.is_empty(),
+            "Merged interface + const must keep distinct cross-file shapes; type-position and value-position resolutions must not collapse. Blocking diagnostics: {blocking:?}. All: {diagnostics:?}"
+        );
+    }
+
     /// Asserts the post-PR-#7521 file-session reuse env policy: OFF unless
     /// the user opts back in via `TSZ_FILE_SESSION_REUSE=1`. Before
     /// PR #7521 the default was ON (set by PRs #6870 / #6893) which


### PR DESCRIPTION
## Summary

AgentName: opus47-vibrant-lovelace-tcji6
Track: Conformance / checker regression coverage for cross-file class identity (issue #10672).
Refs: #10672, #10661, #10634, #10686 (just-merged structural fix).

Pin down the project-mode cross-file class instance-type resolution
fixed by #10686 against the adjacent kysely-shape patterns enumerated
in issue #10672 (`Readonly<ImportedClass>`, PromiseLike via `then`,
private `#field`, merged `interface + const`). The three
`project_mode_*` tests #10686 added directly cover only the basic
Base/Derived self-reference, generic class self-reference, and
typeof-vs-instance split. The kysely-shape adjacent matrix was not
locked in.

## Invariant

> In project mode, a cross-file class reference used in a type position
> (including as the argument of a mapped/utility type, as the
> constraint of a PromiseLike conformance check, or as a private-field
> annotation) must resolve to the class's instance type, not the
> constructor/static type.

This is the structural rule behind #10672. The kysely false positives
in its body (`Readonly<X>` reported as missing instance methods;
builder not recognized as PromiseLike; class instance missing its own
`#props` / `toOperationNode` / `compile` / `execute`) all share this
root cause with #10661 and #10634, which #10686 fixed in
`crates/tsz-checker/src/state/type_environment/lazy.rs::resolve_lazy`.
CLI verification on minimal multi-file reductions of each shape:
all clean on current `main` after #10686. The kysely-context-specific
bug is not minimally reducible per #10672's body.

## Scope

`crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs` only —
five new project-mode tests after the existing `project_mode_*`
block from #10686, plus a shared `project_mode_es2015_strict_options`
helper that factors out the ES2015 / strict / no-emit options
boilerplate. No production code changes.

## Adjacent-case test matrix

| Test | Shape | Cross-file rule under test |
| --- | --- | --- |
| `project_mode_readonly_imported_class_preserves_instance_members` | `Readonly<ImportedClass>` | mapped-type argument resolves the imported class to its instance type |
| `project_mode_imported_class_with_then_method_is_promise_like` | imported `class B<O> { then(...) { ... } }` vs `PromiseLike<U>` | structural `then` member is visible across files |
| `project_mode_imported_class_with_private_field_assignable_across_files` | imported `class Store<V> { #items: V[] }` | private (`#`) field annotations do not break cross-file assignability |
| `project_mode_merged_interface_and_const_value_keep_distinct_shapes_across_files` | merged `interface Op` + `const Op` (kysely-shape) | type-position and value-position cross-file refs stay distinct |
| `project_mode_cross_file_kysely_shape_negative_still_reports_genuine_mismatch` | `Readonly<NodeB> = a /* NodeA */`, `PromiseLike<unknown> = na /* no then */` | the fix does not over-permit — TS2322 / TS2741 still emitted on real mismatches |

Identifiers (class names, generic parameter names, property keys) are
varied across the matrix so the fix is exercised structurally and not
keyed on a specific name.

## Project Corpus Impact

- Row: kysely-project (#10663 family) — regression-prevention only; no
  row delta from this PR.
- Bug family: cross-file class instance-type resolution (kysely-shape).
- Evidence: 10 project_mode tests pass (3 pre-existing from #10686 + 5
  new + 2 unrelated project_mode tests in the same module). All five
  new shapes pass CLI repros against the freshly-built `dist-fast`
  `tsz` on `main` HEAD `642b298`. Negative test confirms a genuine
  cross-file Readonly / missing-`then` mismatch still emits TS2741.

## Verification

- `cargo test -p tsz-cli --lib project_mode_` → 10 passed.
- `cargo clippy -p tsz-common -p tsz-scanner -p tsz-parser -p tsz-binder -p tsz-solver -p tsz-checker -p tsz-emitter -p tsz-lowering -p tsz-lsp --all-targets -- -D warnings` → clean (the CI-equivalent set per `scripts/ci/gcp-full-ci.sh`).
- `cargo fmt --check` → clean.
- `python3 scripts/arch/arch_guard.py` → passed.

Heavy CI (conformance, emit, fourslash, WASM, snapshot) will run on
ready-for-review per §19.5.

## Coordination Notes

- AgentName: opus47-vibrant-lovelace-tcji6.
- Claimed #10672 with a signed comment after verifying #10686 (merged
  on `main` `642b298`) cleared the minimized self-return cross-file
  repro for #10661. The kysely-context-specific bug in #10672 is not
  minimally reducible per the issue body, so this PR locks the
  structural rule down with adjacent-case regression coverage rather
  than adding a stopgap.
- `/simplify` run three times before opening this PR: pass 1
  extracted the `project_mode_es2015_strict_options` helper; pass 2
  removed an ambiguous `@ts-expect-error` probe from the merged
  interface+const test; pass 3 added the negative test so a future
  refactor that accidentally suppresses a real mismatch is caught.
- The merged interface+const test exists only because the kysely
  pattern is ergonomically common — it is not a duplicate of the
  existing typeof split test in #10686. The two tests probe different
  cross-file resolution paths.
- The `tsz-cli` test crate is intentionally excluded from CI clippy
  (see `scripts/ci/gcp-full-ci.sh`); the new tests therefore follow the
  same `let mut options = …` pattern the just-merged #10686 tests use
  for nested-field mutation.

https://claude.ai/code/session_01CSNTKFwt7gPTKjJZdgQVDc

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5nhj3PbrWAChxaaPzi2NH)_