### PR TITLE
chore(arch): ratchet down slack caps and recalibrate post-merge file sizes

### DIFF
--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -282,7 +282,7 @@ FILE_LINE_LIMIT_CHECKS = [
         1920,
     ),
     (
-        "Solver engine boundary: generic call resolver must stay at current 3381 LOC baseline (#8209)",
+        "Solver engine boundary: generic call resolver must stay at current 3378 LOC baseline (#8209)",
         ROOT
         / "crates"
         / "tsz-solver"
@@ -290,7 +290,7 @@ FILE_LINE_LIMIT_CHECKS = [
         / "operations"
         / "generic_call"
         / "resolve.rs",
-        3381,
+        3378,
     ),
     # Pin the async ES5 IR transformer file size while #8277 splits the
     # monolith into staged lowering modules. The cap should ratchet down
@@ -417,7 +417,7 @@ FILE_LINE_LIMIT_CHECKS = [
     (
         "CLI boundary: driver/core monolith size ratchet",
         ROOT / "crates" / "tsz-cli" / "src" / "driver" / "core.rs",
-        3215,
+        3195,
     ),
     # CLI LSP server: structure/outline handler — split by request kind per §19.
     (
@@ -579,7 +579,7 @@ FILE_LINE_LIMIT_CHECKS = [
         / "src"
         / "parser"
         / "state_expressions_literals.rs",
-        3027,
+        3054,
     ),
     (
         "Checker boundary: jsdoc/params.rs size ratchet",
@@ -627,7 +627,7 @@ FILE_LINE_LIMIT_CHECKS = [
         / "state"
         / "type_analysis"
         / "core.rs",
-        2764,
+        2798,
     ),
     (
         "CLI boundary: driver/tests.rs size ratchet",
@@ -773,7 +773,7 @@ FILE_LINE_LIMIT_CHECKS = [
         / "emitter"
         / "es5"
         / "helpers_async.rs",
-        2224,
+        2260,
     ),
     (
         "Checker boundary: state/variable_checking/core.rs size ratchet",
@@ -789,7 +789,7 @@ FILE_LINE_LIMIT_CHECKS = [
     (
         "Emitter boundary: emitter/helpers.rs size ratchet",
         ROOT / "crates" / "tsz-emitter" / "src" / "emitter" / "helpers.rs",
-        2202,
+        2222,
     ),
     (
         "Emitter boundary: declaration_emitter/usage_analyzer.rs size ratchet",
@@ -837,7 +837,7 @@ FILE_LINE_LIMIT_CHECKS = [
         / "rules"
         / "functions"
         / "checking.rs",
-        2118,
+        2198,
     ),
     (
         "LSP boundary: completions/member.rs size ratchet",
@@ -1029,7 +1029,7 @@ SOLVER_IMPORT_COUNT_CHECKS = [
             "crates/tsz-solver/",
             "crates/tsz-checker/",
         ),
-        36,
+        35,
     ),
 ]
 
@@ -1158,7 +1158,7 @@ SNAPSHOT_ROLLBACK_FILE_COUNT_CHECKS = [
         "Checker speculation boundary: snapshot-rollback call sites outside speculation.rs (architecture health metric 5)",
         [ROOT / "crates" / "tsz-checker" / "src"],
         ("crates/tsz-checker/src/context/speculation.rs",),
-        6,
+        4,
     ),
 ]
 

--- a/scripts/arch/test_arch_guard.py
+++ b/scripts/arch/test_arch_guard.py
@@ -483,10 +483,7 @@ class ArchGuardSolverEngineSizeBoundaryTests(unittest.TestCase):
     def _generic_call_resolver_size_check(self):
         for entry in self.arch_guard.FILE_LINE_LIMIT_CHECKS:
             name, path, limit = entry
-            if name == (
-                "Solver engine boundary: generic call resolver must stay at "
-                "current 3381 LOC baseline (#8209)"
-            ):
+            if "generic call resolver" in name and "#8209" in name:
                 return path, limit
         self.fail(
             "generic call resolver size boundary check is missing from "
@@ -495,7 +492,7 @@ class ArchGuardSolverEngineSizeBoundaryTests(unittest.TestCase):
 
     def test_rule_exists_with_current_limit(self):
         path, limit = self._generic_call_resolver_size_check()
-        self.assertEqual(limit, 3381)
+        self.assertEqual(limit, 3378)
         self.assertTrue(
             str(path).endswith(
                 "crates/tsz-solver/src/operations/generic_call/resolve.rs"


### PR DESCRIPTION
AgentName: Studio-F

## Track
Track 10: Guardrails, Tooling, Residency, And Performance Readiness — arch-guard ratchet maintenance.

## Invariant
When live counts fall below their ratchet caps, the cap has silent headroom that makes measurement less useful. When blanket-coverage caps are set at a point-in-time count but concurrent commits grow the files before the PR merges, the caps are too low and CI would fail. Both conditions require correction.

## Scope
- `scripts/arch/arch_guard_shared.py` — 9 cap adjustments
- `scripts/arch/test_arch_guard.py` — fix hardcoded description string lookup

## Changes

### Ratchet pay-downs (genuine slack after recent merges)

| Check | Before | After | Slack removed |
|---|---|---|---|
| `SNAPSHOT_ROLLBACK_FILE_COUNT_CHECKS` | 6 | 4 | 2 sites removed from non-speculation.rs checker code |
| `SOLVER_IMPORT_COUNT_CHECKS` | 36 | 35 | 1 direct `tsz_solver` import removed from frontend |
| `driver/core.rs` FILE_LINE_LIMIT_CHECKS | 3215 | 3195 | 20 lines of slack |
| `generic_call/resolve.rs` FILE_LINE_LIMIT_CHECKS | 3381 | 3378 | 3 lines of slack |

### Cap corrections (files grew on main between blanket-coverage batch and merge)

PR #11704 measured file sizes at one point in time, but several concurrent PRs landed on main before the merge queue ran the synthetic test. These five files are now larger than the caps set in #11704:

| File | Old cap | New cap | Growth |
|---|---|---|---|
| `state_expressions_literals.rs` | 3027 | 3054 | +27 |
| `state/type_analysis/core.rs` | 2764 | 2798 | +34 |
| `emitter/es5/helpers_async.rs` | 2224 | 2260 | +36 |
| `emitter/helpers.rs` | 2202 | 2222 | +20 |
| `relations/subtype/rules/functions/checking.rs` | 2118 | 2198 | +80 |

### Test fix

`ArchGuardSolverEngineSizeBoundaryTests._generic_call_resolver_size_check` looked up the entry by an exact description string containing `"3381"` and asserted `limit == 3381`. Updated the lookup to use a substring match (`"generic call resolver" in name and "#8209" in name`) so future ratchet-down edits don't break this test, and updated the cap assertion to match the new value (3378).

## Verification
- All 226 arch-guard tests pass (`python3 test_arch_guard.py`)
- `test_no_unguarded_oversized_production_files` passes — zero unguarded files
- `test_all_file_limit_caps_are_not_exceeded` passes — all 72 entries within cap

## Project Corpus Impact
Row: n/a
Bug family: n/a
Evidence: arch-guard-only, no compiler behavior change.

## Coordination Notes
Follows #11704 (merged). No overlap with open PRs (checked open PR list). The test fix makes the solver-engine size test robust to future ratchet edits — a pattern worth applying to other hardcoded description lookups in future.

---
_Generated by [Claude Code](https://claude.ai/code/session_0132dRH9JJWjUhYL6SpPuMsB)_