### PR TITLE
fix(emit): re-indent captured multi-line heritage text in TC39 decorator lowering

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -35,6 +35,10 @@ name = "async_awaiter_body_trailing_comment_tests"
 path = "tests/async_awaiter_body_trailing_comment_tests.rs"
 
 [[test]]
+name = "tc39_decorator_extends_multiline_reindent_tests"
+path = "tests/tc39_decorator_extends_multiline_reindent_tests.rs"
+
+[[test]]
 name = "async_method_super_write_tests"
 path = "tests/async_method_super_write_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/expressions/binary_downlevel.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/binary_downlevel.rs
@@ -245,6 +245,50 @@ impl<'a> Printer<'a> {
         output
     }
 
+    /// Re-base the continuation lines of a captured block of text.
+    ///
+    /// [`capture_emit`] renders a sub-expression at the writer's current indent
+    /// (`from_level`) and trims the leading whitespace from the first line so the
+    /// caller can splice it after a prefix such as `let _classSuper = `. Any
+    /// continuation lines, however, keep the absolute indentation they were
+    /// emitted at. When the captured text is reinserted at a different indent
+    /// (`to_level`), those continuation lines must be re-based: strip up to
+    /// `from_level` indentation units of leading whitespace (the capture-time
+    /// base indent) and prepend `to_level` units, preserving the block's
+    /// relative interior indentation.
+    ///
+    /// Single-line captured text is returned unchanged (no continuation lines to
+    /// re-base), so this is a no-op for the common identifier/call base case.
+    pub(in crate::emitter) fn reindent_captured_block(
+        &self,
+        text: &str,
+        from_level: u32,
+        to_level: u32,
+    ) -> String {
+        if !text.contains('\n') {
+            return text.to_string();
+        }
+        let unit = self.writer.indent_unit_width().max(1) as usize;
+        let strip = (from_level as usize).saturating_mul(unit);
+        let target_indent = self.writer.indent_string_at(to_level);
+        let mut result = String::with_capacity(text.len());
+        for (i, line) in text.split('\n').enumerate() {
+            if i == 0 {
+                result.push_str(line);
+                continue;
+            }
+            result.push('\n');
+            if line.trim().is_empty() {
+                // Preserve genuinely blank continuation lines as empty.
+                continue;
+            }
+            let stripped = strip_leading_indent(line, strip);
+            result.push_str(&target_indent);
+            result.push_str(stripped);
+        }
+        result
+    }
+
     /// Unwrap `ParenthesizedExpression` wrapping type assertions for `Math.pow()` args.
     ///
     /// When `(<number>--temp) ** 3` is lowered to `Math.pow(...)`, the type assertion
@@ -863,4 +907,20 @@ impl<'a> Printer<'a> {
             _ => "=".to_string(),
         }
     }
+}
+
+/// Strip up to `count` leading space/tab characters from `s`.
+///
+/// Used by [`Printer::reindent_captured_block`] to remove the capture-time base
+/// indentation from a continuation line before re-applying the target indent.
+fn strip_leading_indent(s: &str, count: usize) -> &str {
+    let mut stripped = 0;
+    for &b in s.as_bytes().iter().take(count) {
+        if b == b' ' || b == b'\t' {
+            stripped += 1;
+        } else {
+            break;
+        }
+    }
+    &s[stripped..]
 }

