### PR TITLE
fix(emit): rename ES5 block-scoped class on out-of-order enclosing-scope name collision

### DIFF
--- a/crates/tsz-emitter/src/emitter/block_scope_shadow_seed.rs
+++ b/crates/tsz-emitter/src/emitter/block_scope_shadow_seed.rs
@@ -1,0 +1,216 @@
+//! Order-independent seeding of value-binding names that an ES5 block-scoped
+//! declaration nested in a sub-block must not capture when lowered to `var`.
+//!
+//! ## Why this exists
+//!
+//! tsc renames a block-scoped class lowered to ES5 (`var Foo = (function(){…})()`)
+//! to `Foo_1` when its name collides with another *value* binding that is
+//! visible throughout the enclosing function/script scope:
+//!
+//! ```ts
+//! function f(b: boolean) {
+//!     if (b) {
+//!         class A { x: number }   // -> var A_1 = …
+//!         let c = [new A()];      //    new A_1()
+//!     }
+//! }
+//! class A {}                      // module-level value binding named `A`
+//! ```
+//!
+//! tsc reaches this decision through its binder pre-pass, so the colliding
+//! outer declaration may appear *textually after* the block-scoped class.
+//! tsz's emitter is a single forward walk, so it must seed the enclosing
+//! scope's visible value-binding names up front; otherwise the collision is
+//! only detected when the outer declaration happens to precede the class.
+//!
+//! ## What is "visible throughout the scope"
+//!
+//! For a function/script scope, the names visible at any nested block are:
+//!   * every declaration directly at the scope's own body level
+//!     (`class` / `function` / `enum` / `namespace` / `var` / `let` / `const`), and
+//!   * every `var` (function-scoped, therefore hoisted) declared anywhere in a
+//!     nested block of the same function — but *not* block-scoped declarations
+//!     (`class` / `let` / `const` / `function` / `enum` / `namespace`) sitting
+//!     inside a sibling/nested block, which are invisible to other blocks.
+//!
+//! Descent stops at nested function/class/accessor/method boundaries because
+//! those open their own scopes.
+
+use super::{NodeIndex, Printer};
+use tsz_parser::parser::NodeList;
+use tsz_parser::parser::node::NodeAccess;
+use tsz_parser::parser::node_flags;
+use tsz_parser::parser::syntax_kind_ext as sk;
+
+impl<'a> Printer<'a> {
+    /// Collect the value-binding names visible throughout the
+    /// function/script scope whose body is `statements`, and seed them so a
+    /// nested-block ES5 class/`let`/`const` lowering renames on collision
+    /// regardless of declaration order.
+    ///
+    /// Must be called immediately after the scope's `enter_function_scope()`
+    /// and before any of its statements are emitted.
+    pub(in crate::emitter) fn seed_block_scope_value_binding_names(
+        &mut self,
+        statements: &NodeList,
+    ) {
+        let mut names: Vec<String> = Vec::new();
+        for &stmt_idx in &statements.nodes {
+            self.collect_body_level_binding_names(stmt_idx, &mut names);
+        }
+        for name in &names {
+            self.ctx
+                .block_scope_state
+                .register_function_scope_shadowed_name(name);
+        }
+    }
+
+    /// Collect binding names declared *directly* at the scope body level.
+    /// `var` declarations also recurse into nested blocks (they hoist), while
+    /// block-scoped declarations are only collected at this level.
+    fn collect_body_level_binding_names(&self, idx: NodeIndex, out: &mut Vec<String>) {
+        let Some(node) = self.arena.get(idx) else {
+            return;
+        };
+
+        match node.kind {
+            k if k == sk::CLASS_DECLARATION
+                || k == sk::FUNCTION_DECLARATION
+                || k == sk::ENUM_DECLARATION
+                || k == sk::MODULE_DECLARATION =>
+            {
+                self.push_decl_name(node, out);
+            }
+            k if k == sk::VARIABLE_STATEMENT => {
+                // Body-level `var`/`let`/`const` are all visible to nested
+                // blocks, so collect every declared name regardless of kind.
+                self.collect_variable_statement_names(node, out, false);
+            }
+            // Body-level nested blocks/control flow: only hoisted `var`
+            // declarations escape into the enclosing function scope.
+            _ => {
+                self.collect_hoisted_var_names(idx, out);
+            }
+        }
+    }
+
+    /// Collect every `var` name declared anywhere beneath `idx`, stopping at
+    /// nested function/class/accessor/method scope boundaries. Block-scoped
+    /// declarations are intentionally ignored — they are not visible across
+    /// sibling blocks.
+    fn collect_hoisted_var_names(&self, idx: NodeIndex, out: &mut Vec<String>) {
+        let Some(node) = self.arena.get(idx) else {
+            return;
+        };
+
+        // Do not descend into constructs that open their own value scope; the
+        // `var`s inside them belong to that scope, not this one.
+        if matches!(
+            node.kind,
+            k if k == sk::FUNCTION_DECLARATION
+                || k == sk::FUNCTION_EXPRESSION
+                || k == sk::ARROW_FUNCTION
+                || k == sk::METHOD_DECLARATION
+                || k == sk::CONSTRUCTOR
+                || k == sk::GET_ACCESSOR
+                || k == sk::SET_ACCESSOR
+                || k == sk::CLASS_DECLARATION
+                || k == sk::CLASS_EXPRESSION
+                || k == sk::MODULE_DECLARATION
+        ) {
+            return;
+        }
+
+        if node.kind == sk::VARIABLE_STATEMENT {
+            // Inside a nested block only hoisted `var` bindings escape to the
+            // enclosing function scope; block-scoped `let`/`const`/`using` are
+            // invisible across blocks and must be skipped.
+            self.collect_variable_statement_names(node, out, true);
+            return;
+        }
+
+        for child in self.arena.get_children(idx) {
+            self.collect_hoisted_var_names(child, out);
+        }
+    }
+
+    /// Collect the binding names declared by a `VARIABLE_STATEMENT`.
+    ///
+    /// A `VARIABLE_STATEMENT` wraps one or more `VARIABLE_DECLARATION_LIST`
+    /// nodes, and the `let`/`const`/`using` flags live on the *list* node, not
+    /// the statement. When `hoisted_var_only` is set, lists declared with
+    /// `let`/`const`/`using` are skipped (they do not hoist across blocks).
+    fn collect_variable_statement_names(
+        &self,
+        node: &tsz_parser::parser::node::Node,
+        out: &mut Vec<String>,
+        hoisted_var_only: bool,
+    ) {
+        let Some(stmt) = self.arena.get_variable(node) else {
+            return;
+        };
+        for &list_idx in &stmt.declarations.nodes {
+            let Some(list_node) = self.arena.get(list_idx) else {
+                continue;
+            };
+            if hoisted_var_only {
+                let flags = list_node.flags as u32;
+                if (flags & (node_flags::LET | node_flags::CONST | node_flags::USING)) != 0 {
+                    continue;
+                }
+            }
+            let Some(list) = self.arena.get_variable(list_node) else {
+                continue;
+            };
+            for &decl_idx in &list.declarations.nodes {
+                let Some(decl_node) = self.arena.get(decl_idx) else {
+                    continue;
+                };
+                let Some(decl) = self.arena.get_variable_declaration(decl_node) else {
+                    continue;
+                };
+                self.collect_binding_name(decl.name, out);
+            }
+        }
+    }
+
+    fn push_decl_name(&self, node: &tsz_parser::parser::node::Node, out: &mut Vec<String>) {
+        let name_idx = match node.kind {
+            k if k == sk::CLASS_DECLARATION => self.arena.get_class(node).map(|c| c.name),
+            k if k == sk::FUNCTION_DECLARATION => self.arena.get_function(node).map(|f| f.name),
+            k if k == sk::ENUM_DECLARATION => self.arena.get_enum(node).map(|e| e.name),
+            k if k == sk::MODULE_DECLARATION => self.arena.get_module(node).map(|m| m.name),
+            _ => None,
+        };
+        if let Some(name_idx) = name_idx {
+            self.collect_binding_name(name_idx, out);
+        }
+    }
+
+    /// Push an identifier binding name (ignoring destructuring patterns, whose
+    /// individual names are handled recursively).
+    fn collect_binding_name(&self, name_idx: NodeIndex, out: &mut Vec<String>) {
+        let Some(name_node) = self.arena.get(name_idx) else {
+            return;
+        };
+        if name_node.is_identifier()
+            && let Some(ident) = self.arena.get_identifier(name_node)
+        {
+            out.push(ident.escaped_text.clone());
+            return;
+        }
+        if matches!(
+            name_node.kind,
+            k if k == sk::ARRAY_BINDING_PATTERN || k == sk::OBJECT_BINDING_PATTERN
+        ) && let Some(pattern) = self.arena.get_binding_pattern(name_node)
+        {
+            for &elem_idx in &pattern.elements.nodes {
+                if let Some(elem_node) = self.arena.get(elem_idx)
+                    && let Some(elem) = self.arena.get_binding_element(elem_node)
+                {
+                    self.collect_binding_name(elem.name, out);
+                }
+            }
+        }
+    }
+}

