### PR TITLE
fix(emit): build hoisted private-helper var-decls by member identity (no duplicate/orphan for shared private names)

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -842,37 +842,21 @@ impl<'a> Printer<'a> {
             }
 
             // Private members in source order. Walk `class.members.nodes`
-            // once and look up each member's pre-computed info entry by
-            // private-identifier name. Accessors share a private name across
-            // get/set, so we dedupe within an accessor pair.
-            let mut emitted_accessor_names: rustc_hash::FxHashSet<String> =
+            // once and look up each member's pre-computed info entry by source
+            // member identity, not by private clean-name. When several members
+            // share a clean-name (an instance and a static `#foo`, or duplicate
+            // declarations in an error case), each member owns a distinct
+            // `_N`-suffixed helper; matching by identity keeps this hoisted
+            // var-decl list in agreement with the initializer/assignment paths
+            // that iterate the same collections. Accessors collapse a get/set
+            // pair into one entry, so we emit each accessor entry once when its
+            // first member is reached.
+            let mut emitted_accessor_entries: rustc_hash::FxHashSet<usize> =
                 rustc_hash::FxHashSet::default();
             for &member_idx in &class.members.nodes {
                 let Some(member_node) = self.arena.get(member_idx) else {
                     continue;
                 };
-                let private_name = match member_node.kind {
-                    k if k == syntax_kind_ext::PROPERTY_DECLARATION => self
-                        .arena
-                        .get_property_decl(member_node)
-                        .and_then(|p| get_private_field_name(self.arena, p.name)),
-                    k if k == syntax_kind_ext::METHOD_DECLARATION => self
-                        .arena
-                        .get_method_decl(member_node)
-                        .and_then(|m| get_private_field_name(self.arena, m.name)),
-                    k if k == syntax_kind_ext::GET_ACCESSOR
-                        || k == syntax_kind_ext::SET_ACCESSOR =>
-                    {
-                        self.arena
-                            .get_accessor(member_node)
-                            .and_then(|a| get_private_field_name(self.arena, a.name))
-                    }
-                    _ => None,
-                };
-                let Some(private_name) = private_name else {
-                    continue;
-                };
-                let clean_name = private_name.strip_prefix('#').unwrap_or(&private_name);
                 match member_node.kind {
                     k if k == syntax_kind_ext::PROPERTY_DECLARATION => {
                         if let Some(accessor) = private_auto_accessors
@@ -882,13 +866,14 @@ impl<'a> Printer<'a> {
                             var_names.push(accessor.get_var_name.clone());
                             var_names.push(accessor.set_var_name.clone());
                         } else if let Some(field) =
-                            private_fields.iter().find(|f| f.name == clean_name)
+                            private_fields.iter().find(|f| f.member_idx == member_idx)
                         {
                             var_names.push(field.weakmap_name.clone());
                         }
                     }
                     k if k == syntax_kind_ext::METHOD_DECLARATION => {
-                        if let Some(method) = private_methods.iter().find(|m| m.name == clean_name)
+                        if let Some(method) =
+                            private_methods.iter().find(|m| m.member_idx == member_idx)
                         {
                             var_names.push(method.fn_var_name.clone());
                         }
@@ -896,12 +881,14 @@ impl<'a> Printer<'a> {
                     k if k == syntax_kind_ext::GET_ACCESSOR
                         || k == syntax_kind_ext::SET_ACCESSOR =>
                     {
-                        if !emitted_accessor_names.insert(clean_name.to_string()) {
-                            continue;
-                        }
-                        if let Some(accessor) =
-                            private_accessors.iter().find(|a| a.name == clean_name)
+                        if let Some((entry_pos, accessor)) = private_accessors
+                            .iter()
+                            .enumerate()
+                            .find(|(_, a)| a.member_indices.contains(&member_idx))
                         {
+                            if !emitted_accessor_entries.insert(entry_pos) {
+                                continue;
+                            }
                             if let Some(ref name) = accessor.get_var_name
                                 && accessor.getter_body.is_some()
                             {

--- a/crates/tsz-emitter/src/transforms/private_fields_es5.rs
+++ b/crates/tsz-emitter/src/transforms/private_fields_es5.rs
@@ -40,6 +40,11 @@ pub use tsz_parser::syntax::transform_utils::is_private_identifier;
 /// Information about a private field in a class
 #[derive(Debug, Clone)]
 pub struct PrivateFieldInfo {
+    /// The source member node this field was collected from. Used to map a
+    /// member back to its own generated helper name when several members share
+    /// the same private clean-name (instance + static, or duplicate-error
+    /// fields). Defaults to `NodeIndex::NONE` for synthesized entries.
+    pub member_idx: NodeIndex,
     /// The private field name without # (e.g., "value" for "#value")
     pub name: String,
     /// The `WeakMap` variable name (e.g., "_`C_value`" for class C, field #value)
@@ -55,6 +60,11 @@ pub struct PrivateFieldInfo {
 /// Information about a private accessor (get/set) in a class
 #[derive(Debug, Clone)]
 pub struct PrivateAccessorInfo {
+    /// The source member nodes (getter and/or setter) merged into this entry.
+    /// A get/set pair that shares one private clean-name is collapsed into a
+    /// single entry, so the hoisted var-decl list can recognize either member
+    /// node and avoid re-deriving the helper name on a separate path.
+    pub member_indices: Vec<NodeIndex>,
     /// The private accessor name without # (e.g., "value" for "#value")
     pub name: String,
     /// The `WeakMap` variable name for the getter (e.g., "_`C_value_get`")
@@ -113,6 +123,7 @@ impl PrivateFieldState {
         let weakmap_name = format!("_{class_name}_{field_name}");
 
         self.private_fields.push(PrivateFieldInfo {
+            member_idx: NodeIndex::NONE,
             name: field_name.to_string(),
             weakmap_name,
             has_initializer,
@@ -450,6 +461,7 @@ pub fn collect_private_fields_with_reserved(
                 let is_static = arena.has_modifier(&prop_data.modifiers, SyntaxKind::StaticKeyword);
 
                 fields.push(PrivateFieldInfo {
+                    member_idx,
                     name: clean_name.to_string(),
                     weakmap_name,
                     has_initializer: prop_data.initializer.is_some(),
@@ -514,6 +526,7 @@ pub fn collect_private_accessors_with_reserved(
                 accessors
                     .entry(clean_name.to_string())
                     .or_insert_with(|| PrivateAccessorInfo {
+                        member_indices: Vec::new(),
                         name: clean_name.to_string(),
                         get_var_name: Some(make_unique_private_name(
                             &format!("_{class_name}_{clean_name}_get"),
@@ -528,6 +541,7 @@ pub fn collect_private_accessors_with_reserved(
                         setter_param: None,
                         is_static,
                     });
+            entry.member_indices.push(member_idx);
 
             // Update based on accessor type
             if member_node.kind == syntax_kind_ext::GET_ACCESSOR {
@@ -557,6 +571,10 @@ pub fn collect_private_accessors_with_reserved(
 /// Information about a private method in a class
 #[derive(Debug, Clone)]
 pub struct PrivateMethodInfo {
+    /// The source member node this method was collected from. See
+    /// [`PrivateFieldInfo::member_idx`] for why this matters when several
+    /// members share the same private clean-name.
+    pub member_idx: NodeIndex,
     /// The private method name without # (e.g., "method" for "#method")
     pub name: String,
     /// The function variable name (e.g., "_`C_method`")
@@ -622,6 +640,7 @@ pub fn collect_private_methods_with_reserved(
             let is_async = arena.has_modifier(&method_data.modifiers, SyntaxKind::AsyncKeyword);
 
             methods.push(PrivateMethodInfo {
+                member_idx,
                 name: clean_name.to_string(),
                 fn_var_name,
                 body: if method_data.body.is_some() {

--- a/crates/tsz-emitter/tests/private_element_naming_tests.rs
+++ b/crates/tsz-emitter/tests/private_element_naming_tests.rs
@@ -122,6 +122,112 @@ class Box {
 }
 
 // ---------------------------------------------------------------------------
+// Rule 1b: members of one class that share a private clean-name (an instance
+// and a static `#foo`, or two same-named declarations) each own a distinct
+// `_N`-suffixed helper. The hoisted var-decl list is built from the same
+// per-member collections as the initializer/assignment paths (keyed on member
+// identity), so it must never declare a duplicate helper name nor reference a
+// helper it failed to declare.
+// ---------------------------------------------------------------------------
+
+/// Extract the module-level `var ...;` hoist line that declares the generated
+/// private helpers for the first class.
+fn hoist_var_line(output: &str) -> String {
+    output
+        .lines()
+        .find(|l| l.trim_start().starts_with("var ") && l.contains("_foo"))
+        .or_else(|| output.lines().find(|l| l.trim_start().starts_with("var ")))
+        .unwrap_or("")
+        .to_string()
+}
+
+/// An instance `#foo` and a static `#foo` share a clean-name. Each must receive
+/// its own helper (`_C_foo` and `_C_foo_1`) in the single hoisted var-decl list,
+/// and the suffixed helper must actually be declared there (not only referenced
+/// by the static initializer on a separate path).
+#[test]
+fn instance_and_static_same_private_name_get_distinct_helpers() {
+    let source = r#"
+class Box {
+    #foo = 1;
+    static #foo = true;
+}
+"#;
+    let output = parse_lower_emit(source, es2015_esnext());
+    let var_line = hoist_var_line(&output);
+
+    assert!(
+        var_line.contains("_Box_foo,") || var_line.contains("_Box_foo;"),
+        "Instance helper keeps the un-suffixed name in the hoist list.\nvar line: {var_line}\nOutput:\n{output}"
+    );
+    assert!(
+        var_line.contains("_Box_foo_1"),
+        "Static helper takes the suffixed name in the hoist list.\nvar line: {var_line}\nOutput:\n{output}"
+    );
+    // The old bug declared `_Box_foo` twice (instance + static both resolved to
+    // the first field's name) and left `_Box_foo_1` undeclared.
+    assert_eq!(
+        count_occurrences(&var_line, "_Box_foo,"),
+        1,
+        "The hoist list must not declare the same helper twice.\nvar line: {var_line}\nOutput:\n{output}"
+    );
+    // Every `_Box_foo_1` reference must be backed by its declaration in the
+    // hoist list.
+    assert!(
+        count_occurrences(&output, "_Box_foo_1") >= 2,
+        "Suffixed helper must be both declared and used.\nOutput:\n{output}"
+    );
+}
+
+/// Same rule, different class/member spelling: keying is on the structural
+/// collision (instance vs static sharing a clean-name), not on `Box`/`foo`.
+#[test]
+fn instance_and_static_same_private_name_get_distinct_helpers_renamed() {
+    let source = r#"
+class Widget {
+    #handle = 1;
+    static #handle = true;
+}
+"#;
+    let output = parse_lower_emit(source, es2015_esnext());
+    let var_line = hoist_var_line(&output);
+
+    assert!(
+        var_line.contains("_Widget_handle_1"),
+        "Static helper must be suffixed regardless of names.\nvar line: {var_line}\nOutput:\n{output}"
+    );
+    assert_eq!(
+        count_occurrences(&var_line, "_Widget_handle,"),
+        1,
+        "No duplicate helper declaration regardless of names.\nvar line: {var_line}\nOutput:\n{output}"
+    );
+}
+
+/// An instance field and an instance method sharing a clean-name also collide;
+/// each owns a distinct helper in the single hoist list.
+#[test]
+fn field_and_method_same_private_name_get_distinct_helpers() {
+    let source = r#"
+class Repo {
+    #foo = 1;
+    #foo() { return 2; }
+}
+"#;
+    let output = parse_lower_emit(source, es2015_esnext());
+    let var_line = hoist_var_line(&output);
+
+    assert!(
+        var_line.contains("_Repo_foo_1"),
+        "Second same-named member must take the suffixed helper.\nvar line: {var_line}\nOutput:\n{output}"
+    );
+    assert_eq!(
+        count_occurrences(&var_line, "_Repo_foo,"),
+        1,
+        "No duplicate helper declaration for field/method collision.\nvar line: {var_line}\nOutput:\n{output}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Rule 2: class-expression temp scope inside a private-field initializer of a
 // class with a synthesized constructor.
 // ---------------------------------------------------------------------------

--- a/crates/tsz-emitter/tests/private_fields_es5.rs
+++ b/crates/tsz-emitter/tests/private_fields_es5.rs
@@ -31,6 +31,7 @@ fn test_private_field_state() {
 fn test_generate_weakmap_var_declaration() {
     let fields = vec![
         PrivateFieldInfo {
+            member_idx: NodeIndex::NONE,
             name: "value".to_string(),
             weakmap_name: "_C_value".to_string(),
             has_initializer: true,
@@ -38,6 +39,7 @@ fn test_generate_weakmap_var_declaration() {
             is_static: false,
         },
         PrivateFieldInfo {
+            member_idx: NodeIndex::NONE,
             name: "count".to_string(),
             weakmap_name: "_C_count".to_string(),
             has_initializer: false,
@@ -54,6 +56,7 @@ fn test_generate_weakmap_var_declaration() {
 fn test_generate_weakmap_instantiation() {
     let fields = vec![
         PrivateFieldInfo {
+            member_idx: NodeIndex::NONE,
             name: "value".to_string(),
             weakmap_name: "_C_value".to_string(),
             has_initializer: true,
@@ -61,6 +64,7 @@ fn test_generate_weakmap_instantiation() {
             is_static: false,
         },
         PrivateFieldInfo {
+            member_idx: NodeIndex::NONE,
             name: "count".to_string(),
             weakmap_name: "_C_count".to_string(),
             has_initializer: false,


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — JavaScript emit correctness (emit→100% campaign, wave 3)

## Invariant
When several class members share a private clean-name (instance `#foo` + static `#foo`, or a duplicate-error field/method), each member owns its own `_N`-suffixed WeakMap/method helper; the hoisted `var`-decl list is built by member identity (matching the init/assignment paths), never by re-finding the first helper with a matching clean-name — eliminating a duplicate `var` declaration and an orphaned reference to an undeclared `_N`-suffixed var.

## Scope
- `crates/tsz-emitter/src/transforms/private_fields_es5.rs` — add `member_idx`/`member_indices` to PrivateField/Method/Accessor info; populate in collect.
- `crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs` — hoisted var-decl loop matches by member identity (also -21 lines).
- tests: `private_element_naming_tests.rs` (+3 structural), `private_fields_es5.rs` (struct ctor updates).

## Project Corpus Impact
- Row: n/a (emit correctness fix)
- Bug family: duplicate/orphaned hoisted private-helper var-decl for shared private clean-names
- Evidence: NET-ZERO on emit witnesses (privateNamesUnique-3/privateNameDuplicateField need tsc's separate duplicate-error degenerate-emit) but fixes a real orphan-reference bug (undeclared var) — verified by new tests that fail under the old name-based lookup.

## Verification
- Full `--js-only` sweep: 13421 pass / 109 fail BEFORE and AFTER — zero regressions, zero new failures (per-test delta empty). privateField 7/9, privateName 143/158 unchanged. 3 new structural unit tests pass (fail under simulated old lookup); `cargo clippy -p tsz-emitter --all-targets -- -D warnings` clean.
- Honest: net-zero on the emit pass-rate metric; landed as a correctness/prerequisite fix (the orphan reference is broken JS). Flipping the witnesses needs tsc duplicate-error recovery semantics (separate larger effort).

## Coordination Notes
Wave-3 correctness fix; structural (member identity), §25/§26 compliant. — opus48-emit100
