### PR TITLE
fix(emit): sound ES5 converted-loop capture (nested-loop detection, binding param threading, name-shadowing) + spread receiver temp

### DIFF
--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -636,6 +636,15 @@ pub struct Printer<'a> {
     /// as `var _a, _b, ...;`. Used for assignment targets in helper expressions.
     pub(crate) hoisted_assignment_temps: Vec<String>,
 
+    /// Depth of converted-loop IIFE bodies currently being emitted. Greater than
+    /// zero while emitting directly inside a `_loop_N` body.
+    pub(crate) loop_iife_body_depth: u32,
+
+    /// Spread-call receiver temps (`var _a;`) that belong to the converted-loop
+    /// IIFE body currently being emitted, flushed at that body's top. Saved and
+    /// restored per IIFE so nested loops keep their own.
+    pub(crate) loop_iife_pending_hoisted_temps: Vec<String>,
+
     /// File-level class temps reserved ahead of legacy decorator computed-name temps.
     pub(crate) hoisted_file_level_class_temps: Vec<String>,
 

--- a/crates/tsz-emitter/src/emitter/core_setup.rs
+++ b/crates/tsz-emitter/src/emitter/core_setup.rs
@@ -340,6 +340,8 @@ impl<'a> Printer<'a> {
             preallocated_logical_assignment_value_temps: VecDeque::new(),
             preallocated_assignment_temps: VecDeque::new(),
             hoisted_assignment_temps: Vec::new(),
+            loop_iife_body_depth: 0,
+            loop_iife_pending_hoisted_temps: Vec::new(),
             hoisted_file_level_class_temps: Vec::new(),
             block_scoped_private_temps: Vec::new(),
             cjs_destructuring_export_temps: Vec::new(),

--- a/crates/tsz-emitter/src/emitter/es5/bindings_for_of.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings_for_of.rs
@@ -238,22 +238,30 @@ impl<'a> Printer<'a> {
             let body_info =
                 super::loop_capture::collect_loop_body_vars(self.arena, for_in_of.statement);
             if (!init_vars.is_empty() || !body_info.block_scoped_vars.is_empty())
-                && let Some(capture_info) = super::loop_capture::check_loop_needs_capture(
+                && super::loop_capture::check_loop_needs_capture(
                     self.arena,
                     for_in_of.statement,
                     &init_vars,
                     &body_info.block_scoped_vars,
                 )
+                .is_some()
             {
-                let init_var_set: std::collections::HashSet<&str> =
-                    init_vars.iter().map(String::as_str).collect();
-                let param_vars: Vec<String> = capture_info
-                    .captured_vars
-                    .iter()
-                    .filter(|v| init_var_set.contains(v.as_str()))
-                    .cloned()
-                    .collect();
+                // Once a for-of loop is converted, all of its own block-scoped
+                // binding variables (the for-of binding, including destructured
+                // names) are threaded as `_loop_N` parameters so each iteration
+                // gets a fresh copy — not just the subset captured by a closure.
+                let param_vars: Vec<String> = init_vars.to_vec();
                 let loop_fn_name = self.ctx.block_scope_state.next_loop_function_name();
+                // The per-iteration binding's destructuring source temp (e.g.
+                // `_b` in `var _b = _a[_i], value = _b[0], i = _b[1]`) is emitted
+                // in the loop header, after the loop function. tsc allocates that
+                // temp before any temp produced inside the loop body, so reserve
+                // it now to keep the global temp numbering aligned.
+                let binding_temp_count =
+                    self.count_for_of_binding_destructure_temps(for_in_of.initializer);
+                if binding_temp_count > 0 {
+                    self.preallocate_temp_names(binding_temp_count);
+                }
                 let body_temp_count =
                     self.count_downlevel_expression_hoisted_temps(for_in_of.statement);
                 if body_temp_count > 0 {
@@ -565,6 +573,64 @@ impl<'a> Printer<'a> {
             || self.arena.get_constructor(node).is_some()
             || self.arena.get_accessor(node).is_some()
             || self.arena.get_class(node).is_some()
+    }
+
+    /// Count the destructuring source temps that the array-indexed for-of value
+    /// binding will allocate for a `let`/`const`/`var` binding pattern. This
+    /// mirrors the temp-allocating branches of
+    /// `emit_for_of_value_binding_array_es5` so the converted-loop path can
+    /// reserve them in tsc's order. Single-binding patterns that inline the
+    /// element expression allocate no temp.
+    pub(in crate::emitter) fn count_for_of_binding_destructure_temps(
+        &self,
+        initializer: NodeIndex,
+    ) -> usize {
+        let Some(init_node) = self.arena.get(initializer) else {
+            return 0;
+        };
+        if init_node.kind != syntax_kind_ext::VARIABLE_DECLARATION_LIST {
+            return 0;
+        }
+        let Some(decl_list) = self.arena.get_variable(init_node) else {
+            return 0;
+        };
+        // for-of allows a single declarator; only the first is processed.
+        let Some(&decl_idx) = decl_list.declarations.nodes.first() else {
+            return 0;
+        };
+        let Some(decl_node) = self.arena.get(decl_idx) else {
+            return 0;
+        };
+        let Some(decl) = self.arena.get_variable_declaration(decl_node) else {
+            return 0;
+        };
+        if !self.is_binding_pattern(decl.name) {
+            return 0;
+        }
+        let Some(pattern_node) = self.arena.get(decl.name) else {
+            return 0;
+        };
+        if self.binding_pattern_is_empty(decl.name) {
+            // Empty pattern: one temp holds the advanced element value.
+            return 1;
+        }
+        if pattern_node.kind == syntax_kind_ext::OBJECT_BINDING_PATTERN {
+            let (obj_count, obj_rest) = self.count_effective_bindings(pattern_node);
+            // Single-property object patterns inline; multi/rest extract a temp.
+            return usize::from(obj_count > 1 || obj_rest);
+        }
+        // Array binding pattern.
+        let (effective_count, has_rest) = self.count_effective_bindings(pattern_node);
+        if effective_count == 1 && !has_rest {
+            // Single element at index 0 inlines as `name = arr[idx][0]`.
+            return 0;
+        }
+        if effective_count == 0 && has_rest {
+            // Rest-only inlines as `name = arr[idx].slice(0)`.
+            return 0;
+        }
+        // Multi-binding or complex array pattern extracts a source temp.
+        1
     }
 
     pub(in crate::emitter) fn estimate_for_of_assignment_temp_reserve(

--- a/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
@@ -1970,12 +1970,48 @@ impl<'a> Printer<'a> {
             return;
         };
 
-        // Emit: obj.method.apply(obj, args_array)
+        // The receiver is emitted twice (once as the property base, once as the
+        // `apply` `thisArg`). When it is a non-simple expression (anything other
+        // than an identifier, `this`, or a literal), evaluating it twice would be
+        // observable, so tsc captures it once into a hoisted temp and reuses it:
+        // `(_a = obj.prop).method.apply(_a, args)`.
+        if crate::transforms::emit_utils::is_simple_copiable_expression(
+            self.arena,
+            access.expression,
+        ) {
+            self.emit(access.expression);
+            if access_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+                self.write(".");
+                self.emit(access.name_or_argument);
+            } else {
+                self.write("[");
+                self.emit(access.name_or_argument);
+                self.write("]");
+            }
+            self.write(".apply(");
+            self.emit(access.expression);
+            self.write(", ");
+            self.emit_spread_args_array(&args.nodes);
+            self.write(")");
+            return;
+        }
+
+        let receiver_temp = self.make_unique_name_hoisted_assignment_fresh();
+        self.write("(");
+        self.write(&receiver_temp);
+        self.write(" = ");
         self.emit(access.expression);
-        self.write(".");
-        self.emit(access.name_or_argument);
+        self.write(")");
+        if access_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            self.write(".");
+            self.emit(access.name_or_argument);
+        } else {
+            self.write("[");
+            self.emit(access.name_or_argument);
+            self.write("]");
+        }
         self.write(".apply(");
-        self.emit(access.expression);
+        self.write(&receiver_temp);
         self.write(", ");
         self.emit_spread_args_array(&args.nodes);
         self.write(")");

--- a/crates/tsz-emitter/src/emitter/es5/loop_capture.rs
+++ b/crates/tsz-emitter/src/emitter/es5/loop_capture.rs
@@ -329,22 +329,19 @@ impl<'a> Printer<'a> {
         &mut self,
         _node: &Node,
         loop_stmt: &tsz_parser::parser::node::LoopData,
-        capture_info: &LoopCaptureInfo,
+        _capture_info: &LoopCaptureInfo,
         init_vars: &[String],
         body_info: &LoopBodyVarInfo,
     ) {
         let loop_fn_name = self.ctx.block_scope_state.next_loop_function_name();
 
-        // Only initializer let/const vars are passed as IIFE parameters.
-        // Body-scoped let/const vars get fresh scope inside the IIFE automatically.
-        let init_var_set: std::collections::HashSet<&str> =
-            init_vars.iter().map(String::as_str).collect();
-        let param_vars: Vec<String> = capture_info
-            .captured_vars
-            .iter()
-            .filter(|v| init_var_set.contains(v.as_str()))
-            .cloned()
-            .collect();
+        // Once a loop is converted, ALL of the loop's own block-scoped binding
+        // variables become `_loop_N` parameters so each iteration receives a
+        // fresh copy of its iteration variable — regardless of whether a given
+        // binding is the one actually captured by a closure. Body-scoped
+        // let/const vars get fresh scope inside the IIFE automatically and are
+        // not threaded as parameters.
+        let param_vars: Vec<String> = init_vars.to_vec();
 
         self.emit_loop_function(
             &loop_fn_name,
@@ -464,6 +461,17 @@ impl<'a> Printer<'a> {
         self.increase_indent();
         let block_scoped_temp_anchor = self.capture_hoist_anchor();
 
+        // The loop IIFE is a function body for the purpose of spread-call
+        // receiver temps: a `(_a = recv).m.apply(_a, ...)` capture emitted
+        // directly inside the loop body belongs to this body, not the enclosing
+        // function. Isolate a pending list for those temps so each (possibly
+        // nested) IIFE flushes only its own `var _a;` at its body top. Other
+        // hoisted temps (e.g. optional-chaining) keep targeting the enclosing
+        // source function scope, matching tsc's transform ordering.
+        let saved_loop_iife_pending_hoisted_temps =
+            std::mem::take(&mut self.loop_iife_pending_hoisted_temps);
+        self.loop_iife_body_depth += 1;
+
         // Emit the body statements inside the IIFE
         self.ctx.block_scope_state.enter_function_scope();
         for var in &outer_shadowed_body_vars {
@@ -488,6 +496,24 @@ impl<'a> Printer<'a> {
         self.lexical_block_missing_initializer_is_loop_body =
             prev_lexical_block_missing_initializer_is_loop_body;
         self.ctx.block_scope_state.exit_scope();
+
+        // Flush this IIFE's own spread-receiver hoist temps (`var _a;`) at its
+        // body top, then restore the enclosing pending list.
+        self.loop_iife_body_depth -= 1;
+        let iife_pending_hoisted_temps = std::mem::replace(
+            &mut self.loop_iife_pending_hoisted_temps,
+            saved_loop_iife_pending_hoisted_temps,
+        );
+        if !iife_pending_hoisted_temps.is_empty() {
+            let indent = self
+                .writer
+                .indent_string_at(block_scoped_temp_anchor.indent_level);
+            self.writer.insert_line_at(
+                block_scoped_temp_anchor.byte_offset,
+                block_scoped_temp_anchor.line_no,
+                &format!("{indent}var {};", iife_pending_hoisted_temps.join(", ")),
+            );
+        }
 
         if !self.block_scoped_private_temps.is_empty() {
             let indent = self
@@ -1116,6 +1142,166 @@ for (let x; ;) {\n\
         assert!(
             output.contains("var _loop_3 = function (x) {\n    ({ set foo(v) { x; } });\n};"),
             "Object literal setters should trigger loop capture.\nOutput:\n{output}"
+        );
+    }
+
+    // A closure that captures an OUTER for-of loop variable from inside a nested
+    // for-of body must convert the outer loop too. Capture analysis must descend
+    // into nested for-of statements (not only `for`/`while`/`do`). Renaming the
+    // loop variables must not change the result — capture is by binding, not by
+    // a hardcoded name.
+    #[test]
+    fn nested_for_of_outer_loop_var_capture_converts_outer_loop() {
+        for (outer_var, inner_var) in [("outer", "inner"), ("p", "q")] {
+            let source = format!(
+                "function f(xs: any[], ys: any[]) {{\n\
+                    for (const {outer_var} of xs)\n\
+                        for (const {inner_var} of ys)\n\
+                            (() => {outer_var} + {inner_var});\n\
+                }}\n"
+            );
+
+            let output = emit_es5(&source);
+
+            assert!(
+                output.contains(&format!("var _loop_1 = function ({outer_var}) {{")),
+                "Outer loop must convert with its own var as the helper parameter.\nOutput:\n{output}"
+            );
+            assert!(
+                output.contains(&format!("var _loop_2 = function ({inner_var}) {{")),
+                "Inner loop must convert with its own var as the helper parameter.\nOutput:\n{output}"
+            );
+            assert!(
+                output.contains(&format!("_loop_1({outer_var});")),
+                "Outer converted loop must be invoked with its iteration variable.\nOutput:\n{output}"
+            );
+        }
+    }
+
+    // When a nested loop re-binds the same name as an enclosing loop variable, a
+    // closure referencing that name inside the nested loop captures the INNER
+    // binding, so the OUTER loop must NOT convert. This holds for any name.
+    #[test]
+    fn nested_loop_shadowing_same_name_does_not_convert_outer_loop() {
+        for var_name in ["v", "z"] {
+            let source = format!(
+                "function f(xs: any[], ys: any[]) {{\n\
+                    for (const {var_name} of xs)\n\
+                        for (const {var_name} of ys)\n\
+                            (() => {var_name});\n\
+                }}\n"
+            );
+
+            let output = emit_es5(&source);
+
+            assert!(
+                output.contains("var _loop_1 = function"),
+                "The inner loop (whose own binding is captured) must convert.\nOutput:\n{output}"
+            );
+            assert!(
+                !output.contains("var _loop_2 = function"),
+                "The outer loop must stay a plain for-loop because its binding is shadowed.\nOutput:\n{output}"
+            );
+        }
+    }
+
+    // Once a for-of loop is converted (because a BODY binding is captured), all
+    // of the loop's own binding variables — including destructured names that
+    // are NOT themselves captured — are threaded as helper parameters so each
+    // iteration receives a fresh copy.
+    #[test]
+    fn converted_for_of_threads_all_binding_vars_even_when_uncaptured() {
+        for (a, b) in [("value", "i"), ("first", "second")] {
+            let source = format!(
+                "declare function pairs(): any[];\n\
+                function f() {{\n\
+                    for (const [{a}, {b}] of pairs()) {{\n\
+                        const bar: any = [];\n\
+                        (() => bar);\n\
+                    }}\n\
+                }}\n"
+            );
+
+            let output = emit_es5(&source);
+
+            assert!(
+                output.contains(&format!("var _loop_1 = function ({a}, {b}) {{")),
+                "Both for-of binding vars must be helper parameters, even though only `bar` is captured.\nOutput:\n{output}"
+            );
+            assert!(
+                output.contains(&format!("_loop_1({a}, {b});")),
+                "The converted loop call must pass both binding vars.\nOutput:\n{output}"
+            );
+        }
+    }
+
+    // A spread method call whose receiver is a non-simple expression captures the
+    // receiver once into a hoisted temp to avoid double evaluation. Inside a
+    // converted-loop IIFE body, that `var _a;` belongs to the IIFE body.
+    #[test]
+    fn converted_loop_spread_method_call_captures_non_simple_receiver_in_iife_temp() {
+        for fn_var in ["value", "k"] {
+            let source = format!(
+                "declare function pairs(): any[];\n\
+                function f(set: any) {{\n\
+                    for (const {fn_var} of pairs()) {{\n\
+                        const bar: any = [];\n\
+                        (() => bar);\n\
+                        set.values.push(...[]);\n\
+                    }}\n\
+                }}\n"
+            );
+
+            let output = emit_es5(&source);
+
+            // Receiver captured once and reused; never evaluated twice.
+            assert!(
+                output.contains(").push.apply("),
+                "Spread method call should lower to `.push.apply(...)`.\nOutput:\n{output}"
+            );
+            assert!(
+                !output.contains("set.values.push.apply(set.values"),
+                "Non-simple receiver must not be emitted twice in the apply call.\nOutput:\n{output}"
+            );
+            // The hoisted receiver temp declaration lives inside the IIFE body,
+            // not at the enclosing function top.
+            assert!(
+                output.contains("var _loop_1 = function ("),
+                "Loop must convert because `bar` is captured.\nOutput:\n{output}"
+            );
+            let iife_start = output.find("var _loop_1 = function (").unwrap();
+            let iife_prefix = &output[..iife_start];
+            assert!(
+                !iife_prefix.contains("var _a;") && !iife_prefix.contains("var _b;"),
+                "Receiver temp must not leak to the enclosing function before the IIFE.\nOutput:\n{output}"
+            );
+        }
+    }
+
+    // Non-loop spread method call with a non-simple receiver also captures into a
+    // hoisted temp at the enclosing function body top (the rule is general, not
+    // loop-specific).
+    #[test]
+    fn non_loop_spread_method_call_captures_non_simple_receiver() {
+        let source = "function f(set: any) {\n\
+            set.values.push(...[]);\n\
+        }\n";
+
+        let output = emit_es5(source);
+
+        assert!(
+            output.contains("var _a;"),
+            "Receiver temp should be hoisted at the function body top.\nOutput:\n{output}"
+        );
+        assert!(
+            output.contains("(_a = set.values).push.apply(_a, [])"),
+            "Non-simple receiver should be captured once and reused.\nOutput:\n{output}"
+        );
+        // A simple identifier receiver needs no temp.
+        let simple = emit_es5("function g(arr: any[]) {\n    arr.push(...[1]);\n}\n");
+        assert!(
+            simple.contains("arr.push.apply(arr, [1])"),
+            "Simple identifier receiver must not be captured into a temp.\nOutput:\n{simple}"
         );
     }
 }

--- a/crates/tsz-emitter/src/emitter/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/helpers.rs
@@ -920,6 +920,26 @@ impl<'a> Printer<'a> {
         name
     }
 
+    /// Like `make_unique_name_hoisted_assignment`, but always advances the temp
+    /// counter to a brand-new name instead of consuming a queued preallocated
+    /// temp. Used by emitters that allocate a hoisted temp while emitting a body
+    /// whose surrounding header has already reserved (but not yet consumed)
+    /// preallocated temps that must keep their lower numbers.
+    ///
+    /// When emitted directly inside a converted-loop IIFE body, the `var _a;`
+    /// declaration belongs to that IIFE (tsc emits spread-call receiver temps in
+    /// the loop body), so the name is recorded in the IIFE's pending list rather
+    /// than the enclosing function's hoist pool.
+    pub(super) fn make_unique_name_hoisted_assignment_fresh(&mut self) -> String {
+        let name = self.make_unique_name_fresh();
+        if self.loop_iife_body_depth > 0 {
+            self.loop_iife_pending_hoisted_temps.push(name.clone());
+        } else {
+            self.hoisted_assignment_temps.push(name.clone());
+        }
+        name
+    }
+
     pub(super) fn preallocate_logical_assignment_value_temps(&mut self, count: usize) {
         self.preallocated_logical_assignment_value_temps.clear();
         for _ in 0..count {

--- a/crates/tsz-emitter/src/transforms/block_scoping_es5.rs
+++ b/crates/tsz-emitter/src/transforms/block_scoping_es5.rs
@@ -473,7 +473,7 @@ pub fn analyze_loop_capture(
         return info;
     }
 
-    let var_set: FxHashSet<&str> = loop_vars.iter().map(std::string::String::as_str).collect();
+    let var_set: FxHashSet<String> = loop_vars.iter().cloned().collect();
 
     // Recursively check for closures that capture loop variables
     check_closure_capture(arena, body_idx, &var_set, &mut info, false);
@@ -481,15 +481,113 @@ pub fn analyze_loop_capture(
     info
 }
 
+/// Collect the binding identifier names declared by a binding name node
+/// (identifier or destructuring pattern) into `out`.
+fn collect_binding_pattern_names(arena: &NodeArena, name_idx: NodeIndex, out: &mut Vec<String>) {
+    let Some(name_node) = arena.get(name_idx) else {
+        return;
+    };
+    if name_node.is_identifier() {
+        if let Some(ident) = arena.get_identifier(name_node) {
+            out.push(ident.escaped_text.clone());
+        }
+    } else if matches!(
+        name_node.kind,
+        syntax_kind_ext::ARRAY_BINDING_PATTERN | syntax_kind_ext::OBJECT_BINDING_PATTERN
+    ) && let Some(pattern) = arena.get_binding_pattern(name_node)
+    {
+        for &elem_idx in &pattern.elements.nodes {
+            if let Some(elem_node) = arena.get(elem_idx)
+                && let Some(elem) = arena.get_binding_element(elem_node)
+            {
+                collect_binding_pattern_names(arena, elem.name, out);
+            }
+        }
+    }
+}
+
+/// Names introduced by a loop's own iteration binding (for-of/for-in binding,
+/// or a for-statement let/const initializer). These shadow same-named loop
+/// variables of an enclosing loop within the nested loop's subtree.
+fn loop_binding_shadow_names(arena: &NodeArena, node: &Node) -> Vec<String> {
+    let mut names = Vec::new();
+    let init_idx = if node.kind == syntax_kind_ext::FOR_OF_STATEMENT
+        || node.kind == syntax_kind_ext::FOR_IN_STATEMENT
+    {
+        arena.get_for_in_of(node).map(|f| f.initializer)
+    } else {
+        arena.get_loop(node).map(|l| l.initializer)
+    };
+    let Some(init_idx) = init_idx else {
+        return names;
+    };
+    if init_idx.is_none() {
+        return names;
+    }
+    let Some(init_node) = arena.get(init_idx) else {
+        return names;
+    };
+    if init_node.kind == syntax_kind_ext::VARIABLE_DECLARATION_LIST
+        && let Some(decl_list) = arena.get_variable(init_node)
+    {
+        for &decl_idx in &decl_list.declarations.nodes {
+            if let Some(decl_node) = arena.get(decl_idx)
+                && let Some(decl) = arena.get_variable_declaration(decl_node)
+            {
+                collect_binding_pattern_names(arena, decl.name, &mut names);
+            }
+        }
+    }
+    names
+}
+
+/// Function parameter names that shadow same-named loop variables within the
+/// function body.
+fn function_param_shadow_names(arena: &NodeArena, params: &[NodeIndex]) -> Vec<String> {
+    let mut names = Vec::new();
+    for &param_idx in params {
+        if let Some(param_node) = arena.get(param_idx)
+            && let Some(param) = arena.get_parameter(param_node)
+        {
+            collect_binding_pattern_names(arena, param.name, &mut names);
+        }
+    }
+    names
+}
+
+/// Return a reduced copy of `loop_vars` with `shadowed` names removed, or
+/// `None` when nothing was shadowed (so the caller can reuse the borrow and
+/// avoid an allocation). Capture is tracked by binding, not by name: a nested
+/// scope that re-declares a loop variable name shields the enclosing loop
+/// variable of that name from being seen as captured inside that subtree.
+fn reduce_loop_vars(
+    loop_vars: &FxHashSet<String>,
+    shadowed: &[String],
+) -> Option<FxHashSet<String>> {
+    if shadowed.iter().any(|n| loop_vars.contains(n)) {
+        let mut reduced = loop_vars.clone();
+        for n in shadowed {
+            reduced.remove(n);
+        }
+        Some(reduced)
+    } else {
+        None
+    }
+}
+
 /// Recursively check for closures that capture variables from the loop
 fn check_closure_capture(
     arena: &NodeArena,
     idx: NodeIndex,
-    loop_vars: &FxHashSet<&str>,
+    loop_vars: &FxHashSet<String>,
     info: &mut LoopCaptureInfo,
     inside_closure: bool,
 ) {
     let Some(node) = arena.get(idx) else { return };
+
+    if loop_vars.is_empty() {
+        return;
+    }
 
     match node.kind {
         // Function declarations/expressions/arrows create closures
@@ -499,12 +597,17 @@ fn check_closure_capture(
         {
             // Inside this function, we're in a closure
             if let Some(func) = arena.get_function(node) {
-                // Check parameters
+                // Check parameters (initializers are evaluated in the function's
+                // own scope; references there are still inside the closure).
                 for &param_idx in &func.parameters.nodes {
                     check_closure_capture(arena, param_idx, loop_vars, info, true);
                 }
-                // Check body
-                check_closure_capture(arena, func.body, loop_vars, info, true);
+                // Parameters shadow same-named loop vars within the body.
+                let shadow = function_param_shadow_names(arena, &func.parameters.nodes);
+                match reduce_loop_vars(loop_vars, &shadow) {
+                    Some(reduced) => check_closure_capture(arena, func.body, &reduced, info, true),
+                    None => check_closure_capture(arena, func.body, loop_vars, info, true),
+                }
             }
         }
 
@@ -513,7 +616,13 @@ fn check_closure_capture(
                 for &param_idx in &method.parameters.nodes {
                     check_closure_capture(arena, param_idx, loop_vars, info, true);
                 }
-                check_closure_capture(arena, method.body, loop_vars, info, true);
+                let shadow = function_param_shadow_names(arena, &method.parameters.nodes);
+                match reduce_loop_vars(loop_vars, &shadow) {
+                    Some(reduced) => {
+                        check_closure_capture(arena, method.body, &reduced, info, true)
+                    }
+                    None => check_closure_capture(arena, method.body, loop_vars, info, true),
+                }
             }
         }
 
@@ -522,7 +631,13 @@ fn check_closure_capture(
                 for &param_idx in &accessor.parameters.nodes {
                     check_closure_capture(arena, param_idx, loop_vars, info, true);
                 }
-                check_closure_capture(arena, accessor.body, loop_vars, info, true);
+                let shadow = function_param_shadow_names(arena, &accessor.parameters.nodes);
+                match reduce_loop_vars(loop_vars, &shadow) {
+                    Some(reduced) => {
+                        check_closure_capture(arena, accessor.body, &reduced, info, true)
+                    }
+                    None => check_closure_capture(arena, accessor.body, loop_vars, info, true),
+                }
             }
         }
 
@@ -533,6 +648,27 @@ fn check_closure_capture(
                 for &member_idx in &class_data.members.nodes {
                     check_class_member_capture(arena, member_idx, loop_vars, info, inside_closure);
                 }
+            }
+        }
+
+        // Nested loops introduce their own iteration bindings, which shadow any
+        // same-named loop variable of the enclosing loop inside the nested
+        // loop's subtree. A reference to that name there refers to the inner
+        // binding, so the enclosing loop is not captured by it.
+        k if k == syntax_kind_ext::FOR_OF_STATEMENT
+            || k == syntax_kind_ext::FOR_IN_STATEMENT
+            || k == syntax_kind_ext::FOR_STATEMENT
+            || k == syntax_kind_ext::WHILE_STATEMENT
+            || k == syntax_kind_ext::DO_STATEMENT =>
+        {
+            let shadow = loop_binding_shadow_names(arena, node);
+            match reduce_loop_vars(loop_vars, &shadow) {
+                Some(reduced) => visit_children(arena, node, |child_idx| {
+                    check_closure_capture(arena, child_idx, &reduced, info, inside_closure);
+                }),
+                None => visit_children(arena, node, |child_idx| {
+                    check_closure_capture(arena, child_idx, loop_vars, info, inside_closure);
+                }),
             }
         }
 
@@ -562,7 +698,7 @@ fn check_closure_capture(
 fn check_class_member_capture(
     arena: &NodeArena,
     idx: NodeIndex,
-    loop_vars: &FxHashSet<&str>,
+    loop_vars: &FxHashSet<String>,
     info: &mut LoopCaptureInfo,
     inside_closure: bool,
 ) {
@@ -579,7 +715,13 @@ fn check_class_member_capture(
                 for &param_idx in &method.parameters.nodes {
                     check_closure_capture(arena, param_idx, loop_vars, info, true);
                 }
-                check_closure_capture(arena, method.body, loop_vars, info, true);
+                let shadow = function_param_shadow_names(arena, &method.parameters.nodes);
+                match reduce_loop_vars(loop_vars, &shadow) {
+                    Some(reduced) => {
+                        check_closure_capture(arena, method.body, &reduced, info, true)
+                    }
+                    None => check_closure_capture(arena, method.body, loop_vars, info, true),
+                }
             }
         }
         k if k == syntax_kind_ext::GET_ACCESSOR || k == syntax_kind_ext::SET_ACCESSOR => {
@@ -587,7 +729,13 @@ fn check_class_member_capture(
                 for &param_idx in &accessor.parameters.nodes {
                     check_closure_capture(arena, param_idx, loop_vars, info, true);
                 }
-                check_closure_capture(arena, accessor.body, loop_vars, info, true);
+                let shadow = function_param_shadow_names(arena, &accessor.parameters.nodes);
+                match reduce_loop_vars(loop_vars, &shadow) {
+                    Some(reduced) => {
+                        check_closure_capture(arena, accessor.body, &reduced, info, true)
+                    }
+                    None => check_closure_capture(arena, accessor.body, loop_vars, info, true),
+                }
             }
         }
         k if k == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION => {
@@ -712,6 +860,17 @@ fn visit_children<F: FnMut(NodeIndex)>(arena: &NodeArena, node: &Node, mut visit
                 visitor(loop_data.condition);
                 visitor(loop_data.incrementor);
                 visitor(loop_data.statement);
+            }
+        }
+        // for-of / for-in use a distinct payload. A closure that captures an
+        // outer loop variable can be buried inside a nested for-of/for-in body
+        // (e.g. `for (let x of xs) for (let y of ys) f(() => x)`), so capture
+        // analysis must descend into these statements too.
+        k if k == syntax_kind_ext::FOR_OF_STATEMENT || k == syntax_kind_ext::FOR_IN_STATEMENT => {
+            if let Some(for_in_of) = arena.get_for_in_of(node) {
+                visitor(for_in_of.initializer);
+                visitor(for_in_of.expression);
+                visitor(for_in_of.statement);
             }
         }
         k if k == syntax_kind_ext::RETURN_STATEMENT => {


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — ES5 converted-loop lowering (emit→100% campaign, wave 3)

## Invariant
ES5 loop-capture lowering must be sound by *binding*, not by *name*: (1) capture detection descends into nested `for-of`/`for-in` bodies; (2) when a loop is converted to a `_loop_N` IIFE, ALL of its own block-scoped binding variables (initializer / for-of binding, including destructured names) become IIFE parameters so each iteration gets a fresh copy — not just the captured subset; (3) a nested scope (loop binding, function/method/accessor params) that re-declares a loop-var name shields the enclosing loop's same-named variable within that subtree. Plus (4) a general ES5 fix: `obj.expr.method(...spread)` with a non-simple receiver captures the receiver once into a hoisted temp (`(_a = obj.expr).method.apply(_a, args)`); inside a converted-loop IIFE the `var _a;` flushes at the IIFE body top while optional-chaining temps keep targeting the enclosing function scope (matching tsc transform ordering).

## Scope
- `crates/tsz-emitter/src/transforms/block_scoping_es5.rs` — detection recursion into for-of/for-in; shadowing-aware (binding-keyed) capture.
- `crates/tsz-emitter/src/emitter/es5/loop_capture.rs` — param threading; IIFE pending-temp flush; unit tests.
- `crates/tsz-emitter/src/emitter/es5/bindings_for_of.rs` — param threading; binding destructure-temp reserve.
- `crates/tsz-emitter/src/emitter/es5/helpers_async.rs` — `emit_method_call_with_spread` receiver capture.
- `crates/tsz-emitter/src/emitter/helpers.rs`, `emitter/core.rs`, `emitter/core_setup.rs` — `make_unique_name_hoisted_assignment_fresh`, IIFE-body-depth pending-temp state.

## Project Corpus Impact
- Row: n/a (ES5 emit-lowering fix)
- Bug family: ES5 converted-loop capture (nested-loop detection, binding param threading, name-shadowing soundness, spread receiver temp)
- Evidence: newLexicalEnvironmentForConvertedLoop(target=es5) FAIL→PASS; full --js-only 115→114.

## Verification
- Witness `newLexicalEnvironmentForConvertedLoop(es5)` FAIL→PASS. **Full --js-only: 13415→13416 pass (115→114 fail), net +1, ZERO new failures.** --dts-only unaffected. tsz-emitter unit suite: same 32 pre-existing failures before/after (zero new). 5 new structural unit tests; clippy clean.
- Fix #3 (binding-not-name capture) corrects latent unsoundness the agent proved necessary: without it `nestedLoopWithOnlyInnerLetCaptured` and `ES5For-of19` regress — both pass with the full change.
- §25/§26 compliant (keyed on binding/scope structure + AST node kind, no identifier/file-name matches).

## Coordination Notes
Wave-3 ES5 lowering fix. Scoped out (broad, not forced): `nestedLoops(es5)` (distinct converted-loop `this`-capture feature: `var this_1 = this;` + `this`→`this_1` substitution); `labeledStatementDeclarationListInLoopNoCrash3/4(es5)` (parser-recovery noise + same this-capture). — opus48-emit100
