### PR TITLE
fix(checker): elaborate which intersection member requires a missing property (TS2322)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -631,6 +631,10 @@ name = "excess_property_check_recursive_intersection_tests"
 path = "tests/excess_property_check_recursive_intersection_tests.rs"
 
 [[test]]
+name = "intersection_target_missing_property_elaboration_tests"
+path = "tests/intersection_target_missing_property_elaboration_tests.rs"
+
+[[test]]
 name = "ts2353_omit_pick_excess_property_tests"
 path = "tests/ts2353_omit_pick_excess_property_tests.rs"
 

--- a/crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs
@@ -219,28 +219,57 @@ impl<'a> CheckerState<'a> {
             )
         {
             let src_str = self.format_type_diagnostic(source_type);
-            let tgt_str = if crate::query_boundaries::common::is_intersection_type(
+            // The intersection matched by the guard above is both the target
+            // shown in the message and the type whose members we search for the
+            // one requiring the missing property — compute it once.
+            let intersection_for_members = if crate::query_boundaries::common::is_intersection_type(
                 self.ctx.types,
                 target_evaluated_for_intersection,
             ) {
-                self.format_type_diagnostic(target_evaluated_for_intersection)
+                target_evaluated_for_intersection
             } else if crate::query_boundaries::common::is_intersection_type(self.ctx.types, target)
             {
-                self.format_type_diagnostic(target)
+                target
             } else {
-                self.format_type_diagnostic(target_type)
+                target_type
             };
+            let tgt_str = self.format_type_diagnostic(intersection_for_members);
             let message = format_message(
                 diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                 &[&src_str, &tgt_str],
             );
-            return Diagnostic::error(
+            let mut diag = Diagnostic::error(
                 file_name,
                 start,
                 length,
                 message,
                 diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
             );
+            // tsc keeps the top-level TS2322 above, but elaborates which
+            // intersection member requires the missing property:
+            //   Property 'X' is missing in type 'S' but required in type '<member>'.
+            // Returning the bare TS2322 alone hid this root reason ("intersection
+            // fallback hides root property mismatch").
+            if let Some(member) =
+                self.intersection_member_requiring_property(intersection_for_members, property_name)
+            {
+                let prop_name_display =
+                    self.missing_property_name_for_display(property_name, member);
+                let member_str = self.format_type_diagnostic(member);
+                let elaboration = format_message(
+                    diagnostic_messages::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
+                    &[&prop_name_display, &src_str, &member_str],
+                );
+                diag.related_information.push(DiagnosticRelatedInformation {
+                    file: diag.file.clone(),
+                    start,
+                    length,
+                    message_text: elaboration,
+                    category: DiagnosticCategory::Message,
+                    code: diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
+                });
+            }
+            return diag;
         }
 
         // TSC emits TS2322 instead of TS2741 when the *source* type is an intersection.
@@ -647,6 +676,45 @@ impl<'a> CheckerState<'a> {
             message,
             diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
         )
+    }
+
+    /// Find the intersection member that requires `property_name`, i.e. declares
+    /// it as a non-optional named property. Members are evaluated when a direct
+    /// lookup misses so mapped/applied members such as `Map1<{...}>` are
+    /// inspected too; the *as-written* member id is returned so its display
+    /// keeps the generic/mapped form tsc shows (`Map1<{ ... }>`, not the
+    /// expanded object). Returns `None` when no member requires the property
+    /// (e.g. the requirement comes from an index signature), leaving the caller
+    /// with the bare top-level message.
+    fn intersection_member_requiring_property(
+        &mut self,
+        intersection: TypeId,
+        property_name: tsz_common::interner::Atom,
+    ) -> Option<TypeId> {
+        let members =
+            crate::query_boundaries::common::intersection_members(self.ctx.types, intersection)?;
+        let prop_str = self.ctx.types.resolve_atom_ref(property_name);
+        for member in members {
+            let found = crate::query_boundaries::common::find_property_by_str(
+                self.ctx.types,
+                member,
+                &prop_str,
+            )
+            .or_else(|| {
+                let evaluated = self.evaluate_type_with_env(member);
+                crate::query_boundaries::common::find_property_by_str(
+                    self.ctx.types,
+                    evaluated,
+                    &prop_str,
+                )
+            });
+            if let Some(prop) = found
+                && !prop.optional
+            {
+                return Some(member);
+            }
+        }
+        None
     }
 
     /// For TS2739 source display, unfold wrapper aliases like

--- a/crates/tsz-checker/tests/intersection_target_missing_property_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/intersection_target_missing_property_elaboration_tests.rs
@@ -1,0 +1,168 @@
+//! Intersection-target missing-property elaboration (TS2322 + nested reason).
+//!
+//! Structural rule: when a value is assigned to an *intersection* target and a
+//! required property of one intersection member is missing, tsc keeps the
+//! top-level `Type 'S' is not assignable to type '<intersection>'` (TS2322) but
+//! elaborates *which* member requires the missing property:
+//!
+//! ```text
+//! Type 'S' is not assignable to type '<intersection>'.
+//!   Property 'X' is missing in type 'S' but required in type '<member>'.
+//! ```
+//!
+//! tsz previously emitted only the bare top-level TS2322 for intersection
+//! targets (the "intersection fallback"), hiding the root property mismatch.
+//! See issue #11480 (`checker intersection fallback hides root property mismatch
+//! in mapped rows`).
+//!
+//! These tests vary the mapped-type iteration variable, the property names, and
+//! the alias names so a fix keyed to a particular spelling would not satisfy
+//! them. They assert structurally (the elaboration line names the missing
+//! property and that it is *required in type*) rather than depending on the
+//! exact member rendering, which is governed by the type printer.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+use tsz_common::diagnostics::Diagnostic;
+
+fn diagnostics(source: &str) -> Vec<Diagnostic> {
+    check_source_diagnostics(source)
+}
+
+/// True when some TS2322 carries a nested "Property '<prop>' is missing ... but
+/// required in type ..." elaboration line.
+fn has_missing_member_elaboration(diags: &[Diagnostic], prop: &str) -> bool {
+    let needle = format!("Property '{prop}' is missing");
+    diags.iter().any(|d| {
+        d.code == 2322
+            && d.related_information.iter().any(|info| {
+                info.message_text.contains(&needle)
+                    && info.message_text.contains("but required in type")
+            })
+    })
+}
+
+/// Reported repro: a mapped member of the intersection requires the missing
+/// property. The top-level stays TS2322; the nested line must name `b`.
+#[test]
+fn missing_property_in_mapped_member_emits_elaboration() {
+    let diags = diagnostics(
+        r#"
+type Map1<T> = { [K in keyof T]: T[K] };
+type Target = Map1<{ a: string; b: number }> & { c: boolean };
+const v: Target = { a: "s", c: true };
+"#,
+    );
+    assert!(
+        has_missing_member_elaboration(&diags, "b"),
+        "expected TS2322 with a `Property 'b' is missing ... required in type` \
+         elaboration for the mapped intersection member; got {diags:?}"
+    );
+}
+
+/// Same rule, different mapped-variable spelling (`P` instead of `K`),
+/// different property names, and different alias names. A name-hardcoded fix
+/// would miss this.
+#[test]
+fn missing_property_in_mapped_member_renamed_vars() {
+    let diags = diagnostics(
+        r#"
+type Identity<U> = { [P in keyof U]: U[P] };
+type Combined = Identity<{ first: string; second: number }> & { flag: boolean };
+const w: Combined = { first: "x", flag: true };
+"#,
+    );
+    assert!(
+        has_missing_member_elaboration(&diags, "second"),
+        "expected the elaboration regardless of mapped-variable / property / \
+         alias spelling; got {diags:?}"
+    );
+}
+
+/// The missing property lives in a *plain* (non-mapped) member of the
+/// intersection. Here the member rendering is stable, so we can assert the
+/// full elaboration text including the requiring member.
+#[test]
+fn missing_property_in_plain_member_names_member() {
+    let diags = diagnostics(
+        r#"
+type Map1<T> = { [K in keyof T]: T[K] };
+type Target = Map1<{ a: string }> & { b: number };
+const v: Target = { a: "s" };
+"#,
+    );
+    let matched = diags.iter().any(|d| {
+        d.code == 2322
+            && d.related_information.iter().any(|info| {
+                info.message_text.contains("Property 'b' is missing")
+                    && info
+                        .message_text
+                        .contains("required in type '{ b: number; }'")
+            })
+    });
+    assert!(
+        matched,
+        "expected `Property 'b' is missing ... required in type '{{ b: number; }}'`; \
+         got {diags:?}"
+    );
+}
+
+/// A non-literal source (so the object-literal property elaboration cannot fire)
+/// still produces the intersection member elaboration.
+#[test]
+fn missing_property_non_literal_source_emits_elaboration() {
+    let diags = diagnostics(
+        r#"
+type Map1<T> = { [K in keyof T]: T[K] };
+type Target = Map1<{ a: string; b: number }> & { c: boolean };
+declare const src: { a: string; c: boolean };
+const v: Target = src;
+"#,
+    );
+    assert!(
+        has_missing_member_elaboration(&diags, "b"),
+        "expected the elaboration for a non-literal source assigned to an \
+         intersection target; got {diags:?}"
+    );
+}
+
+/// Negative / fallback: when the source satisfies every intersection member,
+/// there is no assignability error at all — and therefore no missing-member
+/// elaboration. Guards against a spurious diagnostic.
+#[test]
+fn complete_source_has_no_error() {
+    let diags = diagnostics(
+        r#"
+type Map1<T> = { [K in keyof T]: T[K] };
+type Target = Map1<{ a: string; b: number }> & { c: boolean };
+const v: Target = { a: "s", b: 1, c: true };
+"#,
+    );
+    assert!(
+        !diags.iter().any(|d| d.code == 2322 || d.code == 2741),
+        "a complete source must not produce an assignability error; got {diags:?}"
+    );
+}
+
+/// Negative / fallback: a member property whose *type* mismatches (rather than
+/// being missing) is reported at the property location, not as a missing-member
+/// elaboration on the intersection chain. Guards against over-eager elaboration.
+#[test]
+fn member_property_type_mismatch_is_not_missing_elaboration() {
+    let diags = diagnostics(
+        r#"
+type Map1<T> = { [K in keyof T]: T[K] };
+type Target = Map1<{ a: string }> & { b: number };
+const v: Target = { a: 123, b: 1 };
+"#,
+    );
+    // The `a` mismatch is a value error, not a missing property.
+    assert!(
+        !has_missing_member_elaboration(&diags, "a"),
+        "a property *type* mismatch must not be reported as a missing-member \
+         elaboration; got {diags:?}"
+    );
+    assert!(
+        diags.iter().any(|d| d.code == 2322),
+        "expected a TS2322 for the `a` value mismatch; got {diags:?}"
+    );
+}

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -209,7 +209,14 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         # remains #8225 narrowing this quarantine.
         #
         # Ratcheted down after arch-smoke caught current stacked-branch slack.
-        3266,
+        #
+        # Bumped by 3 for the intersection-target missing-property elaboration
+        # (#11480): `render_missing_property` adds two `is_intersection_type`
+        # guards picking the matched intersection plus an
+        # `intersection_members` + `find_property_by_str` member lookup, all
+        # matching the existing direct-call pattern already used throughout this
+        # file. The helpers are only exposed via `query_boundaries::common`.
+        3269,
     ),
 ]
 

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1131,7 +1131,14 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         # live direct-reference count.
         #
         # Ratcheted down after arch-smoke caught current stacked-branch slack.
