### PR TITLE
fix(dts): substitute inferred type args in direct-call return-type fallback

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
@@ -761,7 +761,27 @@ impl<'a> DeclarationEmitter<'a> {
                 continue;
             };
             let type_text = if func.type_annotation.is_some() {
-                self.emit_type_node_text(func.type_annotation)
+                // When the callee is generic and its return annotation mentions its own
+                // type parameters (e.g. `boxify<T>(obj: T): Boxified<T>`), the raw
+                // annotation text still carries the bare type parameter. Substitute the
+                // inferred type arguments so the returned text reflects the call site
+                // (`Boxified<A | B | C | undefined>`), mirroring
+                // call_expression_source_return_type_text. Fall back to the raw
+                // annotation when substitution is not applicable.
+                let raw = self.emit_type_node_text(func.type_annotation);
+                match raw {
+                    Some(raw_text)
+                        if call.type_arguments.is_none()
+                            && self.source_return_type_mentions_type_parameter(
+                                self.arena, func, &raw_text,
+                            ) =>
+                    {
+                        self.substitute_source_call_type_parameters(
+                            self.arena, func, call, raw_text,
+                        )
+                    }
+                    other => other,
+                }
             } else if func.body.is_some() {
                 self.function_body_single_return_expression(func.body)
                     .and_then(|return_expr| {

--- a/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs
@@ -782,3 +782,61 @@ export function outer<V>() {
         "three-level chain with explicit tuple return annotation: {output}"
     );
 }
+
+// When an unannotated function directly returns a call to a generic function
+// whose return-type annotation references the callee's own type parameter,
+// declaration emit must substitute the inferred type argument into the alias
+// reference instead of copying the callee's bare type parameter verbatim.
+// Regression for mappedTypes4 (`Boxified<T>` -> `Boxified<A | undefined>`).
+#[test]
+fn fix_returned_generic_call_substitutes_inferred_type_argument() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+type Box<T> = {};
+type Boxified<T> = {
+    [P in keyof T]: Box<T[P]>;
+};
+declare function boxify<T>(obj: T): Boxified<T>;
+type A = { a: string };
+type B = { b: string };
+export function f1(x: A | B) {
+    return boxify(x);
+}
+"#,
+    );
+    assert!(
+        output.contains("function f1(x: A | B): Boxified<A | B>"),
+        "inferred return of returned generic call must substitute inferred arg: {output}"
+    );
+    assert!(
+        !output.contains("Boxified<T>"),
+        "must not leak the callee's bare type parameter: {output}"
+    );
+}
+
+// Same rule, different type-parameter spelling on both the callee and its alias,
+// plus a renamed parameter — proves the fix is structural, not keyed to `T`.
+#[test]
+fn fix_returned_generic_call_substitution_is_structural_not_named() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+type Wrap<Elem> = {
+    [Key in keyof Elem]: Elem[Key];
+};
+declare function wrapify<Source>(input: Source): Wrap<Source>;
+type One = { one: number };
+type Two = { two: number };
+export function g(value: One | Two) {
+    return wrapify(value);
+}
+"#,
+    );
+    assert!(
+        output.contains("function g(value: One | Two): Wrap<One | Two>"),
+        "renamed type parameter must still substitute the inferred arg: {output}"
+    );
+    assert!(
+        !output.contains("Wrap<Source>"),
+        "must not leak the callee's bare type parameter `Source`: {output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — declaration emit parity (emit→100% campaign, DTS type-display)

## Invariant
When an unannotated function directly returns a call to a generic callee whose
return annotation references the callee's own type parameters, and the call
supplies no explicit type arguments, `tsc` substitutes the inferred type
arguments into the alias reference in the emitted `.d.ts`; this PR makes tsz do
the same instead of emitting the callee's bare type parameter.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs`
  — in the direct-call primitive-return fast path, when the callee's return
  annotation mentions its type parameters and the call has no explicit type
  args, route through the existing `substitute_source_call_type_parameters`
  helper (mirroring `call_expression_source_return_type_text`); fall back to the
  raw annotation otherwise. No printer string-rewriting; no identifier matching.
- `crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs`
  — 2 tests (one `T`/`Boxified`, one renamed `Source`/`Wrap`/`Elem`/`Key`) to
  prove the rule is structural, not name-keyed.

## Project Corpus Impact
- Row: n/a (declaration emit parity fix)
- Bug family: inferred type-argument substitution in `.d.ts` for direct generic-call returns
- Evidence: `mappedTypes4` DTS 0→1; `mappedType` DTS 27→28; emitter nextest 35→31 failures (repaired 4 adjacent same-class failures).

## Verification
- `mappedTypes4` DTS: `Boxified<T>` → `Boxified<A | B | C | undefined>` (matches tsc), now passes. JS emit unchanged (1/1).
- Regression neighbors vs clean baseline: `mappedType` DTS +1 (27→28, only remaining is the separate pre-existing `mappedTypesArraysTuples` bug); `inferred` DTS unchanged (17/19). **Zero new regressions.**
- `cargo nextest run -p tsz-emitter`: 35 → **31** failures (fixed `mappedTypes4` + 4 adjacent same-class tests: `*_returning_generic_mapped_alias_call_preserves_alias_surface`, `*_implemented_*`, `*_returning_mapped_infer_call_expands_alias_return_type`, `fix_deferred_lookup_preserves_string_literal_key_substitution`); zero NEW failures.
- New unit tests pass; `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings` clean.

## Coordination Notes
Genuine DTS metric-mover. Disjoint from the other in-flight emit PRs (#10837,
#11024, #11457). Draft for now — the repo merge-queue runner appears stopped
(no merges to main since 22:02 UTC); will mark ready/enqueue once the queue
resumes and this rebases onto an unblocked main. — opus48-emit100
