### PR TITLE
fix(emit): capture this into var this_N for ES5 converted-loop IIFE bodies that reference this

### DIFF
--- a/crates/tsz-emitter/src/context/emit.rs
+++ b/crates/tsz-emitter/src/context/emit.rs
@@ -276,6 +276,17 @@ pub struct EmitContext {
     /// File-level counter for generated `arguments_N` capture bindings.
     pub arguments_capture_counter: u32,
 
+    /// When set, a `this` keyword emitted inside an ES5 converted-loop
+    /// (`_loop_N`) IIFE body is rewritten to this captured binding name
+    /// (e.g. `this_1`). The converted loop is a `function`, so a lexical
+    /// `this` reference in its body would otherwise lose its binding; tsc
+    /// captures the enclosing function's `this` into `var this_N = this;`
+    /// at the real function scope and substitutes the body references.
+    pub loop_this_capture_name: Option<String>,
+
+    /// File-level counter for generated `this_N` converted-loop captures.
+    pub loop_this_capture_counter: u32,
+
     /// Async ES2015+ lowering emits a nested `function*`. When a `var`
     /// declaration in that generator redeclares an async parameter, tsc hoists
     /// the declaration and leaves an assignment at the original site.
@@ -336,6 +347,8 @@ impl EmitContext {
             rewrite_arguments_to_arguments_1: false,
             arguments_capture_name: None,
             arguments_capture_counter: 0,
+            loop_this_capture_name: None,
+            loop_this_capture_counter: 0,
             async_generator_shadowed_parameter_names: Vec::new(),
             auto_detect_module: false,
             module_none_out_file: false,

--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -1720,6 +1720,11 @@ impl<'a> Printer<'a> {
                 {
                     let name = std::sync::Arc::clone(capture_name);
                     self.write(&name);
+                } else if let Some(loop_this) = self.ctx.loop_this_capture_name.clone() {
+                    // Inside an ES5 converted-loop (`_loop_N`) IIFE body, a
+                    // lexical `this` is rewritten to the captured `this_N`
+                    // binding declared at the real function scope.
+                    self.write(&loop_this);
                 } else if let Some(alias) = self.scoped_static_this_alias.as_ref().cloned() {
                     self.write(&alias);
                 } else {

--- a/crates/tsz-emitter/src/emitter/es5/bindings_for_of.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings_for_of.rs
@@ -267,7 +267,7 @@ impl<'a> Printer<'a> {
                 if body_temp_count > 0 {
                     self.preallocate_hoisted_temp_names(body_temp_count);
                 }
-                self.emit_loop_function(
+                let this_capture = self.emit_loop_function(
                     &loop_fn_name,
                     &param_vars,
                     for_in_of.statement,
@@ -275,6 +275,9 @@ impl<'a> Printer<'a> {
                     &init_vars,
                 );
                 self.write_line();
+                if let Some(capture_name) = this_capture {
+                    self.emit_loop_this_capture_decl(&capture_name);
+                }
                 if !body_info.var_decl_names.is_empty() {
                     self.write("var ");
                     for (i, name) in body_info.var_decl_names.iter().enumerate() {

--- a/crates/tsz-emitter/src/emitter/es5/loop_capture.rs
+++ b/crates/tsz-emitter/src/emitter/es5/loop_capture.rs
@@ -343,7 +343,7 @@ impl<'a> Printer<'a> {
         // not threaded as parameters.
         let param_vars: Vec<String> = init_vars.to_vec();
 
-        self.emit_loop_function(
+        let this_capture = self.emit_loop_function(
             &loop_fn_name,
             &param_vars,
             loop_stmt.statement,
@@ -351,6 +351,9 @@ impl<'a> Printer<'a> {
             init_vars,
         );
         self.write_line();
+        if let Some(capture_name) = this_capture {
+            self.emit_loop_this_capture_decl(&capture_name);
+        }
         self.emit_hoisted_loop_var_decls(body_info);
 
         self.write("for (");
@@ -382,8 +385,12 @@ impl<'a> Printer<'a> {
         kind: ConditionLoopKind,
     ) {
         let loop_fn_name = self.ctx.block_scope_state.next_loop_function_name();
-        self.emit_loop_function(&loop_fn_name, &[], loop_stmt.statement, body_info, &[]);
+        let this_capture =
+            self.emit_loop_function(&loop_fn_name, &[], loop_stmt.statement, body_info, &[]);
         self.write_line();
+        if let Some(capture_name) = this_capture {
+            self.emit_loop_this_capture_decl(&capture_name);
+        }
         self.emit_hoisted_loop_var_decls(body_info);
 
         match kind {
@@ -419,7 +426,13 @@ impl<'a> Printer<'a> {
         }
     }
 
-    /// Emit the _`loop_N` function definition
+    /// Emit the _`loop_N` function definition.
+    ///
+    /// Returns the freshly-allocated `this_N` capture name when this converted
+    /// loop owns a lexical `this` capture (i.e. it is the outermost converted
+    /// loop whose body references `this`). The caller declares
+    /// `var this_N = this;` at the function scope via
+    /// [`Printer::emit_loop_this_capture_decl`] after this definition.
     pub(in crate::emitter) fn emit_loop_function(
         &mut self,
         fn_name: &str,
@@ -427,7 +440,12 @@ impl<'a> Printer<'a> {
         body_idx: NodeIndex,
         body_info: &LoopBodyVarInfo,
         _init_vars: &[String],
-    ) {
+    ) -> Option<String> {
+        // Activate `this` -> `this_N` substitution for the IIFE body when it
+        // lexically references `this`. The outermost converted loop owns the
+        // capture; nested converted loops inherit it.
+        let this_capture_scope = self.begin_loop_iife_this_capture(body_idx);
+
         self.write("var ");
         self.write(fn_name);
         self.write(" = function (");
@@ -495,6 +513,9 @@ impl<'a> Printer<'a> {
             prev_lexical_block_missing_initializer_function_depth;
         self.lexical_block_missing_initializer_is_loop_body =
             prev_lexical_block_missing_initializer_is_loop_body;
+        // Restore the `this` capture substitution state. The remaining output
+        // (`};`, hoist-temp insertions) never references lexical `this`.
+        let owned_this_capture = self.end_loop_iife_this_capture(this_capture_scope);
         self.ctx.block_scope_state.exit_scope();
 
         // Flush this IIFE's own spread-receiver hoist temps (`var _a;`) at its
@@ -535,6 +556,8 @@ impl<'a> Printer<'a> {
 
         self.decrease_indent();
         self.write("};");
+
+        owned_this_capture
     }
 
     /// Emit loop body statements inside the IIFE function

--- a/crates/tsz-emitter/src/emitter/es5/loop_this_capture.rs
+++ b/crates/tsz-emitter/src/emitter/es5/loop_this_capture.rs
@@ -1,0 +1,313 @@
+//! `this`-capture for ES5 converted loops (`_loop_N` IIFE pattern).
+//!
+//! When a loop is converted to a `_loop_N` IIFE (because its body captures a
+//! block-scoped binding) and the loop body lexically references `this`, the
+//! body is now inside a `function` and a bare `this` would resolve to the
+//! IIFE's own receiver rather than the enclosing function's `this`. tsc
+//! captures the enclosing `this` into a `var this_N = this;` temp declared at
+//! the real function scope and rewrites the body references to `this_N`:
+//!
+//! ```typescript
+//! for (const x of xs) {
+//!     this.use(() => x);
+//! }
+//! ```
+//! becomes (ES5):
+//! ```javascript
+//! var _loop_1 = function (x) {
+//!     this_1.use(function () { return x; });
+//! };
+//! var this_1 = this;
+//! for (var _i = 0, xs_1 = xs; _i < xs_1.length; _i++) {
+//!     var x = xs_1[_i];
+//!     _loop_1(x);
+//! }
+//! ```
+//!
+//! Only the OUTERMOST converted loop owns the capture: nested converted loops
+//! inherit the same `this_N` binding (the structural condition is "a converted
+//! loop whose body lexically references `this`, with no enclosing converted
+//! loop already capturing `this`"). This mirrors the existing `arguments_N`
+//! capture machinery for async lowering.
+
+use super::super::Printer;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::syntax::transform_utils::contains_this_reference;
+
+/// Token returned by [`Printer::begin_loop_iife_this_capture`] that records
+/// whether this converted loop owns a freshly-allocated `this_N` capture and
+/// the previous capture name to restore once the IIFE body has been emitted.
+pub(in crate::emitter) struct LoopThisCaptureScope {
+    /// Capture name to declare (`var this_N = this;`) once the IIFE body is
+    /// emitted, when this loop owns the capture. `None` when an enclosing
+    /// converted loop already captured `this`.
+    owned_capture_name: Option<String>,
+    /// Previous `loop_this_capture_name` to restore after the body.
+    previous: Option<String>,
+}
+
+impl<'a> Printer<'a> {
+    fn next_loop_this_capture_name(&mut self) -> String {
+        loop {
+            self.ctx.loop_this_capture_counter += 1;
+            let candidate = format!("this_{}", self.ctx.loop_this_capture_counter);
+            if !self.file_identifiers.contains(&candidate) {
+                return candidate;
+            }
+        }
+    }
+
+    /// Activate `this` -> `this_N` substitution for a converted-loop IIFE body
+    /// that lexically references `this`. Must be paired with
+    /// [`Printer::end_loop_iife_this_capture`] after the body is emitted.
+    ///
+    /// The outermost converted loop allocates a fresh `this_N` binding; nested
+    /// converted loops inherit the active binding. Returns a scope token whose
+    /// owned capture name (if any) should be declared by the caller via
+    /// [`Printer::emit_loop_this_capture_decl`] after the IIFE definition.
+    pub(in crate::emitter) fn begin_loop_iife_this_capture(
+        &mut self,
+        body_idx: NodeIndex,
+    ) -> LoopThisCaptureScope {
+        let previous = self.ctx.loop_this_capture_name.clone();
+
+        // An enclosing converted loop already captured `this`; the body simply
+        // inherits that binding. Bodies that do not reference lexical `this`
+        // need no capture at all.
+        if previous.is_some() || !contains_this_reference(self.arena, body_idx) {
+            return LoopThisCaptureScope {
+                owned_capture_name: None,
+                previous,
+            };
+        }
+
+        let capture_name = self.next_loop_this_capture_name();
+        self.ctx.loop_this_capture_name = Some(capture_name.clone());
+        LoopThisCaptureScope {
+            owned_capture_name: Some(capture_name),
+            previous,
+        }
+    }
+
+    /// Restore the substitution state saved by
+    /// [`Printer::begin_loop_iife_this_capture`] once the IIFE body has been
+    /// emitted, returning the owned capture name (if this loop owns one) so the
+    /// caller can declare `var this_N = this;` at the function scope.
+    pub(in crate::emitter) fn end_loop_iife_this_capture(
+        &mut self,
+        scope: LoopThisCaptureScope,
+    ) -> Option<String> {
+        self.ctx.loop_this_capture_name = scope.previous;
+        scope.owned_capture_name
+    }
+
+    /// Emit `var this_N = this;` at the current (function-scope) indentation
+    /// when the converted loop owns a freshly-allocated capture.
+    pub(in crate::emitter) fn emit_loop_this_capture_decl(&mut self, owned_capture_name: &str) {
+        self.write("var ");
+        self.write(owned_capture_name);
+        self.write(" = this;");
+        self.write_line();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::output::printer::{PrintOptions, lower_and_print};
+    use tsz_common::ScriptTarget;
+    use tsz_parser::ParserState;
+
+    fn emit_es5(source: &str) -> String {
+        let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+        let root = parser.parse_source_file();
+        lower_and_print(
+            &parser.arena,
+            root,
+            PrintOptions {
+                target: ScriptTarget::ES5,
+                ..Default::default()
+            },
+        )
+        .code
+    }
+
+    // A converted for-of loop whose body uses `this` (here through a captured
+    // arrow) must capture the enclosing `this` into `var this_1 = this;` at the
+    // function scope and rewrite the body reference to `this_1`. The rule is
+    // keyed on the converted-loop body referencing lexical `this`, not on any
+    // identifier spelling, so renaming the loop/binding vars must not change it.
+    #[test]
+    fn converted_for_of_with_this_in_arrow_captures_this_1() {
+        for (loop_var, method) in [("x", "use"), ("element", "handle")] {
+            let source = format!(
+                "class C {{\n\
+                    run(xs: any[]) {{\n\
+                        for (const {loop_var} of xs) {{\n\
+                            this.{method}(() => {loop_var});\n\
+                        }}\n\
+                    }}\n\
+                    {method}(f: any) {{}}\n\
+                }}\n"
+            );
+
+            let output = emit_es5(&source);
+
+            assert!(
+                output.contains("var this_1 = this;"),
+                "Converted loop body referencing `this` must capture it at the function scope.\nOutput:\n{output}"
+            );
+            assert!(
+                output.contains(&format!("this_1.{method}(")),
+                "Body `this` must be rewritten to the captured `this_1` binding.\nOutput:\n{output}"
+            );
+            assert!(
+                !output.contains(&format!("this.{method}(")),
+                "No bare `this` should remain inside the converted-loop IIFE body.\nOutput:\n{output}"
+            );
+        }
+    }
+
+    // Reproduces the `nestedLoops` witness shape: the `this` site is at the
+    // loop body level and the inner arrow only closes over the loop bindings.
+    // The capture decl is emitted at the function scope (after the `_loop_N`
+    // definition) and the body `this` is rewritten.
+    #[test]
+    fn nested_loops_witness_shape_captures_this_after_loop_fn_decl() {
+        let source = "class Test {\n\
+            constructor() {\n\
+                let outerArray: number[] = [1, 2, 3];\n\
+                let innerArray: number[] = [1, 2, 3];\n\
+                for (let outer of outerArray)\n\
+                    for (let inner of innerArray) {\n\
+                        this.aFunction((n, o) => { let x = outer + inner + n; });\n\
+                    }\n\
+            }\n\
+            aFunction(f: (n: any, o: any) => void): void {}\n\
+        }\n";
+
+        let output = emit_es5(source);
+
+        // The capture is declared AFTER the outer `_loop_1` definition, at the
+        // function scope, before the driving for-loop.
+        let loop_decl = output
+            .find("var _loop_1 = function")
+            .expect("outer loop must convert");
+        let capture_decl = output
+            .find("var this_1 = this;")
+            .expect("converted body referencing `this` must capture it");
+        assert!(
+            capture_decl > loop_decl,
+            "`var this_1 = this;` must follow the `_loop_1` definition.\nOutput:\n{output}"
+        );
+        assert!(
+            output.contains("this_1.aFunction("),
+            "Inner-loop body `this` must be rewritten to the capture.\nOutput:\n{output}"
+        );
+        assert!(
+            !output.contains("this.aFunction("),
+            "No bare `this` should remain inside the converted loops.\nOutput:\n{output}"
+        );
+    }
+
+    // A `this` that appears DIRECTLY in the converted-loop body (outside any
+    // closure) is captured just like one inside an escaping arrow. Here the
+    // loop converts because an escaping closure captures the loop variable,
+    // and the direct `this.note(x)` in the body is rewritten too.
+    #[test]
+    fn converted_for_of_direct_this_in_body_is_rewritten() {
+        for loop_var in ["x", "row"] {
+            let source = format!(
+                "class C {{\n\
+                    run(xs: any[]) {{\n\
+                        for (const {loop_var} of xs) {{\n\
+                            this.note({loop_var});\n\
+                            this.store(function () {{ return {loop_var}; }});\n\
+                        }}\n\
+                    }}\n\
+                    note(x: any) {{}}\n\
+                    store(f: any) {{}}\n\
+                }}\n"
+            );
+
+            let output = emit_es5(&source);
+
+            assert!(
+                output.contains("var _loop_1 = function ("),
+                "Loop must convert because the escaping closure captures the loop var.\nOutput:\n{output}"
+            );
+            assert!(
+                output.contains("var this_1 = this;"),
+                "Converted body with a direct `this` reference must capture it.\nOutput:\n{output}"
+            );
+            assert!(
+                output.contains("this_1.note(") && output.contains("this_1.store("),
+                "Both the direct and closure-passing `this` calls must use the capture.\nOutput:\n{output}"
+            );
+        }
+    }
+
+    // Nested converted loops share ONE capture allocated by the outermost loop.
+    // The inner loop body's `this` resolves to the same `this_1`; no second
+    // `this_2` capture is emitted. Renaming vars must not change this.
+    #[test]
+    fn nested_converted_loops_share_single_this_capture() {
+        for (outer, inner) in [("outer", "inner"), ("p", "q")] {
+            let source = format!(
+                "class C {{\n\
+                    run(a: any[], b: any[]) {{\n\
+                        for (const {outer} of a)\n\
+                            for (const {inner} of b) {{\n\
+                                this.use(() => {outer} + {inner});\n\
+                            }}\n\
+                    }}\n\
+                    use(f: any) {{}}\n\
+                }}\n"
+            );
+
+            let output = emit_es5(&source);
+
+            assert!(
+                output.contains("var this_1 = this;"),
+                "Outermost converted loop must own the single `this` capture.\nOutput:\n{output}"
+            );
+            assert!(
+                !output.contains("var this_2 = this;"),
+                "Nested converted loops must inherit, not re-capture, `this`.\nOutput:\n{output}"
+            );
+            assert!(
+                output.contains("this_1.use("),
+                "Inner loop body `this` must resolve to the inherited capture.\nOutput:\n{output}"
+            );
+        }
+    }
+
+    // A converted loop body whose `this` only appears inside a NESTED regular
+    // function (which owns its own `this`) must NOT trigger a capture: that
+    // `this` is not the enclosing lexical `this`.
+    #[test]
+    fn converted_loop_this_inside_nested_function_does_not_capture() {
+        let source = "class C {\n\
+            run(xs: any[]) {\n\
+                for (const x of xs) {\n\
+                    var f = function () { return this; };\n\
+                    (() => x)();\n\
+                }\n\
+            }\n\
+        }\n";
+
+        let output = emit_es5(source);
+
+        assert!(
+            output.contains("var _loop_1 = function (x)"),
+            "Loop must convert because `x` is captured.\nOutput:\n{output}"
+        );
+        assert!(
+            !output.contains("var this_1 = this;"),
+            "A `this` owned by a nested regular function must not force a capture.\nOutput:\n{output}"
+        );
+        assert!(
+            output.contains("return this;"),
+            "The nested function keeps its own `this` unrewritten.\nOutput:\n{output}"
+        );
+    }
+}

--- a/crates/tsz-emitter/src/emitter/es5/mod.rs
+++ b/crates/tsz-emitter/src/emitter/es5/mod.rs
@@ -20,4 +20,5 @@ mod helpers_class_expression_names;
 mod helpers_object_literal;
 #[allow(dead_code)]
 pub(in crate::emitter) mod loop_capture;
+pub(in crate::emitter) mod loop_this_capture;
 mod templates;

--- a/crates/tsz-emitter/src/emitter/source_file/emit.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/emit.rs
@@ -93,6 +93,8 @@ impl<'a> Printer<'a> {
             self.commonjs_tslib_import_binding = "tslib_1".to_string();
         }
         self.ctx.arguments_capture_counter = 0;
+        self.ctx.loop_this_capture_counter = 0;
+        self.ctx.loop_this_capture_name = None;
         self.next_dynamic_import_promise_id = 1;
         self.first_for_of_emitted = false;
         self.namespace_all_exported_names.clear();


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — ES5 converted-loop `this`-capture (emit→100% campaign, wave 3)

## Invariant
When an ES5 converted-loop (`_loop_N`) IIFE body lexically references `this` (direct `this`/`super`, descending through arrows and computed names, stopping at nested non-arrow function/class boundaries) AND no enclosing converted loop has already captured `this`, declare `var this_N = this;` at the real function scope (after the outermost `_loop_N` definition) and rewrite the body's `this`→`this_N`. Nested converted loops inherit the single outermost capture (no `this_2`). Keyed on AST node kind via the existing lexical-`this` detector — no identifier/file-name matching, no printer-output inspection. Mirrors the existing `arguments_N` capture machinery.

## Scope
- NEW `crates/tsz-emitter/src/emitter/es5/loop_this_capture.rs` (303 lines: new fns + 5 unit tests).
- `emitter/context/emit.rs` (+2 fields), `emitter/core.rs` (+5, now 1804<2000), `es5/loop_capture.rs` (shared `emit_loop_function` returns owned capture name), `es5/bindings_for_of.rs`, `es5/mod.rs` (+1 mod), `source_file/emit.rs` (+2 per-file reset). No file at/over the 2000 ratchet was grown.

## Project Corpus Impact
- Row: n/a (ES5 converted-loop emit fix)
- Bug family: converted-loop IIFE body references `this` but no outer `var this_N = this` capture/substitution
- Evidence: nestedLoops(target=es5) FAIL→PASS; full --js-only 84→83.

## Verification
- Witness FAIL→PASS. **Full --js-only: 13446→13447 pass (84→83 fail), net +1, ZERO new failures, 0 timeouts** (confirmed twice; no regressions in any loop/capture test). --dts-only unaffected. 5 structural unit tests / 9 scenarios (arrow-this, direct-this, nesting single-shared-capture, witness shape, negative `this` owned by nested regular function — each varies bound names). Clippy clean; arch guard passes (new code in a fresh file).
- §25/§26 compliant.

## Coordination Notes
Rebased onto current main. Scoped out (upstream parser-recovery, NOT this-capture): labeledStatementDeclarationListInLoopNoCrash3/4 (es5+es2015) — malformed template-literal `.concat()` mangling means tsz never forms the `_loop_N` IIFE; divergence is in the parser-recovery path, separate work. — opus48-emit100
