### PR TITLE
fix(diagnostics): sort diagnostics through one canonical total order

### DIFF
--- a/crates/tsz-cli/src/driver/checker_lib_diagnostics.rs
+++ b/crates/tsz-cli/src/driver/checker_lib_diagnostics.rs
@@ -112,7 +112,7 @@ pub(super) fn check_checker_lib_file_for_interfaces(
         diagnostics
             .retain(|diag| keep_checker_diagnostic_when_program_has_real_syntax_errors(diag.code));
     }
-    diagnostics.sort_by(|a, b| a.start.cmp(&b.start).then_with(|| a.code.cmp(&b.code)));
+    diagnostics.sort_by(|a, b| a.compare(b));
     diagnostics.dedup_by(|a, b| a.start == b.start && a.code == b.code);
 
     // PERF: All callers Arc::clone the same shared DefinitionStore; the
@@ -175,7 +175,7 @@ pub(super) fn check_checker_lib_file_baseline(
     );
 
     let mut diagnostics = std::mem::take(&mut checker.ctx.diagnostics);
-    diagnostics.sort_by(|a, b| a.start.cmp(&b.start).then_with(|| a.code.cmp(&b.code)));
+    diagnostics.sort_by(|a, b| a.compare(b));
     diagnostics.dedup_by(|a, b| a.start == b.start && a.code == b.code);
 
     // PERF: Same as `check_checker_lib_file` — callers ignore stats and the
@@ -1105,14 +1105,7 @@ pub(super) fn collect_checker_lib_baseline_diagnostics_for_codes(
         );
     }
 
-    diagnostics.sort_by(|a, b| {
-        (a.file.as_str(), a.start, a.code, a.message_text.as_str()).cmp(&(
-            b.file.as_str(),
-            b.start,
-            b.code,
-            b.message_text.as_str(),
-        ))
-    });
+    diagnostics.sort_by(|a, b| a.compare(b));
     diagnostics.dedup_by(|a, b| lib_diagnostic_fingerprint(a) == lib_diagnostic_fingerprint(b));
     diagnostics
 }

