### PR TITLE
chore(conformance): remove parserSymbolIndexer5 from accepted regressions; fix test gpgsign

### DIFF
--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -6,7 +6,6 @@ TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 TypeScript/tests/cases/compiler/reorderProperties.ts
 TypeScript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.ts
-TypeScript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolIndexer5.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
 TypeScript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference1.ts

--- a/scripts/setup/test_disk_worktree_guard.py
+++ b/scripts/setup/test_disk_worktree_guard.py
@@ -38,6 +38,7 @@ class DiskWorktreeGuardTests(unittest.TestCase):
         self.run_git(["init"], fake_repo)
         self.run_git(["config", "user.email", "studio-f@example.invalid"], fake_repo)
         self.run_git(["config", "user.name", "Studio F"], fake_repo)
+        self.run_git(["config", "commit.gpgsign", "false"], fake_repo)
         (fake_repo / "README.md").write_text("# fake repo\n", encoding="utf-8")
         self.run_git(["add", "README.md"], fake_repo)
         self.run_git(["commit", "-m", "initial"], fake_repo)


### PR DESCRIPTION
AgentName: claude-sonnet-4-6

## Track
Conformance cleanup + test hygiene

## Invariant
PR #11583 (`53f4c57`) already fixed the parser behavior for the `[s: symbol]: ""` object literal case by emitting `':' expected` at the closing `}`. The `parserSymbolIndexer5.ts` accepted-regression entry was left behind after that fix.

Also: `test_disk_worktree_guard.py`'s `make_fake_repo` helper did not disable `commit.gpgsign` in the temp repo, causing `git commit` to fail (exit 128) in environments where `commit.gpgsign=true` is set globally (both this execution environment and the `tsz-cloud-run` self-hosted CI runners).

## Scope
- `scripts/conformance/conformance-accepted-regressions.txt`: removes the `parserSymbolIndexer5.ts` entry (1 line deleted)
- `scripts/setup/test_disk_worktree_guard.py`: adds `commit.gpgsign = false` to the fake repo's local config so the test passes regardless of global git signing configuration

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- conformance-accepted-regressions cleanup and test-only fix; no compiler behavior path changed

## Verification
- `parserSymbolIndexer5.ts` is fixed by the existing `if self.is_token(SyntaxKind::CloseBraceToken)` check in `recover_object_literal_computed_indexer_tail` (landed in #11583)
- `python3 scripts/setup/test_disk_worktree_guard.py` now passes (2/2 tests)
- All 18 object-literal parser unit tests pass

## Root Cause
1. After #11583 landed and fixed the `parserSymbolIndexer5` conformance regression, the accepted-regression entry was not removed.
2. `test_disk_worktree_guard.py` was written without disabling `commit.gpgsign`, causing lint failures in environments with global commit signing enabled.

## Coordination Notes
- Original PR was a different parser approach that conflicted with #11583's already-merged fix.
- PR is now scoped to two cleanup items that unblock landing.
- AgentName: claude-sonnet-4-6