--- a/crates/tsz-emitter/src/emitter/transform_dispatch.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch.rs
@@ -1819,6 +1819,15 @@ impl<'a> Printer<'a> {
         let mut output = self.capture_emit(runtime_expr);
         self.pending_tc39_class_expression_name = previous_name;
 
+        // `capture_emit` rendered the base expression at the writer's current
+        // indent and trimmed only its first line. The captured text is spliced
+        // after `let _classSuper = `, which sits one level deeper than the class
+        // being lowered. Re-base any continuation lines to that insertion indent
+        // so multi-line bases (e.g. a class expression with members, or an empty
+        // class body whose `}` lands on its own line) are not left flush-left.
+        let base_level = self.writer.indent_level();
+        output = self.reindent_captured_block(&output, base_level, base_level + 1);
+
         if is_arrow {
             output = format!("({output})");
         }

--- a/crates/tsz-emitter/tests/tc39_decorator_extends_multiline_reindent_tests.rs
+++ b/crates/tsz-emitter/tests/tc39_decorator_extends_multiline_reindent_tests.rs
@@ -1,0 +1,133 @@
+//! Regression test for continuation-line indentation of a TC39-decorated
+//! class whose `extends` base is itself a multi-line-emitting expression.
+//!
+//! When emit lowering captures the heritage (super) expression's rendered text
+//! and reinserts it after `let _classSuper = `, every *continuation* line of
+//! that captured text must be re-based to the indentation of the generated
+//! `_classSuper` statement. tsz previously trimmed only the first captured line
+//! and left interior lines at the column they happened to be emitted at,
+//! producing flush-left `});` for an empty class-expression base instead of
+//! tsc's indented `    });`.
+//!
+//! The rule is structural — it keys on the captured text spanning multiple
+//! lines, not on the kind of base expression or the chosen decorator name — so
+//! these tests vary the base members, vary nesting depth, and use a renamed
+//! decorator.
+//!
+//! Source: `crates/tsz-emitter/src/emitter/transform_dispatch.rs`
+//! (`seed_tc39_decorator_extends_text`, routed through
+//! `Printer::reindent_captured_block`).
+
+use tsz_common::common::ScriptTarget;
+use tsz_emitter::context::emit::EmitContext;
+use tsz_emitter::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use tsz_emitter::lowering::LoweringPass;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+fn parse_lower_emit(source: &str) -> String {
+    let opts = PrinterOptions {
+        target: ScriptTarget::ES2022,
+        no_emit_helpers: true,
+        ..Default::default()
+    };
+    let (parser, root) = test_support::parse_source(source);
+    let ctx = EmitContext::with_options(opts.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer = EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, opts);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+#[test]
+fn empty_class_expression_base_close_brace_is_indented_to_class_super() {
+    // The captured base is `class {\n}`. Its continuation `}` line must land at
+    // the `let _classSuper = ` indent (one level), matching tsc:
+    //   let _classSuper = (0, class {
+    //   });
+    let source = concat!(
+        "declare var deco: any;\n",
+        "(@deco\n",
+        "class C1 extends class { } {\n",
+        "    static { super.name; }\n",
+        "});\n",
+    );
+    let output = parse_lower_emit(source);
+
+    assert!(
+        output.contains("    let _classSuper = (0, class {\n    });"),
+        "Empty class-expression base close `}}` must be indented to the `_classSuper` \
+         statement indent (4 spaces).\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("\n});\n    var C1"),
+        "The class-body close must not be left flush-left.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn class_expression_base_with_member_preserves_relative_indentation() {
+    // Member body sits one level deeper than `_classSuper`; the close brace
+    // returns to the `_classSuper` level.
+    let source = concat!(
+        "declare var deco: any;\n",
+        "(@deco\n",
+        "class C1 extends class { m() { return 1; } } {\n",
+        "    static { super.name; }\n",
+        "});\n",
+    );
+    let output = parse_lower_emit(source);
+
+    assert!(
+        output.contains("    let _classSuper = (0, class {\n        m() { return 1; }\n    });"),
+        "A class-expression base with members must keep its body one level deeper \
+         than `_classSuper` and close at the `_classSuper` indent.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn nested_class_expression_base_reindents_to_local_class_super_level() {
+    // Inside a function body the whole lowering is one level deeper, so the
+    // re-based continuation lines must follow the *local* `_classSuper` indent,
+    // proving the fix is keyed on indent levels, not the top-level column.
+    let source = concat!(
+        "declare var deco: any;\n",
+        "function wrap() {\n",
+        "    (@deco\n",
+        "    class C2 extends class { m() { return 5; } } {\n",
+        "        static { super.name; }\n",
+        "    });\n",
+        "}\n",
+    );
+    let output = parse_lower_emit(source);
+
+    assert!(
+        output.contains(
+            "        let _classSuper = (0, class {\n            m() { return 5; }\n        });"
+        ),
+        "Nested class-expression base must re-base continuation lines to the local \
+         `_classSuper` indent (8 spaces), with the member one level deeper.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn single_line_base_is_unchanged() {
+    // An identifier base spans a single captured line: reindenting is a no-op
+    // and the `extends` capture remains on the `_classSuper` line.
+    let source = concat!(
+        "declare var deco: any;\n",
+        "declare class Base {}\n",
+        "(@deco\n",
+        "class C3 extends Base {\n",
+        "    static { super.name; }\n",
+        "});\n",
+    );
+    let output = parse_lower_emit(source);
+
+    assert!(
+        output.contains("let _classSuper = Base;"),
+        "A single-line identifier base must be spliced verbatim with no reindent.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — JavaScript emit raw-output parity (emit→100% campaign, wave 1, fix #3)

## Invariant
When emit lowering captures a sub-expression's rendered text (`capture_emit`) and
reinserts it at a target indentation, `tsc` re-bases every continuation line of
that text to the insertion indent; this PR makes tsz do the same for the TC39
decorator `extends`-seed path, keyed on the captured text spanning multiple
lines (not on the kind of base expression).

## Scope
- `crates/tsz-emitter/src/emitter/expressions/binary_downlevel.rs` — add shared
  `reindent_captured_block(text, from_level, to_level)` next to `capture_emit`
  (unit-aware via `indent_unit_width`/`indent_string_at`; single-line is a no-op).
- `crates/tsz-emitter/src/emitter/transform_dispatch.rs` —
  `seed_tc39_decorator_extends_text` reindents the captured heritage text to the
  `_classSuper` insertion indent before wrapping/storing.
- `crates/tsz-emitter/tests/tc39_decorator_extends_multiline_reindent_tests.rs`
  (new, 4 tests: empty base, members base, nested deeper-indent base, single-line
  no-op; decorator renamed so the tests are structural) + Cargo.toml registration.

## Project Corpus Impact
- Row: n/a (raw-output parity fix)
- Bug family: continuation-line indentation of captured multi-line heritage text
- Evidence: raw CLI output for `esDecorators-classExpression-classSuper.2` now
  matches the tsc baseline (indented `});`).

## Verification
- Witness `esDecorators-classExpression-classSuper.2` (empty class-expression
  base): raw output `});` → `    });`, matching the tsc baseline. Verified with
  the release binary plus members-base and nested-base variants.
- IMPORTANT: the emit harness normalizes leading whitespace, so it reports these
  as PASS both before and after — this fix is **metric-neutral in the emit
  harness** but corrects a real raw-output divergence (North Star: exact tsc
  output). The new unit tests assert the raw behavior.
- Emit regression filters (JS) identical to clean baseline (zero regressions):
  `esDecorators` 217/217, `classSuper` 20/20, `decorator` 637/642,
  `classExpression` 101/107 (non-100% sets byte-identical to baseline).
- New unit tests 4/4; `cargo clippy -p tsz-emitter --all-targets -- -D warnings`
  clean; `cargo nextest run -p tsz-emitter` failing set byte-identical to baseline
  (zero new; documented local-env artifacts).

## Coordination Notes
Wave-1 fix #3. Disjoint files from #10837 and #11024 → independent PR. Flagged as
metric-neutral-but-correct so reviewers know it improves raw parity without
moving the emit pass-rate number. — opus48-emit100
