### PR TITLE
fix(dts): follow alias/export-= portability chain for class heritage instead of synthesizing declare const _base

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -1345,23 +1345,25 @@ impl<'a> DeclarationEmitter<'a> {
     fn constructor_reference_resolves_to_class(&self, expr_idx: NodeIndex) -> bool {
         if let Some(sym_id) = self.value_reference_symbol(expr_idx)
             && let Some(binder) = self.binder
-            && binder.lib_symbol_ids.contains(&sym_id)
         {
-            return true;
-        }
+            if binder.lib_symbol_ids.contains(&sym_id) {
+                return true;
+            }
 
-        if let Some(sym_id) = self.value_reference_symbol(expr_idx)
-            && let Some(binder) = self.binder
-            && let Some(symbol) = binder.symbols.get(sym_id)
-            && (symbol.flags & symbol_flags::CLASS != 0
-                || symbol.declarations.iter().copied().any(|decl_idx| {
-                    self.arena.get(decl_idx).is_some_and(|decl_node| {
-                        decl_node.kind == syntax_kind_ext::CLASS_DECLARATION
-                            || decl_node.kind == syntax_kind_ext::CLASS_EXPRESSION
-                    })
-                }))
-        {
-            return true;
+            // The heritage reference may be an import alias (e.g.
+            // `import { EventEmitter } from "events"`) or a re-export alias
+            // (`export = ...`) whose local binding carries no class flag itself.
+            // Follow the alias/portability chain so a class declared in another
+            // module is recognized as a constructor reference, matching tsc's
+            // direct `extends <name>` emit instead of synthesizing a `_base`
+            // const.
+            let resolved_sym_id = self.resolve_portability_declaration_symbol(sym_id, binder);
+            if self.symbol_is_class_constructor(sym_id, binder)
+                || self.symbol_is_class_constructor(resolved_sym_id, binder)
+                || self.symbol_value_meaning_is_class_constructor(resolved_sym_id, binder)
+            {
+                return true;
+            }
         }
 
         let Some(expr_name) = self.get_identifier_text(expr_idx) else {
@@ -1372,6 +1374,53 @@ impl<'a> DeclarationEmitter<'a> {
                 self.get_identifier_text(class.name).as_deref() == Some(expr_name.as_str())
             })
         })
+    }
+
+    /// Whether `sym_id` denotes a class constructor value: it carries the
+    /// `CLASS` symbol flag or is backed by a class declaration/expression.
+    fn symbol_is_class_constructor(&self, sym_id: SymbolId, binder: &BinderState) -> bool {
+        let Some(symbol) = binder.symbols.get(sym_id) else {
+            return false;
+        };
+        symbol.flags & symbol_flags::CLASS != 0
+            || symbol.declarations.iter().copied().any(|decl_idx| {
+                self.arena.get(decl_idx).is_some_and(|decl_node| {
+                    decl_node.kind == syntax_kind_ext::CLASS_DECLARATION
+                        || decl_node.kind == syntax_kind_ext::CLASS_EXPRESSION
+                })
+            })
+    }
+
+    /// Whether the *value* meaning of `sym_id` is a class constructor that was
+    /// merged into a same-named namespace/module.
+    ///
+    /// This is the classic ambient pattern `namespace N { class N {} } export = N`
+    /// (e.g. `@types/node`'s `events`): the exported symbol is the namespace,
+    /// but its self-named member is a class, so a reference to `N` as a value is
+    /// a class constructor. tsc emits `extends N` directly here rather than
+    /// synthesizing a `_base` const. The match is structural (member name equals
+    /// the namespace's own name); no specific identifier is hard-coded.
+    fn symbol_value_meaning_is_class_constructor(
+        &self,
+        sym_id: SymbolId,
+        binder: &BinderState,
+    ) -> bool {
+        let Some(symbol) = binder.symbols.get(sym_id) else {
+            return false;
+        };
+        if symbol.flags & (symbol_flags::VALUE_MODULE | symbol_flags::NAMESPACE_MODULE) == 0 {
+            return false;
+        }
+        let Some(exports) = symbol.exports.as_ref() else {
+            return false;
+        };
+        let Some(self_member) = exports.get(symbol.escaped_name.as_str()) else {
+            return false;
+        };
+        if self_member == sym_id {
+            return false;
+        }
+        self.symbol_is_class_constructor(self_member, binder)
     }
 
     pub(in crate::declaration_emitter) fn js_extends_entity_reference_has_any_annotation(

--- a/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
@@ -1180,3 +1180,149 @@ export class Person extends Base {
         "Expected inherited this-indexed method call surface: {output}"
     );
 }
