### PR TITLE
fix(emit): emit live-binding getters for named-import re-exports in CJS

### DIFF
--- a/crates/tsz-checker/src/declarations/import/core/import_members.rs
+++ b/crates/tsz-checker/src/declarations/import/core/import_members.rs
@@ -977,7 +977,7 @@ impl<'a> CheckerState<'a> {
             }
         }
     }
-    pub(super) fn import_binding_is_type_only(&self, module_name: &str, import_name: &str) -> bool {
+    pub(crate) fn import_binding_is_type_only(&self, module_name: &str, import_name: &str) -> bool {
         if self.is_import_specifier_type_only(module_name, import_name)
             || self.is_export_type_only_across_binders(module_name, import_name)
             || (import_name == "default" && self.module_default_export_is_type_only(module_name))
@@ -1189,6 +1189,8 @@ impl<'a> CheckerState<'a> {
             || ((flags & (symbol_flags::NAMESPACE_MODULE | symbol_flags::VALUE_MODULE)) != 0
                 && !self.symbol_has_runtime_value_in_binder(target_binder, sym_id))
             || self.declaration_file_direct_export_is_type_only(target_idx, import_name)
+            || ((flags & symbol_flags::CONST_ENUM) != 0
+                && !self.ctx.compiler_options.preserve_const_enums)
     }
 
     fn declaration_file_direct_export_is_type_only(
@@ -1376,6 +1378,10 @@ impl<'a> CheckerState<'a> {
             || ((flags & PURE_TYPE) != 0 && (flags & VALUE) == 0)
             || ((flags & (symbol_flags::NAMESPACE_MODULE | symbol_flags::VALUE_MODULE)) != 0
                 && !self.symbol_has_runtime_value_in_binder(binder, sym_id))
+            // Const enums are type-only for emit unless --preserveConstEnums is set:
+            // `import { ConstEnum }` should be elided when const enum values are inlined.
+            || ((flags & symbol_flags::CONST_ENUM) != 0
+                && !self.ctx.compiler_options.preserve_const_enums)
     }
 
     fn module_default_export_is_type_only(&self, module_name: &str) -> bool {

--- a/crates/tsz-checker/src/declarations/module_checker.rs
+++ b/crates/tsz-checker/src/declarations/module_checker.rs
@@ -641,6 +641,15 @@ impl<'a> CheckerState<'a> {
                     );
                 }
             }
+
+            // Mark specifiers that re-export type-only symbols for emit elision.
+            // When `export { A } from "mod"` and A is type-only in mod (interface,
+            // type alias, uninstantiated namespace, const enum without preserveConstEnums),
+            // the emitter must skip it — mark the specifier NodeIndex so the emitter
+            // can filter it in `collect_export_names_with_options` and the re-export path.
+            if self.import_binding_is_type_only(module_name, &export_name) {
+                self.ctx.type_only_nodes.insert(specifier_idx);
+            }
         }
     }
 
@@ -1039,6 +1048,33 @@ impl<'a> CheckerState<'a> {
                     crate::diagnostics::diagnostic_codes::TYPES_CANNOT_APPEAR_IN_EXPORT_DECLARATIONS_IN_JAVASCRIPT_FILES,
                 );
                 continue;
