### PR TITLE
fix(checker): elaborate tuple element mismatches with TS2626 position

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -35,6 +35,10 @@ name = "union_protected_intersection_property_tests"
 path = "tests/union_protected_intersection_property_tests.rs"
 
 [[test]]
+name = "tuple_element_mismatch_tests"
+path = "tests/tuple_element_mismatch_tests.rs"
+
+[[test]]
 name = "for_await_type_parameter_iterability_tests"
 path = "tests/for_await_type_parameter_iterability_tests.rs"
 

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
@@ -83,6 +83,7 @@ impl<'a> CheckerState<'a> {
                 index,
                 source_element,
                 target_element,
+                ..
             }) => {
                 // For variadic-rest tuples with trailing fixed elements, only
                 // report element-level errors for the leading fixed section.

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -611,30 +611,14 @@ impl<'a> CheckerState<'a> {
                 index,
                 source_element,
                 target_element,
-            } => {
-                if depth == 0 {
-                    let (source_str, target_str) =
-                        self.format_top_level_assignability_message_types_at(source, target, idx);
-                    let base = format_message(
-                        diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                        &[&source_str, &target_str],
-                    );
-                    Diagnostic::error(
-                        file_name,
-                        start,
-                        length,
-                        base,
-                        diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                    )
-                } else {
-                    let source_str = self.format_type_diagnostic(*source_element);
-                    let target_str = self.format_type_diagnostic(*target_element);
-                    let message = format!(
-                        "Type of element at index {index} is incompatible: '{source_str}' is not assignable to '{target_str}'."
-                    );
-                    Diagnostic::error(file_name, start, length, message, reason.diagnostic_code())
-                }
-            }
+                nested_reason,
+            } => self.render_tuple_element_type_mismatch(
+                &rctx,
+                *index,
+                *source_element,
+                *target_element,
+                nested_reason.as_deref(),
+            ),
 
             SubtypeFailureReason::ArrayElementMismatch {
                 source_element,

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -226,16 +226,7 @@ impl<'a> CheckerState<'a> {
                     base,
                     diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                 );
-                diag.related_information.push(DiagnosticRelatedInformation {
-                    file: nested_diag.file,
-                    start: nested_diag.start,
-                    length: nested_diag.length,
-                    message_text: nested_diag.message_text,
-                    category: DiagnosticCategory::Message,
-                    code: nested_diag.code,
-                });
-                diag.related_information
-                    .extend(nested_diag.related_information);
+                Self::push_nested_chain(&mut diag, nested_diag);
                 return diag;
             }
             let prop_name = self.ctx.types.resolve_atom_ref(property_name);
@@ -278,16 +269,7 @@ impl<'a> CheckerState<'a> {
                         idx,
                         depth + 1,
                     );
-                    diag.related_information.push(DiagnosticRelatedInformation {
-                        file: nested_diag.file,
-                        start: nested_diag.start,
-                        length: nested_diag.length,
-                        message_text: nested_diag.message_text,
-                        category: DiagnosticCategory::Message,
-                        code: nested_diag.code,
-                    });
-                    diag.related_information
-                        .extend(nested_diag.related_information);
+                    Self::push_nested_chain(&mut diag, nested_diag);
                 }
             }
             return diag;
@@ -311,17 +293,145 @@ impl<'a> CheckerState<'a> {
             );
             let nested_diag =
                 self.render_failure_reason(nested, nested_source, nested_target, idx, depth + 1);
-            diag.related_information.push(DiagnosticRelatedInformation {
-                file: nested_diag.file,
-                start: nested_diag.start,
-                length: nested_diag.length,
-                message_text: nested_diag.message_text,
-                category: DiagnosticCategory::Message,
-                code: nested_diag.code,
-            });
-            diag.related_information
-                .extend(nested_diag.related_information);
+            Self::push_nested_chain(&mut diag, nested_diag);
         }
         diag
