### PR TITLE
fix(checker): surface leaf relation for same-base generic property mismatches

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -264,13 +264,14 @@ impl<'a> CheckerState<'a> {
                     source_property_type,
                     target_property_type,
                 );
-                let nested_plain_mismatch_from_application = self
-                    .should_render_nested_application_property_mismatch(source, target)
-                    && Self::nested_reason_is_plain_type_mismatch(nested);
-                if !nested_plain_mismatch_from_application
-                    && !self
-                        .nested_reason_reuses_enclosing_application_source(nested_source, source)
-                {
+                // Same-base generic application property mismatches still surface
+                // the leaf relation (e.g. `Type 'number' is not assignable to type
+                // 'string'.`) beneath the `Types of property 'p' are incompatible.`
+                // elaboration, matching tsc. The only chain tsc collapses here is a
+                // nested failure that would re-display the enclosing application
+                // itself (recursive same-base reuse, e.g. `Deep<T>.next`), which the
+                // reuse guard below continues to suppress.
+                if !self.nested_reason_reuses_enclosing_application_source(nested_source, source) {
                     let nested_diag = self.render_failure_reason(
                         nested,
                         nested_source,

--- a/crates/tsz-checker/tests/generic_property_mismatch_display_tests.rs
+++ b/crates/tsz-checker/tests/generic_property_mismatch_display_tests.rs
@@ -179,7 +179,7 @@ targetBox = emptyBox;
 }
 
 #[test]
-fn generic_primitive_property_mismatch_keeps_property_path_when_nested_source_is_unstable() {
+fn generic_primitive_property_mismatch_surfaces_leaf_relation() {
     let diagnostic = ts2322_diagnostic(
         r#"
 interface Box<T> { value: T; }
@@ -199,14 +199,101 @@ stringBox = numberBox;
     );
     assert!(
         has_related(&diagnostic, "Types of property 'value' are incompatible."),
-        "expected fallback property-path message, got {diagnostic:#?}"
+        "expected property-path elaboration, got {diagnostic:#?}"
     );
+    // tsc surfaces the leaf relation beneath the property-path elaboration even
+    // when both sides are instantiations of the same generic base.
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type 'number' is not assignable to type 'string'."
+        ),
+        "expected leaf relation under generic property mismatch, got {diagnostic:#?}"
+    );
+    // The leaf must use the property types, never the enclosing application.
     assert!(
         !has_related(
             &diagnostic,
             "Type 'Box<number>' is not assignable to type 'string'."
         ),
-        "must not render malformed nested primitive reason, got {diagnostic:#?}"
+        "must not render the enclosing application as the leaf source, got {diagnostic:#?}"
+    );
+}
+
+#[test]
+fn generic_primitive_property_mismatch_leaf_is_type_parameter_name_independent() {
+    // The same leaf must appear regardless of the type-parameter spelling.
+    for type_param in ["T", "K", "Value"] {
+        let source = format!(
+            "interface Box<{type_param}> {{ value: {type_param}; }}\n\
+             declare let numberBox: Box<number>;\n\
+             declare let stringBox: Box<string>;\n\
+             stringBox = numberBox;\n"
+        );
+        let diagnostic = ts2322_diagnostic(&source);
+        assert!(
+            has_related(&diagnostic, "Types of property 'value' are incompatible."),
+            "expected property-path elaboration for param {type_param}, got {diagnostic:#?}"
+        );
+        assert!(
+            has_related(
+                &diagnostic,
+                "Type 'number' is not assignable to type 'string'."
+            ),
+            "expected leaf relation for param {type_param}, got {diagnostic:#?}"
+        );
+    }
+}
+
+#[test]
+fn generic_mapped_property_mismatch_surfaces_leaf_relation() {
+    let diagnostic = ts2322_diagnostic(
+        r#"
+type Wrap<T> = { [K in keyof T]: T[K] };
+
+declare let source: Wrap<{ a: number }>;
+declare let target: Wrap<{ a: string }>;
+
+target = source;
+"#,
+    );
+
+    assert!(
+        has_related(&diagnostic, "Types of property 'a' are incompatible."),
+        "expected property-path elaboration for mapped wrapper, got {diagnostic:#?}"
+    );
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type 'number' is not assignable to type 'string'."
+        ),
+        "expected leaf relation under mapped property mismatch, got {diagnostic:#?}"
+    );
+}
+
+#[test]
+fn generic_multi_argument_property_mismatch_surfaces_leaf_relation() {
+    let diagnostic = ts2322_diagnostic(
+        r#"
+interface Pair<A, B> { a: A; b: B; }
+
+declare let source: Pair<number, number>;
+declare let target: Pair<string, number>;
+
+target = source;
+"#,
+    );
+
+    assert!(
+        has_related(&diagnostic, "Types of property 'a' are incompatible."),
+        "expected property-path elaboration for multi-arg generic, got {diagnostic:#?}"
+    );
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type 'number' is not assignable to type 'string'."
+        ),
+        "expected leaf relation under multi-arg generic property mismatch, got {diagnostic:#?}"
     );
 }
 


### PR DESCRIPTION
AgentName: remote-opus-4-8

## Summary

Closes #11591.

