### PR TITLE
fix(dts): fix nested mapped-type as-clause, shadowed-alias inference, and self-recursive stack overflow

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/returned_function_initializer.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/returned_function_initializer.rs
@@ -514,6 +514,11 @@ impl<'a> DeclarationEmitter<'a> {
         if inner_func.body.is_none() {
             return None;
         }
+        if let Some(name) = self.get_identifier_text(inner_func.name)
+            && self.source_function_body_contains_direct_call_to_name(self.arena, inner_func, &name)
+        {
+            return None;
+        }
         if self.body_returns_void(inner_func.body) {
             return Some("void".to_string());
         }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_object_args.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_object_args.rs
@@ -200,6 +200,18 @@ impl<'a> DeclarationEmitter<'a> {
                 self.with_symbol_declarations(alias_sym_id, |alias_arena, decl_idx| {
                     let decl_node = alias_arena.get(decl_idx)?;
                     let alias = alias_arena.get_type_alias(decl_node)?;
+                    let alias_body_node = alias_arena.get(alias.type_node)?;
+                    let body_is_structural = matches!(
+                        alias_body_node.kind,
+                        k if k == syntax_kind_ext::TYPE_LITERAL
+                            || k == syntax_kind_ext::MAPPED_TYPE
+                            || k == syntax_kind_ext::INTERSECTION_TYPE
+                            || k == syntax_kind_ext::UNION_TYPE
+                            || k == syntax_kind_ext::PARENTHESIZED_TYPE
+                    );
+                    if !body_is_structural {
+                        return None;
+                    }
                     let alias_type_params = alias.type_parameters.as_ref()?;
                     let alias_args = type_ref.type_arguments.as_ref()?;
                     let mut next_aliases = aliases.to_vec();

--- a/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
@@ -1649,11 +1649,16 @@ impl<'a> DeclarationEmitter<'a> {
             }
         }
 
-        // tsc keeps mapped-type name-type expressions on a single line; suppress multiline tuple formatting.
-        let saved_indent = self.indent_level;
-        self.indent_level = 0;
-        self.emit_type(name_type_idx);
-        self.indent_level = saved_indent;
+        // tsc keeps mapped-type name-type expressions on a single line; suppress multiline tuple
+        // formatting. When the as-clause itself contains a nested mapped type, preserve indentation.
+        if self.type_node_contains_mapped_type(name_type_idx, 0) {
+            self.emit_type(name_type_idx);
+        } else {
+            let saved_indent = self.indent_level;
+            self.indent_level = 0;
+            self.emit_type(name_type_idx);
+            self.indent_level = saved_indent;
+        }
     }
 
     pub(in crate::declaration_emitter) fn emit_mapped_type_as_clause(


### PR DESCRIPTION
AgentName: Studio-D
Track: emit
Invariant: DTS emitter output matches tsc for self-recursive functions, transparent aliases, and nested mapped-type as-clauses.

## Summary

Three related DTS emitter bugs fixed in a single PR because they share test coverage and the structural conditions overlap.

### 1. Self-recursive function -> stack overflow

**Rule:** When a function's body directly calls itself (e.g. `function f() { return f(); }`), tsc emits `function f(): any;`. tsz previously entered unbounded recursion via `function_body_preferred_return_type_text`.

**Fix:** Added/kept direct self-call guards in the declaration fallback paths.

### 2. Shadowed identity-alias -> wrong substitutions

**Rule:** When inferring object-argument substitutions, tsc only recurses into alias bodies that are structural types (type-literal, mapped, intersection, union, or parenthesized). Transparent identity aliases like `type Partial<T> = T` must be skipped; they are not structural.

**Fix:** Added `body_is_structural` guard in `infer_object_argument_substitutions_from_type_node` (type_inference_source_object_args.rs) that returns `None` when the alias body kind is not one of the five structural kinds.

### 3. Nested mapped-type as-clause -> broken multiline formatting

**Rule:** tsc keeps simple as-clause expressions on one line but preserves indentation when the as-clause itself contains a nested mapped type.

**Fix:** `emit_mapped_type_name_type` (type_emission.rs) now only zeroes `indent_level` when `type_node_contains_mapped_type` returns false for the as-clause node.

## Scope

- `crates/tsz-emitter/src/declaration_emitter/helpers/returned_function_initializer.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_object_args.rs`
- `crates/tsz-emitter/src/declaration_emitter/type_emission.rs`

No new public APIs. No solver or checker changes.

## Project Corpus Impact

- Row: n/a (no project-corpus row yet; these are emitter-only fixes)
- Bug family: dts-emit-inference
- Evidence: 3 focused unit tests that previously failed now pass locally; ready CI will run the full emit gate on exact head.

## Verification

Original draft verification:
```
scripts/safe-run.sh cargo nextest run -p tsz-emitter \
  -E 'test(nested_mapped_type_as_clause) + test(declared_call_return_does_not_treat_shadowed) + test(test_exported_function_returning_shadowed_helper)'
# Summary [   0.033s] 3 tests run: 3 passed
```

2026-05-30 rebase verification on exact head `837ae16f06`:
- `cargo fmt --check`
- `cargo check -p tsz-emitter`
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter -E 'test(nested_mapped_type_as_clause) + test(declared_call_return_does_not_treat_shadowed) + test(test_exported_function_returning_shadowed_helper)'` — 3 passed

Full conformance and emit suites run by CI on ready-for-review promotion.

## Adjacent cases covered by existing tests

Existing tests in `misc_features.rs` and `type_inference_tests.rs` already cover:
1. Named vs unnamed variants of the self-recursive pattern
2. `Partial<T>` (transparent identity alias) vs `Record<K,V>` (structural mapped alias)
3. Single-level vs nested as-clause mapped types

## Coordination Notes

Supersedes draft PR #11659 (`fix/dts-emitter-bugs-dazzling-johnson`) from a previous dazzling-johnson session. That branch was stale (based on an old main, commit signing failed in worktree). All changes from #11659 are applied here on current main. Signed closing comment posted on #11659.

2026-05-30: Rebased onto current `origin/main`; the conflicted self-recursive-call guard was already present on main, so this PR now carries only the remaining three-file DTS diff. Ready CI will verify this exact head before queueing. AgentName: m5-pro-48g-gpt5
