### PR TITLE
fix(emit): int32 enum shift folding + enum-typed decorator metadata Number

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -31,6 +31,14 @@ name = "class_temp_dedup_hoist_buckets_tests"
 path = "tests/class_temp_dedup_hoist_buckets_tests.rs"
 
 [[test]]
+name = "enum_int32_shift_fold_tests"
+path = "tests/enum_int32_shift_fold_tests.rs"
+
+[[test]]
+name = "enum_metadata_number_tests"
+path = "tests/enum_metadata_number_tests.rs"
+
+[[test]]
 name = "comment_tests"
 path = "tests/comment_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/declarations/class/decorators.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/decorators.rs
@@ -614,6 +614,17 @@ impl<'a> Printer<'a> {
             return "Object".to_string();
         };
 
+        // A type reference whose root name resolves to a numeric enum
+        // declaration serializes to `Number`, matching tsc. This covers a bare
+        // enum reference (`E`) and a qualified enum-member reference (`E.A`),
+        // and — via the union serializer's "all members agree" rule — unions of
+        // numeric-enum members (`E.B | E.C`) and `E | number`.
+        if !type_param_names.iter().any(|tp| tp == root)
+            && self.metadata_reference_is_numeric_enum(&parts)
+        {
+            return "Number".to_string();
+        }
+
         if parts.len() == 1 {
             return self.serialize_identifier_type_reference_for_metadata(root, &type_param_names);
         }
