### PR TITLE
fix(checker): stop double-printing type arguments for new G<...>() of generic construct signatures

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -163,6 +163,10 @@ name = "new_expression_regression_tests"
 path = "tests/new_expression_regression_tests.rs"
 
 [[test]]
+name = "new_generic_construct_signature_type_arg_display_tests"
+path = "tests/new_generic_construct_signature_type_arg_display_tests.rs"
+
+[[test]]
 name = "noinfer_diagnostic_display_tests"
 path = "tests/noinfer_diagnostic_display_tests.rs"
 

--- a/crates/tsz-checker/src/query_boundaries/type_computation/complex.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_computation/complex.rs
@@ -49,6 +49,18 @@ pub(crate) fn application_infos_for_type(
     applications
 }
 
+/// Explicit `new D<T>()` display aliases are only needed when the return type is
+/// still a bare, alias-free reference. Generic construct signatures already
+/// return an applied type, and wrapping those again double-prints type args.
+pub(crate) fn should_synthesize_explicit_new_display_alias(
+    db: &dyn TypeDatabase,
+    return_type: TypeId,
+) -> bool {
+    lazy_def_id(db, return_type).is_none()
+        && db.get_display_alias(return_type).is_none()
+        && !tsz_solver::query::is_generic_application(db, return_type)
+}
+
 pub(crate) fn instantiate_type_params_to_constraints(
     db: &dyn QueryDatabase,
     type_id: TypeId,

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -1636,8 +1636,21 @@ impl<'a> CheckerState<'a> {
                     {
                         return app;
                     }
+                    // Only synthesize a `G<args>` display alias when `return_type`
+                    // is a bare reference whose printed form would otherwise omit
+                    // the type arguments (e.g. `new D<string>()` where the construct
+                    // signature was pre-instantiated to empty `type_params`). When
+                    // the constructor is a generic construct signature whose return
+                    // type is already an application — `new<K, V>(): G<K, V>` invoked
+                    // as `new G<string, number>()` — the args are already applied
+                    // (`return_type` is `G<string, number>`), so wrapping it again
+                    // would double-print them as `G<string, number><string, number>`.
                     if query::lazy_def_id(self.ctx.types, return_type).is_none()
                         && self.ctx.types.get_display_alias(return_type).is_none()
+                        && !crate::query_boundaries::common::is_generic_application(
+                            self.ctx.types,
+                            return_type,
+                        )
                     {
                         let factory = self.ctx.types.factory();
                         let app = factory.application(return_type, resolved_args);

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -1636,22 +1636,10 @@ impl<'a> CheckerState<'a> {
                     {
                         return app;
                     }
-                    // Only synthesize a `G<args>` display alias when `return_type`
-                    // is a bare reference whose printed form would otherwise omit
-                    // the type arguments (e.g. `new D<string>()` where the construct
-                    // signature was pre-instantiated to empty `type_params`). When
-                    // the constructor is a generic construct signature whose return
-                    // type is already an application — `new<K, V>(): G<K, V>` invoked
-                    // as `new G<string, number>()` — the args are already applied
-                    // (`return_type` is `G<string, number>`), so wrapping it again
-                    // would double-print them as `G<string, number><string, number>`.
-                    if query::lazy_def_id(self.ctx.types, return_type).is_none()
-                        && self.ctx.types.get_display_alias(return_type).is_none()
-                        && !crate::query_boundaries::common::is_generic_application(
-                            self.ctx.types,
-                            return_type,
-                        )
-                    {
+                    if query::should_synthesize_explicit_new_display_alias(
+                        self.ctx.types,
+                        return_type,
+                    ) {
                         let factory = self.ctx.types.factory();
                         let app = factory.application(return_type, resolved_args);
                         self.ctx.types.store_display_alias(return_type, app);

--- a/crates/tsz-checker/tests/new_generic_construct_signature_type_arg_display_tests.rs
+++ b/crates/tsz-checker/tests/new_generic_construct_signature_type_arg_display_tests.rs
@@ -1,0 +1,170 @@
+//! Regression tests for type-argument display of `new G<...>()` when the
+//! constructor is a generic construct signature whose return type is already a
+//! generic application (e.g. `interface C { new <K, V>(): G<K, V> }`).
+//!
+//! Structural rule: when a generic construct signature is invoked with explicit
+//! type arguments (`new G<string, number>()`), the result type is already the
+//! instantiated application `G<string, number>`. The checker must not wrap it in
+//! a second display alias `G<string, number><string, number>`. tsc prints the
+//! single application `G<string, number>`.
+//!
+//! The fix lives in `get_type_of_new_expression_with_request`: the synthesized
+//! `G<args>` display alias is only created for bare references that would
+//! otherwise omit their arguments (e.g. `new D<string>()` for a class whose
+//! pre-instantiated construct signature dropped the args), never for a type that
+//! is already a generic application.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+fn strict() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        strict_function_types: true,
+        ..CheckerOptions::default()
+    }
+}
+
+/// Reported shape: a two-parameter generic construct signature. The source type
+/// must render as `Foo<string, number>`, not `Foo<string, number><string,
+/// number>`.
+#[test]
+fn new_generic_construct_signature_does_not_double_print_type_args() {
+    let source = r#"
+interface Foo<K, V> { k: K; v: V }
+interface FooCtor { new <K, V>(): Foo<K, V> }
+declare const Foo: FooCtor;
+
+const f = new Foo<string, number>();
+const bad: Foo<string, string> = f;
+"#;
+    let diagnostics = check_source(source, "test.ts", strict());
+    let diag = diagnostics
+        .iter()
+        .find(|diag| diag.code == 2322)
+        .expect("expected TS2322 assigning Foo<string, number> to Foo<string, string>");
+    assert!(
+        diag.message_text.contains(
+            "Type 'Foo<string, number>' is not assignable to type 'Foo<string, string>'."
+        ),
+        "should print the single application form, got: {}",
+        diag.message_text
+    );
+    assert!(
+        !diag
+            .message_text
+            .contains("Foo<string, number><string, number>"),
+        "type arguments must not be printed twice, got: {}",
+        diag.message_text
+    );
+}
+
+/// The bug must not depend on the spelling of the construct signature's type
+/// parameters: a single parameter named `T` reproduces the same way.
+#[test]
+fn new_generic_construct_signature_renamed_single_param_no_double_print() {
+    let source = r#"
+interface Bar<T> { x: T }
+interface BarCtor { new <T>(): Bar<T> }
+declare const Bar: BarCtor;
+
+const b = new Bar<number>();
+const bad: Bar<string> = b;
+"#;
+    let diagnostics = check_source(source, "test.ts", strict());
+    let diag = diagnostics
+        .iter()
+        .find(|diag| diag.code == 2322)
+        .expect("expected TS2322 assigning Bar<number> to Bar<string>");
+    assert!(
+        diag.message_text
+            .contains("Type 'Bar<number>' is not assignable to type 'Bar<string>'."),
+        "should print the single application form, got: {}",
+        diag.message_text
+    );
+    assert!(
+        !diag.message_text.contains("Bar<number><number>"),
+        "type arguments must not be printed twice, got: {}",
+        diag.message_text
+    );
+}
+
+/// Three type parameters with different names (`P`, `Q`, `R`) — proves the fix
+/// is arity- and name-independent.
+#[test]
+fn new_generic_construct_signature_three_params_no_double_print() {
+    let source = r#"
+interface Triple<P, Q, R> { p: P; q: Q; r: R }
+interface TripleCtor { new <P, Q, R>(): Triple<P, Q, R> }
+declare const Triple: TripleCtor;
+
+const t = new Triple<number, string, boolean>();
+const bad: Triple<string, string, boolean> = t;
+"#;
+    let diagnostics = check_source(source, "test.ts", strict());
+    let diag = diagnostics
+        .iter()
+        .find(|diag| diag.code == 2322)
+        .expect("expected TS2322 for the Triple mismatch");
+    assert!(
+        diag.message_text
+            .contains("Type 'Triple<number, string, boolean>' is not assignable to type 'Triple<string, string, boolean>'."),
+        "should print the single application form, got: {}",
+        diag.message_text
+    );
+    assert!(
+        !diag.message_text.contains(">>") && !diag.message_text.contains("><"),
+        "type arguments must not be printed twice, got: {}",
+        diag.message_text
+    );
+}
+
+/// Preservation case: a generic *class* invoked with explicit type arguments
+/// (`new D<string>()`) must still display as `D<string>` — the display alias is
+/// still synthesized for the bare-reference path the fix deliberately preserves.
+#[test]
+fn new_generic_class_still_displays_explicit_type_args() {
+    let source = r#"
+class D<T> { x!: T }
+
+const d = new D<string>();
+const bad: D<number> = d;
+"#;
+    let diagnostics = check_source(source, "test.ts", strict());
+    let diag = diagnostics
+        .iter()
+        .find(|diag| diag.code == 2322)
+        .expect("expected TS2322 assigning D<string> to D<number>");
+    assert!(
+        diag.message_text
+            .contains("Type 'D<string>' is not assignable to type 'D<number>'."),
+        "generic class new-expression should still display its explicit type args, got: {}",
+        diag.message_text
+    );
+    assert!(
+        !diag.message_text.contains("D<string><string>"),
+        "type arguments must not be printed twice, got: {}",
+        diag.message_text
+    );
+}
+
+/// Negative case: an exactly-matching assignment must remain clean — the fix is
+/// display-only and must not change the underlying instantiated type, which is a
+/// structurally correct `Foo<string, number>`.
+#[test]
+fn new_generic_construct_signature_exact_match_has_no_diagnostic() {
+    let source = r#"
+interface Foo<K, V> { k: K; v: V }
+interface FooCtor { new <K, V>(): Foo<K, V> }
+declare const Foo: FooCtor;
+
+const f = new Foo<string, number>();
+const ok: Foo<string, number> = f;
+"#;
+    let diagnostics = check_source(source, "test.ts", strict());
+    assert!(
+        !diagnostics.iter().any(|diag| diag.code == 2322),
+        "matching instantiation must not produce a TS2322, got: {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
AgentName: cloud-opus48 (remote execution / pensive-wright-LHZqv)

## Track
Checker diagnostic rendering for the TS2322/TS2345 mismatch family (relates to #10879).

## Invariant
When a generic **construct signature** `new <K, V>(): G<K, V>` is invoked with
explicit type arguments (`new G<string, number>()`), the result type is already
the instantiated application `G<string, number>`. Its rendered form in
assignability diagnostics must be the single application `G<string, number>` —
never the double-printed `G<string, number><string, number>`. This is keyed on
the structural fact `is_generic_application(return_type)`, not on any lib name
(`Map`/`Set`/…), type-parameter spelling, or arity.

> When a `new`-expression's resolved result type is already a generic
> application, tsc prints it as a single `G<args>`; this change makes tsz stop
> wrapping it in a second display alias, so it prints `G<args>` too.

## Scope
- `crates/tsz-checker/src/types/computation/complex.rs` —
  `get_type_of_new_expression_with_request`: the synthesized `G<args>` display
  alias (intended for *bare* references like `new D<string>()` whose
  pre-instantiated construct signature dropped the args) is now guarded by
  `!is_generic_application(return_type)`, so it never re-wraps a type that
  already carries its arguments.
- `crates/tsz-checker/tests/new_generic_construct_signature_type_arg_display_tests.rs`
  (new) + `Cargo.toml` test registration.

The fix is **display-only**: the underlying instantiated type is unchanged
(structurally correct `G<string, number>`), proven by the exact-match negative
test producing no diagnostic.

## Root cause
For `new D<string>()` where `D` is a generic class, the construct signature is
pre-instantiated to empty `type_params`, so the result prints as the bare `D`;
the checker synthesizes `application(return_type, args)` as a display alias to
restore `D<string>`. For a generic construct signature `new <K, V>(): G<K, V>`,
the result `return_type` is *already* `G<string, number>`, so the same
synthesis produced `application(G<string, number>, [string, number])`, which
renders as `G<string, number><string, number>`. The guard distinguishes the two
because a bare lazy reference has `Some(def_id)`/`!is_generic_application`, while
an already-applied generic has `None`/`is_generic_application`.

## Project Corpus Impact
- Row: n/a (diagnostic-rendering correctness; no project-corpus pass/fail flip targeted)
- Bug family: TS2322/TS2345 type display — generic construct signatures with explicit type args
- Evidence: differential vs `tsc` 6.0.2 on `new Map<string, number>()`,
  `new Set<number>()`, `new Promise<number>()`, and standalone
  `interface C { new <K, V>(): G<K, V> }` construct signatures. Before:
  `Map<string, number><string, number>`; after: `Map<string, number>`, matching
  tsc's first-line type display exactly.

## Verification
- New suite `new_generic_construct_signature_type_arg_display_tests` (5 tests):
  two-param `K/V`, renamed single `T`, three-param `P/Q/R`, generic-class
  preservation (`new D<string>()` still prints `D<string>`), and an exact-match
  negative (no TS2322 — underlying type unchanged). All pass.
- Regression suites green: `new_expression_regression_tests`,
  `typeof_instantiation_expression_tests`,
  `cross_file_lib_generic_heritage_tests`, `bare_alias_display_tests`.
- `cargo clippy -p tsz-checker --tests` clean.
- Differential oracle: tsz first-line type display now matches `tsc` 6.0.2 across
  Map/Set/Promise/WeakMap/Array and user construct signatures.
- §25/§26: the fix is keyed on a structural query (`is_generic_application`), not
  on identifier names, file names, or printer-output string matching; the test
  matrix varies type-parameter names and arity.

## Coordination Notes
- Investigated #10879's literal "routes around assignability boundary" claim
  with the tsc oracle: tsz already matches tsc on the diagnostic **codes** and
  call-vs-assignment routing for the cases probed (object-literal args elaborate
  to TS2322 element-wise like tsc; non-literal args produce TS2345). The
  concrete remaining defect in that family was this type-argument double-print,
  which this PR fixes.
- Follow-up (filed separately): for *same-generic* mismatches (`C<A>` vs `C<B>`)
  tsc elaborates by comparing the differing type **arguments** directly
  (`Type 'A' is not assignable to type 'B'`), whereas tsz drills into
  `Types of property 'x' are incompatible`. That is a broader solver
  relation-reason change and is intentionally **not** bundled here.
- Auto-merge was disabled by `m5-pro-48g-gpt5` because exact-head ready CI was still pending. `merge-queue` remains unset until PR-head CI is green. — cloud-opus48

https://claude.ai/code/session_01FcnUYSNnSqygDNf5wZZYyq
