### PR TITLE
perf(bench): index open issues once when building reduction backlog

### DIFF
--- a/scripts/bench/reduction-backlog.mjs
+++ b/scripts/bench/reduction-backlog.mjs
@@ -151,40 +151,67 @@ function collectExamples(rows, limit) {
   return examples;
 }
 
-function linkedIssues(subsystem, codes, issues) {
-  if (issues.length === 0) return [];
+// Maximum number of issues linked to a single reduction task. Kept as a named
+// constant so the matcher can stop scanning issues once the cap is reached.
+const LINKED_ISSUES_PER_TASK = 5;
+
+// Normalize the open-issue list exactly once so issue linking does not
+// re-lowercase every issue's title and labels for every diagnostic-pattern
+// group. `buildReductionTasks` reuses one index across all groups, turning the
+// old O(groups × issues × title-length) rescan into O(issues) setup plus
+// O(issues) cheap comparisons per group. Closed issues are dropped here so the
+// per-group matcher never reconsiders them. Original issue order is preserved
+// so `linkedIssues` keeps yielding the same first-N matches as before.
+export function buildIssueIndex(issues) {
+  const index = [];
+  for (const issue of issues) {
+    if (issue.state && issue.state !== "open") continue;
+    const normalizedLabels = Array.isArray(issue.labels)
+      ? issue.labels.map((l) => String(l).toLowerCase().replace(/-/g, " "))
+      : [];
+    index.push({
+      issue,
+      labelSet: new Set(normalizedLabels),
+      titleLower: String(issue.title ?? "").toLowerCase(),
+    });
+  }
+  return index;
+}
+
+function linkIssue(issue) {
+  return {
+    number: issue.number,
+    title: issue.title,
+    labels: Array.isArray(issue.labels) ? issue.labels : [],
+    state: issue.state ?? "open",
+    url: issue.html_url ?? `https://github.com/mohsen1/tsz/issues/${issue.number}`,
+  };
+}
+
+function linkedIssues(subsystem, codes, issueIndex) {
+  if (issueIndex.length === 0) return [];
   const codesArray = codes.map((c) => c.toLowerCase());
   const subsystemLower = subsystem.toLowerCase();
   const normalizedSub = subsystem.replace(/-/g, " ").toLowerCase();
   const subsystemWords = normalizedSub.split(/[/\s]+/).filter((w) => w.length > 3);
 
-  return issues
-    .filter((issue) => {
-      if (issue.state && issue.state !== "open") return false;
-
-      const labels = Array.isArray(issue.labels)
-        ? issue.labels.map((l) => String(l).toLowerCase().replace(/-/g, " "))
-        : [];
-      if (labels.some((l) => l === normalizedSub || l === subsystemLower)) return true;
-
-      const title = String(issue.title ?? "").toLowerCase();
-      if (codesArray.some((code) => title.includes(code))) return true;
-      if (subsystemWords.some((word) => title.includes(word))) return true;
-
-      return false;
-    })
-    .slice(0, 5)
-    .map((issue) => ({
-      number: issue.number,
-      title: issue.title,
-      labels: Array.isArray(issue.labels) ? issue.labels : [],
-      state: issue.state ?? "open",
-      url: issue.html_url ?? `https://github.com/mohsen1/tsz/issues/${issue.number}`,
-    }));
+  const linked = [];
+  for (const { issue, labelSet, titleLower } of issueIndex) {
+    const matches =
+      labelSet.has(normalizedSub) ||
+      labelSet.has(subsystemLower) ||
+      codesArray.some((code) => titleLower.includes(code)) ||
+      subsystemWords.some((word) => titleLower.includes(word));
+    if (!matches) continue;
+    linked.push(linkIssue(issue));
+    if (linked.length >= LINKED_ISSUES_PER_TASK) break;
+  }
+  return linked;
 }
 
 export function buildReductionTasks(groups, issues = [], { minRows = 1 } = {}) {
   const tasks = [];
+  const issueIndex = buildIssueIndex(issues);
 
   for (const group of groups.values()) {
     if (group.rows.length < minRows) continue;
@@ -225,7 +252,7 @@ export function buildReductionTasks(groups, issues = [], { minRows = 1 } = {}) {
       },
       suggested_issue_title: suggestedTitle,
       suggested_labels: [...new Set(["bench", ...baseLabels])],
-      linked_issues: linkedIssues(subsystem, codes, issues),
+      linked_issues: linkedIssues(subsystem, codes, issueIndex),
     });
   }
 