--- a/crates/tsz-emitter/src/emitter/functions.rs
+++ b/crates/tsz-emitter/src/emitter/functions.rs
@@ -409,6 +409,10 @@ impl<'a> Printer<'a> {
         let is_function_body_block = self.emitting_function_body_block;
         self.emitting_function_body_block = false;
         self.ctx.block_scope_state.enter_function_scope();
+        // Seed this function scope's visible value-binding names so a
+        // nested-block ES5 class/let/const lowering renames on collision
+        // regardless of declaration order within the function body.
+        self.seed_block_scope_value_binding_names(&block.statements);
         self.skip_block_opening_line_comments(block_node, block);
         self.emit_pending_new_target_capture();
         self.emit_param_prologue(transforms);

--- a/crates/tsz-emitter/src/emitter/mod.rs
+++ b/crates/tsz-emitter/src/emitter/mod.rs
@@ -29,6 +29,7 @@
 
 mod arrow_concise;
 mod binding_patterns;
+mod block_scope_shadow_seed;
 mod class_temp_reservations;
 mod comments;
 mod core;

--- a/crates/tsz-emitter/src/emitter/source_file/emit.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/emit.rs
@@ -115,6 +115,10 @@ impl<'a> Printer<'a> {
         // Enter root scope for block-scoped variable tracking and `var` scope boundaries.
         // This ensures variables declared throughout the file are tracked for renaming.
         self.ctx.block_scope_state.enter_function_scope();
+        // Seed module-level value-binding names so a nested-block ES5 class/let/const
+        // lowering renames on collision regardless of declaration order (tsc decides
+        // this via its binder pre-pass; our forward walk needs the names up front).
+        self.seed_block_scope_value_binding_names(&source.statements);
 
         // Extract comments. Triple-slash reference directives (/// <reference ...>)
         // are preserved as regular comments in CJS/ESM JS output (tsc behavior).

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -188,6 +188,7 @@ impl<'a> Printer<'a> {
             }
             if is_function_body_block {
                 self.ctx.block_scope_state.enter_function_scope();
+                self.seed_block_scope_value_binding_names(&block.statements);
                 self.register_pending_function_body_parameters();
             } else {
                 self.ctx.block_scope_state.enter_scope();
@@ -241,6 +242,7 @@ impl<'a> Printer<'a> {
         }
         if is_function_body_block {
             self.ctx.block_scope_state.enter_function_scope();
+            self.seed_block_scope_value_binding_names(&block.statements);
             self.register_pending_function_body_parameters();
         } else {
             self.ctx.block_scope_state.enter_scope();

--- a/crates/tsz-emitter/src/transforms/block_scoping_es5.rs
+++ b/crates/tsz-emitter/src/transforms/block_scoping_es5.rs
@@ -248,7 +248,19 @@ impl BlockScopeState {
         // with a reserved temp name. Sibling-block classes do not conflict
         // because their scopes are popped before this runs, so the common
         // nested-block case reuses `original_name` exactly like tsc.
+        //
+        // `function_scope_shadowed_names` carries hoisted value-binding names
+        // from this (and enclosing) function/script scope, seeded up front so
+        // the collision is order-independent: a nested-block class renames even
+        // when the colliding outer `var`/`function`/`class`/`enum`/`namespace`
+        // is declared *textually after* the class. tsc decides this via its
+        // binder pre-pass; the forward emit walk needs the seed to match.
+        let shadows_outer_value_binding = self
+            .function_scope_shadowed_names
+            .iter()
+            .any(|names| names.contains(original_name));
         let collides = self_referencing
+            || shadows_outer_value_binding
             || self.reserved_names.contains(original_name)
             || self.scope_stack.iter().any(|scope| {
                 scope.contains_key(original_name) || scope.values().any(|v| v == original_name)

--- a/crates/tsz-emitter/tests/block_scoping_es5.rs
+++ b/crates/tsz-emitter/tests/block_scoping_es5.rs
@@ -355,6 +355,52 @@ fn nested_block_scoped_class_renames_on_outer_var_collision() {
 }
 
 #[test]
+fn nested_block_scoped_class_renames_on_seeded_outer_binding() {
+    // A nested-block class renames when an enclosing function/script scope has
+    // a same-named value binding, even though that binding is registered up
+    // front (seeded) rather than encountered first by the forward walk. This is
+    // the order-independent collision case: tsc renames `class A` to `A_1` when
+    // a module-level `class A`/`function A`/`var A` exists *anywhere* in scope,
+    // including textually after the nested class. Name choice is irrelevant.
+    for name in ["A", "T", "K"] {
+        let mut state = BlockScopeState::new();
+        state.enter_function_scope();
+        // The enclosing scope's visible value binding, seeded before the body.
+        state.register_function_scope_shadowed_name(name);
+
+        state.enter_scope(); // nested block, e.g. inside `if (b) { ... }`
+        assert_eq!(
+            state.register_block_scoped_class(name, false),
+            format!("{name}_1"),
+            "nested-block class renames against a seeded enclosing value binding"
+        );
+        state.exit_scope();
+        state.exit_scope();
+    }
+}
+
+#[test]
+fn function_body_level_class_ignores_seeded_outer_binding() {
+    // A block-scoped class declared *directly* at the function/script body
+    // level lowers to a plain `var` and reuses its name even when an enclosing
+    // scope binds the same name; tsc only renames *nested-block* classes. The
+    // seeded outer binding must therefore not force a body-level rename.
+    for name in ["A", "P", "X"] {
+        let mut state = BlockScopeState::new();
+        state.enter_function_scope();
+        state.register_function_scope_shadowed_name(name);
+
+        // No nested enter_scope(): the class sits at function body level.
+        assert_eq!(
+            state.register_block_scoped_class(name, false),
+            name,
+            "body-level block-scoped class reuses its name despite an outer binding"
+        );
+        state.exit_scope();
+    }
+}
+
+#[test]
 fn top_level_block_scoped_class_redeclaration_reuses_name() {
     // At module/script top level (function-scope mark), a same-name class
     // redeclaration reuses the name (tsc emits `var C` for both of two


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — ES5 block-scoped class out-of-order collision rename (emit→100% campaign, wave 3)

## Invariant
When an ES5 block-scoped class lowered to an IIFE sits in a NESTED block and its name matches a value binding (`var`/`function`/`class`/`enum`/`namespace`) visible throughout an enclosing function/script scope — REGARDLESS of declaration order — the hoisted `var` renames to `Name_N`. Body-level block-scoped classes still reuse their name. Extends the forward-collision fix (#11761): tsz's single forward walk only saw the collision when the outer declaration PRECEDED the class; tsc resolves it via its binder pre-pass. This fix seeds each scope's visible value-binding names up front (body-level declarations of all kinds + hoisted `var`s collected from nested blocks, stopping at nested function/class boundaries) into the block-scope shadow set. Keyed on AST node kind — no identifier/file-name matching, no printer-output inspection.

## Scope
- NEW `crates/tsz-emitter/src/emitter/block_scope_shadow_seed.rs` (216 lines — collector + seeder).
- `emitter/mod.rs` (register), `emitter/source_file/emit.rs` (seed module scope), `emitter/functions.rs` + `statements/core.rs` (seed function-body scopes).
- `transforms/block_scoping_es5.rs` — consult the shadow set in `register_block_scoped_class`.
- `tests/block_scoping_es5.rs` (+2 tests, names A/T/K and A/P/X).

## Project Corpus Impact
- Row: n/a (ES5 block-scoped class-rename fix)
- Bug family: ES5 block-scoped class not renamed when a same-named value binding appears LATER in an enclosing scope (out-of-order collision)
- Evidence: localTypes1(target=es5) FAIL→PASS; full --js-only 77→76.

## Verification
- Witness FAIL→PASS. **Full --js-only: 77→76 fail, net +1, ZERO new failures** (only localTypes1(es5) flipped). 11 adjacent structural repros match tsc (module/body/nested/sibling-block; var/let/function/class outer bindings; both orders; negative no-collision + function-A-sibling). --dts-only unaffected (ES5-JS-var-renaming only). Emitter unit: 21 pre-existing fails identical on clean HEAD; +2 new tests pass; zero new regressions. Clippy clean; arch guard passes (new code in a fresh file, all files <2000).
- §25/§26 compliant.

## Coordination Notes
Rebased onto current main. STOP-reported the other re-triage candidates (NOT this cluster): jsDeclarationsClasses(es5) (multi-cause: inline `@type {*}` JSDoc-cast dropped [checker-coupled] + CJS export ordering for aliased classes); staticFieldWithInterfaceContext (temp-numbering-broad — class-expr `__setFunctionName` temp renumber, the documented global temp-model track); nestedClassDeclaration + nestedGlobalNamespaceInClass (parser-recovery of invalid source). — opus48-emit100
