### PR TITLE
fix(solver): preserve homomorphic mapped relation fingerprints

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -47,6 +47,10 @@ name = "homomorphic_mapped_keyof_modifier_tests"
 path = "tests/homomorphic_mapped_keyof_modifier_tests.rs"
 
 [[test]]
+name = "homomorphic_mapped_index_display_tests"
+path = "tests/homomorphic_mapped_index_display_tests.rs"
+
+[[test]]
 name = "array_declaration_display_summary_tests"
 path = "tests/array_declaration_display_summary_tests.rs"
 

--- a/crates/tsz-checker/tests/homomorphic_mapped_index_display_tests.rs
+++ b/crates/tsz-checker/tests/homomorphic_mapped_index_display_tests.rs
@@ -1,0 +1,94 @@
+use tsz_checker::test_utils::check_source_strict_messages_without_missing_libs as check_strict;
+
+fn ts2322_messages(source: &str) -> Vec<String> {
+    check_strict(source)
+        .into_iter()
+        .filter_map(|(code, message)| (code == 2322).then_some(message))
+        .collect()
+}
+
+#[test]
+fn optional_homomorphic_mapped_index_access_displays_source_index() {
+    let messages = ts2322_messages(
+        r#"
+type Maybe<T> = { [Q in keyof T]?: T[Q] };
+function f<T, U extends T>(x: T, y: Maybe<U>, k: keyof T) {
+    y[k] = x[k];
+}
+"#,
+    );
+
+    assert!(
+        messages.iter().any(|message| message
+            .contains("Type 'T[keyof T]' is not assignable to type 'U[keyof T] | undefined'.")),
+        "expected homomorphic optional mapped index display, got: {messages:#?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .all(|message| !message.contains("Maybe<U>[keyof T]")),
+        "diagnostic should not preserve the alias-index spelling, got: {messages:#?}"
+    );
+}
+
+#[test]
+fn readonly_homomorphic_mapped_index_access_displays_source_index() {
+    let messages = ts2322_messages(
+        r#"
+type Frozen<X> = { readonly [R in keyof X]: X[R] };
+function f<T, U extends T>(x: T, y: Frozen<U>, k: keyof T) {
+    y[k] = x[k];
+}
+"#,
+    );
+
+    assert!(
+        messages
+            .iter()
+            .any(|message| message
+                .contains("Type 'T[keyof T]' is not assignable to type 'U[keyof T")),
+        "expected readonly homomorphic mapped index display, got: {messages:#?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .all(|message| !message.contains("Frozen<U>[keyof T]")),
+        "diagnostic should not preserve the alias-index spelling, got: {messages:#?}"
+    );
+}
+
+#[test]
+fn inline_homomorphic_mapped_assignment_reports_generic_value_mismatch() {
+    let messages = ts2322_messages(
+        r#"
+function f<T, U extends T>(x: { [P in keyof T]: T[P] }, y: { [P in keyof T]: U[P] }) {
+    y = x;
+}
+"#,
+    );
+
+    assert!(
+        messages.iter().any(|message| message.contains(
+            "Type '{ [P in keyof T]: T[P]; }' is not assignable to type '{ [P in keyof T]: U[P]; }'."
+        )),
+        "expected inline homomorphic mapped assignment mismatch, got: {messages:#?}"
+    );
+}
+
+#[test]
+fn constrained_key_homomorphic_mapped_assignment_reports_generic_value_mismatch() {
+    let messages = ts2322_messages(
+        r#"
+function f<T, U extends T, K extends keyof T>(x: { [P in K]: T[P] }, y: { [P in K]: U[P] }) {
+    y = x;
+}
+"#,
+    );
+
+    assert!(
+        messages.iter().any(|message| message.contains(
+            "Type '{ [P in K]: T[P]; }' is not assignable to type '{ [P in K]: U[P]; }'."
+        )),
+        "expected constrained-key homomorphic mapped assignment mismatch, got: {messages:#?}"
+    );
+}

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -297,6 +297,25 @@ impl<'a> TypeFormatter<'a> {
     ) -> Option<String> {
         let mapped_id = match self.interner.lookup(obj) {
             Some(TypeData::Mapped(id)) => id,
+            Some(TypeData::Application(app_id)) => {
+                let app = self.interner.type_application(app_id);
+                let Some(TypeData::Lazy(def_id)) = self.interner.lookup(app.base) else {
+                    return None;
+                };
+                let def_store = self.def_store?;
+                let def = def_store.get(def_id)?;
+                let body = def.body?;
+                let instantiated = crate::computation::instantiate_generic(
+                    self.interner,
+                    body,
+                    &def.type_params,
+                    &app.args,
+                );
+                match self.interner.lookup(instantiated) {
+                    Some(TypeData::Mapped(id)) => id,
+                    _ => return None,
+                }
+            }
             _ => return None,
         };
         let mapped = self.interner.mapped_type(mapped_id);

--- a/crates/tsz-solver/src/relations/compat_mapped.rs
+++ b/crates/tsz-solver/src/relations/compat_mapped.rs
@@ -488,6 +488,12 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
 
         let source_template = s_mapped.template;
         let mut target_template = t_mapped.template;
+        if let Some(assignable) =
+            self.deferred_indexed_mapped_templates_assignable(source_template, target_template)
+        {
+            return Some(assignable);
+        }
+
         let source_param = self.interner.type_param(s_mapped.type_param);
         let target_key_substitution =
             TypeSubstitution::single(t_mapped.type_param.name, source_param);
@@ -512,6 +518,13 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         self.subtype
             .type_param_equivalences
             .push((source_param, target_param));
+
+        if let Some(assignable) =
+            self.deferred_indexed_mapped_templates_assignable(source_template, target_template)
+        {
+            self.subtype.type_param_equivalences.truncate(equiv_start);
+            return Some(assignable);
+        }
 
         let structurally_assignable =
             self.mapped_template_structurally_assignable(source_template, target_template);
@@ -543,6 +556,49 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         let result = self.subtype.is_subtype_of(source_template, target_template);
         self.subtype.type_param_equivalences.truncate(equiv_start);
         Some(result)
+    }
+
+    fn deferred_indexed_mapped_templates_assignable(
+        &mut self,
+        source_template: TypeId,
+        target_template: TypeId,
+    ) -> Option<bool> {
+        let (source_obj, source_idx) = index_access_parts(self.interner, source_template)?;
+        let (target_obj, target_idx) = index_access_parts(self.interner, target_template)?;
+        if !self.homomorphic_mapped_sources_match(source_idx, target_idx) {
+            return None;
+        }
+
+        Some(self.deferred_indexed_object_source_assignable(source_obj, target_obj))
+    }
+
+    fn deferred_indexed_object_source_assignable(
+        &mut self,
+        source_obj: TypeId,
+        target_obj: TypeId,
+    ) -> bool {
+        if self.homomorphic_mapped_sources_match(source_obj, target_obj) {
+            return true;
+        }
+
+        if let (Some(source_param), Some(target_param)) = (
+            type_param_info(self.interner, source_obj),
+            type_param_info(self.interner, target_obj),
+        ) {
+            if source_param.constraint.is_some_and(|constraint| {
+                self.homomorphic_mapped_sources_match(constraint, target_obj)
+            }) {
+                return true;
+            }
+            if target_param.constraint.is_some_and(|constraint| {
+                self.homomorphic_mapped_sources_match(constraint, source_obj)
+            }) {
+                return false;
+            }
+        }
+
+        self.configure_subtype(self.strict_function_types);
+        self.subtype.is_subtype_of(source_obj, target_obj)
     }
 
     /// Returns whether the `as` clause is the identity — the bare iteration

