### PR TITLE
fix(dts): defer object-spread display to solver type when spread strips readonly or collides keys

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
@@ -773,6 +773,14 @@ impl<'a> DeclarationEmitter<'a> {
         if own_members.is_empty() {
             return None;
         }
+        // Object spread merges duplicate keys (the spread overrides earlier
+        // own members, widening optional members to `T | <own>`) and strips
+        // `readonly`. The AST-based reconstruction below cannot model either,
+        // so when the spread source structurally requires that handling, bail
+        // and let the caller fall back to the solver-computed spread type.
+        if self.object_spread_collides_or_strips_readonly(object, spread_expr) {
+            return None;
+        }
         if let Some(spread_arms) = self.object_spread_type_literal_arms(spread_expr) {
             return Self::prepend_members_to_object_type_literal_arm_texts(
                 spread_arms,
@@ -799,6 +807,56 @@ impl<'a> DeclarationEmitter<'a> {
 
         let spread_arms = self.object_spread_type_literal_arms(spread_expr)?;
         Self::prepend_members_to_object_type_literal_arm_texts(spread_arms, &own_members, depth)
+    }
+
+    /// Returns `true` when declaration emit of `{ ...own, ...spread }` cannot be
+    /// reconstructed verbatim from the source AST and must use the
+    /// solver-computed spread type instead. Two structural conditions trigger
+    /// this: (1) an own member key collides with a key on the spread source
+    /// (spread overrides earlier members, widening optionals to a union), or
+    /// (2) the spread source carries `readonly` members (spread strips them).
+    fn object_spread_collides_or_strips_readonly(
+        &self,
+        object: &tsz_parser::parser::node::LiteralExprData,
+        spread_expr: NodeIndex,
+    ) -> bool {
+        let Some(interner) = self.type_interner else {
+            return false;
+        };
+        let Some(spread_type) = self
+            .get_node_type_or_names(&[spread_expr])
+            .or_else(|| self.get_symbol_cached_type(spread_expr))
+            .or_else(|| self.get_type_via_symbol(spread_expr))
+        else {
+            return false;
+        };
+
+        if tsz_solver::type_queries::object_spread_source_has_readonly_member(interner, spread_type)
+        {
+            return true;
+        }
+
+        for &member_idx in &object.elements.nodes {
+            let Some(member_node) = self.arena.get(member_idx) else {
+                continue;
+            };
+            if member_node.kind == syntax_kind_ext::SPREAD_ASSIGNMENT {
+                continue;
+            }
+            let Some(name_idx) = self.object_literal_member_name_idx(member_node) else {
+                continue;
+            };
+            let Some(name) = self.object_literal_member_name_text(name_idx) else {
+                continue;
+            };
+            if name.is_empty() || name == ":" {
+                continue;
+            }
+            if tsz_solver::type_queries::type_has_property_by_str(interner, spread_type, &name) {
+                return true;
+            }
+        }
+        false
     }
 
     fn prepend_members_to_object_type_literal_arm_texts(
@@ -959,6 +1017,16 @@ impl<'a> DeclarationEmitter<'a> {
                 spread_object_text.or_else(|| Some("{}".to_string()))
             }
             tsz_solver::type_queries::ObjectSpreadDtsProjection::PreserveSource => {
+                // Spreading a `readonly` source (e.g. `{ ...x }` where `x` is
+                // `as const`) produces *mutable* members. The source-preserving
+                // text below would keep the `readonly` modifiers, so defer to
+                // the solver-computed spread type instead.
+                if tsz_solver::type_queries::object_spread_source_has_readonly_member(
+                    interner,
+                    spread_type,
+                ) {
+                    return None;
+                }
                 if !self.expression_references_parameter(spread.expression)
                     && self
                         .local_variable_initializer_type_text(spread.expression)

--- a/crates/tsz-solver/src/tests/type_queries_spread_tests.rs
+++ b/crates/tsz-solver/src/tests/type_queries_spread_tests.rs
@@ -12,8 +12,12 @@ use crate::intern::TypeInterner;
 use crate::objects::ObjectLiteralBuilder;
 use crate::type_queries::{
     ObjectSpreadDtsProjection, classify_object_spread_dts_projection, is_valid_spread_type,
+    object_spread_source_has_readonly_member,
 };
-use crate::types::{PropertyInfo, StringIntrinsicKind, TemplateSpan, TypeParamInfo, Visibility};
+use crate::types::{
+    IndexSignature, ObjectFlags, ObjectShape, PropertyInfo, StringIntrinsicKind, TemplateSpan,
+    TypeParamInfo, Visibility,
+};
 
 // =============================================================================
 // Basic spreadable / non-spreadable types
@@ -720,4 +724,155 @@ fn object_spread_dts_projection_matches_falsy_spread_rules() {
         classify_object_spread_dts_projection(&db, object_or_undefined),
         ObjectSpreadDtsProjection::EmptyObject
     );
+}
+
+// =============================================================================
+// object_spread_source_has_readonly_member — object spread strips `readonly`,
+// so the .d.ts reconstruction must fall back to the solver-computed type when
+// the spread source carries any readonly member. Tests vary property/key names
+// and shapes to prove the rule is structural, not name-keyed.
+// =============================================================================
+
+#[test]
+fn readonly_property_member_detected_regardless_of_name() {
+    let db = TypeInterner::new();
+    // `{ readonly a: number }` and `{ readonly something: string }` — the name
+    // choice must not change the result.
+    for name in ["a", "b", "something", "x"] {
+        let obj = db.object(vec![PropertyInfo::readonly(
+            db.intern_string(name),
+            TypeId::NUMBER,
+        )]);
+        assert!(
+            object_spread_source_has_readonly_member(&db, obj),
+            "readonly property `{name}` should be detected"
+        );
+    }
+}
+
+#[test]
+fn mutable_object_has_no_readonly_member() {
+    let db = TypeInterner::new();
+    // `{ a: number; name: string }` — all mutable, nothing to strip.
+    let obj = db.object(vec![
+        PropertyInfo::new(db.intern_string("a"), TypeId::NUMBER),
+        PropertyInfo::new(db.intern_string("name"), TypeId::STRING),
+    ]);
+    assert!(!object_spread_source_has_readonly_member(&db, obj));
+}
+
+#[test]
+fn readonly_string_and_number_index_signatures_detected() {
+    let db = TypeInterner::new();
+    // `{ readonly [x: string]: string }`
+    let ro_string_index = db.object_with_index(ObjectShape {
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::STRING,
+            readonly: true,
+            param_name: None,
+        }),
+        number_index: None,
+    });
+    assert!(object_spread_source_has_readonly_member(
+        &db,
+        ro_string_index
+    ));
+
+    // `{ readonly [n: number]: number }`
+    let ro_number_index = db.object_with_index(ObjectShape {
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: None,
+        number_index: Some(IndexSignature {
+            key_type: TypeId::NUMBER,
+            value_type: TypeId::NUMBER,
+            readonly: true,
+            param_name: None,
+        }),
+    });
+    assert!(object_spread_source_has_readonly_member(
+        &db,
+        ro_number_index
+    ));
+
+    // `{ [x: string]: string }` (mutable index) — not detected.
+    let mutable_index = db.object_with_index(ObjectShape {
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::STRING,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+    });
+    assert!(!object_spread_source_has_readonly_member(
+        &db,
+        mutable_index
+    ));
+}
+
+#[test]
+fn readonly_type_wrapper_detected() {
+    let db = TypeInterner::new();
+    // `Readonly<{ k: number }>` modeled as a `ReadonlyType` wrapper.
+    let inner = db.object(vec![PropertyInfo::new(
+        db.intern_string("k"),
+        TypeId::NUMBER,
+    )]);
+    let wrapped = db.readonly_type(inner);
+    assert!(object_spread_source_has_readonly_member(&db, wrapped));
+}
+
+#[test]
+fn readonly_member_detected_through_union_and_intersection() {
+    let db = TypeInterner::new();
+    let mutable = db.object(vec![PropertyInfo::new(
+        db.intern_string("p"),
+        TypeId::NUMBER,
+    )]);
+    let readonly = db.object(vec![PropertyInfo::readonly(
+        db.intern_string("q"),
+        TypeId::STRING,
+    )]);
+
+    // Union: `{ p: number } | { readonly q: string }` — one arm is readonly.
+    let union = db.union(vec![mutable, readonly]);
+    assert!(object_spread_source_has_readonly_member(&db, union));
+
+    // Intersection: `{ p: number } & { readonly q: string }`.
+    let intersection = db.intersection(vec![mutable, readonly]);
+    assert!(object_spread_source_has_readonly_member(&db, intersection));
+
+    // All-mutable union stays false.
+    let other_mutable = db.object(vec![PropertyInfo::new(
+        db.intern_string("r"),
+        TypeId::BOOLEAN,
+    )]);
+    let mutable_union = db.union(vec![mutable, other_mutable]);
+    assert!(!object_spread_source_has_readonly_member(
+        &db,
+        mutable_union
+    ));
+}
+
+#[test]
+fn intrinsics_have_no_readonly_member() {
+    let db = TypeInterner::new();
+    assert!(!object_spread_source_has_readonly_member(
+        &db,
+        TypeId::OBJECT
+    ));
+    assert!(!object_spread_source_has_readonly_member(&db, TypeId::ANY));
+    assert!(!object_spread_source_has_readonly_member(
+        &db,
+        TypeId::STRING
+    ));
 }

--- a/crates/tsz-solver/src/type_queries/core.rs
+++ b/crates/tsz-solver/src/type_queries/core.rs
@@ -449,6 +449,36 @@ pub fn type_has_readonly_members(db: &dyn TypeDatabase, type_id: TypeId) -> bool
     }
 }
 
