### PR TITLE
fix(emit): emit System.register exportStar helper after hoisted bindings (+3 systemModule*)

### DIFF
--- a/crates/tsz-emitter/src/emitter/module_wrapper/tests.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/tests.rs
@@ -2,6 +2,7 @@ mod amd_bundle;
 mod amd_import_equals;
 mod system_emit;
 mod system_emit_var_hoisting;
+mod system_export_star_order;
 mod system_import_export_order;
 mod system_live_exports;
 mod wrapped_helpers;

--- a/crates/tsz-emitter/src/emitter/module_wrapper/tests/system_emit_parts/part_01.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/tests/system_emit_parts/part_01.rs
@@ -512,12 +512,13 @@ fn system_module_nested_object_export_destructuring_reuses_identifier_source() {
 }
 
 /// Structural rule: when a System module has both `export * from "..."` and
-/// hoisted function declarations, tsc places `exportStar_1` helper immediately
-/// after `"use strict"` (with other helpers), BEFORE `var __moduleName` and
-/// BEFORE hoisted function bodies. Two name variants prove the rule is not
-/// bound to a specific identifier spelling.
+/// hoisted function declarations, tsc places the `exportStar_1` helper at the
+/// tail of the register-factory prologue — AFTER `var __moduleName` and AFTER
+/// the hoisted function bodies, immediately before `return {`. (Verified
+/// against tsc 6.0.3 baselines systemModule9/11/16.) Two name variants prove
+/// the rule is not bound to a specific identifier spelling.
 #[test]
