### PR TITLE
fix(checker): defer excess-property checks for overloaded constructors

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -129,6 +129,9 @@ mod class_namespace_static_relation_routing_arch_tests;
 #[path = "../tests/class_property_typed_const_initializer_tests.rs"]
 mod class_property_typed_const_initializer_tests;
 #[cfg(test)]
+#[path = "../tests/constructor_overload_excess_property_tests.rs"]
+mod constructor_overload_excess_property_tests;
+#[cfg(test)]
 #[path = "../tests/control_flow_tests.rs"]
 mod control_flow_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
+++ b/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
@@ -21,3 +21,7 @@ pub(crate) fn construct_signatures_for_type(
         is_method: shape.is_method,
     }])
 }
+
+pub(crate) fn has_construct_overloads(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    construct_signatures_for_type(db, type_id).is_some_and(|sigs| sigs.len() > 1)
+}

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -7,6 +7,7 @@ use crate::call_checker::CallableContext;
 use crate::context::TypingRequest;
 use crate::query_boundaries::checkers::call as call_checker;
 use crate::query_boundaries::common::ContextualTypeContext;
+use crate::query_boundaries::construct_signatures::has_construct_overloads;
 use crate::query_boundaries::type_computation::complex as query;
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
@@ -851,19 +852,6 @@ impl<'a> CheckerState<'a> {
             constructor_shape_type,
             args.len(),
         );
-        // Detect an overloaded constructor: a construct-signature set with more than
-        // one signature. For overload sets, excess-property checking must be deferred
-        // to overload resolution (`resolve_new_with_checker_adapter`) instead of being
-        // driven by the single contextual signature picked above. Otherwise a fresh
-        // object-literal argument that fits a *later* overload is wrongly reported as
-        // excess against the *first* signature's parameter type. This mirrors the
-        // call-expression path, which sets `check_excess_properties = false` whenever
-        // multiple overload signatures are present (see `call/inner.rs`).
-        let constructor_is_overloaded = crate::query_boundaries::common::get_construct_signatures(
-            self.ctx.types,
-            constructor_shape_type,
-        )
-        .is_some_and(|sigs| sigs.len() > 1);
         let is_generic_new = constructor_shape
             .as_ref()
             .is_some_and(|s| !s.type_params.is_empty())
@@ -923,7 +911,8 @@ impl<'a> CheckerState<'a> {
                 self.ctx.compiler_options.no_implicit_any,
             )
         };
-        let check_excess_properties = !constructor_is_overloaded;
+        let check_excess_properties =
+            !has_construct_overloads(self.ctx.types, constructor_shape_type);
         let prev_generic_excess_skip = self.ctx.generic_excess_skip.take();
         // Preserve literal types in array literals during generic constructor
         // argument collection — mirroring the function call path. This ensures

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -851,6 +851,19 @@ impl<'a> CheckerState<'a> {
             constructor_shape_type,
             args.len(),
         );
+        // Detect an overloaded constructor: a construct-signature set with more than
+        // one signature. For overload sets, excess-property checking must be deferred
+        // to overload resolution (`resolve_new_with_checker_adapter`) instead of being
+        // driven by the single contextual signature picked above. Otherwise a fresh
+        // object-literal argument that fits a *later* overload is wrongly reported as
+        // excess against the *first* signature's parameter type. This mirrors the
+        // call-expression path, which sets `check_excess_properties = false` whenever
+        // multiple overload signatures are present (see `call/inner.rs`).
+        let constructor_is_overloaded = crate::query_boundaries::common::get_construct_signatures(
+            self.ctx.types,
+            constructor_shape_type,
+        )
+        .is_some_and(|sigs| sigs.len() > 1);
         let is_generic_new = constructor_shape
             .as_ref()
             .is_some_and(|s| !s.type_params.is_empty())
@@ -910,7 +923,7 @@ impl<'a> CheckerState<'a> {
                 self.ctx.compiler_options.no_implicit_any,
             )
         };
-        let check_excess_properties = true;
+        let check_excess_properties = !constructor_is_overloaded;
         let prev_generic_excess_skip = self.ctx.generic_excess_skip.take();
         // Preserve literal types in array literals during generic constructor
         // argument collection — mirroring the function call path. This ensures

