### PR TITLE
fix(checker): recognize alias-wrapped indexed recursion

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -159,6 +159,10 @@ name = "variadic_tuple_recursive_zip_tests"
 path = "tests/variadic_tuple_recursive_zip_tests.rs"
 
 [[test]]
+name = "recursive_conditional_alias_index_tests"
+path = "tests/recursive_conditional_alias_index_tests.rs"
+
+[[test]]
 name = "reverse_mapped_inference_tests"
 path = "tests/reverse_mapped_inference_tests.rs"
 

--- a/crates/tsz-checker/src/types/type_checking/type_alias_depth_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_depth_helpers.rs
@@ -1,6 +1,7 @@
 //! Helpers for type-alias recursion depth probes.
 
 use crate::state::CheckerState;
+use tsz_binder::symbol_flags;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::parser::{NodeIndex, NodeList};
@@ -63,14 +64,93 @@ impl<'a> CheckerState<'a> {
         alias_sid: tsz_binder::SymbolId,
         node_idx: NodeIndex,
     ) -> bool {
+        self.type_node_is_bounded_indexed_descent_for_depth_check_inner(alias_sid, node_idx, 0)
+    }
+
+    fn type_node_is_bounded_indexed_descent_for_depth_check_inner(
+        &mut self,
+        alias_sid: tsz_binder::SymbolId,
+        node_idx: NodeIndex,
+        depth: u8,
+    ) -> bool {
+        if depth > 8 {
+            return false;
+        }
         let Some(node) = self.ctx.arena.get(node_idx) else {
             return false;
         };
-        let Some(indexed) = self.ctx.arena.get_indexed_access_type(node) else {
-            return false;
-        };
-        self.type_node_is_deferred_passthrough_for_depth_check(indexed.object_type)
-            || self.type_node_is_alias_type_parameter_ref(alias_sid, indexed.object_type)
+        if let Some(indexed) = self.ctx.arena.get_indexed_access_type(node) {
+            return self.type_node_is_deferred_passthrough_for_depth_check(indexed.object_type)
+                || self.type_node_is_alias_type_parameter_ref(alias_sid, indexed.object_type);
+        }
+
+        if node.kind == syntax_kind_ext::PARENTHESIZED_TYPE
+            && let Some(wrapped) = self.ctx.arena.get_wrapped_type(node)
+        {
+            return self.type_node_is_bounded_indexed_descent_for_depth_check_inner(
+                alias_sid,
+                wrapped.type_node,
+                depth + 1,
+            );
+        }
+
+        if node.kind == syntax_kind_ext::TYPE_REFERENCE
+            && let Some(type_ref) = self.ctx.arena.get_type_ref(node)
+        {
+            let type_name = type_ref.type_name;
+            let arg_nodes = type_ref
+                .type_arguments
+                .as_ref()
+                .map(|args| args.nodes.clone())
+                .unwrap_or_default();
+            if let Some(passthrough_arg) =
+                self.transparent_alias_passthrough_arg_for_depth_check(type_name, &arg_nodes)
+            {
+                return self.type_node_is_bounded_indexed_descent_for_depth_check_inner(
+                    alias_sid,
+                    passthrough_arg,
+                    depth + 1,
+                );
+            }
+        }
+
+        false
+    }
+
+    fn transparent_alias_passthrough_arg_for_depth_check(
+        &mut self,
+        type_name: NodeIndex,
+        arg_nodes: &[NodeIndex],
+    ) -> Option<NodeIndex> {
+        if arg_nodes.is_empty() {
+            return None;
+        }
+
+        let resolved = self
+            .resolve_type_symbol_for_lowering(type_name)
+            .map(tsz_binder::SymbolId)?;
+        let symbol = self.ctx.binder.get_symbol(resolved)?;
+        if !symbol.has_any_flags(symbol_flags::TYPE_ALIAS) {
+            return None;
+        }
+
+        let decl_idx = symbol.primary_declaration()?;
+        let decl_node = self.ctx.arena.get(decl_idx)?;
+        let alias = self.ctx.arena.get_type_alias(decl_node)?;
+        let params = alias.type_parameters.as_ref()?;
+        let body_name =
+            self.type_node_passthrough_reference_name_for_depth_check(alias.type_node)?;
+        let passthrough_index = params.nodes.iter().copied().position(|param_idx| {
+            self.ctx
+                .arena
+                .get(param_idx)
+                .and_then(|param_node| self.ctx.arena.get_type_parameter(param_node))
+                .and_then(|param| self.ctx.arena.get(param.name))
+                .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
+                .is_some_and(|ident| ident.escaped_text == body_name)
+        })?;
+
+        arg_nodes.get(passthrough_index).copied()
     }
 
     pub(crate) fn type_node_contains_unresolved_type_reference_for_depth_check(
@@ -488,5 +568,18 @@ impl<'a> CheckerState<'a> {
             return Some(identifier.escaped_text.as_str());
         }
         None
+    }
+
+    fn type_node_passthrough_reference_name_for_depth_check(
+        &self,
+        node_idx: NodeIndex,
+    ) -> Option<&str> {
+        let node = self.ctx.arena.get(node_idx)?;
+        if node.kind == syntax_kind_ext::PARENTHESIZED_TYPE
+            && let Some(wrapped) = self.ctx.arena.get_wrapped_type(node)
+        {
+            return self.type_node_passthrough_reference_name_for_depth_check(wrapped.type_node);
+        }
+        self.type_node_bare_reference_name(node_idx)
     }
 }

