### PR TITLE
fix(emit): emit __setFunctionName for anonymous class with static fields in object property (ES5)

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
@@ -72,6 +72,13 @@ impl<'a> Printer<'a> {
                     }
                     return self.property_declaration_binding_name(property.name);
                 }
+                syntax_kind_ext::PROPERTY_ASSIGNMENT => {
+                    let prop = self.arena.get_property_assignment(parent_node)?;
+                    if prop.initializer != current {
+                        return None;
+                    }
+                    return self.property_declaration_binding_name(prop.name);
+                }
                 syntax_kind_ext::BINARY_EXPRESSION => {
                     let binary = self.arena.get_binary_expr(parent_node)?;
                     if binary.right != current

--- a/crates/tsz-emitter/src/emitter/source_file/class_expr_object_property_static_naming_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/class_expr_object_property_static_naming_tests.rs
@@ -1,0 +1,154 @@
+//! Structural emit tests for the named-evaluation rule on anonymous class
+//! expressions with static fields assigned as object property values.
+//!
+//! Structural rule: when an anonymous class expression with static members
+//! is the initializer of an object literal property (e.g.,
+//! `{ Foo: class { static x = 1; } }`), tsc must emit
+//! `__setFunctionName(_temp, "Foo")` inside the comma expression, using the
+//! property key as the binding name.
+//!
+//! Named class expressions do NOT get `__setFunctionName` because their own
+//! class name already provides the binding. Classes without static fields
+//! get the property key as the function name through JS named evaluation in
+//! the emitted IIFE (no helper needed).
+
+use crate::context::emit::EmitContext;
+use crate::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use crate::lowering::LoweringPass;
+use tsz_common::ScriptTarget;
+use tsz_parser::ParserState;
+
+fn emit(source: &str, target: ScriptTarget) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        target,
+        use_define_for_class_fields: false,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+// Anonymous class expression with a static field in an object property must
+// get `__setFunctionName` using the property key as the name.
+
+#[test]
+fn anonymous_class_with_static_field_in_object_property_emits_set_function_name_es5() {
+    let source = "var obj = { Foo: class { static x = 1; } };\n";
+    let output = emit(source, ScriptTarget::ES5);
+
+    assert!(
+        output.contains("__setFunctionName"),
+        "Anonymous class with static field in object property must emit __setFunctionName.\n\
+         Output:\n{output}"
+    );
+    assert!(
+        output.contains("\"Foo\""),
+        "The function name must be the property key 'Foo'.\nOutput:\n{output}"
+    );
+}
+
+// Renamed property key — proves the rule uses the actual key, not a fixed string.
+#[test]
+fn renamed_anonymous_class_with_static_field_in_object_property_emits_set_function_name_es5() {
+    let source = "var obj = { Widget: class { static count = 0; } };\n";
+    let output = emit(source, ScriptTarget::ES5);
+
+    assert!(
+        output.contains("__setFunctionName"),
+        "Renaming the property key must not suppress __setFunctionName.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("\"Widget\""),
+        "The function name must be the renamed property key 'Widget'.\nOutput:\n{output}"
+    );
+}
+
+// Multiple object properties with anonymous classes that have static fields:
+// each should get `__setFunctionName` with its own property key.
+#[test]
+fn multiple_anonymous_classes_with_static_fields_in_object_property_each_get_set_function_name() {
+    let source = "var obj = { Alpha: class { static a = 1; }, Beta: class { static b = 2; } };\n";
+    let output = emit(source, ScriptTarget::ES5);
+
+    assert!(
+        output.contains("\"Alpha\""),
+        "First property must get __setFunctionName with 'Alpha'.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("\"Beta\""),
+        "Second property must get __setFunctionName with 'Beta'.\nOutput:\n{output}"
+    );
+}
+
+// Named class expression in an object property must NOT get __setFunctionName
+// because the class already has its own name binding.
+#[test]
+fn named_class_in_object_property_does_not_emit_set_function_name_es5() {
+    let source = "var obj = { Foo: class Bar { static x = 1; } };\n";
+    let output = emit(source, ScriptTarget::ES5);
+
+    // The class name `Bar` is used; __setFunctionName is not needed.
+    assert!(
+        !output.contains("__setFunctionName"),
+        "Named class expression in object property must NOT emit __setFunctionName.\n\
+         Output:\n{output}"
+    );
+}
+
+// Anonymous class with NO static fields in an object property keeps named
+// evaluation through the property key (used as the IIFE function name).
+// No `__setFunctionName` helper is needed.
+#[test]
+fn anonymous_class_without_static_fields_in_object_property_no_set_function_name_es5() {
+    let source = "var obj = { Greet: class { hello() { return 1; } } };\n";
+    let output = emit(source, ScriptTarget::ES5);
+
+    assert!(
+        !output.contains("__setFunctionName"),
+        "Anonymous class without static members in object property must NOT emit \
+         __setFunctionName (named evaluation through IIFE name).\nOutput:\n{output}"
+    );
+    // The property key should be used as the IIFE function name.
+    assert!(
+        output.contains("function Greet"),
+        "Property key 'Greet' must become the IIFE function name.\nOutput:\n{output}"
+    );
+}
+
+// String literal property key: still uses the string as the name.
+#[test]
+fn anonymous_class_with_string_key_and_static_field_emits_set_function_name_es5() {
+    let source = "var obj = { \"myClass\": class { static v = 42; } };\n";
+    let output = emit(source, ScriptTarget::ES5);
+
+    assert!(
+        output.contains("__setFunctionName"),
+        "Anonymous class with static field under a string property key must emit \
+         __setFunctionName.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("\"myClass\""),
+        "The function name must be the string property key 'myClass'.\nOutput:\n{output}"
+    );
+}
+
+// The helper boilerplate must be emitted when only object-property classes
+// need __setFunctionName (i.e., no variable-declaration class triggers it).
+#[test]
+fn set_function_name_helper_boilerplate_emitted_for_object_property_class_es5() {
+    let source = "var obj = { Svc: class { static instances = 0; } };\n";
+    let output = emit(source, ScriptTarget::ES5);
+
+    assert!(
+        output.contains("__setFunctionName = "),
+        "The __setFunctionName helper boilerplate must be emitted when only \
+         object-property static classes trigger it.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/source_file/mod.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/mod.rs
@@ -18,6 +18,8 @@ mod class_expr_computed_static_method_naming_tests;
 #[cfg(test)]
 mod class_expr_es5_interior_comment_tests;
 #[cfg(test)]
+mod class_expr_object_property_static_naming_tests;
+#[cfg(test)]
 mod class_expression_decorator_tests;
 #[cfg(test)]
 mod class_static_alias_tests;

--- a/crates/tsz-emitter/src/lowering/helpers.rs
+++ b/crates/tsz-emitter/src/lowering/helpers.rs
@@ -973,6 +973,13 @@ impl<'a> LoweringPass<'a> {
                     }
                     return self.property_declaration_binding_name_ref(property.name);
                 }
+                syntax_kind_ext::PROPERTY_ASSIGNMENT => {
+                    let prop = self.arena.get_property_assignment(parent_node)?;
+                    if prop.initializer != current {
+                        return None;
+                    }
+                    return self.property_declaration_binding_name_ref(prop.name);
+                }
                 syntax_kind_ext::BINARY_EXPRESSION => {
                     let binary = self.arena.get_binary_expr(parent_node)?;
                     if binary.right != current


### PR DESCRIPTION
## Agent
AgentName: claude-sonnet-4-6 (dazzling-johnson)

## Track
Emit parity: ES5 class lowering — `__setFunctionName` for object property class expressions.

## Invariant
When an anonymous class expression with static members is the initializer of an object
literal property (e.g. `{ Foo: class { static x = 1; } }`), tsc emits
`__setFunctionName(_tmp, "Foo")` inside the static-comma expression, using the property
key as the binding name. tsz was silently skipping this call, diverging from tsc.

## Scope
- `crates/tsz-emitter/src/lowering/helpers.rs` — add `PROPERTY_ASSIGNMENT` arm to `resolve_class_expr_binding_name`
- `crates/tsz-emitter/src/emitter/declarations/class/helpers.rs` — same arm in the Printer version
- `crates/tsz-emitter/src/emitter/source_file/class_expr_object_property_static_naming_tests.rs` — new test file (7 tests)
- `crates/tsz-emitter/src/emitter/source_file/mod.rs` — register new test module

## Root Cause
`resolve_class_expr_binding_name` walks the parent chain of a class expression to find the
named-evaluation binding name. It handled `VARIABLE_DECLARATION`, `PARAMETER`,
`PROPERTY_DECLARATION`, and `BINARY_EXPRESSION` — but was missing `PROPERTY_ASSIGNMENT`
(object literal properties). For class expressions in `{ Foo: class { ... } }`, it fell
through to the `_ => return None` default arm.

This caused two downstream failures:
1. In the **lowering pass** (`helpers_class_expr_static_name.rs`): `class_expr_static_comma_needs_set_function_name` returned `false` (bailing at `resolve_class_expr_binding_name(class_idx).is_none()`), so `transforms.helpers_mut().set_function_name` was never set to `true`, suppressing the helper boilerplate.
2. In the **emitter** (`helpers_async.rs`): `class_expr_set_function_name` was `None`, so `emit_es5_static_class_expression_comma` skipped the `__setFunctionName(_tmp, "Foo")` comma item.

## Fix
Add a `PROPERTY_ASSIGNMENT` arm to both `resolve_class_expr_binding_name` functions (lowering
and Printer) that checks the class is the property's initializer, then delegates to the
existing `property_declaration_binding_name_ref` / `property_declaration_binding_name`
helper to extract the key text — exactly mirroring the existing `PROPERTY_DECLARATION` arm.

## Structural rule (per §26 / §25)
> When an anonymous class expression that requires a static-comma wrapper is the direct
> initializer of an object property, the property key provides the named-evaluation binding
> and must be used as the `__setFunctionName` argument.

The fix is keyed on structural position (`PROPERTY_ASSIGNMENT` parent, initializer matches),
not on any user-chosen identifier name.

## Test matrix
1. `anonymous_class_with_static_field_in_object_property_emits_set_function_name_es5` — reported repro shape (`{ Foo: class { static x = 1; } }`)
2. `renamed_anonymous_class_with_static_field_in_object_property_emits_set_function_name_es5` — renamed key (`Widget`) proves no hardcoding
3. `multiple_anonymous_classes_with_static_fields_in_object_property_each_get_set_function_name` — multiple properties (`Alpha`, `Beta`)
4. `named_class_in_object_property_does_not_emit_set_function_name_es5` — negative: named class must NOT get helper
5. `anonymous_class_without_static_fields_in_object_property_no_set_function_name_es5` — no static fields → named eval through IIFE function name
6. `anonymous_class_with_string_key_and_static_field_emits_set_function_name_es5` — string literal key (`"myClass"`)
7. `set_function_name_helper_boilerplate_emitted_for_object_property_class_es5` — boilerplate emitted when only object-property classes need the helper

## Project Corpus Impact
- Row: `convertClassExpressionToFunctionFromObjectProperty1(target=es5)` and `convertClassExpressionToFunctionFromObjectProperty2(target=es5)` (both currently `+624/-390 lines` in emit-detail.json)
- Bug family: ES5 class expression lowering — missing `__setFunctionName` for object property binding
- Evidence: local `cargo test -p tsz-emitter --lib -- class_expr_object_property_static` — 7/7 pass. Binary output verified with manual test: `{ c: class { static p = 1; } }` now correctly emits `__setFunctionName(_a, "c")` and the helper boilerplate.

## Verification
- `cargo test -p tsz-emitter --lib -- class_expr_object_property_static`: 7/7 pass
- `cargo clippy -p tsz-emitter --all-targets -- -D warnings`: no errors
- Pre-commit hook: formatting applied cleanly
- Manual binary test: `{ Foo: class { static x = 1; } }` → `__setFunctionName(_a, "Foo")` emitted correctly

## Coordination Notes
- No open PRs touch `resolve_class_expr_binding_name` or the lowering static-comma path.
- Sibling open PRs (#11785, #11786, #11788) are checker/solver work with no emitter overlap.
- Emit suite verification (conformance, emit baseline diff) deferred to ready-for-review CI.

https://claude.ai/code/session_01AAgWfNrdFSYvR88HQbA1c2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAgWfNrdFSYvR88HQbA1c2)_