### PR TITLE
test(solver): cover relation policy config coherence

### DIFF
--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -6,3 +6,6 @@ mod cache_agreement;
 
 #[path = "relation_policy_cache_agreement_tests/kind_partitioning.rs"]
 mod kind_partitioning;
+
+#[path = "relation_policy_cache_agreement_tests/policy_config.rs"]
+mod policy_config;

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/policy_config.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/policy_config.rs
@@ -1,0 +1,143 @@
+//! Relation-policy construction coherence tests for relation cache configs.
+
+use crate::caches::db::QueryDatabase;
+use crate::caches::query_cache::QueryCache;
+use crate::intern::TypeInterner;
+use crate::relations::relation_queries::{
+    RelationContext, RelationKind, RelationPolicy, query_relation,
+};
+use crate::types::{
+    FunctionShape, ParamInfo, PropertyInfo, RelationCacheKey, RelationFlags, TypeId,
+};
+
+#[test]
+fn relation_policy_cache_config_unifies_equivalent_flag_and_builder_bits() {
+    let cases = [
+        (
+            "strict subtype checking",
+            RelationPolicy::from_relation_flags(RelationFlags::STRICT_SUBTYPE_CHECKING),
+            RelationPolicy::unflagged_compatibility().with_strict_subtype_checking(true),
+        ),
+        (
+            "strict any propagation",
+            RelationPolicy::from_relation_flags(RelationFlags::STRICT_ANY_PROPAGATION),
+            RelationPolicy::unflagged_compatibility().with_strict_any_propagation(true),
+        ),
+        (
+            "skip weak type checks",
+            RelationPolicy::from_relation_flags(RelationFlags::SKIP_WEAK_TYPE_CHECKS),
+            RelationPolicy::unflagged_compatibility().with_skip_weak_type_checks(true),
+        ),
+        (
+            "disable generic erasure",
+            RelationPolicy::from_relation_flags(RelationFlags::NO_ERASE_GENERICS),
+            RelationPolicy::unflagged_compatibility().with_erase_generics(false),
+        ),
+    ];
+
+    for (name, flagged, builder) in cases {
+        assert_eq!(
+            flagged.cache_config(),
+            builder.cache_config(),
+            "{name} must produce the same cache config through flags and builders",
+        );
+    }
+}
+
+#[test]
+fn assignability_cache_reuses_slot_for_flag_and_builder_strict_subtype_policy() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let run = interner.intern_string("run");
+    let name = interner.intern_string("name");
+    let breed = interner.intern_string("breed");
+
+    let animal = interner.object(vec![PropertyInfo::new(name, TypeId::STRING)]);
+    let dog = interner.object(vec![
+        PropertyInfo::new(name, TypeId::STRING),
+        PropertyInfo::new(breed, TypeId::STRING),
+    ]);
+    let dog_method = interner.function(FunctionShape::new(
+        vec![ParamInfo::unnamed(dog)],
+        TypeId::VOID,
+    ));
+    let animal_method = interner.function(FunctionShape::new(
+        vec![ParamInfo::unnamed(animal)],
+        TypeId::VOID,
+    ));
+    let source = interner.object(vec![PropertyInfo::method(run, dog_method)]);
+    let target = interner.object(vec![PropertyInfo::method(run, animal_method)]);
+
+    let base_flags = RelationFlags::STRICT_FUNCTION_TYPES;
+    let flagged =
+        RelationPolicy::from_relation_flags(base_flags | RelationFlags::STRICT_SUBTYPE_CHECKING);
+    let builder =
+        RelationPolicy::from_relation_flags(base_flags).with_strict_subtype_checking(true);
+    let key = RelationCacheKey::for_assignability(source, target, flagged.cache_config());
+
+    assert_eq!(
+        flagged.cache_config(),
+        builder.cache_config(),
+        "flagged and builder strict-subtype policies must share one cache config",
+    );
+    assert_eq!(
+        key,
+        RelationCacheKey::for_assignability(source, target, builder.cache_config()),
+        "equivalent policy construction must share the assignability cache slot",
+    );
+
+    let flagged_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        flagged,
+        RelationContext::default(),
+    )
+    .is_related();
+    let builder_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        builder,
+        RelationContext::default(),
+    )
+    .is_related();
+
+    assert_eq!(
+        flagged_uncached, builder_uncached,
+        "equivalent strict-subtype policies must agree before cache lookup",
+    );
+    assert!(
+        !flagged_uncached,
+        "strict subtype checking should disable method bivariance for assignability",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, flagged),
+        flagged_uncached,
+        "flagged strict-subtype policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(key),
+        Some(flagged_uncached),
+        "flagged strict-subtype result must populate the shared slot",
+    );
+
+    db.reset_relation_cache_stats();
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, builder),
+        builder_uncached,
+        "builder strict-subtype policy must reuse the equivalent cached answer",
+    );
+    let stats = db.relation_cache_stats();
+    assert!(
+        stats.assignability_hits >= 1,
+        "builder strict-subtype lookup should hit the flagged policy slot",
+    );
+    assert_eq!(
+        stats.assignability_misses, 0,
+        "equivalent builder policy lookup should not miss after flagged policy populated the slot",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 10 relation policy/cache-key tech debt (#8207), solver relation policy construction/cache-config coherence ratchet.

## Invariant
When the same behavior-affecting relation policy is constructed through typed `RelationFlags` or through fluent `RelationPolicy` builder fields, both forms must project to the same `RelationCacheConfig` and reuse the same relation cache slot.

## Scope
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs`
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests/policy_config.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: solver test-only ratchet for relation policy/cache-key contracts; no compiler behavior or project corpus behavior change targeted.

## Verification
- Current base `568f592ab8612c64ee58a9666119a790f5f35dac`, current head `d7c8408841675a1746e973b1f7b9938b3c97a7a8`.
- Before base refresh, `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'`: 24 passed, 6383 skipped on `5bc1061d05a5505c4f13d0a75e1b52443a240e5c`.
- Before base refresh, `cargo fmt --check`: passed on `5bc1061d05a5505c4f13d0a75e1b52443a240e5c`.
- `git diff --cached --check` before original commit: passed.
- Current stack diff check after base refresh: root module plus `policy_config.rs` shard, 146 insertions.
- File-size guard: root module 11 lines; `cache_agreement.rs` 1852 lines; `kind_partitioning.rs` 89 lines; `policy_config.rs` 143 lines, all below the 2000-line cap.
- Ready-review CI for `d7c8408841675a1746e973b1f7b9938b3c97a7a8` passed PR-head checks in https://github.com/mohsen1/tsz/actions/runs/26677267070; only queue-owned `Queue Tested` remains pending before merge-queue execution.

## Coordination Notes
- Fresh M4-B cycle intake was run on 2026-05-30: all previous M4-B stack PRs #11658, #11662, #11724, #11727, #11729, and #11730 are merged.
- This PR starts the next small M4-B cache-policy ratchet directly on `main`.
- Stacked child: #11786 targets this branch because both shards edit the relation-policy test module root; land #11785 first, then refresh/land #11786.
- Non-overlap: this slice covers solver relation policy construction/cache-config tests only; it does not touch checker relation routing owned by M1-B, nor M4-A/M4-C evaluation/inference lanes.
- Auto-merge remains unset. `merge-queue` was added after exact-head PR-head checks passed for `d7c8408841675a1746e973b1f7b9938b3c97a7a8`.
