### PR TITLE
fix(emit): order legacy class member decorators instance-before-static; merge accessor decorators (first-declared)

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -266,6 +266,10 @@ path = "tests/ternary_trailing_comment_tests.rs"
 name = "wave3_small_emit_fixes_tests"
 path = "tests/wave3_small_emit_fixes_tests.rs"
 
+[[test]]
+name = "legacy_decorator_member_order_tests"
+path = "tests/legacy_decorator_member_order_tests.rs"
+
 [lints]
 workspace = true
 

--- a/crates/tsz-emitter/src/emitter/declarations/class/decorators.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/decorators.rs
@@ -312,6 +312,95 @@ impl<'a> Printer<'a> {
         result
     }
 
+    /// Collect parameter decorators across every accessor (getter + setter) that
+    /// shares the same structural name and static-ness as the given accessor.
+    ///
+    /// `tsc` merges a getter/setter pair into a single `__decorate` call, so the
+    /// setter's `@dec param` decorators must be appended to the getter's member
+    /// decorators. Matching is keyed on the structural member name and the
+    /// static modifier, never on a user-chosen identifier spelling.
+    fn collect_accessor_param_decorators(
+        &self,
+        members: &[NodeIndex],
+        name_idx: NodeIndex,
+        is_static: bool,
+    ) -> Vec<(usize, Vec<NodeIndex>)> {
+        let Some(target_name) = self.get_decorator_member_name(name_idx) else {
+            return Vec::new();
+        };
+        let target_key = target_name.dedupe_key();
+        let mut result = Vec::new();
+        for &member_idx in members {
+            let Some(member_node) = self.arena.get(member_idx) else {
+                continue;
+            };
+            if member_node.kind != syntax_kind_ext::GET_ACCESSOR
+                && member_node.kind != syntax_kind_ext::SET_ACCESSOR
+            {
+                continue;
+            }
+            let Some(accessor) = self.arena.get_accessor(member_node) else {
+                continue;
+            };
+            if self.arena.is_static(&accessor.modifiers) != is_static {
+                continue;
+            }
+            let Some(member_name) = self.get_decorator_member_name(accessor.name) else {
+                continue;
+            };
+            if member_name.dedupe_key() != target_key {
+                continue;
+            }
+            result.extend(self.collect_param_decorators(&accessor.parameters));
+        }
+        result
+    }
+
+    /// Member-level decorators for a getter/setter pair sharing the given
+    /// structural name and static-ness. `tsc` emits a single `__decorate` call
+    /// for the pair whose member decorators come from the **first accessor in
+    /// declaration order that has any decorators** (legacy decorators may only
+    /// validly appear on one accessor; if both are decorated, the first declared
+    /// one wins). Matching is keyed structurally on the name and static modifier.
+    fn collect_accessor_member_decorators(
+        &self,
+        members: &[NodeIndex],
+        name_idx: NodeIndex,
+        is_static: bool,
+    ) -> Vec<NodeIndex> {
+        let Some(target_name) = self.get_decorator_member_name(name_idx) else {
+            return Vec::new();
+        };
+        let target_key = target_name.dedupe_key();
+        for &member_idx in members {
+            let Some(member_node) = self.arena.get(member_idx) else {
+                continue;
+            };
+            if member_node.kind != syntax_kind_ext::GET_ACCESSOR
+                && member_node.kind != syntax_kind_ext::SET_ACCESSOR
+            {
+                continue;
+            }
+            let Some(accessor) = self.arena.get_accessor(member_node) else {
+                continue;
+            };
+            if self.arena.is_static(&accessor.modifiers) != is_static {
+                continue;
+            }
+            let Some(member_name) = self.get_decorator_member_name(accessor.name) else {
+                continue;
+            };
+            if member_name.dedupe_key() != target_key {
+                continue;
+            }
+            let decorators = self.collect_class_decorators(&accessor.modifiers);
+            if !decorators.is_empty() {
+                return decorators;
+            }
+        }
+        Vec::new()
+    }
+
     pub(in crate::emitter) fn legacy_member_decorator_needs_private_name_scope(
         &self,
         member_idx: NodeIndex,
@@ -1241,6 +1330,27 @@ impl<'a> Printer<'a> {
         );
     }
 
+    /// Whether a class member node carries the `static` modifier. Works for the
+    /// member kinds that can be legacy-decorated (methods, properties/auto
+    /// accessors, get/set accessors); other kinds report non-static.
+    fn member_node_is_static(&self, member_node: &Node) -> bool {
+        match member_node.kind {
+            k if k == syntax_kind_ext::METHOD_DECLARATION => self
+                .arena
+                .get_method_decl(member_node)
+                .is_some_and(|m| self.arena.is_static(&m.modifiers)),
+            k if k == syntax_kind_ext::PROPERTY_DECLARATION => self
+                .arena
+                .get_property_decl(member_node)
+                .is_some_and(|p| self.arena.is_static(&p.modifiers)),
+            k if k == syntax_kind_ext::GET_ACCESSOR || k == syntax_kind_ext::SET_ACCESSOR => self
+                .arena
+                .get_accessor(member_node)
+                .is_some_and(|a| self.arena.is_static(&a.modifiers)),
+            _ => false,
+        }
+    }
+
     fn emit_legacy_member_decorator_calls_filtered(
         &mut self,
         class_name: &str,
@@ -1273,7 +1383,35 @@ impl<'a> Printer<'a> {
             },
         }
 
+        // `tsc` emits per-member `__decorate` calls for all decorated
+        // instance/prototype members (in declaration order) before any decorated
+        // static members (in declaration order). Pre-partition the members into
+        // instance-first then static order, preserving source order within each
+        // partition. The split is keyed structurally on the `static` modifier,
+        // not on member names.
+        let mut ordered_members: Vec<NodeIndex> = Vec::with_capacity(members.len());
         for &member_idx in members {
+            let is_static = self
+                .arena
+                .get(member_idx)
+                .map(|n| self.member_node_is_static(n))
+                .unwrap_or(false);
+            if !is_static {
+                ordered_members.push(member_idx);
+            }
+        }
+        for &member_idx in members {
+            let is_static = self
+                .arena
+                .get(member_idx)
+                .map(|n| self.member_node_is_static(n))
+                .unwrap_or(false);
+            if is_static {
+                ordered_members.push(member_idx);
+            }
+        }
+
+        for &member_idx in &ordered_members {
             let Some(member_node) = self.arena.get(member_idx) else {
                 continue;
             };
@@ -1336,23 +1474,33 @@ impl<'a> Printer<'a> {
                 _ => continue,
             };
 
-            // Collect decorator nodes from modifiers
-            let decorators = self.collect_class_decorators(modifiers);
+            let is_static = self.arena.is_static(modifiers);
 
-            // Collect parameter decorators for methods
-            let param_decorators: Vec<(usize, Vec<NodeIndex>)> =
-                if let MemberMetadata::Method { ref parameters, .. } = metadata {
-                    self.collect_param_decorators(parameters)
-                } else {
-                    Vec::new()
-                };
+            // Collect member-level decorators. Accessors merge the member
+            // decorators from the whole getter/setter pair into the single
+            // `__decorate` call `tsc` emits; other members use their own.
+            let decorators = if is_accessor {
+                self.collect_accessor_member_decorators(members, name_idx, is_static)
+            } else {
+                self.collect_class_decorators(modifiers)
+            };
+
+            // Collect parameter decorators. Methods use their own parameters.
+            // Accessors merge the parameter decorators from the whole
+            // getter/setter pair (the setter's `@dec param`) into the single
+            // `__decorate` call `tsc` emits for the accessor.
+            let param_decorators: Vec<(usize, Vec<NodeIndex>)> = if is_accessor {
+                self.collect_accessor_param_decorators(members, name_idx, is_static)
+            } else if let MemberMetadata::Method { ref parameters, .. } = metadata {
+                self.collect_param_decorators(parameters)
+            } else {
+                Vec::new()
+            };
 
             // Skip members with no decorators at all (neither member nor parameter level)
             if decorators.is_empty() && param_decorators.is_empty() {
                 continue;
             }
-
-            let is_static = self.arena.is_static(modifiers);
 
             let Some(member_name) = self.get_decorator_member_name(name_idx) else {
                 continue;
@@ -1360,7 +1508,8 @@ impl<'a> Printer<'a> {
             let member_key = member_name.dedupe_key();
 
             // For getter/setter pairs, tsc emits only one __decorate call
-            // for the first accessor that has decorators. Skip the second.
+            // for the first accessor of the pair. Skip the second; its parameter
+            // decorators were already merged in above.
             if is_accessor && !emitted_accessor_names.insert(member_key) {
                 continue;
             }

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_decorators.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_decorators.rs
@@ -70,6 +70,131 @@ impl<'a> ES5ClassTransformer<'a> {
         result
     }
 
+    /// Whether a class member node carries the `static` modifier. Mirrors the
+    /// ES2015+ legacy path; the split is keyed structurally on the modifier, not
+    /// on member names.
+    fn member_node_is_static_es5(&self, member_node: &tsz_parser::parser::node::Node) -> bool {
+        match member_node.kind {
+            k if k == syntax_kind_ext::METHOD_DECLARATION => self
+                .arena
+                .get_method_decl(member_node)
+                .is_some_and(|m| self.arena.is_static(&m.modifiers)),
+            k if k == syntax_kind_ext::PROPERTY_DECLARATION => self
+                .arena
+                .get_property_decl(member_node)
+                .is_some_and(|p| self.arena.is_static(&p.modifiers)),
+            k if k == syntax_kind_ext::GET_ACCESSOR || k == syntax_kind_ext::SET_ACCESSOR => self
+                .arena
+                .get_accessor(member_node)
+                .is_some_and(|a| self.arena.is_static(&a.modifiers)),
+            _ => false,
+        }
+    }
+
+    /// Members reordered so all instance/prototype members (in source order)
+    /// precede all static members (in source order). `tsc` emits per-member
+    /// `__decorate` calls in this instance-before-static order.
+    fn legacy_member_decorate_order_es5(&self, members: &[NodeIndex]) -> Vec<NodeIndex> {
+        let mut ordered = Vec::with_capacity(members.len());
+        for &m in members {
+            if !self
+                .arena
+                .get(m)
+                .map(|n| self.member_node_is_static_es5(n))
+                .unwrap_or(false)
+            {
+                ordered.push(m);
+            }
+        }
+        for &m in members {
+            if self
+                .arena
+                .get(m)
+                .map(|n| self.member_node_is_static_es5(n))
+                .unwrap_or(false)
+            {
+                ordered.push(m);
+            }
+        }
+        ordered
+    }
+
+    /// Member-level decorators for a getter/setter pair sharing the given
+    /// structural name and static-ness. `tsc` takes them from the first accessor
+    /// in declaration order that has any decorators (legacy decorators may only
+    /// validly appear on one accessor; if both are decorated, the first declared
+    /// one wins). Matching is keyed structurally on name and static modifier.
+    fn collect_accessor_member_decorators_es5(
+        &self,
+        members: &[NodeIndex],
+        name_idx: NodeIndex,
+        is_static: bool,
+    ) -> Vec<NodeIndex> {
+        let Some(target) = get_identifier_text(self.arena, name_idx) else {
+            return Vec::new();
+        };
+        for &member_idx in members {
+            let Some(member_node) = self.arena.get(member_idx) else {
+                continue;
+            };
+            if member_node.kind != syntax_kind_ext::GET_ACCESSOR
+                && member_node.kind != syntax_kind_ext::SET_ACCESSOR
+            {
+                continue;
+            }
+            let Some(accessor) = self.arena.get_accessor(member_node) else {
+                continue;
+            };
+            if self.arena.is_static(&accessor.modifiers) != is_static {
+                continue;
+            }
+            if get_identifier_text(self.arena, accessor.name).as_deref() != Some(target.as_str()) {
+                continue;
+            }
+            let decorators = self.collect_decorators_from_modifiers(&accessor.modifiers);
+            if !decorators.is_empty() {
+                return decorators;
+            }
+        }
+        Vec::new()
+    }
+
+    /// Collect parameter decorators across every accessor (getter + setter)
+    /// sharing the given structural name and static-ness, so the setter's
+    /// `@dec param` decorators merge into the accessor's single `__decorate` call.
+    fn collect_accessor_param_decorators_es5(
+        &self,
+        members: &[NodeIndex],
+        name_idx: NodeIndex,
+        is_static: bool,
+    ) -> Vec<(usize, Vec<NodeIndex>)> {
+        let Some(target) = get_identifier_text(self.arena, name_idx) else {
+            return Vec::new();
+        };
+        let mut result = Vec::new();
+        for &member_idx in members {
+            let Some(member_node) = self.arena.get(member_idx) else {
+                continue;
+            };
+            if member_node.kind != syntax_kind_ext::GET_ACCESSOR
+                && member_node.kind != syntax_kind_ext::SET_ACCESSOR
+            {
+                continue;
+            }
+            let Some(accessor) = self.arena.get_accessor(member_node) else {
+                continue;
+            };
+            if self.arena.is_static(&accessor.modifiers) != is_static {
+                continue;
+            }
+            if get_identifier_text(self.arena, accessor.name).as_deref() != Some(target.as_str()) {
+                continue;
+            }
+            result.extend(self.collect_param_decorators_es5(&accessor.parameters));
+        }
+        result
+    }
+
     fn helper_name(&self, name: &str) -> String {
         if self.tslib_prefix {
             format!("{}.{name}", self.tslib_import_binding)
@@ -1208,7 +1333,12 @@ impl<'a> ES5ClassTransformer<'a> {
         // getter/setter pairs produce only one __decorate call (the first one).
         let mut emitted_accessor_names = std::collections::HashSet::<String>::new();
 
-        for &member_idx in &class_data.members.nodes {
+        // `tsc` emits per-member `__decorate` calls for all decorated
+        // instance/prototype members (in declaration order) before any decorated
+        // static members (in declaration order).
+        let ordered_members = self.legacy_member_decorate_order_es5(&class_data.members.nodes);
+
+        for &member_idx in &ordered_members {
             let Some(member_node) = self.arena.get(member_idx) else {
                 continue;
             };
@@ -1286,22 +1416,41 @@ impl<'a> ES5ClassTransformer<'a> {
                 _ => continue,
             };
 
-            let decorators = self.collect_decorators_from_modifiers(modifiers);
+            let is_static = self.arena.is_static(modifiers);
 
-            // Collect parameter decorators for methods/constructors.
-            // Each entry is (runtime_param_index, decorator_nodes).
-            let param_decorators: Vec<(usize, Vec<NodeIndex>)> = match &meta {
-                MemberMeta::Method { parameters, .. } => {
-                    self.collect_param_decorators_es5(parameters)
+            // Member-level decorators. Accessors merge the member decorators from
+            // the whole getter/setter pair into the single `__decorate` call.
+            let decorators = if is_accessor {
+                self.collect_accessor_member_decorators_es5(
+                    &class_data.members.nodes,
+                    name_idx,
+                    is_static,
+                )
+            } else {
+                self.collect_decorators_from_modifiers(modifiers)
+            };
+
+            // Parameter decorators. Methods use their own parameters; accessors
+            // merge the parameter decorators from the whole getter/setter pair
+            // (the setter's `@dec param`) into the accessor's single call.
+            let param_decorators: Vec<(usize, Vec<NodeIndex>)> = if is_accessor {
+                self.collect_accessor_param_decorators_es5(
+                    &class_data.members.nodes,
+                    name_idx,
+                    is_static,
+                )
+            } else {
+                match &meta {
+                    MemberMeta::Method { parameters, .. } => {
+                        self.collect_param_decorators_es5(parameters)
+                    }
+                    _ => Vec::new(),
                 }
-                _ => Vec::new(),
             };
 
             if decorators.is_empty() && param_decorators.is_empty() {
                 continue;
             }
-
-            let is_static = self.arena.is_static(modifiers);
 
             let member_name = get_identifier_text(self.arena, name_idx);
             let Some(member_name) = member_name else {
@@ -1312,7 +1461,8 @@ impl<'a> ES5ClassTransformer<'a> {
             }
 
             // For getter/setter pairs, tsc emits only one __decorate call
-            // for the first accessor that has decorators. Skip the second.
+            // for the first accessor of the pair. Skip the second; its parameter
+            // decorators were already merged in above.
             if is_accessor && !emitted_accessor_names.insert(member_name.clone()) {
                 continue;
             }

--- a/crates/tsz-emitter/tests/legacy_decorator_member_order_tests.rs
+++ b/crates/tsz-emitter/tests/legacy_decorator_member_order_tests.rs
@@ -1,0 +1,217 @@
+//! Legacy (`experimentalDecorators`) per-member `__decorate` call ordering.
+//!
+//! Structural rule: when emitting per-member `__decorate` calls for a class,
+//! `tsc` emits the calls for every decorated instance/prototype member (in
+//! declaration order) before any decorated static member (in declaration
+//! order). For a getter/setter pair `tsc` emits a single `__decorate` call
+//! whose member decorators come from the first accessor (in declaration order)
+//! that has decorators and whose `__param(...)` entries are merged from the
+//! setter's decorated parameters.
+//!
+//! These tests vary identifier spellings (member names, type-parameter-free
+//! decorator expressions) so they pin the structural rule, not a spelling, and
+//! cover both the ES2015+ direct path and the ES5 IIFE-lowering path.
+
+use tsz_common::ScriptTarget;
+use tsz_emitter::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use tsz_parser::ParserState;
+
+fn emit_source(source: &str, options: PrinterOptions) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut printer = EmitterPrinter::with_options(&parser.arena, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+fn legacy_options(target: ScriptTarget) -> PrinterOptions {
+    PrinterOptions {
+        legacy_decorators: true,
+        target,
+        ..Default::default()
+    }
+}
+
+/// Position (byte offset) of the `__decorate` call that targets `member` on the
+/// given `receiver` (e.g. `Cls.prototype` or `Cls`). Asserts the call exists.
+fn decorate_pos(output: &str, receiver: &str, member: &str) -> usize {
+    let needle = format!("], {receiver}, \"{member}\"");
+    output.find(&needle).unwrap_or_else(|| {
+        panic!(
+            "expected a `__decorate` call for `{receiver}` member `{member}`.\nOutput:\n{output}"
+        )
+    })
+}
+
+/// Source whose static members are declared *before* its instance members, so
+/// emitting them in declaration order would interleave static and instance.
+/// `tsc` reorders so every instance member precedes every static member.
+const INTERLEAVED_SOURCE: &str = r#"@((t) => { })
+class Container {
+    @((t, k, d) => { })
+    static alpha() {}
+
+    @((t, k) => { })
+    static beta = 1;
+
+    @((t, k, d) => { })
+    gamma() {}
+
+    @((t, k) => { })
+    delta = 1;
+}
+"#;
+
+#[test]
+fn instance_member_decorators_emit_before_static_es2015() {
+    let output = emit_source(INTERLEAVED_SOURCE, legacy_options(ScriptTarget::ES2015));
+    let gamma = decorate_pos(&output, "Container.prototype", "gamma");
+    let delta = decorate_pos(&output, "Container.prototype", "delta");
+    let alpha = decorate_pos(&output, "Container", "alpha");
+    let beta = decorate_pos(&output, "Container", "beta");
+
+    // Instance group precedes static group; source order preserved within each.
+    assert!(
+        gamma < delta,
+        "instance source order not preserved:\n{output}"
+    );
+    assert!(alpha < beta, "static source order not preserved:\n{output}");
+    assert!(
+        delta < alpha,
+        "all instance `__decorate` calls must precede all static ones:\n{output}"
+    );
+}
+
+#[test]
+fn instance_member_decorators_emit_before_static_es5() {
+    let output = emit_source(INTERLEAVED_SOURCE, legacy_options(ScriptTarget::ES5));
+    let gamma = decorate_pos(&output, "Container.prototype", "gamma");
+    let delta = decorate_pos(&output, "Container.prototype", "delta");
+    let alpha = decorate_pos(&output, "Container", "alpha");
+    let beta = decorate_pos(&output, "Container", "beta");
+
+    assert!(
+        gamma < delta,
+        "instance source order not preserved:\n{output}"
+    );
+    assert!(alpha < beta, "static source order not preserved:\n{output}");
+    assert!(
+        delta < alpha,
+        "all instance `__decorate` calls must precede all static ones:\n{output}"
+    );
+}
+
+/// A getter carrying member decorators paired with a setter carrying parameter
+/// decorators. The two must collapse into a single `__decorate` call whose
+/// member decorators come first and whose `__param(...)` entries follow.
+const ACCESSOR_MERGE_SOURCE: &str = r#"declare function PropDeco(target: Object, key: string): void;
+declare function ParamDeco(target: Object, key: string, idx: number): void;
+class Holder {
+    @PropDeco
+    get value() { return 0; }
+    set value(@ParamDeco next: number) { }
+}
+"#;
+
+#[test]
+fn accessor_getter_decorator_merges_setter_param_es2015() {
+    let output = emit_source(ACCESSOR_MERGE_SOURCE, legacy_options(ScriptTarget::ES2015));
+    // Exactly one __decorate call for the pair.
+    assert_eq!(
+        output.matches("], Holder.prototype, \"value\"").count(),
+        1,
+        "getter/setter pair must produce a single __decorate call:\n{output}"
+    );
+    let call = decorate_pos(&output, "Holder.prototype", "value");
+    let body = &output[..call];
+    let prop = body
+        .rfind("PropDeco")
+        .expect("missing getter member decorator");
+    let param = body
+        .rfind("__param(0, ParamDeco)")
+        .expect("missing merged setter parameter decorator");
+    assert!(
+        prop < param,
+        "member decorator must precede merged __param entry:\n{output}"
+    );
+}
+
+#[test]
+fn accessor_getter_decorator_merges_setter_param_es5() {
+    let output = emit_source(ACCESSOR_MERGE_SOURCE, legacy_options(ScriptTarget::ES5));
+    assert_eq!(
+        output.matches("], Holder.prototype, \"value\"").count(),
+        1,
+        "getter/setter pair must produce a single __decorate call:\n{output}"
+    );
+    let call = decorate_pos(&output, "Holder.prototype", "value");
+    let body = &output[..call];
+    let prop = body
+        .rfind("PropDeco")
+        .expect("missing getter member decorator");
+    let param = body
+        .rfind("__param(0, ParamDeco)")
+        .expect("missing merged setter parameter decorator");
+    assert!(
+        prop < param,
+        "member decorator must precede merged __param entry:\n{output}"
+    );
+}
+
+/// When both accessors of a pair are (invalidly) decorated, `tsc` still emits a
+/// single call using the first-declared accessor's decorators. Here the setter
+/// is declared first, so its decorator wins regardless of the getter's.
+const FIRST_DECLARED_WINS_SOURCE: &str = r#"declare function decFirst(target: any, k: string, d: any): any;
+declare function decSecond(target: any, k: string, d: any): any;
+class Pair {
+    @decFirst set thing(v: number) { }
+    @decSecond get thing() { return 0; }
+}
+"#;
+
+#[test]
+fn first_declared_accessor_decorator_wins_es2015() {
+    let output = emit_source(
+        FIRST_DECLARED_WINS_SOURCE,
+        legacy_options(ScriptTarget::ES2015),
+    );
+    assert_eq!(
+        output.matches("], Pair.prototype, \"thing\"").count(),
+        1,
+        "getter/setter pair must produce a single __decorate call:\n{output}"
+    );
+    let call = decorate_pos(&output, "Pair.prototype", "thing");
+    let body = &output[..call];
+    assert!(
+        body.contains("decFirst"),
+        "first-declared accessor's decorator must be used:\n{output}"
+    );
+    assert!(
+        !body.contains("decSecond"),
+        "second accessor's decorator must not appear in the merged call:\n{output}"
+    );
+}
+
+#[test]
+fn first_declared_accessor_decorator_wins_es5() {
+    let output = emit_source(
+        FIRST_DECLARED_WINS_SOURCE,
+        legacy_options(ScriptTarget::ES5),
+    );
+    assert_eq!(
+        output.matches("], Pair.prototype, \"thing\"").count(),
+        1,
+        "getter/setter pair must produce a single __decorate call:\n{output}"
+    );
+    let call = decorate_pos(&output, "Pair.prototype", "thing");
+    let body = &output[..call];
+    assert!(
+        body.contains("decFirst"),
+        "first-declared accessor's decorator must be used:\n{output}"
+    );
+    assert!(
+        !body.contains("decSecond"),
+        "second accessor's decorator must not appear in the merged call:\n{output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — JavaScript emit parity (emit→100% campaign, wave 3b)

## Invariant
When emitting per-member legacy `__decorate` calls for a class, emit all decorated instance/prototype members (declaration order) before any decorated static members (declaration order); and collapse a getter/setter pair into one `__decorate` call whose member decorators come from the first-declared decorated accessor, with the setter's `__param(...)` entries merged after.

## Scope
- `crates/tsz-emitter/src/emitter/declarations/class/decorators.rs` — ES2015+ legacy path: two-pass instance-before-static ordering (`member_node_is_static`) + accessor merge (first-declared-wins).
- `crates/tsz-emitter/src/transforms/class_es5_ir_decorators.rs` — ES5 IIFE legacy path: same. (TC39 native-decorator path es_decorators.rs left untouched.)
- `crates/tsz-emitter/tests/legacy_decorator_member_order_tests.rs` (new, 6 tests) + Cargo.toml.

## Project Corpus Impact
- Row: n/a (emit parity fix)
- Bug family: legacy per-member decorator call ordering + accessor decorator merge
- Evidence: legacyDecorators-contextualTypes, sourceMapValidationDecorators(es2015+es5) FAIL→PASS.

## Verification
- 3 witnesses FAIL→PASS (JS). Zero regressions: decorator 637→640, legacyDecorators 0→1, sourceMapValidation 90→92, esDecorators/class/accessor unchanged. 6 unit tests (vary names, ES2015+ES5); `cargo clippy -p tsz-emitter --all-targets -- -D warnings` clean. Self-caught+fixed a decoratorOnClassAccessor7 regression (first-declared-accessor rule, verified vs tsc).
- Structural (is_static / member-kind), §25/§26 compliant.

## Coordination Notes
Wave-3b clean fix. — opus48-emit100
