### PR TITLE
fix(checker): resolve source files before declarations for extensionless imports

### DIFF
--- a/crates/tsz-checker/src/module_resolution.rs
+++ b/crates/tsz-checker/src/module_resolution.rs
@@ -45,14 +45,58 @@ use tsz_parser::parser::node::NodeArena;
 // Extension tables
 // ---------------------------------------------------------------------------
 
-/// TypeScript/JavaScript file extensions in resolution priority order.
+/// TypeScript/JavaScript file extensions in *stripping* order.
 ///
-/// `.d.ts` (and friends) must appear before `.ts` so that stripping does not
-/// leave a `.d` artifact in the stem.
+/// `.d.ts` (and friends) must appear before `.ts` so that stripping peels the
+/// whole `.d.ts` suffix instead of leaving a `.d` artifact in the stem. This
+/// ordering is correct for [`strip_ts_extension`] but is **not** the order in
+/// which resolution candidates should be tried — use [`RESOLUTION_EXTENSIONS`]
+/// for that.
 const TS_EXTENSIONS: &[&str] = &[
     ".d.ts", ".d.tsx", ".d.mts", ".d.cts", ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs",
     ".cjs",
 ];
+
+/// File extensions in `tsc` resolution-candidate priority order, mirroring
+/// TypeScript's `getSupportedExtensions`: an implementation (source) file wins
+/// over its declaration counterpart (`.ts` before `.d.ts`, `.mts` before
+/// `.d.mts`, `.cts` before `.d.cts`), `.ts`/`.tsx` precede `.cts`/`.mts`, and
+/// every TypeScript surface precedes its JavaScript counterpart. So `./foo`
+/// resolves to a `foo.ts` source ahead of a sibling `foo.d.ts`, exactly as
+/// `tsc` does. The same order is used by `tsz_core::module_resolver` and by the
+/// triple-slash directive resolver in `state_checking::directive`.
+///
+/// This is intentionally distinct from [`TS_EXTENSIONS`], which is ordered
+/// declaration-first purely so suffix *stripping* works. There is no real
+/// `.d.tsx` file in TypeScript, so it is absent here.
+const RESOLUTION_EXTENSIONS: &[&str] = &[
+    ".ts", ".tsx", ".d.ts", ".cts", ".d.cts", ".mts", ".d.mts", ".js", ".jsx", ".cjs", ".mjs",
+];
+
+/// `tsc` resolution priority of a concrete file path: the position of its
+/// extension in [`RESOLUTION_EXTENSIONS`], where a lower value means higher
+/// priority. The file's actual extension is detected by longest suffix match
+/// (so `foo.d.ts` is ranked as `.d.ts`, never mistaken for `.ts`). Paths with
+/// an unrecognized extension sort last. Used to break extensionless-stem ties
+/// so the highest-priority sibling (source over declaration) wins, matching
+/// `tsc`.
+fn resolution_priority(path: &str) -> usize {
+    // Single pass: the longest matching suffix is the file's real extension
+    // (so `foo.d.ts` ranks as `.d.ts`, not `.ts`), and its index in
+    // `RESOLUTION_EXTENSIONS` is its priority.
+    RESOLUTION_EXTENSIONS
+        .iter()
+        .enumerate()
+        .filter(|(_, ext)| path.ends_with(**ext))
+        .max_by_key(|(_, ext)| ext.len())
+        .map_or(RESOLUTION_EXTENSIONS.len(), |(index, _)| index)
+}
+
+/// `tsc` resolution priority of an indexed target, by its file extension.
+/// Target paths originate from `String`s, so `to_str` never fails in practice.
+fn target_resolution_priority(target: &IndexedTarget<'_>) -> usize {
+    resolution_priority(target.abs_path.to_str().unwrap_or_default())
+}
 
 /// Tails that mark a file as an *arbitrary-extension declaration file*: a file
 /// named `<base>.d.<ext>.ts` where `<ext>` is itself a known TS/JS/JSON
