### PR TITLE
test(solver): cover accessor relation cache

### DIFF
--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -1769,3 +1769,84 @@ fn assignability_cache_disable_method_bivariance_matches_uncached_method_paramet
         "method-bivariant parameter-count slot must remain intact after the sound-method lookup",
     );
 }
+
+#[test]
+fn subtype_cache_split_accessor_variance_matches_uncached_property_policy() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let value = interner.intern_string("value");
+    let wide_write = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
+
+    let wide_accessor = interner.object(vec![PropertyInfo {
+        write_type: wide_write,
+        ..PropertyInfo::new(value, TypeId::STRING)
+    }]);
+    let narrow_accessor = interner.object(vec![PropertyInfo::new(value, TypeId::STRING)]);
+    let policy = RelationPolicy::unflagged_compatibility();
+    let wide_to_narrow_key =
+        RelationCacheKey::for_subtype(wide_accessor, narrow_accessor, policy.cache_config());
+    let narrow_to_wide_key =
+        RelationCacheKey::for_subtype(narrow_accessor, wide_accessor, policy.cache_config());
+
+    let wide_to_narrow_uncached = query_relation(
+        &interner,
+        wide_accessor,
+        narrow_accessor,
+        RelationKind::Subtype,
+        policy,
+        RelationContext::default(),
+    )
+    .is_related();
+    let narrow_to_wide_uncached = query_relation(
+        &interner,
+        narrow_accessor,
+        wide_accessor,
+        RelationKind::Subtype,
+        policy,
+        RelationContext::default(),
+    )
+    .is_related();
+
+    assert!(
+        wide_to_narrow_uncached,
+        "split accessor with a wider write type should satisfy a uniform property target",
+    );
+    assert!(
+        !narrow_to_wide_uncached,
+        "uniform property write type should not satisfy a wider split-accessor target",
+    );
+
+    let wide_to_narrow_cached =
+        db.is_subtype_of_with_policy(wide_accessor, narrow_accessor, policy);
+    assert_eq!(
+        wide_to_narrow_cached, wide_to_narrow_uncached,
+        "cached split-accessor subtype must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(wide_to_narrow_key),
+        Some(wide_to_narrow_cached),
+        "wide-to-narrow split-accessor result must use its own subtype cache slot",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(narrow_to_wide_key),
+        None,
+        "reverse split-accessor lookup must not hit the wide-to-narrow slot",
+    );
+
+    let narrow_to_wide_cached =
+        db.is_subtype_of_with_policy(narrow_accessor, wide_accessor, policy);
+    assert_eq!(
+        narrow_to_wide_cached, narrow_to_wide_uncached,
+        "cached reverse split-accessor subtype must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(narrow_to_wide_key),
+        Some(narrow_to_wide_cached),
+        "reverse split-accessor result must use its own subtype cache slot",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(wide_to_narrow_key),
+        Some(wide_to_narrow_cached),
+        "wide-to-narrow split-accessor slot must remain intact after the reverse lookup",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 10 relation policy/cache-key tech debt (#8207), solver policy/cache agreement test ratchet.

## Invariant
Accessor property relation checks must agree between cached and uncached execution when accessor variance policy changes; this PR ratchets that accessor cache-key coverage.

## Scope
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: solver test-only ratchet for relation policy/cache agreement; no project corpus behavior change targeted.

## Verification
- RED `cargo nextest run -p tsz-solver -E 'test(subtype_cache_split_accessor_variance_matches_uncached_property_policy)'` failed before the test existed with `error: no tests to run`.
- 2026-05-29 after #11724 was rebased, rebased this branch onto `codex/m4-b-callable-cache-20260529`; exact base `d9f73d2f2395c847d2d707f3cbcce66fc38bfee7`, exact head `4d031806ff6d305954c0f5849cd8eb836fbf39b3`.
- `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'`: 21 passed on `4d031806ff6d305954c0f5849cd8eb836fbf39b3`.
- `cargo fmt --check`: passed on `4d031806ff6d305954c0f5849cd8eb836fbf39b3`.
- `git diff --check codex/m4-b-callable-cache-20260529..HEAD`: passed on `4d031806ff6d305954c0f5849cd8eb836fbf39b3`.
- Stack diff check: `git diff --stat codex/m4-b-callable-cache-20260529..HEAD` -> one solver test file, 81 insertions.
- File-size guard: `wc -l crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs` -> 1852 lines, below the 2000-line cap.
- 2026-05-30: retargeted to `main` after #11724 merged as `cdeab1cec40a759fe51893b42ca2758ededf4f83`; rebased exact head `1c090be099af931b1c2a053e3ff01fd4d099a9fd` onto current main.
- 2026-05-30 local rebase verification on `1c090be099af931b1c2a053e3ff01fd4d099a9fd`: `cargo fmt --check`; `cargo nextest run -p tsz-solver -E 'test(subtype_cache_split_accessor_variance_matches_uncached_property_policy)'`; `git diff --check origin/main...HEAD`.

## Coordination Notes
- #11724 has merged, so this PR is now retargeted from `codex/m4-b-callable-cache-20260529` to `main` and rebased cleanly on current main.
- Downstream M4-B stack: #11729 remains stacked on `codex/m4-b-accessor-cache-20260529` and will be retargeted after this PR lands; #11730 remains stacked behind #11729.
- Non-overlap: this slice covers only solver relation cache agreement for accessor property variance policy; it does not touch checker relation routing owned by M1-B, nor M4-A/M4-C evaluation/inference lanes.
- Auto-merge and `merge-queue` remain unset until exact-head ready CI is green.
- Retarget/rebase handoff by AgentName: m5-pro-48g-gpt5.