When both sides of a `TS2322` property mismatch are instantiations of the **same generic base** (`Box<number>` vs `Box<string>`, interface or alias, mapped or plain, any arity), tsc elaborates the full chain down to the leaf relation:

```
Type 'Box<number>' is not assignable to type 'Box<string>'.
  Types of property 'value' are incompatible.
    Type 'number' is not assignable to type 'string'.   <- leaf
```

tsz dropped the leaf, stopping at `Types of property 'value' are incompatible.` — exactly the "diagnostic chain hides root relation mismatch" defect in #11591.

### Structural rule

> When a property-type mismatch arises between two instantiations of the same generic/application base and the property failure is a plain relation mismatch, tsc still elaborates the leaf relation beneath the `Types of property 'p' are incompatible.` line; this change makes tsz emit that leaf too.

The rule is keyed on the **failure-reason shape**, never on an identifier/type-parameter spelling.

### Root cause

`render_property_type_mismatch` (checker `error_reporter/render_failure/nested_application_property_mismatch.rs`) carried an obsolete suppression `nested_plain_mismatch_from_application`: when source/target shared a generic base **and** the nested failure was a plain `TypeMismatch`, it skipped the nested leaf. That workaround dated to an era when the leaf rendered with the *enclosing application* as its source (a malformed `Type 'Box<number>' is not assignable to type 'string'.`). The type plumbing has since been corrected — the leaf now renders with the correct property types (`number`/`string`) — so the suppression only hid a leaf tsc always shows.

### Fix

Remove the `nested_plain_mismatch_from_application` suppression. Keep the `nested_reason_reuses_enclosing_application_source` guard, which still collapses genuinely recursive same-base chains (e.g. `Deep<T>.next`). Net effect: a heuristic special-case is replaced by the precise structural guard that was already present.

## Track
Diagnostics / TS2322 elaboration parity.

## Invariant
TS2322 property-mismatch elaboration matches tsc's message chain. The compatibility gateway and relation outcomes are unchanged — this PR only changes how an existing failure reason is rendered into related-information.

## Scope
- `crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs` — remove the obsolete leaf suppression.
- `crates/tsz-checker/tests/generic_property_mismatch_display_tests.rs` — update the test that previously locked in the dropped leaf; add coverage for the broad class.

**Out of scope (sibling class, follow-up):** array/tuple element mismatches (`number[]` vs `string[]`) also omit their element leaf, but those use the `ArrayElementMismatch` / `TupleElementTypeMismatch` reason variants (no `nested_reason`) and a different render branch. Tuple elaboration is already being addressed in #11657; arrays remain a documented follow-up.

## Adjacent-case test matrix
- Reported repro (mapped wrapper): `generic_mapped_property_mismatch_surfaces_leaf_relation`.
- Generic alias / interface primitive: `generic_primitive_property_mismatch_surfaces_leaf_relation`.
- Type-parameter name independence (`T`/`K`/`Value`): `generic_primitive_property_mismatch_leaf_is_type_parameter_name_independent`.
- Multi-argument generic: `generic_multi_argument_property_mismatch_surfaces_leaf_relation`.
- Negative/recursive guard: existing recursive same-base reuse (`Deep<T>.next`) remains collapsed; `generic_*_flattens_to_missing_member` (missing-property nested reasons) unchanged.

## Project Corpus Impact
- Row: nextjs (issue #11591); same family also appears in vite-vanilla-ts-app, type-challenges-solutions-project, and nextjs-fresh-app diagnostic rows.
- Bug family: diagnostic chain hides root relation mismatch for same-base generic/mapped property mismatches.
- Evidence: minimal repro reproduced with the local `tsz` CLI and via checker unit tests (related-information dumps) showing the leaf dropped pre-fix and present post-fix.

## Verification
- `cargo test -p tsz-checker --test generic_property_mismatch_display_tests` → 11 passed.
- Ran adjacent elaboration suites (`ts2322_tests`, `ts2322_literal_source_display_tests`, `ts2322_pair_disambiguation_widening_tests`, `contextual_ts2345_conformance_tests`, `mapped_type_errors_conformance_tests`, `generic_conflicting_argument_type_display_tests`, `generator_annotation_mismatch_display_tests`, `abstract_constructor_elaboration_tests`, `interface_heritage_display_tests`, `intersection_primitive_member_assignability_tests`) → all green except two `ts2322_tests` cases (`mapped_application_generic_indexed_call_preserves_key_correlation` and its renamed twin) that fail **only locally** because the TypeScript lib submodule is not checked out (`load_lib_files_for_test()` returns empty); they are pre-existing in this local setup and unrelated to this change.
- `cargo clippy -p tsz-checker --tests` → clean.
- **Conformance-safe:** the conformance harness parses only primary diagnostic lines (`file(line,col): error TSxxxx: msg`) via regex; indented elaboration-chain continuation lines are never compared, so adding related-information leaves cannot move conformance.

## Coordination Notes
- Pre-existing local-only failures noted above are a missing-lib artifact, not a regression.
- Sibling tuple/array element-leaf work is tracked separately (#11657 for tuples).
- `/simplify` reviewed (reuse / simplification / efficiency / altitude) — no changes needed; both helper methods remain in use, tests are semantically distinct, and the altitude is correct (special-case removed in favor of the existing structural guard).