### PR TITLE
fix(diagnostics): expand primitive/literal type aliases in messages

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -271,15 +271,30 @@ impl<'a> CheckerState<'a> {
                 }
             }
             let evaluated = self.evaluate_type_with_env(ty);
-            if evaluated != ty
-                && self.ctx.types.get_display_alias(evaluated).is_some()
-                && !crate::query_boundaries::recursive_alias::is_def_non_generic_recursive_alias(
+            if evaluated != ty {
+                if self.ctx.types.get_display_alias(evaluated).is_some()
+                    && !crate::query_boundaries::recursive_alias::is_def_non_generic_recursive_alias(
+                        self.ctx.types.as_type_database(),
+                        &self.ctx.definition_store,
+                        def_id,
+                    )
+                {
+                    return self.format_type_for_assignability_message(evaluated);
+                }
+                // tsc attaches an alias symbol (and renders the alias name) only
+                // to freshly-constructed structural types. A non-generic alias
+                // whose body resolves to a bare intrinsic keyword or a literal
+                // points at a shared singleton type with no alias symbol, so tsc
+                // shows the underlying type (`string`, `42`, `never`, …) —
+                // including through alias chains (`type A = B; type B = string`
+                // renders as `string`). `evaluate_type_with_env` collapses the
+                // chain, so a single check on the evaluated form covers the family.
+                if crate::query_boundaries::common::is_intrinsic_or_literal_type(
                     self.ctx.types.as_type_database(),
-                    &self.ctx.definition_store,
-                    def_id,
-                )
-            {
-                return self.format_type_for_assignability_message(evaluated);
+                    evaluated,
+                ) {
+                    return self.format_type_for_assignability_message(evaluated);
+                }
             }
             let name = self.ctx.types.resolve_atom_ref(def.name);
             return name.to_string();

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -289,7 +289,7 @@ impl<'a> CheckerState<'a> {
                 // including through alias chains (`type A = B; type B = string`
                 // renders as `string`). `evaluate_type_with_env` collapses the
                 // chain, so a single check on the evaluated form covers the family.
-                if crate::query_boundaries::common::is_intrinsic_or_literal_type(
+                if crate::query_boundaries::type_predicates::is_intrinsic_or_literal_type(
                     self.ctx.types.as_type_database(),
                     evaluated,
                 ) {

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -930,6 +930,9 @@ mod ts2590_array_literal_identity_skip_tests;
 #[path = "tests/ts2739_alias_unfold_display_tests.rs"]
 mod ts2739_alias_unfold_display_tests;
 #[cfg(test)]
+#[path = "tests/type_alias_primitive_display_tests.rs"]
+mod type_alias_primitive_display_tests;
+#[cfg(test)]
 #[path = "tests/type_param_default_relation_routing_arch_tests.rs"]
 mod type_param_default_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1713,6 +1713,14 @@ pub(crate) fn is_primitive_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool 
     tsz_solver::visitor::is_primitive_type(db, type_id)
 }
 
+/// True when `type_id` is a bare intrinsic keyword type or a literal type — the
+/// types tsc does not attach an `aliasSymbol` to. A non-generic type alias whose
+/// body resolves to one of these renders structurally in diagnostics rather than
+/// by the alias name.
+pub(crate) fn is_intrinsic_or_literal_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    tsz_solver::visitor::is_intrinsic_or_literal_type(db, type_id)
+}
+
 pub(crate) fn is_literal_type_through_type_constraints(
     db: &dyn TypeDatabase,
     type_id: TypeId,

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1713,14 +1713,6 @@ pub(crate) fn is_primitive_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool 
     tsz_solver::visitor::is_primitive_type(db, type_id)
 }
 
-/// True when `type_id` is a bare intrinsic keyword type or a literal type — the
-/// types tsc does not attach an `aliasSymbol` to. A non-generic type alias whose
-/// body resolves to one of these renders structurally in diagnostics rather than
-/// by the alias name.
-pub(crate) fn is_intrinsic_or_literal_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
-    tsz_solver::visitor::is_intrinsic_or_literal_type(db, type_id)
-}
-
 pub(crate) fn is_literal_type_through_type_constraints(
     db: &dyn TypeDatabase,
     type_id: TypeId,

--- a/crates/tsz-checker/src/query_boundaries/type_predicates.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_predicates.rs
@@ -22,6 +22,14 @@ pub(crate) fn contains_conditional_with_application_extends(
     tsz_solver::type_queries::contains_conditional_with_application_extends(db, type_id)
 }
 
+/// True when `type_id` is a bare intrinsic keyword type or a literal type — the
+/// types tsc does not attach an `aliasSymbol` to. A non-generic type alias whose
+/// body resolves to one of these renders structurally in diagnostics rather than
+/// by the alias name.
+pub(crate) fn is_intrinsic_or_literal_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    tsz_solver::visitor::is_intrinsic_or_literal_type(db, type_id)
+}
+
 /// Primitive index-key types: the only types tsc treats as valid bare keys for
 /// `keyof`/index-signature constraint membership.
 const PRIMITIVE_INDEX_KEYS: [TypeId; 3] = [TypeId::STRING, TypeId::NUMBER, TypeId::SYMBOL];

--- a/crates/tsz-checker/src/tests/type_alias_primitive_display_tests.rs
+++ b/crates/tsz-checker/src/tests/type_alias_primitive_display_tests.rs
@@ -1,0 +1,178 @@
+//! Regression coverage for type-alias name display in assignability
+//! diagnostics (`diagnostics-32-20` family, issue #11611).
+//!
+//! tsc attaches an `aliasSymbol` (and therefore renders the alias name) only to
+//! freshly-constructed structural types — unions, intersections, objects,
+//! arrays, tuples, functions, etc. A non-generic type alias whose body resolves
+//! to a bare intrinsic keyword or a literal points at a shared singleton type
+//! with no alias symbol, so tsc shows the underlying type (`string`, `42`,
+//! `never`, …) rather than the alias name — including through alias chains.
+//!
+//! tsz previously expanded such aliases correctly at top level but leaked the
+//! alias name in nested property positions. These tests pin the tsc-compatible
+//! behavior for both the expand cases and the keep-the-name cases. The variable
+//! names of the aliases are deliberately varied so a hardcoded fix would fail.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn ts2322_message(source: &str) -> String {
+    let diags = check_source_diagnostics(source);
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "expected exactly one TS2322, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    ts2322[0].message_text.clone()
+}
+
+// 1. Reported repro: a primitive alias used as a nested property type expands
+//    to the underlying primitive, not the alias name.
+#[test]
+fn primitive_alias_expands_in_nested_property() {
+    let msg = ts2322_message(
+        r#"
+type ID = string;
+type User = { id: ID; name: string };
+const u: User = { id: 1, name: "x" };
+"#,
+    );
+    assert!(
+        msg.contains("type 'string'") && !msg.contains("type 'ID'"),
+        "expected primitive alias `ID` to render as `string`, got: {msg}"
+    );
+}
+
+// 2a. Equivalent shape: number-bodied alias, different name (`N`).
+#[test]
+fn number_alias_expands_in_nested_property() {
+    let msg = ts2322_message(
+        r#"
+type N = number;
+type Holder = { value: N };
+const h: Holder = { value: "s" };
+"#,
+    );
+    assert!(
+        msg.contains("type 'number'") && !msg.contains("type 'N'"),
+        "expected number alias `N` to render as `number`, got: {msg}"
+    );
+}
+
+// 2b. Equivalent shape: literal-bodied alias renders as the literal.
+#[test]
+fn literal_alias_expands_in_nested_property() {
+    let msg = ts2322_message(
+        r#"
+type Greeting = "hello";
+type Box = { tag: Greeting };
+const b: Box = { tag: "bye" };
+"#,
+    );
+    assert!(
+        msg.contains("type '\"hello\"'") && !msg.contains("type 'Greeting'"),
+        "expected literal alias `Greeting` to render as `\"hello\"`, got: {msg}"
+    );
+}
+
+// 2c. Equivalent shape: `never` keyword alias renders as `never`.
+#[test]
+fn never_alias_expands_in_nested_property() {
+    let msg = ts2322_message(
+        r#"
+type Empty = never;
+type Wrap = { slot: Empty };
+const w: Wrap = { slot: 1 };
+"#,
+    );
+    assert!(
+        msg.contains("type 'never'") && !msg.contains("type 'Empty'"),
+        "expected `never` alias `Empty` to render as `never`, got: {msg}"
+    );
+}
+
+// 3. Renamed-binding case: the rule must not depend on the alias spelling. A
+//    differently-named primitive alias still expands.
+#[test]
+fn renamed_primitive_alias_still_expands() {
+    let msg = ts2322_message(
+        r#"
+type WhateverNameHere = string;
+type Container = { field: WhateverNameHere };
+const c: Container = { field: 42 };
+"#,
+    );
+    assert!(
+        msg.contains("type 'string'") && !msg.contains("WhateverNameHere"),
+        "expected renamed primitive alias to render as `string`, got: {msg}"
+    );
+}
+
+// 4. Alias-chain case: `A = B; B = string` collapses to `string`.
+#[test]
+fn primitive_alias_chain_expands_to_underlying() {
+    let msg = ts2322_message(
+        r#"
+type B = string;
+type A = B;
+type Rec = { k: A };
+const r: Rec = { k: 5 };
+"#,
+    );
+    assert!(
+        msg.contains("type 'string'") && !msg.contains("type 'A'") && !msg.contains("type 'B'"),
+        "expected alias chain `A = B = string` to render as `string`, got: {msg}"
+    );
+}
+
+// 5a. Negative case: a union-bodied alias KEEPS its name (tsc attaches an alias
+//     symbol to union types).
+#[test]
+fn union_alias_keeps_name_in_nested_property() {
+    let msg = ts2322_message(
+        r#"
+type IdLike = string | number;
+type Wrap = { id: IdLike };
+const w: Wrap = { id: true };
+"#,
+    );
+    assert!(
+        msg.contains("type 'IdLike'"),
+        "expected union alias `IdLike` to keep its name, got: {msg}"
+    );
+}
+
+// 5b. Negative case: an object-bodied alias KEEPS its name.
+#[test]
+fn object_alias_keeps_name_at_top_level() {
+    let msg = ts2322_message(
+        r#"
+type Point = { x: number; y: number };
+const p: Point = 5;
+"#,
+    );
+    assert!(
+        msg.contains("type 'Point'"),
+        "expected object alias `Point` to keep its name, got: {msg}"
+    );
+}
+
+// 5c. Negative case: a function-bodied alias KEEPS its name.
+#[test]
+fn function_alias_keeps_name_in_nested_property() {
+    let msg = ts2322_message(
+        r#"
+type Handler = () => number;
+type Wrap = { fn: Handler };
+const w: Wrap = { fn: 5 };
+"#,
+    );
+    assert!(
+        msg.contains("type 'Handler'"),
+        "expected function alias `Handler` to keep its name, got: {msg}"
+    );
+}

