### PR TITLE
fix(emit): ES5 arrow captures this only for super-calls, not super-access; correct super-call receiver

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -31,6 +31,10 @@ name = "es5_super_object_literal_accessor_tests"
 path = "tests/es5_super_object_literal_accessor_tests.rs"
 
 [[test]]
+name = "es5_super_arrow_this_capture_tests"
+path = "tests/es5_super_arrow_this_capture_tests.rs"
+
+[[test]]
 name = "super_missing_member_recovery_tests"
 path = "tests/super_missing_member_recovery_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/expressions/call.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/call.rs
@@ -288,11 +288,7 @@ impl<'a> Printer<'a> {
                 self.write(".");
                 self.emit(access.name_or_argument);
                 self.write(".call(");
-                if self.ctx.arrow_state.this_capture_depth > 0 {
-                    self.write("_this");
-                } else {
-                    self.write("this");
-                }
+                self.emit_es5_super_call_receiver(access.expression);
                 if let Some(ref args) = call.arguments {
                     for &arg_idx in &args.nodes {
                         self.write(", ");
@@ -311,11 +307,7 @@ impl<'a> Printer<'a> {
                 self.write("[");
                 self.emit(access.name_or_argument);
                 self.write("].call(");
-                if self.ctx.arrow_state.this_capture_depth > 0 {
-                    self.write("_this");
-                } else {
-                    self.write("this");
-                }
+                self.emit_es5_super_call_receiver(access.expression);
                 if let Some(ref args) = call.arguments {
                     for &arg_idx in &args.nodes {
                         self.write(", ");
@@ -1193,11 +1185,7 @@ impl<'a> Printer<'a> {
             self.write(" === void 0 ? void 0 : ");
             self.write(&func_temp);
             self.write(".call(");
-            if self.ctx.arrow_state.this_capture_depth > 0 {
-                self.write("_this");
-            } else {
-                self.write("this");
-            }
+            self.emit_es5_super_call_receiver(access.expression);
             self.emit_optional_call_tail_arguments(args.as_ref());
             if needs_parens {
                 self.write(")");

--- a/crates/tsz-emitter/src/emitter/expressions/es5_super_receiver.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/es5_super_receiver.rs
@@ -1,0 +1,34 @@
+//! ES5 `super` member-call receiver selection.
+//!
+//! `super.m(...)` / `super[e](...)` lower to `_super.prototype.m.call(R, ...)`.
+//! The receiver `R` is the lowered function's own `this`, except when the call
+//! sits inside a `this`-capturing arrow: there it must be the captured lexical
+//! `this` (`_this`). The lowering pass marks the callee's `super` keyword with a
+//! [`TransformDirective::SubstituteThis`] carrying the active capture name; this
+//! helper reads that mark so the decision is planned, not reconstructed at emit.
+
+use super::super::Printer;
+use crate::context::transform::TransformDirective;
+use tsz_parser::parser::NodeIndex;
+
+impl<'a> Printer<'a> {
+    /// Emit the receiver argument for a lowered ES5 `super` member call.
+    ///
+    /// `super_keyword_idx` is the callee's underlying `super` keyword node. If
+    /// the lowering pass marked it for lexical-`this` substitution (the call is
+    /// inside a `this`-capturing arrow), emit the capture name (`_this`);
+    /// otherwise emit `this`.
+    pub(in crate::emitter) fn emit_es5_super_call_receiver(
+        &mut self,
+        super_keyword_idx: NodeIndex,
+    ) {
+        if let Some(TransformDirective::SubstituteThis { capture_name }) =
+            self.transforms.get(super_keyword_idx)
+        {
+            let name = std::sync::Arc::clone(capture_name);
+            self.write(&name);
+        } else {
+            self.write("this");
+        }
+    }
+}

--- a/crates/tsz-emitter/src/emitter/expressions/mod.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/mod.rs
@@ -3,5 +3,6 @@ mod access_comment_helpers;
 mod binary_downlevel;
 mod call;
 mod core;
+mod es5_super_receiver;
 mod literals;
 mod static_super;

--- a/crates/tsz-emitter/src/lowering/core.rs
+++ b/crates/tsz-emitter/src/lowering/core.rs
@@ -7,7 +7,9 @@ use tsz_common::ScriptTarget;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::{Node, NodeArena};
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_parser::syntax::transform_utils::{contains_arguments_reference, contains_this_reference};
+use tsz_parser::syntax::transform_utils::{
+    arrow_captures_lexical_this, contains_arguments_reference,
+};
 use tsz_scanner::SyntaxKind;
 
 use crate::transforms::emit_utils;
@@ -1303,7 +1305,7 @@ impl<'a> LoweringPass<'a> {
                 return;
             }
 
-            let contains_this = contains_this_reference(self.arena, idx);
+            let contains_this = arrow_captures_lexical_this(self.arena, idx);
             let async_arrow_needs_awaiter_this =
                 arrow.is_async && self.enclosing_function_bodies.len() > 1;
             let captures_this = contains_this || async_arrow_needs_awaiter_this;
@@ -1485,6 +1487,27 @@ impl<'a> LoweringPass<'a> {
         {
             self.transforms
                 .insert(idx, TransformDirective::ES5SuperCall);
+        }
+
+        // ES5 `super.m(...)` / `super[e](...)` lowers to
+        // `_super.prototype.m.call(R, ...)`. When the call sits inside a
+        // `this`-capturing arrow, `R` must be the captured lexical receiver
+        // (`_this`), not the lowered function's own `this`. Mark the callee's
+        // `super` keyword with the active capture name so the printer threads
+        // `_this` into the synthesized `.call(...)` receiver.
+        if self.ctx.target_es5
+            && self.this_capture_level > 0
+            && let Some(super_keyword_idx) = self.super_member_call_super_keyword(call.expression)
+        {
+            let capture_name = self
+                .enclosing_capture_names
+                .last()
+                .cloned()
+                .unwrap_or_else(|| Arc::from("_this"));
+            self.transforms.insert(
+                super_keyword_idx,
+                TransformDirective::SubstituteThis { capture_name },
+            );
         }
 
         // CJS-like dynamic import: import("mod") needs __importStar helper.

--- a/crates/tsz-emitter/src/lowering/mod.rs
+++ b/crates/tsz-emitter/src/lowering/mod.rs
@@ -45,6 +45,7 @@ mod helpers_private_fields;
 mod import_usage;
 mod name_helpers;
 mod parameter_prologue;
+mod super_capture;
 mod visit_children;
 
 pub use self::core::LoweringPass;

--- a/crates/tsz-emitter/src/lowering/super_capture.rs
+++ b/crates/tsz-emitter/src/lowering/super_capture.rs
@@ -1,0 +1,50 @@
+//! ES5 `super` member-call receiver capture analysis for the lowering pass.
+//!
+//! At ES5, a `super.m(...)` / `super[e](...)` call lowers to
+//! `_super.prototype.m.call(R, ...)`. When the call appears inside a
+//! `this`-capturing arrow, the `.call(...)` receiver `R` must be the captured
+//! lexical `this` (`_this`). These helpers locate the callee's `super`
+//! keyword so the lowering pass can mark it with the active capture name.
+
+use super::*;
+
+impl<'a> LoweringPass<'a> {
+    /// If `callee_idx` is a direct `super` member-access call target
+    /// (`super.m` or `super[e]`, allowing for parentheses), return the
+    /// `NodeIndex` of the underlying `super` keyword. Chained accesses such as
+    /// `super.a.b` are normal calls on `super.a` and return `None`.
+    pub(super) fn super_member_call_super_keyword(
+        &self,
+        callee_idx: NodeIndex,
+    ) -> Option<NodeIndex> {
+        let callee_idx = self.lowering_unwrap_parentheses(callee_idx);
+        let node = self.arena.get(callee_idx)?;
+        if node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            && node.kind != syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+        {
+            return None;
+        }
+        let access = self.arena.get_access_expr(node)?;
+        let base_idx = self.lowering_unwrap_parentheses(access.expression);
+        let base = self.arena.get(base_idx)?;
+        if base.kind == SyntaxKind::SuperKeyword as u16 {
+            Some(base_idx)
+        } else {
+            None
+        }
+    }
+
+    /// Unwrap nested parenthesized expressions to the inner expression index.
+    fn lowering_unwrap_parentheses(&self, mut idx: NodeIndex) -> NodeIndex {
+        while let Some(node) = self.arena.get(idx) {
+            if node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION
+                && let Some(paren) = self.arena.get_parenthesized(node)
+            {
+                idx = paren.expression;
+                continue;
+            }
+            break;
+        }
+        idx
+    }
+}

--- a/crates/tsz-emitter/tests/es5_super_arrow_this_capture_tests.rs
+++ b/crates/tsz-emitter/tests/es5_super_arrow_this_capture_tests.rs
@@ -1,0 +1,161 @@
+//! ES5 lexical-`this` capture for `super` inside arrow functions.
+//!
+//! Structural rules under test:
+//!
+//! 1. A `super.m(...)` / `super[e](...)` **call** inside an arrow lowers to
+//!    `_super.prototype.m.call(_this, ...)`: the arrow captures lexical `this`,
+//!    so the enclosing scope emits `var _this = this;` and the synthesized
+//!    `.call(...)` receiver is the captured `_this`.
+//! 2. A bare `super.x` property **access** inside an arrow lowers to
+//!    `_super.prototype.x` and references no `this`, so it does NOT by itself
+//!    force a `var _this = this;` capture.
+//! 3. In a top-level object literal, an arrow method's `super.m(...)` call uses
+//!    the captured top-level `_this` receiver, while non-arrow methods use
+//!    their own `this`.
+//!
+//! Tests vary class/method/property names and the super shape so the behaviour
+//! is keyed on the structural arrow-vs-method and call-vs-access distinctions,
+//! not on any spelling.
+
+use tsz_common::common::ScriptTarget;
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_lower_print;
+
+fn emit_es5(source: &str) -> String {
+    let opts = PrintOptions {
+        target: ScriptTarget::ES5,
+        ..Default::default()
+    };
+    parse_and_lower_print(source, opts)
+}
+
+/// A `super.m()` call inside an arrow in a class method captures `_this`:
+/// the receiver of the lowered `.call(...)` must be `_this`, and the method
+/// body must declare `var _this = this;`.
+#[test]
+fn super_call_in_arrow_captures_this_receiver() {
+    let source = r#"class Base { greet() {} }
+class Derived extends Base {
+    greet() {
+        var run = () => super.greet();
+    }
+}"#;
+    let output = emit_es5(source);
+    assert!(
+        output.contains("_super.prototype.greet.call(_this)"),
+        "super call inside an arrow must thread the captured receiver `_this`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("var _this = this;"),
+        "method with a super-calling arrow must capture lexical `this`.\nOutput:\n{output}"
+    );
+}
+
+/// Same structural rule with different class/method names and an element-access
+/// super call (`super["..."]()`): the fix must not depend on any spelling.
+#[test]
+fn super_element_call_in_arrow_captures_this_receiver_renamed() {
+    let source = r#"class Animal { speak() {} }
+class Dog extends Animal {
+    bark() {
+        var go = () => super["speak"]();
+    }
+}"#;
+    let output = emit_es5(source);
+    assert!(
+        output.contains(r#"_super.prototype["speak"].call(_this)"#),
+        "super element-access call inside an arrow must thread `_this`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("var _this = this;"),
+        "method with a super-calling arrow must capture lexical `this`.\nOutput:\n{output}"
+    );
+}
+
+/// A bare `super.x` property access inside an arrow does NOT need a `_this`
+/// capture: the lowered form is `_super.prototype.x`, which references no
+/// `this`. The enclosing method must not emit a spurious `var _this = this;`.
+#[test]
+fn super_property_access_in_arrow_does_not_capture_this() {
+    let source = r#"class Base { value = 1; }
+class Derived extends Base {
+    read() {
+        var pick = () => super.value;
+    }
+}"#;
+    let output = emit_es5(source);
+    assert!(
+        output.contains("_super.prototype.value"),
+        "super property access must remain prototype-qualified.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("var _this = this;"),
+        "a super property-access-only arrow must not force a `_this` capture.\nOutput:\n{output}"
+    );
+}
+
+/// Renamed variant of the property-access rule (different class/property names)
+/// proving the no-capture behaviour is structural, not name-based.
+#[test]
+fn super_property_access_in_arrow_does_not_capture_this_renamed() {
+    let source = r#"class Shape { area = 0; }
+class Circle extends Shape {
+    measure() {
+        var grab = () => super.area;
+    }
+}"#;
+    let output = emit_es5(source);
+    assert!(
+        output.contains("_super.prototype.area"),
+        "super property access must remain prototype-qualified.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("var _this = this;"),
+        "a super property-access-only arrow must not force a `_this` capture.\nOutput:\n{output}"
+    );
+}
+
+/// In a top-level object literal, an arrow method's `super.m()` call uses the
+/// captured top-level `_this`, while a non-arrow method uses its own `this`.
+#[test]
+fn object_literal_arrow_super_call_uses_captured_receiver() {
+    let source = r#"var obj = {
+    __proto__: { method() {} },
+    direct: function () { super.method(); },
+    lambda: () => { super.method(); }
+};"#;
+    let output = emit_es5(source);
+    assert!(
+        output.contains("var _this = this;"),
+        "top-level object literal with a super-calling arrow must capture `_this`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_super.method.call(_this)"),
+        "arrow object-literal method super call must use the captured `_this`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_super.method.call(this)"),
+        "non-arrow object-literal method super call must use its own `this`.\nOutput:\n{output}"
+    );
+}
+
+/// Negative/fallback case: an arrow with neither `this` nor a super call must
+/// not capture `_this`, even when it lives in a derived class method.
+#[test]
+fn plain_arrow_without_this_or_super_call_does_not_capture() {
+    let source = r#"class Base { run() {} }
+class Derived extends Base {
+    run() {
+        var add = (a, b) => a + b;
+    }
+}"#;
+    let output = emit_es5(source);
+    assert!(
+        !output.contains("var _this = this;"),
+        "an arrow that uses neither `this` nor a super call must not capture `_this`.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-parser/src/syntax/transform_utils.rs
+++ b/crates/tsz-parser/src/syntax/transform_utils.rs
@@ -34,6 +34,88 @@ pub fn contains_this_reference(arena: &NodeArena, node_idx: NodeIndex) -> bool {
     contains_target_reference(arena, node_idx, ReferenceTarget::This)
 }
 
+/// Check whether an ES5-lowered arrow body must capture lexical `this`.
+///
+/// An arrow captures `this` when it spells `this`, OR when it contains a
+/// `super.m(...)` / `super[e](...)` **call**: at ES5 such a call lowers to
+/// `_super.prototype.m.call(_this, ...)`, threading the captured receiver.
+/// A bare `super.x` / `super[e]` property **access** lowers to
+/// `_super.prototype.x` and references no `this`, so it does not by itself
+/// force a `var _this = this;` capture. The lexical-boundary rules match
+/// [`contains_this_reference`]: nested non-arrow functions stop propagation
+/// while arrows and computed member names stay in scope.
+#[must_use]
+pub fn arrow_captures_lexical_this(arena: &NodeArena, node_idx: NodeIndex) -> bool {
+    let Some(node) = arena.get(node_idx) else {
+        return false;
+    };
+
+    // A literal `this` keyword (or `this` identifier from recovery) captures.
+    if node.kind == SyntaxKind::ThisKeyword as u16 {
+        return true;
+    }
+    if node.is_identifier()
+        && arena
+            .get_identifier(node)
+            .is_some_and(|identifier| identifier.escaped_text == "this")
+    {
+        return true;
+    }
+
+    // A `super(...)`-shaped call where the callee resolves to `super` threads
+    // the captured receiver into the lowered `.call(_this, ...)` form.
+    if (node.kind == syntax_kind_ext::CALL_EXPRESSION)
+        && let Some(call) = arena.get_call_expr(node)
+        && call_expression_callee_is_super(arena, call.expression)
+    {
+        return true;
+    }
+
+    target_reference_children(arena, node_idx, ReferenceTarget::This)
+        .into_iter()
+        .any(|child_idx| arrow_captures_lexical_this(arena, child_idx))
+}
+
+/// Whether a call-expression callee is a direct `super` member call:
+/// `super.m`, `super[e]`, `super(...)`, or those wrapped in parentheses.
+///
+/// Only a member access whose immediate base is `super` counts. A chained
+/// access such as `super.a.b()` is a normal call on `super.a` (which lowers
+/// to `_super.prototype.a`), not a super call, so it does not capture `this`.
+fn call_expression_callee_is_super(arena: &NodeArena, callee_idx: NodeIndex) -> bool {
+    let callee_idx = unwrap_parentheses(arena, callee_idx);
+    let Some(node) = arena.get(callee_idx) else {
+        return false;
+    };
+    if node.kind == SyntaxKind::SuperKeyword as u16 {
+        return true;
+    }
+    if (node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+        || node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION)
+        && let Some(access) = arena.get_access_expr(node)
+    {
+        let base_idx = unwrap_parentheses(arena, access.expression);
+        return arena
+            .get(base_idx)
+            .is_some_and(|base| base.kind == SyntaxKind::SuperKeyword as u16);
+    }
+    false
+}
+
+/// Unwrap nested parenthesized expressions to the inner expression.
+fn unwrap_parentheses(arena: &NodeArena, mut idx: NodeIndex) -> NodeIndex {
+    while let Some(node) = arena.get(idx) {
+        if node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION
+            && let Some(paren) = arena.get_parenthesized(node)
+        {
+            idx = paren.expression;
+            continue;
+        }
+        break;
+    }
+    idx
+}
+
 /// Collect `this` references that appear in computed member names of a class.
 ///
 /// This follows the same scope rules as `contains_this_reference`: nested non-arrow

--- a/crates/tsz-parser/tests/transform_utils_tests.rs
+++ b/crates/tsz-parser/tests/transform_utils_tests.rs
@@ -1,6 +1,8 @@
 //! Tests for transform utility helpers (`contains_this_reference`, `contains_arguments_reference`).
+use crate::parser::node::NodeAccess;
 use crate::parser::test_fixture::parse_source;
 use crate::parser::{NodeIndex, ParserState};
+use crate::syntax::transform_utils::arrow_captures_lexical_this;
 use crate::syntax::transform_utils::contains_arguments_reference;
 use crate::syntax::transform_utils::contains_new_target_reference;
 use crate::syntax::transform_utils::contains_this_reference;
@@ -144,4 +146,81 @@ fn contains_this_reference_detects_nested_class_heritage_clauses() {
     );
 
     assert!(contains_this_reference(parser.get_arena(), initializer));
+}
+
+/// Find the first arrow-function node reachable from `root` (breadth-first).
+fn first_arrow_function(parser: &ParserState, root: NodeIndex) -> NodeIndex {
+    use crate::parser::syntax_kind_ext::ARROW_FUNCTION;
+    let arena = parser.get_arena();
+    let mut queue = vec![root];
+    while let Some(idx) = queue.pop() {
+        if arena
+            .get(idx)
+            .is_some_and(|node| node.kind == ARROW_FUNCTION)
+        {
+            return idx;
+        }
+        queue.extend(arena.get_children(idx));
+    }
+    panic!("no arrow function found");
+}
+
+fn arrow_captures(source: &str) -> bool {
+    let (parser, root) = parse_source(source);
+    let arrow = first_arrow_function(&parser, root);
+    arrow_captures_lexical_this(parser.get_arena(), arrow)
+}
+
+#[test]
+fn arrow_captures_lexical_this_for_super_method_call() {
+    // A `super.m()` call lowers to `_super.prototype.m.call(_this)`, so the
+    // arrow captures `this`. Two name choices prove the rule is structural.
+    assert!(arrow_captures(
+        "class B extends A { m() { var f = () => super.greet(); } }"
+    ));
+    assert!(arrow_captures(
+        "class Dog extends Animal { bark() { var go = () => super.speak(); } }"
+    ));
+}
+
+#[test]
+fn arrow_captures_lexical_this_for_super_element_call() {
+    assert!(arrow_captures(
+        r#"class B extends A { m() { var f = () => super["greet"](); } }"#
+    ));
+}
+
+#[test]
+fn arrow_does_not_capture_for_super_property_access_only() {
+    // Bare `super.x` access lowers to `_super.prototype.x` (no `this`), so an
+    // arrow that only reads a super property must not capture `this`.
+    assert!(!arrow_captures(
+        "class B extends A { m() { var f = () => super.value; } }"
+    ));
+    assert!(!arrow_captures(
+        "class Circle extends Shape { measure() { var g = () => super.area; } }"
+    ));
+}
+
+#[test]
+fn arrow_captures_lexical_this_for_literal_this() {
+    assert!(arrow_captures(
+        "class B extends A { m() { var f = () => this.value; } }"
+    ));
+}
+
+#[test]
+fn arrow_does_not_capture_without_this_or_super_call() {
+    assert!(!arrow_captures(
+        "class B extends A { m() { var f = (a, b) => a + b; } }"
+    ));
+}
+
+#[test]
+fn arrow_does_not_capture_for_chained_super_property_call() {
+    // `super.a.b()` is a normal call on `super.a` (which lowers to
+    // `_super.prototype.a`), not a super call, so it must not capture `this`.
+    assert!(!arrow_captures(
+        "class B extends A { m() { var f = () => super.a.b(); } }"
+    ));
 }


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — ES5 arrow this-capture for super (emit→100% campaign, wave 3)

## Invariant
(1) An ES5 arrow captures lexical `this` iff it spells `this` OR contains a direct `super.m(...)`/`super[e](...)` CALL (lowered to `.call(_this, ...)`). A bare `super.x` property ACCESS lowers to `_super.prototype.x`, references no `this`, and must NOT force a `var _this = this;` capture. (2) A lowered `super.m(...)` `.call(...)` receiver is `_this` when the call is inside a this-capturing arrow, else `this`. Keyed on AST node kinds (super call / arrow this-capture context) — no identifier/file-name matching, no printer-output `.contains()`.

## Scope
- `crates/tsz-parser/src/syntax/transform_utils.rs` — new `arrow_captures_lexical_this` (+helpers); replaces over-broad `contains_this_reference` (which treated any `super` as `this`).
- `crates/tsz-emitter/src/lowering/core.rs` — mark super-call callee's `super` keyword with `SubstituteThis` capture name.
- NEW `crates/tsz-emitter/src/lowering/super_capture.rs` (50 lines), NEW `crates/tsz-emitter/src/emitter/expressions/es5_super_receiver.rs` (31 lines).
- `emitter/expressions/call.rs` — super-call receiver via helper (shrank). access.rs untouched (at ratchet).
- Tests: `es5_super_arrow_this_capture_tests.rs` (+6), `transform_utils_tests.rs` (+6).

## Project Corpus Impact
- Row: n/a (ES5 super/this-capture emit fix)
- Bug family: spurious `var _this = this` for super-access-only arrows + wrong super-call `.call` receiver
- Evidence: superInObjectLiterals_ES5(target=es5) FAIL→PASS; full --js-only 100→99.

## Verification
- Witness FAIL→PASS. **Full --js-only: 100→99 real fail, net +1, ZERO new failures** (the "103/4-timeout" run included transient cold-start timeouts that pass in isolation). DTS unaffected (24, ES5-JS-only). 12 new unit tests (vary class/method/property names, super-call vs super-access, arrow vs object-literal, negative/chained fallback). Clippy clean (tsz-emitter + tsz-parser); arch guard passes (new code in fresh files, no monolith growth).
- §25/§26 compliant. No output surgery.

## Coordination Notes
Rebased onto current main. Also improved superInLambdas (removed spurious `_this` in super-access-only arrows). STOP-reported as DISTINCT bugs (NOT super-receiver family, left for follow-up): nestedSuperCallEmit (real cause = `catch (e: unknown)` typed-binding DROPPED — emits `catch {` not `catch (e)` + trailing comment); superInLambdas residual (bare-`super` recovery + empty-method-body comment drop); superPropertyAccessInComputedPropertiesOfNestedType_ES5 (nested-class computed-name super drops `.prototype` — broad lexical-env rework). — opus48-emit100
