### PR TITLE
fix(emit): single-line synthesized concise-arrow temp block + unparenthesized return-operand class comma-wrapper

### DIFF
--- a/crates/tsz-emitter/src/emitter/arrow_concise.rs
+++ b/crates/tsz-emitter/src/emitter/arrow_concise.rs
@@ -7,13 +7,21 @@ impl<'a> Printer<'a> {
     }
 
     pub(super) fn emit_arrow_concise_body_with_temp_prologue(&mut self, body: NodeIndex) {
-        self.open_brace();
-        self.write_line();
-        self.increase_indent();
-        let hoist_anchor = self.capture_hoist_anchor();
+        // tsc converts a concise-body arrow that needs a hoisted temp (e.g. a
+        // class-expression static-state alias) into a *single-line* block body
+        // `{ var _a; return <expr>; }`. The synthesized block keeps the brace,
+        // `var`, and `return` on the same line; only the emitted expression
+        // (a multi-line class body or comma wrapper) expands across lines.
+        self.write("{ ");
+        let var_insert_pos = self.writer.len();
 
         let prev_emitting_function_body_block = self.emitting_function_body_block;
+        let prev_emitting_concise_arrow_return_argument =
+            self.emitting_concise_arrow_return_argument;
         self.emitting_function_body_block = true;
+        // The expression is the direct operand of the synthesized `return`, so a
+        // class-expression comma wrapper must not be parenthesized.
+        self.emitting_concise_arrow_return_argument = true;
         self.function_scope_depth += 1;
         self.arrow_function_scope_depth += 1;
         self.write("return ");
@@ -21,22 +29,15 @@ impl<'a> Printer<'a> {
         self.write(";");
         self.arrow_function_scope_depth -= 1;
         self.function_scope_depth -= 1;
+        self.emitting_concise_arrow_return_argument = prev_emitting_concise_arrow_return_argument;
         self.emitting_function_body_block = prev_emitting_function_body_block;
 
         if !self.hoisted_assignment_temps.is_empty() {
-            let indent = self.writer.indent_string_at(hoist_anchor.indent_level);
-            let var_decl = format!(
-                "{}var {};",
-                indent,
-                self.hoisted_assignment_temps.join(", ")
-            );
-            self.writer
-                .insert_line_at(hoist_anchor.byte_offset, hoist_anchor.line_no, &var_decl);
+            let var_decl = format!("var {}; ", self.hoisted_assignment_temps.join(", "));
+            self.writer.insert_at(var_insert_pos, &var_decl);
             self.hoisted_assignment_temps.clear();
         }
 
-        self.write_line();
-        self.decrease_indent();
-        self.close_brace();
+        self.write(" }");
     }
 }

--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -420,6 +420,15 @@ pub struct Printer<'a> {
     /// Marker that the next block emission is a function body.
     pub(crate) emitting_function_body_block: bool,
 
+    /// Set while emitting the expression that is the synthesized `return`
+    /// argument of a concise-body arrow function converted to a block body
+    /// (e.g. `=> classExpr` lowered to `=> { var _a; return _a = classExpr,
+    /// _a.x = ..., _a; }`). A class-expression comma wrapper in this position
+    /// is the direct operand of `return`, so it must not be parenthesized,
+    /// matching tsc's transform where the class expression's effective parent
+    /// is the synthesized return statement.
+    pub(crate) emitting_concise_arrow_return_argument: bool,
+
     /// Parameter nodes for the next function body block.
     ///
     /// ES5 block-scoped lowering needs parameters in the function's scope map

