### PR TITLE
fix(checker): optional private field write type widens to T | undefined

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -811,6 +811,9 @@ mod object_spread_optional_merge_tests;
 #[path = "tests/optional_key_extraction_tests.rs"]
 mod optional_key_extraction_tests;
 #[cfg(test)]
+#[path = "../tests/optional_private_field_write_type_tests.rs"]
+mod optional_private_field_write_type_tests;
+#[cfg(test)]
 #[path = "tests/overload_anchor_at_argument_tests.rs"]
 mod overload_anchor_at_argument_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs
@@ -257,6 +257,9 @@ impl<'a> CheckerState<'a> {
             let Some(prop) = self.ctx.arena.get_property_decl(node) else {
                 continue;
             };
+            // Capture the optional flag before the mutable borrow consumed by the
+            // type-resolution calls below. `bool` is Copy so this is zero-cost.
+            let is_optional = prop.question_token;
             let declared_type = if is_write_context {
                 self.class_property_relation_declared_type(decl_idx, prop)
             } else {
@@ -274,6 +277,17 @@ impl<'a> CheckerState<'a> {
                     })
                 {
                     return Some(evaluated);
+                }
+                // An optional private field `#x?: T` has write type `T | undefined`
+                // under strictNullChecks without exactOptionalPropertyTypes, matching
+                // the public field rule (p?: T also widens to T | undefined on write).
+                if is_write_context
+                    && is_optional
+                    && self.ctx.strict_null_checks()
+                    && !self.ctx.exact_optional_property_types()
+                {
+                    let widened = self.ctx.types.factory().union2(type_id, TypeId::UNDEFINED);
+                    return Some(widened);
                 }
                 return Some(type_id);
             }

