### PR TITLE
fix(site): select fresh benchmark artifact state

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -48,6 +48,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "workflow_dispatch redeploy requested — allowing it to queue behind any active deploy"
+            echo "in_flight=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           IN_FLIGHT=$(gh api \
             "repos/${{ github.repository }}/actions/workflows/gh-pages.yml/runs?status=in_progress&per_page=20" \
             --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }})] | length")
@@ -201,31 +207,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          RUN_ID="$(
-            gh run list \
-              --workflow bench.yml \
-              --branch main \
-              --status success \
-              --limit 50 \
-              --json databaseId \
-              --jq '.[].databaseId' |
-            while IFS= read -r candidate_run_id; do
-              artifact_id="$(gh api \
-                "repos/${{ github.repository }}/actions/runs/${candidate_run_id}/artifacts" \
-                --jq '.artifacts[]? | select(.name == "bench-results-merged" and .expired == false) | .id' |
-                head -n 1)"
-
-              if [[ -n "$artifact_id" ]]; then
-                echo "$candidate_run_id"
-                break
-              fi
-            done
-          )"
+          artifact_record="$(gh api \
+            "repos/${{ github.repository }}/actions/artifacts?name=bench-results-merged&per_page=20" \
+            --jq '[.artifacts[]? | select(.expired == false and (.workflow_run.head_branch // "") == "main")] | first | if . == null then "" else [.workflow_run.id, .id, .created_at] | @tsv end')"
+          RUN_ID="$(cut -f1 <<<"${artifact_record}")"
+          ARTIFACT_ID="$(cut -f2 <<<"${artifact_record}")"
+          ARTIFACT_CREATED="$(cut -f3 <<<"${artifact_record}")"
           echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+          echo "artifact_id=${ARTIFACT_ID}" >> "$GITHUB_OUTPUT"
           if [[ -n "$RUN_ID" ]]; then
-            echo "Latest benchmark run with merged artifact: ${RUN_ID}"
+            echo "Latest benchmark merged artifact: run=${RUN_ID} artifact=${ARTIFACT_ID} created=${ARTIFACT_CREATED}"
           else
-            echo "No recent successful benchmark run has a bench-results-merged artifact."
+            echo "No non-expired main benchmark run has a bench-results-merged artifact."
           fi
         continue-on-error: true
 
