### PR TITLE
fix(emit): emit private WeakMap storage before static initializers that may instantiate the class

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -757,9 +757,6 @@ impl<'a> Printer<'a> {
             && static_initializer_alias_source_nodes
                 .iter()
                 .any(|idx| self.node_text_contains_identifier(*idx, &class_name));
-        let static_initializer_directly_uses_private_name = static_initializer_alias_source_nodes
-            .iter()
-            .any(|idx| self.expression_directly_contains_private_identifier(*idx));
         let static_initializer_needs_class_alias = static_initializer_contains_class_name
             && (static_initializer_needs_this_alias
                 || has_static_privates
@@ -2915,14 +2912,18 @@ impl<'a> Printer<'a> {
             self.write("() => { };");
         }
 
-        // Emit static field initializers after class body
-        // For class expressions: use comma expression `(_a = class C {}, _a.field = value, _a)`
-        // For class declarations: use separate statements `ClassName.field = value;`
+        // Emit static field initializers after class body. Class expressions use
+        // a comma expression; class declarations use separate statements.
+        //
+        // For a class *declaration* lowered to the WeakMap pattern, tsc always
+        // emits the private-member init statements before the static field
+        // assignment statements: a static initializer can instantiate the class,
+        // whose constructor populates the WeakMaps, so the storage must exist
+        // first. This holds even without a class/private self-reference, so the
+        // gate fires whenever private lowering and static elements coexist on a
+        // declaration, not only for the self-referential subset.
         let emit_private_inits_before_static_elements = !needs_private_comma_expr
             && has_any_private_lowering
-            && (static_initializer_class_alias.is_some()
-                || has_static_privates
-                || static_initializer_directly_uses_private_name)
             && (!static_field_inits.is_empty() || !deferred_static_blocks.is_empty());
         let mut emitted_private_auto_accessors_pre_static = false;
         if emit_private_inits_before_static_elements {
@@ -3522,16 +3523,10 @@ impl<'a> Printer<'a> {
         //       _a)
         // For class declarations, emit as separate statements after the class body.
         if needs_private_comma_expr && has_post_class_inits {
-            // Emit comma-separated inits inline in the expression.
-            // The `(_a = ` prefix was already emitted before the `class` keyword.
-
-            if (!needs_static_comma_expr || class_expr_static_comma_has_no_scheduled_elements)
-                && let Some(temp) = class_expr_temp.as_ref()
-                && let Some(name) = class_expr_set_function_name.as_ref()
-            {
-                self.emit_class_expr_set_function_name_comma_item(temp, name);
-            }
-
+            // Emit comma-separated inits inline. tsc orders them as:
+            // instance-member helpers (WeakMap/WeakSet/private method+accessor
+            // functions) first, then `__setFunctionName`, then static value
+            // inits. The named-evaluation step is emitted below, after helpers.
             // WeakMap inits: _X_field = new WeakMap()
             let weakmap_inits = self.pending_weakmap_inits.clone();
             for init in &weakmap_inits {
@@ -3634,6 +3629,15 @@ impl<'a> Printer<'a> {
                     );
                     self.decrease_indent();
                 }
+            }
+
+            // Named-evaluation step: after instance helpers, before static
+            // value inits, matching tsc.
+            if (!needs_static_comma_expr || class_expr_static_comma_has_no_scheduled_elements)
+                && let Some(temp) = class_expr_temp.as_ref()
+                && let Some(name) = class_expr_set_function_name.as_ref()
+            {
+                self.emit_class_expr_set_function_name_comma_item(temp, name);
             }
 
             // Emit static private field value initializations as comma items

--- a/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
@@ -2,7 +2,7 @@ use super::super::super::Printer;
 use super::AutoAccessorEmitOptions;
 use crate::transforms::private_fields_es5::get_private_field_name;
 use tsz_parser::parser::NodeIndex;
-use tsz_parser::parser::node::{Node, NodeAccess};
+use tsz_parser::parser::node::Node;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
@@ -225,30 +225,6 @@ impl<'a> Printer<'a> {
             && let Some(paren) = self.arena.get_parenthesized(expr_node)
         {
             return self.is_computed_name_expr_side_effect_free(paren.expression);
-        }
-        false
-    }
-
-    pub(in crate::emitter) fn expression_directly_contains_private_identifier(
-        &self,
-        expr_idx: NodeIndex,
-    ) -> bool {
-        let mut stack = vec![expr_idx];
-        while let Some(current) = stack.pop() {
-            let Some(node) = self.arena.get(current) else {
-                continue;
-            };
-            if node.kind == SyntaxKind::PrivateIdentifier as u16 {
-                return true;
-            }
-            if current != expr_idx
-                && (node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                    || node.kind == syntax_kind_ext::ARROW_FUNCTION
-                    || node.kind == syntax_kind_ext::CLASS_EXPRESSION)
-            {
-                continue;
-            }
-            stack.extend(self.arena.get_children(current));
         }
         false
     }

--- a/crates/tsz-emitter/src/emitter/source_file/private_field_helper_order_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/private_field_helper_order_tests.rs
@@ -52,3 +52,92 @@ class Derived extends Base {
         "Invalid cross-class private reads should not force Get before the first emitted Set.\nOutput:\n{output}"
     );
 }
+
+// Rule: for a class *declaration* lowered to the WeakMap pattern, the private
+// member init statements (`_C_field = new WeakMap()`) must be emitted before the
+// static field initialization statements (`C.x = value;`). A static initializer
+// can instantiate the class, whose constructor populates the WeakMaps, so the
+// storage must exist first. This holds even when the static initializer does not
+// reference the class or a private name.
+
+/// Assert that a `new WeakMap()` / `new WeakSet()` private init statement is
+/// emitted before the given static-field assignment statement.
+fn assert_weakmap_inits_before(output: &str, static_assign: &str) {
+    let static_pos = output.find(static_assign).unwrap_or_else(|| {
+        panic!("expected static assignment `{static_assign}`\nOutput:\n{output}")
+    });
+    let weakmap_pos = output
+        .find("new WeakMap()")
+        .or_else(|| output.find("new WeakSet()"))
+        .unwrap_or_else(|| panic!("expected a WeakMap/WeakSet init\nOutput:\n{output}"));
+    assert!(
+        weakmap_pos < static_pos,
+        "WeakMap/WeakSet inits must precede the static field assignment `{static_assign}`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn private_weakmap_inits_precede_static_field_self_instantiation() {
+    // Reported repro shape: `static inst = new A()` instantiates the class.
+    let source = r#"
+class A {
+  #foo = 1;
+  static inst = new A();
+  #prop = 2;
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+    assert_weakmap_inits_before(&output, "A.inst");
+}
+
+#[test]
+fn private_weakmap_inits_precede_static_field_no_self_reference() {
+    // Same ordering rule must hold even when the static initializer is a plain
+    // literal that neither references the class nor any private name. Renamed
+    // class/field to prove the rule is not keyed on the reported spelling.
+    let source = r#"
+class Widget {
+  #count = 1;
+  static label = 5;
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+    assert_weakmap_inits_before(&output, "Widget.label");
+}
+
+#[test]
+fn private_method_weakset_init_precedes_static_field() {
+    // A private instance method produces a `_C_instances = new WeakSet()` init,
+    // which must also precede the static field statement. Different target
+    // (ES2017) and different member/field names exercise the same rule.
+    let source = r#"
+class Service {
+  #run() { return 1; }
+  static version = "1.0";
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2017);
+    assert_weakmap_inits_before(&output, "Service.version");
+}
+
+#[test]
+fn no_static_field_leaves_private_inits_in_place() {
+    // Negative/fallback case: a class declaration with only instance private
+    // members and no static field still lowers correctly (a WeakMap init is
+    // present) and the change does not synthesize a spurious static assignment.
+    let source = r#"
+class Box {
+  #value = 7;
+  get() { return this.#value; }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+    assert!(
+        output.contains("new WeakMap()"),
+        "expected a private-field WeakMap init.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("Box."),
+        "instance-only class must not emit a static field assignment.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — private-name WeakMap init ordering (emit→100% campaign, wave 3)

## Invariant
For a class declaration lowered to the WeakMap private-member pattern, the private-member init statements (`_C_field = new WeakMap()`, `_C_instances = new WeakSet()`, private method/accessor function defs) MUST be emitted BEFORE the static field initialization statements (`C.x = value;`): a static initializer can instantiate the class, whose constructor populates the WeakMaps, so the storage must exist first. Holds even without a class/private self-reference. Keyed on AST/lowering facts (private-member-init vs static-element ordering) — no identifier/file-name matching, no printer-output `.contains()`. Confirmed against real tsc 6.0.3.

## Scope
- `crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs` — broaden `emit_private_inits_before_static_elements` gate (drop self-reference-only restriction); move class-expression `__setFunctionName` comma item after instance-member helpers. Removed now-unused `static_initializer_directly_uses_private_name` (kept file at its 4191 ratchet).
- `crates/tsz-emitter/src/emitter/declarations/class/helpers.rs` — removed now-dead `expression_directly_contains_private_identifier`.
- `crates/tsz-emitter/src/emitter/source_file/private_field_helper_order_tests.rs` (+4 tests).

## Project Corpus Impact
- Row: n/a (private-name WeakMap-init ordering fix)
- Bug family: WeakMap private-member storage emitted after static initializers that instantiate the class
- Evidence: privateNameAndStaticInitializer(target=es2015) FAIL→PASS; full --js-only 91→86 (real +1; 4 were flaky-timeout resolutions).

## Verification
- Witness FAIL→PASS. **Full --js-only: 13439→13444 pass (real net +1), ZERO regressions overall AND in the private-name family (18→17 fail, none newly broken).** DTS unaffected (separate path). Emitter unit: 42 pre-existing fails unchanged + 4 new tests pass. 4 new structural tests (vary class/field/method names, ES2015 & ES2017, negative no-static-field). Clippy clean; arch guard passes (removed dead code for headroom; emit_es6.rs at 4191 limit).
- §25/§26 compliant.

## Coordination Notes
Rebased onto current main. Classified (NOT fixed): privateFieldsInClassExpressionDeclaration is a STALE BASELINE — checked-in baseline emits bare `_context`/`_instances`/`_method` but real tsc 6.0.3 emits prefixed `_ClassExpression_*`; a name-prefix fix DIVERGES from real tsc (regressed 5 family tests), reverted — underlying tsc rule is file-global optimistic-uniqueness (`createUniqueName`/Optimistic), a separate effort, and the baseline may need regen. privateNameNestedMethodAccess (cross-class lexical-scope alias `new C()`→`new _a()`, broad); privateNameHashCharName (parser-recovery); IncompatibleModifiers/ES5Ban/etc. (diagnostic/broader). — opus48-emit100
