### PR TITLE
fix(emit): emit yield __await for implicit awaits in async-generator for-await downlevel (non-runnable JS)

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -275,6 +275,10 @@ name = "async_loop_emit"
 path = "tests/async_loop_emit.rs"
 
 [[test]]
+name = "for_await_async_generator_keyword_tests"
+path = "tests/for_await_async_generator_keyword_tests.rs"
+
+[[test]]
 name = "while_loop_body_capture_tests"
 path = "tests/while_loop_body_capture_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/es5/bindings_for_await_keyword.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings_for_await_keyword.rs
@@ -1,0 +1,50 @@
+//! Keyword lowering for the implicit awaits emitted by the downlevel
+//! `for await...of` loop transform.
+//!
+//! A `for await...of` statement lowers to a synchronous `for` loop that
+//! awaits the async iterator protocol calls (`iter.next()`, `iter.return()`)
+//! and any async `using` disposal. The keyword used for those implicit awaits
+//! depends on the lowering mode of the *enclosing* function body, mirroring how
+//! an explicit `await` expression is lowered in the same context:
+//!
+//! * Native async (`async function`, target supports `await`): emit `await x`.
+//! * Async-to-generator via `__awaiter` (ES2015/ES2016 async lowering): emit
+//!   `yield x`.
+//! * Async-generator-to-generator via `__asyncGenerator` (an
+//!   `async function*` downleveled below ES2018): emit `yield __await(x)`.
+//!
+//! The third mode is the load-bearing one: the lowered loop body is a plain
+//! `function*`, so a literal `await` there is a `SyntaxError`. tsc wraps the
+//! implicit awaits as `yield __await(...)` exactly as it does for explicit
+//! `await` expressions inside an async generator.
+
+use super::super::Printer;
+
+impl Printer<'_> {
+    /// Emit the opening of an implicit `for await...of` await, leaving the
+    /// awaited expression to be emitted next. Pair every call with
+    /// [`Self::emit_for_await_implicit_await_suffix`].
+    ///
+    /// Produces one of: `await `, `yield `, or `yield __await(` depending on the
+    /// enclosing function body's async lowering mode.
+    pub(in crate::emitter) fn emit_for_await_implicit_await_prefix(&mut self) {
+        if self.ctx.emit_await_as_yield_await {
+            self.write("yield ");
+            self.write_helper("__await");
+            self.write("(");
+        } else if self.ctx.emit_await_as_yield {
+            self.write("yield ");
+        } else {
+            self.write("await ");
+        }
+    }
+
+    /// Close an implicit `for await...of` await opened with
+    /// [`Self::emit_for_await_implicit_await_prefix`]. Only the
+    /// `yield __await(...)` async-generator form needs a closing paren.
+    pub(in crate::emitter) fn emit_for_await_implicit_await_suffix(&mut self) {
+        if self.ctx.emit_await_as_yield_await {
+            self.write(")");
+        }
+    }
+}

--- a/crates/tsz-emitter/src/emitter/es5/bindings_param_patterns.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings_param_patterns.rs
@@ -1287,12 +1287,7 @@ impl<'a> Printer<'a> {
             self.emit_comments_before_pos(actual_start);
         }
 
-        // for (var _d = true, iterable_1 = __asyncValues(iterable), iterable_1_1; iterable_1_1 = [await/yield] iterable_1.next(), _a = iterable_1_1.done, !_a; _d = true) {
-        let await_or_yield = if self.ctx.emit_await_as_yield {
-            "yield"
-        } else {
-            "await"
-        };
+        // for (var _d = true, iterable_1 = __asyncValues(iterable), iterable_1_1; iterable_1_1 = [await/yield/yield __await(...)] iterable_1.next(), _a = iterable_1_1.done, !_a; _d = true) {
         self.write("for (var ");
         self.write(&loop_guard_name);
         self.write(" = true, ");
