### PR TITLE
fix(emit): scoped-static-super rewrite for hoisted decorated static-field super at pre-ES2022 (non-runnable JS)

### DIFF
--- a/crates/tsz-emitter/src/emitter/decorator_static_super_hoist.rs
+++ b/crates/tsz-emitter/src/emitter/decorator_static_super_hoist.rs
@@ -1,0 +1,81 @@
+//! Hoisted-static-field `super` rewrite for pre-ES2022 decorated classes.
+//!
+//! When a TC39-decorated class is lowered for a target below ES2022, plain
+//! static fields cannot stay as class-body declarations: they are hoisted to
+//! `_classThis.<name> = <init>` statements emitted *after* the class. A bare
+//! `super` token is only legal inside a class/object method body, so an
+//! initializer such as `static a = super.x` becomes `_classThis.a = super.x`,
+//! which Node rejects with `'super' keyword unexpected here`.
+//!
+//! `tsc` rewrites the value to the scoped-static-super form
+//! (`Reflect.get(_classSuper, "x", _classThis)` for reads, an IIFE wrapping
+//! `Reflect.set(...)` for writes) before hoisting. The hoist assembly lives in
+//! the `TC39DecoratorEmitter` transform, which only has raw source text. This
+//! helper renders the rewritten *value* (no name, no modifiers, no trailing
+//! `;`) through the main emitter's scoped-static-super machinery and hands it
+//! to the transform via `set_hoisted_static_field_value_text`.
+
+use super::Printer;
+use tsz_parser::parser::NodeIndex;
+
+impl<'a> Printer<'a> {
+    /// Seed both the in-body static-member text and (for pre-ES2022 lowering)
+    /// the hoisted-assignment value text for a static field whose initializer
+    /// references `super` or `this`. Combining the two seedings keeps the
+    /// dispatch call site to a single statement.
+    pub(in crate::emitter) fn seed_tc39_decorator_static_member_and_hoisted(
+        &mut self,
+        emitter: &mut crate::transforms::es_decorators::TC39DecoratorEmitter<'a>,
+        member_idx: NodeIndex,
+        prop: &tsz_parser::parser::node::PropertyDeclData,
+        needs_super_alias: bool,
+        this_alias: Option<&str>,
+        super_alias: Option<&str>,
+    ) {
+        self.seed_tc39_decorator_static_member(emitter, member_idx, prop, this_alias, super_alias);
+        self.seed_tc39_decorator_hoisted_static_field_value(
+            emitter,
+            member_idx,
+            prop,
+            needs_super_alias,
+            this_alias,
+            super_alias,
+        );
+    }
+
+    /// Seed the value-only, scoped-static-super-rewritten initializer text used
+    /// by the hoisted `_classThis.<name> = <value>` assignment for a plain
+    /// static field whose initializer references `super`.
+    pub(in crate::emitter) fn seed_tc39_decorator_hoisted_static_field_value(
+        &mut self,
+        emitter: &mut crate::transforms::es_decorators::TC39DecoratorEmitter<'a>,
+        member_idx: NodeIndex,
+        prop: &tsz_parser::parser::node::PropertyDeclData,
+        needs_super_alias: bool,
+        this_alias: Option<&str>,
+        super_alias: Option<&str>,
+    ) {
+        // Only a `super`-referencing initializer needs the rewrite, and only the
+        // pre-ES2022 lowering hoists static fields out of the class body; the
+        // ES2022 in-body path keeps `super` legal and is rewritten elsewhere.
+        if !needs_super_alias
+            || !self.ctx.needs_es2022_lowering
+            || prop.initializer == NodeIndex::NONE
+        {
+            return;
+        }
+        let start = self.writer.len();
+        let prev_statement_expression = self.ctx.flags.in_statement_expression;
+        self.ctx.flags.in_statement_expression = false;
+        self.emit_expression_with_scoped_static_initializer_mode(
+            prop.initializer,
+            this_alias,
+            super_alias,
+            false,
+        );
+        self.ctx.flags.in_statement_expression = prev_statement_expression;
+        let value = self.writer.get_output()[start..].trim().to_string();
+        self.writer.truncate(start);
+        emitter.set_hoisted_static_field_value_text(member_idx, value);
+    }
+}