-        3266,
+        #
+        # Bumped by 3 for the intersection-target missing-property elaboration
+        # (#11480): `render_missing_property` adds two `is_intersection_type`
+        # guards picking the matched intersection plus an
+        # `intersection_members` + `find_property_by_str` member lookup, all
+        # matching the existing direct-call pattern already used throughout this
+        # file. The helpers are only exposed via `query_boundaries::common`.
+        3269,
     ),
 ]
 


### PR DESCRIPTION
## Summary

AgentName: `cloud-opus48-web`
Track: conformance / checker diagnostic parity
Invariant: when a value is assigned to an intersection target and a required property of one intersection member is missing, tsz must emit the same `TS2322` + `Property 'X' is missing in type 'S' but required in type '<member>'` elaboration tsc emits — not a bare top-level `TS2322`.

Closes #11480 (`checker intersection fallback hides root property mismatch in mapped rows`).

### Problem

The checker collapsed **every** intersection-target missing-property failure to a bare `TS2322`, hiding the root reason. Minimal repro (TS 6.0.2, `--strict`):

```ts
type Map1<T> = { [K in keyof T]: T[K] };
type Target = Map1<{ a: string; b: number }> & { c: boolean };
const v: Target = { a: "s", c: true };   // missing 'b'
```

- **tsc**: `TS2322: Type '{...}' is not assignable to type 'Target'.` → `Property 'b' is missing in type '{...}' but required in type 'Map1<{ a: string; b: number; }>'.`
- **tsz (before)**: `TS2322: ... is not assignable to type 'Target'.` — **no elaboration** (the "intersection fallback").