+            }
+
+            // Mark local re-export specifiers for emit elision when the re-exported
+            // local binding resolves to a type-only symbol (interface, type alias,
+            // uninstantiated namespace, or a const enum without preserveConstEnums).
+            // This covers `import { I1 as I } from "mod"; export { I }` — the import
+            // checker marks the import specifier, but the export specifier has a
+            // different NodeIndex that the emitter checks separately.
+            //
+            // For import-alias bindings, use `import_binding_is_type_only` which has
+            // full const-enum awareness. For other local symbols, `is_local_symbol_type_only`
+            // handles interfaces, type aliases, and uninstantiated namespaces.
+            if is_local && !enclosing_export_is_type_only && !specifier.is_type_only {
+                use tsz_binder::symbol_flags;
+                let is_type_only = if let Some(sym_id) = self.ctx.binder.file_locals.get(&name_str)
+                    && let Some(sym) = self.ctx.binder.get_symbol(sym_id)
+                    && sym.has_any_flags(symbol_flags::ALIAS)
+                    && let Some(ref module_spec) = sym.import_module
+                {
+                    let import_name = sym.import_name.as_deref().unwrap_or(&name_str);
+                    self.import_binding_is_type_only(module_spec, import_name)
+                } else {
+                    self.is_local_symbol_type_only(&name_str)
+                };
+                if is_type_only {
+                    self.ctx.type_only_nodes.insert(specifier_idx);
+                }
             }
 
             if !is_local {

--- a/crates/tsz-emitter/src/emitter/module_emission/core/tests/cjs_named_import_reexport_tests.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/tests/cjs_named_import_reexport_tests.rs
@@ -1,0 +1,249 @@
+/// Tests for CJS emit of named import re-exports.
+///
+/// When TypeScript compiles `import { v1 as v } from "./mod"; export { v }` to
+/// CommonJS, tsc emits a live-binding `Object.defineProperty` getter rather than
+/// a static `exports.v = v` assignment. This file verifies that tsz matches that
+/// behavior across different name spellings and numbers of specifiers, and that
+/// checker-supplied type-only annotations cause specifiers to be elided.
+use crate::emitter::{ModuleKind, Printer, PrinterOptions};
+use tsz_parser::parser::NodeIndex;
+
+use super::parse_test_source;
+
+fn collect_all_export_specifier_indices(
+    source: &str,
+) -> (
+    tsz_parser::ParserState,
+    tsz_parser::parser::NodeIndex,
+    rustc_hash::FxHashSet<NodeIndex>,
+) {
+    let (parser, root) = parse_test_source(source);
+    let mut specifier_indices = rustc_hash::FxHashSet::default();
+    if let Some(sf_node) = parser.arena.get(root)
+        && let Some(sf) = parser.arena.get_source_file(sf_node)
+    {
+        for &stmt_idx in &sf.statements.nodes {
+            let Some(stmt) = parser.arena.get(stmt_idx) else {
+                continue;
+            };
+            let Some(export_decl) = parser.arena.get_export_decl(stmt) else {
+                continue;
+            };
+            let Some(clause_node) = parser.arena.get(export_decl.export_clause) else {
+                continue;
+            };
+            let Some(named_exports) = parser.arena.get_named_imports(clause_node) else {
+                continue;
+            };
+            specifier_indices.extend(named_exports.elements.nodes.iter().copied());
+        }
+    }
+    (parser, root, specifier_indices)
+}
+
+fn emit_commonjs(source: &str) -> String {
+    emit_commonjs_with_type_only(source, rustc_hash::FxHashSet::default())
+}
+
+fn emit_commonjs_with_type_only(
+    source: &str,
+    type_only_nodes: rustc_hash::FxHashSet<NodeIndex>,
+) -> String {
+    let (parser, root) = parse_test_source(source);
+    let options = PrinterOptions {
+        module: ModuleKind::CommonJS,
+        type_only_nodes: std::sync::Arc::new(type_only_nodes),
+        ..Default::default()
+    };
+    let mut printer = Printer::with_options(&parser.arena, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+// ── Object.defineProperty getter for named import re-exports ────────────────
+
+/// When `import { origName as localName } from "mod"; export { localName }`,
+/// tsc emits a live-binding getter so the exported value always reflects the
+/// current module binding, not a snapshot at module-load time.
+/// This test uses alias spelling "v1 → v".
+#[test]
+fn named_import_reexport_emits_define_property_getter_v_alias() {
+    let source = r#"import { v1 as v } from "./mod";
+export { v };
+"#;
+    let output = emit_commonjs(source);
+    assert!(
+        output.contains(r#"Object.defineProperty(exports, "v", { enumerable: true, get: function () { return mod_1.v1; } });"#),
+        "Named import re-export should emit a live-binding getter.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("exports.v = v;"),
+        "Named import re-export must not emit a static assignment.\nOutput:\n{output}"
+    );
+}
+
+/// Same rule with a different alias spelling: "first1 → first".
+/// Verifies the fix is not keyed to a specific identifier name.
+#[test]
+fn named_import_reexport_emits_define_property_getter_first_alias() {
+    let source = r#"import { first1 as first } from "./util";
+export { first };
+"#;
+    let output = emit_commonjs(source);
+    assert!(
+        output.contains(r#"Object.defineProperty(exports, "first", { enumerable: true, get: function () { return util_1.first1; } });"#),
+        "Named import re-export with 'first' alias should emit a live-binding getter.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("exports.first = first;"),
+        "Named import re-export must not emit a static assignment.\nOutput:\n{output}"
+    );
+}
+
+/// Multiple named-import re-exports in a single export clause each get their
+/// own Object.defineProperty getter with the correct source module reference.
+#[test]
+fn multiple_named_import_reexports_each_emit_define_property_getter() {
+    let source = r#"import { alpha1 as alpha, beta1 as beta } from "./pkg";
+export { alpha, beta };
+"#;
+    let output = emit_commonjs(source);
+    assert!(
+        output.contains(r#"Object.defineProperty(exports, "alpha", { enumerable: true, get: function () { return pkg_1.alpha1; } });"#),
+        "alpha re-export should emit a getter.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(r#"Object.defineProperty(exports, "beta", { enumerable: true, get: function () { return pkg_1.beta1; } });"#),
+        "beta re-export should emit a getter.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("exports.alpha = alpha;") && !output.contains("exports.beta = beta;"),
+        "Named import re-exports must not emit static assignments.\nOutput:\n{output}"
+    );
+}
+
+/// A local declaration export (not a named import) still emits a static assignment,
+/// not an Object.defineProperty getter.  This verifies the getter path only fires
+/// when the local name has a CommonJS named-import substitution.
+#[test]
+fn local_var_export_still_emits_static_assignment() {
+    let source = r#"var myVar = 42;
+export { myVar };
+"#;
+    let output = emit_commonjs(source);
+    assert!(
+        output.contains("exports.myVar = myVar;"),
+        "Local variable re-export should still emit a static assignment.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("Object.defineProperty(exports, \"myVar\""),
+        "Local variable re-export should not emit a getter.\nOutput:\n{output}"
+    );
+}
+
+// ── Type-only specifier elision in export-from path ─────────────────────────
+
+/// When the checker marks all specifiers in `export { A, B } from "./mod"` as
+/// type-only (simulating interface / type alias / const enum elision), none of
+/// them should appear in the JavaScript output.
+#[test]
+fn type_only_marked_reexport_from_elides_all_specifiers() {
+    let source = r#"export { InterfaceX, TypeAliasY } from "./types";"#;
+    let (parser, root, all_spec_indices) = collect_all_export_specifier_indices(source);
+    let options = PrinterOptions {
+        module: ModuleKind::CommonJS,
+        type_only_nodes: std::sync::Arc::new(all_spec_indices),
+        ..Default::default()
+    };
+    let mut printer = Printer::with_options(&parser.arena, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert!(
+        !output.contains("InterfaceX") && !output.contains("TypeAliasY"),
+        "Checker-marked type-only specifiers in re-export-from must be elided.\nOutput:\n{output}"
+    );
+}
+
+/// Same elision rule with different specifier names, confirming the fix is
+/// not gated on particular identifier spellings.
+#[test]
+fn type_only_marked_reexport_from_elides_differently_named_specifiers() {
+    let source = r#"export { SomeKind, AnotherAlias } from "./defs";"#;
+    let (parser, root, all_spec_indices) = collect_all_export_specifier_indices(source);
+    let options = PrinterOptions {
+        module: ModuleKind::CommonJS,
+        type_only_nodes: std::sync::Arc::new(all_spec_indices),
+        ..Default::default()
+    };
+    let mut printer = Printer::with_options(&parser.arena, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert!(
+        !output.contains("SomeKind") && !output.contains("AnotherAlias"),
+        "Type-only specifiers with different names must also be elided.\nOutput:\n{output}"
+    );
+    // The __esModule defineProperty is always present; verify the source module's
+    // require() and any specifier-specific defineProperty calls are absent.
+    assert!(
+        !output.contains("require(\"./defs\")"),
+        "No require for the source module should be emitted when all specifiers are type-only.\nOutput:\n{output}"
+    );
+}
+
+/// Mixed case: only some specifiers are type-only.  Value specifier survives;
+/// type-only specifier is elided.
+#[test]
+fn type_only_marked_mixed_reexport_elides_only_type_only_specifiers() {
+    let source = r#"export { ValueA, TypeB } from "./mixed";"#;
+    let (parser, root, all_spec_indices) = collect_all_export_specifier_indices(source);
+    // Mark only the second specifier (TypeB) as type-only.
+    // Collect them in order so we can target just the second one.
+    let (parser2, root2) = parse_test_source(source);
+    let mut type_only_nodes = rustc_hash::FxHashSet::default();
+    if let Some(sf_node) = parser2.arena.get(root2)
+        && let Some(sf) = parser2.arena.get_source_file(sf_node)
+    {
+        for &stmt_idx in &sf.statements.nodes {
+            let Some(stmt) = parser2.arena.get(stmt_idx) else {
+                continue;
+            };
+            let Some(export_decl) = parser2.arena.get_export_decl(stmt) else {
+                continue;
+            };
+            let Some(clause_node) = parser2.arena.get(export_decl.export_clause) else {
+                continue;
+            };
+            let Some(named_exports) = parser2.arena.get_named_imports(clause_node) else {
+                continue;
+            };
+            // Mark only the second element (TypeB) as type-only.
+            if let Some(&second) = named_exports.elements.nodes.get(1) {
+                type_only_nodes.insert(second);
+            }
+        }
+    }
+    let options = PrinterOptions {
+        module: ModuleKind::CommonJS,
+        type_only_nodes: std::sync::Arc::new(type_only_nodes),
+        ..Default::default()
+    };
+    let mut printer = Printer::with_options(&parser2.arena, options);
+    printer.set_source_text(source);
+    printer.emit(root2);
+    let output = printer.get_output().to_string();
+
+    assert!(
+        output.contains("ValueA"),
+        "Value specifier should survive when only the other specifier is type-only.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("TypeB"),
+        "Type-only specifier should be elided from the re-export.\nOutput:\n{output}"
+    );
+    let _ = (parser, root, all_spec_indices); // unused from first parse
+}

--- a/crates/tsz-emitter/src/emitter/module_emission/core/tests/mod.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/tests/mod.rs
@@ -4,6 +4,7 @@ use crate::lowering::LoweringPass;
 use tsz_common::ScriptTarget;
 
 mod cjs_module_exports;
+mod cjs_named_import_reexport_tests;
 mod cjs_namespace_alias;
 mod esm_class_namespace;
 

--- a/crates/tsz-emitter/src/emitter/module_emission/exports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/exports.rs
@@ -667,7 +667,8 @@ impl<'a> Printer<'a> {
                     if let Some(spec_node) = self.arena.get(spec_idx)
                         && let Some(spec) = self.arena.get_specifier(spec_node)
                     {
-                        if spec.is_type_only {
+                        if spec.is_type_only || self.ctx.options.type_only_nodes.contains(&spec_idx)
+                        {
                             continue;
                         }
                         // Get export name and import name (can be string literals)
@@ -1290,6 +1291,29 @@ impl<'a> Printer<'a> {
                                         .runtime_declaration_names
                                         .contains(&local_name)
                                 {
+                                    continue;
+                                }
+
+                                // When the local name is a named-import binding, emit a
+                                // live-binding Object.defineProperty getter using the CJS
+                                // substitution (`t1_1.v1`). This covers the pattern:
+                                //   import { v1 as v } from "./t1"; export { v };
+                                // which must emit:
+                                //   Object.defineProperty(exports, "v",
+                                //     { enumerable: true, get: function () { return t1_1.v1; } });
+                                if let Some(substitution) = self
+                                    .commonjs_named_import_substitutions
+                                    .get(&local_name)
+                                    .cloned()
+                                {
+                                    self.write("Object.defineProperty(exports, \"");
+                                    self.write(&export_name);
+                                    self.write(
+                                        "\", { enumerable: true, get: function () { return ",
+                                    );
+                                    self.write(&substitution);
+                                    self.write("; } });");
+                                    self.write_line();
                                     continue;
                                 }
 


### PR DESCRIPTION
AgentName: dazzling-johnson
Landing agent: cool-clarke-ent0Q

## Track
Emit parity — CommonJS named-import re-export live bindings

## Invariant
When TypeScript compiles `import { v1 as v } from "./mod"; export { v }` to
CommonJS, tsc always emits a live-binding Object.defineProperty getter:

```js
Object.defineProperty(exports, "v", { enumerable: true, get: function () { return mod_1.v1; } });
```

tsz was falling through to the `deferred_local_export_bindings` path which
skips named-import bindings (correctly — they are not locally declared), so
the re-export produced **no output**. Additionally, re-exported type-only
symbols (interfaces, type aliases, uninstantiated namespaces, const enums)
were not being elided from the re-export path because the checker was not
populating `type_only_nodes` for export specifier nodes.

## Scope

**Structural rules implemented:**

1. "When a local export specifier's name is a CJS named-import binding,
   emit an Object.defineProperty live-binding getter using the CJS
   substitution expression (`mod_1.origName`)."

2. "When `export { A } from 'mod'` and A is type-only in mod (interface,
   type alias, uninstantiated namespace, const enum without
   `--preserveConstEnums`), the specifier must be elided from JS output."

3. "When `import { A } from 'mod'; export { A }` and A is a type-only
   binding, the export specifier must be elided from JS output."

**Changes:**

- `crates/tsz-emitter/src/emitter/module_emission/exports.rs`: In the
  `NAMED_EXPORTS` local re-export path, check if the local name has a CJS
  named-import substitution entry; if so, emit the Object.defineProperty
  getter immediately (before falling through to `deferred_local_export_bindings`).
  Also adds `type_only_nodes.contains` check in the re-export-from path
  alongside the existing `spec.is_type_only` syntax check.

- `crates/tsz-checker/src/declarations/module_checker.rs`:
  - `validate_reexported_members`: After existence-check, mark cross-module
    re-export specifiers as type-only when `import_binding_is_type_only` returns true.
  - `check_local_named_exports`: Mark local export specifiers as type-only
    when the local binding is an ALIAS whose import source resolves as
    type-only, or when `is_local_symbol_type_only` holds for non-alias locals.

- `crates/tsz-checker/src/declarations/import/core/import_members.rs`:
  - Widened `import_binding_is_type_only` from `pub(super)` to `pub(crate)`
    so `module_checker.rs` can call it.
  - Added const enum detection to `import_member_binder_symbol_is_type_only`
    and `resolved_import_symbol_is_type_only`: const enums are type-only for
    emit unless `--preserveConstEnums` is set.

## Project Corpus Impact
- Row: emit / exportsAndImports3 (t2.ts, t3.ts)
- Bug family: CJS named-import re-export — missing live-binding getter; type-only const enum / interface / type alias not elided from re-export output.
- Evidence: Local end-to-end diff against tsc baseline — `diff expected_t2.js t2.js` → T2_OK; `diff expected_t3.js t3.js` → T3_OK.

## Verification

**Local tests run (by landing agent cool-clarke-ent0Q on head `f5ab8d9`):**
- `cargo check -p tsz-emitter -p tsz-checker` → clean
- `cargo clippy -p tsz-emitter -p tsz-checker --lib -- -D warnings` → clean
- `cargo test -p tsz-emitter --lib -- cjs_named_import_reexport` → 7 passed, 0 failed (new tests)
- `cargo test -p tsz-emitter --lib -- module_emission` → 111 passed, 1 pre-existing failure
- The single failure (`node_esm_exported_import_equals_require_uses_export_list`) is confirmed pre-existing: it fails identically on base `03091a3` without this PR's changes (unrelated ESM `import =` path).

**CI will run:** conformance, full emit suite, fourslash, WASM.

## Coordination Notes
No other PRs known to overlap with CJS named-import re-export live binding
emission. The const enum type-only detection is a new structural check in
`import_members.rs` that has no known conflicts with open PRs.

Adjacent cases tested by new unit tests (multiple name spellings to satisfy
anti-hardcoding §25):
- `v1 as v` → getter with `mod_1.v1`
- `first1 as first` → getter with `util_1.first1`
- `alpha1 as alpha, beta1 as beta` → two getters
- local var (no substitution) → static assignment still emitted
- type-only-marked `InterfaceX, TypeAliasY` → elided
- type-only-marked `SomeKind, AnotherAlias` → elided (different names)
- mixed `ValueA` (value) + `TypeB` (type-only) → only ValueA emitted

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kidm1kw7FFtoY3WBoTw6RT)_