### PR TITLE
fix(solver): default unbound optional infer to constraint/unknown in conditional types

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -531,6 +531,10 @@ name = "accessor_pair_override_ts2416_tests"
 path = "tests/accessor_pair_override_ts2416_tests.rs"
 
 [[test]]
+name = "conditional_optional_infer_default_tests"
+path = "tests/conditional_optional_infer_default_tests.rs"
+
+[[test]]
 name = "conditional_extends_readonly_identity_tests"
 path = "tests/conditional_extends_readonly_identity_tests.rs"
 

--- a/crates/tsz-checker/tests/conditional_optional_infer_default_tests.rs
+++ b/crates/tsz-checker/tests/conditional_optional_infer_default_tests.rs
@@ -1,0 +1,130 @@
+//! Tests for unbound `infer` defaults when an *optional* property of a
+//! conditional's extends pattern is absent in the check type.
+//!
+//! Structural rule: when matching a check type against a conditional's `infer`
+//! pattern, an absent source property at an *optional* pattern position
+//! contributes no inference candidate (tsc's `inferFromProperties` skips it).
+//! The infer variable stays unbound and defaults to its constraint (or
+//! `unknown`) — tsc's `getInferredType` — and the conditional takes its **true**
+//! branch. Previously tsz injected a spurious `undefined` candidate, which made
+//! a plain `infer R` resolve to `undefined` (instead of `unknown`) and made a
+//! constrained `infer R extends C` fail its constraint and collapse the
+//! conditional to its false branch.
+//!
+//! The assertions use deliberate assignments that error under TS2322 iff the
+//! inferred type is correct, so they distinguish `unknown` / the constraint from
+//! the buggy `undefined` / false-branch results. Each case uses its own alias
+//! names (including renamed infer variables) to prove the behavior is not keyed
+//! to a particular identifier spelling.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+fn strict_options() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        ..Default::default()
+    }
+}
+
+fn count_2322(source: &str) -> usize {
+    check_source(source, "test.ts", strict_options())
+        .iter()
+        .filter(|d| d.code == 2322)
+        .count()
+}
+
+#[test]
+fn plain_unbound_infer_over_absent_optional_defaults_to_unknown() {
+    // R has no candidate (`value` absent) and no constraint -> tsc: `unknown`,
+    // true branch. `unknown` accepts any assignment, so there is no TS2322.
+    // A buggy `undefined` (or the `"NONE"` false branch) would reject `123`.
+    let source = r#"
+        type Unwrap<T> = T extends { value?: infer R } ? R : "NONE";
+        type Res = Unwrap<{ other: 1 }>;
+        const accepted: Res = 123;
+    "#;
+    assert_eq!(count_2322(source), 0);
+}
+
+#[test]
+fn constrained_unbound_infer_over_absent_optional_defaults_to_constraint() {
+    // R has no candidate (`value` absent) but is constrained to `string` ->
+    // tsc: R = `string`, true branch. Only `bad` (a number) must error; the
+    // false-branch bug would instead reject `good`.
+    let source = r#"
+        type Unwrap<T> = T extends { value?: infer R extends string } ? R : "NONE";
+        type Res = Unwrap<{ other: 1 }>;
+        const good: Res = "hello";
+        const bad: Res = 123;
+    "#;
+    assert_eq!(count_2322(source), 1);
+}
+
+#[test]
+fn constrained_unbound_infer_default_is_not_name_sensitive() {
+    // Same as above with the infer variable renamed `Q`; the fix must be keyed to
+    // the structural shape, not the identifier.
+    let source = r#"
+        type Unwrap<T> = T extends { value?: infer Q extends string } ? Q : "NONE";
+        type Res = Unwrap<{ other: 1 }>;
+        const good: Res = "world";
+        const bad: Res = 123;
+    "#;
+    assert_eq!(count_2322(source), 1);
+}
+
+#[test]
+fn present_optional_property_still_infers_the_value_type() {
+    // When the optional property is present, inference is unchanged: R = the
+    // property type (`number`), not `number | undefined`. `bad` must error.
+    let source = r#"
+        type Unwrap<T> = T extends { value?: infer R } ? R : "NONE";
+        type Res = Unwrap<{ value: number }>;
+        const ok: Res = 3;
+        const bad: Res = "x";
+    "#;
+    assert_eq!(count_2322(source), 1);
+}
+
+#[test]
+fn multi_prop_pattern_defaults_only_the_absent_optional_slot() {
+    // `a` is present (X = "hi"); `b` is an absent optional constrained to
+    // `number` (Y = `number`). Only the `["hi", "no"]` assignment must error.
+    let source = r#"
+        type Pick2<T> = T extends { a: infer X; b?: infer Y extends number }
+            ? [X, Y]
+            : "NONE";
+        type Res = Pick2<{ a: "hi" }>;
+        const good: Res = ["hi", 7];
+        const bad: Res = ["hi", "no"];
+    "#;
+    assert_eq!(count_2322(source), 1);
+}
+
+#[test]
+fn required_absent_property_still_takes_the_false_branch() {
+    // Regression guard: an absent *required* property is a hard no-match, so the
+    // conditional takes its false branch (`"FALSE"`). `bad` must error.
+    let source = r#"
+        type Get<T> = T extends { req: infer X } ? X : "FALSE";
+        type Res = Get<{ other: 1 }>;
+        const good: Res = "FALSE";
+        const bad: Res = 5;
+    "#;
+    assert_eq!(count_2322(source), 1);
+}
+
+#[test]
+fn present_optional_violating_constraint_still_takes_the_false_branch() {
+    // Regression guard: a *present* candidate that violates the constraint
+    // (`number` is not assignable to `string`) takes the false branch, distinct
+    // from the absent-optional case which defaults to the constraint.
+    let source = r#"
+        type Get<T> = T extends { v?: infer X extends string } ? X : "FALSE";
+        type Res = Get<{ v: number }>;
+        const good: Res = "FALSE";
+        const bad: Res = 5;
+    "#;
+    assert_eq!(count_2322(source), 1);
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/object_infer.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/object_infer.rs
@@ -2,6 +2,30 @@
 
 use super::*;
 
+/// Outcome of resolving a single `infer` property of a conditional's extends
+/// pattern against the (concrete) check type.
+///
+/// This distinguishes the three cases tsc's `inferFromProperties` produces, which
+/// a plain `Option<TypeId>` cannot:
+///
+/// * [`Candidate`](InferPropertyResolution::Candidate) — the property is present;
+///   its type is the inference candidate.
+/// * [`NoCandidate`](InferPropertyResolution::NoCandidate) — an *optional* pattern
+///   property is absent in the source. tsc contributes no candidate, so the
+///   conditional still matches (true branch) but the infer variable stays unbound
+///   and defaults to its constraint (or `unknown`). Crucially it must **not** pick
+///   up a spurious `undefined`, which would corrupt a plain `infer R` (→ `undefined`
+///   instead of `unknown`) and make a constrained `infer R extends C` fail its
+///   constraint and collapse the conditional to its false branch.
+/// * [`NoMatch`](InferPropertyResolution::NoMatch) — a *required* pattern property
+///   is absent (or the source cannot supply it): the conditional takes its false
+///   branch.
+enum InferPropertyResolution {
+    Candidate(TypeId),
+    NoCandidate,
+    NoMatch,
+}
+
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// Handle object extends pattern: T extends { prop: infer U } ? ...
     pub(super) fn eval_conditional_object_infer(
@@ -122,11 +146,16 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let mut effective_constraint: FxHashMap<Atom, (TypeId, bool)> = FxHashMap::default();
 
         for &(prop_name, info, optional) in infer_props {
-            let Some(inferred) =
-                self.resolve_conditional_infer_property(check_unwrapped, prop_name, optional)
-            else {
-                return self.evaluate(cond.false_type);
-            };
+            let inferred =
+                match self.resolve_conditional_infer_property(check_unwrapped, prop_name, optional)
+                {
+                    InferPropertyResolution::Candidate(ty) => ty,
+                    InferPropertyResolution::NoMatch => return self.evaluate(cond.false_type),
+                    // No candidate from this slot: leave the variable unbound here. If no
+                    // other slot supplies one, pass 2 defaults it to its constraint (or
+                    // `unknown`); a co-located slot that does supply a candidate still wins.
+                    InferPropertyResolution::NoCandidate => continue,
+                };
 
             if let Some(existing) = accumulated.get(&info.name).copied() {
                 // tsc unions co-located infer candidates across property slots.
@@ -160,6 +189,11 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 continue; // already processed this variable
             }
             let Some(mut inferred) = accumulated.get(&info.name).copied() else {
+                // No candidate from any slot (all were absent optionals): default the
+                // variable to its constraint (or `unknown`), matching tsc's
+                // `getInferredType`, and take the true branch.
+                let default_ty = info.constraint.unwrap_or(TypeId::UNKNOWN);
+                subst.insert(info.name, default_ty);
                 continue;
             };
 
@@ -214,11 +248,26 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             return self.interner().conditional(*cond);
         }
 
-        let inferred =
-            self.resolve_conditional_infer_property(check_unwrapped, prop_name, prop_optional);
-
-        let Some(mut inferred) = inferred else {
-            return self.evaluate(cond.false_type);
+        let mut inferred = match self.resolve_conditional_infer_property(
+            check_unwrapped,
+            prop_name,
+            prop_optional,
+        ) {
+            InferPropertyResolution::Candidate(ty) => ty,
+            InferPropertyResolution::NoMatch => return self.evaluate(cond.false_type),
+            InferPropertyResolution::NoCandidate => {
+                // tsc's `getInferredType`: an infer variable with no candidate
+                // resolves to its constraint (or `unknown`), and the conditional
+                // takes its true branch. The absent optional property neither
+                // supplies a spurious `undefined` candidate nor forces the false
+                // branch.
+                let default_ty = info.constraint.unwrap_or(TypeId::UNKNOWN);
+                let subst = TypeSubstitution::single(info.name, default_ty);
+                let true_inst =
+                    instantiate_type_with_infer(self.interner(), cond.true_type, &subst);
+                return self
+                    .evaluate_preserving_tail_application_branch_alias(true_inst, Some(true_inst));
+            }
         };
 
         let mut subst = TypeSubstitution::single(info.name, inferred);
@@ -256,41 +305,40 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         source: TypeId,
         prop_name: Atom,
         optional: bool,
-    ) -> Option<TypeId> {
+    ) -> InferPropertyResolution {
+        // Absent property: an optional pattern position contributes no candidate
+        // (tsc skips it), while a required one fails the match. Shared by every
+        // "property not found" arm below.
+        let absent = if optional {
+            InferPropertyResolution::NoCandidate
+        } else {
+            InferPropertyResolution::NoMatch
+        };
+
         if source == TypeId::OBJECT {
-            return optional.then_some(TypeId::UNDEFINED);
+            return absent;
         }
 
         if let Some(type_id) = self.implicit_sequence_property_type(source, prop_name) {
-            return Some(type_id);
+            return InferPropertyResolution::Candidate(type_id);
         }
 
         if let Some(query_db) = self.query_db() {
             let prop_name_str = self.interner().resolve_atom_ref(prop_name);
             return match query_db.resolve_property_access(source, &prop_name_str) {
-                PropertyAccessResult::Success { type_id, .. } => Some(type_id),
-                PropertyAccessResult::PropertyNotFound { .. } => {
-                    optional.then_some(TypeId::UNDEFINED)
+                PropertyAccessResult::Success { type_id, .. } => {
+                    InferPropertyResolution::Candidate(type_id)
                 }
-                _ => None,
+                PropertyAccessResult::PropertyNotFound { .. } => absent,
+                _ => InferPropertyResolution::NoMatch,
             };
         }
 
         match self.interner().lookup(source) {
             Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
                 let shape = self.interner().object_shape(shape_id);
-                shape
-                    .properties
-                    .iter()
-                    .find(|prop| prop.name == prop_name)
-                    .map(|prop| {
-                        if optional {
-                            self.optional_property_type(prop)
-                        } else {
-                            prop.type_id
-                        }
-                    })
-                    .or_else(|| optional.then_some(TypeId::UNDEFINED))
+                self.property_candidate(&shape.properties, prop_name, optional)
+                    .unwrap_or(absent)
             }
             Some(TypeData::Callable(callable_id)) => {
                 // Callable types (class constructors) have static properties
@@ -298,20 +346,15 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 // E.g., `typeof MyClass extends { defaultProps: infer D }` should
                 // find `defaultProps` in the class constructor's static properties.
                 let shape = self.interner().callable_shape(callable_id);
-                shape
-                    .properties
-                    .iter()
-                    .find(|prop| prop.name == prop_name)
-                    .map(|prop| {
-                        if optional {
-                            self.optional_property_type(prop)
-                        } else {
-                            prop.type_id
-                        }
-                    })
-                    .or_else(|| optional.then_some(TypeId::UNDEFINED))
+                self.property_candidate(&shape.properties, prop_name, optional)
+                    .unwrap_or(absent)
             }
             Some(TypeData::Union(members)) => {
+                // A concrete union check type contributes the union of each member's
+                // candidate. A member that lacks an optional property contributes
+                // `undefined` (the indexed-access reading of an absent optional);
+                // a member that fails the match (required prop absent) fails the
+                // whole conditional.
                 let members = self.interner().type_list(members);
                 let mut inferred_members: SmallVec<[TypeId; 8]> = SmallVec::new();
                 for &member in members.iter() {
@@ -319,19 +362,26 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         Some(TypeData::ReadonlyType(inner)) => inner,
                         _ => member,
                     };
-                    let inferred = self.resolve_conditional_infer_property(
+                    match self.resolve_conditional_infer_property(
                         member_unwrapped,
                         prop_name,
                         optional,
-                    )?;
-                    inferred_members.push(inferred);
+                    ) {
+                        InferPropertyResolution::Candidate(ty) => inferred_members.push(ty),
+                        InferPropertyResolution::NoCandidate => {
+                            inferred_members.push(TypeId::UNDEFINED)
+                        }
+                        InferPropertyResolution::NoMatch => {
+                            return InferPropertyResolution::NoMatch;
+                        }
+                    }
                 }
-                if inferred_members.is_empty() {
-                    None
-                } else if inferred_members.len() == 1 {
-                    Some(inferred_members[0])
-                } else {
-                    Some(self.interner().union_from_slice(&inferred_members))
+                match inferred_members.len() {
+                    0 => absent,
+                    1 => InferPropertyResolution::Candidate(inferred_members[0]),
+                    _ => InferPropertyResolution::Candidate(
+                        self.interner().union_from_slice(&inferred_members),
+                    ),
                 }
             }
             Some(TypeData::Intersection(members)) => {
@@ -344,15 +394,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         Some(TypeData::ReadonlyType(inner)) => inner,
                         _ => member,
                     };
-                    if let Some(inferred) = self.resolve_conditional_infer_property(
-                        member_unwrapped,
-                        prop_name,
-                        optional,
-                    ) {
-                        return Some(inferred);
+                    if let InferPropertyResolution::Candidate(inferred) = self
+                        .resolve_conditional_infer_property(member_unwrapped, prop_name, optional)
+                    {
+                        return InferPropertyResolution::Candidate(inferred);
                     }
                 }
-                optional.then_some(TypeId::UNDEFINED)
+                absent
             }
             _ => {
                 // Fallback: try evaluating the source further and recursing.
@@ -362,10 +410,32 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 if evaluated != source {
                     self.resolve_conditional_infer_property(evaluated, prop_name, optional)
                 } else {
-                    None
+                    InferPropertyResolution::NoMatch
                 }
             }
         }
+    }
+
+    /// Look up `prop_name` among a property list (an object or callable shape),
+    /// returning its candidate type when present. `None` means the property is
+    /// absent — the caller decides whether that is a no-candidate optional or a
+    /// hard no-match.
+    fn property_candidate(
+        &self,
+        properties: &[PropertyInfo],
+        prop_name: Atom,
+        optional: bool,
+    ) -> Option<InferPropertyResolution> {
+        properties
+            .iter()
+            .find(|prop| prop.name == prop_name)
+            .map(|prop| {
+                InferPropertyResolution::Candidate(if optional {
+                    self.optional_property_type(prop)
+                } else {
+                    prop.type_id
+                })
+            })
     }
 
     /// Handle nested object infer pattern

--- a/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_objects.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_objects.rs
@@ -1248,7 +1248,11 @@ fn test_conditional_infer_optional_property_missing_object() {
     let instantiated = instantiate_type(&interner, cond_type, &subst);
     let result = evaluate_type(&interner, instantiated);
 
-    assert_eq!(result, TypeId::UNDEFINED);
+    // `{}` matches `{ a?: infer R }` (the optional `a` is simply absent), so the
+    // conditional takes its true branch. `a` is absent in the source, so it
+    // contributes no inference candidate; an unconstrained `R` therefore defaults
+    // to `unknown` (tsc's `getInferredType`), not `undefined`.
+    assert_eq!(result, TypeId::UNKNOWN);
 }
 
 #[test]


### PR DESCRIPTION
AgentName: opus-remote-bvUAZ

## Structural rule

> When a conditional's `infer` pattern has an **optional** property that is **absent** in the check type, tsc's `inferFromProperties` contributes **no** inference candidate. The conditional still matches (true branch) and the infer variable defaults to its **constraint**, or `unknown` when unconstrained (`getInferredType`). tsz instead injected a spurious `undefined` candidate.

This made:
- a plain `infer R` over an absent optional resolve to `undefined` (should be `unknown`); and
- a constrained `infer R extends C` over an absent optional **fail its constraint** and collapse the conditional to its **false branch** (often `never`) — i.e. "infer placeholder constraints collapse to never in conditional defaults".

## Owner layer

Type semantics belong in the solver. The fix lives in the conditional object-infer evaluation fast path (`crates/tsz-solver/src/evaluation/evaluate_rules/conditional/object_infer.rs`), where `resolve_conditional_infer_property` now returns a three-state result instead of an `Option<TypeId>` that conflated "no candidate" with "present `undefined`":

- `Candidate(ty)` — property present; `ty` is the candidate.
- `NoCandidate` — optional property absent: no candidate, true branch, infer var defaults to its constraint or `unknown`.
- `NoMatch` — required property absent (or source cannot supply it): false branch.

Single-prop and multi-prop callers default unbound vars via `info.constraint.unwrap_or(TypeId::UNKNOWN)` (tsc's `getInferredType`). Union/intersection candidate handling is preserved.

## Adjacent-case test matrix

`crates/tsz-checker/tests/conditional_optional_infer_default_tests.rs` (assertions use TS2322 presence/absence to pin the inferred type, distinguishing `unknown`/constraint from the buggy `undefined`/false-branch):

1. plain unbound infer over absent optional → `unknown` (reported repro);
2. constrained unbound infer over absent optional → the constraint;
3. same as (2) with the infer variable **renamed** (`Q`) — proves the rule is not name-keyed;
4. **present** optional still infers the value type (not `value | undefined`);
5. multi-prop pattern: present `a` + absent-optional constrained `b` defaults only `b`;
6. **negative**: absent **required** property still takes the false branch;
7. **negative**: present candidate that violates the constraint still takes the false branch.

Solver unit test `test_conditional_infer_optional_property_missing_object` updated from the old `undefined` expectation to `unknown`.

## Known unsupported shapes / fallback

The general infer-matching engine path (e.g. `[T] extends [{ a?: infer R }]`, tuple-wrapped non-distributive patterns) routes through `match_infer_object_properties` and is governed by tsz's existing union-inference model, which is itself not yet tsc-faithful for "property not common to all union members". That is a separate, deeper concern and is intentionally out of scope here; this PR does not change that path. The direct conditional object-infer fast path (the path the reported family uses) is fixed.

## Verification

- New checker suite (7 tests) passes; solver `conditional_infer_optional*` suite (6 tests) passes.
- Relevant existing suites checked for regressions: `infer_constraint_whole_candidate_tests`, `infer_extends_constraint_substitution_tests`, `distributive_conditional_default_tests`, `generic_conditional_default_assignability_tests`, `nested_infer_extends_scope_tests`, `recursive_conditional_infer_depth_tests`, `curry_recursive_conditional_infer_tests`, `deferred_conditional_identity_extends_tests`, `inline_conditional_infer_return_tests` — all green.
- `cargo clippy -p tsz-solver --all-targets` and `-p tsz-checker --tests` clean.
- Pre-existing branch failures (`equal_any_*` Equal-trick + `any`, `remove_optional_conditional_constant_branches_no_error`, `test_deep_widen_object_candidate_homomorphic_mapped`, etc.) were confirmed failing on clean HEAD and are unrelated to this change.
- Full conformance/emit/fourslash/WASM left to CI.

## Project Corpus Impact

- Row: `nextjs` (issue #11588, case `solver-28-20`, "infer placeholder constraints collapse to never in conditional defaults"); the same rule covers the sibling `infer`/conditional families across other rows.
- Bug family: conditional-type-infer-defaulting-absent-optional (plain → `unknown`, constrained → constraint).
- Evidence: focused checker + solver unit tests above; minimized repros confirm tsc parity (`{ value?: infer R }` over an object lacking `value` → `unknown`; `{ value?: infer R extends string }` → `string`).

## Coordination Notes

- AgentName: opus-remote-bvUAZ (remote-execution session; runner-derived name kept to comments/body text only — no new `agent:*` label created).
- Addresses #11588. That issue currently carries the canonical `agent:M4-B` lane label (added ~session start) but has no PR, WIP marker, or claiming comment. I have **not** removed the `agent:M4-B` label; posted a coordination comment on the issue linking this PR. If `M4-B` has a competing fix in flight, happy to defer/close this as duplicate with the analysis preserved.
- Track: solver / conditional-type inference parity.
- Invariant: assignability/inference must match tsc `getInferredType`/`inferFromProperties` for absent optional infer positions.