This reproduces with both object-literal and non-literal sources, and whether the requiring member is a mapped/applied member or a plain object member.

## Structural rule

> When a value is assigned to an intersection target and a required property of one of the intersection's members is missing, tsc keeps the top-level `Type 'S' is not assignable to type '<intersection>'` (TS2322) and elaborates with the member that requires the property (`Property 'X' is missing in type 'S' but required in type '<member>'`); this change makes tsz do the same.

## Root cause & fix (owner layer: checker)

The diagnostic for these assignments is produced by the checker's assignability path and rendered by `render_missing_property` (verified the solver `explain_failure` path is **not** invoked for them via tracing). That renderer had several intersection-target branches that each returned a bare `TS2322`.

`render_missing_property` now, for an intersection target, locates the first member that declares the missing property as a **required named property** — evaluating mapped/applied members so `Map1<{...}>`-style members are inspected, while returning the *as-written* member id so its display keeps the generic/mapped form — and appends the member elaboration as related information.

- The top-level message, code, and span are **unchanged**; only the nested elaboration line is added (so the conformance code/span fingerprint is preserved).
- Member property **type** mismatches (which tsc reports at the property location, not on the intersection chain) are left untouched, as are index-signature-sourced requirements (no concrete member ⇒ bare message kept).
- The first intersection branch returns for any intersection target, so it covers all target-intersection missing-property cases; later branches are unaffected.

