### PR TITLE
fix(emit): drop spurious parens on UMD dynamic-import conditional under yield (+2)

### DIFF
--- a/crates/tsz-emitter/src/emitter/expressions/call.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/call.rs
@@ -854,18 +854,34 @@ impl<'a> Printer<'a> {
         }
     }
 
+    /// Whether the parent `await` keyword is lowered to a `yield` keyword in
+    /// the current emit context, mirroring `emit_await_expression`.
+    ///
+    /// A `yield` operand binds looser than `?:`, so `yield a ? b : c` already
+    /// parses as `yield (a ? b : c)`; a native `await` binds tighter than `?:`,
+    /// so `await a ? b : c` parses as `(await a) ? b : c` and needs parens.
+    /// This decides whether an `await`-parented UMD conditional needs wrapping.
+    const fn await_parent_emits_as_yield(&self) -> bool {
+        self.ctx.emit_await_as_yield
+            || self.ctx.emit_await_as_yield_await
+            || (self.ctx.needs_async_lowering && self.function_scope_depth > 0)
+    }
+
     /// Whether a UMD dynamic-`import()` substitution must be parenthesized for
     /// the parent expression it sits in, matching `tsc`'s parenthesizer.
     ///
     /// Statement-level parents (expression statement, `return`, `throw`, `for`
     /// headers) accept a full expression — including a comma sequence — so
     /// neither form needs parentheses. Parents that bind tighter than `?:`
-    /// (operand of `await`/`yield`/unary/binary, object of a member access,
+    /// (operand of native `await`/unary/binary, object of a member access,
     /// callee of a call/new, condition of another conditional) always need
