### PR TITLE
fix(emit): publish legacy-decorator self-alias via ES2022 static block; detect self-ref in static blocks

### DIFF
--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -1224,7 +1224,15 @@ impl<'a> Printer<'a> {
                 let prev_in_static_block = self.ctx.flags.in_class_static_block;
                 self.emitting_function_body_block = true;
                 self.ctx.flags.in_class_static_block = true;
+                // A native `static { ... }` block is a function-body block, but the
+                // outer-scope hoisted temps (e.g. legacy-decorator class-self
+                // aliases destined for the file-top `var C_1;`) do not belong
+                // inside it. Save/restore them so the block's function-body flush
+                // only emits temps generated within the block, mirroring the
+                // lowered static-block IIFE path.
+                let saved_temps = std::mem::take(&mut self.hoisted_assignment_temps);
                 self.emit_block(node, idx);
+                self.hoisted_assignment_temps = saved_temps;
                 self.emitting_function_body_block = prev;
                 self.ctx.flags.in_class_static_block = prev_in_static_block;
             }

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -358,10 +358,7 @@ impl<'a> Printer<'a> {
             }
             self.write(binding_name);
             self.write(" = ");
-            if let Some(alias) = assignment_alias {
-                self.write(alias);
-                self.write(" = ");
-            }
+            self.write_outer_alias_prefix(node, assignment_alias);
             if let Some(temp) = default_export_set_function_name_temp.as_ref() {
                 self.write(temp);
                 self.write(" = ");
@@ -2087,6 +2084,7 @@ impl<'a> Printer<'a> {
             && class.members.nodes.iter().any(|&member_idx| {
                 self.legacy_member_decorator_needs_private_name_scope(member_idx)
             });
+        emitted_any_member |= self.emit_synthetic_static_self_alias_block(node, assignment_alias);
         if self.ctx.options.use_define_for_class_fields && target_supports_native_fields {
             // Find the constructor and collect its parameter properties
             for &member_idx in &class.members.nodes {

--- a/crates/tsz-emitter/src/emitter/declarations/class/mod.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/mod.rs
@@ -5,6 +5,7 @@ mod emit_declaration;
 mod emit_es6;
 mod helpers;
 mod private_method_defs;
+mod static_block_self_alias;
 
 use super::super::core::PropertyNameEmit;
 use tsz_parser::parser::NodeIndex;
@@ -116,6 +117,14 @@ pub(in crate::emitter) fn class_has_self_references(
                 arena
                     .get(acc.body)
                     .map(|n| (n.pos as usize, n.end as usize))
+            }
+            // Static initializer blocks (`static { ... }`) can reference the class
+            // by name just like method/accessor/property bodies. tsc allocates the
+            // same `C_1` alias when a decorated class names itself inside a static
+            // block, so the whole block span participates in self-reference
+            // detection.
+            k if k == tsz_parser::parser::syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION => {
+                Some((member_node.pos as usize, member_node.end as usize))
             }
             _ => continue,
         };

--- a/crates/tsz-emitter/src/emitter/declarations/class/static_block_self_alias.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/static_block_self_alias.rs
@@ -1,0 +1,102 @@
+//! ES2022+ legacy-decorator class self-alias publication.
+//!
+//! When a legacy-decorated (`@experimentalDecorators`) class declaration names
+//! itself in its own body, tsc allocates a hoisted `C_1` alias so the decorator
+//! application (`C = C_1 = __decorate([...], C)`) can rebind the outer name
+//! without breaking internal self-references.
+//!
+//! How that alias is *published* into the class depends on whether the emit
+//! target has native static blocks:
+//!
+//! * Target `< ES2022` (no native static blocks): tsc prefixes the class
+//!   expression with the alias assignment, i.e.
+//!   `let C = C_1 = class C { ... };`. Internal references read `C_1`.
+//! * Target `>= ES2022` (native static blocks): tsc emits a plain
+//!   `let C = class C { ... };` and publishes the alias from a synthetic
+//!   *leading* static block inside the class body: `static { C_1 = this; }`.
+//!   Internal references still read `C_1`.
+//!
+//! This module owns the decision and the synthetic-block emission so the large
+//! `emit_es6` orchestrator only calls two thin helpers.
+
+use super::super::super::{Printer, ScriptTarget};
+use tsz_parser::parser::node::Node;
+
+impl Printer<'_> {
+    /// True when the class-self alias for a legacy-decorated, self-referencing
+    /// class declaration should be published via a synthetic leading
+    /// `static { <alias> = this; }` block (the native-static-block form tsc uses
+    /// at ES2022+), rather than the pre-ES2022 outer-expression alias prefix
+    /// `let C = <alias> = class C { ... }`.
+    ///
+    /// The trigger is purely target-driven: native static blocks exist at
+    /// ES2022+. It is gated to legacy-decorated classes that already carry a
+    /// self-alias (`assignment_alias`), which is the only context where the
+    /// pre-ES2022 outer prefix would otherwise be emitted.
+    fn legacy_decorator_alias_uses_static_block(
+        &self,
+        node: &Node,
+        assignment_alias: Option<&str>,
+    ) -> bool {
+        if assignment_alias.is_none()
+            || (self.ctx.options.target as u32) < (ScriptTarget::ES2022 as u32)
+            || !self.ctx.options.legacy_decorators
+        {
+            return false;
+        }
+        self.arena
+            .get_class(node)
+            .is_some_and(|class| !self.collect_class_decorators(&class.modifiers).is_empty())
+    }
+
+    /// Write the outer-expression alias prefix (`<alias> = `) for a
+    /// legacy-decorated self-referencing class, e.g. `let C = <alias> = class C`.
+    /// Writes nothing when the alias is instead published via a synthetic static
+    /// block (ES2022+ native form).
+    pub(in crate::emitter) fn write_outer_alias_prefix(
+        &mut self,
+        node: &Node,
+        assignment_alias: Option<&str>,
+    ) {
+        if self.legacy_decorator_alias_uses_static_block(node, assignment_alias) {
+            return;
+        }
+        if let Some(alias) = assignment_alias {
+            self.write(alias);
+            self.write(" = ");
+        }
+    }
+
+    /// Emit the synthetic leading `static { <alias> = this; }` block that
+    /// publishes the class-self alias for the native-static-block form (ES2022+).
+    /// Only emits when the static-block form applies and the alias differs from a
+    /// real class name. tsc places this before every user-authored class member.
+    /// Returns whether a block was emitted so the caller can mark a member as
+    /// printed.
+    pub(in crate::emitter) fn emit_synthetic_static_self_alias_block(
+        &mut self,
+        node: &Node,
+        assignment_alias: Option<&str>,
+    ) -> bool {
+        if !self.legacy_decorator_alias_uses_static_block(node, assignment_alias) {
+            return false;
+        }
+        // A self-referencing class always has a real name; resolve it so the
+        // alias is only published when it actually differs from that name.
+        let class_name = self
+            .arena
+            .get_class(node)
+            .filter(|class| class.name.is_some())
+            .map(|class| self.get_identifier_text_idx(class.name))
+            .unwrap_or_default();
+        let alias = match assignment_alias {
+            Some(a) if !class_name.is_empty() && a != class_name => a,
+            _ => return false,
+        };
+        self.write("static { ");
+        self.write(alias);
+        self.write(" = this; }");
+        self.write_line();
+        true
+    }
+}

--- a/crates/tsz-emitter/src/emitter/source_file/legacy_decorator_static_block_self_alias_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/legacy_decorator_static_block_self_alias_tests.rs
@@ -1,0 +1,174 @@
+//! Tests for legacy-decorator class-self alias publication.
+//!
+//! Structural rule: when a legacy-decorated (`@experimentalDecorators`) class
+//! declaration references itself and the target supports native static blocks
+//! (ES2022+), tsc publishes the `C_1` alias via a synthetic leading
+//! `static { C_1 = this; }` block and emits `let C = class C { ... }` (plain).
+//! At targets below ES2022 it keeps the outer-expression alias prefix
+//! `let C = C_1 = class C { ... }`.
+
+use crate::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use tsz_common::ScriptTarget;
+use tsz_parser::ParserState;
+
+fn emit(source: &str, target: ScriptTarget) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut printer = EmitterPrinter::with_options(
+        &parser.arena,
+        PrinterOptions {
+            legacy_decorators: true,
+            // Mirror the `@target: es2022` default so native static fields stay
+            // in the class body (`static x = ...`) rather than lowering to
+            // `static { this.x = ...; }`.
+            use_define_for_class_fields: true,
+            target,
+            ..Default::default()
+        },
+    );
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+// ── ES2022+: internal static-block alias form ──────────────────────────────
+
+#[test]
+fn es2022_static_field_self_ref_publishes_alias_via_static_block() {
+    let source = "declare var dec: any;\n@dec\nclass C1 {\n    static instance = new C1();\n}\n";
+    let output = emit(source, ScriptTarget::ES2022);
+
+    // Plain class expression — no outer-expression alias prefix.
+    assert!(
+        output.contains("let C1 = class C1 {"),
+        "ES2022 decorated self-ref class should keep a plain class expression.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("let C1 = C1_1 = class"),
+        "ES2022 should not use the pre-ES2022 outer-alias prefix.\nOutput:\n{output}"
+    );
+    // Synthetic leading static block publishes the alias.
+    assert!(
+        output.contains("static { C1_1 = this; }"),
+        "ES2022 should publish the self-alias via a synthetic static block.\nOutput:\n{output}"
+    );
+    // Self-reference rewritten to the alias; decorate assignment carries it.
+    assert!(
+        output.contains("static instance = new C1_1();"),
+        "Self-reference should be rewritten to the alias.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("C1 = C1_1 = __decorate("),
+        "Decorate assignment should rebind through the alias.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es2022_static_block_self_ref_publishes_alias_via_static_block() {
+    let source =
+        "declare var dec: any;\n@dec\nclass C2 {\n    static {\n        new C2();\n    }\n}\n";
+    let output = emit(source, ScriptTarget::ES2022);
+
+    assert!(
+        output.contains("static { C2_1 = this; }"),
+        "Static-block self-ref should still publish the alias via a synthetic static block.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("new C2_1();"),
+        "Self-reference inside a static block should be rewritten to the alias.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("C2 = C2_1 = __decorate("),
+        "Decorate assignment should rebind through the alias.\nOutput:\n{output}"
+    );
+    // The file-level alias hoist must NOT leak into the user's static block body.
+    assert!(
+        !output.contains("var C2_1, "),
+        "Alias hoist must not leak inside the static block body.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("var C1_1") && !output.contains("var C2_1;\n        "),
+        "Alias hoist must live at file top, not inside the static block.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es2022_static_method_self_ref_publishes_alias_via_static_block() {
+    // Different member-name / class-name spellings prove the rule is structural,
+    // not keyed on identifier text.
+    let source = "declare var dec: any;\n@dec\nclass Widget {\n    static x() { return Widget.y; }\n    static y = 1;\n}\n";
+    let output = emit(source, ScriptTarget::ES2022);
+
+    assert!(
+        output.contains("static { Widget_1 = this; }"),
+        "Method self-ref should publish a renamed alias via a static block.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("return Widget_1.y;"),
+        "Method body self-reference should use the alias.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("let Widget = Widget_1 = class"),
+        "ES2022 must not use the outer-alias prefix for the renamed class.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es2022_two_decorated_self_ref_classes_hoist_aliases_at_file_top() {
+    // Regression guard: the per-class alias hoists must collect at file top and
+    // not be consumed by a later class's native static block.
+    let source = "declare var dec: any;\n@dec\nclass A {\n    static self = new A();\n}\n@dec\nclass B {\n    static { new B(); }\n}\n";
+    let output = emit(source, ScriptTarget::ES2022);
+
+    assert!(
+        output.contains("var A_1, B_1;"),
+        "Both decorated self-ref aliases should be hoisted together at file top.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("static { A_1 = this; }") && output.contains("static { B_1 = this; }"),
+        "Each class should publish its own alias via a synthetic static block.\nOutput:\n{output}"
+    );
+    // No alias hoist should appear inside B's user static block.
+    assert!(
+        !output.contains("var A_1, B_1;\n        ") && !output.contains("{ var A_1"),
+        "Alias hoist must not leak into a static block body.\nOutput:\n{output}"
+    );
+}
+
+// ── Pre-ES2022: outer-expression alias prefix preserved (fallback) ─────────
+
+#[test]
+fn es2015_static_method_self_ref_keeps_outer_alias_prefix() {
+    let source = "declare var dec: any;\n@dec\nclass Widget {\n    static x() { return Widget.y; }\n    static y = 1;\n}\n";
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains("let Widget = Widget_1 = class Widget {"),
+        "Below ES2022 should keep the outer-expression alias prefix.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("static { Widget_1 = this; }"),
+        "Below ES2022 has no native static blocks; no synthetic alias block.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("return Widget_1.y;"),
+        "Self-reference should still be rewritten to the alias.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es2022_undecorated_self_ref_class_does_not_gain_alias_block() {
+    // Negative case: without class decorators there is no `C_1` alias machinery,
+    // so no synthetic static block should appear.
+    let source = "class Plain {\n    static instance = new Plain();\n}\n";
+    let output = emit(source, ScriptTarget::ES2022);
+
+    assert!(
+        !output.contains("static { Plain_1 = this; }"),
+        "Undecorated classes must not synthesize a self-alias static block.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("static instance = new Plain();"),
+        "Undecorated self-reference should remain the plain class name.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/source_file/mod.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/mod.rs
@@ -28,6 +28,8 @@ mod es5_object_rest_tests;
 #[cfg(test)]
 mod legacy_decorator_computed_tests;
 #[cfg(test)]
+mod legacy_decorator_static_block_self_alias_tests;
+#[cfg(test)]
 mod private_field_helper_order_tests;
 #[cfg(test)]
 mod private_tagged_template_tests;


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — legacy-decorator static-block self-alias publication (emit→100% campaign, wave 3)

## Invariant
Two compounding sub-causes (both contained, both fixed) of legacy-decorated (`@experimentalDecorators`) self-referencing class emission: (1) When such a class self-references AND the target supports native static blocks (>= ES2022), tsc publishes the `C_1` alias via a synthetic leading `static { C_1 = this; }` block on a plain `let C = class C {…}` — NOT the pre-ES2022 outer-expression prefix `let C = C_1 = class C {…}`. (2) self-reference detection must include `CLASS_STATIC_BLOCK_DECLARATION` bodies (previously only method/property/accessor bodies were scanned), else a self-ref inside `static {…}` got no alias (`new C()` unrewritten, missing `C = __decorate` alias). Downstream of (2): the static-block emission must save/restore `hoisted_assignment_temps` (mirroring the IIFE path) so file-level decorator-alias temps stay at file top (no leaked `var C_1;` inside the block). Keyed on AST node kind + target + presence of class decorators — no identifier/file-name/printer-output matching. Verified vs tsc 6.0.3 (es2022 vs es2015).

## Scope
- NEW `crates/tsz-emitter/src/emitter/declarations/class/static_block_self_alias.rs` — decision + emission helpers (`emit_synthetic_static_self_alias_block`, `legacy_decorator_outer_alias_prefix`, `write_outer_alias_prefix`).
- NEW `crates/tsz-emitter/src/emitter/source_file/legacy_decorator_static_block_self_alias_tests.rs` (6 tests).
- `emit_es6.rs` (net -3 lines via extraction → 4189, under 4191 ratchet), `core.rs` (static-block temp save/restore), `declarations/class/mod.rs` (static-block self-ref detection + module reg), `source_file/mod.rs` (test reg).

## Project Corpus Impact
- Row: n/a (legacy-decorator class-emit fix)
- Bug family: legacy-decorated self-ref class alias publication (outer-prefix vs ES2022 static-block) + static-block self-ref detection
- Evidence: staticInitializersAndLegacyClassDecorators FAIL→PASS; full --js-only 84→83.

## Verification
- Witness FAIL→PASS. **Full --js-only: 13446→13447 pass (84→83 fail), net +1, ZERO regressions** (fail-set diff: only the witness removed). Decorator family 657 pass / 1 fail (pre-existing privateNamesAndDecorators, unchanged). DTS unaffected (1645/24). 6 new structural unit tests (static field/block/method self-ref at ES2022, renamed class, two-class file-top-hoist regression guard, ES2015 outer-alias fallback, undecorated negative). Clippy clean; arch guard passes (new logic in fresh file; emit_es6.rs reduced to 4189).
- §25/§26 compliant. typeOfThisInStaticMembers/thisAndSuperInStaticMembers are a DIFFERENT broad nested-this-capture problem, correctly out of scope.

## Coordination Notes
Rebased onto current main. emit_es6.rs is a 4191-line monolith at its ratchet — bundled the new logic into a fresh file + extracted an outer-alias block to net-reduce it; a dedicated split of emit_es6.rs would unblock future class-emit fixes. — opus48-emit100
