### PR TITLE
fix(emit): keep inline named-eval for computed-static-method anon class unless binding loses named evaluation

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -1290,9 +1290,17 @@ impl<'a> Printer<'a> {
                     .get(member_idx)
                     .is_some_and(|m| m.kind == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION)
             });
+        // A computed-named *static method or accessor* is emitted inline in the
+        // class body, so it only requires the `(_tmp = class {...}, ..., _tmp)`
+        // comma wrapping when the binding *also* loses JS named evaluation --
+        // i.e. a `using`/`await using` declaration lowered to
+        // `__addDisposableResource`, which moves the class out of
+        // direct-assignment position. A plain `var X = class {...}` keeps named
+        // evaluation and needs no wrapping for inline computed method names.
         let has_static_computed_method_or_accessor = emits_as_class_expression
             && class.name.is_none()
             && self.resolve_class_expr_binding_name(_idx).is_some()
+            && self.class_expr_binding_loses_named_evaluation(_idx)
             && class.members.nodes.iter().any(|&member_idx| {
                 self.arena
                     .get(member_idx)

--- a/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
@@ -88,6 +88,69 @@ impl<'a> Printer<'a> {
         None
     }
 
+    /// Returns `true` when the class-expression initializer is bound by a
+    /// `using` / `await using` declaration that this target lowers to an
+    /// `__addDisposableResource(env, <class>, ...)` call. That lowering moves
+    /// the class out of direct-assignment position, so JS named evaluation no
+    /// longer assigns the binding name to the (anonymous) class; tsc therefore
+    /// captures the class in a temp and calls `__setFunctionName` explicitly.
+    /// Plain `var`/`let`/`const`/parameter/property/assignment bindings keep
+    /// the class in named-evaluation position and need no such helper. Mirrors
+    /// the lowering-pass gate of the same name.
+    pub(in crate::emitter) fn class_expr_binding_loses_named_evaluation(
+        &self,
+        class_idx: NodeIndex,
+    ) -> bool {
+        if self.ctx.options.target.supports_es2025() {
+            // `using` declarations are emitted verbatim; named evaluation holds.
+            return false;
+        }
+        let mut current = class_idx;
+        let mut hops = 0;
+        while hops < 8 {
+            let Some(parent_idx) = self
+                .arena
+                .get_extended(current)
+                .map(|ext| ext.parent)
+                .filter(|p| !p.is_none())
+            else {
+                return false;
+            };
+            let Some(parent_node) = self.arena.get(parent_idx) else {
+                return false;
+            };
+            match parent_node.kind {
+                syntax_kind_ext::PARENTHESIZED_EXPRESSION
+                | syntax_kind_ext::TYPE_ASSERTION
+                | syntax_kind_ext::AS_EXPRESSION
+                | syntax_kind_ext::SATISFIES_EXPRESSION
+                | syntax_kind_ext::NON_NULL_EXPRESSION => {
+                    current = parent_idx;
+                    hops += 1;
+                }
+                syntax_kind_ext::VARIABLE_DECLARATION => {
+                    let Some(list_idx) = self
+                        .arena
+                        .get_extended(parent_idx)
+                        .map(|ext| ext.parent)
+                        .filter(|p| !p.is_none())
+                    else {
+                        return false;
+                    };
+                    let Some(list_node) = self.arena.get(list_idx) else {
+                        return false;
+                    };
+                    if list_node.kind != syntax_kind_ext::VARIABLE_DECLARATION_LIST {
+                        return false;
+                    }
+                    return (list_node.flags as u32 & tsz_parser::parser::node_flags::USING) != 0;
+                }
+                _ => return false,
+            }
+        }
+        false
+    }
+
     fn identifier_binding_name(&self, name_idx: NodeIndex) -> Option<String> {
         let name_node = self.arena.get(name_idx)?;
         if name_node.kind != SyntaxKind::Identifier as u16 {

--- a/crates/tsz-emitter/src/emitter/source_file/class_expr_computed_static_method_naming_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/class_expr_computed_static_method_naming_tests.rs
@@ -1,0 +1,156 @@
+//! Structural emit tests for the named-evaluation rule on anonymous class
+//! expressions that carry a computed-named *static method* (or accessor).
+//!
+//! Structural rule: a computed static method/accessor name is emitted inline
+//! in the class body and carries no post-construction static state, so it only
+//! forces the `(_tmp = class {...}, __setFunctionName(_tmp, "X"), _tmp)`
+//! wrapping when the binding *also* loses JS named evaluation -- i.e. a
+//! `using`/`await using` declaration lowered to `__addDisposableResource`,
+//! which moves the class out of direct-assignment position. A plain
+//! `var X = class {...}` keeps named evaluation and needs no helper.
+
+use crate::context::emit::EmitContext;
+use crate::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use crate::lowering::LoweringPass;
+use tsz_common::ScriptTarget;
+use tsz_parser::ParserState;
+
+fn emit(source: &str, target: ScriptTarget, use_define_for_class_fields: bool) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        target,
+        use_define_for_class_fields,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+// --- Reported repro: plain `var X = class { static [expr]() {} }` ---
+// Named evaluation holds, so no `__setFunctionName`, no temp-comma wrapping.
+
+#[test]
+fn var_bound_anonymous_class_computed_static_method_keeps_named_evaluation_es2015() {
+    let source = "const KEYS = { dispose: 'd' } as const;\nvar X = class {\n    static [KEYS.dispose]() {}\n};\n";
+    let output = emit(source, ScriptTarget::ES2015, false);
+
+    assert!(
+        !output.contains("__setFunctionName"),
+        "Plain `var X = class {{ static [expr]() {{}} }}` keeps JS named evaluation; \
+         it must NOT emit __setFunctionName.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("var X = class {"),
+        "The anonymous class must stay in direct-assignment position (no temp wrap).\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("(_a = class"),
+        "No temp-comma wrapping should be introduced for an inline computed static method.\nOutput:\n{output}"
+    );
+}
+
+// Renamed binding + renamed computed-name source: proves the rule is keyed on
+// structure (computed static method), not on the identifier `X`/`KEYS`/`dispose`.
+#[test]
+fn renamed_var_bound_anonymous_class_computed_static_method_keeps_named_evaluation_es2015() {
+    let source = "const NAMES = { tag: 't' } as const;\nvar Widget = class {\n    static [NAMES.tag]() {}\n};\n";
+    let output = emit(source, ScriptTarget::ES2015, false);
+
+    assert!(
+        !output.contains("__setFunctionName"),
+        "Renaming the binding/key must not change the rule: still no __setFunctionName.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("var Widget = class {"),
+        "Renamed anonymous class binding must stay in direct-assignment position.\nOutput:\n{output}"
+    );
+}
+
+// Same rule under ES5 lowering and under useDefineForClassFields=true: the
+// inline computed static method still must not trigger __setFunctionName.
+#[test]
+fn var_bound_anonymous_class_computed_static_method_keeps_named_evaluation_es5() {
+    let source = "const KEYS = { dispose: 'd' } as const;\nvar X = class {\n    static [KEYS.dispose]() {}\n};\n";
+    let output = emit(source, ScriptTarget::ES5, false);
+
+    assert!(
+        !output.contains("__setFunctionName"),
+        "ES5 lowering of a var-bound anonymous class with an inline computed static \
+         method must not emit __setFunctionName.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn var_bound_anonymous_class_computed_static_method_keeps_named_evaluation_define_fields() {
+    let source = "const KEYS = { dispose: 'd' } as const;\nvar X = class {\n    static [KEYS.dispose]() {}\n};\n";
+    let output = emit(source, ScriptTarget::ES2015, true);
+
+    assert!(
+        !output.contains("__setFunctionName"),
+        "useDefineForClassFields=true must not change the inline-method rule.\nOutput:\n{output}"
+    );
+}
+
+// --- `using` binding loses named evaluation ---
+// The class is lowered into `__addDisposableResource(env, <class>, ...)`, so
+// tsc captures it in a temp and assigns the name with __setFunctionName.
+
+#[test]
+fn using_bound_anonymous_class_computed_static_method_emits_set_function_name() {
+    let source = "using C1 = class {\n    static [Symbol.dispose]() {}\n};\n";
+    let output = emit(source, ScriptTarget::ES2018, false);
+
+    assert!(
+        output.contains("__setFunctionName"),
+        "A `using` binding moves the anonymous class out of direct-assignment position, \
+         so the inline computed static method requires __setFunctionName.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("__addDisposableResource"),
+        "`using` should lower through __addDisposableResource.\nOutput:\n{output}"
+    );
+}
+
+// Renamed `using` binding + different built-in well-known key: still wraps.
+#[test]
+fn renamed_using_bound_anonymous_class_computed_static_method_emits_set_function_name() {
+    let source = "using disposable = class {\n    static [Symbol.asyncDispose]() {}\n};\n";
+    let output = emit(source, ScriptTarget::ES2018, false);
+
+    assert!(
+        output.contains("__setFunctionName"),
+        "Renaming the `using` binding/key must not change the rule: still __setFunctionName.\nOutput:\n{output}"
+    );
+}
+
+// --- Negative/sibling: computed static *field* still wraps (unchanged) ---
+// A computed static field carries post-construction state (an initializer), so
+// it has always required the temp-comma wrapping regardless of named
+// evaluation. This is the `has_static_field_comma_expr` path, which the
+// inline-method rule change does not touch; the test guards against accidental
+// regression of that path.
+
+#[test]
+fn var_bound_anonymous_class_computed_static_field_still_wraps_es2015() {
+    let source =
+        "const KEYS = { x: 'x' } as const;\nvar X = class {\n    static [KEYS.x] = 1;\n};\n";
+    let output = emit(source, ScriptTarget::ES2015, false);
+
+    // The class must be captured in a temp so the static field initializer can
+    // be assigned to the materialized class object.
+    assert!(
+        output.contains("= class {") && output.contains(" = 1,"),
+        "A computed static *field* with an initializer must keep the temp-comma wrapping \
+         so the field can be assigned to the materialized class.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("var X = class {\n    static"),
+        "A runtime computed static field must not be emitted as a plain inline class body.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/source_file/mod.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/mod.rs
@@ -9,6 +9,8 @@ mod top_level_using_decorated;
 #[cfg(test)]
 mod class_es5_field_initializer_tests;
 #[cfg(test)]
+mod class_expr_computed_static_method_naming_tests;
+#[cfg(test)]
 mod class_expression_decorator_tests;
 #[cfg(test)]
 mod class_static_alias_tests;

--- a/crates/tsz-emitter/src/lowering/helpers.rs
+++ b/crates/tsz-emitter/src/lowering/helpers.rs
@@ -991,6 +991,66 @@ impl<'a> LoweringPass<'a> {
         None
     }
 
+    /// Returns `true` when the class-expression initializer is bound by a
+    /// `using` / `await using` declaration that this target lowers to an
+    /// `__addDisposableResource(env, <class>, ...)` call. That lowering moves
+    /// the class out of direct-assignment position, so JS named evaluation no
+    /// longer assigns the binding name to the (anonymous) class; tsc therefore
+    /// captures the class in a temp and calls `__setFunctionName` explicitly.
+    /// Plain `var`/`let`/`const`/parameter/property/assignment bindings keep
+    /// the class in named-evaluation position and need no such helper.
+    pub(super) fn class_expr_binding_loses_named_evaluation(&self, class_idx: NodeIndex) -> bool {
+        if self.ctx.options.target.supports_es2025() {
+            // `using` declarations are emitted verbatim; named evaluation holds.
+            return false;
+        }
+        let mut current = class_idx;
+        let mut hops = 0;
+        while hops < 8 {
+            let Some(parent_idx) = self
+                .arena
+                .get_extended(current)
+                .map(|ext| ext.parent)
+                .filter(|p| !p.is_none())
+            else {
+                return false;
+            };
+            let Some(parent_node) = self.arena.get(parent_idx) else {
+                return false;
+            };
+            match parent_node.kind {
+                syntax_kind_ext::PARENTHESIZED_EXPRESSION
+                | syntax_kind_ext::TYPE_ASSERTION
+                | syntax_kind_ext::AS_EXPRESSION
+                | syntax_kind_ext::SATISFIES_EXPRESSION
+                | syntax_kind_ext::NON_NULL_EXPRESSION => {
+                    current = parent_idx;
+                    hops += 1;
+                }
+                syntax_kind_ext::VARIABLE_DECLARATION => {
+                    // The owning declaration list carries the `using` flag.
+                    let Some(list_idx) = self
+                        .arena
+                        .get_extended(parent_idx)
+                        .map(|ext| ext.parent)
+                        .filter(|p| !p.is_none())
+                    else {
+                        return false;
+                    };
+                    let Some(list_node) = self.arena.get(list_idx) else {
+                        return false;
+                    };
+                    if list_node.kind != syntax_kind_ext::VARIABLE_DECLARATION_LIST {
+                        return false;
+                    }
+                    return (list_node.flags as u32 & tsz_parser::parser::node_flags::USING) != 0;
+                }
+                _ => return false,
+            }
+        }
+        false
+    }
+
     fn property_declaration_binding_name_ref(&self, name_idx: NodeIndex) -> Option<&str> {
         let name_node = self.arena.get(name_idx)?;
         if name_node.kind == SyntaxKind::Identifier as u16

--- a/crates/tsz-emitter/src/lowering/helpers_class_expr_static_name.rs
+++ b/crates/tsz-emitter/src/lowering/helpers_class_expr_static_name.rs
@@ -56,8 +56,16 @@ impl<'a> LoweringPass<'a> {
                     member.kind == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION
                 })
             });
-        let has_static_computed_method_or_accessor =
-            class.members.nodes.iter().any(|&member_idx| {
+        // A computed-named *static method or accessor* is emitted inline in the
+        // class body, so it carries no post-construction static state. It only
+        // forces the `(_tmp = class {...}, __setFunctionName(_tmp, "X"), _tmp)`
+        // wrapping when the binding *also* loses JS named evaluation -- i.e. a
+        // `using`/`await using` declaration lowered to `__addDisposableResource`
+        // that moves the class out of direct-assignment position. A plain
+        // `var X = class {...}` keeps named evaluation and needs no helper.
+        let has_static_computed_method_or_accessor = self
+            .class_expr_binding_loses_named_evaluation(class_idx)
+            && class.members.nodes.iter().any(|&member_idx| {
                 self.arena
                     .get(member_idx)
                     .is_some_and(|member| match member.kind {


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — class-expression named-evaluation lowering (emit→100% campaign, wave 3)

## Invariant
An anonymous class expression with a computed-named static method/accessor (`var X = class { static [k]() {} }`) keeps JavaScript named evaluation and must be emitted inline — NO `(_tmp = class {...}, __setFunctionName(_tmp, "X"), _tmp)` wrapper and no temp. That wrapper is required only when the binding ALSO loses named evaluation, i.e. a `using`/`await using` declaration this target lowers to `__addDisposableResource(env, <class>, ...)`, moving the class out of direct-assignment position. Gate keyed on (computed static member present) AND (binding loses named evaluation) — structural, not on identifier/printer-output matching.

## Scope
- `crates/tsz-emitter/src/lowering/helpers_class_expr_static_name.rs` — gate computed-static-method trigger on named-evaluation loss.
- `crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs` — same gate on printer-side `needs_static_comma_expr`.
- `crates/tsz-emitter/src/lowering/helpers.rs` + `emitter/declarations/class/helpers.rs` — new `class_expr_binding_loses_named_evaluation` (lowering + printer mirror).
- `crates/tsz-emitter/src/emitter/source_file/class_expr_computed_static_method_naming_tests.rs` (+7 tests) + mod.rs.

## Project Corpus Impact
- Row: n/a (class-expression emit lowering fix)
- Bug family: spurious `__setFunctionName`/temp wrapper for computed-static-method anon class when binding retains named evaluation
- Evidence: staticPropertyNameConflicts(target=es2015,usedefineforclassfields=false) FAIL→PASS; full --js-only 104→103.

## Verification
- 1 witness FAIL→PASS. **Full --js-only: 104→103 fail, net +1, ZERO regressions** (set-diff FIXED=[es2015,udf=false], NEW=none; 4 cold-start parallel-contention "timeouts" verified PASS in isolation, not regressions). DTS unaffected (usingDeclarations dts 2/2).
- 7 structural unit tests (var vs using, renamed binding/key, es2015/es5, define-fields, computed-field negative). A mid-iteration regression (`usingDeclarationsNamedEvaluationDecoratorsAndClassFields` — using-bound anon class with `static [Symbol.dispose]()` legitimately needs `__setFunctionName`) drove the named-evaluation-loss refinement and is back to PASS. Clippy clean.
- §25/§26 compliant.

## Coordination Notes
Rebased onto current main (arch file-size ratchet guard fails on stale branches). Scoped out (separate families, reported): staticPropertyNameConflicts(es5,udf=false) (orphaned trailing comments on dropped type-only computed fields + comma-expr multiline formatting + `exports.X =` ordering in ES5 path); both udf=true variants (broader useDefineForClassFields=true static type-only-field handling). — opus48-emit100
