### PR TITLE
fix(emit): ES5 destructuring-assignment shorthand-default guard + for-of bare-target spread-as-rest

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -167,6 +167,10 @@ name = "destructuring_es5_array_nested_order_tests"
 path = "tests/destructuring_es5_array_nested_order_tests.rs"
 
 [[test]]
+name = "destructuring_assignment_es5_shorthand_default_tests"
+path = "tests/destructuring_assignment_es5_shorthand_default_tests.rs"
+
+[[test]]
 name = "destructuring_downlevel_iteration_read_tests"
 path = "tests/destructuring_downlevel_iteration_read_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/es5/bindings_assignment.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings_assignment.rs
@@ -1417,22 +1417,48 @@ impl<'a> Printer<'a> {
                 }
                 k if k == syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT => {
                     // { name } → name = source.name
+                    // { name = init } (cover-initialized shorthand) → mirror the
+                    // colon-form default branch: extract the property into a temp,
+                    // then assign `name = tmp === void 0 ? init : tmp`.
                     if let Some(shorthand) = self.arena.get_shorthand_property(elem_node) {
                         let name = crate::transforms::emit_utils::identifier_text_or_empty(
                             self.arena,
                             shorthand.name,
                         );
-                        self.emit_assignment_separator(first);
-                        if !self.emit_commonjs_live_export_assignment_target_name(&name) {
-                            self.emit_assignment_target(shorthand.name);
+                        if shorthand.object_assignment_initializer.is_some() {
+                            let temp = self.make_unique_name_hoisted_assignment();
+                            self.emit_assignment_separator(first);
+                            self.write(&temp);
+                            self.write(" = ");
+                            self.emit_assignment_object_key_access(
+                                source,
+                                inline_source,
+                                shorthand.name,
+                                None,
+                            );
+                            self.write(", ");
+                            if !self.emit_commonjs_live_export_assignment_target_name(&name) {
+                                self.emit_assignment_target(shorthand.name);
+                            }
+                            self.write(" = ");
+                            self.write(&temp);
+                            self.write(" === void 0 ? ");
+                            self.emit(shorthand.object_assignment_initializer);
+                            self.write(" : ");
+                            self.write(&temp);
+                        } else {
+                            self.emit_assignment_separator(first);
+                            if !self.emit_commonjs_live_export_assignment_target_name(&name) {
+                                self.emit_assignment_target(shorthand.name);
+                            }
+                            self.write(" = ");
+                            self.emit_assignment_object_key_access(
+                                source,
+                                inline_source,
+                                shorthand.name,
+                                None,
+                            );
                         }
-                        self.write(" = ");
-                        self.emit_assignment_object_key_access(
-                            source,
-                            inline_source,
-                            shorthand.name,
-                            None,
-                        );
                         if !name.is_empty() {
                             rest_props.push(AssignmentRestProp::Static(name));
                         }

--- a/crates/tsz-emitter/src/emitter/es5/bindings_for_of.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings_for_of.rs
@@ -576,28 +576,27 @@ impl<'a> Printer<'a> {
         };
         match init_node.kind {
             k if k == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION => {
-                if let Some(lit) = self.arena.get_literal_expr(init_node)
-                    && lit.elements.nodes.len() > 1
-                {
-                    // One extracted source temp + per-property default temps.
-                    let mut defaults = 0usize;
-                    for &elem_idx in &lit.elements.nodes {
-                        let Some(elem_node) = self.arena.get(elem_idx) else {
-                            continue;
-                        };
-                        if elem_node.kind == syntax_kind_ext::PROPERTY_ASSIGNMENT
-                            && let Some(prop) = self.arena.get_property_assignment(elem_node)
-                            && let Some(value_node) = self.arena.get(prop.initializer)
-                            && value_node.kind == syntax_kind_ext::BINARY_EXPRESSION
-                            && let Some(bin) = self.arena.get_binary_expr(value_node)
-                            && bin.operator_token == SyntaxKind::EqualsToken as u16
-                        {
-                            defaults += 1;
-                        }
+                let Some(lit) = self.arena.get_literal_expr(init_node) else {
+                    return 0;
+                };
+                // Count per-property default temps. A property with a default
+                // (colon form `{ k: name = init }` or shorthand cover-init form
+                // `{ name = init }`) reserves one extract temp so the
+                // `tmp = source.k, name = tmp === void 0 ? init : tmp` guard can
+                // be emitted, mirroring tsc's allocation order.
+                let mut defaults = 0usize;
+                for &elem_idx in &lit.elements.nodes {
+                    if self.for_of_assignment_property_has_default(elem_idx) {
+                        defaults += 1;
                     }
+                }
+                if lit.elements.nodes.len() > 1 {
+                    // Multi-element patterns also extract one source temp.
                     return 1 + defaults;
                 }
-                0
+                // Single-element patterns inline the source, so only the default
+                // extract temp (if any) is reserved.
+                defaults
             }
             k if k == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION => {
                 if let Some(lit) = self.arena.get_literal_expr(init_node)
@@ -610,6 +609,36 @@ impl<'a> Printer<'a> {
                 0
             }
             _ => 0,
+        }
+    }
+
+    /// Whether an object-pattern element carries a default value, in either the
+    /// colon form (`{ k: name = init }`, a `PROPERTY_ASSIGNMENT` whose
+    /// initializer is an `=` binary) or the shorthand cover-initialized form
+    /// (`{ name = init }`, a `SHORTHAND_PROPERTY_ASSIGNMENT` with an
+    /// `object_assignment_initializer`). Both lower to one extract temp.
+    fn for_of_assignment_property_has_default(&self, elem_idx: NodeIndex) -> bool {
+        let Some(elem_node) = self.arena.get(elem_idx) else {
+            return false;
+        };
+        match elem_node.kind {
+            k if k == syntax_kind_ext::PROPERTY_ASSIGNMENT => self
+                .arena
+                .get_property_assignment(elem_node)
+                .and_then(|prop| self.arena.get(prop.initializer))
+                .and_then(|value_node| {
+                    if value_node.kind == syntax_kind_ext::BINARY_EXPRESSION {
+                        self.arena.get_binary_expr(value_node)
+                    } else {
+                        None
+                    }
+                })
+                .is_some_and(|bin| bin.operator_token == SyntaxKind::EqualsToken as u16),
+            k if k == syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT => self
+                .arena
+                .get_shorthand_property(elem_node)
+                .is_some_and(|shorthand| shorthand.object_assignment_initializer.is_some()),
+            _ => false,
         }
     }
 

--- a/crates/tsz-emitter/src/lowering/core.rs
+++ b/crates/tsz-emitter/src/lowering/core.rs
@@ -333,10 +333,26 @@ impl<'a> LoweringPass<'a> {
         let init_has_binding_pattern =
             self.for_of_initializer_has_binding_pattern(for_in_of.initializer);
 
-        if init_has_binding_pattern {
-            // Mark __read helper when destructuring is used with downlevelIteration
-            // TypeScript emits __read to convert iterator results to arrays for destructuring
-            if self.ctx.target_es5 && self.ctx.options.downlevel_iteration {
+        // A for-of whose initializer is a bare expression (not a
+        // VARIABLE_DECLARATION_LIST) is a destructuring-ASSIGNMENT target, e.g.
+        // `for ([a, ...rest] of xs)` / `for ({ a = d } of xs)`. The LHS
+        // array/object literal is a pattern, not a fresh array/object, so the
+        // in-assignment-target flag must be set during its visit. Otherwise a
+        // spread element like `[...rest]` is mis-classified as array
+        // construction and spuriously pulls in the `__spreadArray` helper.
+        let init_is_assignment_target =
+            self.for_of_initializer_is_assignment_target(for_in_of.initializer);
+
+        if init_has_binding_pattern || init_is_assignment_target {
+            // Mark __read helper when binding-pattern destructuring is used with
+            // downlevelIteration. TypeScript emits __read to convert iterator
+            // results to arrays for binding-pattern destructuring. (Bare
+            // assignment targets keep the existing array-indexing lowering and
+            // do not add __read here.)
+            if init_has_binding_pattern
+                && self.ctx.target_es5
+                && self.ctx.options.downlevel_iteration
+            {
                 self.transforms.helpers_mut().mark_read();
             }
             // Set in_assignment_target to prevent spread in destructuring from triggering __spreadArray

--- a/crates/tsz-emitter/src/lowering/helpers.rs
+++ b/crates/tsz-emitter/src/lowering/helpers.rs
@@ -860,6 +860,29 @@ impl<'a> LoweringPass<'a> {
         false
     }
 
+    /// Check whether a for-of initializer is a bare destructuring-ASSIGNMENT
+    /// target (an array/object literal pattern), as opposed to a
+    /// `VARIABLE_DECLARATION_LIST` binding declaration. Such targets are
+    /// patterns, not fresh array/object construction, so spreads inside them
+    /// must be lowered as destructuring rest rather than array spread.
+    pub(super) fn for_of_initializer_is_assignment_target(&self, initializer: NodeIndex) -> bool {
+        let Some(init_node) = self.arena.get(initializer) else {
+            return false;
+        };
+
+        // Variable-declaration-list initializers (`for (const [a] of xs)`) are
+        // bindings, handled by the binding-pattern path.
+        if init_node.kind == syntax_kind_ext::VARIABLE_DECLARATION_LIST {
+            return false;
+        }
+
+        // A bare expression target is a destructuring assignment only when it is
+        // an array or object literal pattern. Plain identifier targets
+        // (`for (x of xs)`) need no special handling.
+        init_node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
+            || init_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+    }
+
     pub(super) fn get_identifier_id(&self, idx: NodeIndex) -> Option<IdentifierId> {
         if idx.is_none() {
             return None;

--- a/crates/tsz-emitter/tests/destructuring_assignment_es5_shorthand_default_tests.rs
+++ b/crates/tsz-emitter/tests/destructuring_assignment_es5_shorthand_default_tests.rs
@@ -1,0 +1,170 @@
+//! ES5 lowering parity for destructuring-ASSIGNMENT targets.
+//!
+//! Two structural rules are covered:
+//!
+//! 1. A shorthand property carrying a cover-initialized default
+//!    (`{ name = init }`) in a destructuring-assignment target lowers to the
+//!    same extract-temp-and-`void 0` guard that the colon form
+//!    (`{ key: name = init }`) emits:
+//!    `tmp = source.key, name = tmp === void 0 ? init : tmp`.
+//!    The fix keys on the structural presence of
+//!    `ShorthandProperty.object_assignment_initializer`, never on the chosen
+//!    identifier name, so renaming the binding must not change the lowering.
+//!
+//! 2. A for-of whose initializer is a bare expression assignment target
+//!    (an array/object literal pattern, not a `VARIABLE_DECLARATION_LIST`) is a
+//!    destructuring-assignment target. A spread element inside it
+//!    (`for ([a, ...rest] of xs)`) must lower as destructuring rest
+//!    (`rest = src.slice(1)`) and must NOT pull in the `__spreadArray` helper
+//!    used for genuine array construction.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_lower_print as parse_lower_emit;
+
+fn es5_opts() -> PrintOptions {
+    PrintOptions {
+        target: ScriptTarget::ES5,
+        module: ModuleKind::CommonJS,
+        ..Default::default()
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Bug A: shorthand-default in a destructuring-assignment target
+// -----------------------------------------------------------------------------
+
+#[test]
+fn assignment_shorthand_default_emits_void0_guard() {
+    // `({ x = 5 } = src)` must extract `src.x` into a temp and guard the
+    // default, exactly like the colon form would.
+    let source = "let x: any; let src: any;\n({ x = 5 } = src);\n";
+    let output = parse_lower_emit(source, es5_opts());
+
+    assert!(
+        output.contains(".x, x = ") && output.contains("=== void 0 ? 5 :"),
+        "shorthand `{{ x = 5 }}` assignment should emit `_t = src.x, x = _t === void 0 ? 5 : _t`.\nOutput:\n{output}"
+    );
+    // Must NOT be the plain no-default lowering `x = src.x`.
+    assert!(
+        !output.contains("x = src.x;") && !output.contains("x = src.x)"),
+        "shorthand default must not be dropped to a plain property read.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn assignment_shorthand_default_is_name_independent() {
+    // Renaming the bound variable must not change the structural lowering:
+    // the void-0 guard is keyed on the AST shape, not the identifier `x`.
+    let source = "let y: any; let src: any;\n({ y = 5 } = src);\n";
+    let output = parse_lower_emit(source, es5_opts());
+
+    assert!(
+        output.contains(".y, y = ") && output.contains("=== void 0 ? 5 :"),
+        "renamed shorthand `{{ y = 5 }}` must still emit the void-0 default guard.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn assignment_colon_default_control_matches_shorthand_shape() {
+    // Control: the colon form `{ x: x = 5 }` already lowered with the void-0
+    // guard. The shorthand form must produce the same structural output, so the
+    // two are intentionally compared for the same guard shape.
+    let shorthand = parse_lower_emit(
+        "let x: any; let src: any;\n({ x = 5 } = src);\n",
+        es5_opts(),
+    );
+    let colon = parse_lower_emit(
+        "let x: any; let src: any;\n({ x: x = 5 } = src);\n",
+        es5_opts(),
+    );
+
+    let guard = "=== void 0 ? 5 :";
+    assert!(
+        shorthand.contains(guard) && colon.contains(guard),
+        "both shorthand and colon defaults must emit the void-0 guard.\nShorthand:\n{shorthand}\nColon:\n{colon}"
+    );
+    assert!(
+        shorthand.contains(".x, x = ") && colon.contains(".x, x = "),
+        "both forms must extract `src.x` into a temp before the guarded assignment.\nShorthand:\n{shorthand}\nColon:\n{colon}"
+    );
+}
+
+#[test]
+fn assignment_shorthand_no_default_keeps_plain_read() {
+    // Negative/fallback: a shorthand WITHOUT a default keeps the plain
+    // property-read lowering (no spurious void-0 guard).
+    let source = "let x: any; let src: any;\n({ x } = src);\n";
+    let output = parse_lower_emit(source, es5_opts());
+
+    assert!(
+        output.contains("x = src.x"),
+        "shorthand without a default should lower to `x = src.x`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("void 0"),
+        "shorthand without a default must not emit a void-0 guard.\nOutput:\n{output}"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Bug B: for-of bare-expression assignment target with a spread
+// -----------------------------------------------------------------------------
+
+#[test]
+fn for_of_bare_array_target_with_rest_lowers_as_slice_not_spread_array() {
+    // `for ([a, ...rest] of xs)` is a destructuring-assignment target, so the
+    // `[...rest]` is a rest pattern, not array construction. The rest must
+    // lower to `.slice(...)` and the `__spreadArray` helper must NOT appear.
+    let source =
+        "let a: any, rest: any; let xs: any[] = [];\nfor ([a, ...rest] of xs) {\n    a;\n}\n";
+    let output = parse_lower_emit(source, es5_opts());
+
+    assert!(
+        output.contains(".slice(1)"),
+        "for-of array rest target should lower to `.slice(1)`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("__spreadArray"),
+        "for-of bare array assignment target must not pull in __spreadArray.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn for_of_bare_array_rest_only_target_lowers_as_slice_not_spread_array() {
+    // Rest-only bare target `for ([...rest] of xs)` lowers to `.slice(0)`.
+    let source = "let rest: any; let xs: any[] = [];\nfor ([...rest] of xs) {\n    rest;\n}\n";
+    let output = parse_lower_emit(source, es5_opts());
+
+    assert!(
+        output.contains(".slice(0)"),
+        "rest-only for-of array target should lower to `.slice(0)`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("__spreadArray"),
+        "rest-only for-of bare target must not pull in __spreadArray.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn for_of_bare_object_shorthand_default_target_emits_void0_guard() {
+    // Combines both rules: a for-of bare object target with a shorthand default
+    // (`for ({ name = "d" } of xs)`) must emit the void-0 default guard from
+    // the property extracted out of each element.
+    let source =
+        "let name: any; let xs: any[] = [];\nfor ({ name = \"d\" } of xs) {\n    name;\n}\n";
+    let output = parse_lower_emit(source, es5_opts());
+
+    assert!(
+        output.contains(".name, name = ") && output.contains("=== void 0 ? \"d\" :"),
+        "for-of bare object shorthand default should emit the void-0 guard.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("__spreadArray"),
+        "object for-of target must not pull in __spreadArray.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — JavaScript emit parity (emit→100% campaign, wave 3b)

## Invariant
When a destructuring-assignment target is a shorthand property carrying a default, lowering emits the same extract-temp-and-void-0 guard it emits for the colon form (`tmp = source.key, name = tmp === void 0 ? init : tmp`); and a for-of initializer that is a bare assignment-target expression sets the in-assignment-target flag so spreads lower as destructuring rest (`.slice`), not array construction (`__spreadArray`).

## Scope
- `crates/tsz-emitter/src/emitter/es5/bindings_assignment.rs` — SHORTHAND_PROPERTY_ASSIGNMENT default branch mirrors the colon form.
- `crates/tsz-emitter/src/lowering/core.rs` + `helpers.rs` — `visit_for_of_statement` sets in_assignment_target for bare-expression targets (new structural `for_of_initializer_is_assignment_target`).
- `crates/tsz-emitter/src/emitter/es5/bindings_for_of.rs` — reserve default temps for shorthand-default for-of object patterns.
- `crates/tsz-emitter/tests/destructuring_assignment_es5_shorthand_default_tests.rs` (new, 7 structural tests) + Cargo.toml.

## Project Corpus Impact
- Row: n/a (emit parity fix)
- Bug family: ES5 destructuring-assignment shorthand-default guard + for-of bare-target spread
- Evidence: shorthandPropertyAssignmentsInDestructuring(es5+es2015) FAIL→PASS; destructuring 228→229, shorthand 41→42.

## Verification
- Witness FAIL→PASS (JS): shorthandPropertyAssignmentsInDestructuring (3/3). Zero regressions: destructuring +1, shorthand +1 (100%), forOf/spread/sourceMap unchanged. 7 unit tests; clippy clean.
- Scope note: the 2 sourceMapValidationForOf witnesses are now semantically correct (spread helper gone, guards match) but blocked on a separate file-wide for-of temp-renumbering model (two-pass) — deferred as a broad change.

## Coordination Notes
Wave-3b clean subset; structural (§25/§26 compliant). — opus48-emit100
