### PR TITLE
fix(checker): drop readonly from fresh `as const` arrays in mutable context

### DIFF
--- a/crates/tsz-checker/src/assignability/readonly_tuple_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/readonly_tuple_diagnostics.rs
@@ -5,9 +5,108 @@ use crate::query_boundaries::common::{
     type_param_info,
 };
 use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
+    /// A *mutable* (not `readonly`-wrapped) array or tuple type. `[...T]` counts
+    /// because a spread tuple is a mutable `Tuple`; `readonly number[]` does not.
+    fn is_mutable_array_or_tuple_type(&mut self, ty: TypeId) -> bool {
+        let evaluated = self.evaluate_type_for_assignability(ty);
+        for candidate in [ty, evaluated] {
+            if readonly_inner_type(self.ctx.types, candidate).is_none()
+                && (is_array_type(self.ctx.types, candidate)
+                    || is_tuple_type(self.ctx.types, candidate))
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Whether a contextual type asks for a mutable array/tuple value — either
+    /// directly (`number[]`, `[number, number]`, `[...T]`) or via a type
+    /// parameter whose constraint is one (`T extends unknown[]`). A `readonly`
+    /// contextual type (`readonly number[]`, `T extends readonly unknown[]`) does
+    /// not, so the source's const-ness is preserved there.
+    fn contextual_demands_mutable_array_or_tuple(&mut self, contextual: TypeId) -> bool {
+        if self.is_mutable_array_or_tuple_type(contextual) {
+            return true;
+        }
+        let evaluated = self.evaluate_type_for_assignability(contextual);
+        for candidate in [contextual, evaluated] {
+            if let Some(constraint) =
+                type_param_info(self.ctx.types, candidate).and_then(|info| info.constraint)
+                && self.is_mutable_array_or_tuple_type(constraint)
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Whether `expr_idx` is a *fresh* array literal whose `readonly`-ness comes
+    /// from `as const` — either the array literal itself (when called with the
+    /// assertion's operand) or an `[...] as const` wrapper (when called with the
+    /// whole assertion expression). An aliased value (a variable) is not fresh.
+    fn is_fresh_const_assertion_array_literal(&self, expr_idx: NodeIndex) -> bool {
+        let idx = self.ctx.arena.skip_parenthesized(expr_idx);
+        let Some(node) = self.ctx.arena.get(idx) else {
+            return false;
+        };
+        if node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION {
+            return true;
+        }
+        (node.kind == syntax_kind_ext::AS_EXPRESSION
+            || node.kind == syntax_kind_ext::TYPE_ASSERTION)
+            && self
+                .ctx
+                .arena
+                .get_type_assertion(node)
+                .filter(|assertion| self.is_const_assertion_type_node(assertion.type_node))
+                .and_then(|assertion| {
+                    let inner = self.ctx.arena.skip_parenthesized(assertion.expression);
+                    self.ctx.arena.get(inner)
+                })
+                .is_some_and(|inner| inner.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION)
+    }
+
+    /// tsc drops the `readonly` modifier from a *fresh* array/tuple literal
+    /// written with `as const` when its contextual type is a mutable array/tuple
+    /// (or a type parameter constrained to one). A fresh literal is not aliased,
+    /// so its const-ness is not binding at a mutable consumption site:
+    ///
+    /// ```text
+    /// const a: number[] = [1, 2] as const;          // ok ([1, 2] is mutable here)
+    /// declare function f<T extends readonly unknown[]>(t: [...T]): T;
+    /// const r = f([1, 2] as const);                 // ok, infers T = [1, 2]
+    /// ```
+    ///
+    /// while keeping it where the target is itself `readonly` or not an
+    /// array/tuple (`const x = [1, 2] as const` stays `readonly [1, 2]`), and
+    /// while an aliased `readonly` value (a variable) is still rejected by the
+    /// normal relation. `expr_idx` may be the array literal itself or the
+    /// enclosing `as const` expression. Returns the readonly-peeled (mutable)
+    /// type when the modifier should be dropped.
+    pub(crate) fn const_assertion_array_literal_drops_readonly(
+        &mut self,
+        expr_idx: NodeIndex,
+        result_type: TypeId,
+        contextual: Option<TypeId>,
+    ) -> Option<TypeId> {
+        let contextual = contextual?;
+        let inner = readonly_inner_type(self.ctx.types, result_type)?;
+        if !(is_array_type(self.ctx.types, inner) || is_tuple_type(self.ctx.types, inner)) {
+            return None;
+        }
+        if !self.is_fresh_const_assertion_array_literal(expr_idx) {
+            return None;
+        }
+        self.contextual_demands_mutable_array_or_tuple(contextual)
+            .then_some(inner)
+    }
+
     fn is_array_or_tuple_like_for_readonly_assignment(&mut self, type_id: TypeId) -> bool {
         let evaluated = self.evaluate_type_for_assignability(type_id);
         for candidate in [type_id, evaluated] {

--- a/crates/tsz-checker/src/assignability/readonly_tuple_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/readonly_tuple_diagnostics.rs
@@ -1,51 +1,14 @@
 //! Readonly array/tuple diagnostic preflights for assignment reporting.
 
 use crate::query_boundaries::common::{
-    array_element_type, is_array_type, is_tuple_type, readonly_inner_type, tuple_list_id,
-    type_param_info,
+    array_element_type, constraint_allows_mutable_array_like, is_array_type, is_tuple_type,
+    readonly_inner_type, tuple_list_id, type_param_info,
 };
 use crate::state::CheckerState;
-use tsz_parser::parser::NodeIndex;
-use tsz_parser::parser::syntax_kind_ext;
+use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
-    /// A *mutable* (not `readonly`-wrapped) array or tuple type. `[...T]` counts
-    /// because a spread tuple is a mutable `Tuple`; `readonly number[]` does not.
-    fn is_mutable_array_or_tuple_type(&mut self, ty: TypeId) -> bool {
-        let evaluated = self.evaluate_type_for_assignability(ty);
-        for candidate in [ty, evaluated] {
-            if readonly_inner_type(self.ctx.types, candidate).is_none()
-                && (is_array_type(self.ctx.types, candidate)
-                    || is_tuple_type(self.ctx.types, candidate))
-            {
-                return true;
-            }
-        }
-        false
-    }
-
-    /// Whether a contextual type asks for a mutable array/tuple value — either
-    /// directly (`number[]`, `[number, number]`, `[...T]`) or via a type
-    /// parameter whose constraint is one (`T extends unknown[]`). A `readonly`
-    /// contextual type (`readonly number[]`, `T extends readonly unknown[]`) does
-    /// not, so the source's const-ness is preserved there.
-    fn contextual_demands_mutable_array_or_tuple(&mut self, contextual: TypeId) -> bool {
-        if self.is_mutable_array_or_tuple_type(contextual) {
-            return true;
-        }
-        let evaluated = self.evaluate_type_for_assignability(contextual);
-        for candidate in [contextual, evaluated] {
-            if let Some(constraint) =
-                type_param_info(self.ctx.types, candidate).and_then(|info| info.constraint)
-                && self.is_mutable_array_or_tuple_type(constraint)
-            {
-                return true;
-            }
-        }
-        false
-    }
-
     /// Whether `expr_idx` is a *fresh* array literal whose `readonly`-ness comes
     /// from `as const` — either the array literal itself (when called with the
     /// assertion's operand) or an `[...] as const` wrapper (when called with the
@@ -55,20 +18,19 @@ impl<'a> CheckerState<'a> {
         let Some(node) = self.ctx.arena.get(idx) else {
             return false;
         };
+        // The assertion operand itself (the `as const` dispatch passes it directly).
         if node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION {
             return true;
         }
-        (node.kind == syntax_kind_ext::AS_EXPRESSION
-            || node.kind == syntax_kind_ext::TYPE_ASSERTION)
+        // An `[...] as const` wrapper (the call-argument site passes the whole
+        // expression) whose operand is an array literal.
+        self.expression_is_const_assertion(idx)
             && self
                 .ctx
                 .arena
                 .get_type_assertion(node)
-                .filter(|assertion| self.is_const_assertion_type_node(assertion.type_node))
-                .and_then(|assertion| {
-                    let inner = self.ctx.arena.skip_parenthesized(assertion.expression);
-                    self.ctx.arena.get(inner)
-                })
+                .map(|assertion| self.ctx.arena.skip_parenthesized(assertion.expression))
+                .and_then(|inner| self.ctx.arena.get(inner))
                 .is_some_and(|inner| inner.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION)
     }
 
@@ -88,7 +50,10 @@ impl<'a> CheckerState<'a> {
     /// while an aliased `readonly` value (a variable) is still rejected by the
     /// normal relation. `expr_idx` may be the array literal itself or the
     /// enclosing `as const` expression. Returns the readonly-peeled (mutable)
-    /// type when the modifier should be dropped.
+    /// type when the modifier should be dropped. The mutable-context test reuses
+    /// [`constraint_allows_mutable_array_like`], which already handles arrays,
+    /// non-empty tuples, type-parameter/`infer` constraints, union members, and
+    /// lazy/application aliases, and rejects `readonly` targets.
     pub(crate) fn const_assertion_array_literal_drops_readonly(
         &mut self,
         expr_idx: NodeIndex,
@@ -103,8 +68,7 @@ impl<'a> CheckerState<'a> {
         if !self.is_fresh_const_assertion_array_literal(expr_idx) {
             return None;
         }
-        self.contextual_demands_mutable_array_or_tuple(contextual)
-            .then_some(inner)
+        constraint_allows_mutable_array_like(self.ctx.types, contextual).then_some(inner)
     }
 
     fn is_array_or_tuple_like_for_readonly_assignment(&mut self, type_id: TypeId) -> bool {

--- a/crates/tsz-checker/src/checkers/call_checker/candidate_collection.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/candidate_collection.rs
@@ -957,6 +957,18 @@ impl<'a> CheckerState<'a> {
             }
             let arg_snap = DiagnosticSpeculationSnapshot::new(&self.ctx);
             let raw_arg_type = self.get_type_of_node_with_request(arg_idx, &request);
+            // A fresh `[...] as const` argument drops its `readonly` modifier when
+            // the parameter expects a mutable array/tuple (including a generic
+            // `[...T]` inference site), matching tsc. The contextual type is not
+            // routed through `request` for as-const literals, so apply the same
+            // rule here on the computed argument type.
+            let raw_arg_type = self
+                .const_assertion_array_literal_drops_readonly(
+                    arg_idx,
+                    raw_arg_type,
+                    expected_context_type.or(expected_type),
+                )
+                .unwrap_or(raw_arg_type);
             let arg_type = if let Some(expected) = expected_context_type.or(expected_type) {
                 let expected_eval = self.evaluate_type_with_env(expected);
                 let expected_shape =

--- a/crates/tsz-checker/src/dispatch/mod.rs
+++ b/crates/tsz-checker/src/dispatch/mod.rs
@@ -616,10 +616,21 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                             &request.read().normal_origin().contextual_opt(None),
                         );
                         self.checker.ctx.in_const_assertion = prev_in_const_assertion;
-                        crate::query_boundaries::widening::apply_const_assertion(
+                        let asserted = crate::query_boundaries::widening::apply_const_assertion(
                             self.checker.ctx.types,
                             expr_type,
-                        )
+                        );
+                        // A fresh `as const` array/tuple literal drops its
+                        // `readonly` modifier when the contextual type is a
+                        // mutable array/tuple (matching tsc); see
+                        // `const_assertion_array_literal_drops_readonly`.
+                        self.checker
+                            .const_assertion_array_literal_drops_readonly(
+                                assertion.expression,
+                                asserted,
+                                request.contextual_type,
+                            )
+                            .unwrap_or(asserted)
                     } else {
                         // Check for duplicate properties in type literal nodes (TS2300)
                         self.checker

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -606,6 +606,9 @@ mod for_in_lhs_relation_routing_arch_tests;
 #[path = "../tests/for_in_narrowing_tests.rs"]
 mod for_in_narrowing_tests;
 #[cfg(test)]
+#[path = "tests/fresh_const_array_mutable_assignment_tests.rs"]
+mod fresh_const_array_mutable_assignment_tests;
+#[cfg(test)]
 #[path = "tests/generic_callback_outer_context_tests.rs"]
 mod generic_callback_outer_context_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/fresh_const_array_mutable_assignment_tests.rs
+++ b/crates/tsz-checker/src/tests/fresh_const_array_mutable_assignment_tests.rs
@@ -1,0 +1,206 @@
+//! Tests for the rule: a *fresh* array/tuple literal written with `as const`
+//! drops its `readonly` modifier when its contextual/target type is a mutable
+//! array/tuple (or a type parameter constrained to one). This matches tsc — a
+//! freshly-constructed literal is not aliased, so its const-ness is not binding
+//! at a mutable consumption site.
+//!
+//! Structural rule: when the assignability source is a fresh `as const` array
+//! literal expression and the target is a mutable array/tuple (directly, or via
+//! a type parameter whose constraint is one), the source's outer `readonly` is
+//! peeled before the element-wise check. An aliased `readonly` value (a
+//! variable), a `readonly` target, a readonly *array* source, or a readonly
+//! *variadic* tuple source keep the modifier and are rejected as before.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Accepted: fresh `as const` literal into a mutable target.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fresh_const_array_to_mutable_array_var_init() {
+    // `const b: number[] = [1, 2] as const;` — tsc accepts (fresh literal).
+    assert!(
+        codes("const b: number[] = [1, 2] as const;").is_empty(),
+        "fresh `as const` array should drop readonly for a mutable array target"
+    );
+}
+
+#[test]
+fn fresh_const_array_to_mutable_tuple_var_init() {
+    assert!(
+        codes("const b: [number, number] = [1, 2] as const;").is_empty(),
+        "fresh `as const` array should drop readonly for a mutable tuple target"
+    );
+}
+
+#[test]
+fn fresh_const_array_in_return_position() {
+    assert!(
+        codes("function g(): number[] { return [1, 2] as const; }").is_empty(),
+        "fresh `as const` array in return position should drop readonly"
+    );
+}
+
+#[test]
+fn fresh_const_array_to_concrete_tuple_argument() {
+    let src = r#"
+declare function f(t: [number, number]): void;
+f([1, 2] as const);
+"#;
+    assert!(
+        codes(src).is_empty(),
+        "fresh `as const` array argument should drop readonly for a mutable tuple param"
+    );
+}
+
+#[test]
+fn fresh_const_array_to_mutable_array_argument() {
+    let src = r#"
+declare function f(t: number[]): void;
+f([1, 2] as const);
+"#;
+    assert!(
+        codes(src).is_empty(),
+        "fresh `as const` array argument should drop readonly for a mutable array param"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Accepted: generic variadic-tuple inference (the reported family).
+// Type-parameter names are varied to prove the rule is structural, not keyed
+// on a particular spelling.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fresh_const_array_into_variadic_generic_tuple_param_t() {
+    let src = r#"
+declare function f<T extends readonly unknown[]>(t: [...T]): T;
+const r = f([1, 2] as const);
+"#;
+    assert!(
+        codes(src).is_empty(),
+        "fresh `as const` array should infer through `[...T]` without a readonly error"
+    );
+}
+
+#[test]
+fn fresh_const_array_into_variadic_generic_tuple_param_renamed() {
+    // Same rule, different type-parameter name (`Elems`) — must still hold.
+    let src = r#"
+declare function f<Elems extends readonly unknown[]>(t: [...Elems]): Elems;
+const r = f([1, 2] as const);
+"#;
+    assert!(
+        codes(src).is_empty(),
+        "rule must not depend on the type-parameter name"
+    );
+}
+
+#[test]
+fn fresh_const_array_into_mutable_constrained_bare_type_param() {
+    // Constraint is mutable `unknown[]`, so readonly is dropped.
+    let src = r#"
+declare function f<K extends unknown[]>(t: K): K;
+const r = f([1, 2] as const);
+"#;
+    assert!(
+        codes(src).is_empty(),
+        "mutable-constrained bare type param should drop the source readonly"
+    );
+}
+
+#[test]
+fn fresh_const_arrays_into_two_variadic_type_params() {
+    // `concat([1, 2] as const, ['a', 'b'] as const)` — both arguments are fresh.
+    let src = r#"
+declare function concat<T extends readonly unknown[], U extends readonly unknown[]>(
+  t: [...T],
+  u: [...U],
+): [...T, ...U];
+const r = concat([1, 2] as const, ['a', 'b'] as const);
+"#;
+    assert!(
+        codes(src).is_empty(),
+        "both fresh `as const` arguments should flow into their `[...T]`/`[...U]` sites"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Still rejected: the readonly modifier is binding.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn aliased_readonly_tuple_variable_still_rejected() {
+    // A variable is not fresh, so readonly stays binding (TS2345).
+    let src = r#"
+declare function f(t: [number, number]): void;
+const a = [1, 2] as const;
+f(a);
+"#;
+    assert!(
+        codes(src).contains(&2345),
+        "aliased readonly tuple must still be rejected against a mutable param"
+    );
+}
+
+#[test]
+fn readonly_array_source_still_rejected_for_variadic_generic() {
+    // A readonly *array* (unbounded) is not a fresh fixed literal: rejected.
+    let src = r#"
+declare function f<T extends readonly unknown[]>(t: [...T]): T;
+declare const arr: readonly number[];
+const r = f(arr);
+"#;
+    assert!(
+        codes(src).contains(&2345),
+        "readonly array source must still be rejected against `[...T]`"
+    );
+}
+
+#[test]
+fn readonly_contextual_target_keeps_modifier() {
+    // A readonly target does not request mutability, so no peeling occurs and
+    // the (already readonly) source is accepted as-is — no diagnostic.
+    assert!(
+        codes("const b: readonly number[] = [1, 2] as const;").is_empty(),
+        "readonly target accepts the readonly source without peeling"
+    );
+}
+
+#[test]
+fn element_mismatch_still_reported_after_dropping_readonly() {
+    // After dropping readonly, the element-wise check still runs: `number` is not
+    // assignable to `string`. tsc reports TS2322 on the elements, never TS4104.
+    let src = "const b: string[] = [1, 2] as const;";
+    let cs = codes(src);
+    assert!(
+        cs.contains(&2322),
+        "element mismatch must still be reported (TS2322), got: {cs:?}"
+    );
+    assert!(
+        !cs.contains(&4104),
+        "must not report the readonly-to-mutable error (TS4104) for a fresh literal, got: {cs:?}"
+    );
+}
+
+#[test]
+fn plain_const_array_without_mutable_context_stays_readonly() {
+    // No mutable contextual type: the `as const` value remains `readonly [1, 2]`
+    // and is rejected when later assigned to a mutable tuple via a variable.
+    let src = r#"
+const a = [1, 2] as const;
+const b: [number, number] = a;
+"#;
+    assert!(
+        !codes(src).is_empty(),
+        "without a mutable contextual type the literal stays readonly"
+    );
+}

--- a/crates/tsz-checker/src/tests/fresh_const_array_mutable_assignment_tests.rs
+++ b/crates/tsz-checker/src/tests/fresh_const_array_mutable_assignment_tests.rs
@@ -20,6 +20,13 @@ fn codes(source: &str) -> Vec<u32> {
         .collect()
 }
 
+fn messages(source: &str) -> Vec<String> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|d| d.message_text)
+        .collect()
+}
+
 // ---------------------------------------------------------------------------
 // Accepted: fresh `as const` literal into a mutable target.
 // ---------------------------------------------------------------------------
@@ -188,6 +195,23 @@ fn element_mismatch_still_reported_after_dropping_readonly() {
     assert!(
         !cs.contains(&4104),
         "must not report the readonly-to-mutable error (TS4104) for a fresh literal, got: {cs:?}"
+    );
+}
+
+#[test]
+fn readonly_constrained_type_param_keeps_modifier_in_inferred_type() {
+    // `T extends readonly unknown[]` does not demand mutability, so the fresh
+    // literal stays `readonly [1, 2]` and the inferred `T` is revealed as such
+    // (guards the type-parameter-constraint path against over-stripping).
+    let src = r#"
+declare function f<T extends readonly unknown[]>(t: T): T;
+const r = f([1, 2] as const);
+const bad: null = r;
+"#;
+    assert!(
+        messages(src).iter().any(|m| m.contains("readonly [1, 2]")),
+        "readonly-constrained type param must keep the readonly modifier, got: {:?}",
+        messages(src)
     );
 }
 


### PR DESCRIPTION
AgentName: eager-pascal-opus48
Branch: `claude/eager-pascal-NfveQ`

Fixes #11606

## Track
Checker parity (TS2345/TS2322/TS4104) — fresh `as const` array/tuple literal freshness for the `readonly` modifier.

## Invariant
A fresh `as const` array/tuple literal must drop its outer `readonly` modifier when (and only when) its contextual/target type is a mutable array/tuple (directly, or via a type parameter constrained to one); in every other case the `readonly` modifier is preserved and the existing relation decides assignability. This must hold structurally, independent of type-parameter names and element shapes.

## Structural rule
> When the assignability source is a **fresh `as const` array/tuple literal** and the target is a **mutable array/tuple** — directly (`number[]`, `[number, number]`, `[...T]`) or via a type parameter whose constraint is one (`T extends unknown[]`) — drop the source's outer `readonly` before the element-wise check. Keep it when the source is aliased (a variable), when the source is a readonly *array* or readonly *variadic* tuple, when the target is itself `readonly`, or when the target's rest is concrete.

A freshly-constructed array literal is not aliased, so its const-ness is not binding at a mutable consumption site — this matches `tsc`.

## Scope
- `crates/tsz-checker/src/assignability/readonly_tuple_diagnostics.rs` — new shared helper `const_assertion_array_literal_drops_readonly` + fresh-literal detector (reusing `constraint_allows_mutable_array_like` and `expression_is_const_assertion`).
- `crates/tsz-checker/src/dispatch/mod.rs` — apply at the `as const` expression (var-init / return / `satisfies`).
- `crates/tsz-checker/src/checkers/call_checker/candidate_collection.rs` — apply at call-argument collection (arguments + generic inference).
- `crates/tsz-checker/src/tests/fresh_const_array_mutable_assignment_tests.rs` (+ `lib.rs` registration) — 15 regression tests.
- No solver/relation, variance, any-propagation, cache-key, or emit changes.

## Root cause
Issue #11606 ("variadic tuple arity inference drops trailing rest under nested spreads", `solver-27-20`) reproduces, but variadic arity inference is **already correct** — tsz infers the same `T` as tsc. The real divergence is fresh array-literal freshness for `readonly`: tsz kept the `readonly` modifier where tsc drops it, emitting spurious `TS2345` (call args / inference) and `TS4104`/`TS2345` (var-init/return).

Verified against `tsc` 6.0.2 across a 40-case matrix. Examples tsc accepts that tsz rejected before this change:

```ts
const b: number[] = [1, 2] as const;                          // var-init
function g(): number[] { return [1, 2] as const; }            // return
declare function f(t: [number, number]): void; f([1, 2] as const);   // argument
declare function h<T extends readonly unknown[]>(t: [...T]): T;
const r = h([1, 2] as const);                                 // variadic [...T] inference
declare function concat<T extends readonly unknown[], U extends readonly unknown[]>(
  t: [...T], u: [...U]): [...T, ...U];
const c = concat([1, 2] as const, ['a', 'b'] as const);       // nested spreads
```

## Owner layer & why
Freshness is an expression-level fact (the source AST node is an array literal directly under `as const`); tuple/array types carry no freshness flag visible to the solver, so a pure solver relation cannot distinguish a fresh literal from an aliased `readonly` value. The fix therefore lives in the checker via one shared helper applied at the two sites where a fresh literal meets a mutable contextual type:
- `dispatch/mod.rs` — the `as const` expression (var-init, return, `satisfies`).
- `checkers/call_checker/candidate_collection.rs` — call-argument collection (the parameter contextual type is not routed through the `request` for `as const` literals).

## Adjacent-case test matrix (`fresh_const_array_mutable_assignment_tests.rs`, 15 tests)
- Fresh `as const` → mutable array / mutable tuple / return position / concrete tuple arg / mutable array arg.
- Generic variadic `[...T]` inference, with a **renamed** type parameter (`Elems`) and a renamed bare param (`K`) to prove the rule is structural, not keyed on spelling.
- Two-type-parameter `concat([...] as const, [...] as const)` (nested spreads).
- Negatives that must still error: aliased readonly variable; readonly *array* source into `[...T]`; element mismatch still reports `TS2322` and never `TS4104`; plain `as const` without a mutable context stays `readonly`; readonly-constrained type param keeps the modifier in the inferred type.
- `readonly` target keeps the modifier (no spurious diagnostic).

## Project Corpus Impact
- Row: `type-challenges-solutions-project` (solver-27-20 family; type-challenges leans heavily on `as const` flowing into variadic-tuple utilities).
- Bug family: fresh array-literal `readonly` freshness on assignment/argument/inference.
- Evidence: 40-case `tsc` 6.0.2 differential matrix (all converge except a contrived double-rest `[...A, ...B]` case, a separate inference ambiguity where tsc itself falls back to `any[]` — out of scope); new 15-test regression suite.

## Verification
- `cargo build -p tsz-cli` — clean.
- `cargo test -p tsz-checker --lib fresh_const_array` — 15/15 regression tests pass (full lib test binary builds clean); full checker suite delegated to CI per repo policy.
- `cargo fmt --check` — clean.
- 40-case CLI differential vs `tsc` 6.0.2 — converged (except the documented out-of-scope double-rest case).

## Known out-of-scope
Double-rest variadic inference `(a: [...A, ...B], b: B) => A` with two free type parameters resolves to `A = any[]` in tsc; tsz over-infers there. That is a distinct inference-ambiguity bug, not readonly freshness, and is a follow-up.

## Coordination Notes
- Issue #11606 has the `WIP` label and a signed claim comment from this agent.
- No overlap with open PRs: only #10537 (draft M1-B relation-routing refactor) touches `candidate_collection.rs`, on unrelated relation-outcome routing; this change adds an independent freshness branch.

## /simplify
Ran 3 passes. Applied: replaced two local predicates with the existing `constraint_allows_mutable_array_like` query; reused `expression_is_const_assertion`; merged imports (−40 lines of duplication). Reviews confirmed correct altitude (one shared helper, two legitimately-distinct contextual-entry call sites), no hardcoding, and cheap guards before any expensive work.