### PR TITLE
fix(emit): single-line comma expression for simple ES5 computed-property lowering

### DIFF
--- a/crates/tsz-emitter/src/emitter/es5/helpers_object_literal.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_object_literal.rs
@@ -570,12 +570,22 @@ impl<'a> Printer<'a> {
         source_range: Option<(u32, u32)>,
         has_trailing_comma: bool,
     ) {
+        // Use multiline layout when any element is an accessor: tsc always emits
+        // Object.defineProperty for accessors, and that descriptor spans multiple
+        // lines, so the whole comma expression must be multiline. Simple
+        // methods/properties stay inline.
+        let has_accessor = elements.iter().any(|&idx| {
+            self.arena.get(idx).is_some_and(|node| {
+                node.kind == syntax_kind_ext::GET_ACCESSOR
+                    || node.kind == syntax_kind_ext::SET_ACCESSOR
+            })
+        });
         self.emit_object_literal_without_spread_es5_with_layout(
             elements,
             source_range,
             has_trailing_comma,
             true,
-            true,
+            has_accessor,
         );
     }
 

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
@@ -1262,7 +1262,18 @@ impl<'a> AstToIr<'a> {
         // Final reference to temp
         comma_parts.push(IRNode::id(temp));
 
-        IRNode::CommaExprMultiline(comma_parts)
+        // Accessors lower to Object.defineProperty call expressions whose descriptor
+        // arguments span multiple lines. Use CommaExprMultiline for those so each
+        // element gets its own indented line (matching tsc). Simple assignments
+        // (method shorthand, property) stay on one line with CommaExpr.
+        let has_call_expr = comma_parts
+            .iter()
+            .any(|part| matches!(part, IRNode::CallExpr { .. }));
+        if has_call_expr {
+            IRNode::CommaExprMultiline(comma_parts)
+        } else {
+            IRNode::CommaExpr(comma_parts)
+        }
     }
 
     /// Lower a single object property to an ES5 assignment or Object.defineProperty call

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
@@ -1262,18 +1262,7 @@ impl<'a> AstToIr<'a> {
         // Final reference to temp
         comma_parts.push(IRNode::id(temp));
 
-        // Accessors lower to Object.defineProperty call expressions whose descriptor
-        // arguments span multiple lines. Use CommaExprMultiline for those so each
-        // element gets its own indented line (matching tsc). Simple assignments
-        // (method shorthand, property) stay on one line with CommaExpr.
-        let has_call_expr = comma_parts
-            .iter()
-            .any(|part| matches!(part, IRNode::CallExpr { .. }));
-        if has_call_expr {
-            IRNode::CommaExprMultiline(comma_parts)
-        } else {
-            IRNode::CommaExpr(comma_parts)
-        }
+        IRNode::object_literal_comma_expr(comma_parts)
     }
 
     /// Lower a single object property to an ES5 assignment or Object.defineProperty call

--- a/crates/tsz-emitter/src/transforms/ir.rs
+++ b/crates/tsz-emitter/src/transforms/ir.rs
@@ -1417,6 +1417,18 @@ impl IRNode {
         }
     }
 
+    /// Create an object-literal comma expression with accessor-aware layout.
+    pub fn object_literal_comma_expr(parts: Vec<Self>) -> Self {
+        if parts
+            .iter()
+            .any(|part| matches!(part, Self::CallExpr { .. }))
+        {
+            Self::CommaExprMultiline(parts)
+        } else {
+            Self::CommaExpr(parts)
+        }
+    }
+
     /// Create the `_a.trys.push([...])` IR for a state-machine try region.
     /// Picks the variant that matches the sparse-slot shape expected by tsc:
     /// `[s, c, f, e]`, `[s, c, , e]`, or `[s, , f, e]`.

--- a/crates/tsz-emitter/src/transforms/ir_printer.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer.rs
@@ -815,7 +815,31 @@ impl<'a> IRPrinter<'a> {
             }
             IRNode::CommaExpr(exprs) => {
                 self.write("(");
-                self.emit_comma_separated(exprs);
+                for (i, expr) in exprs.iter().enumerate() {
+                    if i > 0 {
+                        if self.last_emit_ended_with_line_comment {
+                            // A trailing line comment makes inline ", " a syntax error.
+                            // Put the separator comma on its own line, one indent level
+                            // shallower than the surrounding context (matching tsc).
+                            self.write_line();
+                            self.write_indent_level(self.indent_level.saturating_sub(1));
+                            self.last_emit_ended_with_line_comment = false;
+                            self.write(",");
+                            self.write_line();
+                            self.write_indent();
+                        } else {
+                            self.last_emit_ended_with_line_comment = false;
+                            self.write(", ");
+                        }
+                    }
+                    self.last_emit_ended_with_line_comment = false;
+                    self.emit_node(expr);
+                }
+                if self.last_emit_ended_with_line_comment {
+                    self.write_line();
+                    self.write_indent();
+                    self.last_emit_ended_with_line_comment = false;
+                }
                 self.write(")");
             }
             IRNode::CommaExprMultiline(exprs) => {

--- a/crates/tsz-emitter/tests/computed_property_es5_tests.rs
+++ b/crates/tsz-emitter/tests/computed_property_es5_tests.rs
@@ -1,9 +1,7 @@
 //! Integration tests for ES5 computed property object literal formatting.
 //!
-//! tsc always formats the lowered comma expression as multi-line:
-//!   (_a = {},
-//!       _a[key] = value,
-//!       _a);
+//! tsc always formats the lowered comma expression as single-line:
+//!   (_a = {}, _a[key] = value, _a)
 
 use tsz_common::common::ScriptTarget;
 use tsz_emitter::output::printer::PrintOptions;
@@ -57,36 +55,27 @@ fn assert_comment_forced_comma_is_outdented(output: &str, assignment_fragment: &
     );
 }
 
