### PR TITLE
fix(emit): lower bare super (recovery, no member name) to _super.prototype. at ES5

### DIFF
--- a/crates/tsz-emitter/src/emitter/source_file/es5_super_recovery_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/es5_super_recovery_tests.rs
@@ -1,0 +1,112 @@
+//! ES5 lowering for a bare `super` parser-recovery node (`super` with no
+//! member access, TS1034).
+//!
+//! tsc substitutes the `super` keyword receiver with `_super.prototype`
+//! (instance home) regardless of whether a member name follows, then emits the
+//! dangling member access verbatim. The recovery AST is `super.<missing>`
+//! (`PropertyAccessExpression` with a `NodeIndex::NONE` name), so the lowered
+//! output is `_super.prototype.` — matching tsc. The choice is keyed on the
+//! base being the `super` keyword, not on the spelling of the (present or
+//! missing) property, so these tests vary class, method, and variable names to
+//! prove the substitution is structural rather than name-matched.
+
+use crate::context::emit::EmitContext;
+use crate::emitter::{ModuleKind, Printer as EmitterPrinter, PrinterOptions};
+use crate::lowering::LoweringPass;
+use tsz_common::ScriptTarget;
+use tsz_parser::ParserState;
+
+/// Emit `source` at ES5 through the lowering pass and return the JS output.
+fn emit_es5(source: &str) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        target: ScriptTarget::ES5,
+        module: ModuleKind::None,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+#[test]
+fn bare_super_in_method_arrow_lowers_to_super_prototype_dot() {
+    // `super` used as a value (recovery) inside a nested arrow in an instance
+    // method must lower its receiver to `_super.prototype`, yielding the
+    // dangling `_super.prototype.` form (not `_super.`).
+    let source = "class Base { greet() {} }\n\
+                  class Derived extends Base {\n\
+                  \x20   greet() { var ref = () => () => super; }\n\
+                  }\n";
+    let output = emit_es5(source);
+
+    assert!(
+        output.contains("_super.prototype.;"),
+        "bare super in a method should lower to `_super.prototype.`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("return _super.;"),
+        "bare super must not lower to a bare `_super.` receiver.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn bare_super_in_constructor_arrow_lowers_to_super_prototype_dot() {
+    // Same rule inside a constructor body; different class/variable names prove
+    // the substitution is keyed on the `super` keyword, not on identifiers.
+    let source = "class Animal { run() {} }\n\
+                  class Dog extends Animal {\n\
+                  \x20   constructor() { super(); var fn = () => () => super; }\n\
+                  }\n";
+    let output = emit_es5(source);
+
+    assert!(
+        output.contains("_super.prototype.;"),
+        "bare super in a constructor should lower to `_super.prototype.`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("return _super.;"),
+        "bare super must not lower to a bare `_super.` receiver.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn super_property_access_still_lowers_with_prototype() {
+    // The present-name path is unchanged: `super.prop` still lowers to
+    // `_super.prototype.prop`. Renamed class/property prove no name matching.
+    let source = "class Widget { label = \"w\"; }\n\
+                  class Button extends Widget {\n\
+                  \x20   show() { return super.label; }\n\
+                  }\n";
+    let output = emit_es5(source);
+
+    assert!(
+        output.contains("_super.prototype.label"),
+        "super.label should lower to `_super.prototype.label`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("_super.prototype.;"),
+        "a present member name must not produce a dangling dot.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn super_method_call_still_lowers_with_prototype_call() {
+    // The call path is unchanged after the shared-receiver refactor:
+    // `super.m()` lowers to `_super.prototype.m.call(this)`.
+    let source = "class Shape { area() {} }\n\
+                  class Circle extends Shape {\n\
+                  \x20   area() { super.area(); }\n\
+                  }\n";
+    let output = emit_es5(source);
+
+    assert!(
+        output.contains("_super.prototype.area.call("),
+        "super.area() should lower to `_super.prototype.area.call(...)`.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/source_file/mod.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/mod.rs
@@ -46,3 +46,5 @@ mod empty_statement_comment_elision_tests;
 mod es5_emit_tests;
 #[cfg(test)]
 mod es5_for_of_destructure_temp_order_tests;
+#[cfg(test)]
+mod es5_super_recovery_tests;

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_expressions.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_expressions.rs
@@ -210,6 +210,21 @@ impl<'a> AstToIr<'a> {
         )
     }
 
+    /// The ES5 receiver a `super` keyword lowers to in this member context:
+    /// `_super.prototype` for an instance member home, `_super` for a static
+    /// one. The choice is keyed on the static/instance context of the enclosing
+    /// member, not on the spelling of the property that follows `super`.
+    pub(super) fn es5_super_receiver_base(&self) -> IRNode {
+        if self.is_static.get() {
+            IRNode::id(self.super_name.clone())
+        } else {
+            IRNode::PropertyAccess {
+                object: Box::new(IRNode::id(self.super_name.clone())),
+                property: "prototype".to_string().into(),
+            }
+        }
+    }
+
     /// Check if a call expression callee is super.method or super[expr] and transform to
     /// _super.prototype.method.call(this, args) or _super.prototype[expr].call(this, args)
     fn try_convert_super_method_call(
@@ -227,21 +242,10 @@ impl<'a> AstToIr<'a> {
             let obj_node = self.arena.get(access.expression)?;
             if obj_node.kind == SyntaxKind::SuperKeyword as u16 {
                 let method_name = get_identifier_text(self.arena, access.name_or_argument)?;
-                let super_proto_method = if self.is_static.get() {
-                    // Static: _super.method
-                    IRNode::PropertyAccess {
-                        object: Box::new(IRNode::id(self.super_name.clone())),
-                        property: method_name.into(),
-                    }
-                } else {
-                    // Instance: _super.prototype.method
-                    IRNode::PropertyAccess {
-                        object: Box::new(IRNode::PropertyAccess {
-                            object: Box::new(IRNode::id(self.super_name.clone())),
-                            property: "prototype".to_string().into(),
-                        }),
-                        property: method_name.into(),
-                    }
+                // Static: `_super.method`; instance: `_super.prototype.method`.
+                let super_proto_method = IRNode::PropertyAccess {
+                    object: Box::new(self.es5_super_receiver_base()),
+                    property: method_name.into(),
                 };
                 if is_optional_call {
                     return Some(self.convert_optional_super_method_call(super_proto_method, args));
@@ -266,16 +270,8 @@ impl<'a> AstToIr<'a> {
             let obj_node = self.arena.get(access.expression)?;
             if obj_node.kind == SyntaxKind::SuperKeyword as u16 {
                 let index_expr = self.convert_expression(access.name_or_argument);
-                let super_base = if self.is_static.get() {
-                    IRNode::id(self.super_name.clone())
-                } else {
-                    IRNode::PropertyAccess {
-                        object: Box::new(IRNode::id(self.super_name.clone())),
-                        property: "prototype".to_string().into(),
-                    }
-                };
                 let super_proto_elem = IRNode::ElementAccess {
-                    object: Box::new(super_base),
+                    object: Box::new(self.es5_super_receiver_base()),
                     index: Box::new(index_expr),
                 };
                 if is_optional_call {
@@ -406,21 +402,18 @@ impl<'a> AstToIr<'a> {
             // Check for super.property → _super.prototype.property (instance) or _super.property (static)
             if let Some(obj_node) = self.arena.get(access.expression)
                 && obj_node.kind == SyntaxKind::SuperKeyword as u16
-                && let Some(name) = get_identifier_text(self.arena, access.name_or_argument)
             {
-                return if self.is_static.get() {
-                    IRNode::PropertyAccess {
-                        object: Box::new(IRNode::id(self.super_name.clone())),
-                        property: name.into(),
-                    }
-                } else {
-                    IRNode::PropertyAccess {
-                        object: Box::new(IRNode::PropertyAccess {
-                            object: Box::new(IRNode::id(self.super_name.clone())),
-                            property: "prototype".to_string().into(),
-                        }),
-                        property: name.into(),
-                    }
+                // A bare `super` recovers as `super.<missing>` (TS1034). tsc still
+                // substitutes the `super` receiver with `_super.prototype`
+                // (instance) / `_super` (static) and emits the dangling member
+                // access verbatim, yielding `_super.prototype.` / `_super.`. The
+                // receiver substitution is keyed on the base being the `super`
+                // keyword, independent of whether a property name is present.
+                let property =
+                    get_identifier_text(self.arena, access.name_or_argument).unwrap_or_default();
+                return IRNode::PropertyAccess {
+                    object: Box::new(self.es5_super_receiver_base()),
+                    property: property.into(),
                 };
             }
 
@@ -456,16 +449,8 @@ impl<'a> AstToIr<'a> {
                 && obj_node.kind == SyntaxKind::SuperKeyword as u16
             {
                 let index = self.convert_expression(access.name_or_argument);
-                let super_base = if self.is_static.get() {
-                    IRNode::id(self.super_name.clone())
-                } else {
-                    IRNode::PropertyAccess {
-                        object: Box::new(IRNode::id(self.super_name.clone())),
-                        property: "prototype".to_string().into(),
-                    }
-                };
                 return IRNode::ElementAccess {
-                    object: Box::new(super_base),
+                    object: Box::new(self.es5_super_receiver_base()),
                     index: Box::new(index),
                 };
             }


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — ES5 bare-super receiver lowering (emit→100% campaign, wave 3)

## Invariant
When converting an instance-context `super` property/element access to ES5 IR, the `super` receiver lowers to `_super.prototype` (static context: `_super`), keyed on the base node being the `SuperKeyword` — INDEPENDENT of whether the property-name node is present. A bare `super` (no member access — valid TS1034 recovery) keeps the `_super.prototype` base and emits the dangling member access verbatim (`_super.prototype.;`), matching tsc 6.0.3 (which emits `_super.prototype.` + the same TS1034). tsz previously gated the super-receiver substitution on a present identifier name, so the `NodeIndex::NONE` recovery node fell back to the plain printer (`_super.;`). Keyed on AST node kind (SuperKeyword base) — no identifier/file-name matching, no printer-output inspection.

## Scope
- `crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_expressions.rs` — new `es5_super_receiver_base()`; removed the present-name guard so the substitution applies to the recovery node; DRY-consolidated the 4 super-base construction sites (net -13 lines).
- NEW `crates/tsz-emitter/src/emitter/source_file/es5_super_recovery_tests.rs` (4 tests).

## Project Corpus Impact
- Row: n/a (ES5 super-receiver emit fix)
- Bug family: bare `super.` (recovery, no member name) lowered to `_super.` instead of `_super.prototype.` at ES5
- Evidence: superInLambdas(target=es5) FAIL→PASS; full --js-only 78→77.

## Verification
- Witness FAIL→PASS. **Full --js-only: 78→77 fail, net +1, ZERO regressions** (set-diff: fixed = superInLambdas(es5); no new failures). DTS unaffected (JS-emit IR path; declaration emit never lowers super). Verified vs tsc 6.0.3 (baseline correct, not stale — `_super.prototype.` + TS1034; the dropped empty-method comment is normalized away by the harness ladder). 4 new structural unit tests (bare super in method arrow / constructor arrow, present-name `super.prop`, `super.m()` call; varied class/method/variable names). transforms::class_es5 84/84. Clippy clean; arch guard passes (new tests in a fresh file — es5_emit_tests.rs at its 2080 cap).
- §25/§26 compliant.

## Coordination Notes
Rebased onto current main. Completes the es5-super residual that a prior agent flagged: the spurious `var _this` in super-access-only arrows was fixed earlier; this fixes the remaining bare-super `_super.prototype.` structural diff. — opus48-emit100
