### PR TITLE
fix(emit): honor optional-chaining token in ES5 class-member access/call lowering

### DIFF
--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_expressions.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_expressions.rs
@@ -12,6 +12,58 @@ use tsz_parser::parser::base::NodeList;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
+/// Continuation applied to the (non-nullish) receiver of a downlevel
+/// optional-chain access. Built once and applied to the guarded receiver in
+/// the ternary's false branch.
+pub(super) enum OptionalChainTail {
+    /// `<recv>.name`
+    Property(std::borrow::Cow<'static, str>),
+    /// `<recv>[index]`
+    Element(Box<IRNode>),
+    /// `<recv>.name(args)` — the access carried `?.`, the call did not.
+    MethodCall {
+        property: std::borrow::Cow<'static, str>,
+        arguments: Vec<IRNode>,
+    },
+    /// `<recv>[index](args)` — the access carried `?.`, the call did not.
+    ElementMethodCall {
+        index: Box<IRNode>,
+        arguments: Vec<IRNode>,
+    },
+}
+
+impl OptionalChainTail {
+    fn apply(self, receiver: IRNode) -> IRNode {
+        match self {
+            Self::Property(name) => IRNode::PropertyAccess {
+                object: Box::new(receiver),
+                property: name,
+            },
+            Self::Element(index) => IRNode::ElementAccess {
+                object: Box::new(receiver),
+                index,
+            },
+            Self::MethodCall {
+                property,
+                arguments,
+            } => IRNode::CallExpr {
+                callee: Box::new(IRNode::PropertyAccess {
+                    object: Box::new(receiver),
+                    property,
+                }),
+                arguments,
+            },
+            Self::ElementMethodCall { index, arguments } => IRNode::CallExpr {
+                callee: Box::new(IRNode::ElementAccess {
+                    object: Box::new(receiver),
+                    index,
+                }),
+                arguments,
+            },
+        }
+    }
+}
+
 impl<'a> AstToIr<'a> {
     pub(super) fn convert_call_expression(&self, idx: NodeIndex) -> IRNode {
         let node = self
@@ -65,6 +117,20 @@ impl<'a> AstToIr<'a> {
                 node.is_optional_chain(),
             ) {
                 return super_call;
+            }
+
+            // Optional method call `R?.m(args)` / `R?.[k](args)`: the access
+            // carries `?.` but the call itself does not, so the whole call
+            // short-circuits on `R`. Lower the guard with the call in the
+            // false branch (the IR has no optional-access node, mirroring the
+            // AST printer's non-ES2020 form). `R.m?.()` (an optional *call*
+            // token) is a different shape and is intentionally left to the
+            // existing path.
+            if node.is_optional_chain()
+                && let Some(optional_call) =
+                    self.try_convert_optional_method_call(call.expression, args.clone())
+            {
+                return optional_call;
             }
 
             let callee = self.convert_expression(call.expression);
@@ -258,6 +324,52 @@ impl<'a> AstToIr<'a> {
         }
     }
 
+    /// Lower `R?.m(args)` / `R?.[k](args)` where the *access* carried `?.` but
+    /// the call did not. Returns `None` for any other callee shape (including
+    /// `R.m?.()`, where the call token itself is optional) so the caller falls
+    /// back to its normal path.
+    fn try_convert_optional_method_call(
+        &self,
+        callee_idx: NodeIndex,
+        args: Vec<IRNode>,
+    ) -> Option<IRNode> {
+        let callee_node = self.arena.get(callee_idx)?;
+        let access = self.arena.get_access_expr(callee_node)?;
+        if !access.question_dot_token {
+            return None;
+        }
+        // `super?.m()` cannot capture `super`; leave it to the existing path.
+        if self
+            .arena
+            .get(access.expression)
+            .is_some_and(|n| n.kind == SyntaxKind::SuperKeyword as u16)
+        {
+            return None;
+        }
+
+        if callee_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            let name = get_identifier_text(self.arena, access.name_or_argument)?;
+            return Some(self.lower_optional_chain_guard(
+                access.expression,
+                OptionalChainTail::MethodCall {
+                    property: name.into(),
+                    arguments: args,
+                },
+            ));
+        }
+        if callee_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION {
+            let index = self.convert_expression(access.name_or_argument);
+            return Some(self.lower_optional_chain_guard(
+                access.expression,
+                OptionalChainTail::ElementMethodCall {
+                    index: Box::new(index),
+                    arguments: args,
+                },
+            ));
+        }
+        None
+    }
+
     pub(super) fn convert_new_expression(&self, idx: NodeIndex) -> IRNode {
         let node = self
             .arena
@@ -312,8 +424,17 @@ impl<'a> AstToIr<'a> {
                 };
             }
 
-            let object = self.convert_expression(access.expression);
             if let Some(name) = get_identifier_text(self.arena, access.name_or_argument) {
+                // Optional chain: `R?.prop` short-circuits when `R` is nullish.
+                // The IR has no optional-access node, so lower the guard here the
+                // same way the AST printer does for non-ES2020 targets.
+                if access.question_dot_token {
+                    return self.lower_optional_chain_guard(
+                        access.expression,
+                        OptionalChainTail::Property(name.into()),
+                    );
+                }
+                let object = self.convert_expression(access.expression);
                 return IRNode::PropertyAccess {
                     object: Box::new(object),
                     property: name.into(),
@@ -349,6 +470,15 @@ impl<'a> AstToIr<'a> {
                 };
             }
 
+            // Optional chain: `R?.[idx]` short-circuits when `R` is nullish.
+            if access.question_dot_token {
+                let index = self.convert_expression(access.name_or_argument);
+                return self.lower_optional_chain_guard(
+                    access.expression,
+                    OptionalChainTail::Element(Box::new(index)),
+                );
+            }
+
             let object = self.convert_expression(access.expression);
             let index = self.convert_expression(access.name_or_argument);
             IRNode::ElementAccess {
@@ -357,6 +487,53 @@ impl<'a> AstToIr<'a> {
             }
         } else {
             IRNode::ASTRef(idx)
+        }
+    }
+
+    /// Lower a downlevel optional-chain access whose head receiver is
+    /// `receiver_idx` and whose continuation is `tail`.
+    ///
+    /// Matches the non-ES2020 AST-printer form:
+    /// - simple receiver `R`: `R === null || R === void 0 ? void 0 : R<tail>`
+    /// - other receiver `E`:  `(_t = E) === null || _t === void 0 ? void 0 : _t<tail>`
+    ///
+    /// `receiver_idx` is converted through `convert_expression`, so `this`
+    /// substitution (e.g. the static class alias) and nested lowering still
+    /// apply. The rule keys on the access node's `?.` token, not on any
+    /// identifier name or rendered text.
+    pub(super) fn lower_optional_chain_guard(
+        &self,
+        receiver_idx: NodeIndex,
+        tail: OptionalChainTail,
+    ) -> IRNode {
+        let receiver = self.convert_expression(receiver_idx);
+        let receiver_simple =
+            crate::transforms::emit_utils::is_simple_copiable_expression(self.arena, receiver_idx);
+
+        // `guard_head` is the left operand of the first `=== null` comparison;
+        // `body_receiver` is reused for the second comparison and the access
+        // body. For a simple receiver both are the receiver itself; otherwise
+        // the receiver is captured once via `(_t = E)` and referenced as `_t`.
+        let (guard_head, body_receiver): (IRNode, IRNode) = if receiver_simple {
+            (receiver.clone(), receiver)
+        } else {
+            let temp = self.generate_hoisted_temp();
+            (
+                IRNode::assign(IRNode::id(temp.clone()), receiver).paren(),
+                IRNode::id(temp),
+            )
+        };
+
+        let condition = IRNode::logical_or(
+            IRNode::binary(guard_head, "===", IRNode::NullLiteral),
+            IRNode::binary(body_receiver.clone(), "===", IRNode::Undefined),
+        );
+        let when_false = tail.apply(body_receiver);
+
+        IRNode::ConditionalExpr {
+            condition: Box::new(condition),
+            when_true: Box::new(IRNode::Undefined),
+            when_false: Box::new(when_false),
         }
     }
 
@@ -469,5 +646,119 @@ impl<'a> AstToIr<'a> {
         } else {
             IRNode::ASTRef(idx)
         }
+    }
+}
+
+#[cfg(test)]
+mod optional_chain_in_class_member_tests {
+    use crate::context::emit::EmitContext;
+    use crate::emitter::{Printer as EmitterPrinter, PrinterOptions};
+    use crate::lowering::LoweringPass;
+    use tsz_common::ScriptTarget;
+    use tsz_parser::ParserState;
+
+    /// Emit `source` as ES5 JS through the full class-IR lowering pipeline.
+    fn emit_es5(source: &str) -> String {
+        let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+        let root = parser.parse_source_file();
+        let options = PrinterOptions {
+            target: ScriptTarget::ES5,
+            ..Default::default()
+        };
+        let ctx = EmitContext::with_options(options.clone());
+        let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+        let mut printer =
+            EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+        printer.set_source_text(source);
+        printer.emit(root);
+        printer.get_output().to_string()
+    }
+
+    // Structural rule: when the ES5 class-IR converter sees a property/element
+    // access (or `recv?.m()` method call) carrying `?.`, it must lower the
+    // nullish short-circuit guard rather than dropping the token. The rule keys
+    // on the access node's `?.` flag, not on the receiver's spelling — so these
+    // tests vary class/member names, member kinds, and access/call shapes.
+
+    #[test]
+    fn static_property_initializer_this_optional_property_keeps_guard() {
+        // `this` inside a static initializer is substituted with the class
+        // alias; the optional-property guard must survive that substitution.
+        let output = emit_es5("class Widget {\n    static handle = this?.id;\n}\n");
+        assert!(
+            output.contains("=== null ||") && output.contains("=== void 0 ? void 0 :"),
+            "Static `this?.id` must keep the optional-chain guard.\nOutput:\n{output}"
+        );
+        assert!(
+            !output.contains("Widget.handle = _a.id;"),
+            "Optional access must not be dropped to a plain property access.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn static_property_initializer_this_optional_method_call_keeps_guard() {
+        // Different class/member names; optional method call `this?.compute()`.
+        let output = emit_es5("class Engine {\n    static result = this?.compute();\n}\n");
+        assert!(
+            output.contains("=== null ||")
+                && output.contains("=== void 0 ? void 0 :")
+                && output.contains(".compute()"),
+            "Static `this?.compute()` must guard the call.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn static_property_initializer_this_optional_element_call_keeps_guard() {
+        // Element-access optional method call inside a static initializer.
+        let output = emit_es5("class Store {\n    static v = this?.[\"load\"]();\n}\n");
+        assert!(
+            output.contains("=== null ||")
+                && output.contains("=== void 0 ? void 0 :")
+                && output.contains("[\"load\"]()"),
+            "Static `this?.[\"load\"]()` must guard the element call.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn static_method_body_this_optional_access_keeps_guard() {
+        // Static *method* body (not just initializer), different name again.
+        let output =
+            emit_es5("class Service {\n    static run() {\n        return this?.go();\n    }\n}\n");
+        assert!(
+            output.contains("=== null ||") && output.contains("=== void 0 ? void 0 :"),
+            "Static method `this?.go()` must keep the guard.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn instance_method_body_this_optional_access_keeps_guard() {
+        // Instance method body — proves the fix is not static-specific.
+        let output = emit_es5("class Cache {\n    m() {\n        return this?.entry;\n    }\n}\n");
+        assert!(
+            output.contains("this === null || this === void 0 ? void 0 : this.entry"),
+            "Instance `this?.entry` must keep the guard.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn class_member_identifier_receiver_optional_access_keeps_guard() {
+        // Receiver is a plain identifier, not `this` — proves the rule keys on
+        // the `?.` token, not on the `this` keyword.
+        let output =
+            emit_es5("declare const dep: any;\nclass Host {\n    static value = dep?.field;\n}\n");
+        assert!(
+            output.contains("dep === null || dep === void 0 ? void 0 : dep.field"),
+            "Identifier-receiver `dep?.field` must keep the guard.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn class_member_non_optional_access_is_unchanged() {
+        // Negative case: a non-optional access must NOT gain a guard.
+        let output = emit_es5("class Plain {\n    static value = this.field;\n}\n");
+        assert!(
+            !output.contains("=== void 0 ? void 0 :"),
+            "Non-optional `this.field` must not be lowered to a guard.\nOutput:\n{output}"
+        );
     }
 }


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — ES5 class-member optional-chaining lowering (emit→100% campaign, wave 3)

## Invariant
When the ES5 class-to-IR converter lowers a property access, element access, or method call inside a class member body or static initializer, it must honor the access node's optional-chaining (`?.`) token: `R?.prop` / `R?.[k]` / `R?.m()` lower to the downlevel nullish-guard ternary (`R === null || R === void 0 ? void 0 : R<tail>`, capturing `(_t = E)` for non-simple receivers), not to a plain non-optional access. The decision is keyed on the AST node's `?.` flag — works for `this`, plain identifiers, property/element access, with/without calls, in static and instance members — never on identifier spelling.

## Scope
- `crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_expressions.rs` — `convert_property_access` / `convert_element_access` / `convert_call_expression` now emit the optional-chain guard when `?.` is present; co-located `#[cfg(test)]` module (+7 tests). File 768 lines (under §19 cap).

## Project Corpus Impact
- Row: n/a (ES5 emit-lowering fix)
- Bug family: optional chaining dropped in ES5 class-to-IR conversion (member bodies / static initializers)
- Evidence: thisAndSuperInStaticMembers3(es5), thisAndSuperInStaticMembers4(es5) FAIL→PASS; full --js-only 104→102.

## Verification
- 2 witnesses FAIL→PASS (`static y3 = this?.x()` was emitting `_a.x()` instead of the nullish-guard ternary). **Full --js-only: 104→102 fail, net +2, ZERO new failures** (before/after JSON fail-set diff: NEW failures = []). DTS path structurally unaffected (declaration emitter doesn't use AstToIr).
- 7 structural unit tests (vary class/member names, member kind, access/call shape, negative case). Clippy clean (tsz-emitter, -D warnings). tsz-emitter unit suite: 31 pre-existing failures identical on clean main and branch (zero new).
- §25/§26 compliant (keyed on `?.` AST flag, no identifier/printer-output matching). No output surgery — planned IR facts.

## Coordination Notes
Rebased onto current main (arch file-size ratchet guard fails on stale branches). Scoped out (separate features, reported): thisAndSuperInStaticMembers1/2(es2015) (temp-naming order + super compound-assignment lowering form); typeOfThisInStaticMembers12/13 (computed-property-name capture in nested class); thisInInvalidContextsExternalModule(es5) (trailing-comment + pre-super-arg this capture). — opus48-emit100
