### PR TITLE
fix(emit): unify generated private-element helper naming in class lowering

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -39,6 +39,10 @@ name = "enum_metadata_number_tests"
 path = "tests/enum_metadata_number_tests.rs"
 
 [[test]]
+name = "private_element_naming_tests"
+path = "tests/private_element_naming_tests.rs"
+
+[[test]]
 name = "comment_tests"
 path = "tests/comment_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -807,6 +807,17 @@ pub struct Printer<'a> {
     /// `__classPrivateFieldGet`/`__classPrivateFieldSet` helper calls.
     pub(crate) private_field_weakmaps: FxHashMap<String, String>,
 
+    /// File-wide uniquing set for generated private-element helper names.
+    /// Every generated private-helper variable name (WeakMap/WeakSet storage,
+    /// method/accessor function vars, class-identity prefixes) across all classes
+    /// in the same enclosing lexical scope is accumulated here so nested classes
+    /// that reuse a class name (`class A { #foo; constructor() { class A { #foo } } }`)
+    /// receive `_N`-suffixed helper names instead of colliding. Seeded once from
+    /// `collect_enclosing_source_binding_names`; kept and extended across sibling
+    /// classes; snapshot/restored around nested-class emission like
+    /// `private_field_weakmaps`.
+    pub(crate) generated_private_names: Option<FxHashSet<String>>,
+
     /// Private member kind info for ES2015-ES2021 lowering.
     /// Maps `field_name` (without `#`) → `PrivateMemberKind`.
     /// Used to determine the correct kind argument ("f", "m", "a") and