+    }
+
+    /// Render a tuple element type mismatch.
+    ///
+    /// tsc elaborates a failing tuple element with TS2626
+    /// `Type at position <index> in source is not compatible with type at
+    /// position <index> in target.` (both positions are the element index for
+    /// fixed tuples), nested beneath the outer
+    /// `Type 'S' is not assignable to type 'T'.` line, then the inner element
+    /// failure. This mirrors the chain shape of
+    /// [`Self::render_property_type_mismatch`] but keyed by position instead of
+    /// a property name.
+    pub(super) fn render_tuple_element_type_mismatch(
+        &mut self,
+        ctx: &RenderContext,
+        index: usize,
+        source_element: TypeId,
+        target_element: TypeId,
+        nested_reason: Option<&tsz_solver::SubtypeFailureReason>,
+    ) -> Diagnostic {
+        let source = ctx.source;
+        let target = ctx.target;
+        let idx = ctx.idx;
+        let depth = ctx.depth;
+        let start = ctx.start;
+        let length = ctx.length;
+        let file_name = ctx.file_name.clone();
+        let index_str = index.to_string();
+
+        // TS2626: source and target positions are both the element index for a
+        // fixed tuple element mismatch.
+        let detail = format_message(
+            diagnostic_messages::TYPE_AT_POSITION_IN_SOURCE_IS_NOT_COMPATIBLE_WITH_TYPE_AT_POSITION_IN_TARGET,
+            &[&index_str, &index_str],
+        );
+
+        let mut diag = if depth == 0 {
+            let (source_str, target_str) =
+                self.format_top_level_assignability_message_types_at(source, target, idx);
+            let base = format_message(
+                diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+                &[&source_str, &target_str],
+            );
+            let mut diag = Diagnostic::error(
+                file_name,
+                start,
+                length,
+                base,
+                diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            );
+            diag.related_information.push(DiagnosticRelatedInformation {
+                file: diag.file.clone(),
+                start,
+                length,
+                message_text: detail,
+                category: DiagnosticCategory::Message,
+                code: diagnostic_codes::TYPE_AT_POSITION_IN_SOURCE_IS_NOT_COMPATIBLE_WITH_TYPE_AT_POSITION_IN_TARGET,
+            });
+            diag
+        } else {
+            Diagnostic::error(
+                file_name,
+                start,
+                length,
+                detail,
+                diagnostic_codes::TYPE_AT_POSITION_IN_SOURCE_IS_NOT_COMPATIBLE_WITH_TYPE_AT_POSITION_IN_TARGET,
+            )
+        };
+
+        if depth < 5 {
+            self.push_tuple_element_inner_failure(
+                &mut diag,
+                idx,
+                depth,
+                source_element,
+                target_element,
+                nested_reason,
+            );
+        }
+
+        diag
+    }
+
+    /// Append the inner element failure line beneath a tuple element mismatch.
+    ///
+    /// Uses the structured `nested_reason` when present so deeply nested element
+    /// failures keep elaborating; otherwise falls back to a direct
+    /// `Type 'S' is not assignable to type 'T'.` line for the element pair so the
+    /// chain never stops at the bare `Types of property` header.
+    fn push_tuple_element_inner_failure(
+        &mut self,
+        diag: &mut Diagnostic,
+        idx: tsz_parser::parser::NodeIndex,
+        depth: u32,
+        source_element: TypeId,
+        target_element: TypeId,
+        nested_reason: Option<&tsz_solver::SubtypeFailureReason>,
+    ) {
+        if let Some(nested) = nested_reason {
+            let (nested_source, nested_target) =
+                Self::nested_failure_display_types(nested, source_element, target_element);
+            let nested_diag =
+                self.render_failure_reason(nested, nested_source, nested_target, idx, depth + 1);
+            Self::push_nested_chain(diag, nested_diag);
+        } else {
+            let source_str = self.format_type_diagnostic(source_element);
+            let target_str = self.format_type_diagnostic(target_element);
+            let message = format_message(
+                diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+                &[&source_str, &target_str],
+            );
+            diag.related_information.push(DiagnosticRelatedInformation {
+                file: diag.file.clone(),
+                start: diag.start,
+                length: diag.length,
+                message_text: message,
+                category: DiagnosticCategory::Message,
+                code: diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            });
+        }
+    }
+
+    /// Flatten a fully-rendered nested failure into `diag`'s related
+    /// information: the nested diagnostic's own message line followed by its
+    /// related chain. This is the shared shape every elaboration step uses to
+    /// append a child reason.
+    fn push_nested_chain(diag: &mut Diagnostic, nested_diag: Diagnostic) {
+        diag.related_information.push(DiagnosticRelatedInformation {
+            file: nested_diag.file,
+            start: nested_diag.start,
+            length: nested_diag.length,
+            message_text: nested_diag.message_text,
+            category: DiagnosticCategory::Message,
+            code: nested_diag.code,
+        });
+        diag.related_information
+            .extend(nested_diag.related_information);
     }
 }

