### PR TITLE
fix(checker): match tsc elaboration-chain structure for property mismatches

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1759,6 +1759,10 @@ name = "satisfies_elaboration_chain_tests"
 path = "tests/satisfies_elaboration_chain_tests.rs"
 
 [[test]]
+name = "property_chain_elaboration_collapse_tests"
+path = "tests/property_chain_elaboration_collapse_tests.rs"
+
+[[test]]
 name = "nested_infer_extends_scope_tests"
 path = "tests/nested_infer_extends_scope_tests.rs"
 

--- a/crates/tsz-checker/src/checkers/jsx/props/validation.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/validation.rs
@@ -1414,6 +1414,7 @@ impl<'a> CheckerState<'a> {
                         diagnostic_messages::IS_DECLARED_HERE,
                         &[&prop_name],
                     ),
+                    depth: 0,
                 });
             }
             self.emit_render_request_at_anchor(

--- a/crates/tsz-checker/src/classes/class_implements_checker/core.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/core.rs
@@ -461,6 +461,7 @@ impl<'a> CheckerState<'a> {
                         message_text: detail,
                         category: crate::diagnostics::DiagnosticCategory::Message,
                         code,
+                        depth: 0,
                     });
             }
             return;

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -560,6 +560,7 @@ impl<'a> CheckerState<'a> {
                 start: anchor.start,
                 length: anchor.length,
                 message_text: detail,
+                depth: 0,
             }];
 
             self.emit_render_request_at_anchor(

--- a/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
@@ -347,6 +347,7 @@ impl<'a> CheckerState<'a> {
             start: anchor.start,
             length: anchor.length,
             message_text: detail,
+            depth: 0,
         }];
 
         self.emit_render_request_at_anchor(

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -1002,6 +1002,7 @@ impl<'a> CheckerState<'a> {
                     message_text: diag.message.clone(),
                     category: DiagnosticCategory::Message,
                     code: diag.code,
+                    depth: 0,
                 });
             }
         }

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -402,6 +402,7 @@ impl<'a> CheckerState<'a> {
                         diagnostic_messages::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
                         &[&prop_name, &src_str, &tgt_str],
                     ),
+                    depth: 0,
                 }]
             }
             SubtypeFailureReason::MissingProperties {
@@ -462,6 +463,7 @@ impl<'a> CheckerState<'a> {
                             diagnostic_messages::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE,
                             &[&src_str, &tgt_str, &names.join(", ")],
                         ),
+                        depth: 0,
                     }]
                 } else {
                     let shown: Vec<&str> = names.iter().take(4).map(|s| s.as_str()).collect();
@@ -476,6 +478,7 @@ impl<'a> CheckerState<'a> {
                             diagnostic_messages::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE_AND_MORE,
                             &[&src_str, &tgt_str, &shown.join(", "), &more.to_string()],
                         ),
+                                            depth: 0,
                     }]
                 }
             }
@@ -521,6 +524,7 @@ impl<'a> CheckerState<'a> {
                             diagnostic_messages::TYPES_OF_PROPERTY_ARE_INCOMPATIBLE,
                             &[&self.ctx.types.resolve_atom_ref(*property_name)],
                         ),
+                        depth: 0,
                     },
                     DiagnosticRelatedInformation {
                         category: DiagnosticCategory::Message,
@@ -532,6 +536,7 @@ impl<'a> CheckerState<'a> {
                             diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                             &[&source_str, &target_str],
                         ),
+                        depth: 0,
                     },
                 ]
             }
@@ -563,6 +568,7 @@ impl<'a> CheckerState<'a> {
                             &tgt_str,
                         ],
                     ),
+                    depth: 0,
                 }]
             }
             SubtypeFailureReason::ReturnTypeMismatch {
@@ -608,6 +614,7 @@ impl<'a> CheckerState<'a> {
                         diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                         &[&source_str, &target_str],
                     ),
+                    depth: 0,
                 }];
                 // Drill into nested reason to produce elaboration diagnostics
                 // (e.g. TS2741 "Property 'x' is missing..." when the return type
@@ -653,6 +660,7 @@ impl<'a> CheckerState<'a> {
                         message_text: format!(
                             "{index_kind} index signature is incompatible: '{source_str}' is not assignable to '{target_str}'."
                         ),
+                        depth: 0,
                     },
                     DiagnosticRelatedInformation {
                         category: DiagnosticCategory::Message,
@@ -664,6 +672,7 @@ impl<'a> CheckerState<'a> {
                             diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                             &[&source_str, &target_str],
                         ),
+                        depth: 0,
                     },
                 ]
             }
@@ -695,6 +704,7 @@ impl<'a> CheckerState<'a> {
                         message_text: format!(
                             "Array element type '{source_str}' is not assignable to '{target_str}'."
                         ),
+                        depth: 0,
                     },
                     DiagnosticRelatedInformation {
                         category: DiagnosticCategory::Message,
@@ -706,6 +716,7 @@ impl<'a> CheckerState<'a> {
                             diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                             &[&source_str, &target_str],
                         ),
+                        depth: 0,
                     },
                 ]
             }
@@ -726,6 +737,7 @@ impl<'a> CheckerState<'a> {
                             ),
                         ],
                     ),
