### PR TITLE
fix(dts): render fully-resolved generic-call returns from canonical TypePrinter, not source-text substitution

### DIFF
--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -94,6 +94,10 @@ path = "tests/import_equals_alias_dts_emit_tests.rs"
 name = "inferred_object_index_signature_dts_emit_tests"
 path = "tests/inferred_object_index_signature_dts_emit_tests.rs"
 
+[[test]]
+name = "generic_call_bare_type_param_dts_emit_tests"
+path = "tests/generic_call_bare_type_param_dts_emit_tests.rs"
+
 [dev-dependencies]
 tempfile = { workspace = true }
 

--- a/crates/tsz-cli/tests/generic_call_bare_type_param_dts_emit_tests.rs
+++ b/crates/tsz-cli/tests/generic_call_bare_type_param_dts_emit_tests.rs
@@ -1,0 +1,293 @@
+//! DTS emit for generic calls whose source return type is a *simple* type-
+//! parameter surface (a bare type parameter, or an array of one).
+//!
+//! Structural rule: when a generic call's source return annotation is a bare
+//! type-parameter reference (`T`) or an array of one (`U[]`), and the checker's
+//! canonical type for the call is fully resolved (it contains no `infer`
+//! placeholders and no free type parameters), declaration emit serializes that
+//! canonical type via the type printer instead of reconstructing it by
+//! substituting type parameters into the source return text. The legacy text
+//! path mangled member values containing `<`, `>`, or `,` (e.g. a reverse-
+//! mapped `unboxify(x)` emitting `a: number>, b: Box<string[]`).
+//!
+//! Composite returns (intersection `D & M`, union `T | U`, application
+//! `Foo<T>`) and unresolved-conditional/`infer` returns intentionally keep the
+//! text path, so their tsc-faithful source structure is preserved.
+//!
+//! These cases vary type-parameter names, member spellings, and member-value
+//! generic shapes so the coverage proves the rule rather than a single
+//! spelling. They invoke the full `tsz` binary so the checker's node-type
+//! cache (which the fix consults) is populated.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(name: &str) -> std::io::Result<Self> {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("tsz_bare_tp_dts_{name}_{nanos}"));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+fn emit_dts(name: &str, source: &str) -> Option<String> {
+    let tsz_bin = find_tsz_binary()?;
+    let temp = TempDir::new(name).expect("temp dir");
+    let src_path = temp.path.join("repro.ts");
+    std::fs::write(&src_path, source).expect("write repro file");
+
+    let output = Command::new(tsz_bin)
+        .args([
+            "repro.ts",
+            "--declaration",
+            "--emitDeclarationOnly",
+            "--target",
+            "es2015",
+            "--lib",
+            "es6",
+            "--strict",
+            "--pretty",
+            "false",
+        ])
+        .current_dir(&temp.path)
+        .output()
+        .expect("run tsz declaration emit");
+
+    let dts = std::fs::read_to_string(temp.path.join("repro.d.ts")).unwrap_or_else(|_| {
+        panic!(
+            "expected repro.d.ts to be emitted.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    Some(dts)
+}
+
+// =============================================================================
+// Bare type-parameter return resolving to an object: no reflow mangling
+// =============================================================================
+
+/// Primary repro (mappedTypesArraysTuples): `unboxify<T>(x: Boxified<T>): T`
+/// reverse-mapped inference whose argument members carry nested generic values.
+/// The inferred declaration must render the resolved object members, not the
+/// mangled comma/angle-bracket reflow `a: number>, b: Box<string[]`.
+#[test]
+fn reverse_mapped_object_members_render_without_reflow_mangling() {
+    let Some(dts) = emit_dts(
+        "unboxify",
+        r#"
+type Box<T> = { value: T };
+type Boxified<T> = { [P in keyof T]: Box<T[P]> };
+declare function unboxify<T>(x: Boxified<T>): T;
+declare let src: { a: Box<number>, b: Box<string[]> };
+export let dst = unboxify(src);
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        !dts.contains("number>,"),
+        "member-value reflow must not leak `number>,`:\n{dts}"
+    );
+    assert!(
+        !dts.contains("Box<string[];"),
+        "member-value reflow must not split nested generics:\n{dts}"
+    );
+    assert!(
+        dts.contains("a: number;"),
+        "expected resolved member `a: number;`:\n{dts}"
+    );
+    assert!(
+        dts.contains("b: string[];"),
+        "expected resolved member `b: string[];`:\n{dts}"
+    );
+}
+
+/// Same rule, renamed type parameter (`E`/`K`) and different member spellings
+/// (`first`/`second`). Renaming the bound variables must not change the
+/// outcome — proving the fix is keyed on structure, not on the name `T`/`P`.
+#[test]
+fn reverse_mapped_renamed_type_parameter_still_renders_resolved_members() {
+    let Some(dts) = emit_dts(
+        "unwrap_renamed",
+        r#"
+type Wrap<E> = { value: E };
+type Wrapped<E> = { [K in keyof E]: Wrap<E[K]> };
+declare function unwrap<E>(x: Wrapped<E>): E;
+declare let boxes: { first: Wrap<number[]>, second: Wrap<boolean> };
+export let plain = unwrap(boxes);
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        !dts.contains("number[]>,"),
+        "renamed reverse-mapped case must not leak reflow mangling:\n{dts}"
+    );
+    assert!(
+        dts.contains("first: number[];"),
+        "expected resolved member `first: number[];`:\n{dts}"
+    );
+    assert!(
+        dts.contains("second: boolean;"),
+        "expected resolved member `second: boolean;`:\n{dts}"
+    );
+}
+
+// =============================================================================
+// Array of a bare type parameter (`U[]`) uses resolved element type
+// =============================================================================
+
+/// Primary repro (genericFunctions2): `map<T, U>(items: T[], f: (x: T) => U):
+/// U[]`. The inferred declaration must use the resolved element type
+/// (`number[]`), not lose `U` and collapse to `any[]`.
+#[test]
+fn array_of_type_parameter_return_uses_resolved_element_type() {
+    let Some(dts) = emit_dts(
+        "map_lengths",
+        r#"
+declare function map<T, U>(items: T[], f: (x: T) => U): U[];
+declare var names: string[];
+export let lengths = map(names, x => x.length);
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("lengths: number[]"),
+        "expected resolved array element type `number[]`:\n{dts}"
+    );
+    assert!(
+        !dts.contains("lengths: any[]"),
+        "array-of-type-parameter return must not collapse to `any[]`:\n{dts}"
+    );
+}
+
+/// Adjacent shape: a different result element type (`boolean[]`) and a renamed
+/// type parameter (`A`/`B`) prove the rule is not tied to `number`/`U`.
+#[test]
+fn array_of_renamed_type_parameter_uses_resolved_element_type() {
+    let Some(dts) = emit_dts(
+        "map_flags",
+        r#"
+declare function project<A, B>(items: A[], f: (x: A) => B): B[];
+declare var nums: number[];
+export let flags = project(nums, x => x > 0);
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("flags: boolean[]"),
+        "expected resolved array element type `boolean[]`:\n{dts}"
+    );
+    assert!(
+        !dts.contains("flags: any[]"),
+        "renamed array-of-type-parameter return must not collapse to `any[]`:\n{dts}"
+    );
+}
+
+// =============================================================================
+// Bare type-parameter return resolving to a primitive
+// =============================================================================
+
+/// Primary repro (recursiveTypeReferences1): `head<T>(a: Nest<T>): T` where the
+/// argument's declared type is a recursive alias. The inferred declaration
+/// emits the resolved bare type parameter (`string`), not the argument alias.
+#[test]
+fn bare_type_parameter_return_resolves_to_primitive_not_argument_alias() {
+    let Some(dts) = emit_dts(
+        "head_nest",
+        r#"
+type Nest<T> = T | Nest<T>[];
+declare function head<T>(a: Nest<T>): T;
+declare let xs: Nest<string>;
+export let h = head(xs);
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("h: string"),
+        "expected resolved bare type parameter `string`:\n{dts}"
+    );
+    assert!(
+        !dts.contains("h: Nest<string>"),
+        "bare type-parameter return must not reuse the argument alias:\n{dts}"
+    );
+}
+
+// =============================================================================
+// Negative / fallback: composite returns keep the text path
+// =============================================================================
+
+/// A composite intersection return (`D & M`) must NOT be routed through the
+/// canonical printer (which would merge/reorder the intersection). tsc
+/// preserves the `&` source structure, so the emitted type keeps the `&`
+/// rather than a single merged object literal.
+#[test]
+fn intersection_return_preserves_source_intersection_structure() {
+    let Some(dts) = emit_dts(
+        "combine_intersection",
+        r#"
+declare function combine<D, M>(a: D, b: M): D & M;
+declare let left: { x: number };
+declare let right: { run(): void };
+export let r = combine(left, right);
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    // The intersection surface is preserved as two operands joined by `&`,
+    // not flattened/reordered into a single merged object literal.
+    assert!(
+        dts.contains('&'),
+        "composite intersection return must keep its `&` structure:\n{dts}"
+    );
+    assert!(
+        dts.contains("r: { x: number } & { run(): void }")
+            || dts.contains("x: number") && dts.contains("run(): void") && dts.contains('&'),
+        "intersection members must both survive on the `&` surface:\n{dts}"
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_call.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_call.rs
@@ -107,6 +107,78 @@ impl<'a> DeclarationEmitter<'a> {
         })
     }
 
+    /// True when the function's return type annotation is a *simple* type-
+    /// parameter surface: a bare reference to one of its own declared type
+    /// parameters (the `T` in `unboxify<T>(x: Boxified<T>): T` or `foo1<T>(…): T`),
+    /// or an array of such a reference (the `U[]` in `map<T,U>(…): U[]`).
+    ///
+    /// In those shapes the inferred return type IS just the resolved type
+    /// parameter (optionally inside an array), so tsc emits exactly that type
+    /// with no surrounding *source* structure to preserve. Composite returns
+    /// such as `D & M` (intersection), `T | U` (union), or `Foo<T>`
+    /// (application) are intentionally excluded: tsc keeps their source-level
+    /// structure, which the canonical printer would flatten, reorder, or merge.
+    pub(in crate::declaration_emitter) fn source_return_is_bare_type_parameter(
+        &self,
+        source_arena: &NodeArena,
+        func: &tsz_parser::parser::node::FunctionData,
+    ) -> bool {
+        let Some(annotation_idx) = func.type_annotation.into_option() else {
+            return false;
+        };
+        self.type_node_is_type_parameter_or_array_of(source_arena, func, annotation_idx)
+    }
+
+    fn type_node_is_type_parameter_or_array_of(
+        &self,
+        source_arena: &NodeArena,
+        func: &tsz_parser::parser::node::FunctionData,
+        type_idx: tsz_parser::parser::NodeIndex,
+    ) -> bool {
+        let Some(type_node) = source_arena.get(type_idx) else {
+            return false;
+        };
+        // `T[]` — recurse on the element type so `U[]` (and `U[][]`) qualify
+        // while keeping the same "no composite structure" guarantee.
+        if type_node.kind == syntax_kind_ext::ARRAY_TYPE {
+            let Some(array) = source_arena.get_array_type(type_node) else {
+                return false;
+            };
+            return self.type_node_is_type_parameter_or_array_of(
+                source_arena,
+                func,
+                array.element_type,
+            );
+        }
+        // A bare type-parameter reference is a plain identifier or a type
+        // reference with no type arguments naming a declared type parameter.
+        let name = if type_node.kind == SyntaxKind::Identifier as u16 {
+            self.identifier_text_from_arena(source_arena, type_idx)
+        } else if type_node.kind == syntax_kind_ext::TYPE_REFERENCE {
+            let Some(type_ref) = source_arena.get_type_ref(type_node) else {
+                return false;
+            };
+            if type_ref.type_arguments.is_some() {
+                return false;
+            }
+            self.identifier_text_from_arena(source_arena, type_ref.type_name)
+        } else {
+            None
+        };
+        let Some(name) = name else {
+            return false;
+        };
+        func.type_parameters.as_ref().is_some_and(|type_params| {
+            type_params.nodes.iter().copied().any(|param_idx| {
+                source_arena
+                    .get(param_idx)
+                    .and_then(|param_node| source_arena.get_type_parameter(param_node))
+                    .and_then(|param| self.identifier_text_from_arena(source_arena, param.name))
+                    .is_some_and(|param_name| param_name == name)
+            })
+        })
+    }
+
     pub(in crate::declaration_emitter) fn substitute_source_call_type_parameters(
         &self,
         source_arena: &NodeArena,

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
@@ -351,6 +351,42 @@ impl<'a> DeclarationEmitter<'a> {
         Some(type_text)
     }
 
+    /// Render the canonical `TypeId` for a call expression when, and only when,
+    /// that type is fully resolved: it contains no `infer` placeholders and no
+    /// free type parameters.
+    ///
+    /// Callers must additionally have established that the function's source
+    /// return annotation is a simple type-parameter surface (see
+    /// [`Self::source_return_is_bare_type_parameter`]); together those two facts
+    /// are the structural precondition under which the canonical
+    /// [`TypePrinter`] output is a faithful, reusable declaration type. We can
+    /// then bypass source-text type-parameter substitution, which mangles
+    /// member values containing `<`, `>`, or `,` (e.g. `unboxify(x12)`
+    /// reconstructing `a: number>, b: Box<string[]`).
+    ///
+    /// Returns `None` when type information is unavailable, the type is trivial
+    /// (`any`/`unknown`/`error`), or the type still contains unresolved
+    /// `infer`/type-parameter structure that the canonical printer would
+    /// flatten incorrectly.
+    fn fully_resolved_call_canonical_type_text(&self, expr_idx: NodeIndex) -> Option<String> {
+        let interner = self.type_interner?;
+        self.type_cache.as_ref()?;
+        let call_type_id = self.get_node_type_or_names(&[expr_idx])?;
+        if matches!(call_type_id, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR) {
+            return None;
+        }
+        if tsz_solver::visitor::contains_infer_types(interner, call_type_id)
+            || tsz_solver::visitor::contains_type_parameters(interner, call_type_id)
+        {
+            return None;
+        }
+        let type_text = self.print_type_id_for_inferred_declaration(call_type_id);
+        if type_text.is_empty() || matches!(type_text.as_str(), "any" | "unknown" | "error") {
+            return None;
+        }
+        Some(Self::strip_synthetic_anonymous_object_members(&type_text))
+    }
+
     pub(in crate::declaration_emitter) fn call_expression_source_return_type_text(
         &self,
         expr_idx: NodeIndex,
@@ -420,6 +456,23 @@ impl<'a> DeclarationEmitter<'a> {
                             &type_text,
                         )
                     {
+                        // SF-4 reflow guard: when the function's return is a bare
+                        // type-parameter reference (e.g. the `T` in
+                        // `unboxify<T>(x: Boxified<T>): T`) and the checker's
+                        // canonical type for this call is a fully resolved
+                        // anonymous object, the source-text substitution path
+                        // below can mangle member values containing `<`, `>`, or
+                        // `,` (reconstructing `a: number>, b: Box<string[]`).
+                        // Emit the canonical `TypePrinter` render instead. The
+                        // bare-type-parameter precondition keeps composite returns
+                        // (`D & M`, `T | U`, `Foo<T>`) on the text path so their
+                        // tsc-faithful source structure is preserved.
+                        if self.source_return_is_bare_type_parameter(source_arena, func)
+                            && let Some(canonical_text) =
+                                self.fully_resolved_call_canonical_type_text(expr_idx)
+                        {
+                            return Some(canonical_text);
+                        }
                         if let Some(evaluated) = self
                             .evaluate_source_template_infer_conditional_call(
                                 source_arena,


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — declaration emit canonical-type display (emit→100% campaign, wave 3, §6.4 SF-4/SF-3)

## Invariant
When a generic call's source return annotation is a *simple type-parameter surface* — a bare type parameter (`T`) or an array of one (`U[]`) — AND the checker's canonical type for the call is fully resolved (`!contains_infer_types && !contains_type_parameters`), declaration emit serializes the canonical `TypePrinter` render instead of substituting type parameters into the source return text (which produced `any[]`/recursive-alias mangling). Composite returns (intersection/union/application) and unresolved-conditional/`infer` returns keep the legacy source-text path to preserve tsc-faithful structure. Gate keyed on AST node kind (Identifier / TypeReference-no-args / ArrayType) + solver structural predicates — no identifier-name or printer-output matching.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs` — new `fully_resolved_call_canonical_type_text`; gated insertion in `call_expression_source_return_type_text`.
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_call.rs` — `source_return_is_bare_type_parameter` + `type_node_is_type_parameter_or_array_of`.
- `crates/tsz-cli/tests/generic_call_bare_type_param_dts_emit_tests.rs` (+6 checker-backed integration tests) + Cargo.toml test registration.

## Project Corpus Impact
- Row: n/a (declaration emit parity fix)
- Bug family: DTS generic-call inferred-return display — source-text substitution mangles simple type-param-surface returns
- Evidence: genericFunctions2, recursiveTypeReferences1 FAIL→PASS; full --dts-only 32→30.

## Verification
- 2 witnesses FAIL→PASS (genericFunctions2 `map(...): U[]` was `any[]`; recursiveTypeReferences1 `head(...): T` reused recursive alias). **Full --dts-only: 1637→1639 pass (32→30 fail), net +2, ZERO new failures.** --js-only unaffected (DTS-only change). mappedTypesArraysTuples y12 reflow also fixed (residual y22 is an upstream solver bug).
- 6 checker-backed integration tests in tsz-cli (renamed type params, varied member/element shapes, intersection negative). Tests live in tsz-cli (not tsz-emitter) because the emit-dts unit harness doesn't run the checker, so the node-type cache the gate reads is empty there. Clippy clean (tsz-emitter + tsz-cli, -D warnings).
- §25/§26 compliant; §6.4-aligned (prefer canonical TypePrinter over source-text reconstruction).

## Coordination Notes
Rebased onto current main (arch file-size ratchet guard fails on stale branches). Confirmed (via tracing) as genuine upstream solver SF-1 bugs, NOT fixed here: inferTypes2 (canonical TypeId lost `infer P`), deferredLookupTypeResolution (solver widened type param `A`→`string`, mapped type not evaluated over literal union), mappedTypesArraysTuples y22 (reverse-mapped `Partial` keeps spurious `| undefined`), templateInsideCallback (JSDoc `@overload`/`@typedef` recovery, not object reflow). These are handed to a sibling solver effort. — opus48-emit100