@@ -451,23 +495,49 @@ pub fn resolve_from_source(
 
     let src_dir = Path::new(source_file).parent()?;
 
+    // File matches win over directory-index matches, and within each bucket the
+    // highest `tsc` resolution priority (source before declaration) wins when
+    // several siblings share one extensionless stem. An exact extension-bearing
+    // or arbitrary-extension spelling is unambiguous (only the named file
+    // produces it), so it short-circuits immediately.
+    let mut best_file: Option<(usize, usize)> = None;
+    let mut best_dir: Option<(usize, usize)> = None;
     for target in &index.targets {
-        if let Some(rel) = relative_file_specifier(src_dir, target.abs_path)
-            && (rel.stem == specifier.text
-                || rel.with_extension.as_deref() == Some(specifier.text.as_str())
-                || rel.user_alt.as_deref() == Some(specifier.text.as_str()))
-        {
-            return Some(target.tgt_idx);
+        if let Some(rel) = relative_file_specifier(src_dir, target.abs_path) {
+            if rel.with_extension.as_deref() == Some(specifier.text.as_str())
+                || rel.user_alt.as_deref() == Some(specifier.text.as_str())
+            {
+                return Some(target.tgt_idx);
+            }
+            if rel.stem == specifier.text {
+                keep_higher_priority(&mut best_file, target);
+                continue;
+            }
         }
         if let Some(idx_dir) = target.index_dir
             && let Some(dir) = directory_specifier(src_dir, idx_dir)
             && (dir.primary == specifier.text
                 || dir.alt.as_deref() == Some(specifier.text.as_str()))
         {
-            return Some(target.tgt_idx);
+            keep_higher_priority(&mut best_dir, target);
         }
     }
-    None
+    best_file.or(best_dir).map(|(_, tgt_idx)| tgt_idx)
+}
+
+/// Update `best` to hold `target` when it has a strictly higher `tsc`
+/// resolution priority (lower [`resolution_priority`] value) than the current
+/// winner, leaving earlier equal-priority entries in place for determinism.
+/// `best` tracks `(priority, tgt_idx)`.
+fn keep_higher_priority(best: &mut Option<(usize, usize)>, target: &IndexedTarget<'_>) {
+    let priority = target_resolution_priority(target);
+    let replace = match best {
+        Some((current, _)) => priority < *current,
+        None => true,
+    };
+    if replace {
+        *best = Some((priority, target.tgt_idx));
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -498,11 +568,23 @@ pub fn build_module_resolution_maps(
 
     let index = build_target_index(file_names);
 
+    // Register targets lowest-`tsc`-priority first so that, when several
+    // siblings share one extensionless stem (`foo.ts` + `foo.d.ts`), the
+    // higher-priority implementation file is registered last and wins the
+    // `insert` overwrite — matching tsc's source-before-declaration order.
+    // Unambiguous forms (extension-bearing specifiers, distinct stems) occupy
+    // distinct keys, so the reordering does not affect them. The sort is
+    // stable, so equal-priority siblings keep their original file order.
+    let mut ordered: Vec<&IndexedTarget<'_>> = index.targets.iter().collect();
+    // `sort_by_cached_key` computes each target's priority once rather than the
+    // O(n log n) times a plain `sort_by_key` closure would.
+    ordered.sort_by_cached_key(|target| std::cmp::Reverse(target_resolution_priority(target)));
+
     for (src_idx, src_name) in file_names.iter().enumerate() {
         let Some(src_dir) = Path::new(src_name.as_str()).parent() else {
             continue;
         };
-        for target in &index.targets {
+        for &target in &ordered {
             register_canonical_forms(src_idx, src_dir, target, &mut map, &mut modules);
         }
     }
@@ -918,7 +1000,7 @@ pub fn resolve_specifier_via_file_index(
     // specifiers. A trailing slash (`./foo/`) or dot-chain (`.`, `./`) signals
     // that the user explicitly wants the directory index, not a same-name file.
     if !is_directory_hint {
-        for ext in TS_EXTENSIONS {
+        for ext in RESOLUTION_EXTENSIONS {
             buf.clear();
             buf.push_str(stem);
             buf.push_str(ext);
@@ -941,7 +1023,7 @@ pub fn resolve_specifier_via_file_index(
     // probe the stem, not `base`, to also cover `./lib.ts` → `./lib/index.ts`
     // (unusual, but cheap and symmetric with the extension fan-out).
     if !stem.is_empty() {
-        for ext in TS_EXTENSIONS {
+        for ext in RESOLUTION_EXTENSIONS {
             buf.clear();
             buf.push_str(stem);
             buf.push_str("/index");
@@ -977,7 +1059,7 @@ pub fn probe_file_name_index(specifier: &str, filename_idx: &FileNameIndex) -> O
 
     let stem = strip_ts_extension(&spec_norm);
     let mut buf = String::with_capacity(stem.len() + 8);
-    for ext in TS_EXTENSIONS {
+    for ext in RESOLUTION_EXTENSIONS {
         buf.clear();
         buf.push_str(stem);
         buf.push_str(ext);
@@ -994,7 +1076,7 @@ pub fn probe_file_name_index(specifier: &str, filename_idx: &FileNameIndex) -> O
     }
 
     if !stem.is_empty() {
-        for ext in TS_EXTENSIONS {
+        for ext in RESOLUTION_EXTENSIONS {
             buf.clear();
             buf.push_str(stem);
             buf.push_str("/index");

--- a/crates/tsz-checker/tests/module_resolution.rs
+++ b/crates/tsz-checker/tests/module_resolution.rs
@@ -1485,3 +1485,156 @@ fn test_non_directory_hint_still_uses_extension_fan_out() {
         "'./a' (no slash) must resolve to a/a.ts via extension fan-out",
     );
 }
+
+// ---------------------------------------------------------------------------
+// Extension resolution priority: source before declaration (tsc parity)
+//
+// Regression guard for #11572 (and the #11633 / #11476 family). For an
+// extensionless / stem-form import, tsc resolves the implementation (source)
+// sibling ahead of its declaration counterpart (`.ts` before `.d.ts`, `.tsx`
+// before declaration, `.mts` before `.d.mts`, …). The fan-out and the
+// driver-side resolution map must agree on that order regardless of the file
+// order they happen to see.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_resolution_priority_ranks_source_before_declaration() {
+    // `.d.ts` must be detected as a declaration, never mistaken for `.ts`.
+    assert!(resolution_priority("foo.ts") < resolution_priority("foo.d.ts"));
+    assert!(resolution_priority("foo.tsx") < resolution_priority("foo.d.ts"));
+    assert!(resolution_priority("foo.mts") < resolution_priority("foo.d.mts"));
+    assert!(resolution_priority("foo.cts") < resolution_priority("foo.d.cts"));
+    // TypeScript surfaces outrank JavaScript ones.
+    assert!(resolution_priority("foo.ts") < resolution_priority("foo.js"));
+    assert!(resolution_priority("foo.d.ts") < resolution_priority("foo.js"));
+    // Unknown extensions sort last.
+    assert_eq!(
+        resolution_priority("foo.unknown"),
+        RESOLUTION_EXTENSIONS.len()
+    );
+}
+
+#[test]
+fn test_fan_out_extension_priority_variants() {
+    // Each row places the declaration sibling *before* the source so a
+    // declaration-first fan-out would (wrongly) win; the source must still be
+    // chosen. The final row is the negative/fallback case: with only a
+    // declaration present, the fan-out reorders candidates but never drops it.
+    let cases: &[(&[&str], &str, usize, &str)] = &[
+        (
+            &["/proj/main.ts", "/proj/types.d.ts", "/proj/types.ts"],
+            "./types",
+            2,
+            "extensionless ./types → source types.ts",
+        ),
+        (
+            &["/proj/main.ts", "/proj/widget.d.ts", "/proj/widget.tsx"],
+            "./widget",
+            2,
+            "./widget → source widget.tsx (not the `.ts` spelling)",
+        ),
+        (
+            &["/proj/main.ts", "/proj/esm.d.mts", "/proj/esm.mts"],
+            "./esm",
+            2,
+            "./esm → source esm.mts",
+        ),
+        (
+            &[
+                "/proj/main.ts",
+                "/proj/lib/index.d.ts",
+                "/proj/lib/index.ts",
+            ],
+            "./lib",
+            2,
+            "directory index ./lib → lib/index.ts",
+        ),
+        (
+            &["/proj/main.ts", "/proj/only.d.ts"],
+            "./only",
+            1,
+            "declaration-only ./only still resolves to only.d.ts",
+        ),
+    ];
+    for (files, specifier, expected, label) in cases {
+        let idx = file_index_from(files);
+        assert_eq!(
+            resolve_specifier_via_file_index("/proj/main.ts", specifier, &idx),
+            Some(*expected),
+            "{label}",
+        );
+    }
+}
+
+#[test]
+fn test_probe_file_name_index_prefers_source_over_declaration() {
+    // Project-relative bare path (`probe_file_name_index` path) obeys the same
+    // rule. File order is reversed here to prove order-independence.
+    let files = ["pkg/src/types.ts", "pkg/src/types.d.ts"];
+    let idx = file_index_from(&files);
+    assert_eq!(
+        probe_file_name_index("pkg/src/types", &idx),
+        Some(0),
+        "pkg/src/types must resolve to the source .ts regardless of file order",
+    );
+}
+
+#[test]
+fn test_resolution_map_prefers_source_over_declaration_independent_of_order() {
+    // Driver-side map (`build_module_resolution_maps`, used by the CLI and
+    // server). The extensionless stem `./types` must map to the source file in
+    // BOTH file orderings — a fixture-order-only fix would pass one and fail
+    // the other.
+    for (files, source_idx) in [
+        (
+            vec![
+                "/proj/main.ts".to_string(),
+                "/proj/types.d.ts".to_string(),
+                "/proj/types.ts".to_string(),
+            ],
+            2usize,
+        ),
+        (
+            vec![
+                "/proj/main.ts".to_string(),
+                "/proj/types.ts".to_string(),
+                "/proj/types.d.ts".to_string(),
+            ],
+            1usize,
+        ),
+    ] {
+        let (paths, _modules) = build_module_resolution_maps(&files);
+        assert_eq!(
+            paths.get(&(0, "./types".to_string())),
+            Some(&source_idx),
+            "./types must map to the source sibling for files {files:?}",
+        );
+        // Explicit spellings stay unambiguous and addressable.
+        assert!(paths.contains_key(&(0, "./types.d.ts".to_string())));
+        assert!(paths.contains_key(&(0, "./types.ts".to_string())));
+    }
+}
+
+#[test]
+fn test_resolve_from_source_prefers_source_over_declaration() {
+    // The `TargetIndex`-based resolver mirrors the same priority rule.
+    let files = vec![
+        "/proj/src/main.ts".to_string(),
+        "/proj/src/api.d.ts".to_string(),
+        "/proj/src/api.ts".to_string(),
+    ];
+    let index = build_target_index(&files);
+    let spec = normalize_import_specifier("./api").unwrap();
+    assert_eq!(
+        resolve_from_source("/proj/src/main.ts", &spec, &index),
+        Some(2),
+        "./api must resolve to source api.ts, not api.d.ts",
+    );
+    // Explicit declaration spelling still selects the declaration file.
+    let dts_spec = normalize_import_specifier("./api.d.ts").unwrap();
+    assert_eq!(
+        resolve_from_source("/proj/src/main.ts", &dts_spec, &index),
+        Some(1),
+        "./api.d.ts must still resolve to the declaration file",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-eager-pascal

## Track
Module resolution / `tsc` parity — extensionless import extension priority.

## Invariant
When several project files share one extensionless stem (e.g. `foo.ts` and `foo.d.ts`), `tsc`'s `getSupportedExtensions` resolves an extensionless/stem-form import to the **implementation (source)** sibling ahead of its **declaration** counterpart (`.ts` > `.d.ts`, `.tsx` > decl, `.mts` > `.d.mts`, `.cts` > `.d.cts`), with `.ts`/`.tsx` before `.cts`/`.mts`; this PR makes tsz apply that exact order through the `tsz-checker::module_resolution` layer instead of a declaration-first / file-order-dependent choice.

## Scope
Fixes #11572 and the same root cause behind the rest of the family (#11633 vite-vanilla, #11476 nextjs-fresh).

Root cause: `crates/tsz-checker/src/module_resolution.rs` reused **one** `TS_EXTENSIONS` list for two conflicting purposes. Its declaration-first order (`.d.ts` before `.ts`) is *required* for suffix stripping (`strip_ts_extension` must peel `.d.ts` as a unit), but the same list was also used as the **resolution-candidate priority** in the extensionless fan-out (`resolve_specifier_via_file_index`, `probe_file_name_index`), where first-match wins. So `./foo` resolved a sibling `foo.d.ts` ahead of the `foo.ts` source, diverging from `tsc`. The order-dependent collision also lived in `build_module_resolution_maps` (live in the CLI and `tsz_server` drivers), where the map `insert` overwrites and the winner depended on file order.

Fix (owning layer = `tsz-checker::module_resolution`):
- Add a dedicated `RESOLUTION_EXTENSIONS` priority list (source-first), separate from the stripping-ordered `TS_EXTENSIONS`. The order mirrors what `tsz_core::module_resolver` and the `state_checking::directive` triple-slash resolver already use.
- Route the four fan-out loops through it.
- Tie-break the two stem-collision sites (`build_module_resolution_maps`, the test-only `resolve_from_source`) by the same priority via a shared `resolution_priority` / `target_resolution_priority` helper.

This is a class fix, not a fixture-name patch: it reorders candidates by structural extension priority, never by a specific spelling. It only reorders candidates — it never drops them, so a declaration-only stem (`only.d.ts` with no `only.ts`) still resolves.

## Project Corpus Impact
- Row: `nextjs` (module resolution), shared with `vite-vanilla-ts-app` (#11633) and `nextjs-fresh-app` (#11476) module-resolution rows.
- Bug family: module-resolution extension priority diverges for extensionless imports/aliases.
- Evidence: new `tsz-checker` unit tests assert source-over-declaration for `.ts`/`.tsx`/`.mts`, directory-index, declaration-only fallback, and **file-order independence** across both live paths (`resolve_specifier_via_file_index`, `probe_file_name_index`, `build_module_resolution_maps`) plus `resolve_from_source` (`cargo test -p tsz-checker --lib module_resolution`). Ready-for-review CI runs conformance/emit/fourslash to confirm no baseline drift.

## Verification
- `cargo test -p tsz-checker --lib module_resolution` — 108 passed, 0 failed (incl. the new priority/fan-out/order-independence tests).
- `cargo clippy -p tsz-checker --tests` — clean.
- `cargo fmt -p tsz-checker` — applied.
- Broader resolution-area run (`-- import module resolution duplicate_identifiers`): 562 passed; the only 6 failures (3 `architecture_contract_tests_src::*`, `dynamic_import_defer`, `imported_generator_iterable`, `zod_type_query_regression`) reproduce **identically on clean `main`** (they need embedded-libs/fixtures absent in a minimal local build) and are unrelated to this change — verified by `git stash` + re-run.
- Branch was at `origin/main` tip at branch time; no merge conflict.

## Coordination Notes
- `TS_EXTENSIONS` is now used **only** for stripping; `RESOLUTION_EXTENSIONS` owns resolution priority. There is no real `.d.tsx` file in TypeScript, so it is intentionally absent from the resolution list.
- Full cross-crate unification of the three extension-order lists (`tsz_core::module_resolver`, `directive`, here) is deliberately out of scope to keep this change focused; the lists already agree on source-first order and the new comment documents that.
- Reviewed via 3 `/simplify` rounds (reuse / simplification / efficiency / altitude); converged — collapsed `resolution_priority` to a single scan, removed per-target allocations, made the fan-out tests table-driven, and switched the driver sort to `sort_by_cached_key`.

https://claude.ai/code/session_01KRT57rgCrKLDEUYd9P92EK

---
_Generated by [Claude Code](https://claude.ai/code/session_01KRT57rgCrKLDEUYd9P92EK)_