### PR TITLE
test(checker): lock generic-default branch independence

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -95,6 +95,10 @@ name = "generic_alias_assignability_pollution_tests"
 path = "tests/generic_alias_assignability_pollution_tests.rs"
 
 [[test]]
+name = "generic_default_branch_independence_tests"
+path = "tests/generic_default_branch_independence_tests.rs"
+
+[[test]]
 name = "generic_return_fingerprint_tests"
 path = "tests/generic_return_fingerprint_tests.rs"
 

--- a/crates/tsz-checker/tests/generic_default_branch_independence_tests.rs
+++ b/crates/tsz-checker/tests/generic_default_branch_independence_tests.rs
@@ -1,0 +1,199 @@
+//! Regression coverage: generic type-parameter defaults must stay scoped to
+//! their own declaration and instantiation — they must not "bleed" between
+//! independent branches (independent aliases, independent instantiations of
+//! the same alias, parallel object members, or shadowed inner type params).
+//!
+//! Tracks the `solver-29-20` "generic defaults bleed between independent
+//! branches" family (mohsen1/tsz#11608 and siblings #11589 / #11487).
+//!
+//! Structural rule under test:
+//!
+//! > When a generic declaration has a defaulted type parameter, each
+//! > instantiation resolves that default against *its own* explicitly
+//! > supplied arguments only; a default resolved for one instantiation (or
+//! > one declaration that happens to share a type-parameter name) must never
+//! > be reused for an independent instantiation/declaration.
+//!
+//! Per the repo anti-hardcoding directive (§25) the cases below vary the
+//! user-chosen type-parameter names (`T`/`K`, `A`/`B`, `P`/`Q`) so a fix that
+//! keyed on a specific spelling would fail at least one case.
+
+use tsz_checker::test_utils::{check_source_strict, diagnostic_codes, diagnostics_without_codes};
+
+/// Semantic error codes, dropping TS2318 ("cannot find global type") which is
+/// expected noise in the no-stdlib unit harness. Mirrors the convention in
+/// `distributive_conditional_default_tests.rs`.
+fn errors(source: &str) -> Vec<u32> {
+    diagnostic_codes(&diagnostics_without_codes(
+        &check_source_strict(source),
+        &[2318],
+    ))
+}
+
+/// Two independent aliases that declare different defaults must each resolve
+/// to their own default; the `number` default of one must not leak into the
+/// other. The two aliases use *different* type-parameter names (`T` vs `K`)
+/// so the invariant is exercised across name choices in a single case (§25).
+#[test]
+fn independent_aliases_keep_their_own_default() {
+    let codes = errors(
+        r#"
+type FirstT<T = string> = T;
+type SecondK<K = number> = K;
+
+const a: FirstT = "ok";   // FirstT resolves to string
+const b: SecondK = 1;     // SecondK resolves to number
+const bad: SecondK = "x"; // string is not assignable to number
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![2322],
+        "only the mismatched `SecondK` assignment should error; got {codes:?}"
+    );
+}
+
+/// A default that references an earlier type parameter (`B = A`) must be
+/// resolved independently for each instantiation. `Pair<string>` must yield
+/// `second: string` and `Pair<number>` must yield `second: number` — the
+/// resolved default from one instantiation must not be reused for the other.
+/// Two parameter spellings (`A`/`B` and `P`/`Q`) prove the rule is not keyed
+/// on the names (§25).
+#[test]
+fn earlier_param_default_resolves_per_instantiation() {
+    let codes = errors(
+        r#"
+type PairAB<A, B = A> = { first: A; second: B };
+type PairPQ<P, Q = P> = { first: P; second: Q };
+
+const okAB: PairAB<string> = { first: "a", second: "b" };
+const okPQ: PairPQ<number> = { first: 1, second: 2 };
+
+const badAB: PairAB<number> = { first: 1, second: "b" };  // second: string vs number
+const badPQ: PairPQ<string> = { first: "a", second: 3 };  // second: number vs string
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![2322, 2322],
+        "each instantiation's earlier-param default must be independent across names; got {codes:?}"
+    );
+}
+
+/// A `keyof T` default must be recomputed per instantiation. `Keys<{ x: 1 }>`
+/// must be `"x"` and must not retain the key space of any other
+/// instantiation.
+#[test]
+fn keyof_default_recomputed_per_instantiation() {
+    let codes = errors(
+        r#"
+type Keys<T, K extends keyof T = keyof T> = K;
+
+const k1: Keys<{ a: 1; b: 2 }> = "a"; // "a" | "b"
+const k2: Keys<{ x: 1 }> = "x";       // "x"
+const bad: Keys<{ x: 1 }> = "a";      // "a" not in "x"
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![2322],
+        "keyof default must be scoped to its own type argument; got {codes:?}"
+    );
+}
+
+/// A generic method nested inside a generic object type declares its own
+/// type parameter that shadows the outer one of the same name. Instantiating
+/// the outer type must not capture (substitute into) the inner, independent
+/// type parameter — the inner method stays generic.
+#[test]
+fn shadowed_inner_type_param_is_not_captured() {
+    let codes = errors(
+        r#"
+type Outer<T> = {
+  outer: T;
+  inner: <T>(x: T) => T; // independent, shadowing T
+};
+
+type O = Outer<number>;
+declare const o: O;
+
+const okStr: string = o.inner("hello"); // inner stayed generic <T>(x:T)=>T
+o.outer = 5;                             // outer T = number
+const bad: number = o.inner("hi");       // string is not assignable to number
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![2322],
+        "outer instantiation must not capture the shadowed inner type param; got {codes:?}"
+    );
+}
+
+/// Defaults on a generic *function* must be resolved independently for each
+/// call site. `makeBox(1)` must resolve `U = number` and must not reuse the
+/// `U = string` resolved at an earlier call.
+#[test]
+fn function_generic_default_is_per_call() {
+    let codes = errors(
+        r#"
+function makeBox<T, U = T>(a: T, b?: U): { a: T; b: U } {
+  return { a, b: b as U };
+}
+
+const sBox = makeBox("s"); // { a: string; b: string }
+const nBox = makeBox(1);   // { a: number; b: number }
+
+const okStr: string = sBox.b;
+const okNum: number = nBox.b;
+const bad: string = nBox.b; // number is not assignable to string
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![2322],
+        "function default U must be resolved per call site; got {codes:?}"
+    );
+}
+
+/// A generic class default must be scoped per instantiation, including when
+/// the default is used as the explicit type annotation.
+#[test]
+fn class_generic_default_is_per_instantiation() {
+    let codes = errors(
+        r#"
+class Container<T = boolean> {
+  constructor(public value: T) {}
+}
+
+const strC = new Container("x");          // T = string (inferred)
+const defC: Container = new Container(true); // T = boolean (default)
+
+const okStr: string = strC.value;
+const okBool: boolean = defC.value;
+const bad: number = defC.value; // boolean is not assignable to number
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![2322],
+        "class default T must be scoped per instantiation; got {codes:?}"
+    );
+}
+
+/// Negative/fallback guard: a genuinely wrong default-defaulted value must
+/// still be rejected. Proves the suite is not vacuously passing by silencing
+/// all diagnostics for defaulted generics.
+#[test]
+fn defaulted_generic_still_rejects_real_mismatch() {
+    let codes = errors(
+        r#"
+type Boxed<T = string> = { value: T };
+const wrong: Boxed = { value: 123 }; // number is not assignable to string
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![2322],
+        "a real mismatch against a defaulted generic must still error; got {codes:?}"
+    );
+}

