### PR TITLE
fix(emit): stop false-renaming namespace IIFE param for non-binding name occurrences

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -79,6 +79,10 @@ name = "parenthesized_iife_tests"
 path = "tests/parenthesized_iife_tests.rs"
 
 [[test]]
+name = "namespace_iife_param_nonbinding_tests"
+path = "tests/namespace_iife_param_nonbinding_tests.rs"
+
+[[test]]
 name = "export_equals_type_only_namespace"
 path = "tests/export_equals_type_only_namespace.rs"
 

--- a/crates/tsz-emitter/src/emitter/declarations/namespace.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/namespace.rs
@@ -697,8 +697,28 @@ impl<'a> Printer<'a> {
             }
             return false;
         }
+        // Run the AST-based top-level statement check first so constructs the
+        // source-text scan cannot reason about precisely are classified
+        // structurally. In particular `export import M = Z.M` emits as
+        // `M.M = Z.M` (it reuses the IIFE parameter and is NOT a local
+        // binding), so it must not trigger a rename — but the text scan sees
+        // the `import M` keyword and would misclassify it as a binding.
+        if let Some(block) = self.arena.get_module_block(body_node)
+            && let Some(stmts) = &block.statements
+            && stmts
+                .nodes
+                .iter()
+                .copied()
+                .any(|stmt| self.namespace_statement_conflicts_iife_param(stmt, ns_name))
+        {
+            return true;
+        }
+        if self.namespace_block_contains_instantiated_module_named(body_node, ns_name) {
+            return true;
+        }
         if let Some(text) = self.source_text {
-            let declare_ranges = self.collect_declare_statement_ranges(body_node);
+            let mut mask_ranges = self.collect_declare_statement_ranges(body_node);
+            mask_ranges.extend(self.collect_enum_decl_ranges(body_node));
             return match crate::safe_slice::slice(
                 text,
                 body_node.pos as usize,
@@ -706,7 +726,7 @@ impl<'a> Printer<'a> {
             ) {
                 Ok(body_text) => {
                     let body_pos = body_node.pos as usize;
-                    let masked = Self::mask_ranges_static(body_text, body_pos, &declare_ranges);
+                    let masked = Self::mask_ranges_static(body_text, body_pos, &mask_ranges);
                     Self::text_has_non_namespace_binding_named(&masked, ns_name)
                 }
                 Err(_) => false,
@@ -740,13 +760,37 @@ impl<'a> Printer<'a> {
                         && text_bytes[after_end] != b'$');
 
                 if before_ok && after_ok {
+                    // Look at the first non-whitespace character *after* the
+                    // name. A name immediately followed by `.` is a qualified /
+                    // member reference (`N.foo`) and is never a binding. This
+                    // rejection is unconditional — no binding form places `.`
+                    // directly after the bound identifier.
+                    let mut a = after_end;
+                    while a < text_bytes.len() && text_bytes[a].is_ascii_whitespace() {
+                        a += 1;
+                    }
+                    let followed_by_dot = a < text_bytes.len() && text_bytes[a] == b'.';
+                    let followed_by_paren = a < text_bytes.len() && text_bytes[a] == b'(';
+                    if followed_by_dot {
+                        i = abs + 1;
+                        continue;
+                    }
                     let mut p = abs;
                     while p > 0 && text_bytes[p - 1].is_ascii_whitespace() {
                         p -= 1;
                     }
                     if p > 0 {
                         let prev_char = text_bytes[p - 1];
-                        if prev_char == b'(' || prev_char == b',' {
+                        // Bare `(`/`,` before the name only counts as a binding
+                        // when the name is NOT immediately followed by `(`. A
+                        // name followed by `(` here is a callee (`if (N.f())`,
+                        // `foo(N())`), not a parameter/binding. Genuine
+                        // parameter bindings (`function f(N)`, `f(a, N)`) are
+                        // followed by `)`, `,`, `:`, `=`, etc. — never `(`.
+                        // Function/class declarations like `function N(` are
+                        // handled by the keyword checks below, which run
+                        // independently of this guard.
+                        if (prev_char == b'(' || prev_char == b',') && !followed_by_paren {
                             return true;
                         }
                         let preceding = &text[..p];
@@ -881,7 +925,8 @@ impl<'a> Printer<'a> {
             // decisions and emit incorrectly. Surface span errors instead of
             // returning a false-negative; fall back to false only when source
             // text is literally unavailable.
-            let declare_ranges = self.collect_declare_statement_ranges(body_node);
+            let mut mask_ranges = self.collect_declare_statement_ranges(body_node);
+            mask_ranges.extend(self.collect_enum_decl_ranges(body_node));
             return match crate::safe_slice::slice(
                 text,
                 body_node.pos as usize,
@@ -889,7 +934,7 @@ impl<'a> Printer<'a> {
             ) {
                 Ok(body_text) => {
                     let body_pos = body_node.pos as usize;
-                    let masked = Self::mask_ranges_static(body_text, body_pos, &declare_ranges);
+                    let masked = Self::mask_ranges_static(body_text, body_pos, &mask_ranges);
                     Self::text_has_non_namespace_binding_named(&masked, ns_name)
                 }
                 Err(_) => false,
@@ -1016,6 +1061,79 @@ impl<'a> Printer<'a> {
             }
         }
         ranges
+    }
+
+    /// Collect `(pos, end)` byte ranges of top-level constructs whose source
+    /// text the binding scan cannot interpret correctly and that introduce no
+    /// IIFE-function-scope binding. Currently:
+    ///
+    /// * Enum declarations — enum members are *properties* of the enum object,
+    ///   not function-scope bindings, so an enum member whose name equals the
+    ///   namespace name (e.g. `enum Reservation { ..., TypeScript = 4, ... }`
+    ///   inside `namespace TypeScript`) must not be treated as a shadowing
+    ///   binding. The enum *name* itself is independently checked by the
+    ///   AST-based `declaration_conflicts_iife_param`, so masking the whole
+    ///   span loses no genuine collision.
+    /// * `export import M = Z.M` — emits as `M.M = Z.M`, reusing the IIFE
+    ///   parameter with no local binding, but its `import M` keyword would be
+    ///   misclassified by the scan. A plain `import M = Z.M` *does* bind a
+    ///   local `var M`, so it is intentionally left unmasked.
+    fn collect_enum_decl_ranges(
+        &self,
+        body_node: &tsz_parser::parser::node::Node,
+    ) -> Vec<(usize, usize)> {
+        let mut ranges: Vec<(usize, usize)> = Vec::new();
+        self.collect_enum_decl_ranges_into(body_node, &mut ranges);
+        ranges
+    }
+
+    fn collect_enum_decl_ranges_into(
+        &self,
+        body_node: &tsz_parser::parser::node::Node,
+        ranges: &mut Vec<(usize, usize)>,
+    ) {
+        let Some(block) = self.arena.get_module_block(body_node) else {
+            return;
+        };
+        let Some(stmts) = &block.statements else {
+            return;
+        };
+        for &stmt_idx in &stmts.nodes {
+            let Some(stmt_node) = self.arena.get(stmt_idx) else {
+                continue;
+            };
+            // `export enum E {}` parses as an EXPORT_DECLARATION wrapping the
+            // real enum declaration; resolve through to the inner decl.
+            let decl_node = if stmt_node.kind == syntax_kind_ext::EXPORT_DECLARATION
+                && let Some(export) = self.arena.get_export_decl(stmt_node)
+                && let Some(inner) = self.arena.get(export.export_clause)
+            {
+                inner
+            } else {
+                stmt_node
+            };
+            let is_export_qualified = stmt_node.kind == syntax_kind_ext::EXPORT_DECLARATION;
+            if decl_node.kind == syntax_kind_ext::ENUM_DECLARATION {
+                ranges.push((decl_node.pos as usize, decl_node.end as usize));
+            } else if decl_node.kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION
+                && is_export_qualified
+            {
+                // `export import M = Z.M` emits as `M.M = Z.M`: it reuses the
+                // IIFE parameter and introduces no local binding, so its text
+                // (which contains the `import M` keyword the scan would
+                // otherwise treat as a binding) must be masked. A *plain*
+                // `import M = Z.M` does emit `var M = Z.M`, so it is left
+                // visible and still forces a rename.
+                ranges.push((stmt_node.pos as usize, stmt_node.end as usize));
+            } else if decl_node.kind == syntax_kind_ext::MODULE_DECLARATION
+                && let Some(module) = self.arena.get_module(decl_node)
+                && let Some(inner_body) = self.arena.get(module.body)
+            {
+                // Recurse into sub-namespace bodies so a nested enum member
+                // sharing the outer namespace name is masked too.
+                self.collect_enum_decl_ranges_into(inner_body, ranges);
+            }
+        }
     }
 
     fn namespace_statement_conflicts_iife_param(&self, stmt_idx: NodeIndex, ns_name: &str) -> bool {

--- a/crates/tsz-emitter/tests/namespace_iife_param_nonbinding_tests.rs
+++ b/crates/tsz-emitter/tests/namespace_iife_param_nonbinding_tests.rs
@@ -1,0 +1,172 @@
+//! Regression tests for the namespace-IIFE-parameter false-rename bug.
+//!
+//! TypeScript emits a namespace as
+//! `var N; (function (N) { ... })(N || (N = {}));` and only renames the IIFE
+//! parameter (`N` -> `N_1`) when a *binding* declared in the IIFE's own
+//! function scope (var/let/const/function/class/parameter/plain
+//! `import = ...`) shadows the namespace name. Occurrences that are merely
+//! *uses* of the name — qualified references (`N.foo`), callees
+//! (`if (N.f())`), expression operands, enum-member names, and
+//! export-qualified `export import N = ...` (which emits `N.N = ...` and
+//! reuses the parameter) — must NOT trigger a rename.
+//!
+//! Previously the source-text binding scan treated a name preceded by `(` /
+//! `,` as a binding and the `import` keyword as a binding, which misfired on
+//! all of the above. The structural rule implemented in
+//! `crates/tsz-emitter/src/emitter/declarations/namespace.rs` is:
+//!
+//! > When the namespace name appears in its body only as a qualified
+//! > reference, callee, expression operand, enum-member name, or an
+//! > export-qualified `import =`, it does not shadow the IIFE parameter and
+//! > the parameter must not be renamed; only a genuine function-scope binding
+//! > (var/let/const/function/class/parameter/plain `import =`) forces a
+//! > rename.
+//!
+//! The tests deliberately vary the namespace name so a fix that hardcodes a
+//! particular spelling (`TypeScript`, `Harness`, `M`, ...) would not pass.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use tsz_parser::ParserState;
+
+fn emit(source: &str) -> String {
+    let mut parser = ParserState::new("a.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut printer = EmitterPrinter::with_options(
+        &parser.arena,
+        PrinterOptions {
+            target: ScriptTarget::ES2015,
+            module: ModuleKind::None,
+            ..Default::default()
+        },
+    );
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+/// Asserts the IIFE parameter for `ns` is emitted bare (no `_1`/`_2` suffix).
+fn assert_param_not_renamed(output: &str, ns: &str) {
+    assert!(
+        output.contains(&format!("(function ({ns}) {{")),
+        "expected IIFE parameter `{ns}` to NOT be renamed.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains(&format!("(function ({ns}_1)")),
+        "expected IIFE parameter `{ns}` to NOT be renamed to `{ns}_1`.\nOutput:\n{output}"
+    );
+}
+
+/// Asserts the IIFE parameter for `ns` IS renamed (`ns_1`).
+fn assert_param_renamed(output: &str, ns: &str) {
+    assert!(
+        output.contains(&format!("(function ({ns}_1)")),
+        "expected IIFE parameter `{ns}` to be renamed to `{ns}_1`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn qualified_reference_only_does_not_rename_param() {
+    // The namespace name appears only as a qualified reference / callee in a
+    // guarded expression. tsc keeps the IIFE parameter bare.
+    for ns in ["TypeScript", "Harness", "Zebra"] {
+        let source = format!(
+            "namespace {ns} {{\n    export var flag = true;\n    if ({ns}.flag) {{ {ns}.flag = false; }}\n}}\n"
+        );
+        let output = emit(&source);
+        assert_param_not_renamed(&output, ns);
+    }
+}
+
+#[test]
+fn parenthesized_qualified_reference_does_not_rename_param() {
+    // `(<N.Foo>x)` / `(N.bar)`: the name is preceded by `(` but followed by
+    // `.`, so it is a qualified reference, not a binding.
+    for ns in ["TypeScript", "Outer"] {
+        let source = format!(
+            "namespace {ns} {{\n    export var x: any = 1;\n    export function read() {{ return ({ns}.x); }}\n}}\n"
+        );
+        let output = emit(&source);
+        assert_param_not_renamed(&output, ns);
+    }
+}
+
+#[test]
+fn enum_member_name_equal_to_namespace_does_not_rename_param() {
+    // An enum member sharing the namespace name is a property of the enum
+    // object, not a function-scope binding. Varying both the namespace and
+    // the unrelated enum name proves the rule is structural.
+    for (ns, en) in [("TypeScript", "Reservation"), ("Color", "Palette")] {
+        let source = format!(
+            "namespace {ns} {{\n    export enum {en} {{\n        None = 0,\n        Other = 1,\n        {ns} = 4,\n    }}\n}}\n"
+        );
+        let output = emit(&source);
+        assert_param_not_renamed(&output, ns);
+    }
+}
+
+#[test]
+fn export_import_equals_does_not_rename_param() {
+    // `export import M = Z.M` emits as `M.M = Z.M` and reuses the IIFE
+    // parameter, so no rename. Uses a dotted namespace `A.M` like the
+    // conformance witness, plus a renamed variant.
+    for (outer, alias, target_ns) in [("A", "M", "Z"), ("Outer", "Mid", "Src")] {
+        let source = format!(
+            "namespace {target_ns}.{alias} {{\n    export function bar() {{ return \"\"; }}\n}}\nnamespace {outer}.{alias} {{\n    export import {alias} = {target_ns}.{alias};\n    export function bar() {{}}\n    {alias}.bar();\n}}\n"
+        );
+        let output = emit(&source);
+        // The innermost IIFE parameter for the `alias` sub-namespace must not
+        // be renamed; it should emit `<alias>.<alias> = <target>.<alias>;`.
+        assert!(
+            output.contains(&format!("{alias}.{alias} = {target_ns}.{alias};")),
+            "expected `export import {alias} = {target_ns}.{alias}` to emit \
+             `{alias}.{alias} = {target_ns}.{alias};` and reuse the IIFE \
+             parameter.\nOutput:\n{output}"
+        );
+        assert!(
+            !output.contains(&format!("{alias}_1")),
+            "export-qualified import-equals must not rename the IIFE \
+             parameter to `{alias}_1`.\nOutput:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn inner_local_var_binding_does_rename_param() {
+    // Negative/control: a genuine `var` binding inside an inner function shadows
+    // the namespace name in the IIFE scope, so tsc DOES rename the parameter.
+    for ns in ["M", "Box"] {
+        let source = format!(
+            "namespace {ns} {{\n    export var x = 1;\n    function inner() {{\n        var {ns};\n        var p = x;\n        return {ns};\n    }}\n}}\n"
+        );
+        let output = emit(&source);
+        assert_param_renamed(&output, ns);
+    }
+}
+
+#[test]
+fn inner_function_parameter_does_rename_param() {
+    // A nested function parameter sharing the namespace name is a genuine
+    // binding; tsc renames the IIFE parameter.
+    for ns in ["M", "Widget"] {
+        let source = format!(
+            "namespace {ns} {{\n    export var x = 3;\n    function fn({ns}, p) {{ return p; }}\n}}\n"
+        );
+        let output = emit(&source);
+        assert_param_renamed(&output, ns);
+    }
+}
+
+#[test]
+fn inner_function_declaration_does_rename_param() {
+    // A nested `function N()` declaration is a binding even though `N` is
+    // followed by `(`; the function keyword makes it a declaration, not a
+    // callee. tsc renames the IIFE parameter.
+    for ns in ["M", "Gadget"] {
+        let source = format!(
+            "namespace {ns} {{\n    export var x = 1;\n    function outer() {{\n        function {ns}() {{ return x; }}\n        return {ns};\n    }}\n}}\n"
+        );
+        let output = emit(&source);
+        assert_param_renamed(&output, ns);
+    }
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — JavaScript emit parity (emit→100% campaign, wave 3)

## Invariant
When a namespace name appears in its own body only as a qualified reference, call/cast operand, enum-member name, or export-qualified import-equals (not as the bound name of a var/let/const/function/class/parameter/plain-import in the IIFE function scope), it does not shadow the IIFE parameter and the parameter must not be renamed.

## Scope
- `crates/tsz-emitter/src/emitter/declarations/namespace.rs` — (1) dotted-namespace path runs the existing AST top-level conflict check first; (2) new `collect_enum_decl_ranges` AST collector masks enum bodies + export-import-equals ranges before the text scan; (3) structural rejections in the scan (name followed by `.` = qualified ref; `(`/`,`-before-name only when not a callee). Keyword/parameter binding checks unchanged (source of truth). + 7 structural tests.

## Project Corpus Impact
- Row: n/a (emit parity fix)
- Bug family: namespace IIFE parameter false-rename from non-binding name occurrences
- Evidence: parserRealSource10, parserRealSource14, moduleSharesNameWithImportDeclarationInsideIt2 FAIL→PASS.

## Verification
- Witnesses FAIL→PASS (JS): parserRealSource10, parserRealSource14, moduleSharesNameWithImportDeclarationInsideIt2.
- Zero regressions: namespace 206/2, module 1738→1739, enum 267/0, internalModule 25/0, import 913→914 (no new failures); parserRealSource/collisionCodeGen/reExport/exportImport sweeps clean. 7 unit tests + 26 inline pass; clippy `-D warnings` clean.
- Scope note: parserharness (es5 comment-placement) and isDeclarationVisibleNodeKinds (es5-IR merged-namespace counter) are separate es5 bugs, deferred.

## Coordination Notes
Wave-3 fix; AST/structural per §25 (not text-scan where it mattered). — opus48-emit100
