### PR TITLE
fix(parser): recover stray-annotation computed-indexer object member as two members

### DIFF
--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -1994,6 +1994,7 @@ impl ParserState {
 
         if self.parse_optional(SyntaxKind::ColonToken) {
             let expr = self.parse_assignment_expression();
+            let mut end_pos = self.token_end();
             let initializer = if expr.is_none() {
                 // Emit TS1109 for missing property value: { prop: }
                 self.error_expression_expected();
@@ -2001,15 +2002,19 @@ impl ParserState {
                     self.suppress_object_literal_comma_once = true;
                 }
                 name // Use property name as fallback for error recovery
-            } else if let Some(recovered) =
-                self.recover_object_literal_computed_indexer_tail(name, expr)
-            {
-                recovered
             } else {
+                // Recover a stray-annotation computed-indexer tail
+                // (`{ [s: symbol]: "" }`): emits the diagnostics, consumes the
+                // recovered `]`/`:`, and re-parses the remainder as a fresh
+                // member. Because that advances the scanner onto the next
+                // member, pin this member's end to its parsed value so the
+                // emitter's source-line layout (this member's end vs. the next
+                // member's start) keeps the recovered members on one line.
+                if self.recover_object_literal_computed_indexer_tail(name) {
+                    end_pos = self.arena.get(expr).map_or(end_pos, |node| node.end);
+                }
                 expr
             };
-
-            let end_pos = self.token_end();
             // Regular property assignment with explicit value
             self.arena.add_property_assignment(
                 syntax_kind_ext::PROPERTY_ASSIGNMENT,
@@ -2066,17 +2071,27 @@ impl ParserState {
         }
     }
 
-    fn recover_object_literal_computed_indexer_tail(
-        &mut self,
-        name: NodeIndex,
-        left: NodeIndex,
-    ) -> Option<NodeIndex> {
-        let name_node = self.arena.get(name)?;
-        let name_end = name_node.end;
+    /// Recover the malformed tail of an object-literal member whose computed
+    /// name carried a stray type annotation (`{ [s: symbol]: "" }`).
+    ///
+    /// Rule: when a member's computed name `[expr]` was just closed by a
+    /// recovered `]` (the scanner is *on* a `CloseBracketToken` after a parsed
+    /// value) and that `]` is immediately followed by `:`, tsc does not fold the
+    /// tail into the current member. It closes the member with the parsed value,
+    /// reports `','`/`Property assignment` expected at the `]`/`:`, consumes
+    /// both, then re-reads the remainder as a fresh member. This helper performs
+    /// that as side effects, suppresses the next comma requirement so the outer
+    /// loop re-enters element parsing on the remaining token, and returns `true`
+    /// when it fired so the caller keeps the parsed value (and its source end)
+    /// as the member's initializer instead of the post-recovery scanner position.
+    fn recover_object_literal_computed_indexer_tail(&mut self, name: NodeIndex) -> bool {
+        let Some(name_node) = self.arena.get(name) else {
+            return false;
+        };
         if name_node.kind != syntax_kind_ext::COMPUTED_PROPERTY_NAME
             || !self.is_token(SyntaxKind::CloseBracketToken)
         {
-            return None;
+            return false;
         }
 
         let snapshot = self.scanner.save_state();
@@ -2086,45 +2101,28 @@ impl ParserState {
         self.scanner.restore_state(snapshot);
         self.current_token = current;
         if !has_colon_after_bracket {
-            return None;
+            return false;
         }
 
+        // `']' expected` was already emitted while parsing the computed name; the
+        // recovered `]` now closes the current member's value. tsc reports a
+        // missing separator at the `]` and a missing property at the following
+        // `:`, then re-reads the remaining tokens as a new member.
         self.parse_error_at_current_token("',' expected.", diagnostic_codes::EXPECTED);
-        self.next_token();
+        self.next_token(); // consume the `]`
         self.parse_error_at_current_token(
             "Property assignment expected.",
             diagnostic_codes::PROPERTY_ASSIGNMENT_EXPECTED,
         );
-        self.next_token();
-        let right = self.parse_assignment_expression();
-        if right.is_none() {
-            return Some(left);
-        }
-        // tsc does not fold the trailing value into a comma expression; it
-        // re-reads it as the property name of a fresh object member that then
-        // expects a `:`. When that recovered tail butts directly against the
-        // object's closing `}` (no comma/semicolon separator), tsc reports
-        // TS1005 "':' expected." at the `}` for the missing property colon.
-        // Mirror that here so the recovered comma-expression AST is preserved
-        // while the trailing diagnostic still matches tsc.
-        if self.is_token(SyntaxKind::CloseBraceToken) {
-            self.parse_error_at_current_token("':' expected.", diagnostic_codes::EXPECTED);
-        }
-        let left_start = self.arena.get(left).map_or(name_end, |node| node.pos);
-        let end_pos = self
-            .arena
-            .get(right)
-            .map_or(self.token_end(), |node| node.end);
-        Some(self.arena.add_binary_expr(
-            syntax_kind_ext::BINARY_EXPRESSION,
-            left_start,
-            end_pos,
-            crate::parser::node::BinaryExprData {
-                left,
-                operator_token: SyntaxKind::CommaToken as u16,
-                right,
-            },
-        ))
+        self.next_token(); // consume the stray `:`
+
+        // Let the outer object-literal loop re-enter element parsing on the
+        // remaining token without requiring a comma separator. The trailing
+        // `':' expected` (when the new member's name butts against `}`) and any
+        // missing-comma diagnostic then fall out of normal member parsing,
+        // matching tsc instead of being synthesized here.
+        self.suppress_object_literal_comma_once = true;
+        true
     }
 
     /// Look ahead to check if get/set/async is a method vs property name

--- a/crates/tsz-parser/tests/parser_unit_tests_parts/part_01.rs
+++ b/crates/tsz-parser/tests/parser_unit_tests_parts/part_01.rs
@@ -828,7 +828,11 @@ fn expr_object_literal() {
 }
 
 #[test]
-fn object_literal_private_indexer_tail_recovers_as_comma_initializer() {
+fn object_literal_private_indexer_tail_recovers_as_two_members() {
+    // `{ private [x: string]: string; }`: the stray type annotation in the
+    // computed-name member is recovered as the computed-name property
+    // (`[x]: string`) followed by a fresh member parsed from the trailing
+    // token (`string`). tsc emits this as `{ [x]: string, string }`.
     let source = "const x = { private [x: string]: string; };";
     let (parser, root) = parse_source(source);
     let arena = parser.get_arena();
@@ -839,18 +843,33 @@ fn object_literal_private_indexer_tail_recovers_as_comma_initializer() {
         .expect("object literal expression");
     assert_eq!(
         object_data.elements.nodes.len(),
-        1,
-        "malformed indexer tail should stay on one object property"
+        2,
+        "recovered indexer tail should split into two object members"
     );
 
-    let prop = arena
+    // Member 1: computed-name property assignment `[x]: string`.
+    let prop0 = arena
         .get(object_data.elements.nodes[0])
-        .expect("property assignment");
+        .expect("first member");
+    assert_eq!(prop0.kind, syntax_kind_ext::PROPERTY_ASSIGNMENT);
     let assignment = arena
-        .get_property_assignment(prop)
+        .get_property_assignment(prop0)
         .expect("property assignment data");
-    let (_, op, _) = get_binary(arena, assignment.initializer);
-    assert_eq!(op, SyntaxKind::CommaToken as u16);
+    let name0 = arena.get(assignment.name).expect("computed name");
+    assert_eq!(name0.kind, syntax_kind_ext::COMPUTED_PROPERTY_NAME);
+    // The first member's source end must stop at its parsed value so source
+    // layout stays accurate; it must not extend onto the recovered tail.
+    let value0 = arena.get(assignment.initializer).expect("member value");
+    assert_eq!(
+        prop0.end, value0.end,
+        "first member must end at its parsed value, not the recovered tail"
+    );
+
+    // Member 2: a fresh member parsed from the trailing token.
+    let prop1 = arena
+        .get(object_data.elements.nodes[1])
+        .expect("second member");
+    assert_eq!(prop1.kind, syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT);
 
     let codes: Vec<u32> = parser
         .get_diagnostics()
@@ -865,9 +884,11 @@ fn object_literal_private_indexer_tail_recovers_as_comma_initializer() {
 fn object_literal_computed_indexer_tail_at_close_brace_reports_colon_expected() {
     // parserSymbolIndexer5-shaped input: a malformed computed-indexer member
     // (`[name: type]: value`) whose recovered tail butts directly against the
-    // object's closing `}`. tsc still reports TS1005 "':' expected." at the
-    // `}` for the missing property colon. Vary the computed-name identifier
-    // (here `q`, not `s`) so the assertion keys on the structure, not a name.
+    // object's closing `}`. tsc recovers two members — `[q]: symbol` and a
+    // fresh member whose name is the trailing `""` — and reports TS1005
+    // "':' expected." at the `}` for that second member's missing colon.
+    // Vary the computed-name identifier (here `q`, not `s`) so the assertion
+    // keys on the structure, not a name.
     let source = "var x = {\n    [q: symbol]: \"\"\n}";
     let (parser, root) = parse_source(source);
     let arena = parser.get_arena();
@@ -878,19 +899,34 @@ fn object_literal_computed_indexer_tail_at_close_brace_reports_colon_expected() 
         .expect("object literal expression");
     assert_eq!(
         object_data.elements.nodes.len(),
-        1,
-        "malformed indexer tail should stay on one object property"
+        2,
+        "recovered indexer tail should split into two object members"
     );
 
-    // The recovered initializer is still the comma-expression from #10701.
-    let prop = arena
+    // Member 1: computed-name property `[q]: symbol`; its end must stop at the
+    // parsed value (`symbol`) so the recovered second member stays on the same
+    // source line in emit, matching tsc's `[q]: symbol, "":` output.
+    let prop0 = arena
         .get(object_data.elements.nodes[0])
-        .expect("property assignment");
+        .expect("first member");
+    assert_eq!(prop0.kind, syntax_kind_ext::PROPERTY_ASSIGNMENT);
     let assignment = arena
-        .get_property_assignment(prop)
+        .get_property_assignment(prop0)
         .expect("property assignment data");
-    let (_, op, _) = get_binary(arena, assignment.initializer);
-    assert_eq!(op, SyntaxKind::CommaToken as u16);
+    let name0 = arena.get(assignment.name).expect("computed name");
+    assert_eq!(name0.kind, syntax_kind_ext::COMPUTED_PROPERTY_NAME);
+    let value0 = arena.get(assignment.initializer).expect("member value");
+    assert_eq!(
+        prop0.end, value0.end,
+        "first member must end at its parsed value, not the recovered tail"
+    );
+
+    // Member 2: a fresh member whose name is the trailing string literal `""`,
+    // which (lacking a `:`) requires a colon.
+    let prop1 = arena
+        .get(object_data.elements.nodes[1])
+        .expect("second member");
+    assert_eq!(prop1.kind, syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT);
 
     // The trailing "':' expected." must land at the closing `}` position.
     let close_brace_pos = source.rfind('}').expect("closing brace") as u32;
@@ -903,7 +939,7 @@ fn object_literal_computed_indexer_tail_at_close_brace_reports_colon_expected() 
         parser.get_diagnostics()
     );
 
-    // The earlier recovery diagnostics from #10701 must remain.
+    // The earlier recovery diagnostics must remain.
     let codes: Vec<u32> = parser
         .get_diagnostics()
         .iter()
@@ -911,6 +947,89 @@ fn object_literal_computed_indexer_tail_at_close_brace_reports_colon_expected() 
         .collect();
     assert!(codes.contains(&diagnostic_codes::EXPECTED));
     assert!(codes.contains(&diagnostic_codes::PROPERTY_ASSIGNMENT_EXPECTED));
+}
+
+#[test]
+fn object_literal_computed_indexer_tail_identifier_value_then_close_brace() {
+    // Same recovery rule with a renamed iteration identifier (`k`) and an
+    // identifier trailing token instead of a string literal. The tail `done`
+    // becomes a shorthand member; because it is an identifier (not a literal
+    // requiring a colon) and butts against `}`, no "':' expected." fires here.
+    // Proves the recovery is keyed on the `[expr]` `]:` shape, not a name.
+    let source = "var y = {\n    [k: number]: done\n}";
+    let (parser, root) = parse_source(source);
+    let arena = parser.get_arena();
+    let init = get_var_initializer(arena, root);
+    let object = arena.get(init).expect("object literal");
+    let object_data = arena
+        .get_literal_expr(object)
+        .expect("object literal expression");
+    assert_eq!(
+        object_data.elements.nodes.len(),
+        2,
+        "recovered indexer tail should split into two object members"
+    );
+
+    let prop0 = arena
+        .get(object_data.elements.nodes[0])
+        .expect("first member");
+    assert_eq!(prop0.kind, syntax_kind_ext::PROPERTY_ASSIGNMENT);
+    let assignment = arena
+        .get_property_assignment(prop0)
+        .expect("property assignment data");
+    let name0 = arena.get(assignment.name).expect("computed name");
+    assert_eq!(name0.kind, syntax_kind_ext::COMPUTED_PROPERTY_NAME);
+    let value0 = arena.get(assignment.initializer).expect("member value");
+    assert_eq!(
+        prop0.end, value0.end,
+        "first member must end at its parsed value, not the recovered tail"
+    );
+
+    let prop1 = arena
+        .get(object_data.elements.nodes[1])
+        .expect("second member");
+    assert_eq!(prop1.kind, syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT);
+
+    let codes: Vec<u32> = parser
+        .get_diagnostics()
+        .iter()
+        .map(|diag| diag.code)
+        .collect();
+    assert!(codes.contains(&diagnostic_codes::EXPECTED));
+    assert!(codes.contains(&diagnostic_codes::PROPERTY_ASSIGNMENT_EXPECTED));
+}
+
+#[test]
+fn object_literal_well_formed_computed_member_is_not_split() {
+    // Negative/fallback case: a well-formed computed member (`[k]: 0`) must
+    // not trigger the stray-annotation recovery. The object stays a single
+    // member with no recovery diagnostics. Proves the recovery only fires on
+    // the `]:` mis-shape, not on every computed member.
+    let source = "var z = { [k]: 0 }";
+    let (parser, root) = parse_source(source);
+    let arena = parser.get_arena();
+    let init = get_var_initializer(arena, root);
+    let object = arena.get(init).expect("object literal");
+    let object_data = arena
+        .get_literal_expr(object)
+        .expect("object literal expression");
+    assert_eq!(
+        object_data.elements.nodes.len(),
+        1,
+        "well-formed computed member must remain a single object property"
+    );
+    let prop0 = arena
+        .get(object_data.elements.nodes[0])
+        .expect("only member");
+    assert_eq!(prop0.kind, syntax_kind_ext::PROPERTY_ASSIGNMENT);
+    assert!(
+        !parser
+            .get_diagnostics()
+            .iter()
+            .any(|diag| diag.code == diagnostic_codes::PROPERTY_ASSIGNMENT_EXPECTED),
+        "well-formed computed member must not emit recovery diagnostics, got {:?}",
+        parser.get_diagnostics()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
parser — stray-annotation computed-indexer object-member recovery (emit→100% campaign, wave 3)

## Invariant
When an object-literal member's computed name `[expr]` is closed by a recovered `]` (scanner on `CloseBracketToken` after a parsed value) immediately followed by `:`, recover the member as the computed-name property with its parsed value, emit `,`/`Property assignment expected` at the `]`/`:`, consume both, and re-parse the remaining token as a FRESH member — instead of folding the tail into one property's comma-expression initializer (which dropped the second member's name+colon). The first member's end is pinned to its parsed value so the same-source-line layout keeps both members on one line. Keyed on parser state + token kind (CloseBracket-then-colon in object-member position) — no identifier/file-name matching.

## Scope
- `crates/tsz-parser/src/parser/state_expressions_literals.rs` — the recovery rule (file at 3052, under 3054 ratchet — comments trimmed for headroom).
- `crates/tsz-parser/tests/parser_unit_tests_parts/part_01.rs` (+/updated 4 structural tests; file at 1979<2000).

## Project Corpus Impact
- Row: n/a (parser error-recovery fix)
- Bug family: object-literal computed-name member with stray `: type` annotation folded into comma-expr (dropping the next member)
- Evidence: parserSymbolIndexer5 FAIL→PASS; full --js-only 84→83.

## Verification
- Witness `parserSymbolIndexer5` FAIL→PASS (`[s]: symbol, "": ` now two recovered members, not folded). **Full --js-only: 84→83 fail, net +1, ZERO new failures. Full --dts-only: 24→24, ZERO new.** Baseline verified current vs tsc 6.0.3.
- tsz-parser unit 1052/1052 (2 prior tests updated to the two-member shape + 4 structural tests, renamed iteration vars). tsz-emitter 21 pre-existing fails unchanged. NARROW conformance: parserSymbolIndexer 5/5, parserErrorRecovery 47/47, ObjectLiteral 99/99, computedProperty 146/146, objectLiteral 52/52, parserComputed 41/41 — all 100%. ADDITIONAL targeted check (this PR): `constructorWithIncompleteTypeAnnotation` conformance PASS 1/1 (the test a sibling parser-recovery PR #11754 regressed — confirmed NOT regressed here). Clippy clean; arch guard passes.
- §25/§26 compliant.

## Coordination Notes
Rebased onto current main. PARSER change → relying on FULL conformance-aggregate CI as the final gate (narrow smoke + the targeted constructorWithIncompleteTypeAnnotation check are clean; if full conformance-aggregate flags any regression I will draft+WIP rather than land, per §20.25). Distinct rule from the parked #11754 (leading-binary-operator recovery). — opus48-emit100