+/// Check if a spread source object type carries any readonly member at the top
+/// level — either a readonly property or a readonly index signature, including
+/// through a `ReadonlyType` wrapper, union, or intersection.
+///
+/// Object spread (`{ ...x }`) always produces *mutable* members, so when the
+/// spread source has readonly members the resulting type cannot be reconstructed
+/// verbatim from the source AST in declaration emit; the solver-computed spread
+/// type must be used instead.
+pub fn object_spread_source_has_readonly_member(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    if type_id.is_intrinsic() {
+        return false;
+    }
+    match db.lookup(type_id) {
+        Some(TypeData::ReadonlyType(_)) => true,
+        Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
+            let shape = db.object_shape(shape_id);
+            shape.properties.iter().any(|p| p.readonly)
+                || shape.string_index.is_some_and(|s| s.readonly)
+                || shape.number_index.is_some_and(|s| s.readonly)
+        }
+        Some(TypeData::Union(members) | TypeData::Intersection(members)) => {
+            let members = db.type_list(members);
+            members
+                .iter()
+                .any(|&m| object_spread_source_has_readonly_member(db, m))
+        }
+        _ => false,
+    }
+}
+
 /// Check if a type is the polymorphic `this` type.
 ///
 /// `ThisType` represents `this` in class methods and needs to be resolved


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — declaration emit parity (emit→100% campaign, wave 3)

