### PR TITLE
fix(solver): strict literal overlap for nested type-assertion comparability

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -655,6 +655,10 @@ name = "ts2352_merged_type_alias_const_tests"
 path = "tests/ts2352_merged_type_alias_const_tests.rs"
 
 [[test]]
+name = "ts2352_nested_literal_overlap_tests"
+path = "tests/ts2352_nested_literal_overlap_tests.rs"
+
+[[test]]
 name = "ts2683_tests"
 path = "tests/ts2683_tests.rs"
 

--- a/crates/tsz-checker/tests/ts2352_nested_literal_overlap_tests.rs
+++ b/crates/tsz-checker/tests/ts2352_nested_literal_overlap_tests.rs
@@ -1,0 +1,148 @@
+//! Tests for TS2352 overlap of literal-typed object properties / elements.
+//!
+//! Structural rule: tsc's `checkAssertionWorker` widens only the *top-level*
+//! assertion source via `getWidenedType`. Two distinct literals that are the
+//! direct operands of an assertion (`"x" as "y"`) therefore overlap, but two
+//! distinct literals that appear as a shared *property* or *element* type
+//! (`{ k: "a" } as { k: "b" }`, `["a"] as ["b"]`) are not widened and do not
+//! overlap, so tsc reports TS2352. A literal property is still comparable to a
+//! base-primitive property (`{ n: 1 } as { n: number }`) and to a literal-union
+//! property that contains it (`{ k: "a" } as { k: "a" | "b" }`).
+//!
+//! Regression for the `satisfies` + `as` family: a value preserved as a literal
+//! by `satisfies` (e.g. `{ mode: "dev" } satisfies { mode: "dev" | "prod" }`)
+//! keeps `{ mode: "dev" }`, so casting it to a non-overlapping literal union
+//! must report TS2352.
+
+use tsz_checker::test_utils::check_source_strict_codes as check_strict;
+
+fn ts2352_count(source: &str) -> usize {
+    check_strict(source).iter().filter(|&&c| c == 2352).count()
+}
+
+// ---------------------------------------------------------------------------
+// Positive: nested distinct literals do NOT overlap -> TS2352
+// ---------------------------------------------------------------------------
+
+/// Direct object literal with a distinct string-literal property. Varying the
+/// property name and the literal spelling proves the rule is structural, not
+/// keyed on a particular identifier.
+#[test]
+fn object_property_distinct_string_literal_reports_ts2352() {
+    for (key, src_lit, tgt_lit) in [
+        ("mode", "dev", "prod"),
+        ("kind", "a", "b"),
+        ("tag", "left", "right"),
+    ] {
+        let source = format!("const v = {{ {key}: '{src_lit}' }} as {{ {key}: '{tgt_lit}' }};");
+        assert_eq!(
+            ts2352_count(&source),
+            1,
+            "[{key}: '{src_lit}' as '{tgt_lit}'] expected exactly one TS2352. Codes: {:?}",
+            check_strict(&source)
+        );
+    }
+}
+
+/// Distinct numeric-literal property — same rule, different primitive kind.
+#[test]
+fn object_property_distinct_number_literal_reports_ts2352() {
+    let source = "const v = { n: 1 } as { n: 2 };";
+    assert_eq!(ts2352_count(source), 1, "Codes: {:?}", check_strict(source));
+}
+
+/// The property's literal does not appear in the target's literal *union*.
+#[test]
+fn object_property_literal_not_in_target_union_reports_ts2352() {
+    for (key, value, union) in [("mode", "'dev'", "'prod' | 'test'"), ("size", "1", "2 | 3")] {
+        let source = format!("const v = {{ {key}: {value} }} as {{ {key}: {union} }};");
+        assert_eq!(
+            ts2352_count(&source),
+            1,
+            "[{key}: {value} as {union}] expected TS2352. Codes: {:?}",
+            check_strict(&source)
+        );
+    }
+}
+
+/// The reported `satisfies` + `as` repro: `satisfies` preserves the literal, so
+/// the subsequent cast to a non-overlapping literal union must report TS2352.
+/// Renaming the iteration property and literals proves it is not hardcoded.
+#[test]
+fn satisfies_preserved_literal_then_incompatible_cast_reports_ts2352() {
+    for (key, lit, sat_union, cast_union) in [
+        ("mode", "dev", "'dev' | 'prod'", "'test' | 'prod'"),
+        ("kind", "a", "'a' | 'b'", "'c' | 'd'"),
+    ] {
+        let source = format!(
+            "const config = {{ {key}: '{lit}' }} satisfies {{ {key}: {sat_union} }};\n\
+             const bad = config as {{ {key}: {cast_union} }};"
+        );
+        assert_eq!(
+            ts2352_count(&source),
+            1,
+            "[satisfies {key}: '{lit}'] expected TS2352 on the incompatible cast. Codes: {:?}",
+            check_strict(&source)
+        );
+    }
+}
+
+/// Distinct literal tuple elements do not overlap either.
+#[test]
+fn tuple_element_distinct_literal_reports_ts2352() {
+    let source = "const v = ['a'] as ['b'];";
+    assert_eq!(ts2352_count(source), 1, "Codes: {:?}", check_strict(source));
+}
+
+// ---------------------------------------------------------------------------
+// Negative: cases that DO overlap must NOT report TS2352
+// ---------------------------------------------------------------------------
+
+/// Top-level distinct literals overlap (tsc widens the top-level source).
+#[test]
+fn top_level_distinct_literals_no_ts2352() {
+    for source in [
+        "const a = 'x' as 'y';",
+        "const b = 1 as 2;",
+        "const c = 'x' as 'y' | 'z';",
+    ] {
+        assert_eq!(
+            ts2352_count(source),
+            0,
+            "[{source}] top-level literal assertion must not report TS2352. Codes: {:?}",
+            check_strict(source)
+        );
+    }
+}
+
+/// A literal property is comparable to the same literal inside a target union.
+#[test]
+fn object_property_literal_in_target_union_no_ts2352() {
+    let source = "const v = { mode: 'dev' } as { mode: 'dev' | 'prod' };";
+    assert_eq!(ts2352_count(source), 0, "Codes: {:?}", check_strict(source));
+}
+
+/// A literal property is comparable to a base-primitive target property.
+#[test]
+fn object_property_literal_to_base_primitive_no_ts2352() {
+    for source in [
+        "const v = { n: 1 } as { n: number };",
+        "const w = { s: 'a' } as { s: string };",
+    ] {
+        assert_eq!(
+            ts2352_count(source),
+            0,
+            "[{source}] literal-to-base property must not report TS2352. Codes: {:?}",
+            check_strict(source)
+        );
+    }
+}
+
+/// A property widened to its base primitive (a plain `const` object) overlaps a
+/// literal-union target.
+#[test]
+fn widened_property_to_literal_union_no_ts2352() {
+    let source = "const cobj = { mode: 'dev' };\n\
+                  const v = cobj as { mode: 'prod' };";
+    assert_eq!(ts2352_count(source), 0, "Codes: {:?}", check_strict(source));
+}