@@ -237,6 +230,54 @@ jobs:
           path: artifacts
           run-id: ${{ steps.latest-benchmark.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Download latest benchmark data from GCS
+        run: |
+          set -euo pipefail
+          BUCKET="thirdface-ai-oauth_cloudbuild"
+          TOKEN=$(gcloud auth print-access-token 2>/dev/null || echo "")
+
+          if [[ -z "$TOKEN" ]]; then
+            echo "No OAuth token — GCP auth step may have failed or secret is missing"
+            exit 0
+          fi
+
+          mkdir -p artifacts
+          download_object() {
+            local object="$1"
+            local out="$2"
+            local label="$3"
+            local url="https://storage.googleapis.com/storage/v1/b/${BUCKET}/o/${object//\//%2F}?alt=media"
+            local http status
+            http=$(curl -s -w "\n%{http_code}" -o "${out}.tmp" \
+              -H "Authorization: Bearer ${TOKEN}" "$url")
+            status=$(echo "$http" | tail -1)
+            if [[ "$status" == "200" ]] && jq -e type "${out}.tmp" >/dev/null 2>&1; then
+              mv "${out}.tmp" "$out"
+              echo "Downloaded ${label} from GCS"
+              return 0
+            fi
+            rm -f "${out}.tmp"
+            echo "No ${label} from GCS (HTTP ${status})"
+            return 1
+          }
+
+          if download_object \
+            "tsz-ci-cache/bench-runs/latest.json" \
+            "artifacts/bench-vs-tsgo-gcs-latest.json" \
+            "latest benchmark data"; then
+            rows=$(jq '[.results[]?] | length' artifacts/bench-vs-tsgo-gcs-latest.json 2>/dev/null || echo "0")
+            if [[ "${rows}" -le 0 ]]; then
+              rm -f artifacts/bench-vs-tsgo-gcs-latest.json
+              echo "GCS benchmark artifact has no result rows; skipping it."
+            fi
+          fi
+
+          download_object \
+            "tsz-ci-cache/bench-runs/latest.tsgo-winners.json" \
+            "artifacts/bench-vs-tsgo-gcs-latest.tsgo-winners.json" \
+            "latest benchmark winner report" || true
         continue-on-error: true
 
       - name: Prepare benchmark data for website
@@ -253,7 +294,11 @@ jobs:
 
           if [[ ! -f artifacts/bench-results.json ]]; then
             rm -f artifacts/bench-results-tsgo-winners.json
-            echo "No benchmark artifact downloaded; bench charts will use repository/local fallback data."
+            if [[ -f artifacts/bench-vs-tsgo-gcs-latest.json ]]; then
+              echo "No GitHub benchmark artifact downloaded; bench charts will use GCS latest data."
+            else
+              echo "No benchmark artifact downloaded; bench charts will use repository/local fallback data."
+            fi
             exit 0
           fi
 
@@ -276,7 +321,16 @@ jobs:
           set -euo pipefail
           mkdir -p artifacts
           readiness_out="artifacts/bench-readiness-status.json"
-          artifact="artifacts/bench-vs-tsgo-github-latest.json"
+          artifact="$(node --input-type=module <<'NODE'
+          import { selectLatestBenchmarkArtifact } from "./scripts/bench/benchmark-artifact-selection.mjs";
+
+          const selected = selectLatestBenchmarkArtifact([
+            "artifacts/bench-vs-tsgo-github-latest.json",
+            "artifacts/bench-vs-tsgo-gcs-latest.json",
+          ]);
+          process.stdout.write(selected?.file ?? "artifacts/bench-vs-tsgo-github-latest.json");
+          NODE
+          )"
 
           node scripts/bench/check-artifact-readiness.mjs "${artifact}" --json \
             > "${readiness_out}" || true

--- a/crates/tsz-website/.eleventy.js
+++ b/crates/tsz-website/.eleventy.js
@@ -4,6 +4,7 @@ import {
   renderReadmePerfPng,
   renderReadmePerfSvg,
 } from "../../scripts/bench/readme-perf-svg.mjs";
+import { selectLatestBenchmarkArtifact } from "../../scripts/bench/benchmark-artifact-selection.mjs";
 import { createTsgoWinnerReport } from "../../scripts/bench/tsgo-winner-report.mjs";
 
 export default function (eleventyConfig) {
@@ -36,7 +37,7 @@ export default function (eleventyConfig) {
     "../../artifacts/bench-vs-tsgo-latest.json",
     "bench-snapshot.json",
   ];
-  const latestBenchmarkArtifact = benchmarkArtifacts.find((file) => fs.existsSync(file));
+  const latestBenchmarkArtifact = selectLatestBenchmarkArtifact(benchmarkArtifacts)?.file;
   if (latestBenchmarkArtifact) {
     eleventyConfig.addPassthroughCopy({
       [latestBenchmarkArtifact]: "benchmark-data/latest.json",

--- a/crates/tsz-website/src/_data/benchmark_data.js
+++ b/crates/tsz-website/src/_data/benchmark_data.js
@@ -8,6 +8,7 @@ import {
   PROJECT_ROWS_BY_NAME,
   REQUIRED_PROJECT_ROWS,
 } from "../../../../scripts/bench/project-rows.mjs";
+import { selectLatestBenchmarkArtifact } from "../../../../scripts/bench/benchmark-artifact-selection.mjs";
 import { subsystemForCode } from "../../../../scripts/ci/diagnostic-subsystems.mjs";
 import { fmt } from "./loc.js";
 import { generatedBenchmarkSource } from "./benchmark_generated_sources.js";
@@ -863,18 +864,14 @@ function loadBenchmarks() {
     }
   }
 
-  for (const location of benchmarkArtifactFiles()) {
-    const data = readJsonIfExists(location);
-    if (data?.results) {
-      _benchmarkSourceKind = "artifact";
-      return sanitizeLegacyBenchmarkData(data);
-    }
-  }
-
-  const snapshot = readJsonIfExists(path.join(ROOT, "crates/tsz-website/bench-snapshot.json"));
-  if (snapshot?.results) {
-    _benchmarkSourceKind = "snapshot";
-    return sanitizeLegacyBenchmarkData(snapshot);
+  const snapshotPath = path.join(ROOT, "crates/tsz-website/bench-snapshot.json");
+  const selectedArtifact = selectLatestBenchmarkArtifact([
+    ...benchmarkArtifactFiles(),
+    snapshotPath,
+  ]);
+  if (selectedArtifact) {
+    _benchmarkSourceKind = selectedArtifact.file === snapshotPath ? "snapshot" : "artifact";
+    return sanitizeLegacyBenchmarkData(selectedArtifact.data);
   }
 
   _benchmarkSourceKind = null;

--- a/crates/tsz-website/src/_data/benchmark_mean_chart.js
+++ b/crates/tsz-website/src/_data/benchmark_mean_chart.js
@@ -1,17 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
+import { selectLatestBenchmarkArtifact } from "../../../../scripts/bench/benchmark-artifact-selection.mjs";
 import { REQUIRED_PROJECT_ROWS } from "../../../../scripts/bench/project-rows.mjs";
 import { fmt } from "./loc.js";
 
 const ROOT = path.resolve(import.meta.dirname, "..", "..", "..", "..");
-
-function readJsonIfExists(p) {
-  try {
-    return JSON.parse(fs.readFileSync(p, "utf8"));
-  } catch {
-    return null;
-  }
-}
 
 function sanitizeLegacyBenchmarkResults(data) {
   if (data?.validation?.hyperfine_exit_codes_required === true) {
@@ -77,13 +70,13 @@ function loadBenchmarks() {
     }
   })();
 
-  for (const location of artifactFiles) {
-    const data = readJsonIfExists(location);
-    if (data?.results?.length) return sanitizeLegacyBenchmarkResults(data);
+  const selectedArtifact = selectLatestBenchmarkArtifact([
+    ...artifactFiles,
+    path.join(ROOT, "crates/tsz-website/bench-snapshot.json"),
+  ]);
+  if (selectedArtifact) {
+    return sanitizeLegacyBenchmarkResults(selectedArtifact.data);
   }
-
-  const snapshot = readJsonIfExists(path.join(ROOT, "crates/tsz-website/bench-snapshot.json"));
-  if (snapshot?.results?.length) return sanitizeLegacyBenchmarkResults(snapshot);
 
   return [];
 }

--- a/scripts/bench/benchmark-artifact-selection.mjs
+++ b/scripts/bench/benchmark-artifact-selection.mjs
@@ -1,0 +1,39 @@
+import fs from "node:fs";
+
+export function readBenchmarkArtifact(file) {
+  try {
+    const data = JSON.parse(fs.readFileSync(file, "utf8"));
+    return Array.isArray(data?.results) && data.results.length > 0 ? data : null;
+  } catch {
+    return null;
+  }
+}
+
+export function benchmarkGeneratedAtMs(data) {
+  const timestamp = Date.parse(data?.generated_at ?? "");
+  return Number.isFinite(timestamp) ? timestamp : Number.NEGATIVE_INFINITY;
+}
+
+export function selectLatestBenchmarkArtifact(files) {
+  const candidates = [];
+  for (const [index, file] of files.entries()) {
+    const data = readBenchmarkArtifact(file);
+    if (!data) continue;
+    candidates.push({
+      file,
+      data,
+      generatedAtMs: benchmarkGeneratedAtMs(data),
+      index,
+    });
+  }
+
+  candidates.sort((a, b) => {
+    if (a.generatedAtMs !== b.generatedAtMs) {
+      return b.generatedAtMs - a.generatedAtMs;
+    }
+    return a.index - b.index;
+  });
+
+  const selected = candidates[0];
+  return selected ? { file: selected.file, data: selected.data } : null;
+}

--- a/scripts/bench/test-benchmark-artifact-selection.mjs
+++ b/scripts/bench/test-benchmark-artifact-selection.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { selectLatestBenchmarkArtifact } from "./benchmark-artifact-selection.mjs";
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-bench-artifacts-"));
+
+function writeArtifact(name, generatedAt, results = [{ name: "row", tsz_ms: 1, tsgo_ms: 2 }]) {
+  const file = path.join(tempDir, name);
+  fs.writeFileSync(file, `${JSON.stringify({ generated_at: generatedAt, results })}\n`);
+  return file;
+}
+
+try {
+  const snapshot = writeArtifact("bench-snapshot.json", "2026-05-17T01:23:02.991Z");
+  const github = writeArtifact("bench-vs-tsgo-github-latest.json", "2026-05-28T02:14:24.444Z");
+  const gcs = writeArtifact("bench-vs-tsgo-gcs-latest.json", "2026-05-29T02:14:24.444Z");
+  const empty = writeArtifact("empty.json", "2026-06-01T00:00:00.000Z", []);
+
+  assert.equal(
+    selectLatestBenchmarkArtifact([snapshot, github, gcs])?.file,
+    gcs,
+    "newer GCS benchmark truth should beat older GitHub and snapshot files",
+  );
+  assert.equal(
+    selectLatestBenchmarkArtifact([gcs, github, snapshot])?.file,
+    gcs,
+    "candidate order should not override generated_at freshness",
+  );
+  assert.equal(
+    selectLatestBenchmarkArtifact([empty, github])?.file,
+    github,
+    "empty benchmark JSON should not mask the latest usable artifact",
+  );
+  assert.equal(
+    selectLatestBenchmarkArtifact([path.join(tempDir, "missing.json")]),
+    null,
+    "missing candidates should produce no selected artifact",
+  );
+} finally {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+}
+
+console.log("benchmark artifact selection tests passed");

--- a/scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs
+++ b/scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs
@@ -19,8 +19,38 @@ assert.match(
 
 assert.match(
   workflow,
+  /github\.event_name \}\}" = "workflow_dispatch"[\s\S]+allowing it to queue behind any active deploy[\s\S]+in_flight=false/,
+  "Explicit Pages redeploy dispatches should not be dropped behind an older deploy",
+);
+
+assert.match(
+  workflow,
+  /actions\/artifacts\?name=bench-results-merged&per_page=20[\s\S]+workflow_run\.head_branch[\s\S]+Latest benchmark merged artifact/,
+  "Pages deploy should find merged benchmark artifacts directly instead of scanning a small window of successful Bench runs",
+);
+
+assert.doesNotMatch(
+  workflow,
+  /gh run list[\s\S]+--workflow bench\.yml[\s\S]+--limit 50/,
+  "Pages deploy must not rely on a 50-run success window that gate-only Bench runs can crowd out",
+);
+
+assert.match(
+  workflow,
   /select\(\.name == "bench-results-merged" and \.expired == false\)/,
   "Pages deploy should require a non-expired merged benchmark artifact",
+);
+
+assert.match(
+  workflow,
+  /Download latest benchmark data from GCS[\s\S]+bench-runs\/latest\.json[\s\S]+bench-vs-tsgo-gcs-latest\.json[\s\S]+bench-runs\/latest\.tsgo-winners\.json/,
+  "Pages deploy should use published GCS benchmark truth when credentials are available",
+);
+
+assert.match(
+  workflow,
+  /selectLatestBenchmarkArtifact[\s\S]+bench-vs-tsgo-github-latest\.json[\s\S]+bench-vs-tsgo-gcs-latest\.json/,
+  "Pages readiness status should describe the selected fresh benchmark artifact",
 );
 
 assert.match(

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -379,6 +379,7 @@ run_lint() {
   node scripts/bench/test-reduction-backlog.mjs || return $?
   node scripts/bench/test-timeout-runner.mjs || return $?
   node scripts/bench/test-check-artifact-readiness.mjs || return $?
+  node scripts/bench/test-benchmark-artifact-selection.mjs || return $?
   node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs || return $?
   for script in scripts/ci/*type-challenges*.mjs; do
     node --check "$script" || return $?


### PR DESCRIPTION
## Agent
AgentName: m5-pro-48g-gpt5

## Track
Track 10 / benchmark artifact truth and website compatibility state publishing.

## Invariant
When a long Bench run finishes after `main` has moved, the website build must select the newest valid benchmark artifact by `generated_at` and preserve the project compatibility state from that artifact instead of falling back to an older checked-in snapshot.

## Scope
- `.github/workflows/gh-pages.yml`: discover `bench-results-merged` through the repository artifact endpoint, keep explicit redeploy dispatches queued, optionally ingest GCS latest benchmark truth, and write readiness for the selected artifact.
- `crates/tsz-website`: select the newest valid benchmark artifact across GitHub, GCS, local, and snapshot sources.
- `scripts/bench`: add a shared artifact selector and workflow guard tests.

## Project Corpus Impact
- Row: public benchmark/project compatibility dashboard rows.
- Bug family: benchmark artifact truth / Pages stale state selection.
- Evidence: live `benchmark-data/latest.json` was still generated `2026-05-17T01:23:02.991Z` without `measurement_profile`, while GCS `bench-runs/latest.json` is generated `2026-05-28T02:14:24.444Z` with `measurement_profile`; fresh GitHub artifact run `26548619948` existed but was crowded out of the prior 50-success-run search by gate-only Bench successes.

## Verification
- `node scripts/bench/test-benchmark-artifact-selection.mjs`
- `node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs`
- `node scripts/bench/test-tsgo-winner-report.mjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gh-pages.yml"); puts "yaml ok"'`
- `git diff --check`
- `node --input-type=module` selector smoke: selected `/tmp/tsz-bench-live/latest.json` (`2026-05-28T02:14:24.444Z`) over `crates/tsz-website/bench-snapshot.json` (`2026-05-17T01:23:02.991Z`).
- `node scripts/bench/check-artifact-readiness.mjs /tmp/tsz-bench-live/latest.json --json`: `measurement_profile.present=true`, required rows `green=7`, `red=4`, `missing=0`.

## Coordination Notes
- AgentName: m5-pro-48g-gpt5
- Related issue: #10649.
- No roadmap update: this preserves the existing benchmark truth model and fixes the Pages/state publication path.
- GitHub API rate limiting occurred during investigation after artifact/run inspection; branch is pushed for draft CI to carry the next verification step.