--- a/crates/tsz-solver/src/diagnostics/format/key.rs
+++ b/crates/tsz-solver/src/diagnostics/format/key.rs
@@ -150,6 +150,20 @@ impl<'a> TypeFormatter<'a> {
                 {
                     return self.format_skipped_type_alias_body(*def_id, body);
                 }
+                // tsc attaches an alias symbol (and therefore renders the alias
+                // name) only to freshly-constructed structural types — unions,
+                // intersections, objects, arrays, tuples, functions, mapped,
+                // conditional, etc. A non-generic type alias whose body resolves
+                // to a primitive `Intrinsic` or a `Literal` points at a shared
+                // singleton type that carries no alias symbol, so tsc shows the
+                // underlying type (`string`, `42`, `true`, ...) rather than the
+                // alias name — including through alias chains such as
+                // `type A = B; type B = string`. Mirror that policy here so
+                // nested elaboration positions (which keep the property type as
+                // `Lazy(def)`) do not leak the alias spelling.
+                if let Some(body) = self.type_alias_body_displayed_as_underlying(*def_id) {
+                    return self.format(body);
+                }
                 self.format_def_id_with_type_params(*def_id, "Lazy").into()
             }
             TypeData::Recursive(idx) => format!("Recursive({idx})").into(),
@@ -761,6 +775,43 @@ impl<'a> TypeFormatter<'a> {
                 format!("typeof import(\"{name}\")").into()
             }
             TypeData::Error => Cow::Borrowed("error"),