--- a/crates/tsz-emitter/src/emitter/core_setup.rs
+++ b/crates/tsz-emitter/src/emitter/core_setup.rs
@@ -379,6 +379,7 @@ impl<'a> Printer<'a> {
             prior_enum_string_members: FxHashMap::default(),
             prior_enum_string_values: FxHashMap::default(),
             private_field_weakmaps: FxHashMap::default(),
+            generated_private_names: None,
             private_member_info: FxHashMap::default(),
             pending_weakmap_inits: Vec::new(),
             pending_static_private_inits: Vec::new(),
@@ -753,6 +754,9 @@ impl<'a> Printer<'a> {
                 || file_name.ends_with(".mjs")
                 || file_name.ends_with(".cjs");
             self.set_current_root_js_source(is_js_source);
+            // The generated private-helper name set is file-scoped: reset it so a
+            // reused printer re-seeds from this file's enclosing source bindings.
+            self.generated_private_names = None;
         }
 
         if let Some(source) = self.arena.get_source_file(node)

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -606,8 +606,15 @@ impl<'a> Printer<'a> {
         // Private field lowering: when target < ES2022, transform #fields to WeakMap pattern
         let needs_private_field_lowering = !self.ctx.options.target.supports_es2022()
             && self.ctx.options.target != ScriptTarget::ESNext;
+        // Generated private-helper names are uniquified against a single file-wide
+        // set so nested or sibling classes that reuse a class name receive
+        // `_N`-suffixed helpers instead of colliding (matches tsc's per-file name
+        // generator). Seed once from the enclosing source bindings, then keep the
+        // accumulated set on the emitter and reuse it for every later class.
         let mut used_private_names = if needs_private_field_lowering {
-            collect_enclosing_source_binding_names(self.arena, _idx)
+            self.generated_private_names
+                .take()
+                .unwrap_or_else(|| collect_enclosing_source_binding_names(self.arena, _idx))
         } else {
             rustc_hash::FxHashSet::default()
         };
@@ -677,6 +684,13 @@ impl<'a> Printer<'a> {
         } else {
             None
         };
+
+        // Publish the accumulated generated-name set back onto the emitter so any
+        // nested classes emitted while printing this class body (and later sibling
+        // classes) uniquify their private helpers against the names allocated here.
+        if needs_private_field_lowering {
+            self.generated_private_names = Some(std::mem::take(&mut used_private_names));
+        }
 
         let target_needs_static_block_lowering =
             (self.ctx.options.target as u32) < (ScriptTarget::ES2022 as u32);
@@ -1897,6 +1911,13 @@ impl<'a> Printer<'a> {
                 self.write_line();
                 self.increase_indent();
             }
+            // Temps allocated while emitting field initializers in this synthesized
+            // constructor body (e.g. a class-expression lowered inside a private-field
+            // initializer needing `_a`) must be declared in this constructor's scope,
+            // not leak to the enclosing function/file hoist list. Push a body temp
+            // scope and capture the insertion anchor for the `var` line.
+            self.push_temp_scope();
+            let synth_ctor_hoist_anchor = self.capture_hoist_anchor();
             // Emit _X_instances.add(this) for private methods/accessors
             if let Some(ref ws_name) = self.pending_instances_weakset_add.clone() {
                 self.write(ws_name);
@@ -2026,6 +2047,26 @@ impl<'a> Printer<'a> {
                 }
                 self.write_line();
             }
+            // Insert any temps hoisted while emitting field initializers (e.g.
+            // `_a` for a class expression lowered inside a private-field init) at
+            // the top of this synthesized constructor body, then drop the scope.
+            if !self.hoisted_assignment_temps.is_empty() {
+                let indent = self
+                    .writer
+                    .indent_string_at(synth_ctor_hoist_anchor.indent_level);
+                let var_decl = format!(
+                    "{}var {};",
+                    indent,
+                    self.hoisted_assignment_temps.join(", ")
+                );
+                self.writer.insert_line_at(
+                    synth_ctor_hoist_anchor.byte_offset,
+                    synth_ctor_hoist_anchor.line_no,
+                    &var_decl,
+                );
+                self.hoisted_assignment_temps.clear();
+            }
+            self.pop_temp_scope();
             self.decrease_indent();
             self.write("}");
             self.write_line();

--- a/crates/tsz-emitter/tests/private_element_naming_tests.rs
+++ b/crates/tsz-emitter/tests/private_element_naming_tests.rs
@@ -1,0 +1,195 @@
+//! Regression tests for generated private-element helper naming in ES2015+
+//! class lowering.
+//!
+//! Structural rules covered:
+//!
+//! 1. File-wide uniquing of generated private-helper names. When a nested
+//!    class reuses the enclosing class's name, its private-helper variable
+//!    (`_<Class>_<field>`) collides with the outer class's helper and must be
+//!    uniquified with an `_N` suffix. The uniquing set is accumulated across
+//!    every class in the same lexical scope rather than reset per class.
+//!
+//! 2. Class-expression temp scope inside a private-field initializer. When a
+//!    private field's initializer is a class expression that lowers to a
+//!    comma expression needing a temp (`_a`), and the enclosing class has no
+//!    explicit constructor (so one is synthesized), that temp must be declared
+//!    in the synthesized constructor body (`var _a;`) and must not leak to the
+//!    enclosing function/file hoist list.
+//!
+//! Both rules hold regardless of the class name, the private member name, or
+//! the iteration/binding variable spelling, so each shape is exercised under
+//! at least two distinct name choices. The assertions key on the structural
+//! artifact (uniquified suffix, in-constructor `var` declaration), not on a
+//! fixed fixture string.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::context::emit::EmitContext;
+use tsz_emitter::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use tsz_emitter::lowering::LoweringPass;
+use tsz_parser::parser::ParserState;
+
+fn parse_lower_emit(source: &str, opts: PrinterOptions) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let ctx = EmitContext::with_options(opts.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer = EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, opts);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+fn es2015_esnext() -> PrinterOptions {
+    PrinterOptions {
+        target: ScriptTarget::ES2015,
+        module: ModuleKind::ESNext,
+        ..Default::default()
+    }
+}
+
+fn count_occurrences(haystack: &str, needle: &str) -> usize {
+    haystack.matches(needle).count()
+}
+
+// ---------------------------------------------------------------------------
+// Rule 1: file-wide uniquing of generated private-helper names.
+// ---------------------------------------------------------------------------
+
+/// An inner class that shadows the outer class name has its private-field
+/// helper uniquified against the outer class's helper. With the outer `#foo`
+/// taking `_A_foo`, the inner (same-named) class's `#foo` must become
+/// `_A_foo_1`.
+#[test]
+fn nested_same_named_class_uniquifies_private_helper() {
+    let source = r#"
+class A {
+    #foo: string;
+    constructor() {
+        class A {
+            #foo: string;
+        }
+    }
+}
+"#;
+    let output = parse_lower_emit(source, es2015_esnext());
+
+    assert_eq!(
+        count_occurrences(&output, "_A_foo_1"),
+        // Inner helper appears in: var decl, `.set(this, ...)`, `= new WeakMap()`.
+        3,
+        "Inner same-named class must uniquify its private helper to _A_foo_1.\nOutput:\n{output}"
+    );
+    // The plain `_A_foo` (outer) must never be assigned twice as a fresh
+    // `new WeakMap()`; the inner one is uniquified.
+    assert_eq!(
+        count_occurrences(&output, "_A_foo = new WeakMap()"),
+        1,
+        "Outer helper keeps the un-suffixed name exactly once.\nOutput:\n{output}"
+    );
+    assert_eq!(
+        count_occurrences(&output, "_A_foo_1 = new WeakMap()"),
+        1,
+        "Inner helper takes the suffixed name exactly once.\nOutput:\n{output}"
+    );
+}
+
+/// Same rule, different class/member spelling: the uniquing keys on the
+/// structural collision, not on the identifiers `A`/`foo`.
+#[test]
+fn nested_same_named_class_uniquifies_private_helper_renamed() {
+    let source = r#"
+class Box {
+    #data: string;
+    constructor() {
+        class Box {
+            #data: string;
+        }
+    }
+}
+"#;
+    let output = parse_lower_emit(source, es2015_esnext());
+
+    assert_eq!(
+        count_occurrences(&output, "_Box_data_1 = new WeakMap()"),
+        1,
+        "Inner same-named class must uniquify regardless of names.\nOutput:\n{output}"
+    );
+    assert_eq!(
+        count_occurrences(&output, "_Box_data = new WeakMap()"),
+        1,
+        "Outer helper keeps the un-suffixed name regardless of names.\nOutput:\n{output}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Rule 2: class-expression temp scope inside a private-field initializer of a
+// class with a synthesized constructor.
+// ---------------------------------------------------------------------------
+
+/// A private field initialized with a class expression that lowers to a comma
+/// form needing a temp: the temp is declared inside the synthesized
+/// constructor body, not hoisted to module scope.
+#[test]
+fn class_expression_private_init_temp_stays_in_synthesized_constructor() {
+    let source = r#"
+class Outer {
+    #inner = class {
+        static tag = 1;
+    };
+}
+"#;
+    let output = parse_lower_emit(source, es2015_esnext());
+
+    // The temp must be declared as `var _a;` inside the constructor body, not
+    // appended to the module-level `var _Outer_inner, _a;` line.
+    let ctor_pos = output
+        .find("constructor()")
+        .expect("synthesized constructor should be emitted");
+    let after_ctor = &output[ctor_pos..];
+    assert!(
+        after_ctor.contains("var _a;"),
+        "Class-expression temp must be declared inside the synthesized \
+         constructor body.\nOutput:\n{output}"
+    );
+    // It must not leak onto the module-level WeakMap declaration line.
+    assert!(
+        !output.contains("_Outer_inner, _a"),
+        "Class-expression temp must not leak to the module-level hoist \
+         list.\nOutput:\n{output}"
+    );
+}
+
+/// Same temp-scope rule with two private fields each holding a class
+/// expression, and different class/member spelling. Both temps stay inside the
+/// constructor body.
+#[test]
+fn class_expression_private_init_temps_renamed_two_fields() {
+    let source = r#"
+class Container {
+    #first = class {
+        static a = 1;
+    };
+    #second = class Named {
+        static b = 2;
+    };
+}
+"#;
+    let output = parse_lower_emit(source, es2015_esnext());
+
+    let ctor_pos = output
+        .find("constructor()")
+        .expect("synthesized constructor should be emitted");
+    let after_ctor = &output[ctor_pos..];
+    assert!(
+        after_ctor.contains("var _a, _b;"),
+        "Both class-expression temps must be declared inside the synthesized \
+         constructor body regardless of names.\nOutput:\n{output}"
+    );
+    // The module-level declaration should only carry the WeakMap helpers, not
+    // the in-constructor temps.
+    assert!(
+        !output.contains("_Container_first, _Container_second, _a"),
+        "Class-expression temps must not leak to module scope regardless of \
+         names.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — JavaScript emit parity (emit→100% campaign, wave 2a). STACKED on #11667.

## Invariant
When lowering private class members to WeakMap/method helpers, every generated
helper name and nested-class lowering temp derives from a single file-wide
uniquing set and the synthesized-constructor temp scope; this PR makes tsz
uniquify private-helper names against already-allocated names (nested class
reusing an outer name) and declare class-expression lowering temps inside the
synthesized constructor rather than leaking them to module scope.

## Scope
- `crates/tsz-emitter/src/emitter/core.rs` + `core_setup.rs` — `generated_private_names`
  file-wide uniquing set (seeded from enclosing bindings, reset per source file).
- `crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs` — wire the set
  through private-element emission; synthesized-constructor temp scope + hoist anchor.
- `crates/tsz-emitter/tests/private_element_naming_tests.rs` (new, 4 structural tests) + Cargo.toml.

## Project Corpus Impact
- Row: n/a (emit parity fix)
- Bug family: generated private-element helper naming / nested-class temp scope
- Evidence: privateNameNestedClassNameConflict, privateNameFieldClassExpression FAIL→PASS.

## Verification
- Witnesses FAIL→PASS (JS): privateNameNestedClassNameConflict, privateNameFieldClassExpression.
- Regression families vs pre-edit baseline (zero regressions): privateName 140→142,
  class 1458→1460, privateField 7→7, static 431→431, decorator 637→637; field/constructor/
  accessor/mixin/nested probed — zero new. Unit suite: zero new failures; +4 tests. clippy clean.
- Scope note: this is the clean subset of a larger private-name bundle; 11 sibling
  witnesses are distinct sub-bugs (static/instance _N suffix dual-path, anonymous-class
  prefix + __setFunctionName ordering, static-alias new-receiver rewrite, parse-recovery)
  left for targeted follow-ups; the file-wide uniquing-set infra here unblocks them.

## Coordination Notes
Wave-2a fix #4 (partial, clean). Stacked on #11667 (shares emit_es6.rs); base will
auto-rebase to main when #11667 merges. — opus48-emit100