-    /// parentheses. Remaining assignment-level parents (variable initializer,
-    /// call argument, array element, property value, arrow body, …) accept a
-    /// bare conditional but require parentheses around a comma sequence, so
-    /// `is_sequence` decides those.
+    /// parentheses. A `yield` operand — whether a source-level `yield` or an
+    /// `await` downleveled to `yield` for async-to-generator lowering — binds
+    /// looser than `?:`, so a bare conditional there needs no parentheses.
+    /// Remaining assignment-level parents (variable initializer, call argument,
+    /// array element, property value, arrow body, …) accept a bare conditional
+    /// but require parentheses around a comma sequence, so `is_sequence` decides
+    /// those.
     fn umd_dynamic_import_needs_parens(&self, call_idx: NodeIndex, is_sequence: bool) -> bool {
         let Some(parent_idx) = self.arena.parent_of(call_idx) else {
             return false;
@@ -885,9 +901,14 @@ impl<'a> Printer<'a> {
             return false;
         }
         let tighter_than_conditional = match k {
-            k if k == syntax_kind_ext::AWAIT_EXPRESSION
-                || k == syntax_kind_ext::YIELD_EXPRESSION
-                || k == syntax_kind_ext::PREFIX_UNARY_EXPRESSION
+            // A source-level `yield` operand binds looser than `?:`; a bare
+            // conditional needs no parens (only a comma sequence does).
+            k if k == syntax_kind_ext::YIELD_EXPRESSION => false,
+            // `await` binds tighter than `?:` and needs parens, but when async
+            // lowering rewrites it to `yield` the operand binds looser, so the
+            // bare conditional needs no parens.
+            k if k == syntax_kind_ext::AWAIT_EXPRESSION => !self.await_parent_emits_as_yield(),
+            k if k == syntax_kind_ext::PREFIX_UNARY_EXPRESSION
                 || k == syntax_kind_ext::POSTFIX_UNARY_EXPRESSION
                 || k == syntax_kind_ext::TYPE_OF_EXPRESSION
                 || k == syntax_kind_ext::VOID_EXPRESSION

--- a/crates/tsz-emitter/tests/dynamic_import_amd_umd_parity_tests.rs
+++ b/crates/tsz-emitter/tests/dynamic_import_amd_umd_parity_tests.rs
@@ -30,6 +30,17 @@ fn umd(source: &str) -> String {
     )
 }
 
+fn umd_target(source: &str, target: ScriptTarget) -> String {
+    emit(
+        source,
+        PrintOptions {
+            target,
+            module: ModuleKind::UMD,
+            ..Default::default()
+        },
+    )
+}
+
 fn amd(source: &str) -> String {
     emit(
         source,
@@ -64,6 +75,70 @@ fn umd_await_operand_parenthesizes_conditional() {
             "await (__syncRequire ? Promise.resolve().then(() => __importStar(require('./s'))) : "
         ),
         "await operand must parenthesize the UMD conditional.\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn umd_native_await_operand_parenthesizes_conditional_es2017() {
+    // At ES2017 the `await` is retained (no async-to-generator lowering), and a
+    // native `await` binds tighter than `?:`, so the conditional is wrapped.
+    let out = umd_target(
+        "export async function f() { const req = await import('./s'); }",
+        ScriptTarget::ES2017,
+    );
+    assert!(
+        out.contains("const req = await (__syncRequire ? "),
+        "native await operand must parenthesize the UMD conditional.\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn umd_downleveled_await_yield_operand_does_not_parenthesize_conditional_es2015() {
+    // At ES2015 the async body is downleveled to a generator, so `await`
+    // becomes `yield`. A `yield` operand binds looser than `?:`, so tsc emits a
+    // bare conditional with no parentheses (`yield a ? b : c` parses correctly).
+    let out = umd_target(
+        "export async function f() { const req = await import('./s'); }",
+        ScriptTarget::ES2015,
+    );
+    assert!(
+        out.contains("const req = yield __syncRequire ? "),
+        "a downleveled await→yield operand must not parenthesize the UMD conditional.\nOutput:\n{out}"
+    );
+    assert!(
+        !out.contains("yield (__syncRequire ?"),
+        "the bare conditional under yield must not be wrapped.\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn umd_downleveled_await_yield_does_not_parenthesize_at_es6() {
+    // Same rule at the `es6` alias target: await→yield, bare conditional.
+    let out = umd_target(
+        "export async function f() { const req = await import('./s'); }",
+        ScriptTarget::ES2016,
+    );
+    assert!(
+        out.contains("const req = yield __syncRequire ? ")
+            && !out.contains("yield (__syncRequire ?"),
+        "ES2016 await→yield must emit a bare conditional with no parens.\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn umd_downleveled_yield_rule_is_independent_of_binding_and_specifier_names() {
+    // Renaming the import binding and the module specifier must not change the
+    // paren decision: the rule keys on the await→yield lowering shape, not on
+    // any user-chosen identifier name.
+    let out = umd_target(
+        "export async function loader() { const modHandle = await import('./other-module'); }",
+        ScriptTarget::ES2015,
+    );
+    assert!(
+        out.contains("const modHandle = yield __syncRequire ? ")
+            && out.contains("require('./other-module')")
+            && !out.contains("yield (__syncRequire ?"),
+        "renamed binding/specifier must still emit a bare conditional under yield.\nOutput:\n{out}"
     );
 }
 


### PR DESCRIPTION
AgentName: m3-max-64g-opus48

## Track
Emit parity → 100% (JS emit). Dynamic `import()` lowering for AMD/UMD module format.

## Invariant
When lowering a dynamic `import()` for the AMD/UMD module format, the
`__syncRequire ? <cjs> : <amd>` conditional is parenthesized **only** when its
parent expression binds tighter than `?:`. A native (retained) `await` operand
binds tighter and keeps the parens; but when async-to-generator lowering
rewrites that `await` to `yield` (targets below ES2017), or for a source-level
`yield`, the operand binds looser than `?:`, so the bare conditional needs no
parens. Keyed on AST parent kind + the await→yield module/target lowering facts
(`emit_await_as_yield`, `emit_await_as_yield_await`, `needs_async_lowering` +
function-scope depth), not on identifier/file names or printer output.

## Scope
- `crates/tsz-emitter/src/emitter/expressions/call.rs` — `umd_dynamic_import_needs_parens`
  gains a `const fn await_parent_emits_as_yield` predicate (mirrors
  `emit_await_expression`); a captured comma `_a = spec, ...` sequence still
  parenthesizes via the existing `is_sequence` path. Structured paren-emit
  decision, no text surgery.
- `crates/tsz-emitter/tests/dynamic_import_amd_umd_parity_tests.rs` — 4 new tests.

## Inverted-report correction
The internal hand-off claimed tsc *adds* parens and tsz was missing them. The
opposite is true: tsc 6.0.3 emits the **bare** `yield __syncRequire ? ... : ...`
and tsz was *wrongly adding* a paren, which also displaced the trailing import
comment. Removing the spurious paren fixed both the spelling and the comment.

## Project Corpus Impact
- Row: emit (`--js-only`)
- Bug family: AMD/UMD dynamic `import()` lowering parenthesizes the `__syncRequire ? :` conditional even when the `yield` operand binds looser than `?:`
- Evidence: `scripts/emit/run.sh --js-only -j4` before 77 fail / 13453 pass → after 75 fail / 13455 pass (**+2, zero new failures**). Witnesses flipped: `importCallExpressionAsyncES6UMD`, `importCallExpressionAsyncES5UMD(target=es2015)`. `--dts-only` 24 fail unaffected. `node --check` on both witnesses OK. All 85 `importCallExpression*` JS tests pass.

## Verification
- arch guard `Architecture guardrails passed` (fit inside existing fn, no new file).
- 17/17 `dynamic_import_amd_umd_parity_tests` pass post-rebase, incl. a
  renamed-binding + renamed-specifier test proving no hardcoding, an ES2017
  native-await negative (parens preserved), and statement/return-position cases.
- clippy `-D warnings` clean; `node --check` valid on both witnesses.

## Coordination Notes
Emit is OUTPUT — structured precedence-paren decision in the printer, no
semantic validation, no output surgery. Stayed entirely within the
dynamic-import paren decision; the for-await-of `_d` var and System `execute:`
async-marking paths (distinct clusters) were not touched. Two pre-existing
unrelated crate test failures (createRequire emission + a declaration namespace
import-alias) were confirmed present on clean HEAD before this change.