+        }
+    }
+
+    /// Mirror tsc's `aliasSymbol` policy for diagnostic display: a non-generic
+    /// type alias whose body resolves to a primitive `Intrinsic` or a `Literal`
+    /// is rendered as the underlying type, not by the alias name.
+    ///
+    /// Returns the resolved primitive/literal `TypeId` to format in place of the
+    /// alias name, or `None` when the alias should keep its name (generic alias,
+    /// or a body that is a union/intersection/object/array/tuple/function/…).
+    /// Alias chains are followed (`type A = B; type B = string` → `string`); a
+    /// bounded visited set guards against cyclic alias definitions.
+    fn type_alias_body_displayed_as_underlying(&self, def_id: crate::def::DefId) -> Option<TypeId> {
+        use crate::def::DefKind;
+
+        let def_store = self.def_store?;
+        let mut current_def = def_id;
+        let mut seen = 0usize;
+        loop {
+            // Bound iteration to avoid spinning on a cyclic alias chain.
+            seen += 1;
+            if seen > 64 {
+                return None;
+            }
+
+            let def = def_store.get(current_def)?;
+            if def.kind != DefKind::TypeAlias || !def.type_params.is_empty() {
+                return None;
+            }
+            let body = def.body?;
+            if crate::visitor::is_intrinsic_or_literal_type(self.interner, body) {
+                return Some(body);
+            }
+            match self.interner.lookup(body) {
+                Some(TypeData::Lazy(next_def)) => current_def = next_def,
+                _ => return None,
+            }
         }
     }
 

