### PR TITLE
fix(emit): hoist computed names for no-initializer defined fields

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -47,6 +47,10 @@ name = "computed_property_es5_tests"
 path = "tests/computed_property_es5_tests.rs"
 
 [[test]]
+name = "computed_name_no_init_define_field_tests"
+path = "tests/computed_name_no_init_define_field_tests.rs"
+
+[[test]]
 name = "jsx_spread_tests"
 path = "tests/jsx_spread_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -1154,7 +1154,15 @@ impl<'a> Printer<'a> {
                             let has_accessor = self
                                 .arena
                                 .has_modifier(&prop.modifiers, SyntaxKind::AccessorKeyword);
-                            prop.initializer.is_none() && !is_private && !has_accessor
+                            // A no-initializer field is erased *unless* it is still
+                            // runtime-materialized as a defined field (define
+                            // semantics). Use the shared predicate so this stays in
+                            // lockstep with the runtime field-lowering site, which
+                            // would otherwise reference a temp that was never recorded.
+                            prop.initializer.is_none()
+                                && !is_private
+                                && !has_accessor
+                                && !self.no_init_property_is_runtime_materialized(prop)
                         };
                         (&prop.modifiers, prop.name, Some(is_erased))
                     }
@@ -1692,8 +1700,7 @@ impl<'a> Printer<'a> {
                     // Without that flag the typed-only declaration has no
                     // runtime effect, so skip it.
                     let no_initializer_node = prop.initializer.is_none();
-                    let materialize_no_init =
-                        no_initializer_node && self.ctx.options.use_define_for_class_fields;
+                    let materialize_no_init = self.no_init_property_is_runtime_materialized(prop);
                     if !materialize_no_init
                         && (no_initializer_node
                             || !self.class_property_initializer_has_equals(member_node, prop))
@@ -3910,6 +3917,28 @@ impl<'a> Printer<'a> {
                 self.declared_namespace_names.insert(class_name);
             }
         }
+    }
+
+    /// Structural predicate: is this initializer-less `PROPERTY_DECLARATION`
+    /// still runtime-materialized as a *defined* field?
+    ///
+    /// Under `useDefineForClassFields` a field declared without an initializer is
+    /// not erased: `tsc` materializes it with
+    /// `Object.defineProperty(this, <name>, { ... value: void 0 })`. A computed
+    /// name on such a field is therefore hoisted into a temp exactly like a
+    /// computed-name field that *does* have an initializer.
+    ///
+    /// This is the single source of truth shared by the computed-name
+    /// hoisting-classification pass and the runtime field-lowering site so the
+    /// two cannot disagree about whether a no-initializer field survives to
+    /// runtime. It keys purely on structural facts (no initializer + define
+    /// semantics enabled) and intentionally does not re-check abstract/declare/
+    /// private/accessor — those are filtered independently at each call site.
+    const fn no_init_property_is_runtime_materialized(
+        &self,
+        prop: &tsz_parser::parser::node::PropertyDeclData,
+    ) -> bool {
+        prop.initializer.is_none() && self.ctx.options.use_define_for_class_fields
     }
 
     fn class_property_initializer_has_equals(

--- a/crates/tsz-emitter/src/output/printer.rs
+++ b/crates/tsz-emitter/src/output/printer.rs
@@ -63,6 +63,9 @@ pub struct PrintOptions {
     pub downlevel_iteration: bool,
     /// JSX emit mode
     pub jsx: JsxEmit,
+    /// Emit class fields using `Object.defineProperty` semantics when
+    /// downleveling (mirrors `--useDefineForClassFields`).
+    pub use_define_for_class_fields: bool,
 }
 
 impl PrintOptions {
@@ -108,6 +111,7 @@ impl PrintOptions {
             single_quote: self.single_quote,
             downlevel_iteration: self.downlevel_iteration,
             jsx: self.jsx,
+            use_define_for_class_fields: self.use_define_for_class_fields,
             ..Default::default()
         }
     }

--- a/crates/tsz-emitter/tests/class_member_recovery_tests.rs
+++ b/crates/tsz-emitter/tests/class_member_recovery_tests.rs
@@ -212,8 +212,14 @@ fn lowered_class_expression_field_arrow_initializer_keeps_trailing_comment_after
     );
 }
 
+/// Under `useDefineForClassFields` (target < ES2022) a no-initializer field is
+/// NOT erased: tsc materializes it as a defined field and hoists its non-literal
+/// computed name to a temp, exactly as for an initialized computed field. See the
+/// tsc baseline `staticPropertyNameConflicts(target=es2015,usedefineforclassfields=true)`,
+/// where `[FunctionPropertyNames.name]: number;` emits
+/// `Object.defineProperty(this, _b, { ... value: void 0 })` + `_b = FunctionPropertyNames.name`.
 #[test]
