### PR TITLE
fix(dts): non-rest binding-element return type uses projected property type, not parameter annotation

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_type_annotations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_type_annotations.rs
@@ -269,6 +269,18 @@ impl<'a> DeclarationEmitter<'a> {
         arena: &NodeArena,
         decl_idx: NodeIndex,
     ) -> Option<NodeIndex> {
+        // A non-rest binding element's type is a single property/element projected
+        // out of the destructured source — not the source's own annotation. The
+        // climb below would otherwise resolve such an element to the enclosing
+        // parameter/variable annotation (the whole destructured value), which is
+        // wrong for an inferred return like
+        // `function f({ name: alias }: Named) { return alias; }` (tsc emits
+        // `string`, not `Named`). A rest element (`{ a, ...rest }`) is the
+        // exception: its type *is* structurally derived from the source annotation
+        // (the source object with the bound keys omitted), so it must still reach
+        // that annotation. Decide that distinction once up front.
+        let starts_in_non_rest_binding_element =
+            Self::declaration_is_non_rest_binding_element(arena, decl_idx);
         let mut current = decl_idx;
         for _ in 0..12 {
             let node = arena.get(current)?;
@@ -281,6 +293,16 @@ impl<'a> DeclarationEmitter<'a> {
             {
                 return Some(current);
             }
+            // Crossing a binding pattern means the annotation above describes the
+            // destructured source, not this element. Bail for non-rest elements so
+            // callers fall back to the solver/cache type (the projected property
+            // type). Rest elements continue up to the source annotation.
+            if (node.kind == syntax_kind_ext::OBJECT_BINDING_PATTERN
+                || node.kind == syntax_kind_ext::ARRAY_BINDING_PATTERN)
+                && starts_in_non_rest_binding_element
+            {
+                return None;
+            }
             let parent = arena.parent_of(current)?;
             if parent.is_none() {
                 break;
@@ -288,6 +310,22 @@ impl<'a> DeclarationEmitter<'a> {
             current = parent;
         }
         None
+    }
+
+    /// Whether `decl_idx` (a symbol declaration node) is the name of a binding
+    /// element that is *not* a rest element (`...x`). Used to decide whether the
+    /// enclosing destructured-source annotation may stand in for the element's
+    /// declared type during declaration emit.
+    fn declaration_is_non_rest_binding_element(arena: &NodeArena, decl_idx: NodeIndex) -> bool {
+        let Some(parent_idx) = arena.parent_of(decl_idx) else {
+            return false;
+        };
+        let Some(parent_node) = arena.get(parent_idx) else {
+            return false;
+        };
+        arena
+            .get_binding_element(parent_node)
+            .is_some_and(|binding| !binding.dot_dot_dot_token && binding.name == decl_idx)
     }
 
     pub(in crate::declaration_emitter) fn emit_type_node_text_from_arena(

--- a/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs
@@ -840,3 +840,72 @@ export function g(value: One | Two) {
         "must not leak the callee's bare type parameter `Source`: {output}"
     );
 }
+
+// A returned *non-rest* destructured binding element must NOT have its declaration
+// emit reuse the enclosing parameter/variable annotation as the inferred return
+// type. The element's type is a property/element projection of the destructured
+// source (tsc emits `string` for `function f({ name: alias }: Named) { return alias; }`,
+// never `Named`). The AST heuristic that resolves a returned identifier to its
+// declared source annotation previously climbed across the binding pattern and
+// surfaced the whole source type; it must now decline so the type comes from the
+// solver/cache instead.
+//
+// Property keys (`name`/`value`), aliases (`alias`/`renamed`), and source shapes
+// (named `Named` vs inline literal, flat vs nested) are all varied so the
+// assertion proves the structural rule rather than one spelling. A trailing rest
+// element (`...rest`) is the deliberate exception: its type *is* derived from the
+// source annotation (the source with bound keys omitted), so it must keep
+// emitting a source-annotation-backed return type.
+#[test]
+fn fix_returned_non_rest_binding_element_is_not_parameter_annotation() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+type Named = { name: string };
+export function renamedAlias({ name: alias }: Named) {
+    return alias;
+}
+export function shorthandProp({ name }: Named) {
+    return name;
+}
+export function inlineLiteralRenamed({ value: renamed }: { value: number }) {
+    return renamed;
+}
+type Outer = { p: Named };
+export function nestedRenamed({ p: { name: inner } }: Outer) {
+    return inner;
+}
+type P = { enum: boolean; one: boolean };
+export function withRest({ enum: _enum, ...rest }: P) {
+    return rest;
+}
+"#,
+    );
+
+    // The bug surfaced the destructured-source annotation as the element's return
+    // type. None of these may appear, regardless of the chosen
+    // property/alias/source spelling.
+    for forbidden in [
+        "renamedAlias({ name: alias }: Named): Named",
+        "shorthandProp({ name }: Named): Named",
+        "nestedRenamed({ p: { name: inner } }: Outer): Named",
+    ] {
+        assert!(
+            !output.contains(forbidden),
+            "non-rest binding element must not inherit the destructured-source annotation as its return type, found `{forbidden}`: {output}"
+        );
+    }
+    // The inline-literal renaming must likewise not surface the source object
+    // literal `{ value: number }` as the return type.
+    assert!(
+        !output.contains("inlineLiteralRenamed({ value: renamed }: {\n    value: number;\n}): {\n    value: number;\n}"),
+        "inline-literal binding element must not return the source object literal: {output}"
+    );
+
+    // The rest element keeps deriving its type from the source annotation (the
+    // destructured source with bound keys omitted), so it must still emit a
+    // source-backed return type rather than declining like the non-rest case.
+    assert!(
+        output.contains("withRest({ enum: _enum, ...rest }: P): "),
+        "rest binding element must still emit a source-annotation-derived return type: {output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — declaration emit parity (emit→100% campaign, wave 3)

## Invariant
A non-rest binding element's declared type is a property/element projection of the destructured source, not the source's own annotation — so the declaration emitter's declared-annotation ancestor climb must not cross an object/array binding pattern for a non-rest element (it falls back to the solver/cache type, which is correct). A rest element (`...rest`) is the exception: its type IS derived from the source annotation (with bound keys omitted), so it still reaches that annotation.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_type_annotations.rs` — `annotation_bearing_declaration_from_arena` bails when crossing an OBJECT/ARRAY binding pattern for a non-rest binding element (new `declaration_is_non_rest_binding_element` helper keyed on `dot_dot_dot_token`).
- tests in `fix_verification_returned.rs` (vary keys/aliases/shapes + rest-element exception).

## Project Corpus Impact
- Row: n/a (declaration emit parity fix)
- Bug family: destructured-binding-element return type using the parameter annotation instead of the projected property type
- Evidence: declarationEmitBindingPatternsUnused (`return alias` of `{ name: alias }: Named`) `: Named` → `: string` FAIL→PASS.

## Verification
- Witness FAIL→PASS. **Full --dts-only sweep: 37→36 fail, ZERO new regressions.** Emitter-only (checker/solver already infer `string` correctly — traced); no conformance risk. Rest-aware (fixed a first-attempt `...rest`→any regression, now both pass). JS unchanged. New structural test (fails without fix); clippy `-p tsz-emitter --all-targets -D warnings` clean.

## Coordination Notes
Wave-3 contained DTS fix; emitter AST-heuristic, structural (§25/§26). Branch name says "checker" but the fix is emitter-side. — opus48-emit100