--- a/scripts/bench/test-reduction-backlog.mjs
+++ b/scripts/bench/test-reduction-backlog.mjs
@@ -44,6 +44,7 @@ const {
   readCompatibilityRows,
   groupByPattern,
   buildReductionTasks,
+  buildIssueIndex,
   renderMarkdown,
   createReductionBacklog,
 } = await import(pathToFileURL(SCRIPT));
@@ -266,6 +267,119 @@ withTempDir((dir) => {
   assert.ok(!task.linked_issues.some((i) => i.number === 456), "should not link unrelated issue");
   // Issue 789 is closed, should NOT be linked
   assert.ok(!task.linked_issues.some((i) => i.number === 789), "should not link closed issue");
+}
+
+// --- buildIssueIndex: normalize once, drop closed issues, preserve order ---
+
+{
+  const issues = [
+    { number: 1, title: "Open A", labels: ["Solver", "keyspace-property-indexed"], state: "open" },
+    { number: 2, title: "Closed B", labels: ["solver"], state: "closed" },
+    { number: 3, title: "Open C", labels: undefined, state: undefined },
+  ];
+  const index = buildIssueIndex(issues);
+  // Closed issues are removed; issues with no/undefined state are kept (open by default).
+  assert.equal(index.length, 2, "buildIssueIndex should drop closed issues");
+  assert.deepEqual(index.map((e) => e.issue.number), [1, 3], "should preserve original order of open issues");
+  // Labels are lowercased and hyphens normalized to spaces, exactly once.
+  assert.ok(index[0].labelSet.has("solver"));
+  assert.ok(index[0].labelSet.has("keyspace property indexed"));
+  // Title is lowercased for substring matching.
+  assert.equal(index[0].titleLower, "open a");
+  // Missing labels normalize to an empty set rather than throwing.
+  assert.equal(index[1].labelSet.size, 0);
+}
+
+// --- issue linking: ordering preserved and capped at 5 with early exit ---
+
+{
+  const rows = [
+    {
+      name: "type-fest-project",
+      state: "yellow",
+      exit_class: "exit success",
+      oracle_classification: "tsz-fails-only",
+      primary_subsystem: "keyspace-property-indexed",
+      diagnostic_codes: ["TS2339"],
+      diagnostic_subsystems: [{ subsystem: "keyspace-property-indexed", codes: ["TS2339"], count: 1, examples: [] }],
+      diagnostic_deltas: ["src/a.ts(1,1): error TS2339: Property 'x' does not exist."],
+      repro: null,
+    },
+  ];
+  // Seven issues match by label; linking must keep the first five in input order.
+  const issues = [];
+  for (let n = 10; n < 17; n++) {
+    issues.push({
+      number: n,
+      title: `matching issue ${n}`,
+      labels: ["keyspace-property-indexed"],
+      state: "open",
+      html_url: `https://github.com/mohsen1/tsz/issues/${n}`,
+    });
+  }
+  // Insert a closed match and an unrelated issue to prove they are skipped.
+  issues.splice(2, 0, { number: 999, title: "closed match", labels: ["keyspace-property-indexed"], state: "closed" });
+  issues.push({ number: 500, title: "unrelated narrowing", labels: ["flow-narrowing"], state: "open" });
+
+  const { groups } = groupByPattern(rows);
+  const tasks = buildReductionTasks(groups, issues, { minRows: 1 });
+  assert.equal(tasks.length, 1);
+  const linked = tasks[0].linked_issues;
+  assert.equal(linked.length, 5, "linked issues are capped at 5");
+  assert.deepEqual(
+    linked.map((i) => i.number),
+    [10, 11, 12, 13, 14],
+    "first five open matches in input order, skipping the closed one",
+  );
+  assert.ok(!linked.some((i) => i.number === 999), "closed issue must not be linked");
+  assert.ok(!linked.some((i) => i.number === 500), "unrelated issue must not be linked");
+}
+
+// --- issue linking: matching is invariant to a single shared index across groups ---
+// Linking results must be identical whether two groups are built together (one
+// shared index) or independently — proving the hoisted index does not leak
+// per-group state.
+
+{
+  const rows = [
+    {
+      name: "a",
+      state: "yellow",
+      exit_class: "exit success",
+      primary_subsystem: "keyspace-property-indexed",
+      diagnostic_codes: ["TS2339"],
+      diagnostic_subsystems: [{ subsystem: "keyspace-property-indexed", codes: ["TS2339"], count: 1, examples: [] }],
+      diagnostic_deltas: [],
+      repro: null,
+    },
+    {
+      name: "b",
+      state: "yellow",
+      exit_class: "exit success",
+      primary_subsystem: "flow-narrowing",
+      diagnostic_codes: ["TS2367"],
+      diagnostic_subsystems: [{ subsystem: "flow-narrowing", codes: ["TS2367"], count: 1, examples: [] }],
+      diagnostic_deltas: [],
+      repro: null,
+    },
+  ];
+  const issues = [
+    { number: 1, title: "keyspace bug", labels: ["keyspace-property-indexed"], state: "open" },
+    { number: 2, title: "narrowing bug", labels: ["flow-narrowing"], state: "open" },
+  ];
+  const { groups } = groupByPattern(rows);
+  const tasks = buildReductionTasks(groups, issues, { minRows: 1 });
+  const bySubsystem = new Map(tasks.map((t) => [t.subsystem, t]));
+  assert.deepEqual(
+    bySubsystem.get("keyspace-property-indexed").linked_issues.map((i) => i.number),
+    [1],
+    "keyspace group links only its own issue",
+  );
+  assert.deepEqual(
+    bySubsystem.get("flow-narrowing").linked_issues.map((i) => i.number),
+    [2],
+    "flow-narrowing group links only its own issue",
+  );
 }
 
 // --- exit-class rows without diagnostic codes ---


### PR DESCRIPTION
## Summary

Fixes #11621 (`performance-42-20` — "performance row summary build is quadratic on diagnostic lists").

The synthetic benchmark report has no concrete fixture, so per the generalization gate (§26) this PR fixes the underlying structural inefficiency the title names: the reduction-backlog "row summary build" rescanning the full open-issue list once per diagnostic-pattern group.

`scripts/bench/reduction-backlog.mjs::buildReductionTasks` calls `linkedIssues(subsystem, codes, issues)` once per `(subsystem, code)` group, and the old `linkedIssues` re-lowercased and re-normalized **every** open issue's title and labels on every call. With G diagnostic-pattern groups and I open issues that is `O(G × I × title-length)` string work — quadratic-shaped as both the diagnostic-pattern list and the issue backlog grow (the open backlog is now 700+ issues).

## Structural rule

> When the reduction backlog links open issues to diagnostic-pattern groups, each open issue is normalized exactly once and matched against every group, rather than re-normalized per group.

New `buildIssueIndex(issues)` filters to open issues and precomputes each issue's normalized label set and lowercased title a single time. `buildReductionTasks` builds that index once and reuses it for every group; `linkedIssues` iterates the index and stops early once the per-task link cap (5) is reached. Match semantics and output ordering are preserved — the same first-N open issues are linked, in input order — so report output is byte-identical for any given input.

Complexity goes from `O(groups × issues × title-length)` to `O(issues)` setup + `O(issues)` cheap comparisons per group.

## Owner layer

Project-bench harness tooling (`scripts/bench/reduction-backlog.mjs`). No compiler (checker/solver/binder/emitter) behavior is touched.

## Track

Track 1 benchmark/project-corpus harness.

## Invariant

Reduction-backlog JSON/markdown output is unchanged for identical inputs; only the cost of producing it drops. Verified by the existing suite plus new cases.

## Scope

- `scripts/bench/reduction-backlog.mjs`: hoist issue normalization into a reusable `buildIssueIndex`; `linkedIssues` consumes the index with an early exit at the link cap; extracted `linkIssue` shape helper and named the `LINKED_ISSUES_PER_TASK` constant.
- `scripts/bench/test-reduction-backlog.mjs`: regression coverage.

## Project Corpus Impact

- Row: n/a (harness tooling only — affects how the reduction backlog is built, not any project row's compile/diagnostic result)
- Bug family: project-bench reduction-backlog summary build
- Evidence: `node scripts/bench/test-reduction-backlog.mjs` passes locally (existing + new cases); CI runs the same test in `run_lint` and `node --check` over the script.

## Verification

- `node scripts/bench/test-reduction-backlog.mjs` — pass (existing assertions unchanged + new cases below).
- `node --check scripts/bench/reduction-backlog.mjs` / `test-reduction-backlog.mjs` — pass.
- New tests: `buildIssueIndex` normalization + closed-issue drop + order preservation; linked-issue cap of 5 with early exit skipping a closed and an unrelated issue; cross-group isolation proving the shared index does not leak per-group state.

## Coordination Notes

AgentName: remote-opus48. Claimed #11621 with `WIP`; no other open issue in the `performance-42-20` family carried `WIP` and no open PR targeted it. Behavior-preserving harness change; safe to land independently.

https://claude.ai/code/session_019A1HGXSMfwTmQf2yKLfyFP

---
_Generated by [Claude Code](https://claude.ai/code/session_019A1HGXSMfwTmQf2yKLfyFP)_