--- a/crates/tsz-solver/src/type_queries/assertion_overlap.rs
+++ b/crates/tsz-solver/src/type_queries/assertion_overlap.rs
@@ -1,0 +1,171 @@
+//! Structural property/element overlap checks for type-assertion (`as`)
+//! comparability (TS2352).
+//!
+//! These helpers back [`super::flow::types_are_comparable_for_assertion`]: once
+//! the primitive/union/intersection fast paths have been exhausted, the object
+//! and tuple/array shapes are compared structurally here. The recursion always
+//! re-enters `types_are_comparable_for_assertion_inner` with `nested = true`,
+//! because property and element types are not subject to tsc's top-level
+//! `getWidenedType` and therefore require strict literal overlap.
+
+use super::flow::types_are_comparable_for_assertion_inner;
+use crate::construction::TypeDatabase;
+use crate::types::{TypeData, TypeId};
+use rustc_hash::FxHashMap;
+use tsz_common::Atom;
+
+/// Relaxed version of `types_have_common_properties` for TS2352.
+/// Only requires that shared properties have comparable types.
+/// Missing target properties in the source are allowed.
+pub(super) fn types_have_common_properties_relaxed(
+    db: &dyn TypeDatabase,
+    source: TypeId,
+    target: TypeId,
+    depth: u32,
+) -> bool {
+    fn get_properties(db: &dyn TypeDatabase, type_id: TypeId) -> Vec<(Atom, TypeId, bool)> {
+        if type_id.is_intrinsic() {
+            return Vec::new();
+        }
+        match db.lookup(type_id) {
+            Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
+                let shape = db.object_shape(shape_id);
+                shape
+                    .properties
+                    .iter()
+                    .map(|p| (p.name, p.type_id, p.optional))
+                    .collect()
+            }
+            Some(TypeData::Callable(callable_id)) => {
+                let shape = db.callable_shape(callable_id);
+                shape
+                    .properties
+                    .iter()
+                    .map(|p| (p.name, p.type_id, p.optional))
+                    .collect()
+            }
+            Some(TypeData::Intersection(list_id)) => {
+                let members = db.type_list(list_id);
+                let mut props = Vec::new();
+                for &member in members.iter() {
+                    props.extend(get_properties(db, member));
+                }
+                props
+            }
+            // Arrays have no named properties for overlap checking - element types
+            // are compared separately in types_are_comparable_for_assertion_inner.
+            // Returning empty ensures we don't short-circuit array↔object comparisons.
+            _ => Vec::new(),
+        }
+    }
+
+    // Handle array↔array comparability: check element types directly
+    if let (Some(TypeData::Array(src_elem)), Some(TypeData::Array(tgt_elem))) =
+        (db.lookup(source), db.lookup(target))
+    {
+        return types_are_comparable_for_assertion_inner(db, src_elem, tgt_elem, depth + 1, true);
+    }
+
+    // Handle array↔tuple comparability: array element vs any tuple element
+    if let (Some(TypeData::Array(arr_elem)), Some(TypeData::Tuple(tuple_id))) =
+        (db.lookup(source), db.lookup(target))
+    {
+        let tuple_elements = db.tuple_list(tuple_id);
+        return tuple_elements.iter().any(|elem| {
+            types_are_comparable_for_assertion_inner(db, arr_elem, elem.type_id, depth + 1, true)
+        });
+    }
+    if let (Some(TypeData::Tuple(tuple_id)), Some(TypeData::Array(arr_elem))) =
+        (db.lookup(source), db.lookup(target))
+    {
+        let tuple_elements = db.tuple_list(tuple_id);
+        return tuple_elements.iter().any(|elem| {
+            types_are_comparable_for_assertion_inner(db, elem.type_id, arr_elem, depth + 1, true)
+        });
+    }
+
+    // Handle tuple↔tuple comparability: check element types pairwise.
+    // tsc's isTypeComparableTo checks tuples structurally: each element at
+    // position i must be comparable to the element at position i in the other
+    // tuple. Different-length tuples are not comparable (neither is assignable
+    // to the other), so TS2352 should fire.
+    if let (Some(TypeData::Tuple(src_tuple)), Some(TypeData::Tuple(tgt_tuple))) =
+        (db.lookup(source), db.lookup(target))
+    {
+        let src_elements = db.tuple_list(src_tuple);
+        let tgt_elements = db.tuple_list(tgt_tuple);
+        // Different-length tuples are not comparable
+        if src_elements.len() != tgt_elements.len() {
+            return false;
+        }
+        // All corresponding elements must be comparable
+        return src_elements.iter().zip(tgt_elements.iter()).all(|(s, t)| {
+            types_are_comparable_for_assertion_inner(db, s.type_id, t.type_id, depth + 1, true)
+        });
+    }
+
+    let source_props = get_properties(db, source);
+    let target_props = get_properties(db, target);
+
+    // If both sides have no properties and aren't arrays/tuples, they don't overlap
+    if source_props.is_empty() && target_props.is_empty() {
+        return false;
+    }
+
+    let mut source_by_name: FxHashMap<Atom, Vec<(TypeId, bool)>> = FxHashMap::default();
+    for (name, ty, optional) in &source_props {
+        source_by_name
+            .entry(*name)
+            .or_default()
+            .push((*ty, *optional));
+    }
+
+    // For TS2352: only check that shared properties are comparable.
+    // Missing target properties are allowed.
+    let mut found_common = false;
+    for (target_name, target_ty, target_optional) in &target_props {
+        if let Some(source_entries) = source_by_name.get(target_name) {
+            found_common = true;
+            let any_comparable = source_entries.iter().any(|(source_ty, source_optional)| {
+                if (*source_optional || *target_optional)
+                    && (*source_ty == TypeId::UNDEFINED || *target_ty == TypeId::UNDEFINED)
+                {
+                    return true;
+                }
+                // Property values are nested, so distinct literals (e.g. `"a"` vs
+                // `"b"`) are rejected by the `nested` guard inside the recursive
+                // call rather than a separate value-equality check here.
+                types_are_comparable_for_assertion_inner(
+                    db,
+                    *source_ty,
+                    *target_ty,
+                    depth + 1,
+                    true,
+                )
+            });
+            if !any_comparable {
+                return false;
+            }
+        }
+        // Intentionally NOT returning false for missing target properties
+    }
+
+    if !found_common {
+        // Weak type overlap: if either side has ONLY optional properties (a "weak type"),
+        // it overlaps with any object that has at least one property. Every object
+        // structurally satisfies a weak type (optional properties can all be missing).
+        // This matches tsc's `isTypeComparableTo` which bypasses weak type detection
+        // (TS2559) in comparable contexts like type assertions.
+        let source_is_weak =
+            !source_props.is_empty() && source_props.iter().all(|(_, _, opt)| *opt);
+        let target_is_weak =
+            !target_props.is_empty() && target_props.iter().all(|(_, _, opt)| *opt);
+        if (source_is_weak && !target_props.is_empty())
+            || (target_is_weak && !source_props.is_empty())
+        {
+            return true;
+        }
+    }
+
+    found_common
+}