+                    depth: 0,
                 }]
             }
             SubtypeFailureReason::AbstractConstructorAssignment => {
@@ -737,6 +749,7 @@ impl<'a> CheckerState<'a> {
                     length,
                     message_text: diagnostic_messages::CANNOT_ASSIGN_AN_ABSTRACT_CONSTRUCTOR_TYPE_TO_A_NON_ABSTRACT_CONSTRUCTOR_TYPE
                         .to_string(),
+                                    depth: 0,
                 }]
             }
             _ => return None,
@@ -760,6 +773,7 @@ impl<'a> CheckerState<'a> {
                 start: diag.start,
                 length: diag.length,
                 message_text: diag.message_text.clone(),
+                depth: 0,
             });
         }
 

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -532,6 +532,7 @@ impl<'a> CheckerState<'a> {
                         message_text: elab_message,
                         category: DiagnosticCategory::Message,
                         code: elab_code,
+                        depth: 0,
                     });
                     return diag;
                 }
@@ -581,6 +582,7 @@ impl<'a> CheckerState<'a> {
                     message_text: elaboration,
                     category: DiagnosticCategory::Message,
                     code: diagnostic_codes::TARGET_SIGNATURE_PROVIDES_TOO_FEW_ARGUMENTS_EXPECTED_OR_MORE_BUT_GOT,
+                                    depth: 0,
                 });
                 diag
             }
@@ -1163,6 +1165,7 @@ impl<'a> CheckerState<'a> {
             message_text: inner,
             category: DiagnosticCategory::Message,
             code: inner_code,
+            depth: 0,
         });
         if let Some(constraint) = target_constraint {
             let constraint_str = self.format_type_diagnostic(constraint);
@@ -1177,6 +1180,7 @@ impl<'a> CheckerState<'a> {
                 message_text: elaboration,
                 category: DiagnosticCategory::Message,
                 code: diagnostic_codes::IS_ASSIGNABLE_TO_THE_CONSTRAINT_OF_TYPE_BUT_COULD_BE_INSTANTIATED_WITH_A_DIFFERE,
+                            depth: 0,
             });
         }
         diag
@@ -1218,6 +1222,7 @@ impl<'a> CheckerState<'a> {
                 .to_string(),
             category: DiagnosticCategory::Message,
             code: diagnostic_codes::CANNOT_ASSIGN_AN_ABSTRACT_CONSTRUCTOR_TYPE_TO_A_NON_ABSTRACT_CONSTRUCTOR_TYPE,
+                    depth: 0,
         });
         diag
     }

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -125,6 +125,103 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Fold a run of consecutive plain object-property mismatches into a single
+    /// dotted property path, mirroring `tsc`'s
+    /// `The types of 'a.b.c' are incompatible between these types.` collapse.
+    ///
+    /// Walking stops at the first link that is not a plain `PropertyTypeMismatch`
+    /// or that is a same-base generic application property mismatch (which has
+    /// its own dedicated elaboration), so only homogeneous object-property
+    /// chains are folded. Returns the accumulated property-name path, the leaf
+    /// reason that terminates the chain (if any), and the deepest property's
+    /// source/target display types.
+    fn peel_plain_property_chain<'r>(
+        &self,
+        first_name: tsz_common::interner::Atom,
+        first_src: TypeId,
+        first_tgt: TypeId,
+        first_nested: Option<&'r tsz_solver::SubtypeFailureReason>,
+    ) -> (
+        Vec<std::sync::Arc<str>>,
+        Option<&'r tsz_solver::SubtypeFailureReason>,
+        TypeId,
+        TypeId,
+    ) {
+        use tsz_solver::SubtypeFailureReason as R;
+        let mut names = vec![self.ctx.types.resolve_atom_ref(first_name)];
+        let mut cur_src = first_src;
+        let mut cur_tgt = first_tgt;
+        let mut nested = first_nested;
+        loop {
+            // Only fold a property whose value types are plain — i.e. neither
+            // side is a generic application. tsc keeps a `Box<string>` vs
+            // `Box<number>` boundary visible as its own relation line rather
+            // than folding the property into the dotted path, so the path must
+            // stop at (and not absorb) such a link.
+            if self
+                .application_base_for_property_mismatch_display(cur_src)
+                .is_some()
+                || self
+                    .application_base_for_property_mismatch_display(cur_tgt)
+                    .is_some()
+            {
+                break;
+            }
+            match nested {
+                Some(R::PropertyTypeMismatch {
+                    property_name,
+                    source_property_type,
+                    target_property_type,
+                    nested_reason,
+                }) => {
+                    names.push(self.ctx.types.resolve_atom_ref(*property_name));
+                    cur_src = *source_property_type;
+                    cur_tgt = *target_property_type;
+                    nested = nested_reason.as_deref();
+                }
+                _ => break,
+            }
+        }
+        (names, nested, cur_src, cur_tgt)
+    }
+
+    /// Append the leaf relation line beneath a collapsed property-path header at
+    /// the given elaboration `depth`. Uses the structured leaf reason when
+    /// present so intrinsic/literal display stays accurate; otherwise renders a
+    /// direct `Type 'S' is not assignable to type 'T'.` line for the deepest
+    /// property's types.
+    fn push_property_chain_leaf(
+        &mut self,
+        diag: &mut Diagnostic,
+        leaf: Option<&tsz_solver::SubtypeFailureReason>,
+        leaf_src: TypeId,
+        leaf_tgt: TypeId,
+        idx: tsz_parser::parser::NodeIndex,
+        depth: u32,
+    ) {
+        if let Some(leaf) = leaf {
+            let (s, t) = Self::nested_failure_display_types(leaf, leaf_src, leaf_tgt);
+            let leaf_diag = self.render_failure_reason(leaf, s, t, idx, depth);
+            Self::push_nested_chain(diag, leaf_diag, depth);
+        } else {
+            let s = self.format_type_diagnostic(leaf_src);
+            let t = self.format_type_diagnostic(leaf_tgt);
+            let message = format_message(
+                diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+                &[&s, &t],
+            );
+            diag.related_information.push(DiagnosticRelatedInformation {
+                file: diag.file.clone(),
+                start: diag.start,
+                length: diag.length,
+                message_text: message,
+                category: DiagnosticCategory::Message,
+                code: diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+                depth: depth.min(u8::MAX as u32) as u8,
+            });
+        }
+    }
+
     pub(super) fn render_property_type_mismatch(
         &mut self,
         reason: &tsz_solver::SubtypeFailureReason,
@@ -209,6 +306,7 @@ impl<'a> CheckerState<'a> {
                         message_text: detail,
                         category: DiagnosticCategory::Message,
                         code: reason.diagnostic_code(),
+                        depth: 0,
                     });
                     return diag;
                 }