--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -8,6 +8,7 @@
 //! - Type expansion and instantiation
 
 use super::super::{SubtypeChecker, SubtypeResult, TypeResolver};
+pub(crate) use super::mapped_chain::flatten_mapped_chain;
 use crate::def::DefId;
 use crate::instantiation::instantiate::fill_application_defaults;
 use crate::types::{MappedModifier, MappedType, TypeData, TypeParamInfo};
@@ -1879,85 +1880,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             instantiated
         })
     }
-}
-
-/// Result of flattening a chain of nested homomorphic mapped types.
-pub(crate) struct FlattenedMapped {
-    /// The ultimate source type (e.g., T in Partial<Readonly<T>>)
-    pub source: TypeId,
-    /// The outer mapped key constraint (e.g., `keyof T` or `K`).
-    pub key_constraint: TypeId,
-    /// Whether any mapped type in the chain adds optional (?)
-    pub has_optional: bool,
-    /// Whether any mapped type in the chain adds readonly
-    pub has_readonly: bool,
-}
-
-/// Flatten a chain of nested homomorphic mapped types into a single descriptor.
-///
-/// For `Partial<Readonly<T>>`, this produces:
-///   source=T, `has_optional=true` (from Partial), `has_readonly=true` (from Readonly)
-///
-/// For `Required<Partial<T>>`, this produces:
-///   source=T, `has_optional=false` (Remove cancels Add), `has_readonly=false`
-///
-/// Returns None if the mapped type isn't in homomorphic form (e.g., has name remapping,
-/// or template isn't `X[K]` where K is the iteration param).
-pub(crate) fn flatten_mapped_chain(
-    interner: &dyn crate::construction::TypeDatabase,
-    mapped_id: MappedTypeId,
-) -> Option<FlattenedMapped> {
-    use crate::types::MappedModifier;
-
-    let mapped = interner.mapped_type(mapped_id);
-
-    // Can't flatten mapped types with name remapping (as clause)
-    if mapped.name_type.is_some() {
-        return None;
-    }
-
-    let has_optional = mapped.optional_modifier == Some(MappedModifier::Add);
-    let has_readonly = mapped.readonly_modifier == Some(MappedModifier::Add);
-    let removes_optional = mapped.optional_modifier == Some(MappedModifier::Remove);
-    let removes_readonly = mapped.readonly_modifier == Some(MappedModifier::Remove);
-
-    // Check if template is X[K] where K is the iteration param (homomorphic form)
-    let (obj, idx) = index_access_parts(interner, mapped.template)?;
-    let param = type_param_info(interner, idx)?;
-    if param.name != mapped.type_param.name {
-        return None;
-    }
-
-    // Try to flatten through the source object if it's itself a mapped type.
-    // Evaluate first to normalize Application types (e.g. Application(Partial, [T]))
-    // to their Mapped form, so nested chains like Readonly<Partial<T>> flatten correctly.
-    let obj_eval = crate::evaluation::evaluate::evaluate_type(interner, obj);
-    if let Some(inner_mapped_id) = mapped_type_id(interner, obj_eval)
-        && let Some(inner) = flatten_mapped_chain(interner, inner_mapped_id)
-    {
-        return Some(FlattenedMapped {
-            source: inner.source,
-            key_constraint: mapped.constraint,
-            has_optional: if removes_optional {
-                false
-            } else {
-                has_optional || inner.has_optional
-            },
-            has_readonly: if removes_readonly {
-                false
-            } else {
-                has_readonly || inner.has_readonly
-            },
-        });
-    }
-
-    // Base case: source object is not a mapped type
-    Some(FlattenedMapped {
-        source: obj,
-        key_constraint: mapped.constraint,
-        has_optional,
-        has_readonly,
-    })
 }
 
 /// Check if a mapped type's `name_type` (as-clause) is a "filtering" conditional.