--- a/crates/tsz-cli/src/driver/core.rs
+++ b/crates/tsz-cli/src/driver/core.rs
@@ -1558,12 +1558,7 @@ fn compile_inner(
         diagnostics.extend(config_diagnostics);
         diagnostics.extend(binary_file_diagnostics);
         diagnostics.extend(type_file_diagnostics);
-        diagnostics.sort_by(|left, right| {
-            left.file
-                .cmp(&right.file)
-                .then(left.start.cmp(&right.start))
-                .then(left.code.cmp(&right.code))
-        });
+        diagnostics.sort_by(|left, right| left.compare(right));
 
         return Ok(CompilationResult {
             diagnostics,
@@ -1658,12 +1653,7 @@ fn compile_inner(
         diagnostics.extend(config_diagnostics);
         diagnostics.extend(binary_file_diagnostics);
         diagnostics.extend(type_file_diagnostics);
-        diagnostics.sort_by(|left, right| {
-            left.file
-                .cmp(&right.file)
-                .then(left.start.cmp(&right.start))
-                .then(left.code.cmp(&right.code))
-        });
+        diagnostics.sort_by(|left, right| left.compare(right));
 
         return Ok(CompilationResult {
             diagnostics,
@@ -1905,12 +1895,7 @@ fn compile_inner(
         }
     }
 
-    diagnostics.sort_by(|left, right| {
-        left.file
-            .cmp(&right.file)
-            .then(left.start.cmp(&right.start))
-            .then(left.code.cmp(&right.code))
-    });
+    diagnostics.sort_by(|left, right| left.compare(right));
 
     let has_error = diagnostics
         .iter()
@@ -1985,12 +1970,7 @@ fn compile_inner(
     // The initial has_error was computed before emit for should_emit gating.
     normalize_ts2883_diagnostics_in_place(&mut diagnostics);
     // Re-sort since emit diagnostics were appended after the initial sort.
-    diagnostics.sort_by(|left, right| {
-        left.file
-            .cmp(&right.file)
-            .then(left.start.cmp(&right.start))
-            .then(left.code.cmp(&right.code))
-    });
+    diagnostics.sort_by(|left, right| left.compare(right));
     let has_error = diagnostics
         .iter()
         .any(|diag| diag.category == DiagnosticCategory::Error);

--- a/crates/tsz-common/src/diagnostics/mod.rs
+++ b/crates/tsz-common/src/diagnostics/mod.rs
@@ -164,6 +164,60 @@ impl Diagnostic {
     pub const fn span(&self) -> crate::span::Span {
         crate::span::Span::from_len(self.start, self.length)
     }
+
+    /// Canonical total ordering for diagnostics, mirroring the TypeScript
+    /// compiler's `compareDiagnostics`: by file, then start, then length, then
+    /// code, then message text, then related information.
+    ///
+    /// This is a *total* order over the observable fields, so two diagnostics
+    /// that share a location and code still have a stable, reproducible
+    /// relative order. That is what keeps reported diagnostic order
+    /// deterministic across equivalent relations, regardless of the
+    /// (potentially parallel or hash-map-driven) order in which the
+    /// diagnostics were produced. Every site that emits the final diagnostic
+    /// list must sort through this comparator rather than an ad-hoc partial
+    /// key, otherwise diagnostics that tie on the partial key fall back to
+    /// nondeterministic production order.
+    pub fn compare(&self, other: &Self) -> std::cmp::Ordering {
+        self.compare_skip_related_information(other).then_with(|| {
+            compare_related_information(&self.related_information, &other.related_information)
+        })
+    }
+
+    /// The location/code/message portion of [`Diagnostic::compare`], mirroring
+    /// tsc's `compareDiagnosticsSkipRelatedInformation`. Orders by file, then
+    /// start, then length, then code, then message text.
+    pub fn compare_skip_related_information(&self, other: &Self) -> std::cmp::Ordering {
+        self.file
+            .cmp(&other.file)
+            .then_with(|| self.start.cmp(&other.start))
+            .then_with(|| self.length.cmp(&other.length))
+            .then_with(|| self.code.cmp(&other.code))
+            .then_with(|| self.message_text.cmp(&other.message_text))
+    }
+}
+
+/// Order two related-information lists, mirroring tsc's
+/// `compareRelatedInformation`: shorter lists sort first, then the lists are
+/// compared element-by-element on file, start, length, code, and message text.
+fn compare_related_information(
+    a: &[DiagnosticRelatedInformation],
+    b: &[DiagnosticRelatedInformation],
+) -> std::cmp::Ordering {
+    a.len().cmp(&b.len()).then_with(|| {
+        a.iter()
+            .zip(b.iter())
+            .map(|(left, right)| {
+                left.file
+                    .cmp(&right.file)
+                    .then_with(|| left.start.cmp(&right.start))
+                    .then_with(|| left.length.cmp(&right.length))
+                    .then_with(|| left.code.cmp(&right.code))
+                    .then_with(|| left.message_text.cmp(&right.message_text))
+            })
+            .find(|ordering| ordering.is_ne())
+            .unwrap_or(std::cmp::Ordering::Equal)
+    })
 }
 
 /// Look up a `DiagnosticMessage` (code + category + template) by numeric code.
@@ -315,6 +369,94 @@ mod tests {
             assert_eq!(diagnostic.message_text, "Unknown diagnostic");
             assert!(diagnostic.related_information.is_empty());
         }
+    }
+
+    // =========================================================================
+    // Diagnostic::compare — canonical, total, deterministic ordering
+    //
+    // These lock the rule: when diagnostics tie on a partial key (e.g. same
+    // file+start), the relative order is still fully determined by the
+    // remaining fields (length, code, message, related info) in tsc's
+    // `compareDiagnostics` order — never by production/insertion order. Each
+    // test scrambles insertion order and asserts the same canonical sequence.
+    // =========================================================================
+
+    fn diag(file: &str, start: u32, length: u32, code: u32, message: &str) -> Diagnostic {
+        Diagnostic::error(file, start, length, message, code)
+    }
+
+    /// Sorting through the canonical comparator yields the same order no matter
+    /// how the input was permuted — the property that makes reported diagnostic
+    /// order deterministic across equivalent relations.
+    fn assert_canonical_order_is_permutation_invariant(canonical: &[Diagnostic]) {
+        // The canonical slice must already be sorted by `compare`.
+        for window in canonical.windows(2) {
+            assert_ne!(
+                window[0].compare(&window[1]),
+                std::cmp::Ordering::Greater,
+                "input slice is expected to be in canonical order"
+            );
+        }
+        // Every permutation collapses back to the same canonical order
+        // (`Diagnostic` derives `PartialEq`, so compare the whole slice).
+        let mut reversed = canonical.to_vec();
+        reversed.reverse();
+        let mut rotated = canonical.to_vec();
+        rotated.rotate_left(canonical.len() / 2);
+        for mut permutation in [reversed, rotated] {
+            permutation.sort_by(|a, b| a.compare(b));
+            assert_eq!(permutation, canonical);
+        }
+    }
+
+    #[test]
+    fn compare_orders_by_file_then_start_then_length_then_code_then_message() {
+        // Canonical tsc order: file, then start, then length, then code, then
+        // message text. Several pairs deliberately tie on the earlier keys so
+        // the later tiebreakers are exercised.
+        let canonical = vec![
+            diag("a.ts", 0, 5, 2304, "alpha"),
+            // same file+start as next, shorter length sorts first
+            diag("a.ts", 10, 2, 9999, "zzz"),
+            diag("a.ts", 10, 4, 1000, "aaa"),
+            // same file+start+length, lower code first
+            diag("a.ts", 20, 3, 2322, "msg"),
+            diag("a.ts", 20, 3, 2345, "msg"),
+            // same file+start+length+code, message breaks the tie
+            diag("a.ts", 30, 1, 2304, "aaa"),
+            diag("a.ts", 30, 1, 2304, "bbb"),
+            // file name is the highest-priority key
+            diag("b.ts", 0, 1, 1000, "anything"),
+        ];
+
+        assert_canonical_order_is_permutation_invariant(&canonical);
+    }
+
+    #[test]
+    fn compare_breaks_ties_on_related_information() {
+        // Two diagnostics identical on every primary field differ only in
+        // related information; the shorter related list sorts first, then the
+        // lists compare element-by-element.
+        let bare = diag("a.ts", 0, 1, 2304, "msg");
+        let with_one = diag("a.ts", 0, 1, 2304, "msg").with_related("a.ts", 5, 1, "see a");
+        let with_two = diag("a.ts", 0, 1, 2304, "msg")
+            .with_related("a.ts", 5, 1, "see a")
+            .with_related("a.ts", 9, 1, "see b");
+
+        let canonical = vec![bare, with_one, with_two];
+        assert_canonical_order_is_permutation_invariant(&canonical);
+    }
+
+    #[test]
+    fn compare_is_a_total_order_consistent_with_equality() {
+        let a = diag("a.ts", 0, 1, 2304, "msg");
+        let b = a.clone();
+        assert_eq!(a.compare(&b), std::cmp::Ordering::Equal);
+
+        let c = diag("a.ts", 0, 1, 2304, "msg2");
+        // Antisymmetry: a < c implies c > a.
+        assert_eq!(a.compare(&c), std::cmp::Ordering::Less);
+        assert_eq!(c.compare(&a), std::cmp::Ordering::Greater);
     }
 
     #[test]

--- a/crates/tsz-core/src/diagnostics/mod.rs
+++ b/crates/tsz-core/src/diagnostics/mod.rs
@@ -321,6 +321,22 @@ impl Diagnostic {
         self.span.len()
     }
 
+    /// Canonical total ordering for diagnostics, mirroring the TypeScript
+    /// compiler's `compareDiagnostics`: by file, then start, then length, then
+    /// code, then message. This is a *total* order over the observable fields,
+    /// so diagnostics that tie on file and start still have a stable,
+    /// reproducible relative order independent of the order in which they were
+    /// produced. Sorting through this comparator is what keeps reported
+    /// diagnostic order deterministic across equivalent relations.
+    pub fn compare(&self, other: &Self) -> std::cmp::Ordering {
+        self.file_name
+            .cmp(&other.file_name)
+            .then_with(|| self.span.start.cmp(&other.span.start))
+            .then_with(|| self.span.len().cmp(&other.span.len()))
+            .then_with(|| self.code.cmp(&other.code))
+            .then_with(|| self.message.cmp(&other.message))
+    }
+
     /// Format the diagnostic for display.
     ///
     /// Returns a string like: "file.ts(1,5): error TS2304: Cannot find name 'foo'."
@@ -559,13 +575,10 @@ impl DiagnosticBag {
         self.diagnostics.iter().filter(move |d| d.code == code)
     }
 
-    /// Sort diagnostics by file, then by position.
+    /// Sort diagnostics into the canonical, deterministic order (file, start,
+    /// length, code, message) defined by [`Diagnostic::compare`].
     pub fn sort(&mut self) {
-        self.diagnostics
-            .sort_by(|a, b| match a.file_name.cmp(&b.file_name) {
-                std::cmp::Ordering::Equal => a.span.start.cmp(&b.span.start),
-                other => other,
-            });
+        self.diagnostics.sort_by(|a, b| a.compare(b));
     }
 
     /// Clear all diagnostics.
@@ -874,6 +887,38 @@ mod tests {
         assert_eq!(diagnostics[1].file_name, "a.ts");
         assert_eq!(diagnostics[1].span.start, 5);
         assert_eq!(diagnostics[2].file_name, "b.ts");
+    }
+
+    #[test]
+    fn test_diagnostic_bag_sort_is_deterministic_on_tied_positions() {
+        // Diagnostics that tie on (file, start) must still land in a
+        // deterministic order regardless of insertion order. The canonical
+        // order is length, then code, then message after file+start.
+        let build = |order: [usize; 4]| {
+            let entries = [
+                // same file+start, differing length / code / message
+                Diagnostic::error("a.ts", Span::new(10, 12), "short", 2345),
+                Diagnostic::error("a.ts", Span::new(10, 15), "longer-low-code", 1000),
+                Diagnostic::error("a.ts", Span::new(10, 15), "longer-high-code", 2322),
+                Diagnostic::error("a.ts", Span::new(10, 15), "longer-high-code-2", 2322),
+            ];
+            let mut bag = DiagnosticBag::new();
+            for idx in order {
+                bag.add(entries[idx].clone());
+            }
+            bag.sort();
+            bag.iter().map(|d| d.message.clone()).collect::<Vec<_>>()
+        };
+
+        let expected = vec![
+            "short".to_string(),
+            "longer-low-code".to_string(),
+            "longer-high-code".to_string(),
+            "longer-high-code-2".to_string(),
+        ];
+        assert_eq!(build([0, 1, 2, 3]), expected);
+        assert_eq!(build([3, 2, 1, 0]), expected);
+        assert_eq!(build([2, 0, 3, 1]), expected);
     }
 
     #[test]

--- a/crates/tsz-core/src/parallel/core/checking.rs
+++ b/crates/tsz-core/src/parallel/core/checking.rs
@@ -526,7 +526,7 @@ pub fn check_files_parallel(
         let mut diagnostics = std::mem::take(&mut checker.ctx.diagnostics);
 
         // Sort diagnostics by position for deterministic output within each file.
-        diagnostics.sort_by(|a, b| a.start.cmp(&b.start).then_with(|| a.code.cmp(&b.code)));
+        diagnostics.sort_by(|a, b| a.compare(b));
 
         suppress_parallel_ts2339_cascade_diagnostics(file.arena.as_ref(), &mut diagnostics);
 
@@ -628,7 +628,7 @@ pub fn check_files_parallel(
         );
 
         let mut diagnostics = std::mem::take(&mut checker.ctx.diagnostics);
-        diagnostics.sort_by(|a, b| a.start.cmp(&b.start).then_with(|| a.code.cmp(&b.code)));
+        diagnostics.sort_by(|a, b| a.compare(b));
         diagnostics.dedup_by(|a, b| a.start == b.start && a.code == b.code);
 
         FileCheckResult {
@@ -674,7 +674,7 @@ pub fn check_files_parallel(
         );
 
         let mut diagnostics = std::mem::take(&mut checker.ctx.diagnostics);
-        diagnostics.sort_by(|a, b| a.start.cmp(&b.start).then_with(|| a.code.cmp(&b.code)));
+        diagnostics.sort_by(|a, b| a.compare(b));
         diagnostics.dedup_by(|a, b| a.start == b.start && a.code == b.code);
 
         FileCheckResult {

--- a/crates/tsz-core/src/parallel/diagnostics.rs
+++ b/crates/tsz-core/src/parallel/diagnostics.rs
@@ -264,9 +264,7 @@ pub(crate) fn add_reexported_module_augmentation_enum_conflict_diagnostics(
     }
 
     for result in file_results {
-        result
-            .diagnostics
-            .sort_by(|a, b| a.start.cmp(&b.start).then_with(|| a.code.cmp(&b.code)));
+        result.diagnostics.sort_by(|a, b| a.compare(b));
     }
 }
 
@@ -405,9 +403,7 @@ pub(crate) fn add_parallel_global_augmentation_member_conflict_diagnostics(
     }
 
     for result in file_results {
-        result
-            .diagnostics
-            .sort_by(|a, b| a.start.cmp(&b.start).then_with(|| a.code.cmp(&b.code)));
+        result.diagnostics.sort_by(|a, b| a.compare(b));
         result
             .diagnostics
             .dedup_by(|a, b| a.start == b.start && a.code == b.code);


### PR DESCRIPTION
## Agent
AgentName: opus48-web

## Track
Diagnostics / parity — deterministic diagnostic reporting.

## Invariant
When two diagnostics tie on a prefix of the diagnostic key (e.g. same `file`+`start`, common for several diagnostics emitted at one node), `tsc` still orders them by the full total order `file → start → length → code → messageText → relatedInformation` (`compareDiagnostics`); this PR makes tsz apply that exact total order at **every** final-output sort site, through one shared `Diagnostic::compare` comparator in the diagnostics layer (`tsz_common` / `tsz_core`).

## Scope
Fixes the "diagnostic report order is non-deterministic across equivalent relations" family: #11613 (and the same root cause behind #11594, #11492, #11219).

Root cause: tsz sorted diagnostics with several **divergent ad-hoc partial comparators** that are not total orders —
- `tsz_core::diagnostics::DiagnosticBag::sort` → `(file_name, span.start)` only;
- the parallel checking paths (`tsz-core/src/parallel/{core/checking.rs,diagnostics.rs}`) → `(start, code)`;
- the CLI driver sinks (`tsz-cli/src/driver/{core.rs,checker_lib_diagnostics.rs}`) → `(file, start, code)` (one site `(file, start, code, message)`).

When two diagnostics tie on the partial key, their relative order fell back to **production order**, which is nondeterministic under parallel checking / hash-map iteration. The partial keys also diverged from tsc's canonical order.

Fix (owning layer = diagnostics):
- Add one canonical `Diagnostic::compare` (+ `compare_skip_related_information`) mirroring tsc's `compareDiagnostics`, on both diagnostic types.
- Route every final-output sort site through it.

This is a class fix, not a fix for the single `diagnostics-34-20` spelling. It is also a parity improvement: tsc emits diagnostics in exactly this order, so aligning tsz's final sort to it can only move tsz toward tsc, never away.

## Project Corpus Impact
- Row: `type-challenges-solutions-project` (diagnostics), shared with `nextjs` / `nextjs-fresh-app` diagnostics rows
- Bug family: nondeterministic diagnostic report order across equivalent relations
- Evidence: new `tsz-common` / `tsz-core` unit tests assert permutation invariance, total-order/antisymmetry, and related-information tiebreaks (`cargo test -p tsz-common -p tsz-core --lib diagnostics`). Ready-for-review CI runs conformance/emit/fourslash to confirm no baseline drift.

## Verification
- `cargo check -p tsz-common -p tsz-core -p tsz-cli` — clean.
- `cargo test -p tsz-common --lib diagnostics` and `cargo test -p tsz-core --lib diagnostics::tests` — pass (incl. 4 new tests).
- `cargo clippy -p tsz-common -p tsz-core --lib` and `cargo clippy -p tsz-cli --lib -- -D warnings` — clean. (Pre-existing `field_reassign_with_default` lints in `check_tests_part1.rs` are untouched by this PR.)
- Branch head == `origin/main` tip at branch time; no merge conflict.

## Coordination Notes
- Behavior-preserving: the existing `dedup_by(start, code)` calls are intentionally left unchanged. They remain regression-free under the finer canonical sort — any same-`(start, code)` group differing in `length`/`message` would already be diverging from tsc today (conformance is at 100%), so such groups are fully equal in practice and stay adjacent under the canonical order. Aligning dedup to tsc's full-equality comparer is noted as a possible follow-up, deliberately out of scope here to keep the change focused.
- Reviewed via 3 simplify passes (4 angles each); converged clean.

https://claude.ai/code/session_01KZdjC17n7wfjaxHsu5tRTh

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZdjC17n7wfjaxHsu5tRTh)_