### PR TITLE
fix(emit): inline (void 0) source for ES5 for-in destructuring head with no iteration source

### DIFF
--- a/crates/tsz-emitter/src/emitter/statements/control_flow.rs
+++ b/crates/tsz-emitter/src/emitter/statements/control_flow.rs
@@ -504,16 +504,47 @@ impl<'a> Printer<'a> {
             let Some(pattern_node) = self.arena.get(pattern_idx) else {
                 continue;
             };
-            let temp_name = self.get_temp_var_name();
-            if !first {
-                self.write(", ");
+            // There is no real iteration source here (the binding pattern has
+            // no initializer), so the synthetic source is `void 0`. tsc binds
+            // that source to a temp only when the destructuring reads it more
+            // than once, i.e. when the pattern has more than one element. For a
+            // single-element pattern the source is referenced exactly once, so
+            // tsc inlines the parenthesized `(void 0)` directly into that one
+            // element/member access instead of allocating a source temp:
+            //   `for (var _a = (void 0)[0], x = _a === void 0 ? ... : _a ...)`
+            //   `for (var _b = (void 0).x,  x = _b === void 0 ? ... : _b ...)`
+            // Multi-element patterns keep the shared source temp so the source
+            // is evaluated once:
+            //   `for (var _a = void 0, a = _a[0], b = _a[1] in [])`
+            if self.binding_pattern_has_single_element(pattern_node) {
+                self.emit_es5_destructuring_pattern_direct(pattern_node, "(void 0)", &mut first);
+            } else {
+                let temp_name = self.get_temp_var_name();
+                if !first {
+                    self.write(", ");
+                }
+                first = false;
+                self.write(&temp_name);
+                self.write(" = void 0");
+                self.emit_es5_destructuring_pattern(pattern_node, &temp_name);
             }
-            first = false;
-            self.write(&temp_name);
-            self.write(" = void 0");
-            self.emit_es5_destructuring_pattern(pattern_node, &temp_name);
         }
         true
+    }
+
+    /// Returns true when an object/array binding pattern declares exactly one
+    /// element. tsc only inlines a single-use destructuring source (and skips
+    /// the shared source temp) when the pattern reads the source exactly once,
+    /// which corresponds to a single-element pattern.
+    fn binding_pattern_has_single_element(&self, pattern_node: &Node) -> bool {
+        if pattern_node.kind != syntax_kind_ext::OBJECT_BINDING_PATTERN
+            && pattern_node.kind != syntax_kind_ext::ARRAY_BINDING_PATTERN
+        {
+            return false;
+        }
+        self.arena
+            .get_binding_pattern(pattern_node)
+            .is_some_and(|pattern| pattern.elements.nodes.len() == 1)
     }
 
     pub(in crate::emitter) fn emit_for_of_statement(&mut self, node: &Node) {

--- a/crates/tsz-emitter/tests/statements.rs
+++ b/crates/tsz-emitter/tests/statements.rs
@@ -1524,3 +1524,94 @@ interface I2 extends Foo {
         "Recovered return from erased interface type body should emit before the leftover semicolon.\nOutput:\n{output}"
     );
 }
+
+// =============================================================================
+// ES5 for-in destructuring head: synthetic `void 0` source materialization
+// =============================================================================
+//
+// Structural rule: an ES5 for-in head whose binding pattern has no real
+// iteration source synthesizes `void 0` as the source. tsc inlines the
+// parenthesized `(void 0)` directly into the single element/member access when
+// the pattern has exactly one element (the source is read once), and only falls
+// back to a shared `_x = void 0` source temp when the pattern has more than one
+// element (the source is read multiple times). The tests below vary the bound
+// names and the pattern shape so they prove the rule, not the spelling.
+
+#[test]
+fn es5_for_in_single_array_binding_with_default_inlines_void0() {
+    let source = "for (let [x = 'a' in {}] in { '': 0 }) console.log(x)";
+    let output = parse_and_emit_strict_target(source, "forin.ts", ScriptTarget::ES5);
+
+    assert!(
+        output.contains("(void 0)[0]"),
+        "Single-element array for-in head should inline (void 0)[0].\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("= void 0,"),
+        "Single-element array for-in head must not allocate a source temp.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es5_for_in_single_object_binding_with_default_inlines_void0() {
+    // Renamed iteration variable (`y` not `x`) to prove the rule is structural.
+    let source = "for (let {y = 'a' in {}} in { '': 0 }) console.log(y)";
+    let output = parse_and_emit_strict_target(source, "forin.ts", ScriptTarget::ES5);
+
+    assert!(
+        output.contains("(void 0).y"),
+        "Single-element object for-in head should inline (void 0).y.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("= void 0,"),
+        "Single-element object for-in head must not allocate a source temp.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es5_for_in_single_array_binding_no_default_inlines_void0() {
+    // Single element without a default still reads the source once -> inline.
+    let source = "for (var [first] in []) {}";
+    let output = parse_and_emit_strict_target(source, "forin.ts", ScriptTarget::ES5);
+
+    assert!(
+        output.contains("(void 0)[0]"),
+        "Single-element no-default array for-in head should inline (void 0)[0].\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("= void 0,"),
+        "Single-element for-in head must not allocate a source temp.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es5_for_in_multi_array_binding_uses_source_temp() {
+    // Two elements read the source twice, so tsc binds it to a shared temp.
+    let source = "for (var [a, b] in []) {}";
+    let output = parse_and_emit_strict_target(source, "forin.ts", ScriptTarget::ES5);
+
+    assert!(
+        output.contains("= void 0,"),
+        "Multi-element array for-in head should allocate a shared source temp.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("(void 0)["),
+        "Multi-element array for-in head must not inline the synthetic source.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es5_for_in_multi_object_binding_uses_source_temp() {
+    // Renamed members (`p`/`q`) prove the multi-element fallback is structural.
+    let source = "for (var {p, q} in []) {}";
+    let output = parse_and_emit_strict_target(source, "forin.ts", ScriptTarget::ES5);
+
+    assert!(
+        output.contains("= void 0,"),
+        "Multi-element object for-in head should allocate a shared source temp.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("(void 0)."),
+        "Multi-element object for-in head must not inline the synthetic source.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — emit→100% campaign (wave 3, small genuine fix)

## Invariant
When an ES5 for-in head destructures a binding pattern with no real iteration source, the synthetic `(void 0)` source is inlined into each element access rather than first bound to a temporary, so only value/default temps are allocated.

## Scope
- `crates/tsz-emitter/src/emitter/statements/control_flow.rs` — `emit_for_in_missing_destructuring_initializer_es5` routes through `emit_es5_destructuring_pattern_direct(pattern, "(void 0)", ...)`. + structural unit tests.

## Project Corpus Impact
- Row: n/a (emit parity fix)
- Bug family: ES5 for-in destructuring synthetic-source temp materialization
- Evidence: parserForInStatement8(target=es5) FAIL→PASS

## Verification
- Witness `parserForInStatement8(target=es5)` FAIL→PASS (1/2→2/2). Zero regressions; +unit tests; `cargo clippy -p tsz-emitter --all-targets -- -D warnings` clean.

## Coordination Notes
Wave-3 small fix; isolated, structural, zero-regression, harness-verified. — opus48-emit100
