### PR TITLE
fix(emit): declare nullish-assignment read-cache temps in single-line and constructor bodies

### DIFF
--- a/crates/tsz-emitter/src/emitter/arrow_concise.rs
+++ b/crates/tsz-emitter/src/emitter/arrow_concise.rs
@@ -32,10 +32,9 @@ impl<'a> Printer<'a> {
         self.emitting_concise_arrow_return_argument = prev_emitting_concise_arrow_return_argument;
         self.emitting_function_body_block = prev_emitting_function_body_block;
 
-        if !self.hoisted_assignment_temps.is_empty() {
-            let var_decl = format!("var {}; ", self.hoisted_assignment_temps.join(", "));
-            self.writer.insert_at(var_insert_pos, &var_decl);
-            self.hoisted_assignment_temps.clear();
+        let prologue = self.take_single_line_hoisted_temp_prologue();
+        if !prologue.is_empty() {
+            self.writer.insert_at(var_insert_pos, &prologue);
         }
 
         self.write(" }");

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -2042,24 +2042,25 @@ impl<'a> Printer<'a> {
                 self.write_line();
             }
             // Insert any temps hoisted while emitting field initializers (e.g.
-            // `_a` for a class expression lowered inside a private-field init) at
-            // the top of this synthesized constructor body, then drop the scope.
-            if !self.hoisted_assignment_temps.is_empty() {
-                let indent = self
-                    .writer
-                    .indent_string_at(synth_ctor_hoist_anchor.indent_level);
-                let var_decl = format!(
-                    "{}var {};",
-                    indent,
-                    self.hoisted_assignment_temps.join(", ")
-                );
-                self.writer.insert_line_at(
-                    synth_ctor_hoist_anchor.byte_offset,
-                    synth_ctor_hoist_anchor.line_no,
-                    &var_decl,
-                );
-                self.hoisted_assignment_temps.clear();
-            }
+            // `_a` for a class expression lowered inside a private-field init, or
+            // a `??=` read-cache temp) at the top of this synthesized constructor
+            // body, then drop the scope. Value temps are inserted last so they
+            // land on the first line.
+            let synth_ctor_indent = self
+                .writer
+                .indent_string_at(synth_ctor_hoist_anchor.indent_level);
+            let assignment_temps = std::mem::take(&mut self.hoisted_assignment_temps);
+            self.insert_hoisted_var_line(
+                &assignment_temps,
+                &synth_ctor_hoist_anchor,
+                &synth_ctor_indent,
+            );
+            let value_temps = std::mem::take(&mut self.hoisted_assignment_value_temps);
+            self.insert_hoisted_var_line(
+                &value_temps,
+                &synth_ctor_hoist_anchor,
+                &synth_ctor_indent,
+            );
             self.pop_temp_scope();
             self.decrease_indent();
             self.write("}");

--- a/crates/tsz-emitter/src/emitter/declarations/class_members.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class_members.rs
@@ -1051,7 +1051,15 @@ impl<'a> Printer<'a> {
         {
             self.map_opening_brace(block_node);
             self.write("{ ");
+            let var_insert_pos = self.writer.len();
             self.emit(block.statements.nodes[0]);
+            // A `??=` read-cache temp (or optional-chaining temp) can be created
+            // while emitting the single statement; declare it inline so the body
+            // stays runnable instead of referencing an undeclared `_a`.
+            let prologue = self.take_single_line_hoisted_temp_prologue();
+            if !prologue.is_empty() {
+                self.writer.insert_at(var_insert_pos, &prologue);
+            }
             self.map_closing_brace(block_node);
             self.write(" }");
             return;
@@ -1186,23 +1194,17 @@ impl<'a> Printer<'a> {
             self.end_constructor_using_region(region);
         }
 
-        // Insert any hoisted temps created during statement emit (e.g., `_a` from `??` lowering).
-        if !self.hoisted_assignment_temps.is_empty() {
-            let indent = self
-                .writer
-                .indent_string_at(hoisted_var_anchor.indent_level);
-            let var_decl = format!(
-                "{}var {};",
-                indent,
-                self.hoisted_assignment_temps.join(", ")
-            );
-            self.writer.insert_line_at(
-                hoisted_var_anchor.byte_offset,
-                hoisted_var_anchor.line_no,
-                &var_decl,
-            );
-            self.hoisted_assignment_temps.clear();
-        }
+        // Insert any hoisted temps created during statement emit (e.g., `_a` from
+        // `??`/`??=` lowering). Assignment-target temps and logical-assignment
+        // value temps are inserted at the same anchor (value temps end up on the
+        // first line, matching `insert_function_body_hoisted_temps_at`).
+        let hoisted_indent = self
+            .writer
+            .indent_string_at(hoisted_var_anchor.indent_level);
+        let assignment_temps = std::mem::take(&mut self.hoisted_assignment_temps);
+        self.insert_hoisted_var_line(&assignment_temps, &hoisted_var_anchor, &hoisted_indent);
+        let value_temps = std::mem::take(&mut self.hoisted_assignment_value_temps);
+        self.insert_hoisted_var_line(&value_temps, &hoisted_var_anchor, &hoisted_indent);
 
         self.decrease_indent();
         self.write("}");

--- a/crates/tsz-emitter/src/emitter/functions.rs
+++ b/crates/tsz-emitter/src/emitter/functions.rs
@@ -382,12 +382,11 @@ impl<'a> Printer<'a> {
             }
             self.emit(stmt_idx);
         }
-        if let Some(byte_offset) = var_insert_pos
-            && !self.hoisted_assignment_temps.is_empty()
-        {
-            let var_decl = format!("var {}; ", self.hoisted_assignment_temps.join(", "));
-            self.writer.insert_at(byte_offset, &var_decl);
-            self.hoisted_assignment_temps.clear();
+        if let Some(byte_offset) = var_insert_pos {
+            let prologue = self.take_single_line_hoisted_temp_prologue();
+            if !prologue.is_empty() {
+                self.writer.insert_at(byte_offset, &prologue);
+            }
         }
         self.write(" }");
     }
@@ -1426,6 +1425,101 @@ mod tests {
             "Async arrow inside class method should pass `this` to __awaiter.\nOutput:\n{}",
             result.code
         );
+    }
+
+    /// Lowering `??=` on a member-access target below ES2020 introduces a
+    /// read-cache temp (`(_a = obj.p) !== null && _a !== void 0 ? _a : ...`).
+    /// That temp lives in `hoisted_assignment_value_temps` and must be declared
+    /// as `var _a;` at the top of the enclosing function body — including for
+    /// *single-line* bodies, where the prologue is injected inline. Without the
+    /// declaration the output references an undeclared `_a` and throws
+    /// `ReferenceError` at runtime under strict mode. These tests vary the object
+    /// and property spellings so the fix is keyed on structure, not names.
+    fn emit_es2015(source: &str) -> String {
+        use crate::output::printer::{PrintOptions, lower_and_print};
+        let (parser, root) = parse_test_source(source);
+        lower_and_print(&parser.arena, root, PrintOptions::es6()).code
+    }
+
+    /// Every generated `(_x = ...)` read-cache temp must have a matching
+    /// `var _x;` declaration in the output, otherwise the emit is non-runnable.
+    fn assert_value_temp_declared(output: &str, temp: &str) {
+        assert!(
+            output.contains(&format!("({temp} = ")),
+            "expected read-cache temp `{temp}` to be used.\nOutput:\n{output}"
+        );
+        assert!(
+            output.contains(&format!("var {temp};"))
+                || output.contains(&format!("var {temp},"))
+                || output.contains(&format!(", {temp};"))
+                || output.contains(&format!(", {temp},")),
+            "read-cache temp `{temp}` is used but never declared (`var {temp};` missing).\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn nullish_assign_in_single_line_function_declares_value_temp() {
+        let output = emit_es2015("function f() { box.value ??= 1; }");
+        assert_value_temp_declared(&output, "_a");
+    }
+
+    #[test]
+    fn nullish_assign_in_single_line_method_declares_value_temp() {
+        // Different object/property spelling than the function case.
+        let output = emit_es2015("class Counter { bump() { this.count ??= 0; } }");
+        assert_value_temp_declared(&output, "_a");
+    }
+
+    #[test]
+    fn nullish_assign_on_super_property_declares_value_temp() {
+        let source = "class Base { get slot() { return 0; } set slot(v: number) {} }\n\
+            class Derived extends Base { run() { super.slot ??= 3; } }";
+        let output = emit_es2015(source);
+        assert_value_temp_declared(&output, "_a");
+        assert!(
+            output.contains("(_a = super.slot)"),
+            "super-property read-cache temp must wrap the `super` read.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn nullish_assign_in_single_line_constructor_declares_value_temp() {
+        let output = emit_es2015("class C { constructor() { store.flag ??= 1; } }");
+        assert_value_temp_declared(&output, "_a");
+    }
+
+    #[test]
+    fn nullish_assign_in_multiline_constructor_declares_value_temp() {
+        let source = "class C {\n    constructor() {\n        const y = 1;\n        store.flag ??= y;\n    }\n}";
+        let output = emit_es2015(source);
+        assert_value_temp_declared(&output, "_a");
+    }
+
+    #[test]
+    fn nullish_assign_in_field_initializer_declares_value_temp() {
+        // Synthesized constructor path for a field initializer that lowers `??=`.
+        let output = emit_es2015("class C { x = (bag.item ??= 2); }");
+        assert_value_temp_declared(&output, "_a");
+    }
+
+    #[test]
+    fn nullish_assign_complex_receiver_declares_both_temps() {
+        // A non-simple receiver also allocates an assignment-target temp `_b`;
+        // both the value temp `_a` and the receiver temp `_b` must be declared.
+        let output = emit_es2015("function f() { make().value ??= 1; }");
+        assert_value_temp_declared(&output, "_a");
+        assert!(
+            output.contains("var _b;")
+                || output.contains(", _b;")
+                || output.contains("var _a, _b;"),
+            "receiver temp `_b` must be declared.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn nullish_assign_in_block_body_arrow_declares_value_temp() {
+        let output = emit_es2015("const f = () => { box.value ??= 1; };");
+        assert_value_temp_declared(&output, "_a");
     }
 
     #[test]

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -210,14 +210,17 @@ impl<'a> Printer<'a> {
                 self.emit(stmt_idx);
             }
             // Inject hoisted temp vars inline for single-line function bodies.
-            // Temps like `_a` are created during emit (e.g. optional chaining lowering),
-            // so we insert `var _a; ` at the position right after `{ `.
-            if let Some(byte_offset) = var_insert_pos
-                && !self.hoisted_assignment_temps.is_empty()
-            {
-                let var_decl = format!("var {}; ", self.hoisted_assignment_temps.join(", "));
-                self.writer.insert_at(byte_offset, &var_decl);
-                self.hoisted_assignment_temps.clear();
+            // Temps like `_a` are created during emit (e.g. optional chaining
+            // lowering or `??=` read-cache lowering), so we insert
+            // `var _a; ` at the position right after `{ `. Both assignment-target
+            // temps and logical-assignment value temps must be declared, otherwise
+            // the value temp is referenced without a binding (non-runnable
+            // strict-mode output).
+            if let Some(byte_offset) = var_insert_pos {
+                let prologue = self.take_single_line_hoisted_temp_prologue();
+                if !prologue.is_empty() {
+                    self.writer.insert_at(byte_offset, &prologue);
+                }
             }
             self.map_closing_brace(node);
             self.write(" }");
@@ -721,6 +724,61 @@ impl<'a> Printer<'a> {
             self.write(";");
             self.write_line();
         }
+    }
+
+    /// Build the inline `var _a; ` prologue for a *single-line* function/method
+    /// body (e.g. `m() { o.v ??= 1; }`) and clear the underlying pools.
+    ///
+    /// Mirrors the multi-line [`Self::emit_function_body_hoisted_temps`] ordering
+    /// (logical-assignment value temps first, then assignment-target/for-of
+    /// temps). The single-line block emitters historically flushed only
+    /// `hoisted_assignment_temps`, which dropped the `var` declaration for
+    /// nullish-assignment (`??=`) read-cache temps and produced non-runnable
+    /// strict-mode output (`ReferenceError: _a is not defined`).
+    pub(in crate::emitter) fn take_single_line_hoisted_temp_prologue(&mut self) -> String {
+        let mut prologue = String::new();
+
+        if !self.hoisted_assignment_value_temps.is_empty() {
+            prologue.push_str("var ");
+            prologue.push_str(&self.hoisted_assignment_value_temps.join(", "));
+            prologue.push_str("; ");
+            self.hoisted_assignment_value_temps.clear();
+        }
+
+        if !self.hoisted_assignment_temps.is_empty() || !self.hoisted_for_of_temps.is_empty() {
+            let ref_vars: Vec<&str> = self
+                .hoisted_assignment_temps
+                .iter()
+                .chain(self.hoisted_for_of_temps.iter())
+                .map(String::as_str)
+                .collect();
+            prologue.push_str("var ");
+            prologue.push_str(&ref_vars.join(", "));
+            prologue.push_str("; ");
+            self.hoisted_assignment_temps.clear();
+            self.hoisted_for_of_temps.clear();
+        }
+
+        prologue
+    }
+
+    /// Insert a `var <names>;` line for a multi-line function/constructor body at
+    /// `anchor`, indented by `indent`. Inserting the assignment-target temps and
+    /// the logical-assignment value temps at the *same* anchor (assignment first,
+    /// value second) leaves the value temps on the first line, matching
+    /// [`Self::emit_function_body_hoisted_temps`]. No-op when `names` is empty.
+    pub(in crate::emitter) fn insert_hoisted_var_line(
+        &mut self,
+        names: &[String],
+        anchor: &HoistAnchor,
+        indent: &str,
+    ) {
+        if names.is_empty() {
+            return;
+        }
+        let var_decl = format!("{indent}var {};", names.join(", "));
+        self.writer
+            .insert_line_at(anchor.byte_offset, anchor.line_no, &var_decl);
     }
 
     pub(in crate::emitter) fn insert_function_body_hoisted_temps_at(


### PR DESCRIPTION
## Agent
AgentName: cloud-opus48-pensive-wright

## Track
emit/js — correctness fix (non-runnable JS → runnable). Fixes #11763.

## Invariant
When a function/method/constructor/arrow body-emit site flushes hoisted
assignment-target temps (`hoisted_assignment_temps`) as `var` declarations, it
must also flush the logical-assignment (`??=`) read-cache **value** temps
(`hoisted_assignment_value_temps`) created while emitting that body. Lowering
`obj.p ??= rhs` below ES2020 produces `(_a = obj.p) !== null && _a !== void 0 ? _a : (obj.p = rhs)`;
the `_a` read-cache temp must be declared (`var _a;`) in the enclosing body.
Multi-line function bodies and the module preamble already declared both pools;
the single-line block emitters and the constructor body emitters declared only
the assignment-target pool, so under strict mode the value temp was referenced
without a binding — `ReferenceError: _a is not defined` at runtime. Keyed on
AST node kind + temp-pool state, never on identifier/file-name matching.

## Scope
- `crates/tsz-emitter/src/emitter/statements/core.rs` — new
  `take_single_line_hoisted_temp_prologue` (declares value temps first, then
  assignment-target/for-of temps, mirroring `emit_function_body_hoisted_temps`)
  and a shared `insert_hoisted_var_line` helper; single-line block path routed
  through the prologue helper.
- `crates/tsz-emitter/src/emitter/functions.rs` — `emit_single_line_block`
  routed through the prologue helper; new unit tests.
- `crates/tsz-emitter/src/emitter/arrow_concise.rs` — concise/block arrow
  single-line path routed through the prologue helper.
- `crates/tsz-emitter/src/emitter/declarations/class_members.rs` — single-line
  constructor body routed through the prologue helper; multi-line constructor
  body declares value temps via `insert_hoisted_var_line`.
- `crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs` — synthesized
  field-initializer constructor declares value temps via `insert_hoisted_var_line`.

## Project Corpus Impact
- Row: n/a (emit CORRECTNESS fix — non-runnable JS → runnable)
- Bug family: dropped `??=` read-cache `var _a;` declaration in single-line and
  constructor bodies (#11763)
- Evidence: `o.v ??= 1` inside a function/method/super-property/constructor/
  field-initializer/block-arrow at `--target es2015` previously emitted `_a`
  with no `var _a;` (strict-mode `ReferenceError`); it now declares the temp and
  `node` runs the output (repro prints `1`). All six body shapes verified plus a
  complex-receiver two-temp (`_a`/`_b`) case.

## Verification
- `cargo build -p tsz-cli`; manual `tsz --target es2015` + `node` run of every
  affected shape (function, method, `super.x`/`super[k]`, single-line and
  multi-line constructor, field-initializer synthesized constructor, block
  arrow) — all now declare `var _a;` and execute correctly.
- `cargo test -p tsz-emitter --lib`: 8 new structural tests pass; failure set is
  byte-identical to the pre-change baseline (the 20 pre-existing failures are
  unrelated DTS/module/decorator/async-ES5 tests that fail without the full
  fixture environment) — **zero new failures**.
- `cargo fmt --check` clean; `cargo clippy -p tsz-emitter --all-targets` clean.
- Rebased onto current `main`; no conflicts. Emitter-only change.
- §25/§26 compliant: tests vary object/property spellings (`box`/`store`/`bag`,
  `value`/`count`/`flag`/`slot`) and cover a renamed-receiver and a negative
  complex-receiver two-temp case; the fix keys on temp-pool state and node kind,
  not on names. Altitude check confirmed all six flush sites
  (`emit_function_body_hoisted_temps`, `insert_function_body_hoisted_temps_at`,
  the new single-line prologue, both constructor sites, and the source-file
  preamble) now handle both temp pools — no remaining sibling site.

## Coordination Notes
Freshly-discovered, previously-unfiled emit correctness bug (no existing issue/PR
covered it; verified against open emit PR #11762, which is a different
scoped-static-super destructuring-default-target bug in `static_super.rs`). Filed
#11763 and claimed it. — cloud-opus48-pensive-wright


---
_Generated by [Claude Code](https://claude.ai/code/session_018rFDWNw9FBnzm776MDYFdz)_