--- a/crates/tsz-emitter/src/emitter/core_setup.rs
+++ b/crates/tsz-emitter/src/emitter/core_setup.rs
@@ -292,6 +292,7 @@ impl<'a> Printer<'a> {
             enum_namespace_export: None,
             namespace_export_inner: false,
             emitting_function_body_block: false,
+            emitting_concise_arrow_return_argument: false,
             pending_function_body_parameters: Vec::new(),
             current_new_target_substitution: None,
             pending_new_target_capture_initializer: None,

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -1425,6 +1425,7 @@ impl<'a> Printer<'a> {
         let needs_any_comma_expr =
             needs_static_comma_expr || needs_private_comma_expr || needs_computed_prop_comma_expr;
         let class_expr_comma_needs_parens = needs_any_comma_expr
+            && !self.emitting_concise_arrow_return_argument
             && self
                 .arena
                 .get_extended(_idx)

--- a/crates/tsz-emitter/src/emitter/source_file/class_static_alias_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/class_static_alias_tests.rs
@@ -74,3 +74,84 @@ fn es5_static_block_reuses_surrounding_class_alias() {
         "Static block `this` references should use the surrounding class alias.\nOutput:\n{output}"
     );
 }
+
+// A concise-body arrow returning an anonymous `class extends <base>` with a
+// static field (the mixin pattern) is lowered to a single-line block body
+// `(...) => { var _a; return _a = class extends <base> {...}, _a.<field> = ...,
+// _a; }`. tsc keeps the synthesized `{ var _a; return` on the arrow's `=>`
+// line and does *not* parenthesize the comma wrapper (it is the direct operand
+// of the synthesized `return`). These assertions are keyed on the structural
+// shape, not on the chosen identifier spellings, so they hold for any base /
+// parameter / field names.
+
+#[test]
+fn es2015_mixin_arrow_concise_class_expr_is_single_line_block_without_paren() {
+    let source = "const Mixin = (Sup) =>\n    class extends Sup {\n        static label = \"x\";\n        go() {}\n    }\n";
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains("(Sup) => { var _a; return _a = class extends Sup {"),
+        "Mixin arrow body should be a single-line `{{ var _a; return _a = class ...`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("return (_a = "),
+        "Comma wrapper that is the direct `return` operand must not be parenthesized.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a.label = \"x\","),
+        "Static field initializer should be a comma item on the wrapper.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a; };"),
+        "Single-line block should close with `_a; }};` on one line.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es2015_mixin_arrow_renamed_param_and_base_keeps_single_line_block() {
+    // Same structural shape, different parameter / base / field spellings: the
+    // fix must not depend on the chosen identifiers.
+    let source = "const make = (B) =>\n    class extends B {\n        static tag = 1;\n        run() {}\n    }\n";
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains("(B) => { var _a; return _a = class extends B {"),
+        "Renamed mixin should still emit a single-line block body.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("return (_a = "),
+        "Renamed mixin comma wrapper must not be parenthesized after `return`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a.tag = 1,") && output.contains("_a; };"),
+        "Renamed mixin static field should be a comma item closing with `_a; }};`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es2015_mixin_arrow_typed_param_and_return_keeps_single_line_block() {
+    // Annotated mixin (type parameter + parameter type + return type) lowers to
+    // the same runtime shape once types are erased.
+    let source = concat!(
+        "type Ctor<T> = new (...a: any[]) => T;\n",
+        "const Printable = <T extends Ctor<object>>(superClass: T): Ctor<object> & { message: string } & T =>\n",
+        "    class extends superClass {\n",
+        "        static message = \"hello\";\n",
+        "        print() {}\n",
+        "    }\n",
+    );
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains("(superClass) => { var _a; return _a = class extends superClass {"),
+        "Annotated mixin should erase types and emit a single-line block body.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("return (_a = "),
+        "Annotated mixin comma wrapper must not be parenthesized after `return`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a.message = \"hello\","),
+        "Annotated mixin static field should be a comma item.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/tests/optional_chaining_tests.rs
+++ b/crates/tsz-emitter/tests/optional_chaining_tests.rs
@@ -100,11 +100,16 @@ fn concise_arrow_optional_method_call_gets_temp_prologue() {
     let source = "const typeHandlers = {};\nconst onSomeEvent = (p) => typeHandlers[p.t]?.(p);";
     let output = emit_es2016(source);
 
+    // tsc converts the concise body into a *single-line* block hosting the
+    // hoisted `var _a;` temp (see baseline
+    // `mappedTypeGenericIndexedAccess.js`, where the identical
+    // `const onSomeEvent = (p) => typeHandlers[p.t]?.(p);` is emitted on one
+    // line as `(p) => { var _a; return ...; }`).
     assert!(
         output.contains(
-            "const onSomeEvent = (p) => {\n    var _a;\n    return (_a = typeHandlers[p.t]) === null || _a === void 0 ? void 0 : _a.call(typeHandlers, p);\n};"
+            "const onSomeEvent = (p) => { var _a; return (_a = typeHandlers[p.t]) === null || _a === void 0 ? void 0 : _a.call(typeHandlers, p); };"
         ),
-        "Concise arrow optional-call temp should be declared inside a synthesized block.\nOutput:\n{output}"
+        "Concise arrow optional-call temp should be declared inside a single-line synthesized block.\nOutput:\n{output}"
     );
 }
 


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
emit/js — concise-arrow / class-expression emit layout (emit→100% campaign, wave 3)

## Invariant
When a concise-arrow body needs a hoisted temp and is converted to a block (e.g. body is an anonymous `class extends <base>` with static state, lowered to `(...) => { var _a; return _a = class extends <base> {...}, _a.<field> = ..., _a; }`): (a) emit the synthesized arrow block SINGLE-LINE (matching tsc), and (b) treat the emitted expression as a `return` operand so a class-expression comma-wrapper is NOT parenthesized — exactly as when the AST parent is a RETURN_STATEMENT. Keyed on AST structure (concise-arrow-body-needing-temp + return-operand position), not identifier/printer-output matching.

## Scope
- `crates/tsz-emitter/src/emitter/arrow_concise.rs` — synthesized concise-arrow temp block emitted single-line; set return-argument flag.
- `crates/tsz-emitter/src/emitter/core.rs` + `core_setup.rs` — new `emitting_concise_arrow_return_argument` printer flag (default-init).
- `crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs` — suppress comma-wrapper parens when flag set (1 line).
- `crates/tsz-emitter/src/emitter/source_file/class_static_alias_tests.rs` (+3 tests); `tests/optional_chaining_tests.rs` (corrected 1 test to tsc's single-line output).

## Project Corpus Impact
- Row: n/a (concise-arrow/class-expression emit-layout fix)
- Bug family: synthesized concise-arrow temp-block layout + class-expression comma-wrapper parenthesization
- Evidence: mixinClassesAnnotated, mixinClassesAnonymous FAIL→PASS (mixinClasses family 3/3); full --js-only 102→100.

## Verification
- 2 witnesses FAIL→PASS. **Full --js-only: 102→100 fail, net +2, ZERO new failures, 0 timeouts** (FIXED={mixinClassesAnnotated,mixinClassesAnonymous}). --dts-only 24==24 (zero new). Validated vs tsc baseline `mappedTypeGenericIndexedAccess.js:68` (identical single-line concise-arrow). Clippy clean.
- 3 new structural unit tests (base/param/field renames, anonymous, type-param+annotated). Corrected pre-existing `concise_arrow_optional_method_call_gets_temp_prologue` which asserted a multi-line shape that never matched tsc.
- §25/§26 compliant. No output surgery — planned facts.

## Coordination Notes
Rebased onto current main (arch file-size ratchet guard fails on stale branches; arch guard passes on rebased head). Note: `emit_es6.rs` is a pre-existing 4187-line monolith (separate split-cleanup concern, tracked by its size ratchet); this PR adds 1 line within the ratchet and does not refactor it. — opus48-emit100

