### PR TITLE
fix(dts): reuse source assertion type node for type-asserted inferred declarations (preserve entity-name computed keys)

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
@@ -122,6 +122,20 @@ impl<'a> DeclarationEmitter<'a> {
                 self.preferred_expression_type_text(unary.expression)
                     .or_else(|| self.infer_fallback_type_text_at(unary.expression, depth + 1))
             }
+            // A type-asserted expression (`expr as T`, `<T>expr`) reuses the
+            // source assertion *type node* in tsc's declaration output, exactly
+            // as the annotation-position emitter does. Reusing the node (not the
+            // solver-resolved type) preserves entity-name computed property keys
+            // (`{ [n]: T }`) and other source-only spellings that type
+            // resolution would otherwise flatten to literal values.
+            // `explicit_asserted_type_text` returns `None` for `as const`, so
+            // those continue to flow through the default solver path below.
+            k if k == syntax_kind_ext::AS_EXPRESSION || k == syntax_kind_ext::TYPE_ASSERTION => {
+                self.explicit_asserted_type_text(node_id).or_else(|| {
+                    self.get_node_type(node_id)
+                        .map(|type_id| self.print_type_id(type_id))
+                })
+            }
             k if k == syntax_kind_ext::ARROW_FUNCTION
                 || k == syntax_kind_ext::FUNCTION_EXPRESSION =>
             {

--- a/crates/tsz-emitter/src/declaration_emitter/tests/computed_properties.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/computed_properties.rs
@@ -586,3 +586,92 @@ namespace X.A.B.C {
         "Expected exported empty inner namespace to be preserved inside the declare namespace: {output}"
     );
 }
+
+// =============================================================================
+// Type-asserted arrow body reuses the source assertion type node (entity-name
+// computed property keys are preserved verbatim instead of being resolved to
+// their literal values). tsc reuses the `as`-cast type node in declaration
+// emit, so `() => null! as { [n]: T }` keeps the `[n]` reference rather than
+// flattening it to the literal key. See `declarationEmitPartialReuseComputedProperty`.
+// =============================================================================
+
+#[test]
+fn asserted_arrow_body_preserves_entity_name_computed_keys() {
+    let output = emit_dts_with_binding(
+        r#"
+const key = "A";
+export const o = () => null! as { [key]: string, foo: string };
+"#,
+    );
+    assert!(
+        output.contains("[key]: string"),
+        "Expected entity-name computed key `[key]` to be preserved verbatim: {output}"
+    );
+    assert!(
+        output.contains("foo: string"),
+        "Expected sibling literal member to be preserved: {output}"
+    );
+    assert!(
+        !output.contains("A: string"),
+        "Computed key must NOT be resolved to its literal value `A`: {output}"
+    );
+}
+
+#[test]
+fn asserted_arrow_body_preserves_renamed_entity_name_computed_keys() {
+    // Renaming the entity-name reference must not change the behavior — the rule
+    // is structural ("the key is an entity-name expression"), not name-specific.
+    let output = emit_dts_with_binding(
+        r#"
+const tag = "B";
+export const make = () => null! as { [tag]: number, bar: number };
+"#,
+    );
+    assert!(
+        output.contains("[tag]: number"),
+        "Expected renamed entity-name computed key `[tag]` to be preserved verbatim: {output}"
+    );
+    assert!(
+        !output.contains("B: number"),
+        "Computed key must NOT be resolved to its literal value `B`: {output}"
+    );
+}
+
+#[test]
+fn asserted_arrow_body_preserves_numeric_entity_name_computed_keys() {
+    let output = emit_dts_with_binding(
+        r#"
+const poz = 1;
+const neg = -1;
+export const o = () => null! as { [poz]: number, [neg]: number };
+"#,
+    );
+    assert!(
+        output.contains("[poz]: number"),
+        "Expected entity-name computed key `[poz]` to be preserved verbatim: {output}"
+    );
+    assert!(
+        output.contains("[neg]: number"),
+        "Expected entity-name computed key `[neg]` to be preserved verbatim: {output}"
+    );
+    assert!(
+        !output.contains("1: number") && !output.contains("[-1]: number"),
+        "Computed keys must NOT be resolved to their literal values: {output}"
+    );
+}
+
+#[test]
+fn asserted_arrow_body_reuses_source_type_for_plain_annotation() {
+    // Negative/fallback case: a non-computed assertion still reuses the source
+    // type node, matching tsc's node-reuse behavior, and is not silently
+    // dropped or replaced with `any`.
+    let output = emit_dts_with_binding(
+        r#"
+export const f = () => null! as { value: string };
+"#,
+    );
+    assert!(
+        output.contains("() =>") && output.contains("value: string"),
+        "Expected source assertion object type to be reused: {output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — declaration emit parity (emit→100% campaign, wave 3)

## Invariant
When an arrow/function body (or expression) is a type-asserted expression (`expr as T` / `<T>expr`, excluding `as const`/`satisfies`), the declaration emitter reuses the source assertion type node — preserving verbatim entity-name computed keys (`[n]`, `[poz]`) — instead of printing the solver-resolved type (which flattens them to literal values). `as const` and cross-module inferred (no source node) continue through the solver path.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs` — new AS_EXPRESSION/TYPE_ASSERTION arm in `infer_fallback_type_text_at` delegating to `explicit_asserted_type_text` (source type-node reuse), solver fallback otherwise.
- `crates/tsz-emitter/src/declaration_emitter/tests/computed_properties.rs` — 4 structural tests.

## Project Corpus Impact
- Row: n/a (declaration emit parity fix)
- Bug family: type-asserted inferred declaration loses source entity-name computed keys
- Evidence: declarationEmitPartialReuseComputedProperty FAIL→PASS.

## Verification
- Witness FAIL→PASS (a.d.ts preserves `[n]`/`[poz]`/`[neg]`; b.d.ts cross-module still resolves — exact tsc match). **Full --dts-only sweep: 1631→1632 pass, 38→37 fail, ZERO new regressions.** JS unchanged. 4 new unit tests (fail without fix) + restored a pre-existing-broken test; clippy `-p tsz-emitter --lib -D warnings` clean.
- Structural (node kind + existing source-reuse helper), §25/§26 compliant.
- Scope note: declarationEmitExactOptionalPropertyTypesNodeNotReused (intersection-structure preservation) + declarationEmitBindingPatternsUnused (checker destructured-return inference) are separate broader efforts, deferred.

## Coordination Notes
Wave-3 contained DTS fix. — opus48-emit100
