### PR TITLE
fix(solver): constrained infer is a whole-candidate check, not a union filter

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1087,6 +1087,10 @@ name = "infer_extends_constraint_substitution_tests"
 path = "tests/infer_extends_constraint_substitution_tests.rs"
 
 [[test]]
+name = "infer_constraint_whole_candidate_tests"
+path = "tests/infer_constraint_whole_candidate_tests.rs"
+
+[[test]]
 name = "fresh_intersection_display_tests"
 path = "tests/fresh_intersection_display_tests.rs"
 

--- a/crates/tsz-checker/tests/infer_constraint_whole_candidate_tests.rs
+++ b/crates/tsz-checker/tests/infer_constraint_whole_candidate_tests.rs
@@ -1,0 +1,203 @@
+//! Regression tests for constrained-`infer` whole-candidate semantics.
+//!
+//! A constrained `infer U extends C` is a *whole-candidate* check in tsc: the
+//! inferred candidate `X` is kept only when `X` (as a whole) is assignable to
+//! the constraint `C`; otherwise the conditional takes its false branch. tsc
+//! never keeps a matching subset of a union candidate while dropping the rest.
+//!
+//! The one wrinkle is optional positions (optional tuple element / optional
+//! property): they contribute an extra `undefined` to the candidate (an absent
+//! element reads as `undefined`). tsc strips that optionality-`undefined`
+//! before the whole-candidate check, but still does not partially filter the
+//! remaining union.
+//!
+//! Previously tsz partially filtered union candidates against the constraint
+//! (e.g. `[1 | 2 | "x"] extends [infer U extends number]` wrongly produced
+//! `1 | 2` instead of the false branch), which diverged from tsc.
+//!
+//! These tests assert the resolved type by feeding the conditional result into
+//! assignments whose acceptance/rejection pins the type down, and they vary the
+//! `infer`/type-parameter names so the fix cannot be name-specific.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+fn strict_options() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        ..Default::default()
+    }
+}
+
+/// Count TS2322 "not assignable" diagnostics produced by `source`.
+fn ts2322_count(source: &str) -> usize {
+    check_source(source, "test.ts", strict_options())
+        .iter()
+        .filter(|d| d.code == 2322)
+        .count()
+}
+
+/// Assert the conditional result type is exactly `"NO"` (the false branch):
+/// assigning `"NO"` is accepted and assigning some other value is rejected.
+fn assert_false_branch_no(type_decl: &str) {
+    let ok = format!("{type_decl}\nconst ok: R = \"NO\";\n");
+    let bad = format!("{type_decl}\nconst bad: R = \"other\";\n");
+    assert_eq!(
+        ts2322_count(&ok),
+        0,
+        "expected false branch (\"NO\") to accept \"NO\":\n{ok}"
+    );
+    assert_eq!(
+        ts2322_count(&bad),
+        1,
+        "expected false branch (\"NO\") to reject \"other\":\n{bad}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Required positions: whole-candidate check, no partial union filtering.
+// ---------------------------------------------------------------------------
+
+/// Reported repro: a union candidate with a non-conforming member must take the
+/// false branch, not be filtered down to its matching members.
+#[test]
+fn required_tuple_union_partial_match_takes_false_branch() {
+    assert_false_branch_no(
+        "type C<T> = T extends [infer U extends number] ? U : \"NO\";\n\
+         type R = C<[1 | 2 | \"x\"]>;",
+    );
+}
+
+/// Same rule for an object property position (different surface, same rule).
+#[test]
+fn required_property_union_partial_match_takes_false_branch() {
+    assert_false_branch_no(
+        "type C<T> = T extends { a: infer U extends number } ? U : \"NO\";\n\
+         type R = C<{ a: 1 | 2 | \"x\" }>;",
+    );
+}
+
+/// Renamed binder variables (K instead of U, P instead of T) must behave
+/// identically — proves the fix is structural, not name-specific.
+#[test]
+fn required_union_partial_match_renamed_params() {
+    assert_false_branch_no(
+        "type Cond<P> = P extends [infer K extends number] ? K : \"NO\";\n\
+         type R = Cond<[1 | 2 | \"x\"]>;",
+    );
+}
+
+/// A union candidate that *wholly* satisfies the constraint is kept in full.
+#[test]
+fn required_union_all_members_match_keeps_full_union() {
+    // `R = 1 | 2`: accepts both members, rejects an outsider.
+    let src_ok1 = "type C<T> = T extends [infer U extends number] ? U : \"NO\";\n\
+                   type R = C<[1 | 2]>;\nconst a: R = 1;";
+    let src_ok2 = "type C<T> = T extends [infer U extends number] ? U : \"NO\";\n\
+                   type R = C<[1 | 2]>;\nconst b: R = 2;";
+    let src_bad = "type C<T> = T extends [infer U extends number] ? U : \"NO\";\n\
+                   type R = C<[1 | 2]>;\nconst c: R = 3;";
+    assert_eq!(ts2322_count(src_ok1), 0, "1 should be assignable to 1 | 2");
+    assert_eq!(ts2322_count(src_ok2), 0, "2 should be assignable to 1 | 2");
+    assert_eq!(
+        ts2322_count(src_bad),
+        1,
+        "3 should not be assignable to 1 | 2"
+    );
+}
+
+/// A single non-conforming candidate still takes the false branch.
+#[test]
+fn required_single_non_matching_takes_false_branch() {
+    assert_false_branch_no(
+        "type C<T> = T extends [infer U extends number] ? U : \"NO\";\n\
+         type R = C<[\"x\"]>;",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Optional positions: strip optionality-`undefined`, then whole-candidate check.
+// ---------------------------------------------------------------------------
+
+/// Optional property whose value matches the constraint: the optionality
+/// `undefined` is stripped and the real type is inferred.
+#[test]
+fn optional_property_matching_infers_stripped_type() {
+    // `R = string`: a string is accepted, a non-string is rejected.
+    let ok = "type C<T> = T extends { a?: infer U extends string } ? U : \"NO\";\n\
+              type R = C<{ a?: string }>;\nconst a: R = \"hi\";";
+    let bad = "type C<T> = T extends { a?: infer U extends string } ? U : \"NO\";\n\
+               type R = C<{ a?: string }>;\nconst b: R = 123;";
+    assert_eq!(
+        ts2322_count(ok),
+        0,
+        "optional matching prop should infer string"
+    );
+    assert_eq!(ts2322_count(bad), 1, "result should be string, not number");
+}
+
+/// Optional property with a union that only *partly* matches: after stripping
+/// `undefined`, the remaining union does not satisfy the constraint as a whole,
+/// so the conditional takes the false branch (no partial filtering to `"x"`).
+#[test]
+fn optional_property_partial_union_takes_false_branch() {
+    assert_false_branch_no(
+        "type C<T> = T extends { a?: infer U extends string } ? U : \"NO\";\n\
+         type R = C<{ a?: \"x\" | 1 }>;",
+    );
+}
+
+/// Optional property union that *wholly* matches keeps the full union (still no
+/// stray `undefined`).
+#[test]
+fn optional_property_full_union_keeps_union_without_undefined() {
+    let ok1 = "type C<T> = T extends { a?: infer U extends string } ? U : \"NO\";\n\
+               type R = C<{ a?: \"x\" | \"y\" }>;\nconst a: R = \"x\";";
+    let ok2 = "type C<T> = T extends { a?: infer U extends string } ? U : \"NO\";\n\
+               type R = C<{ a?: \"x\" | \"y\" }>;\nconst b: R = \"y\";";
+    let bad_other = "type C<T> = T extends { a?: infer U extends string } ? U : \"NO\";\n\
+                     type R = C<{ a?: \"x\" | \"y\" }>;\nconst c: R = \"z\";";
+    let bad_undef = "type C<T> = T extends { a?: infer U extends string } ? U : \"NO\";\n\
+                     type R = C<{ a?: \"x\" | \"y\" }>;\nconst d: R = undefined;";
+    assert_eq!(ts2322_count(ok1), 0);
+    assert_eq!(ts2322_count(ok2), 0);
+    assert_eq!(ts2322_count(bad_other), 1, "result is \"x\" | \"y\"");
+    assert_eq!(
+        ts2322_count(bad_undef),
+        1,
+        "optionality undefined must be stripped from the result"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Distributive conditionals: each member is evaluated independently, so a
+// distributive union still yields per-member results (not a silent filter).
+// ---------------------------------------------------------------------------
+
+/// `T extends infer U extends number ? U : "NO"` distributed over
+/// `1 | 2 | "x"` yields `1 | 2 | "NO"` — the `"x"` member maps to the false
+/// branch rather than being dropped.
+#[test]
+fn distributive_union_maps_failing_member_to_false_branch() {
+    let accepts_no = "type C<T> = T extends infer U extends number ? U : \"NO\";\n\
+                      type R = C<1 | 2 | \"x\">;\nconst a: R = \"NO\";";
+    let accepts_1 = "type C<T> = T extends infer U extends number ? U : \"NO\";\n\
+                     type R = C<1 | 2 | \"x\">;\nconst b: R = 1;";
+    let rejects_str = "type C<T> = T extends infer U extends number ? U : \"NO\";\n\
+                       type R = C<1 | 2 | \"x\">;\nconst c: R = \"x\";";
+    assert_eq!(
+        ts2322_count(accepts_no),
+        0,
+        "\"NO\" is a member of 1 | 2 | \"NO\""
+    );
+    assert_eq!(
+        ts2322_count(accepts_1),
+        0,
+        "1 is a member of 1 | 2 | \"NO\""
+    );
+    assert_eq!(
+        ts2322_count(rejects_str),
+        1,
+        "\"x\" maps to the false branch, so it is not in the result"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/array_infer.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/array_infer.rs
@@ -169,7 +169,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             _ => None,
         };
 
-        let Some(mut inferred) = inferred else {
+        let Some(inferred) = inferred else {
             return self.evaluate(cond.false_type);
         };
 
@@ -178,19 +178,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         if let Some(constraint) = info.constraint {
             let mut checker = self.conditional_subtype_checker();
             checker.allow_bivariant_rest = true;
-            let is_union = matches!(self.interner().lookup(inferred), Some(TypeData::Union(_)));
-            if is_union && !cond.is_distributive {
-                // For unions in non-distributive conditionals, use filter that adds undefined
-                inferred = self.filter_inferred_by_constraint_or_undefined(
-                    inferred,
-                    constraint,
-                    &mut checker,
-                );
-            } else {
-                // For single values or distributive conditionals, fail if constraint doesn't match
-                if !checker.is_subtype_of(inferred, constraint) {
-                    return self.evaluate(cond.false_type);
-                }
+            if !checker.is_subtype_of(inferred, constraint) {
+                // Whole-candidate constraint check (tsc): a constrained `infer`
+                // whose full candidate is not assignable to the constraint takes
+                // the false branch. No per-member union filtering; distributive
+                // conditionals have already split union members.
+                return self.evaluate(cond.false_type);
             }
             subst.insert(info.name, inferred);
         }
@@ -513,11 +506,20 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             return self.interner().conditional(*cond);
         }
 
+        // `optionality_undefined` tracks whether the `undefined` in the inferred
+        // candidate came from an optional source element (absent element reads as
+        // `undefined`) rather than from the element's own declared type. A
+        // constrained `infer` strips that optionality-`undefined` before applying
+        // the constraint, matching tsc.
+        let mut optionality_undefined = false;
         let inferred = match check_key {
             Some(TypeData::Tuple(check_elements)) => {
                 let check_elements = self.interner().tuple_list(check_elements);
                 if check_elements.is_empty() {
-                    extends_elem.optional.then_some(TypeId::UNDEFINED)
+                    extends_elem.optional.then(|| {
+                        optionality_undefined = true;
+                        TypeId::UNDEFINED
+                    })
                 } else if check_elements.len() == 1 && !check_elements[0].rest {
                     let elem = &check_elements[0];
                     // Optional source cannot fill a required pattern slot.
@@ -525,6 +527,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         None
                     } else {
                         let ty = if elem.optional {
+                            optionality_undefined = true;
                             self.interner().union2(elem.type_id, TypeId::UNDEFINED)
                         } else {
                             elem.type_id
@@ -548,6 +551,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                             let check_elements = self.interner().tuple_list(check_elements);
                             if check_elements.is_empty() {
                                 if extends_elem.optional {
+                                    optionality_undefined = true;
                                     inferred_members.push(TypeId::UNDEFINED);
                                     continue;
                                 }
@@ -559,6 +563,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                                     return self.evaluate(cond.false_type);
                                 }
                                 let elem_type = if elem.optional {
+                                    optionality_undefined = true;
                                     self.interner().union2(elem.type_id, TypeId::UNDEFINED)
                                 } else {
                                     elem.type_id
@@ -591,9 +596,14 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         if let Some(constraint) = info.constraint {
             let mut checker = self.conditional_subtype_checker();
             checker.allow_bivariant_rest = true;
-            let Some(filtered) =
+            let filtered = if optionality_undefined {
+                self.filter_optional_inferred_by_constraint(inferred, constraint, &mut checker)
+            } else {
                 self.filter_inferred_by_constraint(inferred, constraint, &mut checker)
-            else {
+            };
+            let Some(filtered) = filtered else {
+                // Constraint not satisfied: take the false branch, substituting any
+                // bindings already established for this pattern.
                 let false_inst =
                     instantiate_type_with_infer(self.interner(), cond.false_type, &subst);
                 return self.evaluate(false_inst);

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/object_infer.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/object_infer.rs
@@ -149,12 +149,11 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // Pass 2: apply each variable's effective constraint to its fully-accumulated type,
         // then build the substitution in declaration order.
         //
-        // Constraint semantics differ by how the union arose:
-        // - Multi-slot accumulation: the whole union must satisfy the constraint (tsc fails
-        //   the conditional when `string | number extends string` is false).
-        // - Single-slot with a union source property: filter per-member and keep matching
-        //   parts (preserving the original `filter_inferred_by_constraint_or_undefined`
-        //   behaviour for non-distributive unions).
+        // A constrained `infer` is a whole-candidate check (tsc): the accumulated
+        // candidate is kept only when it is assignable to the constraint as a
+        // whole; otherwise the conditional takes its false branch. Optional
+        // properties first strip the optionality-`undefined` they contribute, then
+        // apply the same whole-candidate check.
         let mut subst = TypeSubstitution::new();
         for &(_, info, _) in infer_props {
             if subst.get(info.name).is_some() {
@@ -167,26 +166,26 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             if let Some(&(constraint, opt)) = effective_constraint.get(&info.name) {
                 let mut checker = self.conditional_subtype_checker();
                 checker.allow_bivariant_rest = true;
-                let is_union = matches!(self.interner().lookup(inferred), Some(TypeData::Union(_)));
-                let is_multi = multi_slot.contains(&info.name);
 
                 if opt {
-                    let Some(filtered) =
-                        self.filter_inferred_by_constraint(inferred, constraint, &mut checker)
-                    else {
+                    // Optional property: strip the optionality-`undefined` from the
+                    // candidate, then apply the constraint as a whole-candidate check.
+                    let Some(filtered) = self.filter_optional_inferred_by_constraint(
+                        inferred,
+                        constraint,
+                        &mut checker,
+                    ) else {
                         let false_inst =
                             instantiate_type_with_infer(self.interner(), cond.false_type, &subst);
                         return self.evaluate(false_inst);
                     };
                     inferred = filtered;
-                } else if is_union && !cond.is_distributive && !is_multi {
-                    // Union from a single source property — filter members, keep matching.
-                    inferred = self.filter_inferred_by_constraint_or_undefined(
-                        inferred,
-                        constraint,
-                        &mut checker,
-                    );
                 } else if !checker.is_subtype_of(inferred, constraint) {
+                    // A constrained `infer U extends C` is a whole-candidate check in
+                    // tsc: if the full inferred candidate is not assignable to the
+                    // constraint, the conditional resolves to its false branch. No
+                    // per-member union filtering. Distributive conditionals have
+                    // already split union check types into individual members.
                     return self.evaluate(cond.false_type);
                 }
             }
@@ -227,29 +226,23 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         if let Some(constraint) = info.constraint {
             let mut checker = self.conditional_subtype_checker();
             checker.allow_bivariant_rest = true;
-            let is_union = matches!(self.interner().lookup(inferred), Some(TypeData::Union(_)));
             if prop_optional {
+                // Optional property: strip the optionality-`undefined` from the
+                // candidate, then apply the constraint as a whole-candidate check.
                 let Some(filtered) =
-                    self.filter_inferred_by_constraint(inferred, constraint, &mut checker)
+                    self.filter_optional_inferred_by_constraint(inferred, constraint, &mut checker)
                 else {
                     let false_inst =
                         instantiate_type_with_infer(self.interner(), cond.false_type, &subst);
                     return self.evaluate(false_inst);
                 };
                 inferred = filtered;
-            } else if is_union && !cond.is_distributive {
-                // Non-distributive union candidates keep the historical partial-match
-                // behavior; distributive conditionals have already split union members.
-                inferred = self.filter_inferred_by_constraint_or_undefined(
-                    inferred,
-                    constraint,
-                    &mut checker,
-                );
-            } else {
-                // For non-distributive single values, fail if constraint doesn't match
-                if !checker.is_subtype_of(inferred, constraint) {
-                    return self.evaluate(cond.false_type);
-                }
+            } else if !checker.is_subtype_of(inferred, constraint) {
+                // Whole-candidate constraint check (tsc): a constrained `infer`
+                // whose full candidate is not assignable to the constraint takes
+                // the false branch. No per-member union filtering; distributive
+                // conditionals have already split union members.
+                return self.evaluate(cond.false_type);
             }
             subst.insert(info.name, inferred);
         }
@@ -470,7 +463,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             _ => None,
         };
 
-        let Some(mut inferred) = inferred else {
+        let Some(inferred) = inferred else {
             return self.evaluate(cond.false_type);
         };
 
@@ -479,20 +472,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         if let Some(constraint) = info.constraint {
             let mut checker = self.conditional_subtype_checker();
             checker.allow_bivariant_rest = true;
-            let is_union = matches!(self.interner().lookup(inferred), Some(TypeData::Union(_)));
-            if is_union && !cond.is_distributive {
-                // Non-distributive union candidates keep the historical partial-match
-                // behavior; distributive conditionals have already split union members.
-                inferred = self.filter_inferred_by_constraint_or_undefined(
-                    inferred,
-                    constraint,
-                    &mut checker,
-                );
-            } else {
-                // For non-distributive single values, fail if constraint doesn't match
-                if !checker.is_subtype_of(inferred, constraint) {
-                    return self.evaluate(cond.false_type);
-                }
+            if !checker.is_subtype_of(inferred, constraint) {
+                // Whole-candidate constraint check (tsc): a constrained `infer`
+                // whose full candidate is not assignable to the constraint takes
+                // the false branch. No per-member union filtering; distributive
+                // conditionals have already split union members.
+                return self.evaluate(cond.false_type);
             }
             subst.insert(info.name, inferred);
         }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -336,10 +336,22 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         }
     }
 
-    /// Filter an inferred type by its constraint.
+    /// Validate an inferred candidate against a constrained `infer U extends C`.
     ///
-    /// Returns `Some(filtered_type)` if any part of the inferred type satisfies the constraint,
-    /// or None if no part satisfies it.
+    /// tsc treats the constraint as a whole-candidate check, not a per-member
+    /// union filter: it infers a candidate `X` for `U`, and if `X` is not
+    /// assignable to `C` it replaces `X` with `C` and re-checks the conditional
+    /// structurally — a re-check that fails at the position that produced `X`,
+    /// so the conditional resolves to its false branch. tsc never keeps a
+    /// matching subset of a union candidate while dropping the rest.
+    ///
+    /// We therefore mirror that exactly: return `Some(inferred)` when the whole
+    /// candidate satisfies the constraint, and `None` otherwise so the caller
+    /// takes the false branch. Distributive conditionals have already split a
+    /// union check type into individual members before reaching here, so each
+    /// member is validated independently — the distributive `1 | 2 | "x"` case
+    /// still yields `1 | 2 | <false-branch>` rather than a silently filtered
+    /// `1 | 2`.
     pub(crate) fn filter_inferred_by_constraint(
         &self,
         inferred: TypeId,
@@ -350,67 +362,62 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             return Some(inferred);
         }
 
-        if let Some(TypeData::Union(members)) = self.interner().lookup(inferred) {
-            let members = self.interner().type_list(members);
-            let mut filtered: SmallVec<[TypeId; 8]> = SmallVec::new();
-            for &member in members.iter() {
-                if checker.is_subtype_of(member, constraint) {
-                    filtered.push(member);
-                }
-            }
-            return match filtered.len() {
-                0 => None,
-                1 => Some(filtered[0]),
-                _ => Some(self.interner().union_from_slice(&filtered)),
-            };
-        }
-
         checker
             .is_subtype_of(inferred, constraint)
             .then_some(inferred)
     }
 
-    /// Filter an inferred type by its constraint, returning undefined for non-matching parts.
+    /// Validate a constrained `infer U extends C` candidate inferred from an
+    /// *optional* source position (optional tuple element or optional property).
     ///
-    /// Similar to `filter_inferred_by_constraint`, but returns `undefined` instead of None
-    /// when parts don't match the constraint.
-    pub(crate) fn filter_inferred_by_constraint_or_undefined(
+    /// An optional position contributes an extra `undefined` to the inferred
+    /// candidate (an absent element/property reads as `undefined`). tsc strips
+    /// that optionality-`undefined` before applying the constraint, and then
+    /// performs the same whole-candidate check as a required position — it does
+    /// *not* keep a matching subset of the remaining union. So:
+    ///
+    /// * `{ a?: string }` against `{ a?: infer R extends string }` strips the
+    ///   `undefined` and yields `R = string`.
+    /// * `{ a?: "x" | 1 }` strips the `undefined`, leaving `"x" | 1`, which is
+    ///   not assignable to `string`, so the conditional takes its false branch
+    ///   (tsc does not partially filter the candidate down to `"x"`).
+    ///
+    /// Returns the stripped candidate when it satisfies the constraint, or
+    /// `None` so the caller selects the false branch.
+    pub(crate) fn filter_optional_inferred_by_constraint(
         &self,
         inferred: TypeId,
         constraint: TypeId,
         checker: &mut SubtypeChecker<'_, R>,
-    ) -> TypeId {
-        if inferred == constraint {
+    ) -> Option<TypeId> {
+        let stripped = self.strip_optionality_undefined(inferred);
+        self.filter_inferred_by_constraint(stripped, constraint, checker)
+    }
+
+    /// Remove the `undefined` member that an optional source position adds to an
+    /// inferred candidate. Only strips a top-level `undefined` union member; a
+    /// bare `undefined` candidate (no other members) is left untouched so the
+    /// constraint check can still reject it.
+    fn strip_optionality_undefined(&self, inferred: TypeId) -> TypeId {
+        let Some(TypeData::Union(members)) = self.interner().lookup(inferred) else {
+            return inferred;
+        };
+        let members = self.interner().type_list(members);
+        // Fast path: no optionality-`undefined` to strip, so avoid rebuilding.
+        if !members.contains(&TypeId::UNDEFINED) {
             return inferred;
         }
-
-        if let Some(TypeData::Union(members)) = self.interner().lookup(inferred) {
-            let members = self.interner().type_list(members);
-            let mut filtered: SmallVec<[TypeId; 8]> = SmallVec::new();
-            let mut had_non_matching = false;
-            for &member in members.iter() {
-                if checker.is_subtype_of(member, constraint) {
-                    filtered.push(member);
-                } else {
-                    had_non_matching = true;
-                }
-            }
-
-            if had_non_matching {
-                filtered.push(TypeId::UNDEFINED);
-            }
-
-            return match filtered.len() {
-                0 => TypeId::UNDEFINED,
-                1 => filtered[0],
-                _ => self.interner().union_from_slice(&filtered),
-            };
-        }
-
-        if checker.is_subtype_of(inferred, constraint) {
-            inferred
-        } else {
-            TypeId::UNDEFINED
+        let kept: SmallVec<[TypeId; 8]> = members
+            .iter()
+            .copied()
+            .filter(|&m| m != TypeId::UNDEFINED)
+            .collect();
+        match kept.len() {
+            // The candidate was only `undefined`; leave it so the constraint can
+            // still reject it.
+            0 => inferred,
+            1 => kept[0],
+            _ => self.interner().union_from_slice(&kept),
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #11486.

**Structural rule (verified against tsc 6.0.2):**
> When a constrained `infer U extends C` infers a whole candidate `X` (non-distributive), tsc keeps `X` iff `X` is assignable to `C`; otherwise the conditional resolves to its false branch. tsc never keeps a matching subset of a union candidate while dropping the rest. Optional positions first strip the optionality-`undefined` they contribute, then apply the same whole-candidate check.

tsz previously *partially filtered* union candidates against the constraint. The same "partial-match for non-distributive unions" logic was duplicated across `filter_inferred_by_constraint` (union branch), `filter_inferred_by_constraint_or_undefined`, and four call sites in `conditional.rs`, `conditional/object_infer.rs`, and `conditional/array_infer.rs`.

Minimal repro (tsc 6.0.2 → tsz before this PR):
```ts
type E = [1 | 2 | "x"] extends [infer U extends number] ? U : "NO";
//  tsc: "NO"   tsz (buggy): 1 | 2
type O = { a: 1 | 2 | "x" } extends { a: infer U extends number } ? U : "NO";
//  tsc: "NO"   tsz (buggy): 1 | 2
```

## Owner layer & why

This is type-relation semantics, so the fix lives entirely in the **solver**:
- `filter_inferred_by_constraint` now does a single whole-candidate subtype check (1 check instead of N) and returns `None` so callers take the false branch when the candidate isn't assignable to the constraint.
- `filter_inferred_by_constraint_or_undefined` (the partial-filter helper) is removed.
- Optional positions add an optionality-`undefined` to the candidate; `strip_optionality_undefined` removes it (with a `contains` fast-path) and `filter_optional_inferred_by_constraint` then applies the whole-candidate check. `array_infer` tracks whether the `undefined` came from optionality so genuine required `T | undefined` elements are not corrupted.
- Distributive conditionals still split the union check type into members first, so `T extends infer U extends number ? U : "NO"` over `1 | 2 | "x"` still yields `1 | 2 | "NO"`.

## Adjacent-case test matrix (`infer_constraint_whole_candidate_tests.rs`)

- Required tuple union partial-match → false branch (reported repro)
- Required object-property union partial-match → false branch (different surface, same rule)
- Renamed binder variables (`P`/`K` instead of `T`/`U`) — proves the fix is structural, not name-specific
- Required union all-members-match → full union kept
- Required single non-matching → false branch
- Optional property matching → optionality-`undefined` stripped, infers `string`
- Optional property partial union → false branch (no filtering to `"x"`)
- Optional property full union → union kept, no stray `undefined`
- Distributive union maps the failing member to the false branch

## Verification

- `cargo test -p tsz-checker --test infer_constraint_whole_candidate_tests` → 9 passed.
- Previously-failing solver lib tests `test_conditional_infer_optional_tuple_element_with_constraint` / `test_conditional_infer_optional_property_with_constraint` → pass.
- 92 conditional/infer/extends/tuple/mapped/template/keyof checker test binaries → 0 failures.
- `cargo test -p tsz-solver --lib` → only the 11 pre-existing, unrelated failures (template-widening / file-size-ceiling), identical to `main`; no new failures.
- `cargo clippy -p tsz-solver` → clean.
- CLI cross-check against `tsc 6.0.2` for the required/optional/distributive cases above: all match.

## Track

Conformance / checker–solver parity.

## Invariant

A constrained `infer` is a whole-candidate constraint check (with optionality-`undefined` stripped for optional positions); no per-member union filtering. Routes through solver query helpers only.

## Scope

Solver `evaluate_rules` infer/conditional handling + a new checker regression test. No checker/emitter behavior added outside the diagnostic outcomes this rule governs.

## Project Corpus Impact

- Row: `nextjs-fresh-app` (issue #11486, case `solver-28-20`); the rule is project-agnostic and applies to the whole `solver` infer-constraint family across rows.
- Bug family: constrained-`infer` union over-acceptance (false-positive narrowing of conditional results).
- Evidence: tsc 6.0.2 cross-check above + new `tsz_checker` regression suite.

## Coordination Notes

AgentName: `opus48-web`. Issue #11486 marked WIP. Verified no overlap with open PRs (diagnostics-ordering #11666, generic-defaults #11661, narrowing #11649, tuple #11657, TS2394 Studio-A #10670 are all distinct families). `/simplify` run 3× before opening.


---
_Generated by [Claude Code](https://claude.ai/code/session_015nJqmPaWkLEymUNU34JAS9)_