### PR TITLE
fix(diagnostics): make diagnostic ordering deterministic across layers

### DIFF
--- a/crates/tsz-core/src/diagnostics/mod.rs
+++ b/crates/tsz-core/src/diagnostics/mod.rs
@@ -323,12 +323,29 @@ impl Diagnostic {
 
     /// Canonical total ordering for diagnostics, mirroring the TypeScript
     /// compiler's `compareDiagnostics`: by file, then start, then length, then
-    /// code, then message. This is a *total* order over the observable fields,
-    /// so diagnostics that tie on file and start still have a stable,
-    /// reproducible relative order independent of the order in which they were
-    /// produced. Sorting through this comparator is what keeps reported
-    /// diagnostic order deterministic across equivalent relations.
+    /// code, then message, then related information. This is a *total* order
+    /// over the observable fields, so diagnostics that tie on the
+    /// location/code/message key still have a stable, reproducible relative
+    /// order independent of the order in which they were produced. Sorting
+    /// through this comparator is what keeps reported diagnostic order
+    /// deterministic across equivalent relations.
+    ///
+    /// The related-information tiebreaker is required for that guarantee:
+    /// two diagnostics that share file/start/length/code/message but carry
+    /// different "see also" locations are genuinely distinct in the rendered
+    /// output, so leaving them tied would let a downstream stable sort or
+    /// `dedup` keep whichever happened to be produced first — which varies with
+    /// relation traversal/memoization order. tsc breaks the same tie with
+    /// `compareRelatedInformation`.
     pub fn compare(&self, other: &Self) -> std::cmp::Ordering {
+        self.compare_skip_related_information(other)
+            .then_with(|| compare_related_information(&self.related, &other.related))
+    }
+
+    /// The location/code/message portion of [`Diagnostic::compare`], mirroring
+    /// tsc's `compareDiagnosticsSkipRelatedInformation`. Orders by file, then
+    /// start, then length, then code, then message text.
+    pub fn compare_skip_related_information(&self, other: &Self) -> std::cmp::Ordering {
         self.file_name
             .cmp(&other.file_name)
             .then_with(|| self.span.start.cmp(&other.span.start))
@@ -371,6 +388,32 @@ impl Diagnostic {
     pub fn to_range(&self, source_file: &mut SourceFile) -> Range {
         source_file.span_to_range(self.span)
     }
+}
+
+/// Order two related-information lists, mirroring tsc's
+/// `compareRelatedInformation`: shorter lists sort first, then the lists are
+/// compared element-by-element on file, start, length, and message text.
+///
+/// [`DiagnosticRelatedInfo`] does not carry a diagnostic code (tsc's related
+/// entries are message-only "see also" notes), so the per-element key stops at
+/// the message text.
+fn compare_related_information(
+    a: &[DiagnosticRelatedInfo],
+    b: &[DiagnosticRelatedInfo],
+) -> std::cmp::Ordering {
+    a.len().cmp(&b.len()).then_with(|| {
+        a.iter()
+            .zip(b.iter())
+            .map(|(left, right)| {
+                left.file_name
+                    .cmp(&right.file_name)
+                    .then_with(|| left.span.start.cmp(&right.span.start))
+                    .then_with(|| left.span.len().cmp(&right.span.len()))
+                    .then_with(|| left.message.cmp(&right.message))
+            })
+            .find(|ordering| ordering.is_ne())
+            .unwrap_or(std::cmp::Ordering::Equal)
+    })
 }
 
 impl fmt::Display for Diagnostic {
@@ -919,6 +962,66 @@ mod tests {
         assert_eq!(build([0, 1, 2, 3]), expected);
         assert_eq!(build([3, 2, 1, 0]), expected);
         assert_eq!(build([2, 0, 3, 1]), expected);
+    }
+
+    #[test]
+    fn test_compare_breaks_ties_on_related_information() {
+        // Diagnostics identical on file/start/length/code/message but differing
+        // only in their related "see also" entries are genuinely distinct in the
+        // rendered output. They must order deterministically (shorter related
+        // list first, then element-by-element) instead of falling back to
+        // production order, mirroring tsc's `compareRelatedInformation`.
+        //
+        // Each pool entry shares the primary key and is distinguished only by a
+        // tag passed in `related`, so the assertions exercise the related
+        // tiebreaker alone.
+        let make = |tag: &str, related: &[(&str, u32, &str)]| {
+            let mut diag = Diagnostic::error("a.ts", Span::new(0, 1), "msg", 2304);
+            for &(file, start, message) in related {
+                diag = diag.with_related(DiagnosticRelatedInfo::new(
+                    file,
+                    Span::new(start, start + 1),
+                    message,
+                ));
+            }
+            // Pair the diagnostic with a tag so the test can identify entries
+            // after sorting; the tag lives outside the diagnostic and never
+            // affects the comparator.
+            (tag.to_string(), diag)
+        };
+
+        let bare = make("bare", &[]);
+        let with_one = make("with_one", &[("a.ts", 5, "see a")]);
+        let see_x = make("see_x", &[("a.ts", 5, "see x")]);
+        let see_y = make("see_y", &[("a.ts", 5, "see y")]);
+        let with_two = make("with_two", &[("a.ts", 5, "see a"), ("a.ts", 9, "see b")]);
+
+        let expected = vec!["bare", "with_one", "see_x", "see_y", "with_two"];
+
+        let permute = |order: &[usize]| {
+            let pool = [
+                bare.clone(),
+                with_one.clone(),
+                see_x.clone(),
+                see_y.clone(),
+                with_two.clone(),
+            ];
+            let mut v: Vec<_> = order.iter().map(|&i| pool[i].clone()).collect();
+            v.sort_by(|a, b| a.1.compare(&b.1));
+            v.into_iter().map(|(tag, _)| tag).collect::<Vec<_>>()
+        };
+        assert_eq!(permute(&[0, 1, 2, 3, 4]), expected);
+        assert_eq!(permute(&[4, 3, 2, 1, 0]), expected);
+        assert_eq!(permute(&[2, 4, 0, 3, 1]), expected);
+
+        // Antisymmetry on the related tiebreaker.
+        assert_eq!(bare.1.compare(&with_one.1), std::cmp::Ordering::Less);
+        assert_eq!(with_one.1.compare(&bare.1), std::cmp::Ordering::Greater);
+        assert_eq!(see_x.1.compare(&see_y.1), std::cmp::Ordering::Less);
+        assert_eq!(see_y.1.compare(&see_x.1), std::cmp::Ordering::Greater);
+        // Identical related info ties.
+        let twin = make("with_one_twin", &[("a.ts", 5, "see a")]);
+        assert_eq!(with_one.1.compare(&twin.1), std::cmp::Ordering::Equal);
     }
 
     #[test]

--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -200,6 +200,10 @@ mod decorator_tests;
 mod modifier_ordering_tests;
 
 #[cfg(test)]
+#[path = "../../tests/parse_diagnostic_order_tests.rs"]
+mod parse_diagnostic_order_tests;
+
+#[cfg(test)]
 #[path = "../../tests/parser_unit_tests.rs"]
 mod parser_unit_tests;
 

--- a/crates/tsz-parser/src/parser/state.rs
+++ b/crates/tsz-parser/src/parser/state.rs
@@ -100,6 +100,23 @@ pub struct ParseDiagnostic {
     pub code: u32,
 }
 
+impl ParseDiagnostic {
+    /// Canonical ordering for parse diagnostics, mirroring the TypeScript
+    /// compiler's `compareDiagnostics`. All parse diagnostics for one parse
+    /// belong to the same source file, so the file key is constant and the
+    /// order is fully determined by `(start, length, code, message)`. This is a
+    /// total order over the observable fields, so diagnostics that tie on
+    /// position still have a stable, reproducible order independent of the
+    /// scanner/parser merge order in which they were produced.
+    pub fn compare(&self, other: &Self) -> std::cmp::Ordering {
+        self.start
+            .cmp(&other.start)
+            .then_with(|| self.length.cmp(&other.length))
+            .then_with(|| self.code.cmp(&other.code))
+            .then_with(|| self.message.cmp(&other.message))
+    }
+}
+
 pub struct IncrementalParseResult {
     pub statements: NodeList,
     pub end_pos: u32,

--- a/crates/tsz-parser/src/parser/state_statements.rs
+++ b/crates/tsz-parser/src/parser/state_statements.rs
@@ -153,8 +153,11 @@ impl ParserState {
                 code: diag.code,
             });
         }
-        // Sort diagnostics by position to maintain correct order after merging
-        self.parse_diagnostics.sort_by_key(|d| d.start);
+        // Sort diagnostics into tsc's canonical `compareDiagnostics` order after
+        // merging scanner- and parser-produced entries. Sorting by `start` alone
+        // left position ties resolved by production/merge order, which is not
+        // guaranteed to match tsc and is fragile under reordering.
+        self.parse_diagnostics.sort_by(|a, b| a.compare(b));
 
         // Create source file node
         let end_pos = self.token_end();

--- a/crates/tsz-parser/tests/parse_diagnostic_order_tests.rs
+++ b/crates/tsz-parser/tests/parse_diagnostic_order_tests.rs
@@ -1,0 +1,81 @@
+//! Tests for the canonical, deterministic ordering of parse diagnostics.
+//!
+//! These lock the rule that parse diagnostics are sorted through
+//! [`ParseDiagnostic::compare`] (tsc's `compareDiagnostics` key restricted to a
+//! single file): by start, then length, then code, then message. Sorting by
+//! position alone left ties resolved by scanner/parser merge order, which made
+//! the reported order fragile under reordering.
+
+use crate::parser::state::ParseDiagnostic;
+
+fn diag(start: u32, length: u32, code: u32, message: &str) -> ParseDiagnostic {
+    ParseDiagnostic {
+        start,
+        length,
+        message: message.to_string(),
+        code,
+    }
+}
+
+/// Sorting through the canonical comparator yields the same order no matter how
+/// the input was permuted — the property that keeps reported parse-diagnostic
+/// order deterministic.
+fn assert_permutation_invariant(canonical: &[ParseDiagnostic]) {
+    for window in canonical.windows(2) {
+        assert_ne!(
+            window[0].compare(&window[1]),
+            std::cmp::Ordering::Greater,
+            "input slice is expected to already be in canonical order"
+        );
+    }
+    let keys: Vec<_> = canonical
+        .iter()
+        .map(|d| (d.start, d.length, d.code, d.message.clone()))
+        .collect();
+
+    let mut reversed = canonical.to_vec();
+    reversed.reverse();
+    let mut rotated = canonical.to_vec();
+    rotated.rotate_left(canonical.len() / 2);
+    for mut permutation in [reversed, rotated] {
+        permutation.sort_by(|a, b| a.compare(b));
+        let got: Vec<_> = permutation
+            .iter()
+            .map(|d| (d.start, d.length, d.code, d.message.clone()))
+            .collect();
+        assert_eq!(got, keys);
+    }
+}
+
+#[test]
+fn parse_diagnostic_order_breaks_position_ties_by_length_code_message() {
+    let canonical = vec![
+        diag(0, 5, 1005, "alpha"),
+        // same start, shorter length sorts first
+        diag(10, 2, 9999, "zzz"),
+        diag(10, 4, 1000, "aaa"),
+        // same start+length, lower code first
+        diag(20, 3, 1109, "msg"),
+        diag(20, 3, 1128, "msg"),
+        // same start+length+code, message breaks the tie
+        diag(30, 1, 1005, "aaa"),
+        diag(30, 1, 1005, "bbb"),
+    ];
+    assert_permutation_invariant(&canonical);
+}
+
+#[test]
+fn parse_diagnostic_compare_is_total_and_antisymmetric() {
+    let a = diag(5, 2, 1005, "msg");
+    let b = a.clone();
+    assert_eq!(a.compare(&b), std::cmp::Ordering::Equal);
+
+    let c = diag(5, 2, 1005, "msg2");
+    assert_eq!(a.compare(&c), std::cmp::Ordering::Less);
+    assert_eq!(c.compare(&a), std::cmp::Ordering::Greater);
+
+    // Position ties never collapse to `Equal` when later keys differ.
+    let shorter = diag(5, 1, 9999, "z");
+    let longer = diag(5, 9, 1000, "a");
+    assert_eq!(shorter.compare(&longer), std::cmp::Ordering::Less);
+}


### PR DESCRIPTION
## Agent
AgentName: web-opus48-dq1ou

Fixes #11594.

## Track
Diagnostics / determinism (checker→reporting pipeline).

## Invariant
When two diagnostics share file/start/length/code/message but differ in their related "see also" information (tsz-core), or share a start position but differ in length/code/message (parser), `tsc` orders them by its `compareDiagnostics`/`compareRelatedInformation` total order; this PR makes tsz do the same by completing the diagnostic comparators rather than relying on production order.

## Scope
Root cause of "diagnostic report order is non-deterministic across equivalent relations": two diagnostic comparators were *partial* keys, so entries that tied on the partial key fell back to the order they were produced in — which varies with relation traversal / scanner-parser merge order.

- `crates/tsz-core/src/diagnostics/mod.rs`: `Diagnostic::compare` omitted the related-information tiebreaker (its doc claimed a "total order over the observable fields" but `related` is observable and rendered). Added `compare_related_information` (mirrors tsc's `compareRelatedInformation`) and split out `compare_skip_related_information`, matching the already-complete canonical comparator in `tsz-common`.
- `crates/tsz-parser/src/parser/state.rs` + `state_statements.rs`: parse diagnostics were sorted by `start` only. Added `ParseDiagnostic::compare` (`start, length, code, message`) and sort through it.

This is the general rule, not a per-fixture patch: any layer that emits/sorts diagnostics now uses a complete, tsc-faithful total order, so equivalent relations always emit in the same sequence. The CLI/checker final-report path already routed through `tsz-common`'s complete comparator; this closes the remaining tsz-core and parser gaps.

Deliberately out of scope (behavior-changing, unrelated to ordering determinism): the `dedup_by((start, code))` sites in `parallel/diagnostics.rs` and `checker_lib_diagnostics.rs`. They run *after* a full-comparator sort, so their result is already deterministic; changing the dedup key would alter which duplicates collapse and risk conformance drift.

## Project Corpus Impact
- Row: `nextjs` (issue #11594, case `diagnostics-34-20`)
- Bug family: diagnostics — non-deterministic report order across equivalent relations
- Evidence: comparator completeness gap in `tsz-core`/`tsz-parser`; new permutation-invariance unit tests prove order is independent of input order. Final CLI path already used the complete `tsz-common` comparator, so no diagnostic-text change is expected — only stable tiebreaking.

## Verification
- `cargo test -p tsz-core --lib diagnostics::` — 26 passed (incl. new `test_compare_breaks_ties_on_related_information`).
- `cargo test -p tsz-parser --lib parse_diagnostic_order` — 2 passed (permutation-invariance + totality/antisymmetry).
- `cargo clippy -p tsz-core -p tsz-parser --all-targets --all-features -- -D warnings` — clean.
- Rebased on latest `main`, no conflicts.

## Coordination Notes
- Claimed #11594 via RNG from the unowned, non-WIP bug pool; issue labeled `WIP` with a signed claim comment. No overlapping open PR (checked all 18 open PRs for diagnostic/ordering work).
- Reviewed with `/simplify` (3 passes); fixed a misleading test comment, otherwise clean. The `.find(...).unwrap_or(Equal)` pattern is kept intentionally to mirror the canonical `tsz-common` sibling.
- Signed: web-opus48-dq1ou

---
_Generated by [Claude Code](https://claude.ai/code/session_016gJMEi9FxL9i284X52Ldhq)_