--- a/crates/tsz-checker/tests/tuple_element_mismatch_tests.rs
+++ b/crates/tsz-checker/tests/tuple_element_mismatch_tests.rs
@@ -1,0 +1,140 @@
+//! Tuple element type-mismatch diagnostics must carry the element position.
+//!
+//! tsc treats a failing tuple element specially: the outer TS2322
+//! `Type 'S' is not assignable to type 'T'.` line is followed by TS2626
+//! `Type at position N in source is not compatible with type at position N in
+//! target.`, then the inner element failure. Earlier tsz dropped the position
+//! and emitted only the bare outer/inner type lines.
+
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn ts2322(source: &str) -> Diagnostic {
+    let diagnostics: Vec<Diagnostic> = check_source_diagnostics(source)
+        .into_iter()
+        .filter(|diagnostic| diagnostic.code == 2322)
+        .collect();
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "expected exactly one TS2322 diagnostic, got {diagnostics:#?}"
+    );
+    diagnostics.into_iter().next().unwrap()
+}
+
+fn related(diagnostic: &Diagnostic) -> Vec<String> {
+    diagnostic
+        .related_information
+        .iter()
+        .map(|related| related.message_text.clone())
+        .collect()
+}
+
+fn has_related(diagnostic: &Diagnostic, expected: &str) -> bool {
+    related(diagnostic)
+        .iter()
+        .any(|message| message == expected)
+}
+
+#[test]
+fn tuple_second_element_mismatch_reports_position_1() {
+    let diagnostic = ts2322(
+        r#"
+declare let y: [string, string];
+let x: [string, number] = y;
+"#,
+    );
+    let messages = related(&diagnostic);
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type at position 1 in source is not compatible with type at position 1 in target."
+        ),
+        "missing TS2626 position elaboration; related = {messages:#?}"
+    );
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type 'string' is not assignable to type 'number'."
+        ),
+        "missing inner element failure; related = {messages:#?}"
+    );
+}
+
+#[test]
+fn tuple_first_element_mismatch_reports_position_0() {
+    let diagnostic = ts2322(
+        r#"
+declare let y: [boolean, string];
+let x: [string, string] = y;
+"#,
+    );
+    let messages = related(&diagnostic);
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type at position 0 in source is not compatible with type at position 0 in target."
+        ),
+        "missing TS2626 position elaboration; related = {messages:#?}"
+    );
+}
+
+#[test]
+fn tuple_element_object_property_mismatch_chains_through_position() {
+    let diagnostic = ts2322(
+        r#"
+declare let y: [{ a: string }];
+let x: [{ a: number }] = y;
+"#,
+    );
+    let messages = related(&diagnostic);
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type at position 0 in source is not compatible with type at position 0 in target."
+        ),
+        "missing TS2626 position elaboration; related = {messages:#?}"
+    );
+    assert!(
+        has_related(&diagnostic, "Types of property 'a' are incompatible."),
+        "missing nested property elaboration; related = {messages:#?}"
+    );
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type 'string' is not assignable to type 'number'."
+        ),
+        "missing leaf element failure; related = {messages:#?}"
+    );
+}
+
+#[test]
+fn nested_tuple_element_mismatch_chains_each_position() {
+    let diagnostic = ts2322(
+        r#"
+declare let y: [[string]];
+let x: [[number]] = y;
+"#,
+    );
+    let messages = related(&diagnostic);
+    // The outer tuple has one element at position 0; the inner tuple's failing
+    // element is also at position 0, so the chain repeats the position line.
+    let position_lines = messages
+        .iter()
+        .filter(|message| {
+            message.as_str()
+                == "Type at position 0 in source is not compatible with type at position 0 in target."
+        })
+        .count();
+    assert!(
+        position_lines >= 2,
+        "expected nested position elaborations for both tuple levels; related = {messages:#?}"
+    );
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type 'string' is not assignable to type 'number'."
+        ),
+        "missing leaf element failure; related = {messages:#?}"
+    );
+}

--- a/crates/tsz-solver/src/diagnostics/core.rs
+++ b/crates/tsz-solver/src/diagnostics/core.rs
@@ -150,10 +150,17 @@ pub enum SubtypeFailureReason {
         target_count: usize,
     },
     /// Tuple element type mismatch.
+    ///
+    /// tsc elaborates a failing tuple element with the outer
+    /// `Type 'S' is not assignable to type 'T'.` line, then TS2626
+    /// `Type at position <index> in source is not compatible with type at
+    /// position <index> in target.`, then the inner element failure carried in
+    /// `nested_reason`.
     TupleElementTypeMismatch {
         index: usize,
         source_element: TypeId,
         target_element: TypeId,
+        nested_reason: Option<Box<Self>>,
     },
     /// Array element type mismatch.
     ArrayElementMismatch {
@@ -446,6 +453,7 @@ pub mod codes {
 
     pub use dc::INDEX_SIGNATURE_FOR_TYPE_IS_MISSING_IN_TYPE as MISSING_INDEX_SIGNATURE;
     pub use dc::IS_ASSIGNABLE_TO_THE_CONSTRAINT_OF_TYPE_BUT_COULD_BE_INSTANTIATED_WITH_A_DIFFERE as TYPE_PARAM_INSTANTIATED_WITH_DIFFERENT_SUBTYPE;
+    pub use dc::TYPE_AT_POSITION_IN_SOURCE_IS_NOT_COMPATIBLE_WITH_TYPE_AT_POSITION_IN_TARGET as TUPLE_ELEMENT_POSITION_MISMATCH;
     pub use dc::TYPES_OF_PROPERTY_ARE_INCOMPATIBLE as PROPERTY_TYPE_MISMATCH;
 
     // Function/call errors
@@ -742,11 +750,36 @@ impl SubtypeFailureReason {
             )),
 
             Self::TupleElementTypeMismatch {
-                index: _,
+                index,
                 source_element,
                 target_element,
+                nested_reason,
+            } => {
+                // tsc elaborates a failing tuple element with TS2626
+                // "Type at position N in source is not compatible with type at
+                // position N in target." (both positions are the element index
+                // for fixed tuples), followed by the inner element failure.
+                let mut diag = PendingDiagnostic::error(
+                    codes::TYPE_NOT_ASSIGNABLE,
+                    vec![source.into(), target.into()],
+                )
+                .with_related(PendingDiagnostic::error(
+                    codes::TUPLE_ELEMENT_POSITION_MISMATCH,
+                    vec![(*index).into(), (*index).into()],
+                ));
+                if let Some(nested) = nested_reason {
+                    diag =
+                        diag.with_related(nested.to_diagnostic(*source_element, *target_element));
+                } else {
+                    diag = diag.with_related(PendingDiagnostic::error(
+                        codes::TYPE_NOT_ASSIGNABLE,
+                        vec![(*source_element).into(), (*target_element).into()],
+                    ));
+                }
+                diag
             }
-            | Self::ArrayElementMismatch {
+
+            Self::ArrayElementMismatch {
                 source_element,
                 target_element,
             } => PendingDiagnostic::error(

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -1705,6 +1705,27 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         None
     }
 
+    /// Build a `TupleElementTypeMismatch` for a failing element pair, recursing
+    /// into the element failure so the rendered chain carries the inner reason
+    /// (matching tsc, which walks a tuple element exactly like a numerically
+    /// keyed object property).
+    fn tuple_element_type_mismatch(
+        &mut self,
+        index: usize,
+        source_element: TypeId,
+        target_element: TypeId,
+    ) -> SubtypeFailureReason {
+        let nested_reason = self
+            .explain_failure(source_element, target_element)
+            .map(Box::new);
+        SubtypeFailureReason::TupleElementTypeMismatch {
+            index,
+            source_element,
+            target_element,
+            nested_reason,
+        }
+    }
+
     /// Explain why a tuple type assignment failed.
     fn explain_tuple_failure(
         &mut self,
@@ -1765,11 +1786,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                         if s_elem.rest {
                             let tp_array = self.interner.array(tail_elem.type_id);
                             if !self.check_subtype(s_elem.type_id, tp_array).is_true() {
-                                return Some(SubtypeFailureReason::TupleElementTypeMismatch {
-                                    index: source_end - 1,
-                                    source_element: s_elem.type_id,
-                                    target_element: tail_elem.type_id,
-                                });
+                                return Some(self.tuple_element_type_mismatch(
+                                    source_end - 1,
+                                    s_elem.type_id,
+                                    tail_elem.type_id,
+                                ));
                             }
                             source_end -= 1;
                             continue;
@@ -1796,11 +1817,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                         break;
                     }
                     if !assignable {
-                        return Some(SubtypeFailureReason::TupleElementTypeMismatch {
-                            index: source_end - 1,
-                            source_element: s_elem.type_id,
-                            target_element: tail_elem.type_id,
-                        });
+                        return Some(self.tuple_element_type_mismatch(
+                            source_end - 1,
+                            s_elem.type_id,
+                            tail_elem.type_id,
+                        ));
                     }
                     source_end -= 1;
                 }
@@ -1820,11 +1841,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                                 .check_subtype(s_elem.type_id, t_fixed.type_id)
                                 .is_true()
                             {
-                                return Some(SubtypeFailureReason::TupleElementTypeMismatch {
-                                    index: j,
-                                    source_element: s_elem.type_id,
-                                    target_element: t_fixed.type_id,
-                                });
+                                return Some(self.tuple_element_type_mismatch(
+                                    j,
+                                    s_elem.type_id,
+                                    t_fixed.type_id,
+                                ));
                             }
                         }
                         None => {
@@ -1844,11 +1865,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     for (j, s_elem) in source_iter {
                         if s_elem.rest {
                             if !self.check_subtype(s_elem.type_id, variadic_array).is_true() {
-                                return Some(SubtypeFailureReason::TupleElementTypeMismatch {
-                                    index: j,
-                                    source_element: s_elem.type_id,
-                                    target_element: variadic_array,
-                                });
+                                return Some(self.tuple_element_type_mismatch(
+                                    j,
+                                    s_elem.type_id,
+                                    variadic_array,
+                                ));
                             }
                         } else if variadic_is_type_param {
                             return Some(SubtypeFailureReason::TypeMismatch {
@@ -1856,11 +1877,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                                 target_type: variadic,
                             });
                         } else if !self.check_subtype(s_elem.type_id, variadic).is_true() {
-                            return Some(SubtypeFailureReason::TupleElementTypeMismatch {
-                                index: j,
-                                source_element: s_elem.type_id,
-                                target_element: variadic,
-                            });
+                            return Some(self.tuple_element_type_mismatch(
+                                j,
+                                s_elem.type_id,
+                                variadic,
+                            ));
                         }
                     }
                     return None;
@@ -1889,19 +1910,24 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     // missing property (e.g., {} vs {a: string}), return MissingProperty
                     // to produce TS2741 instead of generic TS2322. This matches tsc behavior
                     // for tuple literals where elements have missing properties.
-                    if let Some(nested) = self.explain_failure(s_elem.type_id, t_elem.type_id)
-                        && matches!(
-                            nested,
+                    // Reuse the single `explain_failure` walk both to detect the
+                    // missing-property short-circuit and as the element's nested
+                    // reason, avoiding a second recursive type walk.
+                    let nested = self.explain_failure(s_elem.type_id, t_elem.type_id);
+                    if matches!(
+                        nested,
+                        Some(
                             SubtypeFailureReason::MissingProperty { .. }
                                 | SubtypeFailureReason::MissingProperties { .. }
                         )
-                    {
-                        return Some(nested);
+                    ) {
+                        return nested;
                     }
                     return Some(SubtypeFailureReason::TupleElementTypeMismatch {
                         index: i,
                         source_element: s_elem.type_id,
                         target_element: t_elem.type_id,
+                        nested_reason: nested.map(Box::new),
                     });
                 }
             } else if !t_elem.optional {


### PR DESCRIPTION
## Agent
AgentName: opus-4-8-web (Claude Code on the web)

## Track
Conformance / diagnostics parity (TS2322-family elaboration).

## Summary

Fixes #11491 (case `diagnostics-33-20`). Tuple element type-mismatch diagnostics dropped the element index/position.

`SubtypeFailureReason::TupleElementTypeMismatch` carried an `index`, but both render paths discarded it (`index: _`) and emitted the same flat chain as a plain array element mismatch. At depth>0 the checker even produced a non-tsc message (`Type of element at index N is incompatible: ...`).

tsc treats a failing tuple element specially: the outer `Type 'S' is not assignable to type 'T'.` (TS2322) line is followed by **TS2626** `Type at position N in source is not compatible with type at position N in target.`, then the inner element failure. tsz now emits that chain and recurses into nested element failures.

## Invariant
When a fixed tuple element at index `i` is not assignable, `tsc` elaborates with TS2626 keyed by position `i` followed by the inner element reason; this PR makes tsz do X through the solver (`explain_tuple_failure` threads a structured `nested_reason`) and the checker rendering boundary (`render_tuple_element_type_mismatch`). Assignability decisions are unchanged — only how an already-failing tuple element relation is *explained*. The set of emitted diagnostic codes is unchanged; the failing element now carries its position and inner reason.

This generalizes across the failing element's position (0, 1, …), nested object-property failures inside an element (TS2626 → TS2326 → leaf), and nested tuples (TS2626 repeated per level) — not just the reported fixture.

## Scope
- `tsz-solver`: add `nested_reason` to `TupleElementTypeMismatch`; populate it via a single `explain_failure` walk; render TS2626 in `to_diagnostic`.
- `tsz-checker`: `render_tuple_element_type_mismatch` emits the TS2626 chain; extract shared `push_nested_chain` helper (now used 4×); tolerate the new field at the call-site match.
- New regression test target `tuple_element_mismatch_tests`.

## Project Corpus Impact
- Row: nextjs-fresh-app (issue #11491, case `diagnostics-33-20`); same diagnostics-33 family also appears on `nextjs` (#11593) and `type-challenges-solutions-project` (#11612) and benefits from the same fix.
- Bug family: tuple element-mismatch diagnostic elaboration (dropped position)
- Evidence: new unit tests in `crates/tsz-checker/tests/tuple_element_mismatch_tests.rs`; full conformance/emit/fourslash run via ready-for-review CI.

## Verification
- `cargo build -p tsz-solver -p tsz-checker` — clean.
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets -- -D warnings` — clean.
- New `tuple_element_mismatch_tests` (4 tests): position 0/1, nested object-property chain, nested-tuple chain — all pass.
- Re-ran `ts2322_tests`, `generic_property_mismatch_display_tests`, `ts2430_tests`, `abstract_constructor_elaboration_tests`, `union_tuple_source_display_tests`, `tuple_index_access_tests`, `class_arrow_property_type_inference_tests` — no regressions. (Two pre-existing `ts2322_tests` failures about mapped-type key correlation reproduce on clean `main` and are unrelated.)
- `/simplify` run 3× to convergence (extracted `push_nested_chain`, removed a redundant `explain_failure` walk, inlined needless bindings).

## Coordination Notes
No open PR references issue range 11476–11639 or the `diagnostics-33-20` case family (checked open/draft PRs). Issue #11491 marked `WIP` with a signed claim comment.
