### PR TITLE
fix(emit): emit CommonJS exports.X before trailing computed-prop side-effects in ES5 export-class IIFE

### DIFF
--- a/crates/tsz-emitter/src/emitter/source_file/commonjs_export_class_es5_computed_order_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/commonjs_export_class_es5_computed_order_tests.rs
@@ -1,0 +1,131 @@
+//! Structural emit tests for CommonJS export ordering of a top-level
+//! `export class` lowered to an ES5 IIFE that also carries trailing
+//! computed-property-name side-effect statements.
+//!
+//! Structural rule: when an `export class` is lowered to an ES5
+//! `var X = (function () { ... }());` IIFE and the class declares
+//! erased computed-named members whose key expressions are NOT
+//! side-effect-free, `tsc` emits the deferred CommonJS export assignment
+//! `exports.X = X;` immediately AFTER the class IIFE statement and BEFORE
+//! the trailing computed-property side-effect statements. tsz must match
+//! this order (it mirrors the ES2015+ ordering in `emit_es6.rs`).
+//!
+//! The rule is keyed on the AST/IR shape (export class -> ES5 IIFE +
+//! computed-property side effects), not on any identifier spelling, so the
+//! tests below vary the class name, the key-source object name, and the
+//! member key while asserting the same ordering.
+
+use crate::context::emit::EmitContext;
+use crate::emitter::{ModuleKind, Printer as EmitterPrinter, PrinterOptions};
+use crate::lowering::LoweringPass;
+use tsz_common::ScriptTarget;
+use tsz_parser::ParserState;
+
+fn emit_commonjs(source: &str, target: ScriptTarget, use_define_for_class_fields: bool) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        target,
+        module: ModuleKind::CommonJS,
+        use_define_for_class_fields,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+/// Index of the FIRST line equal to (trimmed) `needle`, or `None`.
+fn line_index_eq(output: &str, needle: &str) -> Option<usize> {
+    output.lines().position(|l| l.trim() == needle)
+}
+
+/// Index of the first line that (trimmed) starts with `prefix`, or `None`.
+fn line_index_starts_with(output: &str, prefix: &str) -> Option<usize> {
+    output.lines().position(|l| l.trim().starts_with(prefix))
+}
+
+// --- Reported repro shape (es5, useDefineForClassFields=false) ---
+
+#[test]
+fn export_class_es5_export_assignment_precedes_computed_side_effects() {
+    // The instance computed member `[K.name]` is erased (no `=` initializer,
+    // udf=false) but its key expression `K.name` is not side-effect-free, so
+    // it is emitted as a trailing side-effect statement after the IIFE.
+    let source = "const K = { name: 'name' } as const;\n\
+                  export class Exported {\n\
+                  \x20\x20\x20\x20static [K.name]: number;\n\
+                  \x20\x20\x20\x20[K.name]: string;\n\
+                  }\n";
+    let output = emit_commonjs(source, ScriptTarget::ES5, false);
+
+    let export_line = line_index_starts_with(&output, "exports.Exported = Exported;");
+    let side_effect_line = line_index_starts_with(&output, "K.name,");
+
+    assert!(
+        export_line.is_some(),
+        "Expected a deferred `exports.Exported = Exported;` line.\nOutput:\n{output}"
+    );
+    assert!(
+        side_effect_line.is_some(),
+        "Expected a trailing computed-name side-effect statement `K.name, ...`.\nOutput:\n{output}"
+    );
+    assert!(
+        export_line < side_effect_line,
+        "`exports.Exported = Exported;` must be emitted BEFORE the trailing \
+         computed-property side-effect statement.\nOutput:\n{output}"
+    );
+}
+
+// --- Renamed class / key-source / member key: proves the rule is keyed on the
+// shape, not on the spelling `Exported`/`K`/`name`. ---
+
+#[test]
+fn export_class_es5_renamed_symbols_keep_export_before_side_effects() {
+    let source = "const Names = { len: 'len' } as const;\n\
+                  export class Widget {\n\
+                  \x20\x20\x20\x20static [Names.len]: number;\n\
+                  \x20\x20\x20\x20[Names.len]: string;\n\
+                  }\n";
+    let output = emit_commonjs(source, ScriptTarget::ES5, false);
+
+    let export_line = line_index_starts_with(&output, "exports.Widget = Widget;");
+    let side_effect_line = line_index_starts_with(&output, "Names.len,");
+
+    assert!(
+        export_line.is_some() && side_effect_line.is_some(),
+        "Renamed symbols must still produce the export line and the trailing \
+         side-effect statement.\nOutput:\n{output}"
+    );
+    assert!(
+        export_line < side_effect_line,
+        "Renaming the class/key-source/member must NOT change the export-before-\
+         side-effects ordering (rule is structural).\nOutput:\n{output}"
+    );
+}
+
+// --- No trailing computed side effects: the deferred export still lands right
+// after the class IIFE. Negative-shape guard so the handoff doesn't drop the
+// assignment when there is nothing to order it against. ---
+
+#[test]
+fn export_class_es5_without_computed_members_still_emits_export() {
+    let source = "export class Plain {\n\
+                  \x20\x20\x20\x20m() {}\n\
+                  }\n";
+    let output = emit_commonjs(source, ScriptTarget::ES5, false);
+
+    assert!(
+        line_index_starts_with(&output, "exports.Plain = Plain;").is_some(),
+        "A plain `export class` must still emit its CommonJS export assignment.\nOutput:\n{output}"
+    );
+    assert!(
+        line_index_eq(&output, "var Plain = /** @class */ (function () {").is_some()
+            || output.contains("var Plain ="),
+        "The class must be lowered to an ES5 IIFE binding.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/source_file/mod.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/mod.rs
@@ -20,6 +20,8 @@ mod class_expression_decorator_tests;
 #[cfg(test)]
 mod class_static_alias_tests;
 #[cfg(test)]
+mod commonjs_export_class_es5_computed_order_tests;
+#[cfg(test)]
 mod decorator_metadata_tests;
 #[cfg(test)]
 mod derived_constructor_tests;

--- a/crates/tsz-emitter/src/emitter/transform_dispatch_chain.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch_chain.rs
@@ -33,6 +33,23 @@ impl<'a> Printer<'a> {
             EmitDirective::ES5Class { class_node } => {
                 let class_binding_name = self.register_es5_class_binding_name(*class_node);
                 let mut es5_emitter = self.create_es5_class_emitter_with_decorators(*class_node);
+                // Hand off any deferred CommonJS `export class` assignment so the
+                // ES5 emitter places `exports.X = X;` immediately after the class
+                // IIFE statement and BEFORE its trailing computed-property
+                // side-effect statements (matching tsc and the ES2015+ path).
+                // Consuming it here prevents the chained CommonJSExport fallback
+                // from emitting the assignment after those side effects.
+                if self
+                    .pending_commonjs_class_export_name
+                    .as_ref()
+                    .is_some_and(|(class_idx, _)| *class_idx == *class_node)
+                {
+                    let (_, export_name) = self
+                        .pending_commonjs_class_export_name
+                        .take()
+                        .expect("pending class export should be present");
+                    es5_emitter.set_pending_commonjs_class_export_name(Some(export_name));
+                }
                 let es5_output = self.emit_es5_class_output(
                     &mut es5_emitter,
                     *class_node,

--- a/crates/tsz-emitter/src/transforms/class_es5.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5.rs
@@ -91,6 +91,10 @@ pub struct ClassES5Emitter<'a> {
     /// Outer names (e.g. a class-expression alias) excluded from generator state
     /// variable selection inside `__awaiter`/`__generator` method bodies.
     outer_reserved_for_generator_state: Vec<String>,
+    /// Deferred CommonJS `exports.<name> = <name>;` assignment for a top-level
+    /// `export class` lowered to an ES5 IIFE. Emitted right after the IIFE
+    /// statement, before trailing computed-property side effects.
+    pending_commonjs_class_export_name: Option<String>,
 }
 
 impl<'a> ClassES5Emitter<'a> {
@@ -115,6 +119,7 @@ impl<'a> ClassES5Emitter<'a> {
             block_scope_reserved_names: Vec::new(),
             outer_reserved_for_generator_state: Vec::new(),
             tc39_wrap_output: true,
+            pending_commonjs_class_export_name: None,
         }
     }
 
@@ -130,6 +135,12 @@ impl<'a> ClassES5Emitter<'a> {
 
     pub fn set_block_scope_shadowed_names(&mut self, names: Vec<String>) {
         self.block_scope_shadowed_names = names;
+    }
+
+    /// Schedule a deferred CommonJS `exports.<name> = <name>;` assignment for a
+    /// top-level `export class` lowered to an ES5 IIFE.
+    pub fn set_pending_commonjs_class_export_name(&mut self, name: Option<String>) {
+        self.pending_commonjs_class_export_name = name;
     }
 
     pub fn set_block_scope_reserved_names(&mut self, names: Vec<String>) {
@@ -517,6 +528,9 @@ impl<'a> ClassES5Emitter<'a> {
         }
         printer.set_block_scope_shadowed_names(self.block_scope_shadowed_names.clone());
         printer.set_block_scope_reserved_names(self.block_scope_reserved_names.clone());
+        printer.set_pending_commonjs_class_export_name(
+            self.pending_commonjs_class_export_name.clone(),
+        );
         if !self.outer_reserved_for_generator_state.is_empty() {
             printer.set_outer_reserved_for_generator_state(
                 self.outer_reserved_for_generator_state.clone(),

--- a/crates/tsz-emitter/src/transforms/ir_printer.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer.rs
@@ -87,6 +87,12 @@ pub struct IRPrinter<'a> {
     namespace_ast_exported_names: rustc_hash::FxHashSet<String>,
     block_scope_shadowed_names: Vec<String>,
     block_scope_reserved_names: Vec<String>,
+    /// Deferred CommonJS `exports.<name> = <name>;` assignment for a top-level
+    /// `export class` lowered to an ES5 IIFE. When set, the assignment is
+    /// emitted immediately after the class IIFE statement and BEFORE any
+    /// trailing computed-property-name side-effect statements, mirroring the
+    /// ES2015+ class export ordering in `emit_es6.rs`.
+    pending_commonjs_class_export_name: Option<String>,
 }
 
 impl<'a> IRPrinter<'a> {
@@ -319,6 +325,7 @@ impl<'a> IRPrinter<'a> {
             namespace_ast_exported_names: rustc_hash::FxHashSet::default(),
             block_scope_shadowed_names: Vec::new(),
             block_scope_reserved_names: Vec::new(),
+            pending_commonjs_class_export_name: None,
         }
     }
 
@@ -350,6 +357,7 @@ impl<'a> IRPrinter<'a> {
             namespace_ast_exported_names: rustc_hash::FxHashSet::default(),
             block_scope_shadowed_names: Vec::new(),
             block_scope_reserved_names: Vec::new(),
+            pending_commonjs_class_export_name: None,
         }
     }
 
@@ -381,7 +389,21 @@ impl<'a> IRPrinter<'a> {
             namespace_ast_exported_names: rustc_hash::FxHashSet::default(),
             block_scope_shadowed_names: Vec::new(),
             block_scope_reserved_names: Vec::new(),
+            pending_commonjs_class_export_name: None,
         }
+    }
+
+    /// Schedule a deferred CommonJS `exports.<name> = <name>;` assignment for a
+    /// top-level `export class` lowered to an ES5 IIFE. Emitted right after the
+    /// class IIFE statement, before any trailing computed-property side effects.
+    pub fn set_pending_commonjs_class_export_name(&mut self, name: Option<String>) {
+        self.pending_commonjs_class_export_name = name;
+    }
+
+    /// Consume the scheduled CommonJS class export name, clearing it so a single
+    /// IIFE statement emits the assignment exactly once.
+    pub(super) const fn take_pending_commonjs_class_export_name(&mut self) -> Option<String> {
+        self.pending_commonjs_class_export_name.take()
     }
 
     /// Set transform directives for `ASTRef` emission

--- a/crates/tsz-emitter/src/transforms/ir_printer_class_emit.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer_class_emit.rs
@@ -63,6 +63,20 @@ impl<'a> IRPrinter<'a> {
         self.emit_es5_class_expression(name, base_class.as_deref(), super_param.as_deref(), body);
         self.write(";");
 
+        // A top-level `export class` lowered to this IIFE carries a deferred
+        // CommonJS export assignment. tsc emits `exports.X = X;` immediately
+        // after the class statement and BEFORE any trailing computed-property
+        // side-effect statements, matching the ES2015+ ordering in `emit_es6.rs`.
+        if let Some(export_name) = self.take_pending_commonjs_class_export_name() {
+            self.write_line();
+            self.write_indent();
+            self.write("exports.");
+            self.write(&export_name);
+            self.write(" = ");
+            self.write(&export_name);
+            self.write(";");
+        }
+
         for init in computed_prop_temp_inits {
             self.write_line();
             self.write_indent();


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — ES5 export-class IIFE CJS export ordering (emit→100% campaign, wave 3)

## Invariant
When a top-level `export class` is lowered to an ES5 `var X = (function(){...}())` IIFE and the class declares erased computed-named members whose key expressions are not side-effect-free, the deferred CommonJS `exports.X = X;` assignment must be emitted immediately AFTER the IIFE statement and BEFORE the trailing computed-property-name side-effect statements (`FunctionPropertyNames.name, FunctionPropertyNames.name;`) — mirroring the ES2015+ ordering. tsz previously emitted `exports.X = X;` after the side-effect statements. Keyed on IR/AST shape (ES5ClassIIFE node + export-class node index) — no identifier/file-name matching, no printer-output inspection. (Note: the comma-expression line-wrapping diffs in this test are whitespace-normalized away by the harness ladder; the export-line REORDERING is the sole structural failure.)

## Scope
- `crates/tsz-emitter/src/transforms/ir_printer.rs`, `transforms/class_es5.rs` — thread the deferred export name through `ClassES5Emitter`→`IRPrinter`.
- `crates/tsz-emitter/src/transforms/ir_printer_class_emit.rs` — emit `exports.X = X;` between the IIFE statement and `computed_prop_temp_inits` in `emit_es5_class_iife_node`.
- `crates/tsz-emitter/src/emitter/transform_dispatch_chain.rs` — hand off + consume the pending export name in the chained ES5Class directive.
- `crates/tsz-emitter/src/emitter/source_file/commonjs_export_class_es5_computed_order_tests.rs` (+3 tests).

## Project Corpus Impact
- Row: n/a (ES5 export-class emit-ordering fix)
- Bug family: deferred CommonJS `exports.X` emitted after (not before) trailing computed-property side-effect statements in ES5 export-class IIFE
- Evidence: staticPropertyNameConflicts(target=es5,usedefineforclassfields=false) FAIL→PASS; full --js-only 81→80.

## Verification
- Witness FAIL→PASS. **Full --js-only: 13449→13450 pass (81→80 fail), net +1, ZERO regressions** (set-diff: newly-passing = the es5,udf=false variant; newly-failing empty after excluding 8 transient cold-start timeouts that pass in isolation). DTS unaffected (no DTS baselines for this family; ES5 IIFE JS path only). 3 new structural unit tests (repro; renamed class/key-source/member; negative no-computed-members). Clippy clean; arch guard passes (avoided pushing transform_dispatch.rs past its 2124 ratchet by handling only the active chained path).
- §25/§26 compliant; emit as planned facts (deferred export name threaded to the IIFE boundary; no output surgery).

## Coordination Notes
Rebased onto current main. Used the corrected harness understanding (comments+whitespace normalized → only structural export-ordering fails). STOP-reported (broad, out of scope): staticPropertyNameConflicts(es2015,udf=true) + (es5,udf=true) — separate useDefineForClassFields declare-only-static-field emission model (`Object.defineProperty` vs tsc elision). — opus48-emit100
