### PR TITLE
fix(ci): dispatch merge queue synthetic CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,7 @@ jobs:
           arch_tool_only=false
           compiler_checks_required=true
           unit_packages=""
-          if [[ "${CI_EVENT_NAME}" == "push" \
-                && "${CI_REF}" == refs/heads/automation/merge-queue/* ]]; then
+          if [[ "${CI_REF}" == refs/heads/automation/merge-queue/* ]]; then
             # Queue branches are synthetic latest-main merge commits. The PR
             # head has already passed required PR CI before queueing, so keep
             # only the required summary check alive for queue throughput.

--- a/.github/workflows/poor-mans-merge-queue.yml
+++ b/.github/workflows/poor-mans-merge-queue.yml
@@ -35,7 +35,7 @@ permissions:
   pull-requests: write
   checks: read
   statuses: write
-  actions: read
+  actions: write
 
 concurrency:
   group: poor-mans-merge-queue-${{ github.repository }}
@@ -56,6 +56,7 @@ jobs:
           GH_TOKEN: ${{ secrets.TSZ_PR_AUTOMATION_TOKEN || github.token }}
           HAS_AUTOMATION_TOKEN: ${{ secrets.TSZ_PR_AUTOMATION_TOKEN != '' }}
           REPOSITORY: ${{ github.repository }}
+          CI_WORKFLOW: ci.yml
           DRY_RUN_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
           INVALIDATE_OPEN_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.invalidate_open || github.event_name == 'push' }}
           MAX_PRS_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.max_prs || 200 }}
@@ -75,6 +76,7 @@ jobs:
           args=(
             --repository "${REPOSITORY}"
             --base main
+            --ci-workflow "${CI_WORKFLOW}"
             --max-prs "${MAX_PRS_INPUT}"
           )
           if [[ "${dry_run}" == "true" ]]; then
@@ -87,7 +89,7 @@ jobs:
           if [[ "${PR_EVENT_ACTION}" == "closed" && -n "${PR_NUMBER}" ]]; then
             echo "Closed PR event only wakes the queue; no status invalidation needed."
           elif [[ -n "${PR_NUMBER}" ]]; then
-            args=(--repository "${REPOSITORY}" --base main --invalidate-pr "${PR_NUMBER}")
+            args=(--repository "${REPOSITORY}" --base main --ci-workflow "${CI_WORKFLOW}" --invalidate-pr "${PR_NUMBER}")
             if [[ "${dry_run}" == "true" ]]; then
               args+=(--dry-run)
             fi

--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -7,6 +7,7 @@ const DEFAULT_MAX_PRS = 200;
 const DEFAULT_QUEUE_BRANCH_PREFIX = "automation/merge-queue";
 const DEFAULT_QUEUE_LABEL = "merge-queue";
 const DEFAULT_STATUS_CONTEXT = "Queue Tested";
+const DEFAULT_CI_WORKFLOW = "ci.yml";
 const DEFAULT_PR_REQUIRED_CHECKS = ["CI Summary", "GitGuardian Security Checks"];
 const DEFAULT_MERGE_REQUIRED_CHECKS = ["CI Summary"];
 const DEFAULT_WAIT_ATTEMPTS = 90;
@@ -28,6 +29,7 @@ function usage() {
     "  --status-context <name>         Required status context to post",
     "  --queue-label <name>            Label that marks a PR ready for the queue",
     "  --queue-branch-prefix <prefix>  Temporary branch namespace",
+    "  --ci-workflow <id>              CI workflow file/id to dispatch for synthetic branches",
     "  --agent-name <name>             AgentName for queue failure comments",
     "  --pr-required-check <name>      PR-head check required before queueing",
     "  --merge-required-check <name>   Synthetic merge check required before merge",
@@ -55,6 +57,7 @@ export function parseArgs(argv) {
   const options = {
     agentName: process.env.AGENT_NAME || "M1-A",
     base: process.env.BASE_BRANCH || DEFAULT_BASE,
+    ciWorkflow: process.env.CI_WORKFLOW || DEFAULT_CI_WORKFLOW,
     cleanupQueueBranches: false,
     cleanupSupersededOpenQueueBranches: false,
     dryRun: false,
@@ -91,6 +94,9 @@ export function parseArgs(argv) {
     } else if (arg === "--queue-branch-prefix") {
       options.queueBranchPrefix = argv[++index];
       if (!options.queueBranchPrefix) throw new Error("--queue-branch-prefix requires a branch prefix");
+    } else if (arg === "--ci-workflow") {
+      options.ciWorkflow = argv[++index];
+      if (!options.ciWorkflow) throw new Error("--ci-workflow requires a workflow file/id");
     } else if (arg === "--agent-name") {
       options.agentName = argv[++index];
       if (!options.agentName) throw new Error("--agent-name requires an AgentName");
@@ -562,6 +568,22 @@ function postComment(repository, number, body) {
   ]);
 }
 
+export function syntheticCiDispatchArgs(repository, workflow, branch) {
+  if (!repository) throw new Error("repository is required");
+  if (!workflow) throw new Error("workflow is required");
+  if (!branch) throw new Error("branch is required");
+  const workflowId = encodeURIComponent(String(workflow));
+  return [
+    "api", "-X", "POST",
+    `repos/${repository}/actions/workflows/${workflowId}/dispatches`,
+    "-f", `ref=${branch}`,
+  ];
+}
+
+function dispatchSyntheticCi(repository, synthetic, options) {
+  runGh(syntheticCiDispatchArgs(repository, options.ciWorkflow, synthetic.branch));
+}
+
 export function failureCommentBody(agentName, reason) {
   const lines = [
     `AgentName: ${cleanAgentName(agentName)}`,
@@ -945,6 +967,7 @@ function prepareSyntheticMerge(repository, pr, baseOid, options) {
   const mergeOid = git(["rev-parse", "HEAD"]).trim();
   if (!options.dryRun) {
     git(["push", forceWithLeaseArg(branch), "origin", `${mergeOid}:refs/heads/${branch}`], { stdio: "inherit" });
+    dispatchSyntheticCi(repository, { branch, mergeOid }, options);
   }
   return { branch, mergeOid };
 }

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -23,6 +23,7 @@ import {
   skipOwnerReasonCounts,
   skipReasonCounts,
   supersededOpenQueueBranchReason,
+  syntheticCiDispatchArgs,
 } from "./poor-mans-merge-queue.mjs";
 
 function check(overrides = {}) {
@@ -63,6 +64,7 @@ if (originalAgentName === undefined) {
 }
 assert.equal(parseArgs(["--repository", "owner/repo", "--agent-name", "M4-B"]).agentName, "M4-B");
 assert.equal(parseArgs(["--repository", "owner/repo", "--queue-label", "ready-to-merge"]).queueLabel, "ready-to-merge");
+assert.equal(parseArgs(["--repository", "owner/repo", "--ci-workflow", "queue-ci.yml"]).ciWorkflow, "queue-ci.yml");
 assert.equal(parseArgs(["--repository", "owner/repo", "--cleanup-queue-branches"]).cleanupQueueBranches, true);
 assert.equal(
   parseArgs(["--repository", "owner/repo", "--cleanup-superseded-open-queue-branches"]).cleanupSupersededOpenQueueBranches,
@@ -122,6 +124,22 @@ assert.match(
 assert.equal(
   supersededOpenQueueBranchReason("automation/merge-queue/pr-123", "a56115afffffffffffffffffffffffffffffffffff"),
   null,
+);
+assert.deepEqual(
+  syntheticCiDispatchArgs("owner/repo", "ci.yml", "automation/merge-queue/pr-123"),
+  [
+    "api", "-X", "POST",
+    "repos/owner/repo/actions/workflows/ci.yml/dispatches",
+    "-f", "ref=automation/merge-queue/pr-123",
+  ],
+);
+assert.deepEqual(
+  syntheticCiDispatchArgs("owner/repo", ".github/workflows/ci.yml", "automation/merge-queue/pr-123"),
+  [
+    "api", "-X", "POST",
+    "repos/owner/repo/actions/workflows/.github%2Fworkflows%2Fci.yml/dispatches",
+    "-f", "ref=automation/merge-queue/pr-123",
+  ],
 );
 
 const paginatedObjectArrayUrls = [];


### PR DESCRIPTION
## Agent
AgentName: m5-pro-48g-gpt5

## Track
CI / merge queue

## Invariant
When the merge queue creates a synthetic latest-main merge branch, that exact branch must produce a `CI Summary`; the queue should not depend on branch-push side effects that GitHub may suppress for automation tokens.

## Scope
- Dispatch `ci.yml` explicitly after pushing `automation/merge-queue/pr-*` synthetic branches.
- Treat workflow-dispatched synthetic queue refs as lightweight CI, matching the push path.
- Grant the queue workflow `actions: write` so the dispatch can be made by the workflow token path too.
- Add focused Node coverage for the new dispatch argument path.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI/queue orchestration only; no compiler, project corpus, or benchmark semantics changed.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `node --check scripts/ci/poor-mans-merge-queue.mjs && node --check scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --base main --ci-workflow ci.yml --dry-run --verbose --max-prs 50`

## Coordination Notes
- Queue evidence before this PR: #10722 required a manual `Queue Tested` repair because `automation/merge-queue/pr-10722` never produced a synthetic `CI Summary` from branch push.
- Current queue candidates remain blocked pending this repair; after merge, rerun the queue and verify #10724 or the next candidate advances without manual status patching.