### PR TITLE
chore(arch): blanket FILE_LINE_LIMIT_CHECKS coverage — 45 new guards + enforcement test

### DIFF
--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -519,6 +519,400 @@ FILE_LINE_LIMIT_CHECKS = [
         / "access.rs",
         2554,
     ),
+    # --- Blanket coverage batch: all production files > 2000 lines per §19 ---
+    # These entries pin the current baseline and prevent silent growth.
+    # Each file is a candidate for splitting; ratchet down as submodules land.
+    (
+        "Checker boundary: types/property_access_type/resolve.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-checker"
+        / "src"
+        / "types"
+        / "property_access_type"
+        / "resolve.rs",
+        3152,
+    ),
+    (
+        "Checker boundary: types/type_checking/duplicate_identifiers_helpers.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-checker"
+        / "src"
+        / "types"
+        / "type_checking"
+        / "duplicate_identifiers_helpers.rs",
+        3150,
+    ),
+    (
+        "Checker boundary: error_reporter/properties.rs size ratchet",
+        ROOT / "crates" / "tsz-checker" / "src" / "error_reporter" / "properties.rs",
+        3107,
+    ),
+    (
+        "Checker boundary: declarations/import/declaration.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-checker"
+        / "src"
+        / "declarations"
+        / "import"
+        / "declaration.rs",
+        3066,
+    ),
+    (
+        "Checker boundary: state/state_checking/property.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-checker"
+        / "src"
+        / "state"
+        / "state_checking"
+        / "property.rs",
+        3036,
+    ),
+    (
+        "Parser boundary: parser/state_expressions_literals.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-parser"
+        / "src"
+        / "parser"
+        / "state_expressions_literals.rs",
+        3027,
+    ),
+    (
+        "Checker boundary: jsdoc/params.rs size ratchet",
+        ROOT / "crates" / "tsz-checker" / "src" / "jsdoc" / "params.rs",
+        2941,
+    ),
+    (
+        "Checker boundary: types/type_checking/duplicate_identifiers.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-checker"
+        / "src"
+        / "types"
+        / "type_checking"
+        / "duplicate_identifiers.rs",
+        2916,
+    ),
+    (
+        "Checker boundary: flow/control_flow/core.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-checker"
+        / "src"
+        / "flow"
+        / "control_flow"
+        / "core.rs",
+        2886,
+    ),
+    (
+        "Solver boundary: type_queries/flow.rs size ratchet",
+        ROOT / "crates" / "tsz-solver" / "src" / "type_queries" / "flow.rs",
+        2874,
+    ),
+    (
+        "Checker boundary: types/utilities/core.rs size ratchet",
+        ROOT / "crates" / "tsz-checker" / "src" / "types" / "utilities" / "core.rs",
+        2779,
+    ),
+    (
+        "Checker boundary: state/type_analysis/core.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-checker"
+        / "src"
+        / "state"
+        / "type_analysis"
+        / "core.rs",
+        2764,
+    ),
+    (
+        "CLI boundary: driver/tests.rs size ratchet",
+        ROOT / "crates" / "tsz-cli" / "src" / "driver" / "tests.rs",
+        2736,
+    ),
+    (
+        "Checker boundary: types/class_type/constructor.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-checker"
+        / "src"
+        / "types"
+        / "class_type"
+        / "constructor.rs",
+        2688,
+    ),
+    (
+        "Solver boundary: diagnostics/format/compound.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-solver"
+        / "src"
+        / "diagnostics"
+        / "format"
+        / "compound.rs",
+        2602,
+    ),
+    (
+        "Checker boundary: assignability/assignability_diagnostics.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-checker"
+        / "src"
+        / "assignability"
+        / "assignability_diagnostics.rs",
+        2600,
+    ),
+    (
+        "Checker boundary: state/type_resolution/module.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-checker"
+        / "src"
+        / "state"
+        / "type_resolution"
+        / "module.rs",
+        2596,
+    ),
+    (
+        "Parser boundary: parser/state_statements_class_members.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-parser"
+        / "src"
+        / "parser"
+        / "state_statements_class_members.rs",
+        2587,
+    ),
+    (
+        "Checker boundary: state/type_environment/core.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-checker"
+        / "src"
+        / "state"
+        / "type_environment"
+        / "core.rs",
+        2568,
+    ),
+    (
+        "Conformance boundary: conformance runner size ratchet",
+        ROOT / "crates" / "conformance" / "src" / "runner.rs",
+        2485,
+    ),
+    (
+        "Emitter boundary: emitter/module_emission/core/mod.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-emitter"
+        / "src"
+        / "emitter"
+        / "module_emission"
+        / "core"
+        / "mod.rs",
+        2484,
+    ),
+    (
+        "Emitter boundary: emitter/source_file/emit.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-emitter"
+        / "src"
+        / "emitter"
+        / "source_file"
+        / "emit.rs",
+        2462,
+    ),
+    (
+        "Checker boundary: jsdoc/diagnostics.rs size ratchet",
+        ROOT / "crates" / "tsz-checker" / "src" / "jsdoc" / "diagnostics.rs",
+        2437,
+    ),
+    (
+        "Checker boundary: state/variable_checking/destructuring.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-checker"
+        / "src"
+        / "state"
+        / "variable_checking"
+        / "destructuring.rs",
+        2250,
+    ),
+    (
+        "Checker boundary: state/state_checking_members/interface_checks.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-checker"
+        / "src"
+        / "state"
+        / "state_checking_members"
+        / "interface_checks.rs",
+        2250,
+    ),
+    (
+        "Solver boundary: operations/constraints/walker.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-solver"
+        / "src"
+        / "operations"
+        / "constraints"
+        / "walker.rs",
+        2230,
+    ),
+    (
+        "Emitter boundary: emitter/es5/helpers_async.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-emitter"
+        / "src"
+        / "emitter"
+        / "es5"
+        / "helpers_async.rs",
+        2224,
+    ),
+    (
+        "Checker boundary: state/variable_checking/core.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-checker"
+        / "src"
+        / "state"
+        / "variable_checking"
+        / "core.rs",
+        2207,
+    ),
+    (
+        "Emitter boundary: emitter/helpers.rs size ratchet",
+        ROOT / "crates" / "tsz-emitter" / "src" / "emitter" / "helpers.rs",
+        2202,
+    ),
+    (
+        "Emitter boundary: declaration_emitter/usage_analyzer.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-emitter"
+        / "src"
+        / "declaration_emitter"
+        / "usage_analyzer.rs",
+        2154,
+    ),
+    (
+        "Emitter boundary: emitter/transform_dispatch.rs size ratchet",
+        ROOT / "crates" / "tsz-emitter" / "src" / "emitter" / "transform_dispatch.rs",
+        2124,
+    ),
+    (
+        "Solver boundary: visitors/visitor_predicates.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-solver"
+        / "src"
+        / "visitors"
+        / "visitor_predicates.rs",
+        2123,
+    ),
+    (
+        "Solver boundary: operations/call_args.rs size ratchet",
+        ROOT / "crates" / "tsz-solver" / "src" / "operations" / "call_args.rs",
+        2122,
+    ),
+    (
+        "LSP boundary: navigation/definition.rs size ratchet",
+        ROOT / "crates" / "tsz-lsp" / "src" / "navigation" / "definition.rs",
+        2121,
+    ),
+    (
+        "Solver boundary: relations/subtype/rules/functions/checking.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-solver"
+        / "src"
+        / "relations"
+        / "subtype"
+        / "rules"
+        / "functions"
+        / "checking.rs",
+        2118,
+    ),
+    (
+        "LSP boundary: completions/member.rs size ratchet",
+        ROOT / "crates" / "tsz-lsp" / "src" / "completions" / "member.rs",
+        2117,
+    ),
+    (
+        "Emitter boundary: emitter/module_wrapper/system_emit.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-emitter"
+        / "src"
+        / "emitter"
+        / "module_wrapper"
+        / "system_emit.rs",
+        2093,
+    ),
+    (
+        "LSP boundary: hierarchy/call_hierarchy.rs size ratchet",
+        ROOT / "crates" / "tsz-lsp" / "src" / "hierarchy" / "call_hierarchy.rs",
+        2091,
+    ),
+    (
+        "Solver boundary: intern/core/interner.rs size ratchet",
+        ROOT / "crates" / "tsz-solver" / "src" / "intern" / "core" / "interner.rs",
+        2086,
+    ),
+    (
+        "CLI boundary: bin/tsz_server/tests_navigation.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-cli"
+        / "src"
+        / "bin"
+        / "tsz_server"
+        / "tests_navigation.rs",
+        2044,
+    ),
+    (
+        "Solver boundary: operations/core/call_resolution.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-solver"
+        / "src"
+        / "operations"
+        / "core"
+        / "call_resolution.rs",
+        2031,
+    ),
+    (
+        "LSP boundary: hover/core.rs size ratchet",
+        ROOT / "crates" / "tsz-lsp" / "src" / "hover" / "core.rs",
+        2029,
+    ),
+    (
+        "Emitter boundary: emitter/statements/control_flow.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-emitter"
+        / "src"
+        / "emitter"
+        / "statements"
+        / "control_flow.rs",
+        2029,
+    ),
+    (
+        "Solver boundary: evaluation/evaluate.rs size ratchet",
+        ROOT / "crates" / "tsz-solver" / "src" / "evaluation" / "evaluate.rs",
+        2019,
+    ),
+    (
+        "Emitter boundary: transforms/module_commonjs.rs size ratchet",
+        ROOT / "crates" / "tsz-emitter" / "src" / "transforms" / "module_commonjs.rs",
+        2016,
+    ),
 ]
 
 # Pin field counts on giant coordination structs so workstream-4 (Checker

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -296,6 +296,7 @@ FILE_LINE_LIMIT_CHECKS = [
     # monolith into staged lowering modules. The cap should ratchet down
     # as more phases (helper scheduling, temp/hoist planning, suspended
     # target lowering, ...) are extracted into sibling submodules.
+    # Ratcheted 5150→4918 after submodule extraction reduced the core engine.
     (
         "Emitter boundary: async ES5 IR engine size ratchet (#8277)",
         ROOT
@@ -304,7 +305,14 @@ FILE_LINE_LIMIT_CHECKS = [
         / "src"
         / "transforms"
         / "async_es5_ir.rs",
-        5150,
+        4918,
+    ),
+    # Emitter ES decorators: PR #10778 tracks sharding into 7 focused submodules.
+    # Ratchet down as submodules land.
+    (
+        "Emitter boundary: es_decorators monolith size ratchet (#10778)",
+        ROOT / "crates" / "tsz-emitter" / "src" / "transforms" / "es_decorators.rs",
+        5755,
     ),
     # Config monolith: tsconfig/compiler-options parser. Issue #8280 tracks
     # splitting into option-domain submodules. Ratchet down as each domain lands.

--- a/scripts/arch/test_arch_guard.py
+++ b/scripts/arch/test_arch_guard.py
@@ -1104,6 +1104,50 @@ class ArchGuardAllFileLimitChecksPassTests(unittest.TestCase):
                 f"for the live file ({hits}). Bump the cap or split the file.",
             )
 
+    def test_no_unguarded_oversized_production_files(self):
+        """Every production .rs file over 2000 lines must appear in FILE_LINE_LIMIT_CHECKS.
+
+        Prevents new monoliths from growing unchecked. When a file legitimately exceeds
+        2000 lines, add a FILE_LINE_LIMIT_CHECKS entry for it in the same PR; ratchet
+        the cap down as the file is split per §19.
+        """
+        arch_guard = self.arch_guard
+        guarded = {
+            pathlib.Path(path).resolve()
+            for _, path, _ in arch_guard.FILE_LINE_LIMIT_CHECKS
+        }
+        limit = 2000
+        unguarded = []
+        crates_root = ROOT / "crates"
+        if not crates_root.exists():
+            return
+        for path in crates_root.rglob("*.rs"):
+            rel = path.relative_to(ROOT).as_posix()
+            rel_parts = set(rel.split("/"))
+            if arch_guard.EXCLUDE_DIRS.intersection(rel_parts):
+                continue
+            if "tests" in rel_parts or "benches" in rel_parts:
+                continue
+            if arch_guard.is_test_file(rel):
+                continue
+            if path.resolve() in guarded:
+                continue
+            try:
+                n = len(path.read_text(encoding="utf-8", errors="ignore").splitlines())
+            except OSError:
+                continue
+            if n > limit:
+                unguarded.append((n, rel))
+        if unguarded:
+            unguarded.sort(reverse=True)
+            lines = "\n".join(f"  {n:5d}  {r}" for n, r in unguarded)
+            self.fail(
+                f"Found {len(unguarded)} production file(s) over {limit} lines with "
+                f"no FILE_LINE_LIMIT_CHECKS guard.\n"
+                f"Add an entry for each file in the same PR that grows it past {limit} "
+                f"lines; ratchet down as submodules land (§19):\n{lines}"
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
AgentName: Studio-F

## Track
Track 10: Guardrails, Tooling, Residency, And Performance Readiness — arch-guard coverage gap closure.

## Invariant
When a production file over 2000 lines has no `FILE_LINE_LIMIT_CHECKS` entry, silent growth is possible. Prior to this PR, 45 such files had no ratchet of any kind.

## Scope
- `scripts/arch/arch_guard_shared.py` — ratchet pay-down (async_es5_ir.rs cap 5150→4918), new entry for es_decorators.rs, and 45 new blanket coverage entries
- `scripts/arch/test_arch_guard.py` — new enforcement test `test_no_unguarded_oversized_production_files`

## Changes

### Commit 1: ratchet pay-down + es_decorators gap closure

**async_es5_ir.rs: cap 5150 → 4918 (ratchet pay-down)**
Submodule extraction reduced the core engine by 232 lines; old cap had 232 lines of silent headroom.

**es_decorators.rs: add ratchet at 5755 (gap closure)**
Largest unratcheted file before this batch. PR #10778 claims the split work.

### Commit 2: blanket coverage — 45 files + enforcement test

A filesystem audit found 45 production `.rs` files over 2000 lines with no `FILE_LINE_LIMIT_CHECKS` entry. Each is now pinned at its current baseline. Ratchet each cap down as submodules land per §19.

**New enforcement test** `test_no_unguarded_oversized_production_files`:
Scans all production Rust files under `crates/` (same exclusions as regex-scan logic: `EXCLUDE_DIRS`, `tests/`/`benches/` subdirs, `is_test_file`). Fails immediately if any file over 2000 lines has no guard. Future contributors must add a `FILE_LINE_LIMIT_CHECKS` entry in the same PR that grows a file past 2000 lines.

Files covered (45 new entries, sorted by size):
- Checker: property_access_type/resolve.rs (3152), duplicate_identifiers_helpers.rs (3150), error_reporter/properties.rs (3107), declarations/import/declaration.rs (3066), state/state_checking/property.rs (3036), jsdoc/params.rs (2941), duplicate_identifiers.rs (2916), flow/control_flow/core.rs (2886), utilities/core.rs (2779), type_analysis/core.rs (2764), class_type/constructor.rs (2688), assignability_diagnostics.rs (2600), type_resolution/module.rs (2596), type_environment/core.rs (2568), jsdoc/diagnostics.rs (2437), destructuring.rs (2250), interface_checks.rs (2250), variable_checking/core.rs (2207)
- Solver: type_queries/flow.rs (2874), diagnostics/format/compound.rs (2602), operations/constraints/walker.rs (2230), visitors/visitor_predicates.rs (2123), operations/call_args.rs (2122), relations/subtype/.../checking.rs (2118), intern/core/interner.rs (2086), operations/core/call_resolution.rs (2031), evaluation/evaluate.rs (2019)
- Emitter: module_emission/core/mod.rs (2484), source_file/emit.rs (2462), es5/helpers_async.rs (2224), emitter/helpers.rs (2202), declaration_emitter/usage_analyzer.rs (2154), transform_dispatch.rs (2124), module_wrapper/system_emit.rs (2093), statements/control_flow.rs (2029), transforms/module_commonjs.rs (2016)
- Parser: state_expressions_literals.rs (3027), state_statements_class_members.rs (2587)
- LSP: navigation/definition.rs (2121), completions/member.rs (2117), hierarchy/call_hierarchy.rs (2091), hover/core.rs (2029)
- CLI: driver/tests.rs (2736), bin/tsz_server/tests_navigation.rs (2044)
- Conformance: runner.rs (2485)

## Verification
- `test_no_unguarded_oversized_production_files` passes (zero unguarded files remain)
- `test_all_file_limit_caps_are_not_exceeded` passes (all caps match live sizes)
- `test_all_file_limit_paths_exist` passes
- All 226 arch-guard tests pass (`python3 test_arch_guard.py`)

## Project Corpus Impact
Row: n/a
Bug family: n/a
Evidence: arch-guard-only, no compiler behavior change.

## Coordination Notes
Stacks cleanly on #11699 (merged). The enforcement test closes the coverage loop: once this PR lands, any new file that grows past 2000 lines without a guard will fail `arch-tool-smoke` CI immediately. `es_decorators.rs` split work remains in #10778 (draft).

---
_Generated by [Claude Code](https://claude.ai/code/session_0132dRH9JJWjUhYL6SpPuMsB)_