-fn system_export_star_helper_appears_before_var_module_name() {
+fn system_export_star_helper_appears_after_var_module_name() {
     for func_name in &["foo", "bar"] {
         let src = format!("export * from \"a\";\nexport function {func_name}() {{}}\n");
         let output = emit_system_es2015(&src);
@@ -533,14 +534,21 @@ fn system_export_star_helper_appears_before_var_module_name() {
             .unwrap_or_else(|| {
                 panic!("hoisted function {func_name} missing in output:\n{output}")
             });
+        let return_pos = output
+            .find("return {")
+            .unwrap_or_else(|| panic!("`return {{` missing in output:\n{output}"));
 
         assert!(
-            helper_pos < module_name_pos,
-            "exportStar_1 must appear BEFORE var __moduleName (func={func_name}).\nOutput:\n{output}"
+            module_name_pos < helper_pos,
+            "var __moduleName must appear BEFORE the exportStar_1 helper (func={func_name}).\nOutput:\n{output}"
         );
         assert!(
-            module_name_pos < func_pos,
-            "var __moduleName must appear BEFORE hoisted function {func_name}.\nOutput:\n{output}"
+            func_pos < helper_pos,
+            "hoisted function {func_name} must appear BEFORE the exportStar_1 helper.\nOutput:\n{output}"
+        );
+        assert!(
+            helper_pos < return_pos,
+            "exportStar_1 helper must appear BEFORE `return {{` (func={func_name}).\nOutput:\n{output}"
         );
     }
 }

--- a/crates/tsz-emitter/src/emitter/module_wrapper/tests/system_export_star_order.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/tests/system_export_star_order.rs
@@ -1,0 +1,100 @@
+use crate::emitter::{ModuleKind, Printer, PrinterOptions};
+use tsz_common::ScriptTarget;
+
+fn emit_system(source: &str) -> String {
+    let mut parser = tsz_parser::ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut printer = Printer::with_options(
+        &parser.arena,
+        PrinterOptions {
+            module: ModuleKind::System,
+            target: ScriptTarget::ESNext,
+            ..Default::default()
+        },
+    );
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+/// Returns the byte offset of `needle` in `haystack`, asserting it is present.
+fn index_of(haystack: &str, needle: &str) -> usize {
+    haystack
+        .find(needle)
+        .unwrap_or_else(|| panic!("expected to find {needle:?} in:\n{haystack}"))
+}
+
+// Structural rule: in a `System.register` factory body, the `exportStar_1`
+// re-export helper (and its `exportedNames_1` exclusion map) must be emitted
+// AFTER the hoisted `var` declarations and the `__moduleName` binding, just
+// above `return { setters, execute }` — matching tsc. It must NOT precede the
+// hoisted bindings.
+#[test]
+fn export_star_helper_after_hoisted_vars() {
+    let output = emit_system(
+        r#"export * from "./other";
+export const x = 1;
+"#,
+    );
+
+    // The helper block exists.
+    let export_star_idx = index_of(&output, "function exportStar_1(m)");
+    let module_name_idx = index_of(&output, "var __moduleName = context_1 && context_1.id;");
+    let return_idx = index_of(&output, "return {");
+
+    assert!(
+        export_star_idx > module_name_idx,
+        "exportStar_1 helper must come after the __moduleName binding (hoisted vars).\nOutput:\n{output}"
+    );
+    assert!(
+        export_star_idx < return_idx,
+        "exportStar_1 helper must come before the `return {{` object.\nOutput:\n{output}"
+    );
+
+    // The exclusion map likewise follows the hoisted bindings.
+    let exported_names_idx = index_of(&output, "var exportedNames_1 = {");
+    assert!(
+        exported_names_idx > module_name_idx,
+        "exportedNames_1 map must come after the __moduleName binding.\nOutput:\n{output}"
+    );
+}
+
+// Same structural rule with a hoisted function declaration present. tsc emits
+// the hoisted `function ...` + its `exports_1(...)` call BEFORE the
+// `exportStar_1` helper. Varying the export/local names proves the ordering is
+// keyed on statement shape, not on a particular spelling.
+#[test]
+fn export_star_helper_after_hoisted_function() {
+    let output = emit_system(
+        r#"export * from "./dep";
+export function compute() {}
+"#,
+    );
+
+    let func_decl_idx = index_of(&output, "function compute() {");
+    let func_export_idx = index_of(&output, "exports_1(\"compute\", compute);");
+    let export_star_idx = index_of(&output, "function exportStar_1(m)");
+
+    assert!(
+        func_decl_idx < export_star_idx,
+        "Hoisted function declaration must precede the exportStar_1 helper.\nOutput:\n{output}"
+    );
+    assert!(
+        func_export_idx < export_star_idx,
+        "Hoisted function's exports_1 registration must precede the exportStar_1 helper.\nOutput:\n{output}"
+    );
+}
+
+// A module with NO export-star re-export must not emit the helper at all,
+// proving the placement change did not introduce the helper unconditionally.
+#[test]
+fn no_export_star_helper_without_reexport() {
+    let output = emit_system(
+        r#"export const value = 7;
+"#,
+    );
+    assert!(
+        !output.contains("function exportStar_1"),
+        "exportStar_1 helper must not appear when there is no `export *` re-export.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/module_wrapper/wrapper_entry.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/wrapper_entry.rs
@@ -479,7 +479,6 @@ impl<'a> Printer<'a> {
         self.write("\"use strict\";");
         self.write_line();
         self.emit_system_helpers_if_needed(source);
-        self.emit_system_export_star_helpers_if_needed(source, &system_plan);
         let mut dep_vars =
             self.collect_system_dependency_vars(&system_dependencies, source, &system_plan);
         for (dep, actions) in &system_plan.actions {
@@ -519,6 +518,14 @@ impl<'a> Printer<'a> {
         let hoisted_func_stmts = self.emit_system_hoisted_functions(source);
         self.ctx.options.module = prev_module;
         self.ctx.original_module_kind = prev_original;
+
+        // The `exportStar_1` re-export helper (and its `exportedNames_1`
+        // exclusion map) is emitted after the hoisted `var` declarations,
+        // the `__moduleName` binding, and the hoisted function declarations,
+        // immediately before the `return { setters, execute }` object. TSC
+        // emits these helpers at the tail of the register-factory prologue so
+        // they sit just above `return`, not before the hoisted bindings.
+        self.emit_system_export_star_helpers_if_needed(source, &system_plan);
 
         self.write("return {");
         self.write_line();


### PR DESCRIPTION
AgentName: m3-max-64g-opus48

## Track
Emit parity → 100% (JS emit). Module-format / System.register wrapper schedule.

## Invariant
When emitting a `System.register` factory body, the `exportStar_1` re-export
helper (and its `exportedNames_1` exclusion map) is emitted **after** the
hoisted `var` declarations, the `__moduleName` binding, and the hoisted
function declarations — immediately before the `return { setters, execute }`
object. Keyed on the System module format + statement-hoisting structure, not
on any identifier name or printer output.

## Scope
- `crates/tsz-emitter/src/emitter/module_wrapper/wrapper_entry.rs` — move the
  `emit_system_export_star_helpers_if_needed` call from before the hoisted-var
  block to after the hoisted-function block.
- `module_wrapper/tests/system_emit_parts/part_01.rs` — correct a
  **bug-encoding** ordering test that asserted the wrong (helper-before-var)
  order; renamed to `..._appears_after_var_module_name`.
- `module_wrapper/tests/system_export_star_order.rs` (new) — 3 structural tests.
- `module_wrapper/tests.rs` — register the new module.

This **recovers a #11772 regression**: that branch shipped a unit test whose
premise contradicts tsc 6.0.3 baselines, and the emitter matched the wrong test.
Both the emitter and the assertion are corrected to verified tsc order.

## Project Corpus Impact
- Row: emit (`--js-only`)
- Bug family: System.register export-star helper schedule (helper emitted before hoisted bindings)
- Evidence: `scripts/emit/run.sh --js-only -j4` before 13452 pass / 78 fail → after 13455 pass / 75 fail (**+3, zero regressions** across all 13,530 JS tests). Witnesses flipped: `systemModule9`, `systemModule11`, `systemModule16` (all 32 systemModule* now pass). DTS unaffected. CI: all conformance shards + emit + fourslash + snapshot-gate PASS.

## Verification
- emitter clippy clean; arch guard `Architecture guardrails passed`.
- `system_export_star*` (9 tests) + all 209 system/module_wrapper unit tests pass.
- Full `--js-only` net +3, zero regressions; CI heavy suites all green.

## Coordination Notes
Emit is OUTPUT — schedule-order fix (move one structured call), no output
surgery, no semantic validation added. The corrected sibling test from #11772
was a wrong assertion vs tsc 6.0.3. Out of scope / STOP-reported:
topLevelAwait/operationsAvailableOnPromisedType (for-await-of downlevel) and
importCallExpressionAsync*UMD (dynamic import precedence parens) are distinct
causes, separate PRs.
