### PR TITLE
docs(readme): refresh public compatibility metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ test suite against it.
 
 <!-- CONFORMANCE_START -->
 ```
-Progress: [████████████████████] 100.0% (12,582/12,582 tests)
+Progress: [████████████████████] 100.0% (12,579/12,585 tests)
 ```
 <!-- CONFORMANCE_END -->
 
@@ -77,8 +77,8 @@ Progress: [████████████████████] 100.0% 
 
 <!-- EMIT_START -->
 ```
-JavaScript:  [████████████████████] 99.2% (13,421 / 13,530 tests)
-Declaration: [████████████████████] 97.7% (1,631 / 1,669 tests)
+JavaScript:  [████████████████████] 99.2% (13,415 / 13,530 tests)
+Declaration: [████████████████████] 98.1% (1,638 / 1,669 tests)
 ```
 <!-- EMIT_END -->
 

--- a/scripts/ci/test_refresh_readme.py
+++ b/scripts/ci/test_refresh_readme.py
@@ -15,6 +15,28 @@ spec.loader.exec_module(refresh_readme)
 
 
 class RefreshReadmeTests(unittest.TestCase):
+    def test_ci_suite_metric_shape_normalizes_to_counts(self):
+        summary = refresh_readme.normalize_suite_summary({
+            "suite": "conformance",
+            "pass_rate": "100.0",
+            "passed": 12579,
+            "total": 12585,
+        }, "conformance")
+
+        self.assertEqual(summary["passed"], 12579)
+        self.assertEqual(summary["total"], 12585)
+
+    def test_snapshot_suite_metric_shape_normalizes_to_counts(self):
+        summary = refresh_readme.normalize_suite_summary({
+            "summary": {
+                "passed": 6558,
+                "total": 6562,
+            },
+        }, "fourslash")
+
+        self.assertEqual(summary["passed"], 6558)
+        self.assertEqual(summary["total"], 6562)
+
     def test_ci_emit_metric_shape_normalizes_to_readme_summary(self):
         summary = refresh_readme.normalize_emit_summary({
             "suite": "emit",

--- a/scripts/refresh-readme.py
+++ b/scripts/refresh-readme.py
@@ -2,9 +2,9 @@
 """Refresh README.md progress blocks from the latest suite artifact JSON files.
 
 Reads:
-  - scripts/conformance/conformance-detail.json  (or conformance-snapshot.json)
+  - .ci-metrics/conformance.json (or scripts/conformance/conformance-detail.json)
   - .ci-metrics/emit.json (or scripts/emit/emit-detail.json)
-  - scripts/fourslash/fourslash-detail.json
+  - .ci-metrics/fourslash.json (or scripts/fourslash/fourslash-detail.json)
   - https://tsz.dev/benchmark-data/latest.json
 
 Updates the progress blocks between marker comments in README.md:
@@ -46,17 +46,63 @@ def progress_bar(current, total, width=20):
     return f"[{'█' * filled}{'░' * empty}] {pct * 100:.1f}%"
 
 
-def load_conformance():
-    for name in ["conformance-snapshot.json", "conformance-detail.json"]:
-        p = ROOT / "scripts" / "conformance" / name
-        if p.exists():
-            with open(p) as f:
-                data = json.load(f)
-            s = data.get("summary", {})
-            total = s.get("total", s.get("total_tests", 0))
-            passed = s.get("passed", 0)
+def load_metric_json(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def normalize_suite_summary(data, suite):
+    summary = data.get("summary")
+    if summary:
+        return {
+            "passed": summary.get("passed"),
+            "total": summary.get("total", summary.get("total_tests")),
+        }
+
+    if data.get("suite") != suite:
+        return None
+
+    return {
+        "passed": data.get("passed"),
+        "total": data.get("total"),
+    }
+
+
+def suite_metric_candidates(explicit_path, default_paths):
+    candidates = []
+    if explicit_path is not None:
+        path = explicit_path
+        if not path.is_absolute():
+            path = ROOT / path
+        candidates.append(path)
+    candidates.extend(default_paths)
+    return candidates
+
+
+def load_suite_counts(suite, explicit_path, default_paths):
+    for p in suite_metric_candidates(explicit_path, default_paths):
+        if not p.exists():
+            continue
+        summary = normalize_suite_summary(load_metric_json(p), suite)
+        if summary is None:
+            continue
+        passed = summary.get("passed")
+        total = summary.get("total")
+        if passed is not None and total is not None:
             return passed, total
     return None, None
+
+
+def load_conformance(args):
+    return load_suite_counts(
+        "conformance",
+        args.conformance_metrics_json,
+        [
+            ROOT / ".ci-metrics" / "conformance.json",
+            ROOT / "scripts" / "conformance" / "conformance-snapshot.json",
+            ROOT / "scripts" / "conformance" / "conformance-detail.json",
+        ],
+    )
 
 
 def normalize_emit_summary(data):
@@ -148,13 +194,19 @@ def load_emit(args, readme_text):
     return None
 
 
-def load_fourslash():
-    p = ROOT / "scripts" / "fourslash" / "fourslash-detail.json"
-    if not p.exists():
+def load_fourslash(args):
+    passed, total = load_suite_counts(
+        "fourslash",
+        args.fourslash_metrics_json,
+        [
+            ROOT / ".ci-metrics" / "fourslash.json",
+            ROOT / "scripts" / "fourslash" / "fourslash-detail.json",
+            ROOT / "scripts" / "fourslash" / "fourslash-snapshot.json",
+        ],
+    )
+    if passed is None or total is None:
         return None
-    with open(p) as f:
-        data = json.load(f)
-    return data.get("summary", {})
+    return {"passed": passed, "total": total}
 
 
 def replace_block(text, start_marker, end_marker, new_content):
@@ -207,6 +259,16 @@ def parse_args():
         "--emit-metrics-json",
         type=Path,
         help="use a local emit metrics artifact instead of the default .ci-metrics/emit.json",
+    )
+    parser.add_argument(
+        "--conformance-metrics-json",
+        type=Path,
+        help="use a local conformance metrics artifact instead of the default .ci-metrics/conformance.json",
+    )
+    parser.add_argument(
+        "--fourslash-metrics-json",
+        type=Path,
+        help="use a local fourslash metrics artifact instead of the default .ci-metrics/fourslash.json",
     )
     return parser.parse_args()
 
@@ -292,7 +354,7 @@ def main():
         )
 
     # Conformance
-    passed, total = load_conformance()
+    passed, total = load_conformance(args)
     if passed is not None:
         bar = progress_bar(passed, total)
         block = f"```\nProgress: {bar} ({passed:,}/{total:,} tests)\n```"
@@ -312,7 +374,7 @@ def main():
         text = replace_block(text, "<!-- EMIT_START -->", "<!-- EMIT_END -->", block)
 
     # Fourslash
-    fs = load_fourslash()
+    fs = load_fourslash(args)
     if fs is not None:
         bar = progress_bar(fs["passed"], fs["total"])
         block = f"```\nProgress: {bar} ({fs['passed']:,} / {fs['total']:,} tests)\n```"


### PR DESCRIPTION
## AgentName
AgentName: m5-pro-48g-gpt5

## Track
Docs / public metric surfaces

## Invariant
README compatibility blocks should be generated from the same fresh suite metric shape that the website deploy consumes, so README and `tsz.dev/compatibility` do not drift when GCS metrics are newer than checked-in snapshots.

## Scope
- Update `scripts/refresh-readme.py` to read GCS-style `.ci-metrics/{conformance,fourslash}.json` and explicit `--conformance-metrics-json` / `--fourslash-metrics-json` overrides.
- Keep the existing emit metrics override path and local snapshot fallbacks.
- Refresh README conformance and emit numbers from the latest GCS metrics downloaded with authenticated `gcloud`.
- Add focused unit coverage for suite metric normalization.

## Project Corpus Impact
- Row: n/a.
- Bug family: n/a.
- Evidence: docs/readme tooling only; no compiler, benchmark runner, emit harness, checker, solver, parser, binder, LSP, or WASM behavior changes.

## Verification
- `python3 -m unittest scripts.ci.test_refresh_readme`
- `python3 scripts/refresh-readme.py --benchmark-json /tmp/tsz-live-metrics/bench-latest.json --emit-metrics-json /tmp/tsz-live-metrics/emit.json --conformance-metrics-json /tmp/tsz-live-metrics/conformance.json --fourslash-metrics-json /tmp/tsz-live-metrics/fourslash.json --write`
- `git diff --check`
- Live website redeploy run `26658640473` completed successfully; `https://tsz.dev/compatibility/` now shows conformance `12,579 / 12,585`, JavaScript emit `13,415 / 13,530`, declaration emit `1,638 / 1,669`, fourslash `6,558 / 6,562`, built at `ea3f7e6`.

## Coordination Notes
Opened as a ready PR because the change is narrowly scoped to generated README content and its refresh helper. No roadmap update needed.
