### PR TITLE
refactor(checker): replace rendered-type lookups with structural name queries in augmentation and heritage resolution

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/recursive_heritage_constraint.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/recursive_heritage_constraint.rs
@@ -209,11 +209,6 @@ impl<'a> CheckerState<'a> {
         &mut self,
         type_id: TypeId,
     ) -> Option<tsz_binder::SymbolId> {
-        // Use the structural identifier name rather than the rendered display string.
-        // `named_type_display_name` returns the type's declared identifier (symbol/def
-        // name) or None for non-named types. This avoids rendering side effects and
-        // "globalThis." prefix artifacts that the previous format_type_diagnostic path
-        // had to strip manually.
         let name = self.named_type_display_name(type_id)?;
 
         if let Some(index) = &self.ctx.global_file_locals_index

--- a/crates/tsz-checker/src/checkers/generic_checker/recursive_heritage_constraint.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/recursive_heritage_constraint.rs
@@ -209,18 +209,15 @@ impl<'a> CheckerState<'a> {
         &mut self,
         type_id: TypeId,
     ) -> Option<tsz_binder::SymbolId> {
-        let name = self.format_type_diagnostic(type_id);
-        let name = name.strip_prefix("globalThis.").unwrap_or(&name);
-        if name.is_empty()
-            || !name
-                .chars()
-                .all(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphanumeric())
-        {
-            return None;
-        }
+        // Use the structural identifier name rather than the rendered display string.
+        // `named_type_display_name` returns the type's declared identifier (symbol/def
+        // name) or None for non-named types. This avoids rendering side effects and
+        // "globalThis." prefix artifacts that the previous format_type_diagnostic path
+        // had to strip manually.
+        let name = self.named_type_display_name(type_id)?;
 
         if let Some(index) = &self.ctx.global_file_locals_index
-            && let Some(candidates) = index.get(name)
+            && let Some(candidates) = index.get(name.as_str())
         {
             for &(file_idx, sym_id) in candidates {
                 if self
@@ -238,7 +235,7 @@ impl<'a> CheckerState<'a> {
         let lib_binders = self.get_lib_binders();
         self.ctx
             .binder
-            .get_global_type_with_libs(name, &lib_binders)
+            .get_global_type_with_libs(name.as_str(), &lib_binders)
     }
 
     pub(super) fn member_has_conflicting_constraint_property(

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -183,6 +183,12 @@ mod generic_default_application_arg_preservation_tests;
 #[path = "tests/generic_method_override_variance_tests.rs"]
 mod generic_method_override_variance_tests;
 #[cfg(test)]
+#[path = "tests/global_augmentation_structural_lookup_arch_tests.rs"]
+mod global_augmentation_structural_lookup_arch_tests;
+#[cfg(test)]
+#[path = "tests/heritage_constraint_structural_name_lookup_arch_tests.rs"]
+mod heritage_constraint_structural_name_lookup_arch_tests;
+#[cfg(test)]
 #[path = "../tests/heritage_type_only_tests.rs"]
 mod heritage_type_only_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/global_augmentation_structural_lookup_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/global_augmentation_structural_lookup_arch_tests.rs
@@ -1,0 +1,25 @@
+/// Global augmentation property lookup must use structural type identity,
+/// not rendered display strings.
+///
+/// `global_augmentations` is keyed by simple interface identifier names.
+/// Rendering a type with `format_type_diagnostic` can produce complex strings
+/// like `"Foo<Bar>"` or `"typeof X"` that would never match a key and that
+/// vary with printer settings. The correct approach is to use
+/// `module_augmentation_lookup_name_for_type` which resolves the identifier
+/// structurally via symbol/def/shape queries.
+#[test]
+fn object_type_augmentation_lookup_uses_structural_name() {
+    let src = include_str!("../types/property_access_augmentation.rs");
+
+    assert!(
+        !src.contains("self.format_type_diagnostic(object_type)"),
+        "`resolve_object_type_global_augmentation` must not use `format_type_diagnostic` \
+         to derive the augmentation lookup key; use `module_augmentation_lookup_name_for_type` instead"
+    );
+
+    assert!(
+        src.contains("module_augmentation_lookup_name_for_type(object_type)"),
+        "`resolve_object_type_global_augmentation` must resolve the augmentation key \
+         via `module_augmentation_lookup_name_for_type` (structural symbol/def lookup)"
+    );
+}

--- a/crates/tsz-checker/src/tests/heritage_constraint_structural_name_lookup_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/heritage_constraint_structural_name_lookup_arch_tests.rs
@@ -1,0 +1,35 @@
+/// Heritage type-name resolution for generic constraints must use structural
+/// identity, not rendered display strings.
+///
+/// `symbol_id_for_heritage_type_name` is called as a last-resort fallback when
+/// checking whether a type satisfies a heritage constraint. The previous
+/// implementation called `format_type_diagnostic`, stripped a possible
+/// `"globalThis."` prefix, and validated identifier characters — all artefacts
+/// of using the printer as an identity oracle.
+///
+/// The correct approach is `named_type_display_name`, which returns the type's
+/// declared identifier name from structural symbol/def/shape queries (or `None`
+/// for unnamed types). This is deterministic, printer-independent, and avoids
+/// the character-set guard that was needed only to filter out rendered non-names.
+#[test]
+fn heritage_type_name_resolution_uses_structural_lookup() {
+    let src = include_str!("../checkers/generic_checker/recursive_heritage_constraint.rs");
+
+    assert!(
+        !src.contains("self.format_type_diagnostic(type_id)"),
+        "`symbol_id_for_heritage_type_name` must not use `format_type_diagnostic` \
+         to derive the heritage type name; use `named_type_display_name` instead"
+    );
+
+    assert!(
+        src.contains("self.named_type_display_name(type_id)"),
+        "`symbol_id_for_heritage_type_name` must resolve the type name structurally \
+         via `named_type_display_name`"
+    );
+
+    assert!(
+        !src.contains("strip_prefix(\"globalThis.\")"),
+        "`symbol_id_for_heritage_type_name` must not strip a `globalThis.` prefix; \
+         `named_type_display_name` produces bare identifier names without renderer artefacts"
+    );
+}

--- a/crates/tsz-checker/src/types/property_access_augmentation.rs
+++ b/crates/tsz-checker/src/types/property_access_augmentation.rs
@@ -272,15 +272,14 @@ impl<'a> CheckerState<'a> {
             // rendered display string. Global augmentation keys are always simple interface
             // names; rendering the type produces forms like "Foo<Bar>" that would never
             // match a key and that vary with printer settings.
-            if let Some(type_name) = self.module_augmentation_lookup_name_for_type(object_type) {
-                if self
+            if let Some(type_name) = self.module_augmentation_lookup_name_for_type(object_type)
+                && self
                     .ctx
                     .binder
                     .global_augmentations
                     .contains_key(&type_name)
-                {
-                    return self.resolve_augmentation_property_by_name(&type_name, property_name);
-                }
+            {
+                return self.resolve_augmentation_property_by_name(&type_name, property_name);
             }
             return None;
         };
@@ -298,16 +297,15 @@ impl<'a> CheckerState<'a> {
         // If the symbol's escaped_name didn't match, check the type's structural identifier.
         // This handles aliased or application-wrapped types where the symbol name and the
         // augmentation key differ.
-        if let Some(type_name) = self.module_augmentation_lookup_name_for_type(object_type) {
-            if type_name != *name
-                && self
-                    .ctx
-                    .binder
-                    .global_augmentations
-                    .contains_key(&type_name)
-            {
-                return self.resolve_augmentation_property_by_name(&type_name, property_name);
-            }
+        if let Some(type_name) = self.module_augmentation_lookup_name_for_type(object_type)
+            && type_name != *name
+            && self
+                .ctx
+                .binder
+                .global_augmentations
+                .contains_key(&type_name)
+        {
+            return self.resolve_augmentation_property_by_name(&type_name, property_name);
         }
         None
     }

--- a/crates/tsz-checker/src/types/property_access_augmentation.rs
+++ b/crates/tsz-checker/src/types/property_access_augmentation.rs
@@ -268,14 +268,19 @@ impl<'a> CheckerState<'a> {
         let Some(def_id) =
             crate::query_boundaries::property_access::def_id(self.ctx.types, object_type)
         else {
-            let display_name = self.format_type_diagnostic(object_type);
-            if self
-                .ctx
-                .binder
-                .global_augmentations
-                .contains_key(&display_name)
-            {
-                return self.resolve_augmentation_property_by_name(&display_name, property_name);
+            // No DefId: look up via the type's structural identifier name rather than the
+            // rendered display string. Global augmentation keys are always simple interface
+            // names; rendering the type produces forms like "Foo<Bar>" that would never
+            // match a key and that vary with printer settings.
+            if let Some(type_name) = self.module_augmentation_lookup_name_for_type(object_type) {
+                if self
+                    .ctx
+                    .binder
+                    .global_augmentations
+                    .contains_key(&type_name)
+                {
+                    return self.resolve_augmentation_property_by_name(&type_name, property_name);
+                }
             }
             return None;
         };
@@ -290,15 +295,19 @@ impl<'a> CheckerState<'a> {
             return self.resolve_augmentation_property_by_name(name, property_name);
         }
 
-        let display_name = self.format_type_diagnostic(object_type);
-        if display_name != *name
-            && self
-                .ctx
-                .binder
-                .global_augmentations
-                .contains_key(&display_name)
-        {
-            return self.resolve_augmentation_property_by_name(&display_name, property_name);
+        // If the symbol's escaped_name didn't match, check the type's structural identifier.
+        // This handles aliased or application-wrapped types where the symbol name and the
+        // augmentation key differ.
+        if let Some(type_name) = self.module_augmentation_lookup_name_for_type(object_type) {
+            if type_name != *name
+                && self
+                    .ctx
+                    .binder
+                    .global_augmentations
+                    .contains_key(&type_name)
+            {
+                return self.resolve_augmentation_property_by_name(&type_name, property_name);
+            }
         }
         None
     }


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Track 2 (Type Evaluation) / Refactor only — burns down rendered-type decision debt (Phase 0 priority §5)

## Invariant
When a type's identifier name is needed as a lookup key (global augmentation map or generic heritage symbol table), `tsc` uses the type's declared symbol name, not a rendered display string; this PR makes tsz do the same by routing through structural symbol/def/shape queries.

## Scope
- `crates/tsz-checker/src/types/property_access_augmentation.rs` — `resolve_object_type_global_augmentation`: two `format_type_diagnostic` decision sites replaced with `module_augmentation_lookup_name_for_type`
- `crates/tsz-checker/src/checkers/generic_checker/recursive_heritage_constraint.rs` — `symbol_id_for_heritage_type_name`: `format_type_diagnostic` + manual `globalThis.`-strip + character-set guard replaced with `named_type_display_name`
- `crates/tsz-checker/src/tests/global_augmentation_structural_lookup_arch_tests.rs` — new architecture contract test
- `crates/tsz-checker/src/tests/heritage_constraint_structural_name_lookup_arch_tests.rs` — new architecture contract test

## Verification
- `cargo check -p tsz-checker` passes clean
- Architecture contract tests assert:
  - `resolve_object_type_global_augmentation` no longer calls `format_type_diagnostic(object_type)`
  - `symbol_id_for_heritage_type_name` no longer calls `format_type_diagnostic(type_id)` or `strip_prefix("globalThis.")`
- Conformance and emit suites run on CI (ready-for-review trigger)

## Project Corpus Impact
- Row: n/a (refactor only; no semantic behavior change for well-formed types)
- Bug family: rendered-type decision debt (Phase 0 §5 cleanup)
- Evidence: `format_type_diagnostic` on the two changed call sites can only produce meaningful augmentation-map hits when it returns a bare identifier, which is exactly what `module_augmentation_lookup_name_for_type` / `named_type_display_name` return structurally — so no behavioral change for any named type; unnamed/complex types that the old code would have missed are still missed.

## Coordination Notes
- Issue #8775 tracks `format_type_diagnostic` decision debt; this is a focused two-site slice
- No overlap with open PRs — checked all 17 open PRs; none touch augmentation lookup or heritage constraint name resolution
- Adjacent sites (`jsdoc/`, `assignability/destructuring`) use `format_type_diagnostic` only for final diagnostic message strings (not decisions) and are not changed here

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQWMvBNYiwPESQg7beu781)_
