### PR TITLE
fix(emit): mark System.register execute async for all top-level await forms (non-runnable JS)

### DIFF
--- a/crates/tsz-emitter/src/emitter/module_wrapper/tests.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/tests.rs
@@ -5,4 +5,5 @@ mod system_emit_var_hoisting;
 mod system_export_star_order;
 mod system_import_export_order;
 mod system_live_exports;
+mod system_top_level_await;
 mod wrapped_helpers;

--- a/crates/tsz-emitter/src/emitter/module_wrapper/tests/system_top_level_await.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/tests/system_top_level_await.rs
@@ -1,0 +1,146 @@
+//! Regression tests for `System.register` `execute` async-ness.
+//!
+//! When a `module=system` source has top-level `await` — directly, via an
+//! `await using` declaration, or via a downleveled `for await...of` loop — the
+//! generated `execute` callback must be `async function`, otherwise the inlined
+//! `await` operators produce non-runnable JS (a `node --check` `SyntaxError`).
+//!
+//! Structural rule: an `execute` body that inlines top-level statements
+//! containing top-level await (not nested inside a function-like boundary)
+//! must be emitted as `execute: async function () { ... }`.
+
+use crate::context::emit::EmitContext;
+use crate::emitter::{ModuleKind, Printer, PrinterOptions};
+use crate::lowering::LoweringPass;
+use tsz_common::ScriptTarget;
+
+fn emit_system(source: &str, target: ScriptTarget) -> String {
+    let mut parser = tsz_parser::ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut printer = Printer::with_options(
+        &parser.arena,
+        PrinterOptions {
+            module: ModuleKind::System,
+            target,
+            ..Default::default()
+        },
+    );
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+/// Lowered emit path so downlevel transforms (e.g. `for await...of`) run.
+fn emit_system_lowered(source: &str, target: ScriptTarget) -> String {
+    let mut parser = tsz_parser::ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        module: ModuleKind::System,
+        target,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let emit_plan = LoweringPass::new(&parser.arena, &ctx).run_plan(root);
+    let mut printer = Printer::with_emit_plan_and_options(&parser.arena, emit_plan, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+#[test]
+fn system_top_level_await_expression_makes_execute_async() {
+    let output = emit_system("export const x = 1;\nawait x;\n", ScriptTarget::ES2017);
+    assert!(
+        output.contains("execute: async function () {"),
+        "top-level await must mark execute async.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("await x;"),
+        "await expression should survive in the async execute body.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn system_no_top_level_await_keeps_execute_sync() {
+    let output = emit_system("export const x = 1;\nx;\n", ScriptTarget::ES2017);
+    assert!(
+        output.contains("execute: function () {"),
+        "no top-level await must keep execute synchronous.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("execute: async function"),
+        "execute must not be async without top-level await.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn system_await_nested_in_function_keeps_execute_sync() {
+    // The `await` lives inside an async function body — a fresh async context —
+    // so it must NOT force the module wrapper's execute callback to be async.
+    let output = emit_system(
+        "export const x = 1;\nasync function run() { await x; }\nrun;\n",
+        ScriptTarget::ES2017,
+    );
+    assert!(
+        !output.contains("execute: async function"),
+        "await inside a nested function must not make execute async.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn system_top_level_await_inside_block_makes_execute_async() {
+    // Top-level await reachable through nested control flow (an `if` block) still
+    // forces the wrapper to be async.
+    let output = emit_system(
+        "export const x = 1;\nif (x) {\n    await x;\n}\n",
+        ScriptTarget::ES2017,
+    );
+    assert!(
+        output.contains("execute: async function () {"),
+        "top-level await inside a block must mark execute async.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn system_for_await_of_downlevel_makes_execute_async_es2015() {
+    // `for await...of` downleveled to ES2015 emits `await iterator.next()` /
+    // `await iterator.return()` inside execute, which requires async.
+    let output = emit_system_lowered(
+        "export {};\nconst arr = [Promise.resolve()];\nfor await (const item of arr) {\n    item;\n}\n",
+        ScriptTarget::ES2015,
+    );
+    assert!(
+        output.contains("execute: async function () {"),
+        "downleveled top-level for-await-of must mark execute async.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("await "),
+        "downleveled for-await-of should emit await operators.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn system_for_await_of_renamed_binder_makes_execute_async_es2015() {
+    // Renamed iteration variable (`element` instead of `item`) proves the rule
+    // is structural (await-modifier on the for-of), not keyed on any identifier.
+    let output = emit_system_lowered(
+        "export {};\nconst xs = [Promise.resolve()];\nfor await (const element of xs) {\n    element;\n}\n",
+        ScriptTarget::ES2015,
+    );
+    assert!(
+        output.contains("execute: async function () {"),
+        "renamed for-await-of binder must still mark execute async.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn system_await_using_makes_execute_async() {
+    let output = emit_system(
+        "export {};\ndeclare const d: AsyncDisposable;\nawait using r = d;\nr;\n",
+        ScriptTarget::ESNext,
+    );
+    assert!(
+        output.contains("execute: async function () {"),
+        "top-level await-using must mark execute async.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/module_wrapper/wrapper_entry.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/wrapper_entry.rs
@@ -3,6 +3,7 @@ use super::{SystemDependencyAction, SystemDependencyPlan};
 use crate::emitter::ModuleKind;
 use std::collections::{HashMap, HashSet};
 use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
@@ -532,22 +533,7 @@ impl<'a> Printer<'a> {
         self.increase_indent();
         self.emit_system_setters(&system_dependencies, &dep_vars, &system_plan);
         self.write_line();
-        let execute_is_async = source.statements.nodes.iter().any(|&stmt_idx| {
-            let Some(stmt_node) = self.arena.get(stmt_idx) else {
-                return false;
-            };
-            if stmt_node.kind != syntax_kind_ext::VARIABLE_STATEMENT {
-                return false;
-            }
-            let Some(var_stmt) = self.arena.get_variable(stmt_node) else {
-                return false;
-            };
-            var_stmt.declarations.nodes.iter().any(|&decl_list_idx| {
-                self.arena.get(decl_list_idx).is_some_and(|decl_list_node| {
-                    tsz_parser::parser::node_flags::is_await_using(decl_list_node.flags as u32)
-                })
-            })
-        });
+        let execute_is_async = self.system_execute_needs_async(&source.statements);
         if execute_is_async {
             self.write("execute: async function () {");
         } else {
@@ -571,6 +557,87 @@ impl<'a> Printer<'a> {
         self.decrease_indent();
         self.write("});");
         self.write_line();
+    }
+
+    /// Decide whether a `System.register` module's `execute` body must be an
+    /// `async function`.
+    ///
+    /// The wrapper's `execute` callback inlines the module's top-level
+    /// statements. If any of those statements use top-level `await` — directly
+    /// (`await x`), via an `await using` declaration, or via a `for await...of`
+    /// loop whose downleveled iteration emits `await iterator.next()` /
+    /// `await iterator.return()` — the inlined body contains `await` operators
+    /// and the callback must therefore be `async`. Emitting a plain
+    /// `function () {` around top-level `await` produces non-runnable JS.
+    ///
+    /// The walk descends through nested control flow (top-level `if`/`for`/
+    /// `while`/`try`/blocks) but stops at function-like boundaries: a nested
+    /// function/method/arrow/accessor/constructor opens its own async context,
+    /// so an `await` inside it does not require the module wrapper to be async.
+    fn system_execute_needs_async(&self, statements: &tsz_parser::parser::base::NodeList) -> bool {
+        let mut stack: Vec<NodeIndex> = statements.nodes.clone();
+        while let Some(idx) = stack.pop() {
+            if idx.is_none() {
+                continue;
+            }
+            let Some(node) = self.arena.get(idx) else {
+                continue;
+            };
+
+            // Top-level `await <expr>`.
+            if node.kind == syntax_kind_ext::AWAIT_EXPRESSION {
+                return true;
+            }
+
+            // `for await (... of ...)` — its downleveled form emits `await`.
+            if node.kind == syntax_kind_ext::FOR_OF_STATEMENT
+                && self
+                    .arena
+                    .get_for_in_of(node)
+                    .is_some_and(|for_in_of| for_in_of.await_modifier)
+            {
+                return true;
+            }
+
+            // `await using` declaration list.
+            if node.kind == syntax_kind_ext::VARIABLE_STATEMENT {
+                if let Some(var_stmt) = self.arena.get_variable(node) {
+                    let has_await_using =
+                        var_stmt.declarations.nodes.iter().any(|&decl_list_idx| {
+                            self.arena.get(decl_list_idx).is_some_and(|decl_list_node| {
+                                tsz_parser::parser::node_flags::is_await_using(
+                                    decl_list_node.flags as u32,
+                                )
+                            })
+                        });
+                    if has_await_using {
+                        return true;
+                    }
+                }
+            }
+
+            // A nested function-like declaration opens a fresh async context;
+            // do not descend into its body.
+            if self.is_system_async_context_boundary(node.kind) {
+                continue;
+            }
+
+            stack.extend(self.arena.get_children(idx));
+        }
+        false
+    }
+
+    /// Function-like node kinds that introduce a new async/await context. An
+    /// `await` (or `for await`) nested inside one of these does not force the
+    /// enclosing `System.register` `execute` callback to be async.
+    const fn is_system_async_context_boundary(&self, kind: u16) -> bool {
+        kind == syntax_kind_ext::FUNCTION_DECLARATION
+            || kind == syntax_kind_ext::FUNCTION_EXPRESSION
+            || kind == syntax_kind_ext::ARROW_FUNCTION
+            || kind == syntax_kind_ext::METHOD_DECLARATION
+            || kind == syntax_kind_ext::CONSTRUCTOR
+            || kind == syntax_kind_ext::GET_ACCESSOR
+            || kind == syntax_kind_ext::SET_ACCESSOR
     }
 
     fn collect_system_hoisted_function_names(


### PR DESCRIPTION
AgentName: m3-max-64g-opus48

## Track
Emit correctness (bugs-on-top) — non-runnable JS emit. System.register top-level await.

## Invariant
When a module is emitted under `module=system` and its top-level body contains
top-level `await` — a bare `await` expression, an `await using` declaration, or
a `for await...of` loop whose downleveled iteration emits
`await iterator.next()`/`await iterator.return()` — the generated
`System.register` `execute` callback MUST be `async function`. Keyed on AST node
kind (`AWAIT_EXPRESSION`, for-of `await_modifier`, `await using` decl-list flag)
walked over top-level statements, stopping at function-like boundaries — not on
identifier names.

## Scope
- `crates/tsz-emitter/src/emitter/module_wrapper/wrapper_entry.rs` — replace the
  narrow `await using`-only check with a `system_execute_needs_async` walker +
  `is_system_async_context_boundary` helper (1524 lines, under ratchet).
- `module_wrapper/tests/system_top_level_await.rs` (new) — 7 tests.
- `module_wrapper/tests.rs` — register the module.

## Bug
tsz only marked `execute` async for top-level `await using`; any other top-level
await form produced a non-async `execute: function () {` wrapping `await`
operators → `SyntaxError: await is only valid in async functions`.

## Project Corpus Impact
- Row: n/a (emit CORRECTNESS fix — non-runnable JS → runnable)
- Bug family: System.register `execute` callback not marked async when top-level body has top-level await (other than `await using`)
- Evidence: `node --check` before = SyntaxError, after = runnable for `topLevelAwait.1(module=system,target=es2015)` and `(target=es2017)`, incl. a renamed-binder variant. `--js-only -j4` 77→77 / `--dts-only` 24→24 (net-zero — witnesses still differ from tsc only in pre-existing `_d`/`_a` temp-var naming — but the JS is now runnable). Zero new failures.

## Verification
- arch guard `Architecture guardrails passed`; clippy `-D warnings` clean.
- `cargo nextest -p tsz-emitter` system/module_wrapper families: 125/125 pass (incl. 7 new: top-level await expr, no-await negative, await-nested-in-function boundary, await-in-block, for-await-of downlevel es2015, renamed-binder, await-using).

## Coordination Notes
Emit is OUTPUT — structured async-marking decision in the module wrapper, no
semantic validation, no output surgery. This resolves the "System execute body
isn't marked async" item that the systemModule wrapper-order PR (#11780)
STOP-reported. Remaining `_d`/`_a` temp-var naming divergence in these witnesses
is a separate global-temp-numbering cluster (static-members), not this fix.
