### PR TITLE
fix(emit): reserve ES5 for-of destructuring temps in source order for correct global numbering

### DIFF
--- a/crates/tsz-emitter/src/emitter/es5/bindings_for_of.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings_for_of.rs
@@ -175,12 +175,12 @@ impl<'a> Printer<'a> {
         };
 
         // For assignment-pattern for-of with object/array literals, tsc allocates
-        // destructuring temps before choosing the array temp in the loop header.
-        // Reserve those temps now so later lowering reuses them in order.
-        let reserve_count = self.estimate_for_of_assignment_temp_reserve(for_in_of.initializer);
-        if reserve_count > 0 {
-            self.preallocate_temp_names(reserve_count);
-        }
+        // the destructuring source/nested temps before any for-of loop-control
+        // (index/array) temp, in source order across all sibling statements. That
+        // ordering is reserved up front by
+        // `preallocate_for_of_assignment_destructure_temps_for_statements`, which
+        // fills `preallocated_assignment_temps`; the body destructuring below
+        // replays those names. No per-loop reservation is needed here.
         if using_info.is_some() {
             let resource_temp_count =
                 self.count_es5_resource_expression_hoisted_temps(for_in_of.expression);
@@ -631,81 +631,6 @@ impl<'a> Printer<'a> {
         }
         // Multi-binding or complex array pattern extracts a source temp.
         1
-    }
-
-    pub(in crate::emitter) fn estimate_for_of_assignment_temp_reserve(
-        &self,
-        initializer: NodeIndex,
-    ) -> usize {
-        let Some(init_node) = self.arena.get(initializer) else {
-            return 0;
-        };
-        match init_node.kind {
-            k if k == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION => {
-                let Some(lit) = self.arena.get_literal_expr(init_node) else {
-                    return 0;
-                };
-                // Count per-property default temps. A property with a default
-                // (colon form `{ k: name = init }` or shorthand cover-init form
-                // `{ name = init }`) reserves one extract temp so the
-                // `tmp = source.k, name = tmp === void 0 ? init : tmp` guard can
-                // be emitted, mirroring tsc's allocation order.
-                let mut defaults = 0usize;
-                for &elem_idx in &lit.elements.nodes {
-                    if self.for_of_assignment_property_has_default(elem_idx) {
-                        defaults += 1;
-                    }
-                }
-                if lit.elements.nodes.len() > 1 {
-                    // Multi-element patterns also extract one source temp.
-                    return 1 + defaults;
-                }
-                // Single-element patterns inline the source, so only the default
-                // extract temp (if any) is reserved.
-                defaults
-            }
-            k if k == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION => {
-                if let Some(lit) = self.arena.get_literal_expr(init_node)
-                    && lit.elements.nodes.len() > 1
-                {
-                    // One extracted source temp. Additional nested/default temps are emitted
-                    // later and use normal allocation.
-                    return 1;
-                }
-                0
-            }
-            _ => 0,
-        }
-    }
-
-    /// Whether an object-pattern element carries a default value, in either the
-    /// colon form (`{ k: name = init }`, a `PROPERTY_ASSIGNMENT` whose
-    /// initializer is an `=` binary) or the shorthand cover-initialized form
-    /// (`{ name = init }`, a `SHORTHAND_PROPERTY_ASSIGNMENT` with an
-    /// `object_assignment_initializer`). Both lower to one extract temp.
-    fn for_of_assignment_property_has_default(&self, elem_idx: NodeIndex) -> bool {
-        let Some(elem_node) = self.arena.get(elem_idx) else {
-            return false;
-        };
-        match elem_node.kind {
-            k if k == syntax_kind_ext::PROPERTY_ASSIGNMENT => self
-                .arena
-                .get_property_assignment(elem_node)
-                .and_then(|prop| self.arena.get(prop.initializer))
-                .and_then(|value_node| {
-                    if value_node.kind == syntax_kind_ext::BINARY_EXPRESSION {
-                        self.arena.get_binary_expr(value_node)
-                    } else {
-                        None
-                    }
-                })
-                .is_some_and(|bin| bin.operator_token == SyntaxKind::EqualsToken as u16),
-            k if k == syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT => self
-                .arena
-                .get_shorthand_property(elem_node)
-                .is_some_and(|shorthand| shorthand.object_assignment_initializer.is_some()),
-            _ => false,
-        }
     }
 
     /// Emit the for-of loop body (common logic for both array and iterator modes)