@@ -674,6 +685,107 @@ impl<'a> Printer<'a> {
 
         let name = self.get_identifier_text_idx(idx);
         (!name.is_empty()).then_some(vec![name])
+    }
+
+    /// Resolve the metadata entity name `parts` to a declared enum and report
+    /// whether that enum is homogeneously numeric (no string-valued member).
+    ///
+    /// `parts` is the dotted entity name of a `design:type` type reference,
+    /// e.g. `["E"]` for `E` or `["E", "A"]` for the enum-member reference
+    /// `E.A`. The enum is identified by the *declaration* segment of the path
+    /// (the bare name, or the leading segment for an `Enum.Member` reference),
+    /// resolved against enum declarations in the same source file so we do not
+    /// depend on type-parameter names or the printed form of the type.
+    fn metadata_reference_is_numeric_enum(&self, parts: &[String]) -> bool {
+        let Some(enum_name) = parts.first() else {
+            return false;
+        };
+        // For a longer path (`Ns.E`, `E.Member`) try the enum-declaration name
+        // candidates: the leading segment and the segment just before the last.
+        // This recognizes both `E` (bare) and `E.A` (member) without assuming a
+        // specific namespace layout.
+        let mut candidates: Vec<&str> = vec![enum_name.as_str()];
+        if parts.len() >= 2 {
+            candidates.push(parts[parts.len() - 2].as_str());
+        }
+        candidates
+            .iter()
+            .any(|name| self.is_declared_numeric_enum(name))
+    }
+
+    /// True when the source file declares an enum named `name` and every member
+    /// is numeric (no string/template-valued initializer). A const enum counts
+    /// the same as a regular numeric enum for metadata purposes.
+    fn is_declared_numeric_enum(&self, name: &str) -> bool {
+        if name.is_empty() {
+            return false;
+        }
+        let mut found = false;
+        for node in &self.arena.nodes {
+            if node.kind != syntax_kind_ext::ENUM_DECLARATION {
+                continue;
+            }
+            let Some(enum_data) = self.arena.get_enum(node) else {
+                continue;
+            };
+            if self.get_identifier_text_idx(enum_data.name) != name {
+                continue;
+            }
+            found = true;
+            for &member_idx in &enum_data.members.nodes {
+                let Some(member_node) = self.arena.get(member_idx) else {
+                    continue;
+                };
+                let Some(member) = self.arena.get_enum_member(member_node) else {
+                    continue;
+                };
+                if member.initializer.is_some()
+                    && self.metadata_enum_initializer_is_string(member.initializer)
+                {
+                    return false;
+                }
+            }
+        }
+        found
+    }
+
+    /// Syntactic string-initializer test for an enum member, mirroring the
+    /// string-vs-numeric split used by the ES5 enum transform: string/template
+    /// literals and `"x" + ...` concatenations are string members; everything
+    /// else (numeric literals, bitwise/arithmetic expressions, member refs) is
+    /// treated as numeric.
+    fn metadata_enum_initializer_is_string(&self, idx: NodeIndex) -> bool {
+        let Some(node) = self.arena.get(idx) else {
+            return false;
+        };
+        match node.kind {
+            k if k == SyntaxKind::StringLiteral as u16 => true,
+            k if k == SyntaxKind::NoSubstitutionTemplateLiteral as u16 => true,
+            k if k == syntax_kind_ext::TEMPLATE_EXPRESSION => true,
+            k if k == syntax_kind_ext::PARENTHESIZED_EXPRESSION => self
+                .arena
+                .get_parenthesized(node)
+                .is_some_and(|p| self.metadata_enum_initializer_is_string(p.expression)),
+            k if k == syntax_kind_ext::AS_EXPRESSION
+                || k == syntax_kind_ext::TYPE_ASSERTION
+                || k == syntax_kind_ext::SATISFIES_EXPRESSION =>
+            {
+                self.arena
+                    .get_type_assertion(node)
+                    .is_some_and(|a| self.metadata_enum_initializer_is_string(a.expression))
+            }
+            k if k == syntax_kind_ext::NON_NULL_EXPRESSION => self
+                .arena
+                .get_unary_expr_ex(node)
+                .is_some_and(|u| self.metadata_enum_initializer_is_string(u.expression)),
+            k if k == syntax_kind_ext::BINARY_EXPRESSION => {
+                self.arena.get_binary_expr(node).is_some_and(|bin| {
+                    bin.operator_token == SyntaxKind::PlusToken as u16
+                        && self.metadata_enum_initializer_is_string(bin.left)
+                })
+            }
+            _ => false,
+        }
     }
 
     fn metadata_entity_expression_parts(&self, parts: &[String]) -> Vec<String> {

--- a/crates/tsz-emitter/src/transforms/enum_es5.rs
+++ b/crates/tsz-emitter/src/transforms/enum_es5.rs
@@ -1377,7 +1377,16 @@ impl<'a> EnumES5Transformer<'a> {
         match node.kind {
             k if k == SyntaxKind::NumericLiteral as u16 => {
                 let lit = self.arena.get_literal(node)?;
-                lit.text.parse().ok()
+                // Parse hex/binary/octal/separator forms (e.g. `0xFF_FF_FF_FF`)
+                // via the shared numeric parser, falling back to a plain decimal
+                // integer parse. Only fold to an integer when the parsed value is
+                // an exact, in-range integer (float members use the float path).
+                lit.text.parse::<i64>().ok().or_else(|| {
+                    tsz_common::numeric::parse_numeric_literal_value(&lit.text).and_then(|v| {
+                        (v.is_finite() && v == v.trunc() && v.abs() < 9_007_199_254_740_992.0)
+                            .then_some(v as i64)
+                    })
+                })
             }
             k if k == SyntaxKind::Identifier as u16 => {
                 // Resolve references to previously evaluated enum members
@@ -1491,18 +1500,30 @@ impl<'a> EnumES5Transformer<'a> {
                     o if o == SyntaxKind::AsteriskToken as u16 => left.checked_mul(right),
                     o if o == SyntaxKind::SlashToken as u16 => (right != 0).then(|| left / right),
                     o if o == SyntaxKind::PercentToken as u16 => (right != 0).then(|| left % right),
+                    // Bitwise shifts use ECMAScript int32 semantics: the left
+                    // operand is coerced to i32, the shift count is the low 5
+                    // bits of the right operand, and `<<`/`>>` sign-extend while
+                    // `>>>` is an unsigned (zero-fill) shift. Mirrors the masking
+                    // in `enums/evaluator.rs` and `const_enum_eval.rs`.
                     o if o == SyntaxKind::LessThanLessThanToken as u16 => {
-                        Some(left.wrapping_shl(right as u32))
+                        Some(i64::from((left as i32).wrapping_shl(right as u32 & 0x1f)))
                     }
                     o if o == SyntaxKind::GreaterThanGreaterThanToken as u16 => {
-                        Some(left.wrapping_shr(right as u32))
+                        Some(i64::from((left as i32).wrapping_shr(right as u32 & 0x1f)))
                     }
                     o if o == SyntaxKind::GreaterThanGreaterThanGreaterThanToken as u16 => {
-                        Some((left as u64).wrapping_shr(right as u32) as i64)
+                        Some(i64::from((left as u32).wrapping_shr(right as u32 & 0x1f)))
                     }
-                    o if o == SyntaxKind::AmpersandToken as u16 => Some(left & right),
-                    o if o == SyntaxKind::BarToken as u16 => Some(left | right),
-                    o if o == SyntaxKind::CaretToken as u16 => Some(left ^ right),
+                    // Bitwise and/or/xor also operate on int32 in ECMAScript.
+                    o if o == SyntaxKind::AmpersandToken as u16 => {
+                        Some(i64::from(left as i32 & right as i32))
+                    }
+                    o if o == SyntaxKind::BarToken as u16 => {
+                        Some(i64::from(left as i32 | right as i32))
+                    }
+                    o if o == SyntaxKind::CaretToken as u16 => {
+                        Some(i64::from(left as i32 ^ right as i32))
+                    }
                     _ => None,
                 }
             }
@@ -1512,7 +1533,8 @@ impl<'a> EnumES5Transformer<'a> {
                 let op = unary.operator;
                 match op {
                     o if o == SyntaxKind::MinusToken as u16 => Some(operand.checked_neg()?),
-                    o if o == SyntaxKind::TildeToken as u16 => Some(!operand),
+                    // Bitwise NOT operates on int32 in ECMAScript.
+                    o if o == SyntaxKind::TildeToken as u16 => Some(i64::from(!(operand as i32))),
                     o if o == SyntaxKind::ExclamationToken as u16 => Some(i64::from(operand == 0)),
                     o if o == SyntaxKind::PlusToken as u16 => Some(operand),
                     _ => None,

--- a/crates/tsz-emitter/tests/enum_int32_shift_fold_tests.rs
+++ b/crates/tsz-emitter/tests/enum_int32_shift_fold_tests.rs
@@ -1,0 +1,131 @@
+//! Constant folding of bitwise operators in numeric enum initializers must use
+//! ECMAScript int32 semantics.
+//!
+//! Structural rule: when a numeric enum member initializer is a constant
+//! bitwise expression (`<<`, `>>`, `>>>`, `&`, `|`, `^`, `~`), tsc coerces the
+//! operands to int32, masks the shift count to its low 5 bits, sign-extends for
+//! `<<`/`>>`, and zero-fills for `>>>`. Numeric literals (including hex/binary
+//! /octal forms and digit separators) are parsed to their integer value first.
+//! This change makes tsz fold the same values rather than performing a raw i64
+//! shift on the source spelling.
+//!
+//! Tests vary member names, bases, and shift counts so they pin the int32 rule
+//! rather than a single rendered fingerprint.
+
+use tsz_common::common::ScriptTarget;
+use tsz_emitter::context::emit::EmitContext;
+use tsz_emitter::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use tsz_emitter::lowering::LoweringPass;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+fn parse_lower_emit(source: &str, opts: PrinterOptions) -> String {
+    let (parser, root) = test_support::parse_source(source);
+    let ctx = EmitContext::with_options(opts.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer = EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, opts);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+fn emit_es2015(source: &str) -> String {
+    parse_lower_emit(
+        source,
+        PrinterOptions {
+            target: ScriptTarget::ES2015,
+            ..Default::default()
+        },
+    )
+}
+
+fn assert_member(output: &str, enum_name: &str, member: &str, value: &str) {
+    let needle = format!(r#"{enum_name}[{enum_name}["{member}"] = {value}] = "{member}";"#);
+    assert!(
+        output.contains(&needle),
+        "expected `{needle}` in output.\nOutput:\n{output}"
+    );
+}
+
+/// Left-shift folding masks the shift count to 5 bits and sign-extends the i32
+/// result. `1 << 32` masks to `1 << 0` = 1; `1 << -1` masks to `1 << 31`, which
+/// as a signed int32 is the minimum value.
+#[test]
+fn left_shift_masks_count_and_sign_extends() {
+    let output = emit_es2015(
+        r#"
+enum Shl {
+    A = 1 << 1,
+    B = 1 << 32,
+    C = 1 << 123,
+    E = 1 << -1,
+    G = 1 << -123,
+}
+"#,
+    );
+    assert_member(&output, "Shl", "A", "2");
+    assert_member(&output, "Shl", "B", "1");
+    assert_member(&output, "Shl", "C", "134217728");
+    assert_member(&output, "Shl", "E", "-2147483648");
+    assert_member(&output, "Shl", "G", "32");
+}
+
+/// A signed right shift coerces the left operand to int32 first, so a literal
+/// whose value exceeds i32 range (`0xFFFFFFFF` = all bits set) is treated as
+/// `-1`. Renaming the member or the enum does not change the folded value.
+#[test]
+fn signed_right_shift_uses_int32_left_operand() {
+    let output = emit_es2015(
+        r#"
+enum Sar {
+    First = 0xFF_FF_FF_FF >> 1,
+    Second = 0xFFFFFFFF >> 32,
+    Third = 0xFFFFFFFF >> -1,
+}
+"#,
+    );
+    // `-1 >> n` is `-1` for every masked count.
+    assert_member(&output, "Sar", "First", "-1");
+    assert_member(&output, "Sar", "Second", "-1");
+    assert_member(&output, "Sar", "Third", "-1");
+}
+
+/// An unsigned right shift coerces the left operand to a u32, so `0xFFFFFFFF`
+/// (parsed from a digit-separated hex literal) behaves as `4294967295`.
+#[test]
+fn unsigned_right_shift_is_zero_fill() {
+    let output = emit_es2015(
+        r#"
+enum Shr {
+    Lo = 0xFF_FF_FF_FF >>> 1,
+    Zero = 0xFFFFFFFF >>> 32,
+    Hi = 0xFFFFFFFF >>> 123,
+}
+"#,
+    );
+    assert_member(&output, "Shr", "Lo", "2147483647");
+    assert_member(&output, "Shr", "Zero", "4294967295");
+    assert_member(&output, "Shr", "Hi", "31");
+}
+
+/// Hex/binary/octal numeric literals (and separators) parse to their integer
+/// value before folding, and bitwise AND/OR/XOR operate on int32 operands.
+#[test]
+fn radix_literals_parse_and_bitwise_ops_are_int32() {
+    let output = emit_es2015(
+        r#"
+enum Bits {
+    Hex = 0xFF & 0x0F,
+    Bin = 0b1010 | 0b0101,
+    Xor = 0xFFFFFFFF ^ 0,
+    Sep = 1_000_000 + 1,
+}
+"#,
+    );
+    assert_member(&output, "Bits", "Hex", "15");
+    assert_member(&output, "Bits", "Bin", "15");
+    // `0xFFFFFFFF ^ 0` coerces to int32 -> -1.
+    assert_member(&output, "Bits", "Xor", "-1");
+    assert_member(&output, "Bits", "Sep", "1000001");
+}

--- a/crates/tsz-emitter/tests/enum_metadata_number_tests.rs
+++ b/crates/tsz-emitter/tests/enum_metadata_number_tests.rs
@@ -1,0 +1,116 @@
+//! `design:type` decorator metadata for a property whose type refers to a
+//! numeric enum serializes to `Number`.
+//!
+//! Structural rule: when a metadata type reference (a bare identifier, a
+//! qualified enum-member reference, or a union of such) resolves to a
+//! homogeneously numeric enum declaration, tsc serializes the design type as
+//! `Number`. This change makes tsz do the same by resolving the reference's
+//! declaration to an enum and confirming no member has a string initializer,
+//! rather than emitting the enum's own name. The "all members agree" rule in
+//! the union serializer then folds `E.B | E.C` and `E | number` to `Number`.
+//!
+//! Tests vary the enum and member names so they pin the structural rule rather
+//! than a single spelling.
+
+use tsz_common::ScriptTarget;
+use tsz_emitter::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use tsz_parser::ParserState;
+
+fn emit_source(source: &str, options: PrinterOptions) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut printer = EmitterPrinter::with_options(&parser.arena, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+fn legacy_metadata_options() -> PrinterOptions {
+    PrinterOptions {
+        legacy_decorators: true,
+        emit_decorator_metadata: true,
+        target: ScriptTarget::ES2015,
+        ..Default::default()
+    }
+}
+
+fn assert_metadata(output: &str, member: &str, serialized: &str) {
+    let needle = format!("__metadata(\"design:type\", {serialized})\n], D.prototype, \"{member}\"");
+    assert!(
+        output.contains(&needle),
+        "expected `{member}` metadata to serialize to `{serialized}`.\nOutput:\n{output}"
+    );
+}
+
+/// A bare numeric-enum reference, a single enum-member reference, a union of
+/// enum members, and a union of the enum with `number` all serialize to
+/// `Number`. The enum here uses non-default member names to prove the rule is
+/// not keyed on any particular spelling.
+#[test]
+fn numeric_enum_references_serialize_as_number() {
+    let source = r#"declare const PropDeco: PropertyDecorator;
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+class D {
+    @PropDeco
+    a: Color.Red;
+    @PropDeco
+    b: Color.Green | Color.Blue;
+    @PropDeco
+    c: Color;
+    @PropDeco
+    d: Color | number;
+}
+"#;
+    let output = emit_source(source, legacy_metadata_options());
+    assert_metadata(&output, "a", "Number");
+    assert_metadata(&output, "b", "Number");
+    assert_metadata(&output, "c", "Number");
+    assert_metadata(&output, "d", "Number");
+}
+
+/// A const numeric enum is also serialized as `Number`, and an explicitly
+/// numeric-initialized enum stays numeric regardless of member names.
+#[test]
+fn const_and_initialized_numeric_enum_serialize_as_number() {
+    let source = r#"declare const PropDeco: PropertyDecorator;
+const enum Flag {
+    On = 1,
+    Off = 0,
+}
+class D {
+    @PropDeco
+    a: Flag;
+    @PropDeco
+    b: Flag.On;
+}
+"#;
+    let output = emit_source(source, legacy_metadata_options());
+    assert_metadata(&output, "a", "Number");
+    assert_metadata(&output, "b", "Number");
+}
+
+/// A string (or heterogeneous) enum must NOT serialize to `Number`: its
+/// members are not all numeric. A string enum reference falls back to the enum
+/// object reference (not `Number`), matching tsc.
+#[test]
+fn string_enum_reference_does_not_serialize_as_number() {
+    let source = r#"declare const PropDeco: PropertyDecorator;
+enum Dir {
+    Up = "UP",
+    Down = "DOWN",
+}
+class D {
+    @PropDeco
+    a: Dir;
+}
+"#;
+    let output = emit_source(source, legacy_metadata_options());
+    assert!(
+        !output.contains("__metadata(\"design:type\", Number)\n], D.prototype, \"a\""),
+        "A string enum reference must not serialize as Number.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — JavaScript emit parity (emit→100% campaign, wave 2)

## Invariant
(1) Constant-folded numeric bitwise shifts in enum-IIFE evaluation must use
ECMAScript int32 semantics (operands→i32, shift count masked to low 5 bits,
result truncated to 32 bits) and parse every numeric-literal form; (2) an
emitted-metadata (`design:type`) reference whose declared symbol is a
homogeneously-numeric enum (incl. qualified members and all-numeric unions)
serializes to `Number`. This PR makes tsz match `tsc` on both.

## Scope
- `crates/tsz-emitter/src/transforms/enum_es5.rs` — `evaluate_constant_expression`
  parses via `tsz_common::numeric::parse_numeric_literal_value` and implements
  int32 shift/bitwise semantics (mirroring `const_enum_eval.rs`).
- `crates/tsz-emitter/src/emitter/declarations/class/decorators.rs` — metadata
  serializer AST-scan: a `design:type` ref resolving to an all-numeric enum
  declaration serializes to `Number` (string/heterogeneous enums excluded).
- New `enum_int32_shift_fold_tests.rs` (4) + `enum_metadata_number_tests.rs` (3),
  registered in Cargo.toml.

## Project Corpus Impact
- Row: n/a (emit parity)
- Bug family: enum constant-fold int32 semantics + enum-typed decorator metadata
- Evidence: overshifts FAIL→PASS; metadataOfUnion (+null variants) FAIL→PASS; metadata family 85→86 pass.

## Verification
- Witnesses FAIL→PASS (JS): overshifts, metadataOfUnion (3/3 incl. null variants).
- Regression families vs clean HEAD baseline (zero regressions): enum 267/0,
  decorator 637/5, metadata 85→86 (failed 1→0), class 1458/22, computedProperty
  295/0, static 431/17. Unit suite: zero new failures; +7 tests. clippy clean.
- Note: the 3rd candidate (instanceMemberWithComputedPropertyName2) already passes
  on `main` (earlier fix) — no change needed; not in this PR.

## Coordination Notes
Wave-2 fix #10 (clean subset). Disjoint from in-flight DTS/private-name work. — opus48-emit100
