### PR TITLE
fix(dts): guard direct-call return inference against self-recursive local functions

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
@@ -782,7 +782,13 @@ impl<'a> DeclarationEmitter<'a> {
                     }
                     other => other,
                 }
-            } else if func.body.is_some() {
+            } else if func.body.is_some()
+                && !self.source_function_body_contains_direct_call_to_name(
+                    self.arena,
+                    func,
+                    &symbol.escaped_name,
+                )
+            {
                 self.function_body_single_return_expression(func.body)
                     .and_then(|return_expr| {
                         self.declaration_summary_primitive_expression_type_text(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_call.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_call.rs
@@ -31,14 +31,24 @@ impl<'a> DeclarationEmitter<'a> {
             return false;
         };
 
-        let mut search = body_text;
-        while let Some(offset) = search.find(name) {
-            let after_name = &search[offset + name.len()..];
-            let after_ws = after_name.trim_start();
-            if after_ws.starts_with('(') || after_ws.starts_with('<') {
-                return true;
+        let mut pos = 0usize;
+        while let Some(found) = body_text[pos..].find(name) {
+            let abs_start = pos + found;
+            let abs_end = abs_start + name.len();
+            // Left word boundary: the character before `name` must not be an identifier char.
+            // This prevents e.g. a function named "f" from matching the "f" inside "if (".
+            let at_word_start = abs_start == 0 || {
+                let prev = body_text.as_bytes()[abs_start - 1];
+                !prev.is_ascii_alphanumeric() && prev != b'_' && prev != b'$'
+            };
+            if at_word_start {
+                let after_name = &body_text[abs_end..];
+                let after_ws = after_name.trim_start();
+                if after_ws.starts_with('(') || after_ws.starts_with('<') {
+                    return true;
+                }
             }
-            search = after_name;
+            pos = abs_end;
         }
         false
     }


### PR DESCRIPTION
## AgentName
AgentName: dazzling-johnson
Promotion normalization by AgentName: m5-pro-48g-gpt5 on 2026-05-29.

## Track
Emit / DTS declaration emitter.

## Invariant
Self-recursive local functions that lack return-type annotations must not cause infinite recursion in the declaration emitter; they fall back to `any`/fallback inference instead of looping.

## Summary
- Fixes a SIGABRT/stack overflow in the DTS declaration emitter triggered by a local function that recursively calls itself when the outer exported function's return type must be inferred.
- Strengthens the existing `source_function_body_contains_direct_call_to_name` text-search guard with a left-word-boundary check, preventing false positives for functions whose names appear as suffixes of keywords, for example `"f"` inside `"if ("`.

## Root Cause
When `direct_call_primitive_return_type_text` encounters a callee with no return-type annotation and a body, it falls through to `function_body_preferred_return_type_text`. That helper restarts inference with `depth = 0`, so the depth guard (`depth > 8 -> None`) never fires for self-recursive functions: the cycle keeps resetting and never terminates.

The sister function `call_expression_source_return_type_text` already carries a `source_function_body_contains_direct_call_to_name` guard at the same branch; `direct_call_primitive_return_type_text` was missing it.

Structural rule: when a callee's function body directly calls itself, skip body-based return-type inference for that callee rather than recursing forever.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs` adds the self-recursive direct-call guard to `direct_call_primitive_return_type_text`.
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_call.rs` strengthens `source_function_body_contains_direct_call_to_name` with a left-word-boundary check.
- No parser, binder, checker, solver, LSP, WASM, or benchmark changes.

## Reproducer
```typescript
export declare function pick<T>(value: T): T extends () => infer R ? R : never;
export function wrap<T>(value: T) {
    function pick(value: T) {
        return pick(value);
    }
    return pick(value);
}
```

Without the fix this causes a stack overflow. With the fix `wrap` is emitted as `export declare function wrap<T>(value: T): T;`, instead of borrowing the outer `pick` conditional return type through `infer R`.

## Project Corpus Impact
- Row: n/a (emitter unit crash fix; no project-corpus row is identified for this draft).
- Bug family: declaration-emitter infinite recursion / SIGABRT.
- Evidence: unit test `test_exported_function_returning_shadowed_helper_does_not_borrow_top_level_return_type` covers the crash-class repro; ready-review CI will run the heavy emit gate.

## Verification
Original draft verification:
```bash
cargo test -p tsz-emitter -- declaration_emitter
# 1281 passed; 11 pre-existing failures; target test ok
```
The draft notes the 11 declaration-emitter failures were pre-existing, confirmed by stashing this fix and running the tests with the SIGABRT-causing test excluded.

No full conformance, emit, or fourslash suite was run locally for this promotion; ready-review CI owns those gates.

## Coordination Notes
No WIP label, WIP title, or blocker comment was present when `m5-pro-48g-gpt5` audited this old draft on 2026-05-29. Promoted for ready-review CI because the branch is focused, has no known overlap blocker, and the user requested including old drafts.

---
_Generated by [Claude Code](https://claude.ai/code/session_018SG5aujDM9Y3NMzBW652y6)_
