### PR TITLE
fix(emit): emit object-literal accessor super as _super.X (not _super.prototype.X) at ES5

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -27,6 +27,10 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 
 [[test]]
+name = "es5_super_object_literal_accessor_tests"
+path = "tests/es5_super_object_literal_accessor_tests.rs"
+
+[[test]]
 name = "class_temp_dedup_hoist_buckets_tests"
 path = "tests/class_temp_dedup_hoist_buckets_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -775,6 +775,11 @@ pub struct Printer<'a> {
     /// Whether the active ES5 `super` home is a static class member.
     pub(crate) es5_super_home_is_static: bool,
 
+    /// Whether the active ES5 `super` home is an object-literal member (method or
+    /// accessor). Object-literal super accesses bind directly to the literal's
+    /// `__proto__` and are emitted as `_super.X`, never `_super.prototype.X`.
+    pub(crate) es5_super_home_is_object_literal: bool,
+
     /// Whether the current root source file has a JavaScript-like extension.
     pub(crate) is_current_root_js_source: bool,
 

--- a/crates/tsz-emitter/src/emitter/core_setup.rs
+++ b/crates/tsz-emitter/src/emitter/core_setup.rs
@@ -372,6 +372,7 @@ impl<'a> Printer<'a> {
             class_member_emit_depth: 0,
             es5_super_home_function_depth: None,
             es5_super_home_is_static: false,
+            es5_super_home_is_object_literal: false,
             is_current_root_js_source: false,
             const_enum_values: FxHashMap::default(),
             const_enum_import_aliases: FxHashMap::default(),

--- a/crates/tsz-emitter/src/emitter/declarations/class_members.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class_members.rs
@@ -1518,14 +1518,21 @@ impl<'a> Printer<'a> {
                 let is_static = self.has_effective_static_modifier_js(&accessor.modifiers);
                 let prev_es5_super_home_depth = self.es5_super_home_function_depth;
                 let prev_es5_super_home_static = self.es5_super_home_is_static;
+                let prev_es5_super_home_object_literal = self.es5_super_home_is_object_literal;
                 self.function_scope_depth += 1;
                 if self.ctx.target_es5 {
                     self.es5_super_home_function_depth = Some(self.function_scope_depth);
                     self.es5_super_home_is_static = is_static;
+                    // See `emit_accessor_body`: ES5 class accessors are lowered
+                    // via the class IR pipeline, so an accessor reaching this
+                    // direct-printer path is an object-literal accessor whose
+                    // `super` home is not prototype-qualified.
+                    self.es5_super_home_is_object_literal = self.class_member_emit_depth == 0;
                 }
                 self.emit_block_with_param_prologue(accessor.body, &transforms);
                 self.es5_super_home_function_depth = prev_es5_super_home_depth;
                 self.es5_super_home_is_static = prev_es5_super_home_static;
+                self.es5_super_home_is_object_literal = prev_es5_super_home_object_literal;
                 self.function_scope_depth -= 1;
             } else {
                 let compact_body = self.should_emit_compact_empty_accessor_body(accessor_node);
@@ -1555,9 +1562,16 @@ impl<'a> Printer<'a> {
             self.function_scope_depth += 1;
             let prev_es5_super_home_depth = self.es5_super_home_function_depth;
             let prev_es5_super_home_static = self.es5_super_home_is_static;
+            let prev_es5_super_home_object_literal = self.es5_super_home_is_object_literal;
             if self.ctx.target_es5 {
                 self.es5_super_home_function_depth = Some(self.function_scope_depth);
                 self.es5_super_home_is_static = is_static;
+                // At ES5, class accessor bodies are lowered through the class IR
+                // pipeline and never reach this direct-printer path, so any
+                // accessor emitted here is an object-literal accessor. Its
+                // `super` home binds to the literal's `__proto__` and must emit
+                // `_super.X`, not `_super.prototype.X`.
+                self.es5_super_home_is_object_literal = self.class_member_emit_depth == 0;
             }
             self.ctx.block_scope_state.enter_scope();
             self.push_temp_scope();
@@ -1571,6 +1585,7 @@ impl<'a> Printer<'a> {
             self.ctx.block_scope_state.exit_scope();
             self.es5_super_home_function_depth = prev_es5_super_home_depth;
             self.es5_super_home_is_static = prev_es5_super_home_static;
+            self.es5_super_home_is_object_literal = prev_es5_super_home_object_literal;
             self.function_scope_depth -= 1;
             self.emitting_function_body_block = prev_emitting_function_body_block;
         } else {

--- a/crates/tsz-emitter/src/emitter/expressions/access.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/access.rs
@@ -9,8 +9,14 @@ use tsz_scanner::SyntaxKind;
 
 impl<'a> Printer<'a> {
     pub(in crate::emitter) fn emit_es5_super_property_base(&mut self) {
+        // An object-literal `super` home binds directly to the literal's
+        // `__proto__`, so it is never prototype-qualified (`_super.X`). A
+        // class instance-method home at the current function scope is
+        // prototype-qualified (`_super.prototype.X`); static homes and homes
+        // captured at an outer scope fall back to the bare `_super` receiver.
         if self.es5_super_home_function_depth == Some(self.function_scope_depth)
             && !self.es5_super_home_is_static
+            && !self.es5_super_home_is_object_literal
         {
             self.write("_super.prototype");
         } else {

--- a/crates/tsz-emitter/tests/es5_super_object_literal_accessor_tests.rs
+++ b/crates/tsz-emitter/tests/es5_super_object_literal_accessor_tests.rs
@@ -1,0 +1,117 @@
+//! ES5 object-literal accessor `super` base selection.
+//!
+//! Structural rule: when an ES5-lowered `super` property access sits inside an
+//! object-literal accessor (`get`/`set`) whose home is the literal's
+//! `__proto__`, the base is the bare home object (`_super.X`), never the
+//! prototype-qualified class form (`_super.prototype.X`). The same accessor
+//! syntax inside a derived class instead binds `super` to the class prototype.
+//!
+//! These tests vary member/property/class names so the behaviour is keyed on
+//! the structural object-literal-vs-class distinction, not on any spelling.
+
+use tsz_common::common::ScriptTarget;
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_lower_print;
+
+fn emit_es5(source: &str) -> String {
+    let opts = PrintOptions {
+        target: ScriptTarget::ES5,
+        ..Default::default()
+    };
+    parse_and_lower_print(source, opts)
+}
+
+/// A `get` accessor in an object literal must use `_super.X` (object-literal
+/// home), not `_super.prototype.X`.
+#[test]
+fn object_literal_get_accessor_super_is_not_prototype_qualified() {
+    let source = r#"var obj = {
+    __proto__: { ping() {} },
+    get value() {
+        super.ping();
+        return 1;
+    }
+};"#;
+    let output = emit_es5(source);
+    assert!(
+        output.contains("_super.ping.call(this)"),
+        "object-literal get accessor super should bind to the literal home (_super.ping).\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("_super.prototype.ping"),
+        "object-literal get accessor super must NOT be prototype-qualified.\nOutput:\n{output}"
+    );
+}
+
+/// A `set` accessor in an object literal must use `_super.X` too. Different
+/// member/property names than the `get` test to prove the rule is structural.
+#[test]
+fn object_literal_set_accessor_super_is_not_prototype_qualified() {
+    let source = r#"var bag = {
+    __proto__: { notify() {} },
+    set flag(next) {
+        super.notify();
+    }
+};"#;
+    let output = emit_es5(source);
+    assert!(
+        output.contains("_super.notify.call(this)"),
+        "object-literal set accessor super should bind to the literal home (_super.notify).\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("_super.prototype.notify"),
+        "object-literal set accessor super must NOT be prototype-qualified.\nOutput:\n{output}"
+    );
+}
+
+/// Object-literal accessors nested inside a derived class method still bind
+/// `super` to the literal home (the object-literal accessor establishes its own
+/// non-prototype super home, independent of the enclosing class).
+#[test]
+fn object_literal_accessor_inside_class_method_uses_literal_home() {
+    let source = r#"class Animal { roar() {} }
+class Lion extends Animal {
+    build() {
+        var spec = {
+            __proto__: { roar() {} },
+            get loud() {
+                super.roar();
+                return 2;
+            }
+        };
+        return spec;
+    }
+}"#;
+    let output = emit_es5(source);
+    assert!(
+        output.contains("_super.roar.call(this)"),
+        "object-literal accessor inside a class method should use the literal home (_super.roar).\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("_super.prototype.roar.call(this)"),
+        "object-literal accessor inside a class method must NOT be prototype-qualified.\nOutput:\n{output}"
+    );
+}
+
+/// Negative/contrast case: a `get` accessor declared directly on a derived
+/// class binds `super` to the class prototype (`_super.prototype.X`). This
+/// proves the fix did not over-broaden to all accessors.
+#[test]
+fn class_get_accessor_super_remains_prototype_qualified() {
+    let source = r#"class Base { greet() {} }
+class Greeter extends Base {
+    get message() {
+        super.greet();
+        return 3;
+    }
+}"#;
+    let output = emit_es5(source);
+    assert!(
+        output.contains("_super.prototype.greet.call(this)"),
+        "class get accessor super must remain prototype-qualified (_super.prototype.greet).\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — JavaScript emit parity (emit→100% campaign, wave 3b)

## Invariant
An ES5-lowered `super.X` inside an object-literal accessor (get/set) emits the object-literal `__proto__` home form `_super.X`, not the class-prototype form `_super.prototype.X`; class instance-method accessors remain prototype-qualified.

## Scope
- `crates/tsz-emitter/src/emitter/core.rs` + `core_setup.rs` — new `es5_super_home_is_object_literal` flag.
- `crates/tsz-emitter/src/emitter/declarations/class_members.rs` — set the flag at the object-literal accessor home-set sites (keyed structurally on `class_member_emit_depth == 0`).
- `crates/tsz-emitter/src/emitter/expressions/access.rs` — consult it in `emit_es5_super_property_base`.
- `crates/tsz-emitter/tests/es5_super_object_literal_accessor_tests.rs` (new, 4 structural tests incl. a class-accessor negative case).

## Project Corpus Impact
- Row: n/a (emit parity fix)
- Bug family: ES5 object-literal accessor super-property base selection
- Evidence: superInObjectLiterals_ES5(es5) diff +3/-3 → +1/-1 (accessor super-base corrected; remaining diff is an unrelated arrow this-capture bug).

## Verification
- Zero regressions (JS): super 200/211, objectLiteral 158/162, class 1460/1480, static 431/448, lambda 43/45, arrow 336/338, accessor 314/318, getset 7/7 — identical with/without the fix. 4 new unit tests pass; `cargo clippy -p tsz-emitter --all-targets -- -D warnings` clean.
- Scope note: clean subset of the es5-super cluster. The 4 cluster witnesses each have additional independent bugs (arrow this-capture depth, class-IR super propagation in computed keys, optional-chain-on-this guard, comment placement) that are separate, broader-blast-radius fixes — deferred. This PR corrects the accessor super-base in isolation and moves superInObjectLiterals_ES5 closer to passing.

## Coordination Notes
Wave-3b partial; structural, zero-regression. — opus48-emit100
