### PR TITLE
test(solver): cover cycle policy relation cache

### DIFF
--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -342,6 +342,97 @@ fn assignability_cache_strict_null_checks_matches_uncached_relation_policy() {
 }
 
 #[test]
+fn assignability_cache_assume_related_on_cycle_matches_uncached_depth_policy() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let mut source = TypeId::STRING;
+    let mut target = TypeId::NUMBER;
+    for _ in 0..128 {
+        source = interner.array(source);
+        target = interner.array(target);
+    }
+
+    let assume_related = RelationPolicy::default().with_assume_related_on_cycle(true);
+    let reject_overflow = RelationPolicy::default().with_assume_related_on_cycle(false);
+    let assume_key =
+        RelationCacheKey::for_assignability(source, target, assume_related.cache_config());
+    let reject_key =
+        RelationCacheKey::for_assignability(source, target, reject_overflow.cache_config());
+
+    assert_ne!(
+        assume_key, reject_key,
+        "cycle/depth-overflow policies must occupy distinct assignability cache slots",
+    );
+
+    let assume_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        assume_related,
+        RelationContext::default(),
+    );
+    let reject_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        reject_overflow,
+        RelationContext::default(),
+    );
+
+    assert!(
+        assume_uncached.depth_exceeded,
+        "deep nested array comparison should exceed the relation depth budget",
+    );
+    assert!(
+        reject_uncached.depth_exceeded,
+        "the non-assuming policy should see the same depth overflow",
+    );
+    assert!(
+        assume_uncached.is_related(),
+        "assume-related policy should treat relation depth overflow as related",
+    );
+    assert!(
+        !reject_uncached.is_related(),
+        "non-assuming policy should treat relation depth overflow as not related",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, assume_related),
+        assume_uncached.is_related(),
+        "cached assume-related overflow policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(assume_key),
+        Some(assume_uncached.is_related()),
+        "assume-related result must be stored in its own assignability slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(reject_key),
+        None,
+        "non-assuming lookup must not hit the assume-related slot",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, reject_overflow),
+        reject_uncached.is_related(),
+        "cached non-assuming overflow policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(reject_key),
+        Some(reject_uncached.is_related()),
+        "non-assuming result must be stored in its own assignability slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(assume_key),
+        Some(assume_uncached.is_related()),
+        "assume-related slot must remain intact after the non-assuming lookup",
+    );
+}
+
+#[test]
 fn assignability_cache_strict_function_types_matches_uncached_function_variance() {
     let interner = TypeInterner::new();
     let db = QueryCache::new(&interner);


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 10 relation policy/cache-key tech debt (#8207), stacked solver policy/cache agreement test ratchet.

## Invariant
When relation checking exceeds its recursion/depth budget, `assume_related_on_cycle` changes whether overflow is treated as related; the cached assignability path must agree with uncached `query_relation` and use a distinct policy-shaped cache key from the non-assuming overflow policy.

## Scope
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: solver test-only ratchet for relation policy/cache agreement; no project corpus behavior change targeted.

## Verification
- RED `cargo nextest run -p tsz-solver -E 'test(assignability_cache_assume_related_on_cycle_matches_uncached_depth_policy)'` failed before the test existed with `error: no tests to run`.
- 2026-05-29 after upstream `main` advanced to `2ab3db6688`: branch is synced with `origin/main`; exact head `a957302e47bd3d60ed792dc5ab4467153c0d26f2`.
- `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'`: 17 passed on `a957302e47bd3d60ed792dc5ab4467153c0d26f2`.
- `cargo fmt --check`: passed on `a957302e47bd3d60ed792dc5ab4467153c0d26f2`.
- `git diff --check origin/main..HEAD`: passed on `a957302e47bd3d60ed792dc5ab4467153c0d26f2`.
- Stack diff check: `git diff --stat origin/main..HEAD` -> one solver test file, 91 insertions.
- File-size guard: `wc -l crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs` -> 1487 lines, below the 2000-line cap.
- Mainline guard recheck: `python3 scripts/arch/arch_guard.py` passed on current `origin/main` `2ab3db66882e07bd4f501ce1d4479e921436d0c9`.
- Fresh ready-review CI is running on `a957302e47bd3d60ed792dc5ab4467153c0d26f2`.

## Coordination Notes
- Rebased after upstream `main` advanced to `2ab3db6688`; this branch is synced with current `origin/main`.
- This PR is ready for heavy CI/manager queue review; merge-queue should remain unset until exact-head ready checks complete.
- This branch is one commit, one solver test file, 91 insertions.
- Downstream M4-B stack: #11658 is stacked on this branch; #11662 is stacked on #11658.
- Non-overlap: this slice covers only `assume_related_on_cycle` / relation depth-overflow cache agreement; it does not touch checker relation routing owned by M1-B, nor M4-A/M4-C evaluation/inference lanes.
- No `WIP`, auto-merge, or intentional `merge-queue` state set.
