### PR TITLE
fix(emit): unique ES5 namespace IIFE param when a nested binding shadows the namespace name

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/namespace.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/namespace.rs
@@ -141,11 +141,13 @@ impl<'a> Printer<'a> {
             if let Some(text) = self.source_text_for_map() {
                 es5_emitter.set_source_text(text);
             }
+            es5_emitter.set_iife_param_rename_counter(self.namespace_iife_param_counter.clone());
             let output = if use_cjs {
                 es5_emitter.emit_exported_namespace(idx)
             } else {
                 es5_emitter.emit_namespace(idx)
             };
+            self.namespace_iife_param_counter = es5_emitter.take_iife_param_rename_counter();
             self.next_disposable_env_id = es5_emitter.disposable_env_counter();
             for generated_name in es5_emitter.take_generated_disposable_env_names() {
                 self.generated_temp_names.insert(generated_name);
@@ -716,161 +718,12 @@ impl<'a> Printer<'a> {
         if self.namespace_block_contains_instantiated_module_named(body_node, ns_name) {
             return true;
         }
-        if let Some(text) = self.source_text {
-            let mut mask_ranges = self.collect_declare_statement_ranges(body_node);
-            mask_ranges.extend(self.collect_enum_decl_ranges(body_node));
-            return match crate::safe_slice::slice(
-                text,
-                body_node.pos as usize,
-                body_node.end as usize,
-            ) {
-                Ok(body_text) => {
-                    let body_pos = body_node.pos as usize;
-                    let masked = Self::mask_ranges_static(body_text, body_pos, &mask_ranges);
-                    Self::text_has_non_namespace_binding_named(&masked, ns_name)
-                }
-                Err(_) => false,
-            };
-        }
-        false
-    }
-
-    /// Scan for runtime bindings while skipping `namespace`/`module` declarations.
-    /// Nested sub-namespaces have their own IIFE scope and should not force the
-    /// enclosing namespace's IIFE parameter to be renamed.
-    fn text_has_non_namespace_binding_named(text: &str, name: &str) -> bool {
-        let stripped = Self::strip_comments(text);
-        let text = &stripped;
-        let name_bytes = name.as_bytes();
-        let text_bytes = text.as_bytes();
-        let name_len = name_bytes.len();
-
-        let mut i = 0;
-        while i + name_len <= text_bytes.len() {
-            if let Some(pos) = text[i..].find(name) {
-                let abs = i + pos;
-                let before_ok = abs == 0
-                    || (!text_bytes[abs - 1].is_ascii_alphanumeric()
-                        && text_bytes[abs - 1] != b'_'
-                        && text_bytes[abs - 1] != b'$');
-                let after_end = abs + name_len;
-                let after_ok = after_end >= text_bytes.len()
-                    || (!text_bytes[after_end].is_ascii_alphanumeric()
-                        && text_bytes[after_end] != b'_'
-                        && text_bytes[after_end] != b'$');
-
-                if before_ok && after_ok {
-                    // Look at the first non-whitespace character *after* the
-                    // name. A name immediately followed by `.` is a qualified /
-                    // member reference (`N.foo`) and is never a binding. This
-                    // rejection is unconditional — no binding form places `.`
-                    // directly after the bound identifier.
-                    let mut a = after_end;
-                    while a < text_bytes.len() && text_bytes[a].is_ascii_whitespace() {
-                        a += 1;
-                    }
-                    let followed_by_dot = a < text_bytes.len() && text_bytes[a] == b'.';
-                    let followed_by_paren = a < text_bytes.len() && text_bytes[a] == b'(';
-                    if followed_by_dot {
-                        i = abs + 1;
-                        continue;
-                    }
-                    let mut p = abs;
-                    while p > 0 && text_bytes[p - 1].is_ascii_whitespace() {
-                        p -= 1;
-                    }
-                    if p > 0 {
-                        let prev_char = text_bytes[p - 1];
-                        // Bare `(`/`,` before the name only counts as a binding
-                        // when the name is NOT immediately followed by `(`. A
-                        // name followed by `(` here is a callee (`if (N.f())`,
-                        // `foo(N())`), not a parameter/binding. Genuine
-                        // parameter bindings (`function f(N)`, `f(a, N)`) are
-                        // followed by `)`, `,`, `:`, `=`, etc. — never `(`.
-                        // Function/class declarations like `function N(` are
-                        // handled by the keyword checks below, which run
-                        // independently of this guard.
-                        if (prev_char == b'(' || prev_char == b',') && !followed_by_paren {
-                            return true;
-                        }
-                        let preceding = &text[..p];
-                        let binding_keywords: &[&str] =
-                            &["var", "let", "const", "function", "class", "import"];
-                        for &kw in binding_keywords {
-                            if preceding.ends_with(kw) {
-                                let kw_start = p - kw.len();
-                                let kw_before_ok = kw_start == 0
-                                    || (!text_bytes[kw_start - 1].is_ascii_alphanumeric()
-                                        && text_bytes[kw_start - 1] != b'_'
-                                        && text_bytes[kw_start - 1] != b'$');
-                                if kw_before_ok {
-                                    return true;
-                                }
-                            }
-                        }
-                        let parameter_modifier_keywords: &[&str] =
-                            &["private", "public", "protected", "readonly", "override"];
-                        for &kw in parameter_modifier_keywords {
-                            if preceding.ends_with(kw) {
-                                let kw_start = p - kw.len();
-                                let kw_before_ok = kw_start == 0
-                                    || (!text_bytes[kw_start - 1].is_ascii_alphanumeric()
-                                        && text_bytes[kw_start - 1] != b'_'
-                                        && text_bytes[kw_start - 1] != b'$');
-                                if kw_before_ok
-                                    && Self::keyword_is_in_parameter_context(text_bytes, kw_start)
-                                {
-                                    return true;
-                                }
-                            }
-                        }
-                    }
-                }
-                i = abs + 1;
-            } else {
-                break;
-            }
-        }
-        false
-    }
-
-    fn keyword_is_in_parameter_context(text_bytes: &[u8], kw_start: usize) -> bool {
-        let mut p = kw_start;
-        loop {
-            while p > 0 && text_bytes[p - 1].is_ascii_whitespace() {
-                p -= 1;
-            }
-            if p == 0 {
-                return false;
-            }
-            let prev_char = text_bytes[p - 1];
-            if prev_char == b'(' || prev_char == b',' {
-                return true;
-            }
-            if !prev_char.is_ascii_alphanumeric() && prev_char != b'_' && prev_char != b'$' {
-                return false;
-            }
-
-            let ident_end = p;
-            let mut ident_start = ident_end - 1;
-            while ident_start > 0
-                && (text_bytes[ident_start - 1].is_ascii_alphanumeric()
-                    || text_bytes[ident_start - 1] == b'_'
-                    || text_bytes[ident_start - 1] == b'$')
-            {
-                ident_start -= 1;
-            }
-            let Ok(ident) = std::str::from_utf8(&text_bytes[ident_start..ident_end]) else {
-                return false;
-            };
-            if !matches!(
-                ident,
-                "private" | "public" | "protected" | "readonly" | "override"
-            ) {
-                return false;
-            }
-            p = ident_start;
-        }
+        crate::transforms::namespace_iife_binding_scan::namespace_body_text_has_binding_named(
+            self.arena,
+            self.source_text,
+            body_node,
+            ns_name,
+        )
     }
 
     fn namespace_body_has_name_conflict(
@@ -916,31 +769,17 @@ impl<'a> Printer<'a> {
         if self.namespace_block_contains_instantiated_module_named(body_node, ns_name) {
             return true;
         }
-        // Use source text scan for bindings in nested functions/classes at any depth.
-        // Nested namespace/module declarations have their own IIFE scope and do not
-        // shadow this IIFE parameter at call sites, so exclude those keywords here.
-        if let Some(text) = self.source_text {
-            // safe_slice: C → migrated. A bad span here would silently report
-            // "no binding found", which can change namespace shadowing
-            // decisions and emit incorrectly. Surface span errors instead of
-            // returning a false-negative; fall back to false only when source
-            // text is literally unavailable.
-            let mut mask_ranges = self.collect_declare_statement_ranges(body_node);
-            mask_ranges.extend(self.collect_enum_decl_ranges(body_node));
-            return match crate::safe_slice::slice(
-                text,
-                body_node.pos as usize,
-                body_node.end as usize,
-            ) {
-                Ok(body_text) => {
-                    let body_pos = body_node.pos as usize;
-                    let masked = Self::mask_ranges_static(body_text, body_pos, &mask_ranges);
-                    Self::text_has_non_namespace_binding_named(&masked, ns_name)
-                }
-                Err(_) => false,
-            };
-        }
-        false
+        // Use source text scan for bindings in nested functions/classes at any
+        // depth. Nested namespace/module declarations have their own IIFE scope
+        // and do not shadow this IIFE parameter at call sites, so they are
+        // excluded by the masking inside the shared scan. This scan is shared
+        // with the ES5 IR transform path so both targets agree.
+        crate::transforms::namespace_iife_binding_scan::namespace_body_text_has_binding_named(
+            self.arena,
+            self.source_text,
+            body_node,
+            ns_name,
+        )
     }
 
     fn namespace_block_contains_instantiated_module_named(
@@ -996,144 +835,6 @@ impl<'a> Printer<'a> {
             return self.module_decl_chain_contains_instantiated_name(module.body, ns_name);
         }
         self.namespace_block_contains_instantiated_module_named(body_node, ns_name)
-    }
-
-    /// Collect (pos, end) byte ranges of every statement inside a namespace
-    /// body that is type-only (`declare`). Their bodies are erased at emit
-    /// time, so identifiers introduced inside them — including a same-named
-    /// inner namespace — must not be counted when deciding whether to rename
-    /// the IIFE parameter.
-    fn collect_declare_statement_ranges(
-        &self,
-        body_node: &tsz_parser::parser::node::Node,
-    ) -> Vec<(usize, usize)> {
-        let mut ranges: Vec<(usize, usize)> = Vec::new();
-        let Some(block) = self.arena.get_module_block(body_node) else {
-            return ranges;
-        };
-        let Some(stmts) = &block.statements else {
-            return ranges;
-        };
-        for &stmt_idx in &stmts.nodes {
-            let Some(stmt_node) = self.arena.get(stmt_idx) else {
-                continue;
-            };
-            // Resolve the inner declaration. `export declare ...` parses as an
-            // EXPORT_DECLARATION wrapping the real decl, whose modifier list
-            // carries `declare`.
-            let (decl_node, decl_pos, decl_end) = if stmt_node.kind
-                == syntax_kind_ext::EXPORT_DECLARATION
-                && let Some(export) = self.arena.get_export_decl(stmt_node)
-                && let Some(inner) = self.arena.get(export.export_clause)
-            {
-                (inner, stmt_node.pos as usize, stmt_node.end as usize)
-            } else {
-                (stmt_node, stmt_node.pos as usize, stmt_node.end as usize)
-            };
-            let modifiers = match decl_node.kind {
-                k if k == syntax_kind_ext::VARIABLE_STATEMENT => self
-                    .arena
-                    .get_variable(decl_node)
-                    .and_then(|v| v.modifiers.clone()),
-                k if k == syntax_kind_ext::FUNCTION_DECLARATION => self
-                    .arena
-                    .get_function(decl_node)
-                    .and_then(|f| f.modifiers.clone()),
-                k if k == syntax_kind_ext::CLASS_DECLARATION => self
-                    .arena
-                    .get_class(decl_node)
-                    .and_then(|c| c.modifiers.clone()),
-                k if k == syntax_kind_ext::ENUM_DECLARATION => self
-                    .arena
-                    .get_enum(decl_node)
-                    .and_then(|e| e.modifiers.clone()),
-                k if k == syntax_kind_ext::MODULE_DECLARATION => self
-                    .arena
-                    .get_module(decl_node)
-                    .and_then(|m| m.modifiers.clone()),
-                _ => None,
-            };
-            if self
-                .arena
-                .has_modifier(&modifiers, SyntaxKind::DeclareKeyword)
-            {
-                ranges.push((decl_pos, decl_end));
-            }
-        }
-        ranges
-    }
-
-    /// Collect `(pos, end)` byte ranges of top-level constructs whose source
-    /// text the binding scan cannot interpret correctly and that introduce no
-    /// IIFE-function-scope binding. Currently:
-    ///
-    /// * Enum declarations — enum members are *properties* of the enum object,
-    ///   not function-scope bindings, so an enum member whose name equals the
-    ///   namespace name (e.g. `enum Reservation { ..., TypeScript = 4, ... }`
-    ///   inside `namespace TypeScript`) must not be treated as a shadowing
-    ///   binding. The enum *name* itself is independently checked by the
-    ///   AST-based `declaration_conflicts_iife_param`, so masking the whole
-    ///   span loses no genuine collision.
-    /// * `export import M = Z.M` — emits as `M.M = Z.M`, reusing the IIFE
-    ///   parameter with no local binding, but its `import M` keyword would be
-    ///   misclassified by the scan. A plain `import M = Z.M` *does* bind a
-    ///   local `var M`, so it is intentionally left unmasked.
-    fn collect_enum_decl_ranges(
-        &self,
-        body_node: &tsz_parser::parser::node::Node,
-    ) -> Vec<(usize, usize)> {
-        let mut ranges: Vec<(usize, usize)> = Vec::new();
-        self.collect_enum_decl_ranges_into(body_node, &mut ranges);
-        ranges
-    }
-
-    fn collect_enum_decl_ranges_into(
-        &self,
-        body_node: &tsz_parser::parser::node::Node,
-        ranges: &mut Vec<(usize, usize)>,
-    ) {
-        let Some(block) = self.arena.get_module_block(body_node) else {
-            return;
-        };
-        let Some(stmts) = &block.statements else {
-            return;
-        };
-        for &stmt_idx in &stmts.nodes {
-            let Some(stmt_node) = self.arena.get(stmt_idx) else {
-                continue;
-            };
-            // `export enum E {}` parses as an EXPORT_DECLARATION wrapping the
-            // real enum declaration; resolve through to the inner decl.
-            let decl_node = if stmt_node.kind == syntax_kind_ext::EXPORT_DECLARATION
-                && let Some(export) = self.arena.get_export_decl(stmt_node)
-                && let Some(inner) = self.arena.get(export.export_clause)
-            {
-                inner
-            } else {
-                stmt_node
-            };
-            let is_export_qualified = stmt_node.kind == syntax_kind_ext::EXPORT_DECLARATION;
-            if decl_node.kind == syntax_kind_ext::ENUM_DECLARATION {
-                ranges.push((decl_node.pos as usize, decl_node.end as usize));
-            } else if decl_node.kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION
-                && is_export_qualified
-            {
-                // `export import M = Z.M` emits as `M.M = Z.M`: it reuses the
-                // IIFE parameter and introduces no local binding, so its text
-                // (which contains the `import M` keyword the scan would
-                // otherwise treat as a binding) must be masked. A *plain*
-                // `import M = Z.M` does emit `var M = Z.M`, so it is left
-                // visible and still forces a rename.
-                ranges.push((stmt_node.pos as usize, stmt_node.end as usize));
-            } else if decl_node.kind == syntax_kind_ext::MODULE_DECLARATION
-                && let Some(module) = self.arena.get_module(decl_node)
-                && let Some(inner_body) = self.arena.get(module.body)
-            {
-                // Recurse into sub-namespace bodies so a nested enum member
-                // sharing the outer namespace name is masked too.
-                self.collect_enum_decl_ranges_into(inner_body, ranges);
-            }
-        }
     }
 
     fn namespace_statement_conflicts_iife_param(&self, stmt_idx: NodeIndex, ns_name: &str) -> bool {
@@ -1233,64 +934,6 @@ impl<'a> Printer<'a> {
             }
             _ => false,
         }
-    }
-
-    /// Replace bytes inside `ranges` (absolute source positions) with spaces in
-    /// `body_text`, where `body_text` starts at absolute offset `body_pos`.
-    /// Used to neutralize identifiers that come from `declare` (ambient)
-    /// declarations before running the source-text binding scan.
-    fn mask_ranges_static(body_text: &str, body_pos: usize, ranges: &[(usize, usize)]) -> String {
-        if ranges.is_empty() {
-            return body_text.to_string();
-        }
-        let mut bytes = body_text.as_bytes().to_vec();
-        for &(start, end) in ranges {
-            let local_start = start.saturating_sub(body_pos);
-            let local_end = end.saturating_sub(body_pos).min(bytes.len());
-            if local_start >= bytes.len() {
-                continue;
-            }
-            for b in &mut bytes[local_start..local_end] {
-                if !b.is_ascii_whitespace() {
-                    *b = b' ';
-                }
-            }
-        }
-        String::from_utf8(bytes).unwrap_or_else(|_| body_text.to_string())
-    }
-
-    /// Strip single-line and block comments from text, replacing them with spaces.
-    fn strip_comments(text: &str) -> String {
-        let bytes = text.as_bytes();
-        let mut result = Vec::with_capacity(bytes.len());
-        let mut i = 0;
-        while i < bytes.len() {
-            if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'/' {
-                // Single-line comment: replace with spaces until newline
-                while i < bytes.len() && bytes[i] != b'\n' {
-                    result.push(b' ');
-                    i += 1;
-                }
-            } else if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
-                // Block comment: replace with spaces
-                result.push(b' ');
-                result.push(b' ');
-                i += 2;
-                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
-                    result.push(b' ');
-                    i += 1;
-                }
-                if i + 1 < bytes.len() {
-                    result.push(b' ');
-                    result.push(b' ');
-                    i += 2;
-                }
-            } else {
-                result.push(bytes[i]);
-                i += 1;
-            }
-        }
-        String::from_utf8(result).unwrap_or_default()
     }
 
     /// Collect exported *variable* names from a namespace body for identifier qualification.

