### PR TITLE
fix(checker): emit TS2345 for generic arg with stricter type-param constraint (tsc#11703)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -50,51 +50,6 @@ impl<'a> CheckerState<'a> {
         false
     }
 
-    /// Returns `true` when `actual` is a generic function whose every type parameter has a
-    /// constraint, `expected` is a generic function with the same arity but no constraints,
-    /// and both have only a single relevant call signature.
-    ///
-    /// In that shape the mismatch is a constraint-strictness incompatibility that can never
-    /// be resolved by outer inference — deferral would silently drop a real TS2345.
-    pub(crate) fn generic_arg_constraint_mismatch_is_structural(
-        &self,
-        actual: TypeId,
-        expected: TypeId,
-    ) -> bool {
-        use crate::query_boundaries::common::{callable_shape_for_type, function_shape_for_type};
-
-        let source_constraints: Vec<Option<tsz_solver::TypeId>> =
-            if let Some(shape) = function_shape_for_type(self.ctx.types, actual) {
-                shape.type_params.iter().map(|tp| tp.constraint).collect()
-            } else if let Some(shape) = callable_shape_for_type(self.ctx.types, actual) {
-                let Some(sig) = shape.call_signatures.first() else {
-                    return false;
-                };
-                sig.type_params.iter().map(|tp| tp.constraint).collect()
-            } else {
-                return false;
-            };
-
-        if source_constraints.is_empty() || !source_constraints.iter().all(|c| c.is_some()) {
-            return false;
-        }
-
-        let target_constraints: Vec<Option<tsz_solver::TypeId>> =
-            if let Some(shape) = function_shape_for_type(self.ctx.types, expected) {
-                shape.type_params.iter().map(|tp| tp.constraint).collect()
-            } else if let Some(shape) = callable_shape_for_type(self.ctx.types, expected) {
-                let Some(sig) = shape.call_signatures.first() else {
-                    return false;
-                };
-                sig.type_params.iter().map(|tp| tp.constraint).collect()
-            } else {
-                return false;
-            };
-
-        target_constraints.len() == source_constraints.len()
-            && target_constraints.iter().all(|c| c.is_none())
-    }
-
     /// Check if a callable type's parameters contain type parameters within intersections.
     /// This distinguishes narrowed callback parameters (e.g., `(x: number & T) => void`)
     /// from callbacks with standalone enclosing-scope type parameters (e.g., `(x: T) => void`).

--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -50,6 +50,51 @@ impl<'a> CheckerState<'a> {
         false
     }
 
+    /// Returns `true` when `actual` is a generic function whose every type parameter has a
+    /// constraint, `expected` is a generic function with the same arity but no constraints,
+    /// and both have only a single relevant call signature.
+    ///
+    /// In that shape the mismatch is a constraint-strictness incompatibility that can never
+    /// be resolved by outer inference — deferral would silently drop a real TS2345.
+    pub(crate) fn generic_arg_constraint_mismatch_is_structural(
+        &self,
+        actual: TypeId,
+        expected: TypeId,
+    ) -> bool {
+        use crate::query_boundaries::common::{callable_shape_for_type, function_shape_for_type};
+
+        let source_constraints: Vec<Option<tsz_solver::TypeId>> =
+            if let Some(shape) = function_shape_for_type(self.ctx.types, actual) {
+                shape.type_params.iter().map(|tp| tp.constraint).collect()
+            } else if let Some(shape) = callable_shape_for_type(self.ctx.types, actual) {
+                let Some(sig) = shape.call_signatures.first() else {
+                    return false;
+                };
+                sig.type_params.iter().map(|tp| tp.constraint).collect()
+            } else {
+                return false;
+            };
+
+        if source_constraints.is_empty() || !source_constraints.iter().all(|c| c.is_some()) {
+            return false;
+        }
+
+        let target_constraints: Vec<Option<tsz_solver::TypeId>> =
+            if let Some(shape) = function_shape_for_type(self.ctx.types, expected) {
+                shape.type_params.iter().map(|tp| tp.constraint).collect()
+            } else if let Some(shape) = callable_shape_for_type(self.ctx.types, expected) {
+                let Some(sig) = shape.call_signatures.first() else {
+                    return false;
+                };
+                sig.type_params.iter().map(|tp| tp.constraint).collect()
+            } else {
+                return false;
+            };
+
+        target_constraints.len() == source_constraints.len()
+            && target_constraints.iter().all(|c| c.is_none())
+    }
+
     /// Check if a callable type's parameters contain type parameters within intersections.
     /// This distinguishes narrowed callback parameters (e.g., `(x: number & T) => void`)
     /// from callbacks with standalone enclosing-scope type parameters (e.g., `(x: T) => void`).

