### PR TITLE
fix(solver): preserve multi-member unique-symbol unions in DTS value widening

### DIFF
--- a/crates/tsz-solver/src/visitors/visitor_extract.rs
+++ b/crates/tsz-solver/src/visitors/visitor_extract.rs
@@ -1130,7 +1130,7 @@ mod widen_unique_symbol_dts_tests {
     fn standalone_unique_symbol_widens_to_symbol() {
         // A standalone `unique symbol` value surface prints as `symbol` in .d.ts.
         let interner = TypeInterner::new();
-        let sym = interner.intern(TypeData::UniqueSymbol(SymbolRef(42)));
+        let sym = interner.unique_symbol(SymbolRef(42));
         let widened = widen_unique_symbol_value_type_for_dts(&interner, sym);
         assert_eq!(widened, TypeId::SYMBOL);
     }
@@ -1142,8 +1142,8 @@ mod widen_unique_symbol_dts_tests {
         // into a single `symbol`, dropping the declared identities. This is the
         // `indirectUniqueSymbolDeclarationEmit` witness shape.
         let interner = TypeInterner::new();
-        let sym_a = interner.intern(TypeData::UniqueSymbol(SymbolRef(1)));
-        let sym_b = interner.intern(TypeData::UniqueSymbol(SymbolRef(2)));
+        let sym_a = interner.unique_symbol(SymbolRef(1));
+        let sym_b = interner.unique_symbol(SymbolRef(2));
         let union = interner.union(vec![sym_a, sym_b]);
         let widened = widen_unique_symbol_value_type_for_dts(&interner, union);
         assert_eq!(widened, union, "2-member unique-symbol union preserved");
@@ -1161,9 +1161,9 @@ mod widen_unique_symbol_dts_tests {
     #[test]
     fn three_distinct_unique_symbols_in_union_are_preserved() {
         let interner = TypeInterner::new();
-        let sym_a = interner.intern(TypeData::UniqueSymbol(SymbolRef(10)));
-        let sym_b = interner.intern(TypeData::UniqueSymbol(SymbolRef(20)));
-        let sym_c = interner.intern(TypeData::UniqueSymbol(SymbolRef(30)));
+        let sym_a = interner.unique_symbol(SymbolRef(10));
+        let sym_b = interner.unique_symbol(SymbolRef(20));
+        let sym_c = interner.unique_symbol(SymbolRef(30));
         let union = interner.union(vec![sym_a, sym_b, sym_c]);
         let widened = widen_unique_symbol_value_type_for_dts(&interner, union);
         assert_eq!(widened, union);
@@ -1181,7 +1181,7 @@ mod widen_unique_symbol_dts_tests {
         // passthrough non-unique-symbol member) must still widen that
         // unique-symbol member — the guard only triggers for >= 2 distinct ones.
         let interner = TypeInterner::new();
-        let sym = interner.intern(TypeData::UniqueSymbol(SymbolRef(7)));
+        let sym = interner.unique_symbol(SymbolRef(7));
         let union = interner.union(vec![sym, TypeId::STRING]);
         let widened = widen_unique_symbol_value_type_for_dts(&interner, union);
         match interner.lookup(widened) {
@@ -1206,8 +1206,8 @@ mod widen_unique_symbol_dts_tests {
         // Renamed-binding equivalence: the guard keys on distinct `SymbolRef`s,
         // not on any particular id value or user-chosen name.
         let interner = TypeInterner::new();
-        let sym_a = interner.intern(TypeData::UniqueSymbol(SymbolRef(999)));
-        let sym_b = interner.intern(TypeData::UniqueSymbol(SymbolRef(1000)));
+        let sym_a = interner.unique_symbol(SymbolRef(999));
+        let sym_b = interner.unique_symbol(SymbolRef(1000));
         let union = interner.union(vec![sym_a, sym_b]);
         assert_eq!(
             widen_unique_symbol_value_type_for_dts(&interner, union),

--- a/crates/tsz-solver/src/visitors/visitor_extract.rs
+++ b/crates/tsz-solver/src/visitors/visitor_extract.rs
@@ -290,6 +290,31 @@ fn widen_unique_symbol_value_type_for_dts_inner(
         }
         Some(TypeData::Union(list_id)) => {
             let members = types.type_list(list_id);
+            // A union with two or more *distinct* unique-symbol members must be
+            // preserved verbatim. Widening each member to `symbol` would dedupe
+            // the distinct identities into a single `symbol`, losing the
+            // `typeof x | typeof y` form that tsc prints for inferred value
+            // surfaces (e.g. `indirectUniqueSymbolDeclarationEmit`). A union
+            // with a single distinct unique-symbol member still widens to
+            // `symbol`, matching the standalone case.
+            //
+            // Keyed on structural TypeData (UniqueSymbol carrying its declaring
+            // `SymbolRef`), not on any user-chosen name (§25/§26).
+            let mut distinct_unique_symbols: smallvec::SmallVec<[SymbolRef; 4]> =
+                smallvec::SmallVec::new();
+            for &member in members.iter() {
+                if member.is_intrinsic() {
+                    continue;
+                }
+                if let Some(TypeData::UniqueSymbol(symbol_ref)) = types.lookup(member)
+                    && !distinct_unique_symbols.contains(&symbol_ref)
+                {
+                    distinct_unique_symbols.push(symbol_ref);
+                }
+            }
+            if distinct_unique_symbols.len() >= 2 {
+                return type_id;
+            }
             let mut changed = false;
             let widened_members = members
                 .iter()
@@ -1092,5 +1117,101 @@ fn collect_infer_sig(
         if let Some(default) = param.default {
             collect_infer_bindings_inner(types, default, result, visited);
         }
+    }
+}
+
+#[cfg(test)]
+mod widen_unique_symbol_dts_tests {
+    use super::widen_unique_symbol_value_type_for_dts;
+    use crate::construction::TypeInterner;
+    use crate::types::{SymbolRef, TypeData, TypeId};
+
+    #[test]
+    fn standalone_unique_symbol_widens_to_symbol() {
+        // A standalone `unique symbol` value surface prints as `symbol` in .d.ts.
+        let interner = TypeInterner::new();
+        let sym = interner.intern(TypeData::UniqueSymbol(SymbolRef(42)));
+        let widened = widen_unique_symbol_value_type_for_dts(&interner, sym);
+        assert_eq!(widened, TypeId::SYMBOL);
+    }
+
+    #[test]
+    fn two_distinct_unique_symbols_in_union_are_preserved() {
+        // `typeof x | typeof y` over two distinct unique symbols must stay a
+        // 2-member union; widening each member to `symbol` would dedupe them
+        // into a single `symbol`, dropping the declared identities. This is the
+        // `indirectUniqueSymbolDeclarationEmit` witness shape.
+        let interner = TypeInterner::new();
+        let sym_a = interner.intern(TypeData::UniqueSymbol(SymbolRef(1)));
+        let sym_b = interner.intern(TypeData::UniqueSymbol(SymbolRef(2)));
+        let union = interner.union(vec![sym_a, sym_b]);
+        let widened = widen_unique_symbol_value_type_for_dts(&interner, union);
+        assert_eq!(widened, union, "2-member unique-symbol union preserved");
+        match interner.lookup(widened) {
+            Some(TypeData::Union(list_id)) => {
+                let members = interner.type_list(list_id);
+                assert_eq!(members.len(), 2);
+                assert!(members.contains(&sym_a));
+                assert!(members.contains(&sym_b));
+            }
+            other => panic!("expected a 2-member union, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn three_distinct_unique_symbols_in_union_are_preserved() {
+        let interner = TypeInterner::new();
+        let sym_a = interner.intern(TypeData::UniqueSymbol(SymbolRef(10)));
+        let sym_b = interner.intern(TypeData::UniqueSymbol(SymbolRef(20)));
+        let sym_c = interner.intern(TypeData::UniqueSymbol(SymbolRef(30)));
+        let union = interner.union(vec![sym_a, sym_b, sym_c]);
+        let widened = widen_unique_symbol_value_type_for_dts(&interner, union);
+        assert_eq!(widened, union);
+        match interner.lookup(widened) {
+            Some(TypeData::Union(list_id)) => {
+                assert_eq!(interner.type_list(list_id).len(), 3);
+            }
+            other => panic!("expected a 3-member union, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn single_distinct_unique_symbol_union_widens_to_symbol() {
+        // A union that contains only one distinct unique symbol (paired with a
+        // passthrough non-unique-symbol member) must still widen that
+        // unique-symbol member — the guard only triggers for >= 2 distinct ones.
+        let interner = TypeInterner::new();
+        let sym = interner.intern(TypeData::UniqueSymbol(SymbolRef(7)));
+        let union = interner.union(vec![sym, TypeId::STRING]);
+        let widened = widen_unique_symbol_value_type_for_dts(&interner, union);
+        match interner.lookup(widened) {
+            Some(TypeData::Union(list_id)) => {
+                let members = interner.type_list(list_id);
+                assert!(
+                    members.contains(&TypeId::SYMBOL),
+                    "lone unique symbol widened to symbol"
+                );
+                assert!(members.contains(&TypeId::STRING));
+                assert!(
+                    !members.contains(&sym),
+                    "the unique-symbol member must not survive"
+                );
+            }
+            other => panic!("expected a widened union, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn distinct_unique_symbol_union_independent_of_symbolref_value() {
+        // Renamed-binding equivalence: the guard keys on distinct `SymbolRef`s,
+        // not on any particular id value or user-chosen name.
+        let interner = TypeInterner::new();
+        let sym_a = interner.intern(TypeData::UniqueSymbol(SymbolRef(999)));
+        let sym_b = interner.intern(TypeData::UniqueSymbol(SymbolRef(1000)));
+        let union = interner.union(vec![sym_a, sym_b]);
+        assert_eq!(
+            widen_unique_symbol_value_type_for_dts(&interner, union),
+            union
+        );
     }
 }


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — declaration emit parity (emit→100% campaign, wave 3)

## Invariant
When an inferred declaration value type is a union of two or more DISTINCT
unique-symbol members, the DTS value-surface widening must preserve the union
(`typeof x | typeof y`) instead of widening each member to `symbol` and deduping
to one. A single unique-symbol member still widens to `symbol` (matches tsc), and
mutable-binding widening (`let z = cond ? x : y → symbol`) is unchanged.

## Scope
- `crates/tsz-solver/src/visitors/visitor_extract.rs` — Union arm of
  `widen_unique_symbol_value_type_for_dts_inner` counts distinct UniqueSymbol
  members (keyed on structural SymbolRef); ≥2 → return the union unchanged.
  Deliberately NOT widen_type_cached (its standalone arm must keep widening for
  mutable bindings to match tsc). +5 unit tests.

## Project Corpus Impact
- Row: n/a (declaration emit parity fix)
- Bug family: unique-symbol union DTS value widening
- Evidence: indirectUniqueSymbolDeclarationEmit FAIL→PASS
- Evidence: indirectUniqueSymbolDeclarationEmit FAIL→PASS; uniqueSymbol dts 7/8→8/8, symbol dts 35/36→36/36.

## Verification
- Witness FAIL (`symbol`) → PASS (`typeof x | typeof y`). Zero regressions
  (uniqueSymbol/symbol/conditional/declarationEmit families unchanged except the
  +2 fixed). 5 solver unit tests pass; `cargo clippy -p tsz-solver --all-targets -- -D warnings` clean.

## Coordination Notes
Wave-3 solver fix; root-caused to the DTS-specific widening visitor. — opus48-emit100

