### PR TITLE
fix(solver): treat protected members as hierarchical in assignability

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -103,6 +103,10 @@ name = "generic_alias_assignability_pollution_tests"
 path = "tests/generic_alias_assignability_pollution_tests.rs"
 
 [[test]]
+name = "class_protected_widening_assignability_tests"
+path = "tests/class_protected_widening_assignability_tests.rs"
+
+[[test]]
 name = "generic_default_branch_independence_tests"
 path = "tests/generic_default_branch_independence_tests.rs"
 

--- a/crates/tsz-checker/tests/class_protected_widening_assignability_tests.rs
+++ b/crates/tsz-checker/tests/class_protected_widening_assignability_tests.rs
@@ -1,0 +1,203 @@
+//! Regression coverage: `protected` member assignability is *hierarchical*,
+//! not strictly nominal like `private`.
+//!
+//! Tracks the `binder-11-20` "augmentation drops private/protected mirror
+//! visibility" family (mohsen1/tsz#11631).
+//!
+//! Structural rule under test:
+//!
+//! > When a target property is `protected`, a source object is assignable as
+//! > long as the source property is declared in the target's
+//! > protected-declaring class *or in a class derived from it*. The source is
+//! > allowed to widen the member from `protected` to `public` in the derived
+//! > class. (`private` is unaffected: it still requires the exact same
+//! > declaration — declaration identity.)
+//!
+//! This mirrors tsc's `isPropertyInClassDerivedFrom` / `isValidOverrideOf`.
+//! Behavior was verified against `tsc` 6.0.2 for every case below.
+//!
+//! Per the anti-hardcoding directive (§25) the cases vary the user-chosen
+//! member and class names (`p`/`kind`/`items`, `Base`/`Shape`/`Repo`) and
+//! include a generic variant, so a fix keyed on a specific spelling would fail
+//! at least one case.
+
+use tsz_checker::test_utils::{check_source_strict, diagnostic_codes, diagnostics_without_codes};
+
+/// Semantic error codes, dropping TS2318 ("cannot find global type") which is
+/// expected noise in the no-stdlib unit harness.
+fn errors(source: &str) -> Vec<u32> {
+    diagnostic_codes(&diagnostics_without_codes(
+        &check_source_strict(source),
+        &[2318],
+    ))
+}
+
+/// A subclass that widens an inherited `protected` member to `public` is still
+/// assignable to its base. tsc accepts the assignment and only reports the
+/// later out-of-class `protected` access (TS2445).
+#[test]
+fn widen_protected_to_public_then_assign_to_base() {
+    let codes = errors(
+        r#"
+class Base { protected p = 1; }
+class Sub extends Base { public p = 2; }
+
+const s = new Sub();
+s.p;                  // ok: public on Sub
+const b: Base = s;    // ok: Sub is assignable to Base (widening is legal)
+b.p;                  // TS2445: still protected through the Base view
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![2445],
+        "widening protected->public must not block Sub -> Base assignment; got {codes:?}"
+    );
+}
+
+/// The same rule across a multi-level chain and with different member/class
+/// spellings, including a class that only inherits the protected member.
+#[test]
+fn widen_protected_deep_chain_independent_of_names() {
+    let codes = errors(
+        r#"
+class Animal { protected kind = "a"; }
+class Pet extends Animal {}
+class Dog extends Pet { public kind = "d"; }
+
+const a: Animal = new Dog();   // ok
+const p: Pet = new Dog();      // ok
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "deep-chain widening must be assignable for every base; got {codes:?}"
+    );
+}
+
+/// A derived class that keeps the member `protected` (a plain override) is also
+/// assignable to its base — declaration identity is *not* required for
+/// protected members.
+#[test]
+fn protected_override_stays_protected_assigns_to_base() {
+    let codes = errors(
+        r#"
+class Shape { protected kind = "s"; }
+class Circle extends Shape { protected kind = "c"; }
+const sh: Shape = new Circle();
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "protected override in a derived class must remain assignable to base; got {codes:?}"
+    );
+}
+
+/// Generic + renamed-identifier variant: widening a generic protected member to
+/// public in a concrete subclass stays assignable to the generic base.
+#[test]
+fn widen_protected_generic_base() {
+    let codes = errors(
+        r#"
+abstract class Repo<E> { protected items: E[] = []; }
+class UserRepo extends Repo<string> { public items: string[] = []; }
+const r: Repo<string> = new UserRepo();
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "generic protected widening must stay assignable; got {codes:?}"
+    );
+}
+
+/// Index-signature variant: a class that carries a string index signature is
+/// compared through the with-index object path. Widening a protected member to
+/// public there must also stay assignable to the base (covers the third
+/// nominal-decision call site).
+#[test]
+fn widen_protected_with_index_signature() {
+    let codes = errors(
+        r#"
+class Base { protected p = 1; [k: string]: unknown; }
+class Sub extends Base { public p = 2; [k: string]: unknown; }
+const b: Base = new Sub();
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "protected widening must stay assignable through the index-signature path; got {codes:?}"
+    );
+}
+
+/// Negative guard: an *unrelated* class whose public member happens to share the
+/// name of a target's protected member is NOT assignable. The derived-class
+/// relationship is required.
+#[test]
+fn unrelated_class_with_public_member_is_rejected() {
+    let codes = errors(
+        r#"
+class Guarded { protected p = 1; }
+class Loose { p = 2; }            // unrelated, not derived from Guarded
+const g: Guarded = new Loose();   // TS2322: not a class derived from Guarded
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![2322],
+        "an unrelated class must not satisfy a protected member; got {codes:?}"
+    );
+}
+
+/// Negative guard: two *unrelated* classes that each declare a `protected`
+/// member of the same name are not interchangeable.
+#[test]
+fn unrelated_protected_declarations_are_rejected() {
+    let codes = errors(
+        r#"
+class Left { protected tag = 1; }
+class Right { protected tag = 2; }
+const l: Left = new Right(); // TS2322: different protected-declaring classes
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![2322],
+        "unrelated protected declarations must not be assignable; got {codes:?}"
+    );
+}
+
+/// Guard: `private` remains *strictly* nominal. Two classes with an identical
+/// shape but separate `private` declarations are not assignable, proving the
+/// fix only relaxed `protected`, not `private`.
+#[test]
+fn private_members_remain_strictly_nominal() {
+    let codes = errors(
+        r#"
+class Token { private brand: void = undefined; id = 1; }
+class Ticket { private brand: void = undefined; id = 1; }
+const t: Token = new Ticket(); // TS2322: separate private declarations
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![2322],
+        "separate private declarations must stay non-assignable; got {codes:?}"
+    );
+}
+
+/// Guard: narrowing visibility on override (public -> protected) is still a
+/// class-extension error (TS2415), unchanged by this fix.
+#[test]
+fn narrowing_public_to_protected_still_errors() {
+    let codes = errors(
+        r#"
+class Base { p = 1; }
+class Sub extends Base { protected p = 2; }
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![2415],
+        "narrowing public->protected on override must still report TS2415; got {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/relations/compat_overrides.rs
+++ b/crates/tsz-solver/src/relations/compat_overrides.rs
@@ -7,8 +7,12 @@
 //! - **Enum nominality**: Different enums are not assignable even if structurally
 //!   identical. String enums are strictly nominal; numeric enums allow number
 //!   assignability.
-//! - **Private brand checking**: Classes with private/protected fields use nominal
-//!   typing — the `parent_id` on each property must match exactly.
+//! - **Private brand checking**: Classes with private/protected fields use
+//!   nominal typing. `private` requires an exact `parent_id` match (declaration
+//!   identity); `protected` is hierarchical — the source property's declaring
+//!   class must derive from (or equal) the target's protected-declaring class,
+//!   so widening `protected` to `public` in a subclass stays assignable. See
+//!   `nominal_member_origin_ok`.
 //! - **Redeclaration compatibility**: Variable redeclarations (`var x: T; var x: U`)
 //!   require nominal identity for enums and bidirectional structural subtyping for
 //!   other types.
@@ -217,28 +221,37 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             .object_shape(crate::types::ObjectShapeId(target_shape_id));
 
         // Check Target requirements (Nominality)
-        // If Target has a private/protected property, Source MUST match its origin exactly.
+        // If Target has a private/protected property, Source must satisfy the
+        // matching nominal rule: `private` demands declaration identity, while
+        // `protected` is hierarchical (a derived class may widen it to `public`).
+        // Both are decided by the shared `nominal_member_origin_ok`.
         for target_prop in &target_shape.properties {
-            if target_prop.visibility == Visibility::Private
-                || target_prop.visibility == Visibility::Protected
-            {
-                let source_prop = crate::utils::lookup_property(
-                    self.interner,
-                    &source_shape.properties,
-                    Some(crate::types::ObjectShapeId(source_shape_id)),
-                    target_prop.name,
-                );
+            if !matches!(
+                target_prop.visibility,
+                Visibility::Private | Visibility::Protected
+            ) {
+                continue;
+            }
 
-                match source_prop {
-                    Some(sp) => {
-                        // CRITICAL: The parent_id must match exactly.
-                        if sp.parent_id != target_prop.parent_id {
-                            return Some(false);
-                        }
-                    }
-                    None => {
+            let source_prop = crate::utils::lookup_property(
+                self.interner,
+                &source_shape.properties,
+                Some(crate::types::ObjectShapeId(source_shape_id)),
+                target_prop.name,
+            );
+
+            match source_prop {
+                Some(sp) => {
+                    if !self.subtype.nominal_member_origin_ok(
+                        sp.parent_id,
+                        target_prop.parent_id,
+                        target_prop.visibility,
+                    ) {
                         return Some(false);
                     }
+                }
+                None => {
+                    return Some(false);
                 }
             }
         }

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -966,9 +966,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             let s_prop = self.lookup_property(source_props, source_shape_id, t_prop.name);
 
             if let Some(sp) = s_prop {
-                // Check nominal identity for private/protected properties
+                // Check nominal identity for private/protected properties.
+                // `protected` is hierarchical (shared `nominal_member_origin_ok`).
                 if t_prop.visibility != Visibility::Public {
-                    if sp.parent_id != t_prop.parent_id {
+                    if !self.nominal_member_origin_ok(
+                        sp.parent_id,
+                        t_prop.parent_id,
+                        t_prop.visibility,
+                    ) {
                         return Some(SubtypeFailureReason::PropertyNominalMismatch {
                             property_name: t_prop.name,
                         });
@@ -1235,11 +1240,16 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             if let Some(sp) =
                 self.lookup_property(&source_shape.properties, Some(source_shape_id), t_prop.name)
             {
-                // Check nominal identity for private/protected properties
-                // Private and protected members are nominally typed - they must
-                // originate from the same declaration (same parent_id)
+                // Check nominal identity for private/protected properties.
+                // `private` requires the same declaration; `protected` is
+                // hierarchical (a derived class may widen it to public) —
+                // decided by the shared `nominal_member_origin_ok`.
                 if t_prop.visibility != Visibility::Public {
-                    if sp.parent_id != t_prop.parent_id {
+                    if !self.nominal_member_origin_ok(
+                        sp.parent_id,
+                        t_prop.parent_id,
+                        t_prop.visibility,
+                    ) {
                         return Some(SubtypeFailureReason::PropertyNominalMismatch {
                             property_name: t_prop.name,
                         });

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -368,6 +368,49 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         SubtypeResult::True
     }
 
+    /// Decide whether a source property satisfies a *nominal* (private or
+    /// protected) target property, given the two declaring-class symbols
+    /// (`parent_id`s) and the target member's visibility.
+    ///
+    /// - `private` requires *declaration identity*: the source property must
+    ///   originate from the exact same declaration.
+    /// - `protected` is *hierarchical*: tsc accepts the member when the source
+    ///   property is declared in the target's protected-declaring class or in a
+    ///   class derived from it (`isPropertyInClassDerivedFrom`). The source may
+    ///   also legally widen the member from `protected` to `public`, so its own
+    ///   visibility is not consulted.
+    ///
+    /// Falls back to declaration identity when class symbols or the inheritance
+    /// graph are unavailable, preserving the previous strict nominal behavior
+    /// for shapes that carry no hierarchy information. This is the single source
+    /// of truth shared by the structural property check and the `CompatChecker`
+    /// nominal-brand override.
+    pub(crate) fn nominal_member_origin_ok(
+        &self,
+        source_parent: Option<tsz_binder::SymbolId>,
+        target_parent: Option<tsz_binder::SymbolId>,
+        target_visibility: Visibility,
+    ) -> bool {
+        // Same declaration satisfies both private and protected (covers the
+        // inherited-without-override case, where both sides resolve to the
+        // original declaring class).
+        if source_parent == target_parent {
+            return true;
+        }
+        // `private` requires strict declaration identity, which just failed.
+        if target_visibility != Visibility::Protected {
+            return false;
+        }
+        // `protected`: the source's declaring class must derive from (or equal)
+        // the target's protected-declaring class.
+        match (source_parent, target_parent, self.inheritance_graph) {
+            (Some(src_class), Some(tgt_class), Some(graph)) => {
+                graph.is_derived_from(src_class, tgt_class)
+            }
+            _ => false,
+        }
+    }
+
     /// Check if a source property is compatible with a target property.
     ///
     /// This validates property compatibility for structural object subtyping:
@@ -444,9 +487,13 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         source_receiver: Option<TypeId>,
         target_receiver: Option<TypeId>,
     ) -> SubtypeResult {
-        // Rule: Private and Protected properties are nominal.
+        // Rule: Private and Protected properties are nominal, but with different
+        // strictness — `private` demands declaration identity, while `protected`
+        // is hierarchical (a derived class may widen it to `public`). Both are
+        // decided by the shared `nominal_member_origin_ok`.
         if target.visibility != Visibility::Public {
-            if source.parent_id != target.parent_id {
+            if !self.nominal_member_origin_ok(source.parent_id, target.parent_id, target.visibility)
+            {
                 // Trace: Property nominal mismatch
                 if let Some(tracer) = &mut self.tracer
                     && !tracer.on_mismatch_dyn(
@@ -1109,9 +1156,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             if let Some(sp) =
                 self.lookup_property(&source.properties, Some(source_shape_id), t_prop.name)
             {
-                // Visibility check (Nominal)
+                // Visibility check (Nominal) — `private` needs declaration
+                // identity, `protected` is hierarchical (shared helper).
                 if t_prop.visibility != Visibility::Public {
-                    if sp.parent_id != t_prop.parent_id {
+                    if !self.nominal_member_origin_ok(
+                        sp.parent_id,
+                        t_prop.parent_id,
+                        t_prop.visibility,
+                    ) {
                         return SubtypeResult::False;
                     }
                 } else if sp.visibility != Visibility::Public {

--- a/crates/tsz-solver/tests/lawyer_tests.rs
+++ b/crates/tsz-solver/tests/lawyer_tests.rs
@@ -1070,3 +1070,88 @@ fn test_constructor_accessibility_with_overrides() {
         "Same type should be assignable (structural fallback)"
     );
 }
+
+/// Builds a single-property class instance shape with the given member
+/// visibility and declaring-class symbol. Mirrors the shapes the checker
+/// produces for class instance types.
+fn class_shape_with_member(
+    interner: &TypeInterner,
+    member: tsz_common::interner::Atom,
+    visibility: Visibility,
+    declaring_class: tsz_binder::SymbolId,
+) -> TypeId {
+    interner.object(vec![PropertyInfo {
+        visibility,
+        parent_id: Some(declaring_class),
+        ..PropertyInfo::new(member, TypeId::NUMBER)
+    }])
+}
+
+/// A `protected` member declared on a base class is satisfied by a *derived*
+/// class that widens the member to `public`. The derived-class relationship is
+/// proven through the inheritance graph (mirrors tsc's
+/// `isPropertyInClassDerivedFrom`).
+#[test]
+fn test_protected_widened_in_derived_class_is_assignable() {
+    use crate::classes::inheritance::InheritanceGraph;
+
+    let interner = TypeInterner::new();
+    let p = interner.intern_string("p");
+
+    let base_sym = tsz_binder::SymbolId(1);
+    let derived_sym = tsz_binder::SymbolId(2);
+
+    // Base declares `protected p`; Derived widens to `public p`.
+    let base = class_shape_with_member(&interner, p, Visibility::Protected, base_sym);
+    let derived = class_shape_with_member(&interner, p, Visibility::Public, derived_sym);
+
+    let graph = InheritanceGraph::new();
+    graph.add_inheritance(derived_sym, &[base_sym]);
+
+    let mut checker = CompatChecker::new(&interner);
+    checker.set_inheritance_graph(Some(&graph));
+
+    assert!(
+        checker.is_assignable(derived, base),
+        "a derived class widening a protected member to public must be assignable to its base"
+    );
+
+    // The reverse is NOT assignable: Base is not derived from Derived.
+    assert!(
+        !checker.is_assignable(base, derived),
+        "base must not be assignable to a derived class' protected member origin"
+    );
+}
+
+/// Even with both classes registered in the inheritance graph, two *unrelated*
+/// classes (no derivation edge) are not assignable through a protected member —
+/// the derived-class relationship is required.
+#[test]
+fn test_protected_unrelated_classes_with_graph_still_rejected() {
+    use crate::classes::inheritance::InheritanceGraph;
+
+    let interner = TypeInterner::new();
+    let p = interner.intern_string("p");
+
+    let left_sym = tsz_binder::SymbolId(1);
+    let right_sym = tsz_binder::SymbolId(2);
+    let common_root = tsz_binder::SymbolId(3);
+
+    let left = class_shape_with_member(&interner, p, Visibility::Protected, left_sym);
+    let right = class_shape_with_member(&interner, p, Visibility::Public, right_sym);
+
+    // Both derive from an unrelated common root, but neither derives from the
+    // other — so `right`'s `p` is not declared in `left` or a class derived
+    // from `left`.
+    let graph = InheritanceGraph::new();
+    graph.add_inheritance(left_sym, &[common_root]);
+    graph.add_inheritance(right_sym, &[common_root]);
+
+    let mut checker = CompatChecker::new(&interner);
+    checker.set_inheritance_graph(Some(&graph));
+
+    assert!(
+        !checker.is_assignable(right, left),
+        "unrelated classes must not satisfy a protected member even when both are in the graph"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes a false-positive `TS2322` where tsz rejected assigning a subclass to its
base when the subclass widened an inherited `protected` member to `public`
(legal in TypeScript). Closes #11631 (`binder-11-20` "augmentation drops
private/protected mirror visibility" family).

Verified against `tsc` 6.0.2: tsc accepts the assignment and only reports the
later out-of-class access (`TS2445`); tsz previously emitted a spurious
`TS2322` on the assignment itself.

## Structural rule

> When a target property is `protected`, a source object is assignable as long
> as the source property is declared in the target's protected-declaring class
> *or in a class derived from it*; the source may legally widen the member from
> `protected` to `public`. `private` is unchanged — it still requires the exact
> same declaration (declaration identity). Mirrors tsc's
> `isPropertyInClassDerivedFrom` / `isValidOverrideOf`.

## Track

Conformance / TS2322 parity (checker/solver assignability).

## Invariant

Protected-member assignability is hierarchical (resolved through the nominal
class inheritance graph), not declaration-identical. Private-member
assignability remains strictly nominal. A single helper
`SubtypeChecker::nominal_member_origin_ok(source_parent, target_parent,
target_visibility)` is the one source of truth, shared by every nominal
property-compatibility decision.

## Scope

- `crates/tsz-solver/src/relations/subtype/rules/objects.rs`: add
  `nominal_member_origin_ok`; route the structural property check, the
  fast-fail prepass, and the with-index-signature object path through it.
- `crates/tsz-solver/src/relations/subtype/explain.rs`: route both
  failure-reason decision sites through the same helper so the diagnostic path
  agrees with the relation result.
- `crates/tsz-solver/src/relations/compat_overrides.rs`: route the
  nominal-brand override's target loop through the same helper (this path is
  reached by the checker first and would otherwise short-circuit reject).
- Tests: `crates/tsz-checker/tests/class_protected_widening_assignability_tests.rs`
  (9 end-to-end cases) and two solver-level unit tests in
  `crates/tsz-solver/tests/lawyer_tests.rs` that wire an `InheritanceGraph`.

Per §25 the cases vary member/class spellings (`p`/`kind`/`items`,
`Base`/`Shape`/`Repo`) and include generic, deep-chain, and index-signature
variants; per §26 the matrix covers the repro plus equivalent shapes and
negative/fallback guards (unrelated classes, private strict nominal, narrowing
`public`→`protected`).

## Project Corpus Impact

- Row: `vite-vanilla-ts-app` (case `binder-11-20`), and any row that assigns a
  subclass widening a protected member to its base.
- Bug family: protected-member assignability treated as declaration-identical.
- Evidence: behavior verified against `tsc` 6.0.2; new checker + solver unit
  tests; existing visibility suites (`private_brands`,
  `union_protected_intersection_property_tests`, solver lawyer/subtype
  visibility tests) stay green.

## Verification

- `cargo test -p tsz-checker --test class_protected_widening_assignability_tests` → 9 passed.
- `cargo test -p tsz-solver --lib -- protected private brand nominal visibility derived` → 61 passed.
- `cargo test -p tsz-checker --lib -- protected private accessib visibility ts2445 ts2341 ts2415` → 147 passed.
- `cargo clippy -p tsz-solver --lib --tests -- -D warnings` → clean; `cargo fmt` clean.

## Coordination Notes

AgentName: opus48-web-pensive-wright
#11631 was unowned and not WIP when claimed; marked WIP with a signed comment.
Also closed sibling #11589 as already-resolved (covered by merged #11661) while
triaging this family. `/simplify` run 3×: collapsed two near-duplicate helpers
into one shared `nominal_member_origin_ok`, simplified the test builder via
`PropertyInfo::new`, and (pass 2) found + fixed two additional decision sites
(with-index object path + the explain/diagnostic path) so the rule is applied
everywhere, not just at the reported repro.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnjMaBCpqWbMAfwMCLJxaK)_