### PR TITLE
fix(dts): preserve source parenthesized-type wrappers in array-element and union-member emission

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/tests/infer_paren_and_union_intersection.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/infer_paren_and_union_intersection.rs
@@ -144,3 +144,88 @@ fn template_literal_type_text_reescapes_backtick_and_dollar_brace() {
         "backtick and ${{ in template text must be escaped: {output:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Fix C: a source-parenthesized array element keeps its parens verbatim in
+// the copied annotation (`(T)[]` stays `(T)[]`, not `T[]`). The fix keys on
+// the source `PARENTHESIZED_TYPE` array element, never on the element's name.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parenthesized_array_element_keeps_parens() {
+    // `(Foo)[]` is a redundant-but-user-written grouping that tsc preserves
+    // verbatim in the .d.ts.
+    let output = emit_dts("export type T = (Foo)[];");
+    assert!(
+        output.contains("(Foo)[]"),
+        "source-parenthesized array element must keep parens: {output}"
+    );
+}
+
+#[test]
+fn parenthesized_array_element_keeps_parens_renamed() {
+    // Same rule, different element spelling: proves the fix is not keyed on a
+    // particular type-reference name.
+    let output = emit_dts("export type T = (Widget9)[];");
+    assert!(
+        output.contains("(Widget9)[]"),
+        "source-parenthesized array element must keep parens (renamed): {output}"
+    );
+}
+
+#[test]
+fn unparenthesized_array_element_stays_unparenthesized() {
+    // Negative/fallback case: a bare array element gets no synthesized parens.
+    let output = emit_dts("export type T = Foo[];");
+    assert!(
+        output.contains("Foo[]") && !output.contains("(Foo)[]"),
+        "bare array element must stay unparenthesized: {output}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fix C: a *bare* intersection member of a union keeps its source spelling
+// (`T | T & undefined` stays unparenthesized), while a *source-parenthesized*
+// intersection member keeps its parens. Both branches key on the source
+// `PARENTHESIZED_TYPE` wrapper, never on the member's spelling.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unparenthesized_intersection_union_member_stays_unparenthesized() {
+    // `T | T & undefined` is the verbatim source; tsc preserves the exact
+    // unparenthesized grouping rather than synthesizing `T | (T & undefined)`.
+    let output = emit_dts("export declare function f<T>(a: T | T & undefined): void;");
+    assert!(
+        output.contains("a: T | T & undefined"),
+        "bare intersection union member must stay unparenthesized: {output}"
+    );
+    assert!(
+        !output.contains("a: T | (T & undefined)"),
+        "bare intersection union member must not gain synthesized parens: {output}"
+    );
+}
+
+#[test]
+fn unparenthesized_intersection_union_member_stays_unparenthesized_renamed() {
+    // Different type-parameter spelling proves the rule is structural.
+    let output = emit_dts("export declare function g<Elem>(a: Elem | Elem & null): void;");
+    assert!(
+        output.contains("a: Elem | Elem & null"),
+        "bare intersection union member must stay unparenthesized (renamed): {output}"
+    );
+    assert!(
+        !output.contains("(Elem & null)"),
+        "bare intersection union member must not gain synthesized parens (renamed): {output}"
+    );
+}
+
+#[test]
+fn parenthesized_intersection_union_member_keeps_parens() {
+    // When the source parenthesizes the intersection arm, those parens
+    // round-trip so the grouping stays unambiguous.
+    let output = emit_dts("export declare function f<T>(a: T | (T & undefined)): void;");
+    assert!(
+        output.contains("a: T | (T & undefined)"),
+        "source-parenthesized intersection union member must keep parens: {output}"
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
@@ -151,16 +151,28 @@ impl<'a> DeclarationEmitter<'a> {
             // Array type
             k if k == syntax_kind_ext::ARRAY_TYPE => {
                 if let Some(arr) = self.arena.get_array_type(type_node) {
+                    // Preserve a source-level parenthesized array element so the
+                    // user's parens round-trip verbatim (e.g. `(T)[]` stays
+                    // `(T)[]`, not `T[]`). Detect the source `PARENTHESIZED_TYPE`
+                    // wrapper structurally on the array element, mirroring the
+                    // conditional-type arms. This only affects verbatim source
+                    // copy; synthesized array types print through the solver
+                    // TypePrinter, which normalizes parens independently.
+                    let element_source_was_parenthesized = self
+                        .arena
+                        .get(arr.element_type)
+                        .is_some_and(|n| n.kind == syntax_kind_ext::PARENTHESIZED_TYPE);
                     let inner = self.peel_paren(arr.element_type);
-                    let needs_parens = self.arena.get(inner).is_some_and(|n| {
-                        n.kind == syntax_kind_ext::FUNCTION_TYPE
-                            || n.kind == syntax_kind_ext::CONSTRUCTOR_TYPE
-                            || n.kind == syntax_kind_ext::UNION_TYPE
-                            || n.kind == syntax_kind_ext::INTERSECTION_TYPE
-                            || n.kind == syntax_kind_ext::CONDITIONAL_TYPE
-                            || n.kind == syntax_kind_ext::TYPE_OPERATOR
-                            || n.kind == syntax_kind_ext::INFER_TYPE
-                    });
+                    let needs_parens = element_source_was_parenthesized
+                        || self.arena.get(inner).is_some_and(|n| {
+                            n.kind == syntax_kind_ext::FUNCTION_TYPE
+                                || n.kind == syntax_kind_ext::CONSTRUCTOR_TYPE
+                                || n.kind == syntax_kind_ext::UNION_TYPE
+                                || n.kind == syntax_kind_ext::INTERSECTION_TYPE
+                                || n.kind == syntax_kind_ext::CONDITIONAL_TYPE
+                                || n.kind == syntax_kind_ext::TYPE_OPERATOR
+                                || n.kind == syntax_kind_ext::INFER_TYPE
+                        });
                     if needs_parens {
                         self.write("(");
                     }
@@ -191,17 +203,30 @@ impl<'a> DeclarationEmitter<'a> {
                             self.emit_named_tuple_type_multiline(type_idx);
                             continue;
                         }
+                        // An intersection member of a union keeps its source
+                        // grouping verbatim: if the user parenthesized the arm
+                        // (`"a" | (string & {})`) those parens round-trip, but a
+                        // bare source intersection arm (`T | T & undefined`)
+                        // stays unparenthesized. Detect the source
+                        // `PARENTHESIZED_TYPE` wrapper structurally; do not
+                        // synthesize parens that the source did not have.
+                        // Synthesized union members print through the solver
+                        // TypePrinter (`print_type_id`), which adds the
+                        // normalized `(T & undefined)` parens on its own path.
+                        let member_source_was_parenthesized = self
+                            .arena
+                            .get(type_idx)
+                            .is_some_and(|n| n.kind == syntax_kind_ext::PARENTHESIZED_TYPE);
                         let inner = self.peel_paren(type_idx);
                         let needs_parens = self.arena.get(inner).is_some_and(|n| {
                             n.kind == syntax_kind_ext::FUNCTION_TYPE
                                 || n.kind == syntax_kind_ext::CONSTRUCTOR_TYPE
                                 || n.kind == syntax_kind_ext::CONDITIONAL_TYPE
-                                // An intersection member of a union is
-                                // parenthesized so the grouping round-trips
-                                // unambiguously: `string & {} | T` reads as
-                                // `(string & {}) | T`. Mirrors the intersection
-                                // arm, which parenthesizes nested unions.
-                                || n.kind == syntax_kind_ext::INTERSECTION_TYPE
+                                // A source-parenthesized intersection member of a
+                                // union keeps its parens so the grouping
+                                // round-trips unambiguously: `(string & {}) | T`.
+                                || (member_source_was_parenthesized
+                                    && n.kind == syntax_kind_ext::INTERSECTION_TYPE)
                         });
                         if needs_parens {
                             self.write("(");


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — declaration emit parity (emit→100% campaign, wave 3b)

## Invariant
When the declaration emitter copies a verbatim source type annotation into .d.ts, source-level `PARENTHESIZED_TYPE` wrappers are preserved in array-element and union-member position (user parens round-trip), while synthesized types keep solver-`TypePrinter` normalized parenthesization.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/type_emission.rs` — ARRAY_TYPE arm ORs `element_source_was_parenthesized` into needs_parens; UNION_TYPE arm parenthesizes an INTERSECTION_TYPE member only when the source member was parenthesized (mirrors the existing CONDITIONAL_TYPE source-paren pattern). Keys on AST node kind, not printer output.
- `crates/tsz-emitter/src/declaration_emitter/tests/infer_paren_and_union_intersection.rs` — 6 new structural tests.

## Project Corpus Impact
- Row: n/a (declaration emit parity fix)
- Bug family: source parenthesized-type round-trip in array-element / union-member position
- Evidence: spreadObjectOrFalsy FAIL→PASS; spread dts 4→5; also fixed pre-existing explore_intersection_type_in_union.

## Verification
- Witness FAIL→PASS (DTS): spreadObjectOrFalsy (`T | T & undefined` verbatim). Zero regressions: declarationEmit/array/union/intersection/parenthesized/recursive unchanged, spread +1; JS unchanged. 16 module tests pass (6 new + fixed a pre-existing); clippy `-p tsz-emitter --lib -D warnings` clean.
- Scope note: recursiveTypeReferences1's paren diff (`(T12)[]`) is now correct, but it stays FAIL on a separate variable-type-widening inference bug — deferred.

## Coordination Notes
Wave-3b DTS fix; structural (§25/§26). — opus48-emit100