@@ -1316,10 +1311,11 @@ impl<'a> Printer<'a> {
         self.write("; ");
         self.write(&loop_result_name);
         self.write(" = ");
-        self.write(await_or_yield);
-        self.write(" ");
+        self.emit_for_await_implicit_await_prefix();
         self.write(&loop_iterator_name);
-        self.write(".next(), ");
+        self.write(".next()");
+        self.emit_for_await_implicit_await_suffix();
+        self.write(", ");
         self.write(&loop_done_name);
         self.write(" = ");
         self.write(&loop_result_name);
@@ -1446,11 +1442,6 @@ impl<'a> Printer<'a> {
             self.write_line();
             self.increase_indent();
             if using_async {
-                let await_kw = if self.ctx.emit_await_as_yield {
-                    "yield"
-                } else {
-                    "await"
-                };
                 self.write(kw);
                 self.write(" ");
                 self.write(&result_name);
@@ -1465,9 +1456,9 @@ impl<'a> Printer<'a> {
                 self.write(")");
                 self.write_line();
                 self.increase_indent();
-                self.write(await_kw);
-                self.write(" ");
+                self.emit_for_await_implicit_await_prefix();
                 self.write(&result_name);
+                self.emit_for_await_implicit_await_suffix();
                 self.write(";");
                 self.write_line();
                 self.decrease_indent();
@@ -1531,7 +1522,7 @@ impl<'a> Printer<'a> {
         self.write_line();
         self.increase_indent();
 
-        // Cleanup: if (!_e && !_d && (_a = _b.return)) [await/yield] _a.call(_b);
+        // Cleanup: if (!_e && !_d && (_a = _b.return)) [await/yield/yield __await(...)] _a.call(_b);
         self.write("if (!");
         self.write(&loop_guard_name);
         self.write(" && !");
@@ -1541,12 +1532,13 @@ impl<'a> Printer<'a> {
         self.write(" = ");
         self.write(&loop_iterator_name);
         self.write(".return)) ");
-        self.write(await_or_yield);
-        self.write(" ");
+        self.emit_for_await_implicit_await_prefix();
         self.write(&return_temp_name);
         self.write(".call(");
         self.write(&loop_iterator_name);
-        self.write(");");
+        self.write(")");
+        self.emit_for_await_implicit_await_suffix();
+        self.write(";");
 
         self.write_line();
         self.decrease_indent();

--- a/crates/tsz-emitter/src/emitter/es5/mod.rs
+++ b/crates/tsz-emitter/src/emitter/es5/mod.rs
@@ -6,6 +6,7 @@
 mod bindings;
 mod bindings_assignment;
 mod bindings_disposable_names;
+mod bindings_for_await_keyword;
 mod bindings_for_of;
 mod bindings_param_patterns;
 mod bindings_patterns;

--- a/crates/tsz-emitter/tests/for_await_async_generator_keyword_tests.rs
+++ b/crates/tsz-emitter/tests/for_await_async_generator_keyword_tests.rs
@@ -1,0 +1,127 @@
+//! Regression tests for the implicit-await keyword emitted by the downlevel
+//! `for await...of` transform inside an async generator.
+//!
+//! Rule: when a `for await...of` is lowered inside an `async function*` that is
+//! itself downleveled to a `function*` wrapped in `__asyncGenerator` (target
+//! below ES2018), the implicit awaits on the async-iterator protocol calls
+//! (`iter.next()`, `iter.return()`) must be emitted as `yield __await(...)`,
+//! not as a literal `await`. A literal `await` inside the generator body is a
+//! `SyntaxError`. This mirrors how an explicit `await` expression is lowered in
+//! the same context.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::{PrintOptions, lower_and_print};
+use tsz_parser::parser::ParserState;
+
+fn emit(source: &str, target: ScriptTarget) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let opts = PrintOptions {
+        target,
+        module: ModuleKind::CommonJS,
+        remove_comments: true,
+        ..PrintOptions::default()
+    };
+    lower_and_print(&parser.arena, root, opts).code
+}
+
+/// Helper asserting the loop transform never emits a bare `await` keyword,
+/// which would be a `SyntaxError` inside a `function*` body. The two spellings
+/// the transform can produce are `<temp> = await <iter>.next()` (loop step) and
+/// `(...)) await <temp>.call(<iter>)` (return cleanup). The `__await(` helper
+/// call and the helper's own definition are unaffected by these checks.
+fn assert_no_bare_await(output: &str) {
+    assert!(
+        !output.contains(" = await "),
+        "async-generator for-await loop step must not emit a bare `await`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains(")) await "),
+        "async-generator for-await return cleanup must not emit a bare `await`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_generator_for_await_lowers_next_to_yield_await_es2015() {
+    let output = emit(
+        "async function* g(source: any) {
+            for await (const item of source) { item; }
+        }",
+        ScriptTarget::ES2015,
+    );
+
+    assert!(
+        output.contains("__asyncGenerator"),
+        "async generator below ES2018 should lower via __asyncGenerator.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("yield __await(source_1.next())"),
+        "the iterator `.next()` step must be `yield __await(...)` in an async generator.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("yield __await(_b.call(source_1))"),
+        "the `.return()` cleanup must be `yield __await(...)` in an async generator.\nOutput:\n{output}"
+    );
+    assert_no_bare_await(&output);
+}
+
+#[test]
+fn async_generator_for_await_lowers_next_to_yield_await_es2017() {
+    let output = emit(
+        "async function* g(source: any) {
+            for await (const item of source) { item; }
+        }",
+        ScriptTarget::ES2017,
+    );
+
+    assert!(
+        output.contains("yield __await(source_1.next())"),
+        "ES2017 async generator must also use `yield __await(...)`.\nOutput:\n{output}"
+    );
+    assert_no_bare_await(&output);
+}
+
+/// The fix must be keyed on the async-generator lowering mode, not on any
+/// identifier spelling. Renaming the parameter/iteration variable must keep the
+/// `yield __await(...)` form.
+#[test]
+fn async_generator_for_await_keyword_is_name_independent() {
+    let output = emit(
+        "async function* gen(xs: any) {
+            for await (const value of xs) { value; }
+        }",
+        ScriptTarget::ES2015,
+    );
+
+    assert!(
+        output.contains("yield __await(xs_1.next())"),
+        "renamed iteration source must still emit `yield __await(...)`.\nOutput:\n{output}"
+    );
+    assert_no_bare_await(&output);
+}
+
+/// Negative case: an ordinary `async function` (not a generator) downleveled
+/// below ES2017 lowers via `__awaiter`, where the implicit await must be a
+/// plain `yield` with NO `__await` wrapper. The fix must not regress this.
+#[test]
+fn async_non_generator_for_await_uses_plain_yield() {
+    let output = emit(
+        "async function f(y: any) {
+            for await (const x of y) { x; }
+        }",
+        ScriptTarget::ES2015,
+    );
+
+    assert!(
+        output.contains("__awaiter"),
+        "ordinary async function should lower via __awaiter.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("yield y_1.next()"),
+        "non-generator async for-await must emit plain `yield iter.next()`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("yield __await(y_1.next())"),
+        "non-generator async for-await must NOT wrap in __await.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — async-generator for-await downlevel (correctness, non-runnable JS)

## Invariant
When a `for await...of` (ForOfStatement with await modifier) is lowered inside a function body emitted in async-generator-to-generator mode (`emit_await_as_yield_await` — an `async function*` downleveled below ES2018 to a `function*` wrapped in `__asyncGenerator`), the implicit awaits on `iter.next()`, the `iter.return()` cleanup, and the async-`using` dispose MUST be emitted as `yield __await(<expr>)` (mirroring explicit-`await` lowering), NOT a literal `await` — which is a SyntaxError inside the `function*` body. Mode-keyed (lowering-mode flags), not name-keyed. tsc 6.0.3 emits `yield __await(...)`.

## Scope
- NEW `crates/tsz-emitter/src/emitter/es5/bindings_for_await_keyword.rs` — `emit_for_await_implicit_await_prefix`/`_suffix` (pick `await `/`yield `/`yield __await(...)` from the lowering-mode flags).
- `crates/tsz-emitter/src/emitter/es5/bindings_param_patterns.rs` — the 3 keyword sites (loop `.next()` step, `.return()` cleanup, async `using` dispose) call the helpers (net -20/+32, shrank at call sites).
- `es5/mod.rs` (register) + `tests/for_await_async_generator_keyword_tests.rs` (new, 4 tests).

## Project Corpus Impact
- Row: n/a (emit CORRECTNESS fix — non-runnable JS → runnable)
- Bug family: async-generator for-await downlevel emits literal `await` (invalid in `function*`) instead of `yield __await(...)`
- Evidence: `async function* g(y){ for await (const x of y) {...} }` at es2015/es2017 — `node --check` before = SyntaxError, after = valid (2× `yield __await(...)`); matches tsc 6.0.3 `emitter.forAwait` baselines.

## Verification
- node --check VALID at es2015/es2017 (was invalid); async `using` dispose also `yield __await(result_1)`. **Full --js-only fail-SET IDENTICAL (79/79, net-zero — the emit suite's listed cases don't include this multi-file forAwait source, so no row flips; correctness confirmed by node --check + conformance smoke), ZERO regressions. --dts-only IDENTICAL (24/24).** tsz-emitter async/generator/for-of/await/optional-chain family 309/309 (+4 new tests, name-independent + async-non-generator negative). Conformance smoke: emitter.forAwait 1/1, asyncGenerator 21/21. Clippy clean; arch guard passes.
- §25/§26 compliant. Emitter-only (conformance-safe).

## Coordination Notes
Rebased onto current main. Separate non-runnable bug found, NOT bundled (kept this PR contained): labeled for-await (`outer: for await (...) { continue outer; }`) lowers the label onto the wrapping `try` instead of the inner `for`, so `continue outer` targets a non-loop label (SyntaxError); tsc places `outer:` on the inner `for`. Flagged for follow-up. — opus48-emit100
