### PR TITLE
fix(emit): preserve inner/trailing comments when lowering static fields and Object.assign spreads

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -275,6 +275,10 @@ name = "ternary_trailing_comment_tests"
 path = "tests/ternary_trailing_comment_tests.rs"
 
 [[test]]
+name = "static_field_lowering_trailing_comment_tests"
+path = "tests/static_field_lowering_trailing_comment_tests.rs"
+
+[[test]]
 name = "wave3_small_emit_fixes_tests"
 path = "tests/wave3_small_emit_fixes_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/core_setup.rs
+++ b/crates/tsz-emitter/src/emitter/core_setup.rs
@@ -850,6 +850,62 @@ impl<'a> Printer<'a> {
         self.scoped_static_super_assignment_target = prev_super_assignment_target;
     }
 
+    /// Re-emit a lowered static field initializer (`ClassName.field = <init>`)
+    /// with the comment cursor temporarily rewound so that comments living
+    /// *inside* the initializer expression are available again.
+    ///
+    /// While the class body is emitted, static fields are skipped and the
+    /// comment cursor is advanced past their whole source span. That cursor
+    /// advance also consumes comments nested inside the initializer (e.g. the
+    /// trailing comment on the last member of `static A = class { m() {} // x }`).
+    /// Those comments are re-attached here by rewinding the cursor to the first
+    /// comment at or after the initializer's start before emission, then
+    /// restoring it to the position past the initializer's last token so the
+    /// surrounding emission state is unchanged.
+    pub(in crate::emitter) fn emit_static_field_initializer_with_inner_comments(
+        &mut self,
+        init_idx: NodeIndex,
+        this_alias: Option<&str>,
+        super_base_alias: Option<&str>,
+        super_direct_access: bool,
+    ) {
+        let saved_comment_idx = self.comment_emit_idx;
+        let mut restored_comment_idx = saved_comment_idx;
+        if !self.ctx.options.remove_comments
+            && let Some(init_node) = self.arena.get(init_idx)
+        {
+            let init_pos = init_node.pos;
+            let init_end = self.find_token_end_before_trivia(init_node.pos, init_node.end);
+            // Rewind to the first comment that starts at or after the
+            // initializer so nested trailing comments emit inline again.
+            let mut first_inner = saved_comment_idx;
+            while first_inner > 0 && self.all_comments[first_inner - 1].pos >= init_pos {
+                first_inner -= 1;
+            }
+            // After emission, resume at the first comment strictly past the
+            // initializer's content so comments that genuinely follow the
+            // field assignment are not re-emitted twice.
+            restored_comment_idx = saved_comment_idx;
+            while restored_comment_idx < self.all_comments.len()
+                && self.all_comments[restored_comment_idx].end <= init_end
+            {
+                restored_comment_idx += 1;
+            }
+            self.comment_emit_idx = first_inner;
+        }
+
+        self.emit_expression_with_scoped_static_initializer_mode(
+            init_idx,
+            this_alias,
+            super_base_alias,
+            super_direct_access,
+        );
+
+        // Never move the cursor backwards relative to where emission left it,
+        // and never expose comments the surrounding code already consumed.
+        self.comment_emit_idx = self.comment_emit_idx.max(restored_comment_idx);
+    }
+
     /// Enter the CommonJS-export-body mask while emitting `f`: clear
     /// `options.module` to `None` (so inner statements do not re-apply
     /// module-level transforms) and save the outer module on

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -3303,7 +3303,7 @@ impl<'a> Printer<'a> {
                     self.write_line();
                     self.write("value: ");
                     let before = self.writer.len();
-                    self.emit_expression_with_scoped_static_initializer_mode(
+                    self.emit_static_field_initializer_with_inner_comments(
                         *init_idx,
                         static_initializer_this_binding,
                         static_initializer_super_base,
@@ -3342,7 +3342,7 @@ impl<'a> Printer<'a> {
                     }
                     self.write(" = ");
                     let before = self.writer.len();
-                    self.emit_expression_with_scoped_static_initializer_mode(
+                    self.emit_static_field_initializer_with_inner_comments(
                         *init_idx,
                         static_initializer_this_binding,
                         static_initializer_super_base,

--- a/crates/tsz-emitter/src/emitter/expressions/literals.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/literals.rs
@@ -504,7 +504,7 @@ impl<'a> Printer<'a> {
             let es2018_num = ScriptTarget::ES2018 as u32;
             if has_spread && target_num < es2018_num {
                 // Target is ES2015/ES2016/ES2017: lower to Object.assign()
-                self.emit_object_literal_with_object_assign(&emitted_properties);
+                self.emit_object_literal_with_object_assign(node, &emitted_properties);
                 if self.object_spread_has_recovered_trailing_empty_object(node, &emitted_properties)
                 {
                     self.write(", {}");
@@ -1458,7 +1458,7 @@ impl<'a> Printer<'a> {
     /// - `{ ...a, x: 1, ...b }` → `Object.assign(Object.assign(Object.assign({}, a), { x: 1 }), b)`
     ///
     /// The pattern left-folds: each spread/segment adds one more `Object.assign` wrapping.
-    fn emit_object_literal_with_object_assign(&mut self, elements: &[NodeIndex]) {
+    fn emit_object_literal_with_object_assign(&mut self, node: &Node, elements: &[NodeIndex]) {
         // Segment elements into alternating spans of regular props and spread elements.
         // Each segment is either a slice of regular properties or a single spread node.
         #[derive(Clone)]
@@ -1466,6 +1466,20 @@ impl<'a> Printer<'a> {
             Props(&'a [NodeIndex]),
             Spread(NodeIndex),
         }
+
+        // A trailing line comment on the object literal's last element (e.g.
+        // `{ a: 1, ...b } // c`) must survive the Object.assign lowering. tsc
+        // emits it after the final argument and moves the closing `)` to the
+        // next line. The argument span and the literal's closing brace bound
+        // the comment scan so we never steal comments belonging to outer code.
+        let last_element_trailing = (!self.ctx.options.remove_comments)
+            .then(|| elements.last().copied())
+            .flatten()
+            .and_then(|last_idx| self.arena.get(last_idx).map(|n| (n.pos, n.end)))
+            .map(|(last_pos, last_end_raw)| {
+                let token_end = self.find_token_end_before_trivia(last_pos, last_end_raw);
+                (token_end, node.end)
+            });
 
         let mut segs: Vec<Seg<'_>> = Vec::new();
         let mut seg_start = 0usize;
@@ -1533,6 +1547,7 @@ impl<'a> Printer<'a> {
                         // Single spread of simple literal: Object.assign(expr)
                         self.write("Object.assign(");
                         self.emit_spread_expression_node(*spread_idx);
+                        self.emit_object_assign_last_element_trailing(last_element_trailing);
                         self.write(")");
                     } else {
                         // Multiple segments, simple literal first: use expr as seed
@@ -1542,6 +1557,9 @@ impl<'a> Printer<'a> {
                     // Non-literal spread: seed is {}
                     self.write("Object.assign({}, ");
                     self.emit_spread_expression_node(*spread_idx);
+                    if segs.len() == 1 {
+                        self.emit_object_assign_last_element_trailing(last_element_trailing);
+                    }
                     self.write(")");
                 }
             }
@@ -1552,7 +1570,8 @@ impl<'a> Printer<'a> {
         }
 
         // Emit remaining segments, each adding `, seg)` to close one Object.assign.
-        for seg in segs.iter().skip(1) {
+        let last_seg_i = segs.len().saturating_sub(1);
+        for (i, seg) in segs.iter().enumerate().skip(1) {
             self.write(", ");
             match seg {
                 Seg::Props(props) => {
@@ -1562,7 +1581,30 @@ impl<'a> Printer<'a> {
                     self.emit_spread_expression_node(*spread_idx);
                 }
             }
+            // The outermost (last) Object.assign call wraps the final source
+            // element, so its trailing comment belongs right before this `)`.
+            if i == last_seg_i {
+                self.emit_object_assign_last_element_trailing(last_element_trailing);
+            }
             self.write(")");
+        }
+    }
+
+    /// Emit a trailing comment captured from the last element of an object
+    /// literal that was lowered to `Object.assign(...)`. tsc renders it after
+    /// the final argument with the closing `)` moved onto the next line, e.g.
+    /// `Object.assign({ a: 1 }, b // c\n)`.
+    fn emit_object_assign_last_element_trailing(
+        &mut self,
+        last_element_trailing: Option<(u32, u32)>,
+    ) {
+        if let Some((token_end, max_pos)) = last_element_trailing
+            && self.has_trailing_comment_on_same_line(token_end, max_pos)
+        {
+            // `emit_trailing_comments_before` writes its own leading space, so
+            // do not add one here.
+            self.emit_trailing_comments_before(token_end, max_pos);
+            self.write_line();
         }
     }
 

--- a/crates/tsz-emitter/tests/static_field_lowering_trailing_comment_tests.rs
+++ b/crates/tsz-emitter/tests/static_field_lowering_trailing_comment_tests.rs
@@ -1,0 +1,152 @@
+//! Tests for trailing-comment preservation when class fields and object
+//! spreads are lowered for pre-ES2018/pre-ES2022 targets.
+//!
+//! Structural rule 1: when a static class field is lowered out of the class
+//! body into a `ClassName.field = <init>` assignment (target < ES2022 /
+//! `useDefineForClassFields = false`), comments that live *inside* the field's
+//! initializer expression (e.g. a trailing line comment on the last member of
+//! `static A = class { m() {} // x }`) must still be emitted inline. The class
+//! body skip used to advance the comment cursor past the whole field span,
+//! including those nested comments, so the re-emitted initializer lost them.
+//!
+//! Structural rule 2: when an object literal with a spread is lowered to
+//! `Object.assign(...)` (target < ES2018), a trailing line comment on the
+//! literal's last element must be emitted after the final argument with the
+//! closing `)` on the next line, matching `tsc`.
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_print_with_opts;
+use tsz_emitter::output::printer::PrintOptions;
+
+// ── Rule 1: nested-initializer trailing comments survive static lowering ─────
+
+/// Reported repro shape: trailing comment on the last method of a class
+/// expression assigned to a static field.
+#[test]
+fn static_field_class_expr_last_method_trailing_comment_inline() {
+    let source = "class D {\n    static A = class {\n        m() {} // keep me\n    }\n    static B = 1;\n}\n";
+    let output = parse_and_print_with_opts(source, PrintOptions::es6());
+    assert!(
+        output.contains("D.A = class"),
+        "static field must be lowered to assignment\nOutput:\n{output}"
+    );
+    // The comment must trail the method on the same line, not float to a
+    // standalone line after the assignment.
+    assert!(
+        output.contains("m() { } // keep me"),
+        "trailing comment must stay inline on the method\nOutput:\n{output}"
+    );
+    // It must NOT have been hoisted to its own line before/after `D.B`.
+    assert!(
+        !output.contains("\n// keep me"),
+        "comment must not be relocated to a standalone line\nOutput:\n{output}"
+    );
+}
+
+/// Same rule with renamed identifiers and a different member name — the fix is
+/// not keyed on any user-chosen name.
+#[test]
+fn static_field_class_expr_renamed_last_method_trailing_comment_inline() {
+    let source = "class Widget {\n    static Inner = class {\n        render() {} // note here\n    }\n    static Count = 0;\n}\n";
+    let output = parse_and_print_with_opts(source, PrintOptions::es6());
+    assert!(
+        output.contains("Widget.Inner = class"),
+        "static field must be lowered\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("render() { } // note here"),
+        "trailing comment must stay inline on the renamed method\nOutput:\n{output}"
+    );
+}
+
+/// Trailing comment on the last property of an object-literal initializer of a
+/// lowered static field (no spread involved).
+#[test]
+fn static_field_object_literal_last_prop_trailing_comment_inline() {
+    let source = "class D {\n    static C = {\n        a: 1,\n        b: 2 // last prop\n    };\n    static E = 3;\n}\n";
+    let output = parse_and_print_with_opts(source, PrintOptions::es6());
+    assert!(
+        output.contains("D.C = {"),
+        "static object-literal field must be lowered\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("b: 2 // last prop"),
+        "trailing comment must stay inline on the last property\nOutput:\n{output}"
+    );
+}
+
+// ── Rule 2: trailing comments survive Object.assign spread lowering ──────────
+
+/// Trailing comment on the last element of a spread object literal lowered to
+/// `Object.assign(...)`. The comment lands after the final argument and the
+/// closing `)` moves to the next line.
+#[test]
+fn object_spread_object_assign_trailing_comment_before_paren() {
+    let source = "const g = {\n    a: 1,\n    ...{ b: 2 } // trailing\n};\n";
+    let output = parse_and_print_with_opts(source, PrintOptions::es6());
+    assert!(
+        output.contains("Object.assign("),
+        "spread must lower to Object.assign at ES2015\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("// trailing\n"),
+        "trailing comment must precede the closing paren on its own line\nOutput:\n{output}"
+    );
+    // Exactly one space before the comment (the emitter writes its own space).
+    assert!(
+        !output.contains("}  // trailing"),
+        "comment must have a single leading space, not two\nOutput:\n{output}"
+    );
+}
+
+/// Same rule inside a lowered static field initializer (both lowerings stack),
+/// matching the reported `useBeforeDeclaration_propertyAssignment` witness.
+#[test]
+fn static_field_object_spread_object_assign_trailing_comment() {
+    let source = "class D {\n    static C = {\n        x: 1,\n        ...{ y: 2 } // should be an error\n    };\n}\n";
+    let output = parse_and_print_with_opts(source, PrintOptions::es6());
+    assert!(
+        output.contains("D.C = Object.assign("),
+        "static spread field must lower to Object.assign\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("// should be an error\n"),
+        "trailing comment must survive both lowerings\nOutput:\n{output}"
+    );
+}
+
+// ── Negative cases: no spurious output without a comment ─────────────────────
+
+/// No trailing comment present: lowering must not invent a comment, a stray
+/// space, or a newline before the closing paren.
+#[test]
+fn object_spread_object_assign_no_comment_no_spurious_output() {
+    let source = "const g = {\n    a: 1,\n    ...{ b: 2 }\n};\n";
+    let output = parse_and_print_with_opts(source, PrintOptions::es6());
+    assert!(
+        output.contains("Object.assign({ a: 1 }, { b: 2 })"),
+        "no-comment spread must lower compactly with closing paren inline\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("} \n)") && !output.contains("}\n)"),
+        "no-comment case must not move the closing paren to its own line\nOutput:\n{output}"
+    );
+}
+
+/// Static field whose initializer has no inner comment: lowering must not
+/// relocate or fabricate comments.
+#[test]
+fn static_field_class_expr_no_inner_comment_clean() {
+    let source = "class D {\n    static A = class {\n        m() {}\n    }\n    static B = 1;\n}\n";
+    let output = parse_and_print_with_opts(source, PrintOptions::es6());
+    assert!(
+        output.contains("D.A = class"),
+        "static field must be lowered\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("//"),
+        "no comment must be emitted when source has none\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — lowering-transform comment preservation (emit→100% campaign, wave 3)

## Invariant
Two related comment-drop bugs in target-lowering transforms, both keyed on AST node kind: (1) When a static class field is lowered out of the class body into `ClassName.field = <init>` (target < ES2022 / useDefineForClassFields=false), comments INSIDE the initializer expression (e.g. a trailing comment on the last member of `static A = class { m() {} // x }`) must still emit — the class-body skip was advancing the monotonic comment cursor past the field's whole source span (including nested comments) before the initializer was re-emitted after the class body; the fix rewinds the cursor to the initializer's start during re-emission. (2) When an object literal with a spread is lowered to `Object.assign(...)` (target < ES2018), a trailing line comment on the literal's last element must emit after the final argument with `)` on the next line, matching tsc.

## Scope
- `crates/tsz-emitter/src/emitter/core_setup.rs` — new `emit_static_field_initializer_with_inner_comments` (cursor rewind/restore).
- `crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs` — both static-field re-emit call sites use the helper (net -1 line).
- `crates/tsz-emitter/src/emitter/expressions/literals.rs` — `emit_object_assign_last_element_trailing`.
- `crates/tsz-emitter/tests/static_field_lowering_trailing_comment_tests.rs` (+7 tests) + Cargo.toml registration.

## Project Corpus Impact
- Row: n/a (lowering-transform comment-emit fix)
- Bug family: comments dropped when static fields / spread object literals are lowered for downlevel targets
- Evidence: useBeforeDeclaration_propertyAssignment FAIL→PASS; full --js-only 101→100.

## Verification
- Witness FAIL→PASS. **Full --js-only: 101→100 fail, net +1, ZERO new failures, 0 timeouts.** DTS unaffected (modified fns not on DTS path). 7 new structural unit tests (renamed identifiers, method vs object-prop vs spread, negative no-comment). tsz-emitter suite: 31 pre-existing fails identical with/without change. Clippy clean.
- §25/§26 compliant (keyed on AST node kind, no identifier/printer-output matching). No output surgery.

## Coordination Notes
Rebased onto current main (arch guard passes; emit_es6.rs 4186). HOLDING merge-queue per user-specified landing order (#10664/#10537/#10440/#10409/#10281 first, per m5-pro-48g-gpt5) — will enqueue after that set lands. Skipped/classified (NOT emit bugs): interfaceDeclaration4/invalidTypeOfTarget/mappedTypeProperties/reachabilityChecksNoCrash1/nestedGlobalNamespaceInClass/unusedLocalsAndParameters/objectTypesWithOptionalProperties2 (parser-recovery); unusedLocalsStartingWithUnderscore (--noCheck artifact); staticFieldWithInterfaceContext (separate class-expr comma-expr temp/comment cluster). — opus48-emit100
