### PR TITLE
fix(emit): keep original name for non-self-referencing, non-colliding ES5 block-scoped class

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
@@ -124,18 +124,22 @@ impl<'a> Printer<'a> {
                 !legacy_class_decorators.is_empty() || has_ctor_param_decorators;
 
             if self.ctx.target_es5 {
+                // A self-referencing block-scoped class renames its outer `var`
+                // binding to keep it distinct from the hoisted self-alias /
+                // `Name = __decorate(...)` assignment (tsc emits `var Foo_1` for
+                // a self-referencing `class Foo` inside a `try`/`if` block).
+                let class_self_references = class_has_self_references(
+                    self.arena,
+                    self.source_text_for_map(),
+                    &class_name,
+                    &class.members.nodes,
+                );
                 let binding_name = self
                     .ctx
                     .block_scope_state
-                    .register_block_scoped_class(&class_name);
+                    .register_block_scoped_class(&class_name, class_self_references);
                 let binding_name = (binding_name != class_name).then_some(binding_name);
-                let needs_alias = needs_class_decorate
-                    && class_has_self_references(
-                        self.arena,
-                        self.source_text_for_map(),
-                        &class_name,
-                        &class.members.nodes,
-                    );
+                let needs_alias = needs_class_decorate && class_self_references;
                 let alias_name = needs_alias.then(|| self.make_unique_name_from_base(&class_name));
                 let mut es5_emitter = ClassES5Emitter::new(self.arena);
                 es5_emitter.set_block_scope_shadowed_names(

--- a/crates/tsz-emitter/src/emitter/transform_dispatch.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch.rs
@@ -15,6 +15,9 @@ use tsz_parser::parser::node::NodeAccess;
 #[path = "transform_dispatch_chain.rs"]
 mod transform_dispatch_chain;
 
+#[path = "transform_dispatch_class_binding.rs"]
+mod transform_dispatch_class_binding;
+
 enum EmitDirective {
     Identity,
     ES5Class {
@@ -936,19 +939,6 @@ impl<'a> Printer<'a> {
         self.ctx
             .block_scope_state
             .reserve_names(es5_emitter.block_scope_reserved_names());
-    }
-
-    fn register_es5_class_binding_name(&mut self, class_node: NodeIndex) -> Option<String> {
-        let class_data = self
-            .arena
-            .get(class_node)
-            .and_then(|node| self.arena.get_class(node))?;
-        let original_name = self.get_identifier_text_opt(class_data.name)?;
-        let emitted_name = self
-            .ctx
-            .block_scope_state
-            .register_block_scoped_class(&original_name);
-        (emitted_name != original_name).then_some(emitted_name)
     }
 
     fn emit_es5_class_output(

--- a/crates/tsz-emitter/src/emitter/transform_dispatch_class_binding.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch_class_binding.rs
@@ -1,0 +1,42 @@
+//! ES5 block-scoped class binding-name resolution, split out of
+//! `transform_dispatch.rs`.
+//!
+//! Computes the emitted `var` binding name for a class lowered to an ES5 IIFE.
+//! A nested-block class only renames to `Name_N` when it self-references (which
+//! forces the hoisted self-alias pattern) or when its name collides with a
+//! binding already visible in scope; otherwise it reuses its source name, just
+//! like tsc.
+
+use super::declarations::class::class_has_self_references;
+use super::*;
+
+impl<'a> Printer<'a> {
+    pub(super) fn register_es5_class_binding_name(
+        &mut self,
+        class_node: NodeIndex,
+    ) -> Option<String> {
+        let (name_idx, members) = {
+            let class_data = self
+                .arena
+                .get(class_node)
+                .and_then(|node| self.arena.get_class(node))?;
+            (class_data.name, class_data.members.nodes.clone())
+        };
+        let original_name = self.get_identifier_text_opt(name_idx)?;
+        // A self-referencing block-scoped class forces the hoisted self-alias
+        // pattern, so its outer `var` binding must rename (tsc emits
+        // `var Foo_1` for `class Foo { static f(): Foo { return new Foo() } }`
+        // inside a block). Plain block-scoped classes keep their name.
+        let self_referencing = class_has_self_references(
+            self.arena,
+            self.source_text_for_map(),
+            &original_name,
+            &members,
+        );
+        let emitted_name = self
+            .ctx
+            .block_scope_state
+            .register_block_scoped_class(&original_name, self_referencing);
+        (emitted_name != original_name).then_some(emitted_name)
+    }
+}

--- a/crates/tsz-emitter/src/transforms/block_scoping_es5.rs
+++ b/crates/tsz-emitter/src/transforms/block_scoping_es5.rs
@@ -211,18 +211,54 @@ impl BlockScopeState {
 
     /// Register a class declaration lowered to ES5.
     ///
-    /// Class declarations are block-scoped, but ES5 emits `var`. A class inside
-    /// a nested block therefore needs a synthetic binding even when no outer
-    /// declaration currently has the same name; otherwise the lowered `var`
-    /// would leak out of the block.
-    pub fn register_block_scoped_class(&mut self, original_name: &str) -> String {
+    /// Class declarations are block-scoped, but ES5 emits `var`. A nested-block
+    /// class only needs a synthetic `Name_N` binding when either:
+    ///   * `self_referencing` is true — the class body refers to its own name
+    ///     (e.g. `static f(): Foo { return new Foo() }` or a decorated class),
+    ///     which forces the hoisted self-alias pattern and a renamed outer
+    ///     `var Foo_1`; or
+    ///   * its name *actually* collides with another binding already visible in
+    ///     the enclosing function/block scopes or with a reserved temp name.
+    ///
+    /// tsc keeps the original name otherwise — even for two same-named classes
+    /// in disjoint sibling blocks — relying on plain `var` function-scoping.
+    /// Synthesizing a suffix unconditionally diverges from tsc (`var C_1` where
+    /// tsc emits `var C`).
+    pub fn register_block_scoped_class(
+        &mut self,
+        original_name: &str,
+        self_referencing: bool,
+    ) -> String {
         // An empty scope stack means there is no enclosing block at all — the
         // class sits at module/script top level (e.g. inside a System/AMD/UMD
         // wrapper that never opened a block scope). At top level the lowered
         // `var` *is* the binding, so it must reuse the name rather than getting
         // a synthetic `Name_1` that would diverge from the hoisted declaration.
+        // Use `var`-declaration semantics so a same-name redeclaration (e.g.
+        // two `export default class C`) reuses `C` instead of renaming the
+        // second to `C_1`; tsc emits `var C` for both.
         if self.function_scope_marks.last().copied().unwrap_or(true) {
-            return self.register_variable(original_name);
+            return self.register_var_declaration(original_name);
+        }
+
+        // Self-referencing nested-block classes always rename (the self-alias
+        // pattern requires a distinct outer binding). Otherwise only rename
+        // when the name genuinely conflicts with a binding already visible in
+        // scope (e.g. an outer `var C` the lowered class would clash with) or
+        // with a reserved temp name. Sibling-block classes do not conflict
+        // because their scopes are popped before this runs, so the common
+        // nested-block case reuses `original_name` exactly like tsc.
+        let collides = self_referencing
+            || self.reserved_names.contains(original_name)
+            || self.scope_stack.iter().any(|scope| {
+                scope.contains_key(original_name) || scope.values().any(|v| v == original_name)
+            });
+
+        if !collides {
+            if let Some(current_scope) = self.scope_stack.last_mut() {
+                current_scope.insert(original_name.to_string(), original_name.to_string());
+            }
+            return original_name.to_string();
         }
 
         let mut suffix = 1u32;

--- a/crates/tsz-emitter/tests/block_scoping_es5.rs
+++ b/crates/tsz-emitter/tests/block_scoping_es5.rs
@@ -219,11 +219,21 @@ fn class_decl_at_loop_capture_function_level_keeps_local_name() {
 
     state.enter_function_scope();
     state.register_function_parameter("row");
-    assert_eq!(state.register_block_scoped_class("RowClass"), "RowClass");
-    state.enter_scope();
     assert_eq!(
-        state.register_block_scoped_class("NestedClass"),
-        "NestedClass_1"
+        state.register_block_scoped_class("RowClass", false),
+        "RowClass"
+    );
+    state.enter_scope();
+    // A non-self-referencing nested-block class with no name collision keeps
+    // its original name (tsc emits `var NestedClass`, not `NestedClass_1`).
+    assert_eq!(
+        state.register_block_scoped_class("NestedClass", false),
+        "NestedClass"
+    );
+    // A self-referencing nested-block class still renames its outer binding.
+    assert_eq!(
+        state.register_block_scoped_class("SelfRefClass", true),
+        "SelfRefClass_1"
     );
     state.exit_scope();
     state.exit_scope();
@@ -253,4 +263,113 @@ fn function_level_shadowed_names_stay_local_nested_blocks_rename() {
     );
     state.exit_scope();
     state.exit_scope();
+}
+
+#[test]
+fn nested_block_scoped_class_without_collision_keeps_name() {
+    // A non-self-referencing block-scoped class in a nested block keeps its
+    // original name; tsc emits `var Widget`, not `var Widget_1`. Name choice is
+    // irrelevant — the rule is structural.
+    for name in ["Widget", "Box", "Shape"] {
+        let mut state = BlockScopeState::new();
+        state.enter_function_scope();
+        state.enter_scope(); // nested block, e.g. inside `if (b) { ... }`
+
+        assert_eq!(
+            state.register_block_scoped_class(name, false),
+            name,
+            "non-colliding, non-self-referencing block class reuses its name"
+        );
+
+        state.exit_scope();
+        state.exit_scope();
+    }
+}
+
+#[test]
+fn nested_block_scoped_class_self_reference_renames() {
+    // A self-referencing block-scoped class forces the hoisted self-alias
+    // pattern, so its outer binding renames to `Name_1` even without an outer
+    // collision (tsc: `var Foo_1` for `class Foo { static f(): Foo {...} }`).
+    for name in ["Foo", "Node", "Tree"] {
+        let mut state = BlockScopeState::new();
+        state.enter_function_scope();
+        state.enter_scope();
+
+        assert_eq!(
+            state.register_block_scoped_class(name, true),
+            format!("{name}_1"),
+            "self-referencing block class renames its outer binding"
+        );
+
+        state.exit_scope();
+        state.exit_scope();
+    }
+}
+
+#[test]
+fn sibling_block_scoped_classes_share_name() {
+    // Two same-named, non-self-referencing classes in disjoint sibling blocks
+    // both keep the original name — tsc emits `var C` twice, relying on plain
+    // `var` function-scoping rather than synthesizing `C_1`/`C_2`.
+    for name in ["C", "Item", "Cell"] {
+        let mut state = BlockScopeState::new();
+        state.enter_function_scope();
+
+        state.enter_scope();
+        assert_eq!(state.register_block_scoped_class(name, false), name);
+        state.exit_scope();
+
+        state.enter_scope();
+        assert_eq!(
+            state.register_block_scoped_class(name, false),
+            name,
+            "second sibling-block class reuses the name; sibling scope was popped"
+        );
+        state.exit_scope();
+
+        state.exit_scope();
+    }
+}
+
+#[test]
+fn nested_block_scoped_class_renames_on_outer_var_collision() {
+    // When an enclosing scope already binds the name (e.g. `var C = 1`), the
+    // lowered class must rename to avoid clashing with that hoisted var.
+    for name in ["C", "Color", "Group"] {
+        let mut state = BlockScopeState::new();
+        state.enter_function_scope();
+        // Outer binding the lowered class would otherwise clash with.
+        state.register_var_declaration(name);
+
+        state.enter_scope();
+        assert_eq!(
+            state.register_block_scoped_class(name, false),
+            format!("{name}_1"),
+            "block class renames when an outer same-name binding exists"
+        );
+        state.exit_scope();
+
+        state.exit_scope();
+    }
+}
+
+#[test]
+fn top_level_block_scoped_class_redeclaration_reuses_name() {
+    // At module/script top level (function-scope mark), a same-name class
+    // redeclaration reuses the name (tsc emits `var C` for both of two
+    // `export default class C`), instead of renaming the second to `C_1`.
+    for name in ["C", "Default", "Main"] {
+        let mut state = BlockScopeState::new();
+        state.enter_function_scope();
+
+        assert_eq!(state.register_block_scoped_class(name, false), name);
+        assert_eq!(
+            state.register_block_scoped_class(name, false),
+            name,
+            "top-level class redeclaration reuses the name like `var`"
+        );
+
+        state.exit_scope();
+    }
 }


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — ES5 block-scoped class name preservation (emit→100% campaign, wave 3)

## Invariant
When an ES5 `var`-lowered block-scoped class's name neither self-references (which forces the hoisted self-alias `Name_N` pattern) NOR collides with a binding already visible in the enclosing scopes / reserved temps, tsz emits the class under its ORIGINAL name (matching tsc) instead of unconditionally synthesizing `Name_N`. Top-level redeclarations use `var`-redeclaration semantics (`var C` twice, not `C`/`C_1`). Keyed on AST/scope structure + the existing `class_has_self_references` structural inspector — no identifier-name or printer-output matching. Verified vs tsc 6.0.3 (nested no-collision, sibling-block duplicates, outer-var collision `C_1`, self-ref `Foo_1`, decorated-without-self-ref `Foo`, top-level redeclaration).

## Scope
- `crates/tsz-emitter/src/transforms/block_scoping_es5.rs` — collision/self-ref-gated rename in `register_block_scoped_class`; top-level `var`-redeclaration branch.
- NEW `crates/tsz-emitter/src/emitter/transform_dispatch_class_binding.rs` (42 lines) — extracted `register_es5_class_binding_name` to keep transform_dispatch.rs under its 2124 ratchet (now 2114).
- `crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs` — decorated path passes the self-reference flag.
- `crates/tsz-emitter/tests/block_scoping_es5.rs` (+5 tests, varied names; updated 1).

## Project Corpus Impact
- Row: n/a (ES5 block-scoped class-emit fix)
- Bug family: spurious `Name_1` rename of non-self-referencing, non-colliding ES5 block-scoped classes
- Evidence: multipleDefaultExports03(target=es5) FAIL→PASS; full --js-only 81→80.

## Verification
- Witness FAIL→PASS. **Full --js-only: 13449→13450 pass (81→80 fail), net +1, ZERO new failures.** DTS unaffected (declaration emit doesn't use the ES5 block-scoping transform). 27/27 block-scoping unit tests pass (+5 new, each varies the class name across 3 spellings). Broad class/es5/decorator/block/system filter: same 9 pre-existing failures with/without the change. Clippy clean; arch guard passes (extracted to a new file, transform_dispatch.rs 2114<2124).
- §25/§26 compliant.

## Coordination Notes
Rebased onto current main. Branch name is `codex/emit100-js-tla-system-untried` (it triaged topLevelAwait/operationsAvailableOnPromisedType too); the landed fix is the block-scoped-class-rename. STOP-reported (broad/out-of-scope): topLevelAwait.1-system (System `execute:` async + for-await-of temp/System-hoist model), operationsAvailableOnPromisedType (helper ordering + native `[...c]`→__spreadArray at ES5 + async-gen try temp numbering), nestedClassDeclaration/nestedGlobalNamespaceInClass (parser-recovery of #35717 crash cases), localTypes1 (separate `var E = void 0` vs `var E` enum-hoist diff). — opus48-emit100
