### PR TITLE
fix(dts): serialize inferred object-literal index signatures and readonly from solver type, not source text

### DIFF
--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -90,6 +90,10 @@ path = "tests/parenthesized_type_dts_emit_tests.rs"
 name = "import_equals_alias_dts_emit_tests"
 path = "tests/import_equals_alias_dts_emit_tests.rs"
 
+[[test]]
+name = "inferred_object_index_signature_dts_emit_tests"
+path = "tests/inferred_object_index_signature_dts_emit_tests.rs"
+
 [dev-dependencies]
 tempfile = { workspace = true }
 

--- a/crates/tsz-cli/tests/inferred_object_index_signature_dts_emit_tests.rs
+++ b/crates/tsz-cli/tests/inferred_object_index_signature_dts_emit_tests.rs
@@ -1,0 +1,287 @@
+//! DTS emit for inferred object-literal index signatures and returned-local
+//! multi-line object type annotations.
+//!
+//! Two structural rules are covered:
+//!
+//! Rule A: when declaration emit needs the inferred type of an object literal
+//! whose members are all non-emittable computed keys (e.g. `["" + ""]`), the
+//! checker collapses those dynamic members into index signatures on the solver
+//! type. The emitter must serialize that structural type rather than dropping
+//! to an empty `{}` via the source-text object-literal fallback.
+//!
+//! Rule B: when a function returns a local whose declared type annotation is a
+//! multi-line object type literal (`{ ... }` spanning several lines), the
+//! emitter must serialize the local's structural type rather than copying the
+//! raw source slice, which preserves source indentation/member ordering and can
+//! capture trailing tokens when the annotation has no terminator.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(name: &str) -> std::io::Result<Self> {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("tsz_inferred_idx_dts_{name}_{nanos}"));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+fn emit_dts(name: &str, source: &str) -> Option<String> {
+    let tsz_bin = find_tsz_binary()?;
+    let temp = TempDir::new(name).expect("temp dir");
+    let src_path = temp.path.join("repro.ts");
+    std::fs::write(&src_path, source).expect("write repro file");
+
+    let output = Command::new(tsz_bin)
+        .args([
+            "repro.ts",
+            "--declaration",
+            "--emitDeclarationOnly",
+            "--target",
+            "es2015",
+            "--lib",
+            "es6",
+            "--pretty",
+            "false",
+        ])
+        .current_dir(&temp.path)
+        .output()
+        .expect("run tsz declaration emit");
+
+    let dts = std::fs::read_to_string(temp.path.join("repro.d.ts")).unwrap_or_else(|_| {
+        panic!(
+            "expected repro.d.ts to be emitted.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    Some(dts)
+}
+
+// =============================================================================
+// Rule A: inferred object-literal index signatures from dynamic computed keys
+// =============================================================================
+
+/// Primary repro (computedPropertyNamesDeclarationEmit5): an object whose
+/// members are all dynamic-string computed keys infers `{ [x: string]: any; }`.
+#[test]
+fn dynamic_computed_string_keys_infer_string_index_signature() {
+    let Some(dts) = emit_dts(
+        "dyn_string",
+        r#"
+var v = {
+    ["" + ""]: 0,
+    ["" + ""]() { },
+    get ["" + ""]() { return 0; },
+    set ["" + ""](x) { }
+};
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("[x: string]: any;"),
+        "dynamic computed keys must collapse to a string index signature:\n{dts}"
+    );
+    assert!(
+        !dts.contains("declare var v: {}"),
+        "the index signature must not be dropped to an empty object:\n{dts}"
+    );
+}
+
+/// Adjacent case: a single dynamic-string computed property (different spelling
+/// of the computed key) proves the rule is not tied to the `"" + ""` shape.
+#[test]
+fn single_dynamic_computed_string_key_infers_string_index_signature() {
+    let Some(dts) = emit_dts(
+        "single_dyn",
+        r#"
+declare const key: string;
+var rec = {
+    [key.toUpperCase()]: 123
+};
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("[x: string]:"),
+        "a single dynamic computed string key must infer a string index signature:\n{dts}"
+    );
+    assert!(
+        !dts.contains("declare var rec: {}"),
+        "the index signature must not be dropped:\n{dts}"
+    );
+}
+
+/// Negative/fallback case: an object literal with only concrete (emittable)
+/// properties keeps its named members and must NOT synthesize a spurious index
+/// signature.
+#[test]
+fn concrete_only_object_literal_keeps_named_members() {
+    let Some(dts) = emit_dts(
+        "concrete_only",
+        r#"
+var p = {
+    a: 1,
+    b: "two"
+};
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("a: number;") && dts.contains("b: string;"),
+        "concrete members must be preserved:\n{dts}"
+    );
+    assert!(
+        !dts.contains("[x: string]:") && !dts.contains("[x: number]:"),
+        "no spurious index signature for a concrete-only object:\n{dts}"
+    );
+}
+
+// =============================================================================
+// Rule B: returned-local multi-line object type annotation
+// =============================================================================
+
+/// Primary repro (readonlyInDeclarationFile, `function g`): a returned local
+/// with a multi-line object type literal annotation must be printed
+/// structurally (readonly preserved, index signature first, normalized indent),
+/// not copied from source text.
+#[test]
+fn returned_local_multiline_object_annotation_prints_structurally() {
+    let Some(dts) = emit_dts(
+        "returned_local",
+        r#"
+function g() {
+    var x: {
+        readonly a: string;
+        readonly [x: string]: Object;
+    }
+    return x;
+}
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("readonly [x: string]: Object;"),
+        "readonly index signature must be preserved in the return type:\n{dts}"
+    );
+    assert!(
+        dts.contains("readonly a: string;"),
+        "readonly property must be preserved in the return type:\n{dts}"
+    );
+    assert!(
+        !dts.contains("return;") && !dts.contains("return x"),
+        "raw source text (trailing `return`) must not leak into the type:\n{dts}"
+    );
+    // Index signatures are ordered before named members by the printer.
+    let idx_pos = dts.find("readonly [x: string]: Object;").unwrap();
+    let prop_pos = dts.find("readonly a: string;").unwrap();
+    assert!(
+        idx_pos < prop_pos,
+        "index signature should precede the named member:\n{dts}"
+    );
+}
+
+/// Adjacent case: renamed local + different member names/types prove the rule is
+/// not tied to the `x` / `a` spelling in the primary repro.
+#[test]
+fn returned_local_multiline_object_annotation_renamed_members() {
+    let Some(dts) = emit_dts(
+        "returned_local_renamed",
+        r#"
+function build() {
+    var result: {
+        readonly title: number;
+        readonly [k: string]: Object;
+    }
+    return result;
+}
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("readonly [k: string]: Object;"),
+        "renamed index signature parameter is preserved:\n{dts}"
+    );
+    assert!(
+        dts.contains("readonly title: number;"),
+        "renamed readonly member is preserved:\n{dts}"
+    );
+    assert!(
+        !dts.contains("return;") && !dts.contains("return result"),
+        "raw source text must not leak into the renamed return type:\n{dts}"
+    );
+}
+
+/// Adjacent case: a non-readonly multi-line object annotation (no index
+/// signature) is still printed structurally without leaking raw source text.
+#[test]
+fn returned_local_multiline_plain_object_annotation_prints_structurally() {
+    let Some(dts) = emit_dts(
+        "returned_local_plain",
+        r#"
+function make() {
+    var obj: {
+        first: string;
+        second: number;
+    }
+    return obj;
+}
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("first: string;") && dts.contains("second: number;"),
+        "plain multi-line object members are preserved structurally:\n{dts}"
+    );
+    assert!(
+        !dts.contains("return;") && !dts.contains("return obj"),
+        "raw source text must not leak into the plain return type:\n{dts}"
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs
@@ -178,6 +178,16 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         if computed_members.is_empty() && overridden_members.is_empty() {
+            // Every member was a non-emittable computed key (e.g. `["" + ""]`).
+            // The syntax-recovery path has nothing concrete to inject, but the
+            // checker already collapsed those dynamic computed members into
+            // index signatures on the solver type. Serialize that structural
+            // type rather than dropping to an empty `{}` via the source-text
+            // object-literal fallback.
+            if has_non_emittable_computed_members {
+                let printed = self.print_type_id(type_id);
+                return (!printed.trim().is_empty()).then_some(printed);
+            }
             return None;
         }
 

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl_function_initializers.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl_function_initializers.rs
@@ -359,6 +359,15 @@ impl<'a> DeclarationEmitter<'a> {
             .function_parameter_type_text(func, returned_identifier)
             .or_else(|| self.returned_function_initializer_type_text(func, returned_identifier))
             .or_else(|| {
+                // A multi-line object type literal annotation should be printed
+                // structurally rather than copied from source text, which would
+                // preserve source indentation/ordering and can capture trailing
+                // tokens when the annotation has no terminator.
+                if self.referenced_declared_annotation_is_multiline_object_type(returned_identifier)
+                    && let Some(type_id) = self.reference_declared_type_id(returned_identifier)
+                {
+                    return Some(self.print_type_id_for_inferred_declaration(type_id));
+                }
                 let type_text =
                     self.reference_declared_source_type_annotation_text(returned_identifier)?;
                 if let Some(type_id) = self.reference_declared_type_id(returned_identifier)
@@ -462,6 +471,58 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         None
+    }
+
+    /// True when the referenced value's declared type annotation is an object
+    /// type literal (`{ ... }`) whose source span covers more than one physical
+    /// line. Raw source-text reconstruction of such annotations preserves the
+    /// original indentation, source member ordering, and can capture trailing
+    /// tokens when the annotation is not terminated; the normalizing structural
+    /// type printer avoids all of that, so callers should prefer it.
+    pub(in crate::declaration_emitter) fn referenced_declared_annotation_is_multiline_object_type(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> bool {
+        let Some(binder) = self.binder else {
+            return false;
+        };
+        let Some(sym_id) = self.value_reference_symbol(expr_idx) else {
+            return false;
+        };
+        let Some(symbol) = binder.symbols.get(sym_id) else {
+            return false;
+        };
+
+        for decl_idx in symbol.declarations.iter().copied() {
+            let Some(decl_node) = self.arena.get(decl_idx) else {
+                continue;
+            };
+            let type_annotation = self
+                .arena
+                .get_variable_declaration(decl_node)
+                .map(|decl| decl.type_annotation)
+                .or_else(|| {
+                    self.arena
+                        .get_property_decl(decl_node)
+                        .map(|decl| decl.type_annotation)
+                })
+                .filter(|type_idx| type_idx.is_some());
+            let Some(type_annotation) = type_annotation else {
+                continue;
+            };
+            let Some(type_node) = self.arena.get(type_annotation) else {
+                continue;
+            };
+            if type_node.kind != syntax_kind_ext::TYPE_LITERAL {
+                continue;
+            }
+            if let Some(slice) = self.get_source_slice(type_node.pos, type_node.end)
+                && slice.contains('\n')
+            {
+                return true;
+            }
+        }
+        false
     }
 
     pub(in crate::declaration_emitter) fn template_index_signature_element_access_type_text(


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — declaration emit parity (emit→100% campaign, wave 3b)

## Invariant
When declaration emit needs the type of a value (inferred object literal with a synthesized index signature) or a function-return that is a returned local with a multi-line object-type annotation, it serializes the solver's structural type via the normalizing type printer rather than dropping the synthesized index signature or copying raw source text.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs` — when all members are non-emittable computed keys, serialize the solver TypeId via `print_type_id` (checker already collapsed dynamic computed members into the index signature) instead of returning None → `{}`.
- `.../helpers/variable_decl_function_initializers.rs` — new structural `referenced_declared_annotation_is_multiline_object_type` (keys on source NODE kind TYPE_LITERAL + multi-line source span) routes those returns through `print_type_id_for_inferred_declaration` (preserves readonly/modifiers, tsc ordering).
- `crates/tsz-cli/tests/inferred_object_index_signature_dts_emit_tests.rs` (new, 6 structural tests) + Cargo.toml.

## Project Corpus Impact
- Row: n/a (declaration emit parity fix)
- Bug family: inferred object-literal index-signature / readonly DTS serialization
- Evidence: computedPropertyNamesDeclarationEmit5_ES5 (es5+es2015), readonlyInDeclarationFile (es5+es2015), +ES6 variant FAIL→PASS.

## Verification
- 5 witnesses FAIL→PASS (DTS). Zero regressions, net +8: declarationEmit 359→362, computedProperty 19→22, readonly 8→10 (fully fixed), inferred/index unchanged; JS unchanged. 6 unit tests; `cargo clippy -p tsz-emitter --lib -- -D warnings` clean.
- Structural (solver-TypeId print + source-node-kind checks), no §25/§26 antipatterns; no canonical-display refactor or solver/checker work needed.

## Coordination Notes
Wave-3b DTS fix; clean subset. — opus48-emit100
