### PR TITLE
fix(checker): unify unknown-object member-access diagnostic gate

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -135,6 +135,10 @@ name = "optional_chain_literal_nullish_ts2339_tests"
 path = "tests/optional_chain_literal_nullish_ts2339_tests.rs"
 
 [[test]]
+name = "optional_chain_indexed_unknown_tests"
+path = "tests/optional_chain_indexed_unknown_tests.rs"
+
+[[test]]
 name = "new_expression_regression_tests"
 path = "tests/new_expression_regression_tests.rs"
 

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -76,6 +76,34 @@ impl<'a> CheckerState<'a> {
         self.get_type_of_element_access_with_request(idx, &TypingRequest::NONE)
     }
 
+    /// Resolve the member-access result type when the (resolved) object type is
+    /// `unknown`, under `strictNullChecks`.
+    ///
+    /// `tsc` forbids accessing a member of a value of type `unknown` — by name
+    /// (`x.p`), by index (`x[k]`), or through an optional chain (`x?.p` / `x?.[k]`)
+    /// — so under `strictNullChecks` we emit the diagnostic and return `Some`:
+    /// `TS18046` (`'x' is of type 'unknown'.`) when the base expression has a
+    /// printable name, otherwise the object form `TS2571` (`Object is of type
+    /// 'unknown'.`), returning `ERROR` to stop cascading diagnostics. When
+    /// `strictNullChecks` is off, `unknown` behaves like `any`; we return `None` so
+    /// each caller can apply its own non-strict fallback (index-signature handling
+    /// for element access, `error_property_not_exist_at` for property access).
+    ///
+    /// This is the single decision gate for the unknown-object access result,
+    /// shared by the element-access `literal_string`/`literal_index` arms and the
+    /// property-access path, so the `TS2571`/`TS18046` choice is not re-derived
+    /// independently in each place.
+    pub(crate) fn unknown_object_access_result(&mut self, base_expr: NodeIndex) -> Option<TypeId> {
+        if !self.ctx.compiler_options.strict_null_checks {
+            return None;
+        }
+        if self.error_is_of_type_unknown(base_expr) {
+            Some(TypeId::ERROR)
+        } else {
+            Some(TypeId::ANY)
+        }
+    }
+
     pub(crate) fn get_type_of_element_access_with_request(
         &mut self,
         idx: NodeIndex,
@@ -1157,18 +1185,11 @@ impl<'a> CheckerState<'a> {
                     Some(property_type.unwrap_or(TypeId::ERROR))
                 }
                 PropertyAccessResult::IsUnknown => {
-                    if self.ctx.compiler_options.strict_null_checks {
+                    let unknown_result = self.unknown_object_access_result(access.expression);
+                    if unknown_result.is_some() {
                         use_index_signature_check = false;
-                        // TS18046: 'x' is of type 'unknown'.
-                        // Without strictNullChecks, unknown is treated like any.
-                        if self.error_is_of_type_unknown(access.expression) {
-                            Some(TypeId::ERROR)
-                        } else {
-                            Some(TypeId::ANY)
-                        }
-                    } else {
-                        None
                     }
+                    unknown_result
                 }
                 PropertyAccessResult::PropertyNotFound { .. } => {
                     // TS2576 parity for element access on instance/super with a static member name.
@@ -1296,20 +1317,11 @@ impl<'a> CheckerState<'a> {
                     Some(property_type.unwrap_or(TypeId::ERROR))
                 }
                 PropertyAccessResult::IsUnknown => {
-                    if self.ctx.compiler_options.strict_null_checks {
-                        if !keep_index_signature_check {
-                            use_index_signature_check = false;
-                        }
-                        // TS18046: 'x' is of type 'unknown'.
-                        // Without strictNullChecks, unknown is treated like any.
-                        if self.error_is_of_type_unknown(access.expression) {
-                            Some(TypeId::ERROR)
-                        } else {
-                            Some(TypeId::ANY)
-                        }
-                    } else {
-                        None
+                    let unknown_result = self.unknown_object_access_result(access.expression);
+                    if unknown_result.is_some() && !keep_index_signature_check {
+                        use_index_signature_check = false;
                     }
+                    unknown_result
                 }
                 PropertyAccessResult::PropertyNotFound { .. } => None,
             };

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -2765,12 +2765,12 @@ impl<'a> CheckerState<'a> {
                 ),
 
                 PropertyAccessResult::IsUnknown => {
-                    if self.ctx.compiler_options.strict_null_checks {
-                        return if self.error_is_of_type_unknown(access.expression) {
-                            TypeId::ERROR
-                        } else {
-                            TypeId::ANY
-                        };
+                    // Shared unknown-object decision gate (TS18046/TS2571 under
+                    // strictNullChecks). `None` means non-strict, where property
+                    // access reports the missing property instead of falling
+                    // through to index signatures the way element access does.
+                    if let Some(result) = self.unknown_object_access_result(access.expression) {
+                        return result;
                     }
                     self.error_property_not_exist_at(
                         property_name,

--- a/crates/tsz-checker/tests/optional_chain_indexed_unknown_tests.rs
+++ b/crates/tsz-checker/tests/optional_chain_indexed_unknown_tests.rs
@@ -1,0 +1,275 @@
+//! Parity regression matrix for the `unknown`-object element-access decision
+//! (`TS2571` / `TS18046`) on plain and optional-chained indexed access.
+//!
+//! Tracks issue #11360 ("false positive TS2571 on optional chaining with
+//! indexed access"). `tsc` forbids indexing a value of type `unknown`
+//! regardless of whether the access is optional (`x[k]` and `x?.[k]` behave
+//! identically), choosing the named form `TS18046` when the base expression
+//! has a printable name and the object form `TS2571` otherwise. These tests
+//! lock that behaviour — and, crucially, prove that the diagnostic does *not*
+//! fire once the base has been narrowed away from `unknown` or is a perfectly
+//! well-typed indexable value reached through an optional chain.
+//!
+//! Per the anti-hardcoding gate, every binder-introduced name (type
+//! parameters, parameters) is varied across cases so a fix keyed on a specific
+//! spelling would fail here.
+
+use tsz_checker::test_utils::{check_source_strict, diagnostic_count, diagnostics_with_code};
+
+const TS2571_OBJECT_IS_UNKNOWN: u32 = 2571;
+const TS18046_IS_OF_TYPE_UNKNOWN: u32 = 18046;
+
+fn count(source: &str, code: u32) -> usize {
+    diagnostic_count(&check_source_strict(source), code)
+}
+
+/// The two unknown-object diagnostics are mutually exclusive per access site;
+/// this asserts the *total* unknown-object diagnostics on a snippet.
+fn unknown_object_diags(source: &str) -> usize {
+    let diags = check_source_strict(source);
+    diagnostic_count(&diags, TS2571_OBJECT_IS_UNKNOWN)
+        + diagnostic_count(&diags, TS18046_IS_OF_TYPE_UNKNOWN)
+}
+
+// ---------------------------------------------------------------------------
+// Positive cases: indexing `unknown` is an error, optional or not.
+// ---------------------------------------------------------------------------
+
+/// Complex (un-named) base of type `unknown` indexed -> object form `TS2571`.
+#[test]
+fn complex_base_unknown_indexed_reports_ts2571() {
+    let source = r#"
+function read(value: unknown) {
+    return (value as unknown)["k"];
+}
+"#;
+    assert_eq!(
+        count(source, TS2571_OBJECT_IS_UNKNOWN),
+        1,
+        "indexing a complex `unknown` base must report TS2571 (object form)"
+    );
+    assert_eq!(count(source, TS18046_IS_OF_TYPE_UNKNOWN), 0);
+}
+
+/// A named property-access base of type `unknown` -> named form `TS18046`,
+/// identical for plain and optional element access.
+#[test]
+fn named_base_unknown_indexed_reports_ts18046_plain_and_optional() {
+    let plain = r#"
+function read(holder: { payload: unknown }) {
+    return holder.payload["k"];
+}
+"#;
+    let optional = r#"
+function read(holder: { payload: unknown }) {
+    return holder.payload?.["k"];
+}
+"#;
+    for source in [plain, optional] {
+        let diags = check_source_strict(source);
+        let named = diagnostics_with_code(&diags, TS18046_IS_OF_TYPE_UNKNOWN);
+        assert_eq!(
+            named.len(),
+            1,
+            "named `unknown` base must report exactly one TS18046, got: {named:?}"
+        );
+        assert!(
+            named[0].message_text.contains("'holder.payload'"),
+            "TS18046 must name the base expression, got: {:?}",
+            named[0].message_text
+        );
+        assert_eq!(diagnostic_count(&diags, TS2571_OBJECT_IS_UNKNOWN), 0);
+    }
+}
+
+/// An element-access base whose element type is `unknown` is itself un-named,
+/// so a further index reports the object form `TS2571` (plain and optional).
+#[test]
+fn element_base_unknown_indexed_reports_ts2571_plain_and_optional() {
+    let plain = r#"
+function read(items: unknown[]) {
+    return items[0]["k"];
+}
+"#;
+    let optional = r#"
+function read(items: unknown[]) {
+    return items[0]?.["k"];
+}
+"#;
+    for source in [plain, optional] {
+        assert_eq!(
+            count(source, TS2571_OBJECT_IS_UNKNOWN),
+            1,
+            "indexing an un-named `unknown` element base must report TS2571"
+        );
+        assert_eq!(count(source, TS18046_IS_OF_TYPE_UNKNOWN), 0);
+    }
+}
+
+/// The optional-chain short-circuit does not rescue `unknown`: a possibly
+/// `undefined` *and* `unknown` union still collapses to `unknown` after `?.`.
+#[test]
+fn optional_chain_does_not_rescue_unknown_union() {
+    let source = r#"
+function read(maybe: unknown | undefined) {
+    return (maybe as unknown)?.["k"];
+}
+"#;
+    assert_eq!(
+        unknown_object_diags(source),
+        1,
+        "`?.` removes nullishness but not `unknown`; one unknown-object diagnostic expected"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Property access (dot) shares the same unknown-object decision gate as element
+// access, so the named/object diagnostic choice must match.
+// ---------------------------------------------------------------------------
+
+/// Named property-access base of type `unknown`, accessed by name (plain and
+/// optional) -> named form `TS18046`.
+#[test]
+fn named_base_unknown_property_access_reports_ts18046() {
+    let plain = r#"
+function read(holder: { payload: unknown }) {
+    return holder.payload.field;
+}
+"#;
+    let optional = r#"
+function read(holder: { payload: unknown }) {
+    return holder.payload?.field;
+}
+"#;
+    for source in [plain, optional] {
+        assert_eq!(
+            count(source, TS18046_IS_OF_TYPE_UNKNOWN),
+            1,
+            "named `unknown` base property access must report TS18046"
+        );
+        assert_eq!(count(source, TS2571_OBJECT_IS_UNKNOWN), 0);
+    }
+}
+
+/// Complex (un-named) base of type `unknown`, property-accessed -> object form
+/// `TS2571`, mirroring the element-access object-form case.
+#[test]
+fn complex_base_unknown_property_access_reports_ts2571() {
+    let source = r#"
+function read(value: unknown) {
+    return (value as unknown).field;
+}
+"#;
+    assert_eq!(count(source, TS2571_OBJECT_IS_UNKNOWN), 1);
+    assert_eq!(count(source, TS18046_IS_OF_TYPE_UNKNOWN), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Negative cases: the diagnostic must NOT fire for well-typed indexable bases
+// reached through an optional chain, nor after narrowing away from `unknown`.
+// These are the cases a "false positive TS2571" regression would break.
+// ---------------------------------------------------------------------------
+
+/// Optional element access on an index-signature property: no unknown-object
+/// diagnostic. (Type-parameter / property names deliberately non-idiomatic.)
+#[test]
+fn optional_index_signature_access_is_accepted() {
+    let source = r#"
+function read(container: { bag?: { [slot: string]: number } }) {
+    return container.bag?.["slot"];
+}
+"#;
+    assert_eq!(
+        unknown_object_diags(source),
+        0,
+        "optional access into an index signature is well-typed, not `unknown`"
+    );
+}
+
+/// Optional element access directly on a possibly-`undefined` index signature.
+#[test]
+fn optional_access_on_possibly_undefined_index_signature_is_accepted() {
+    let source = r#"
+function read(lookup?: { [entry: string]: number }) {
+    return lookup?.["entry"];
+}
+"#;
+    assert_eq!(unknown_object_diags(source), 0);
+}
+
+/// Generic `T | undefined` indexed by `keyof T` through an optional chain:
+/// no unknown-object diagnostic. Renamed type parameter (`Shape`/`Field`) to
+/// defeat any name-keyed fix.
+#[test]
+fn generic_keyof_optional_access_is_accepted() {
+    let source = r#"
+function pick<Shape, Field extends keyof Shape>(
+    source: Shape | undefined,
+    field: Field,
+) {
+    return source?.[field];
+}
+"#;
+    assert_eq!(unknown_object_diags(source), 0);
+}
+
+/// Nested optional chain of well-typed members ending in indexed access.
+#[test]
+fn nested_optional_chain_indexed_access_is_accepted() {
+    let source = r#"
+function read(root: { branch?: { leaves?: number[] } }) {
+    return root.branch?.leaves?.[0];
+}
+"#;
+    assert_eq!(unknown_object_diags(source), 0);
+}
+
+/// `unknown` narrowed to an indexable object via `typeof` + `in` before access
+/// must not report the unknown-object diagnostic (`tsc` accepts the index).
+#[test]
+fn in_narrowed_unknown_indexed_access_is_accepted() {
+    let plain = r#"
+function read(candidate: unknown) {
+    if (candidate && typeof candidate === "object" && "field" in candidate) {
+        return candidate["field"];
+    }
+}
+"#;
+    let optional = r#"
+function read(candidate: unknown) {
+    if (candidate && typeof candidate === "object" && "field" in candidate) {
+        return candidate?.["field"];
+    }
+}
+"#;
+    for source in [plain, optional] {
+        assert_eq!(
+            unknown_object_diags(source),
+            0,
+            "`in`-narrowed `unknown` is indexable; no unknown-object diagnostic expected"
+        );
+    }
+}
+
+/// Negative/fallback guard: a possibly-`undefined` (but not `unknown`) base
+/// indexed *without* an optional chain still reports the possibly-undefined
+/// family (TS18048), never the unknown-object family. Proves the unknown path
+/// is not over-applied.
+#[test]
+fn possibly_undefined_non_optional_index_is_not_unknown_object() {
+    let source = r#"
+function read(table: { [column: string]: number } | undefined) {
+    return table["column"];
+}
+"#;
+    assert_eq!(
+        unknown_object_diags(source),
+        0,
+        "possibly-undefined (not unknown) base must not report TS2571/TS18046"
+    );
+    assert_eq!(
+        count(source, 18048),
+        1,
+        "possibly-undefined base indexed without `?.` must report TS18048"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-eager-pascal

## Track
Conformance / checker diagnostics (TS2571 / TS18046 parity)

## Invariant
When a member of a value of type `unknown` is accessed — by name (`x.p`), by
index (`x[k]`), or through an optional chain (`x?.p` / `x?.[k]`) — `tsc` forbids
the access under `strictNullChecks`, reporting `TS18046` (`'x' is of type
'unknown'.`) when the base expression has a printable name and the object form
`TS2571` (`Object is of type 'unknown'.`) otherwise; this PR makes tsz route
every such case through a single checker-layer decision gate so the
`TS18046`/`TS2571` choice (and the non-strict fallback) can no longer drift
between the element-access and property-access paths.

## Scope
- `crates/tsz-checker/src/types/computation/access.rs`: add
  `unknown_object_access_result(base_expr) -> Option<TypeId>`, the single
  decision gate for "object is `unknown`" member access. Both element-access
  `IsUnknown` arms (`literal_string` and `literal_index`) now route through it
  instead of independently re-deriving the `ERROR`/`ANY`/fall-through result.
- `crates/tsz-checker/src/types/property_access_type/resolve.rs`: the
  property-access `IsUnknown` arm now uses the same gate (`Some` ⇒ strict
  result, `None` ⇒ non-strict property-not-exist fallback), removing the third
  copy of the decision.
- `crates/tsz-checker/tests/optional_chain_indexed_unknown_tests.rs` (+ Cargo
  entry): new parity regression matrix (12 cases).

This is a behavior-preserving consolidation (the three sites had identical
strict-mode logic and matching non-strict fallbacks); it does not change any
emitted diagnostic. Addresses #11360.

## Project Corpus Impact
- Row: n/a (no project-corpus row changes; behavior-preserving DRY + tests)
- Bug family: false-positive `TS2571`/`TS18046` on member access of `unknown`
- Evidence: new `tsz-checker` integration test
  `optional_chain_indexed_unknown_tests` (12 cases) passes; related existing
  targets (`element_access_structural_codes_tests`,
  `object_element_access_diagnostics_tests`,
  `optional_chain_continuation_undefined_tests`,
  `optional_chain_literal_nullish_ts2339_tests`,
  `property_access`/`indexed_access`/`ts7053`/narrowing targets) unchanged.

## Verification
- `cargo build -p tsz-cli` ✓
- `cargo test -p tsz-checker --test optional_chain_indexed_unknown_tests` → 12 passed ✓
- Related element/property/indexed-access + unknown-narrowing test targets: all green ✓
- `cargo clippy -p tsz-checker --tests` → clean ✓
- CLI parity sweep (strict + non-strict) on plain/optional indexed & dot access of
  `unknown`, narrowed `unknown` (`typeof`/`in`/`instanceof`), generics with `keyof`,
  index signatures, tuples, and possibly-`undefined`/`null` bases: output matches
  pre-change behavior and `tsc`.

## Coordination Notes
- AgentName: opus48-eager-pascal, branch `claude/eager-pascal-YyE3b`.
- Investigation summary: the false-positive `TS2571` reported in #11360 is not
  reproducible on `main` across a broad optional-chaining + indexed-access matrix
  — the common cases already match `tsc`. The real, addressable defect in that
  area was the split decision (three independent copies of the unknown-object
  access result logic, with a subtle `use_index_signature_check` asymmetry),
  which this PR collapses into one gate per §22's "one decision gate" rule and
  locks with a regression matrix so the false-positive class cannot silently
  reappear. The matrix varies binder-introduced names (anti-hardcoding gate).
- Per §24.5/§26, the fix lives in the checker orchestration layer: the solver
  emits the pure `IsUnknown` fact; the `ERROR`/`ANY`/fallthrough response is a
  `strictNullChecks` policy decision and stays in the checker.

https://claude.ai/code/session_01WvGUp6tRZ39xN43i8orPaC

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvGUp6tRZ39xN43i8orPaC)_