### PR TITLE
test(checker): cover remapped homomorphic modifiers

### DIFF
--- a/crates/tsz-checker/tests/homomorphic_mapped_keyof_modifier_tests.rs
+++ b/crates/tsz-checker/tests/homomorphic_mapped_keyof_modifier_tests.rs
@@ -117,6 +117,43 @@ fn readonly_tuple_property_through_alias_is_clean() {
     );
 }
 
+/// Identity key remapping (`as K`) remains homomorphic: when the mapped result
+/// is intersected with extra members, `readonly` from the source still applies.
+#[test]
+fn remapped_identity_intersection_preserves_readonly_modifier() {
+    let src = r#"
+        type Rename<T> = { [K in keyof T as K]: T[K] };
+        type Source = { readonly a?: number; b?: string; c: boolean };
+        type Wrapped = Rename<Source> & { d: number };
+        let x: Wrapped = { c: true, d: 1 };
+        x.a = 1;
+    "#;
+    assert_eq!(
+        codes(src),
+        vec![2540],
+        "expected only TS2540 for writing through remapped readonly property"
+    );
+}
+
+/// Same structural rule with renamed binders: optionality inherited from the
+/// homomorphic source must survive the `as Key` remap and intersection merge.
+#[test]
+fn remapped_identity_intersection_preserves_optional_modifier() {
+    let src = r#"
+        type CopyShape<Item> = { [Field in keyof Item as Field]: Item[Field] };
+        type Input = { readonly a?: number; b?: string; c: boolean };
+        type Output = CopyShape<Input> & { d: number };
+        declare const out: Output;
+        const mustBeNumber: number = out.a;
+        const ok: Output = { c: false, d: 1 };
+    "#;
+    assert_eq!(
+        codes(src),
+        vec![2322],
+        "expected only TS2322 because remapped optional property reads as number | undefined"
+    );
+}
+
 /// Regression guard: a mutable array property continued to work before the fix
 /// and must keep working (covariant assignability to inherited `unknown`).
 #[test]


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Semantic campaign regression coverage for mapped/key-remapped modifier preservation

## Invariant
When an identity key-remapped homomorphic mapped type `{ [K in keyof T as K]: T[K] }` is intersected with extra members, `tsc` preserves source `readonly` and optional modifiers; this PR locks the same checker-observed solver behavior without adding production logic.

## Scope
- `crates/tsz-checker/tests/homomorphic_mapped_keyof_modifier_tests.rs`

## Project Corpus Impact
- Row: type-fest-project
- Bug family: mapped key operations can lose optional/readonly modifier intent after merges (#10806)
- Evidence: focused checker coverage for the issue-family witness, plus a renamed binder variant proving the rule is structural and not tied to `T`/`K` spellings. Current `main` already matches TypeScript 6 on the minimized CLI probes, so this is regression coverage and stale-issue cleanup evidence rather than a production-code fix.

## Verification
- `cargo nextest run -p tsz-checker --test homomorphic_mapped_keyof_modifier_tests`
- `cargo fmt --check`
- `git diff --check`

## Coordination Notes
- M4-A; cycle intake showed no open M4-A PRs.
- Overlap search found prior merged M4-A homomorphic modifier work (#10491), and no open M4-A PR claims this exact identity `as K` plus intersection witness.
- M4-C #11656 overlaps default-recursive TS2589/infer use-site work, so this PR intentionally avoids that family.
- Ready for manager/queue-owner review after PR-head checks pass; do not add `merge-queue` until exact-head `CI Summary` and `GitGuardian Security Checks` are green.