@@ -226,9 +324,49 @@ impl<'a> CheckerState<'a> {
                     base,
                     diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                 );
-                Self::push_nested_chain(&mut diag, nested_diag);
+                Self::push_nested_chain(&mut diag, nested_diag, depth + 1);
                 return diag;
             }
+
+            // Plain object-property chain. tsc collapses a run of >= 2
+            // consecutive property links into a single
+            // `The types of 'a.b.c' are incompatible between these types.` line,
+            // then renders the leaf relation one level deeper. A single property
+            // link keeps the `Types of property 'X' are incompatible.` form
+            // handled below.
+            let (path, leaf, leaf_src, leaf_tgt) = self.peel_plain_property_chain(
+                property_name,
+                source_property_type,
+                target_property_type,
+                nested_reason,
+            );
+            let leaf_is_plain = leaf.is_none_or(Self::nested_reason_is_plain_type_mismatch);
+            if path.len() >= 2 && leaf_is_plain {
+                let dotted = path.join(".");
+                let detail = format_message(
+                    diagnostic_messages::THE_TYPES_OF_ARE_INCOMPATIBLE_BETWEEN_THESE_TYPES,
+                    &[&dotted],
+                );
+                let mut diag = Diagnostic::error(
+                    file_name,
+                    start,
+                    length,
+                    base,
+                    diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+                );
+                diag.related_information.push(DiagnosticRelatedInformation {
+                    file: diag.file.clone(),
+                    start,
+                    length,
+                    message_text: detail,
+                    category: DiagnosticCategory::Message,
+                    code: diagnostic_codes::THE_TYPES_OF_ARE_INCOMPATIBLE_BETWEEN_THESE_TYPES,
+                    depth: 0,
+                });
+                self.push_property_chain_leaf(&mut diag, leaf, leaf_src, leaf_tgt, idx, 1);
+                return diag;
+            }
+
             let prop_name = self.ctx.types.resolve_atom_ref(property_name);
             let detail = format_message(
                 diagnostic_messages::TYPES_OF_PROPERTY_ARE_INCOMPATIBLE,
@@ -248,6 +386,7 @@ impl<'a> CheckerState<'a> {
                 message_text: detail,
                 category: DiagnosticCategory::Message,
                 code: reason.diagnostic_code(),
+                depth: 0,
             });
             if let Some(nested) = nested_reason {
                 let (nested_source, nested_target) = Self::nested_failure_display_types(
@@ -270,7 +409,7 @@ impl<'a> CheckerState<'a> {
                         idx,
                         depth + 1,
                     );
-                    Self::push_nested_chain(&mut diag, nested_diag);
+                    Self::push_nested_chain(&mut diag, nested_diag, depth + 1);
                 }
             }
             return diag;
@@ -294,7 +433,7 @@ impl<'a> CheckerState<'a> {
             );
             let nested_diag =
                 self.render_failure_reason(nested, nested_source, nested_target, idx, depth + 1);
-            Self::push_nested_chain(&mut diag, nested_diag);
+            Self::push_nested_chain(&mut diag, nested_diag, depth + 1);
         }
         diag
     }
@@ -354,6 +493,7 @@ impl<'a> CheckerState<'a> {
                 message_text: detail,
                 category: DiagnosticCategory::Message,
                 code: diagnostic_codes::TYPE_AT_POSITION_IN_SOURCE_IS_NOT_COMPATIBLE_WITH_TYPE_AT_POSITION_IN_TARGET,
+                            depth: 0,
             });
             diag
         } else {
@@ -400,7 +540,7 @@ impl<'a> CheckerState<'a> {
                 Self::nested_failure_display_types(nested, source_element, target_element);
             let nested_diag =
                 self.render_failure_reason(nested, nested_source, nested_target, idx, depth + 1);
-            Self::push_nested_chain(diag, nested_diag);
+            Self::push_nested_chain(diag, nested_diag, depth + 1);
         } else {
             let source_str = self.format_type_diagnostic(source_element);
             let target_str = self.format_type_diagnostic(target_element);
@@ -415,6 +555,7 @@ impl<'a> CheckerState<'a> {
                 message_text: message,
                 category: DiagnosticCategory::Message,
                 code: diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+                depth: (depth + 1).min(u8::MAX as u32) as u8,
             });
         }
     }