## Invariant
When an object-literal initializer contains a spread whose source type carries `readonly` members (property or index signature, through `ReadonlyType` / union / intersection — spread strips `readonly`), OR an own member key collides with a spread-source key (spread overrides and widens optionals to a union), the declaration emitter's AST-text reconstruction cannot model the result, so it must defer to the solver-computed spread `TypeId` (which already applies tsc's object-spread semantics). The decision is keyed on `TypeId` structure + AST node kind — no identifier/file-name matches, no printer-output inspection.

## Scope
- `crates/tsz-solver/src/type_queries/core.rs` — new query `object_spread_source_has_readonly_member`.
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs` — `object_spread_collides_or_strips_readonly` guard in the multi-member spread builder + readonly-strip guard in `single_spread_object_literal_type_text` (defer to solver type).
- `crates/tsz-solver/src/tests/type_queries_spread_tests.rs` — 6 structural unit tests.

## Project Corpus Impact
- Row: n/a (declaration emit parity fix)
- Bug family: DTS object-spread display (readonly-strip + key-collision not modeled by AST text reconstruction)
- Evidence: constAssertions, spreadDuplicate, spreadDuplicateExact FAIL→PASS; full --dts-only 1637→1640.

## Verification
- 3 witnesses FAIL→PASS. **Full --dts-only: 1637→1640 pass (32→29 fail), net +3, ZERO new failures** (rebuilt dist-fast vs clean baseline). JS spread + constAssertions emit unaffected (141/141 + 1/1).
- 6 structural unit tests (varied names a/b/x/k/p/q/r; readonly prop; string+number readonly index; ReadonlyType wrapper; union/intersection; mutable + intrinsic negatives). All 378 solver readonly/spread tests pass. Clippy clean (tsz-emitter + tsz-solver).
- §25/§26 compliant; §3/§6.4-aligned (emitter asks solver for the structural fact rather than reconstructing from source text).

## Coordination Notes
Wave-3 contained DTS fix. Skipped (broad, classified, not forced): emitClassExpressionInDeclarationFile (mixin member ordering — solver); strictFunctionTypes1/declarationEmitInferredDefaultExportType/declarationMapsMultifile (wrong inferred types — solver SF-1); declarationEmitInferredTypeAlias4/reactTransitiveImportHasValidDeclaration/declarationEmitUsingTypeAlias2/declarationEmitPathMappingMonorepo (broad canonical-display/portability); declarationEmitExactOptionalPropertyTypesNodeNotReused x2 (mapped+intersection collapse — solver). — opus48-emit100