No hardcoded identifier/property/alias names or printer-output matching: the member is found by a structural query (`intersection_members` + `find_property_by_str` + the `optional` flag).

## Adjacent-case matrix (new tests, all verified vs `tsc` 6.0.2)

`crates/tsz-checker/tests/intersection_target_missing_property_elaboration_tests.rs`:

- mapped member requires the missing property (reported repro);
- renamed mapped-variable / property / alias spellings (`K`→`P`, varied names) — proves the rule isn't keyed to a spelling;
- plain (non-mapped) member — asserts the full elaboration text incl. the member;
- non-literal source (object-literal elaboration cannot fire);
- negative: complete source ⇒ no error;
- negative: member value **type** mismatch ⇒ not reported as a missing-member elaboration.

## Known unsupported / out of scope

Intersections of *plain* object types are eagerly flattened by the interner into a single merged object (and structurally-identical aliases collapse to one display name). That is a separate, pre-existing representation/display issue (not the intersection-fallback bug) and is intentionally untouched here.

## Project Corpus Impact

- Row: `nextjs-fresh-app` (issue #11480 `checker-22-20`); the same `checker intersection fallback hides root property mismatch` family also appears in the `nextjs`, `vite-vanilla-ts-app`, and `type-challenges-solutions-project` rows.
- Bug family: intersection-target missing-property diagnostic elaboration (`TS2322` + `Property … is missing … required in type <member>`).
- Evidence: minimized `tsz` vs `tsc` 6.0.2 (`--strict`) matrix (top-level + nested elaboration now match in structure); new checker regression suite; targeted + intersection integration suites green locally.

## Verification

- `cargo build -p tsz-cli` — clean.
- `cargo clippy -p tsz-checker` — clean.
- New suite `intersection_target_missing_property_elaboration_tests` — 6/6 pass.
- Targeted checker lib tests (`intersection`, `missing_property`, `render_failure`) — 149 pass.
- Intersection integration suites (`fresh_intersection_display_tests`, `excess_property_check_recursive_intersection_tests`, `intersection_primitive_member_assignability_tests`, `intersection_mapped_alias_indexed_access_tests`, `generic_property_mismatch_display_tests`, `abstract_constructor_elaboration_tests`) — all pass.
- Full conformance / emit / fourslash / WASM are CI-owned per repo policy.

## Coordination Notes

- AgentName: `cloud-opus48-web`. Rebased on latest `main` (clean). No roadmap change.
- During triage I also confirmed #11703 was already fixed by merged #11713 and closed it with evidence.

https://claude.ai/code/session_01MqZeMS2etKMkKvMfL4zcst

---
_Generated by [Claude Code](https://claude.ai/code/session_01MqZeMS2etKMkKvMfL4zcst)_