+
+// =============================================================================
+// JS heritage references to imported / re-exported classes
+//
+// Structural rule: when a JS class `extends X` and `X` resolves (through an
+// import alias or `export =` re-export) to a class constructor — including the
+// classic `namespace N { class N {} } export = N` value-meaning merge — tsc
+// emits `extends X` directly instead of synthesizing a `declare const X_base`
+// alias. The synthetic `_base` alias is only for non-nameable heritage
+// expressions (mixin calls, anonymous constructors, `any` values, etc.).
+// =============================================================================
+
+#[test]
+fn test_js_extends_export_equals_namespace_class_merge_stays_nameable() {
+    // `import { EventEmitter }` resolves through `export = EventEmitter` to the
+    // namespace whose self-named member is `class EventEmitter`. Its value
+    // meaning is a class constructor, so no `_base` alias is synthesized.
+    let source = r#"
+declare module "events" {
+    namespace EventEmitter {
+        class EventEmitter {
+            constructor();
+        }
+    }
+    export = EventEmitter;
+}
+import { EventEmitter } from "events";
+export class Listener extends EventEmitter {
+}
+"#;
+    let output = emit_js_dts_with_usage_analysis(source);
+    assert!(
+        output.contains("export class Listener extends EventEmitter {"),
+        "Expected imported namespace+class merge heritage to stay nameable: {output}"
+    );
+    assert!(
+        !output.contains("Listener_base"),
+        "Did not expect a synthetic base alias for an imported class constructor: {output}"
+    );
+}
+
+#[test]
+fn test_js_extends_export_equals_namespace_class_merge_rename_independent() {
+    // Same rule, different identifier spellings: the match is structural
+    // (member name equals the namespace's own name), not keyed on a specific
+    // identifier such as `EventEmitter`.
+    let source = r#"
+declare module "ui-widget" {
+    namespace Gadget {
+        class Gadget {
+            constructor();
+        }
+    }
+    export = Gadget;
+}
+import { Gadget } from "ui-widget";
+export class Panel extends Gadget {
+}
+"#;
+    let output = emit_js_dts_with_usage_analysis(source);
+    assert!(
+        output.contains("export class Panel extends Gadget {"),
+        "Expected the rule to hold for arbitrary identifier spellings: {output}"
+    );
+    assert!(
+        !output.contains("Panel_base"),
+        "Did not expect a synthetic base alias for a renamed imported class: {output}"
+    );
+}
+
+#[test]
+fn test_js_extends_imported_nested_namespace_class_stays_nameable() {
+    // `import { Inner }` re-exported as `export = a.b` resolves to the class
+    // `Inner` declared in the nested namespace — a class constructor, so the
+    // heritage stays nameable.
+    let source = r#"
+declare module "nested-mod" {
+    namespace a.b {
+        class Inner { }
+    }
+    export = a.b;
+}
+import { Inner } from "nested-mod";
+export class Outer extends Inner {
+}
+"#;
+    let output = emit_js_dts_with_usage_analysis(source);
+    assert!(
+        output.contains("export class Outer extends Inner {"),
+        "Expected nested-namespace re-exported class heritage to stay nameable: {output}"
+    );
+    assert!(
+        !output.contains("Outer_base"),
+        "Did not expect a synthetic base alias for a nested re-exported class: {output}"
+    );
+}
+
+#[test]
+fn test_js_extends_imported_namespace_without_class_member_is_not_class_constructor() {
+    // Negative case: the imported namespace's self-named member is a *variable*,
+    // not a class, so its value meaning is NOT a class constructor. The new
+    // nameability rule keys on a class member, so it must not flip on here and
+    // produce a `class Probe` declaration in the heritage merge. (`tsc` would
+    // error on extending a non-constructor; we only assert tsz does not treat
+    // the value-meaning as a class.)
+    let with_class = emit_js_dts_with_usage_analysis(
+        r#"
+declare module "klass-mod" {
+    namespace Probe {
+        class Probe {
+            constructor();
+        }
+    }
+    export = Probe;
+}
+import { Probe } from "klass-mod";
+export class C1 extends Probe {
+}
+"#,
+    );
+    let with_value = emit_js_dts_with_usage_analysis(
+        r#"
+declare module "value-mod" {
+    namespace Probe {
+        let Probe: number;
+    }
+    export = Probe;
+}
+import { Probe } from "value-mod";
+export class C2 extends Probe {
+}
+"#,
+    );
+    // The class-member case stays nameable (no `_base` alias).
+    assert!(
+        with_class.contains("export class C1 extends Probe {") && !with_class.contains("C1_base"),
+        "Expected the class-member merge to keep heritage nameable: {with_class}"
+    );
+    // The non-class-member case must NOT be recognized by the class-constructor
+    // value-meaning rule: it does not get the nameable-class treatment that the
+    // class case does. The two outputs must differ in heritage handling.
+    assert!(
+        with_value.contains("C2_base") || !with_value.contains("extends Probe {"),
+        "Expected a non-class same-named member to not be treated as a class constructor: {with_value}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — declaration emit parity (emit→100% campaign, wave 3)

## Invariant
When a JS class `extends X` and `X` resolves — through an import alias or `export =` re-export, including the `namespace N { class N {} } export = N` value-meaning merge — to a class constructor, `tsc` emits `extends X` directly. This makes tsz follow that alias/portability chain (and recognize the namespace's self-named class member) instead of synthesizing a spurious `declare const X_base` const. The match is structural (resolved-symbol class flag/decl, or member name == namespace's own name) — no identifier/file/alias names hard-coded, no printer-output inspection.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs` — `constructor_reference_resolves_to_class` now resolves through `resolve_portability_declaration_symbol`; adds `symbol_is_class_constructor` and `symbol_value_meaning_is_class_constructor`.
- `crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs` — 4 structural unit tests.

## Project Corpus Impact
- Row: n/a (declaration emit parity fix)
- Bug family: DTS class-heritage alias/portability resolution (spurious `declare const X_base`)
- Evidence: importDeclFromTypeNodeInJsSource FAIL→PASS; full --dts-only 35→34.

## Verification
- Witness `importDeclFromTypeNodeInJsSource` FAIL→PASS. **Full --dts-only: 1634/1669 → 1635/1669 (35→34 fail), net +1, ZERO regressions** (set diff: regressions NONE, fixed [importDeclFromTypeNodeInJsSource]).
- 4 new structural unit tests (two identifier spellings to prove rename-independence, a nested-namespace re-export case, a negative non-class-member case). Full tsz-emitter suite: same 32 pre-existing failures with/without the change (verified by revert+rerun). Clippy clean. JS surface unaffected (changed fn only reachable from declaration-emit heritage).
- §25/§26 compliant.

## Coordination Notes
Wave-3 contained DTS fix. Scoped out (broad, not forced): `jsDeclarationEmitExportedClassWithExtends` (needs binder nodenext package.json `exports` + transitive `export *` resolution — `resolve_import_symbol` returns None); `declarationEmitInferredTypeAlias4` (different family: function-local recursive type-alias inlining). — opus48-emit100
