### PR TITLE
fix(emit): valid setter-descriptor for super-property in destructuring-default assignment target in static member

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -287,6 +287,10 @@ name = "static_field_lowering_trailing_comment_tests"
 path = "tests/static_field_lowering_trailing_comment_tests.rs"
 
 [[test]]
+name = "static_super_destructure_default_target_tests"
+path = "tests/static_super_destructure_default_target_tests.rs"
+
+[[test]]
 name = "wave3_small_emit_fixes_tests"
 path = "tests/wave3_small_emit_fixes_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/expressions/static_super.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/static_super.rs
@@ -31,6 +31,22 @@ impl<'a> Printer<'a> {
         if self.in_async_captured_super() {
             return false;
         }
+        // When a `super`-property assignment (`super.x = <default>`) sits in a
+        // destructuring assignment-*target* position (e.g. an array/object
+        // pattern element with a default: `[super.x = 0] = [0]`), it is not a
+        // value-producing assignment expression. tsc emits the setter-descriptor
+        // member-expression as the target with the right-hand side as the
+        // destructuring default (`({ set value(_a) { Reflect.set(...) } }).value
+        // = <default>`), not the comma/IIFE value form. Decline the value
+        // lowering here so the caller falls through to the native `left = right`
+        // emit, where `left` is the `super.x` access that itself renders as the
+        // setter-descriptor while the assignment-target flag is set. Emitting the
+        // value/IIFE form in this position produces invalid (non-runnable) JS
+        // because an IIFE call is not a legal destructuring assignment target.
+        if self.scoped_static_super_assignment_target && operator == SyntaxKind::EqualsToken as u16
+        {
+            return false;
+        }
         let Some(member) = self.scoped_static_super_member(left) else {
             return false;
         };

--- a/crates/tsz-emitter/tests/static_super_destructure_default_target_tests.rs
+++ b/crates/tsz-emitter/tests/static_super_destructure_default_target_tests.rs
@@ -1,0 +1,176 @@
+//! Valid lowering for a `super`-property used as a destructuring
+//! assignment-*target* with a default, inside a static class member.
+//!
+//! When a static field initializer at ES2015+ (with
+//! `useDefineForClassFields`) contains a destructuring assignment whose target
+//! element is a `super` property with a default — e.g.
+//! `static z = [super.a = 0] = [0]` or `static z = { x: super.a = 0 } = ...` —
+//! the `super.a = 0` element is an assignment *target* (an array/object pattern
+//! element with a default), not a value-producing assignment expression.
+//!
+//! tsc emits the scoped-static-super setter-descriptor member-expression as the
+//! target, with the right-hand side as the destructuring default:
+//!
+//! ```js
+//! [({ set value(_a) { Reflect.set(_b, "a", _a, _b); } }).value = 0] = [0]
+//! ```
+//!
+//! Previously tsz lowered the inner `super.a = 0` through the value/IIFE path,
+//! emitting `[(() => { ...; return ...; })()] = [0]`. An IIFE *call* is not a
+//! legal destructuring assignment target, so that output is a `SyntaxError`
+//! (non-runnable JS). These tests pin the valid setter-descriptor shape and
+//! guard against the IIFE-as-target regression. They intentionally vary the
+//! class/member/property identifier spellings so the rule cannot be satisfied
+//! by name-matching.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_lower_print as parse_lower_emit;
+
+fn es2015_define_opts() -> PrintOptions {
+    PrintOptions {
+        target: ScriptTarget::ES2015,
+        module: ModuleKind::ESNext,
+        use_define_for_class_fields: true,
+        ..Default::default()
+    }
+}
+
+/// An IIFE in array/object destructuring assignment-target position is invalid
+/// JS. No valid lowering for these shapes should ever contain one.
+fn assert_no_iife_in_target(output: &str) {
+    assert!(
+        !output.contains("(() => {"),
+        "static-super destructure target must not lower to an IIFE \
+         (invalid destructuring assignment target).\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("})()] ="),
+        "found an IIFE call as an array-destructuring element target.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("})() }"),
+        "found an IIFE call as an object-destructuring element target.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn array_destructure_super_target_with_default_uses_setter_descriptor() {
+    // z9 witness shape: `[super.a = 0] = [0]`.
+    let source = "\
+declare class B { static a: any; }
+class C extends B {
+    static z = [super.a = 0] = [0];
+}
+";
+    let output = parse_lower_emit(source, es2015_define_opts());
+
+    assert_no_iife_in_target(&output);
+    // The `super.a` target renders as the setter-descriptor member-expression,
+    // and the default `= 0` follows it as the destructuring default.
+    assert!(
+        output.contains("set value(_a) { Reflect.set("),
+        "expected scoped-static-super setter-descriptor for the target.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(".value = 0] = [0]"),
+        "expected `({{ set value(_a) {{ ... }} }}).value = 0] = [0]` target form.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn object_destructure_super_target_with_default_uses_setter_descriptor() {
+    // z12 witness shape: `{ x: super.a = 0 } = { x: 0 }`.
+    let source = "\
+declare class B { static a: any; }
+class C extends B {
+    static z = { x: super.a = 0 } = { x: 0 };
+}
+";
+    let output = parse_lower_emit(source, es2015_define_opts());
+
+    assert_no_iife_in_target(&output);
+    assert!(
+        output.contains("set value(_a) { Reflect.set("),
+        "expected scoped-static-super setter-descriptor for the target.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(".value = 0 } = { x: 0 }"),
+        "expected `{{ x: ({{ set value(_a) {{ ... }} }}).value = 0 }} = {{ x: 0 }}` form.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn renamed_class_member_property_still_uses_valid_target_lowering() {
+    // Same rule, different identifier spellings (class `Widget`, base `Base`,
+    // static member `slot`, super property `count`). If the fix were keyed on
+    // a specific name it would regress here.
+    let source = "\
+declare class Base { static count: any; }
+class Widget extends Base {
+    static slot = [super.count = 7] = [7];
+}
+";
+    let output = parse_lower_emit(source, es2015_define_opts());
+
+    assert_no_iife_in_target(&output);
+    assert!(
+        output.contains("set value(_a) { Reflect.set("),
+        "expected setter-descriptor target regardless of identifier names.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(".value = 7] = [7]"),
+        "expected the renamed-case array target to carry its default.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn element_access_super_target_with_default_uses_setter_descriptor() {
+    // Super *element* access target with a default: `[super["a"] = 0] = [0]`.
+    // Exercises the element-access branch, not just property access.
+    let source = "\
+declare class B { static a: any; }
+class C extends B {
+    static z = [super[\"a\"] = 0] = [0];
+}
+";
+    let output = parse_lower_emit(source, es2015_define_opts());
+
+    assert_no_iife_in_target(&output);
+    assert!(
+        output.contains("set value(_a) { Reflect.set("),
+        "expected setter-descriptor target for super element-access.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(".value = 0] = [0]"),
+        "expected element-access array target to carry its default.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn super_target_without_default_unaffected() {
+    // Negative/baseline: a super target *without* a default (z8 shape) already
+    // used the setter-descriptor and must keep doing so (no IIFE, no `.value =`
+    // default appended).
+    let source = "\
+declare class B { static a: any; }
+class C extends B {
+    static z = [super.a] = [0];
+}
+";
+    let output = parse_lower_emit(source, es2015_define_opts());
+
+    assert_no_iife_in_target(&output);
+    assert!(
+        output.contains("set value(_a) { Reflect.set("),
+        "expected setter-descriptor target for the no-default case.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(".value] = [0]"),
+        "no-default target must remain `({{ ... }}).value] = [0]`.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — correctness fix (non-runnable JS), sibling of #11756/#11759.

## Invariant
When a `super`-property/element access is the LHS of an `=` binary expression that sits in a scoped-static-super destructuring assignment-TARGET position (`scoped_static_super_assignment_target` set — array element default `[super.a = 0] = ...`, object property default `{ x: super.a = 0 } = ...`), tsc emits the setter-descriptor member-expression as the target with the RHS as the destructuring default (`({ set value(_a){ Reflect.set(...) } }).value = <default>`), NOT the value/IIFE form (which produces an IIFE in destructuring-target position — a runtime SyntaxError). The fix declines the value lowering in that position so the access renders via the existing setter-descriptor path. Keyed on AST node kind + the assignment-target flag — no identifier/file-name matching.

## Scope
- `crates/tsz-emitter/src/emitter/expressions/static_super.rs` — guard in `emit_scoped_static_super_assignment` (16 lines, reuses the existing setter-descriptor machinery; no monolith growth).
- `crates/tsz-emitter/tests/static_super_destructure_default_target_tests.rs` (new, 5 tests) + Cargo.toml registration.

## Project Corpus Impact
- Row: n/a (emit CORRECTNESS fix — non-runnable JS → runnable)
- Bug family: invalid IIFE-as-destructuring-target for super-property in array/object destructuring assignment target with default, in a static member
- Evidence: z9 (`[super.a = 0] = [0]`) + z12 (`{ x: super.a = 0 } = ...`) + element-access + renamed variants — `node --check`: before = SyntaxError, after = valid; matches tsc 6.0.3 shape.

## Verification
- Invalid IIFE-as-target replaced with valid setter-descriptor (node --check confirms full emitted file valid). **Full --js-only fail-SET byte-identical to baseline (81/81, net-zero — thisAndSuperInStaticMembers1/2 also need the out-of-scope temp-numbering rework to fully flip), ZERO regressions. --dts-only byte-identical (24/24).** NARROW conformance: thisAndSuperInStaticMembers 4/4, typeOfThisInStaticMembers 13/13. 5 new structural unit tests (array+default, object+default, renamed class/member/property, element-access+default, no-default baseline). Clippy clean; arch guard passes.
- §25/§26 compliant. Emitter-only (conformance-safe). CORRECTNESS fix landed on top of emit-100 work (per "fix bugs you can fix on top"): eliminates non-runnable JS without flipping an emit witness today.

## Coordination Notes
Rebased onto current main. Sibling of #11759 (#11756) — same scoped-static-super assignment-target correctness family, different (array/object destructuring default) shape. — opus48-emit100
