### PR TITLE
fix(checker): suppress default-recursive TS2589 wrapper cascades

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -115,6 +115,10 @@ name = "generic_default_branch_independence_tests"
 path = "tests/generic_default_branch_independence_tests.rs"
 
 [[test]]
+name = "generic_default_recursive_alias_diagnostics_tests"
+path = "tests/generic_default_recursive_alias_diagnostics_tests.rs"
+
+[[test]]
 name = "generic_return_fingerprint_tests"
 path = "tests/generic_return_fingerprint_tests.rs"
 

--- a/crates/tsz-checker/src/state/type_resolution/core.rs
+++ b/crates/tsz-checker/src/state/type_resolution/core.rs
@@ -75,6 +75,39 @@ impl<'a> CheckerState<'a> {
             })
     }
 
+    fn type_node_is_outside_symbol_declarations(
+        &self,
+        node_idx: NodeIndex,
+        sym_id: tsz_binder::SymbolId,
+    ) -> bool {
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return true;
+        };
+        let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
+            return true;
+        };
+
+        !symbol.declarations.iter().any(|&decl_idx| {
+            self.ctx
+                .arena
+                .get(decl_idx)
+                .is_some_and(|decl| node.pos >= decl.pos && node.end <= decl.end)
+        })
+    }
+
+    fn def_body_involves_depth_poisoned_def(&self, def_id: tsz_solver::DefId) -> bool {
+        if !self.ctx.definition_store.has_any_depth_poisoned() {
+            return false;
+        }
+
+        self.ctx
+            .type_env
+            .try_borrow()
+            .ok()
+            .and_then(|env| env.get_def(def_id))
+            .is_some_and(|body| self.ctx.type_involves_depth_poisoned_def(body))
+    }
+
     /// Get type from a type reference node (e.g., "number", "string", "`MyType`").
     pub(crate) fn get_type_from_type_reference(&mut self, idx: NodeIndex) -> TypeId {
         // Fuel check: prevent infinite loops in circular type references
@@ -366,6 +399,13 @@ impl<'a> CheckerState<'a> {
                         && self.type_alias_has_same_input_recursive_conditional_union_body(sym_id);
                     let default_reset_recursive_alias = is_type_alias
                         && self.type_alias_has_default_reset_recursive_conditional_body(sym_id);
+                    let default_reset_dependency_alias = is_type_alias
+                        && !default_reset_recursive_alias
+                        && self.type_alias_body_references_default_reset_recursive_alias(sym_id);
+                    let default_reset_conditional_check_alias = is_type_alias
+                        && !default_reset_recursive_alias
+                        && self
+                            .type_alias_conditional_check_references_defaulted_alias_with_omitted_args(sym_id);
                     let should_check_depth =
                         is_class || !args_have_type_params || default_reset_recursive_alias;
                     if should_check_depth {
@@ -429,7 +469,18 @@ impl<'a> CheckerState<'a> {
                                     })
                                 });
 