@@ -423,7 +564,13 @@ impl<'a> CheckerState<'a> {
     /// information: the nested diagnostic's own message line followed by its
     /// related chain. This is the shared shape every elaboration step uses to
     /// append a child reason.
-    fn push_nested_chain(diag: &mut Diagnostic, nested_diag: Diagnostic) {
+    ///
+    /// `child_depth` is the render depth at which `nested_diag` was produced; it
+    /// becomes the nested message line's elaboration depth so the plain reporter
+    /// can indent each chain level by 2 more spaces than its parent, matching
+    /// `tsc`. The nested diagnostic's own related chain already carries absolute
+    /// depths from its render, so it is appended unchanged.
+    fn push_nested_chain(diag: &mut Diagnostic, nested_diag: Diagnostic, child_depth: u32) {
         diag.related_information.push(DiagnosticRelatedInformation {
             file: nested_diag.file,
             start: nested_diag.start,
@@ -431,6 +578,7 @@ impl<'a> CheckerState<'a> {
             message_text: nested_diag.message_text,
             category: DiagnosticCategory::Message,
             code: nested_diag.code,
+            depth: child_depth.min(u8::MAX as u32) as u8,
         });
         diag.related_information
             .extend(nested_diag.related_information);

--- a/crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs
@@ -267,6 +267,7 @@ impl<'a> CheckerState<'a> {
                     message_text: elaboration,
                     category: DiagnosticCategory::Message,
                     code: diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
+                    depth: 0,
                 });
             }
             return diag;

--- a/crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs
@@ -242,6 +242,7 @@ impl<'a> CheckerState<'a> {
                 message_text: detail,
                 category: DiagnosticCategory::Message,
                 code: diagnostic_codes::PROPERTY_IS_OPTIONAL_IN_TYPE_BUT_REQUIRED_IN_TYPE,
+                depth: 0,
             });
             diag
         } else {
@@ -409,6 +410,7 @@ impl<'a> CheckerState<'a> {
                 message_text: detail,
                 category: DiagnosticCategory::Message,
                 code: reason.diagnostic_code(),
+                depth: 0,
             });
         }
         diag
@@ -468,6 +470,7 @@ impl<'a> CheckerState<'a> {
                     message_text: nested_diag.message_text,
                     category: DiagnosticCategory::Message,
                     code: nested_diag.code,
+                    depth: 0,
                 });
             } else {
                 let ret_source_str = self.format_type_diagnostic(source_return);
@@ -482,6 +485,7 @@ impl<'a> CheckerState<'a> {
                     message_text: ret_msg,
                     category: DiagnosticCategory::Message,
                     code: reason.diagnostic_code(),
+                    depth: 0,
                 });
             }
 
@@ -511,6 +515,7 @@ impl<'a> CheckerState<'a> {
                     message_text: nested_diag.message_text,
                     category: DiagnosticCategory::Message,
                     code: nested_diag.code,
+                    depth: 0,
                 });
             }
             diag

--- a/crates/tsz-checker/src/state/state_checking/core.rs
+++ b/crates/tsz-checker/src/state/state_checking/core.rs
@@ -245,6 +245,7 @@ impl<'a> CheckerState<'a> {
                         diagnostic_messages::ADD_A_TYPE_ANNOTATION_TO_THE_VARIABLE,
                         &[&var_name],
                     ),
