### PR TITLE
fix(ci): retry merge queue read api calls

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -12,6 +12,8 @@ const DEFAULT_PR_REQUIRED_CHECKS = ["CI Summary", "GitGuardian Security Checks"]
 const DEFAULT_MERGE_REQUIRED_CHECKS = ["CI Summary"];
 const DEFAULT_WAIT_ATTEMPTS = 90;
 const DEFAULT_WAIT_INTERVAL_MS = 20_000;
+const GH_API_RETRY_ATTEMPTS = 4;
+const GH_API_RETRY_DELAY_MS = 1_500;
 const GH_MAX_BUFFER_BYTES = 24 * 1024 * 1024;
 const SUCCESSFUL_CHECK_STATES = new Set(["SUCCESS", "NEUTRAL", "SKIPPED"]);
 const SUCCESSFUL_STATUS_STATES = new Set(["SUCCESS"]);
@@ -160,8 +162,42 @@ function run(command, args, options = {}) {
   return result.stdout || "";
 }
 
+export function ghApiCallIsReadOnly(args) {
+  if (!Array.isArray(args) || args[0] !== "api") return false;
+  for (let index = 1; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "-X" || arg === "--method") {
+      const method = String(args[index + 1] || "").toUpperCase();
+      return method === "GET";
+    }
+    if (String(arg).startsWith("--method=")) {
+      const method = String(arg).slice("--method=".length).toUpperCase();
+      return method === "GET";
+    }
+    if (["-f", "-F", "--field", "--raw-field", "--input"].includes(arg)) return false;
+  }
+  return true;
+}
+
+function runWithRetry(command, args, { attempts, delayMs }) {
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return run(command, args);
+    } catch (error) {
+      lastError = error;
+      if (attempt === attempts) break;
+      console.warn(`${command} ${args.join(" ")} failed; retrying ${attempt}/${attempts - 1}`);
+      sleep(delayMs);
+    }
+  }
+  throw lastError;
+}
+
 function runGh(args) {
-  return run("gh", args);
+  return ghApiCallIsReadOnly(args)
+    ? runWithRetry("gh", args, { attempts: GH_API_RETRY_ATTEMPTS, delayMs: GH_API_RETRY_DELAY_MS })
+    : run("gh", args);
 }
 
 function runGhJson(args) {

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -7,6 +7,7 @@ import {
   failureCommentBody,
   forceWithLeaseArgForOid,
   formatResult,
+  ghApiCallIsReadOnly,
   hasPendingPlaceholderQueueStatus,
   normalizePullRequestState,
   normalizeRestPullRequest,
@@ -141,6 +142,12 @@ assert.deepEqual(
     "-f", "ref=automation/merge-queue/pr-123",
   ],
 );
+assert.equal(ghApiCallIsReadOnly(["api", "repos/owner/repo/pulls?state=open", "--jq", "."]), true);
+assert.equal(ghApiCallIsReadOnly(["api", "-X", "GET", "repos/owner/repo/pulls"]), true);
+assert.equal(ghApiCallIsReadOnly(["api", "--method=GET", "repos/owner/repo/pulls"]), true);
+assert.equal(ghApiCallIsReadOnly(["api", "-X", "POST", "repos/owner/repo/statuses/abc"]), false);
+assert.equal(ghApiCallIsReadOnly(["api", "repos/owner/repo/actions/workflows/ci.yml/dispatches", "-f", "ref=main"]), false);
+assert.equal(ghApiCallIsReadOnly(["pr", "view", "1"]), false);
 
 const paginatedObjectArrayUrls = [];
 assert.deepEqual(


### PR DESCRIPTION
## Agent
AgentName: m5-pro-48g-gpt5

## Track
CI / merge queue

## Invariant
When GitHub has a transient read API failure while the merge queue is inspecting PRs or checks, the queue should retry the read instead of creating a red queue run. Mutating operations must stay single-shot to avoid duplicated side effects.

## Scope
- Retry read-only `gh api` calls used by the queue.
- Do not retry mutating `gh api` calls such as statuses, comments, dispatches, or merges.
- Add focused Node coverage for read-only vs mutating API call classification.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI/queue orchestration only; no compiler or project corpus behavior changed.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `node --check scripts/ci/poor-mans-merge-queue.mjs && node --check scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`

## Coordination Notes
- During the 3-hour queue watch, runs 26576823193 and 26576871718 failed on transient-looking read-only `gh api` calls, while adjacent queue runs succeeded. This PR reduces that queue noise without changing merge semantics.