### PR TITLE
test(emitter): cover JSX unicode-escape intrinsic + extended-escape adjacent cases

### DIFF
--- a/crates/tsz-emitter/src/emitter/jsx/mod.rs
+++ b/crates/tsz-emitter/src/emitter/jsx/mod.rs
@@ -909,6 +909,76 @@ const b = <video data-\u0076ideo />;"#;
         );
     }
 
+    /// Intrinsic tag names emit as JS string literals; unicode escapes in the
+    /// name must be cooked because `tsc` rebuilds the argument as a fresh JS
+    /// string. Covers `\uXXXX` and `\u{X...}` escape forms, both at the head of
+    /// the name and inside hyphenated kebab segments.
+    ///
+    /// Witness: `unicodeEscapesInJsxtags.tsx` (`@jsx react`) expects
+    /// `React.createElement("a", null)`, `React.createElement("a-b", null)`,
+    /// and `React.createElement("a-c", null)` for the source
+    /// `<a/>`, `<a-b/>`, `<a-c/>` (and their `\u{...}` variants).
+    #[test]
+    fn jsx_classic_unicode_escape_intrinsic_tag_name_is_cooked() {
+        let source = r#"const a = <a/>;
+const b = <a-b/>;
+const c = <a-c/>;
+const d = <\u{0061}/>;
+const e = <\u{0061}-b/>;
+const f = <a-\u{0063}/>;"#;
+        let output = emit_jsx_react(source);
+        // Anchor each assertion to the originating `const` binding so a regression
+        // in only the `\u{...}` path can't be masked by the plain `<a/>` path
+        // emitting the same `React.createElement("a", null)` fragment.
+        for (label, fragment) in [
+            (r"a head", r#"const a = React.createElement("a", null)"#),
+            (
+                r"a head, hyphen tail",
+                r#"const b = React.createElement("a-b", null)"#,
+            ),
+            (
+                r"hyphen head, c tail",
+                r#"const c = React.createElement("a-c", null)"#,
+            ),
+            (
+                r"\u{0061} head",
+                r#"const d = React.createElement("a", null)"#,
+            ),
+            (
+                r"\u{0061} head, hyphen tail",
+                r#"const e = React.createElement("a-b", null)"#,
+            ),
+            (
+                r"hyphen head, \u{0063} tail",
+                r#"const f = React.createElement("a-c", null)"#,
+            ),
+        ] {
+            assert!(
+                output.contains(fragment),
+                "Intrinsic JSX tag with unicode escape ({label}) should emit cooked string `{fragment}`.\nOutput: {output}"
+            );
+        }
+    }
+
+    /// Component tag references emit as JS expressions; unicode escapes in the
+    /// component identifier (including the extended `\u{X...}` form) must be
+    /// preserved verbatim because the identifier is a value reference, not a
+    /// string. Mirrors the existing
+    /// `jsx_classic_unicode_escape_component_and_member_names_are_preserved`
+    /// coverage for the `\uXXXX` form.
+    ///
+    /// Witness: `unicodeEscapesInJsxtags.tsx` expects
+    /// `React.createElement(Comp\u{0061}, { x: 12 })` for `<Comp\u{0061} x={12} />`.
+    #[test]
+    fn jsx_classic_extended_unicode_escape_component_name_is_preserved() {
+        let source = r#"const a = <Comp\u{0061} x={12} />;"#;
+        let output = emit_jsx_react(source);
+        assert!(
+            output.contains(r#"React.createElement(Comp\u{0061}, { x: 12 })"#),
+            "Component tag identifier extended-escape spelling should be preserved in expression emit.\nOutput: {output}"
+        );
+    }
+
     #[test]
     fn jsx_classic_self_closing_trailing_line_comment_is_preserved() {
         let source = "const x = (<Item value={1} /> // kept\n);";


### PR DESCRIPTION
AgentName: opus47-1m-vibrant-lovelace
Related: #8512 (JSX/react emit failure family)

## Track
Track 9 — JavaScript emit parity (JSX/react emit family).

## Invariant (structural rule)
JSX names cross a cooked-vs-raw boundary that depends on whether the name is emitted as a JS **string literal** or as a JS **expression**:

> When a JSX tag name (or attribute name) is lowered to a JS **string literal** argument — i.e. an intrinsic lowercase tag, a hyphenated/kebab tag, or a hyphenated attribute key — unicode escapes in the name (both the `\uXXXX` and the extended `\u{X...}` forms) are decoded to their cooked characters because `tsc` rebuilds the value as a fresh JS string. When the same JSX name is lowered to a JS **identifier expression** — capitalized component, dotted member access, or identifier-shaped attribute key — the raw source spelling (including its escape sequences) round-trips verbatim because the identifier is a value reference, not a string.

## Scope
Test-only addition under `crates/tsz-emitter/src/emitter/jsx/mod.rs`. No emitter or parser code changes — tsz already implements the rule correctly via `emit_jsx_tag_name_as_argument`/`get_jsx_attr_name` (using `resolve_identifier_text` for the cooked path) and the standard identifier emit (preserving `original_text` for the raw path); this PR pins the rule with explicit owning-crate coverage so a regression on the `\u{X...}` extended form or the kebab-intrinsic cases is caught before it ships to the conformance harness.

## Project Corpus Impact
- Row: `n/a` (test-only; no corpus behavior change)
- Bug family: `unicodeEscapesInJsxtags`-shaped JSX-name lowering (slice of #8512)
- Evidence: `cargo test -p tsz-emitter --lib jsx_classic` → 13 passed (11 prior + 2 new). The remaining `unicodeEscapesInJsxtags.tsx` conformance gap is **not** in the unicode-escape rule itself but in orthogonal emit policy (triple-slash directive preservation, empty-statement folding, comment scoping) that the existing line-ending PR #10577 set the precedent for fixing in narrow slices.

## Verification
- `cargo test -p tsz-emitter --lib jsx_classic` → 13 passed, 0 failed.
- `cargo test -p tsz-emitter --lib jsx_classic_unicode_escape_intrinsic_tag_name_is_cooked` → 1 passed (6 anchored sub-assertions covering `<a/>`/`<a-b/>`/`<a-c/>` and the `\u{0061}` head, `\u{0061}-b`, `a-\u{0063}` extended-escape variants).
- `cargo test -p tsz-emitter --lib jsx_classic_extended_unicode_escape_component_name_is_preserved` → 1 passed.
- `/simplify` run 3 times; first round flagged an anchoring weakness (multiple sub-assertions checked the same `React.createElement("a", null)` fragment so a `\u{...}` regression could have been masked by the plain `<a/>` case) — fixed by anchoring each assertion to its originating `const a` … `const f` binding. Rounds 2 and 3 found nothing.

## Adjacent-case matrix (proves the rule, not the spelling)
1. Plain intrinsic `<a/>`, `<a-b/>`, `<a-c/>` — anchored on `const a/b/c`.
2. Renamed escape form `<\u{0061}/>` head — anchored on `const d`.
3. Escape on either side of a kebab hyphen — `<\u{0061}-b/>` (`const e`) and `<a-\u{0063}/>` (`const f`).
4. Component-side extended escape preserves raw spelling: `<Comp\u{0061} x={12} />` → `React.createElement(Comp\u{0061}, { x: 12 })`.
5. Already-covered `\uXXXX` form for component / member / attribute identifier names left untouched in the existing tests.

## Coordination Notes
Narrow test-coverage slice of the JSX/react emit family (#8512). Does not duplicate the line-ending slice (PR #10577, merged 2026-05-27) or the parser-recovery `jsxNamespacePrefixInName` subfamily (open). The `\u{...}` extended-escape coverage in particular was missing — the existing `jsx_classic_unicode_escape_component_and_member_names_are_preserved` only covered `\uXXXX`.

Auto-merge will be enabled after the PR is created; the change is unit-test-only so the gate is light CI (lint + unit + dist-binaries) — no heavy conformance/emit suite needed.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1HWpjtZ6MgH5xM9ZrTHZz)_