### PR TITLE
fix(emit): keep empty string-literal-named enum members (gate skip on name-node syntax kind, not text)

### DIFF
--- a/crates/tsz-emitter/src/transforms/enum_es5.rs
+++ b/crates/tsz-emitter/src/transforms/enum_es5.rs
@@ -530,13 +530,29 @@ impl<'a> EnumES5Transformer<'a> {
             // Skip members whose name resolved to empty and are not a
             // `PrivateIdentifier` (which gets its own error-recovery emit path).
             // This covers parse-error recovery nodes such as invalid characters
-            // (e.g. `¬`) inside an enum body: tsc discards those members entirely
-            // rather than emitting a spurious `E[E[""] = 0] = "";` line.
+            // (e.g. `¬`) inside an enum body: those recover into an empty
+            // `Identifier` node, and tsc discards the member entirely rather
+            // than emitting a spurious `E[E[""] = 0] = "";` line.
+            //
+            // A member explicitly named with the empty string literal
+            // (`enum E { "" }`) is a *legitimate* member whose name node is a
+            // `StringLiteral`/`NoSubstitutionTemplateLiteral`. tsc emits it as
+            // `E[E[""] = n] = "";`, so we must not treat that empty name as a
+            // recovery node. Distinguish by the name node's syntax kind, not by
+            // the resolved text.
             let is_private_identifier = self
                 .arena
                 .get(member_data.name)
                 .is_some_and(|n| n.kind == SyntaxKind::PrivateIdentifier as u16);
-            if member_name.is_empty() && !is_computed && !is_private_identifier {
+            let is_string_literal_name = self.arena.get(member_data.name).is_some_and(|n| {
+                n.kind == SyntaxKind::StringLiteral as u16
+                    || n.kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16
+            });
+            if member_name.is_empty()
+                && !is_computed
+                && !is_private_identifier
+                && !is_string_literal_name
+            {
                 continue;
             }
 

--- a/crates/tsz-emitter/src/transforms/enum_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/enum_es5_ir.rs
@@ -91,7 +91,17 @@ fn transform_enum_members(
         };
 
         let member_name = crate::transforms::emit_utils::enum_member_name(arena, member_data.name);
-        if member_name.is_empty() {
+        // An empty resolved name means either a legitimate empty string-literal
+        // member (`enum E { "" }`, whose name node is a `StringLiteral`/
+        // `NoSubstitutionTemplateLiteral`) or a parse-error recovery node (an
+        // empty `Identifier`, e.g. from an invalid character). tsc emits the
+        // former (`E[E[""] = n] = "";`) and discards the latter. Distinguish by
+        // the name node's syntax kind, not by the resolved text.
+        let is_string_literal_name = arena.get(member_data.name).is_some_and(|n| {
+            n.kind == SyntaxKind::StringLiteral as u16
+                || n.kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16
+        });
+        if member_name.is_empty() && !is_string_literal_name {
             continue;
         }
 

--- a/crates/tsz-emitter/tests/enum_es5.rs
+++ b/crates/tsz-emitter/tests/enum_es5.rs
@@ -803,3 +803,65 @@ fn invalid_char_member_between_valid_members_is_skipped() {
         "invalid member must not emit an empty-string key, got:\n{output}"
     );
 }
+
+#[test]
+fn empty_string_literal_member_name_is_emitted() {
+    // A member explicitly named with the empty string literal (`enum E { "" }`)
+    // is a legitimate member. tsc emits `E[E[""] = n] = "";`. The empty-name
+    // skip (for parse-error recovery) must NOT swallow it, because its name node
+    // is a real `StringLiteral`, not an empty recovery `Identifier`.
+    // Vary the enum name and surrounding members vs. the conformance witness so
+    // the assertion proves the structural rule rather than one spelling.
+    let output = transform_enum("enum Color { A, B, \"\" }");
+    assert!(
+        output.contains("Color[Color[\"\"] = 2] = \"\";"),
+        "empty-string-named member must emit reverse mapping, got:\n{output}"
+    );
+    assert!(
+        output.contains("Color[Color[\"A\"] = 0] = \"A\";")
+            && output.contains("Color[Color[\"B\"] = 1] = \"B\";"),
+        "surrounding members must still emit, got:\n{output}"
+    );
+}
+
+#[test]
+fn empty_string_literal_member_name_emits_when_first() {
+    // The empty-string member can appear in any position, including first, and
+    // auto-increment must continue normally for later members. Use a different
+    // enum name and member spellings to keep the test keyed to the node kind,
+    // not a fixed layout.
+    let output = transform_enum("enum E2 { \"\", First, Second }");
+    assert!(
+        output.contains("E2[E2[\"\"] = 0] = \"\";"),
+        "leading empty-string member must emit at index 0, got:\n{output}"
+    );
+    assert!(
+        output.contains("E2[E2[\"First\"] = 1] = \"First\";")
+            && output.contains("E2[E2[\"Second\"] = 2] = \"Second\";"),
+        "members after empty-string member must auto-increment, got:\n{output}"
+    );
+}
+
+#[test]
+fn empty_string_member_emits_but_invalid_char_member_is_skipped() {
+    // The empty-string literal member (legitimate, name node = StringLiteral)
+    // must emit, while an invalid-char parse-error member (name node = empty
+    // Identifier) in the same enum is still discarded. This proves the fix
+    // distinguishes the two empty-name cases by node kind, not resolved text.
+    let output = transform_enum("enum Mix {\n    \"\",\n    \u{00AC},\n    Tail\n}");
+    assert!(
+        output.contains("Mix[Mix[\"\"] = 0] = \"\";"),
+        "empty-string member must emit, got:\n{output}"
+    );
+    assert!(
+        output.contains("Mix[Mix[\"Tail\"] = 1] = \"Tail\";"),
+        "trailing member must auto-increment past the skipped invalid member, got:\n{output}"
+    );
+    // Exactly one empty-string key (the legitimate member). The invalid-char
+    // recovery member must not add a second `[""]` mapping.
+    assert_eq!(
+        output.matches("[\"\"]").count(),
+        1,
+        "invalid-char member must not emit an additional empty-string key, got:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/tests/namespace_es5_ir.rs
+++ b/crates/tsz-emitter/tests/namespace_es5_ir.rs
@@ -183,6 +183,24 @@ fn test_namespace_es5_enum_emit_lowered() {
 }
 
 #[test]
+fn test_namespace_es5_enum_empty_string_member_emitted() {
+    // The IR enum transformer (used for namespace-nested enums) must emit a
+    // member explicitly named with the empty string literal, whose name node is
+    // a `StringLiteral`, rather than dropping it as a parse-error recovery node.
+    // Vary the enum/namespace names vs. the conformance witness.
+    let output = transform_and_emit("namespace N { export enum Tag { Open, Close, \"\" } }");
+    assert!(
+        output.contains("Tag[Tag[\"\"] = 2] = \"\";"),
+        "namespace-nested empty-string member must emit reverse mapping, got:\n{output}"
+    );
+    assert!(
+        output.contains("Tag[Tag[\"Open\"] = 0] = \"Open\";")
+            && output.contains("Tag[Tag[\"Close\"] = 1] = \"Close\";"),
+        "surrounding members must still emit, got:\n{output}"
+    );
+}
+
+#[test]
 fn test_namespace_es5_exported_empty_namespace_skipped() {
     let ir = transform_namespace("export namespace M { }");
     assert!(


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — enum lowering (emit→100% campaign, wave 3); regression fix for #11671

## Invariant
When an enum member's name node is a string-literal syntax node (`StringLiteral` / `NoSubstitutionTemplateLiteral`), it is a legitimate member that tsc emits as `E[E["<text>"] = n] = "<text>";` even when the literal text is empty (`""`). The empty-name *skip* (which discards invalid-character parse-error members, e.g. a bare empty `Identifier` produced from `¬`) must be gated on the name node's SYNTAX KIND, not on the resolved name text — an empty string-literal name is not a parse error.

## Scope
- `crates/tsz-emitter/src/transforms/enum_es5.rs` — top-level enum path: add `is_string_literal_name` exemption to the empty-name skip guard.
- `crates/tsz-emitter/src/transforms/enum_es5_ir.rs` — namespace-nested enum path: same exemption.
- tests in `enum_es5.rs` (+3) and `namespace_es5_ir.rs` (+1).

## Project Corpus Impact
- Row: n/a (enum-emit regression fix)
- Bug family: enum member emission — empty string-literal name dropped by overly-broad parse-error skip (introduced in #11671)
- Evidence: 10 `*OperatorWithEnumType` witnesses FAIL→PASS; full --js-only 13415→13425.

## Verification
- **10 witnesses FAIL→PASS** (bitwiseNot/decrement/decrementInvalid/delete/increment/incrementInvalid/negate/plus/typeof/voidOperatorWithEnumType). **Full --js-only: 13415→13425 pass (115→105 fail), net +10, ZERO regressions** (set diff empty). --dts-only byte-identical (enums not lowered in DTS).
- 4 new structural unit tests (enum names Color/E2/Mix; mixed empty-string + invalid-char case proving node-kind discrimination). Pre-existing invalid-char skip tests + `parserErrorRecovery_ClassElement3` (the `¬` test motivating #11671's guard) still pass. Clippy clean.
- §25/§26 compliant (keyed on name-node syntax kind, not resolved text / identifier names).

## Coordination Notes
Regression fix for #11671's empty-resolved-name skip (too broad). 3 pre-existing unrelated tsz-emitter unit failures (createRequire import emission, export-star reexports) confirmed present on clean baseline with this change reverted — not caused here. — opus48-emit100
