### PR TITLE
fix(diagnostics): report optional-but-required properties with TS2327

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1818,5 +1818,9 @@ path = "tests/optional_chain_continuation_undefined_tests.rs"
 name = "structural_dispatch_void_tests"
 path = "tests/structural_dispatch_void_tests.rs"
 
+[[test]]
+name = "optional_property_required_elaboration_tests"
+path = "tests/optional_property_required_elaboration_tests.rs"
+
 [lints]
 workspace = true

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -533,6 +533,9 @@ impl<'a> CheckerState<'a> {
                 ]
             }
             SubtypeFailureReason::OptionalPropertyRequired { property_name } => {
+                // Present-but-optional source property assigned to a required
+                // target: tsc reports TS2327 ("is optional ... but required"),
+                // not the absent-property message TS2741.
                 let src_str = self.format_type_for_diagnostic_role(
                     source,
                     DiagnosticTypeDisplayRole::DefaultDiagnostic,
@@ -545,12 +548,12 @@ impl<'a> CheckerState<'a> {
                     self.finalize_pair_display_for_diagnostic(source, target, src_str, tgt_str);
                 vec![DiagnosticRelatedInformation {
                     category: DiagnosticCategory::Error,
-                    code: diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
+                    code: diagnostic_codes::PROPERTY_IS_OPTIONAL_IN_TYPE_BUT_REQUIRED_IN_TYPE,
                     file: self.ctx.file_name.clone(),
                     start,
                     length,
                     message_text: format_message(
-                        diagnostic_messages::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
+                        diagnostic_messages::PROPERTY_IS_OPTIONAL_IN_TYPE_BUT_REQUIRED_IN_TYPE,
                         &[
                             &self.ctx.types.resolve_atom_ref(*property_name),
                             &src_str,

--- a/crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs
@@ -192,6 +192,12 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Render an `OptionalPropertyRequired` failure: a source property that is
+    /// present but optional assigned to a required target property. tsc reports
+    /// TS2327 ("Property '_' is optional in type '_' but required in type '_'."),
+    /// not the absent-property message TS2741. The rule is structural, so it
+    /// covers inline `{ x?: T }` and mapped (`Partial<T>`, `{ [K in keyof T]?:
+    /// T[K] }`) sources alike.
     pub(super) fn render_optional_property_required(
         &mut self,
         ctx: &RenderContext,
@@ -219,7 +225,7 @@ impl<'a> CheckerState<'a> {
                 .checked_js_global_element_access_fallback_target_display(idx)
                 .unwrap_or_else(|| self.format_type_diagnostic(target));
             let detail = format_message(
-                diagnostic_messages::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
+                diagnostic_messages::PROPERTY_IS_OPTIONAL_IN_TYPE_BUT_REQUIRED_IN_TYPE,
                 &[&prop_name, &source_str, &target_str],
             );
             let mut diag = Diagnostic::error(
@@ -235,7 +241,7 @@ impl<'a> CheckerState<'a> {
                 length,
                 message_text: detail,
                 category: DiagnosticCategory::Message,
-                code: diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
+                code: diagnostic_codes::PROPERTY_IS_OPTIONAL_IN_TYPE_BUT_REQUIRED_IN_TYPE,
             });
             diag
         } else {
@@ -247,7 +253,7 @@ impl<'a> CheckerState<'a> {
                 .checked_js_global_element_access_fallback_target_display(idx)
                 .unwrap_or_else(|| self.format_type_diagnostic(target));
             let message = format_message(
-                diagnostic_messages::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
+                diagnostic_messages::PROPERTY_IS_OPTIONAL_IN_TYPE_BUT_REQUIRED_IN_TYPE,
                 &[&prop_name, &source_str, &target_str],
             );
             Diagnostic::error(
@@ -255,7 +261,7 @@ impl<'a> CheckerState<'a> {
                 start,
                 length,
                 message,
-                diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
+                diagnostic_codes::PROPERTY_IS_OPTIONAL_IN_TYPE_BUT_REQUIRED_IN_TYPE,
             )
         }
     }

--- a/crates/tsz-checker/tests/optional_property_required_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/optional_property_required_elaboration_tests.rs
@@ -1,0 +1,174 @@
+//! TS2327 elaboration: "Property '_' is optional in type '_' but required in
+//! type '_'." must accompany the top-level TS2322/TS2345 when a source object
+//! property is present-but-optional and the target requires it.
+//!
+//! Structural rule: when a source property is present but optional and the
+//! corresponding target property is required, tsc reports TS2327 (the property
+//! is optional, not absent), not the absent-property message TS2741. The rule
+//! is keyed on the optional/required modifier, so it covers inline `{ x?: T }`
+//! and mapped (`Partial<T>`, `{ [K in keyof T]?: T[K] }`) sources alike, and
+//! both the variable-initializer (TS2322) and call-argument (TS2345) paths.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+use tsz_common::diagnostics::Diagnostic;
+
+fn diagnostics(source: &str) -> Vec<Diagnostic> {
+    check_source_diagnostics(source)
+}
+
+/// True when some top-level diagnostic with `code` carries an elaboration line
+/// that is the TS2327 "is optional ... but required" message for `prop`.
+fn has_optional_required_elaboration(diags: &[Diagnostic], code: u32, prop: &str) -> bool {
+    let needle = format!("Property '{prop}' is optional in type ");
+    diags.iter().any(|d| {
+        d.code == code
+            && d.related_information.iter().any(|info| {
+                info.message_text.starts_with(&needle)
+                    && info.message_text.contains("but required in type")
+            })
+    })
+}
+
+/// True when any diagnostic — as its primary message or as an elaboration
+/// line — claims the property is "missing" (TS2741).
+fn any_missing_message(diags: &[Diagnostic], prop: &str) -> bool {
+    let needle = format!("Property '{prop}' is missing in type ");
+    diags.iter().any(|d| {
+        d.message_text.starts_with(&needle)
+            || d.related_information
+                .iter()
+                .any(|info| info.message_text.starts_with(&needle))
+    })
+}
+
+#[test]
+fn inline_optional_source_emits_ts2327() {
+    let diags = diagnostics(
+        r#"
+declare let a: { x?: number };
+declare let b: { x: number };
+b = a;
+"#,
+    );
+    assert!(
+        has_optional_required_elaboration(&diags, 2322, "x"),
+        "expected TS2322 with TS2327 'is optional' elaboration; got {diags:?}"
+    );
+    assert!(
+        !any_missing_message(&diags, "x"),
+        "must not report a present-but-optional property as 'missing'; got {diags:?}"
+    );
+}
+
+#[test]
+fn elaboration_is_property_name_independent() {
+    // Same shape with a different property key — proves the rule is structural,
+    // not keyed on the spelling 'x'.
+    let diags = diagnostics(
+        r#"
+declare let a: { greeting?: string };
+declare let b: { greeting: string };
+b = a;
+"#,
+    );
+    assert!(
+        has_optional_required_elaboration(&diags, 2322, "greeting"),
+        "expected TS2327 for a renamed property; got {diags:?}"
+    );
+}
+
+#[test]
+fn mapped_partial_source_emits_ts2327() {
+    // The reported `diagnostics-35-20` shape: the optional modifier comes from a
+    // mapped (`Partial`-style) output, and the optional context must survive.
+    // Defined locally so the test does not depend on the lib globals.
+    let diags = diagnostics(
+        r#"
+type Partialish<T> = { [K in keyof T]?: T[K] };
+declare let a: Partialish<{ x: number }>;
+declare let b: { x: number };
+b = a;
+"#,
+    );
+    assert!(
+        has_optional_required_elaboration(&diags, 2322, "x"),
+        "expected TS2327 for a mapped Partial-style source; got {diags:?}"
+    );
+    assert!(
+        !any_missing_message(&diags, "x"),
+        "must not report a mapped-optional property as 'missing'; got {diags:?}"
+    );
+}
+
+#[test]
+fn renamed_mapped_optional_source_emits_ts2327() {
+    // Inline mapped type with a renamed iteration variable — proves the rule is
+    // not tied to `Partial` by name or to any iteration-variable spelling.
+    let diags = diagnostics(
+        r#"
+type Loosen<T> = { [Prop in keyof T]?: T[Prop] };
+declare let a: Loosen<{ y: string }>;
+declare let b: { y: string };
+b = a;
+"#,
+    );
+    assert!(
+        has_optional_required_elaboration(&diags, 2322, "y"),
+        "expected TS2327 for an inline mapped-optional source; got {diags:?}"
+    );
+}
+
+#[test]
+fn call_argument_optional_source_emits_ts2327() {
+    // The argument path produces TS2345 at the top level but the same TS2327
+    // elaboration underneath.
+    let diags = diagnostics(
+        r#"
+type Partialish<T> = { [K in keyof T]?: T[K] };
+declare function need(p: { x: number }): void;
+declare let a: Partialish<{ x: number }>;
+need(a);
+"#,
+    );
+    assert!(
+        has_optional_required_elaboration(&diags, 2345, "x"),
+        "expected TS2345 with TS2327 elaboration; got {diags:?}"
+    );
+}
+
+#[test]
+fn genuinely_absent_property_still_reports_missing() {
+    // Negative/guard case: an *absent* property must still report TS2741
+    // ("is missing"), not TS2327 — the fix must not blur the distinction.
+    let diags = diagnostics(
+        r#"
+declare let a: {};
+declare let b: { x: number };
+b = a;
+"#,
+    );
+    assert!(
+        any_missing_message(&diags, "x"),
+        "an absent property must still be reported as 'missing'; got {diags:?}"
+    );
+    assert!(
+        !has_optional_required_elaboration(&diags, 2322, "x"),
+        "an absent property must not be reported as 'optional'; got {diags:?}"
+    );
+}
+
+#[test]
+fn matching_optionality_does_not_error() {
+    // Negative case: both optional — assignable, so no diagnostic at all.
+    let diags = diagnostics(
+        r#"
+declare let a: { x?: number };
+declare let b: { x?: number };
+b = a;
+"#,
+    );
+    assert!(
+        !diags.iter().any(|d| d.code == 2322),
+        "optional-to-optional assignment must not error; got {diags:?}"
+    );
+}

--- a/crates/tsz-checker/tests/ts2322_tests_parts/part_02.rs
+++ b/crates/tsz-checker/tests/ts2322_tests_parts/part_02.rs
@@ -71,7 +71,7 @@ fn test_ts2322_namespace_export_assignment_optional_to_required() {
 }
 
 #[test]
-fn test_ts2322_optional_property_required_includes_related_missing_property_detail() {
+fn test_ts2322_optional_property_required_includes_related_optional_property_detail() {
     let source = r#"
         let source: { one?: number } = {};
         let target: { one: number } = source;
@@ -83,14 +83,17 @@ fn test_ts2322_optional_property_required_includes_related_missing_property_deta
         .find(|diag| diag.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE)
         .expect("expected TS2322 for optional-to-required property assignment");
 
+    // The source property is present-but-optional, so tsc reports TS2327
+    // ("is optional ... but required"), not the absent-property message TS2741.
     assert!(
         ts2322.related_information.iter().any(|info| {
-            info.code == diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE
+            info.code == diagnostic_codes::PROPERTY_IS_OPTIONAL_IN_TYPE_BUT_REQUIRED_IN_TYPE
                 && info
                     .message_text
-                    .contains("Property 'one' is missing in type")
+                    .contains("Property 'one' is optional in type")
+                && info.message_text.contains("but required in type")
         }),
-        "Expected TS2322 to include missing-property elaboration as related information, got: {ts2322:?}"
+        "Expected TS2322 to include the TS2327 optional-but-required elaboration, got: {ts2322:?}"
     );
 }
 
@@ -188,7 +191,7 @@ fn test_ts2345_missing_many_properties_formats_related_detail_once() {
 }
 
 #[test]
-fn test_ts2345_optional_property_required_includes_related_missing_property_detail() {
+fn test_ts2345_optional_property_required_includes_related_optional_property_detail() {
     let source = r#"
         declare function takes(value: { one: number }): void;
         const arg: { one?: number } = {};
@@ -203,14 +206,17 @@ fn test_ts2345_optional_property_required_includes_related_missing_property_deta
         })
         .expect("expected TS2345 for optional-to-required argument mismatch");
 
+    // The argument property is present-but-optional, so tsc reports TS2327
+    // ("is optional ... but required"), not the absent-property message TS2741.
     assert!(
         ts2345.related_information.iter().any(|info| {
-            info.code == diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE
+            info.code == diagnostic_codes::PROPERTY_IS_OPTIONAL_IN_TYPE_BUT_REQUIRED_IN_TYPE
                 && info
                     .message_text
-                    .contains("Property 'one' is missing in type")
+                    .contains("Property 'one' is optional in type")
+                && info.message_text.contains("but required in type")
         }),
-        "Expected TS2345 to include missing-property elaboration for optional-to-required mismatch, got: {ts2345:?}"
+        "Expected TS2345 to include the TS2327 optional-but-required elaboration, got: {ts2345:?}"
     );
 }
 

--- a/crates/tsz-solver/src/diagnostics/core.rs
+++ b/crates/tsz-solver/src/diagnostics/core.rs
@@ -437,6 +437,7 @@ pub mod codes {
     pub use dc::CANNOT_ASSIGN_TO_BECAUSE_IT_IS_A_READ_ONLY_PROPERTY as READONLY_PROPERTY;
     pub use dc::OBJECT_LITERAL_MAY_ONLY_SPECIFY_KNOWN_PROPERTIES_AND_DOES_NOT_EXIST_IN_TYPE as EXCESS_PROPERTY;
     pub use dc::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE as PROPERTY_MISSING;
+    pub use dc::PROPERTY_IS_OPTIONAL_IN_TYPE_BUT_REQUIRED_IN_TYPE as PROPERTY_OPTIONAL_BUT_REQUIRED;
     pub use dc::PROPERTY_IS_PRIVATE_AND_ONLY_ACCESSIBLE_WITHIN_CLASS as PROPERTY_VISIBILITY_MISMATCH;
     pub use dc::PROPERTY_IS_PROTECTED_AND_ONLY_ACCESSIBLE_THROUGH_AN_INSTANCE_OF_CLASS_THIS_IS_A as PROPERTY_NOMINAL_MISMATCH;
     pub use dc::THE_TYPE_IS_READONLY_AND_CANNOT_BE_ASSIGNED_TO_THE_MUTABLE_TYPE as READONLY_TO_MUTABLE;
@@ -540,9 +541,10 @@ impl SubtypeFailureReason {
     /// `render_failure_reason` should use this to stay in sync.
     pub const fn diagnostic_code(&self) -> u32 {
         match self {
-            Self::MissingProperty { .. } | Self::OptionalPropertyRequired { .. } => {
-                codes::PROPERTY_MISSING
-            }
+            Self::MissingProperty { .. } => codes::PROPERTY_MISSING,
+            // A present-but-optional source property assigned to a required
+            // target is TS2327, not the absent-property message TS2741.
+            Self::OptionalPropertyRequired { .. } => codes::PROPERTY_OPTIONAL_BUT_REQUIRED,
             Self::MissingProperties { .. } => codes::MISSING_PROPERTIES,
             Self::PropertyTypeMismatch { .. } => codes::PROPERTY_TYPE_MISMATCH,
             Self::ReadonlyPropertyMismatch { .. } => codes::READONLY_PROPERTY,
@@ -630,13 +632,16 @@ impl SubtypeFailureReason {
             }
 
             Self::OptionalPropertyRequired { property_name } => {
-                // This is a specific case of type not assignable
+                // The source property is present but optional while the target
+                // requires it. tsc reports TS2327 ("Property 'x' is optional in
+                // type 'S' but required in type 'T'."), not the absent-property
+                // message TS2741.
                 PendingDiagnostic::error(
                     codes::TYPE_NOT_ASSIGNABLE,
                     vec![source.into(), target.into()],
                 )
                 .with_related(PendingDiagnostic::error(
-                    codes::PROPERTY_MISSING, // Close enough - property is "missing" because it's optional
+                    codes::PROPERTY_OPTIONAL_BUT_REQUIRED,
                     vec![(*property_name).into(), source.into(), target.into()],
                 ))
             }

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -987,8 +987,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 //
                 // Always emit OptionalPropertyRequired when source is optional and target is
                 // required, regardless of exactOptionalPropertyTypes mode. This matches tsc's
-                // diagnostic priority: the optional-vs-required message ("Property 'x' is
-                // missing in type") takes precedence over a type-level mismatch message.
+                // diagnostic priority: the optional-vs-required message (TS2327, "Property 'x'
+                // is optional in type 'S' but required in type 'T'.") takes precedence over a
+                // type-level mismatch message. The property is present-but-optional, not
+                // absent, so this is TS2327 rather than the missing-property TS2741.
                 // The main subtype check gates whether the assignment is actually compatible
                 // (e.g., {a?: T} vs {a: T|undefined} passes in standard mode and never
                 // reaches this explain path).


### PR DESCRIPTION
## Agent
AgentName: `claude-opus-4-8-web` (Claude Code on the web)

## Track
Conformance / diagnostics parity (TS2322/TS2345 elaboration).

## Summary
Fixes the "optional context is removed" half of the `diagnostics-35-20` family (#11595, and the same case across #11220, #11178, #11052, #11493, #11306, #11136, #11094, #11009, #10966, #11614, #11263).

When a source object property is **present but optional** and the target property is **required**, tsc reports **TS2327** *"Property 'x' is optional in type 'S' but required in type 'T'."* — not the absent-property message **TS2741** *"Property 'x' is missing in type ..."*.

tsz already produced the `OptionalPropertyRequired` failure reason and even carried the TS2327 message constant, but **every** rendering path mapped the reason to TS2741 (a documented `// Close enough` approximation), so TS2327 was never emitted anywhere. This strips the optional context from the diagnostic — most visibly when the optional modifier comes from a mapped utility type (`Partial<T>`, `DeepPartial<T>`, `{ [K in keyof T]?: T[K] }`).

### Before / after
```ts
declare let a: Partial<{ x: number }>;
declare let b: { x: number };
b = a;
```
- before: `TS2322 … ↳ Property 'x' is missing in type 'Partial<{ x: number; }>' but required …` (TS2741, wrong)
- after / tsc: `TS2322 … ↳ Property 'x' is optional in type 'Partial<{ x: number; }>' but required …` (TS2327)

## Invariant
When a source property is present-but-optional and the corresponding target property is required, `tsc` emits TS2327; this change makes tsz emit TS2327 (preserving the optional context). Genuinely-absent properties still emit TS2741. Assignability decisions are unchanged — only how an already-failing optional/required relation is *explained*. The rule is keyed on the structural optional/required modifier, so it covers inline (`{ x?: T }`) and mapped (`Partial`-style) sources alike, across both the variable-initializer (TS2322) and call-argument (TS2345) paths.

## Scope
- `tsz-solver` `diagnostics/core.rs`: `OptionalPropertyRequired.diagnostic_code()` and `to_diagnostic` now use the TS2327 code/message (`PROPERTY_OPTIONAL_BUT_REQUIRED`).
- `tsz-solver` `relations/subtype/explain.rs`: corrected the misleading `// Close enough` / "is missing" comment.
- `tsz-checker` `error_reporter/render_failure_property_helpers.rs` (`render_optional_property_required`) and `error_reporter/fingerprint_policy.rs` (`related_from_failure_reason`): both render paths now emit the TS2327 elaboration.
- New regression target `optional_property_required_elaboration_tests`; updated two `ts2322_tests` cases that previously locked the TS2741 approximation.

## Project Corpus Impact
- Row: `nextjs` (#11595); shared `diagnostics-35-20` family across `nextjs-fresh-app`, `zod`, `rxjs`, `type-fest`, `ts-essentials`, `utility-types`, `type-challenges`, `vite-vanilla-ts-app`, `kysely`, `large-ts-repo`, `ts-toolbelt`.
- Bug family: optional/required property diagnostic elaboration (optional context dropped → reported as "missing").
- Evidence: new unit tests in `crates/tsz-checker/tests/optional_property_required_elaboration_tests.rs`; full conformance/emit/fourslash run via ready-for-review CI.

## Verification
- `cargo build -p tsz-solver -p tsz-checker -p tsz-cli` — clean.
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets` — clean.
- New `optional_property_required_elaboration_tests` (7 tests) — pass: inline, renamed-property, mapped `Partial`-style, renamed mapped-variable, call-argument, plus negatives for genuinely-absent property (still TS2741) and matching optionality (no error).
- `ts2322_tests` — only the two pre-existing `mapped_application_generic_indexed_call` failures remain (reproduce on clean `main`, unrelated); the two optional/required cases were updated to assert TS2327 and pass.
- Spot-checked `generic_property_mismatch_display_tests`, `generic_conditional_default_assignability_tests`, `deferred_keyof_index_access_assignability_tests` — pass.
- CLI repros confirm the TS2327 chain for inline, `Partial`/`DeepPartial`, and TS2345 argument cases.
- Conformance-safe: the affected line is an indented elaboration line, which the conformance fingerprint parser skips (only top-level `TSxxxx` lines form fingerprints); the top-level TS2322/TS2345 is unchanged. Project-bench diagnostics (full-text comparison) now match tsc.

## Coordination Notes
- Claimed #11595 with `WIP` label and a signed comment containing the minimal repro and root cause.
- Distinct from open PR #11657 (tuple-element TS2626 elaboration): that PR covers the `diagnostics-33-20` tuple family; this PR covers the `diagnostics-35-20` optional/required family. No file or behavior overlap.
- `/simplify` reviews (reuse/simplification/efficiency/altitude) returned clean.

https://claude.ai/code/session_01BTZnhaXPSWBg364XuR1oXu

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTZnhaXPSWBg364XuR1oXu)_