### PR TITLE
fix(dts): indent inferred method/namespaced object-literal return at current indent_level

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
@@ -1281,7 +1281,9 @@ impl<'a> DeclarationEmitter<'a> {
                 {
                     text
                 } else if let Some(text) = self
-                    .infer_fallback_type_text_at(ret.expression, 0)
+                    // Base the inferred object-literal return text at the current
+                    // `indent_level` so a class method nests one level deeper.
+                    .infer_fallback_type_text_at(ret.expression, self.indent_level)
                     .filter(|text| !text.is_empty())
                 {
                     text

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -17,3 +17,4 @@ include!("simple_declarations_parts/part_02.rs");
 include!("simple_declarations_parts/part_03.rs");
 include!("simple_declarations_parts/part_04.rs");
 include!("simple_declarations_parts/part_05.rs");
+include!("simple_declarations_parts/part_06.rs");

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations_parts/part_06.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations_parts/part_06.rs
@@ -1,0 +1,101 @@
+// Inferred object-literal return types must be indented relative to the
+// emitter's current `indent_level`. A class method (or a namespaced function)
+// nests its synthesized return shape one level deeper than a top-level
+// function, matching tsc's declaration indentation. Regression coverage for the
+// fix that bases `infer_fallback_type_text_at` on `self.indent_level` instead
+// of a fixed depth of 0 (see declarationMapsMultifile emit parity).
+
+#[test]
+fn inferred_class_method_object_return_uses_member_relative_indent() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+export class Foo {
+    doThing(x: { a: number }) {
+        return { b: x.a };
+    }
+}
+"#,
+    );
+
+    // Method body lives at class-member indent (one level): the inferred object
+    // return type's members sit at two levels (8 spaces) and the closing brace
+    // at one level (4 spaces).
+    assert!(
+        output.contains("    }): {\n        b: any;\n    };"),
+        "Expected inferred method object return type to nest one level deeper than the method: {output}"
+    );
+    // The bug emitted members at the base indent (4 spaces) with a column-0
+    // closing brace; ensure that broken shape is gone.
+    assert!(
+        !output.contains("    }): {\n    b: any;\n};"),
+        "Did not expect the inferred method object return type to ignore the member indent level: {output}"
+    );
+}
+
+#[test]
+fn inferred_namespaced_method_object_return_uses_deeper_indent() {
+    // Rename every bound surface (namespace/class/method/parameter/property) to
+    // prove the rule keys on structural nesting depth, not on identifier names.
+    let output = emit_dts_with_usage_analysis(
+        r#"
+export namespace Outer {
+    export class Widget {
+        build(input: { width: number }) {
+            return { size: input.width };
+        }
+    }
+}
+"#,
+    );
+
+    // namespace (1) -> class (2) -> method members (3 -> 12 spaces), closing (2 -> 8 spaces).
+    assert!(
+        output.contains("        }): {\n            size: any;\n        };"),
+        "Expected namespaced method object return type to track the namespace+class indent depth: {output}"
+    );
+}
+
+#[test]
+fn inferred_method_nested_object_return_scales_recursively() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+export class Box {
+    pack(p: { weight: number }) {
+        return { value: p.weight, meta: { tag: p.weight } };
+    }
+}
+"#,
+    );
+
+    // The nested object literal inside the method return must indent one level
+    // deeper again. Method return members sit at indent level 2 (8 spaces), so
+    // the nested object's own members sit at level 3 (12 spaces) with its
+    // closing brace back at level 2 (8 spaces).
+    assert!(
+        output.contains("        meta: {\n            tag: any;\n        };"),
+        "Expected nested inferred object members to indent recursively relative to the method: {output}"
+    );
+}
+
+#[test]
+fn inferred_top_level_function_object_return_keeps_base_indent() {
+    // Negative/control: a top-level function emits at indent level 0, so its
+    // inferred object return type keeps the base (4-space members, column-0
+    // closing brace). This proves the fix is no-op at the base level.
+    let output = emit_dts_with_usage_analysis(
+        r#"
+export function make(x: { a: number }) {
+    return { b: x.a };
+}
+"#,
+    );
+
+    assert!(
+        output.contains("): {\n    b: any;\n};"),
+        "Expected a top-level function inferred object return type to keep base indentation: {output}"
+    );
+    assert!(
+        !output.contains("): {\n        b: any;\n    };"),
+        "Did not expect a top-level function return type to be indented as a class member: {output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/dts — inferred declaration-return indentation (emit→100% campaign, wave 3; correctness fix, net-zero-on-emit)

## Invariant
When the declaration emitter synthesizes a function/method body's inferred object-literal return type as text, the object-literal indentation must be based on the emitter's current `indent_level`, not a hardcoded depth of 0. A class method (or namespaced function) nests its inferred return shape one level deeper than a top-level function. Keyed on emitter state (`indent_level`), not identifier names or printer output. At top level `indent_level == 0`, so prior behavior is preserved. (Annotated returns via `emit_type` already thread indentation correctly; only the inferred text-reconstruction path was wrong.)

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs` — `collect_unique_return_type_text_from_statement` passes `self.indent_level` (was hardcoded `0`) into `infer_fallback_type_text_at`; file at 1999 lines (under 2000 cap).
- `crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations_parts/part_06.rs` (new, 4 tests) + `simple_declarations.rs` include.

## Project Corpus Impact
- Row: n/a (declaration-emit correctness fix; net-zero on emit pass count today)
- Bug family: inferred method/namespaced-function object-literal return indentation in .d.ts
- Evidence: no witness flips yet (the targeted tests need additional solver/portability fixes — see Coordination Notes); full --dts-only 24→24, ZERO regressions; 4 new unit tests guard the fix (all fail with fix reverted).

## Verification
- **Full --dts-only: 24→24 fail, net 0, ZERO regressions** (full diff: 0 flips, 0 new). 4 structural unit tests (class method, renamed namespaced method, recursive nesting, top-level negative control) — confirmed all FAIL with the fix reverted, proving they guard it. 7 unrelated pre-existing test_js_*/JSDoc failures confirmed identical on clean main. Clippy clean; arch guard passes. JS emit unaffected (helper only reachable in .d.ts emit).
- §25/§26 compliant (keyed on emitter `indent_level` state). This is a contained correctness fix; landed for bug-fix-on-top value and to unblock the contained portion of declarationMapsMultifile.

## Coordination Notes
Rebased onto current main; HOLDING merge-queue per user landing order (queue LAST among my emit PRs — net-zero on emit metric). Root-cause split for the targeted witnesses (remaining parts are NOT contained-emitter):
- declarationMapsMultifile: this indentation fix (done) + (2) solver/checker: method-body `get_node_type(x.a)` returns ANY not number + (3) broad portability: `declare const c: import("./a").Foo` should reuse locally-imported name.
- declarationEmitInferredDefaultExportType: solver inference (empty-array `never[]` + `undefined`-literal widening).
- declarationEmitUsingTypeAlias2: solver conditional-type resolution + JSDoc stripping + property-key emission + portability name-reference.
- declarationEmitPathMappingMonorepo: already passing on clean main (stale target).
— opus48-emit100