+                    depth: 0,
                 };
                 if let Some(last) = self.ctx.diagnostics.last_mut() {
                     last.related_information.push(related);

--- a/crates/tsz-checker/tests/property_chain_elaboration_collapse_tests.rs
+++ b/crates/tsz-checker/tests/property_chain_elaboration_collapse_tests.rs
@@ -1,0 +1,160 @@
+//! Regression tests for the assignability property-chain elaboration shape.
+//!
+//! Structural rule: when an object-to-object assignment fails through a chain
+//! of plain property mismatches, `tsc` renders the elaboration the same way
+//! `flattenDiagnosticMessageText` does — with progressive (2-space-per-level)
+//! indentation, and with a run of >= 2 consecutive property links collapsed
+//! into a single `The types of 'a.b.c' are incompatible between these types.`
+//! line. A single property link keeps the `Types of property 'X' are
+//! incompatible.` form. tsz previously rendered the chain flat (every entry at
+//! one indentation level) and never collapsed multi-level property paths, so
+//! the chain structure — and therefore the root relation — was obscured.
+//!
+//! The chain depth is carried on each `DiagnosticRelatedInformation` so the CLI
+//! reporter can indent each level; these tests assert the structural depths and
+//! collapsed messages directly, independent of the reporter, and vary property
+//! names so the collapse cannot be name-hardcoded.
+
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_source_strict;
+
+fn single_ts2322(source: &str) -> Diagnostic {
+    let mut diags: Vec<Diagnostic> = check_source_strict(source)
+        .into_iter()
+        .filter(|diag| diag.code == 2322)
+        .collect();
+    assert_eq!(
+        diags.len(),
+        1,
+        "expected exactly one TS2322 for `{source}`, got: {diags:?}"
+    );
+    diags.remove(0)
+}
+
+/// The leaf relation line of a chain must sit one elaboration level deeper than
+/// the property header above it. A single failing property keeps the
+/// `Types of property 'X' are incompatible.` header (no collapse) with the leaf
+/// indented beneath it.
+#[test]
+fn single_property_mismatch_indents_leaf_one_level_deeper() {
+    let diag = single_ts2322(
+        "declare const src: { a: number; b: string };\n\
+         const t: { a: number; b: number } = src;\n",
+    );
+    let related = &diag.related_information;
+    assert_eq!(related.len(), 2, "got: {related:?}");
+    assert!(
+        related[0].message_text.contains("Types of property 'b'"),
+        "header: {}",
+        related[0].message_text
+    );
+    assert_eq!(related[0].depth, 0, "header is the first elaboration level");
+    assert!(
+        related[1]
+            .message_text
+            .contains("Type 'string' is not assignable to type 'number'"),
+        "leaf: {}",
+        related[1].message_text
+    );
+    assert_eq!(
+        related[1].depth, 1,
+        "leaf must be one level deeper than its header"
+    );
+}
+
+/// A run of >= 2 plain property links collapses into a single dotted-path line,
+/// with the leaf relation one level deeper. Verified with two distinct name
+/// choices so the rule is structural, not a spelling match.
+#[test]
+fn nested_property_chain_collapses_to_dotted_path() {
+    for (source, dotted, leaf) in [
+        (
+            "declare const src: { a: { b: { c: string } } };\n\
+             const t: { a: { b: { c: number } } } = src;\n",
+            "'a.b.c'",
+            "Type 'string' is not assignable to type 'number'",
+        ),
+        (
+            "declare const src: { alpha: { beta: { gamma: boolean } } };\n\
+             const t: { alpha: { beta: { gamma: string } } } = src;\n",
+            "'alpha.beta.gamma'",
+            "Type 'boolean' is not assignable to type 'string'",
+        ),
+    ] {
+        let diag = single_ts2322(source);
+        let related = &diag.related_information;
+        assert_eq!(
+            related.len(),
+            2,
+            "collapsed chain for `{source}`: {related:?}"
+        );
+        assert!(
+            related[0].message_text.contains("The types of")
+                && related[0].message_text.contains(dotted)
+                && related[0]
+                    .message_text
+                    .contains("are incompatible between these types"),
+            "collapsed header: {}",
+            related[0].message_text
+        );
+        assert_eq!(related[0].depth, 0);
+        assert!(
+            related[1].message_text.contains(leaf),
+            "leaf: {}",
+            related[1].message_text
+        );
+        assert_eq!(related[1].depth, 1, "leaf one level under collapsed header");
+    }
+}
+
+/// A two-level chain collapses (the threshold is >= 2 links), independent of the
+/// chosen property names.
+#[test]
+fn two_level_property_chain_collapses() {
+    let diag = single_ts2322(
+        "declare const src: { outer: { inner: boolean } };\n\
+         const t: { outer: { inner: string } } = src;\n",
+    );
+    let related = &diag.related_information;
+    assert_eq!(related.len(), 2, "got: {related:?}");
+    assert!(
+        related[0].message_text.contains("'outer.inner'")
+            && related[0]
+                .message_text
+                .contains("are incompatible between these types"),
+        "collapsed header: {}",
+        related[0].message_text
+    );
+    assert_eq!(related[0].depth, 0);
+    assert_eq!(related[1].depth, 1);
+}
+
+/// Negative/fallback case: a property whose value types are a generic
+/// application (`Box<string>` vs `Box<number>`) keeps the application boundary
+/// visible rather than being folded into a dotted property path. The collapse
+/// must stop at — and not absorb — the application-typed property. Uses a
+/// user-defined generic so the test does not depend on lib types.
+#[test]
+fn generic_application_property_is_not_collapsed() {
+    let diag = single_ts2322(
+        "interface Box<T> { value: T; }\n\
+         declare const src: { m: Box<string> };\n\
+         const t: { m: Box<number> } = src;\n",
+    );
+    let related = &diag.related_information;
+    assert!(
+        !related.is_empty(),
+        "expected an elaboration chain, got none"
+    );
+    // The header is the single-property form for `m`, never a dotted
+    // `'m.value'` collapse across the `Box<_>` application boundary.
+    assert!(
+        related[0].message_text.contains("Types of property 'm'"),
+        "header must stay the single-property form: {}",
+        related[0].message_text
+    );
+    assert!(
+        !related[0].message_text.contains("'m.value'"),
+        "application-typed property must not be folded into a dotted path: {related:?}"
+    );
+}

--- a/crates/tsz-cli/src/bin/tsz.rs
+++ b/crates/tsz-cli/src/bin/tsz.rs
@@ -3239,9 +3239,7 @@ fn list_files_only_unsupported_js_root_diagnostics(
     files: &[std::path::PathBuf],
     files_from_config: bool,
 ) -> Vec<tsz::checker::diagnostics::Diagnostic> {
-    use tsz::checker::diagnostics::{
-        Diagnostic, DiagnosticCategory, DiagnosticRelatedInformation, diagnostic_codes,
-    };
+    use tsz::checker::diagnostics::{Diagnostic, diagnostic_codes};
     use tsz_common::file_extensions::is_js_file;
 
     if discovery.allow_js || !discovery.files_explicitly_set {
@@ -3262,32 +3260,27 @@ fn list_files_only_unsupported_js_root_diagnostics(
             );
             diagnostic
                 .related_information
-                .push(DiagnosticRelatedInformation {
-                    category: DiagnosticCategory::Message,
-                    code: diagnostic_codes::THE_FILE_IS_IN_THE_PROGRAM_BECAUSE,
-                    file: String::new(),
-                    start: 0,
-                    length: 0,
-                    message_text: "The file is in the program because:".to_string(),
-                });
+                .push(Diagnostic::related_message(
+                    diagnostic_codes::THE_FILE_IS_IN_THE_PROGRAM_BECAUSE,
+                    String::new(),
+                    0,
+                    0,
+                    "The file is in the program because:",
+                ));
+            let (code, message): (u32, &str) = if files_from_config {
+                (
+                    diagnostic_codes::PART_OF_FILES_LIST_IN_TSCONFIG_JSON,
+                    "Part of 'files' list in tsconfig.json",
+                )
+            } else {
+                (
+                    diagnostic_codes::ROOT_FILE_SPECIFIED_FOR_COMPILATION,
+                    "Root file specified for compilation",
+                )
+            };
             diagnostic
                 .related_information
-                .push(DiagnosticRelatedInformation {
-                    category: DiagnosticCategory::Message,
-                    code: if files_from_config {
-                        diagnostic_codes::PART_OF_FILES_LIST_IN_TSCONFIG_JSON
-                    } else {
-                        diagnostic_codes::ROOT_FILE_SPECIFIED_FOR_COMPILATION
-                    },
-                    file: String::new(),
-                    start: 0,
-                    length: 0,
-                    message_text: if files_from_config {
-                        "Part of 'files' list in tsconfig.json".to_string()
-                    } else {
-                        "Root file specified for compilation".to_string()
-                    },
-                });
+                .push(Diagnostic::related_message(code, String::new(), 0, 0, message));
             diagnostic
         })
         .collect()

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -379,6 +379,7 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
                         start: 0,
                         length: 0,
                         message_text: "The file is in the program because:".to_string(),
+                        depth: 0,
                     });
                 ts6504
                     .related_information