--- a/crates/tsz-checker/tests/constructor_overload_excess_property_tests.rs
+++ b/crates/tsz-checker/tests/constructor_overload_excess_property_tests.rs
@@ -1,0 +1,194 @@
+//! Regression tests for overloaded-constructor excess-property false positives.
+//!
+//! Structural rule: when a `new` expression's target has more than one construct
+//! signature (an overload set), a fresh object-literal argument that fits a *later*
+//! overload must not be reported as an excess-property error (TS2353) against an
+//! *earlier* overload's parameter type. Excess-property checking is deferred to
+//! overload resolution, exactly as the call-expression path already does for
+//! overloaded function calls. Only when *no* overload accepts the argument should a
+//! diagnostic surface (TS2769 "No overload matches this call").
+//!
+//! See issue #10678 (kysely: false TS2353 excess property `executor` on
+//! `KyselyConfig` — constructor-arg type resolved to the wrong overload).
+
+use crate::test_utils::check_source_codes as get_error_codes;
+
+/// Class constructor overloads where the literal fits the *second* overload by
+/// supplying a property the first overload lacks. tsc accepts this.
+#[test]
+fn class_ctor_overload_literal_fits_later_overload_no_ts2353() {
+    let source = r#"
+interface ConfigA { a: number }
+interface PropsB { a: number; executor: string }
+declare class K {
+    constructor(args: ConfigA);
+    constructor(args: PropsB);
+}
+const k = new K({ a: 1, executor: "x" });
+"#;
+    let errors = get_error_codes(source);
+    assert!(
+        !errors.contains(&2353),
+        "overloaded ctor: literal fitting a later overload must not emit TS2353, got: {errors:?}"
+    );
+    assert!(
+        !errors.contains(&2769),
+        "a matching overload exists; TS2769 must not fire, got: {errors:?}"
+    );
+}
+
+/// Same rule, different property/type names — proves the fix is structural, not
+/// keyed to any particular identifier spelling.
+#[test]
+fn class_ctor_overload_renamed_members_no_ts2353() {
+    let source = r#"
+interface Plain { id: number }
+interface Extended { id: number; label: string }
+declare class Widget {
+    constructor(opts: Plain);
+    constructor(opts: Extended);
+}
+const w = new Widget({ id: 7, label: "hi" });
+"#;
+    let errors = get_error_codes(source);
+    assert!(
+        !errors.contains(&2353) && !errors.contains(&2769),
+        "renamed overloaded ctor must accept later-overload literal, got: {errors:?}"
+    );
+}
+
+/// Overload order should not matter: the wider overload listed first still works.
+#[test]
+fn class_ctor_overload_wider_first_no_error() {
+    let source = r#"
+interface ConfigA { a: number }
+interface PropsB { a: number; executor: string }
+declare class K {
+    constructor(args: PropsB);
+    constructor(args: ConfigA);
+}
+const k = new K({ a: 1, executor: "x" });
+"#;
+    let errors = get_error_codes(source);
+    assert!(
+        !errors.contains(&2353) && !errors.contains(&2769),
+        "overload order must not change acceptance, got: {errors:?}"
+    );
+}
+
+/// Interface construct signatures (not a class) exercise the same `new` path.
+#[test]
+fn interface_construct_signature_overload_no_ts2353() {
+    let source = r#"
+interface Ctor {
+    new (args: { a: number }): unknown;
+    new (args: { a: number; executor: string }): unknown;
+}
+declare const C: Ctor;
+const k = new C({ a: 1, executor: "x" });
+"#;
+    let errors = get_error_codes(source);
+    assert!(
+        !errors.contains(&2353) && !errors.contains(&2769),
+        "interface construct-signature overload must accept later-overload literal, got: {errors:?}"
+    );
+}
+
+/// Alias wrapping the constructor type must behave identically.
+#[test]
+fn aliased_constructor_overload_no_ts2353() {
+    let source = r#"
+interface ConfigA { a: number }
+interface PropsB { a: number; executor: string }
+interface KCtor {
+    new (args: ConfigA): unknown;
+    new (args: PropsB): unknown;
+}
+type KAlias = KCtor;
+declare const K: KAlias;
+const k = new K({ a: 1, executor: "x" });
+"#;
+    let errors = get_error_codes(source);
+    assert!(
+        !errors.contains(&2353) && !errors.contains(&2769),
+        "aliased overloaded ctor must accept later-overload literal, got: {errors:?}"
+    );
+}
+
+/// `super(...)` to an overloaded base constructor follows the same `new` resolution.
+#[test]
+fn super_call_to_overloaded_base_ctor_no_ts2353() {
+    let source = r#"
+class Base {
+    constructor(a: { x: number });
+    constructor(a: { x: number; y: number });
+    constructor(a: any) { void a; }
+}
+class Sub extends Base {
+    constructor() { super({ x: 1, y: 2 }); }
+}
+"#;
+    let errors = get_error_codes(source);
+    assert!(
+        !errors.contains(&2353),
+        "super() to overloaded base ctor must not emit TS2353, got: {errors:?}"
+    );
+}
+
+/// Negative: a single (non-overloaded) constructor must STILL report excess
+/// properties. The deferral only applies to genuine overload sets.
+#[test]
+fn single_constructor_still_reports_excess_ts2353() {
+    let source = r#"
+class K {
+    constructor(a: { x: number }) { void a; }
+}
+const k = new K({ x: 1, y: 2 });
+"#;
+    let errors = get_error_codes(source);
+    assert!(
+        errors.contains(&2353),
+        "single ctor with a fresh excess property must still emit TS2353, got: {errors:?}"
+    );
+}
+
+/// Negative: when *no* overload accepts the literal (every candidate rejects an
+/// excess property), tsc reports TS2769 — and tsz must not additionally emit a
+/// spurious TS2353 against the first overload.
+#[test]
+fn no_matching_overload_reports_ts2769_only() {
+    let source = r#"
+declare class K {
+    constructor(a: { x: number });
+    constructor(a: { y: number });
+}
+const k = new K({ x: 1, y: 2, z: 3 });
+"#;
+    let errors = get_error_codes(source);
+    assert!(
+        errors.contains(&2769),
+        "no overload accepts the literal; TS2769 must fire, got: {errors:?}"
+    );
+    assert!(
+        !errors.contains(&2353),
+        "the no-overload case must not also emit a spurious TS2353, got: {errors:?}"
+    );
+}
+
+/// Negative: an overload mismatch driven by an incompatible property *type*
+/// (not excess) still reports TS2769 when nothing matches.
+#[test]
+fn overload_type_mismatch_reports_ts2769() {
+    let source = r#"
+declare class K {
+    constructor(a: { mode: "x" });
+    constructor(a: { mode: "y" });
+}
+const k = new K({ mode: "z" });
+"#;
+    let errors = get_error_codes(source);
+    assert!(
+        errors.contains(&2769),
+        "incompatible literal must report TS2769, got: {errors:?}"
+    );
+}


