### PR TITLE
fix(emit): emit class-lowering hoisted temps/inits once across hoist buckets

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -27,6 +27,10 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 
 [[test]]
+name = "class_temp_dedup_hoist_buckets_tests"
+path = "tests/class_temp_dedup_hoist_buckets_tests.rs"
+
+[[test]]
 name = "comment_tests"
 path = "tests/comment_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -1494,6 +1494,10 @@ impl<'a> Printer<'a> {
                 .hoisted_assignment_temps
                 .iter()
                 .any(|name| name == alias)
+            && !self
+                .hoisted_file_level_class_temps
+                .iter()
+                .any(|name| name == alias)
         {
             self.hoisted_assignment_temps.push(alias.clone());
         }
@@ -2886,7 +2890,10 @@ impl<'a> Printer<'a> {
             let instances_ws = self.pending_instances_weakset_add.take();
             let method_defs = std::mem::take(&mut self.pending_private_method_defs);
             let accessor_defs = std::mem::take(&mut self.pending_private_accessor_defs);
-            let weakmap_inits = self.pending_weakmap_inits.clone();
+            // Consume the pending WeakMap inits here so the later post-class
+            // emission path (which re-checks `pending_weakmap_inits`) does not
+            // emit the same `_X = new WeakMap()` lines a second time.
+            let weakmap_inits = std::mem::take(&mut self.pending_weakmap_inits);
             let private_auto_instance_storage_inits: Vec<String> = private_auto_accessors
                 .iter()
                 .filter(|a| !a.is_static)

--- a/crates/tsz-emitter/src/emitter/source_file/emit.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/emit.rs
@@ -2276,8 +2276,24 @@ impl<'a> Printer<'a> {
                 .insert_line_at(hoist_byte_offset, hoist_line, &var_decl);
         }
 
-        if !self.hoisted_file_level_class_temps.is_empty() {
-            let var_decl = format!("var {};", self.hoisted_file_level_class_temps.join(", "));
+        // A class-lowering temp can be reachable from more than one hoist
+        // bucket (e.g. a class alias reserved as a file-level class temp that
+        // is also collected with the private-field var names). Emit each name
+        // in exactly one `var` declaration: a name already declared by the
+        // ref-vars or deferred buckets must not be re-declared here.
+        let file_level_class_temps: Vec<String> = self
+            .hoisted_file_level_class_temps
+            .iter()
+            .filter(|name| {
+                !ref_vars.contains(name)
+                    && !self
+                        .hoisted_deferred_static_class_result_temps
+                        .contains(name)
+            })
+            .cloned()
+            .collect();
+        if !file_level_class_temps.is_empty() {
+            let var_decl = format!("var {};", file_level_class_temps.join(", "));
             self.writer
                 .insert_line_at(hoist_byte_offset, hoist_line, &var_decl);
         }

--- a/crates/tsz-emitter/tests/class_temp_dedup_hoist_buckets_tests.rs
+++ b/crates/tsz-emitter/tests/class_temp_dedup_hoist_buckets_tests.rs
@@ -1,0 +1,160 @@
+//! Regression tests for class-lowering hoisted temp / post-class init
+//! double-emission across hoist buckets and pending-init paths.
+//!
+//! Structural rule: when a class-lowering hoisted temp declaration or a
+//! post-class initialization line (e.g. `_X = new WeakMap()`) is reachable
+//! from more than one emission path, each artifact must be declared/emitted
+//! exactly once across all hoist buckets and pending-init paths.
+//!
+//! Two distinct shapes are covered:
+//!
+//! 1. A private field whose `WeakMap` initializer is reachable from both the
+//!    pre-static-elements private-init path and the post-class init path.
+//!    The `_X = new WeakMap()` line must appear exactly once.
+//!
+//! 2. A class alias temp (`var _a;`) that is reserved as a file-level class
+//!    temp and is also collected with the class's other hoisted temps. The
+//!    `var _a;` declaration must appear exactly once.
+//!
+//! Both shapes hold regardless of the class name, member name, or how many
+//! members exist, so the assertions count occurrences of the structural
+//! artifact rather than matching a fixed fixture string. Each shape is run
+//! under at least two distinct name choices to prove the dedup keys on the
+//! double-emission structure, not on a user-chosen identifier.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::context::emit::EmitContext;
+use tsz_emitter::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use tsz_emitter::lowering::LoweringPass;
+use tsz_parser::parser::ParserState;
+
+fn parse_lower_emit(source: &str, opts: PrinterOptions) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let ctx = EmitContext::with_options(opts.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer = EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, opts);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+fn es2015_esnext() -> PrinterOptions {
+    PrinterOptions {
+        target: ScriptTarget::ES2015,
+        module: ModuleKind::ESNext,
+        ..Default::default()
+    }
+}
+
+fn count_occurrences(haystack: &str, needle: &str) -> usize {
+    haystack.matches(needle).count()
+}
+
+/// A private field referenced from a static block lowers the field into a
+/// `WeakMap`. The `_<Class>_<field> = new WeakMap()` initializer is reachable
+/// from both the pre-static private-init path and the later post-class init
+/// path; it must be emitted exactly once.
+#[test]
+fn private_field_weakmap_init_emitted_once_with_static_block() {
+    let source = r#"
+class Widget {
+    #value: number;
+    constructor(v: number) { this.#value = v; }
+    read() { return this.#value; }
+    static {
+        helper = { get(o: Widget) { return o.#value; } };
+    }
+}
+let helper: { get(o: Widget): number };
+"#;
+    let output = parse_lower_emit(source, es2015_esnext());
+
+    let init_count = count_occurrences(&output, "= new WeakMap()");
+    assert_eq!(
+        init_count, 1,
+        "WeakMap initializer must be emitted exactly once across the \
+         pre-static and post-class init paths.\nOutput:\n{output}"
+    );
+    // The storage temp must also be declared exactly once.
+    let decl_count = count_occurrences(&output, "var _Widget_value;");
+    assert_eq!(
+        decl_count, 1,
+        "Private field storage temp must be declared exactly once.\n\
+         Output:\n{output}"
+    );
+}
+
+/// Same `WeakMap`-init invariant under different class/member names. The dedup
+/// must key on the double-emission structure, not on the spelling of the
+/// class or the private field.
+#[test]
+fn private_field_weakmap_init_emitted_once_under_renamed_members() {
+    let source = r#"
+class Sprocket {
+    #count: number;
+    constructor(n: number) { this.#count = n; }
+    total() { return this.#count; }
+    static {
+        peer = { fetch(o: Sprocket) { return o.#count; } };
+    }
+}
+let peer: { fetch(o: Sprocket): number };
+"#;
+    let output = parse_lower_emit(source, es2015_esnext());
+
+    assert_eq!(
+        count_occurrences(&output, "= new WeakMap()"),
+        1,
+        "WeakMap initializer must be emitted exactly once regardless of \
+         class/member names.\nOutput:\n{output}"
+    );
+    assert_eq!(
+        count_occurrences(&output, "var _Sprocket_count;"),
+        1,
+        "Private field storage temp must be declared exactly once \
+         regardless of names.\nOutput:\n{output}"
+    );
+}
+
+/// A class with a static initializer that references `this` reserves a class
+/// alias temp (`var _a;`). That temp is reachable from the file-level class
+/// temp bucket; it must be declared exactly once.
+#[test]
+fn static_this_class_alias_temp_declared_once() {
+    let source = r#"
+class Gadget {
+    static label = this;
+}
+export {};
+"#;
+    let output = parse_lower_emit(source, es2015_esnext());
+
+    let alias_decls = count_occurrences(&output, "var _a;");
+    assert_eq!(
+        alias_decls, 1,
+        "Class alias temp `var _a;` must be declared exactly once across \
+         hoist buckets.\nOutput:\n{output}"
+    );
+}
+
+/// Same class-alias invariant with a different class name and an additional
+/// static member, proving the dedup is structural rather than fixture-keyed.
+#[test]
+fn static_this_class_alias_temp_declared_once_renamed() {
+    let source = r#"
+class Contraption {
+    static origin = this;
+    static count = 0;
+}
+export {};
+"#;
+    let output = parse_lower_emit(source, es2015_esnext());
+
+    assert_eq!(
+        count_occurrences(&output, "var _a;"),
+        1,
+        "Class alias temp must be declared exactly once regardless of the \
+         class name or extra static members.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — JavaScript emit parity (emit→100% campaign, wave 2a)

## Invariant
When a class-lowering hoisted temp declaration or post-class initialization line
is reachable from more than one emission path, `tsc` emits each artifact exactly
once; this PR makes tsz emit each hoisted temp / `_X = new WeakMap()` init once
across all hoist buckets and pending-init paths rather than duplicating it.

## Scope
- `crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs` — (1) consume
  `pending_weakmap_inits` with `std::mem::take` in the pre-static-elements branch
  so the post-class branch doesn't re-emit; (2) two-bucket membership guard on the
  static-initializer class-alias push; (3) structural dedup at var-emission so a
  file-level-reserved alias already in the ref/deferred buckets isn't re-declared.
- `crates/tsz-emitter/src/emitter/source_file/emit.rs` — bucket dedup support.
- `crates/tsz-emitter/tests/class_temp_dedup_hoist_buckets_tests.rs` (new, 4
  structural tests, names varied) + Cargo.toml registration.

## Project Corpus Impact
- Row: n/a (emit parity fix)
- Bug family: duplicate class-lowering hoisted temps / WeakMap inits
- Evidence: 7 emit tests FAIL→PASS; class family 1452→1458, static 413→431 pass.

## Verification
- Witnesses FAIL→PASS (JS): classNameReferencesInStaticElements, classStaticBlock17,
  errorSuperCalls, javascriptThisAssignmentInStaticBlock,
  thisInArrowFunctionInStaticInitializer1, typeOfThisInStaticMembers2,
  typeOfThisInStaticMembers6.
- Regression families vs clean baseline (zero regressions): class 1452→1458,
  static 413→431, privateName 140→140, WeakMap 2→2, decorator 637→637 (net +24).
- `cargo nextest run -p tsz-emitter`: 32→31 failures (also fixed pre-existing
  `class_static_alias_tests::es2015_static_async_arrow_declares_class_alias_once`),
  zero new. New tests 4/4. `cargo clippy ... -D warnings` clean.

## Coordination Notes
Wave-2a fix #3 of the emit→100% campaign. — opus48-emit100
