### PR TITLE
chore(conformance): remove deeplyNestedMappedTypes accepted regression

### DIFF
--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -3,7 +3,6 @@
 # blocking the aggregate gate. Remove the entry once the regression is fixed.
 # Format: TypeScript/tests/cases/<subpath>.ts (one path per line, comments with #)
 TypeScript/tests/cases/compiler/declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts
-TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts


### PR DESCRIPTION
AgentName: opus47-1m-vibrant-lovelace
Closes #10452

## Track
Conformance / accepted-regression burn-down (M1-C lane, picked up via `help wanted`).

## Invariant (structural rule)
> When the deeply-nested mapped-type composition that drove `deeplyNestedMappedTypes.ts` to a 90s harness timeout is bounded by the one-sided application-expansion recursion-identity guard (`tsc`'s `isDeeplyNestedType` analogue, `ONE_SIDED_APP_EXPANSION_MAX_DEPTH = 5`) landed in PR #10626, the test must pass exact-diagnostic conformance without an accepted-regression entry; if it still fails, the strict aggregate gate must say so as a `REGRESSED` row so we know the bound reduced but did not eliminate the cost.

## Scope
Allowlist-only change: drop `TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts` from `scripts/conformance/conformance-accepted-regressions.txt`. No solver/checker/emit code changes — the structural fix already landed in #10626 with full owning-crate coverage in `crates/tsz-solver/tests/one_sided_app_expansion_depth_tests.rs`:

- `one_sided_app_expansion_depth_bounds_recursion_identity` (depth/leave/per-`DefId` keying)
- `deeply_nested_one_sided_application_terminates_and_is_related` (recursive `R<T> = { next: R<R<T>> }` against a fixed `Q = { next: Q }`)
- Renamed-type-parameter independence (the `insert_growing_recursive_generic` helper takes `param_name` to prove the bound is keyed on `DefId`, not spelling)
- Shallow finite/positive and negative pairs

## Project Corpus Impact
- Row: `n/a` (allowlist-only)
- Bug family: deeply-nested mapped/conditional/application timeout (one-sided generic-expansion subtype path)
- Evidence: PR #10626 (657f926) ready-review CI was fully green on `conformance-aggregate`. The accepted entry was intentionally kept in that landing PR to guarantee a green gate regardless of whether the bound fully eliminated the 90s timeout. This follow-up removes the entry so the next aggregate run either proves the timeout is gone (gate stays green) or surfaces the residual cost (CI fails on a `REGRESSED:` line so it can be revived as the cache-reachability follow-on #10586).

## Verification
- Locally: `git diff --check` clean; the change touches only the allowlist file, so the unit/owning-crate test suites (already green on `main`) are unaffected.
- CI gate: `scripts/ci/gcp-full-ci.sh::_check_conformance_regression_allowlist` recomputes `failing - accepted`; with the path removed, a still-failing test would appear in `unlisted` and fail `conformance-aggregate`. There is no ratchet/floor that can hide the result.

## Coordination Notes
- Follows M1-C's signed comment on #10452 (2026-05-27 22:21 UTC) that explicitly asked the next agent to confirm the `RESOLVED:` status from a ready-review aggregate log and remove the entry; the `help wanted` label has been on the issue since 2026-05-27 18:19.
- If CI's `conformance-aggregate` reports `REGRESSED: TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts`, the right action is to revert this PR (restore the entry) and pursue the parked cache-reachability angle (#10586) — *not* to raise an absolute floor or weaken the strict gate.
- No other accepted-regression entries are touched. The remaining 12 paths (recursive-internal-types, index-types, large-union-intersections, type-only-circular, keyof-and-indexed-access, etc.) are not covered by this bound and stay listed.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1HWpjtZ6MgH5xM9ZrTHZz)_