### PR TITLE
fix(checker): detect default-reset recursive aliases

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
+++ b/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
@@ -977,7 +977,7 @@ impl<'a> CheckerState<'a> {
             .any(|node_idx| self.type_node_contains_scoped_type_parameter_for_depth_check(node_idx))
     }
 
-    fn type_node_contains_scoped_type_parameter_for_depth_check(
+    pub(crate) fn type_node_contains_scoped_type_parameter_for_depth_check(
         &self,
         node_idx: NodeIndex,
     ) -> bool {

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -912,6 +912,13 @@ impl<'a> CheckerState<'a> {
                 if self.type_arg_nodes_all_are_deferred_passthrough_for_depth_check(type_args) {
                     return false;
                 }
+                if self
+                    .type_args_reset_defaulted_alias_params_with_scoped_transform_for_depth_check(
+                        alias_sid, type_args,
+                    )
+                {
+                    return true;
+                }
                 if type_args.nodes.iter().copied().all(|arg_idx| {
                     self.type_node_is_deferred_passthrough_for_depth_check(arg_idx)
                         || self.type_node_is_bounded_indexed_descent_for_depth_check(

--- a/crates/tsz-checker/src/types/type_checking/type_alias_depth_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_depth_helpers.rs
@@ -105,6 +105,39 @@ impl<'a> CheckerState<'a> {
             })
     }
 
+    pub(crate) fn type_args_reset_defaulted_alias_params_with_scoped_transform_for_depth_check(
+        &mut self,
+        alias_sid: tsz_binder::SymbolId,
+        type_args: &NodeList,
+    ) -> bool {
+        let Some(type_param_nodes) = self.alias_type_parameter_nodes_for_depth_check(alias_sid)
+        else {
+            return false;
+        };
+        let supplied_count = type_args.nodes.len();
+        if supplied_count >= type_param_nodes.len() {
+            return false;
+        }
+        let omitted = &type_param_nodes[supplied_count..];
+        if omitted.is_empty()
+            || !omitted.iter().copied().all(|param_idx| {
+                self.ctx
+                    .arena
+                    .get(param_idx)
+                    .and_then(|param_node| self.ctx.arena.get_type_parameter(param_node))
+                    .is_some_and(|param| param.default != NodeIndex::NONE)
+            })
+        {
+            return false;
+        }
+
+        type_args.nodes.iter().copied().any(|arg_idx| {
+            self.type_node_contains_scoped_type_parameter_for_depth_check(arg_idx)
+                && !self.type_node_is_deferred_passthrough_for_depth_check(arg_idx)
+                && !self.type_node_is_bounded_indexed_descent_for_depth_check(alias_sid, arg_idx)
+        })
+    }
+
     fn type_name_is_deferred_passthrough_for_depth_check(&mut self, name_idx: NodeIndex) -> bool {
         let Some(name_node) = self.ctx.arena.get(name_idx) else {
             return false;
@@ -185,6 +218,18 @@ impl<'a> CheckerState<'a> {
             .get_children(node_idx)
             .into_iter()
             .any(|child_idx| self.type_node_contains_infer_binding_named(child_idx, name))
+    }
+
+    fn alias_type_parameter_nodes_for_depth_check(
+        &self,
+        alias_sid: tsz_binder::SymbolId,
+    ) -> Option<Vec<NodeIndex>> {
+        let symbol = self.ctx.binder.get_symbol(alias_sid)?;
+        let decl_idx = symbol.primary_declaration()?;
+        let decl_node = self.ctx.arena.get(decl_idx)?;
+        let alias = self.ctx.arena.get_type_alias(decl_node)?;
+        let type_params = alias.type_parameters.as_ref()?;
+        Some(type_params.nodes.clone())
     }
 
     fn type_node_is_alias_type_parameter_ref(

--- a/crates/tsz-checker/tests/ts2589_tests.rs
+++ b/crates/tsz-checker/tests/ts2589_tests.rs
@@ -877,6 +877,38 @@ type Foo<T> = T extends unknown
     );
 }
 
+/// Recursive conditional aliases that omit a defaulted parameter while
+/// transforming an earlier argument are unconditionally infinite. Each
+/// recursive type reference resets the omitted parameter to its default, so the
+/// recursion never makes progress toward the terminating branch.
+#[test]
+fn recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589() {
+    let source = r#"
+type Link<T, Depth extends number = 4> = [Depth] extends [0] ? T : Link<T[]>;
+type Chain<Value, Step extends number = 4> =
+  [Step] extends [0] ? Value : Chain<Promise<Value>>;
+"#;
+    let diags = check_source_diagnostics(source);
+    let ts2589 = diags.iter().filter(|d| d.code == 2589).collect::<Vec<_>>();
+    assert_eq!(
+        ts2589.len(),
+        2,
+        "Should emit TS2589 for each default-resetting recursive conditional alias. Got: {diags:?}"
+    );
+
+    let spans = ts2589
+        .iter()
+        .map(|diag| {
+            let start = diag.start as usize;
+            &source[start..(start + diag.length as usize).min(source.len())]
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        spans.contains(&"Link<T[]>") && spans.contains(&"Chain<Promise<Value>>"),
+        "TS2589 should anchor at the recursive references, got spans {spans:?} from {diags:?}"
+    );
+}
+
 /// TS2589 at a type alias definition is anchored at the LAST recursive
 /// self-reference in source order — the same node `tsc` reports against
 /// (its `currentNode` when `instantiationDepth === 100` fires while


### PR DESCRIPTION
## Agent
AgentName: M4-C

## Track
M4-C inference/contextual typing/instantiation-state parity

## Invariant
When a recursive conditional alias omits trailing defaulted generic parameters while transforming an earlier scoped parameter, `tsc` reports definition-site TS2589 at the recursive reference because each recursive call resets the omitted defaults; this PR makes tsz detect that shape through the existing checker depth-probe path and existing evaluator confirmation.

## Scope
- Detect recursive alias references that reset omitted trailing defaulted parameters while supplying a transformed scoped argument.
- Reuse the existing definition-site TS2589 evaluation/anchoring path.
- Add focused TS2589 coverage for `Link<T[]>` and `Chain<Promise<Value>>` default-reset recursion.

## Project Corpus Impact
- Row: kysely-project (#11214 family)
- Bug family: generic defaults reset across recursive conditional aliases
- Evidence: focused checker test added for default-reset recursive conditional aliases; adjacent TS2589 bounded recursion tests remain green.

## Verification
- `cargo nextest run -p tsz-checker --lib recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589`
- `cargo nextest run -p tsz-checker --lib -E 'test(recursive_conditional_type_alias_definition_emits_ts2589) | test(recursive_conditional_type_alias_anchors_ts2589_at_last_self_reference) | test(bounded_recursive_conditional_no_ts2589_at_definition) | test(bounded_recursive_alias_with_indexed_type_parameter_arg_no_ts2589) | test(recursive_conditional_alias_with_parameter_dependent_helper_args_no_definition_ts2589)'`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`

## Coordination Notes
- Fresh worktree: `/Users/mohsen/code/tsz-m4c-generic-defaults-20260529`.
- Local initial nextest attempt was blocked by disk exhaustion while linking all checker tests; cache-preserving cleanup plus removal of this fresh worktree's generated `.target` restored space, then library-only nextest verification passed.
- No roadmap update: this is a focused checker TS2589 parity fix under the existing M4-C lane.
