### PR TITLE
fix(emit): skip ambient (declare) classes in --importHelpers tslib-binding scan

### DIFF
--- a/crates/tsz-emitter/src/emitter/source_file/emit.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/emit.rs
@@ -1,9 +1,9 @@
 use super::super::Printer;
 use super::super::core::JsxEmit;
 use tsz_common::common::{ModuleKind, ScriptTarget};
-use tsz_parser::parser::node::{Node, NodeAccess};
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::Node;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_parser::parser::{NodeIndex, NodeList};
 use tsz_scanner::SyntaxKind;
 
 impl<'a> Printer<'a> {
@@ -2401,48 +2401,6 @@ impl<'a> Printer<'a> {
                 .arguments
                 .as_ref()
                 .is_some_and(|args| args.nodes.len() >= 2)
-    }
-
-    pub(in crate::emitter) fn import_helpers_need_tslib_binding_for_class_emit(
-        &self,
-        statements: &NodeList,
-    ) -> bool {
-        self.ctx.options.import_helpers
-            && statements
-                .nodes
-                .iter()
-                .copied()
-                .any(|idx| self.node_needs_tslib_binding_for_class_emit(idx))
-    }
-
-    fn node_needs_tslib_binding_for_class_emit(&self, idx: NodeIndex) -> bool {
-        let Some(node) = self.arena.get(idx) else {
-            return false;
-        };
-
-        if matches!(
-            node.kind,
-            k if k == syntax_kind_ext::CLASS_DECLARATION
-                || k == syntax_kind_ext::CLASS_EXPRESSION
-        ) && let Some(class_data) = self.arena.get_class(node)
-        {
-            let needs_extends_helper = self.ctx.target_es5
-                && crate::transforms::emit_utils::get_extends_expression_index(
-                    self.arena,
-                    &class_data.heritage_clauses,
-                )
-                .is_some();
-            let needs_decorator_helper =
-                self.ctx.options.legacy_decorators && self.class_has_decorators(class_data);
-            if needs_extends_helper || needs_decorator_helper {
-                return true;
-            }
-        }
-
-        self.arena
-            .get_children(idx)
-            .into_iter()
-            .any(|child_idx| self.node_needs_tslib_binding_for_class_emit(child_idx))
     }
 }
 

--- a/crates/tsz-emitter/src/emitter/source_file/import_helpers_class_scan.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/import_helpers_class_scan.rs
@@ -1,0 +1,79 @@
+//! Ambient-aware scan that decides whether `--importHelpers` must bind the
+//! `tslib` module for class emit (the downlevel `__extends`/`__decorate`
+//! helpers).
+//!
+//! Only classes that actually reach JS emit can use a tslib helper. Ambient
+//! declarations — a class carrying the `declare` modifier, or any class nested
+//! inside an ambient `declare namespace`/`declare module` — produce no runtime
+//! output, so they never require a tslib binding. The scan therefore skips
+//! ambient classes and does not descend into ambient module bodies.
+
+use super::super::Printer;
+use tsz_parser::parser::node::NodeAccess;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_parser::parser::{NodeIndex, NodeList};
+use tsz_scanner::SyntaxKind;
+
+impl<'a> Printer<'a> {
+    pub(in crate::emitter) fn import_helpers_need_tslib_binding_for_class_emit(
+        &self,
+        statements: &NodeList,
+    ) -> bool {
+        self.ctx.options.import_helpers
+            && statements
+                .nodes
+                .iter()
+                .copied()
+                .any(|idx| self.node_needs_tslib_binding_for_class_emit(idx))
+    }
+
+    fn node_needs_tslib_binding_for_class_emit(&self, idx: NodeIndex) -> bool {
+        let Some(node) = self.arena.get(idx) else {
+            return false;
+        };
+
+        // Ambient `declare namespace`/`declare module` bodies are fully erased
+        // in JS emit, so no class inside them can reference a tslib helper.
+        // Stop descending instead of recursing into their members.
+        if node.kind == syntax_kind_ext::MODULE_DECLARATION
+            && let Some(module_data) = self.arena.get_module(node)
+            && self
+                .arena
+                .has_modifier(&module_data.modifiers, SyntaxKind::DeclareKeyword)
+        {
+            return false;
+        }
+
+        if matches!(
+            node.kind,
+            k if k == syntax_kind_ext::CLASS_DECLARATION
+                || k == syntax_kind_ext::CLASS_EXPRESSION
+        ) && let Some(class_data) = self.arena.get_class(node)
+        {
+            // A `declare class` is ambient: no runtime emit, no helper.
+            if self
+                .arena
+                .has_modifier(&class_data.modifiers, SyntaxKind::DeclareKeyword)
+            {
+                return false;
+            }
+
+            let needs_extends_helper = self.ctx.target_es5
+                && crate::transforms::emit_utils::get_extends_expression_index(
+                    self.arena,
+                    &class_data.heritage_clauses,
+                )
+                .is_some();
+            let needs_decorator_helper =
+                self.ctx.options.legacy_decorators && self.class_has_decorators(class_data);
+            if needs_extends_helper || needs_decorator_helper {
+                return true;
+            }
+        }
+
+        self.arena
+            .get_children(idx)
+            .into_iter()
+            .any(|child_idx| self.node_needs_tslib_binding_for_class_emit(child_idx))
+    }
+}

