### PR TITLE
fix(emit): synthesized derived-class decorator constructor forwards super(...arguments)

### DIFF
--- a/crates/tsz-emitter/src/emitter/source_file/tc39_decorator_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/tc39_decorator_tests.rs
@@ -1537,3 +1537,80 @@ class D {
         "ES5 TC39 public accessors should sink decorator/proKey assignments into computed Object.defineProperty keys and use bracket access for computed names.\nOutput:\n{output}"
     );
 }
+
+/// Structural rule: when the ES-decorators transform synthesizes a constructor
+/// for a *derived* class (one with an `extends` heritage clause) that has no
+/// explicit constructor but needs to run member initializers, tsc emits a
+/// zero-parameter constructor whose `super` call forwards the implicit
+/// `arguments` object (`constructor() { super(...arguments); }`), not an
+/// explicit rest parameter (`constructor(...args) { super(...args); }`).
+///
+/// This test varies the base/derived class, decorator, and member names to
+/// prove the behavior is keyed on the structural shape (derived + decorated
+/// member + synthesized ctor), not on a particular spelling.
+#[test]
+fn tc39_synthesized_ctor_for_derived_decorated_class_forwards_arguments_es2022() {
+    let source = "\
+declare var trace: any;
+class Base {}
+class Derived extends Base {
+    @trace
+    run() {}
+}
+";
+
+    let output = emit_with_options(
+        source,
+        PrinterOptions {
+            module: ModuleKind::ESNext,
+            target: ScriptTarget::ES2022,
+            import_helpers: false,
+            use_define_for_class_fields: true,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        output.contains("constructor() {") && output.contains("super(...arguments);"),
+        "Synthesized ctor for a derived decorated class must be zero-parameter and forward `...arguments`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("constructor(...args)") && !output.contains("super(...args)"),
+        "Synthesized ctor must not introduce an explicit rest parameter.\nOutput:\n{output}"
+    );
+}
+
+/// Same structural rule under a different target (es2015) and a fresh set of
+/// names (different base/derived/decorator/member identifiers) so a fix that
+/// matched a particular spelling would not satisfy both tests.
+#[test]
+fn tc39_synthesized_ctor_for_derived_decorated_class_forwards_arguments_es2015() {
+    let source = "\
+declare var log: any;
+class Animal {}
+class Dog extends Animal {
+    @log
+    bark() {}
+}
+";
+
+    let output = emit_with_options(
+        source,
+        PrinterOptions {
+            module: ModuleKind::ESNext,
+            target: ScriptTarget::ES2015,
+            import_helpers: false,
+            use_define_for_class_fields: true,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        output.contains("super(...arguments);"),
+        "Synthesized ctor for a derived decorated class (es2015) must forward `...arguments`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("constructor(...args)") && !output.contains("super(...args)"),
+        "Synthesized ctor (es2015) must not introduce an explicit rest parameter.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/transforms/es_decorators.rs
+++ b/crates/tsz-emitter/src/transforms/es_decorators.rs
@@ -2777,11 +2777,11 @@ impl<'a> TC39DecoratorEmitter<'a> {
             }
             output.push_str(&format!("{indent}}}\n"));
         } else {
-            // Synthetic constructor: derived decorated classes forward the caller's
-            // arguments via an explicit rest parameter, matching tsc's output shape.
+            // Synthetic ctor for a derived decorated class: tsc emits a
+            // zero-parameter `constructor() { super(...arguments); }`, not a rest param.
             if has_extends {
-                output.push_str("...args) {\n");
-                output.push_str(&format!("{inner_indent}super(...args);\n"));
+                output.push_str(") {\n");
+                output.push_str(&format!("{inner_indent}super(...arguments);\n"));
             } else {
                 output.push_str(") {\n");
             }

--- a/crates/tsz-emitter/tests/es_decorators.rs
+++ b/crates/tsz-emitter/tests/es_decorators.rs
@@ -899,7 +899,12 @@ fn test_iife_closes_properly() {
 }
 
 // =============================================================================
-// Derived class synthetic constructor: super(...args) and ordering
+// Derived class synthetic constructor: zero-param ctor forwarding ...arguments
+//
+// tsc synthesizes `constructor() { super(...arguments); ... }` (zero-parameter,
+// implicit `arguments` forwarding) for a derived decorated class that needs to
+// run member initializers — NOT an explicit rest parameter. See conformance
+// witnesses esDecoratorsMetadata2(target=es2015|es2022).
 // =============================================================================
 
 #[test]
@@ -907,12 +912,16 @@ fn derived_class_with_instance_member_decorator_synthesizes_super_call() {
     let source = "@dec class Child extends Base { @dec method() {} }";
     let output = emit_decorator_with(source, true, true);
     assert!(
-        output.contains("constructor(...args)"),
-        "Expected synthetic constructor with rest parameter.\nOutput:\n{output}"
+        output.contains("constructor() {"),
+        "Expected zero-parameter synthetic constructor.\nOutput:\n{output}"
     );
     assert!(
-        output.contains("super(...args)"),
-        "Expected super(...args) forwarding call in synthetic constructor.\nOutput:\n{output}"
+        output.contains("super(...arguments)"),
+        "Expected super(...arguments) forwarding call in synthetic constructor.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("constructor(...args)") && !output.contains("super(...args)"),
+        "Synthetic constructor must not introduce an explicit rest parameter.\nOutput:\n{output}"
     );
     assert!(
         output.contains("__runInitializers"),
@@ -925,28 +934,36 @@ fn derived_class_renamed_params_still_synthesizes_super_call() {
     let source = "@myDec class Beta extends Alpha { @myDec go() {} }";
     let output = emit_decorator_with(source, true, true);
     assert!(
-        output.contains("constructor(...args)"),
-        "Expected synthetic constructor regardless of class/method name.\nOutput:\n{output}"
+        output.contains("constructor() {"),
+        "Expected zero-parameter synthetic constructor regardless of class/method name.\nOutput:\n{output}"
     );
     assert!(
-        output.contains("super(...args)"),
-        "Expected super(...args) in synthetic constructor regardless of class name.\nOutput:\n{output}"
+        output.contains("super(...arguments)"),
+        "Expected super(...arguments) in synthetic constructor regardless of class name.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("constructor(...args)") && !output.contains("super(...args)"),
+        "Synthetic constructor must not introduce an explicit rest parameter.\nOutput:\n{output}"
     );
 }
 
 #[test]
 fn derived_class_member_only_decorator_synthesizes_super_call() {
     // Member-only decorators (no class decorator) on a derived class also need
-    // a synthetic constructor with super(...args).
+    // a synthetic constructor that forwards `...arguments`.
     let source = "class Leaf extends Root { @dec handle() {} }";
     let output = emit_decorator_with(source, true, true);
     assert!(
-        output.contains("constructor(...args)"),
-        "Expected synthetic constructor for member-decorated derived class.\nOutput:\n{output}"
+        output.contains("constructor() {"),
+        "Expected zero-parameter synthetic constructor for member-decorated derived class.\nOutput:\n{output}"
     );
     assert!(
-        output.contains("super(...args)"),
-        "Expected super call in synthetic constructor for member-only decorated derived class.\nOutput:\n{output}"
+        output.contains("super(...arguments)"),
+        "Expected super(...arguments) call in synthetic constructor for member-only decorated derived class.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("constructor(...args)") && !output.contains("super(...args)"),
+        "Synthetic constructor must not introduce an explicit rest parameter.\nOutput:\n{output}"
     );
 }
 


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — ES-decorators synthesized derived-constructor (emit→100% campaign, wave 3)

## Invariant
When the ES-decorators transform synthesizes a constructor for a DERIVED class (heritage `extends` clause) that has no explicit constructor but must run member initializers, tsc emits a zero-parameter `constructor() { super(...arguments); }` forwarding the implicit `arguments` object — NOT an explicit rest parameter `constructor(...args) { super(...args); }`. Gated solely on the existing `has_extends` flag — no identifier/file-name string matches, no printer-output `.contains()`, no output surgery.

## Scope
- `crates/tsz-emitter/src/transforms/es_decorators.rs` — 2-line emit fix in `render_decorated_constructor`'s `has_extends` synthesized-ctor branch (file kept net-zero at its 5755-line ratchet by trimming a comment).
- `crates/tsz-emitter/tests/es_decorators.rs` — corrected 3 pre-existing unit tests that asserted the divergent `...args` shape to the tsc-correct `super(...arguments)` form (+ negative-assert no rest param).
- `crates/tsz-emitter/src/emitter/source_file/tc39_decorator_tests.rs` — +2 structural tests (es2022 + es2015; varied base/derived/decorator/member names).

## Project Corpus Impact
- Row: n/a (ES-decorators emit fix)
- Bug family: synthesized derived-class constructor uses explicit `...args` rest instead of `super(...arguments)` forwarding
- Evidence: esDecoratorsMetadata2(target=es2015) + esDecoratorsMetadata2(target=es2022) FAIL→PASS; full --js-only 92→90.

## Verification
- 2 witnesses FAIL→PASS. **Full --js-only: 92→90 fail, net +2, ZERO new failures** (diff = exactly the 2 witnesses; no regressions across the decorator family or elsewhere). --dts-only unaffected (1645/1669; zero decorator/metadata DTS fails; change is JS constructor-body path only). Decorator unit suite 189/190. Clippy clean; arch guard passes.
- §25/§26 compliant (gated on `has_extends` structural flag).

## Coordination Notes
Rebased onto current main. Scoped out (broad, NOT this root cause): staticInitializersAndLegacyClassDecorators (class self-reference temp aliasing `C1_1 = class` + static-block emission + decorator class-alias `__decorate` shape — needs broad legacy-decorator + self-reference rework). NOTE pre-existing unrelated unit failure on clean main HEAD: `tc39_es2015_nonstatic_private_members_use_storage_and_descriptor_temps` (non-derived class, private-member storage — cannot be affected by this `has_extends`-gated change; flagged for separate fix). — opus48-emit100
