### PR TITLE
fix(parser): seed missing left operand for leading-binary-operator expression-statement recovery

### DIFF
--- a/crates/tsz-parser/src/parser/state_expressions.rs
+++ b/crates/tsz-parser/src/parser/state_expressions.rs
@@ -275,7 +275,28 @@ impl ParserState {
         min_precedence: u8,
         start_pos: u32,
     ) -> NodeIndex {
-        let mut left = self.parse_unary_expression();
+        self.parse_binary_expression_chain_seeded(min_precedence, start_pos, None)
+    }
+
+    /// Binary-expression precedence climbing with an optional pre-parsed left
+    /// operand. When `seed` is `Some`, that node is used as the initial left
+    /// operand instead of calling `parse_unary_expression`. This mirrors tsc's
+    /// `parseBinaryExpressionRest(precedence, leftOperand)`, which is reached
+    /// during error recovery when `parsePrimaryExpression` synthesizes a missing
+    /// identifier (via `createMissingNode`) for a statement that begins with a
+    /// binary operator. The operator is then consumed by this loop and the
+    /// missing node becomes the binary expression's left operand, so the
+    /// emitted tree is `<missing> <op> <rhs>` rather than dropping the operator.
+    pub(crate) fn parse_binary_expression_chain_seeded(
+        &mut self,
+        min_precedence: u8,
+        start_pos: u32,
+        seed: Option<NodeIndex>,
+    ) -> NodeIndex {
+        let mut left = match seed {
+            Some(node) => node,
+            None => self.parse_unary_expression(),
+        };
 
         loop {
             let op = if self.is_token(SyntaxKind::GreaterThanToken) {

--- a/crates/tsz-parser/src/parser/state_switch_recovery.rs
+++ b/crates/tsz-parser/src/parser/state_switch_recovery.rs
@@ -295,11 +295,16 @@ impl ParserState {
         // in the tree and emitted (` || a`), rather than being skipped. We mirror
         // that by seeding the binary-expression chain with a missing identifier.
         // Comma at statement start is left to the normal `parse_expression`
-        // sequence handling, and assignment operators are handled by
-        // `parse_assignment_expression`, so this only seeds non-comma operators.
-        let started_with_binary_operator_skip_path =
-            started_with_binary_operator && self.token() == SyntaxKind::CommaToken;
-        let expression = if started_with_binary_operator && self.token() != SyntaxKind::CommaToken {
+        // sequence handling. `?` is the conditional-expression separator rather
+        // than a pure binary operator, so it stays on the legacy skip/recovery
+        // path too.
+        let started_with_binary_operator_skip_path = started_with_binary_operator
+            && matches!(
+                self.token(),
+                SyntaxKind::CommaToken | SyntaxKind::QuestionToken
+            );
+        let expression = if started_with_binary_operator && !started_with_binary_operator_skip_path
+        {
             self.error_expression_expected();
             let start_pos = self.token_pos();
             let missing_left = self.create_missing_expression();

--- a/crates/tsz-parser/src/parser/state_switch_recovery.rs
+++ b/crates/tsz-parser/src/parser/state_switch_recovery.rs
@@ -284,7 +284,27 @@ impl ParserState {
         self.jsx_missing_brace_semicolon_window_start = Some(start_pos);
 
         let started_with_binary_operator = !self.is_expression_start() && self.is_binary_operator();
-        let expression = if started_with_binary_operator {
+        // A statement that begins with a purely-binary operator (e.g. `|| a`,
+        // `!= b`, `&& c`; not `+`/`-`/`*`/`/`, which are unary/JSX/regex at
+        // statement start and stay on their existing paths) is recovered by tsc
+        // as `<missing> <op> <rhs>`: its
+        // `parsePrimaryExpression` synthesizes a missing identifier (via
+        // `createMissingNode`, reporting TS1109 at the operator position without
+        // consuming it) and then `parseBinaryExpressionRest` consumes the
+        // operator and parses the right operand. The operator is therefore kept
+        // in the tree and emitted (` || a`), rather than being skipped. We mirror
+        // that by seeding the binary-expression chain with a missing identifier.
+        // Comma at statement start is left to the normal `parse_expression`
+        // sequence handling, and assignment operators are handled by
+        // `parse_assignment_expression`, so this only seeds non-comma operators.
+        let started_with_binary_operator_skip_path =
+            started_with_binary_operator && self.token() == SyntaxKind::CommaToken;
+        let expression = if started_with_binary_operator && self.token() != SyntaxKind::CommaToken {
+            self.error_expression_expected();
+            let start_pos = self.token_pos();
+            let missing_left = self.create_missing_expression();
+            self.parse_binary_expression_chain_seeded(2, start_pos, Some(missing_left))
+        } else if started_with_binary_operator {
             self.error_expression_expected();
             self.next_token();
             let right = if self.is_expression_start() {
@@ -501,7 +521,7 @@ impl ParserState {
             let has_numeric_follow_error = self.current_token_has_numeric_literal_follow_error();
             if jsx_head_needs_semicolon && has_numeric_follow_error {
                 self.parse_error_at_current_token("';' expected.", diagnostic_codes::EXPECTED);
-            } else if started_with_binary_operator {
+            } else if started_with_binary_operator_skip_path {
                 self.parse_error_at_current_token("';' expected.", diagnostic_codes::EXPECTED);
                 if self.is_assignment_operator(self.token()) {
                     self.next_token();

--- a/crates/tsz-parser/tests/parser_improvement_expression_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_expression_recovery_tests.rs
@@ -29,6 +29,22 @@ fn binary_ops_with_missing_left(source: &str) -> Vec<SyntaxKind> {
         .collect()
 }
 
+fn conditional_exprs_with_missing_condition(source: &str) -> usize {
+    let (parser, _root) = parse_source(source);
+    let arena = parser.get_arena();
+    arena
+        .nodes
+        .iter()
+        .filter(|node| node.kind == syntax_kind_ext::CONDITIONAL_EXPRESSION)
+        .filter_map(|node| arena.get_conditional_expr(node))
+        .filter(|conditional| {
+            arena
+                .get(conditional.condition)
+                .is_some_and(|condition| condition.pos == condition.end)
+        })
+        .count()
+}
+
 #[test]
 fn test_incomplete_binary_expression_recovery() {
     // Test recovery from incomplete binary expression: a +
@@ -198,5 +214,18 @@ fn test_statement_starting_with_binary_operator_does_not_drop_operator() {
         second_is_binary_expr_statement,
         "leading-binary-operator statement should recover as a binary expression, not a bare operand; diagnostics: {:?}",
         parser.get_diagnostics()
+    );
+}
+
+#[test]
+fn test_statement_starting_with_question_does_not_seed_conditional_condition() {
+    // `?` has conditional-expression precedence, but it is not a pure binary
+    // operator. At statement start it must stay on the existing skip/recovery
+    // path instead of fabricating a missing conditional condition.
+    let missing_condition_count =
+        conditional_exprs_with_missing_condition("q = () => { } ? a : b\n");
+    assert_eq!(
+        missing_condition_count, 0,
+        "statement-start `?` should not become a conditional expression with a missing condition"
     );
 }

--- a/crates/tsz-parser/tests/parser_improvement_expression_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_expression_recovery_tests.rs
@@ -1,6 +1,33 @@
 //! Tests for parser improvements to reduce TS1005 and TS2300 false positives — expression recovery.
 
+use crate::parser::syntax_kind_ext;
 use crate::parser::test_fixture::parse_source;
+use tsz_scanner::SyntaxKind;
+
+/// Walk every node in the arena and return the operator tokens of binary
+/// expressions whose left operand is a missing identifier (zero-width synthesized
+/// node). A statement that begins with a binary operator is recovered by tsc as
+/// `<missing> <op> <rhs>`; this helper lets tests assert the operator is kept in
+/// the tree rather than skipped.
+fn binary_ops_with_missing_left(source: &str) -> Vec<SyntaxKind> {
+    let (parser, _root) = parse_source(source);
+    let arena = parser.get_arena();
+    arena
+        .nodes
+        .iter()
+        .filter(|node| node.kind == syntax_kind_ext::BINARY_EXPRESSION)
+        .filter_map(|node| arena.get_binary_expr(node))
+        .filter(|binary| {
+            // A missing/synthesized left operand is a zero-width node (pos == end).
+            arena
+                .get(binary.left)
+                .is_some_and(|left| left.pos == left.end)
+        })
+        .map(|binary| {
+            SyntaxKind::try_from_u16(binary.operator_token).unwrap_or(SyntaxKind::Unknown)
+        })
+        .collect()
+}
 
 #[test]
 fn test_incomplete_binary_expression_recovery() {
@@ -96,5 +123,80 @@ function validFunction() {
     assert!(
         error_count <= 2,
         "Expected limited errors with recovery, got {error_count}",
+    );
+}
+
+#[test]
+fn test_statement_starting_with_logical_or_keeps_operator_as_missing_left_binary() {
+    // `a = () => { } || b` — tsc parses `a = () => { }` as the first statement
+    // (the arrow short-circuits `parseAssignmentExpressionOrHigher`, so `||`
+    // begins a new statement). The trailing `|| b` is recovered as
+    // `<missing> || b`: `parsePrimaryExpression` synthesizes a missing
+    // identifier without consuming the operator, then `parseBinaryExpressionRest`
+    // consumes `||` and parses the right operand. The operator must survive in
+    // the tree so the emitter prints ` || b` rather than dropping it.
+    let ops = binary_ops_with_missing_left("a = () => { } || b\n");
+    assert!(
+        ops.contains(&SyntaxKind::BarBarToken),
+        "expected a `<missing> || b` binary expression for `|| b` statement, got {ops:?}"
+    );
+}
+
+#[test]
+fn test_statement_starting_with_binary_operator_varies_with_operator_and_names() {
+    // The recovery rule is keyed on "statement begins with a binary operator",
+    // not on a specific operator spelling or identifier name. A block-bodied
+    // arrow as an assignment value short-circuits `parseAssignmentExpression`,
+    // so the trailing operator reliably begins a new statement. Vary both the
+    // operator and the operand names; every case must keep the operator with a
+    // synthesized missing left operand. Only operators that are NOT also
+    // expression starts are used: `+`/`-`/`*`/`/`/`<` are unary/JSX/regex at
+    // statement start, so they take a different (pre-existing) recovery path.
+    // `!=`, `&&`, `|`, `==` are purely binary and exercise the seeded chain.
+    let cases = [
+        ("x = () => { } != y\n", SyntaxKind::ExclamationEqualsToken),
+        (
+            "foo = () => { } && bar\n",
+            SyntaxKind::AmpersandAmpersandToken,
+        ),
+        (
+            "gamma = () => { } == delta\n",
+            SyntaxKind::EqualsEqualsToken,
+        ),
+        ("u = () => { } | v\n", SyntaxKind::BarToken),
+    ];
+    for (source, op) in cases {
+        let ops = binary_ops_with_missing_left(source);
+        assert!(
+            ops.contains(&op),
+            "expected `<missing> {op:?} rhs` recovery for source {source:?}, got {ops:?}"
+        );
+    }
+}
+
+#[test]
+fn test_statement_starting_with_binary_operator_does_not_drop_operator() {
+    // Regression guard: previously the parser skipped a leading binary operator
+    // and produced just the right operand (`|| b` became `b`). Confirm the
+    // recovered second statement is a binary expression, not the bare operand.
+    let (parser, root) = parse_source("c = () => { } || d\n");
+    let arena = parser.get_arena();
+    let sf = arena.get_source_file_at(root).expect("source file");
+    let second_is_binary_expr_statement = sf
+        .statements
+        .nodes
+        .iter()
+        .filter_map(|&stmt| arena.get(stmt))
+        .filter(|node| node.kind == syntax_kind_ext::EXPRESSION_STATEMENT)
+        .filter_map(|node| arena.get_expression_statement(node))
+        .any(|expr_stmt| {
+            arena
+                .get(expr_stmt.expression)
+                .is_some_and(|expr| expr.kind == syntax_kind_ext::BINARY_EXPRESSION)
+        });
+    assert!(
+        second_is_binary_expr_statement,
+        "leading-binary-operator statement should recover as a binary expression, not a bare operand; diagnostics: {:?}",
+        parser.get_diagnostics()
     );
 }


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100
Repair AgentName: m5-pro-48g-gpt5

## Track
parser — leading-binary-operator expression-statement recovery (emit→100% campaign, wave 3)

## Invariant
When an expression statement truly begins with a pure binary operator such as `||`, `!=`, `&&`, `|`, or `==`, `tsc` recovers it as `<missing> <op> <rhs>` by synthesizing a missing left operand without consuming the operator, then consuming the operator in binary-expression rest. `tsz` now preserves that operator in the tree.

The seed path deliberately excludes comma and `?`: comma stays on the existing sequence/recovery path, and `?` is the conditional-expression separator rather than a pure binary operator. This preserves `constructorWithIncompleteTypeAnnotation.ts` recovery.

## Scope
- `crates/tsz-parser/src/parser/state_expressions.rs` — optional seeded binary-expression chain entrypoint.
- `crates/tsz-parser/src/parser/state_switch_recovery.rs` — statement-start pure-binary recovery, narrowed to skip comma and `?`.
- `crates/tsz-parser/tests/parser_improvement_expression_recovery_tests.rs` — missing-left binary operator tests plus a guard that statement-start `?` does not fabricate a missing conditional condition.

## Project Corpus Impact
- Row: n/a (parser error-recovery fix)
- Bug family: leading pure-binary-operator expression-statement recovery; conditional-marker recovery false positive avoided
- Evidence: original emit witness `parserArrowFunctionExpression2` is the intended improvement; focused conformance witness `constructorWithIncompleteTypeAnnotation` passes after the `?` narrowing.

## Verification
Original draft verification from opus48-emit100:
- Full --js-only: `13444→13445` pass (`86→85` fail), net +1, zero new failures.
- Full --dts-only: identical set (`1645/24`, 0 new).
- `tsz-parser` unit: `1053/0` (+3 new).
- Narrow conformance families: `parserErrorRecovery`, `parser(all)`, `parserArrowFunction`, `parserUnary`, `logicalNot/conditionalOperator`, `binaryArithmetic` all 100%.

2026-05-30 repair verification by m5-pro-48g-gpt5 on rebased head `dc660238f2`:
- `cargo fmt --check`
- `cargo nextest run -p tsz-parser -E 'test(statement_starting_with)'` — 4 passed
- `scripts/safe-run.sh --limit 50% -- ./scripts/conformance/conformance.sh run --filter constructorWithIncompleteTypeAnnotation --verbose` — 1/1 passed, 0 fingerprint-only
- `git diff --check`

Ready CI will run full conformance, emit, fourslash, WASM, project guard/canary, lint, and unit gates on this exact head.

## Coordination Notes
- Rebased onto current `origin/main` after #11700 and #10780 landed.
- The prior WIP blocker was the conformance regression in `constructorWithIncompleteTypeAnnotation.ts`; root cause was treating statement-start `?` as eligible for missing-left seeding. That is fixed in `dc660238f2`.
- Removing `WIP` and marking ready after this body update. AgentName: m5-pro-48g-gpt5