--- a/crates/tsz-solver/tests/instantiate_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/instantiate_tests_parts/part_00.rs
@@ -882,6 +882,55 @@ fn test_substitution_from_args_circular_defaults_resolve_to_any() {
     assert_eq!(subst.get(u_name), Some(TypeId::ANY));
 }
 
+/// `from_args` must resolve an earlier-param-referencing default (`B = A`)
+/// independently for each call. Two independent instantiations of the same
+/// `<A, B = A>` parameter list with different first arguments must not let
+/// the default resolved for one call leak into the other — i.e. the defaults
+/// must not "bleed between independent branches" (mohsen1/tsz#11608).
+#[test]
+fn test_substitution_from_args_earlier_param_default_independent_per_call() {
+    let interner = TypeInterner::new();
+    let a_name = interner.intern_string("A");
+    let b_name = interner.intern_string("B");
+
+    // B defaults to A.
+    let a_type = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: a_name,
+        constraint: None,
+        default: None,
+        is_const: false,
+    }));
+    let type_params = vec![
+        TypeParamInfo {
+            name: a_name,
+            constraint: None,
+            default: None,
+            is_const: false,
+        },
+        TypeParamInfo {
+            name: b_name,
+            constraint: None,
+            default: Some(a_type), // B = A
+            is_const: false,
+        },
+    ];
+
+    // Branch 1: A = string -> B resolves to string.
+    let subst_str = TypeSubstitution::from_args(&interner, &type_params, &[TypeId::STRING]);
+    assert_eq!(subst_str.get(a_name), Some(TypeId::STRING));
+    assert_eq!(subst_str.get(b_name), Some(TypeId::STRING));
+
+    // Branch 2: A = number -> B resolves to number, independent of branch 1.
+    let subst_num = TypeSubstitution::from_args(&interner, &type_params, &[TypeId::NUMBER]);
+    assert_eq!(subst_num.get(a_name), Some(TypeId::NUMBER));
+    assert_eq!(subst_num.get(b_name), Some(TypeId::NUMBER));
+
+    // Re-resolving branch 1 after branch 2 must still yield string — there is
+    // no shared/cached default state across calls.
+    let subst_str_again = TypeSubstitution::from_args(&interner, &type_params, &[TypeId::STRING]);
+    assert_eq!(subst_str_again.get(b_name), Some(TypeId::STRING));
+}
+
 // ============================================
 // Template Literal Instantiation Tests
 // ============================================


