### PR TITLE
test(solver): cover method count relation cache

### DIFF
--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -1485,3 +1485,102 @@ fn assignability_cache_in_callback_param_check_matches_uncached_relation_policy(
         "ordinary method slot must remain intact after the callback-mode lookup",
     );
 }
+
+#[test]
+fn assignability_cache_disable_method_bivariance_matches_uncached_method_parameter_count() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let mut source_shape = FunctionShape::new(
+        vec![
+            ParamInfo::unnamed(TypeId::STRING),
+            ParamInfo::unnamed(TypeId::NUMBER),
+        ],
+        TypeId::VOID,
+    );
+    source_shape.is_method = true;
+    let source = interner.function(source_shape);
+
+    let mut target_shape =
+        FunctionShape::new(vec![ParamInfo::unnamed(TypeId::STRING)], TypeId::VOID);
+    target_shape.is_method = true;
+    let target = interner.function(target_shape);
+
+    let bivariant_method = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_FUNCTION_TYPES | RelationFlags::ALLOW_BIVARIANT_PARAM_COUNT,
+    );
+    let sound_method = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_FUNCTION_TYPES
+            | RelationFlags::ALLOW_BIVARIANT_PARAM_COUNT
+            | RelationFlags::DISABLE_METHOD_BIVARIANCE,
+    );
+    let bivariant_key =
+        RelationCacheKey::for_assignability(source, target, bivariant_method.cache_config());
+    let sound_key =
+        RelationCacheKey::for_assignability(source, target, sound_method.cache_config());
+
+    assert_ne!(
+        bivariant_key, sound_key,
+        "method-bivariant and sound-method parameter-count policies must occupy distinct assignability cache slots",
+    );
+
+    let bivariant_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        bivariant_method,
+        RelationContext::default(),
+    )
+    .is_related();
+    let sound_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        sound_method,
+        RelationContext::default(),
+    )
+    .is_related();
+
+    assert!(
+        bivariant_uncached,
+        "method bivariance should allow extra required method parameters when the count exception is enabled",
+    );
+    assert!(
+        !sound_uncached,
+        "disabling method bivariance should also disable the method parameter-count exception",
+    );
+
+    let bivariant_cached = db.is_assignable_to_with_policy(source, target, bivariant_method);
+    assert_eq!(
+        bivariant_cached, bivariant_uncached,
+        "cached method-bivariant parameter-count policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(bivariant_key),
+        Some(bivariant_cached),
+        "method-bivariant parameter-count result must use its own cache slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(sound_key),
+        None,
+        "sound-method lookup must not hit the method-bivariant parameter-count slot",
+    );
+
+    let sound_cached = db.is_assignable_to_with_policy(source, target, sound_method);
+    assert_eq!(
+        sound_cached, sound_uncached,
+        "cached sound-method parameter-count policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(sound_key),
+        Some(sound_cached),
+        "sound-method parameter-count result must use its own cache slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(bivariant_key),
+        Some(bivariant_cached),
+        "method-bivariant parameter-count slot must remain intact after the sound-method lookup",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 10 relation policy/cache-key tech debt (#8207), solver policy/cache agreement test ratchet.

## Invariant
When method parameter-count compatibility is enabled for method syntax, disabling method bivariance must change the assignability answer and must occupy a distinct assignability cache slot; this PR ratchets that solver relation-policy contract.

## Scope
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: solver test-only ratchet for relation policy/cache agreement; no project corpus behavior change targeted.

## Verification
- RED `cargo nextest run -p tsz-solver -E 'test(assignability_cache_disable_method_bivariance_matches_uncached_method_parameter_count)'` failed before the test existed with `error: no tests to run`.
- 2026-05-29 after #10989 landed through the repo-local merge queue, rebased this branch onto current `origin/main`; exact base `daed8ff911dc8c6ce204b38391b133df335d7489b`, exact head `9be51474122945388954634a8a2d7f50975213cf`.
- `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'`: 18 passed on `9be51474122945388954634a8a2d7f50975213cf`.
- `cargo fmt --check`: passed on `9be51474122945388954634a8a2d7f50975213cf`.
- `git diff --check origin/main..HEAD`: passed on `9be51474122945388954634a8a2d7f50975213cf`.
- Stack diff check: `git diff --stat origin/main..HEAD` -> one solver test file, 99 insertions.
- File-size guard: `wc -l crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs` -> 1586 lines, below the 2000-line cap.

## Coordination Notes
- #10989 has merged, so this PR is now the first M4-B cache-policy slice on `main`.
- This PR is ready/off queue while exact-head ready-review CI starts for `9be51474122945388954634a8a2d7f50975213cf`.
- Downstream M4-B stack: #11662 remains stacked on this branch and will be rebased after this head update.
- Non-overlap: this slice covers only the solver relation cache agreement for method parameter-count behavior under `DISABLE_METHOD_BIVARIANCE`; it does not touch checker relation routing owned by M1-B, nor M4-A/M4-C evaluation/inference lanes.
- Auto-merge and `merge-queue` remain unset until exact-head PR-head checks are green.