--- a/crates/tsz-checker/src/error_reporter/call_errors_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_tests.rs
@@ -1659,3 +1659,43 @@ take(h);
             .collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn no_ts2345_for_generic_component_props_contextual_inference() {
+    let source = r#"
+type ComponentProps<T> = T extends (props: infer P) => unknown ? P : never;
+declare function wrapComponent<P>(component: (props: P) => unknown): (props: P) => unknown;
+const WrappedComponent = wrapComponent(
+  <T extends string = "span">(props: { as?: T | undefined; className?: string }) => null,
+);
+type RetrievedProps = ComponentProps<typeof WrappedComponent>;
+"#;
+    let diagnostics = check_source_with_strict_null(source);
+    assert!(
+        !diagnostics.iter().any(|d| d.code == 2345),
+        "Expected contextual generic props inference to stay deferrable, got: {:?}",
+        diagnostics
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn no_ts2345_for_higher_order_generic_callback_inference() {
+    let source = r#"
+declare function f2<T>(cb: <S extends number>(x: S) => T): T;
+declare function f3<T>(cb: <S extends Array<S>>(x: S) => T): T;
+let x2 = f2(x => x);
+let x3 = f3(x => x);
+"#;
+    let diagnostics = check_source_with_strict_null(source);
+    assert!(
+        !diagnostics.iter().any(|d| d.code == 2345),
+        "Expected constrained higher-order callback inference to stay deferrable, got: {:?}",
+        diagnostics
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/tsz-checker/src/error_reporter/call_errors_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_tests.rs
@@ -1596,3 +1596,66 @@ const r = foo({ transform: (x: string) => x.length });
             .collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn ts2345_generic_arg_with_constrained_tp_passed_to_unconstrained_generic_param() {
+    // tsc#11703: `take(g)` must emit TS2345 because `g: <U extends object>(x: U) => U`
+    // has a stricter constraint than the unconstrained `<T>(x: T) => T` that `take` expects.
+    // The mismatch is structural and cannot be resolved by outer inference.
+    let source = r#"
+declare function take<T>(f: (x: T) => T): void;
+declare const g: <U extends object>(x: U) => U;
+take(g);
+"#;
+    let diagnostics = check_source_with_strict_null(source);
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2345),
+        "Expected TS2345 when passing a constrained-TP generic function to an \
+         unconstrained-TP generic parameter, got: {:?}",
+        diagnostics
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn ts2345_generic_arg_constrained_tp_different_names() {
+    // The same rule holds regardless of how the type parameters are named.
+    // `<A extends string>(x: A) => A` passed to `<X>(x: X) => X` must also error.
+    let source = r#"
+declare function take<X>(f: (x: X) => X): void;
+declare const g: <A extends string>(x: A) => A;
+take(g);
+"#;
+    let diagnostics = check_source_with_strict_null(source);
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2345),
+        "Expected TS2345 for constrained-TP generic arg regardless of type param names, \
+         got: {:?}",
+        diagnostics
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn no_ts2345_unconstrained_generic_arg_passed_to_unconstrained_generic_param() {
+    // `<V>(x: V) => V` passed to `<T>(x: T) => T` is structurally compatible — no error.
+    let source = r#"
+declare function take<T>(f: (x: T) => T): void;
+declare const h: <V>(x: V) => V;
+take(h);
+"#;
+    let diagnostics = check_source_with_strict_null(source);
+    assert!(
+        !diagnostics.iter().any(|d| d.code == 2345),
+        "Expected no TS2345 when passing an unconstrained generic function to an \
+         unconstrained generic parameter, got: {:?}",
+        diagnostics
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -3,7 +3,9 @@ use tsz_solver::classes::inheritance::InheritanceGraph;
 use tsz_solver::computation::{TypeSubstitution, evaluate_type, instantiate_type_cached};
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 use tsz_solver::relations::subtype::TypeResolver;
-use tsz_solver::{ObjectShape, PropertyInfo, SubtypeFailureReason, TypeId};
+use tsz_solver::{
+    ObjectShape, ParamInfo, PropertyInfo, SubtypeFailureReason, TypeId, TypeParamInfo,
+};
 
 use crate::state::CheckerState;
 
@@ -272,6 +274,87 @@ pub(crate) fn contextual_callable_member_has_unclassified_generic_parameter_drif
     source_params.len() <= member_sig.params.len()
         && tsz_solver::contains_type_parameters(db, source_param.type_id)
         && tsz_solver::contains_type_parameters(db, member_param.type_id)
+}
+
+fn direct_type_param_name(db: &dyn TypeDatabase, type_id: TypeId) -> Option<Atom> {
+    tsz_solver::type_queries::get_type_parameter_info(db, type_id).map(|info| info.name)
+}
+
+fn signature_uses_only_naked_type_params(
+    db: &dyn TypeDatabase,
+    params: &[ParamInfo],
+    return_type: TypeId,
+    type_params: &[TypeParamInfo],
+) -> bool {
+    if params.is_empty() {
+        return false;
+    }
+    let names: Vec<_> = type_params.iter().map(|tp| tp.name).collect();
+    let params_are_naked = params.iter().all(|param| {
+        direct_type_param_name(db, param.type_id).is_some_and(|name| names.contains(&name))
+    });
+    params_are_naked
+        && direct_type_param_name(db, return_type).is_some_and(|name| names.contains(&name))
+}
+
+fn generic_signature_constraints_and_naked_shape(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<(Vec<Option<TypeId>>, bool)> {
+    if let Some(shape) = tsz_solver::type_queries::get_function_shape(db, type_id) {
+        let constraints = shape.type_params.iter().map(|tp| tp.constraint).collect();
+        let naked = signature_uses_only_naked_type_params(
+            db,
+            &shape.params,
+            shape.return_type,
+            &shape.type_params,
+        );
+        return Some((constraints, naked));
+    }
+    let shape = tsz_solver::type_queries::get_callable_shape_for_type(db, type_id)?;
+    let sig = shape.call_signatures.first()?;
+    let constraints = sig.type_params.iter().map(|tp| tp.constraint).collect();
+    let naked =
+        signature_uses_only_naked_type_params(db, &sig.params, sig.return_type, &sig.type_params);
+    Some((constraints, naked))
+}
+
+/// Return `true` when `actual` is a generic function whose every type parameter
+/// has a constraint, while `expected` is a same-arity generic function whose
+/// type parameters are all unconstrained.
+///
+/// In that shape the mismatch is a constraint-strictness incompatibility that
+/// outer inference cannot repair, so contextual-call diagnostics must not be
+/// deferred away.
+pub(crate) fn generic_arg_constraint_mismatch_is_structural(
+    db: &dyn TypeDatabase,
+    actual: TypeId,
+    expected: TypeId,
+) -> bool {
+    let Some((source_constraints, source_is_naked)) =
+        generic_signature_constraints_and_naked_shape(db, actual)
+    else {
+        return false;
+    };
+    if source_constraints.is_empty()
+        || !source_is_naked
+        || !source_constraints.iter().all(Option::is_some)
+        || !source_constraints
+            .iter()
+            .filter_map(|constraint| *constraint)
+            .any(|constraint| constraint != TypeId::UNKNOWN)
+    {
+        return false;
+    }
+
+    let Some((target_constraints, target_is_naked)) =
+        generic_signature_constraints_and_naked_shape(db, expected)
+    else {
+        return false;
+    };
+    target_is_naked
+        && target_constraints.len() == source_constraints.len()
+        && target_constraints.iter().all(Option::is_none)
 }
 
 pub(crate) fn homomorphic_mapped_source_assignable_to_target<R: TypeResolver>(

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -1585,7 +1585,11 @@ impl<'a> CheckerState<'a> {
             // Do not defer when the actual is a same-arity generic function with all type
             // parameters constrained but the expected has none constrained. That is a
             // structural constraint-strictness mismatch — inference cannot resolve it.
-            if self.generic_arg_constraint_mismatch_is_structural(actual, expected) {
+            if assign_query::generic_arg_constraint_mismatch_is_structural(
+                self.ctx.types,
+                actual,
+                expected,
+            ) {
                 return false;
             }
             return true;

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -1582,6 +1582,12 @@ impl<'a> CheckerState<'a> {
         // Defer callable mismatches only when a callable has its own generic signatures
         // (higher-order inference may still resolve them), not for outer-scope type params.
         if callable_mismatch && (actual_has_generic_signatures || expected_has_generic_signatures) {
+            // Do not defer when the actual is a same-arity generic function with all type
+            // parameters constrained but the expected has none constrained. That is a
+            // structural constraint-strictness mismatch — inference cannot resolve it.
+            if self.generic_arg_constraint_mismatch_is_structural(actual, expected) {
+                return false;
+            }
             return true;
         }
         if !callable_mismatch

--- a/crates/tsz-solver/src/operations/generic_call/contextual_signature_instantiation.rs
+++ b/crates/tsz-solver/src/operations/generic_call/contextual_signature_instantiation.rs
@@ -3,7 +3,7 @@
 use crate::inference::infer::{InferenceContext, InferenceVar};
 use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::operations::{AssignabilityChecker, CallEvaluator};
-use crate::types::{FunctionShape, ParamInfo, TupleElement, TypeId, TypePredicate};
+use crate::types::{FunctionShape, ParamInfo, TupleElement, TypeId, TypeParamInfo, TypePredicate};
 use rustc_hash::FxHashMap;
 
 impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
@@ -181,6 +181,125 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             is_method: target_fn.is_method,
         };
         Some(self.interner.function(instantiated))
+    }
+
+    /// Check whether a generic function argument's type-parameter constraints are
+    /// strictly stronger than the corresponding outer type parameters of the call
+    /// site, which would make the argument structurally incompatible.
+    ///
+    /// Structural rule (mirrors PR #11702's same-arity check for assignment):
+    /// `<U extends C>(x: U) => U` is NOT assignable to `<T>(x: T) => T` when
+    /// `C` strictly narrows `T`'s effective constraint (`unknown` when `T` is
+    /// unconstrained). Only fires when the source and the outer target have the
+    /// same arity (same number of relevant type parameters).
+    ///
+    /// Returns `Some(generic_target_id)` (the reconstructed generic target, used
+    /// as the "expected" type in `ArgumentTypeMismatch`) when the check fails;
+    /// returns `None` when the argument is compatible.
+    pub(crate) fn check_generic_arg_stricter_constraint_mismatch(
+        &mut self,
+        arg_type: TypeId,
+        raw_param_type: TypeId,
+        outer_type_params: &[TypeParamInfo],
+    ) -> Option<TypeId> {
+        if outer_type_params.is_empty() {
+            return None;
+        }
+
+        // Source must be a generic function with at least one constraint.
+        let source_fn = Self::get_contextual_signature_cached(self.interner, arg_type)?;
+        tracing::trace!(
+            arg_type = arg_type.0,
+            source_tp_count = source_fn.type_params.len(),
+            "check_generic_arg_stricter_constraint_mismatch: source_fn"
+        );
+        if source_fn.type_params.is_empty()
+            || !source_fn
+                .type_params
+                .iter()
+                .any(|tp| tp.constraint.is_some())
+        {
+            tracing::trace!(
+                "check_generic_arg_stricter_constraint_mismatch: no constrained tp, skip"
+            );
+            return None;
+        }
+
+        // Quick guard: raw_param_type must reference type parameters at all.
+        if !crate::visitor::contains_type_parameters(self.interner, raw_param_type) {
+            tracing::trace!(
+                raw_param_type = raw_param_type.0,
+                "check_generic_arg_stricter_constraint_mismatch: no type params in raw_param_type, skip"
+            );
+            return None;
+        }
+
+        // Get the target fn shape first so we know which names are local
+        // (bound inside raw_param_type itself, e.g. `<V>(x: T, y: V) => T`).
+        let target_fn = Self::get_contextual_signature_cached(self.interner, raw_param_type)?;
+        let local_tp_names: rustc_hash::FxHashSet<tsz_common::Atom> =
+            target_fn.type_params.iter().map(|tp| tp.name).collect();
+
+        // Collect outer type param names that appear (non-locally) in raw_param_type.
+        // TypeParameters created with `fresh_type_param` have unique TypeIds that
+        // won't match a re-interned version, so we match by name (Atom) instead of TypeId.
+        let all_tp_names_in_param: rustc_hash::FxHashSet<tsz_common::Atom> =
+            crate::visitor::collect_all_types(self.interner, raw_param_type)
+                .into_iter()
+                .filter_map(|ty| crate::type_param_info(self.interner.as_type_database(), ty))
+                .map(|info| info.name)
+                .filter(|name| !local_tp_names.contains(name))
+                .collect();
+
+        let relevant_outer_tps: Vec<&TypeParamInfo> = outer_type_params
+            .iter()
+            .filter(|tp| all_tp_names_in_param.contains(&tp.name))
+            .collect();
+
+        tracing::trace!(
+            relevant_count = relevant_outer_tps.len(),
+            source_tp_count = source_fn.type_params.len(),
+            "check_generic_arg_stricter_constraint_mismatch: arity check"
+        );
+
+        // Only apply when the outer target arity matches the source arity.
+        if relevant_outer_tps.is_empty() || relevant_outer_tps.len() != source_fn.type_params.len()
+        {
+            tracing::trace!("check_generic_arg_stricter_constraint_mismatch: arity mismatch, skip");
+            return None;
+        }
+
+        // Build a locally-generic version of the target function by promoting the
+        // outer type params to local quantifiers. This is equivalent to what tsc
+        // does when it reconstructs a canonical `<T>(x: T) => T` generic for the
+        // comparison — the outer T becomes a fresh local quantifier, and the
+        // PR #11702 same-arity constraint check in `checking.rs` handles the rest.
+        let generic_target = FunctionShape {
+            type_params: relevant_outer_tps.iter().map(|&&tp| tp).collect(),
+            params: target_fn.params.clone(),
+            return_type: target_fn.return_type,
+            this_type: target_fn.this_type,
+            type_predicate: target_fn.type_predicate.clone(),
+            is_constructor: target_fn.is_constructor,
+            is_method: target_fn.is_method,
+        };
+        let generic_target_id = self.interner.function(generic_target);
+
+        // Delegate to the standard assignability check. PR #11702's fix in
+        // `checking.rs` (same-arity generic constraint comparison) handles
+        // detecting when the source constraint is strictly stronger.
+        let assignable = self.checker.is_assignable_to(arg_type, generic_target_id);
+        tracing::trace!(
+            arg_type = arg_type.0,
+            generic_target_id = generic_target_id.0,
+            assignable,
+            "check_generic_arg_stricter_constraint_mismatch: assignability result"
+        );
+        if assignable {
+            return None;
+        }
+
+        Some(generic_target_id)
     }
 
     pub(super) fn conflicting_contextual_param_candidate_substitution(

--- a/crates/tsz-solver/src/operations/generic_call/contextual_signature_instantiation.rs
+++ b/crates/tsz-solver/src/operations/generic_call/contextual_signature_instantiation.rs
@@ -7,6 +7,28 @@ use crate::types::{FunctionShape, ParamInfo, TupleElement, TypeId, TypeParamInfo
 use rustc_hash::FxHashMap;
 
 impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
+    fn direct_type_param_name(&self, type_id: TypeId) -> Option<tsz_common::Atom> {
+        crate::type_param_info(self.interner.as_type_database(), type_id).map(|info| info.name)
+    }
+
+    fn function_uses_only_naked_type_params(
+        &self,
+        func: &FunctionShape,
+        names: &[tsz_common::Atom],
+    ) -> bool {
+        if func.params.is_empty() {
+            return false;
+        }
+        let params_are_naked = func.params.iter().all(|param| {
+            self.direct_type_param_name(param.type_id)
+                .is_some_and(|name| names.contains(&name))
+        });
+        params_are_naked
+            && self
+                .direct_type_param_name(func.return_type)
+                .is_some_and(|name| names.contains(&name))
+    }
+
     pub(super) fn constrain_return_context_params_with_rest(
         &mut self,
         infer_ctx: &mut InferenceContext<'_>,
@@ -213,14 +235,23 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             source_tp_count = source_fn.type_params.len(),
             "check_generic_arg_stricter_constraint_mismatch: source_fn"
         );
-        if source_fn.type_params.is_empty()
-            || !source_fn
-                .type_params
-                .iter()
-                .any(|tp| tp.constraint.is_some())
+        let source_tp_names: Vec<_> = source_fn.type_params.iter().map(|tp| tp.name).collect();
+        let all_source_tps_constrained = source_fn
+            .type_params
+            .iter()
+            .all(|tp| tp.constraint.is_some());
+        let has_strict_source_constraint = source_fn
+            .type_params
+            .iter()
+            .filter_map(|tp| tp.constraint)
+            .any(|constraint| constraint != TypeId::UNKNOWN);
+        if source_tp_names.is_empty()
+            || !all_source_tps_constrained
+            || !has_strict_source_constraint
+            || !self.function_uses_only_naked_type_params(&source_fn, &source_tp_names)
         {
             tracing::trace!(
-                "check_generic_arg_stricter_constraint_mismatch: no constrained tp, skip"
+                "check_generic_arg_stricter_constraint_mismatch: source shape is not strict naked generic, skip"
             );
             return None;
         }
@@ -240,16 +271,29 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         let local_tp_names: rustc_hash::FxHashSet<tsz_common::Atom> =
             target_fn.type_params.iter().map(|tp| tp.name).collect();
 
-        // Collect outer type param names that appear (non-locally) in raw_param_type.
-        // TypeParameters created with `fresh_type_param` have unique TypeIds that
-        // won't match a re-interned version, so we match by name (Atom) instead of TypeId.
-        let all_tp_names_in_param: rustc_hash::FxHashSet<tsz_common::Atom> =
-            crate::visitor::collect_all_types(self.interner, raw_param_type)
-                .into_iter()
-                .filter_map(|ty| crate::type_param_info(self.interner.as_type_database(), ty))
-                .map(|info| info.name)
-                .filter(|name| !local_tp_names.contains(name))
-                .collect();
+        let outer_tp_names: Vec<_> = outer_type_params.iter().map(|tp| tp.name).collect();
+        if !self.function_uses_only_naked_type_params(&target_fn, &outer_tp_names) {
+            tracing::trace!(
+                "check_generic_arg_stricter_constraint_mismatch: target shape is not naked outer generic, skip"
+            );
+            return None;
+        }
+
+        let mut all_tp_names_in_param = Vec::new();
+        for ty in target_fn
+            .params
+            .iter()
+            .map(|param| param.type_id)
+            .chain(std::iter::once(target_fn.return_type))
+        {
+            let name = self.direct_type_param_name(ty)?;
+            if local_tp_names.contains(&name) {
+                return None;
+            }
+            if !all_tp_names_in_param.contains(&name) {
+                all_tp_names_in_param.push(name);
+            }
+        }
 
         let relevant_outer_tps: Vec<&TypeParamInfo> = outer_type_params
             .iter()
@@ -300,6 +344,25 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         }
 
         Some(generic_target_id)
+    }
+
+    pub(crate) fn arg_mismatch(
+        &mut self,
+        arg_type: TypeId,
+        raw_param_type: TypeId,
+        final_param_type: TypeId,
+        func: &FunctionShape,
+    ) -> Option<TypeId> {
+        if let Some(expected) =
+            self.conflicting_contextual_signature_instantiation_type(arg_type, final_param_type)
+        {
+            return Some(expected);
+        }
+        self.check_generic_arg_stricter_constraint_mismatch(
+            arg_type,
+            raw_param_type,
+            &func.type_params,
+        )
     }
 
     pub(super) fn conflicting_contextual_param_candidate_substitution(

--- a/crates/tsz-solver/src/operations/generic_call/contextual_signature_instantiation.rs
+++ b/crates/tsz-solver/src/operations/generic_call/contextual_signature_instantiation.rs
@@ -279,7 +279,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             params: target_fn.params.clone(),
             return_type: target_fn.return_type,
             this_type: target_fn.this_type,
-            type_predicate: target_fn.type_predicate.clone(),
+            type_predicate: target_fn.type_predicate,
             is_constructor: target_fn.is_constructor,
             is_method: target_fn.is_method,
         };

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -2965,6 +2965,24 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                         fallback_return: TypeId::ERROR,
                     };
                 }
+                if let Some(expected) = self.check_generic_arg_stricter_constraint_mismatch(
+                    arg_type,
+                    raw_param_type,
+                    &func.type_params,
+                ) {
+                    tracing::debug!(
+                        index = i,
+                        arg_type = arg_type.0,
+                        expected = expected.0,
+                        "check_generic_arg_stricter_constraint_mismatch: returning ArgumentTypeMismatch"
+                    );
+                    return CallResult::ArgumentTypeMismatch {
+                        index: i,
+                        expected,
+                        actual: arg_type,
+                        fallback_return: TypeId::ERROR,
+                    };
+                }
             }
         }
         let final_args: Vec<TypeId> = arg_types

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -2955,27 +2955,8 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 };
                 let final_param_type =
                     instantiate_type(self.interner, raw_param_type, &final_subst);
-                if let Some(expected) = self
-                    .conflicting_contextual_signature_instantiation_type(arg_type, final_param_type)
-                {
-                    return CallResult::ArgumentTypeMismatch {
-                        index: i,
-                        expected,
-                        actual: arg_type,
-                        fallback_return: TypeId::ERROR,
-                    };
-                }
-                if let Some(expected) = self.check_generic_arg_stricter_constraint_mismatch(
-                    arg_type,
-                    raw_param_type,
-                    &func.type_params,
-                ) {
-                    tracing::debug!(
-                        index = i,
-                        arg_type = arg_type.0,
-                        expected = expected.0,
-                        "check_generic_arg_stricter_constraint_mismatch: returning ArgumentTypeMismatch"
-                    );
+                let mismatch = self.arg_mismatch(arg_type, raw_param_type, final_param_type, func);
+                if let Some(expected) = mismatch {
                     return CallResult::ArgumentTypeMismatch {
                         index: i,
                         expected,

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -8,4 +8,3 @@ TypeScript/tests/cases/compiler/reorderProperties.ts
 TypeScript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
 TypeScript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference1.ts
-TypeScript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolIndexer5.ts


### PR DESCRIPTION
## Summary

AgentName: M4-C
Track: M4-C / Conformance / TS2345 parity
Invariant: When a constrained generic function is passed as an argument to a parameter expecting an unconstrained naked same-arity generic function, tsz must emit TS2345 to match tsc without regressing contextual higher-order inference.

### Problem

Given:

```typescript
declare function take<T>(f: (x: T) => T): void;
declare const g: <U extends object>(x: U) => U;
take(g); // tsc: TS2345
```

tsc rejects the call because the argument generic has a stricter type-parameter constraint than the expected same-arity generic parameter. tsz was incorrectly allowing this path to be deferred away.

### Fix

The solver detects stricter generic-argument constraints during contextual signature instantiation only for naked same-arity generic function shapes like `<U extends object>(x: U) => U` against `<T>(x: T) => T`. It skips inference-owned wrapper shapes, including prop-object contextual inference and higher-order callback inference, and treats `extends unknown` as non-strict.

The checker deferral guard routes the matching structural helper through `query_boundaries::assignability`, keeping the diagnostic decision behind the checker boundary.

The PR is rebased over the architecture-ratchet repairs and keeps `generic_call/resolve.rs` below the current line-count baseline by routing the resolver-facing decision through `arg_mismatch`.

## Scope

- `crates/tsz-solver/src/operations/generic_call/contextual_signature_instantiation.rs` — detect stricter naked generic-argument constraints while preserving inference-owned generic wrappers.
- `crates/tsz-solver/src/operations/generic_call/resolve.rs` — call the combined contextual generic mismatch helper without growing the oversized resolver.
- `crates/tsz-checker/src/query_boundaries/assignability.rs` — host the structural same-arity constraint helper behind the assignability boundary.
- `crates/tsz-checker/src/types/computation/call_result.rs` — prevent deferral for structural constraint-strictness mismatches.
- `crates/tsz-checker/src/error_reporter/call_errors_tests.rs` — cover the exact repro, renamed type parameters, unconstrained negative case, and two conformance regression guards.
- `scripts/conformance/conformance-accepted-regressions.txt` — remove stale `parserSymbolIndexer5.ts` accepted regression resolved by the ready CI run.

## Project Corpus Impact

- Row: `genericCallWithGenericSignatureArguments` family
- Bug family: TS2345 missing diagnostic for constrained naked generic function argument passed to unconstrained generic parameter
- Evidence: Focused checker unit coverage plus targeted conformance filters for `genericCallInferenceConditionalType2` and `genericFunctionParameters` pass locally; full conformance/project corpus remains CI-owned per repo policy.

## Verification

Local on refreshed head `b116f337a00`:

```bash
cargo fmt --check
# passed

git diff --check origin/main..HEAD
# passed

python3 scripts/arch/arch_guard.py
# passed

cargo nextest run -p tsz-checker --lib -E 'test(~ts2345_generic_arg) + test(~no_ts2345_unconstrained) + test(~generic_component_props) + test(~higher_order_generic_callback)'
# 5 tests passed

./scripts/conformance/conformance.sh run --filter genericCallInferenceConditionalType2 --test-dir /Users/mohsen/code/tsz/TypeScript/tests/cases --verbose
# 1/1 passed

./scripts/conformance/conformance.sh run --filter genericFunctionParameters --test-dir /Users/mohsen/code/tsz/TypeScript/tests/cases --verbose
# 1/1 passed
```

Local before the final moving-main rebase, after the same code changes:

```bash
scripts/safe-run.sh scripts/ci/github-suite.sh lint
# passed
```

CI:

- Awaiting exact-head ready checks for `b116f337a00`.

## Coordination Notes

- AgentName: M4-C
- Took over this previously unlabelled draft because it is M4-C-lane contextual generic call work.
- #11719 cleared the unrelated latest-main architecture-ratchet blocker; this branch has been repeatedly rebased over current main while the queue advanced.
- Builds on PR #11702's same-arity generic constraint comparison.
- Do not enqueue until exact-head ready PR checks are green.
