### PR TITLE
test(solver): cover top-level-only any cache mode

### DIFF
--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -4,6 +4,9 @@
 #[path = "relation_policy_cache_agreement_tests/cache_agreement.rs"]
 mod cache_agreement;
 
+#[path = "relation_policy_cache_agreement_tests/any_mode_partitioning.rs"]
+mod any_mode_partitioning;
+
 #[path = "relation_policy_cache_agreement_tests/kind_partitioning.rs"]
 mod kind_partitioning;
 

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/any_mode_partitioning.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/any_mode_partitioning.rs
@@ -1,0 +1,74 @@
+//! Effective `any`-propagation cache partitioning tests.
+
+use crate::caches::db::QueryDatabase;
+use crate::caches::query_cache::QueryCache;
+use crate::intern::TypeInterner;
+use crate::relations::relation_queries::{
+    RelationContext, RelationKind, RelationPolicy, query_relation,
+};
+use crate::relations::subtype::{AnyPropagationMode, SubtypeChecker};
+use crate::types::{CachedAnyMode, PropertyInfo, RelationCacheKey, TypeId};
+
+#[test]
+fn subtype_cache_top_level_only_any_mode_partitions_nested_lookup() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let value = interner.intern_string("value");
+
+    let source = interner.object(vec![PropertyInfo::new(value, TypeId::ANY)]);
+    let target = interner.object(vec![PropertyInfo::new(value, TypeId::NUMBER)]);
+    let policy =
+        RelationPolicy::default().with_any_propagation_mode(AnyPropagationMode::TopLevelOnly);
+    let mut cached_checker = SubtypeChecker::new(&interner)
+        .with_query_db(&db)
+        .with_any_propagation_mode(AnyPropagationMode::TopLevelOnly);
+
+    let top_level_key = cached_checker.debug_cache_key_for(source, target);
+    let nested_config = top_level_key
+        .config
+        .with_any_mode(CachedAnyMode::TopLevelOnlyNested);
+    let nested_property_key =
+        RelationCacheKey::for_subtype(TypeId::STRICT_ANY, TypeId::NUMBER, nested_config);
+    let wrong_top_level_property_key =
+        RelationCacheKey::for_subtype(TypeId::STRICT_ANY, TypeId::NUMBER, top_level_key.config);
+
+    assert_ne!(
+        nested_property_key, wrong_top_level_property_key,
+        "nested top-level-only any checks must not alias the top-level any-mode slot",
+    );
+
+    let uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Subtype,
+        policy,
+        RelationContext::default(),
+    )
+    .is_related();
+    let cached = cached_checker.check_subtype(source, target).is_true();
+
+    assert!(
+        !uncached,
+        "top-level-only any propagation should reject a nested `any` property mismatch",
+    );
+    assert_eq!(
+        cached, uncached,
+        "cached top-level-only subtype must match the uncached relation facade",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(top_level_key),
+        Some(cached),
+        "outer object relation must use the top-level any-mode cache slot",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(nested_property_key),
+        Some(false),
+        "nested property relation must use the nested any-mode cache slot",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(wrong_top_level_property_key),
+        None,
+        "nested property relation must not populate the top-level any-mode slot",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 4: semantic campaign / relation policy cache-key ratchet

## Invariant
When subtype checking runs with top-level-only any propagation, the outer relation uses the top-level any-mode cache slot while nested property relations use the nested any-mode slot. This PR proves the solver cache path keeps those answers separate through `SubtypeChecker` query-db caching.

## Scope
- Add a new relation-policy cache agreement shard for effective any-mode partitioning.
- Wire the shard into the existing relation policy cache agreement test root.

## Project Corpus Impact
- Row: n/a
- Bug family: relation policy/cache correctness
- Evidence: solver-test-only cache-key invariant; no project fixture metadata or compiler behavior change.

## Verification
- Current base `main` at `f87d87d8acae714ae082e8daee7d50866d5efc7e` after parent #11785 merged.
- Current remote head `19442ce175aaf93d651cad071c060e1e877a59c1`; tree/diff matches the locally verified retargeted head.
- GREEN after retargeting to `main`: `cargo nextest run -p tsz-solver -E "test(relation_policy_cache_agreement_tests)"`: 25 passed, 6383 skipped.
- GREEN after retargeting to `main`: `cargo fmt --check`.
- GREEN after retargeting to `main`: `git diff --check origin/main...HEAD`.
- Diff after retargeting to `main`: `relation_policy_cache_agreement_tests.rs` plus `any_mode_partitioning.rs` only, 77 insertions.
- GREEN draft-light CI for `19442ce175aaf93d651cad071c060e1e877a59c1`: `CI Light Summary`, `lint`, `unit`, `dist-binaries`, GitGuardian, cargo-deny/shear, project-row-drift, unit-cloudbuild, gate, and queue-one-pr passed.

## Coordination Notes
Refs #8207. Parent #11785 has landed, so this PR was rebased onto `main` and retargeted from the old stack base to `main`. Draft-light CI is now green on `19442ce175aaf93d651cad071c060e1e877a59c1`; ready-review CI can run next. Auto-merge and `merge-queue` remain unset until exact-head full CI is green.