### PR TITLE
fix(emit): preserve trailing comments in downleveled async/generator bodies

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -31,6 +31,10 @@ name = "comment_tests"
 path = "tests/comment_tests.rs"
 
 [[test]]
+name = "async_awaiter_body_trailing_comment_tests"
+path = "tests/async_awaiter_body_trailing_comment_tests.rs"
+
+[[test]]
 name = "async_method_super_write_tests"
 path = "tests/async_method_super_write_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/functions.rs
+++ b/crates/tsz-emitter/src/emitter/functions.rs
@@ -415,13 +415,21 @@ impl<'a> Printer<'a> {
         self.emit_param_prologue(transforms);
         let hoist_anchor = is_function_body_block.then(|| self.capture_hoist_anchor());
 
-        for &stmt_idx in &block.statements.nodes {
-            let before_len = self.writer.len();
-            self.emit(stmt_idx);
-            if self.writer.len() > before_len {
-                self.write_line();
+        let stmts: Vec<NodeIndex> = block.statements.nodes.to_vec();
+        let block_close_pos = {
+            let close_end = self.find_block_closing_brace_end(block_node);
+            if close_end > block_node.pos {
+                close_end - 1
+            } else {
+                block_node.end
             }
-        }
+        };
+        self.emit_block_statement_list_with_comments(
+            &stmts,
+            0,
+            block_close_pos,
+            is_function_body_block,
+        );
 
         self.ctx.block_scope_state.exit_scope();
         if let Some(anchor) = hoist_anchor {
@@ -429,6 +437,44 @@ impl<'a> Printer<'a> {
         }
         self.decrease_indent();
         self.write("}");
+    }
+
+    /// Emit the statements of a downleveled async body block (the body that
+    /// becomes `__awaiter(this, ..., function* () { ... })`) through the shared
+    /// comment-aware per-statement loop.
+    ///
+    /// The naive `self.emit(stmt); self.write_line();` loops that previously
+    /// drove these wrappers dropped same-line trailing comments on body
+    /// statements (e.g. `const req = yield foo; // ONE`). Routing them through
+    /// `emit_block_statement_list_with_comments` preserves leading/trailing
+    /// comment handling and `comment_emit_idx` advancement exactly as the
+    /// canonical `emit_block` loop does.
+    ///
+    /// `block_idx` is the original async body block node. Directive prologues
+    /// (e.g. `"use strict"`) are not re-emitted here because the awaiter body
+    /// itself is not a fresh module/function-source boundary that introduces
+    /// one; any leading string-literal statement is emitted as an ordinary
+    /// statement, matching tsc.
+    pub(in crate::emitter) fn emit_async_body_block_statements(&mut self, block_idx: NodeIndex) {
+        let Some(block_node) = self.arena.get(block_idx) else {
+            return;
+        };
+        let Some(block) = self.arena.get_block(block_node) else {
+            return;
+        };
+        let stmts: Vec<NodeIndex> = block.statements.nodes.to_vec();
+        // Position of the body block's closing `}`, used as the upper bound for
+        // trailing-comment scanning on the final statement (so the awaiter's own
+        // synthetic `})` does not steal the comment).
+        let block_close_pos = {
+            let close_end = self.find_block_closing_brace_end(block_node);
+            if close_end > block_node.pos {
+                close_end - 1
+            } else {
+                block_node.end
+            }
+        };
+        self.emit_block_statement_list_with_comments(&stmts, 0, block_close_pos, true);
     }
 
     fn skip_block_opening_line_comments(

--- a/crates/tsz-emitter/src/emitter/functions_arrow.rs
+++ b/crates/tsz-emitter/src/emitter/functions_arrow.rs
@@ -1407,14 +1407,7 @@ impl<'a> Printer<'a> {
                     let hoist_start =
                         body_has_for_await.then(|| self.begin_async_arrow_generator_hoists());
                     self.emit_object_rest_param_prologue_entries(&object_rest_param_prologue);
-                    if let Some(body_node) = self.arena.get(func.body)
-                        && let Some(block) = self.arena.get_block(body_node)
-                    {
-                        for &stmt in &block.statements.nodes {
-                            self.emit(stmt);
-                            self.write_line();
-                        }
-                    }
+                    self.emit_async_body_block_statements(func.body);
                     if let Some(hoist_start) = hoist_start {
                         self.insert_async_arrow_generator_hoists(hoist_start);
                     }
@@ -1543,10 +1536,7 @@ impl<'a> Printer<'a> {
         {
             let statements = block.statements.clone();
             if !self.emit_statement_list_with_using_scope(&statements) {
-                for &stmt in &statements.nodes {
-                    self.emit(stmt);
-                    self.write_line();
-                }
+                self.emit_async_body_block_statements(func.body);
             }
         }
         if let Some(hoist_start) = hoist_start {
@@ -1778,14 +1768,7 @@ impl<'a> Printer<'a> {
                 self.increase_indent();
                 let hoist_start =
                     body_has_for_await.then(|| self.begin_async_arrow_generator_hoists());
-                if let Some(body_node) = self.arena.get(func.body)
-                    && let Some(block) = self.arena.get_block(body_node)
-                {
-                    for &stmt in &block.statements.nodes {
-                        self.emit(stmt);
-                        self.write_line();
-                    }
-                }
+                self.emit_async_body_block_statements(func.body);
                 if let Some(hoist_start) = hoist_start {
                     self.insert_async_arrow_generator_hoists(hoist_start);
                 }

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -373,6 +373,146 @@ impl<'a> Printer<'a> {
         // stmt_node.end past the statement boundary into the next statement's tokens,
         // so using next_stmt.pos as the scan limit prevents over-scanning.
         let stmts: Vec<NodeIndex> = block.statements.nodes.to_vec();
+        self.emit_block_statement_list_with_comments(
+            &stmts,
+            directive_prologue_count,
+            block_close_pos,
+            is_function_body_block,
+        );
+
+        if let Some(anchor) = hoisted_var_anchor {
+            self.insert_function_body_hoisted_temps_at(anchor);
+        }
+
+        if let Some(anchor) = block_scoped_private_anchor
+            && !self.block_scoped_private_temps.is_empty()
+        {
+            let indent = self.writer.indent_string_at(anchor.indent_level);
+            let let_decl = format!(
+                "{}let {};",
+                indent,
+                self.block_scoped_private_temps.join(", ")
+            );
+            self.writer
+                .insert_line_at(anchor.byte_offset, anchor.line_no, &let_decl);
+            self.block_scoped_private_temps.clear();
+        }
+
+        // Close the block-level using try/catch/finally if active
+        if let Some((env_name, error_name, result_name, using_async)) = block_using_names {
+            self.decrease_indent();
+            self.write("}");
+            self.write_line();
+            self.write("catch (");
+            self.write(&error_name);
+            self.write(") {");
+            self.write_line();
+            self.increase_indent();
+            self.write(&env_name);
+            self.write(".error = ");
+            self.write(&error_name);
+            self.write(";");
+            self.write_line();
+            self.write(&env_name);
+            self.write(".hasError = true;");
+            self.write_line();
+            self.decrease_indent();
+            self.write("}");
+            self.write_line();
+            self.write("finally {");
+            self.write_line();
+            self.increase_indent();
+            if using_async {
+                // tsc emits: const result_N = __disposeResources(env_N);
+                //            if (result_N) await result_N;
+                // (inside __awaiter generator, `await` becomes `yield`)
+                let await_kw = if self.ctx.emit_await_as_yield {
+                    "yield"
+                } else {
+                    "await"
+                };
+                self.write(if self.ctx.target_es5 { "var" } else { "const" });
+                self.write(" ");
+                self.write(&result_name);
+                self.write(" = ");
+                self.write_helper("__disposeResources");
+                self.write("(");
+                self.write(&env_name);
+                self.write(");");
+                self.write_line();
+                self.write("if (");
+                self.write(&result_name);
+                self.write(")");
+                self.write_line();
+                self.increase_indent();
+                self.write(await_kw);
+                self.write(" ");
+                self.write(&result_name);
+                self.write(";");
+                self.write_line();
+                self.decrease_indent();
+            } else {
+                self.write_helper("__disposeResources");
+                self.write("(");
+                self.write(&env_name);
+                self.write(");");
+                self.write_line();
+            }
+            self.decrease_indent();
+            self.write("}");
+            self.write_line();
+            // Restore previous block_using_env
+            self.block_using_env = prev_block_using_env;
+        } else {
+            self.block_using_env = prev_block_using_env;
+        }
+
+        // Emit comments between the last statement and the closing `}`.
+        // tsc preserves these comments inside the block at the block's
+        // indentation level for both function bodies and control-flow blocks.
+        if !self.ctx.options.remove_comments {
+            self.emit_comments_before_pos(block_close_pos);
+        }
+        self.restore_static_super_scope(static_super_scope);
+        self.decrease_indent();
+        self.map_closing_brace(node);
+        self.write_with_end_marker("}");
+        self.ctx.block_scope_state.exit_scope();
+        if private_static_shadow {
+            self.private_static_class_alias_shadow_depth -= 1;
+        }
+        // Restore declared_namespace_names for non-function blocks to prevent
+        // block-scoped let declarations from leaking to sibling blocks.
+        if let Some(prev) = prev_declared_ns {
+            self.declared_namespace_names = prev;
+        }
+        // Trailing comments after the block's closing brace are handled by
+        // the calling context (class member loop, statement loop, etc.)
+    }
+
+    /// Emit a block's statement list with full leading/trailing comment
+    /// handling and `comment_emit_idx` advancement, matching the canonical
+    /// `emit_block` per-statement loop.
+    ///
+    /// This is the single shared per-statement emission loop. `emit_block`
+    /// delegates to it, and the downleveled async-body `__awaiter` wrappers
+    /// (`function* () { ... }`) call it instead of a naive
+    /// `self.emit(stmt); self.write_line();` loop so that same-line trailing
+    /// comments on wrapped body statements (e.g. `const req = yield foo; // ONE`)
+    /// are preserved exactly as tsc emits them.
+    ///
+    /// `stmts` is the full statement list; `directive_prologue_count` statements
+    /// at the front are assumed to have already been emitted (e.g. by
+    /// `emit_leading_directive_prologue_statements`) and are skipped here.
+    /// `block_close_pos` is the source position of the block's closing `}` and
+    /// caps trailing-comment scanning for the final statement.
+    pub(in crate::emitter) fn emit_block_statement_list_with_comments(
+        &mut self,
+        stmts: &[NodeIndex],
+        directive_prologue_count: usize,
+        block_close_pos: u32,
+        is_function_body_block: bool,
+    ) {
         let prev_recovered_module_syntax_block_depth = self.recovered_module_syntax_block_depth;
         self.recovered_module_syntax_block_depth += 1;
         let prev_lexical_block_missing_initializer_function_depth =
@@ -555,115 +695,6 @@ impl<'a> Printer<'a> {
             prev_lexical_block_missing_initializer_function_depth;
         self.lexical_block_missing_initializer_is_loop_body =
             prev_lexical_block_missing_initializer_is_loop_body;
-
-        if let Some(anchor) = hoisted_var_anchor {
-            self.insert_function_body_hoisted_temps_at(anchor);
-        }
-
-        if let Some(anchor) = block_scoped_private_anchor
-            && !self.block_scoped_private_temps.is_empty()
-        {
-            let indent = self.writer.indent_string_at(anchor.indent_level);
-            let let_decl = format!(
-                "{}let {};",
-                indent,
-                self.block_scoped_private_temps.join(", ")
-            );
-            self.writer
-                .insert_line_at(anchor.byte_offset, anchor.line_no, &let_decl);
-            self.block_scoped_private_temps.clear();
-        }
-
-        // Close the block-level using try/catch/finally if active
-        if let Some((env_name, error_name, result_name, using_async)) = block_using_names {
-            self.decrease_indent();
-            self.write("}");
-            self.write_line();
-            self.write("catch (");
-            self.write(&error_name);
-            self.write(") {");
-            self.write_line();
-            self.increase_indent();
-            self.write(&env_name);
-            self.write(".error = ");
-            self.write(&error_name);
-            self.write(";");
-            self.write_line();
-            self.write(&env_name);
-            self.write(".hasError = true;");
-            self.write_line();
-            self.decrease_indent();
-            self.write("}");
-            self.write_line();
-            self.write("finally {");
-            self.write_line();
-            self.increase_indent();
-            if using_async {
-                // tsc emits: const result_N = __disposeResources(env_N);
-                //            if (result_N) await result_N;
-                // (inside __awaiter generator, `await` becomes `yield`)
-                let await_kw = if self.ctx.emit_await_as_yield {
-                    "yield"
-                } else {
-                    "await"
-                };
-                self.write(if self.ctx.target_es5 { "var" } else { "const" });
-                self.write(" ");
-                self.write(&result_name);
-                self.write(" = ");
-                self.write_helper("__disposeResources");
-                self.write("(");
-                self.write(&env_name);
-                self.write(");");
-                self.write_line();
-                self.write("if (");
-                self.write(&result_name);
-                self.write(")");
-                self.write_line();
-                self.increase_indent();
-                self.write(await_kw);
-                self.write(" ");
-                self.write(&result_name);
-                self.write(";");
-                self.write_line();
-                self.decrease_indent();
-            } else {
-                self.write_helper("__disposeResources");
-                self.write("(");
-                self.write(&env_name);
-                self.write(");");
-                self.write_line();
-            }
-            self.decrease_indent();
-            self.write("}");
-            self.write_line();
-            // Restore previous block_using_env
-            self.block_using_env = prev_block_using_env;
-        } else {
-            self.block_using_env = prev_block_using_env;
-        }
-
-        // Emit comments between the last statement and the closing `}`.
-        // tsc preserves these comments inside the block at the block's
-        // indentation level for both function bodies and control-flow blocks.
-        if !self.ctx.options.remove_comments {
-            self.emit_comments_before_pos(block_close_pos);
-        }
-        self.restore_static_super_scope(static_super_scope);
-        self.decrease_indent();
-        self.map_closing_brace(node);
-        self.write_with_end_marker("}");
-        self.ctx.block_scope_state.exit_scope();
-        if private_static_shadow {
-            self.private_static_class_alias_shadow_depth -= 1;
-        }
-        // Restore declared_namespace_names for non-function blocks to prevent
-        // block-scoped let declarations from leaking to sibling blocks.
-        if let Some(prev) = prev_declared_ns {
-            self.declared_namespace_names = prev;
-        }
-        // Trailing comments after the block's closing brace are handled by
-        // the calling context (class member loop, statement loop, etc.)
     }
 
     pub(in crate::emitter) fn emit_function_body_hoisted_temps(&mut self) {

--- a/crates/tsz-emitter/tests/async_awaiter_body_trailing_comment_tests.rs
+++ b/crates/tsz-emitter/tests/async_awaiter_body_trailing_comment_tests.rs
@@ -1,0 +1,103 @@
+//! Regression tests: same-line trailing comments on statements inside a
+//! downleveled async body (the `__awaiter(this, ..., function* () { ... })`
+//! wrapper) must be preserved, matching tsc.
+//!
+//! Rule: when an async function/method/arrow body is lowered into an
+//! `__awaiter` generator wrapper (target ES2015+ with a module transform),
+//! every wrapped body statement that carries a same-line trailing comment in
+//! source keeps that comment, exactly as the canonical block emit loop does.
+//! Previously the awaiter-body loops emitted statements naively
+//! (`emit(stmt); write_line();`) and dropped the trailing comments.
+//!
+//! These assertions intentionally vary the comment text and the wrapped
+//! statement kind so they assert the structural behavior, not a single
+//! fingerprint.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::{PrintOptions, lower_and_print};
+use tsz_parser::parser::ParserState;
+
+fn emit_es2015_commonjs(source: &str) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let opts = PrintOptions {
+        target: ScriptTarget::ES2015,
+        module: ModuleKind::CommonJS,
+        remove_comments: false,
+        ..PrintOptions::default()
+    };
+    lower_and_print(&parser.arena, root, opts).code
+}
+
+#[test]
+fn async_function_body_statement_keeps_same_line_trailing_comment() {
+    let output = emit_es2015_commonjs(
+        "export async function fn() {\n    const req = await Promise.resolve(1); // ALPHA\n}\n",
+    );
+    assert!(
+        output.contains("function* ()"),
+        "Async function should downlevel to an __awaiter generator wrapper.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("// ALPHA"),
+        "Trailing comment on the wrapped body statement must be preserved.\nOutput:\n{output}"
+    );
+    // The comment must stay on the same line as the lowered statement, not
+    // leak onto its own line.
+    assert!(
+        output
+            .lines()
+            .any(|line| line.contains("yield") && line.contains("// ALPHA")),
+        "Trailing comment must stay on the lowered yield statement line.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_method_body_statement_keeps_same_line_trailing_comment() {
+    let output = emit_es2015_commonjs(
+        "export class C {\n    async m() {\n        let v = await Promise.resolve(2); // BETA\n    }\n}\n",
+    );
+    assert!(
+        output.contains("// BETA"),
+        "Trailing comment on an async method body statement must be preserved.\nOutput:\n{output}"
+    );
+    assert!(
+        output
+            .lines()
+            .any(|line| line.contains("yield") && line.contains("// BETA")),
+        "Async method trailing comment must stay on the lowered statement line.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_arrow_body_statement_keeps_same_line_trailing_comment() {
+    // Top-level async arrow path (no `this` capture).
+    let output = emit_es2015_commonjs(
+        "export const run = async () => {\n    const n = await Promise.resolve(3); // GAMMA\n};\n",
+    );
+    assert!(
+        output.contains("// GAMMA"),
+        "Trailing comment on an async arrow body statement must be preserved.\nOutput:\n{output}"
+    );
+    assert!(
+        output
+            .lines()
+            .any(|line| line.contains("yield") && line.contains("// GAMMA")),
+        "Async arrow trailing comment must stay on the lowered statement line.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_body_preserves_trailing_comments_on_multiple_statement_kinds() {
+    // Vary statement kind (expression statement, variable statement, return)
+    // and comment text so the test exercises the rule, not one spelling.
+    let output = emit_es2015_commonjs(
+        "export async function multi() {\n    await Promise.resolve(); // FIRST\n    const x = 1; // SECOND\n    return x; // THIRD\n}\n",
+    );
+    for marker in ["// FIRST", "// SECOND", "// THIRD"] {
+        assert!(
+            output.contains(marker),
+            "Trailing comment {marker} must be preserved on its body statement.\nOutput:\n{output}"
+        );
+    }
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — JavaScript emit parity (emit→100% campaign, wave 1, fix #1)

## Invariant
When a statement carrying a same-line trailing comment is emitted inside a body
that is downleveled into an async/generator `__awaiter(this, void 0, void 0,
function* () { ... })` wrapper, `tsc` keeps the trailing comment attached to the
rewritten statement on the same line; this PR makes tsz do the same by routing
the awaiter-body statement loops through the canonical comment-aware
statement-list emitter instead of a naive `emit(stmt); write_line()` loop.

## Scope
- `crates/tsz-emitter/src/emitter/statements/core.rs` — extract the canonical
  per-statement loop body of `emit_block` into a reusable
  `emit_block_statement_list_with_comments` (leading/trailing comment handling +
  `comment_emit_idx` advancement). `emit_block` now delegates to it
  (behavior-preserving; loop moved, not rewritten).
- `crates/tsz-emitter/src/emitter/functions.rs` — new
  `emit_async_body_block_statements`; `emit_block_with_param_prologue` uses the
  shared loop.
- `crates/tsz-emitter/src/emitter/functions_arrow.rs` — three naive awaiter-body
  loops now call the shared helper. Single-line same-line body path left
  untouched.
- `crates/tsz-emitter/Cargo.toml` + new
  `crates/tsz-emitter/tests/async_awaiter_body_trailing_comment_tests.rs`
  (4 tests; comment text and statement kind varied so they assert the structural
  rule, not a fingerprint).

## Project Corpus Impact
- Row: n/a (emit parity fix; no project-corpus row gated on it)
- Bug family: trailing-comment relocation in downleveled async/generator bodies
- Evidence: emit witnesses `importCallExpressionAsyncES6AMD` and
  `importCallExpressionAsyncES6System` go FAIL → PASS (JS emit).

## Verification
- Witnesses (JS, fresh `main` base): `importCallExpressionAsyncES6AMD` 1/1,
  `importCallExpressionAsyncES6System` 1/1 — both PASS.
- Emit regression filters (JS): `asyncawait` 12/12, `comment` 244/244,
  `importCallExpression` 85/85, `generator` 125/126, `asyncArrow` 51/53 — the
  non-100% ones are pre-existing ES5-target failures unrelated to this change
  (verified on the clean baseline).
- `cargo clippy -p tsz-emitter --all-targets -- -D warnings`: clean.
- New unit tests: 4/4 pass.
- Note: `cargo nextest run -p tsz-emitter` shows 36 failing tests in *this local
  environment*, identical with and without this change (agent-verified clean
  baseline) and in modules unrelated to comment handling
  (`async_es5_ir`, `es_decorators`, `declaration_emitter`, …). The `unit` CI job
  is green on `main` (#10779), so these are a local-env artifact; deferring to CI
  for authoritative unit/emit gating.

## Coordination Notes
First landable fix from the emit→100% campaign (wave 1). Files are disjoint from
the in-flight #2 (computed-name hoist) and #3 (captured-heritage re-indent)
fixes, so those land as independent PRs. — opus48-emit100
