### PR TITLE
fix(checker): preserve default-recursive TS2589 use sites

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/core.rs
+++ b/crates/tsz-checker/src/state/type_resolution/core.rs
@@ -360,7 +360,12 @@ impl<'a> CheckerState<'a> {
                     // to avoid false positives with recursive conditional types.
                     // For classes: always check because recursive tuple spreads (e.g.,
                     // `Foo<[...Elements, "abc"]>`) need depth detection even with type params.
-                    let should_check_depth = is_class || !args_have_type_params;
+                    let computed_recursive_alias = is_type_alias
+                        && self.type_alias_has_computed_recursive_conditional_body(sym_id);
+                    let default_reset_recursive_alias = is_type_alias
+                        && self.type_alias_has_default_reset_recursive_conditional_body(sym_id);
+                    let should_check_depth =
+                        is_class || !args_have_type_params || default_reset_recursive_alias;
                     if should_check_depth {
                         // During symbol resolution, ensure_relation_input_ready is skipped,
                         // leaving the alias body unregistered in the TypeEnvironment. Without
@@ -382,8 +387,6 @@ impl<'a> CheckerState<'a> {
                         // probes. The TS2589-specific evaluator treats any repeated
                         // Application cycle as overflow, which is too aggressive for
                         // bounded recursive conditional aliases.
-                        let computed_recursive_alias = is_type_alias
-                            && self.type_alias_has_computed_recursive_conditional_body(sym_id);
                         let (exceeded, tuple_too_large) =
                             if computed_recursive_alias && let Some(base_def_id) = base_def_id {
                                 (
@@ -1218,7 +1221,11 @@ impl<'a> CheckerState<'a> {
                                     })
                                 },
                             );
-                        if !args_have_type_params {
+                        let computed_recursive_alias =
+                            self.type_alias_has_computed_recursive_conditional_body(sym_id);
+                        let default_reset_recursive_alias =
+                            self.type_alias_has_default_reset_recursive_conditional_body(sym_id);
+                        if !args_have_type_params || default_reset_recursive_alias {
                             // Clear overflow flags before probing.
                             self.ctx.types.take_tuple_too_large();
                             self.ctx.depth_exceeded.set(false);
@@ -1228,8 +1235,6 @@ impl<'a> CheckerState<'a> {
                             // bounded recursive conditional aliases.
                             let app_def_id = query::get_application_info(self.ctx.types, result)
                                 .and_then(|(base, _)| query::get_lazy_def_id(self.ctx.types, base));
-                            let computed_recursive_alias =
-                                self.type_alias_has_computed_recursive_conditional_body(sym_id);
                             let (exceeded, tuple_too_large) =
                                 if computed_recursive_alias && let Some(app_def_id) = app_def_id {
                                     (

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -913,6 +913,11 @@ impl<'a> CheckerState<'a> {
                     return false;
                 }
                 if self
+                    .type_args_contain_subtractive_alias_guard_for_depth_check(alias_sid, type_args)
+                {
+                    return false;
+                }
+                if self
                     .type_args_reset_defaulted_alias_params_with_scoped_transform_for_depth_check(
                         alias_sid, type_args,
                     )
@@ -961,6 +966,9 @@ impl<'a> CheckerState<'a> {
                     !self.type_args_match_alias_params(alias_sid, type_args)
                         && !self
                             .type_arg_nodes_all_are_deferred_passthrough_for_depth_check(type_args)
+                        && !self.type_args_contain_subtractive_alias_guard_for_depth_check(
+                            alias_sid, type_args,
+                        )
                         && type_args.nodes.iter().copied().any(|arg_idx| {
                             !self.type_node_is_deferred_passthrough_for_depth_check(arg_idx)
                                 && !self.type_node_is_bounded_indexed_descent_for_depth_check(
@@ -1066,6 +1074,8 @@ impl<'a> CheckerState<'a> {
             if resolved == Some(alias_sid)
                 && let Some(type_args) = &type_ref.type_arguments
                 && !self.type_args_match_alias_params(alias_sid, type_args)
+                && !self
+                    .type_args_contain_subtractive_alias_guard_for_depth_check(alias_sid, type_args)
                 && type_args.nodes.iter().copied().any(|arg_idx| {
                     !self.type_node_is_deferred_passthrough_for_depth_check(arg_idx)
                         && self

--- a/crates/tsz-checker/src/types/type_checking/type_alias_depth_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_depth_helpers.rs
@@ -119,13 +119,20 @@ impl<'a> CheckerState<'a> {
             return false;
         }
         let omitted = &type_param_nodes[supplied_count..];
+        let alias_param_names = self.alias_type_parameter_names_for_depth_check(alias_sid);
         if omitted.is_empty()
             || !omitted.iter().copied().all(|param_idx| {
                 self.ctx
                     .arena
                     .get(param_idx)
                     .and_then(|param_node| self.ctx.arena.get_type_parameter(param_node))
-                    .is_some_and(|param| param.default != NodeIndex::NONE)
+                    .is_some_and(|param| {
+                        param.default != NodeIndex::NONE
+                            && !self.type_node_contains_alias_type_parameter_name_for_depth_check(
+                                param.default,
+                                &alias_param_names,
+                            )
+                    })
             })
         {
             return false;
@@ -136,6 +143,81 @@ impl<'a> CheckerState<'a> {
                 && !self.type_node_is_deferred_passthrough_for_depth_check(arg_idx)
                 && !self.type_node_is_bounded_indexed_descent_for_depth_check(alias_sid, arg_idx)
         })
+    }
+
+    pub(crate) fn type_args_contain_subtractive_alias_guard_for_depth_check(
+        &mut self,
+        alias_sid: tsz_binder::SymbolId,
+        type_args: &NodeList,
+    ) -> bool {
+        let alias_param_names = self.alias_type_parameter_names_for_depth_check(alias_sid);
+        type_args.nodes.iter().copied().any(|arg_idx| {
+            self.type_node_is_subtractive_alias_guard_for_depth_check(arg_idx, &alias_param_names)
+        })
+    }
+
+    pub(crate) fn type_alias_has_default_reset_recursive_conditional_body(
+        &mut self,
+        alias_sid: tsz_binder::SymbolId,
+    ) -> bool {
+        let Some(symbol) = self.ctx.binder.get_symbol(alias_sid) else {
+            return false;
+        };
+        let declarations = symbol.declarations.clone();
+        declarations.into_iter().any(|decl_idx| {
+            self.ctx.arena.get(decl_idx).is_some_and(|decl_node| {
+                decl_node.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION
+                    && self
+                        .ctx
+                        .arena
+                        .get_type_alias(decl_node)
+                        .is_some_and(|alias| {
+                            self.ctx
+                                .arena
+                                .kind_at(alias.type_node)
+                                .is_some_and(|kind| kind == syntax_kind_ext::CONDITIONAL_TYPE)
+                                && self.type_node_has_default_reset_recursive_alias_ref(
+                                    alias.type_node,
+                                    alias_sid,
+                                )
+                        })
+            })
+        })
+    }
+
+    fn type_node_has_default_reset_recursive_alias_ref(
+        &mut self,
+        node_idx: NodeIndex,
+        alias_sid: tsz_binder::SymbolId,
+    ) -> bool {
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return false;
+        };
+
+        if node.kind == syntax_kind_ext::TYPE_REFERENCE
+            && let Some(type_ref) = self.ctx.arena.get_type_ref(node)
+        {
+            let resolved = self
+                .resolve_type_symbol_for_lowering(type_ref.type_name)
+                .map(tsz_binder::SymbolId);
+            if resolved == Some(alias_sid)
+                && let Some(type_args) = &type_ref.type_arguments
+                && self
+                    .type_args_reset_defaulted_alias_params_with_scoped_transform_for_depth_check(
+                        alias_sid, type_args,
+                    )
+            {
+                return true;
+            }
+        }
+
+        self.ctx
+            .arena
+            .get_children(node_idx)
+            .into_iter()
+            .any(|child_idx| {
+                self.type_node_has_default_reset_recursive_alias_ref(child_idx, alias_sid)
+            })
     }
 
     fn type_name_is_deferred_passthrough_for_depth_check(&mut self, name_idx: NodeIndex) -> bool {
@@ -230,6 +312,128 @@ impl<'a> CheckerState<'a> {
         let alias = self.ctx.arena.get_type_alias(decl_node)?;
         let type_params = alias.type_parameters.as_ref()?;
         Some(type_params.nodes.clone())
+    }
+
+    fn alias_type_parameter_names_for_depth_check(
+        &self,
+        alias_sid: tsz_binder::SymbolId,
+    ) -> Vec<String> {
+        let Some(type_param_nodes) = self.alias_type_parameter_nodes_for_depth_check(alias_sid)
+        else {
+            return Vec::new();
+        };
+        type_param_nodes
+            .into_iter()
+            .filter_map(|param_idx| {
+                let param_node = self.ctx.arena.get(param_idx)?;
+                let param = self.ctx.arena.get_type_parameter(param_node)?;
+                self.ctx
+                    .arena
+                    .get_identifier_text(param.name)
+                    .map(str::to_owned)
+            })
+            .collect()
+    }
+
+    fn type_node_is_subtractive_alias_guard_for_depth_check(
+        &mut self,
+        node_idx: NodeIndex,
+        alias_param_names: &[String],
+    ) -> bool {
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return false;
+        };
+        if node.kind == syntax_kind_ext::PARENTHESIZED_TYPE
+            && let Some(wrapped) = self.ctx.arena.get_wrapped_type(node)
+        {
+            return self.type_node_is_subtractive_alias_guard_for_depth_check(
+                wrapped.type_node,
+                alias_param_names,
+            );
+        }
+        if node.kind != syntax_kind_ext::TYPE_REFERENCE {
+            return false;
+        }
+        let Some(type_ref) = self.ctx.arena.get_type_ref(node) else {
+            return false;
+        };
+        let Some(type_args) = type_ref.type_arguments.as_ref() else {
+            return false;
+        };
+        if type_args.nodes.len() != 2 {
+            return false;
+        }
+        let Some(source_name) = self.type_node_bare_reference_name(type_args.nodes[0]) else {
+            return false;
+        };
+        let Some(removed_name) = self.type_node_bare_reference_name(type_args.nodes[1]) else {
+            return false;
+        };
+        if source_name == removed_name
+            || !alias_param_names.iter().any(|name| name == source_name)
+            || !alias_param_names.iter().any(|name| name == removed_name)
+        {
+            return false;
+        }
+
+        self.ctx
+            .arena
+            .get_identifier_text(type_ref.type_name)
+            .is_some_and(|name| name == "Exclude")
+            && self.type_name_resolves_to_global_type_for_depth_check(type_ref.type_name, "Exclude")
+    }
+
+    fn type_name_resolves_to_global_type_for_depth_check(
+        &mut self,
+        type_name: NodeIndex,
+        expected_name: &str,
+    ) -> bool {
+        let Some(resolved) = self
+            .resolve_type_symbol_for_lowering(type_name)
+            .map(tsz_binder::SymbolId)
+        else {
+            return false;
+        };
+        let lib_binders = self.get_lib_binders();
+        self.ctx
+            .binder
+            .get_global_type_with_libs(expected_name, &lib_binders)
+            .is_some_and(|global| global == resolved)
+    }
+
+    fn type_node_contains_alias_type_parameter_name_for_depth_check(
+        &self,
+        node_idx: NodeIndex,
+        names: &[String],
+    ) -> bool {
+        if names.is_empty() {
+            return false;
+        }
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return false;
+        };
+        if self
+            .type_node_bare_reference_name(node_idx)
+            .is_some_and(|reference_name| names.iter().any(|name| reference_name == name))
+        {
+            return true;
+        }
+        if self
+            .ctx
+            .arena
+            .get_identifier(node)
+            .is_some_and(|identifier| names.contains(&identifier.escaped_text))
+        {
+            return true;
+        }
+
+        self.ctx
+            .arena
+            .get_children(node_idx)
+            .into_iter()
+            .any(|child_idx| {
+                self.type_node_contains_alias_type_parameter_name_for_depth_check(child_idx, names)
+            })
     }
 
     fn type_node_is_alias_type_parameter_ref(

--- a/crates/tsz-checker/tests/ts2589_tests.rs
+++ b/crates/tsz-checker/tests/ts2589_tests.rs
@@ -885,15 +885,18 @@ type Foo<T> = T extends unknown
 fn recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589() {
     let source = r#"
 type Link<T, Depth extends number = 4> = [Depth] extends [0] ? T : Link<T[]>;
+type Solve<T> = Link<T> extends infer U ? U : never;
+type Box<Item> = { value: Item };
 type Chain<Value, Step extends number = 4> =
-  [Step] extends [0] ? Value : Chain<Promise<Value>>;
+  [Step] extends [0] ? Value : Chain<Box<Value>>;
+type Resolve<Value> = Chain<Value> extends infer Output ? Output : never;
 "#;
     let diags = check_source_diagnostics(source);
     let ts2589 = diags.iter().filter(|d| d.code == 2589).collect::<Vec<_>>();
     assert_eq!(
         ts2589.len(),
-        2,
-        "Should emit TS2589 for each default-resetting recursive conditional alias. Got: {diags:?}"
+        4,
+        "Should emit TS2589 at both the default-resetting recursive alias definitions and use sites. Got: {diags:?}"
     );
 
     let spans = ts2589
@@ -904,7 +907,10 @@ type Chain<Value, Step extends number = 4> =
         })
         .collect::<Vec<_>>();
     assert!(
-        spans.contains(&"Link<T[]>") && spans.contains(&"Chain<Promise<Value>>"),
+        spans.contains(&"Link<T[]>")
+            && spans.contains(&"Link<T>")
+            && spans.contains(&"Chain<Box<Value>>")
+            && spans.contains(&"Chain<Value>"),
         "TS2589 should anchor at the recursive references, got spans {spans:?} from {diags:?}"
     );
 }


### PR DESCRIPTION
## Agent
AgentName: M4-C

## Track
Checker TS2589 parity; M4-C inference/instantiation lane.

## Invariant
When a recursive conditional alias omits a parameter-independent default while transforming earlier scoped parameters, tsz reports TS2589 at both the recursive definition reference and concrete use-site instantiation; bounded subtractive recursion through global Exclude remains accepted.

## Scope
- crates/tsz-checker/src/types/type_checking/type_alias_depth_helpers.rs
- crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
- crates/tsz-checker/src/state/type_resolution/core.rs
- crates/tsz-checker/tests/ts2589_tests.rs

## Project Corpus Impact
- Row: n/a
- Bug family: recursive conditional alias instantiation-depth diagnostics
- Evidence: checker unit coverage for TS2589 default-reset use sites plus existing issue_6761 Permutation/Combination safeguards. No project-corpus fixture metadata changed.

## Verification
- cargo clippy -p tsz-checker --lib --tests -- -D warnings
- cargo nextest run -p tsz-checker --lib recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589
- cargo nextest run -p tsz-checker --lib ts2589_tests::
- cargo fmt --check
- git diff --check
- python3 scripts/arch/arch_guard.py
- scripts/arch/check-checker-boundaries.sh

## Coordination Notes
- AgentName: M4-C
- Fresh worktree: /Users/mohsen/code/tsz-m4c-default-recursive-use-20260529
- Based on origin/main e1d43eb8fd8 after rebase.
- Current head: 53f95945ec.
- No owned M4-C PRs or issues were open before publishing.
- Overlap check found no open PR claiming this TS2589 default-reset/use-site slice.
- Lint failure on 21e7e7f746 was fixed by replacing the manual contains pattern and force-pushing 53f95945ec.
