### PR TITLE
test(solver): cover callable relation cache

### DIFF
--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -180,6 +180,89 @@ fn assignability_cache_strict_any_matches_uncached_relation_policy() {
 }
 
 #[test]
+fn assignability_cache_strict_function_types_does_not_imply_strict_any_policy() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let value = interner.intern_string("value");
+
+    let source = interner.object(vec![PropertyInfo::new(value, TypeId::ANY)]);
+    let target = interner.object(vec![PropertyInfo::new(value, TypeId::NUMBER)]);
+
+    let strict_functions =
+        RelationPolicy::from_relation_flags(RelationFlags::STRICT_FUNCTION_TYPES);
+    let strict_any = strict_functions.with_strict_any_propagation(true);
+    let strict_functions_key =
+        RelationCacheKey::for_assignability(source, target, strict_functions.cache_config());
+    let strict_any_key =
+        RelationCacheKey::for_assignability(source, target, strict_any.cache_config());
+
+    assert_ne!(
+        strict_functions_key, strict_any_key,
+        "strict-function and strict-any policies must occupy distinct assignability cache slots",
+    );
+
+    let strict_functions_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        strict_functions,
+        RelationContext::default(),
+    )
+    .is_related();
+    let strict_any_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        strict_any,
+        RelationContext::default(),
+    )
+    .is_related();
+
+    assert!(
+        strict_functions_uncached,
+        "strict function types alone should still allow nested `any` to satisfy a number property",
+    );
+    assert!(
+        !strict_any_uncached,
+        "explicit strict-any propagation must reject the nested `any` property mismatch",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, strict_functions),
+        strict_functions_uncached,
+        "cached strict-function policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(strict_functions_key),
+        Some(strict_functions_uncached),
+        "strict-function result must be stored in the strict-function assignability slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(strict_any_key),
+        None,
+        "strict-any lookup must not hit the strict-function slot",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, strict_any),
+        strict_any_uncached,
+        "cached strict-any policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(strict_any_key),
+        Some(strict_any_uncached),
+        "strict-any result must be stored in its own assignability slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(strict_functions_key),
+        Some(strict_functions_uncached),
+        "strict-function slot must remain intact after the strict-any lookup",
+    );
+}
+
+#[test]
 fn assignability_cache_skip_weak_type_checks_matches_uncached_relation_policy() {
     let interner = TypeInterner::new();
     let db = QueryCache::new(&interner);

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -9,7 +9,8 @@ use crate::relations::relation_queries::{
 };
 use crate::relations::subtype::AnyPropagationMode;
 use crate::types::{
-    FunctionShape, ParamInfo, PropertyInfo, RelationCacheKey, RelationFlags, TypeId, TypeParamInfo,
+    CallSignature, CallableShape, FunctionShape, ParamInfo, PropertyInfo, RelationCacheKey,
+    RelationFlags, TypeId, TypeParamInfo,
 };
 
 #[test]
@@ -592,6 +593,107 @@ fn assignability_cache_strict_function_types_matches_uncached_function_variance(
     assert!(
         stats.assignability_misses >= 2,
         "strict and loose variance policies should miss in separate cache slots",
+    );
+}
+
+#[test]
+fn assignability_cache_callable_signatures_match_uncached_function_variance() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let name = interner.intern_string("name");
+    let breed = interner.intern_string("breed");
+
+    let animal = interner.object(vec![PropertyInfo::new(name, TypeId::STRING)]);
+    let dog = interner.object(vec![
+        PropertyInfo::new(name, TypeId::STRING),
+        PropertyInfo::new(breed, TypeId::STRING),
+    ]);
+
+    let source = interner.callable(CallableShape {
+        call_signatures: vec![CallSignature::new(
+            vec![ParamInfo::unnamed(dog)],
+            TypeId::VOID,
+        )],
+        ..CallableShape::default()
+    });
+    let target = interner.callable(CallableShape {
+        call_signatures: vec![CallSignature::new(
+            vec![ParamInfo::unnamed(animal)],
+            TypeId::VOID,
+        )],
+        ..CallableShape::default()
+    });
+
+    let strict_policy = RelationPolicy::from_relation_flags(RelationFlags::STRICT_FUNCTION_TYPES);
+    let loose_policy = RelationPolicy::unflagged_compatibility();
+    let strict_key =
+        RelationCacheKey::for_assignability(source, target, strict_policy.cache_config());
+    let loose_key =
+        RelationCacheKey::for_assignability(source, target, loose_policy.cache_config());
+
+    assert_ne!(
+        strict_key, loose_key,
+        "callable strict and loose variance policies must occupy distinct assignability cache slots",
+    );
+
+    let strict_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        strict_policy,
+        RelationContext::default(),
+    )
+    .is_related();
+    let loose_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        loose_policy,
+        RelationContext::default(),
+    )
+    .is_related();
+
+    assert!(
+        !strict_uncached,
+        "strict callable parameter variance should reject `(dog) => void` where `(animal) => void` is required",
+    );
+    assert!(
+        loose_uncached,
+        "loose callable parameter variance should accept the bivariant call-signature comparison",
+    );
+
+    let strict_cached = db.is_assignable_to_with_policy(source, target, strict_policy);
+    assert_eq!(
+        strict_cached, strict_uncached,
+        "cached strict callable variance must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(strict_key),
+        Some(strict_cached),
+        "strict callable result must use its own cache slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(loose_key),
+        None,
+        "loose callable lookup must not hit the strict callable slot",
+    );
+
+    let loose_cached = db.is_assignable_to_with_policy(source, target, loose_policy);
+    assert_eq!(
+        loose_cached, loose_uncached,
+        "cached loose callable variance must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(loose_key),
+        Some(loose_cached),
+        "loose callable result must use its own cache slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(strict_key),
+        Some(strict_cached),
+        "strict callable slot must remain intact after the loose callable lookup",
     );
 }
 

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -1485,3 +1485,102 @@ fn assignability_cache_in_callback_param_check_matches_uncached_relation_policy(
         "ordinary method slot must remain intact after the callback-mode lookup",
     );
 }
