### PR TITLE
fix(emit): capture this into _this when an ES5 derived super-call argument references this

### DIFF
--- a/crates/tsz-emitter/src/emitter/source_file/derived_constructor_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/derived_constructor_tests.rs
@@ -77,6 +77,64 @@ fn derived_constructor_fields_follow_parenthesized_super_call() {
 }
 
 #[test]
+fn super_arg_this_without_fields_captures_this_es5() {
+    // A `this` reference inside the super-call arguments must materialize the
+    // captured `_this` form even when the constructor has no field initializer
+    // and `super(...)` is its only statement. tsc emits
+    // `var _this = _super.call(this, _this) || this; return _this;` rather than
+    // the inlined `return _super.call(this, this) || this;` tail form.
+    let source = "class Base { constructor(t: any) {} }\nclass OnlySuperArg extends Base {\n    constructor() {\n        super(this);\n    }\n}\n";
+
+    let es5_output = emit(source, ScriptTarget::ES5);
+
+    assert!(
+        es5_output.contains(
+            "function OnlySuperArg() {\n        var _this = _super.call(this, _this) || this;\n        return _this;\n    }"
+        ),
+        "ES5 derived constructor with `this` in the super-call argument and no fields must capture `_this`.\nOutput:\n{es5_output}"
+    );
+    assert!(
+        !es5_output.contains("return _super.call(this, this) || this;"),
+        "The inline tail-super-return form must not be used when a super-call argument references `this`.\nOutput:\n{es5_output}"
+    );
+}
+
+#[test]
+fn super_arg_this_without_fields_captures_this_es5_renamed() {
+    // Same rule with different class/parameter spellings: the fix keys on the
+    // AST shape (a `this` reference inside super-call arguments), not on any
+    // identifier name.
+    let source = "class Animal { constructor(p: any) {} }\nclass Dog extends Animal {\n    constructor() {\n        super(this);\n    }\n}\n";
+
+    let es5_output = emit(source, ScriptTarget::ES5);
+
+    assert!(
+        es5_output.contains(
+            "function Dog() {\n        var _this = _super.call(this, _this) || this;\n        return _this;\n    }"
+        ),
+        "Renamed class/parameter must still capture `_this` when `this` appears in the super-call argument.\nOutput:\n{es5_output}"
+    );
+}
+
+#[test]
+fn super_arg_without_this_keeps_inline_tail_return_es5() {
+    // Negative / fallback case: a super-call argument that does NOT reference
+    // `this` keeps the inline tail-super-return form, proving the capture is
+    // gated on the structural `this`-in-argument shape, not on having any
+    // argument at all.
+    let source = "class Base { constructor(t: any) {} }\nclass NoThisArg extends Base {\n    constructor() {\n        super(42);\n    }\n}\n";
+
+    let es5_output = emit(source, ScriptTarget::ES5);
+
+    assert!(
+        es5_output.contains(
+            "function NoThisArg() {\n        return _super.call(this, 42) || this;\n    }"
+        ),
+        "A super-call argument without `this` should keep the inline tail-super-return form.\nOutput:\n{es5_output}"
+    );
+}
+
+#[test]
 fn pre_super_nested_class_emits_legacy_decorators() {
     let source = "declare const decorate: any;\nclass Base {}\nclass Derived extends Base {\n    prop = true;\n    constructor() {\n        @decorate(this)\n        class Inner {\n            @decorate(this)\n            method() {}\n            @decorate(this)\n            prop;\n        }\n        super();\n    }\n}\n";
 

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_constructor.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_constructor.rs
@@ -360,6 +360,13 @@ impl<'a> ES5ClassTransformer<'a> {
             return;
         }
 
+        // A `this` reference inside the super-call arguments (`super(this)`)
+        // forces tsc to materialize the captured `_this` form
+        // (`var _this = _super.call(this, _this) || this; return _this;`) so the
+        // argument can thread the captured receiver. The inline tail-super-return
+        // form cannot capture those arguments, so disable it in that case.
+        let super_args_reference_this = super_stmt_idx
+            .is_some_and(|super_idx| self.super_call_arguments_reference_this(super_idx));
         let can_use_tail_super_return = super_stmt_idx.is_some()
             && stmts_after_super == 0
             && instance_props.is_empty()
@@ -369,7 +376,8 @@ impl<'a> ES5ClassTransformer<'a> {
             && !has_auto_accessors
             && !has_private_accessors
             && !needs_pre_super_this_capture
-            && !needs_this_capture;
+            && !needs_this_capture
+            && !super_args_reference_this;
 
         if can_use_tail_super_return {
             let mut prev_stmt_end = body_node.pos;
@@ -1079,6 +1087,30 @@ impl<'a> ES5ClassTransformer<'a> {
             return (callee.kind == SyntaxKind::SuperKeyword as u16).then_some(current);
         }
         None
+    }
+
+    /// Whether any argument of the super-call statement contains a `this`
+    /// keyword reference (respecting lexical-`this` boundaries). When true, an
+    /// ES5 derived constructor must capture `this` into `_this` so the argument
+    /// threads the captured receiver instead of the raw, not-yet-initialized
+    /// `this`.
+    fn super_call_arguments_reference_this(&self, stmt_idx: NodeIndex) -> bool {
+        let Some(call_idx) = self.root_super_call_from_statement(stmt_idx) else {
+            return false;
+        };
+        let Some(call_node) = self.arena.get(call_idx) else {
+            return false;
+        };
+        let Some(call) = self.arena.get_call_expr(call_node) else {
+            return false;
+        };
+        let Some(ref call_args) = call.arguments else {
+            return false;
+        };
+        call_args
+            .nodes
+            .iter()
+            .any(|&arg_idx| contains_this_reference(self.arena, arg_idx))
     }
 
     fn is_parenthesized_root_super_call_statement(&self, stmt_idx: NodeIndex) -> bool {


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — ES5 derived-constructor this-in-super-arg capture (emit→100% campaign, wave 3)

## Invariant
When an ES5-downleveled derived constructor's `super(...)` call has any argument expression containing a `this` keyword reference, tsc captures `this` into `_this` (`var _this = _super.call(this, _this) || this; return _this;`) rather than the inlined tail-super-return form (`return _super.call(this, this) || this;`) — because the inlined form references the pre-super `this`. So the tail-super-return optimization must be DISABLED when any super-call argument contains a `this` reference. Keyed on AST node kind (super-call argument containing `this`, via `contains_this_reference`, lexical-boundary aware) — no identifier/file-name matching, no printer-output inspection. Falling through to the existing full path already emits the arg-captured `_super.call(this, _this)` + `return _this`.

## Scope
- `crates/tsz-emitter/src/transforms/class_es5_ir_constructor.rs` — new `super_call_arguments_reference_this(...)`; `&& !super_args_reference_this` guard on `can_use_tail_super_return`.
- `crates/tsz-emitter/src/emitter/source_file/derived_constructor_tests.rs` (+3 tests).

## Project Corpus Impact
- Row: n/a (ES5 derived-constructor emit fix)
- Bug family: ES5 tail-super-return fast path skips `this`→`_this` capture when a super-call argument references `this`
- Evidence: thisInInvalidContextsExternalModule(target=es5) FAIL→PASS; full --js-only 79→78.

## Verification
- Witness FAIL→PASS (`ClassWithNoInitializer`: now `var _this = _super.call(this, _this) || this; return _this;`). **Full --js-only: 79→78 fail, net +1, ZERO regressions** (newly-fixed = exactly the target; no new failures). DTS unaffected (ES5 class IR JS-only path). The other verbose diffs (`// Error` etc. trailing comments) are comment-only, normalized by the harness ladder. 3 new structural unit tests (no-field super-arg-this capture; renamed-class; negative `super(42)` keeps inline tail form). Clippy clean; arch guard passes.
- §25/§26 compliant.

## Coordination Notes
Rebased onto current main. Root cause: the no-field/super-only fast path (`can_use_tail_super_return` → `emit_super_call_return_ir`) didn't rewrite `this` args to `_this`; the full path (`emit_super_call_ir` with `capture_args_this=true`) already did, which is why the sibling field-bearing case was correct. — opus48-emit100
