### PR TITLE
fix(site): publish fresh emit compatibility metrics

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -233,9 +233,17 @@ jobs:
         continue-on-error: true
 
       - name: Download latest benchmark data from GCS
+        env:
+          SCCACHE_GCS_KEY_JSON: ${{ secrets.SCCACHE_GCS_KEY_JSON }}
         run: |
           set -euo pipefail
           BUCKET="thirdface-ai-oauth_cloudbuild"
+
+          if [[ -n "${SCCACHE_GCS_KEY_JSON:-}" ]]; then
+            key_file="${RUNNER_TEMP:-/tmp}/tsz-gcs-key.json"
+            printf '%s' "${SCCACHE_GCS_KEY_JSON}" > "${key_file}"
+            gcloud auth activate-service-account --key-file="${key_file}" >/dev/null 2>&1 || true
+          fi
           TOKEN=$(gcloud auth print-access-token 2>/dev/null || echo "")
 
           if [[ -z "$TOKEN" ]]; then
@@ -338,8 +346,17 @@ jobs:
         continue-on-error: true
 
       - name: Download latest suite metrics from GCS
+        env:
+          SCCACHE_GCS_KEY_JSON: ${{ secrets.SCCACHE_GCS_KEY_JSON }}
         run: |
+          set -euo pipefail
           BUCKET="thirdface-ai-oauth_cloudbuild"
+
+          if [[ -n "${SCCACHE_GCS_KEY_JSON:-}" ]]; then
+            key_file="${RUNNER_TEMP:-/tmp}/tsz-gcs-key.json"
+            printf '%s' "${SCCACHE_GCS_KEY_JSON}" > "${key_file}"
+            gcloud auth activate-service-account --key-file="${key_file}" >/dev/null 2>&1 || true
+          fi
           TOKEN=$(gcloud auth print-access-token 2>/dev/null || echo "")
 
           if [[ -z "$TOKEN" ]]; then

--- a/README.md
+++ b/README.md
@@ -85,14 +85,14 @@ to ensure correct code generation.
 
 <!-- EMIT_START -->
 ```
-JavaScript:  [███████████████████░] 96.8% (13,094 / 13,530 tests)
-Declaration: [███████████████████░] 96.2% (1,606 / 1,669 tests)
+JavaScript:  [████████████████████] 99.0% (13,401 / 13,530 tests)
+Declaration: [███████████████████░] 97.0% (1,619 / 1,669 tests)
 ```
 <!-- EMIT_END -->
 
-This block is generated from the checked-in emit artifact with
-`python3 scripts/refresh-readme.py --write`; release claims should cite the
-current CI artifact.
+This block is generated from the latest CI emit metric when available, falling
+back to the checked-in emit artifact with `python3 scripts/refresh-readme.py
+--write`; release claims should cite the current CI artifact.
 
 ### Language Service
 

