### PR TITLE
test(checker): cover recursive variadic tuple zip

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -155,6 +155,10 @@ name = "tuple_infer_mapped_recursive_tests"
 path = "tests/tuple_infer_mapped_recursive_tests.rs"
 
 [[test]]
+name = "variadic_tuple_recursive_zip_tests"
+path = "tests/variadic_tuple_recursive_zip_tests.rs"
+
+[[test]]
 name = "reverse_mapped_inference_tests"
 path = "tests/reverse_mapped_inference_tests.rs"
 

--- a/crates/tsz-checker/tests/variadic_tuple_recursive_zip_tests.rs
+++ b/crates/tsz-checker/tests/variadic_tuple_recursive_zip_tests.rs
@@ -1,0 +1,60 @@
+//! Regression coverage for recursive variadic tuple inference.
+//!
+//! Structural rule: when a recursive conditional peels two concrete tuples with
+//! `[infer Head, ...infer Tail]` and prepends a paired head onto the recursively
+//! inferred tail, tuple arity and element positions must remain exact.
+
+use tsz_checker::test_utils::check_source_codes;
+
+fn assert_only_bad_assignment_fails(source: &str, label: &str) {
+    let codes = check_source_codes(source);
+    assert_eq!(
+        codes,
+        vec![2322],
+        "{label}: expected exactly one TS2322 from the deliberate bad leaf, got {codes:?}"
+    );
+}
+
+#[test]
+fn recursive_zip_preserves_nested_variadic_tail_positions() {
+    assert_only_bad_assignment_fails(
+        r#"
+type Prepend_28<T, A extends readonly any[]> = [T, ...A];
+type Zip_28<A extends readonly any[], B extends readonly any[]> =
+  A extends [infer AH, ...infer AT]
+    ? B extends [infer BH, ...infer BT]
+      ? [Prepend_28<[AH, BH], Zip_28<AT, BT>>]
+      : []
+    : [];
+
+type Z_28 = Zip_28<[1, 2, 3], [string, boolean, string]>;
+declare const zipped: Z_28;
+const shape: [[[1, string], [[2, boolean], [[3, string]]]]] = zipped;
+const ok: Z_28 = [[[1, "a"], [[2, true], [[3, "b"]]]]];
+const bad: Z_28 = [[[1, "a"], [[2, true], [[3, 123]]]]];
+"#,
+        "reported Zip_28 tuple composition",
+    );
+}
+
+#[test]
+fn renamed_pair_chain_preserves_variadic_tail_positions() {
+    assert_only_bad_assignment_fails(
+        r#"
+type AddFirst<Item, Rest extends readonly unknown[]> = [Item, ...Rest];
+type PairChain<Left extends readonly unknown[], Right extends readonly unknown[]> =
+  Left extends [infer FirstLeft, ...infer RemainingLeft]
+    ? Right extends [infer FirstRight, ...infer RemainingRight]
+      ? [AddFirst<{ left: FirstLeft; right: FirstRight }, PairChain<RemainingLeft, RemainingRight>>]
+      : []
+    : [];
+
+type Result = PairChain<["x", "y"], [10, 20]>;
+declare const result: Result;
+const shape: [[{ left: "x"; right: 10 }, [{ left: "y"; right: 20 }]]] = result;
+const ok: Result = [[{ left: "x", right: 10 }, [{ left: "y", right: 20 }]]];
+const bad: Result = [[{ left: "x", right: 10 }, [{ left: "y", right: 99 }]]];
+"#,
+        "renamed PairChain tuple composition",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
M4-A semantic campaign regression coverage for recursive variadic tuple inference

## Invariant
When a recursive conditional peels two concrete tuples with `[infer Head, ...infer Tail]` and prepends a paired head onto the recursively inferred tail, `tsc` preserves exact tuple arity and element positions. This PR locks the same behavior through checker-observed solver evaluation.

## Scope
- `crates/tsz-checker/Cargo.toml`
- `crates/tsz-checker/tests/variadic_tuple_recursive_zip_tests.rs`

## Project Corpus Impact
- Row: type-fest-project
- Bug family: variadic tuple spread inference around recursive tails (#10809)
- Evidence: focused checker regression coverage for the reported `Zip_28` shape and a renamed `PairChain` variant; local CLI probes on current `main` matched TypeScript 6 for the minimized witness before adding durable coverage.

## Verification
- `cargo nextest run -p tsz-checker --test variadic_tuple_recursive_zip_tests`
- `cargo fmt --check`
- `git diff --check`

## Coordination Notes
- M4-A; `scripts/agents/list-owned-work.sh M4-A` showed no open M4-A PRs at cycle intake.
- Open-issue overlap check found #10809 as the concrete variadic tuple witness; related placeholder family issues remain open until exact row fixtures are attached or independently covered.
- Owner layer: solver semantics observed through checker tests; no checker-side semantic shortcut or production code change.