### PR TITLE
fix(emit): match tsc for AMD/UMD/System dynamic import() downlevel emit

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -298,6 +298,10 @@ path = "tests/wave3_small_emit_fixes_tests.rs"
 name = "legacy_decorator_member_order_tests"
 path = "tests/legacy_decorator_member_order_tests.rs"
 
+[[test]]
+name = "dynamic_import_amd_umd_parity_tests"
+path = "tests/dynamic_import_amd_umd_parity_tests.rs"
+
 [lints]
 workspace = true
 

--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -1099,7 +1099,7 @@ impl<'a> Printer<'a> {
 
             // Call expression
             k if k == syntax_kind_ext::CALL_EXPRESSION => {
-                self.emit_call_expression(node);
+                self.emit_call_expression(idx, node);
             }
 
             // New expression

--- a/crates/tsz-emitter/src/emitter/expressions/call.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/call.rs
@@ -5,7 +5,7 @@ use tsz_parser::parser::{NodeIndex, node::Node, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 
 impl<'a> Printer<'a> {
-    pub(in crate::emitter) fn emit_call_expression(&mut self, node: &Node) {
+    pub(in crate::emitter) fn emit_call_expression(&mut self, idx: NodeIndex, node: &Node) {
         let Some(call) = self.arena.get_call_expr(node) else {
             return;
         };
@@ -362,11 +362,11 @@ impl<'a> Printer<'a> {
         {
             match self.ctx.original_module_kind {
                 Some(ModuleKind::System) => {
-                    self.emit_system_dynamic_import_call(node, call.arguments.as_ref());
+                    self.emit_system_dynamic_import_call(call.arguments.as_ref());
                     return;
                 }
                 Some(ModuleKind::AMD | ModuleKind::UMD) => {
-                    self.emit_amd_or_umd_dynamic_import_call(call.arguments.as_ref());
+                    self.emit_amd_or_umd_dynamic_import_call(idx, call.arguments.as_ref());
                     return;
                 }
                 _ => {}
@@ -392,40 +392,15 @@ impl<'a> Printer<'a> {
             && let Some(expr_node) = self.arena.get(call.expression)
             && expr_node.kind == SyntaxKind::ImportKeyword as u16
         {
-            // Get the first valid argument (the module specifier)
+            // Get the first valid argument (the module specifier). String
+            // literals (and the no-argument case) lower to
+            // `Promise.resolve().then(() => __importStar(require("mod")))`;
+            // expression specifiers use the `Promise.resolve(`${spec}`)` form.
             let first_arg = call
                 .arguments
                 .as_ref()
                 .and_then(|args| args.nodes.iter().copied().find(|n| n.is_some()));
-            let first_arg_node = first_arg.and_then(|idx| self.arena.get(idx));
-            let is_string_literal_or_none = first_arg_node
-                .map(|n| {
-                    n.kind == SyntaxKind::StringLiteral as u16
-                        || n.kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16
-                        // Missing/error-recovered nodes have zero length
-                        || n.end <= n.pos
-                })
-                .unwrap_or(true); // no args => treat as simple path
-
-            if is_string_literal_or_none {
-                // Simple string or no args:
-                //   Promise.resolve().then(() => __importStar(require("mod")))
-                //   Promise.resolve().then(() => __importStar(require()))
-                self.emit_dynamic_import_commonjs_branch(first_arg, None);
-            } else {
-                // Expression specifier with rewrite helper wrapping
-                self.write("Promise.resolve(`${");
-                if self.ctx.options.rewrite_relative_import_extensions {
-                    if let Some(first) = first_arg {
-                        self.emit_rewrite_helper_call(first);
-                    }
-                } else if let Some(first) = first_arg {
-                    self.emit_dynamic_import_template_specifier(first);
-                }
-                self.write("}`).then(s => ");
-                self.write_helper("__importStar");
-                self.write("(require(s)))");
-            }
+            self.emit_dynamic_import_commonjs_promise(first_arg, None);
             return;
         }
 
@@ -807,22 +782,52 @@ impl<'a> Printer<'a> {
         }
     }
 
-    fn emit_system_dynamic_import_call(
-        &mut self,
-        node: &Node,
-        args: Option<&tsz_parser::parser::NodeList>,
-    ) {
-        self.write("context_1.import");
-        self.emit_call_arguments(node, args);
+    /// Emit a dynamic `import()` for System output as `context_1.import(spec)`.
+    ///
+    /// The System loader's `import` hook only accepts the module id, so `tsc`
+    /// drops any options/attributes (`import(spec, { with: ... })`) argument.
+    fn emit_system_dynamic_import_call(&mut self, args: Option<&tsz_parser::parser::NodeList>) {
+        self.write("context_1.import(");
+        if let Some(first) = self.first_dynamic_import_argument(args) {
+            self.emit_maybe_rewritten_module_specifier_arg(first);
+        }
+        self.write(")");
     }
 
-    fn emit_amd_or_umd_dynamic_import_call(&mut self, args: Option<&tsz_parser::parser::NodeList>) {
+    /// Emit a downlevel dynamic `import()` for AMD/UMD output.
+    ///
+    /// AMD emits a single `new Promise(...).then(__importStar)` call expression.
+    /// UMD additionally guards it with `__syncRequire ? <cjs> : <amd>`, a
+    /// `ConditionalExpression`. Because UMD repeats the specifier across both
+    /// branches, a specifier that is neither a string literal nor a bare
+    /// identifier is captured once into a hoisted temp (`_a = spec, ...`),
+    /// turning the substitution into a comma `SequenceExpression`; this mirrors
+    /// `tsc`. AMD never captures, and string-literal/identifier specifiers are
+    /// repeated inline.
+    fn emit_amd_or_umd_dynamic_import_call(
+        &mut self,
+        call_idx: NodeIndex,
+        args: Option<&tsz_parser::parser::NodeList>,
+    ) {
         let first_arg = self.first_dynamic_import_argument(args);
-        let needs_temp = first_arg.is_some_and(|arg| !self.dynamic_import_arg_is_string_like(arg));
-        let temp = needs_temp.then(|| self.make_unique_name_hoisted());
+        let is_umd = matches!(self.ctx.original_module_kind, Some(ModuleKind::UMD));
+        let capture = is_umd
+            && first_arg.is_some_and(|arg| {
+                !self.dynamic_import_arg_is_string_like(arg)
+                    && !self.dynamic_import_arg_is_identifier(arg)
+            });
 
-        if let Some(temp_name) = temp.as_deref() {
-            self.write(temp_name);
+        // A captured specifier yields a comma sequence, which needs parentheses
+        // in more parent positions than a bare conditional, so the paren
+        // decision depends on which substitution form is emitted.
+        let needs_parens = is_umd && self.umd_dynamic_import_needs_parens(call_idx, capture);
+        if needs_parens {
+            self.write("(");
+        }
+
+        let temp = if capture {
+            let temp = self.make_unique_name_hoisted();
+            self.write(&temp);
             self.write(" = ");
             if self.ctx.options.rewrite_relative_import_extensions {
                 if let Some(first) = first_arg {
@@ -832,14 +837,114 @@ impl<'a> Printer<'a> {
                 self.emit(first);
             }
             self.write(", ");
-        }
+            Some(temp)
+        } else {
+            None
+        };
 
-        if matches!(self.ctx.original_module_kind, Some(ModuleKind::UMD)) {
+        if is_umd {
             self.write("__syncRequire ? ");
-            self.emit_dynamic_import_commonjs_branch(first_arg, temp.as_deref());
+            self.emit_dynamic_import_commonjs_promise(first_arg, temp.as_deref());
             self.write(" : ");
         }
         self.emit_dynamic_import_amd_branch(first_arg, temp.as_deref());
+
+        if needs_parens {
+            self.write(")");
+        }
+    }
+
+    /// Whether a UMD dynamic-`import()` substitution must be parenthesized for
+    /// the parent expression it sits in, matching `tsc`'s parenthesizer.
+    ///
+    /// Statement-level parents (expression statement, `return`, `throw`, `for`
+    /// headers) accept a full expression — including a comma sequence — so
+    /// neither form needs parentheses. Parents that bind tighter than `?:`
+    /// (operand of `await`/`yield`/unary/binary, object of a member access,
+    /// callee of a call/new, condition of another conditional) always need
+    /// parentheses. Remaining assignment-level parents (variable initializer,
+    /// call argument, array element, property value, arrow body, …) accept a
+    /// bare conditional but require parentheses around a comma sequence, so
+    /// `is_sequence` decides those.
+    fn umd_dynamic_import_needs_parens(&self, call_idx: NodeIndex, is_sequence: bool) -> bool {
+        let Some(parent_idx) = self.arena.parent_of(call_idx) else {
+            return false;
+        };
+        if parent_idx.is_none() {
+            return false;
+        }
+        let Some(parent) = self.arena.get(parent_idx) else {
+            return false;
+        };
+        let k = parent.kind;
+        if k == syntax_kind_ext::EXPRESSION_STATEMENT
+            || k == syntax_kind_ext::RETURN_STATEMENT
+            || k == syntax_kind_ext::THROW_STATEMENT
+            || k == syntax_kind_ext::FOR_STATEMENT
+        {
+            return false;
+        }
+        let tighter_than_conditional = match k {
+            k if k == syntax_kind_ext::AWAIT_EXPRESSION
+                || k == syntax_kind_ext::YIELD_EXPRESSION
+                || k == syntax_kind_ext::PREFIX_UNARY_EXPRESSION
+                || k == syntax_kind_ext::POSTFIX_UNARY_EXPRESSION
+                || k == syntax_kind_ext::TYPE_OF_EXPRESSION
+                || k == syntax_kind_ext::VOID_EXPRESSION
+                || k == syntax_kind_ext::DELETE_EXPRESSION
+                || k == syntax_kind_ext::BINARY_EXPRESSION =>
+            {
+                true
+            }
+            k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                || k == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION =>
+            {
+                self.arena
+                    .get_access_expr(parent)
+                    .is_some_and(|access| access.expression == call_idx)
+            }
+            k if k == syntax_kind_ext::CALL_EXPRESSION || k == syntax_kind_ext::NEW_EXPRESSION => {
+                self.arena
+                    .get_call_expr(parent)
+                    .is_some_and(|call| call.expression == call_idx)
+            }
+            k if k == syntax_kind_ext::CONDITIONAL_EXPRESSION => self
+                .arena
+                .get_conditional_expr(parent)
+                .is_some_and(|cond| cond.condition == call_idx),
+            _ => false,
+        };
+        tighter_than_conditional || is_sequence
+    }
+
+    /// Emit the CommonJS branch of a downlevel dynamic import as a Promise.
+    ///
+    /// A captured temp, a string literal, or the no-argument case lets the
+    /// `require` reference the value directly via
+    /// `Promise.resolve().then(() => require(x))`. A bare identifier specifier
+    /// (never captured) is coerced through a template so the runtime `require`
+    /// receives a string: `Promise.resolve(`${id}`).then(s => require(s))`.
+    fn emit_dynamic_import_commonjs_promise(
+        &mut self,
+        first_arg: Option<NodeIndex>,
+        temp: Option<&str>,
+    ) {
+        if temp.is_some() || first_arg.is_none_or(|arg| self.dynamic_import_arg_is_string_like(arg))
+        {
+            self.emit_dynamic_import_commonjs_branch(first_arg, temp);
+            return;
+        }
+        self.write("Promise.resolve(`${");
+        if self.ctx.options.rewrite_relative_import_extensions {
+            if let Some(first) = first_arg {
+                self.emit_rewrite_helper_call(first);
+            }
+        } else if let Some(first) = first_arg {
+            self.emit_dynamic_import_template_specifier(first);
+        }
+        self.write("}`).then(s => ");
+        self.write_helper("__importStar");
+        self.write("(require(s)))");
     }
 
     fn first_dynamic_import_argument(
@@ -860,6 +965,10 @@ impl<'a> Printer<'a> {
                 || node.kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16
                 || node.end <= node.pos
         })
+    }
+
+    fn dynamic_import_arg_is_identifier(&self, arg: NodeIndex) -> bool {
+        self.arena.get(arg).is_some_and(|node| node.is_identifier())
     }
 
     fn emit_dynamic_import_commonjs_branch(

--- a/crates/tsz-emitter/src/emitter/module_wrapper/tests/system_emit_parts/part_00.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/tests/system_emit_parts/part_00.rs
@@ -391,9 +391,9 @@ import(path);
     );
     assert!(
         output.contains(
-            "_a = path, new Promise((resolve_1, reject_1) => { require([_a], resolve_1, reject_1); }).then(__importStar);"
+            "new Promise((resolve_1, reject_1) => { require([path], resolve_1, reject_1); }).then(__importStar);"
         ),
-        "AMD dynamic import should use async require with one eager specifier evaluation.\nOutput:\n{output}"
+        "AMD dynamic import inlines a bare identifier specifier without a temp, matching tsc.\nOutput:\n{output}"
     );
 }
 
@@ -440,9 +440,9 @@ fn exported_async_function_dynamic_import_keeps_amd_wrapper_kind() {
     );
     assert!(
         output.contains(
-            "return _a = path, new Promise((resolve_1, reject_1) => { require([_a], resolve_1, reject_1); }).then(__importStar);"
+            "return new Promise((resolve_1, reject_1) => { require([path], resolve_1, reject_1); }).then(__importStar);"
         ),
-        "Dynamic import inside the CJS-export-masked async body should use AMD async require.\nOutput:\n{output}"
+        "Dynamic import inside the CJS-export-masked async body should use AMD async require, inlining the identifier specifier.\nOutput:\n{output}"
     );
     assert!(
         !output.contains("Promise.resolve().then(() => __importStar(require(path)))"),
@@ -488,9 +488,9 @@ fn exported_async_function_dynamic_import_keeps_umd_wrapper_kind() {
     );
     assert!(
         output.contains(
-            "return _a = path, __syncRequire ? Promise.resolve().then(() => __importStar(require(_a))) : new Promise((resolve_1, reject_1) => { require([_a], resolve_1, reject_1); }).then(__importStar);"
+            "return __syncRequire ? Promise.resolve(`${path}`).then(s => __importStar(require(s))) : new Promise((resolve_1, reject_1) => { require([path], resolve_1, reject_1); }).then(__importStar);"
         ),
-        "Dynamic import inside the CJS-export-masked async body should use the UMD loader branch.\nOutput:\n{output}"
+        "Dynamic import inside the CJS-export-masked async body should use the UMD loader branch, coercing the bare identifier specifier through a template without a temp.\nOutput:\n{output}"
     );
 }
 

--- a/crates/tsz-emitter/tests/dynamic_import_amd_umd_parity_tests.rs
+++ b/crates/tsz-emitter/tests/dynamic_import_amd_umd_parity_tests.rs
@@ -1,0 +1,208 @@
+//! Parity tests for downlevel dynamic `import()` emit under AMD / UMD / System.
+//!
+//! Structural rule: when a downlevel dynamic `import()` lowers to a low-
+//! precedence substitution (a UMD `__syncRequire ? ... : ...` conditional, or a
+//! `_a = spec, ...` comma sequence when a complex specifier is captured), tsz
+//! must parenthesize it exactly where `tsc` does — based on the parent
+//! expression, not on a fixed wrap — and must capture a temp only for the
+//! specifier shapes `tsc` captures (UMD, non-string, non-identifier). System
+//! modules emit `context_1.import(<specifier>)` and drop the options/attributes
+//! argument. Verified against `tsc` 6.x.
+//!
+//! Owner layer: emitter (`crates/tsz-emitter/src/emitter/expressions/call.rs`).
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_lower_print as emit;
+
+fn umd(source: &str) -> String {
+    emit(
+        source,
+        PrintOptions {
+            target: ScriptTarget::ES2017,
+            module: ModuleKind::UMD,
+            ..Default::default()
+        },
+    )
+}
+
+fn amd(source: &str) -> String {
+    emit(
+        source,
+        PrintOptions {
+            target: ScriptTarget::ES2017,
+            module: ModuleKind::AMD,
+            ..Default::default()
+        },
+    )
+}
+
+fn system(source: &str) -> String {
+    emit(
+        source,
+        PrintOptions {
+            target: ScriptTarget::ES2017,
+            module: ModuleKind::System,
+            ..Default::default()
+        },
+    )
+}
+
+// --- UMD conditional parenthesization by parent context ---------------------
+
+#[test]
+fn umd_await_operand_parenthesizes_conditional() {
+    // `await` binds tighter than `?:`, so the conditional must be wrapped;
+    // otherwise the emit means `(await __syncRequire) ? ... : ...`.
+    let out = umd("export async function f() { await import('./s'); }");
+    assert!(
+        out.contains(
+            "await (__syncRequire ? Promise.resolve().then(() => __importStar(require('./s'))) : "
+        ),
+        "await operand must parenthesize the UMD conditional.\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn umd_member_access_object_parenthesizes_conditional() {
+    let out = umd("export async function f() { import('./s').then(m => m); }");
+    assert!(
+        out.contains(
+            "(__syncRequire ? Promise.resolve().then(() => __importStar(require('./s'))) : "
+        ) && out.contains(").then(__importStar)).then(m => m);"),
+        "member-access object must parenthesize the UMD conditional.\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn umd_statement_position_does_not_parenthesize_conditional() {
+    let out = umd("export async function f() { import('./s'); }");
+    assert!(
+        out.contains(
+            "{ __syncRequire ? Promise.resolve().then(() => __importStar(require('./s'))) : "
+        ),
+        "a bare conditional in statement position must not be parenthesized.\nOutput:\n{out}"
+    );
+    assert!(
+        !out.contains("(__syncRequire ?"),
+        "statement position should not wrap the conditional.\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn umd_return_position_does_not_parenthesize_conditional() {
+    let out = umd("export async function f() { return import('./s'); }");
+    assert!(
+        out.contains(
+            "return __syncRequire ? Promise.resolve().then(() => __importStar(require('./s'))) : "
+        ),
+        "a bare conditional in return position must not be parenthesized.\nOutput:\n{out}"
+    );
+}
+
+// --- Specifier shapes: capture rule + CommonJS branch form ------------------
+
+#[test]
+fn umd_string_specifier_inlines_without_temp() {
+    let out = umd("export async function f() { import('./s'); }");
+    assert!(
+        out.contains("require('./s')") && !out.contains("_a = "),
+        "string-literal specifier must be inlined without a temp.\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn umd_identifier_specifier_uses_template_form_without_temp() {
+    // Bare identifier: no temp, CommonJS branch coerces via a template.
+    let out = umd("export async function f(p: string) { import(p); }");
+    assert!(
+        out.contains("__syncRequire ? Promise.resolve(`${p}`).then(s => __importStar(require(s))) : new Promise((resolve_1, reject_1) => { require([p], resolve_1, reject_1); }).then(__importStar);"),
+        "identifier specifier must use the template CommonJS form and inline `[p]`, with no temp.\nOutput:\n{out}"
+    );
+    assert!(
+        !out.contains("_a = p"),
+        "identifier specifier must not be captured into a temp.\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn umd_complex_specifier_is_captured_into_temp() {
+    // Property-access specifier is captured once and reused in both branches.
+    let out = umd("class C { _p = 'x'; async m() { return import(this._p); } }");
+    assert!(
+        out.contains("_a = this._p, __syncRequire ? Promise.resolve().then(() => __importStar(require(_a))) : new Promise((resolve_1, reject_1) => { require([_a], resolve_1, reject_1); }).then(__importStar);"),
+        "a complex specifier must be captured into a temp reused by both branches.\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn umd_captured_sequence_parenthesizes_in_assignment_position() {
+    // A comma sequence (captured temp) needs parens as a variable initializer,
+    // unlike a bare conditional.
+    let out = umd("class C { _p = 'x'; async m() { const a = import(this._p); return a; } }");
+    assert!(
+        out.contains("const a = (_a = this._p, __syncRequire ?"),
+        "a captured comma sequence must be parenthesized as a variable initializer.\nOutput:\n{out}"
+    );
+}
+
+// --- AMD never captures and never parenthesizes -----------------------------
+
+#[test]
+fn amd_identifier_specifier_inlines_without_temp() {
+    let out = amd("export async function f(p: string) { return import(p); }");
+    assert!(
+        out.contains("return new Promise((resolve_1, reject_1) => { require([p], resolve_1, reject_1); }).then(__importStar);"),
+        "AMD inlines the identifier specifier without a temp.\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn amd_complex_specifier_inlines_without_temp() {
+    // AMD has a single branch, so even a complex specifier is inlined raw.
+    let out = amd("class C { _p = 'x'; async m() { await import(this._p); } }");
+    assert!(
+        out.contains("require([this._p], resolve_1, reject_1)") && !out.contains("_a = this._p"),
+        "AMD inlines a complex specifier raw with no temp.\nOutput:\n{out}"
+    );
+}
+
+// --- Iteration-variable independence: the rule is structural, not a name -----
+
+#[test]
+fn umd_identifier_rule_is_independent_of_specifier_name() {
+    let out = umd("export async function f(moduleSpecifier: string) { import(moduleSpecifier); }");
+    assert!(
+        out.contains("Promise.resolve(`${moduleSpecifier}`).then(s => __importStar(require(s)))"),
+        "the identifier template form must not depend on the specifier name.\nOutput:\n{out}"
+    );
+}
+
+// --- System drops the options/attributes argument ---------------------------
+
+#[test]
+fn system_dynamic_import_drops_options_argument() {
+    let out =
+        system("export async function f() { await import('./s', { with: { type: 'json' } }); }");
+    assert!(
+        out.contains("context_1.import('./s')"),
+        "System dynamic import emits only the specifier.\nOutput:\n{out}"
+    );
+    assert!(
+        !out.contains("with: { type:"),
+        "System dynamic import must drop the import-attributes argument.\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn system_dynamic_import_inlines_identifier_specifier() {
+    let out = system("export async function f(p: string) { await import(p); }");
+    assert!(
+        out.contains("context_1.import(p)"),
+        "System dynamic import inlines the identifier specifier.\nOutput:\n{out}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes three tsc divergences in downlevel dynamic `import()` emit under AMD / UMD / System, all rooted in `emit_amd_or_umd_dynamic_import_call` / `emit_system_dynamic_import_call` (`crates/tsz-emitter/src/emitter/expressions/call.rs`). Closes #11359.

**Structural rule:** *When a downlevel dynamic `import()` lowers to a low-precedence substitution (a UMD `__syncRequire ? <cjs> : <amd>` conditional, or a `_a = spec, …` comma sequence when a complex specifier is captured), tsz must parenthesize it exactly where the parent expression requires — and must capture a temp only for the specifier shapes tsc captures — so the emitted operation matches tsc.*

### 1. UMD substitution was never parenthesized
`await import('x')` emitted `await __syncRequire ? … : …`, which parses as `(await __syncRequire) ? … : …` — the wrong operation. Same bug for `import('x').then(…)`. Added `umd_dynamic_import_needs_parens(call_idx, is_sequence)`, classifying the parent like tsc's parenthesizer:
- statement / `return` / `throw` / `for` headers → bare form, no parens;
- await/yield/unary/binary operands, member-access objects, call/new callees, conditional conditions → always parens;
- remaining assignment-level parents (var init, call arg, array elem, property value, arrow body) → parens only around the comma sequence (lower precedence than `?:`).

### 2. Wrong specifier-capture rule
tsc captures a specifier into a temp **only for UMD** and **only when it is neither a string literal nor a bare identifier** (AMD has one branch and never captures). tsz captured for every non-string specifier — including identifiers, and even under AMD — emitting a spurious `_a = id, …` sequence and `var _a;` hoist. The CommonJS branch now uses the direct `Promise.resolve().then(() => require(x))` form for a captured temp / string literal and the template `Promise.resolve(\`${id}\`).then(s => require(s))` form for a bare identifier, matching tsc.

### 3. System dropped nothing
The System loader's `import` hook takes only the module id, so tsc emits `context_1.import(<specifier>)` and drops any options/attributes (`import(x, { with: … })`) argument. `emit_system_dynamic_import_call` now emits only the specifier.

## Track
Emit parity — AMD/UMD/System downlevel dynamic `import()`.

## Invariant
"A downlevel dynamic `import()` substitution is parenthesized exactly where tsc's parenthesizer requires for its parent expression and substitution form (conditional vs. comma sequence); a temp is captured only for UMD non-string, non-identifier specifiers; System emits only the specifier."

## Scope
`crates/tsz-emitter`:
- `src/emitter/expressions/call.rs` — rewrite `emit_amd_or_umd_dynamic_import_call`; add `umd_dynamic_import_needs_parens`, `emit_dynamic_import_commonjs_promise`, `dynamic_import_arg_is_identifier`; rewrite `emit_system_dynamic_import_call` to drop options; thread the call `NodeIndex` for parent lookup.
- `src/emitter/core.rs` — pass the node index to `emit_call_expression`.
- `src/emitter/module_wrapper/tests/system_emit_parts/part_00.rs` — update three stale identifier-specifier expectations to the tsc-correct (no-temp) form.
- `tests/dynamic_import_amd_umd_parity_tests.rs` (new) — 13 parity tests.

The ES5 async path (`async_es5_ir_convert.rs`) routes through a separate string-based IR and is intentionally out of scope; its identifier-capture + parenthesization parity is noted as follow-up.

## Project Corpus Impact
- Row: emit(js) (issue #11359); related family #11330, #11362.
- Bug family: downlevel dynamic `import()` emit (AMD/UMD/System) — parenthesization, specifier capture, System options drop.
- Evidence: verified against locally-installed `tsc` 6.0.2/6.0.3 as oracle across string / identifier / property-access / call / template specifiers, every parent context (await, member-access, call-arg, var-init, statement, return, conditional, throw, for), and AMD/UMD/System/CommonJS targets. 13 new emitter unit tests; full `tsz-emitter` suite shows zero new failures vs. base (identical pre-existing failure set).

## Verification
```
cargo test -p tsz-emitter --test dynamic_import_amd_umd_parity_tests   # 13/13 PASS
cargo test -p tsz-emitter                                              # no new failures vs base
cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings # clean
```
Differential vs `tsc` 6.0.2 across modules {commonjs, amd, umd, system, es2020, esnext, node16} × specifier shapes × parent contexts: all match (aside from a pre-existing `var _a;` hoist-placement nuance in the unchanged hoist mechanism, and a pre-existing static-default-import `__importDefault` divergence — both unrelated to dynamic import).

## Coordination Notes
AgentName: `opus48-pensive-wright` (runner: claude/pensive-wright-Z3cyH). Claiming #11359 (Studio-C lane, was not WIP, no competing PR — #11765 is unrelated async catch-binding). No overlap with open dynamic-import work. ES5 async-IR parity left as a tracked follow-up.

https://claude.ai/code/session_01LxgcE6uWmw9CqQC7N5XYSH

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxgcE6uWmw9CqQC7N5XYSH)_