-fn downlevel_define_type_only_computed_property_does_not_allocate_temp() {
+fn downlevel_define_type_only_computed_property_hoists_temp() {
     let output = print_with_printer_options(
         "class C {\n    [side.effect]: string;\n}\n",
         PrinterOptions {
@@ -224,8 +230,45 @@ fn downlevel_define_type_only_computed_property_does_not_allocate_temp() {
     );
 
     assert!(
+        output.contains("Object.defineProperty(this, _a, {"),
+        "No-init computed field under define semantics must materialize through the hoisted temp.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("value: void 0"),
+        "No-init defined field uses `value: void 0`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a = side.effect;"),
+        "Computed name expression must be hoisted to the temp after the class body.\nOutput:\n{output}"
+    );
+    // The name must NOT be inlined as a literal property key.
+    assert!(
+        !output.contains("Object.defineProperty(this, \"side.effect\""),
+        "Computed name must not be inlined as a literal property name.\nOutput:\n{output}"
+    );
+}
+
+/// Without `useDefineForClassFields`, a no-initializer typed-only computed
+/// property has no runtime field, so no temp is allocated; only the side-effect
+/// of evaluating the name expression is emitted.
+#[test]
+fn downlevel_no_define_type_only_computed_property_does_not_allocate_temp() {
+    let output = print_with_printer_options(
+        "class C {\n    [side.effect]: string;\n}\n",
+        PrinterOptions {
+            target: ScriptTarget::ES2015,
+            use_define_for_class_fields: false,
+            ..Default::default()
+        },
+    );
+
+    assert!(
         !output.contains("_a = side.effect"),
-        "Type-only computed property should not allocate an unused temp.\nOutput:\n{output}"
+        "Without define semantics, type-only computed property should not allocate a temp.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("Object.defineProperty(this, _a"),
+        "Without define semantics, type-only computed property must not be materialized.\nOutput:\n{output}"
     );
     assert!(
         output.contains("}\nside.effect;"),

--- a/crates/tsz-emitter/tests/computed_name_no_init_define_field_tests.rs
+++ b/crates/tsz-emitter/tests/computed_name_no_init_define_field_tests.rs
@@ -1,0 +1,169 @@
+//! Computed-name class fields WITHOUT an initializer, under
+//! `useDefineForClassFields` and a pre-ES2022 target, are still
+//! runtime-materialized as defined fields.
+//!
+//! Structural rule: when a class property declaration has a non-literal
+//! computed name and is runtime-materialized as a defined field under define
+//! semantics (whether or not it has an initializer), its computed name is
+//! hoisted to a temp and referenced at the materialization site, exactly as for
+//! a computed-name field that DOES have an initializer.
+//!
+//! tsc (target=es2015, useDefineForClassFields):
+//! ```js
+//! var _a;
+//! class C {
+//!     constructor() {
+//!         Object.defineProperty(this, _a, { ... value: void 0 });
+//!     }
+//! }
+//! _a = x;
+//! ```
+//!
+//! These tests vary the computed-name expression and the bound name so they
+//! pin the structural behavior rather than a single rendered fingerprint.
+
+use tsz_common::common::ScriptTarget;
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_print_with_opts;
+
+fn emit_define_es2015(source: &str) -> String {
+    let opts = PrintOptions {
+        target: ScriptTarget::ES2015,
+        use_define_for_class_fields: true,
+        ..Default::default()
+    };
+    parse_and_print_with_opts(source, opts)
+}
+
+/// A no-initializer field with a computed identifier name must hoist the name to
+/// a temp, reference the temp at the `Object.defineProperty` site, and assign the
+/// temp after the class body.
+#[test]
+fn no_init_computed_identifier_field_hoists_temp() {
+    let source = r#"const x = 1;
+class C {
+    [x]: string;
+}
+"#;
+    let output = emit_define_es2015(source);
+
+    assert!(
+        output.contains("var _a;"),
+        "Computed name temp should be declared before the class.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("Object.defineProperty(this, _a, {"),
+        "No-init computed field must materialize via the hoisted temp, not the inline name.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("value: void 0"),
+        "No-init defined field uses `value: void 0`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a = x;"),
+        "Computed name expression must be hoisted to the temp after the class body.\nOutput:\n{output}"
+    );
+    // The raw key expression must NOT appear inline as a property-name string.
+    assert!(
+        !output.contains("Object.defineProperty(this, \"x\","),
+        "Computed name must not be emitted inline as a literal property name.\nOutput:\n{output}"
+    );
+}
+
+/// The rule keys on structure, not the spelling of the bound name or the key
+/// expression. A different name (`k`) and a different non-literal expression
+/// (member access) must behave identically.
+#[test]
+fn no_init_computed_member_access_field_hoists_temp_other_name() {
+    let source = r#"const keys = { id: "id" };
+class Model {
+    [keys.id]: number;
+}
+"#;
+    let output = emit_define_es2015(source);
+
+    assert!(
+        output.contains("var _a;"),
+        "Computed name temp should be declared before the class.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("Object.defineProperty(this, _a, {"),
+        "No-init computed field must materialize via the hoisted temp.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a = keys.id;"),
+        "Member-access computed name must be hoisted to the temp after the class body.\nOutput:\n{output}"
+    );
+}
+
+/// A no-init computed field SIBLING to an initialized computed field must keep
+/// temp ordering deterministic: the first member gets `_a`, the second `_b`,
+/// matching source order and tsc's allocation.
+#[test]
+fn no_init_and_initialized_computed_siblings_keep_temp_order() {
+    let source = r#"const a = "a";
+const b = "b";
+class C {
+    [a]: string;
+    [b] = 1;
+}
+"#;
+    let output = emit_define_es2015(source);
+
+    assert!(
+        output.contains("var _a, _b;"),
+        "Both computed names should be hoisted to temps.\nOutput:\n{output}"
+    );
+    // First member (no initializer) -> _a, defined with value: void 0.
+    assert!(
+        output.contains("Object.defineProperty(this, _a, {"),
+        "First (no-init) computed field should materialize through _a.\nOutput:\n{output}"
+    );
+    // Second member (initialized) -> _b.
+    assert!(
+        output.contains("Object.defineProperty(this, _b, {"),
+        "Second (initialized) computed field should materialize through _b.\nOutput:\n{output}"
+    );
+    // Temp assignments preserve source order: _a = a, _b = b.
+    let a_pos = output
+        .find("_a = a")
+        .expect("_a = a hoist assignment should be present");
+    let b_pos = output
+        .find("_b = b")
+        .expect("_b = b hoist assignment should be present");
+    assert!(
+        a_pos < b_pos,
+        "Hoisted temp assignments should preserve source order (_a before _b).\nOutput:\n{output}"
+    );
+}
+
+/// Negative/fallback: WITHOUT `useDefineForClassFields`, a no-initializer typed
+/// field has no runtime effect, so it must NOT be materialized and must NOT
+/// allocate a hoist temp for its computed name.
+#[test]
+fn no_init_computed_field_without_define_is_erased() {
+    let opts = PrintOptions {
+        target: ScriptTarget::ES2015,
+        use_define_for_class_fields: false,
+        ..Default::default()
+    };
+    let source = r#"const x = 1;
+class C {
+    [x]: string;
+}
+"#;
+    let output = parse_and_print_with_opts(source, opts);
+
+    assert!(
+        !output.contains("Object.defineProperty(this, _a"),
+        "Without define semantics, a no-init typed field must not be materialized.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("var _a;"),
+        "Without materialization, no computed-name temp should be allocated.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — JavaScript emit parity (emit→100% campaign, wave 1, fix #2)

## Invariant
When a class property declaration has a non-literal computed name and is
runtime-materialized as a defined field under `useDefineForClassFields`
(target < ES2022) — whether or not it has an initializer — `tsc` hoists the
computed name to a temp and references it at the `Object.defineProperty(this,
_temp, { … value: void 0 … })` site; this PR makes tsz do the same by having the
computed-name hoisting-classification pass and the runtime-materialization site
agree through one shared structural predicate.

## Scope
- `crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs` — add
  `no_init_property_is_runtime_materialized(prop)` (the single source of truth:
  `initializer.is_none() && use_define_for_class_fields`) and use it in BOTH the
  hoisting-classification pass and the `materialize_no_init` runtime site, so a
  no-init defined field is no longer mis-classified as erased.
- `crates/tsz-emitter/src/output/printer.rs` — expose
  `use_define_for_class_fields` on the public `PrintOptions` (default `false`;
  needed to exercise define semantics via the public printer in tests).
- `crates/tsz-emitter/tests/computed_name_no_init_define_field_tests.rs` (new,
  4 tests; bound name + expression kind varied, includes initialized+no-init
  sibling temp-ordering and a no-define negative case) + Cargo.toml registration.
- `crates/tsz-emitter/tests/class_member_recovery_tests.rs` — corrected a test
  that encoded the pre-fix (non-tsc) behavior; split into a define-semantics
  case (hoists temp) and a no-define negative case, justified against the tsc
  baseline `staticPropertyNameConflicts(target=es2015,usedefineforclassfields=true)`.

## Project Corpus Impact
- Row: n/a (emit parity fix)
- Bug family: computed-name temp hoisting for no-initializer defined fields
- Evidence: emit witness `instanceMemberWithComputedPropertyName2` FAIL → PASS
  (JS); `computedProperty` filter 294/295 → 295/295.

## Verification
- Witness `instanceMemberWithComputedPropertyName2` (JS): FAIL → PASS.
- Emit regression filters (JS) identical to clean baseline (zero regressions):
  `computedProperty` 295/295, `useDefineForClassFields` 57/63, `classFields`
  63/69, `classExpression` 101/107 — the non-100% sets are byte-identical to the
  pre-change baseline (pre-existing static-field bugs in
  `staticPropertyNameConflicts`, out of scope here).
- New unit tests 4/4; `class_member_recovery_tests` 19/19.
- `cargo nextest run -p tsz-emitter`: 36 failing tests, byte-identical set to the
  clean baseline (zero new failures); these are the documented local-env
  artifacts unrelated to this change (`unit` CI is green on `main`).
- `cargo clippy -p tsz-emitter --all-targets -- -D warnings`: clean.

## Coordination Notes
Wave-1 fix #2 of the emit→100% campaign. Disjoint files from #10837 (async
trailing comments) and the queued #3 (captured-heritage re-indent), so all land
independently. — opus48-emit100
