### PR TITLE
fix(emit): valid setter-descriptor for super-property object-rest assignment target in static member (Fixes #11756)

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -39,6 +39,10 @@ name = "super_missing_member_recovery_tests"
 path = "tests/super_missing_member_recovery_tests.rs"
 
 [[test]]
+name = "static_super_object_rest_assignment_target_tests"
+path = "tests/static_super_object_rest_assignment_target_tests.rs"
+
+[[test]]
 name = "class_temp_dedup_hoist_buckets_tests"
 path = "tests/class_temp_dedup_hoist_buckets_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/es5/bindings_assignment.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings_assignment.rs
@@ -664,6 +664,15 @@ impl<'a> Printer<'a> {
         if self.assignment_object_rest_target_needs_temp(target) {
             let temp = self.make_unique_name_hoisted_assignment();
             self.write(&temp);
+        } else if self.pattern_has_scoped_static_super_assignment_target(target) {
+            // A `super.x` rest target (`{ ...super.x } = ...`) inside a scoped
+            // static-super context must be lowered to the setter-descriptor
+            // form so it stays a valid assignment LHS. Emitting it through the
+            // plain path would produce `Reflect.get(...) = __rest(...)`, which
+            // is a non-runnable call-expression-as-LHS. Routing through the
+            // scoped-static-super assignment-target emitter yields the
+            // `({ set value(_a) { Reflect.set(...) } }).value` form tsc emits.
+            self.emit_with_scoped_static_super_assignment_targets(target);
         } else {
             self.emit(target);
         }

--- a/crates/tsz-emitter/tests/static_super_object_rest_assignment_target_tests.rs
+++ b/crates/tsz-emitter/tests/static_super_object_rest_assignment_target_tests.rs
@@ -1,0 +1,174 @@
+//! Object-rest assignment-target lowering for a `super` property inside a
+//! scoped static-super context (issue #11756).
+//!
+//! Structural rule: when a `super.<prop>` / `super["<prop>"]` access appears in
+//! the assignment-TARGET position of an object-rest destructuring assignment
+//! (`{ ...super.x } = ...`) inside a scoped static-super context that requires
+//! the `Reflect.set`/`Reflect.get` rewrite, tsc lowers the target to the
+//! setter-descriptor form `({ set value(_a) { Reflect.set(base, "x", _a, recv);
+//! } }).value`. Before this fix tsz emitted the read form `Reflect.get(base,
+//! "x", recv)` in LHS position, producing a call-expression-as-assignment-target
+//! (`Reflect.get(...) = __rest(...)`) — a runtime `SyntaxError` (non-runnable
+//! JavaScript).
+//!
+//! These tests vary the class, base, member, and rest property names so the
+//! behaviour is keyed on the structural "super property in object-rest target"
+//! shape, not on any particular identifier spelling. The negative case proves a
+//! non-super object-rest target is unaffected.
+
+use tsz_common::common::ScriptTarget;
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_lower_print;
+
+fn lower_es2015(source: &str) -> String {
+    let opts = PrintOptions {
+        target: ScriptTarget::ES2015,
+        ..Default::default()
+    };
+    parse_and_lower_print(source, opts)
+}
+
+/// The reported repro shape: `{ ...super.a } = { x: 0 }` in a static field of a
+/// derived class. The `super.a` rest target must lower to the setter-descriptor
+/// form, never to a `Reflect.get(...)` left-hand side.
+#[test]
+fn object_rest_super_property_target_lowers_to_setter_descriptor() {
+    let source = concat!(
+        "declare class B { static a: any; }\n",
+        "class C extends B {\n",
+        "    static x: any = undefined!;\n",
+        "    static z13 = { ...super.a } = { x: 0 };\n",
+        "}\n",
+    );
+    let output = lower_es2015(source);
+    assert!(
+        output.contains("set value(") && output.contains(".value = "),
+        "object-rest super target should lower to the setter-descriptor form.\nOutput:\n{output}"
+    );
+    // The crux of the correctness fix: no call expression in LHS position.
+    assert!(
+        !output.contains("Reflect.get(") || !reflect_get_used_as_lhs(&output),
+        "object-rest super target must not emit `Reflect.get(...) = ...` (invalid LHS).\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("__rest("),
+        "object-rest lowering should still call the `__rest` helper.\nOutput:\n{output}"
+    );
+}
+
+/// Same rule with different class/base/member/property names, proving the fix is
+/// keyed on the structural shape rather than the `C`/`B`/`a` spelling. Uses an
+/// element access (`super["title"]`) as the rest target.
+#[test]
+fn object_rest_super_element_target_lowers_for_other_names() {
+    let source = concat!(
+        "declare class Widget { static title: any; }\n",
+        "class Panel extends Widget {\n",
+        "    static seed: any = undefined!;\n",
+        "    static leftover = { ...super[\"title\"] } = { label: 1 };\n",
+        "}\n",
+    );
+    let output = lower_es2015(source);
+    assert!(
+        output.contains("set value(") && output.contains(".value = "),
+        "renamed object-rest super element target should still lower to the setter-descriptor form.\nOutput:\n{output}"
+    );
+    assert!(
+        !reflect_get_used_as_lhs(&output),
+        "renamed object-rest super target must not produce a `Reflect.get(...)` assignment LHS.\nOutput:\n{output}"
+    );
+}
+
+/// A `super.prop` rest target wrapped through a property-access spelling with a
+/// distinct member name confirms the property-access path also routes through the
+/// setter-descriptor emitter.
+#[test]
+fn object_rest_super_property_target_property_access_other_member() {
+    let source = concat!(
+        "declare class Store { static cache: any; }\n",
+        "class Shop extends Store {\n",
+        "    static init: any = undefined!;\n",
+        "    static rest = { ...super.cache } = { hit: 0 };\n",
+        "}\n",
+    );
+    let output = lower_es2015(source);
+    assert!(
+        output.contains("set value(") && output.contains(".value = "),
+        "property-access super rest target should lower to the setter-descriptor form.\nOutput:\n{output}"
+    );
+    assert!(
+        !reflect_get_used_as_lhs(&output),
+        "property-access super rest target must not produce a `Reflect.get(...)` assignment LHS.\nOutput:\n{output}"
+    );
+}
+
+/// Negative / regression case: an object-rest assignment whose rest target is a
+/// plain identifier (not a `super` property) is unaffected — it keeps the normal
+/// `target = __rest(...)` lowering and never grows a setter descriptor.
+#[test]
+fn object_rest_plain_identifier_target_is_unaffected() {
+    let source = concat!(
+        "declare class Base { static a: any; }\n",
+        "class Derived extends Base {\n",
+        "    static x: any = undefined!;\n",
+        "    static plain = (() => { let rest; ({ ...rest } = { y: 0 }); return rest; })();\n",
+        "}\n",
+    );
+    let output = lower_es2015(source);
+    assert!(
+        output.contains("__rest("),
+        "plain identifier object-rest should still call `__rest`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("set value("),
+        "plain identifier object-rest target must not grow a setter descriptor.\nOutput:\n{output}"
+    );
+}
+
+/// Returns true if any `Reflect.get(` call appears immediately on the left-hand
+/// side of an assignment (`Reflect.get(...) = `), which is the invalid
+/// call-expression-as-LHS shape this fix removes. Scans for the closing-paren
+/// followed by ` = ` after a `Reflect.get(` opener at the same nesting depth.
+fn reflect_get_used_as_lhs(output: &str) -> bool {
+    let bytes = output.as_bytes();
+    let needle = b"Reflect.get(";
+    let mut search_from = 0;
+    while let Some(rel) = find_subslice(&bytes[search_from..], needle) {
+        let open = search_from + rel + needle.len();
+        // Walk to the matching close paren of this `Reflect.get(` call.
+        let mut depth = 1usize;
+        let mut i = open;
+        while i < bytes.len() && depth > 0 {
+            match bytes[i] {
+                b'(' => depth += 1,
+                b')' => depth -= 1,
+                _ => {}
+            }
+            i += 1;
+        }
+        // After the matching `)`, an immediate ` = ` (not `==`/`=>`) means the
+        // call expression is being used as an assignment target.
+        let rest = &output[i..];
+        let trimmed = rest.trim_start();
+        if let Some(after_eq) = trimmed.strip_prefix("= ")
+            && !after_eq.starts_with('=')
+        {
+            return true;
+        }
+        search_from = open;
+    }
+    false
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — correctness fix (non-runnable JS). Fixes #11756.

## Invariant
When a `super.<prop>` / `super["<prop>"]` access appears in the assignment-TARGET position of an object-rest destructuring assignment (`{ ...super.x } = ...`) inside a scoped static-super context that requires the `Reflect` rewrite, route the target through the scoped-static-super assignment-target emitter so it lowers to the VALID setter-descriptor form `({ set value(_a) { Reflect.set(...) } }).value` — NOT the read-only `Reflect.get(...)` as an assignment LHS (which is non-runnable: `node --check` rejects a call expression as an assignment target). Keyed on AST node kind + assignment-target position — no identifier/file-name matching.

## Scope
- `crates/tsz-emitter/src/emitter/es5/bindings_assignment.rs` — branch in `emit_assignment_object_rest_target` (single chokepoint for object-rest targets) routing scoped-static-super targets through `emit_with_scoped_static_super_assignment_targets`.
- `crates/tsz-emitter/tests/static_super_object_rest_assignment_target_tests.rs` (new, 4 tests).

## Project Corpus Impact
- Row: n/a (emit CORRECTNESS fix — non-runnable JS → runnable)
- Bug family: invalid assignment-target LHS (`Reflect.get(...) = ...`) for super-property object-rest assignment in static member (#11756)
- Evidence: z13 shape `{ ...super.a } = { x: 0 }` in a static member (es2015) now emits valid setter-descriptor JS that `node --check` accepts; previously a runtime SyntaxError.

## Verification
- Invalid LHS replaced with valid setter-descriptor (matches tsc 6.0.3 SHAPE + the surrounding z8–z12 cases). **Full --js-only: failure set byte-IDENTICAL to baseline (net-zero on the emit metric — the `thisAndSuperInStaticMembers1/2` witnesses also need the separate broad temp-numbering rework to fully flip), ZERO regressions. --dts-only: byte-identical (DTS never calls the edited fn).** NARROW conformance: thisAndSuperInStaticMembers 4/4, typeOfThisInStaticMembers 13/13 — no regression. 4 new structural unit tests (varied class/base/member/property names, property + element access, negative plain-identifier-rest). Clippy clean; arch guard passes.
- §25/§26 compliant. Emitter-only change (conformance-safe).
- This is a CORRECTNESS fix landed on top of the emit-100 work (per "fix bugs you can fix on top"): it does not flip an emit witness today but eliminates non-runnable JS output.

## Coordination Notes
Rebased onto current main. Found a SEPARATE pre-existing non-runnable-emit bug for follow-up: z9 (`[super.a = 0] = [0]` — IIFE inside an array-destructuring target), independent of z13, untouched here. — opus48-emit100