@@ -389,6 +390,7 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
                         start: 0,
                         length: 0,
                         message_text: "Root file specified for compilation".to_string(),
+                        depth: 0,
                     });
                 diagnostics.push(ts6504);
             }

--- a/crates/tsz-cli/src/driver/core.rs
+++ b/crates/tsz-cli/src/driver/core.rs
@@ -665,13 +665,9 @@ fn build_info_to_compilation_cache(build_info: &BuildInfo, base_dir: &Path) -> C
                         start: r.start,
                         length: r.length,
                         message_text: r.message_text.clone(),
-                        category: match r.category {
-                            0 => DiagnosticCategory::Warning,
-                            1 => DiagnosticCategory::Error,
-                            2 => DiagnosticCategory::Suggestion,
-                            _ => DiagnosticCategory::Message,
-                        },
+                        category: DiagnosticCategory::from_cache_index(r.category),
                         code: r.code,
+                        depth: 0,
                     })
                     .collect(),
             })

--- a/crates/tsz-cli/src/reporting/reporter.rs
+++ b/crates/tsz-cli/src/reporting/reporter.rs
@@ -312,7 +312,11 @@ impl Reporter {
     /// Format related information in non-pretty mode.
     /// tsc format: `  message` (no file/line/code prefix — just indented text).
     fn format_related_plain(&mut self, out: &mut String, related: &DiagnosticRelatedInformation) {
-        out.push_str("  ");
+        // tsc indents each nested elaboration level by 2 more spaces than its
+        // parent. `depth == 0` is the first level (2 spaces); deeper chain
+        // links carry their nesting depth so the chain structure is visible.
+        let indent = 2 * (related.depth as usize + 1);
+        out.push_str(&" ".repeat(indent));
         let message = self.translate_message(related.code, &related.message_text);
         out.push_str(&message);
     }

--- a/crates/tsz-common/src/diagnostics/mod.rs
+++ b/crates/tsz-common/src/diagnostics/mod.rs
@@ -20,6 +20,19 @@ pub enum DiagnosticCategory {
     Message,
 }
 
+impl DiagnosticCategory {
+    /// Map a cached numeric category (as serialized by the incremental cache)
+    /// back to a [`DiagnosticCategory`]; unknown values fall back to `Message`.
+    pub const fn from_cache_index(index: u8) -> Self {
+        match index {
+            0 => Self::Warning,
+            1 => Self::Error,
+            2 => Self::Suggestion,
+            _ => Self::Message,
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct DiagnosticMessage {
     pub code: u32,
@@ -43,6 +56,12 @@ pub struct DiagnosticRelatedInformation {
     pub start: u32,
     pub length: u32,
     pub message_text: String,
+    /// Nesting depth of this entry within a diagnostic's elaboration message
+    /// chain, used to render `tsc`-style progressive indentation in plain
+    /// output. `0` is the first elaboration level (rendered at 2 spaces); each
+    /// deeper level adds 2 more spaces. Genuine cross-location related
+    /// information (not part of an elaboration chain) stays at `0`.
+    pub depth: u8,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -107,6 +126,28 @@ impl Diagnostic {
         }
     }
 
+    /// Build a `Message`-category related entry at the first elaboration depth
+    /// (rendered at 2 spaces). Use this for elaboration/related lines that are
+    /// not part of a deeper chain so the `depth` field need not be spelled out
+    /// at every call site.
+    pub fn related_message(
+        code: u32,
+        file: impl Into<String>,
+        start: u32,
+        length: u32,
+        message_text: impl Into<String>,
+    ) -> DiagnosticRelatedInformation {
+        DiagnosticRelatedInformation {
+            category: DiagnosticCategory::Message,
+            code,
+            file: file.into(),
+            start,
+            length,
+            message_text: message_text.into(),
+            depth: 0,
+        }
+    }
+
     pub fn with_related(
         mut self,
         file: impl Into<String>,
@@ -121,6 +162,7 @@ impl Diagnostic {
             start,
             length,
             message_text: message.into(),
+            depth: 0,
         });
         self
     }

--- a/crates/tsz-lsp/tests/diagnostics_tests.rs
+++ b/crates/tsz-lsp/tests/diagnostics_tests.rs
@@ -34,6 +34,7 @@ fn test_convert_diagnostic_with_related_info() {
         message_text: "Related here".to_string(),
         category: DiagnosticCategory::Message,
         code: 0,
+        depth: 0,
     };
     let related_other = DiagnosticRelatedInformation {
         file: "other.ts".to_string(),
@@ -42,6 +43,7 @@ fn test_convert_diagnostic_with_related_info() {
         message_text: "Ignored".to_string(),
         category: DiagnosticCategory::Message,
         code: 0,
+        depth: 0,
     };
     let diag = Diagnostic {
         file: "test.ts".to_string(),
@@ -276,6 +278,7 @@ fn test_ts_diagnostic_with_related_information() {
         message_text: "The expected type comes from property 'x'.".to_string(),
         category: DiagnosticCategory::Message,
         code: 0,
+        depth: 0,
     });
     let ts_diag = convert_to_ts_diagnostic(&diag, &line_map, source);
     assert_eq!(ts_diag.code, 2322);
@@ -433,6 +436,7 @@ fn test_convert_diagnostic_all_related_info_from_other_files_filtered_out() {
         message_text: "From another file".to_string(),
         category: DiagnosticCategory::Message,
         code: 0,
+        depth: 0,
     });
     let lsp_diag = convert_diagnostic(&diag, &line_map, source);
     assert!(
@@ -698,6 +702,7 @@ fn test_convert_to_ts_diagnostic_related_info_filtered_by_file() {
         message_text: "from other file".to_string(),
         category: DiagnosticCategory::Message,
         code: 0,
+        depth: 0,
     });
     let ts_diag = convert_to_ts_diagnostic(&diag, &line_map, source);
     assert!(
@@ -1227,6 +1232,7 @@ fn test_diagnostic_with_related_info_same_file() {
         message_text: "Declared here".to_string(),
         category: DiagnosticCategory::Message,
         code: 0,
+        depth: 0,
     });
     let lsp_diag = convert_diagnostic(&diag, &line_map, source);
     let _ = lsp_diag;
@@ -1337,6 +1343,7 @@ fn test_diagnostic_multiple_related_info() {
             message_text: format!("Related {i}"),
             category: DiagnosticCategory::Message,
             code: 0,
+            depth: 0,
         });
     }
     let lsp_diag = convert_diagnostic(&diag, &line_map, source);

--- a/crates/tsz-solver/src/diagnostics/builders.rs
+++ b/crates/tsz-solver/src/diagnostics/builders.rs
@@ -697,6 +697,7 @@ impl TypeDiagnostic {
                 message_text: rel.message.clone(),
                 category: DiagnosticCategory::Message,
                 code: 0,
+                depth: 0,
             })
             .collect();
 


### PR DESCRIPTION
AgentName: claude-opus-eager-pascal

## Summary

**AgentName:** claude-opus-eager-pascal
**Track:** Conformance / diagnostics parity (TS2322 elaboration)
**Invariant:** When an object-to-object assignment fails through a chain of plain property mismatches, tsz renders the elaboration the way tsc's `flattenDiagnosticMessageText` does — depth-indented, with a run of ≥2 consecutive property links collapsed into the dotted `The types of 'a.b.c' are incompatible between these types.` form.

Closes #11610 ("diagnostic chain hides root relation mismatch for mapped property intersections").

### Problem (reduced, corpus-independent repro)

The bench "chain hides root relation" symptom is the assignability elaboration chain being rendered **flat and uncollapsed**, unlike tsc. Two structural divergences:

1. **No depth indentation** — every chain entry sat at a fixed 2-space indent; tsc indents each nested level by 2 more spaces.
2. **No property-path collapse** — tsc folds a run of ≥2 `Types of property 'X' are incompatible.` links into one `The types of 'a.b.c' are incompatible between these types.` line.

```ts
type Mapped<T> = { [K in keyof T]: T[K] };
declare const src: Mapped<{ a: { b: number } }> & { c: string };
const t: { a: { b: string }; c: string } = src;
```

`tsc 6.0.2 --strict`:
```
error TS2322: Type 'Mapped<...> & { c: string; }' is not assignable to type '{ a: { b: string; }; c: string; }'.
  The types of 'a.b' are incompatible between these types.
    Type 'number' is not assignable to type 'string'.
```
tsz before: three flat `Types of property 'a' / 'b' / Type number…` lines at one indent level.

### Structural rule

> When relating two object types and the failure is a chain of consecutive plain property-type mismatches, tsc (a) renders the elaboration with depth-proportional indentation and (b) collapses a run of ≥2 property links into `The types of '<dotted.path>' are incompatible between these types.`; this change makes tsz do the same. The fold stops at any property whose value types are generic applications (e.g. `Box<string>` vs `Box<number>`), preserving tsc's application-relation line.

### Fix (owner layer: checker diagnostic rendering)

- `DiagnosticRelatedInformation` gains a `depth` field; the plain CLI reporter indents `(depth+1)*2` spaces. `depth: 0` reproduces the prior 2-space output, so all non-chain related-info is unchanged.
- `render_property_type_mismatch` peels a maximal run of plain object-property links (`peel_plain_property_chain`), emits the collapsed dotted header for length ≥2, and renders the leaf one level deeper (`push_property_chain_leaf`). `push_nested_chain` now stamps each nested level's depth.
- A `DiagnosticRelatedInformation::related_message` constructor and a `DiagnosticCategory::from_cache_index` helper keep the touched CLI monoliths (`bin/tsz.rs`, `driver/core.rs`) **under** their arch-guard size ratchets.

## Scope

- `crates/tsz-common/src/diagnostics/mod.rs` — `depth` field + `related_message`/`from_cache_index` helpers.
- `crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs` — collapse + depth stamping (the substantive change).
- `crates/tsz-cli/src/reporting/reporter.rs` — progressive plain-mode indentation.
- Mechanical `depth` plumbing across checker/cli/solver related-info construction sites + `tsz-lsp` test literals.
- New regression suite `crates/tsz-checker/tests/property_chain_elaboration_collapse_tests.rs`.

## Project Corpus Impact

- Row: `type-challenges-solutions-project` (#11610 family `diagnostics-31-20`); the same flat/uncollapsed chain divergence appears in the `nextjs`, `vite-vanilla-ts-app`, and `nextjs-fresh-app` `diagnostic …` rows.
- Bug family: assignability property-mismatch elaboration chain structure (depth indentation + dotted-path collapse).
- Evidence: minimized repros checked against `tsc 6.0.2 --strict` (13 fixtures incl. renamed-property variants); see Verification.

## Verification

Local on the rebased head (cherry-picked onto current `main`):

```bash
cargo fmt --check                                   # clean
python3 scripts/arch/arch_guard.py                  # Architecture guardrails passed.
cargo clippy -p tsz-checker -p tsz-cli -p tsz-common -p tsz-solver  # clean
cargo test -p tsz-checker --test property_chain_elaboration_collapse_tests  # 4 passed
cargo test -p tsz-checker --test ts2322_tests       # 281 passed (see note)
# adjacent suites green: satisfies_elaboration_chain_tests, tuple_element_mismatch_tests,
# generic_property_mismatch_display_tests, optional_property_required_elaboration_tests,
# ts2430_tests, abstract_constructor_elaboration_tests
```

13/13 tsc-parity fixtures now match exactly (single-level, 2-/3-level collapse, mapped intersection, renamed properties `alpha.beta.gamma`).

**Pre-existing failures (not introduced here):** `ts2322_tests::{,renamed_}mapped_application_generic_indexed_call_preserves_key_correlation` fail on `main` *without* this change too — they assert a mapped-type key-correlation **relation** (a different bug family), which a diagnostic-rendering change cannot affect. Left untouched per scope rules.

**Conformance safety:** the conformance fingerprint parser keys only the primary `error TSxxxx:` line and skips whitespace-led continuation lines, so chain-structure changes cannot move the 100% baseline.

## Known unsupported shapes (follow-ups, documented not fixed here)

Out of scope for this PR (pre-existing divergences; only their *indentation* improved, not regressed): array-element chains (`Array element type …`), generic-application property boundaries (`Box<string>` vs `Box<number>` — correctly **not** collapsed), function-parameter sub-chains, and tuple-length `Source has N element(s)…` detail.

## Coordination Notes

- AgentName: claude-opus-eager-pascal
- Tracked issue #11610 (labeled it for ownership + signed comment); no existing PR referenced it and it had no `agent:*` lane.
- Branch was based on the pre-rewrite `main`; replanted as a single clean commit cherry-picked onto current `origin/main` (no conflicts).
- Implementation and verification are complete; this PR is ready. The earlier `project-corpus-pr-body` failure was a transient `gh api` blip in `check-pr-ready-state.mjs` (body + ready-state checks verified clean locally); re-triggering exact-head CI.

https://claude.ai/code/session_019X33jY9r5xDedBfyPo2EpT