--- a/crates/tsz-solver/src/type_queries/flow.rs
+++ b/crates/tsz-solver/src/type_queries/flow.rs
@@ -859,14 +859,25 @@ pub fn types_are_comparable_for_assertion(
     source: TypeId,
     target: TypeId,
 ) -> bool {
-    types_are_comparable_for_assertion_inner(db, source, target, 0)
+    types_are_comparable_for_assertion_inner(db, source, target, 0, false)
 }
 
-fn types_are_comparable_for_assertion_inner(
+/// `nested` tracks whether we have descended into an object property or a
+/// tuple/array element. tsc's `checkAssertionWorker` widens only the
+/// *top-level* assertion source via `getWidenedType`, so two distinct literals
+/// that appear as the direct operands of an assertion (e.g. `"x" as "y"`, or a
+/// member of the top-level union in `"x" as "y" | "z"`) are treated as
+/// overlapping, whereas distinct literals nested inside a shared property
+/// (e.g. `{ k: "a" } as { k: "b" }`) are *not* widened and therefore do not
+/// overlap. Union/intersection/readonly/enum decomposition of the top-level
+/// types keeps `nested` unchanged; only descending through a property or
+/// element sets it.
+pub(super) fn types_are_comparable_for_assertion_inner(
     db: &dyn TypeDatabase,
     source: TypeId,
     target: TypeId,
     depth: u32,
+    nested: bool,
 ) -> bool {
     // Prevent infinite recursion
     if depth > 5 {
@@ -876,6 +887,24 @@ fn types_are_comparable_for_assertion_inner(
     // Same type is always comparable
     if source == target {
         return true;
+    }
+
+    // Cache the structural views once; this function pattern-matches both
+    // operands repeatedly across the decomposition cases below.
+    let source_data = db.lookup(source);
+    let target_data = db.lookup(target);
+
+    // Nested distinct literals do not overlap. The equal case is handled above,
+    // so reaching here with two literal operands while `nested` means the
+    // values differ; tsc does not widen nested literals, so `"a"` and `"b"` (or
+    // `1` and `2`) are not comparable as shared property/element types. Enum
+    // literals are `TypeData::Enum`, not `TypeData::Literal`, so same-enum
+    // member comparability is unaffected.
+    if nested
+        && matches!(source_data, Some(TypeData::Literal(_)))
+        && matches!(target_data, Some(TypeData::Literal(_)))
+    {
+        return false;
     }
 
     // `never` is comparable to any type (it's the bottom type, subtype of all types).
@@ -901,57 +930,69 @@ fn types_are_comparable_for_assertion_inner(
     // NOTE: callers should pre-resolve Lazy types (via checker evaluation) before
     // invoking this function to avoid false TS2352 on assertions like
     // `{mode: ""} as UserSettings` where a nested interface property stays Lazy.
-    let source_is_lazy = matches!(db.lookup(source), Some(TypeData::Lazy(_)));
-    let target_is_lazy = matches!(db.lookup(target), Some(TypeData::Lazy(_)));
+    let source_is_lazy = matches!(source_data, Some(TypeData::Lazy(_)));
+    let target_is_lazy = matches!(target_data, Some(TypeData::Lazy(_)));
     if depth > 0 && source_is_lazy && target_is_lazy {
         return true;
     }
 
     // Unwrap ReadonlyType wrappers
-    if let Some(TypeData::ReadonlyType(inner)) = db.lookup(source) {
-        return types_are_comparable_for_assertion_inner(db, inner, target, depth + 1);
+    if let Some(TypeData::ReadonlyType(inner)) = source_data {
+        return types_are_comparable_for_assertion_inner(db, inner, target, depth + 1, nested);
     }
-    if let Some(TypeData::ReadonlyType(inner)) = db.lookup(target) {
-        return types_are_comparable_for_assertion_inner(db, source, inner, depth + 1);
+    if let Some(TypeData::ReadonlyType(inner)) = target_data {
+        return types_are_comparable_for_assertion_inner(db, source, inner, depth + 1, nested);
     }
 
     // Check union types
-    if let Some(TypeData::Union(list_id)) = db.lookup(source) {
+    if let Some(TypeData::Union(list_id)) = source_data {
         let members = db.type_list(list_id);
         return members
             .iter()
-            .any(|&m| types_are_comparable_for_assertion_inner(db, m, target, depth + 1));
+            .any(|&m| types_are_comparable_for_assertion_inner(db, m, target, depth + 1, nested));
     }
-    if let Some(TypeData::Union(list_id)) = db.lookup(target) {
+    if let Some(TypeData::Union(list_id)) = target_data {
         let members = db.type_list(list_id);
         return members
             .iter()
-            .any(|&m| types_are_comparable_for_assertion_inner(db, source, m, depth + 1));
+            .any(|&m| types_are_comparable_for_assertion_inner(db, source, m, depth + 1, nested));
     }
 
     // For intersection source S1 & S2 & ... & Sn: any member comparable to target suffices.
     // For intersection target T1 & T2 & ... & Tn: source must be comparable to every member
     // (tsc's eachTypeRelatedToType via comparableRelation).
-    if let Some(TypeData::Intersection(list_id)) = db.lookup(source) {
+    if let Some(TypeData::Intersection(list_id)) = source_data {
         let members = db.type_list(list_id);
         return members
             .iter()
-            .any(|&m| types_are_comparable_for_assertion_inner(db, m, target, depth + 1));
+            .any(|&m| types_are_comparable_for_assertion_inner(db, m, target, depth + 1, nested));
     }
-    if let Some(TypeData::Intersection(list_id)) = db.lookup(target) {
+    if let Some(TypeData::Intersection(list_id)) = target_data {
         let members = db.type_list(list_id);
         return members
             .iter()
-            .all(|&m| types_are_comparable_for_assertion_inner(db, source, m, depth + 1));
+            .all(|&m| types_are_comparable_for_assertion_inner(db, source, m, depth + 1, nested));
     }
 
     // Enum comparability: unwrap to member type union, matching
     // `types_are_comparable_inner` behavior.
-    if let Some(TypeData::Enum(_def_id, members_type_id)) = db.lookup(source) {
-        return types_are_comparable_for_assertion_inner(db, members_type_id, target, depth + 1);
+    if let Some(TypeData::Enum(_def_id, members_type_id)) = source_data {
+        return types_are_comparable_for_assertion_inner(
+            db,
+            members_type_id,
+            target,
+            depth + 1,
+            nested,
+        );
     }
-    if let Some(TypeData::Enum(_def_id, members_type_id)) = db.lookup(target) {
-        return types_are_comparable_for_assertion_inner(db, source, members_type_id, depth + 1);
+    if let Some(TypeData::Enum(_def_id, members_type_id)) = target_data {
+        return types_are_comparable_for_assertion_inner(
+            db,
+            source,
+            members_type_id,
+            depth + 1,
+            nested,
+        );
     }
 
     // Check primitive ↔ literal comparability
@@ -1016,13 +1057,13 @@ fn types_are_comparable_for_assertion_inner(
         && let Some(TypeData::TypeParameter(info)) = db.lookup(target)
         && let Some(constraint) = info.constraint
     {
-        return types_are_comparable_for_assertion_inner(db, source, constraint, depth + 1);
+        return types_are_comparable_for_assertion_inner(db, source, constraint, depth + 1, nested);
     }
     if is_empty_object_type(db, target)
         && let Some(TypeData::TypeParameter(info)) = db.lookup(source)
         && let Some(constraint) = info.constraint
     {
-        return types_are_comparable_for_assertion_inner(db, constraint, target, depth + 1);
+        return types_are_comparable_for_assertion_inner(db, constraint, target, depth + 1, nested);
     }
 
     if callable_signatures_overlap_for_assertion(db, source, target, depth) {
@@ -1031,7 +1072,7 @@ fn types_are_comparable_for_assertion_inner(
 
     // For type assertions, only check that overlapping properties are comparable.
     // Do NOT require all target properties to exist in the source.
-    types_have_common_properties_relaxed(db, source, target, depth)
+    super::assertion_overlap::types_have_common_properties_relaxed(db, source, target, depth)
 }
 
 fn type_param_primitive_comparable_with_constraint(
@@ -1107,7 +1148,7 @@ fn assertion_signatures_are_comparable(
         }
     }
 
-    types_are_comparable_for_assertion_inner(db, source_return, target_return, depth + 1)
+    types_are_comparable_for_assertion_inner(db, source_return, target_return, depth + 1, true)
 }
 
 fn signature_param_types_are_comparable_for_assertion(
@@ -1127,12 +1168,13 @@ fn signature_param_types_are_comparable_for_assertion(
                     source_member,
                     target_member,
                     depth + 1,
+                    true,
                 )
             })
         });
     }
 
-    types_are_comparable_for_assertion_inner(db, source, target, depth + 1)
+    types_are_comparable_for_assertion_inner(db, source, target, depth + 1, true)
 }
 
 fn nullable_callable_union_members(db: &dyn TypeDatabase, type_id: TypeId) -> Option<Vec<TypeId>> {
@@ -1247,167 +1289,6 @@ fn is_keyof_to_string_number_symbol(
         return true;
     }
     false
-}
-
-/// Relaxed version of `types_have_common_properties` for TS2352.
-/// Only requires that shared properties have comparable types.
-/// Missing target properties in the source are allowed.
-fn types_have_common_properties_relaxed(
-    db: &dyn TypeDatabase,
-    source: TypeId,
-    target: TypeId,
-    depth: u32,
-) -> bool {
-    fn get_properties(db: &dyn TypeDatabase, type_id: TypeId) -> Vec<(Atom, TypeId, bool)> {
-        if type_id.is_intrinsic() {
-            return Vec::new();
-        }
-        match db.lookup(type_id) {
-            Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
-                let shape = db.object_shape(shape_id);
-                shape
-                    .properties
-                    .iter()
-                    .map(|p| (p.name, p.type_id, p.optional))
-                    .collect()
-            }
-            Some(TypeData::Callable(callable_id)) => {
-                let shape = db.callable_shape(callable_id);
-                shape
-                    .properties
-                    .iter()
-                    .map(|p| (p.name, p.type_id, p.optional))
-                    .collect()
-            }
-            Some(TypeData::Intersection(list_id)) => {
-                let members = db.type_list(list_id);
-                let mut props = Vec::new();
-                for &member in members.iter() {
-                    props.extend(get_properties(db, member));
-                }
-                props
-            }
-            // Arrays have no named properties for overlap checking - element types
-            // are compared separately in types_are_comparable_for_assertion_inner.
-            // Returning empty ensures we don't short-circuit array↔object comparisons.
-            _ => Vec::new(),
-        }
-    }
-
-    // Handle array↔array comparability: check element types directly
-    if let (Some(TypeData::Array(src_elem)), Some(TypeData::Array(tgt_elem))) =
-        (db.lookup(source), db.lookup(target))
-    {
-        return types_are_comparable_for_assertion_inner(db, src_elem, tgt_elem, depth + 1);
-    }
-
-    // Handle array↔tuple comparability: array element vs any tuple element
-    if let (Some(TypeData::Array(arr_elem)), Some(TypeData::Tuple(tuple_id))) =
-        (db.lookup(source), db.lookup(target))
-    {
-        let tuple_elements = db.tuple_list(tuple_id);
-        return tuple_elements.iter().any(|elem| {
-            types_are_comparable_for_assertion_inner(db, arr_elem, elem.type_id, depth + 1)
-        });
-    }
-    if let (Some(TypeData::Tuple(tuple_id)), Some(TypeData::Array(arr_elem))) =
-        (db.lookup(source), db.lookup(target))
-    {
-        let tuple_elements = db.tuple_list(tuple_id);
-        return tuple_elements.iter().any(|elem| {
-            types_are_comparable_for_assertion_inner(db, elem.type_id, arr_elem, depth + 1)
-        });
-    }
-
-    // Handle tuple↔tuple comparability: check element types pairwise.
-    // tsc's isTypeComparableTo checks tuples structurally: each element at
-    // position i must be comparable to the element at position i in the other
-    // tuple. Different-length tuples are not comparable (neither is assignable
-    // to the other), so TS2352 should fire.
-    if let (Some(TypeData::Tuple(src_tuple)), Some(TypeData::Tuple(tgt_tuple))) =
-        (db.lookup(source), db.lookup(target))
-    {
-        let src_elements = db.tuple_list(src_tuple);
-        let tgt_elements = db.tuple_list(tgt_tuple);
-        // Different-length tuples are not comparable
-        if src_elements.len() != tgt_elements.len() {
-            return false;
-        }
-        // All corresponding elements must be comparable
-        return src_elements.iter().zip(tgt_elements.iter()).all(|(s, t)| {
-            types_are_comparable_for_assertion_inner(db, s.type_id, t.type_id, depth + 1)
-        });
-    }
-
-    let source_props = get_properties(db, source);
-    let target_props = get_properties(db, target);
-
-    // If both sides have no properties and aren't arrays/tuples, they don't overlap
-    if source_props.is_empty() && target_props.is_empty() {
-        return false;
-    }
-
-    use rustc_hash::FxHashMap;
-    let mut source_by_name: FxHashMap<Atom, Vec<(TypeId, bool)>> = FxHashMap::default();
-    for (name, ty, optional) in &source_props {
-        source_by_name
-            .entry(*name)
-            .or_default()
-            .push((*ty, *optional));
-    }
-
-    // For TS2352: only check that shared properties are comparable.
-    // Missing target properties are allowed.
-    let mut found_common = false;
-    for (target_name, target_ty, target_optional) in &target_props {
-        if let Some(source_entries) = source_by_name.get(target_name) {
-            found_common = true;
-            let any_comparable = source_entries.iter().any(|(source_ty, source_optional)| {
-                if (*source_optional || *target_optional)
-                    && (*source_ty == TypeId::UNDEFINED || *target_ty == TypeId::UNDEFINED)
-                {
-                    return true;
-                }
-                if are_distinct_literal_values(db, *source_ty, *target_ty) {
-                    return false;
-                }
-                types_are_comparable_for_assertion_inner(db, *source_ty, *target_ty, depth + 1)
-            });
-            if !any_comparable {
-                return false;
-            }
-        }
-        // Intentionally NOT returning false for missing target properties
-    }
-
-    if !found_common {
-        // Weak type overlap: if either side has ONLY optional properties (a "weak type"),
-        // it overlaps with any object that has at least one property. Every object
-        // structurally satisfies a weak type (optional properties can all be missing).
-        // This matches tsc's `isTypeComparableTo` which bypasses weak type detection
-        // (TS2559) in comparable contexts like type assertions.
-        let source_is_weak =
-            !source_props.is_empty() && source_props.iter().all(|(_, _, opt)| *opt);
-        let target_is_weak =
-            !target_props.is_empty() && target_props.iter().all(|(_, _, opt)| *opt);
-        if (source_is_weak && !target_props.is_empty())
-            || (target_is_weak && !source_props.is_empty())
-        {
-            return true;
-        }
-    }
-
-    found_common
-}
-
-fn are_distinct_literal_values(db: &dyn TypeDatabase, source: TypeId, target: TypeId) -> bool {
-    let Some(TypeData::Literal(source_lit)) = db.lookup(source) else {
-        return false;
-    };
-    let Some(TypeData::Literal(target_lit)) = db.lookup(target) else {
-        return false;
-    };
-    source_lit != target_lit
 }
 
 fn types_are_comparable_inner(
@@ -1798,7 +1679,7 @@ fn types_have_common_properties(
     if let (Some(TypeData::Array(src_elem)), Some(TypeData::Array(tgt_elem))) =
         (db.lookup(source), db.lookup(target))
     {
-        return types_are_comparable_for_assertion_inner(db, src_elem, tgt_elem, depth + 1);
+        return types_are_comparable_for_assertion_inner(db, src_elem, tgt_elem, depth + 1, false);
     }
 
     // Handle array↔tuple comparability: array element vs any tuple element
@@ -1807,7 +1688,7 @@ fn types_have_common_properties(
     {
         let tuple_elements = db.tuple_list(tuple_id);
         return tuple_elements.iter().any(|elem| {
-            types_are_comparable_for_assertion_inner(db, arr_elem, elem.type_id, depth + 1)
+            types_are_comparable_for_assertion_inner(db, arr_elem, elem.type_id, depth + 1, false)
         });
     }
     if let (Some(TypeData::Tuple(tuple_id)), Some(TypeData::Array(arr_elem))) =
@@ -1815,7 +1696,7 @@ fn types_have_common_properties(
     {
         let tuple_elements = db.tuple_list(tuple_id);
         return tuple_elements.iter().any(|elem| {
-            types_are_comparable_for_assertion_inner(db, elem.type_id, arr_elem, depth + 1)
+            types_are_comparable_for_assertion_inner(db, elem.type_id, arr_elem, depth + 1, false)
         });
     }
 
@@ -1835,7 +1716,7 @@ fn types_have_common_properties(
         }
         // All corresponding elements must be comparable
         return src_elements.iter().zip(tgt_elements.iter()).all(|(s, t)| {
-            types_are_comparable_for_assertion_inner(db, s.type_id, t.type_id, depth + 1)
+            types_are_comparable_for_assertion_inner(db, s.type_id, t.type_id, depth + 1, false)
         });
     }
 

--- a/crates/tsz-solver/src/type_queries/mod.rs
+++ b/crates/tsz-solver/src/type_queries/mod.rs
@@ -27,6 +27,7 @@
 //! }
 //! ```
 
+pub mod assertion_overlap;
 pub mod classifiers;
 mod core;
 pub mod data;


### PR DESCRIPTION
Fixes #11344.

## AgentName
AgentName: claude-opus-4-8 (remote execution / eager-pascal)
Promotion normalization by AgentName: m5-pro-48g-gpt5 on 2026-05-29.

## Track
Conformance / checker-solver parity (TS2352 type-assertion overlap).

## Invariant
`as` conversions report **TS2352** when source and target do not sufficiently overlap. tsc's `checkAssertionWorker` widens only the **top-level** assertion source via `getWidenedType`; nested object-property and tuple/array-element types are **not** widened and use the strict comparable relation.

## Structural Rule
When comparing type-assertion overlap, two distinct literals that appear as a shared **object property** or **tuple/array element** type are not comparable (tsc does not widen nested literals). Only the top-level operand is widened, so distinct literals that are the direct operands of an assertion, or members of a top-level union, still overlap.

This makes tsz match tsc 6.0.2 on:

| Source | Cast | tsc / tsz now |
|---|---|---|
| `{ mode: 'dev' } satisfies { mode: 'dev'|'prod' }` | `as { mode: 'test'|'prod' }` | **TS2352** |
| `{ mode: 'dev' }` | `as { mode: 'prod' }` | **TS2352** |
| `{ n: 1 }` | `as { n: 2 | 3 }` | **TS2352** |
| `['a']` | `as ['b']` | **TS2352** |
| `'x'` | `as 'y'` | no error |
| `'x'` | `as 'y' | 'z'` | no error |
| `{ mode: 'dev' }` | `as { mode: 'dev'|'prod' }` | no error |
| `{ n: 1 }` | `as { n: number }` | no error |
| `const cobj = { mode: 'dev' }; cobj` | `as { mode: 'prod' }` | no error (property widened to `string`) |

Before this change tsz silently accepted the first four because `satisfies` correctly preserves `config: { mode: "dev" }` but the overlap check then widened the comparison.

## Owner Layer / Approach
Type semantics live in the solver. `types_are_comparable_for_assertion_inner` now threads a `nested: bool`:

- `false` at the top level and through union / intersection / readonly / enum decomposition of the top-level operands.
- `true` when descending into an object property, a tuple/array element, or a callable signature param/return.

When `nested`, two distinct `TypeData::Literal` operands are not comparable. Enum members are `TypeData::Enum`, so same-enum comparability is unchanged, and literal-to-base-primitive overlap still holds. The general non-assertion comparable relation passes `nested = false`, so TS2367 / narrowing behavior is untouched.

The structural property/element overlap helpers move to a new `type_queries::assertion_overlap` module to keep `flow.rs` under its maintainability ceiling. The now-redundant `are_distinct_literal_values` value check was removed, and repeated `db.lookup` views are cached.

## Scope
- `crates/tsz-solver/src/type_queries/assertion_overlap.rs` adds the assertion-overlap structural helpers.
- `crates/tsz-solver/src/type_queries/flow.rs` delegates nested assertion-overlap checks while staying under the file-size ceiling.
- `crates/tsz-solver/src/type_queries/mod.rs` wires the new module.
- `crates/tsz-checker/tests/ts2352_nested_literal_overlap_tests.rs` adds the focused TS2352 regression matrix.
- `crates/tsz-checker/Cargo.toml` registers the new checker test target.

## Adjacent-Case Test Matrix
`crates/tsz-checker/tests/ts2352_nested_literal_overlap_tests.rs` covers, with varied property names, literal spellings, and primitive kinds:

1. Reported `satisfies` + `as` repro (string and renamed variants).
2. Direct object-literal property mismatch (string and number).
3. Property literal vs literal-union.
4. Tuple element mismatch.
5. Negatives: top-level distinct literals, literal-in-union, literal-to-base, and `const`-widened property.

## Known Unsupported / Follow-Up
- Distinct **function return-type** literals at top level (`(() => 'a') as (() => 'b')`) are still accepted because the arrow's return type is widened to `string` upstream. That is a separate return-type-widening gap, not introduced here.
- The TS2352 **message text** renders some sources widened (`{ mode: string }` vs tsc's `{ mode: "dev" }`); this is pre-existing renderer behavior in `error_type_assertion_no_overlap` and is orthogonal to the overlap decision fixed here.

## Project Corpus Impact
- Row: n/a (parity bug fix; no project-corpus row regressed).
- Bug family: type-assertion (`as`) literal overlap / `satisfies` + `as`.
- Evidence: tsc 6.0.2 vs tsz diff on the matrix above; full conformance, emit, and fourslash gates run on ready-review CI.

## Verification
Original draft verification:
```bash
cargo build -p tsz-cli
cargo test -p tsz-checker --test ts2352_nested_literal_overlap_tests
cargo test -p tsz-solver --lib
cargo clippy -p tsz-solver -p tsz-checker --all-targets
```
The draft notes the new 9-case matrix and existing TS2352 suites were green, the solver file-size ceiling regression was resolved, and remaining solver-lib failures were pre-existing and unrelated.

No full conformance, emit, or fourslash suite was run locally for this promotion; ready-review CI owns those gates.

## Coordination Notes
Originally drew #11360, which did not reproduce on the then-current tree. Pivoted to #11344, whose repro reproduced a concrete divergence. No WIP label, WIP title, blocker comment, or competing open PR for this path was present when `m5-pro-48g-gpt5` audited this old draft on 2026-05-29. Promoted for ready-review CI because the branch is focused and the user requested including old drafts.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Vy7bxYeZnymL5QuFH1HVo)_
