### PR TITLE
fix(parser): recover bare super to super.<missing> PropertyAccess (matches tsc static-super lowering)

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -31,6 +31,10 @@ name = "es5_super_object_literal_accessor_tests"
 path = "tests/es5_super_object_literal_accessor_tests.rs"
 
 [[test]]
+name = "super_missing_member_recovery_tests"
+path = "tests/super_missing_member_recovery_tests.rs"
+
+[[test]]
 name = "class_temp_dedup_hoist_buckets_tests"
 path = "tests/class_temp_dedup_hoist_buckets_tests.rs"
 

--- a/crates/tsz-emitter/tests/super_missing_member_recovery_tests.rs
+++ b/crates/tsz-emitter/tests/super_missing_member_recovery_tests.rs
@@ -1,0 +1,128 @@
+//! `super` error-recovery emit: bare `super` not followed by an argument list
+//! or member access.
+//!
+//! Structural rule: when `super` is not followed by `(`, `.`, `[`, or `<`, tsc
+//! recovers by parsing it as a `super.<missing-identifier>` property access
+//! (it consumes an expected `.` token and a missing right-hand identifier).
+//! That property access is then emitted verbatim as `super.`, and — when it
+//! appears in a static-member context that requires downleveling — it is
+//! lowered through the static-member `super` rewrite with an empty property
+//! key (`Reflect.get(base, "", self)`). Before this fix tsz parsed bare
+//! `super` as a lone `SuperKeyword`, emitting `super` (no trailing dot) and
+//! skipping the static-super lowering.
+//!
+//! These tests vary class/member names so the behaviour is keyed on the
+//! structural "super has no following member access" shape, not on any
+//! particular identifier spelling.
+
+use tsz_common::common::ScriptTarget;
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::{parse_and_lower_print, parse_and_print_with_opts};
+
+fn print_es2015(source: &str) -> String {
+    let opts = PrintOptions {
+        target: ScriptTarget::ES2015,
+        ..Default::default()
+    };
+    parse_and_print_with_opts(source, opts)
+}
+
+fn lower_es2015(source: &str) -> String {
+    let opts = PrintOptions {
+        target: ScriptTarget::ES2015,
+        ..Default::default()
+    };
+    parse_and_lower_print(source, opts)
+}
+
+/// Bare `super` in a non-class function context emits `super.` verbatim (the
+/// recovered missing-member property access), not a lone `super`.
+#[test]
+fn bare_super_in_function_emits_trailing_dot() {
+    let source = "function outer() {\n    var captured = super;\n}\n";
+    let output = print_es2015(source);
+    assert!(
+        output.contains("var captured = super.;"),
+        "bare `super` should recover as `super.` (missing-member property access).\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("super;"),
+        "bare `super` must not be emitted as a lone `super` keyword.\nOutput:\n{output}"
+    );
+}
+
+/// Same rule with a different identifier and an arrow body, proving the fix is
+/// keyed on the structural "no member access after super" shape.
+#[test]
+fn bare_super_in_arrow_emits_trailing_dot() {
+    let source = "function host() {\n    var ref = () => super;\n}\n";
+    let output = print_es2015(source);
+    assert!(
+        output.contains("() => super."),
+        "bare `super` in an arrow should recover as `super.`.\nOutput:\n{output}"
+    );
+}
+
+/// A bare `super` inside a static field initializer must be lowered through the
+/// static-member `super` rewrite with an empty property key.
+#[test]
+fn bare_super_in_static_field_lowers_to_reflect_get_empty_key() {
+    let source = concat!(
+        "class Animal { static run() {} }\n",
+        "class Dog extends Animal {\n",
+        "    static legs = super;\n",
+        "}\n",
+    );
+    let output = lower_es2015(source);
+    assert!(
+        output.contains("Reflect.get(") && output.contains(", \"\", "),
+        "bare `super` in a static field should lower to `Reflect.get(base, \"\", self)`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("= super;") && !output.contains("= super,"),
+        "bare `super` in a static field must not survive as a lone `super`.\nOutput:\n{output}"
+    );
+}
+
+/// Same static-member lowering with different class/member names, confirming
+/// the empty-key `Reflect.get` rewrite is structural, not name-specific.
+#[test]
+fn bare_super_in_static_field_lowers_for_other_names() {
+    let source = concat!(
+        "class Vehicle { static start() {} }\n",
+        "class Car extends Vehicle {\n",
+        "    static wheels = super;\n",
+        "}\n",
+    );
+    let output = lower_es2015(source);
+    assert!(
+        output.contains("Reflect.get(") && output.contains(", \"\", "),
+        "renamed bare-super static field should still lower to an empty-key `Reflect.get`.\nOutput:\n{output}"
+    );
+}
+
+/// Negative / regression case: a valid `super.member` access is unaffected by
+/// the recovery path — it keeps its real property name and is not collapsed to
+/// the missing-member form.
+#[test]
+fn valid_super_member_access_is_unaffected() {
+    let source = concat!(
+        "class Base { greet() {} }\n",
+        "class Sub extends Base {\n",
+        "    hello() { super.greet(); }\n",
+        "}\n",
+    );
+    let output = print_es2015(source);
+    assert!(
+        output.contains("super.greet()"),
+        "valid `super.greet()` must be preserved.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("super.;"),
+        "valid super access must not produce a missing-member `super.`.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -680,23 +680,50 @@ impl ParserState {
         let end_pos = self.token_end();
         self.next_token();
 
+        let super_node = self
+            .arena
+            .add_token(SyntaxKind::SuperKeyword as u16, start_pos, end_pos);
+
         // If super is followed by (, ., [, or <, return just the super keyword.
         // The caller (parse_member_expression_rest) will handle the access chain.
-        if !self.is_token(SyntaxKind::OpenParenToken)
-            && !self.is_token(SyntaxKind::DotToken)
-            && !self.is_token(SyntaxKind::OpenBracketToken)
-            && !self.is_token(SyntaxKind::LessThanToken)
+        if self.is_token(SyntaxKind::OpenParenToken)
+            || self.is_token(SyntaxKind::DotToken)
+            || self.is_token(SyntaxKind::OpenBracketToken)
+            || self.is_token(SyntaxKind::LessThanToken)
         {
-            // super must be followed by an argument list or member access.
-            // Emit TS1034 at the current token position (matching tsc's parseExpectedToken).
-            self.parse_error_at_current_token(
-                diagnostic_messages::SUPER_MUST_BE_FOLLOWED_BY_AN_ARGUMENT_LIST_OR_MEMBER_ACCESS,
-                diagnostic_codes::SUPER_MUST_BE_FOLLOWED_BY_AN_ARGUMENT_LIST_OR_MEMBER_ACCESS,
-            );
+            return super_node;
         }
 
-        self.arena
-            .add_token(SyntaxKind::SuperKeyword as u16, start_pos, end_pos)
+        // `super` must be followed by an argument list or member access. When it
+        // is not, tsc recovers by consuming an (expected) `.` token and parsing
+        // the right side of the dot, which yields a missing-identifier
+        // PropertyAccessExpression (`super.<missing>`). The downstream emitter
+        // then prints `super.` verbatim, and the static-member super lowering
+        // sees a real property access (e.g. `Reflect.get(base, "", self)` with an
+        // empty key). Matching tsc structurally — rather than returning a bare
+        // `super` keyword — keeps error-recovery emit aligned with tsc.
+        //
+        // Emit TS1034 at the current token position (matching tsc's
+        // `parseExpectedToken(DotToken, ...)`).
+        let missing_name_pos = self.token_pos();
+        self.parse_error_at_current_token(
+            diagnostic_messages::SUPER_MUST_BE_FOLLOWED_BY_AN_ARGUMENT_LIST_OR_MEMBER_ACCESS,
+            diagnostic_codes::SUPER_MUST_BE_FOLLOWED_BY_AN_ARGUMENT_LIST_OR_MEMBER_ACCESS,
+        );
+
+        // Build `super.<missing>`: a property access whose name is the missing
+        // identifier (NodeIndex::NONE), spanning from `super` to the recovery
+        // point. The dot token is synthetic (no `.` exists in the source).
+        self.arena.add_access_expr(
+            syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION,
+            start_pos,
+            missing_name_pos,
+            AccessExprData {
+                expression: super_node,
+                name_or_argument: NodeIndex::NONE,
+                question_dot_token: false,
+            },
+        )
     }
 
     /// Parse import expression: import(...), import.meta, or import.defer(...)


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — JS emit / parser recovery (emit→100% campaign, wave 3)

## Invariant
When `super` is not followed by `(`, `.`, `[`, or `<` (always a syntax error), the parser recovers by producing a `super.<missing-identifier>` PropertyAccessExpression (expected `.`, missing RHS name) — matching tsc — so it emits `super.` and, in static-member context, flows through the existing static-super downlevel rewrite (empty-key `Reflect.get(base, "", self)`); valid `super(`/`super.`/`super[`/`super<` paths are unchanged.

## Scope
- `crates/tsz-parser/src/parser/state_expressions_literals.rs` — `parse_super_expression` error fall-through builds a PROPERTY_ACCESS_EXPRESSION (expression=super, name=NONE) instead of a lone SuperKeyword. No emitter change (existing missing-name access + static-super lowering handle it).
- `crates/tsz-emitter/tests/super_missing_member_recovery_tests.rs` (new, 5 structural tests incl. static-super lowering + arrow + negative guard).

## Project Corpus Impact
- Row: n/a (emit parity / parser recovery)
- Bug family: bare-`super` error-recovery node shape
- Evidence: superErrors, superAccess2 FAIL→PASS (+ superInLambdas(es2015) bonus).

## Verification
- 3 witnesses FAIL→PASS. **Full --js-only sweep: 13414→13417 pass, 116→113 fail, ZERO new failures** (net +3, set-diff verified). Parser nextest 1043/1043; super checker 76/76; binder 499/499; clippy `-p tsz-parser -p tsz-emitter --all-targets -D warnings` clean.
- Parser change — heavy CI (conformance/fourslash) on this PR will confirm no conformance regression.
- Scope note: remaining static/super witnesses (typeOfThisInStaticMembers12, thisAndSuperInStaticMembers1/2, staticFieldWithInterfaceContext, strictPropertyInitialization, staticInitializersAndLegacyClassDecorators) are class-lowering tangles (this-capture, two-tier temp scoping, field-init ordering) — deferred as dedicated efforts.

## Coordination Notes
Wave-3 fix; structural super-recovery node shape. — opus48-emit100
