### PR TITLE
fix(checker): reset property-access narrowing across closure boundaries

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -31,6 +31,10 @@ web-time = { workspace = true }
 stacker = "0.1.23"
 
 [[test]]
+name = "closure_boundary_property_narrowing_tests"
+path = "tests/closure_boundary_property_narrowing_tests.rs"
+
+[[test]]
 name = "union_protected_intersection_property_tests"
 path = "tests/union_protected_intersection_property_tests.rs"
 

--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -2175,6 +2175,17 @@ impl<'a> FlowAnalyzer<'a> {
                         // Class property initializers run outside the surrounding
                         // function's flow point, so outer bindings do not inherit its narrowing.
                         initial_type
+                    } else if self.is_member_like_reference(reference) {
+                        // Property/element-access (and qualified-name) references do not
+                        // inherit control-flow narrowing across a function/closure boundary:
+                        // the closure may run after the property has been reassigned, so tsc
+                        // resets such references to their declared type at the function start
+                        // (mirrors the `PropertyAccessExpression`/`ElementAccessExpression`
+                        // exclusion in `getTypeAtFlowNode`'s `FlowStart` handling). Only the
+                        // base of an immediately-invoked function expression keeps narrowing,
+                        // and those are bound inline without a `START` boundary, so they never
+                        // reach this branch.
+                        initial_type
                     } else if self.is_captured_variable(reference)
                         && !self.is_effectively_const_for_narrowing(reference)
                     {

--- a/crates/tsz-checker/src/flow/control_flow/references.rs
+++ b/crates/tsz-checker/src/flow/control_flow/references.rs
@@ -216,7 +216,7 @@ impl<'a> FlowAnalyzer<'a> {
         property_match
     }
 
-    fn is_member_like_reference(&self, idx: NodeIndex) -> bool {
+    pub(crate) fn is_member_like_reference(&self, idx: NodeIndex) -> bool {
         let idx = self.skip_parens_and_assertions(idx);
         self.arena.get(idx).is_some_and(|node| {
             node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION

--- a/crates/tsz-checker/tests/closure_boundary_property_narrowing_tests.rs
+++ b/crates/tsz-checker/tests/closure_boundary_property_narrowing_tests.rs
@@ -1,0 +1,216 @@
+//! Tests for control-flow narrowing across function/closure boundaries.
+//!
+//! Structural rule: a property-access / element-access reference (e.g. `x.a`,
+//! `x["a"]`) read inside a nested arrow function, function expression, or
+//! object-literal method does NOT inherit the enclosing control-flow narrowing.
+//! Such a closure may run after the property has been reassigned, so tsc resets
+//! the reference to its declared type at the function boundary and re-emits the
+//! relevant `strictNullChecks` diagnostic (TS18048 / TS2532). This mirrors the
+//! `PropertyAccessExpression` / `ElementAccessExpression` / `this` exclusion in
+//! TypeScript's `getTypeAtFlowNode` `FlowStart` handling.
+//!
+//! Conversely, narrowing of a constant-like reference (a `const` local or a
+//! never-reassigned parameter — a plain identifier) IS preserved across the
+//! boundary, and an immediately-invoked function expression (IIFE) keeps the
+//! narrowing because it executes inline.
+
+use tsz_checker::test_utils::check_source_strict_codes;
+
+// ---------------------------------------------------------------------------
+// Positive cases: property/element narrowing must be DROPPED in a closure.
+// ---------------------------------------------------------------------------
+
+/// Reported repro: property access inside a stored arrow function.
+#[test]
+fn property_narrowing_dropped_in_arrow() {
+    let codes = check_source_strict_codes(
+        r#"
+function f(x: { a?: { b: number } }) {
+  if (x.a) {
+    const g = () => x.a.b;
+    return g();
+  }
+}
+"#,
+    );
+    assert!(
+        codes.contains(&18048),
+        "expected TS18048 for property narrowing lost across arrow boundary, got: {codes:?}"
+    );
+}
+
+/// Equivalent shape #1: function expression instead of an arrow.
+#[test]
+fn property_narrowing_dropped_in_function_expression() {
+    let codes = check_source_strict_codes(
+        r#"
+function f(x: { a?: { b: number } }) {
+  if (x.a) {
+    const g = function () { return x.a.b; };
+    return g();
+  }
+}
+"#,
+    );
+    assert!(
+        codes.contains(&18048),
+        "expected TS18048 for property narrowing lost across function-expression boundary, got: {codes:?}"
+    );
+}
+
+/// Equivalent shape #2: object-literal method.
+#[test]
+fn property_narrowing_dropped_in_object_method() {
+    let codes = check_source_strict_codes(
+        r#"
+function f(x: { a?: { b: number } }) {
+  if (x.a) {
+    const o = { m() { return x.a.b; } };
+    return o.m();
+  }
+}
+"#,
+    );
+    assert!(
+        codes.contains(&18048),
+        "expected TS18048 for property narrowing lost across object-method boundary, got: {codes:?}"
+    );
+}
+
+/// Equivalent shape #3: callback passed as an argument (the common real-world
+/// `.map`/`.forEach` pattern).
+#[test]
+fn property_narrowing_dropped_in_callback_argument() {
+    let codes = check_source_strict_codes(
+        r#"
+function f(x: { a?: { b: number } }) {
+  if (x.a) {
+    return [1].map(() => x.a.b);
+  }
+}
+"#,
+    );
+    assert!(
+        codes.contains(&18048),
+        "expected TS18048 for property narrowing lost across callback boundary, got: {codes:?}"
+    );
+}
+
+/// Different property/variable spelling — proves the rule is structural, not a
+/// match against a particular identifier.
+#[test]
+fn property_narrowing_dropped_independent_of_names() {
+    let codes = check_source_strict_codes(
+        r#"
+function handle(payload: { result?: { count: number } }) {
+  if (payload.result) {
+    const run = () => payload.result.count;
+    return run();
+  }
+}
+"#,
+    );
+    assert!(
+        codes.contains(&18048),
+        "expected TS18048 regardless of identifier spelling, got: {codes:?}"
+    );
+}
+
+/// Element-access reference (`x["a"]`) is also dropped — tsc reports TS2532.
+#[test]
+fn element_access_narrowing_dropped_in_arrow() {
+    let codes = check_source_strict_codes(
+        r#"
+function f(x: { a?: { b: number } }) {
+  if (x["a"]) {
+    const g = () => x["a"].b;
+    return g();
+  }
+}
+"#,
+    );
+    assert!(
+        codes.contains(&2532),
+        "expected TS2532 for element-access narrowing lost across arrow boundary, got: {codes:?}"
+    );
+}
+
+/// `this.prop` in a method closure is a property access too, so its narrowing
+/// is dropped (tsc reports TS2532 here).
+#[test]
+fn this_property_narrowing_dropped_in_arrow() {
+    let codes = check_source_strict_codes(
+        r#"
+class C {
+  a?: { b: number };
+  m() { if (this.a) { const g = () => this.a.b; return g(); } }
+}
+"#,
+    );
+    assert!(
+        codes.contains(&2532),
+        "expected TS2532 for this-property narrowing lost across arrow boundary, got: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative cases: narrowing that MUST still be preserved.
+// ---------------------------------------------------------------------------
+
+/// A `const` local that captured the narrowed value keeps its type in a closure.
+#[test]
+fn const_local_narrowing_preserved_in_arrow() {
+    let codes = check_source_strict_codes(
+        r#"
+function f(x: { a?: { b: number } }) {
+  const a = x.a;
+  if (a) {
+    const g = () => a.b;
+    return g();
+  }
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&18048) && !codes.contains(&2532),
+        "const-local narrowing must be preserved across the arrow boundary, got: {codes:?}"
+    );
+}
+
+/// A never-reassigned parameter (a plain identifier) keeps its narrowing.
+#[test]
+fn const_parameter_narrowing_preserved_in_arrow() {
+    let codes = check_source_strict_codes(
+        r#"
+function f(p?: number) {
+  if (p !== undefined) {
+    const g = () => p.toFixed();
+    return g();
+  }
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&18048),
+        "parameter identifier narrowing must be preserved across the arrow boundary, got: {codes:?}"
+    );
+}
+
+/// An immediately-invoked function expression executes inline, so the property
+/// narrowing is preserved (no `START` boundary is crossed).
+#[test]
+fn property_narrowing_preserved_in_iife() {
+    let codes = check_source_strict_codes(
+        r#"
+function f(x: { a?: { b: number } }) {
+  if (x.a) {
+    return (() => x.a.b)();
+  }
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&18048),
+        "IIFE property narrowing must be preserved, got: {codes:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #11600 (control-flow narrowing lost/retained at joins involving closures).

**Structural rule:** when a property-access / element-access reference (e.g. `x.a`, `x["a"]`, `this.a`) is read inside a nested arrow function, function expression, or object-literal method, tsc does **not** carry the enclosing control-flow narrowing across the function boundary — the closure may run after the property has been reassigned, so the reference is reset to its declared type at the function start, re-emitting the relevant `strictNullChecks` diagnostic (`TS18048` / `TS2532`). This mirrors the `PropertyAccessExpression` / `ElementAccessExpression` / `this` exclusion in TypeScript's `getTypeAtFlowNode` `FlowStart` handling.

tsz already reset narrowing for hoisted `function` declarations, but the `FlowStart` closure-boundary handler in the checker flow analyzer crossed into the outer (narrowed) flow for every non-captured reference — including member-like references — silently suppressing valid diagnostics.

Minimized repro (verified against `tsc` 6.0.2):

```ts
function f(x: { a?: { b: number } }) {
  if (x.a) {
    const g = () => x.a.b;   // tsc: TS18048 'x.a' is possibly 'undefined'; tsz (before): no error
    return g();
  }
}
```

## Owner layer & why

The fix is in `tsz-checker` flow analysis (`flow/control_flow/core.rs`), the `FlowStart` closure-boundary arm of `check_flow`. This is the single shared place where reference narrowing is or isn't carried across a function boundary, so the rule is expressed once for all closure forms rather than special-cased per call site. It reuses the existing `is_member_like_reference` helper (property/element access + qualified name).

## Track
Checker / control-flow narrowing parity.

## Invariant
Narrowing of a non-constant reference does not survive a non-IIFE function boundary; only constant-like identifier references (const locals, never-reassigned parameters) do, and immediately-invoked function expressions keep narrowing because they are bound inline with no `FlowStart` boundary.

## Scope
- `crates/tsz-checker/src/flow/control_flow/core.rs` — add member-like-reference arm to the `FlowStart` handler (returns declared type instead of crossing the boundary).
- `crates/tsz-checker/src/flow/control_flow/references.rs` — widen `is_member_like_reference` to `pub(crate)`.
- `crates/tsz-checker/tests/closure_boundary_property_narrowing_tests.rs` — new regression suite (+ `Cargo.toml` test registration).

## Adjacent-case test matrix
- Reported repro: property access in a stored arrow → `TS18048`.
- Equivalent shapes: function expression, object-literal method, callback argument (`.map`) → `TS18048`.
- Renamed-binding case: different property/variable spelling (`payload.result.count`) → still `TS18048` (rule is structural, not name-matched).
- Element access (`x["a"]`) and `this.a` → `TS2532`.
- Negative/fallback cases preserved: `const` local capture, never-reassigned parameter identifier, and IIFE → no diagnostic.

## Known unsupported shapes / fallback
None introduced. Constant-like identifier references and IIFEs follow the existing (unchanged) preservation paths; only member-like references at a closure `FlowStart` now reset to the declared type.

## Verification
- `cargo test -p tsz-checker --test closure_boundary_property_narrowing_tests` → 10 passed.
- Curated narrowing regression targets (`control_flow_type_guard_tests`, `discriminant_narrow_function_lazy_preserved_tests`, `discriminant_literal_reference_narrowing_tests`, `typeof_function_like_flow_tests`, `unique_symbol_discriminant_narrowing_tests`, `array_isarray_mutual_subtype_narrowing_tests`, `enum_equality_narrowing_tests`, `ts2339_union_narrow_display_tests`) → 133 passed, 0 failed.
- `cargo clippy -p tsz-checker --tests` → clean.
- Differential vs `tsc` 6.0.2 across 22 narrowing/closure cases (arrow/func-expr/method/callback/returned/IIFE, const vs property vs element vs `this`) → all match after the fix.

## Project Corpus Impact
- Row: `type-challenges-solutions-project` (issue #11600); the same closure-boundary rule applies to all project rows that use property narrowing inside callbacks (e.g. `nextjs`, `nextjs-fresh-app`).
- Bug family: checker control-flow narrowing across function/closure boundaries (false-negative `TS18048`/`TS2532`).
- Evidence: minimized repro + 22-case differential against `tsc` 6.0.2; new unit regression suite.

## Coordination Notes
AgentName: opus48-eager-pascal. Issue #11600 marked `WIP` and claimed via signed comment. No overlapping open PRs found for closure/narrowing flow. Branch is at `origin/main` tip (no conflicts).

---
_Generated by [Claude Code](https://claude.ai/code/session_018Sf2WL8D6UMQ52jkUkVjJL)_