+
+#[test]
+fn assignability_cache_disable_method_bivariance_matches_uncached_method_parameter_count() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let mut source_shape = FunctionShape::new(
+        vec![
+            ParamInfo::unnamed(TypeId::STRING),
+            ParamInfo::unnamed(TypeId::NUMBER),
+        ],
+        TypeId::VOID,
+    );
+    source_shape.is_method = true;
+    let source = interner.function(source_shape);
+
+    let mut target_shape =
+        FunctionShape::new(vec![ParamInfo::unnamed(TypeId::STRING)], TypeId::VOID);
+    target_shape.is_method = true;
+    let target = interner.function(target_shape);
+
+    let bivariant_method = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_FUNCTION_TYPES | RelationFlags::ALLOW_BIVARIANT_PARAM_COUNT,
+    );
+    let sound_method = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_FUNCTION_TYPES
+            | RelationFlags::ALLOW_BIVARIANT_PARAM_COUNT
+            | RelationFlags::DISABLE_METHOD_BIVARIANCE,
+    );
+    let bivariant_key =
+        RelationCacheKey::for_assignability(source, target, bivariant_method.cache_config());
+    let sound_key =
+        RelationCacheKey::for_assignability(source, target, sound_method.cache_config());
+
+    assert_ne!(
+        bivariant_key, sound_key,
+        "method-bivariant and sound-method parameter-count policies must occupy distinct assignability cache slots",
+    );
+
+    let bivariant_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        bivariant_method,
+        RelationContext::default(),
+    )
+    .is_related();
+    let sound_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        sound_method,
+        RelationContext::default(),
+    )
+    .is_related();
+
+    assert!(
+        bivariant_uncached,
+        "method bivariance should allow extra required method parameters when the count exception is enabled",
+    );
+    assert!(
+        !sound_uncached,
+        "disabling method bivariance should also disable the method parameter-count exception",
+    );
+
+    let bivariant_cached = db.is_assignable_to_with_policy(source, target, bivariant_method);
+    assert_eq!(
+        bivariant_cached, bivariant_uncached,
+        "cached method-bivariant parameter-count policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(bivariant_key),
+        Some(bivariant_cached),
+        "method-bivariant parameter-count result must use its own cache slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(sound_key),
+        None,
+        "sound-method lookup must not hit the method-bivariant parameter-count slot",
+    );
+
+    let sound_cached = db.is_assignable_to_with_policy(source, target, sound_method);
+    assert_eq!(
+        sound_cached, sound_uncached,
+        "cached sound-method parameter-count policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(sound_key),
+        Some(sound_cached),
+        "sound-method parameter-count result must use its own cache slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(bivariant_key),
+        Some(bivariant_cached),
+        "method-bivariant parameter-count slot must remain intact after the sound-method lookup",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 10 relation policy/cache-key tech debt (#8207), solver policy/cache agreement test ratchet.

## Invariant
Callable-signature relation checks must agree between cached and uncached execution when function variance policy changes; this PR ratchets the callable cache-key coverage.

## Scope
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: solver test-only ratchet for relation policy/cache agreement; no project corpus behavior change targeted.

## Verification
- RED `cargo nextest run -p tsz-solver -E 'test(assignability_cache_callable_signatures_match_uncached_function_variance)'` failed before the test existed with `error: no tests to run`.
- 2026-05-29 after #11662 was rebased, rebased this branch onto `codex/m4-b-sft-any-cache-20260529`; exact base `f328e349aeb3e8fbebf7205ad807bc91b1f57a07`, exact head `d9f73d2f2395c847d2d707f3cbcce66fc38bfee7`.
- `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'`: 20 passed on `d9f73d2f2395c847d2d707f3cbcce66fc38bfee7`.
- `cargo fmt --check`: passed on `d9f73d2f2395c847d2d707f3cbcce66fc38bfee7`.
- `git diff --check codex/m4-b-sft-any-cache-20260529..HEAD`: passed on `d9f73d2f2395c847d2d707f3cbcce66fc38bfee7`.
- Stack diff check: `git diff --stat codex/m4-b-sft-any-cache-20260529..HEAD` -> one solver test file, 103 insertions and 1 deletion.
- File-size guard: `wc -l crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs` -> 1771 lines, below the 2000-line cap.
- 2026-05-30: #11662 merged into `main`; PR retargeted from `codex/m4-b-sft-any-cache-20260529` to `main`. Ready CI will verify the exact GitHub head.

## Coordination Notes
- #11662 is merged; this PR is now unstacked onto `main` and ready for heavy CI.
- Downstream M4-B stack: #11727 remains stacked on this branch and will be retargeted after this PR merges.
- Non-overlap: this slice covers only solver relation cache agreement for callable-signature function variance policy; it does not touch checker relation routing owned by M1-B, nor M4-A/M4-C evaluation/inference lanes.
- Auto-merge and `merge-queue` remain unset until exact-head ready CI is green.

AgentName: m5-pro-48g-gpt5