--- a/crates/tsz-solver/src/relations/subtype/rules/mapped_chain.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/mapped_chain.rs
@@ -1,0 +1,119 @@
+//! Homomorphic mapped-chain flattening for subtype relations.
+
+use crate::types::{MappedModifier, MappedTypeId, TypeId};
+use crate::visitor::{index_access_parts, keyof_inner_type, mapped_type_id, type_param_info};
+
+/// Result of flattening a chain of nested homomorphic mapped types.
+pub(crate) struct FlattenedMapped {
+    /// The ultimate source type (e.g., `T` in `Partial<Readonly<T>>`).
+    pub source: TypeId,
+    /// The outer mapped key constraint (e.g., `keyof T` or `K`).
+    pub key_constraint: TypeId,
+    /// Whether any mapped type in the chain adds optional (`?`).
+    pub has_optional: bool,
+    /// Whether any mapped type in the chain adds readonly.
+    pub has_readonly: bool,
+}
+
+/// Flatten a chain of nested homomorphic mapped types into a single descriptor.
+///
+/// For `Partial<Readonly<T>>`, this produces:
+/// source = `T`, `has_optional = true`, `has_readonly = true`.
+///
+/// For `Required<Partial<T>>`, this produces:
+/// source = `T`, `has_optional = false`, `has_readonly = false`.
+///
+/// Returns `None` if the mapped type is not in homomorphic form.
+pub(crate) fn flatten_mapped_chain(
+    interner: &dyn crate::construction::TypeDatabase,
+    mapped_id: MappedTypeId,
+) -> Option<FlattenedMapped> {
+    let mapped = interner.mapped_type(mapped_id);
+
+    // Can't flatten mapped types with name remapping (`as` clause).
+    if mapped.name_type.is_some() {
+        return None;
+    }
+
+    let has_optional = mapped.optional_modifier == Some(MappedModifier::Add);
+    let has_readonly = mapped.readonly_modifier == Some(MappedModifier::Add);
+    let removes_optional = mapped.optional_modifier == Some(MappedModifier::Remove);
+    let removes_readonly = mapped.readonly_modifier == Some(MappedModifier::Remove);
+
+    // Check if template is `X[K]` where `K` is the iteration param.
+    let (obj, idx) = index_access_parts(interner, mapped.template)?;
+    let param = type_param_info(interner, idx)?;
+    if param.name != mapped.type_param.name {
+        return None;
+    }
+    if !mapped_constraint_matches_template_source(interner, mapped.constraint, obj) {
+        return None;
+    }
+
+    // Try to flatten through the source object if it's itself a mapped type.
+    let obj_eval = crate::evaluation::evaluate::evaluate_type(interner, obj);
+    if let Some(inner_mapped_id) = mapped_type_id(interner, obj_eval)
+        && let Some(inner) = flatten_mapped_chain(interner, inner_mapped_id)
+    {
+        return Some(FlattenedMapped {
+            source: inner.source,
+            key_constraint: mapped.constraint,
+            has_optional: if removes_optional {
+                false
+            } else {
+                has_optional || inner.has_optional
+            },
+            has_readonly: if removes_readonly {
+                false
+            } else {
+                has_readonly || inner.has_readonly
+            },
+        });
+    }
+
+    Some(FlattenedMapped {
+        source: obj,
+        key_constraint: mapped.constraint,
+        has_optional,
+        has_readonly,
+    })
+}
+
+fn mapped_constraint_matches_template_source(
+    interner: &dyn crate::construction::TypeDatabase,
+    constraint: TypeId,
+    source: TypeId,
+) -> bool {
+    if keyof_inner_type(interner, constraint)
+        .is_some_and(|operand| homomorphic_source_identity_matches(interner, operand, source))
+    {
+        return true;
+    }
+
+    if let Some(param) = type_param_info(interner, constraint)
+        && let Some(param_constraint) = param.constraint
+    {
+        return keyof_inner_type(interner, param_constraint)
+            .is_some_and(|operand| homomorphic_source_identity_matches(interner, operand, source));
+    }
+
+    false
+}
+
+fn homomorphic_source_identity_matches(
+    interner: &dyn crate::construction::TypeDatabase,
+    left: TypeId,
+    right: TypeId,
+) -> bool {
+    if left == right {
+        return true;
+    }
+
+    match (
+        type_param_info(interner, left),
+        type_param_info(interner, right),
+    ) {
+        (Some(left_param), Some(right_param)) => left_param.name == right_param.name,
+        _ => false,
+    }
+}

