### PR TITLE
fix(parser): restore ':' expected on recovered computed-indexer tail at close brace

### DIFF
--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -2046,6 +2046,16 @@ impl ParserState {
         if right.is_none() {
             return Some(left);
         }
+        // tsc does not fold the trailing value into a comma expression; it
+        // re-reads it as the property name of a fresh object member that then
+        // expects a `:`. When that recovered tail butts directly against the
+        // object's closing `}` (no comma/semicolon separator), tsc reports
+        // TS1005 "':' expected." at the `}` for the missing property colon.
+        // Mirror that here so the recovered comma-expression AST is preserved
+        // while the trailing diagnostic still matches tsc.
+        if self.is_token(SyntaxKind::CloseBraceToken) {
+            self.parse_error_at_current_token("':' expected.", diagnostic_codes::EXPECTED);
+        }
         let left_start = self.arena.get(left).map_or(name_end, |node| node.pos);
         let end_pos = self
             .arena

--- a/crates/tsz-parser/tests/parser_unit_tests_parts/part_01.rs
+++ b/crates/tsz-parser/tests/parser_unit_tests_parts/part_01.rs
@@ -862,6 +862,58 @@ fn object_literal_private_indexer_tail_recovers_as_comma_initializer() {
 }
 
 #[test]
+fn object_literal_computed_indexer_tail_at_close_brace_reports_colon_expected() {
+    // parserSymbolIndexer5-shaped input: a malformed computed-indexer member
+    // (`[name: type]: value`) whose recovered tail butts directly against the
+    // object's closing `}`. tsc still reports TS1005 "':' expected." at the
+    // `}` for the missing property colon. Vary the computed-name identifier
+    // (here `q`, not `s`) so the assertion keys on the structure, not a name.
+    let source = "var x = {\n    [q: symbol]: \"\"\n}";
+    let (parser, root) = parse_source(source);
+    let arena = parser.get_arena();
+    let init = get_var_initializer(arena, root);
+    let object = arena.get(init).expect("object literal");
+    let object_data = arena
+        .get_literal_expr(object)
+        .expect("object literal expression");
+    assert_eq!(
+        object_data.elements.nodes.len(),
+        1,
+        "malformed indexer tail should stay on one object property"
+    );
+
+    // The recovered initializer is still the comma-expression from #10701.
+    let prop = arena
+        .get(object_data.elements.nodes[0])
+        .expect("property assignment");
+    let assignment = arena
+        .get_property_assignment(prop)
+        .expect("property assignment data");
+    let (_, op, _) = get_binary(arena, assignment.initializer);
+    assert_eq!(op, SyntaxKind::CommaToken as u16);
+
+    // The trailing "':' expected." must land at the closing `}` position.
+    let close_brace_pos = source.rfind('}').expect("closing brace") as u32;
+    assert!(
+        parser.get_diagnostics().iter().any(|diag| diag.code
+            == diagnostic_codes::EXPECTED
+            && diag.start == close_brace_pos
+            && diag.message == "':' expected."),
+        "expected TS1005 \"':' expected.\" at the closing brace, got {:?}",
+        parser.get_diagnostics()
+    );
+
+    // The earlier recovery diagnostics from #10701 must remain.
+    let codes: Vec<u32> = parser
+        .get_diagnostics()
+        .iter()
+        .map(|diag| diag.code)
+        .collect();
+    assert!(codes.contains(&diagnostic_codes::EXPECTED));
+    assert!(codes.contains(&diagnostic_codes::PROPERTY_ASSIGNMENT_EXPECTED));
+}
+
+#[test]
 fn expr_yield() {
     // `function* gen() { yield 1; yield* other(); }`
     let (parser, _) = parse_source("function* gen() { yield 1; yield* other(); }");


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
semantic campaign / regression fix — parser conformance (unblocks merge queue)

## Invariant
When a recovered computed-indexer object member's trailing value is immediately
followed by the object's closing `}` (no comma/semicolon separator), `tsc`
reports `TS1005: ':' expected` at the `}`; this PR makes tsz do the same.

## Scope
- `crates/tsz-parser/src/parser/state_expressions_literals.rs` — in
  `recover_object_literal_computed_indexer_tail` (added by #10701), emit
  `':' expected` at the closing brace when the recovered tail butts against `}`.
  Preserves #10701's comma-expression recovery AST.
- `crates/tsz-parser/tests/parser_unit_tests_parts/part_01.rs` — new structural
  unit test `object_literal_computed_indexer_tail_at_close_brace_reports_colon_expected`
  (uses identifier `q`, not `s`, to prove the rule is structural).

## Project Corpus Impact
- Row: n/a (conformance regression fix)
- Bug family: object-literal computed-indexer error recovery
- Evidence: conformance `parserSymbolIndexer5` 0/1 → **1/1** (restores the
  missing `TS1005 ':' expected` at 3:1); `privateIndexer2` stays 1/1.

## Verification
- `parserSymbolIndexer5` BEFORE: fingerprint-only fail (`TS1005 3:1 ':' expected` missing, 0/1).
  AFTER: **1/1 passed**.
- #10701 preserved: `privateIndexer2` 1/1; unit test
  `object_literal_private_indexer_tail_recovers_as_comma_initializer` passes
  (comma-expr AST + EXPECTED + PROPERTY_ASSIGNMENT_EXPECTED intact).
- Conformance slices (zero regressions): parser 794/794, ObjectLiteral 99/99,
  Indexer 99/99, computedProperty 146/146, Symbols 142/142.
- `cargo nextest run -p tsz-parser`: 1033/1033.
- `cargo clippy -p tsz-parser --all-targets -- -D warnings`: clean.

## Coordination Notes
Fixes the #11456 regression introduced by #10701 that blocks `conformance-aggregate`
(and the merge-queue synthetic-merge gate) for all PRs off current `main`. Landing
this first unblocks the emit→100% PRs (#10837, #11024). — opus48-emit100

Fixes #11456
