### PR TITLE
fix(emit): advance comment cursor past ES5 class-expression interior to stop leaked trailing comment

### DIFF
--- a/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
@@ -1353,7 +1353,7 @@ impl<'a> Printer<'a> {
     }
 
     /// Emit an ES5-compatible class expression by wrapping the class IIFE in an expression.
-    pub(in crate::emitter) fn emit_class_expression_es5(&mut self, class_node: NodeIndex) {
+    pub(in crate::emitter) fn emit_class_expression_es5_inner(&mut self, class_node: NodeIndex) {
         let Some(node) = self.arena.get(class_node) else {
             return;
         };

--- a/crates/tsz-emitter/src/emitter/es5/helpers_class_expression_comments.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_class_expression_comments.rs
@@ -1,0 +1,53 @@
+//! Comment-cursor reconciliation for ES5 class-expression lowering.
+//!
+//! When an ES6 class expression is downleveled to the ES5 IIFE form, the
+//! interior emission is performed by a sub-emitter (`ClassES5Emitter`) that
+//! reads comments directly from the source text and prints member comments
+//! (e.g. a constructor's JSDoc) inside the generated IIFE. The main `Printer`
+//! maintains a separate global comment cursor (`comment_emit_idx`) over
+//! `all_comments`. Because the sub-emitter does not advance that cursor, any
+//! comment that lived *inside* the class body would otherwise remain pending
+//! and be re-emitted by the next leading/trailing comment scan after the
+//! statement — duplicating it (and dumping it after the IIFE).
+//!
+//! This mirrors the reconciliation the ES5 class *declaration* and namespace
+//! dispatch arms already perform: after the sub-emitter prints the lowered
+//! form, advance the cursor past every comment that falls inside the lowered
+//! node's source range.
+
+use super::super::*;
+
+impl<'a> Printer<'a> {
+    /// Emit an ES5-lowered class expression and reconcile the global comment
+    /// cursor so interior member comments handled by the sub-emitter are not
+    /// re-emitted after the statement.
+    pub(in crate::emitter) fn emit_class_expression_es5(&mut self, class_node: NodeIndex) {
+        self.emit_class_expression_es5_inner(class_node);
+        self.advance_comment_cursor_past_node_interior(class_node);
+    }
+
+    /// Advance `comment_emit_idx` past every pending comment that lies strictly
+    /// inside `node`'s source range (i.e. before its closing token). Used after
+    /// a sub-emitter has already emitted those interior comments itself.
+    ///
+    /// The end boundary is narrowed with `find_token_end_before_trivia` so
+    /// comments in the node's trailing trivia — which logically belong to the
+    /// following construct — are left for the normal trailing/leading scan.
+    pub(in crate::emitter) fn advance_comment_cursor_past_node_interior(
+        &mut self,
+        node_idx: NodeIndex,
+    ) {
+        if self.ctx.options.remove_comments {
+            return;
+        }
+        let Some(node) = self.arena.get(node_idx) else {
+            return;
+        };
+        let close_pos = self.find_token_end_before_trivia(node.pos, node.end);
+        while self.comment_emit_idx < self.all_comments.len()
+            && self.all_comments[self.comment_emit_idx].pos < close_pos
+        {
+            self.comment_emit_idx += 1;
+        }
+    }
+}

--- a/crates/tsz-emitter/src/emitter/es5/mod.rs
+++ b/crates/tsz-emitter/src/emitter/es5/mod.rs
@@ -15,6 +15,7 @@ mod helpers;
 mod helpers_async;
 mod helpers_async_generator;
 mod helpers_async_shadowing;
+mod helpers_class_expression_comments;
 mod helpers_class_expression_names;
 mod helpers_object_literal;
 #[allow(dead_code)]

--- a/crates/tsz-emitter/src/emitter/source_file/class_expr_es5_interior_comment_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/class_expr_es5_interior_comment_tests.rs
@@ -1,0 +1,124 @@
+//! Regression tests for interior-comment handling when an ES6 class
+//! expression is downleveled to the ES5 IIFE form.
+//!
+//! Structural rule: when an ES5 class expression is lowered to an IIFE by the
+//! sub-emitter (which prints interior member comments itself by reading the
+//! source text), the main emitter must advance its global comment cursor past
+//! every comment inside that class expression's source range. Otherwise those
+//! interior comments (e.g. a constructor's JSDoc) remain pending and are
+//! re-emitted as a leaked leading/trailing comment after the statement,
+//! duplicating them.
+//!
+//! These cases vary the class/base names, named vs anonymous, and with/without
+//! `extends` to prove the fix keys on the lowered node shape — not on any
+//! particular identifier spelling.
+
+use crate::context::emit::EmitContext;
+use crate::emitter::{ModuleKind, Printer as EmitterPrinter, PrinterOptions};
+use crate::lowering::LoweringPass;
+use tsz_common::ScriptTarget;
+use tsz_parser::ParserState;
+
+fn emit_es5_cjs(file: &str, source: &str) -> String {
+    let mut parser = ParserState::new(file.to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        target: ScriptTarget::ES5,
+        module: ModuleKind::CommonJS,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+/// The constructor JSDoc must appear exactly once (inside the IIFE), never as a
+/// trailing duplicate after `}())`.
+fn count_param_jsdoc(output: &str) -> usize {
+    output.matches("@param {number} p").count()
+}
+
+#[test]
+fn named_export_assigned_class_expression_does_not_duplicate_ctor_jsdoc() {
+    // `module.exports = class Thing { ... }` — named class expression.
+    let source = "module.exports = class Thing {\n    /**\n     * @param {number} p\n     */\n    constructor(p) {\n        this.t = 12 + p;\n    }\n}\n";
+    let output = emit_es5_cjs("index.js", source);
+
+    assert_eq!(
+        count_param_jsdoc(&output),
+        1,
+        "constructor JSDoc must be emitted exactly once (inside the IIFE).\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("function Thing(p)"),
+        "class expression must lower to an ES5 constructor function.\nOutput:\n{output}"
+    );
+    // The IIFE close must not be immediately followed by a leaked JSDoc block.
+    assert!(
+        !output.contains("}());\n/**"),
+        "no JSDoc should leak after the IIFE close.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn anonymous_export_assigned_class_expression_does_not_duplicate_ctor_jsdoc() {
+    // `module.exports = class { ... }` — anonymous class expression. The
+    // synthesized constructor name differs from the named case, proving the fix
+    // is not keyed to a specific identifier.
+    let source = "module.exports = class {\n    /**\n     * @param {number} p\n     */\n    constructor(p) {\n        this.t = 12 + p;\n    }\n}\n";
+    let output = emit_es5_cjs("index.js", source);
+
+    assert_eq!(
+        count_param_jsdoc(&output),
+        1,
+        "constructor JSDoc must be emitted exactly once for anonymous class.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("}());\n/**"),
+        "no JSDoc should leak after the anonymous IIFE close.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn extending_export_assigned_class_expression_does_not_duplicate_ctor_jsdoc() {
+    // Class expression with `extends` — exercises the derived-constructor IIFE
+    // path (different base name `Base`/`Widget` to vary spelling).
+    let source = "module.exports = class Widget extends Base {\n    /**\n     * @param {number} p\n     */\n    constructor(p) {\n        super();\n        this.t = 12 + p;\n    }\n}\n";
+    let output = emit_es5_cjs("index.js", source);
+
+    assert_eq!(
+        count_param_jsdoc(&output),
+        1,
+        "constructor JSDoc must be emitted exactly once for a derived class expression.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("__extends"),
+        "derived class expression must use the __extends helper at ES5.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("}\n/**"),
+        "no JSDoc should leak after the derived IIFE.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn class_expression_without_interior_comment_is_unaffected() {
+    // Negative/fallback case: a class expression with no interior comments must
+    // emit no stray comments and still lower correctly.
+    let source = "module.exports = class Plain {\n    constructor(p) {\n        this.t = 12 + p;\n    }\n}\n";
+    let output = emit_es5_cjs("index.js", source);
+
+    assert_eq!(
+        count_param_jsdoc(&output),
+        0,
+        "no JSDoc exists in source, so none should be emitted.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("function Plain(p)"),
+        "class expression must still lower to an ES5 constructor function.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/source_file/mod.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/mod.rs
@@ -11,6 +11,8 @@ mod class_es5_field_initializer_tests;
 #[cfg(test)]
 mod class_expr_computed_static_method_naming_tests;
 #[cfg(test)]
+mod class_expr_es5_interior_comment_tests;
+#[cfg(test)]
 mod class_expression_decorator_tests;
 #[cfg(test)]
 mod class_static_alias_tests;


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — ES5 class-expression interior-comment cursor reconciliation (emit→100% campaign, wave 3)

## Invariant
When an ES6 class EXPRESSION is downleveled to the ES5 IIFE form, the sub-emitter (`ClassES5Emitter`) prints interior member comments by reading source text directly but does not advance the main `Printer`'s global `comment_emit_idx` cursor. The main emitter must advance that cursor past every comment inside the class expression's source range so interior comments (e.g. a constructor's JSDoc) are not re-emitted as a leaked trailing comment after `}())`. This mirrors the reconciliation the ES5 class-DECLARATION and namespace dispatch arms already perform. Keyed purely on the lowered node's source range — no identifier/file-name matching, no printer-output `.contains()`.

## Scope
- NEW `crates/tsz-emitter/src/emitter/es5/helpers_class_expression_comments.rs` (53 lines) — `emit_class_expression_es5` wrapper + `advance_comment_cursor_past_node_interior`.
- NEW `crates/tsz-emitter/src/emitter/source_file/class_expr_es5_interior_comment_tests.rs` (124 lines, 4 tests).
- `es5/helpers_async.rs` (net 0: renamed body fn to `_inner`), `es5/mod.rs` (+1 mod), `source_file/mod.rs` (+2 mod).

## Project Corpus Impact
- Row: n/a (ES5 class-expression emit fix)
- Bug family: leaked interior comment after ES5 class-expression IIFE (`}())`) due to un-advanced global comment cursor
- Evidence: jsDeclarationsExportAssignedClassExpression / ...Anonymous / ...AnonymousWithSub (target=es5) FAIL→PASS; full --js-only 93→90.

## Verification
- 3 witnesses FAIL→PASS. **Full --js-only: 93→90 fail, net +3, ZERO new regressions** (after-fails ⊆ before-fails; diff = exactly the 3). DTS unaffected (family DTS 8/8 pass; JS-emit-only). 4 new structural unit tests (named/anonymous/extends/negative, varied class+base names); 523 related emitter unit tests pass. Clippy clean; arch guard passes (new code in fresh files, no monolith growth).
- §25/§26 compliant. No output surgery — cursor reconciliation only.

## Coordination Notes
Rebased onto current main. Scoped out (multi-bug, NOT contained): jsDeclarationsClasses(es5) (dropped inline `@type {*}` cast + exports.J/JJ CJS ordering + `_this.prop` derived-ctor super lowering); isDeclarationVisibleNodeKinds(es5) (namespace IIFE param name-uniquing `schema_1`). — opus48-emit100