--- a/crates/tsz-checker/tests/recursive_conditional_alias_index_tests.rs
+++ b/crates/tsz-checker/tests/recursive_conditional_alias_index_tests.rs
@@ -1,0 +1,63 @@
+//! Recursive conditional evaluation with indexed-access recursion.
+//!
+//! Structural rule: when a distributive recursive conditional's true branch
+//! recurses through an indexed access of the narrowed array member, transparent
+//! aliases around that indexed access must not break the recursion frontier.
+//! `R<Id<T[0]>>` should evaluate like `R<T[0]>`: one branch per array-member
+//! union member, no eager TS2589 at the alias definition.
+
+use tsz_checker::test_utils::check_source_codes;
+
+#[track_caller]
+fn assert_codes(source: &str, expected: &[u32], label: &str) {
+    let actual = check_source_codes(source);
+    assert_eq!(
+        actual, expected,
+        "[{label}] expected diagnostic codes {expected:?}, got {actual:?}"
+    );
+}
+
+#[test]
+fn recursive_conditional_direct_indexed_access_distributes_array_union() {
+    let source = r#"
+type Recur<T> = T extends any[] ? { k: Recur<T[0]> } : { v: T };
+type Actual = Recur<[string] | [number]>;
+declare const actual: Actual;
+const ok: { k: { v: string } } | { k: { v: number } } = actual;
+const bad: { k: { v: boolean } } = actual;
+"#;
+
+    assert_codes(source, &[2322], "direct recursive indexed access");
+}
+
+#[test]
+fn recursive_conditional_alias_wrapped_indexed_access_distributes_array_union() {
+    let source = r#"
+type Identity<T> = T;
+type Recur<T> = T extends any[] ? { k: Recur<Identity<T[0]>> } : { v: T };
+type Actual = Recur<Identity<[string] | [number]>>;
+declare const actual: Actual;
+const ok: { k: { v: string } } | { k: { v: number } } = actual;
+const bad: { k: { v: boolean } } = actual;
+"#;
+
+    assert_codes(source, &[2322], "alias-wrapped recursive indexed access");
+}
+
+#[test]
+fn recursive_conditional_renamed_alias_wrapped_indexed_access_distributes() {
+    let source = r#"
+type Same<Value> = Value;
+type Walk<Item> = Item extends any[] ? { k: Walk<Same<Item[0]>> } : { v: Item };
+type Actual = Walk<Same<[string] | [number]>>;
+declare const actual: Actual;
+const ok: { k: { v: string } } | { k: { v: number } } = actual;
+const bad: { k: { v: boolean } } = actual;
+"#;
+
+    assert_codes(
+        source,
+        &[2322],
+        "renamed alias-wrapped recursive indexed access",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Semantic campaign: recursive conditional / indexed-access evaluation

## Invariant
When a distributive recursive conditional recurses through a transparent alias around a bounded indexed-access descent, `tsc` treats `R<Alias<T[0]>>` like `R<T[0]>`; this PR makes tsz's recursion-depth classifier recognize that structural progress instead of emitting definition-site TS2589.

## Scope
- `crates/tsz-checker/src/types/type_checking/type_alias_depth_helpers.rs`
- `crates/tsz-checker/tests/recursive_conditional_alias_index_tests.rs`
- `crates/tsz-checker/Cargo.toml`

## Project Corpus Impact
- Row: large-ts-repo
- Bug family: recursive conditional distribution over array/indexed-access recursion (#11338)
- Evidence: focused checker regression tests cover the direct recursive indexed-access baseline, an alias-wrapped `Identity<T[0]>` variant, and a renamed `Same<Value>` / `Walk<Item>` variant. The failing pre-fix behavior was TS2589 on the alias-wrapped recursive branch where `tsc` reports only the intentional TS2322 wrong-branch assignment.

## Verification
- RED: `cargo nextest run -p tsz-checker --test recursive_conditional_alias_index_tests` failed before the fix with TS2589 for both alias-wrapped cases.
- GREEN: `cargo nextest run -p tsz-checker --test recursive_conditional_alias_index_tests`
- `cargo nextest run -p tsz-checker --test conditional_infer_tests bounded_recursive_conditional_alias_array_branch_no_ts2589 recursive_awaited_application_emits_ts2589_at_outer_alias`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`

## Coordination Notes
- M4-A; cycle intake found no open owned M4-A PRs.
- Open PR overlap check found M4-B relation-cache stack (#10739/#10989/#11658/#11662), M4-C/default-generic work (#11661), and DTS mapped/infer work (#11659/#10703); this PR avoids relation-cache policy, contextual inference session state, and emitter/DTS formatting.
- The fix is intentionally narrow: only transparent one-parameter alias bodies are unwrapped for the existing bounded-indexed-descent classifier. Arbitrary alias evaluation remains outside this checker-side depth guard.
- Ready for review and PR-head CI; keep `merge-queue` off until exact-head `CI Summary` and `GitGuardian Security Checks` are green.