--- a/crates/tsz-emitter/src/emitter/mod.rs
+++ b/crates/tsz-emitter/src/emitter/mod.rs
@@ -35,6 +35,7 @@ mod comments;
 mod core;
 mod core_setup;
 pub(crate) mod declarations;
+mod decorator_static_super_hoist;
 mod es5;
 mod expressions;
 mod function_parameters;

--- a/crates/tsz-emitter/src/emitter/source_file/tc39_decorator_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/tc39_decorator_tests.rs
@@ -1614,3 +1614,201 @@ class Dog extends Animal {
         "Synthesized ctor (es2015) must not introduce an explicit rest parameter.\nOutput:\n{output}"
     );
 }
+
+/// Assert no hoisted `_classThis.<name> = super...` assignment leaked a bare
+/// `super` token outside the class body (a `'super' keyword unexpected here`
+/// `SyntaxError` at runtime). The hoist statements are the lines that begin
+/// with the class-this alias receiver.
+fn assert_no_hoisted_super_leak(output: &str) {
+    for line in output.lines() {
+        let trimmed = line.trim_start();
+        assert!(
+            !(trimmed.starts_with("_classThis.") && trimmed.contains("= super")),
+            "Hoisted static-field assignment must rewrite `super`, not emit a bare \
+             `super` outside the class body.\nOffending line: {trimmed}\nOutput:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn tc39_es2015_decorated_static_super_read_hoists_reflect_get() {
+    // Read of `super.<name>` in a hoisted static field initializer (pre-ES2022,
+    // decorated class) must lower to `Reflect.get(_classSuper, "<name>",
+    // _classThis)`, never a bare `super.<name>` in `_classThis.<name> = ...`.
+    let source = "\
+declare var dec: any;
+declare class Base { static p: number; }
+@dec
+class C extends Base {
+    static a = super.p;
+}
+";
+
+    let output = emit_with_options(
+        source,
+        PrinterOptions {
+            target: ScriptTarget::ES2015,
+            use_define_for_class_fields: false,
+            ..Default::default()
+        },
+    );
+
+    assert_no_hoisted_super_leak(&output);
+    assert!(
+        output.contains("_classThis.a = Reflect.get(_classSuper, \"p\", _classThis);"),
+        "Hoisted static-field read of `super.p` should be `Reflect.get(_classSuper, \"p\", _classThis)`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn tc39_es2015_decorated_static_super_write_hoists_reflect_set_iife() {
+    // Assignment to `super.<name>` in a hoisted static field initializer must
+    // lower to an IIFE wrapping `Reflect.set(...)`, preserving a valid LHS.
+    let source = "\
+declare var dec: any;
+declare class Base { static q: number; }
+@dec
+class D extends Base {
+    static b = super.q = 1;
+}
+";
+
+    let output = emit_with_options(
+        source,
+        PrinterOptions {
+            target: ScriptTarget::ES2015,
+            use_define_for_class_fields: false,
+            ..Default::default()
+        },
+    );
+
+    assert_no_hoisted_super_leak(&output);
+    assert!(
+        output.contains("Reflect.set(_classSuper, \"q\""),
+        "Hoisted static-field write to `super.q` should lower through `Reflect.set(_classSuper, \"q\", ...)`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("= super.q ="),
+        "Hoisted static-field write must not keep a bare `super.q =` LHS.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn tc39_es2015_decorated_static_super_prefix_update_hoists_reflect() {
+    // Prefix update `++super.<name>` in a hoisted static field initializer must
+    // route through `Reflect.get`/`Reflect.set`, not a bare `super`.
+    let source = "\
+declare var dec: any;
+declare class Base { static r: number; }
+@dec
+class E extends Base {
+    static c = ++super.r;
+}
+";
+
+    let output = emit_with_options(
+        source,
+        PrinterOptions {
+            target: ScriptTarget::ES2015,
+            use_define_for_class_fields: false,
+            ..Default::default()
+        },
+    );
+
+    assert_no_hoisted_super_leak(&output);
+    assert!(
+        output.contains("Reflect.set(_classSuper, \"r\"")
+            && output.contains("Reflect.get(_classSuper, \"r\""),
+        "Hoisted static-field prefix update of `super.r` should use `Reflect.get`/`Reflect.set`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn tc39_es2015_decorated_static_super_index_read_hoists_reflect_get() {
+    // The rule is keyed on the `super` element-access shape, not on the
+    // identifier spelling: `super["<name>"]` must lower the same way.
+    let source = "\
+declare var dec: any;
+declare class Base { static s: number; }
+@dec
+class F extends Base {
+    static d = super[\"s\"];
+}
+";
+
+    let output = emit_with_options(
+        source,
+        PrinterOptions {
+            target: ScriptTarget::ES2015,
+            use_define_for_class_fields: false,
+            ..Default::default()
+        },
+    );
+
+    assert_no_hoisted_super_leak(&output);
+    assert!(
+        output.contains("_classThis.d = Reflect.get(_classSuper, \"s\", _classThis);"),
+        "Hoisted static-field read of `super[\"s\"]` should be `Reflect.get(_classSuper, \"s\", _classThis)`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn tc39_es2020_decorated_static_super_read_hoists_reflect_get() {
+    // The rule holds for every pre-ES2022 target that hoists static fields,
+    // not only ES2015.
+    let source = "\
+declare var dec: any;
+declare class Base { static t: number; }
+@dec
+class G extends Base {
+    static e = super.t;
+}
+";
+
+    let output = emit_with_options(
+        source,
+        PrinterOptions {
+            target: ScriptTarget::ES2020,
+            use_define_for_class_fields: false,
+            ..Default::default()
+        },
+    );
+
+    assert_no_hoisted_super_leak(&output);
+    assert!(
+        output.contains("_classThis.e = Reflect.get(_classSuper, \"t\", _classThis);"),
+        "ES2020 hoisted static-field read of `super.t` should also rewrite to `Reflect.get`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn tc39_es2015_decorated_static_plain_initializer_unchanged() {
+    // Negative/fallback case: a static field initializer with no `super` must
+    // keep its plain hoisted assignment (no Reflect rewrite, no IIFE).
+    let source = "\
+declare var dec: any;
+@dec
+class H {
+    static f = 41 + 1;
+}
+";
+
+    let output = emit_with_options(
+        source,
+        PrinterOptions {
+            target: ScriptTarget::ES2015,
+            use_define_for_class_fields: false,
+            ..Default::default()
+        },
+    );
+
+    assert_no_hoisted_super_leak(&output);
+    assert!(
+        output.contains("_classThis.f = 41 + 1;"),
+        "A super-free static-field initializer must keep its plain hoisted value.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("Reflect.get(_classSuper") && !output.contains("Reflect.set(_classSuper"),
+        "A super-free static-field initializer must not introduce scoped-super Reflect calls.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/transform_dispatch.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch.rs
@@ -1543,10 +1543,11 @@ impl<'a> Printer<'a> {
                         && self.node_is_this_keyword(prop.initializer)
                         && !is_auto_accessor;
                     if needs_super_alias || needs_this_alias {
-                        self.seed_tc39_decorator_static_member(
+                        self.seed_tc39_decorator_static_member_and_hoisted(
                             emitter,
                             member_idx,
                             prop,
+                            needs_super_alias,
                             class_this_var.as_deref(),
                             class_super_var.as_deref(),
                         );
@@ -1719,7 +1720,7 @@ impl<'a> Printer<'a> {
         emitter.set_static_block_text(member_idx, output);
     }
 
-    fn seed_tc39_decorator_static_member(
+    pub(in crate::emitter) fn seed_tc39_decorator_static_member(
         &mut self,
         emitter: &mut crate::transforms::es_decorators::TC39DecoratorEmitter<'a>,
         member_idx: NodeIndex,

--- a/crates/tsz-emitter/src/transforms/es_decorators.rs
+++ b/crates/tsz-emitter/src/transforms/es_decorators.rs
@@ -193,6 +193,15 @@ pub struct TC39DecoratorEmitter<'a> {
     /// Static member text rendered by the main emitter when raw source text
     /// would miss scoped static `super` rewrites in field initializers.
     static_member_texts: FxHashMap<NodeIndex, String>,
+    /// Value-only initializer text for plain static fields whose initializer
+    /// references `super`. When a TC39-decorated class is lowered for a
+    /// pre-ES2022 target, plain static fields are hoisted to
+    /// `_classThis.<name> = <init>` statements *outside* the class body, where
+    /// `super` is no longer a valid token. The main emitter renders the
+    /// scoped-static-super rewrite (`Reflect.get`/`Reflect.set` against
+    /// `_classSuper`/`_classThis`) here so the hoisted assignment stays
+    /// runnable.
+    hoisted_static_field_value_texts: FxHashMap<NodeIndex, String>,
     /// Extends expression text rendered by the main emitter when raw source
     /// text would preserve type-only syntax or named-evaluation-sensitive forms.
     extends_text: Option<String>,
@@ -221,6 +230,7 @@ impl<'a> TC39DecoratorEmitter<'a> {
             decorator_expression_texts: FxHashMap::default(),
             static_block_texts: FxHashMap::default(),
             static_member_texts: FxHashMap::default(),
+            hoisted_static_field_value_texts: FxHashMap::default(),
             extends_text: None,
             outer_this_var: None,
             use_define_for_class_fields: false,
@@ -285,6 +295,14 @@ impl<'a> TC39DecoratorEmitter<'a> {
 
     pub fn set_static_member_text(&mut self, member_idx: NodeIndex, text: String) {
         self.static_member_texts.insert(member_idx, text);
+    }
+
+    /// Record the scoped-static-super-rewritten value text used by the hoisted
+    /// `_classThis.<name> = <value>` assignment for a plain static field whose
+    /// initializer references `super` (pre-ES2022 decorated-class lowering).
+    pub fn set_hoisted_static_field_value_text(&mut self, member_idx: NodeIndex, text: String) {
+        self.hoisted_static_field_value_texts
+            .insert(member_idx, text);
     }
 
     pub fn set_extends_text(&mut self, text: String) {

--- a/crates/tsz-emitter/src/transforms/es_decorators_class_body.rs
+++ b/crates/tsz-emitter/src/transforms/es_decorators_class_body.rs
@@ -232,9 +232,12 @@ impl<'a> TC39DecoratorEmitter<'a> {
                 if decorated_field_idx_set.contains(member_idx) {
                     continue;
                 }
-                let Some(assignment) =
-                    self.plain_static_field_assignment(member_node, _class_alias, indent)
-                else {
+                let Some(assignment) = self.plain_static_field_assignment(
+                    *member_idx,
+                    member_node,
+                    _class_alias,
+                    indent,
+                ) else {
                     continue;
                 };
                 plain_static_field_idx_set.insert(*member_idx);

--- a/crates/tsz-emitter/src/transforms/es_decorators_node_utils.rs
+++ b/crates/tsz-emitter/src/transforms/es_decorators_node_utils.rs
@@ -44,6 +44,7 @@ impl<'a> TC39DecoratorEmitter<'a> {
 
     pub(super) fn plain_static_field_assignment(
         &self,
+        member_idx: NodeIndex,
         member_node: &tsz_parser::parser::node::Node,
         class_ref: &str,
         indent: &str,
@@ -68,7 +69,12 @@ impl<'a> TC39DecoratorEmitter<'a> {
 
         let (property_access, property_key) = self.static_field_assignment_name(prop.name)?;
         let value = if prop.initializer.is_some() {
-            if class_ref == "_classThis" && self.node_is_this_keyword(prop.initializer) {
+            if let Some(text) = self.hoisted_static_field_value_texts.get(&member_idx) {
+                // The initializer references `super`; raw source text would
+                // hoist a bare `super.x` outside the class body. The main
+                // emitter already rendered the scoped-static-super rewrite.
+                text.clone()
+            } else if class_ref == "_classThis" && self.node_is_this_keyword(prop.initializer) {
                 class_ref.to_string()
             } else {
                 self.node_text(prop.initializer)


### PR DESCRIPTION
## Agent
AgentName: opus48-emit100

## Track
emit/js — correctness (non-runnable JS): decorated-class hoisted static-field super

## Invariant
When a TC39-decorated class is lowered for a pre-ES2022 target (static fields hoisted out of the class body to `_classThis.<name> = <init>`), and a static field initializer references the `super` keyword, the hoisted value MUST use the scoped-static-super rewrite (`Reflect.get(_classSuper, "x", _classThis)` for reads; an IIFE wrapping `Reflect.set(...)` for writes/updates) — the SAME rewrite already applied to the in-body ES2022 path — instead of raw source text. A raw `super` in `_classThis.<name> = super.x;` is a SyntaxError (`super` is illegal outside the class body). Keyed on AST node kind (super reference in a hoisted static-field initializer) — no identifier/file-name matching.

## Scope
- NEW `crates/tsz-emitter/src/emitter/decorator_static_super_hoist.rs` — seeds the rewritten value via the existing `emit_expression_with_scoped_static_initializer_mode` machinery (gated pre-ES2022); also hosts a combined `seed_tc39_decorator_static_member_and_hoisted` helper to keep transform_dispatch.rs a single call site.
- `crates/tsz-emitter/src/transforms/es_decorators_node_utils.rs` — `plain_static_field_assignment` (relocated here by #10778's sharding) now takes `member_idx` + consults the seeded value map.
- `crates/tsz-emitter/src/transforms/es_decorators.rs` — value map field + setter; `es_decorators_class_body.rs` passes member_idx.
- `crates/tsz-emitter/src/emitter/transform_dispatch.rs` — single combined seed call (2119 ≤ 2124 ratchet, below baseline).
- `emitter/mod.rs` (register) + `source_file/tc39_decorator_tests.rs` (+6 tests).

## Project Corpus Impact
- Row: n/a (emit CORRECTNESS fix — non-runnable JS → runnable)
- Bug family: decorated-class hoisted static-field initializer emits raw `super` (invalid outside class body) at pre-ES2022
- Evidence: `@dec class C extends Base { static a = super.x; }` — `node --check` before = SyntaxError at ES2015/2017/2020/2021, after = valid `_classThis.a = Reflect.get(_classSuper, "x", _classThis)`; matches tsc 6.0.3. Original witness: esDecorators-classDeclaration-classSuper.5.

## Verification
- node --check VALID at ES2015/2017/2020/2021/2022 (was invalid pre-ES2022); reads/writes/prefix-update + `super[...]` index all match tsc byte-for-byte. **Full --js-only fail-SET IDENTICAL (78/78, net-zero — the conformance witness runs only at ES2022 where output was already correct), ZERO regressions. --dts-only IDENTICAL (24/24).** 6 new structural tests (read/write/prefix-update, super[...] index, ES2020, super-free negative). Conformance smoke: classDeclaration/classSuper 7/7, classExpression/classSuper 6/6. Clippy clean; arch guard passes (all ratchets respected; transform_dispatch.rs reduced to 2119).
- §25/§26 compliant. Emitter-only (conformance-safe).

## Coordination Notes
Rebased onto current main AFTER sibling #10778 sharded es_decorators.rs into 8 submodules — re-applied the behavioral change onto the new shards (hooked into es_decorators_node_utils.rs), dropped the now-redundant relocation, consolidated seed calls to respect the transform_dispatch.rs ratchet. — opus48-emit100
