### PR TITLE
fix(emit): keep catch binding identifier + elide redundant assertion parens in ES5 class IR path

### DIFF
--- a/crates/tsz-emitter/src/emitter/source_file/derived_constructor_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/derived_constructor_tests.rs
@@ -180,3 +180,98 @@ fn pre_super_this_capture_stops_at_ordinary_functions() {
         "Nested class expressions should also evaluate their heritage expression with the pre-super receiver capture.\nOutput:\n{output}"
     );
 }
+
+#[test]
+fn es5_super_lowered_catch_keeps_typed_binding_identifier() {
+    // A `catch` binding is parsed as a VariableDeclaration; the ES5 class IR
+    // lowering must keep the binding identifier while erasing its type
+    // annotation, regardless of the chosen binding name or annotation type.
+    for (binding, annotation) in [("e", "unknown"), ("caught", "any"), ("problem", "Error")] {
+        let source = format!(
+            "class Base {{ constructor(x: boolean) {{}} }}\n\
+             class Derived extends Base {{\n\
+            \x20   constructor() {{\n\
+            \x20       try {{\n\
+            \x20           super(true);\n\
+            \x20       }} catch ({binding}: {annotation}) {{\n\
+            \x20           super(false);\n\
+            \x20       }}\n\
+            \x20   }}\n\
+             }}\n"
+        );
+
+        let output = emit(&source, ScriptTarget::ES5);
+
+        assert!(
+            output.contains(&format!("catch ({binding}) {{")),
+            "ES5 super-lowered catch must keep the binding `{binding}` and erase `: {annotation}`.\nOutput:\n{output}"
+        );
+        assert!(
+            !output.contains("catch {"),
+            "ES5 super-lowered catch must not drop the binding parens for `catch ({binding}: {annotation})`.\nOutput:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn es5_super_lowered_catch_drops_redundant_type_assertion_parens() {
+    // `(x as T).member` only needs parens for the TS assertion; once the
+    // assertion is erased the parens are redundant, so the ES5 class IR must
+    // emit `x.member`, not `(x).member`. Vary the binding name to prove the
+    // rule is structural, not keyed on a specific identifier.
+    for binding in ["e", "failure"] {
+        let source = format!(
+            "class Base {{ constructor(x: boolean) {{}} }}\n\
+             class Derived extends Base {{\n\
+            \x20   constructor() {{\n\
+            \x20       try {{\n\
+            \x20           super(true);\n\
+            \x20       }} catch ({binding}: unknown) {{\n\
+            \x20           console.log(({binding} as Error).message);\n\
+            \x20           super(false);\n\
+            \x20       }}\n\
+            \x20   }}\n\
+             }}\n"
+        );
+
+        let output = emit(&source, ScriptTarget::ES5);
+
+        assert!(
+            output.contains(&format!("console.log({binding}.message);")),
+            "Redundant type-assertion parens should be dropped, emitting `{binding}.message`.\nOutput:\n{output}"
+        );
+        assert!(
+            !output.contains(&format!("({binding}).message")),
+            "ES5 class IR must not re-wrap the erased assertion in parens.\nOutput:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn es5_super_lowered_catch_keeps_untyped_binding_and_meaningful_parens() {
+    // Negative/guard cases: an untyped binding must still be kept, and parens
+    // that are NOT solely scoping a type assertion (e.g. wrapping a binary
+    // expression) must be preserved.
+    let source = "class Base { constructor(x: boolean) {} }\n\
+         class Derived extends Base {\n\
+        \x20   constructor() {\n\
+        \x20       try {\n\
+        \x20           super(true);\n\
+        \x20       } catch (err) {\n\
+        \x20           console.log((1 + 2) * 3);\n\
+        \x20           super(false);\n\
+        \x20       }\n\
+        \x20   }\n\
+         }\n";
+
+    let output = emit(source, ScriptTarget::ES5);
+
+    assert!(
+        output.contains("catch (err) {"),
+        "An untyped catch binding must be kept by the ES5 super lowering.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("(1 + 2) * 3"),
+        "Parens scoping a binary expression are load-bearing and must be preserved.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_control_flow.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_control_flow.rs
@@ -4,7 +4,10 @@
 //! Extracted from `class_es5_ast_to_ir.rs` so the central AST→IR conversion
 //! file stays under the §19 2000-line cap. Behavior is unchanged.
 
-use super::{AstToIr, IRCatchClause, IRNode, IRSwitchCase, get_identifier_text};
+use super::{
+    AstToIr, IRCatchClause, IRNode, IRSwitchCase, catch_binding_identifier_text,
+    get_identifier_text,
+};
 use tsz_parser::parser::NodeIndex;
 
 impl<'a> AstToIr<'a> {
@@ -37,7 +40,7 @@ impl<'a> AstToIr<'a> {
                 let param = if catch.variable_declaration.is_none() {
                     None
                 } else {
-                    get_identifier_text(self.arena, catch.variable_declaration)
+                    catch_binding_identifier_text(self.arena, catch.variable_declaration)
                 };
                 let catch_block = self.arena.get(catch.block);
                 let body = if let Some(block_node) = catch_block

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_expressions.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_expressions.rs
@@ -625,9 +625,78 @@ impl<'a> AstToIr<'a> {
             .get(idx)
             .expect("NodeIndex must be valid in arena");
         if let Some(paren) = self.arena.get_parenthesized(node) {
+            // Parentheses that exist only to scope a type assertion become
+            // redundant once the assertion is erased: `(e as Error).message`
+            // emits `e.message`, not `(e).message`. Mirror the normal emitter's
+            // policy of dropping such parens when the erased inner expression is
+            // a simple primary whose meaning cannot change without parens.
+            if self.parenthesized_wraps_erasable_simple_primary(paren.expression) {
+                return self.convert_expression(paren.expression);
+            }
             IRNode::Parenthesized(Box::new(self.convert_expression(paren.expression)))
         } else {
             IRNode::ASTRef(idx)
+        }
+    }
+
+    /// True when a parenthesized expression directly wraps a type assertion
+    /// (`as`/`<T>`/satisfies) whose underlying expression, after erasing the
+    /// assertion, is a simple primary that does not require the parentheses.
+    fn parenthesized_wraps_erasable_simple_primary(&self, inner_idx: NodeIndex) -> bool {
+        let Some(inner) = self.arena.get(inner_idx) else {
+            return false;
+        };
+        // Only the type-assertion forms make the wrapping parens purely
+        // syntactic. Everything else keeps its parens.
+        if !(inner.kind == syntax_kind_ext::TYPE_ASSERTION
+            || inner.kind == syntax_kind_ext::AS_EXPRESSION
+            || inner.kind == syntax_kind_ext::SATISFIES_EXPRESSION)
+        {
+            return false;
+        }
+        // Peel the type-assertion chain to the underlying expression.
+        let mut cur = inner_idx;
+        loop {
+            let Some(node) = self.arena.get(cur) else {
+                return false;
+            };
+            let is_assertion = node.kind == syntax_kind_ext::TYPE_ASSERTION
+                || node.kind == syntax_kind_ext::AS_EXPRESSION
+                || node.kind == syntax_kind_ext::SATISFIES_EXPRESSION;
+            if is_assertion {
+                let Some(assertion) = self.arena.get_type_assertion(node) else {
+                    return false;
+                };
+                cur = assertion.expression;
+                continue;
+            }
+            // `node` is the erased underlying expression. An optional-chain
+            // member is load-bearing in access position, so never strip those.
+            if node.is_optional_chain()
+                || self
+                    .arena
+                    .get_access_expr(node)
+                    .is_some_and(|a| a.question_dot_token)
+            {
+                return false;
+            }
+            return matches!(
+                node.kind,
+                k if k == SyntaxKind::Identifier as u16
+                    || k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                    || k == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+                    || k == SyntaxKind::ThisKeyword as u16
+                    || k == SyntaxKind::SuperKeyword as u16
+                    || k == SyntaxKind::NullKeyword as u16
+                    || k == SyntaxKind::TrueKeyword as u16
+                    || k == SyntaxKind::FalseKeyword as u16
+                    || k == SyntaxKind::NumericLiteral as u16
+                    || k == SyntaxKind::BigIntLiteral as u16
+                    || k == SyntaxKind::StringLiteral as u16
+                    || k == syntax_kind_ext::TEMPLATE_EXPRESSION
+                    || k == SyntaxKind::NoSubstitutionTemplateLiteral as u16
+                    || k == syntax_kind_ext::NON_NULL_EXPRESSION
+            );
         }
     }
 

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_helpers.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_helpers.rs
@@ -254,6 +254,26 @@ pub(super) fn get_identifier_text(arena: &NodeArena, idx: NodeIndex) -> Option<S
     }
 }
 
+/// Resolve the binding-name identifier text of a `catch` clause's
+/// `VariableDeclaration` node.
+///
+/// A catch binding is always parsed as a `VariableDeclaration` whose `name`
+/// field holds the binding (`catch (e)` and `catch (e: unknown)` differ only by
+/// the erased `type_annotation`). The es5 class-transform IR keeps just the
+/// binding identifier, so the type annotation is dropped while the identifier
+/// is preserved. Returns `None` for destructuring binding patterns, which this
+/// IR path does not lower as a simple catch parameter.
+pub(super) fn catch_binding_identifier_text(arena: &NodeArena, idx: NodeIndex) -> Option<String> {
+    let node = arena.get(idx)?;
+    // A catch binding is a `VariableDeclaration`; descend to its `name` so the
+    // type annotation is erased but the binding identifier is kept.
+    if let Some(var_decl) = arena.get_variable_declaration(node) {
+        return get_identifier_text(arena, var_decl.name);
+    }
+    // Defensive: if the binding is already a bare identifier, accept it.
+    get_identifier_text(arena, idx)
+}
+
 /// Collect accessor pairs (getter/setter) from class members.
 /// When `collect_static` is true, collects static accessors; otherwise collects instance accessors.
 pub(super) fn has_effective_static_modifier(


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — ES5 class-IR catch-clause binding + assertion-paren (emit→100% campaign, wave 3)

## Invariant
In the ES5 class-transform IR path (the only path that reconstructs a catch clause AST→IR→print, used when a derived constructor body contains `super()` calls): (1) a `CatchClause`'s catch parameter is the binding-name identifier of the clause's `VariableDeclaration` (its `name` field) — erase the type annotation but KEEP the identifier (previously read via `get_identifier_text` on the VariableDeclaration node, which always returns None for a catch binding, so EVERY catch binding — typed or untyped — was dropped, emitting `catch {` instead of `catch (e)`). (2) A `ParenthesizedExpression` directly wrapping a type assertion (`as`/`<T>`/satisfies) whose erased inner is a simple safe primary (identifier, property/element access, this/super, literal, template, non-null — never an optional-chain member) is redundant; emit the inner directly (`e.message` not `(e).message`). Both mirror the normal AST emitter's already-correct policy. Keyed on AST node kind — no name/printer-string matching.

## Scope
- `crates/tsz-emitter/src/transforms/class_es5_ir_helpers.rs` — new `catch_binding_identifier_text`.
- `crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_control_flow.rs` — catch param via the helper.
- `crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_expressions.rs` — paren-elision in `convert_parenthesized` + `parenthesized_wraps_erasable_simple_primary`.
- `crates/tsz-emitter/src/emitter/source_file/derived_constructor_tests.rs` (+3 tests).

## Project Corpus Impact
- Row: n/a (ES5 class-IR catch/assertion emit fix)
- Bug family: ES5 derived-constructor IR path drops catch binding + adds redundant assertion parens
- Evidence: nestedSuperCallEmit(target=es5) FAIL→PASS; full --js-only 92→91.

## Verification
- Witness FAIL→PASS. **Full --js-only: 92→91 fail, net +1, ZERO new regressions** (name-diffed before/after fail sets). --dts-only unaffected (ES5 JS class-IR path not reached by DTS emit). 3 new structural unit tests (binding/annotation combos, 2 names for paren-elision, negative untyped-binding + meaningful-parens guard). Broader derived-constructor/catch/parenthesized/try families pass. Clippy clean; arch guard passes; no monolith touched.
- §25/§26 compliant.

## Coordination Notes
Rebased onto current main. Noted (pre-existing on base, NOT regressions, local-env-only): 4 async-ES5-IR catch-binding-rename unit tests (`_a.sent()`-rename in the async IR path) — separate from this normal-catch-IR fix; flagged for follow-up. — opus48-emit100