-/// Multiple computed properties should be emitted multi-line, one per line.
+/// Multiple computed properties should be emitted on a single line.
 #[test]
-fn computed_property_multiline_multiple_keys() {
+fn computed_property_single_line_multiple_keys() {
     let source = r#"var v = { [p1]: 0, [p2]: 1, [p3]: 2 };"#;
     let output = emit_es5(source);
-    // Each assignment should be on its own line (multi-line format)
+    // All assignments should appear on one line (single-line format matching tsc)
     assert!(
-        output.contains("_a[p1] = 0,\n"),
-        "Each computed property assignment should be on its own line.\nOutput:\n{output}"
-    );
-    assert!(
-        output.contains("_a[p2] = 1,\n"),
-        "Each computed property assignment should be on its own line.\nOutput:\n{output}"
+        output.contains("_a[p1] = 0, _a[p2] = 1, _a[p3] = 2"),
+        "Each computed property assignment should be on the same line as the others.\nOutput:\n{output}"
     );
 }
 
-/// Single computed property should also be emitted multi-line.
+/// Single computed property should be emitted on a single line.
 #[test]
-fn computed_property_multiline_single_key() {
+fn computed_property_single_line_single_key() {
     let source = r#"var o = { [+"foo"]: "", [+"bar"]: 0 };"#;
     let output = emit_es5(source);
-    // Should have comma + newline between assignments
+    // Should be all on one line (single-line format matching tsc)
     assert!(
-        output.contains(",\n"),
-        "Computed property comma expression should use multi-line format.\nOutput:\n{output}"
-    );
-    // Should NOT be all on one line
-    assert!(
-        !output.contains("_a = {}, _a"),
-        "Computed property assignments should NOT be on a single line.\nOutput:\n{output}"
+        output.contains("_a = {}, _a"),
+        "Computed property comma expression should use single-line format.\nOutput:\n{output}"
     );
 }
 


### PR DESCRIPTION
AgentName: claude-sonnet-4-6

## AgentName
claude-sonnet-4-6 (remote execution, session claude/dazzling-johnson-EllR1)

## Track
emit — JS emit parity

## Invariant
When `tsc` lowers an object literal with computed properties to ES5, it uses a **single-line** comma expression `(_a = {}, _a[key] = value, _a)` for simple cases (methods, regular property assignments). It only uses multiline format when an accessor (`get`/`set`) is present, because `Object.defineProperty` descriptors span multiple lines.

## Scope
Fix three code paths that were incorrectly emitting `CommaExprMultiline` for all ES5 computed-property lowering:

1. **`helpers_object_literal.rs`** (non-class top-level path): Was hardcoded to `use_multiline=true`. Now detects whether any element is a `GET_ACCESSOR` or `SET_ACCESSOR` and only uses multiline in that case.

2. **`class_es5_ast_to_ir.rs`** (class body IR path): Was always creating `IRNode::CommaExprMultiline`. Now checks if any element produces a `CallExpr` (i.e., `Object.defineProperty` from accessor lowering) and uses `CommaExprMultiline` only then; otherwise uses `CommaExpr`.

3. **`ir_printer.rs`**: Updated `CommaExpr` printer to handle trailing line comments correctly — when an element ends with a `// comment`, puts the separator comma on its own line one indent level shallower, matching the `CommaExprMultiline` behavior for that edge case.

Also corrects two unit test assertions in `computed_property_es5_tests.rs` that were asserting the (wrong) multiline format.

## Structural Rule
"When an ES5 computed-property object literal contains only method/property assignments (no accessors), `tsc` emits the lowered comma expression inline as `(_a = {}, _a[key] = value, _a)`; when any accessor is present, multiline format is used because `Object.defineProperty` descriptor arguments span multiple lines."

## Adjacent Cases Covered
- Simple computed method: `{ [key]() {} }` → single-line
- Multiple computed properties: `{ [p1]: 0, [p2]: 1 }` → single-line
- `using` declaration with `[Symbol.dispose]()` → single-line
- Computed accessor: `{ get [key]() {} }` → multiline (Object.defineProperty)
- Mixed methods + accessor: `{ k() {}, get l() {} }` → multiline
- Trailing line comment on element: comma forced to own outdented line

## Project Corpus Impact
- Row: emit parity (`usingDeclarations.1(target=es5)` and related computed-property emit tests)
- Bug family: ES5 computed-property comma-expression multiline vs inline formatting
- **Row**: emit parity — `usingDeclarations.1(target=es5)` and other emit tests with computed properties
- **Bug family**: ES5 computed-property comma-expression multiline vs inline formatting
- **Evidence**: Verified with `tsc` directly: `(_a = {}, _a[Symbol.dispose] = function () { }, _a)` is single-line in tsc output; confirmed with `cargo nextest run -p tsz-emitter --test computed_property_es5_tests` (13/13 pass, 0 new regressions in full 3834-test suite)

## Verification
- All 13 `computed_property_es5_tests` pass
- Full `tsz-emitter` suite: 3819 pass, 15 fail (all 15 are pre-existing failures unrelated to this change — confirmed by running the same test set on main)
- `clippy --workspace --all-targets -- -D warnings`: exit code 0

## Coordination Notes
- No open PRs overlap with this change (checked before starting)
- The async/generator suspended-object-literal path (`lower_suspended_object_literal` in `async_es5_ir_objects.rs`) intentionally keeps `CommaExprMultiline` — those paths cross await/yield suspension points and must be multiline by construction


---
_Generated by [Claude Code](https://claude.ai/code/session_017gHzxeBjkfeCzrNTaQ9DZ3)_