### PR DESCRIPTION
## Summary

Adds regression coverage proving that generic type-parameter **defaults stay
scoped to their own declaration and instantiation** and never "bleed" between
independent branches. This pins the behavior tracked by the `solver-29-20`
"generic defaults bleed between independent branches" family (#11608, with
siblings #11589 / #11487).

Investigation found the reported divergence is **not reproducible** — tsz
already matches `tsc` across every shape I probed (basic defaults, earlier-param
references, `keyof` defaults, shadowed inner type params, forward references,
function generics, class generics). Rather than leave the invariant unguarded,
this PR converts the report into durable regression tests at two altitudes.

**Structural rule under test:** when a generic declaration has a defaulted type
parameter, each instantiation resolves that default against *its own* supplied
arguments only; a default resolved for one instantiation (or for a declaration
that merely shares a type-parameter name) is never reused for an independent
instantiation/declaration.

## Track
Conformance / regression-prevention (no behavior change).

## Invariant
Generic-default resolution is per-declaration and per-instantiation; defaults do
not bleed across independent branches. `TypeSubstitution::from_args` builds a
fresh substitution per call (no shared/cached default state).

## Scope
- `crates/tsz-checker/tests/generic_default_branch_independence_tests.rs` (new):
  7 end-to-end cases over the full AST → binder → solver → checker pipeline —
  independent aliases, earlier-param defaults (`B = A`) per instantiation,
  `keyof` defaults, shadowed inner type params (no capture), function-generic
  defaults per call, class-generic defaults, and a negative guard.
- `crates/tsz-checker/Cargo.toml`: register the new test target (crate uses
  `autotests = false`).
- `crates/tsz-solver/tests/instantiate_tests_parts/part_00.rs`: one low-level
  `from_args` unit test proving `B = A` resolves independently across calls.

Per the anti-hardcoding directive (§25), cases vary type-parameter spellings
(`T`/`K`, `A`/`B`, `P`/`Q`) so a name-keyed implementation would fail.

## Project Corpus Impact
- Row: type-challenges-solutions-project (case solver-29-20)
- Bug family: generic-default branch independence (defaults bleeding across instantiations)
- Evidence: tests-only; no compiler code changed. New tests pass locally and no project-corpus behavior changes (the behavior was already correct; this only locks it in).

## Verification
- `cargo test -p tsz-checker --test generic_default_branch_independence_tests` → 7 passed.
- `cargo test -p tsz-solver test_substitution_from_args_earlier_param_default_independent_per_call` → ok.
- `cargo clippy -p tsz-checker --test generic_default_branch_independence_tests -- -D warnings` → clean.
- `cargo clippy -p tsz-solver --tests -- -D warnings` → clean.

## Coordination Notes
AgentName: claude-opus-web-eager-pascal
#11608 was unowned and not WIP when claimed. Tests-only, behavior-preserving; no
overlap with the owned kysely / accepted-regression PRs. Posted repro evidence on
#11608 and closed it as already-correct; this suite carries the knowledge forward.

https://claude.ai/code/session_01HwELbr4qBPpEE2ajKoMxqn