-                        if exceeded || circular_mapped || tuple_too_large {
+                        let suppress_depth_cascade = exceeded
+                            && (default_reset_dependency_alias
+                                || default_reset_conditional_check_alias
+                                || (!default_reset_recursive_alias
+                                    && base_def_id.is_some_and(|def_id| {
+                                        self.def_body_involves_depth_poisoned_def(def_id)
+                                    })));
+
+                        if (exceeded && !suppress_depth_cascade)
+                            || circular_mapped
+                            || tuple_too_large
+                        {
                             use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
                             let (message, code) = if tuple_too_large
                                 || (exceeded
@@ -454,8 +505,20 @@ impl<'a> CheckerState<'a> {
                                 self.emit_ts2615_for_circular_mapped_type(idx, type_id);
                             }
 
+                            if code
+                                == diagnostic_codes::TYPE_INSTANTIATION_IS_EXCESSIVELY_DEEP_AND_POSSIBLY_INFINITE
+                                && default_reset_recursive_alias
+                                && self.type_node_is_outside_symbol_declarations(idx, sym_id)
+                                && let Some(base_def_id) = base_def_id
+                            {
+                                self.ctx.definition_store.mark_depth_poisoned(base_def_id);
+                                self.ctx.clear_type_evaluation_caches_for_def(base_def_id);
+                            }
+
                             // tsc returns `any` for excessively deep types to
                             // suppress cascading errors (e.g., TS2322).
+                            return TypeId::ANY;
+                        } else if suppress_depth_cascade {
                             return TypeId::ANY;
                         }
                     }
@@ -1231,6 +1294,12 @@ impl<'a> CheckerState<'a> {
                             self.type_alias_has_same_input_recursive_conditional_union_body(sym_id);
                         let default_reset_recursive_alias =
                             self.type_alias_has_default_reset_recursive_conditional_body(sym_id);
+                        let default_reset_dependency_alias = !default_reset_recursive_alias
+                            && self
+                                .type_alias_body_references_default_reset_recursive_alias(sym_id);
+                        let default_reset_conditional_check_alias = !default_reset_recursive_alias
+                            && self
+                                .type_alias_conditional_check_references_defaulted_alias_with_omitted_args(sym_id);
                         if !args_have_type_params || default_reset_recursive_alias {
                             // Clear overflow flags before probing.
                             self.ctx.types.take_tuple_too_large();
@@ -1285,7 +1354,18 @@ impl<'a> CheckerState<'a> {
                                     self.type_alias_is_unconditional_tuple_spread(ref_sym)
                                 });
 
-                            if exceeded || circular_mapped || tuple_too_large {
+                            let suppress_depth_cascade = exceeded
+                                && (default_reset_dependency_alias
+                                    || default_reset_conditional_check_alias
+                                    || (!default_reset_recursive_alias
+                                        && app_def_id.is_some_and(|def_id| {
+                                            self.def_body_involves_depth_poisoned_def(def_id)
+                                        })));
+
+                            if (exceeded && !suppress_depth_cascade)
+                                || circular_mapped
+                                || tuple_too_large
+                            {
                                 use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
                                 let (message, code) = if tuple_too_large
                                     || (exceeded && tuple_spread_alias)
@@ -1308,8 +1388,20 @@ impl<'a> CheckerState<'a> {
                                     self.emit_ts2615_for_circular_mapped_type(idx, result);
                                 }
 
+                                if code
+                                    == diagnostic_codes::TYPE_INSTANTIATION_IS_EXCESSIVELY_DEEP_AND_POSSIBLY_INFINITE
+                                    && default_reset_recursive_alias
+                                    && self.type_node_is_outside_symbol_declarations(idx, sym_id)
+                                    && let Some(app_def_id) = app_def_id
+                                {
+                                    self.ctx.definition_store.mark_depth_poisoned(app_def_id);
+                                    self.ctx.clear_type_evaluation_caches_for_def(app_def_id);
+                                }
+
                                 // tsc returns `any` for excessively deep types to
                                 // suppress cascading errors (e.g., TS2322).
+                                result = TypeId::ANY;
+                            } else if suppress_depth_cascade {
                                 result = TypeId::ANY;
                             }
                         }

--- a/crates/tsz-checker/src/types/type_checking/type_alias_depth_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_depth_helpers.rs
@@ -265,6 +265,282 @@ impl<'a> CheckerState<'a> {
         })
     }
 
+    pub(crate) fn type_alias_body_references_default_reset_recursive_alias(
+        &mut self,
+        alias_sid: tsz_binder::SymbolId,
+    ) -> bool {
+        let Some(symbol) = self.ctx.binder.get_symbol(alias_sid) else {
+            return false;
+        };
+        let declarations = symbol.declarations.clone();
+        declarations.into_iter().any(|decl_idx| {
+            self.ctx.arena.get(decl_idx).is_some_and(|decl_node| {
+                decl_node.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION
+                    && self
+                        .ctx
+                        .arena
+                        .get_type_alias(decl_node)
+                        .is_some_and(|alias| {
+                            self.type_node_references_default_reset_recursive_alias(
+                                alias.type_node,
+                                alias_sid,
+                            )
+                        })
+            })
+        })
+    }
+
+    pub(crate) fn type_alias_conditional_check_references_defaulted_alias_with_omitted_args(
+        &mut self,
+        alias_sid: tsz_binder::SymbolId,
+    ) -> bool {
+        let Some(symbol) = self.ctx.binder.get_symbol(alias_sid) else {
+            return false;
+        };
+        let declarations = symbol.declarations.clone();
+        declarations.into_iter().any(|decl_idx| {
+            self.ctx.arena.get(decl_idx).is_some_and(|decl_node| {
+                decl_node.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION
+                    && self
+                        .ctx
+                        .arena
+                        .get_type_alias(decl_node)
+                        .and_then(|alias| {
+                            self.ctx
+                                .arena
+                                .get(alias.type_node)
+                                .and_then(|body| self.ctx.arena.get_conditional_type(body))
+                        })
+                        .is_some_and(|conditional| {
+                            self.type_node_references_defaulted_alias_with_omitted_args(
+                                conditional.check_type,
+                                alias_sid,
+                            )
+                        })
+            })
+        })
+    }
+
+    fn type_node_references_defaulted_alias_with_omitted_args(
+        &mut self,
+        node_idx: NodeIndex,
+        owner_alias_sid: tsz_binder::SymbolId,
+    ) -> bool {
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return false;
+        };
+
+        if node.kind == syntax_kind_ext::TYPE_REFERENCE
+            && let Some(type_ref) = self.ctx.arena.get_type_ref(node)
+            && let Some(ref_sid) = self
+                .resolve_type_symbol_for_lowering(type_ref.type_name)
+                .map(tsz_binder::SymbolId)
+            && ref_sid != owner_alias_sid
+            && self.type_reference_omits_defaulted_alias_arg(ref_sid, type_ref)
+            && self.type_alias_has_default_omitting_recursive_conditional_body(ref_sid)
+        {
+            return true;
+        }
+
+        self.ctx
+            .arena
+            .get_children(node_idx)
+            .into_iter()
+            .any(|child_idx| {
+                self.type_node_references_defaulted_alias_with_omitted_args(
+                    child_idx,
+                    owner_alias_sid,
+                )
+            })
+    }
+
+    fn type_reference_omits_defaulted_alias_arg(
+        &self,
+        alias_sid: tsz_binder::SymbolId,
+        type_ref: &tsz_parser::parser::node::TypeRefData,
+    ) -> bool {
+        let Some(symbol) = self.ctx.binder.get_symbol(alias_sid) else {
+            return false;
+        };
+        if !symbol.has_any_flags(symbol_flags::TYPE_ALIAS) {
+            return false;
+        }
+        let Some(decl_idx) = symbol.primary_declaration() else {
+            return false;
+        };
+        let Some(decl_node) = self.ctx.arena.get(decl_idx) else {
+            return false;
+        };
+        let Some(alias) = self.ctx.arena.get_type_alias(decl_node) else {
+            return false;
+        };
+        let Some(type_parameters) = alias.type_parameters.as_ref() else {
+            return false;
+        };
+
+        let supplied = type_ref
+            .type_arguments
+            .as_ref()
+            .map_or(0, |args| args.nodes.len());
+        type_parameters
+            .nodes
+            .iter()
+            .copied()
+            .skip(supplied)
+            .any(|param_idx| {
+                self.ctx
+                    .arena
+                    .get(param_idx)
+                    .and_then(|param_node| self.ctx.arena.get_type_parameter(param_node))
+                    .is_some_and(|param| param.default != NodeIndex::NONE)
+            })
+    }
+
+    fn type_node_references_default_reset_recursive_alias(
+        &mut self,
+        node_idx: NodeIndex,
+        owner_alias_sid: tsz_binder::SymbolId,
+    ) -> bool {
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return false;
+        };
+
+        if node.kind == syntax_kind_ext::TYPE_REFERENCE
+            && let Some(type_ref) = self.ctx.arena.get_type_ref(node)
+            && let Some(ref_sid) = self
+                .resolve_type_symbol_for_lowering(type_ref.type_name)
+                .map(tsz_binder::SymbolId)
+            && ref_sid != owner_alias_sid
+            && (self.type_alias_has_default_reset_recursive_conditional_body(ref_sid)
+                || self.type_alias_has_default_omitting_recursive_conditional_body(ref_sid))
+        {
+            return true;
+        }
+
+        self.ctx
+            .arena
+            .get_children(node_idx)
+            .into_iter()
+            .any(|child_idx| {
+                self.type_node_references_default_reset_recursive_alias(child_idx, owner_alias_sid)
+            })
+    }
+
+    fn type_alias_has_default_omitting_recursive_conditional_body(
+        &mut self,
+        alias_sid: tsz_binder::SymbolId,
+    ) -> bool {
+        let Some(symbol) = self.ctx.binder.get_symbol(alias_sid) else {
+            return false;
+        };
+        let declarations = symbol.declarations.clone();
+        declarations.into_iter().any(|decl_idx| {
+            self.ctx.arena.get(decl_idx).is_some_and(|decl_node| {
+                decl_node.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION
+                    && self
+                        .ctx
+                        .arena
+                        .get_type_alias(decl_node)
+                        .is_some_and(|alias| {
+                            self.ctx
+                                .arena
+                                .kind_at(alias.type_node)
+                                .is_some_and(|kind| kind == syntax_kind_ext::CONDITIONAL_TYPE)
+                                && self.type_node_has_default_omitting_recursive_alias_ref(
+                                    alias.type_node,
+                                    alias_sid,
+                                )
+                        })
+            })
+        })
+    }
+
+    fn type_node_has_default_omitting_recursive_alias_ref(
+        &mut self,
+        node_idx: NodeIndex,
+        alias_sid: tsz_binder::SymbolId,
+    ) -> bool {
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return false;
+        };
+
+        if node.kind == syntax_kind_ext::TYPE_REFERENCE
+            && let Some(type_ref) = self.ctx.arena.get_type_ref(node)
+        {
+            let resolved = self
+                .resolve_type_symbol_for_lowering(type_ref.type_name)
+                .map(tsz_binder::SymbolId);
+            if resolved == Some(alias_sid)
+                && let Some(type_args) = &type_ref.type_arguments
+                && self.type_args_omit_defaulted_alias_params_with_alias_transform(
+                    alias_sid, type_args,
+                )
+            {
+                return true;
+            }
+        }
+
+        self.ctx
+            .arena
+            .get_children(node_idx)
+            .into_iter()
+            .any(|child_idx| {
+                self.type_node_has_default_omitting_recursive_alias_ref(child_idx, alias_sid)
+            })
+    }
+
+    fn type_args_omit_defaulted_alias_params_with_alias_transform(
+        &self,
+        alias_sid: tsz_binder::SymbolId,
+        type_args: &NodeList,
+    ) -> bool {
+        let Some(type_param_nodes) = self.alias_type_parameter_nodes_for_depth_check(alias_sid)
+        else {
+            return false;
+        };
+        let supplied_count = type_args.nodes.len();
+        if supplied_count >= type_param_nodes.len() {
+            return false;
+        }
+        let alias_param_names = self.alias_type_parameter_names_for_depth_check(alias_sid);
+        let omitted = &type_param_nodes[supplied_count..];
+        if omitted.is_empty()
+            || !omitted.iter().copied().all(|param_idx| {
+                self.ctx
+                    .arena
+                    .get(param_idx)
+                    .and_then(|param_node| self.ctx.arena.get_type_parameter(param_node))
+                    .is_some_and(|param| {
+                        param.default != NodeIndex::NONE
+                            && !self.type_node_contains_alias_type_parameter_name_for_depth_check(
+                                param.default,
+                                &alias_param_names,
+                            )
+                    })
+            })
+        {
+            return false;
+        }
+
+        type_args
+            .nodes
+            .iter()
+            .copied()
+            .enumerate()
+            .any(|(arg_index, arg_idx)| {
+                self.type_node_contains_alias_type_parameter_name_for_depth_check(
+                    arg_idx,
+                    &alias_param_names,
+                ) && self
+                    .type_node_passthrough_reference_name_for_depth_check(arg_idx)
+                    .is_none_or(|name| {
+                        alias_param_names
+                            .get(arg_index)
+                            .is_none_or(|param_name| param_name != name)
+                    })
+            })
+    }
+
     fn type_node_has_default_reset_recursive_alias_ref(
         &mut self,
         node_idx: NodeIndex,

--- a/crates/tsz-checker/tests/generic_default_recursive_alias_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/generic_default_recursive_alias_diagnostics_tests.rs
@@ -1,0 +1,89 @@
+//! Regression coverage for defaulted recursive aliases whose recursive branch
+//! is detected as excessively deep.
+//!
+//! Tracks the solver-29-20 issue family. The structural rule is:
+//! when a defaulted generic alias has already emitted TS2589 at the recursive
+//! alias boundary, later aliases that merely reference the failed instantiation
+//! should recover through the error type instead of cascading another TS2589 at
+//! the reference site.
+
+use tsz_checker::test_utils::{check_source_strict, diagnostic_codes, diagnostics_without_codes};
+
+fn semantic_codes(source: &str) -> Vec<u32> {
+    diagnostic_codes(&diagnostics_without_codes(
+        &check_source_strict(source),
+        &[2318],
+    ))
+}
+
+#[test]
+fn defaulted_recursive_alias_does_not_cascade_ts2589_to_use_alias() {
+    let codes = semantic_codes(
+        r#"
+type Link29<T, D extends number = 4> = [D] extends [0] ? T : Link29<T[]>;
+type Solve29<T> = Link29<T> extends infer U ? U : never;
+type A = Solve29<string>;
+"#,
+    );
+
+    assert_eq!(
+        codes,
+        vec![2589, 2589],
+        "tsc reports the recursive alias boundary and wrapper alias only; got {codes:?}"
+    );
+}
+
+#[test]
+fn renamed_defaulted_recursive_alias_does_not_cascade_ts2589_to_use_alias() {
+    let codes = semantic_codes(
+        r#"
+type Route<X, N extends number = 4> = [N] extends [0] ? X : Route<X[]>;
+type Project<X> = Route<X> extends infer Y ? Y : never;
+type Q = Project<number>;
+"#,
+    );
+
+    assert_eq!(
+        codes,
+        vec![2589, 2589],
+        "renamed aliases and params should follow the same TS2589 recovery rule; got {codes:?}"
+    );
+}
+
+#[test]
+fn direct_recursive_alias_use_still_reports_ts2589() {
+    let codes = semantic_codes(
+        r#"
+type Foo<T extends "true", B> = { "true": Foo<T, Foo<T, B>> }[T];
+let f1: Foo<"true", {}>;
+"#,
+    );
+
+    assert_eq!(
+        codes,
+        vec![2589],
+        "direct recursive alias instantiation still owns its use-site TS2589; got {codes:?}"
+    );
+}
+
+#[test]
+fn ordinary_conditional_tuple_builder_still_reports_depth_at_deep_use() {
+    let codes = semantic_codes(
+        r#"
+type BuildTuple<T, N extends number> = N extends N
+  ? number extends N
+    ? T[]
+    : _BuildTuple<T, N, []>
+  : never;
+type _BuildTuple<T, N extends number, R extends unknown[]> =
+  R["length"] extends N ? R : _BuildTuple<T, N, [T, ...R]>;
+type Thousand = BuildTuple<number, 1000>;
+"#,
+    );
+
+    assert_eq!(
+        codes,
+        vec![2589],
+        "ordinary nonrecursive conditional wrappers should still report deep concrete instantiations; got {codes:?}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-C

## Track
Semantic campaign: M4-C inference/session and defaulted generic instantiation diagnostics.

## Invariant
When a defaulted generic alias recursively re-applies itself while omitting the defaulted parameter, `tsc` reports TS2589 at the recursive alias boundary and at the first dependent wrapper alias, then recovers later wrapper uses through the error/any path. This PR makes tsz suppress those later wrapper-use TS2589 cascades in checker type-reference depth probing.

## Scope
- `crates/tsz-checker/src/state/type_resolution/core.rs`
- `crates/tsz-checker/src/types/type_checking/type_alias_depth_helpers.rs`
- `crates/tsz-checker/src/types/type_checking/type_alias_checking.rs`
- `crates/tsz-checker/tests/generic_default_recursive_alias_diagnostics_tests.rs`
- `crates/tsz-checker/Cargo.toml`

## Project Corpus Impact
- Row: kysely-project / large-ts-repo issue family
- Bug family: solver-29-20 defaulted recursive generic alias TS2589 cascade
- Evidence: direct TS 6.0.3 CLI smoke on the `Link29`/`Solve29` repro now matches `tsc` with two TS2589 diagnostics instead of tsz's prior three.

## Verification
- RED: `cargo nextest run -p tsz-checker --test generic_default_recursive_alias_diagnostics_tests` failed with `[2589, 2589, 2589]` before the fix.
- `cargo nextest run -p tsz-checker --test generic_default_recursive_alias_diagnostics_tests`
- `cargo nextest run -p tsz-checker --test generic_default_branch_independence_tests`
- `cargo nextest run -p tsz-checker --lib -E 'test(recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589) + test(recursive_type_alias_ts2589_at_usage_not_definition) + test(infinite_tail_recursive_conditional_alias_with_concrete_args_emits_ts2589)'`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter "recursiveConditionalTypes" --verbose`
- `scripts/safe-run.sh scripts/ci/github-suite.sh lint`
- Direct smoke: `cargo run -p tsz-cli --bin tsz -- --noEmit --pretty false <Link29 repro>` and `node TypeScript/lib/tsc.js --noEmit --pretty false <Link29 repro>` both report two TS2589 diagnostics at lines 1:62 and 2:19.

## Coordination Notes
- AgentName: M4-C
- Issues: addresses the solver-29-20 defaulted generic alias cascade shape from #11214 and #11300; sibling project-row issues with the same family can use this PR as evidence after CI.
- Overlap: open PRs at creation time are emit/CI or M4-B relation-cache work; no open M4-C PRs were present.
- Status: ready head updated to `00bff30b6b` after fixing the ready-CI `recursiveConditionalTypes` fingerprint regression and local lint failure; waiting for exact-head CI.