### PR DESCRIPTION
AgentName: remote-opus48
Track: Checker / TS2322-family compatibility (excess-property freshness)
Fixes: #10678

## Invariant
> When a `new` expression's target has more than one construct signature (an
> overload set), excess-property checking is deferred to overload resolution
> instead of being driven by a single contextually-picked signature. A fresh
> object literal that fits a *later* overload must not be reported as excess
> against an *earlier* overload's parameter type. Excess only surfaces when **no**
> overload accepts the argument (TS2769). Single (non-overloaded) constructors are
> unchanged and still report TS2353.

This restores parity with `tsc` and matches the **existing call-expression path**,
which already sets `check_excess_properties = false` when multiple overload
signatures are present (`types/computation/call/inner.rs`).

## Root cause
`get_type_of_new_expression_with_request` (`types/computation/complex.rs`) selects a
single contextual construct signature via `get_construct_signature` (prefer generic,
else the first arity match) and collects arguments with `check_excess_properties =
true` against that one signature. For an overloaded constructor, a fresh object
literal that actually fits a later overload is wrongly flagged as excess (TS2353)
against the first overload's parameter type. The real, freshness-aware overload
resolution (`resolve_new`) runs *after* this premature check, so it also added a
spurious second diagnostic in the no-match case.

## Scope
- `crates/tsz-checker/src/query_boundaries/construct_signatures.rs` — expose `has_construct_overloads` as the narrow checker-facing structural query.
- `crates/tsz-checker/src/types/computation/complex.rs` — gate constructor argument excess-property collection on that query while staying under the 2000-line ratchet.
- `crates/tsz-checker/tests/constructor_overload_excess_property_tests.rs` — new
  owning-crate tests (registered in `lib.rs`).

No new public API; the checker-facing structural fact stays behind `query_boundaries`.

## Structural rule / adjacency
The fix is keyed on a structural fact (construct-signature count), not on any
identifier spelling, file, or printer output. Tests cover the rule across:
- class ctor overloads where a later overload fits (reported repro shape);
- **renamed** members/type-params (proves not spelling-specific);
- reversed overload order;
- interface construct signatures (not just classes);
- alias-wrapped constructor type;
- `super(...)` to an overloaded base ctor;
- negatives: single ctor still emits TS2353; no-overload emits **TS2769 only**
  (no spurious TS2353); incompatible-literal emits TS2769.

## Project Corpus Impact
- Row: kysely-project (#10678 — false TS2353 `executor` on `KyselyConfig`; the
  constructor-arg type was resolved to the wrong overload).
- Bug family: overloaded-constructor / construct-signature selection driving
  premature excess-property freshness errors.
- Evidence: minimal standalone repro reproduces the false TS2353 before the change
  and is clean after (`tsz --noEmit --strict`); 9 new unit tests pass.

## Verification
- `cargo build -p tsz-cli`; CLI probes for all overload/single/union/super/no-match
  shapes match `tsc`.
- `cargo nextest run -p tsz-checker --lib -E 'test(class_ctor_overload) or test(interface_construct_signature_overload_no_ts2353) or test(aliased_constructor_overload_no_ts2353) or test(super_call_to_overloaded_base_ctor_no_ts2353) or test(single_constructor_still_reports_excess_ts2353) or test(no_matching_overload_reports_ts2769_only)'` → 8 passed.
- `cargo nextest run -p tsz-checker --lib -E 'test(overload_type_mismatch_reports_ts2769)'` → 1 passed.
- `cargo fmt --check`; `python3 scripts/arch/arch_guard.py`; `git diff --check`.
- Confirmed the unrelated red tests in this local environment fail identically
  **without** this change (reverted `complex.rs` to parent and re-ran), so they are
  pre-existing/lib-fixture-dependent, not regressions from this PR. Full
  conformance/emit/fourslash run in ready-for-review CI.

## Coordination Notes
Picked up #10678 (was `help wanted`, owner lane `agent:Studio-A`, not WIP, no open
PR). Marked the issue `WIP` with a signed claim comment. Earlier handoffs said
"naive reductions pass" — the missing ingredient was an *overloaded* constructor,
captured here. Signed remote-opus48.
