### PR TITLE
fix(emit): materialize do-while condition case in ES5 async state machine (positive backedge)

### DIFF
--- a/crates/tsz-emitter/src/transforms/async_es5_ir_condition_await.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_condition_await.rs
@@ -266,43 +266,42 @@ impl<'a> AsyncES5Transformer<'a> {
         self.labeled_continue_targets.truncate(continue_stack_len);
         self.labeled_break_targets.truncate(break_stack_len);
 
-        // When the body contains a `continue`, flush it into its own case so
-        // `continue` can jump directly to the condition label. Without a
-        // flush, there is no distinct label for the condition to target.
-        // When there is no `continue`, the condition check is appended to
-        // the current case (body + condition share one case), which matches
-        // tsc's emitted shape and produces the minimum number of cases.
-        let condition_start_label = if has_loop_continue {
-            let cond_label = self.state.next_label();
-            if Self::loop_statements_end_control_flow(current_statements) {
-                // Body case already exits unconditionally; close it without a
-                // fallthrough label if there is anything to close.
-                if !current_statements.is_empty() {
-                    cases.push(IRGeneratorCase {
-                        label: *current_label,
-                        statements: std::mem::take(current_statements),
-                    });
-                }
-            } else {
-                // Either there are pending body statements, or the loop body
-                // already flushed its last case internally and left
-                // `current_statements` empty (e.g. a single `if` with an await
-                // inside one branch). In either case we need a visible
-                // `_a.label = cond_label` so that `continue` can jump here and
-                // any test helpers can locate the condition label.
-                current_statements.push(Self::generator_label_assignment(cond_label));
+        // tsc always materializes the do-while condition test as its own
+        // generator case: the loop's continue target. The body's last case
+        // falls through to it (via `_a.label = cond_label`) unless the body
+        // already ended in control flow; a `continue` jumps to it. Flush the
+        // body and make `cond_label` the current case regardless of whether the
+        // body contains a `continue`, so the back-edge structure matches tsc's
+        // emitted shape (body case, condition case, exit case).
+        let cond_label = self.state.next_label();
+        if Self::loop_statements_end_control_flow(current_statements) {
+            // Body case already exits unconditionally; close it without a
+            // fallthrough label if there is anything to close.
+            if !current_statements.is_empty() {
                 cases.push(IRGeneratorCase {
                     label: *current_label,
                     statements: std::mem::take(current_statements),
                 });
             }
-            *current_label = cond_label;
-            cond_label
         } else {
-            *current_label
-        };
+            // Either there are pending body statements, or the loop body
+            // already flushed its last case internally and left
+            // `current_statements` empty (e.g. a single `if` with an await
+            // inside one branch). In either case emit a visible
+            // `_a.label = cond_label` so control falls through to the condition
+            // case (and any `continue` can jump here).
+            current_statements.push(Self::generator_label_assignment(cond_label));
+            cases.push(IRGeneratorCase {
+                label: *current_label,
+                statements: std::mem::take(current_statements),
+            });
+        }
+        *current_label = cond_label;
 
-        if let Some(operand_idx) = condition_await_operand {
+        // Evaluate the condition starting at `cond_label`. An awaited condition
+        // yields its operand in the condition case, then tests `_a.sent()` in
+        // the following case; a plain condition tests inline.
+        let condition = if let Some(operand_idx) = condition_await_operand {
             let operand = self.expression_to_ir(operand_idx);
             self.push_generator_yield(
                 opcodes::YIELD,
@@ -312,30 +311,30 @@ impl<'a> AsyncES5Transformer<'a> {
                 current_statements,
                 current_label,
             );
-            current_statements.push(IRNode::IfBreak {
-                condition: Box::new(Self::negated_condition(IRNode::GeneratorSent)),
-                target_label: exit_placeholder,
-            });
+            IRNode::GeneratorSent
         } else {
-            let condition = self.expression_to_ir(loop_data.condition);
-            current_statements.push(IRNode::IfBreak {
-                condition: Box::new(Self::negated_condition(condition)),
-                target_label: exit_placeholder,
-            });
-        }
-        current_statements.push(Self::generator_break_statement(loop_label));
+            self.expression_to_ir(loop_data.condition)
+        };
+        // Positive test: when the condition holds, branch back to the loop
+        // start; otherwise fall through to the exit case (matching tsc, which
+        // emits `if (cond) return [3 /*break*/, start]; _a.label = exit;`).
+        current_statements.push(IRNode::IfBreak {
+            condition: Box::new(condition),
+            target_label: loop_label,
+        });
 
+        let exit_label = self.state.next_label();
+        current_statements.push(Self::generator_label_assignment(exit_label));
         cases.push(IRGeneratorCase {
             label: *current_label,
             statements: std::mem::take(current_statements),
         });
+        *current_label = exit_label;
 
-        let exit_label = self.state.next_label();
         Self::patch_if_break_target(cases, exit_placeholder, exit_label);
         if has_loop_continue {
-            Self::patch_if_break_target(cases, continue_placeholder, condition_start_label);
+            Self::patch_if_break_target(cases, continue_placeholder, cond_label);
         }
-        *current_label = exit_label;
     }
 
     /// Process a `for (init; cond; incr) body` statement inside an async

--- a/crates/tsz-emitter/tests/async_loop_emit.rs
+++ b/crates/tsz-emitter/tests/async_loop_emit.rs
@@ -125,6 +125,60 @@ fn async_do_while_awaited_condition_uses_positive_sent_backedge() {
 }
 
 #[test]
+fn async_do_while_body_await_without_continue_materializes_condition_case() {
+    // A do-while whose body awaits but contains no `continue` must still get a
+    // dedicated condition case (the post-body fallthrough). tsc emits
+    // `_a.sent(); _a.label = 2; case 2: if (cond) return [3 /*break*/, 0]; _a.label = 3;`
+    // rather than collapsing the condition into the body case with a negated
+    // test. Use non-default identifiers to prove the rule keys on the do-while
+    // structure, not on a particular spelling.
+    let output = emit_es5(
+        "declare var first, second: any;
+        async function run() {
+            do {
+                await first;
+            } while (second);
+        }",
+    );
+
+    assert!(
+        output.contains("_a.sent();\n                    _a.label = 2;\n                case 2:\n                    if (second) return [3 /*break*/, 0];\n                    _a.label = 3;\n                case 3: return [2 /*return*/];"),
+        "A no-continue do-while with an awaiting body should fall through to a dedicated condition case using tsc's positive backedge test.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("if (!second)"),
+        "The do-while condition must use the positive backedge test, never a negated `if (!cond)` collapse.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_do_while_unlabeled_break_targets_exit_with_condition_case() {
+    // An unlabeled `break` inside an awaiting do-while body jumps directly to
+    // the loop exit case, while the post-body condition case is still
+    // materialized. Renamed identifiers keep the assertion structural.
+    let output = emit_es5(
+        "declare var alpha, beta: any;
+        async function run() {
+            do {
+                await alpha;
+                break;
+            } while (beta);
+        }",
+    );
+
+    // body: yield alpha (case 0), then `_a.sent(); break -> exit` (case 1).
+    assert!(
+        output.contains("_a.sent();\n                    return [3 /*break*/, 3];"),
+        "An unlabeled break should jump straight to the do-while exit case.\nOutput:\n{output}"
+    );
+    // condition case is still present with the positive backedge test.
+    assert!(
+        output.contains("case 2:\n                    if (beta) return [3 /*break*/, 0];\n                    _a.label = 3;\n                case 3: return [2 /*return*/];"),
+        "The do-while condition case must remain materialized even when the body breaks.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn async_conditional_true_await_reserves_false_label_after_resume() {
     let output = emit_es5(
         "declare var x, y, z, a: any;


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
emit/js — ES5 async/generator state-machine lowering (emit→100% campaign, wave 3)

## Invariant
When a `do { body } while (cond)` is lowered into the ES5 async/generator state machine, the condition test is always materialized as its own generator case (the loop's continue target): the body's last case falls through via `_a.label = cond_label` (or `continue` jumps to it), the condition is tested POSITIVELY (`if (cond) return [3 /*break*/, loop_start]`), then falls through `_a.label = exit_label` into the exit case. Previously tsz created the condition case only when the body contained a `continue`, and collapsed the test into a negated `if (!cond) break exit; break loop_start` form. Keyed on the do-while node structure within an async/generator region — not identifiers/spelling.

## Scope
- `crates/tsz-emitter/src/transforms/async_es5_ir_condition_await.rs` — `process_do_while_statement_in_async_with_label`: always materialize the condition case; positive backedge + fall-through.
- `crates/tsz-emitter/tests/async_loop_emit.rs` — +2 structural tests (no-continue awaiting body; unlabeled break; renamed identifiers).

## Project Corpus Impact
- Row: n/a (ES5 async-lowering emit fix)
- Bug family: ES5 async state-machine do-while condition-case materialization
- Evidence: es5-asyncFunctionDoStatements(target=es5) FAIL→PASS; full --js-only 102→101.

## Verification
- Witness `es5-asyncFunctionDoStatements(es5)` FAIL→PASS. **Full --js-only: 13428→13429 pass (102→101 fail), net +1, ZERO new failures, 0 new timeouts.** --dts-only unaffected (JS-path-only; dts strips bodies).
- All 16 async_do_while unit tests pass (14 existing + 2 new). Clippy clean (-D warnings).
- §25/§26 compliant (keyed on do-while node structure, no identifier/printer-output matching). No output surgery — planned state-machine cases.

## Coordination Notes
Rebased onto current main (arch file-size ratchet guard fails on stale branches). Scoped out (broad, reported, NOT forced): es5-asyncFunctionTryStatements (file-global monotonic catch-binding rename counter `e_1..e_6` across functions — needs a counter threaded like `disposable_env_counter`; 5 pre-existing unit failures already track this family); transformNestedGeneratorsWithTry (compounding: catch-rename + un-lowered nested async fn-expr + `__awaiter` return type-arg); asyncArrowFunctionCapturesArguments_es5 (distinct: needs outer `function(){ var arguments_1 = arguments; return __awaiter(...) }` wrapper). — opus48-emit100