--- a/crates/tsz-solver/src/diagnostics/format/keyof_alias_display_tests.rs
+++ b/crates/tsz-solver/src/diagnostics/format/keyof_alias_display_tests.rs
@@ -41,3 +41,89 @@ fn keyof_display_alias_does_not_repaint_unit_literal_union() {
         "A unit-literal union must render by members, never as `keyof R`"
     );
 }
+
+#[test]
+fn lazy_primitive_alias_renders_as_underlying_not_alias_name() {
+    // `type N = number` used in a nested position arrives at the formatter as
+    // `Lazy(N)`. tsc renders such a primitive-bodied alias as `number` (no
+    // `aliasSymbol` is attached to the shared intrinsic), not as `N`.
+    let db = TypeInterner::new();
+    let def_store = crate::def::DefinitionStore::new();
+
+    let n_def = def_store.register(crate::def::DefinitionInfo::type_alias(
+        db.intern_string("N"),
+        vec![],
+        TypeId::NUMBER,
+    ));
+    let lazy_n = db.lazy(n_def);
+
+    let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+    assert_eq!(
+        fmt.format(lazy_n),
+        "number",
+        "A primitive-bodied type alias must render structurally, not by name"
+    );
+}
+
+#[test]
+fn lazy_literal_alias_renders_as_literal_not_alias_name() {
+    // `type Greeting = "hello"` renders as `"hello"`, never `Greeting`.
+    let db = TypeInterner::new();
+    let def_store = crate::def::DefinitionStore::new();
+
+    let body = db.literal_string("hello");
+    let def = def_store.register(crate::def::DefinitionInfo::type_alias(
+        db.intern_string("Greeting"),
+        vec![],
+        body,
+    ));
+    let lazy = db.lazy(def);
+
+    let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+    assert_eq!(fmt.format(lazy), "\"hello\"");
+}
+
+#[test]
+fn lazy_primitive_alias_chain_renders_as_underlying() {
+    // `type A = B; type B = string` collapses to `string` through the chain.
+    let db = TypeInterner::new();
+    let def_store = crate::def::DefinitionStore::new();
+
+    let b_def = def_store.register(crate::def::DefinitionInfo::type_alias(
+        db.intern_string("B"),
+        vec![],
+        TypeId::STRING,
+    ));
+    let a_def = def_store.register(crate::def::DefinitionInfo::type_alias(
+        db.intern_string("A"),
+        vec![],
+        db.lazy(b_def),
+    ));
+    let lazy_a = db.lazy(a_def);
+
+    let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+    assert_eq!(fmt.format(lazy_a), "string");
+}
+
+#[test]
+fn lazy_union_alias_keeps_its_name() {
+    // A union-bodied alias is a freshly-constructed structural type and keeps
+    // its alias name (`IdLike`), unlike a primitive-bodied alias.
+    let db = TypeInterner::new();
+    let def_store = crate::def::DefinitionStore::new();
+
+    let body = db.union(vec![TypeId::STRING, TypeId::NUMBER]);
+    let def = def_store.register(crate::def::DefinitionInfo::type_alias(
+        db.intern_string("IdLike"),
+        vec![],
+        body,
+    ));
+    let lazy = db.lazy(def);
+
+    let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+    assert_eq!(
+        fmt.format(lazy),
+        "IdLike",
+        "A union-bodied alias must keep its name"
+    );
+}

--- a/crates/tsz-solver/src/diagnostics/format/tests_parts/part_02.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests_parts/part_02.rs
@@ -1227,9 +1227,14 @@ fn union_array_of_intrinsic_stays_after_primitive_builtin() {
     let union_id = db.union_preserve_members(vec![react_child_ref, any_array, TypeId::BOOLEAN]);
 
     let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+    // `ReactChild = string` is a primitive-bodied alias, so it renders as
+    // `string` (tsc attaches no `aliasSymbol` to the shared intrinsic). The
+    // point of this test is the union member ordering: the array of an
+    // intrinsic element type must not inherit `any`'s low builtin key, so it
+    // stays after the `boolean` primitive rather than sorting to the front.
     assert_eq!(
         fmt.format(union_id),
-        "boolean | any[] | ReactChild",
+        "boolean | any[] | string",
         "Arrays of intrinsic element types should not inherit `any`'s low builtin key"
     );
 }

--- a/crates/tsz-solver/src/visitors/visitor_predicates.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates.rs
@@ -291,6 +291,22 @@ pub fn is_widening_primitive_intrinsic(types: &dyn TypeDatabase, type_id: TypeId
     }
 }
 
+/// Check if a type is a bare intrinsic keyword type (`any`, `unknown`, `never`,
+/// `void`, `object`, `null`, `undefined`, `boolean`, `number`, `string`,
+/// `bigint`, `symbol`) or a literal type.
+///
+/// These are exactly the types tsc does not attach an `aliasSymbol` to: they
+/// resolve to shared singleton types rather than freshly-constructed structural
+/// types. A type alias whose body resolves to one of them is therefore rendered
+/// structurally (`string`, `42`, `true`, …) in diagnostics rather than by the
+/// alias name, mirroring tsc's display policy.
+pub fn is_intrinsic_or_literal_type(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    matches!(
+        types.lookup(type_id),
+        Some(TypeData::Intrinsic(_) | TypeData::Literal(_))
+    )
+}
+
 /// Check if a type is a primitive type (intrinsic or literal).
 pub fn is_primitive_type(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
     // Check well-known intrinsic primitive TypeIds first.


### PR DESCRIPTION
## Agent
AgentName: opus-eager-pascal

## Track
Diagnostics / type display parity (TS2322 family)

## Invariant
When a non-generic type alias's body resolves (through alias chains) to a bare
intrinsic keyword (`string`, `number`, `never`, `void`, `object`, …) or a
literal type, `tsc` attaches no `aliasSymbol` and renders the underlying type in
diagnostics rather than the alias name; this PR makes tsz do the same through
the solver `TypeFormatter` and the checker assignability-message formatter.

## Scope
- `crates/tsz-solver/src/visitors/visitor_predicates.rs` — new structural
  predicate `is_intrinsic_or_literal_type`.
- `crates/tsz-solver/src/diagnostics/format/key.rs` — `TypeData::Lazy` display
  arm expands primitive/literal-bodied aliases via a chain-following helper.
- `crates/tsz-checker/src/query_boundaries/common.rs` — checker wrapper for the
  predicate.
- `crates/tsz-checker/src/error_reporter/core_formatting.rs` —
  `format_type_for_assignability_message` expands primitive/literal-bodied
  aliases instead of emitting `def.name`.
- Tests: solver formatter unit tests + checker end-to-end TS2322 message tests;
  one existing solver test expectation corrected to tsc-accurate output.

## Project Corpus Impact
- Row: `type-challenges-solutions-project` (issue #11611); cross-row siblings
  `nextjs` (#11592) and `nextjs-fresh-app` (#11490) share the family.
- Bug family: `diagnostics` — type-alias name leaks into nested assignability
  messages.
- Evidence: `tsc` 6.0.2 vs tsz diffs captured on minimal fixtures (see below);
  owning-crate unit tests added in `tsz-solver` and `tsz-checker`.

## Verification
Minimal fixtures compared against `tsc` 6.0.2 (tsz's pinned target):

| alias body | tsc | tsz (before) | tsz (after) |
|---|---|---|---|
| `type ID = string` (nested prop) | `string` | `ID` ❌ | `string` ✅ |
| `type Lit = "hello"` | `"hello"` | `Lit` ❌ | `"hello"` ✅ |
| `type Big = 100n` | `100n` | `Big` ❌ | `100n` ✅ |
| `type Bool = true` | `true` | `Bool` ❌ | `true` ✅ |
| `type E = never` | `never` | `E` ❌ | `never` ✅ |
| `type A = B; type B = string` | `string` | `A` ❌ | `string` ✅ |
| `type IDU = string\|number` (union) | `IDU` | `IDU` ✅ | `IDU` ✅ |
| `type Arr = string[]` (array) | `Arr` | `Arr` ✅ | `Arr` ✅ |
| `type Fn = () => number` (function) | `Fn` | `Fn` ✅ | `Fn` ✅ |

New unit tests:
- `tsz-solver`: `lazy_primitive_alias_renders_as_underlying_not_alias_name`,
  `lazy_literal_alias_renders_as_literal_not_alias_name`,
  `lazy_primitive_alias_chain_renders_as_underlying`,
  `lazy_union_alias_keeps_its_name`.
- `tsz-checker`: `type_alias_primitive_display_tests` (9 tests covering the
  reported repro, primitive/literal/`never`, a renamed alias, an alias chain,
  and union/object/function keep-the-name negatives).

Each test varies the alias spelling so a hardcoded fix would fail. Ran the
`tsz-solver` `diagnostics::format` suite (207 passing) and the new
`tsz-checker` tests locally.

## Coordination Notes
- AgentName `opus-eager-pascal`. Closes #11611; also fixes #11592 and #11490.
- Closed #11579 (overload-implementation family) as already-fixed with evidence
  during issue triage for this work.
- Structural rule only — no string-matching of printer output, no per-test
  suppressions (§25/§26 compliant). Predicate lives once in the solver visitor
  and is shared by both display paths.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbADeNwmD551GPyQa5eFZA)_