### PR TITLE
fix(dts): reference in-scope import-equals aliases by name and retain them in declaration emit

### DIFF
--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -86,6 +86,10 @@ path = "tests/recursive_const_arrow_dts_emit_tests.rs"
 name = "parenthesized_type_dts_emit_tests"
 path = "tests/parenthesized_type_dts_emit_tests.rs"
 
+[[test]]
+name = "import_equals_alias_dts_emit_tests"
+path = "tests/import_equals_alias_dts_emit_tests.rs"
+
 [dev-dependencies]
 tempfile = { workspace = true }
 

--- a/crates/tsz-cli/tests/import_equals_alias_dts_emit_tests.rs
+++ b/crates/tsz-cli/tests/import_equals_alias_dts_emit_tests.rs
@@ -1,0 +1,230 @@
+//! DTS emit for `import alias = Q.R.S` entity-name aliases.
+//!
+//! Structural rule: when a declaration-emit type references a symbol that is
+//! the resolved target of an in-scope `import alias = Q.R.S` declaration, tsc
+//! references that symbol by the bare alias name (rather than expanding the
+//! qualified path), and the alias declaration is retained (not elided) because
+//! it is used. The alias is only substituted where it is in lexical scope and
+//! where the target symbol is not more directly nameable by its own local name.
+//!
+//! Witnesses: internalAliasClassInsideTopLevelModuleWith{out,}Export,
+//! internalAliasClassInsideLocalModuleWithoutExport. Regression guard:
+//! privacyTopLevelInternalReferenceImportWith{out,}Export (alias must NOT be
+//! used where the target is locally nameable).
+//!
+//! AgentName: opus48-emit100
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(name: &str) -> std::io::Result<Self> {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("tsz_ie_alias_dts_{name}_{nanos}"));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+fn emit_dts(name: &str, source: &str) -> Option<String> {
+    let tsz_bin = find_tsz_binary()?;
+    let temp = TempDir::new(name).expect("temp dir");
+    let src_path = temp.path.join("repro.ts");
+    std::fs::write(&src_path, source).expect("write repro file");
+
+    let output = Command::new(tsz_bin)
+        .args([
+            "repro.ts",
+            "--declaration",
+            "--emitDeclarationOnly",
+            "--target",
+            "es2015",
+            "--module",
+            "commonjs",
+            "--pretty",
+            "false",
+        ])
+        .current_dir(&temp.path)
+        .output()
+        .expect("run tsz declaration emit");
+
+    let dts = std::fs::read_to_string(temp.path.join("repro.d.ts")).unwrap_or_else(|_| {
+        panic!(
+            "expected repro.d.ts to be emitted.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    Some(dts)
+}
+
+/// Primary repro shape: a top-level `import alias = ns.Class` aliases a class
+/// that is referenced only through an inferred type. The inferred type must
+/// print as the alias name, and the alias must be retained.
+#[test]
+fn top_level_import_equals_alias_used_for_inferred_type() {
+    let Some(dts) = emit_dts(
+        "toplevel",
+        r#"
+export namespace x {
+    export class c {
+        foo(a: number) { return a; }
+    }
+}
+import xc = x.c;
+export var cProp = new xc();
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("var cProp: xc"),
+        "inferred type should print as alias name `xc`, not the expanded path:\n{dts}"
+    );
+    assert!(
+        !dts.contains("cProp: xc.c") && !dts.contains("cProp: x.c"),
+        "alias target must not expand to a qualified path:\n{dts}"
+    );
+    assert!(
+        dts.contains("import xc = x.c"),
+        "the used import-equals alias must be retained:\n{dts}"
+    );
+}
+
+/// Renamed alias / namespace / class: prove the rule is structural, not keyed
+/// on the spelling `x`/`c`/`xc` from the primary repro.
+#[test]
+fn top_level_import_equals_alias_renamed_identifiers() {
+    let Some(dts) = emit_dts(
+        "renamed",
+        r#"
+export namespace Outer {
+    export class Widget {
+        render(n: number) { return n; }
+    }
+}
+import W = Outer.Widget;
+export var instance = new W();
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("var instance: W"),
+        "inferred type should print as renamed alias `W`:\n{dts}"
+    );
+    assert!(
+        !dts.contains("instance: W.Widget") && !dts.contains("instance: Outer.Widget"),
+        "renamed alias target must not expand to a qualified path:\n{dts}"
+    );
+    assert!(
+        dts.contains("import W = Outer.Widget"),
+        "the renamed import-equals alias must be retained:\n{dts}"
+    );
+}
+
+/// Nested-namespace alias: `import c = x.c` inside `m2.m3` must be retained and
+/// the inferred type printed as the local alias `c`, even though a same-named
+/// class `x.c` exists in another scope.
+#[test]
+fn nested_namespace_import_equals_alias_used_locally() {
+    let Some(dts) = emit_dts(
+        "nested",
+        r#"
+export namespace x {
+    export class c {
+        foo(a: number) { return a; }
+    }
+}
+export namespace m2 {
+    export namespace m3 {
+        import c = x.c;
+        export var cProp = new c();
+        var cReturnVal = cProp.foo(10);
+    }
+}
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("import c = x.c"),
+        "the nested-namespace import-equals alias must be retained:\n{dts}"
+    );
+    assert!(
+        dts.contains("var cProp: c"),
+        "inferred type should print as the local alias `c`:\n{dts}"
+    );
+    assert!(
+        !dts.contains("cProp: x.c") && !dts.contains("cProp: c.c"),
+        "local alias target must not expand to a qualified path:\n{dts}"
+    );
+}
+
+/// Regression guard: a top-level alias must NOT be used to name a type when the
+/// target is directly nameable in its own scope. Inside `m_private`, the return
+/// type of `f_private` is `c_private` (the local class name), not the top-level
+/// alias `im_c_private = m_private.c_private`.
+#[test]
+fn top_level_alias_not_used_when_target_is_locally_nameable() {
+    let Some(dts) = emit_dts(
+        "locally_nameable",
+        r#"
+export namespace m_private {
+    export class c_private {}
+    export function f_private() {
+        return new c_private();
+    }
+}
+export import im_c_private = m_private.c_private;
+export var topUse = new im_c_private();
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("function f_private(): c_private"),
+        "return type inside the namespace must use the local name `c_private`, \
+         not the top-level alias:\n{dts}"
+    );
+    assert!(
+        !dts.contains("f_private(): im_c_private"),
+        "the same-scope alias must not shadow the local name:\n{dts}"
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
@@ -20,6 +20,7 @@ impl<'a> DeclarationEmitter<'a> {
         self.symbol_module_specifier_cache.clear();
         self.import_plan = ImportPlan::default();
         self.local_namespace_alias_targets.clear();
+        self.local_import_equals_alias_for_target.clear();
 
         self.reset_writer();
         self.indent_level = 0;

--- a/crates/tsz-emitter/src/declaration_emitter/core/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/mod.rs
@@ -318,6 +318,17 @@ pub struct DeclarationEmitter<'a> {
     /// and `escaped_name`. Used to substitute alias names when printing qualified type names
     /// only when a target has a single unambiguous alias.
     pub(super) local_namespace_alias_targets: FxHashMap<(SymbolId, String), FxHashSet<String>>,
+    /// Maps the resolved target SymbolId of an `import alias = Q.R.S` declaration
+    /// to the alias name(s) plus the alias's enclosing scope symbol. Unlike
+    /// `local_namespace_alias_targets`, which keys on the *leftmost* segment to
+    /// alias a namespace prefix, this map keys on the symbol the *whole* qualified
+    /// path resolves to. tsc references such a symbol by the alias name directly
+    /// (e.g. `import xc = x.c; var p: xc`) but only where the alias is in lexical
+    /// scope, so each entry records the alias's enclosing namespace/module symbol
+    /// (`SymbolId::NONE` for top-level/file scope). When printing a type whose
+    /// symbol equals the recorded target and the current emit position is within
+    /// that scope, we emit the alias name instead of the expanded qualified path.
+    pub(super) local_import_equals_alias_for_target: FxHashMap<SymbolId, Vec<(String, SymbolId)>>,
 }
 
 pub(super) struct SourceMapState {

--- a/crates/tsz-emitter/src/declaration_emitter/core/setup.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/setup.rs
@@ -124,6 +124,7 @@ impl<'a> DeclarationEmitter<'a> {
             isolated_declarations: false,
             all_enum_values: FxHashMap::default(),
             local_namespace_alias_targets: FxHashMap::default(),
+            local_import_equals_alias_for_target: FxHashMap::default(),
         }
     }
 
@@ -251,6 +252,7 @@ impl<'a> DeclarationEmitter<'a> {
             isolated_declarations: false,
             all_enum_values: FxHashMap::default(),
             local_namespace_alias_targets: FxHashMap::default(),
+            local_import_equals_alias_for_target: FxHashMap::default(),
         }
     }
 
@@ -505,7 +507,24 @@ impl<'a> DeclarationEmitter<'a> {
                     self.local_namespace_alias_targets
                         .entry((parent_sym_id, leftmost))
                         .or_default()
-                        .insert(alias_name);
+                        .insert(alias_name.clone());
+
+                    // Record the symbol the *whole* qualified path resolves to.
+                    // `import alias = Q.R.S` makes `alias` reference that symbol
+                    // directly, so a type printed with that exact symbol should
+                    // render as the bare alias name rather than the expanded path.
+                    let resolved = self
+                        .import_equals_entity_target_symbol(binder, import_eq.module_specifier)
+                        .or_else(|| binder.resolve_import_symbol(alias_sym_id));
+                    if let Some(target_sym_id) = resolved {
+                        // `parent_sym_id` is the alias's enclosing namespace/module
+                        // symbol (SymbolId::NONE at file/top-level scope). The alias
+                        // name is only usable within that scope.
+                        self.local_import_equals_alias_for_target
+                            .entry(target_sym_id)
+                            .or_default()
+                            .push((alias_name, parent_sym_id));
+                    }
                 }
             } else if stmt_node.kind == syntax_kind_ext::MODULE_DECLARATION {
                 self.recurse_module_body(binder, stmt_node);

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs
@@ -768,6 +768,8 @@ impl<'a> DeclarationEmitter<'a> {
 
             let module_path_resolver = |sym_id| self.resolve_symbol_module_path(sym_id);
             let namespace_alias_resolver = |sym_id| self.resolve_namespace_import_alias(sym_id);
+            let import_equals_alias_resolver =
+                |sym_id| self.resolve_import_equals_alias_for_symbol(sym_id);
             let local_import_alias_name_resolver =
                 |sym_id| self.can_reference_local_import_alias_by_name(sym_id);
             let has_local_import_alias_resolver = |sym_id| {
@@ -782,6 +784,7 @@ impl<'a> DeclarationEmitter<'a> {
                 .with_node_arena(self.arena)
                 .with_module_path_resolver(&module_path_resolver)
                 .with_namespace_alias_resolver(&namespace_alias_resolver)
+                .with_import_equals_alias_resolver(&import_equals_alias_resolver)
                 .with_local_import_alias_name_resolver(&local_import_alias_name_resolver)
                 .with_has_local_import_alias_resolver(&has_local_import_alias_resolver)
                 .with_strict_null_checks(self.strict_null_checks);
@@ -1336,6 +1339,8 @@ impl<'a> DeclarationEmitter<'a> {
         }
         let module_path_resolver = |sym_id| self.resolve_symbol_module_path(sym_id);
         let namespace_alias_resolver = |sym_id| self.resolve_namespace_import_alias(sym_id);
+        let import_equals_alias_resolver =
+            |sym_id| self.resolve_import_equals_alias_for_symbol(sym_id);
         let local_import_alias_name_resolver =
             |sym_id| self.can_reference_local_import_alias_by_name(sym_id);
         let has_local_import_alias_resolver = |sym_id| {
@@ -1350,6 +1355,7 @@ impl<'a> DeclarationEmitter<'a> {
             .with_node_arena(self.arena)
             .with_module_path_resolver(&module_path_resolver)
             .with_namespace_alias_resolver(&namespace_alias_resolver)
+            .with_import_equals_alias_resolver(&import_equals_alias_resolver)
             .with_local_import_alias_name_resolver(&local_import_alias_name_resolver)
             .with_has_local_import_alias_resolver(&has_local_import_alias_resolver)
             .with_strict_null_checks(self.strict_null_checks)

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing_paths.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing_paths.rs
@@ -444,6 +444,83 @@ impl<'a> DeclarationEmitter<'a> {
             && (symbol.import_name.is_none() || symbol.import_name.as_deref() == Some("*"))
     }
 
+    /// When `sym_id` is the resolved target of a single in-scope
+    /// `import alias = Q.R.S` declaration, return the alias name so the type
+    /// printer can reference the symbol directly (e.g. `import xc = x.c;` makes
+    /// the type of `new xc()` print as `xc`, not `xc.c` or `x.c`). Ambiguous
+    /// targets (multiple aliases) fall back to the normal qualified path.
+    pub(crate) fn resolve_import_equals_alias_for_symbol(
+        &self,
+        sym_id: SymbolId,
+    ) -> Option<String> {
+        let candidates = self.local_import_equals_alias_for_target.get(&sym_id)?;
+        // tsc only uses an `import alias = Q.R.S` to name `S` when the alias is
+        // the most direct in-scope reference. If `S`'s own enclosing scope
+        // already encloses the current emit position, `S` is reachable by its
+        // local name there (e.g. inside `m_private`, `c_private` names itself),
+        // so tsc prints the original name rather than a same-scope alias.
+        if self.import_equals_target_locally_nameable(sym_id) {
+            return None;
+        }
+        // Keep only aliases whose declaration scope encloses the current emit
+        // position. An alias declared inside `m2.m3` may not be used to name a
+        // type at the top level (there tsc prints the expanded `x.c` instead).
+        let mut in_scope = candidates
+            .iter()
+            .filter(|(_, scope_sym)| self.import_equals_alias_scope_is_visible(*scope_sym));
+        let first = in_scope.next()?;
+        // Only substitute when the in-scope alias is unambiguous.
+        if in_scope.next().is_some() {
+            return None;
+        }
+        Some(first.0.clone())
+    }
+
+    /// Whether the import-equals target symbol is directly reachable by its own
+    /// (unqualified, scope-local) name at the current emit position, i.e. the
+    /// symbol's enclosing namespace/module scope encloses the current scope.
+    /// When true, tsc prefers the symbol's own name over an alias.
+    fn import_equals_target_locally_nameable(&self, sym_id: SymbolId) -> bool {
+        let Some(binder) = self.binder else {
+            return false;
+        };
+        let Some(target_scope) = binder.symbols.get(sym_id).map(|sym| sym.parent) else {
+            return false;
+        };
+        // Top-level symbols are always locally nameable.
+        if !target_scope.is_some() {
+            return true;
+        }
+        self.import_equals_alias_scope_is_visible(target_scope)
+    }
+
+    /// Whether an `import alias = ...` declared in `alias_scope` is in lexical
+    /// scope at the current emit position. `SymbolId::NONE` denotes file/top-level
+    /// scope, which is always visible. Otherwise the alias scope must be the
+    /// current enclosing namespace or one of its ancestors.
+    fn import_equals_alias_scope_is_visible(&self, alias_scope: SymbolId) -> bool {
+        if !alias_scope.is_some() {
+            return true;
+        }
+        let Some(binder) = self.binder else {
+            return false;
+        };
+        let mut current = self.enclosing_namespace_symbol;
+        while let Some(cur) = current {
+            if cur == alias_scope {
+                return true;
+            }
+            current = binder.symbols.get(cur).and_then(|sym| {
+                if sym.parent.is_some() {
+                    Some(sym.parent)
+                } else {
+                    None
+                }
+            });
+        }
+        false
+    }
+
     pub(crate) fn resolve_namespace_import_alias(&self, sym_id: SymbolId) -> Option<String> {
         let binder = self.binder?;
 

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/visibility.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/visibility.rs
@@ -1137,6 +1137,60 @@ impl<'a> DeclarationEmitter<'a> {
         idx
     }
 
+    /// Resolve the symbol that the entity name on the right-hand side of an
+    /// `import alias = Q.R.S` declaration refers to. Walks the qualified-name
+    /// chain left-to-right: the leftmost identifier resolves through normal
+    /// scope lookup, then each `.right` member is looked up in the running
+    /// symbol's exports/members tables. Returns the final member symbol.
+    pub(in crate::declaration_emitter) fn import_equals_entity_target_symbol(
+        &self,
+        binder: &tsz_binder::BinderState,
+        entity_idx: NodeIndex,
+    ) -> Option<SymbolId> {
+        // Collect member names from leftmost to rightmost.
+        let mut chain: Vec<NodeIndex> = Vec::new();
+        let mut current = entity_idx;
+        loop {
+            let node = self.arena.get(current)?;
+            if let Some(qn) = self.arena.get_qualified_name(node) {
+                chain.push(qn.right);
+                current = qn.left;
+            } else {
+                break;
+            }
+        }
+        // `current` is now the leftmost identifier node.
+        let leftmost_name = self
+            .arena
+            .get(current)
+            .and_then(|n| self.arena.get_identifier(n))
+            .map(|id| id.escaped_text.clone())?;
+        let mut sym_id = self.resolve_identifier_symbol(current, &leftmost_name)?;
+
+        // Walk member names right-to-left (chain was pushed leftmost-first).
+        for &member_idx in chain.iter().rev() {
+            let member_name = self
+                .arena
+                .get(member_idx)
+                .and_then(|n| self.arena.get_identifier(n))
+                .map(|id| id.escaped_text.clone())?;
+            let resolved = self.resolve_portability_symbol(sym_id, binder);
+            let symbol = binder.symbols.get(resolved)?;
+            let next = symbol
+                .exports
+                .as_ref()
+                .and_then(|exports| exports.get(&member_name))
+                .or_else(|| {
+                    symbol
+                        .members
+                        .as_ref()
+                        .and_then(|members| members.get(&member_name))
+                })?;
+            sym_id = next;
+        }
+        Some(sym_id)
+    }
+
     pub(in crate::declaration_emitter) fn leftmost_qualified_name_ident(
         &self,
         idx: NodeIndex,

--- a/crates/tsz-emitter/src/declaration_emitter/usage_analyzer.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/usage_analyzer.rs
@@ -625,9 +625,18 @@ impl<'a> UsageAnalyzer<'a> {
         let Some(ident) = self.arena.get_identifier(name_node) else {
             return;
         };
-        // Look up the symbol by name: first in file_locals, then in scope tables
-        // (needed for import aliases inside namespaces).
-        let sym_id = if let Some(sym_id) = self.binder.file_locals.get(&ident.escaped_text) {
+        // Prefer lexical, scope-aware resolution of this exact reference node:
+        // it resolves to the in-scope binding (e.g. the namespace-local
+        // `import c = x.c` alias) rather than the ambiguous result of a global
+        // name-only scan that could match a same-named declaration in an
+        // unrelated scope (such as the underlying class `x.c`). Fall back to
+        // the bound node symbol and then name lookup when scope resolution is
+        // unavailable.
+        let sym_id = if let Some(sym_id) = self.binder.resolve_identifier(self.arena, name_idx) {
+            sym_id
+        } else if let Some(sym_id) = self.binder.get_node_symbol(name_idx) {
+            sym_id
+        } else if let Some(sym_id) = self.binder.file_locals.get(&ident.escaped_text) {
             sym_id
         } else {
             let mut found = None;

--- a/crates/tsz-emitter/src/emitter/types/printer/mod.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/mod.rs
@@ -44,6 +44,10 @@ pub struct TypePrinter<'a> {
     module_path_resolver: Option<&'a dyn Fn(SymbolId) -> Option<String>>,
     /// Optional resolver for reusing in-scope namespace import aliases.
     namespace_alias_resolver: Option<&'a dyn Fn(SymbolId) -> Option<String>>,
+    /// Optional resolver mapping a symbol that is the resolved target of an
+    /// in-scope `import alias = Q.R.S` declaration to its alias name, so the
+    /// symbol is printed as the bare alias rather than its expanded path.
+    import_equals_alias_resolver: Option<&'a dyn Fn(SymbolId) -> Option<String>>,
     /// Optional resolver for deciding whether a local import alias survives in emitted output.
     local_import_alias_name_resolver: Option<&'a dyn Fn(SymbolId) -> bool>,
     /// Optional resolver for checking whether a foreign symbol has a local import
@@ -78,6 +82,7 @@ impl<'a> TypePrinter<'a> {
             node_arena: None,
             module_path_resolver: None,
             namespace_alias_resolver: None,
+            import_equals_alias_resolver: None,
             local_import_alias_name_resolver: None,
             has_local_import_alias_resolver: None,
             strict_null_checks: true,
@@ -163,6 +168,15 @@ impl<'a> TypePrinter<'a> {
         resolver: &'a dyn Fn(SymbolId) -> Option<String>,
     ) -> Self {
         self.namespace_alias_resolver = Some(resolver);
+        self
+    }
+
+    /// Set a resolver mapping an `import alias = Q.R.S` target symbol to its alias name.
+    pub fn with_import_equals_alias_resolver(
+        mut self,
+        resolver: &'a dyn Fn(SymbolId) -> Option<String>,
+    ) -> Self {
+        self.import_equals_alias_resolver = Some(resolver);
         self
     }
 

--- a/crates/tsz-emitter/src/emitter/types/printer/symbol_resolution.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/symbol_resolution.rs
@@ -303,6 +303,14 @@ impl<'a> TypePrinter<'a> {
         let arena = self.symbol_arena?;
         let sym = arena.get(sym_id)?;
 
+        // When the symbol itself is the resolved target of an in-scope
+        // `import alias = Q.R.S` declaration, tsc references it by the bare
+        // alias name (e.g. `import xc = x.c; var p: xc`). Return the alias
+        // directly instead of expanding the qualified path to `xc.c`/`x.c`.
+        if let Some(alias) = self.resolve_import_equals_alias(sym_id) {
+            return Some(alias);
+        }
+
         // When a symbol is a "default" export alias, resolve the underlying
         // declaration's actual name (e.g., `export default class MyComponent`
         // should print "MyComponent", not "default").
@@ -429,6 +437,11 @@ impl<'a> TypePrinter<'a> {
 
     pub(crate) fn resolve_namespace_import_alias(&self, sym_id: SymbolId) -> Option<String> {
         self.namespace_alias_resolver
+            .and_then(|resolver| resolver(sym_id))
+    }
+
+    pub(crate) fn resolve_import_equals_alias(&self, sym_id: SymbolId) -> Option<String> {
+        self.import_equals_alias_resolver
             .and_then(|resolver| resolver(sym_id))
     }
 


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — declaration emit parity (emit→100% campaign, wave 2)

## Invariant
When a declaration-emit type references a symbol that is the resolved target of
an in-scope `import alias = Q.R.S` declaration, `tsc` references it by the bare
alias name (not the expanded qualified path) and retains the alias as used —
but only where the alias is in lexical scope and the target is not more directly
nameable by its own local name. This PR makes tsz match that.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/core/{mod.rs,setup.rs,emit_declarations.rs}`
  — `local_import_equals_alias_for_target` map (target-symbol-keyed + alias scope).
- `helpers/visibility.rs` — `import_equals_entity_target_symbol` (walks `Q.R.S`).
- `helpers/type_printing_paths.rs` / `type_printing.rs` — resolver + scope-visibility
  and locally-nameable guards, wired into both DTS print sites.
- `usage_analyzer.rs` — lexical `resolve_identifier` so the namespace-local alias
  is marked used.
- `emitter/types/printer/{mod.rs,symbol_resolution.rs}` — alias resolver field +
  short-circuit in `resolve_symbol_qualified_name`.
- `crates/tsz-cli/tests/import_equals_alias_dts_emit_tests.rs` (new, 4 structural
  tests incl. renamed-identifier + locally-nameable guard) + Cargo.toml.

## Project Corpus Impact
- Row: n/a (declaration emit parity)
- Bug family: import-equals alias references + import retention in DTS
- Evidence: internalAliasClassInsideTopLevelModuleWith{,out}Export,
  internalAliasClassInsideLocalModuleWithoutExport FAIL→PASS; alias 92→95, internalAlias 34→37.

## Verification
- Witnesses FAIL→PASS (DTS): the 3 internalAlias* tests above.
- Regression families vs clean baseline (zero regressions): declarationEmit 359/15,
  import 276/2, alias 92→95 (+3), extends 21/1, internalAlias 34→37 (+3); JS emit
  unchanged. 4 new unit tests pass; `cargo clippy -p tsz-emitter --lib -- -D warnings` clean.
- Scope note: clean subset of a larger alias/heritage bundle; 4 sibling witnesses
  (typeof-import heritage synthesis, empty-array/undefined inference, conditional-type
  eval) are distinct root causes left for targeted follow-ups.

## Coordination Notes
Wave-2 fix #7 (clean subset). — opus48-emit100
