### PR TITLE
fix(dts): use current indent depth (not +1) for array element access object union

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
@@ -130,7 +130,7 @@ impl<'a> DeclarationEmitter<'a> {
                     self.get_node_type_or_names(&[elem_idx])
                         .map(|type_id| self.print_type_id(type_id))
                 })
-                .or_else(|| self.infer_fallback_type_text_at(elem_idx, self.indent_level + 1))?;
+                .or_else(|| self.infer_fallback_type_text_at(elem_idx, self.indent_level))?;
             element_types.push(elem_type);
             element_sources.push(elem_idx);
         }
@@ -150,7 +150,7 @@ impl<'a> DeclarationEmitter<'a> {
             }
         }
         if let Some(source_union_text) =
-            self.source_object_literal_union_text(&distinct_sources, self.indent_level + 1)
+            self.source_object_literal_union_text(&distinct_sources, self.indent_level)
         {
             return Some(source_union_text);
         }

--- a/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification.rs
@@ -1790,3 +1790,46 @@ let gResult3 = g(helloOrWorld);
         );
     }
 }
+
+// When an array element access produces a union of object types, the DTS emitter
+// formats the union at the current output indent level (depth=0 at top level),
+// giving 4-space member indentation — matching tsc's output.
+#[test]
+fn fix_array_element_access_union_uses_top_level_indent_depth() {
+    let output = emit_dts(
+        r#"
+let x1 = [{ a: 0 }, { a: 1, b: "x" }][0];
+let x2 = [{ a: 1, b: 2 }, { a: "abc" }, {}][0];
+"#,
+    );
+
+    // 4-space member indentation (depth=0) at top level, matching tsc
+    assert!(
+        output.contains("declare let x1: {\n    a: number;\n    b?: undefined;\n} | {\n    a: number;\n    b: string;\n}"),
+        "array element union must use top-level 4-space indent:\n{output}"
+    );
+    assert!(
+        output.contains("declare let x2: {\n    a: number;\n    b: number;\n} | {\n    a: string;\n    b?: undefined;\n} | {\n    a?: undefined;\n    b?: undefined;\n}"),
+        "3-member union from array element must use 4-space indent:\n{output}"
+    );
+    // Ensure no 8-space indentation (depth=1 was the old wrong behavior)
+    assert!(
+        !output.contains("        a: number;"),
+        "must not use 8-space (depth=1) indentation for top-level array element union:\n{output}"
+    );
+}
+
+// Renamed variable to prove the rule is not spelling-dependent.
+#[test]
+fn fix_array_element_access_union_indent_name_independent() {
+    let output = emit_dts(
+        r#"
+let renamed_k = [{ p: 0 }, { p: 1, q: "x" }][0];
+"#,
+    );
+
+    assert!(
+        output.contains("declare let renamed_k: {\n    p: number;\n    q?: undefined;\n} | {\n    p: number;\n    q: string;\n}"),
+        "renamed variable still gets 4-space indent:\n{output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: claude-sonnet-4-6-dazzling-johnson

## Track
Track 9 — Emit/DTS Parity Recovery

## Invariant
When `arr[N]` element access on an array literal produces a union of object types, the DTS emitter formats each union arm at the current output indent level (`self.indent_level`), not at `indent_level + 1`. At top level (`indent_level = 0`), this gives 4-space member indentation and 0-space closing `}`, matching tsc's output.

Structural rule: "For a top-level variable declaration inferred from an array literal element access, tsc formats each union arm at depth `indent_level` (0 at top-level), producing 4-space member indentation — not 8-space."

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs`
  - Line 133: `infer_fallback_type_text_at(elem_idx, self.indent_level + 1)` → `infer_fallback_type_text_at(elem_idx, self.indent_level)`
  - Line 153: `source_object_literal_union_text(&distinct_sources, self.indent_level + 1)` → `source_object_literal_union_text(&distinct_sources, self.indent_level)`
- `crates/tsz-emitter/src/declaration_emitter/tests/fix_verification.rs` — two new fix verification tests

## Fix

`ObjectTypeLiteralArm::render()` computes `member_indent = "    ".repeat(depth + 1)` and `closing_indent = "    ".repeat(depth)`. When `array_literal_element_union_type_text` was passing `self.indent_level + 1` as depth, a top-level variable (`indent_level = 0`) got depth=1, producing 8-space member indentation and 4-space closing `}`. tsc produces 4-space member indentation (depth=0) for this case.

`self.indent_level` already correctly captures the nesting context (0 at top-level, 1 inside a class body), so no extra `+1` is needed.

## Adjacent cases verified

1. `let a1 = [{a: 0}, {a: 1, b: "x"}][0]` → `{a: number; b?: undefined;} | {a: number; b: string;}` (4-space, depth=0) ✓
2. `let a2 = [{a: 1, b: 2}, {a: "abc"}, {}][0]` → 3-member union at 4-space ✓
3. `let renamed_k = [{p: 0}, {p: 1, q: "x"}][0]` → same depth regardless of variable/property name ✓
4. Nested `d1 = [{kind: 'a', pos: {x: 0, y: 0}}, {kind: 'b', pos: ...}][0]` → nested pos union at correct depth ✓
5. Full `objectLiteralNormalization.ts` test output matches tsc v6.0.3 baseline verbatim ✓

## Project Corpus Impact
- Row: n/a — emit-only fix, no corpus perf or correctness regression
- Bug family: `objectLiteralNormalization` DTS baseline — array element access union formatting depth
- Evidence: tsc v6.0.3 baseline (`tests/baselines/reference/objectLiteralNormalization.js`, section `[objectLiteralNormalization.d.ts]`) shows 4-space member indent for `a1`/`a2` inferred from `[...][0]`. Before fix: tsz produced 8-space (depth=1). After fix: tsz produces 4-space (depth=0) matching tsc. Stale snapshot shows `objectLiteralNormalization | +14/-20 lines` — this fix addresses the indentation delta.

## Verification
- `cargo clippy -p tsz-emitter` — no new warnings
- Two new unit tests: `fix_array_element_access_union_uses_top_level_indent_depth` and `fix_array_element_access_union_indent_name_independent` — both pass
- Full objectLiteralNormalization source run through current binary matches tsc v6.0.3 baseline verbatim
- CI emit suite: `objectLiteralNormalization` DTS should move from fail to pass

## Coordination Notes
- No overlap with open draft PRs (checked #11659 which is about nested mapped-type formatting — different code path)
- One-function, two-call-site change with a clear structural invariant
- PR #11687 (parenthesized type stripping) is independent and does not affect this code path

---
_Generated by [Claude Code](https://claude.ai/code/session_013KokZDEMrUPeFKbmPFPha7)_