### PR TITLE
test(solver): cover relation kind cache slots

### DIFF
--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -3,3 +3,6 @@
 
 #[path = "relation_policy_cache_agreement_tests/cache_agreement.rs"]
 mod cache_agreement;
+
+#[path = "relation_policy_cache_agreement_tests/kind_partitioning.rs"]
+mod kind_partitioning;

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/kind_partitioning.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/kind_partitioning.rs
@@ -1,0 +1,89 @@
+//! Relation-kind partitioning tests for relation caches.
+
+use crate::caches::db::QueryDatabase;
+use crate::caches::query_cache::QueryCache;
+use crate::intern::TypeInterner;
+use crate::relations::relation_queries::{
+    RelationContext, RelationKind, RelationPolicy, query_relation,
+};
+use crate::types::{PropertyInfo, RelationCacheKey, TypeId};
+
+#[test]
+fn relation_policy_cache_relation_kind_partitions_assignability_and_subtype() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let unrelated = interner.intern_string("unrelated");
+    let optional = interner.intern_string("optional");
+
+    let source = interner.object(vec![PropertyInfo::new(unrelated, TypeId::STRING)]);
+    let target = interner.object(vec![PropertyInfo::opt(optional, TypeId::NUMBER)]);
+    let policy = RelationPolicy::default();
+    let assignability_key =
+        RelationCacheKey::for_assignability(source, target, policy.cache_config());
+    let subtype_key = RelationCacheKey::for_subtype(source, target, policy.cache_config());
+
+    assert_ne!(
+        assignability_key, subtype_key,
+        "assignability and subtype must occupy distinct relation cache keys",
+    );
+
+    let assignability_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        policy,
+        RelationContext::default(),
+    )
+    .is_related();
+    let subtype_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Subtype,
+        policy,
+        RelationContext::default(),
+    )
+    .is_related();
+
+    assert!(
+        !assignability_uncached,
+        "assignability should reject unrelated source properties against a weak target",
+    );
+    assert!(
+        subtype_uncached,
+        "structural subtype should allow the same source when the target property is optional",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, policy),
+        assignability_uncached,
+        "cached assignability must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(assignability_key),
+        Some(assignability_uncached),
+        "assignability result must be stored in the assignability cache slot",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(subtype_key),
+        None,
+        "subtype lookup must not hit the assignability cache slot",
+    );
+
+    assert_eq!(
+        db.is_subtype_of_with_policy(source, target, policy),
+        subtype_uncached,
+        "cached subtype must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(subtype_key),
+        Some(subtype_uncached),
+        "subtype result must be stored in the subtype cache slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(assignability_key),
+        Some(assignability_uncached),
+        "assignability slot must remain intact after the subtype lookup",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 10 relation policy/cache-key tech debt (#8207), solver relation cache partitioning ratchet.

## Invariant
Relation cache entries must be partitioned by relation kind as well as source, target, and policy config. For the same source/target/config, an assignability result must not satisfy a subtype lookup, especially when Lawyer-layer weak-type checks make assignability reject while structural subtype accepts.

## Scope
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs`
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests/kind_partitioning.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: solver test-only ratchet for relation cache partitioning; no compiler behavior or project corpus behavior change targeted.

## Verification
- RED `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_relation_kind_partitions_assignability_and_subtype)'` failed before the test existed with `error: no tests to run`.
- `cargo nextest run -p tsz-solver --lib -E 'test(relation_policy_cache_relation_kind_partitions_assignability_and_subtype)'`: 1 passed after retargeting to main.
- `cargo nextest run -p tsz-solver --lib -E 'test(relation_policy_cache_agreement_tests)'`: 22 passed after retargeting to main.
- `cargo fmt --check`: passed on `9b009ccaf7bb030ca3b09966194b9a52dfd7ad8c`.
- `git diff --check origin/main...HEAD`: passed.
- Stack diff check before commit: module root plus new `kind_partitioning.rs` shard, 92 insertions.
- File-size guard: root test file 8 lines; `cache_agreement.rs` 1852 lines; `kind_partitioning.rs` 89 lines, all below the 2000-line cap.

## Coordination Notes
- Rebasing update: #11729 has merged; this PR is now retargeted to `main` at head `9b009ccaf7bb030ca3b09966194b9a52dfd7ad8c`.
- This was the downstream tip of the M4-B cache-policy stack; after #11729 merged, it is an independent main-based test-only slice.
- Non-overlap: this slice covers only solver relation cache kind partitioning tests; it does not touch checker relation routing owned by M1-B, nor M4-A/M4-C evaluation/inference lanes.
- Ready for heavy CI on main; auto-merge and `merge-queue` remain unset until exact-head ready CI is green.

