### PR TITLE
fix(emit): avoid ternary else-branch duplication in concise arrow trailing comments

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -226,6 +226,10 @@ path = "tests/async_loop_emit.rs"
 name = "while_loop_body_capture_tests"
 path = "tests/while_loop_body_capture_tests.rs"
 
+[[test]]
+name = "ternary_trailing_comment_tests"
+path = "tests/ternary_trailing_comment_tests.rs"
+
 [lints]
 workspace = true
 

--- a/crates/tsz-emitter/src/emitter/comments/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/comments/helpers.rs
@@ -1,6 +1,105 @@
 use crate::emitter::Printer;
 use tsz_parser::parser::node::Node;
 
+/// Scan `bytes[start_pos..end_pos]` and return two boundary markers for the
+/// last non-trivia content seen at brace depth 0:
+///
+/// - `last_token_end`: position after the last `}`, `]`, `)`, or `;`.
+/// - `last_non_trivia_at_depth0`: position after any non-whitespace character,
+///   including string literals, identifiers, and operators but not comments.
+///
+/// Both are `None` when the range contains no non-whitespace content at depth 0.
+fn scan_depth0_token_bounds(
+    bytes: &[u8],
+    start_pos: usize,
+    end_pos: usize,
+) -> (Option<usize>, Option<usize>) {
+    let mut depth: i32 = 0;
+    let mut last_token_end: Option<usize> = None;
+    let mut last_non_trivia_at_depth0: Option<usize> = None;
+    let mut i = start_pos;
+
+    while i < end_pos {
+        let ch = bytes[i];
+        match ch {
+            b'{' | b'[' | b'(' => {
+                depth += 1;
+                i += 1;
+            }
+            b'}' | b']' | b')' => {
+                depth -= 1;
+                if depth < 0 {
+                    // Gone past our scope into a parent — stop.
+                    break;
+                }
+                if depth == 0 {
+                    // This is the closing bracket/brace/paren at the top
+                    // level of this node — a real terminator for the
+                    // value expression. Tracking `]` and `)` (not just
+                    // `}`) lets us pick the right end for property
+                    // values like `items: [...]` whose last inner `}`
+                    // sits at the same depth-0 boundary as the closing
+                    // `]`.
+                    last_token_end = Some(i + 1);
+                    last_non_trivia_at_depth0 = Some(i + 1);
+                }
+                i += 1;
+            }
+            b';' => {
+                if depth == 0 {
+                    last_token_end = Some(i + 1);
+                    last_non_trivia_at_depth0 = Some(i + 1);
+                }
+                i += 1;
+            }
+            b'\'' | b'"' | b'`' => {
+                let quote = ch;
+                i += 1;
+                while i < end_pos {
+                    if bytes[i] == b'\\' {
+                        i += 2;
+                    } else if bytes[i] == quote {
+                        i += 1;
+                        break;
+                    } else {
+                        i += 1;
+                    }
+                }
+                // Track end of string as a non-trivia position so that
+                // standalone string expression statements (ASI, no `;`)
+                // get the correct token_end for trailing comment detection.
+                if depth == 0 {
+                    last_non_trivia_at_depth0 = Some(i);
+                }
+            }
+            b'/' if i + 1 < end_pos && bytes[i + 1] == b'/' => {
+                i += 2;
+                while i < end_pos && bytes[i] != b'\n' && bytes[i] != b'\r' {
+                    i += 1;
+                }
+            }
+            b'/' if i + 1 < end_pos && bytes[i + 1] == b'*' => {
+                i += 2;
+                while i + 1 < end_pos {
+                    if bytes[i] == b'*' && bytes[i + 1] == b'/' {
+                        i += 2;
+                        break;
+                    }
+                    i += 1;
+                }
+            }
+            _ => {
+                if depth == 0 && !matches!(ch, b' ' | b'\t' | b'\r' | b'\n') {
+                    last_non_trivia_at_depth0 = Some(i + 1);
+                }
+                i += 1;
+            }
+        }
+    }
+
+    (last_token_end, last_non_trivia_at_depth0)
+}
+
 impl<'a> Printer<'a> {
     // =========================================================================
     // Comment Emission Helpers
@@ -174,11 +273,15 @@ impl<'a> Printer<'a> {
 
     /// Find the position right after the node's actual code content ends.
     /// This gives us the position where trailing comments begin. Our parser's
-    /// node.end extends past trailing trivia into the next token's position,
+    /// `node.end` extends past trailing trivia into the next token's position,
     /// so we need to find the actual end of the node's code.
     ///
     /// Uses forward scanning with brace depth tracking to find the correct
     /// closing `}` at depth 0, avoiding confusion with parent scope braces.
+    ///
+    /// Prefers `last_token_end` (closing bracket/semicolon) over
+    /// `last_non_trivia_at_depth0`. Use `find_last_expr_end_before_trivia`
+    /// instead when the expression body may end with a non-bracket token.
     pub(in crate::emitter) fn find_token_end_before_trivia(&self, pos: u32, end: u32) -> u32 {
         let Some(text) = self.source_text else {
             return end;
@@ -191,97 +294,10 @@ impl<'a> Printer<'a> {
             return end;
         }
 
-        // Forward scan: track the last `}` or `;` at brace depth 0.
-        // This correctly identifies the node's own closing token without
-        // accidentally matching a parent scope's closing brace.
-        let mut depth: i32 = 0;
-        let mut last_token_end: Option<usize> = None;
-        let mut last_non_trivia_at_depth0: Option<usize> = None;
-        let mut i = start_pos;
+        let (last_token_end, last_non_trivia_at_depth0) =
+            scan_depth0_token_bounds(bytes, start_pos, end_pos);
 
-        while i < end_pos {
-            let ch = bytes[i];
-            match ch {
-                b'{' | b'[' | b'(' => {
-                    depth += 1;
-                    i += 1;
-                }
-                b'}' | b']' | b')' => {
-                    depth -= 1;
-                    if depth < 0 {
-                        // We've gone past our scope into a parent - stop
-                        break;
-                    }
-                    if depth == 0 {
-                        // This is the closing bracket/brace/paren at the top
-                        // level of this node — a real terminator for the
-                        // value expression. Tracking `]` and `)` (not just
-                        // `}`) lets us pick the right end for property
-                        // values like `items: [...]` whose last inner `}`
-                        // sits at the same depth-0 boundary as the closing
-                        // `]`. Without this, comma scans started inside the
-                        // array and falsely matched the array's own trailing
-                        // comma as a property-level trailing comma.
-                        last_token_end = Some(i + 1);
-                        last_non_trivia_at_depth0 = Some(i + 1);
-                    }
-                    i += 1;
-                }
-                b';' => {
-                    if depth == 0 {
-                        last_token_end = Some(i + 1);
-                        last_non_trivia_at_depth0 = Some(i + 1);
-                    }
-                    i += 1;
-                }
-                b'\'' | b'"' | b'`' => {
-                    // Skip string literals to avoid false matches
-                    let quote = ch;
-                    i += 1;
-                    while i < end_pos {
-                        if bytes[i] == b'\\' {
-                            i += 2; // skip escaped char
-                        } else if bytes[i] == quote {
-                            i += 1;
-                            break;
-                        } else {
-                            i += 1;
-                        }
-                    }
-                    // Track end of string as a non-trivia position so that
-                    // standalone string expression statements (ASI, no `;`)
-                    // get the correct token_end for trailing comment detection.
-                    if depth == 0 {
-                        last_non_trivia_at_depth0 = Some(i);
-                    }
-                }
-                b'/' if i + 1 < end_pos && bytes[i + 1] == b'/' => {
-                    // Skip single-line comments
-                    i += 2;
-                    while i < end_pos && bytes[i] != b'\n' && bytes[i] != b'\r' {
-                        i += 1;
-                    }
-                }
-                b'/' if i + 1 < end_pos && bytes[i + 1] == b'*' => {
-                    // Skip multi-line comments
-                    i += 2;
-                    while i + 1 < end_pos {
-                        if bytes[i] == b'*' && bytes[i + 1] == b'/' {
-                            i += 2;
-                            break;
-                        }
-                        i += 1;
-                    }
-                }
-                _ => {
-                    if depth == 0 && !matches!(ch, b' ' | b'\t' | b'\r' | b'\n') {
-                        last_non_trivia_at_depth0 = Some(i + 1);
-                    }
-                    i += 1;
-                }
-            }
-        }
-
+        // Prefer last_token_end (closing bracket/semicolon) over last_non_trivia.
         let mut token_end = last_token_end
             .or(last_non_trivia_at_depth0)
             .map_or(end, |e| e as u32);
@@ -294,6 +310,54 @@ impl<'a> Printer<'a> {
         // located the correct boundary and the suffix scan would overshoot
         // into parent closing braces (e.g., `}` of an object literal after
         // the last property).
+        if last_token_end.is_none() && last_non_trivia_at_depth0.is_none() && token_end <= end {
+            let mut j = end_pos;
+            while j < bytes.len() {
+                match bytes[j] {
+                    b' ' | b'\t' => j += 1,
+                    b'/' if j + 1 < bytes.len() && bytes[j + 1] == b'/' => break,
+                    b'/' if j + 1 < bytes.len() && bytes[j + 1] == b'*' => break,
+                    b';' | b'}' => {
+                        token_end = (j + 1) as u32;
+                        break;
+                    }
+                    _ => break,
+                }
+            }
+        }
+
+        token_end
+    }
+
+    /// Like `find_token_end_before_trivia` but prefers `last_non_trivia_at_depth0`
+    /// over `last_token_end`.
+    ///
+    /// Use this for concise arrow body expressions where the body may end with a
+    /// non-bracket token — for example the else-branch of a ternary
+    /// `x ? foo() : '-'`. There `last_token_end` would point to `foo()`'s `)`,
+    /// while `last_non_trivia_at_depth0` correctly points to the end of `'-'`.
+    pub(in crate::emitter) fn find_last_expr_end_before_trivia(&self, pos: u32, end: u32) -> u32 {
+        let Some(text) = self.source_text else {
+            return end;
+        };
+        let bytes = text.as_bytes();
+        let end_pos = std::cmp::min(end as usize, bytes.len());
+        let start_pos = pos as usize;
+
+        if start_pos >= end_pos {
+            return end;
+        }
+
+        let (last_token_end, last_non_trivia_at_depth0) =
+            scan_depth0_token_bounds(bytes, start_pos, end_pos);
+
+        // Prefer last_non_trivia_at_depth0: for expression bodies the very last
+        // non-whitespace character is always the correct end boundary, even when
+        // an intermediate closing bracket is present.
+        let mut token_end = last_non_trivia_at_depth0
+            .or(last_token_end)
+            .map_or(end, |e| e as u32);
+
         if last_token_end.is_none() && last_non_trivia_at_depth0.is_none() && token_end <= end {
             let mut j = end_pos;
             while j < bytes.len() {

--- a/crates/tsz-emitter/src/emitter/functions_arrow.rs
+++ b/crates/tsz-emitter/src/emitter/functions_arrow.rs
@@ -335,7 +335,7 @@ impl<'a> Printer<'a> {
         let Some(body_node) = self.arena.get(body_idx) else {
             return;
         };
-        let body_token_end = self.find_token_end_before_trivia(body_node.pos, body_node.end);
+        let body_token_end = self.find_last_expr_end_before_trivia(body_node.pos, body_node.end);
         let comment_end = std::cmp::max(body_node.end, arrow_end);
         if let Some((defer_start, defer_end)) = self.arrow_concise_body_trailing_comment_defer_range
             && body_token_end == defer_start
@@ -369,7 +369,7 @@ impl<'a> Printer<'a> {
             if body.kind == syntax_kind_ext::BLOCK {
                 return None;
             }
-            return Some(self.find_token_end_before_trivia(body.pos, body.end));
+            return Some(self.find_last_expr_end_before_trivia(body.pos, body.end));
         }
 
         if node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION {

--- a/crates/tsz-emitter/tests/ternary_trailing_comment_tests.rs
+++ b/crates/tsz-emitter/tests/ternary_trailing_comment_tests.rs
@@ -1,0 +1,126 @@
+//! Tests for ternary (conditional) expression trailing-comment handling in
+//! concise arrow function bodies.
+//!
+//! Structural rule: when the then-branch of a ternary inside a concise arrow
+//! body is a call expression and a trailing line comment follows, tsz must not
+//! write the source text between the call's closing `)` and the comment as
+//! "leading comment trivia" — that text (` : <else> `) was already emitted by
+//! `emit_conditional` and must not appear twice in the output.
+//!
+//! Root cause: `find_token_end_before_trivia` previously preferred
+//! `last_token_end` (set by the `)` of the call expression) over
+//! `last_non_trivia_at_depth0` (set by the last character of the else branch).
+//! `emit_comments_in_range` then wrote the source slice between those two
+//! positions — the else branch — as comment leading trivia, duplicating it.
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_print;
+
+// ── Positive cases: no duplication ───────────────────────────────────────────
+
+/// Reported repro: call expression in then-branch with trailing line comment.
+#[test]
+fn ternary_call_then_trailing_comment_no_else_duplication() {
+    let source =
+        "declare function foo(): string;\nconst f = (x: boolean) => x ? foo() : '-' // c\n";
+    let output = parse_and_print(source);
+    assert!(
+        !output.contains("'-' : '-'"),
+        "else branch '-' must not appear twice\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("x ? foo() : '-'"),
+        "full ternary must be present\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("// c"),
+        "trailing comment must be preserved\nOutput:\n{output}"
+    );
+}
+
+/// Method call in then-branch (different call spelling).
+#[test]
+fn ternary_method_call_then_trailing_comment_no_else_duplication() {
+    let source = "const g = (x: string) => x ? x.toUpperCase() : '-' // transform\n";
+    let output = parse_and_print(source);
+    assert!(
+        !output.contains("'-' : '-'"),
+        "else branch '-' must not appear twice\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("x ? x.toUpperCase() : '-'"),
+        "full ternary must be present\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("// transform"),
+        "trailing comment must be preserved\nOutput:\n{output}"
+    );
+}
+
+/// Renamed parameter — structural rule is not name-dependent.
+#[test]
+fn ternary_call_then_trailing_comment_renamed_param_no_duplication() {
+    let source = "declare function bar(): number;\nconst h = (flag: boolean) => flag ? bar() : 0 // result\n";
+    let output = parse_and_print(source);
+    assert!(
+        !output.contains("0 : 0"),
+        "else branch 0 must not appear twice\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("flag ? bar() : 0"),
+        "full ternary must be present\nOutput:\n{output}"
+    );
+}
+
+/// String else-branch (not just `-`).
+#[test]
+fn ternary_call_then_string_else_trailing_comment_no_duplication() {
+    let source = "declare function foo(): string;\nconst k = (x: boolean) => x ? foo() : \"default\" // note\n";
+    let output = parse_and_print(source);
+    assert!(
+        !output.contains("\"default\" : \"default\""),
+        "else branch 'default' must not appear twice\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("// note"),
+        "trailing comment must be preserved\nOutput:\n{output}"
+    );
+}
+
+// ── Negative cases: these must keep working ──────────────────────────────────
+
+/// Identifier in then-branch: must continue to work correctly.
+#[test]
+fn ternary_identifier_then_trailing_comment_correct() {
+    let source = "const j = (x: string) => x ? x : '-' // id\n";
+    let output = parse_and_print(source);
+    assert!(
+        !output.contains("'-' : '-'"),
+        "identifier then-branch must not cause duplication\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("x ? x : '-'"),
+        "full ternary must be present\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("// id"),
+        "trailing comment must be preserved\nOutput:\n{output}"
+    );
+}
+
+/// No trailing comment: call expression in then-branch must emit correctly.
+#[test]
+fn ternary_call_then_no_comment_correct() {
+    let source = "declare function foo(): string;\nconst m = (x: boolean) => x ? foo() : '-'\n";
+    let output = parse_and_print(source);
+    assert!(
+        !output.contains("'-' : '-'"),
+        "no-comment case must not duplicate else branch\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("x ? foo() : '-'"),
+        "full ternary must be present\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes a JS emit bug where the else-branch of a ternary expression was duplicated
in the output when the then-branch was a call expression and a trailing line
comment followed the ternary.

**Repro:**
```ts
declare function foo(): string;
const f = (x: boolean) => x ? foo() : '-' // c
```

**Before (buggy output):**
```js
const f = (x) => x ? foo() : '-' : '-' // c
```

**After (correct output):**
```js
const f = (x) => x ? foo() : '-' // c
```

---

AgentName: claude-sonnet-4-6 (dazzling-johnson)

## Track

Emitter — JS emit correctness

## Invariant

When `find_token_end_before_trivia` is called for a concise arrow body
expression, the returned position must be the end of the actual expression
content, not the end of an intermediate closing bracket inside the expression.

## Scope

- `crates/tsz-emitter/src/emitter/comments/helpers.rs`: extract shared scan body
  into free function `scan_depth0_token_bounds`; add new method
  `find_last_expr_end_before_trivia` that prefers `last_non_trivia_at_depth0`.
- `crates/tsz-emitter/src/emitter/functions_arrow.rs`: use
  `find_last_expr_end_before_trivia` in `emit_arrow_concise_body_trailing_comments`
  and `rightmost_concise_arrow_body_comment_start` (both must agree so the
  deferred-comment comparison at `body_token_end == defer_start` stays consistent).
- `crates/tsz-emitter/tests/ternary_trailing_comment_tests.rs`: 6 new regression
  tests covering call, method call, renamed param, string else-branch, identifier
  then-branch, and no-comment variants.

## Root Cause

`find_token_end_before_trivia` prefers `last_token_end` (set by `}`, `]`, `)`,
`;` at depth 0) over `last_non_trivia_at_depth0` (any non-whitespace).

For `x ? foo() : '-'`:
- `foo()`'s `)` sets `last_token_end = after_paren`
- `'-'` is a string literal → only sets `last_non_trivia_at_depth0 = after_quote`
- Result: `last_token_end.or(last_non_trivia) = after_paren` (wrong)

`emit_comments_in_range(after_paren, comment_end, ...)` then writes
`source[after_paren..comment_pos] = " : '-' "` as leading-comment trivia,
duplicating the already-emitted else branch.

For identifiers in the then-branch (`x ? x : '-'`), `last_token_end` is `None`
so `last_non_trivia_at_depth0` wins — the bug is call-expression-specific.

## Fix

Extract the scan body into a module-level free function `scan_depth0_token_bounds`
(no `self`, takes `&[u8]` and positions). Add `find_last_expr_end_before_trivia`
that calls it and uses `last_non_trivia_at_depth0.or(last_token_end)`. The
original priority in `find_token_end_before_trivia` is unchanged, preserving all
other callers.

## Structural rule

When the concise body of an arrow function ends with a non-bracket token (ternary
else-branch, string literal, identifier), the trailing-comment start boundary must
be the end of that last non-whitespace token, not the end of any intermediate
closing bracket inside the expression.

## Project Corpus Impact

- Row: emitter / concise arrow functions
- Bug family: trailing comment trivia duplication
- Evidence: 6 unit tests pass locally; `comment_tests` (39 tests) all still green

## Verification

```
cargo test -p tsz-emitter --test ternary_trailing_comment_tests  # 6/6 pass
cargo test -p tsz-emitter --test comment_tests                   # 39/39 pass
```

## Coordination Notes

This PR targets `claude/dazzling-johnson-Fm1lB`. No other PRs address this bug
family. The fix is narrow: only the two concise-arrow-body call sites are changed;
all ~50 other callers of `find_token_end_before_trivia` are unaffected.