--- a/crates/tsz-checker/tests/optional_private_field_write_type_tests.rs
+++ b/crates/tsz-checker/tests/optional_private_field_write_type_tests.rs
@@ -1,0 +1,182 @@
+//! Tests for TS2322 on optional private field writes (#x?: T).
+//!
+//! Structural rule: When a private class field is optional (`#x?: T`), under
+//! `strictNullChecks` without `exactOptionalPropertyTypes`, its write-context
+//! type is `T | undefined`, matching the public optional field rule.
+//!
+//! Repro: kysely false TS2322 assigning `undefined` to `#promise?: Promise<void>`
+//! (GitHub issue #10749).
+
+use crate::context::CheckerOptions;
+
+fn diags_with_options(source: &str, options: CheckerOptions) -> Vec<u32> {
+    crate::test_utils::check_source(source, "test.ts", options)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn strict_opts() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn eopt_opts() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        exact_optional_property_types: true,
+        ..CheckerOptions::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Minimal repro from issue #10749
+// ---------------------------------------------------------------------------
+
+#[test]
+fn optional_private_promise_field_assign_undefined_no_error() {
+    let source = r#"
+class Mutex {
+    #promise?: Promise<void>
+    unlock(): void {
+        this.#promise = undefined
+    }
+}
+"#;
+    let diags = diags_with_options(source, strict_opts());
+    let ts2322: Vec<_> = diags.iter().filter(|&&c| c == 2322).collect();
+    assert!(
+        ts2322.is_empty(),
+        "assigning undefined to optional #promise should not produce TS2322; got codes: {diags:?}"
+    );
+}
+
+#[test]
+fn optional_private_fn_field_assign_undefined_no_error() {
+    // Different name from the repro — ensures the fix is not name-keyed.
+    let source = r#"
+class Mutex {
+    #resolve?: () => void
+    unlock(): void {
+        this.#resolve = undefined
+    }
+}
+"#;
+    let diags = diags_with_options(source, strict_opts());
+    let ts2322: Vec<_> = diags.iter().filter(|&&c| c == 2322).collect();
+    assert!(
+        ts2322.is_empty(),
+        "assigning undefined to optional #resolve should not produce TS2322; got codes: {diags:?}"
+    );
+}
+
+#[test]
+fn optional_private_field_different_names_no_error() {
+    // Another name variation: #counter?, #state? — verifies structural, not spelling match.
+    let source = r#"
+class Counter {
+    #counter?: number
+    #state?: string
+    reset(): void {
+        this.#counter = undefined
+        this.#state = undefined
+    }
+}
+"#;
+    let diags = diags_with_options(source, strict_opts());
+    let ts2322: Vec<_> = diags.iter().filter(|&&c| c == 2322).collect();
+    assert!(
+        ts2322.is_empty(),
+        "assigning undefined to optional #counter/#state should not produce TS2322; got codes: {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative: wrong-type assignment still errors
+// ---------------------------------------------------------------------------
+
+#[test]
+fn optional_private_field_wrong_type_still_errors() {
+    let source = r#"
+class Foo {
+    #bar?: number
+    bad(): void {
+        this.#bar = "string"
+    }
+}
+"#;
+    let diags = diags_with_options(source, strict_opts());
+    let ts2322_count = diags.iter().filter(|&&c| c == 2322).count();
+    assert_eq!(
+        ts2322_count, 1,
+        "assigning a string to optional #bar: number should produce TS2322; got codes: {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative: non-optional private field rejects undefined
+// ---------------------------------------------------------------------------
+
+#[test]
+fn non_optional_private_field_rejects_undefined() {
+    let source = r#"
+class Foo {
+    #bar: number = 0
+    bad(): void {
+        this.#bar = undefined
+    }
+}
+"#;
+    let diags = diags_with_options(source, strict_opts());
+    let ts2322_count = diags.iter().filter(|&&c| c == 2322).count();
+    assert_eq!(
+        ts2322_count, 1,
+        "assigning undefined to non-optional #bar should produce TS2322; got codes: {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// exactOptionalPropertyTypes: assigning undefined IS an error
+// ---------------------------------------------------------------------------
+
+#[test]
+fn exact_optional_private_field_rejects_undefined() {
+    let source = r#"
+class Foo {
+    #val?: number
+    bad(): void {
+        this.#val = undefined
+    }
+}
+"#;
+    let diags = diags_with_options(source, eopt_opts());
+    let ts2322_count = diags.iter().filter(|&&c| c == 2322).count();
+    assert_eq!(
+        ts2322_count, 1,
+        "with exactOptionalPropertyTypes, assigning undefined to optional #val should produce TS2322; got codes: {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Public optional field behaves identically (regression guard)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn optional_public_field_assign_undefined_no_error() {
+    let source = r#"
+class Foo {
+    bar?: number
+    reset(): void {
+        this.bar = undefined
+    }
+}
+"#;
+    let diags = diags_with_options(source, strict_opts());
+    let ts2322: Vec<_> = diags.iter().filter(|&&c| c == 2322).collect();
+    assert!(
+        ts2322.is_empty(),
+        "assigning undefined to optional public field should not produce TS2322; got codes: {diags:?}"
+    );
+}

--- a/crates/tsz-checker/tests/optional_private_field_write_type_tests.rs
+++ b/crates/tsz-checker/tests/optional_private_field_write_type_tests.rs
@@ -5,7 +5,7 @@
 //! type is `T | undefined`, matching the public optional field rule.
 //!
 //! Repro: kysely false TS2322 assigning `undefined` to `#promise?: Promise<void>`
-//! (GitHub issue #10749).
+//! (issue #10749).
 
 use crate::context::CheckerOptions;
 


### PR DESCRIPTION
## Summary

**AgentName:** dazzling-johnson  
**Track:** conformance / checker correctness  
**Fixes:** #10749

### Structural rule

When a private class field is optional (`#x?: T`), under `strictNullChecks` without `exactOptionalPropertyTypes`, its write-context type is `T | undefined` — matching the rule for public optional fields (`x?: T`).

### Root cause

`private_property_declared_access_type` in `computed_helpers_private.rs` has a fast path for private fields that calls `class_property_relation_declared_type`, which returns the raw declared type `T`. The function returned early without applying the `| undefined` widening for optional fields. The public-field code path goes through `PropertyInfo.optional` and already does this widening correctly.

### Fix

Extract `prop.question_token` (a `bool`, Copy) before the mutable borrow consumed by `class_property_relation_declared_type`, then widen via `factory.union2(type_id, TypeId::UNDEFINED)` when all four conditions hold:
1. `is_write_context` — assignment target, not read
2. `is_optional` — field has a `?` token
3. `strict_null_checks()` — widening only matters with SNS
4. `!exact_optional_property_types()` — EOPT keeps `T` exactly

### Invariant

The checker must not reject `this.#x = undefined` when `#x` is declared as `#x?: T` under standard strictNullChecks.

### Scope

Single function, three lines of logic. No new allocations on the non-optional fast path.

## Adjacent cases covered by tests

| Case | Expected |
|------|----------|
| `#promise?: Promise<void>` assigned `undefined` (original repro) | no error |
| `#resolve?: () => void` assigned `undefined` (different name) | no error |
| `#counter?: number`, `#state?: string` (further name variation) | no error |
| `#bar?: number` assigned `"string"` | TS2322 |
| Non-optional `#bar: number` assigned `undefined` | TS2322 |
| Optional `#val?: number` + `exactOptionalPropertyTypes` assigned `undefined` | TS2322 |
| Public optional `bar?: number` assigned `undefined` (regression guard) | no error |

## Project Corpus Impact

**Row:** kysely  
**Bug family:** false TS2322 on optional private field write  
**Evidence:** The issue lists 6 false-positive TS2322 errors in kysely's `Mutex` class (`#promise?: Promise<void>`, `#resolve?: () => void`) that disappear with this fix. Local unit tests verify the exact repro pattern and three name-varied equivalents.

## Verification

```
cargo test -p tsz-checker --lib optional_private_field
# running 7 tests … test result: ok. 7 passed; 0 failed
cargo check -p tsz-checker
# Finished dev profile
```

## Coordination Notes

- No overlap with other open PRs (checked open/draft PR list before starting).
- Draft: waiting for CI (lint + dist-fast + unit).
- Will mark ready once draft CI is green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGbPuygVBPuAyKNCYZ3uax)_