### PR TITLE
fix(checker): bound same-input recursive conditional unions

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -179,6 +179,10 @@ name = "recursive_conditional_alias_index_tests"
 path = "tests/recursive_conditional_alias_index_tests.rs"
 
 [[test]]
+name = "recursive_conditional_infer_depth_tests"
+path = "tests/recursive_conditional_infer_depth_tests.rs"
+
+[[test]]
 name = "reverse_mapped_inference_tests"
 path = "tests/reverse_mapped_inference_tests.rs"
 

--- a/crates/tsz-checker/src/state/type_resolution/core.rs
+++ b/crates/tsz-checker/src/state/type_resolution/core.rs
@@ -362,6 +362,8 @@ impl<'a> CheckerState<'a> {
                     // `Foo<[...Elements, "abc"]>`) need depth detection even with type params.
                     let computed_recursive_alias = is_type_alias
                         && self.type_alias_has_computed_recursive_conditional_body(sym_id);
+                    let same_input_recursive_union_alias = is_type_alias
+                        && self.type_alias_has_same_input_recursive_conditional_union_body(sym_id);
                     let default_reset_recursive_alias = is_type_alias
                         && self.type_alias_has_default_reset_recursive_conditional_body(sym_id);
                     let should_check_depth =
@@ -387,19 +389,21 @@ impl<'a> CheckerState<'a> {
                         // probes. The TS2589-specific evaluator treats any repeated
                         // Application cycle as overflow, which is too aggressive for
                         // bounded recursive conditional aliases.
-                        let (exceeded, tuple_too_large) =
-                            if computed_recursive_alias && let Some(base_def_id) = base_def_id {
-                                (
-                                    self.evaluate_type_for_ts2589_check(type_id, base_def_id),
-                                    self.ctx.types.take_tuple_too_large(),
-                                )
-                            } else {
-                                self.evaluate_type_with_env_uncached(type_id);
-                                (
-                                    self.ctx.depth_exceeded.get(),
-                                    self.ctx.types.take_tuple_too_large(),
-                                )
-                            };
+                        let (exceeded, tuple_too_large) = if (computed_recursive_alias
+                            || same_input_recursive_union_alias)
+                            && let Some(base_def_id) = base_def_id
+                        {
+                            (
+                                self.evaluate_type_for_ts2589_check(type_id, base_def_id),
+                                self.ctx.types.take_tuple_too_large(),
+                            )
+                        } else {
+                            self.evaluate_type_with_env_uncached(type_id);
+                            (
+                                self.ctx.depth_exceeded.get(),
+                                self.ctx.types.take_tuple_too_large(),
+                            )
+                        };
 
                         // Also detect circular mapped-type aliases that the evaluator
                         // can't expand: if the alias body is a mapped type that
@@ -1223,6 +1227,8 @@ impl<'a> CheckerState<'a> {
                             );
                         let computed_recursive_alias =
                             self.type_alias_has_computed_recursive_conditional_body(sym_id);
+                        let same_input_recursive_union_alias =
+                            self.type_alias_has_same_input_recursive_conditional_union_body(sym_id);
                         let default_reset_recursive_alias =
                             self.type_alias_has_default_reset_recursive_conditional_body(sym_id);
                         if !args_have_type_params || default_reset_recursive_alias {
@@ -1235,19 +1241,21 @@ impl<'a> CheckerState<'a> {
                             // bounded recursive conditional aliases.
                             let app_def_id = query::get_application_info(self.ctx.types, result)
                                 .and_then(|(base, _)| query::get_lazy_def_id(self.ctx.types, base));
-                            let (exceeded, tuple_too_large) =
-                                if computed_recursive_alias && let Some(app_def_id) = app_def_id {
-                                    (
-                                        self.evaluate_type_for_ts2589_check(result, app_def_id),
-                                        self.ctx.types.take_tuple_too_large(),
-                                    )
-                                } else {
-                                    self.evaluate_type_with_env_uncached(result);
-                                    (
-                                        self.ctx.depth_exceeded.get(),
-                                        self.ctx.types.take_tuple_too_large(),
-                                    )
-                                };
+                            let (exceeded, tuple_too_large) = if (computed_recursive_alias
+                                || same_input_recursive_union_alias)
+                                && let Some(app_def_id) = app_def_id
+                            {
+                                (
+                                    self.evaluate_type_for_ts2589_check(result, app_def_id),
+                                    self.ctx.types.take_tuple_too_large(),
+                                )
+                            } else {
+                                self.evaluate_type_with_env_uncached(result);
+                                (
+                                    self.ctx.depth_exceeded.get(),
+                                    self.ctx.types.take_tuple_too_large(),
+                                )
+                            };
 
                             // Also detect circular mapped-type aliases that the evaluator
                             // can't expand: if the alias body is a mapped type that

--- a/crates/tsz-checker/src/types/type_checking/mod.rs
+++ b/crates/tsz-checker/src/types/type_checking/mod.rs
@@ -29,4 +29,5 @@ mod property_init;
 mod type_alias_checking;
 mod type_alias_depth_helpers;
 mod type_alias_missing_name_coverage;
+mod type_alias_recursion_patterns;
 mod unused;

--- a/crates/tsz-checker/src/types/type_checking/type_alias_recursion_patterns.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_recursion_patterns.rs
@@ -1,0 +1,124 @@
+//! Recursive type-alias shape classifiers used by depth checking.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::NodeAccess;
+use tsz_parser::parser::syntax_kind_ext;
+
+impl<'a> CheckerState<'a> {
+    /// True when a conditional alias has a branch whose top-level union contains
+    /// the same alias applied to the same type parameters.
+    ///
+    /// Productive recursive object shapes such as `{ next: Node<T> }` are valid
+    /// in `tsc`, but top-level union growth like `U | Recur<T>` does not make
+    /// progress on the recursive input and must be bounded by the TS2589
+    /// instantiation-depth path at concrete use sites.
+    pub(crate) fn type_alias_has_same_input_recursive_conditional_union_body(
+        &mut self,
+        alias_sid: tsz_binder::SymbolId,
+    ) -> bool {
+        let Some(symbol) = self.ctx.binder.get_symbol(alias_sid) else {
+            return false;
+        };
+        let declarations = symbol.declarations.clone();
+        declarations.into_iter().any(|decl_idx| {
+            self.ctx.arena.get(decl_idx).is_some_and(|decl_node| {
+                decl_node.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION
+                    && self
+                        .ctx
+                        .arena
+                        .get_type_alias(decl_node)
+                        .is_some_and(|alias| {
+                            self.conditional_body_has_same_input_recursive_union_branch(
+                                alias.type_node,
+                                alias_sid,
+                            )
+                        })
+            })
+        })
+    }
+
+    fn conditional_body_has_same_input_recursive_union_branch(
+        &mut self,
+        node_idx: NodeIndex,
+        alias_sid: tsz_binder::SymbolId,
+    ) -> bool {
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return false;
+        };
+
+        if node.kind == syntax_kind_ext::CONDITIONAL_TYPE
+            && let Some(cond) = self.ctx.arena.get_conditional_type(node)
+            && (self.type_node_top_level_union_contains_same_input_recursive_alias_ref(
+                cond.true_type,
+                alias_sid,
+            ) || self.type_node_top_level_union_contains_same_input_recursive_alias_ref(
+                cond.false_type,
+                alias_sid,
+            ))
+        {
+            return true;
+        }
+
+        self.ctx
+            .arena
+            .get_children(node_idx)
+            .into_iter()
+            .any(|child_idx| {
+                self.conditional_body_has_same_input_recursive_union_branch(child_idx, alias_sid)
+            })
+    }
+
+    fn type_node_top_level_union_contains_same_input_recursive_alias_ref(
+        &self,
+        node_idx: NodeIndex,
+        alias_sid: tsz_binder::SymbolId,
+    ) -> bool {
+        let Some(unwrapped_idx) = self.unwrap_parenthesized_type(node_idx) else {
+            return false;
+        };
+        let Some(node) = self.ctx.arena.get(unwrapped_idx) else {
+            return false;
+        };
+
+        if node.kind != syntax_kind_ext::UNION_TYPE {
+            return false;
+        }
+
+        self.ctx
+            .arena
+            .get_composite_type(node)
+            .is_some_and(|union| {
+                union.types.nodes.iter().copied().any(|member_idx| {
+                    self.type_node_is_same_input_recursive_alias_ref(member_idx, alias_sid)
+                })
+            })
+    }
+
+    fn type_node_is_same_input_recursive_alias_ref(
+        &self,
+        node_idx: NodeIndex,
+        alias_sid: tsz_binder::SymbolId,
+    ) -> bool {
+        let Some(unwrapped_idx) = self.unwrap_parenthesized_type(node_idx) else {
+            return false;
+        };
+        let Some(node) = self.ctx.arena.get(unwrapped_idx) else {
+            return false;
+        };
+        if node.kind != syntax_kind_ext::TYPE_REFERENCE {
+            return false;
+        }
+        let Some(type_ref) = self.ctx.arena.get_type_ref(node) else {
+            return false;
+        };
+        let resolved = self
+            .resolve_type_symbol_for_lowering(type_ref.type_name)
+            .map(tsz_binder::SymbolId);
+        resolved == Some(alias_sid)
+            && type_ref
+                .type_arguments
+                .as_ref()
+                .is_some_and(|args| self.type_args_match_alias_params(alias_sid, args))
+    }
+}

--- a/crates/tsz-checker/tests/recursive_conditional_infer_depth_tests.rs
+++ b/crates/tsz-checker/tests/recursive_conditional_infer_depth_tests.rs
@@ -1,0 +1,78 @@
+//! Recursive conditional aliases with non-progressing `infer` branches.
+//!
+//! Structural rule: when a recursive conditional alias recurses on the same
+//! input after an `infer` branch, `tsc` reports bounded TS2589 instead of
+//! overflowing. The checker must surface the same depth diagnostic and recover.
+
+use tsz_checker::test_utils::check_source_codes;
+
+#[track_caller]
+fn assert_codes(source: &str, expected: &[u32], label: &str) {
+    let actual = check_source_codes(source);
+    assert_eq!(
+        actual, expected,
+        "[{label}] expected diagnostic codes {expected:?}, got {actual:?}"
+    );
+}
+
+#[test]
+fn recursive_infer_branch_on_same_input_emits_ts2589() {
+    let source = r#"
+type Recur<T> = T extends { a: infer U } ? U | Recur<T> : never;
+type Actual = Recur<{ a: { b: string } | { c: number } }>;
+declare const actual: Actual;
+const useActual: { b: string } | { c: number } = actual;
+const bad: { d: boolean } = actual;
+"#;
+
+    assert_codes(source, &[2589], "same-input recursive infer branch");
+}
+
+#[test]
+fn renamed_recursive_infer_branch_on_same_input_emits_ts2589() {
+    let source = r#"
+type PickAgain<Item> = Item extends { value: infer Part } ? Part | PickAgain<Item> : never;
+type Result = PickAgain<{ value: { left: string } | { right: number } }>;
+declare const result: Result;
+const useResult: { left: string } | { right: number } = result;
+const bad: { done: boolean } = result;
+"#;
+
+    assert_codes(source, &[2589], "renamed same-input recursive infer branch");
+}
+
+#[test]
+fn terminating_recursive_infer_branch_does_not_emit_ts2589() {
+    let source = r#"
+type Unbox<T> = T extends { a: infer U } ? U : never;
+type Actual = Unbox<{ a: { b: string } | { c: number } }>;
+declare const actual: Actual;
+const ok: { b: string } | { c: number } = actual;
+"#;
+
+    assert_codes(source, &[], "terminating infer branch");
+}
+
+#[test]
+fn non_matching_same_input_recursive_condition_does_not_emit_ts2589() {
+    let source = r#"
+type Recur<T> = T extends { a: infer U } ? U | Recur<T> : never;
+type Actual = Recur<string>;
+declare const actual: Actual;
+const ok: never = actual;
+"#;
+
+    assert_codes(source, &[], "non-matching same-input recursive condition");
+}
+
+#[test]
+fn productive_recursive_object_branch_does_not_emit_ts2589() {
+    let source = r#"
+type Node<T> = T extends unknown ? { value: T; next: Node<T> } : never;
+type Actual = Node<number>;
+declare const actual: Actual;
+const ok: number = actual.next.next.value;
+"#;
+
+    assert_codes(source, &[], "productive recursive object branch");
+}


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Track: recursive conditional / checker depth handling for M4-A recursive conditional ownership.

## Invariant
When a concrete recursive conditional alias grows a top-level union by reapplying the same alias to the same input, tsz must report bounded TS2589 like tsc instead of overflowing during relation or diagnostic formatting; productive recursive object branches must remain accepted.

## Scope
- `crates/tsz-checker/src/types/type_checking/type_alias_recursion_patterns.rs` adds a shape classifier for same-input recursive conditional union branches.
- `crates/tsz-checker/src/state/type_resolution/core.rs` routes that shape through the existing TS2589 evaluator at concrete type-reference/application sites.
- `crates/tsz-checker/tests/recursive_conditional_infer_depth_tests.rs` covers positive, renamed, terminating, non-matching, and productive-object cases.

## Project Corpus Impact
- Row: kysely-project (#11357 family)
- Bug family: recursive conditional infer / same-input union growth nontermination
- Evidence: minimized #11357-style repro now reports TS2589 instead of stack overflow; focused checker tests cover the regression shape and non-regression shapes.

## Verification
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `cargo nextest run -p tsz-checker --test recursive_conditional_infer_depth_tests`
- `cargo nextest run -p tsz-checker --test recursive_conditional_alias_index_tests`
- `cargo nextest run -p tsz-checker --lib -E 'test(infinite_tail_recursive_conditional_alias_with_concrete_args_emits_ts2589) or test(intersection_growth_emits_ts2589_no_cascade) or test(direct_recursion_still_emits_ts2589) or test(terminating_infer_alias_no_ts2589)'`
- `cargo run -p tsz-cli --bin tsz -- --noEmit --strict <minimized-repro>` reports `TS2589`

## Coordination Notes
- No open M4-A PRs were owned before opening this branch (`scripts/agents/list-owned-work.sh M4-A`).
- Open PR overlap checked before publishing; this PR is scoped to checker recursive conditional TS2589 depth routing and does not overlap active emit/DTS or M4-B cache stacks.
- Rebased after #11719 merged so local architecture guard now passes on current `main`.