--- a/crates/tsz-solver/src/relations/subtype/rules/mod.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/mod.rs
@@ -11,6 +11,7 @@
 //! - `objects`: Object property matching and index signatures
 //! - `functions`: Function/callable signature compatibility
 //! - `generics`: Type parameters, references, and applications
+//! - `mapped_chain`: Homomorphic mapped-chain flattening
 //! - `mapped_expansion`: Concrete mapped-type relation expansion
 //! - `conditionals`: Conditional type checking
 
@@ -20,6 +21,7 @@ pub mod generics;
 pub mod intrinsic_object;
 pub mod intrinsics;
 pub mod literals;
+pub mod mapped_chain;
 pub mod mapped_expansion;
 pub mod mapped_key_constraints;
 pub mod objects;

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -9,5 +9,4 @@ TypeScript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.
 TypeScript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolIndexer5.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
-TypeScript/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts
 TypeScript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference1.ts


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Conformance / advanced mapped-type relation and diagnostic parity.

## Invariant
When a homomorphic mapped type iterates keys from one generic source but its value template indexes another generic source, relation checks must preserve that generic value mismatch. Diagnostics for homomorphic mapped alias applications indexed by generic keys should display the source indexed access, not the alias application spelling.

## Scope
- Tighten solver mapped-chain flattening so the key domain must match the template source before a homomorphic chain can collapse.
- Compare deferred mapped indexed templates before target-key substitution erases `T[P]` vs `U[P]` distinctions.
- Expand homomorphic mapped indexed-access diagnostic formatting through mapped alias applications.
- Add focused checker coverage for optional/readonly alias display and inline mapped assignment mismatches.
- Remove `mappedTypeRelationships.ts` from accepted conformance regressions.

## Project Corpus Impact
- Row: n/a
- Bug family: conformance fingerprint-only drift in homomorphic mapped/indexed relation diagnostics
- Evidence: focused conformance `mappedTypeRelationships` now passes 1/1 with zero fingerprint-only failures; no project corpus row targeted.

## Verification
- `cargo nextest run -p tsz-checker --test homomorphic_mapped_index_display_tests`: 4 passed
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`: Architecture guardrails passed
- `scripts/safe-run.sh --limit 50% -- ./scripts/conformance/conformance.sh run --filter "mappedTypeRelationships" --verbose`: 1/1 passed, 0 fingerprint-only
- File-size guard: `generics.rs` 1928 lines, new `mapped_chain.rs` 119 lines

## Coordination Notes
- AgentName: M4-A
- Live owned-work check before this branch found no open M4-A PRs; #8203 remains the standing solver architecture debt issue.
- Non-overlap: avoids M4-B relation-cache policy work and M4-C instantiation-canonicalization stack. This slice changes mapped relation semantics and diagnostic formatting for one accepted conformance path.
- PR is draft for initial light CI; ready/queue decisions should follow exact-head checks per TSZ merge-queue policy.