### PR TITLE
fix(dts): preserve infer/intersection parens in type-display + re-escape template text

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/tests/infer_paren_and_union_intersection.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/infer_paren_and_union_intersection.rs
@@ -1,0 +1,146 @@
+//! Declaration-emit parenthesization regression tests:
+//!
+//! * source-parenthesized `infer` operands in conditional types,
+//! * intersection members nested inside a union,
+//! * template-literal type text re-escaping.
+//!
+//! Each fix is exercised with at least two distinct bound-variable name
+//! choices so the test fails if any fix were keyed on a specific identifier
+//! spelling rather than the structural shape.
+
+use super::*;
+
+// ---------------------------------------------------------------------------
+// Fix A: a source-parenthesized `infer X` *check* operand of a conditional
+// keeps its parens, because the conditional's own `extends` keyword would
+// otherwise be reabsorbed as the infer type-parameter's constraint clause.
+// This holds whether or not the infer already carries its own constraint.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn check_operand_parenthesized_infer_keeps_parens_no_constraint() {
+    // `(infer A) extends infer B ? ...` must not collapse to
+    // `infer A extends infer B ? ...`.
+    let output = emit_dts("export type T<X> = (infer A) extends infer B ? infer C : infer D;");
+    assert!(
+        output.contains("(infer A) extends infer B ?"),
+        "parenthesized infer check operand must keep parens: {output}"
+    );
+}
+
+#[test]
+fn check_operand_parenthesized_infer_keeps_parens_renamed() {
+    // Same rule, different iteration-variable spelling: proves the fix is
+    // not keyed on the name `A`.
+    let output = emit_dts("export type T<X> = (infer Z9) extends infer Q ? infer R : infer S;");
+    assert!(
+        output.contains("(infer Z9) extends infer Q ?"),
+        "parenthesized infer check operand must keep parens (renamed): {output}"
+    );
+}
+
+#[test]
+fn nested_check_operand_parenthesized_infer_keeps_parens() {
+    // The inner conditional sits in the outer conditional's extends position;
+    // its own `(infer U)` check operand must still be parenthesized.
+    let output =
+        emit_dts("export type T<X> = X extends ((infer U) extends number ? 1 : 0) ? 1 : 0;");
+    assert!(
+        output.contains("(infer U) extends number ?"),
+        "nested parenthesized infer check operand must keep parens: {output}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fix A: a source-parenthesized `infer U extends C` *extends* operand keeps
+// its parens, but a bare `(infer U)` extends operand (no constraint) drops
+// the redundant parens.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn extends_operand_parenthesized_infer_with_constraint_keeps_parens() {
+    let output =
+        emit_dts("export type T<X> = X extends (infer U extends number) ? [X, U] : never;");
+    assert!(
+        output.contains("(infer U extends number) ?"),
+        "constrained infer extends operand must keep parens: {output}"
+    );
+}
+
+#[test]
+fn extends_operand_parenthesized_infer_with_constraint_keeps_parens_renamed() {
+    // Renamed iteration variable proves the rule is structural.
+    let output =
+        emit_dts("export type T<X> = X extends (infer Vee extends string) ? [X, Vee] : never;");
+    assert!(
+        output.contains("(infer Vee extends string) ?"),
+        "constrained infer extends operand must keep parens (renamed): {output}"
+    );
+}
+
+#[test]
+fn extends_operand_parenthesized_infer_without_constraint_drops_redundant_parens() {
+    // Negative/fallback case: a bare `(infer U)` extends operand has no
+    // constraint clause to capture the conditional's tokens, so tsc drops
+    // the redundant parens.
+    let output = emit_dts("export type T<X> = X extends (infer U) ? [X, U] : never;");
+    assert!(
+        output.contains("extends infer U ?") && !output.contains("(infer U) ?"),
+        "bare infer extends operand should drop redundant parens: {output}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fix B(a): an intersection member nested in a union is parenthesized so the
+// grouping round-trips (`A & B | C` => `(A & B) | C`).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn intersection_member_in_union_is_parenthesized() {
+    let output = emit_dts("export declare function f(x: \"a\" | (string & {})): void;");
+    assert!(
+        output.contains("\"a\" | (string & {})"),
+        "intersection member in union must be parenthesized: {output}"
+    );
+}
+
+#[test]
+fn intersection_member_in_union_is_parenthesized_other_shape() {
+    // A different member ordering and a non-empty intersection arm proves the
+    // rule is about the intersection shape, not the literal `string & {}`.
+    let output = emit_dts("export type U = number | (boolean & { tag: 1 });");
+    assert!(
+        output.contains("(boolean & {"),
+        "intersection member in union must be parenthesized (other shape): {output}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fix B(b): template-literal type text spans are re-escaped for the
+// backtick-delimited context (control chars become escape sequences again).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn template_literal_type_text_is_reescaped() {
+    let output = emit_dts("export type T = `${string}:\\t${number}\\r\\n`;");
+    assert!(
+        output.contains("`${string}:\\t${number}\\r\\n`"),
+        "template-literal text must re-escape control chars: {output:?}"
+    );
+    // The cooked tab/newline must not leak through verbatim.
+    assert!(
+        !output.contains('\t'),
+        "template-literal text must not emit a literal tab: {output:?}"
+    );
+}
+
+#[test]
+fn template_literal_type_text_reescapes_backtick_and_dollar_brace() {
+    // A backtick and a `${` in the literal text must be escaped so the text
+    // does not prematurely close the template or start a substitution.
+    let output = emit_dts("export type T = `a\\`b\\${c}d${string}`;");
+    assert!(
+        output.contains("a\\`b\\${c}d"),
+        "backtick and ${{ in template text must be escaped: {output:?}"
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/tests/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/mod.rs
@@ -298,6 +298,7 @@ mod export_specifiers;
 mod fix_verification;
 mod fix_verification_returned;
 mod generics_and_ambient;
+mod infer_paren_and_union_intersection;
 mod js_define_property;
 mod js_expando_features;
 mod jsdoc_template_defaults;

--- a/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
@@ -52,6 +52,20 @@ impl<'a> DeclarationEmitter<'a> {
         }
     }
 
+    /// Whether an `INFER_TYPE` node carries a non-empty type-parameter
+    /// constraint slot (e.g. `infer U extends string`). The constraint is
+    /// detected structurally via the infer type-parameter's `constraint`
+    /// slot, never by matching the type-parameter name.
+    fn infer_type_has_constraint(&self, infer_idx: NodeIndex) -> bool {
+        self.arena
+            .get(infer_idx)
+            .filter(|node| node.kind == syntax_kind_ext::INFER_TYPE)
+            .and_then(|node| self.arena.get_infer_type(node))
+            .and_then(|infer| self.arena.get(infer.type_parameter))
+            .and_then(|tp_node| self.arena.get_type_parameter(tp_node))
+            .is_some_and(|tp| tp.constraint.is_some())
+    }
+
     pub(crate) fn emit_type(&mut self, type_idx: NodeIndex) {
         let Some(type_node) = self.arena.get(type_idx) else {
             return;
@@ -182,6 +196,12 @@ impl<'a> DeclarationEmitter<'a> {
                             n.kind == syntax_kind_ext::FUNCTION_TYPE
                                 || n.kind == syntax_kind_ext::CONSTRUCTOR_TYPE
                                 || n.kind == syntax_kind_ext::CONDITIONAL_TYPE
+                                // An intersection member of a union is
+                                // parenthesized so the grouping round-trips
+                                // unambiguously: `string & {} | T` reads as
+                                // `(string & {}) | T`. Mirrors the intersection
+                                // arm, which parenthesizes nested unions.
+                                || n.kind == syntax_kind_ext::INTERSECTION_TYPE
                         });
                         if needs_parens {
                             self.write("(");
@@ -669,6 +689,17 @@ impl<'a> DeclarationEmitter<'a> {
                             || node.kind == syntax_kind_ext::INTERSECTION_TYPE
                             || (check_source_was_parenthesized
                                 && node.kind == syntax_kind_ext::MAPPED_TYPE)
+                            // A source-parenthesized `infer X` check operand
+                            // must keep its parens: the conditional's own
+                            // `extends` keyword immediately follows, so without
+                            // parens it is reabsorbed as the infer
+                            // type-parameter's constraint clause and changes
+                            // meaning (e.g. `(infer A) extends infer B ? C : D`
+                            // would reparse as `infer A extends infer B`). This
+                            // applies whether or not the infer already carries
+                            // its own source constraint.
+                            || (check_source_was_parenthesized
+                                && node.kind == syntax_kind_ext::INFER_TYPE)
                     });
 
                     if check_needs_parens {
@@ -694,6 +725,16 @@ impl<'a> DeclarationEmitter<'a> {
                                 && (node.kind == syntax_kind_ext::FUNCTION_TYPE
                                     || node.kind == syntax_kind_ext::CONSTRUCTOR_TYPE
                                     || node.kind == syntax_kind_ext::MAPPED_TYPE))
+                            // A source-parenthesized `infer U extends C` extends
+                            // operand keeps its parens: tsc preserves the source
+                            // grouping (e.g.
+                            // `T extends (infer U extends number) ? X : Y`
+                            // stays parenthesized). Gate on the infer carrying
+                            // its own constraint so a bare `(infer U)` extends
+                            // operand still drops its redundant parens.
+                            || (extends_source_was_parenthesized
+                                && node.kind == syntax_kind_ext::INFER_TYPE
+                                && self.infer_type_has_constraint(extends_inner))
                     });
 
                     if extends_needs_parens {

--- a/crates/tsz-emitter/src/emitter/types/printer/type_printing.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/type_printing.rs
@@ -19,6 +19,31 @@ mod type_printing_composites;
 #[path = "type_printing_references.rs"]
 mod type_printing_references;
 
+/// Re-escape a cooked template-literal text span so it can be placed back
+/// inside backtick delimiters. The solver stores the cooked value (e.g. a
+/// real tab/newline for `\t`/`\n`), so this converts the characters that are
+/// significant in a backtick-delimited context back into escape sequences,
+/// analogous to `escape_string_for_double_quote` for double-quoted strings.
+fn escape_text_for_backtick(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 4);
+    let mut chars = s.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '`' => out.push_str("\\`"),
+            // Escape the `$` of a `${` sequence so it is not re-read as the
+            // start of a substitution when the text round-trips.
+            '$' if chars.peek() == Some(&'{') => out.push_str("\\$"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\0' => out.push_str("\\0"),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
 impl<'a> TypePrinter<'a> {
     pub(crate) fn property_is_hidden_in_declaration_shape(
         &self,
@@ -1063,7 +1088,12 @@ impl<'a> TypePrinter<'a> {
         for span in spans.iter() {
             match span {
                 tsz_solver::types::TemplateSpan::Text(atom) => {
-                    result.push_str(&self.resolve_atom(*atom));
+                    // Resolved atoms hold the *cooked* text span, so control
+                    // characters and template-significant characters (`` ` ``,
+                    // `\`, `${`) must be re-escaped for the backtick-delimited
+                    // context — otherwise a cooked `\t`/`\r\n` would be written
+                    // as a literal tab/newline.
+                    result.push_str(&escape_text_for_backtick(&self.resolve_atom(*atom)));
                 }
                 tsz_solver::types::TemplateSpan::Type(type_id) => {
                     let printed = self.print_type(*type_id);

--- a/crates/tsz-emitter/src/emitter/types/printer/type_printing_composites.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/type_printing_composites.rs
@@ -99,8 +99,13 @@ impl<'a> TypePrinter<'a> {
             // Parenthesize function/constructor types and conditional types in union position.
             // Conditional types need parens because `extends` binds more tightly than `|`:
             // `A | B extends C ? D : E` parses as `(A | B) extends C ? D : E`.
+            // Intersection members need parens so the grouping round-trips
+            // unambiguously: an intersection nested in a union (`A & B | C`)
+            // must render as `(A & B) | C`. Mirrors `print_intersection`,
+            // which parenthesizes nested unions.
             let part = if self.type_needs_parentheses_in_composition(type_id)
                 || visitor::conditional_type_id(self.interner, type_id).is_some()
+                || visitor::intersection_list_id(self.interner, type_id).is_some()
             {
                 format!("({s})")
             } else {


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — declaration emit parity (emit→100% campaign, wave 2a)

## Invariant
(A) A source-parenthesized `infer` operand in a conditional type keeps its parens
where dropping them would let the conditional's `extends`/branch tokens be
reabsorbed on reparse. (B) A composite type-display member binding more loosely
than its enclosing operator (intersection nested in a union) must be
parenthesized, and template-literal text spans must be re-escaped for their
backtick-delimiter context. This PR makes tsz match `tsc` on both.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/type_emission.rs` — check-type
  infer keeps parens (conditional `extends` follows); extends-type infer keeps
  parens only when it carries a constraint slot; new structural
  `infer_type_has_constraint` (reads the constraint slot, no name match). Also
  intersection-in-union parens on the AST union arm.
- `crates/tsz-emitter/src/emitter/types/printer/type_printing_composites.rs` —
  intersection-member parenthesization in structural `print_union`.
- `crates/tsz-emitter/src/emitter/types/printer/type_printing.rs` — new
  `escape_text_for_backtick` for `TemplateSpan::Text` atoms.
- `crates/tsz-emitter/src/declaration_emitter/tests/` — 10 structural unit tests
  (names varied, includes a bare-`(infer U)` paren-drop negative case).

## Project Corpus Impact
- Row: n/a (declaration emit parity)
- Bug family: DTS infer/union/intersection parenthesization + template re-escape
- Evidence: inferTypes1, inferTypesWithExtends1, templateLiteralTypes2,
  templateLiteralsInTypes all FAIL→PASS.

## Verification
- Witnesses FAIL→PASS (DTS): all 4 above.
- Regression families vs clean baseline (zero regressions): conditional 17/0,
  infer 33→35 pass (+2 witnesses; 4 remaining pre-existing, separate bugs),
  templateLiteral 4→6 pass (+2), union 13/0, intersection 3/0.
- 10 unit tests pass; `cargo clippy -p tsz-emitter --all-targets -- -D warnings` clean.

## Coordination Notes
Wave-2a fixes #1+#2 of the emit→100% campaign. Disjoint from #11667
(class-temp dedup). — opus48-emit100
