### PR TITLE
fix(checker): resolve type-parameter constraint apparent type for TS7053

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1639,6 +1639,10 @@ name = "ts7053_intersection_record_constrained_param_tests"
 path = "tests/ts7053_intersection_record_constrained_param_tests.rs"
 
 [[test]]
+name = "ts7053_record_constraint_index_tests"
+path = "tests/ts7053_record_constraint_index_tests.rs"
+
+[[test]]
 name = "tuple_union_contextual_typing_tests"
 path = "tests/tuple_union_contextual_typing_tests.rs"
 

--- a/crates/tsz-checker/src/types/utilities/core.rs
+++ b/crates/tsz-checker/src/types/utilities/core.rs
@@ -2512,47 +2512,36 @@ impl<'a> CheckerState<'a> {
         // constraint — both for a constraint that lacks the needed index
         // signature (`T extends Item`) and for an unconstrained `T`, whose base
         // constraint `unknown` has no index signatures at all.
-        let check_type =
-            if crate::query_boundaries::common::is_type_parameter(self.ctx.types, object_type) {
-                if crate::query_boundaries::common::is_type_parameter(self.ctx.types, index_type) {
+        let is_type_param =
+            crate::query_boundaries::common::is_type_parameter(self.ctx.types, object_type);
+        let check_type = if is_type_param {
+            if crate::query_boundaries::common::is_type_parameter(self.ctx.types, index_type) {
+                return false;
+            }
+            match crate::query_boundaries::common::type_parameter_constraint(
+                self.ctx.types,
+                object_type,
+            ) {
+                // A constraint that still mentions type parameters (e.g.
+                // `Record<K, number>`) can't be resolved until instantiation.
+                Some(constraint)
+                    if crate::query_boundaries::common::contains_type_parameters(
+                        self.ctx.types,
+                        constraint,
+                    ) =>
+                {
                     return false;
                 }
-                match crate::query_boundaries::common::type_parameter_constraint(
-                    self.ctx.types,
-                    object_type,
-                ) {
-                    // A constraint that still mentions type parameters (e.g.
-                    // `Record<K, number>`) can't be resolved until instantiation.
-                    Some(constraint)
-                        if crate::query_boundaries::common::contains_type_parameters(
-                            self.ctx.types,
-                            constraint,
-                        ) =>
-                    {
-                        return false;
-                    }
-                    // A concrete constraint may still be an unevaluated wrapper
-                    // (e.g. `T extends Record<string, V>`, where the constraint
-                    // is an `Application` of a mapped type). Resolve it to its
-                    // apparent type through the checker environment so the
-                    // index-signature queries below inspect the structural shape
-                    // (`{ [k: string]: V }`) rather than an opaque application
-                    // node — otherwise a resolver-less evaluation leaves the
-                    // wrapper intact and the constraint looks unindexable.
-                    Some(constraint) => {
-                        crate::query_boundaries::dispatch::evaluate_type_with_resolver(
-                            self.ctx.types,
-                            &self.ctx,
-                            constraint,
-                        )
-                    }
-                    // Unconstrained: the base constraint is `unknown`, which has
-                    // no index signatures, so a concrete key can't index it.
-                    None => TypeId::UNKNOWN,
-                }
-            } else {
-                object_type
-            };
+                // Keep the raw constraint; it is resolved to its apparent type
+                // below (intersections are handled member-by-member there).
+                Some(constraint) => constraint,
+                // Unconstrained: the base constraint is `unknown`, which has
+                // no index signatures, so a concrete key can't index it.
+                None => TypeId::UNKNOWN,
+            }
+        } else {
+            object_type
+        };
 
         if check_type == TypeId::ANY || check_type == TypeId::ERROR {
             return false;
@@ -2578,7 +2567,76 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        let unwrapped_type = query::unwrap_readonly_for_lookup(self.ctx.types, check_type);
+        // A type parameter is indexed against the *apparent type* of its
+        // constraint. The constraint may be an unevaluated application/alias/
+        // mapped type whose head is a `Lazy(DefId)` (e.g. `Record<string, V>`,
+        // `Partial<Record<…>>`, a user mapped alias). The downstream
+        // index-signature queries evaluate with a resolver-less pass that cannot
+        // expand a `Lazy(DefId)`, so resolve through the checker environment here —
+        // matching tsc's `getApparentType` of the constraint.
+        if is_type_param {
+            // An intersection constraint is indexable when *any* member supplies a
+            // usable index signature (tsc's apparent-type lookup over the
+            // constituents). Resolve each member separately: merging the whole
+            // intersection drops member index signatures, which would re-introduce
+            // the false positive.
+            if let Some(members) =
+                crate::query_boundaries::common::intersection_members(self.ctx.types, check_type)
+            {
+                return members.iter().all(|&member| {
+                    self.constraint_member_reports_no_index_signature(
+                        member,
+                        index_type,
+                        wants_string,
+                        wants_number,
+                    )
+                });
+            }
+            return self.constraint_member_reports_no_index_signature(
+                check_type,
+                index_type,
+                wants_string,
+                wants_number,
+            );
+        }
+
+        self.object_reports_no_index_signature(check_type, index_type, wants_string, wants_number)
+    }
+
+    /// Resolve a single type-parameter-constraint member to its apparent type
+    /// through the checker environment, then decide whether it lacks the needed
+    /// index signature. A member that resolves to `any`/error is treated as
+    /// indexable (no report), matching tsc.
+    fn constraint_member_reports_no_index_signature(
+        &self,
+        member: TypeId,
+        index_type: TypeId,
+        wants_string: bool,
+        wants_number: bool,
+    ) -> bool {
+        let resolved =
+            crate::query_boundaries::state::type_environment::evaluate_type_with_resolver(
+                self.ctx.types,
+                &self.ctx,
+                member,
+            );
+        if resolved == TypeId::ANY || resolved == TypeId::ERROR {
+            return false;
+        }
+        self.object_reports_no_index_signature(resolved, index_type, wants_string, wants_number)
+    }
+
+    /// Decide whether a concrete (non-type-parameter, non-intersection) object
+    /// type lacks the index signature needed for the requested key kind. Returns
+    /// `true` when tsc would report TS7053 for this receiver.
+    fn object_reports_no_index_signature(
+        &self,
+        object_type: TypeId,
+        index_type: TypeId,
+        wants_string: bool,
+        wants_number: bool,
+    ) -> bool {
+        let unwrapped_type = query::unwrap_readonly_for_lookup(self.ctx.types, object_type);
 
         if wants_string
             && let Some(string_index) =

--- a/crates/tsz-checker/src/types/utilities/core.rs
+++ b/crates/tsz-checker/src/types/utilities/core.rs
@@ -2580,9 +2580,7 @@ impl<'a> CheckerState<'a> {
             // constituents). Resolve each member separately: merging the whole
             // intersection drops member index signatures, which would re-introduce
             // the false positive.
-            if let Some(members) =
-                crate::query_boundaries::common::intersection_members(self.ctx.types, check_type)
-            {
+            if let Some(members) = query::get_intersection_members(self.ctx.types, check_type) {
                 return members.iter().all(|&member| {
                     self.constraint_member_reports_no_index_signature(
                         member,

--- a/crates/tsz-checker/tests/ts7053_record_constraint_index_tests.rs
+++ b/crates/tsz-checker/tests/ts7053_record_constraint_index_tests.rs
@@ -1,0 +1,148 @@
+//! TS7053 — indexing a type parameter whose constraint resolves (via its
+//! apparent type) to a shape with a string index signature.
+//!
+//! Structural rule: when the indexed object is a type parameter, indexability is
+//! governed by the *apparent type* of its base constraint. A constraint written
+//! as an unevaluated application / alias / mapped type (e.g. `Record<string, V>`,
+//! `Partial<Record<…>>`, `Readonly<Record<…>>`, a user mapped alias) — or an
+//! intersection containing one — must be reduced to its apparent type before the
+//! implicit-any-index check decides the key is unusable. tsc allows the access
+//! because the resolved constraint carries a string index signature; tsz must
+//! match. Constraints that genuinely lack a matching index signature still
+//! report TS7053.
+//!
+//! Issue: <https://github.com/mohsen1/tsz/issues/10674>
+use tsz_checker::context::{CheckerOptions, ScriptTarget};
+use tsz_checker::test_utils::check_source;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            target: ScriptTarget::ES2022,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+// Reported repro: a `Record<string, V>` application constraint indexed by a
+// `string` key. tsc clean; previously tsz emitted a false TS7053.
+#[test]
+fn record_string_constraint_no_ts7053() {
+    let result =
+        codes(r#"function f<T extends Record<string, unknown>>(o: T, k: string) { return o[k]; }"#);
+    assert!(
+        !result.contains(&7053),
+        "expected no TS7053 for o[k] on T extends Record<string, unknown>, got: {result:?}"
+    );
+    let numeric =
+        codes(r#"function g<T extends Record<string, number>>(o: T, k: string) { return o[k]; }"#);
+    assert!(
+        !numeric.contains(&7053),
+        "expected no TS7053 for Record<string, number> constraint, got: {numeric:?}"
+    );
+}
+
+// Name independence: renaming the type parameter must not change the outcome.
+#[test]
+fn record_constraint_is_name_independent() {
+    let result = codes(
+        r#"function f<XYZ extends Record<string, unknown>>(o: XYZ, key: string) { return o[key]; }"#,
+    );
+    assert!(
+        !result.contains(&7053),
+        "expected no TS7053 with renamed type parameter, got: {result:?}"
+    );
+}
+
+// Wrapper applications over `Record` (`Partial`, `Readonly`) still expose the
+// string index signature on the apparent type.
+#[test]
+fn wrapped_record_constraint_no_ts7053() {
+    let partial = codes(
+        r#"function f<T extends Partial<Record<string, number>>>(o: T, k: string) { return o[k]; }"#,
+    );
+    assert!(
+        !partial.contains(&7053),
+        "expected no TS7053 for Partial<Record<…>> constraint, got: {partial:?}"
+    );
+    let readonly = codes(
+        r#"function f<T extends Readonly<Record<string, number>>>(o: T, k: string) { return o[k]; }"#,
+    );
+    assert!(
+        !readonly.contains(&7053),
+        "expected no TS7053 for Readonly<Record<…>> constraint, got: {readonly:?}"
+    );
+}
+
+// A user-defined mapped-type alias behaves like `Record`: name-independent, so a
+// differently-named iteration variable must also resolve.
+#[test]
+fn user_mapped_alias_constraint_no_ts7053() {
+    let result = codes(
+        r#"
+type MyRec<V> = { [K in string]: V };
+function f<T extends MyRec<number>>(o: T, k: string) { return o[k]; }
+"#,
+    );
+    assert!(
+        !result.contains(&7053),
+        "expected no TS7053 for a user mapped-alias constraint, got: {result:?}"
+    );
+    // Different iteration-variable spelling — proves the fix is structural.
+    let renamed = codes(
+        r#"
+type OtherRec<V> = { [Prop in string]: V };
+function f<T extends OtherRec<number>>(o: T, k: string) { return o[k]; }
+"#,
+    );
+    assert!(
+        !renamed.contains(&7053),
+        "expected no TS7053 with renamed mapped iteration variable, got: {renamed:?}"
+    );
+}
+
+// Intersection constraint where one member carries the string index signature.
+#[test]
+fn intersection_with_record_member_no_ts7053() {
+    let result = codes(
+        r#"function f<T extends Record<string, number> & { a: number }>(o: T, k: string) { return o[k]; }"#,
+    );
+    assert!(
+        !result.contains(&7053),
+        "expected no TS7053 for `Record<…> & {{ a: number }}` constraint, got: {result:?}"
+    );
+}
+
+// Negative control: a constraint that genuinely lacks a string index signature
+// must still report TS7053.
+#[test]
+fn object_constraint_without_index_still_emits_ts7053() {
+    let result = codes(r#"function f<T extends { a: number }>(o: T, k: string) { return o[k]; }"#);
+    assert!(
+        result.contains(&7053),
+        "expected TS7053 for a constraint without a string index signature, got: {result:?}"
+    );
+}
+
+// Negative control: a constraint that resolves (through an alias) to a plain
+// object without an index signature must still report TS7053 — the apparent-type
+// resolution must not over-suppress.
+#[test]
+fn alias_to_plain_object_constraint_still_emits_ts7053() {
+    let result = codes(
+        r#"
+type Plain = { a: number };
+function f<T extends Plain>(o: T, k: string) { return o[k]; }
+"#,
+    );
+    assert!(
+        result.contains(&7053),
+        "expected TS7053 for an alias-to-plain-object constraint, got: {result:?}"
+    );
+}


### PR DESCRIPTION
AgentName: cloud-opus47-confident-thompson-JHDm1
Track: Conformance / checker false-positives (kysely row)
Closes: part of #10674 (third, disjoint sub-cause)

## Invariant

When the indexed receiver is a type parameter, the implicit-any-index (TS7053) check must use the *apparent type* of its base constraint — matching tsc's `getApparentType`. A constraint that carries a string index signature (directly, through an application/alias/mapped wrapper, or as an intersection member) makes a `string`-keyed access legal.

## Problem

Repro: `function f<T extends Record<string, unknown>>(o: T, k: string) { return o[k]; }` — tsz emitted a false TS7053; tsc is clean.

`should_report_no_index_signature` used the *raw* `extends` constraint. For a type parameter, the constraint of `T extends Record<...>` is stored as an unevaluated application whose head is a `Lazy(DefId)`. The downstream index-signature queries (`classify_element_indexable`, `get_index_info`) evaluate with a *resolver-less* pass that cannot expand a `Lazy(DefId)`, so the constraint looked unindexable and a false TS7053 fired. Direct receivers were already clean because the checker resolves their type — with the environment — before this check; the type-parameter path fetched the constraint raw.

## Fix (owner layer: checker boundary)

Resolve the constraint to its apparent type through the checker environment (`evaluate_type_with_resolver(self.ctx.types, &self.ctx, ...)`, the canonical environment-aware evaluate already used elsewhere) before the index-signature queries run. The semantic computation stays in the solver; the checker only routes the constraint through the environment it owns.

Intersection constraints are walked member-by-member and resolved individually — merging the whole intersection collapses to a single object shape that drops member index signatures (a separate, deeper solver-merge bug), which would re-introduce the false positive. An intersection reports only when no member supplies a usable index signature.

The decision logic is factored into two small private helpers (`constraint_member_reports_no_index_signature`, `object_reports_no_index_signature`); the non-type-parameter path is unchanged.

## Scope / generalization

Structural rule, name-independent. Positives now clean (were false TS7053), matching tsc:

- `T extends Record<string, unknown>` and `Record<string, number>`
- `T extends Partial<Record<string, number>>`
- `T extends Readonly<Record<string, number>>`
- user mapped alias `{ [K in string]: V }` (any iteration-variable name)
- renamed type parameter (e.g. `XYZ`)
- nested chain `U extends T extends Record<...>`
- intersection `Record<string, number> & { a: number }`
- union `Record<string, number> | Record<string, string>`

Negatives preserved (still TS7053, matching tsc): `T extends { a: number }`, an alias to a plain object, unconstrained `T`, and `Record<string, number> | { a: number }` (one member lacks the index).

Out of scope (separate, deeper bug): intersection *merge* dropping member index signatures — worked around here by per-member resolution.

## Project Corpus Impact

- Row: kysely-project (#10663). Targets the TS7053 false-positive family (#10674), specifically the type-parameter-constraint sub-cause that #10694 (direct receivers) and #10734 (conditional `{}` union) do not touch — disjoint code paths.
- Bug family: implicit-any-index (TS7053) on apparent-type-bearing type-parameter constraints.
- Evidence: new owning-crate unit test `ts7053_record_constraint_index_tests.rs` (7 cases); local `tsz` CLI run on the matrix above; conformance/emit gates run in ready CI.

## Verification

- `cargo test -p tsz-checker --test ts7053_record_constraint_index_tests` → 7 passed.
- Regression batch (all green): `ts7053_unconstrained_type_param_index_tests`, `indexed_access_unconstrained_param_tests`, `element_access_structural_codes_tests`, `intersection_index_signature_fingerprint_tests`, `homomorphic_indexed_access_tests`, `intersection_mapped_alias_indexed_access_tests`.
- `cargo fmt -p tsz-checker --check` and `cargo clippy -p tsz-checker --all-targets` clean.
- Full positive/negative/edge matrix verified with a freshly built `tsz` CLI under `--strict --noImplicitAny`.
- Rebased on latest `main`; no conflicts.

## Coordination Notes

Linked issue #10674 carries a signed coordination comment describing this disjoint sub-cause. Kept the `agent:Studio-A` ownership label (kysely row coordination). Independent of PR #10734 (different code path).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMCEB1VBynw6oXtKAMUB6H)_