--- a/crates/tsz-emitter/src/emitter/declarations/namespace/tests.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/namespace/tests.rs
@@ -655,3 +655,114 @@ fn namespace_invalid_default_expression_export_is_preserved_verbatim() {
         "Invalid default expression export should not become a namespace property assignment.\nOutput:\n{output}"
     );
 }
+
+/// ES5 target: a nested function *parameter* sharing the namespace name shadows
+/// the IIFE parameter at reference sites, so tsc renames the IIFE parameter
+/// (`schema` -> `schema_1`). This previously only worked at ES2015+ because the
+/// ES5 IR collision scan only inspected top-level member names.
+#[test]
+fn es5_namespace_iife_param_renamed_for_nested_function_param() {
+    let source = "namespace schema {\n  export function f(schema: any): number { return 0; }\n}";
+    let (parser, root) = parse_test_source(source);
+
+    let mut printer = Printer::new(
+        &parser.arena,
+        PrintOptions {
+            target: ScriptTarget::ES5,
+            ..Default::default()
+        },
+    );
+    printer.set_source_text(source);
+    printer.print(root);
+    let output = printer.finish().code;
+
+    assert!(
+        output.contains("(function (schema_1)"),
+        "ES5 namespace IIFE param should rename to schema_1 when a nested function parameter shadows the namespace name.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("schema_1.f = f;"),
+        "Member export should use the renamed parameter schema_1.\nOutput:\n{output}"
+    );
+}
+
+/// Same rule, different chosen names — the fix must be keyed on the AST shape
+/// (a binding shadowing the namespace name), not on the spelling `schema`.
+#[test]
+fn es5_namespace_iife_param_renamed_for_nested_function_param_renamed_idents() {
+    let source = "namespace build {\n  export function make(build: any): number { return 0; }\n}";
+    let (parser, root) = parse_test_source(source);
+
+    let mut printer = Printer::new(
+        &parser.arena,
+        PrintOptions {
+            target: ScriptTarget::ES5,
+            ..Default::default()
+        },
+    );
+    printer.set_source_text(source);
+    printer.print(root);
+    let output = printer.finish().code;
+
+    assert!(
+        output.contains("(function (build_1)"),
+        "ES5 namespace IIFE param should rename to build_1 regardless of identifier spelling.\nOutput:\n{output}"
+    );
+}
+
+/// ES5 target: reopening the same namespace several times, each with a shadowing
+/// parameter, increments the rename suffix monotonically across blocks
+/// (`m_1`, `m_2`), matching tsc's declaration-merging behavior.
+#[test]
+fn es5_namespace_iife_param_suffix_increments_across_reopenings() {
+    let source = "namespace m {\n  export function a(m: any): number { return 0; }\n}\nnamespace m {\n  export function b(m: any): number { return 0; }\n}";
+    let (parser, root) = parse_test_source(source);
+
+    let mut printer = Printer::new(
+        &parser.arena,
+        PrintOptions {
+            target: ScriptTarget::ES5,
+            ..Default::default()
+        },
+    );
+    printer.set_source_text(source);
+    printer.print(root);
+    let output = printer.finish().code;
+
+    assert!(
+        output.contains("(function (m_1)"),
+        "First reopening should rename to m_1.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("(function (m_2)"),
+        "Second reopening should increment the suffix to m_2.\nOutput:\n{output}"
+    );
+}
+
+/// ES5 target negative case: no binding shadows the namespace name, so the IIFE
+/// parameter keeps the original name (no rename).
+#[test]
+fn es5_namespace_iife_param_not_renamed_without_shadowing_binding() {
+    let source = "namespace m {\n  export function f(x: any): number { return 0; }\n}";
+    let (parser, root) = parse_test_source(source);
+
+    let mut printer = Printer::new(
+        &parser.arena,
+        PrintOptions {
+            target: ScriptTarget::ES5,
+            ..Default::default()
+        },
+    );
+    printer.set_source_text(source);
+    printer.print(root);
+    let output = printer.finish().code;
+
+    assert!(
+        output.contains("(function (m)"),
+        "ES5 namespace IIFE param should stay `m` when nothing shadows the namespace name.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("(function (m_1)"),
+        "No rename should occur without a shadowing binding.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/transform_dispatch.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch.rs
@@ -398,11 +398,13 @@ impl<'a> Printer<'a> {
                             .collect(),
                     );
                 }
+                ns_emitter.set_iife_param_rename_counter(self.namespace_iife_param_counter.clone());
                 let output = if use_cjs {
                     ns_emitter.emit_exported_namespace(namespace_node)
                 } else {
                     ns_emitter.emit_namespace(namespace_node)
                 };
+                self.namespace_iife_param_counter = ns_emitter.take_iife_param_rename_counter();
                 self.sync_es5_namespace_emitter_block_scope(&ns_emitter);
                 self.write(output.trim_end_matches('\n'));
                 // Skip comments within the namespace range - the ES5 namespace emitter
@@ -1992,7 +1994,9 @@ impl<'a> Printer<'a> {
                 }
                 ns_emitter
                     .set_should_declare_var(*should_declare_var && !self.in_top_level_using_scope);
+                ns_emitter.set_iife_param_rename_counter(self.namespace_iife_param_counter.clone());
                 let output = ns_emitter.emit_exported_namespace(*namespace_node);
+                self.namespace_iife_param_counter = ns_emitter.take_iife_param_rename_counter();
                 self.sync_es5_namespace_emitter_block_scope(&ns_emitter);
                 self.write(output.trim_end_matches('\n'));
                 // Advance comment cursor past comments inside the namespace body,

--- a/crates/tsz-emitter/src/emitter/transform_dispatch_chain.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch_chain.rs
@@ -130,7 +130,9 @@ impl<'a> Printer<'a> {
                 }
                 ns_emitter
                     .set_should_declare_var(*should_declare_var && !self.in_top_level_using_scope);
+                ns_emitter.set_iife_param_rename_counter(self.namespace_iife_param_counter.clone());
                 let output = ns_emitter.emit_namespace(*namespace_node);
+                self.namespace_iife_param_counter = ns_emitter.take_iife_param_rename_counter();
                 self.write(output.trim_end_matches('\n'));
                 // Advance comment cursor past comments inside the namespace body,
                 // since the sub-emitter already handled them.
@@ -192,7 +194,10 @@ impl<'a> Printer<'a> {
                     }) {
                         ns_emitter.set_should_declare_var(should_declare_var);
                     }
+                    ns_emitter
+                        .set_iife_param_rename_counter(self.namespace_iife_param_counter.clone());
                     let output = ns_emitter.emit_exported_namespace(idx);
+                    self.namespace_iife_param_counter = ns_emitter.take_iife_param_rename_counter();
                     self.sync_es5_namespace_emitter_block_scope(&ns_emitter);
                     if let Some(module_decl) = self.arena.get_module(node) {
                         let ns_name = self.get_identifier_text_idx(module_decl.name);

--- a/crates/tsz-emitter/src/transforms/mod.rs
+++ b/crates/tsz-emitter/src/transforms/mod.rs
@@ -66,6 +66,7 @@ pub mod module_commonjs;
 pub mod module_commonjs_ir;
 pub mod namespace_es5;
 pub mod namespace_es5_ir;
+pub mod namespace_iife_binding_scan;
 pub mod private_fields_es5;
 pub mod spread_es5;
 

--- a/crates/tsz-emitter/src/transforms/namespace_es5.rs
+++ b/crates/tsz-emitter/src/transforms/namespace_es5.rs
@@ -134,6 +134,19 @@ impl<'a> NamespaceES5Emitter<'a> {
         self.transformer.set_source_text(text);
     }
 
+    /// Seed the cross-block IIFE-parameter rename suffix counters before
+    /// transforming this namespace block (see
+    /// `NamespaceES5Transformer::set_iife_param_rename_counter`).
+    pub fn set_iife_param_rename_counter(&mut self, counter: rustc_hash::FxHashMap<String, u32>) {
+        self.transformer.set_iife_param_rename_counter(counter);
+    }
+
+    /// Read back the IIFE-parameter rename suffix counters after transforming
+    /// this block so the dispatcher can persist increments.
+    pub fn take_iife_param_rename_counter(&self) -> rustc_hash::FxHashMap<String, u32> {
+        self.transformer.take_iife_param_rename_counter()
+    }
+
     /// Set whether to emit a 'var' declaration for the namespace
     /// When false (e.g., when merging with a class/enum/function), the 'var' is omitted
     pub const fn set_should_declare_var(&mut self, value: bool) {

--- a/crates/tsz-emitter/src/transforms/namespace_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/namespace_es5_ir.rs
@@ -149,6 +149,13 @@ pub struct NamespaceES5Transformer<'a> {
     const_enum_values: FxHashMap<String, Vec<ScopedConstEnum>>,
     const_enum_import_aliases: FxHashMap<String, String>,
     remove_comments: bool,
+    /// Monotonic per-namespace-name suffix counter for IIFE parameter renames.
+    /// `tsc` renames the IIFE parameter with an incrementing suffix across
+    /// reopenings of the same namespace (`schema` → `schema_1`, `schema_2`,
+    /// ...). Each namespace block is transformed by a fresh transformer, so the
+    /// dispatcher seeds this from its shared counter before transforming a block
+    /// and reads it back afterwards to persist the increment.
+    iife_param_rename_counter: RefCell<FxHashMap<String, u32>>,
 }
 
 impl<'a> NamespaceES5Transformer<'a> {
@@ -172,6 +179,7 @@ impl<'a> NamespaceES5Transformer<'a> {
             const_enum_values: FxHashMap::default(),
             const_enum_import_aliases: FxHashMap::default(),
             remove_comments: false,
+            iife_param_rename_counter: RefCell::new(FxHashMap::default()),
         }
     }
 
@@ -195,6 +203,7 @@ impl<'a> NamespaceES5Transformer<'a> {
             const_enum_values: FxHashMap::default(),
             const_enum_import_aliases: FxHashMap::default(),
             remove_comments: false,
+            iife_param_rename_counter: RefCell::new(FxHashMap::default()),
         }
     }
 
@@ -268,6 +277,30 @@ impl<'a> NamespaceES5Transformer<'a> {
     /// These will be merged with locally-collected exports for rewriting references.
     pub fn set_prior_exported_vars(&mut self, vars: std::collections::HashSet<String>) {
         self.prior_exported_vars = vars;
+    }
+
+    /// Seed the IIFE-parameter rename suffix counters from the dispatcher's
+    /// shared, cross-block counter map (`namespace_iife_param_counter`). Call
+    /// before transforming a namespace block so a renamed parameter continues
+    /// the incrementing suffix sequence established by earlier reopenings.
+    pub fn set_iife_param_rename_counter(&mut self, counter: FxHashMap<String, u32>) {
+        self.iife_param_rename_counter = RefCell::new(counter);
+    }
+
+    /// Read back the IIFE-parameter rename suffix counters after transforming a
+    /// block so the dispatcher can persist increments into its shared map.
+    pub fn take_iife_param_rename_counter(&self) -> FxHashMap<String, u32> {
+        self.iife_param_rename_counter.borrow().clone()
+    }
+
+    /// Allocate the next monotonic rename suffix for `ns_name`, mirroring the
+    /// ES2015 printer path (`schema` → `schema_1`, `schema_2`, ...). The counter
+    /// is shared across reopenings via the dispatcher.
+    fn next_renamed_iife_param(&self, ns_name: &str) -> String {
+        let mut counters = self.iife_param_rename_counter.borrow_mut();
+        let counter = counters.entry(ns_name.to_string()).or_insert(0);
+        *counter += 1;
+        format!("{ns_name}_{counter}")
     }
 
     /// Collect exported variable names from a namespace declaration without emitting.
@@ -406,10 +439,18 @@ impl<'a> NamespaceES5Transformer<'a> {
             return None;
         }
 
-        // Detect collision: if a member name matches the innermost namespace name,
-        // rename the IIFE parameter (e.g., A -> A_1)
+        // Detect collision: rename the IIFE parameter (e.g., A -> A_1) when a
+        // top-level member OR any nested-scope binding (e.g. a parameter
+        // `function f(A) {}`) shadows the innermost namespace name.
         let innermost_name = name_parts.last().map_or("", |s| s.as_str());
-        let param_name = detect_and_apply_param_rename(&mut body, innermost_name);
+        let nested_conflict =
+            self.namespace_body_has_nested_binding(innermost_body, innermost_name);
+        let param_name = detect_and_apply_param_rename_with_extra(
+            &mut body,
+            innermost_name,
+            nested_conflict,
+            || self.next_renamed_iife_param(innermost_name),
+        );
 
         // Root name is the first part
         let name = name_parts.first().cloned().unwrap_or_default();
@@ -446,6 +487,29 @@ impl<'a> NamespaceES5Transformer<'a> {
                 .map(Into::into),
             invalid_namespace_static: self.has_invalid_namespace_static_modifier(ns_idx),
         })
+    }
+
+    /// Returns `true` when the namespace body introduces a runtime binding
+    /// named `ns_name` from a *nested* scope (a nested function's parameter, or
+    /// a binding declared inside a nested function/class body). Such a binding
+    /// shadows the namespace name at reference sites, so `tsc` renames the IIFE
+    /// parameter. The top-level member scan in
+    /// `detect_and_apply_param_rename_with_extra` does not see these deeper
+    /// bindings; this source-text scan (shared with the ES2015 printer path)
+    /// does.
+    fn namespace_body_has_nested_binding(&self, body_idx: NodeIndex, ns_name: &str) -> bool {
+        if ns_name.is_empty() {
+            return false;
+        }
+        let Some(body_node) = self.arena.get(body_idx) else {
+            return false;
+        };
+        crate::transforms::namespace_iife_binding_scan::namespace_body_text_has_binding_named(
+            self.arena,
+            self.source_text,
+            body_node,
+            ns_name,
+        )
     }
 
     fn namespace_body_using_region(
@@ -1672,10 +1736,17 @@ impl<'a> NamespaceES5Transformer<'a> {
             return None;
         }
 
-        // Detect collision: if a member name matches the innermost namespace name,
-        // rename the IIFE parameter (e.g., A -> A_1)
+        // Detect collision: rename the IIFE parameter (e.g., A -> A_1) when a
+        // top-level member OR any nested-scope binding (e.g. a parameter
+        // `function f(A) {}`) shadows the innermost namespace name.
         let innermost_name = name_parts.last().map_or("", |s| s.as_str());
-        let param_name = detect_and_apply_param_rename(&mut body, innermost_name);
+        let nested_conflict = self.namespace_body_has_nested_binding(ns_data.body, innermost_name);
+        let param_name = detect_and_apply_param_rename_with_extra(
+            &mut body,
+            innermost_name,
+            nested_conflict,
+            || self.next_renamed_iife_param(innermost_name),
+        );
 
         let name = name_parts.first().cloned().unwrap_or_default();
 

--- a/crates/tsz-emitter/src/transforms/namespace_es5_ir_helpers.rs
+++ b/crates/tsz-emitter/src/transforms/namespace_es5_ir_helpers.rs
@@ -948,22 +948,6 @@ pub(super) fn collect_member_names_from_node(
     }
 }
 
-/// Generate a unique parameter name by appending `_1`, `_2`, etc.
-/// Ensures the generated name doesn't collide with any existing member name.
-pub(super) fn generate_unique_param_name(
-    ns_name: &str,
-    member_names: &std::collections::HashSet<String>,
-) -> String {
-    let mut suffix = 1;
-    loop {
-        let candidate = format!("{ns_name}_{suffix}");
-        if !member_names.contains(&candidate) {
-            return candidate;
-        }
-        suffix += 1;
-    }
-}
-
 /// Rename namespace references in body IR nodes.
 /// Updates `NamespaceExport.namespace` and nested `NamespaceIIFE.parent_name`
 /// from `old_name` to `new_name`.
@@ -995,12 +979,32 @@ pub(super) fn rename_namespace_refs_in_node(node: &mut IRNode, old_name: &str, n
     }
 }
 