@@ -1192,68 +1117,81 @@ impl<'a> Printer<'a> {
         {
             // Assignment destructuring pattern in for-of: {name: nameA} or [, nameA]
             // Lower to: nameA = element_expr.name or nameA = element_expr[1]
-            let mut first = true;
-            match init_node.kind {
-                k if k == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION => {
-                    if let Some(lit) = self.arena.get_literal_expr(init_node) {
-                        let elem_count = lit.elements.nodes.len();
-                        if elem_count > 1 {
-                            // Multi-element: need temp
-                            let temp = self.make_unique_name_hoisted_assignment();
-                            self.write(&temp);
-                            self.write(" = ");
-                            self.write(&element_expr);
-                            first = false;
-                            self.emit_assignment_array_destructuring(
-                                &lit.elements.nodes,
-                                &temp,
-                                &mut first,
-                                None,
-                            );
-                        } else {
-                            // Single element: inline
-                            self.emit_assignment_array_destructuring(
-                                &lit.elements.nodes,
-                                &element_expr,
-                                &mut first,
-                                None,
-                            );
-                        }
-                    }
-                }
-                _ => {
-                    // Object pattern
-                    if let Some(lit) = self.arena.get_literal_expr(init_node) {
-                        let elem_count = lit.elements.nodes.len();
-                        if elem_count > 1 {
-                            let temp = self.make_unique_name_hoisted_assignment();
-                            self.write(&temp);
-                            self.write(" = ");
-                            self.write(&element_expr);
-                            first = false;
-                            self.emit_assignment_object_destructuring(
-                                &lit.elements.nodes,
-                                &temp,
-                                &mut first,
-                                None,
-                            );
-                        } else {
-                            self.emit_assignment_object_destructuring(
-                                &lit.elements.nodes,
-                                &element_expr,
-                                &mut first,
-                                None,
-                            );
-                        }
-                    }
-                }
-            }
+            self.emit_for_of_assignment_target_destructuring_es5(init_node, &element_expr);
             self.write_semicolon();
         } else {
             self.emit_expression(initializer);
             self.write(" = ");
             self.write(&element_expr);
             self.write_semicolon();
+        }
+    }
+
+    /// Lower an assignment-target destructuring pattern used as the for-of
+    /// initializer (`for ([..] of x)` / `for ({..} of x)`) against the
+    /// `element_expr` (`array[index]`). The single shared lowering used by both
+    /// the real emit and the temp-allocation pre-pass, so they allocate the
+    /// hoisted destructuring temps in identical order.
+    pub(in crate::emitter) fn emit_for_of_assignment_target_destructuring_es5(
+        &mut self,
+        init_node: &Node,
+        element_expr: &str,
+    ) {
+        let mut first = true;
+        match init_node.kind {
+            k if k == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION => {
+                if let Some(lit) = self.arena.get_literal_expr(init_node) {
+                    let elem_count = lit.elements.nodes.len();
+                    if elem_count > 1 {
+                        // Multi-element: need temp
+                        let temp = self.make_unique_name_hoisted_assignment();
+                        self.write(&temp);
+                        self.write(" = ");
+                        self.write(element_expr);
+                        first = false;
+                        self.emit_assignment_array_destructuring(
+                            &lit.elements.nodes,
+                            &temp,
+                            &mut first,
+                            None,
+                        );
+                    } else {
+                        // Single element: inline
+                        self.emit_assignment_array_destructuring(
+                            &lit.elements.nodes,
+                            element_expr,
+                            &mut first,
+                            None,
+                        );
+                    }
+                }
+            }
+            _ => {
+                // Object pattern
+                if let Some(lit) = self.arena.get_literal_expr(init_node) {
+                    let elem_count = lit.elements.nodes.len();
+                    if elem_count > 1 {
+                        let temp = self.make_unique_name_hoisted_assignment();
+                        self.write(&temp);
+                        self.write(" = ");
+                        self.write(element_expr);
+                        first = false;
+                        self.emit_assignment_object_destructuring(
+                            &lit.elements.nodes,
+                            &temp,
+                            &mut first,
+                            None,
+                        );
+                    } else {
+                        self.emit_assignment_object_destructuring(
+                            &lit.elements.nodes,
+                            element_expr,
+                            &mut first,
+                            None,
+                        );
+                    }
+                }
+            }
         }
     }
 }

