### PR TITLE
refactor(checker): replace typeof-prefix strip with structural TypeQuery detection in TS18013 class-name lookup

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -942,6 +942,9 @@ mod type_alias_primitive_display_tests;
 #[path = "tests/type_param_default_relation_routing_arch_tests.rs"]
 mod type_param_default_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/typeof_class_name_structural_lookup_arch_tests.rs"]
+mod typeof_class_name_structural_lookup_arch_tests;
+#[cfg(test)]
 #[path = "tests/union_call_resolution_tests.rs"]
 mod union_call_resolution_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/typeof_class_name_structural_lookup_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/typeof_class_name_structural_lookup_arch_tests.rs
@@ -1,0 +1,36 @@
+/// Class-name derivation for TS18013 must use structural `TypeQuery` detection,
+/// not the type renderer.
+///
+/// `get_private_identifier_declaring_class_name` needs the class name when the
+/// receiver's type is `typeof X` (a `TypeData::TypeQuery`). The previous
+/// implementation called `format_type_diagnostic`, then stripped the `"typeof "`
+/// prefix from the rendered string, and filtered by character content — all
+/// artifacts of using the printer as an identity oracle.
+///
+/// The correct approach is `classify_type_query`, which queries the solver's
+/// structural representation directly and returns `TypeQueryKind::TypeQuery(sym_ref)`
+/// when the type is a `TypeQuery`. The symbol name is then read from the binder,
+/// not reconstructed by parsing a rendered string.
+#[test]
+fn typeof_class_name_derivation_uses_structural_query() {
+    let src = include_str!("../types/queries/core.rs");
+
+    assert!(
+        !src.contains("strip_prefix(\"typeof \")"),
+        "`get_private_identifier_declaring_class_name` must not strip a `typeof ` prefix \
+         from a rendered type string; use `classify_type_query` to detect `TypeQuery` types \
+         structurally"
+    );
+
+    assert!(
+        src.contains("classify_type_query"),
+        "`get_private_identifier_declaring_class_name` must detect `typeof X` types \
+         structurally via `classify_type_query`, not by parsing the printer's output"
+    );
+
+    assert!(
+        src.contains("TypeQueryKind::TypeQuery"),
+        "`get_private_identifier_declaring_class_name` must match on `TypeQueryKind::TypeQuery` \
+         to distinguish `typeof X` from other type kinds"
+    );
+}

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -1596,9 +1596,6 @@ impl<'a> CheckerState<'a> {
         }
         self.get_class_name_from_expression(object_expr)
             .or_else(|| {
-                // For `typeof X` types (TypeData::TypeQuery), extract the symbol name
-                // directly rather than parsing the rendered "typeof " prefix from the
-                // type printer — the printer output is not a reliable identity source.
                 if let crate::query_boundaries::common::TypeQueryKind::TypeQuery(sym_ref) =
                     crate::query_boundaries::common::classify_type_query(
                         self.ctx.types,

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -1,6 +1,9 @@
 //! Modifier, member access, and query methods for `CheckerState`.
 
-use crate::query_boundaries::common::contains_type_parameters;
+use crate::query_boundaries::common::{
+    TypeQueryKind, classify_type_query, contains_error_type, contains_type_parameters,
+    split_nullish_type,
+};
 use crate::state::{CheckerState, MemberAccessLevel};
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
@@ -1308,7 +1311,7 @@ impl<'a> CheckerState<'a> {
     /// - Max depth protection (20 levels)
     /// - Comprehensive type traversal including function parameters
     pub(crate) fn type_contains_error(&self, type_id: TypeId) -> bool {
-        crate::query_boundaries::common::contains_error_type(self.ctx.types, type_id)
+        contains_error_type(self.ctx.types, type_id)
     }
 
     /// Returns whether a type references type parameters.
@@ -1353,10 +1356,7 @@ impl<'a> CheckerState<'a> {
             return cached;
         }
 
-        let split = crate::query_boundaries::common::split_nullish_type(
-            self.ctx.types.as_type_database(),
-            type_id,
-        );
+        let split = split_nullish_type(self.ctx.types.as_type_database(), type_id);
         self.ctx
             .narrowing_cache
             .split_nullish_cache
@@ -1596,11 +1596,8 @@ impl<'a> CheckerState<'a> {
         }
         self.get_class_name_from_expression(object_expr)
             .or_else(|| {
-                if let crate::query_boundaries::common::TypeQueryKind::TypeQuery(sym_ref) =
-                    crate::query_boundaries::common::classify_type_query(
-                        self.ctx.types,
-                        object_type,
-                    )
+                if let TypeQueryKind::TypeQuery(sym_ref) =
+                    classify_type_query(self.ctx.types, object_type)
                 {
                     let sym_id = tsz_binder::SymbolId(sym_ref.0);
                     self.get_cross_file_symbol(sym_id)

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -1596,19 +1596,22 @@ impl<'a> CheckerState<'a> {
         }
         self.get_class_name_from_expression(object_expr)
             .or_else(|| {
-                let fallback = self.format_type_diagnostic(object_type);
-                fallback
-                    .strip_prefix("typeof ")
-                    .map(str::trim)
-                    .filter(|name| {
-                        !name.is_empty()
-                            && !name.contains('{')
-                            && !name.contains("=>")
-                            && *name != "any"
-                            && *name != "unknown"
-                            && *name != "object"
-                    })
-                    .map(str::to_string)
+                // For `typeof X` types (TypeData::TypeQuery), extract the symbol name
+                // directly rather than parsing the rendered "typeof " prefix from the
+                // type printer — the printer output is not a reliable identity source.
+                if let crate::query_boundaries::common::TypeQueryKind::TypeQuery(sym_ref) =
+                    crate::query_boundaries::common::classify_type_query(
+                        self.ctx.types,
+                        object_type,
+                    )
+                {
+                    let sym_id = tsz_binder::SymbolId(sym_ref.0);
+                    self.get_cross_file_symbol(sym_id)
+                        .filter(|s| !s.escaped_name.is_empty())
+                        .map(|s| s.escaped_name.clone())
+                } else {
+                    None
+                }
             })
             .unwrap_or_else(|| "the class".to_string())
     }


### PR DESCRIPTION
## Agent
AgentName: dazzling-johnson

## Track
Phase 0 §5 refactor — burns down rendered-type decision debt (one `format_type_diagnostic` + `strip_prefix("typeof ")` decision site)

## Invariant
When deriving a class name for TS18013 from a `typeof X` receiver, tsc uses the TypeQuery's underlying symbol name; the printer is not consulted. This PR makes tsz do the same by routing through `classify_type_query` → `TypeQueryKind::TypeQuery(sym_ref)` → symbol name lookup, instead of rendering the type and stripping the `"typeof "` prefix.

## Scope
- `crates/tsz-checker/src/types/queries/core.rs` — `get_private_identifier_declaring_class_name` fallback path for TS18013: replaces `format_type_diagnostic` + `strip_prefix("typeof ")` + character-set guard with `classify_type_query` structural detection
- `crates/tsz-checker/src/tests/typeof_class_name_structural_lookup_arch_tests.rs` — new architecture contract test asserting the structural path is used

## Verification
- `cargo check -p tsz-checker` passes clean
- Architecture contract test asserts:
  - `get_private_identifier_declaring_class_name` no longer calls `strip_prefix("typeof ")`
  - `classify_type_query` is used to detect `TypeData::TypeQuery` structurally
  - `TypeQueryKind::TypeQuery` is matched to extract the underlying symbol

## Project Corpus Impact
- Row: n/a (refactor only; no semantic behavior change — `typeof X` types produce the same class name, now from the symbol rather than the printer)
- Bug family: rendered-type decision debt (Phase 0 §5 cleanup)
- Evidence: the old code rendered `"typeof ClassName"` and stripped the prefix; the new code calls `classify_type_query` which returns `TypeQueryKind::TypeQuery(sym_ref)` and extracts the symbol name directly — identical output for named `typeof X` receivers, `None` for non-TypeQuery types (same behavior as the old fallback's character-set guard rejecting complex types)

## Coordination Notes
- Issue #8775 tracks `format_type_diagnostic` decision debt; this is a focused one-site slice
- Adjacent to PR #11733 (augmentation/heritage resolution sites) — no overlap
- No existing PRs touch `get_private_identifier_declaring_class_name`

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQWMvBNYiwPESQg7beu781)_