### PR TITLE
fix(ci): accept latest bench prep manifest artifacts

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -648,12 +648,16 @@ jobs:
             `bench-prep/${targetSha}/bench-prep.env`,
             "/bench-prep/${_BENCH_TARGET_SHA}/bench-prep.env",
             "bench-prep/${_BENCH_TARGET_SHA}/bench-prep.env",
+            "/bench-prep/latest/bench-prep.env",
+            "bench-prep/latest/bench-prep.env",
           ]);
           const tar = findLocation([
             `/bench-prep/${targetSha}/bench-prep.tar`,
             `bench-prep/${targetSha}/bench-prep.tar`,
             "/bench-prep/${_BENCH_TARGET_SHA}/bench-prep.tar",
             "bench-prep/${_BENCH_TARGET_SHA}/bench-prep.tar",
+            "/bench-prep/latest/bench-prep.tar",
+            "bench-prep/latest/bench-prep.tar",
           ]);
           if (!env || !tar) {
             console.error(`Cloud Build artifact manifest did not include bench prep env/tar for ${targetSha}.`);
@@ -820,12 +824,16 @@ jobs:
             `bench-prep/${targetSha}/bench-prep.env`,
             "/bench-prep/${_BENCH_TARGET_SHA}/bench-prep.env",
             "bench-prep/${_BENCH_TARGET_SHA}/bench-prep.env",
+            "/bench-prep/latest/bench-prep.env",
+            "bench-prep/latest/bench-prep.env",
           ]);
           const tar = findLocation([
             `/bench-prep/${targetSha}/bench-prep.tar`,
             `bench-prep/${targetSha}/bench-prep.tar`,
             "/bench-prep/${_BENCH_TARGET_SHA}/bench-prep.tar",
             "bench-prep/${_BENCH_TARGET_SHA}/bench-prep.tar",
+            "/bench-prep/latest/bench-prep.tar",
+            "bench-prep/latest/bench-prep.tar",
           ]);
           if (!env || !tar) {
             console.error(`Cloud Build artifact manifest did not include bench prep env/tar for ${targetSha}.`);

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -49,6 +49,12 @@ assert.match(
 
 assert.match(
   workflow,
+  /"\/bench-prep\/latest\/bench-prep\.env"[\s\S]+"bench-prep\/latest\/bench-prep\.tar"/,
+  "Cloud Build manifest parsing should accept latest prep entries and still validate their manifest target before use",
+);
+
+assert.match(
+  workflow,
   /expected \$\{target_sha\} \/ PGO=1\."\s*\n\s+exit 1/,
   "PGO prep path should report the expected target and exit immediately",
 );


### PR DESCRIPTION
AgentName: m5-pro-48g-gpt5

## Track
Benchmark/dashboard infrastructure freshness.

## Invariant
When Cloud Build benchmark prep publishes the validated `bench-prep/latest/{bench-prep.env,bench-prep.tar}` artifacts in its manifest, the Bench workflow should be allowed to download those manifest locations and then validate `BENCH_TARGET_SHA` and `BENCH_PGO_OPTIMIZED` before shard fanout. This keeps latest benchmark data fresh without trusting stale or root-level artifacts.

## Scope
- `.github/workflows/bench.yml` — accept `bench-prep/latest` env/tar entries from the exact Cloud Build artifact manifest in both prep-artifact download paths, while keeping the existing target/Pgo validation.
- `scripts/bench/test-bench-workflow-cloudbuild-prep.mjs` — assert the manifest parser accepts latest entries and still validates before use.

## Project Corpus Impact
- Row: benchmark dashboard / project corpus metadata freshness
- Bug family: Bench workflow Cloud Build prep artifact discovery misses latest manifest env/tar entries
- Evidence: recent Bench runs were leaving `https://tsz.dev/benchmark-data/latest.json` at the May 28 artifact because `bench-prep-artifact` failed after Cloud Build success with “neither SHA-scoped, latest, nor manifest artifacts exposed valid bench-prep env/tar”; this PR lets the manifest latest entries feed the existing validation path.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `git diff --check`

## Coordination Notes
- Infrastructure-only benchmark freshness fix; no compiler behavior changes.
- Opened after merging the stale PR runway so the website/README refresh can consume a fresh benchmark artifact.