-/// Detect collision between namespace name and body member names,
-/// and if found, rename the body's namespace references and return the new parameter name.
-pub(super) fn detect_and_apply_param_rename(body: &mut [IRNode], ns_name: &str) -> Option<String> {
+/// Detect a collision between the innermost namespace name and the names bound
+/// in the namespace body, and if found rename the body's namespace references
+/// and return the new IIFE parameter name.
+///
+/// `collect_body_member_names` only sees *top-level* declarations of the
+/// namespace body (functions/classes/vars/enums). A binding that shadows the
+/// namespace name from a *nested* scope — e.g. a parameter `function f(N) {}`
+/// or a binding declared inside a nested function body — is invisible to that
+/// scan but still forces `tsc` to rename the IIFE parameter. Callers pass
+/// `extra_conflict = true` when the source-text binding scan
+/// (`namespace_iife_binding_scan`) found such a nested binding, so the
+/// reference rewrite still runs.
+///
+/// `make_renamed` supplies the new parameter name (`schema_1`, `schema_2`, ...)
+/// and is only invoked when a rename is required. It is provided by the caller
+/// so the suffix can continue a monotonic counter shared across namespace
+/// reopenings, matching `tsc`.
+pub(super) fn detect_and_apply_param_rename_with_extra(
+    body: &mut [IRNode],
+    ns_name: &str,
+    extra_conflict: bool,
+    make_renamed: impl FnOnce() -> String,
+) -> Option<String> {
     let member_names = collect_body_member_names(body);
-    member_names.contains(ns_name).then(|| {
-        let renamed = generate_unique_param_name(ns_name, &member_names);
+    (member_names.contains(ns_name) || extra_conflict).then(|| {
+        let renamed = make_renamed();
         rename_namespace_refs_in_body(body, ns_name, &renamed);
         renamed
     })

--- a/crates/tsz-emitter/src/transforms/namespace_iife_binding_scan.rs
+++ b/crates/tsz-emitter/src/transforms/namespace_iife_binding_scan.rs
@@ -1,0 +1,406 @@
+//! Shared detection of bindings inside a namespace body that shadow the
+//! namespace name at the IIFE call site.
+//!
+//! When a namespace is lowered to an IIFE (`(function (N) { ... })(N || (N = {}))`),
+//! `tsc` renames the IIFE parameter (`N` -> `N_1`, `N_2`, ...) whenever the
+//! namespace body introduces *any* runtime binding named `N` at *any* nesting
+//! depth — including a nested function's parameter or a binding declared inside
+//! a nested function/class body. The rename is unconditional on whether the
+//! namespace name is actually referenced: a lone `function f(N) {}` inside
+//! `namespace N { ... }` is enough.
+//!
+//! The ES2015 printer path (`crates/tsz-emitter/src/emitter/declarations/namespace.rs`)
+//! and the ES5 IR transform path (`namespace_es5_ir.rs`) must agree, so the
+//! source-text binding scan lives here and is shared by both. The scan operates
+//! on the namespace body source text after masking out type-only (`declare`)
+//! statements and enum declarations, whose identifiers introduce no
+//! function-scope binding that could shadow the parameter.
+
+use tsz_parser::parser::node::{Node, NodeArena};
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
+
+/// Returns `true` when the namespace body (a `MODULE_BLOCK`) contains a binding
+/// named `ns_name` at any depth (nested function parameters, nested
+/// `var`/`let`/`const`/`function`/`class`/`import` declarations). Type-only
+/// (`declare`) statements and enum declarations are masked before scanning, so
+/// their identifiers never trigger a rename.
+///
+/// `body_node` is the `MODULE_BLOCK` node; `source_text` is the full source
+/// file text. Returns `false` when `source_text` is unavailable or the body
+/// span cannot be sliced.
+pub(crate) fn namespace_body_text_has_binding_named(
+    arena: &NodeArena,
+    source_text: Option<&str>,
+    body_node: &Node,
+    ns_name: &str,
+) -> bool {
+    let Some(text) = source_text else {
+        return false;
+    };
+    let mut mask_ranges = collect_declare_statement_ranges(arena, body_node);
+    mask_ranges.extend(collect_enum_decl_ranges(arena, body_node));
+    match crate::safe_slice::slice(text, body_node.pos as usize, body_node.end as usize) {
+        Ok(body_text) => {
+            let body_pos = body_node.pos as usize;
+            let masked = mask_ranges_static(body_text, body_pos, &mask_ranges);
+            text_has_non_namespace_binding_named(&masked, ns_name)
+        }
+        Err(_) => false,
+    }
+}
+
+/// Scan `text` for a binding occurrence of `name`.
+///
+/// A binding is recognized when `name` appears as a whole word and is:
+/// * preceded by a binding keyword (`var`/`let`/`const`/`function`/`class`/
+///   `import`),
+/// * a bare parameter (`(name` or `,name`) not immediately followed by `(`, or
+/// * a parameter-property modifier binding (`private`/`public`/`protected`/
+///   `readonly`/`override` in a parameter context).
+///
+/// A `name` immediately followed by `.` is a qualified member reference
+/// (`N.foo`) and never a binding.
+fn text_has_non_namespace_binding_named(text: &str, name: &str) -> bool {
+    let stripped = strip_comments(text);
+    let text = &stripped;
+    let name_bytes = name.as_bytes();
+    let text_bytes = text.as_bytes();
+    let name_len = name_bytes.len();
+
+    let mut i = 0;
+    while i + name_len <= text_bytes.len() {
+        if let Some(pos) = text[i..].find(name) {
+            let abs = i + pos;
+            let before_ok = abs == 0
+                || (!text_bytes[abs - 1].is_ascii_alphanumeric()
+                    && text_bytes[abs - 1] != b'_'
+                    && text_bytes[abs - 1] != b'$');
+            let after_end = abs + name_len;
+            let after_ok = after_end >= text_bytes.len()
+                || (!text_bytes[after_end].is_ascii_alphanumeric()
+                    && text_bytes[after_end] != b'_'
+                    && text_bytes[after_end] != b'$');
+
+            if before_ok && after_ok {
+                // A name immediately followed by `.` is a qualified / member
+                // reference (`N.foo`) and is never a binding.
+                let mut a = after_end;
+                while a < text_bytes.len() && text_bytes[a].is_ascii_whitespace() {
+                    a += 1;
+                }
+                let followed_by_dot = a < text_bytes.len() && text_bytes[a] == b'.';
+                let followed_by_paren = a < text_bytes.len() && text_bytes[a] == b'(';
+                if followed_by_dot {
+                    i = abs + 1;
+                    continue;
+                }
+                let mut p = abs;
+                while p > 0 && text_bytes[p - 1].is_ascii_whitespace() {
+                    p -= 1;
+                }
+                if p > 0 {
+                    let prev_char = text_bytes[p - 1];
+                    // Bare `(`/`,` before the name only counts as a binding
+                    // when the name is NOT immediately followed by `(`. A name
+                    // followed by `(` here is a callee (`if (N.f())`,
+                    // `foo(N())`), not a parameter/binding. Genuine parameter
+                    // bindings (`function f(N)`, `f(a, N)`) are followed by
+                    // `)`, `,`, `:`, `=`, etc. — never `(`.
+                    if (prev_char == b'(' || prev_char == b',') && !followed_by_paren {
+                        return true;
+                    }
+                    let preceding = &text[..p];
+                    let binding_keywords: &[&str] =
+                        &["var", "let", "const", "function", "class", "import"];
+                    for &kw in binding_keywords {
+                        if preceding.ends_with(kw) {
+                            let kw_start = p - kw.len();
+                            let kw_before_ok = kw_start == 0
+                                || (!text_bytes[kw_start - 1].is_ascii_alphanumeric()
+                                    && text_bytes[kw_start - 1] != b'_'
+                                    && text_bytes[kw_start - 1] != b'$');
+                            if kw_before_ok {
+                                return true;
+                            }
+                        }
+                    }
+                    let parameter_modifier_keywords: &[&str] =
+                        &["private", "public", "protected", "readonly", "override"];
+                    for &kw in parameter_modifier_keywords {
+                        if preceding.ends_with(kw) {
+                            let kw_start = p - kw.len();
+                            let kw_before_ok = kw_start == 0
+                                || (!text_bytes[kw_start - 1].is_ascii_alphanumeric()
+                                    && text_bytes[kw_start - 1] != b'_'
+                                    && text_bytes[kw_start - 1] != b'$');
+                            if kw_before_ok && keyword_is_in_parameter_context(text_bytes, kw_start)
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+            i = abs + 1;
+        } else {
+            break;
+        }
+    }
+    false
+}
+
+/// Determine whether a parameter-property modifier keyword at `kw_start` is in a
+/// parameter context (preceded, after skipping other modifiers, by `(` or `,`).
+fn keyword_is_in_parameter_context(text_bytes: &[u8], kw_start: usize) -> bool {
+    let mut p = kw_start;
+    loop {
+        while p > 0 && text_bytes[p - 1].is_ascii_whitespace() {
+            p -= 1;
+        }
+        if p == 0 {
+            return false;
+        }
+        let prev_char = text_bytes[p - 1];
+        if prev_char == b'(' || prev_char == b',' {
+            return true;
+        }
+        if !prev_char.is_ascii_alphanumeric() && prev_char != b'_' && prev_char != b'$' {
+            return false;
+        }
+
+        let ident_end = p;
+        let mut ident_start = ident_end - 1;
+        while ident_start > 0
+            && (text_bytes[ident_start - 1].is_ascii_alphanumeric()
+                || text_bytes[ident_start - 1] == b'_'
+                || text_bytes[ident_start - 1] == b'$')
+        {
+            ident_start -= 1;
+        }
+        let Ok(ident) = std::str::from_utf8(&text_bytes[ident_start..ident_end]) else {
+            return false;
+        };
+        if !matches!(
+            ident,
+            "private" | "public" | "protected" | "readonly" | "override"
+        ) {
+            return false;
+        }
+        p = ident_start;
+    }
+}
+
+/// Strip single-line and block comments from text, replacing them with spaces.
+fn strip_comments(text: &str) -> String {
+    let bytes = text.as_bytes();
+    let mut result = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'/' {
+            while i < bytes.len() && bytes[i] != b'\n' {
+                result.push(b' ');
+                i += 1;
+            }
+        } else if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+            result.push(b' ');
+            result.push(b' ');
+            i += 2;
+            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                result.push(b' ');
+                i += 1;
+            }
+            if i + 1 < bytes.len() {
+                result.push(b' ');
+                result.push(b' ');
+                i += 2;
+            }
+        } else {
+            result.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8(result).unwrap_or_default()
+}
+
+/// Replace bytes inside `ranges` (absolute source positions) with spaces in
+/// `body_text`, where `body_text` starts at absolute offset `body_pos`.
+fn mask_ranges_static(body_text: &str, body_pos: usize, ranges: &[(usize, usize)]) -> String {
+    if ranges.is_empty() {
+        return body_text.to_string();
+    }
+    let mut bytes = body_text.as_bytes().to_vec();
+    for &(start, end) in ranges {
+        let local_start = start.saturating_sub(body_pos);
+        let local_end = end.saturating_sub(body_pos).min(bytes.len());
+        if local_start >= bytes.len() {
+            continue;
+        }
+        for b in &mut bytes[local_start..local_end] {
+            if !b.is_ascii_whitespace() {
+                *b = b' ';
+            }
+        }
+    }
+    String::from_utf8(bytes).unwrap_or_else(|_| body_text.to_string())
+}
+
+/// Collect `(pos, end)` byte ranges of every type-only (`declare`) statement in
+/// the namespace body. Their bodies are erased at emit time, so identifiers
+/// introduced inside them must not be counted as shadowing bindings.
+fn collect_declare_statement_ranges(arena: &NodeArena, body_node: &Node) -> Vec<(usize, usize)> {
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    let Some(block) = arena.get_module_block(body_node) else {
+        return ranges;
+    };
+    let Some(stmts) = &block.statements else {
+        return ranges;
+    };
+    for &stmt_idx in &stmts.nodes {
+        let Some(stmt_node) = arena.get(stmt_idx) else {
+            continue;
+        };
+        let (decl_node, decl_pos, decl_end) = if stmt_node.kind
+            == syntax_kind_ext::EXPORT_DECLARATION
+            && let Some(export) = arena.get_export_decl(stmt_node)
+            && let Some(inner) = arena.get(export.export_clause)
+        {
+            (inner, stmt_node.pos as usize, stmt_node.end as usize)
+        } else {
+            (stmt_node, stmt_node.pos as usize, stmt_node.end as usize)
+        };
+        let modifiers = match decl_node.kind {
+            k if k == syntax_kind_ext::VARIABLE_STATEMENT => arena
+                .get_variable(decl_node)
+                .and_then(|v| v.modifiers.clone()),
+            k if k == syntax_kind_ext::FUNCTION_DECLARATION => arena
+                .get_function(decl_node)
+                .and_then(|f| f.modifiers.clone()),
+            k if k == syntax_kind_ext::CLASS_DECLARATION => {
+                arena.get_class(decl_node).and_then(|c| c.modifiers.clone())
+            }
+            k if k == syntax_kind_ext::ENUM_DECLARATION => {
+                arena.get_enum(decl_node).and_then(|e| e.modifiers.clone())
+            }
+            k if k == syntax_kind_ext::MODULE_DECLARATION => arena
+                .get_module(decl_node)
+                .and_then(|m| m.modifiers.clone()),
+            _ => None,
+        };
+        if arena.has_modifier(&modifiers, SyntaxKind::DeclareKeyword) {
+            ranges.push((decl_pos, decl_end));
+        }
+    }
+    ranges
+}
+
+/// Collect `(pos, end)` byte ranges of enum declarations and `export import`
+/// equals declarations in the namespace body (and nested sub-namespace bodies).
+/// Enum members are *properties* of the enum object, not function-scope
+/// bindings, and `export import M = Z.M` reuses the IIFE parameter, so neither
+/// must be treated as a shadowing binding.
+fn collect_enum_decl_ranges(arena: &NodeArena, body_node: &Node) -> Vec<(usize, usize)> {
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    collect_enum_decl_ranges_into(arena, body_node, &mut ranges);
+    ranges
+}
+
+fn collect_enum_decl_ranges_into(
+    arena: &NodeArena,
+    body_node: &Node,
+    ranges: &mut Vec<(usize, usize)>,
+) {
+    let Some(block) = arena.get_module_block(body_node) else {
+        return;
+    };
+    let Some(stmts) = &block.statements else {
+        return;
+    };
+    for &stmt_idx in &stmts.nodes {
+        let Some(stmt_node) = arena.get(stmt_idx) else {
+            continue;
+        };
+        let decl_node = if stmt_node.kind == syntax_kind_ext::EXPORT_DECLARATION
+            && let Some(export) = arena.get_export_decl(stmt_node)
+            && let Some(inner) = arena.get(export.export_clause)
+        {
+            inner
+        } else {
+            stmt_node
+        };
+        let is_export_qualified = stmt_node.kind == syntax_kind_ext::EXPORT_DECLARATION;
+        if decl_node.kind == syntax_kind_ext::ENUM_DECLARATION {
+            ranges.push((decl_node.pos as usize, decl_node.end as usize));
+        } else if decl_node.kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION
+            && is_export_qualified
+        {
+            // `export import M = Z.M` emits as `M.M = Z.M`: it reuses the IIFE
+            // parameter and introduces no local binding.
+            ranges.push((stmt_node.pos as usize, stmt_node.end as usize));
+        } else if decl_node.kind == syntax_kind_ext::MODULE_DECLARATION
+            && let Some(module) = arena.get_module(decl_node)
+            && let Some(inner_body) = arena.get(module.body)
+        {
+            collect_enum_decl_ranges_into(arena, inner_body, ranges);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_function_parameter_binding() {
+        // function f(schema) { ... } binds `schema`.
+        assert!(text_has_non_namespace_binding_named(
+            "{ function f(schema) { return 0; } }",
+            "schema"
+        ));
+    }
+
+    #[test]
+    fn detects_function_parameter_binding_renamed_var() {
+        // Same shape, different chosen names — must still detect.
+        assert!(text_has_non_namespace_binding_named(
+            "{ function build(build) { return 0; } }",
+            "build"
+        ));
+    }
+
+    #[test]
+    fn detects_var_let_const_binding() {
+        assert!(text_has_non_namespace_binding_named("{ var n = 1; }", "n"));
+        assert!(text_has_non_namespace_binding_named("{ let n = 1; }", "n"));
+        assert!(text_has_non_namespace_binding_named(
+            "{ const n = 1; }",
+            "n"
+        ));
+    }
+
+    #[test]
+    fn ignores_qualified_member_reference() {
+        // `schema.foo = ...` is a member reference, not a binding.
+        assert!(!text_has_non_namespace_binding_named(
+            "{ schema.createValidator = createValidator; }",
+            "schema"
+        ));
+    }
+
+    #[test]
+    fn ignores_callee_reference() {
+        // `schema()` is a call, not a binding.
+        assert!(!text_has_non_namespace_binding_named(
+            "{ return schema(); }",
+            "schema"
+        ));
+    }
+
+    #[test]
+    fn ignores_unrelated_names() {
+        assert!(!text_has_non_namespace_binding_named(
+            "{ function f(x) { return x; } }",
+            "schema"
+        ));
+    }
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — ES5 namespace IIFE parameter uniquing (emit→100% campaign, wave 3)

## Invariant
When a namespace body introduces any runtime binding named like the namespace at any nesting depth (a nested function parameter, or a binding declared inside a nested function/class body), tsc renames the namespace IIFE parameter with a monotonic per-name suffix (`N_1`, `N_2`, ...) across reopenings. tsz at ES5 was FAILING to rename (emitted `(function (schema) {` for every block); now it renames like tsc (and like the already-correct ES2015 path). Keyed on AST/source binding shape — no identifier/file-name matching, no printer-output `.contains()`.

## Scope
- NEW `crates/tsz-emitter/src/transforms/namespace_iife_binding_scan.rs` — shared source-text binding scan (masks declare/enum ranges) used by BOTH the es2015 printer path and the es5 IR transform (removed ~270 lines of duplicated private helpers from `namespace.rs` — DRY).
- `transforms/namespace_es5_ir.rs` — `namespace_body_has_nested_binding` + monotonic `next_renamed_iife_param`/`iife_param_rename_counter`.
- `transforms/namespace_es5_ir_helpers.rs` — `detect_and_apply_param_rename_with_extra` (extra_conflict flag + caller name generator).
- `transforms/namespace_es5.rs` + `transform_dispatch.rs` + `transform_dispatch_chain.rs` + `declarations/namespace.rs` — seed/read-back the shared `namespace_iife_param_counter` so suffixes increment across reopenings.
- `declarations/namespace/tests.rs` (+4 ES5 tests) + 6 tests in the new module.

## Project Corpus Impact
- Row: n/a (ES5 namespace-IIFE-param emit fix)
- Bug family: ES5 namespace IIFE param not uniqued when a nested binding shadows the namespace name
- Evidence: isDeclarationVisibleNodeKinds(target=es5) FAIL→PASS; full --js-only 79→78.

## Verification
- Witness FAIL→PASS (2/2 with es2015). **Full --js-only: 79→78 fail, net +1, ZERO regressions** (after-fail set strict subset of before). DTS unaffected (IIFE param naming can't affect .d.ts). Verified vs tsc 6.0.3 (baseline correct, NOT stale — tsc renames `schema_1..schema_8`, 9th keeps `schema`). 10 new structural unit tests (nested-param rename, renamed-idents variant, multi-reopening suffix increment, no-collision negative). Clippy clean; arch guard passes (new code in a fresh file; all touched files <2000, largest 1799).
- §25/§26 compliant; emit as planned facts (no output surgery).

## Coordination Notes
Rebased onto current main. DRY win: the es2015 printer now delegates to the shared scan module instead of its own ~270-line duplicate, so es2015/es5 binding-collision detection agree. — opus48-emit100