--- a/scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs
+++ b/scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs
@@ -49,6 +49,18 @@ assert.match(
 
 assert.match(
   workflow,
+  /Download latest benchmark data from GCS[\s\S]+SCCACHE_GCS_KEY_JSON:[\s\S]+gcloud auth activate-service-account[\s\S]+gcloud auth print-access-token/,
+  "Pages deploy should activate the GCS service-account secret before downloading benchmark truth",
+);
+
+assert.match(
+  workflow,
+  /Download latest suite metrics from GCS[\s\S]+SCCACHE_GCS_KEY_JSON:[\s\S]+gcloud auth activate-service-account[\s\S]+metrics\/latest\/\$\{suite\}\.json/,
+  "Pages deploy should activate the GCS service-account secret before downloading suite metrics",
+);
+
+assert.match(
+  workflow,
   /selectLatestBenchmarkArtifact[\s\S]+bench-vs-tsgo-github-latest\.json[\s\S]+bench-vs-tsgo-gcs-latest\.json/,
   "Pages readiness status should describe the selected fresh benchmark artifact",
 );

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -113,6 +113,29 @@ publish_latest_metric() {
   fi
 }
 
+write_emit_metric() {
+  local out="$1"
+  local js_passed="$2" js_total="$3" js_skipped="$4" js_timeouts="$5"
+  local dts_passed="$6" dts_total="$7" dts_skipped="$8"
+
+  local js_rate dts_rate
+  js_rate="$(awk -v p="$js_passed" -v t="$js_total" 'BEGIN { if (t > 0) printf "%.1f", (p / t) * 100; else print "0.0" }')"
+  dts_rate="$(awk -v p="$dts_passed" -v t="$dts_total" 'BEGIN { if (t > 0) printf "%.1f", (p / t) * 100; else print "0.0" }')"
+  jq -n \
+    --arg suite "emit" \
+    --arg js_pass_rate "$js_rate" \
+    --argjson js_passed "$js_passed" \
+    --argjson js_total "$js_total" \
+    --argjson js_skipped "$js_skipped" \
+    --argjson js_timeouts "$js_timeouts" \
+    --arg dts_pass_rate "$dts_rate" \
+    --argjson dts_passed "$dts_passed" \
+    --argjson dts_total "$dts_total" \
+    --argjson dts_skipped "$dts_skipped" \
+    '{suite:$suite, js_pass_rate:$js_pass_rate, js_passed:$js_passed, js_total:$js_total, js_skipped:$js_skipped, js_timeouts:$js_timeouts, dts_pass_rate:$dts_pass_rate, dts_passed:$dts_passed, dts_total:$dts_total, dts_skipped:$dts_skipped}' \
+    > "$out"
+}
+
 suite_needs_group() {
   ci_suite_needs_group "$@"
 }
@@ -400,6 +423,8 @@ run_lint() {
   done
   python3 scripts/ci/test_ci_resources.py || return $?
   python3 scripts/ci/test_gcp_full_ci_conformance_artifacts.py || return $?
+  python3 scripts/ci/test_gcp_full_ci_emit_metrics.py || return $?
+  python3 scripts/ci/test_refresh_readme.py || return $?
   python3 scripts/conformance/test_query_conformance.py || return $?
   # Use the dedicated ci-lint profile (debug=false, incremental=false,
   # codegen-units=256). Workspace clippy artifacts go to .target/ci-lint/
@@ -1560,6 +1585,10 @@ run_emit_shard() {
   if [[ "$shard_count" -eq 1 ]]; then
     ci_section "Emit aggregate"
     validate_emit_aggregate_counts "$js_p" "$js_t" "$js_s" "$js_to" "$dts_p" "$dts_t" "$dts_s" 1 1
+    write_emit_metric "$METRICS_DIR/emit.json" \
+      "$js_p" "$js_t" "$js_s" "$js_to" \
+      "$dts_p" "$dts_t" "$dts_s"
+    publish_latest_metric emit "$METRICS_DIR/emit.json"
   fi
   return 0
 }
@@ -1605,6 +1634,10 @@ run_emit_aggregate() {
 
   validate_emit_aggregate_counts "$js_passed" "$js_total" "$js_skipped" "$js_timeouts" \
     "$dts_passed" "$dts_total" "$dts_skipped" "$files_count" "$expected_shards"
+  write_emit_metric "$METRICS_DIR/emit.json" \
+    "$js_passed" "$js_total" "$js_skipped" "$js_timeouts" \
+    "$dts_passed" "$dts_total" "$dts_skipped"
+  publish_latest_metric emit "$METRICS_DIR/emit.json"
 }
 
 run_fourslash_shard() {
@@ -1827,21 +1860,9 @@ aggregate_emit() {
     return 1
   fi
 
-  js_rate="$(awk -v p="$js_passed" -v t="$js_total" 'BEGIN { if (t > 0) printf "%.1f", (p / t) * 100; else print "0.0" }')"
-  dts_rate="$(awk -v p="$dts_passed" -v t="$dts_total" 'BEGIN { if (t > 0) printf "%.1f", (p / t) * 100; else print "0.0" }')"
-  jq -n \
-    --arg suite "emit" \
-    --arg js_pass_rate "$js_rate" \
-    --argjson js_passed "$js_passed" \
-    --argjson js_total "$js_total" \
-    --argjson js_skipped "$js_skipped" \
-    --argjson js_timeouts "$js_timeouts" \
-    --arg dts_pass_rate "$dts_rate" \
-    --argjson dts_passed "$dts_passed" \
-    --argjson dts_total "$dts_total" \
-    --argjson dts_skipped "$dts_skipped" \
-    '{suite:$suite, js_pass_rate:$js_pass_rate, js_passed:$js_passed, js_total:$js_total, js_skipped:$js_skipped, js_timeouts:$js_timeouts, dts_pass_rate:$dts_pass_rate, dts_passed:$dts_passed, dts_total:$dts_total, dts_skipped:$dts_skipped}' \
-    > "$METRICS_DIR/emit.json"
+  write_emit_metric "$METRICS_DIR/emit.json" \
+    "$js_passed" "$js_total" "$js_skipped" "$js_timeouts" \
+    "$dts_passed" "$dts_total" "$dts_skipped"
 
   base_js="$(jq -r '.summary.jsPass // 0' scripts/emit/emit-snapshot.json)"
   base_dts="$(jq -r '.summary.dtsPass // 0' scripts/emit/emit-snapshot.json)"

--- a/scripts/ci/test_gcp_full_ci_emit_metrics.py
+++ b/scripts/ci/test_gcp_full_ci_emit_metrics.py
@@ -1,0 +1,74 @@
+"""Contract tests for emit metrics publication."""
+
+import json
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+GCP_FULL_CI = ROOT / "scripts" / "ci" / "gcp-full-ci.sh"
+
+
+class EmitMetricPublicationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.script = GCP_FULL_CI.read_text(encoding="utf-8")
+
+    def function_body(self, name, end_marker):
+        start = self.script.index(f"{name}() {{")
+        end = self.script.index(end_marker, start)
+        return self.script[start:end]
+
+    def test_write_emit_metric_schema(self):
+        helper = self.function_body("write_emit_metric", "\nsuite_needs_group() {")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = pathlib.Path(temp_dir)
+            out = temp / "emit.json"
+            runner = temp / "run.sh"
+            runner.write_text(
+                f"""#!/usr/bin/env bash
+set -Eeuo pipefail
+{helper}
+write_emit_metric "{out}" 13401 13530 1 0 1619 1669 11862
+""",
+                encoding="utf-8",
+            )
+            subprocess.run(["bash", str(runner)], check=True, cwd=temp)
+            data = json.loads(out.read_text(encoding="utf-8"))
+
+        self.assertEqual(data["suite"], "emit")
+        self.assertEqual(data["js_pass_rate"], "99.0")
+        self.assertEqual(data["js_passed"], 13401)
+        self.assertEqual(data["js_total"], 13530)
+        self.assertEqual(data["js_skipped"], 1)
+        self.assertEqual(data["js_timeouts"], 0)
+        self.assertEqual(data["dts_pass_rate"], "97.0")
+        self.assertEqual(data["dts_passed"], 1619)
+        self.assertEqual(data["dts_total"], 1669)
+        self.assertEqual(data["dts_skipped"], 11862)
+
+    def test_single_shard_emit_publishes_latest_metric(self):
+        body = self.function_body("run_emit_shard", "\nrun_emit_aggregate() {")
+        validate_idx = body.index(
+            'validate_emit_aggregate_counts "$js_p" "$js_t" "$js_s" "$js_to" "$dts_p" "$dts_t" "$dts_s" 1 1',
+        )
+        write_idx = body.index('write_emit_metric "$METRICS_DIR/emit.json"', validate_idx)
+        publish_idx = body.index('publish_latest_metric emit "$METRICS_DIR/emit.json"', write_idx)
+        self.assertLess(validate_idx, write_idx)
+        self.assertLess(write_idx, publish_idx)
+
+    def test_multi_shard_emit_aggregate_publishes_latest_metric(self):
+        body = self.function_body("run_emit_aggregate", "\nrun_fourslash_shard() {")
+        validate_idx = body.index(
+            'validate_emit_aggregate_counts "$js_passed" "$js_total" "$js_skipped" "$js_timeouts"',
+        )
+        write_idx = body.index('write_emit_metric "$METRICS_DIR/emit.json"', validate_idx)
+        publish_idx = body.index('publish_latest_metric emit "$METRICS_DIR/emit.json"', write_idx)
+        self.assertLess(validate_idx, write_idx)
+        self.assertLess(write_idx, publish_idx)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test_refresh_readme.py
+++ b/scripts/ci/test_refresh_readme.py
@@ -1,0 +1,61 @@
+"""Tests for README metric refresh helpers."""
+
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+REFRESH_README = ROOT / "scripts" / "refresh-readme.py"
+
+spec = importlib.util.spec_from_file_location("refresh_readme", REFRESH_README)
+refresh_readme = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(refresh_readme)
+
+
+class RefreshReadmeTests(unittest.TestCase):
+    def test_ci_emit_metric_shape_normalizes_to_readme_summary(self):
+        summary = refresh_readme.normalize_emit_summary({
+            "suite": "emit",
+            "js_passed": 13401,
+            "js_total": 13530,
+            "js_skipped": 1,
+            "js_timeouts": 0,
+            "dts_passed": 1619,
+            "dts_total": 1669,
+            "dts_skipped": 11862,
+        })
+
+        self.assertEqual(summary["jsPass"], 13401)
+        self.assertEqual(summary["jsTotal"], 13530)
+        self.assertEqual(summary["jsSkip"], 1)
+        self.assertEqual(summary["jsTimeout"], 0)
+        self.assertEqual(summary["dtsPass"], 1619)
+        self.assertEqual(summary["dtsTotal"], 1669)
+        self.assertEqual(summary["dtsSkip"], 11862)
+
+    def test_existing_readme_emit_block_is_not_downgraded_by_old_snapshot(self):
+        readme_summary = refresh_readme.emit_summary_from_readme(
+            """<!-- EMIT_START -->
+```
+JavaScript:  [████████████████████] 99.0% (13,401 / 13,530 tests)
+Declaration: [███████████████████░] 97.0% (1,619 / 1,669 tests)
+```
+<!-- EMIT_END -->""",
+        )
+        snapshot_summary = {
+            "jsPass": 13094,
+            "jsTotal": 13530,
+            "dtsPass": 1606,
+            "dtsTotal": 1669,
+        }
+
+        selected = refresh_readme.prefer_readme_emit_summary(snapshot_summary, readme_summary)
+
+        self.assertEqual(selected["jsPass"], 13401)
+        self.assertEqual(selected["dtsPass"], 1619)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/refresh-readme.py
+++ b/scripts/refresh-readme.py
@@ -3,7 +3,7 @@
 
 Reads:
   - scripts/conformance/conformance-detail.json  (or conformance-snapshot.json)
-  - scripts/emit/emit-detail.json
+  - .ci-metrics/emit.json (or scripts/emit/emit-detail.json)
   - scripts/fourslash/fourslash-detail.json
   - https://tsz.dev/benchmark-data/latest.json
 
@@ -22,6 +22,7 @@ Usage:
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -58,13 +59,93 @@ def load_conformance():
     return None, None
 
 
-def load_emit():
-    p = ROOT / "scripts" / "emit" / "emit-detail.json"
-    if not p.exists():
+def normalize_emit_summary(data):
+    summary = data.get("summary")
+    if summary:
+        return summary
+
+    if data.get("suite") != "emit":
         return None
-    with open(p) as f:
-        data = json.load(f)
-    return data.get("summary", {})
+
+    return {
+        "jsPass": data.get("js_passed"),
+        "jsTotal": data.get("js_total"),
+        "jsSkip": data.get("js_skipped", 0),
+        "jsTimeout": data.get("js_timeouts", 0),
+        "dtsPass": data.get("dts_passed"),
+        "dtsTotal": data.get("dts_total"),
+        "dtsSkip": data.get("dts_skipped", 0),
+    }
+
+
+def emit_summary_from_readme(text):
+    section = text.split("<!-- EMIT_START -->", 1)
+    if len(section) != 2:
+        return None
+    section = section[1].split("<!-- EMIT_END -->", 1)[0]
+
+    summary = {}
+    for line in section.splitlines():
+        if "JavaScript" in line:
+            prefix = "js"
+        elif "Declaration" in line:
+            prefix = "dts"
+        else:
+            continue
+
+        match = re.search(r"\(([\d,]+)\s*/\s*([\d,]+)", line)
+        if not match:
+            continue
+        summary[f"{prefix}Pass"] = int(match.group(1).replace(",", ""))
+        summary[f"{prefix}Total"] = int(match.group(2).replace(",", ""))
+
+    if {"jsPass", "jsTotal", "dtsPass", "dtsTotal"}.issubset(summary):
+        summary.setdefault("jsSkip", 0)
+        summary.setdefault("jsTimeout", 0)
+        summary.setdefault("dtsSkip", 0)
+        return summary
+    return None
+
+
+def prefer_readme_emit_summary(candidate, readme_summary):
+    if readme_summary is None:
+        return candidate
+
+    same_domain = (
+        readme_summary.get("jsTotal") == candidate.get("jsTotal")
+        and readme_summary.get("dtsTotal") == candidate.get("dtsTotal")
+    )
+    ahead_or_equal = (
+        readme_summary.get("jsPass", 0) >= candidate.get("jsPass", 0)
+        and readme_summary.get("dtsPass", 0) >= candidate.get("dtsPass", 0)
+    )
+    return readme_summary if same_domain and ahead_or_equal else candidate
+
+
+def load_emit(args, readme_text):
+    readme_summary = emit_summary_from_readme(readme_text)
+    candidates = []
+    if args.emit_metrics_json is not None:
+        path = args.emit_metrics_json
+        if not path.is_absolute():
+            path = ROOT / path
+        candidates.append(path)
+    candidates.extend([
+        ROOT / ".ci-metrics" / "emit.json",
+        ROOT / "scripts" / "emit" / "emit-detail.json",
+    ])
+
+    for p in candidates:
+        if not p.exists():
+            continue
+        with open(p) as f:
+            data = json.load(f)
+        summary = normalize_emit_summary(data)
+        if summary is not None:
+            if args.emit_metrics_json is None and p == ROOT / "scripts" / "emit" / "emit-detail.json":
+                return prefer_readme_emit_summary(summary, readme_summary)
+            return summary
+    return None
 
 
 def load_fourslash():
@@ -121,6 +202,11 @@ def parse_args():
         "--skip-performance",
         action="store_true",
         help="skip the README performance chart block and PNG generation",
+    )
+    parser.add_argument(
+        "--emit-metrics-json",
+        type=Path,
+        help="use a local emit metrics artifact instead of the default .ci-metrics/emit.json",
     )
     return parser.parse_args()
 
@@ -213,7 +299,7 @@ def main():
         text = replace_block(text, "<!-- CONFORMANCE_START -->", "<!-- CONFORMANCE_END -->", block)
 
     # Emit
-    emit = load_emit()
+    emit = load_emit(args, original)
     if emit is not None:
         js_bar = progress_bar(emit["jsPass"], emit["jsTotal"])
         dts_bar = progress_bar(emit["dtsPass"], emit["dtsTotal"])


### PR DESCRIPTION
## Agent
AgentName: m5-pro-48g-gpt5

## Track
Track 10 / public benchmark and compatibility publication freshness.

## Invariant
When CI has a fresher emit result than the checked-in snapshot, public README and website compatibility surfaces should use that CI metric instead of silently falling back to stale checked-in emit detail.

## Scope
- `.github/workflows/gh-pages.yml`: activate the GCS service-account secret before downloading benchmark truth and suite metrics.
- `scripts/ci/gcp-full-ci.sh`: write and publish `metrics/latest/emit.json` from both the single-shard GitHub emit path and the multi-shard aggregate path.
- `scripts/refresh-readme.py`: read `.ci-metrics/emit.json` / explicit emit metric artifacts and avoid downgrading a newer README emit block when local CI metrics are absent.
- `README.md`: refresh emit compatibility totals to latest main CI metric.
- `scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs`, `scripts/ci/test_gcp_full_ci_emit_metrics.py`, `scripts/ci/test_refresh_readme.py`: cover Pages GCS auth, emit metric schema/publication, and README no-downgrade behavior.

## Project Corpus Impact
- Row: n/a.
- Bug family: public compatibility metric publication / stale emit dashboard state.
- Evidence: GCS had fresh conformance/fourslash metrics but no `tsz-ci-cache/metrics/latest/emit.json`; latest main emit shard `25093d12c7b4689554956b2aeeac92733a84f77a` reported JS `13401/13530` and DTS `1619/1669`, while live compatibility and README showed stale checked-in snapshot values `13094/13530` and `1606/1669`. After manually publishing the current emit metric, a Pages redeploy still showed stale values because `gh-pages.yml` never activated GCS credentials before metric download.

## Verification
- `python3 scripts/ci/test_gcp_full_ci_emit_metrics.py`
- `python3 scripts/ci/test_refresh_readme.py`
- `python3 -m py_compile scripts/refresh-readme.py scripts/ci/test_gcp_full_ci_emit_metrics.py scripts/ci/test_refresh_readme.py`
- `python3 scripts/refresh-readme.py --skip-performance --emit-metrics-json .ci-metrics/emit.json`
- `python3 scripts/refresh-readme.py --skip-performance` with `.ci-metrics` temporarily absent; confirmed no README downgrade.
- `node scripts/bench/test-readme-perf-svg.mjs`
- `node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gh-pages.yml"); puts "yaml ok"'`
- `git diff --check`
- Published current latest emit metric to `gs://thirdface-ai-oauth_cloudbuild/tsz-ci-cache/metrics/latest/emit.json` from main shard `25093d12c7b4689554956b2aeeac92733a84f77a`.

## Coordination Notes
- AgentName: m5-pro-48g-gpt5
- Related issue: #10649.
- No roadmap update: this preserves the existing public metric model and fixes missing GCS auth / emit publication paths.
- README performance PNG generation was rerun against the now-fresh benchmark endpoint; the generated PNG bytes were unchanged, so no image asset diff is included.
