### PR TITLE
test(solver): cover canonical instantiation substitution keys

### DIFF
--- a/crates/tsz-solver/src/caches/instantiation_cache_test.rs
+++ b/crates/tsz-solver/src/caches/instantiation_cache_test.rs
@@ -13,6 +13,8 @@
 //! 4. The empty / identity short-circuit runs BEFORE cache-key construction,
 //!    leaving the cache untouched on no-op substitutions.
 //! 5. Results from a `depth_exceeded` walk are NOT cached.
+//! 6. Semantically equal substitutions hit the same cache slot even if their
+//!    `FxHashMap` insertion order differs.
 //!
 //! Tests use `TypeInterner` + `QueryCache` and route the cache parameter
 //! explicitly through the `_cached` overloads, mirroring how the hot evaluator
@@ -57,6 +59,43 @@ fn object_with(interner: &TypeInterner, t_id: TypeId) -> TypeId {
         single_quoted_name: false,
     };
     interner.object(vec![prop])
+}
+
+/// Build an object type `{ a: T; b: U }` over two given type-ids.
+fn object_with_pair(interner: &TypeInterner, t_id: TypeId, u_id: TypeId) -> TypeId {
+    let a = interner.intern_string("a");
+    let b = interner.intern_string("b");
+    let prop_a = PropertyInfo {
+        name: a,
+        type_id: t_id,
+        write_type: t_id,
+        optional: false,
+        readonly: false,
+        is_method: false,
+        is_class_prototype: false,
+        visibility: Visibility::Public,
+        parent_id: None,
+        declaration_order: 0,
+        is_string_named: true,
+        is_symbol_named: false,
+        single_quoted_name: false,
+    };
+    let prop_b = PropertyInfo {
+        name: b,
+        type_id: u_id,
+        write_type: u_id,
+        optional: false,
+        readonly: false,
+        is_method: false,
+        is_class_prototype: false,
+        visibility: Visibility::Public,
+        parent_id: None,
+        declaration_order: 1,
+        is_string_named: true,
+        is_symbol_named: false,
+        single_quoted_name: false,
+    };
+    interner.object(vec![prop_a, prop_b])
 }
 
 #[test]
@@ -122,6 +161,48 @@ fn cache_distinct_substitutions_do_not_alias() {
     assert!(
         entries >= 2,
         "expected >= 2 distinct cache entries, got {entries}"
+    );
+}
+
+#[test]
+fn cache_canonicalizes_substitution_insertion_order() {
+    // The cache key is the canonical substitution payload, not the source
+    // FxHashMap's insertion order. Rebuilding the same semantic substitution in
+    // reverse order must hit the first cache entry instead of creating a second.
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let (t_atom, t_id) = type_param(&interner, "T");
+    let (u_atom, u_id) = type_param(&interner, "U");
+    let body = object_with_pair(&interner, t_id, u_id);
+
+    let mut subst_tu = TypeSubstitution::new();
+    subst_tu.insert(t_atom, TypeId::STRING);
+    subst_tu.insert(u_atom, TypeId::NUMBER);
+
+    let mut subst_ut = TypeSubstitution::new();
+    subst_ut.insert(u_atom, TypeId::NUMBER);
+    subst_ut.insert(t_atom, TypeId::STRING);
+
+    let r1 = instantiate_type_cached(&interner, Some(&db), body, &subst_tu);
+    let stats_after_first = db.statistics();
+    assert_eq!(
+        stats_after_first.instantiation_cache_entries, 1,
+        "first non-leaf instantiation should create one cache entry"
+    );
+
+    let r2 = instantiate_type_cached(&interner, Some(&db), body, &subst_ut);
+    let stats_after_second = db.statistics();
+
+    assert_eq!(r1, r2, "equal substitutions must produce equal results");
+    assert_eq!(
+        stats_after_second.instantiation_cache_entries,
+        stats_after_first.instantiation_cache_entries,
+        "reversed insertion order must reuse the canonical cache slot"
+    );
+    assert!(
+        stats_after_second.instantiation_cache_hits > stats_after_first.instantiation_cache_hits,
+        "reversed insertion order should register a cache hit"
     );
 }
 

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -2,15 +2,13 @@
 # Add a test path here (one per line) to allow it to fail in CI without
 # blocking the aggregate gate. Remove the entry once the regression is fixed.
 # Format: TypeScript/tests/cases/<subpath>.ts (one path per line, comments with #)
-TypeScript/tests/cases/compiler/declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
-TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
-TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 TypeScript/tests/cases/compiler/reorderProperties.ts
 TypeScript/tests/cases/conformance/externalModules/typeOnly/circular2.ts
 TypeScript/tests/cases/conformance/externalModules/typeOnly/circular4.ts
 TypeScript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.ts
+TypeScript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolIndexer5.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
 TypeScript/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts


### PR DESCRIPTION
AgentName: M4-C

## Track
Track 3: Inference Sessions, Instantiation, And Cache Contracts

## Invariant
Instantiation-cache keys must represent the semantic substitution payload, not incidental `FxHashMap` insertion order. Two equal type-parameter substitutions applied to the same body should reuse the same cache slot and report a cache hit.

## Scope
- Adds a focused solver cache wiring regression test in `crates/tsz-solver/src/caches/instantiation_cache_test.rs`.
- Builds `{ a: T; b: U }` and instantiates it with the same substitutions inserted in opposite orders.
- Verifies the second call reuses the first canonical cache entry instead of creating a duplicate.
- Syncs `scripts/conformance/conformance-accepted-regressions.txt` to the ready CI aggregate observed on this head: add `parserSymbolIndexer5.ts` and remove three now-resolved compiler entries.

## Project Corpus Impact
- Row: n/a
- Bug family: M4-C Track 3 instantiation-cache substitution keying; conformance accepted-regression drift from ready CI
- Evidence: solver test-only cache ratchet plus CI aggregate artifact evidence from run 26599294272/job 78381570461; no compiler production behavior change.

## Verification
- `git diff --check origin/main...HEAD`
- `cargo fmt --check`
- `cargo nextest run -p tsz-solver cache_canonicalizes_substitution_insertion_order`
- `cargo nextest run -p tsz-solver instantiation_cache_wiring_tests`
- CI ready-run evidence for conformance drift: run 26599294272, aggregate job 78381570461, shard artifact `conformance-shard-5/conformance-failures-5.txt`

## Coordination Notes
- Non-overlap check: M4-C owned PR list was empty before starting; current Kysely/contextual issues and active PRs were checked for overlap.
- This intentionally avoids M4-B relation/cache policy work and M4-A mapped/conditional evaluation work.
- Opened as draft for light CI first, then marked ready after draft checks passed.
- `merge-queue` was removed after the ready-run `project-corpus-pr-body` gate required bullet-form Project Corpus Impact fields; body is corrected before rerunning the failed check.
- Ready CI conformance aggregate found current accepted-regression drift: `12611/12624` observed vs `12622/12624` expected, with `parserSymbolIndexer5.ts` newly failing and three accepted compiler regressions resolved. Tracking issue: #11254.