--- a/crates/tsz-emitter/src/emitter/es5/for_of_destructure_prealloc.rs
+++ b/crates/tsz-emitter/src/emitter/es5/for_of_destructure_prealloc.rs
@@ -1,0 +1,168 @@
+//! ES5 for-of assignment-target destructuring temp pre-pass.
+//!
+//! Extracted from `bindings_for_of.rs` / `helpers.rs` so the `emit.rs` and
+//! `helpers.rs` monoliths stay under their §19 size ratchet. Behavior is
+//! unchanged: this module owns the temp pre-allocation that reserves the
+//! hoisted destructuring temps for assignment-target `for-of` loops before any
+//! for-of loop-control (index/array) temp.
+
+use super::super::Printer;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::ForInOfData;
+use tsz_parser::parser::syntax_kind_ext;
+
+impl<'a> Printer<'a> {
+    /// Pre-pass that allocates the hoisted destructuring-assignment temps for all
+    /// ES5 array-indexing assignment-target `for-of` statements in `statements`,
+    /// in source order, before any loop is emitted.
+    ///
+    /// tsc assigns auto-generated temp names at print time in source order: the
+    /// hoisted `var _a, _b, ...;` declaration prints at the top of the scope, so
+    /// every assignment-target for-of destructuring temp claims a low number
+    /// before any for-of loop-control (index/array) temp. tsz allocates names
+    /// eagerly while emitting, so without this pre-pass the destructuring and
+    /// loop-control temps interleave. Running the real destructuring lowering for
+    /// each such for-of into a throwaway writer reserves those temps in the exact
+    /// order the later emit consumes them.
+    ///
+    /// Runs at a scope boundary where `hoisted_assignment_temps` is empty (source
+    /// file / function body). The dry-run lowering allocates names through the
+    /// normal `make_unique_name_hoisted_assignment` path, so they accumulate in
+    /// `hoisted_assignment_temps`; we then move them into
+    /// `preallocated_assignment_temps` so the real emit replays the same names in
+    /// the same order while the loop-control (index/array) temps take the higher
+    /// numbers.
+    pub(in crate::emitter) fn prealloc_for_of_destructure_temps(
+        &mut self,
+        statements: &[NodeIndex],
+    ) {
+        if !self.ctx.target_es5 || self.ctx.options.downlevel_iteration {
+            return;
+        }
+        for &stmt_idx in statements {
+            self.visit_for_of_assignment_temp_prealloc(stmt_idx);
+        }
+        // The dry runs pushed every allocated destructuring temp onto the hoist
+        // pool; hand them to the assignment-temp queue (in order) and clear the
+        // pool so the real emit re-records them as it replays the names.
+        let collected = std::mem::take(&mut self.hoisted_assignment_temps);
+        for name in collected {
+            self.preallocated_assignment_temps.push_back(name);
+        }
+    }
+
+    fn visit_for_of_assignment_temp_prealloc(&mut self, idx: NodeIndex) {
+        if idx.is_none() {
+            return;
+        }
+        let Some(node) = self.arena.get(idx) else {
+            return;
+        };
+
+        if node.kind == syntax_kind_ext::FOR_OF_STATEMENT {
+            if let Some(for_in_of) = self.arena.get_for_in_of(node) {
+                if !for_in_of.await_modifier {
+                    self.prealloc_for_of_assignment_destructure_temps(for_in_of);
+                }
+                self.visit_for_of_assignment_temp_prealloc(for_in_of.statement);
+            }
+            return;
+        }
+
+        // Descend into nested statement containers, but stop at function/class
+        // boundaries — those introduce their own temp scope and hoist pool.
+        match node.kind {
+            k if k == syntax_kind_ext::BLOCK || k == syntax_kind_ext::CASE_BLOCK => {
+                if let Some(block) = self.arena.get_block(node) {
+                    for &stmt in &block.statements.nodes {
+                        self.visit_for_of_assignment_temp_prealloc(stmt);
+                    }
+                }
+            }
+            k if k == syntax_kind_ext::IF_STATEMENT => {
+                if let Some(if_stmt) = self.arena.get_if_statement(node) {
+                    self.visit_for_of_assignment_temp_prealloc(if_stmt.then_statement);
+                    self.visit_for_of_assignment_temp_prealloc(if_stmt.else_statement);
+                }
+            }
+            k if k == syntax_kind_ext::TRY_STATEMENT => {
+                if let Some(try_stmt) = self.arena.get_try(node) {
+                    self.visit_for_of_assignment_temp_prealloc(try_stmt.try_block);
+                    self.visit_for_of_assignment_temp_prealloc(try_stmt.catch_clause);
+                    self.visit_for_of_assignment_temp_prealloc(try_stmt.finally_block);
+                }
+            }
+            k if k == syntax_kind_ext::CATCH_CLAUSE => {
+                if let Some(catch_clause) = self.arena.get_catch_clause(node) {
+                    self.visit_for_of_assignment_temp_prealloc(catch_clause.block);
+                }
+            }
+            k if k == syntax_kind_ext::FOR_STATEMENT
+                || k == syntax_kind_ext::FOR_IN_STATEMENT
+                || k == syntax_kind_ext::WHILE_STATEMENT
+                || k == syntax_kind_ext::DO_STATEMENT =>
+            {
+                if let Some(loop_data) = self.arena.get_loop(node) {
+                    self.visit_for_of_assignment_temp_prealloc(loop_data.statement);
+                } else if let Some(for_in_of) = self.arena.get_for_in_of(node) {
+                    self.visit_for_of_assignment_temp_prealloc(for_in_of.statement);
+                }
+            }
+            k if k == syntax_kind_ext::SWITCH_STATEMENT => {
+                if let Some(sw) = self.arena.get_switch(node) {
+                    self.visit_for_of_assignment_temp_prealloc(sw.case_block);
+                }
+            }
+            k if k == syntax_kind_ext::CASE_CLAUSE || k == syntax_kind_ext::DEFAULT_CLAUSE => {
+                if let Some(clause) = self.arena.get_case_clause(node) {
+                    for &stmt in &clause.statements.nodes {
+                        self.visit_for_of_assignment_temp_prealloc(stmt);
+                    }
+                }
+            }
+            k if k == syntax_kind_ext::LABELED_STATEMENT => {
+                if let Some(labeled) = self.arena.get_labeled_statement(node) {
+                    self.visit_for_of_assignment_temp_prealloc(labeled.statement);
+                }
+            }
+            k if k == syntax_kind_ext::WITH_STATEMENT => {
+                if let Some(with_stmt) = self.arena.get_with_statement(node) {
+                    self.visit_for_of_assignment_temp_prealloc(with_stmt.then_statement);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// If `for_in_of` is an assignment-target destructuring for-of that takes the
+    /// ES5 array-indexing path, run its destructuring lowering into a throwaway
+    /// writer so the hoisted temps it allocates claim their numbers now.
+    fn prealloc_for_of_assignment_destructure_temps(&mut self, for_in_of: &ForInOfData) {
+        let Some(init_node) = self.arena.get(for_in_of.initializer) else {
+            return;
+        };
+        if init_node.kind != syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
+            && init_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+        {
+            return;
+        }
+        // Empty assignment patterns allocate no destructuring temp.
+        if self
+            .arena
+            .get_literal_expr(init_node)
+            .is_some_and(|lit| lit.elements.nodes.is_empty())
+        {
+            return;
+        }
+
+        // Swap in a scratch writer (no source map) so the destructuring text and
+        // mappings produced by this dry run are discarded; only the temp counter
+        // and the allocated hoist-pool names advance.
+        let scratch = crate::output::source_writer::SourceWriter::new();
+        let real_writer = std::mem::replace(&mut self.writer, scratch);
+
+        self.emit_for_of_assignment_target_destructuring_es5(init_node, "_");
+
+        self.writer = real_writer;
+    }
+}

--- a/crates/tsz-emitter/src/emitter/es5/mod.rs
+++ b/crates/tsz-emitter/src/emitter/es5/mod.rs
@@ -10,6 +10,7 @@ mod bindings_for_of;
 mod bindings_param_patterns;
 mod bindings_patterns;
 mod bindings_read;
+mod for_of_destructure_prealloc;
 mod helpers;
 mod helpers_async;
 mod helpers_async_generator;

--- a/crates/tsz-emitter/src/emitter/source_file/emit.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/emit.rs
@@ -1489,10 +1489,10 @@ impl<'a> Printer<'a> {
         self.preallocated_temp_names.clear();
         self.reserved_iterator_return_temps.clear();
         self.iterator_for_of_depth = 0;
-
         self.prepare_logical_assignment_value_temps(source_idx);
         self.prepare_object_rest_assignment_temps(source_idx);
         self.preallocate_iterator_return_temps_for_statements(&source.statements.nodes);
+        self.prealloc_for_of_destructure_temps(&source.statements.nodes);
         self.reserve_pending_file_level_class_temps();
 
         let mut hoisted_var_byte_offset = if is_file_module {

--- a/crates/tsz-emitter/src/emitter/source_file/es5_for_of_destructure_temp_order_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/es5_for_of_destructure_temp_order_tests.rs
@@ -1,0 +1,172 @@
+//! ES5 for-of assignment-target destructuring temp-ordering tests.
+//!
+//! Structural rule: when an ES5 array-indexing `for-of` statement's target is a
+//! destructuring assignment pattern that needs a hoisted source/nested temp, tsc
+//! allocates that hoisted destructuring temp (in source order across all sibling
+//! for-of statements) BEFORE allocating any for-of loop-control (index/array)
+//! temp. tsz reserves those temps in a pre-pass so the global temp numbering
+//! matches.
+//!
+//! These tests vary the binding names and pattern shapes so a fix keyed on a
+//! particular identifier or spelling would fail.
+
+use crate::context::emit::EmitContext;
+use crate::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use crate::lowering::LoweringPass;
+use tsz_common::ScriptTarget;
+use tsz_parser::ParserState;
+
+fn emit_es5(source: &str, downlevel_iteration: bool) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        target: ScriptTarget::ES5,
+        downlevel_iteration,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+/// Reported repro shape: two sibling array assignment-target for-of loops over
+/// non-identifier iterables. tsc allocates both destructuring source temps
+/// (`_a`, `_b`) first, then the loop-control index/array temps (`_i`, `_c`, ...).
+#[test]
+fn array_assignment_for_of_allocates_destructure_temps_before_loop_control() {
+    let source = "var nameA;\n\
+         for ([, nameA] of getA()) { nameA; }\n\
+         for ([, nameA] of getB()) { nameA; }\n";
+    let output = emit_es5(source, false);
+
+    // Both destructuring source temps claim the low numbers up front.
+    assert!(
+        output.contains("var _a, _b;"),
+        "Destructuring source temps must be hoisted first as _a, _b.\nOutput:\n{output}"
+    );
+    // First loop: index `_i` (special), array `_c` (first auto temp after the
+    // reserved destructuring temps), body source temp `_a`.
+    assert!(
+        output.contains("for (var _i = 0, _c = getA(); _i < _c.length; _i++)"),
+        "First loop control temps must follow the destructuring temps.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a = _c[_i], nameA = _a[1]"),
+        "First loop source temp should be the first auto temp (_a).\nOutput:\n{output}"
+    );
+    // Second loop's destructuring source temp is `_b`; its loop-control temps
+    // (`_d`, `_e`) come even later.
+    assert!(
+        output.contains("for (var _d = 0, _e = getB(); _d < _e.length; _d++)"),
+        "Second loop control temps must follow all destructuring temps.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_b = _e[_d], nameA = _b[1]"),
+        "Second loop destructuring source temp must be _b.\nOutput:\n{output}"
+    );
+}
+
+/// Same rule with renamed binding identifiers. If the fix were keyed on the name
+/// `nameA`, this differently-named case would diverge.
+#[test]
+fn array_assignment_for_of_temp_order_is_name_agnostic() {
+    let source = "var zzz;\n\
+         for ([, zzz] of getA()) { zzz; }\n\
+         for ([, zzz] of getB()) { zzz; }\n";
+    let output = emit_es5(source, false);
+
+    assert!(
+        output.contains("var _a, _b;"),
+        "Destructuring source temps must be hoisted first regardless of name.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a = _c[_i], zzz = _a[1]"),
+        "First loop source temp should be _a regardless of binding name.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("for (var _d = 0, _e = getB(); _d < _e.length; _d++)"),
+        "Loop-control temps must follow the destructuring temps regardless of name.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_b = _e[_d], zzz = _b[1]"),
+        "Second loop source temp must be _b regardless of binding name.\nOutput:\n{output}"
+    );
+}
+
+/// Object assignment-target shape: same two-pass ordering applies to
+/// `for ({ k: v } of ...)`.
+#[test]
+fn object_assignment_for_of_allocates_destructure_temps_before_loop_control() {
+    // Two object properties so the lowering extracts a source temp.
+    let source = "var v0, v1;\n\
+         for ({ a: v0, b: v1 } of getA()) { v0; }\n\
+         for ({ a: v0, b: v1 } of getB()) { v0; }\n";
+    let output = emit_es5(source, false);
+
+    assert!(
+        output.contains("var _a, _b;"),
+        "Object destructuring source temps must be hoisted first.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a = _c[_i], v0 = _a.a, v1 = _a.b"),
+        "First object loop source temp should be _a.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("for (var _d = 0, _e = getB(); _d < _e.length; _d++)"),
+        "Object loop-control temps must follow the destructuring temps.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_b = _e[_d], v0 = _b.a, v1 = _b.b"),
+        "Second object loop source temp should be _b.\nOutput:\n{output}"
+    );
+}
+
+/// Default-value object shorthand assignment target inside a function expression.
+/// The function body opens a fresh temp scope, so the destructuring temp must
+/// claim `_a` before the loop-control array temp `_b`.
+#[test]
+fn function_scoped_for_of_default_allocates_destructure_temp_first() {
+    let source = "(function () {\n  var s0;\n  for ({ s0 = 5 } of [{ s0: 1 }]) { }\n});\n";
+    let output = emit_es5(source, false);
+
+    assert!(
+        output.contains("for (var _i = 0, _b = [{ s0: 1 }]; _i < _b.length; _i++)"),
+        "Function-scoped loop array temp must be _b (after destructure temp _a).\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a = _b[_i].s0, s0 = _a === void 0 ? 5 : _a"),
+        "Function-scoped destructure temp must be _a.\nOutput:\n{output}"
+    );
+}
+
+/// Negative/fallback: a single-element array assignment target inlines the source
+/// expression, so it allocates no extra hoisted destructuring temp — the loop
+/// control temps stay at the low numbers.
+#[test]
+fn single_element_array_assignment_for_of_inlines_without_extra_temp() {
+    let source = "var only;\n\
+         for ([only] of getA()) { only; }\n\
+         for ([only] of getB()) { only; }\n";
+    let output = emit_es5(source, false);
+
+    // No hoisted source temp: the value is read inline as `array[index][0]`, so
+    // the loop-control temps start at the lowest auto numbers (`_a`, `_b`, ...).
+    assert!(
+        !output.contains("var _a, _b;"),
+        "Single-element array target should not hoist any destructure source temp.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("for (var _i = 0, _a = getA(); _i < _a.length; _i++)")
+            && output.contains("only = _a[_i][0]"),
+        "First single-element loop should inline from its array temp _a.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("for (var _b = 0, _c = getB(); _b < _c.length; _b++)")
+            && output.contains("only = _c[_b][0]"),
+        "Second single-element loop control temps start at _b without a source temp.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/source_file/mod.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/mod.rs
@@ -31,3 +31,5 @@ mod private_tagged_template_tests;
 mod empty_statement_comment_elision_tests;
 #[cfg(test)]
 mod es5_emit_tests;
+#[cfg(test)]
+mod es5_for_of_destructure_temp_order_tests;

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -193,6 +193,9 @@ impl<'a> Printer<'a> {
                 self.ctx.block_scope_state.enter_scope();
             }
             self.preallocate_iterator_return_temps_for_statements(&block.statements.nodes);
+            if is_function_body_block {
+                self.prealloc_for_of_destructure_temps(&block.statements.nodes);
+            }
             self.map_opening_brace(node);
             self.write("{ ");
             let var_insert_pos = if is_function_body_block {
@@ -240,6 +243,9 @@ impl<'a> Printer<'a> {
             self.ctx.block_scope_state.enter_scope();
         }
         self.preallocate_iterator_return_temps_for_statements(&block.statements.nodes);
+        if is_function_body_block {
+            self.prealloc_for_of_destructure_temps(&block.statements.nodes);
+        }
         // Compute the block's closing `}` position so comment scans don't
         // overshoot into comments belonging to the closing brace line.
         // Use find_token_end_before_trivia which correctly skips `}` inside


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — ES5 for-of destructuring temp-allocation order (emit→100% campaign, wave 3)

## Invariant
When an ES5 array-indexing `for-of` statement's target is a destructuring pattern needing hoisted source/nested temps, tsc allocates those destructuring temps in source order across all sibling `for-of` statements BEFORE any for-of loop-control (index/array) temp — because tsc assigns auto-generated names at print time and the hoisted `var _a, _b, ...;` declaration prints first. tsz allocated eagerly during emission, interleaving the two categories and mis-numbering. The fix reserves the destructuring temps up front (a scratch dry-run of the real lowering into a discarded SourceWriter) so global numbering matches. Gated structurally on `target_es5 && !downlevel_iteration` + AST node kind (FOR_OF_STATEMENT with ARRAY/OBJECT_LITERAL assignment target) — no identifier/printer-output matching.

## Scope
- `crates/tsz-emitter/src/emitter/es5/for_of_destructure_prealloc.rs` — NEW module (168 lines): `prealloc_for_of_destructure_temps` + visitors. Registered in es5/mod.rs.
- `crates/tsz-emitter/src/emitter/es5/bindings_for_of.rs` — pre-pass moved out (1346→1197 lines).
- `crates/tsz-emitter/src/emitter/source_file/emit.rs` (1-line call), `statements/core.rs` (function-body-scope call), `source_file/mod.rs`.
- `crates/tsz-emitter/src/emitter/source_file/es5_for_of_destructure_temp_order_tests.rs` (+5 tests).

## Project Corpus Impact
- Row: n/a (ES5 emit temp-ordering fix)
- Bug family: ES5 for-of assignment-destructuring hoisted-temp allocation order (global `_a/_b/...` numbering)
- Evidence: 4 sourceMapValidationDestructuringForOf{Array,Object}BindingPattern[DefaultValues]2(es5) FAIL→PASS; full --js-only 101→97.

## Verification
- 4 witnesses FAIL→PASS (diff was `.js` temp-naming order, NOT `.js.map`; byte-identical to tsc baseline after). **Full --js-only: 13429→13433 pass (101→97 fail), net +4, ZERO regressions.** --dts-only unaffected (24, none on touched paths). 5 new structural unit tests. arch guard passes (emit.rs/helpers.rs at ratchet, unbumped; core/core_setup/helpers byte-identical to main). Clippy clean.
- §25/§26 compliant. No output surgery — planned facts (scratch dry-run reserves names).

## Coordination Notes
Rebased onto current main; split the pre-pass into a NEW module to respect the arch file-size ratchet (emit.rs/helpers.rs are at-limit monoliths). HOLDING merge-queue per user-specified landing order (#10664/#10537/#10440/#10409/#10281 first, per m5-pro-48g-gpt5) — enqueue after that set lands. 5th witness STOP-reported as distinct: sourceMapValidationDestructuringForArrayBindingPatternDefaultValues2(es5) is a regular-for closure-capture (_loop) deferred-allocation case, separate root cause. — opus48-emit100
