### PR TITLE
fix(dts): preserve source parens around composite inner types in annotation-position emission (refine #11687)

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/tests/infer_paren_and_union_intersection.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/infer_paren_and_union_intersection.rs
@@ -229,3 +229,147 @@ fn parenthesized_intersection_union_member_keeps_parens() {
         "source-parenthesized intersection union member must keep parens: {output}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Fix D (refines #11687): a `PARENTHESIZED_TYPE` reached directly by
+// `emit_type` (an annotation-like position: type-alias RHS, mapped-type
+// value, function/constructor return, type-predicate target, …) preserves
+// its source parens when the inner type is a composite that benefits from
+// explicit grouping (union, intersection, conditional, mapped/type-literal,
+// tuple) or an `infer` carrying a constraint, and strips them when the inner
+// is atomic or a function/constructor type. The decision keys on the peeled
+// inner node *kind*, never on names or rendered output.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn alias_rhs_parenthesized_intersection_keeps_parens() {
+    // `keyofIntersection` / `parenthesisDoesNotBlockAliasSymbolCreation`:
+    // a source-parenthesized intersection in alias-RHS position keeps parens.
+    let output = emit_dts("export type T<A, B> = (A & B);");
+    assert!(
+        output.contains("= (A & B);"),
+        "parenthesized intersection in alias-RHS must keep parens: {output}"
+    );
+}
+
+#[test]
+fn alias_rhs_parenthesized_intersection_keeps_parens_renamed() {
+    // Renamed type parameters prove the rule is structural, not name-keyed.
+    let output = emit_dts("export type Wrap<Left, Right> = (Left & Right);");
+    assert!(
+        output.contains("= (Left & Right);"),
+        "parenthesized intersection in alias-RHS must keep parens (renamed): {output}"
+    );
+}
+
+#[test]
+fn alias_rhs_parenthesized_union_keeps_parens() {
+    let output = emit_dts("export type T = (string | number);");
+    assert!(
+        output.contains("= (string | number);"),
+        "parenthesized union in alias-RHS must keep parens: {output}"
+    );
+}
+
+#[test]
+fn alias_rhs_parenthesized_tuple_keeps_parens() {
+    // `destructuringInFunctionType`: `type T1 = ([a, b, c]);` keeps parens.
+    let output = emit_dts("export type T = ([number, string]);");
+    assert!(
+        output.contains("= ([number, string]);"),
+        "parenthesized tuple in alias-RHS must keep parens: {output}"
+    );
+}
+
+#[test]
+fn predicate_target_parenthesized_union_keeps_parens() {
+    // `narrowingUnionToUnion`: `x is (string | 0)` keeps parens.
+    let output = emit_dts("export declare function check(x: unknown): x is (string | 0);");
+    assert!(
+        output.contains("x is (string | 0)"),
+        "parenthesized type-predicate target union must keep parens: {output}"
+    );
+}
+
+#[test]
+fn predicate_target_parenthesized_intersection_keeps_parens() {
+    // `typeGuardOfFormThisMember`: `this is (Networked & this)` keeps parens.
+    let output = emit_dts(
+        "export interface Thing { isNet(): this is (Networked & this); }\ninterface Networked {}",
+    );
+    assert!(
+        output.contains("this is (Networked & this)"),
+        "parenthesized type-predicate target intersection must keep parens: {output}"
+    );
+}
+
+#[test]
+fn mapped_type_value_parenthesized_conditional_keeps_parens() {
+    // `recursiveTypeReferences2`: a source-parenthesized conditional as a
+    // mapped-type value keeps parens.
+    let output = emit_dts("export type M<T> = { [K in keyof T]?: (T[K] extends string ? 1 : 0) };");
+    assert!(
+        output.contains("(T[K] extends string ? 1 : 0)"),
+        "parenthesized conditional mapped-type value must keep parens: {output}"
+    );
+}
+
+#[test]
+fn function_return_parenthesized_infer_with_constraint_keeps_parens() {
+    // `inferTypesWithExtends1` X3: a function-return-position
+    // `(infer U extends string)` keeps parens (the trailing `extends` would
+    // otherwise re-absorb the enclosing conditional's tokens).
+    let output = emit_dts(
+        "export type T<F> = F extends (...a: any[]) => (infer U extends string) ? U : never;",
+    );
+    assert!(
+        output.contains("=> (infer U extends string) ?"),
+        "parenthesized constrained infer in function return must keep parens: {output}"
+    );
+}
+
+#[test]
+fn function_return_parenthesized_infer_with_constraint_keeps_parens_renamed() {
+    // Renamed infer variable proves the rule is structural.
+    let output = emit_dts(
+        "export type T<F> = F extends (...a: any[]) => (infer Vee extends number) ? Vee : never;",
+    );
+    assert!(
+        output.contains("=> (infer Vee extends number) ?"),
+        "parenthesized constrained infer in function return must keep parens (renamed): {output}"
+    );
+}
+
+#[test]
+fn annotation_redundant_parens_around_keyword_are_stripped() {
+    // #11687's win: `var x: (string)` → `string`.
+    let output = emit_dts("export declare var x: (string);");
+    assert!(
+        output.contains("var x: string;") && !output.contains("(string)"),
+        "redundant parens around a keyword type must be stripped: {output}"
+    );
+}
+
+#[test]
+fn annotation_redundant_parens_around_function_type_are_stripped() {
+    // #11687's win: `var f: (() => c)` → `() => c` in direct annotation
+    // position. (Function-type parens are *kept* only as union/array members,
+    // which are handled by their own structural arms.)
+    let output = emit_dts("export declare var f: (() => string);");
+    assert!(
+        output.contains("var f: () => string;") && !output.contains("(() => string)"),
+        "redundant parens around a function type must be stripped: {output}"
+    );
+}
+
+#[test]
+fn annotation_bare_parenthesized_infer_drops_redundant_parens() {
+    // Negative/fallback: a bare `(infer U)` with no constraint has nothing to
+    // capture trailing tokens, so the redundant parens drop. Exercised via the
+    // function-return annotation position so it reaches this arm directly.
+    let output = emit_dts("export type T<F> = F extends (...a: any[]) => (infer U) ? U : never;");
+    assert!(
+        !output.contains("=> (infer U)"),
+        "bare infer (no constraint) in annotation position should drop redundant parens: {output}"
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/tests/type_formatting.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/type_formatting.rs
@@ -1761,24 +1761,26 @@ fn test_typeof_type() {
 // Parenthesized type preservation
 // =============================================================================
 
-/// tsc preserves user-written parentheses in type annotations verbatim in the
-/// generated `.d.ts`. Both simple types like `(string)` and compound types
-/// like `(string | number)` or `(() => void)` are emitted with their original
-/// parentheses intact.
+/// tsc strips *redundant* parentheses around atomic/simple type annotations
+/// (`var x: (string)` → `string`) but *preserves* them around composite types
+/// such as unions, intersections, conditionals, and tuples (see the
+/// `parenthesized_*` tests below and
+/// `tests::infer_paren_and_union_intersection`).
 
 #[test]
 fn parenthesized_simple_type_annotation_stripped() {
-    // Simple parenthesized primitive — e.g. `var x: (string)` stays `(string)`
+    // Redundant parens around a primitive keyword are stripped:
+    // `var x: (string)` → `string`.
     let output = emit_dts("export declare var x: (string);");
     assert!(
-        output.contains("x: (string)"),
-        "Expected source parens preserved: {output}"
+        output.contains("x: string;") && !output.contains("(string)"),
+        "Expected redundant parens stripped around keyword type: {output}"
     );
-    // Renamed variable — prove the rule is not spelling-dependent
+    // Renamed variable — prove the rule is not spelling-dependent.
     let output2 = emit_dts("export declare var value: (number);");
     assert!(
-        output2.contains("value: (number)"),
-        "Expected source parens preserved for number: {output2}"
+        output2.contains("value: number;") && !output2.contains("(number)"),
+        "Expected redundant parens stripped around keyword type (renamed): {output2}"
     );
 }
 

--- a/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
@@ -66,6 +66,36 @@ impl<'a> DeclarationEmitter<'a> {
             .is_some_and(|tp| tp.constraint.is_some())
     }
 
+    /// Whether a source `PARENTHESIZED_TYPE` reached directly by `emit_type`
+    /// (an annotation-like position, not a structural caller that already
+    /// peels) should keep its source parens around `inner` (the fully peeled
+    /// inner type), matching tsc.
+    ///
+    /// tsc strips redundant parens around atomic/simple operands and
+    /// function/constructor types in these positions, but preserves the source
+    /// grouping when the inner type is a composite that benefits from explicit
+    /// parentheses (union, intersection, conditional, mapped/type-literal,
+    /// tuple) or an `infer` carrying a constraint. The decision is purely
+    /// structural — keyed on the inner node kind, never on identifier names or
+    /// rendered output.
+    fn annotation_paren_keeps_source_parens(&self, inner: NodeIndex) -> bool {
+        let Some(node) = self.arena.get(inner) else {
+            return false;
+        };
+        let k = node.kind;
+        k == syntax_kind_ext::UNION_TYPE
+            || k == syntax_kind_ext::INTERSECTION_TYPE
+            || k == syntax_kind_ext::CONDITIONAL_TYPE
+            || k == syntax_kind_ext::MAPPED_TYPE
+            || k == syntax_kind_ext::TYPE_LITERAL
+            || k == syntax_kind_ext::TUPLE_TYPE
+            // A source-parenthesized `infer U extends C` keeps its parens: the
+            // trailing `extends` would otherwise re-absorb following tokens
+            // (e.g. an enclosing conditional's own clause). A bare `(infer U)`
+            // with no constraint drops the redundant parens.
+            || (k == syntax_kind_ext::INFER_TYPE && self.infer_type_has_constraint(inner))
+    }
+
     pub(crate) fn emit_type(&mut self, type_idx: NodeIndex) {
         let Some(type_node) = self.arena.get(type_idx) else {
             return;
@@ -461,18 +491,36 @@ impl<'a> DeclarationEmitter<'a> {
                 }
             }
 
-            // Parenthesized type — strip the parens and emit the inner type.
-            // tsc strips source-level parenthesization in annotation positions:
-            // `var x: (string)` → `string`, `var l: (() => c)` → `() => c`.
-            // Structural position callers (array element, union/intersection
-            // arm, conditional branch, optional/rest tuple element) all call
-            // `peel_paren` before `emit_type(inner)` and never reach this arm.
-            // Type argument positions are handled explicitly in
-            // `emit_type_arguments`. Any remaining call reaching this arm is
-            // in an annotation context where stripping is correct.
+            // Parenthesized type reached directly (an annotation-like position
+            // not pre-peeled by a structural caller: type-alias RHS, mapped-type
+            // value, function/constructor return, type-predicate target,
+            // `as`-cast type, variable/property/parameter annotation, …).
+            //
+            // tsc strips *redundant* source parens around atomic/simple operands
+            // and function/constructor types in these positions
+            // (`var x: (string)` → `string`, `var f: (() => string)` →
+            // `() => string`), but *preserves* the source parens when the inner
+            // type is a composite that benefits from explicit grouping — a
+            // union, intersection, conditional, mapped/type-literal, or tuple —
+            // and when the inner is an `infer` carrying a constraint (whose
+            // trailing `extends` would otherwise re-absorb following tokens).
+            // The decision keys on the peeled inner node *kind*, never on names
+            // or rendered output.
+            //
+            // Structural-position callers (array element, union/intersection
+            // arm, conditional branch, optional/rest tuple element, indexed
+            // access, type operator) all call `peel_paren` before
+            // `emit_type(inner)` and manage their own parens, so they never
+            // reach this arm; type-argument positions are handled explicitly in
+            // `emit_type_arguments`.
             k if k == syntax_kind_ext::PARENTHESIZED_TYPE => {
-                if let Some(paren) = self.arena.get_wrapped_type(type_node) {
-                    self.emit_type(paren.type_node);
+                let inner = self.peel_paren(type_idx);
+                if self.annotation_paren_keeps_source_parens(inner) {
+                    self.write("(");
+                    self.emit_type(inner);
+                    self.write(")");
+                } else {
+                    self.emit_type(inner);
                 }
             }
 


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — declaration emit parity / REGRESSION FIX (emit→100% campaign, wave 3)

## Invariant
When a `PARENTHESIZED_TYPE` is reached directly by `emit_type` in an annotation position, the source parens are kept iff the peeled inner node is `UNION_TYPE`, `INTERSECTION_TYPE`, `CONDITIONAL_TYPE`, `MAPPED_TYPE`, `TYPE_LITERAL`, `TUPLE_TYPE`, or an `INFER_TYPE` carrying a constraint; otherwise stripped — matching tsc, which strips redundant parens around simple/function types but preserves them around composite inner types (alias RHS, mapped value, return, type-predicate target).

## Scope
- `crates/tsz-emitter/src/declaration_emitter/type_emission.rs` — new `annotation_paren_keeps_source_parens` helper (keys on inner node kind, reuses `infer_type_has_constraint`); rewritten PARENTHESIZED_TYPE arm. Refines #11687.
- `crates/tsz-emitter/src/declaration_emitter/tests/{infer_paren_and_union_intersection.rs,type_formatting.rs}` — 12 new tests; corrected a stale assertion red since #11687.

## Project Corpus Impact
- Row: n/a (declaration emit parity / regression fix)
- Bug family: annotation-position parenthesized-type stripping (over-strip introduced by #11687)
- Evidence: full --dts-only 48→38 fails (net +10).

## Verification
- Reclaims 6 regressions: keyofIntersection, narrowingUnionToUnion, parenthesisDoesNotBlockAliasSymbolCreation, recursiveTypeReferences2, inferTypesWithExtends1 (re-fixes #11668), destructuringInFunctionType — all FAIL→PASS.
- Preserves #11687's wins: declFileTypeAnnotationParenType/UnionType (es5+es2015) STAY PASS.
- Bonus +4: typeGuardOfFormThisMember/Errors (es5+es2015) also flipped (same #11687 victim class).
- **Full --dts-only sweep: 1621→1631 pass, 48→38 fail, ZERO new failures.** 28 paren-emit unit tests pass; clippy `-p tsz-emitter --all-targets -D warnings` clean; JS unchanged.

## Coordination Notes
Fixes the regression from #11687 (over-broad annotation-position paren stripping) without reverting its valid simple-type strips. — opus48-emit100