--- a/crates/tsz-emitter/src/emitter/source_file/import_helpers_class_scan_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/import_helpers_class_scan_tests.rs
@@ -1,0 +1,88 @@
+//! Tests for the ambient-aware `--importHelpers` tslib class-emit scan.
+//!
+//! Rule under test: a class that is ambient — carrying the `declare` modifier,
+//! or nested inside an ambient `declare namespace`/`declare module` — produces
+//! no runtime emit, so it must never trigger the synthesized
+//! `var tslib_1 = require("tslib");` import. A genuinely emitted derived class
+//! on an es5 target still must.
+
+use crate::context::emit::EmitContext;
+use crate::emitter::{ModuleKind, Printer as EmitterPrinter, PrinterOptions};
+use crate::lowering::LoweringPass;
+use tsz_common::ScriptTarget;
+use tsz_parser::ParserState;
+
+fn emit_cjs_es5_import_helpers(source: &str) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        target: ScriptTarget::ES5,
+        module: ModuleKind::CommonJS,
+        import_helpers: true,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+#[test]
+fn ambient_declare_class_extends_does_not_require_tslib_es5() {
+    // A top-level `declare class D extends C` is ambient: no runtime emit, so
+    // the `__extends` helper is never used and tslib must not be required.
+    let source = "export {};\ndeclare class C { }\ndeclare class D extends C { }\n";
+
+    let output = emit_cjs_es5_import_helpers(source);
+
+    assert!(
+        !output.contains("require(\"tslib\")"),
+        "Ambient declare-class heritage must not pull in a tslib import.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn class_inside_declare_namespace_extends_does_not_require_tslib_es5() {
+    // Classes nested in a `declare namespace` are ambient; the whole namespace
+    // body is erased, so no member can reference a tslib helper.
+    let source = "export {};\ndeclare namespace N {\n\tclass C { }\n\tclass D extends C { }\n}\n";
+
+    let output = emit_cjs_es5_import_helpers(source);
+
+    assert!(
+        !output.contains("require(\"tslib\")"),
+        "Classes inside a declare-namespace must not pull in a tslib import.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn class_inside_declare_namespace_extends_renamed_does_not_require_tslib_es5() {
+    // Same rule with different identifiers: the fix must key off the ambient
+    // structure, not specific names.
+    let source = "export {};\ndeclare namespace Outer {\n\tclass Base { }\n\tclass Sub extends Base { }\n}\n";
+
+    let output = emit_cjs_es5_import_helpers(source);
+
+    assert!(
+        !output.contains("require(\"tslib\")"),
+        "Renamed declare-namespace classes must not pull in a tslib import.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn emitted_derived_class_still_requires_tslib_es5() {
+    // Negative control: a real (non-ambient) derived class on es5 genuinely
+    // lowers to `__extends`, so the tslib import must still be emitted. This
+    // proves the ambient guard does not over-suppress.
+    let source = "export {};\nclass C { }\nclass D extends C { }\n";
+
+    let output = emit_cjs_es5_import_helpers(source);
+
+    assert!(
+        output.contains("require(\"tslib\")"),
+        "An emitted es5 derived class must still require tslib for __extends.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/source_file/mod.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/mod.rs
@@ -1,5 +1,8 @@
 mod const_enums;
 mod emit;
+mod import_helpers_class_scan;
+#[cfg(test)]
+mod import_helpers_class_scan_tests;
 mod recovery;
 #[cfg(test)]
 mod tc39_decorator_tests;


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — importHelpers ambient-class scan (emit→100% campaign, wave 3)

## Invariant
A class declaration/expression that is ambient — carrying the `declare` modifier, or nested inside an ambient `declare namespace`/`declare module` — produces no runtime emit, so the `--importHelpers` class-emit scan must NOT treat its `extends`/decorator as needing a `tslib` helper binding (no spurious `var tslib_1 = require("tslib");`). Keyed purely on AST node kind + the `DeclareKeyword` modifier — no identifier/file-name string matches, no printer-output `.contains()`.

## Scope
- NEW `crates/tsz-emitter/src/emitter/source_file/import_helpers_class_scan.rs` — extracted scan with the ambient-skip rule.
- NEW `crates/tsz-emitter/src/emitter/source_file/import_helpers_class_scan_tests.rs` (4 tests).
- `crates/tsz-emitter/src/emitter/source_file/emit.rs` — removed the two scan fns (2462→2421 lines; net file SHRINK) + trimmed unused imports.
- `crates/tsz-emitter/src/emitter/source_file/mod.rs` — register the new modules.

## Project Corpus Impact
- Row: n/a (importHelpers emit fix)
- Bug family: spurious tslib require emitted for ambient (`declare`) derived classes under --importHelpers at es5
- Evidence: importHelpersInAmbientContext(target=es5) FAIL→PASS; full --js-only 92→91.

## Verification
- Witness FAIL→PASS. **Full --js-only: 13438→13439 pass (92→91 fail), net +1, ZERO new failures** (fail-set diff: fixed=[importHelpersInAmbientContext(es5)], new=[]). DTS unaffected (modified fn's 3 callers are all JS-emit paths). 4 structural unit tests (two name variations for ambient-namespace, top-level `declare class`, + negative control proving a real es5 derived class still emits the tslib require). Clippy clean; arch guard passes (new logic in a new file; emit.rs shrank).
- §25/§26 compliant.

## Coordination Notes
Rebased onto current main. Classified the rest of the candidate set as parser-recovery (skipped, broad): interfaceDeclaration4, objectTypesWithOptionalProperties2, mappedTypeProperties, invalidTypeOfTarget, constructorWithIncompleteTypeAnnotation, jsFileCompilationTypeArgumentSyntaxOfCall, reachabilityChecksNoCrash1. — opus48-emit100
