### PR TITLE
fix(solver): infer suffix elements in variadic tuple constraint matching

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1898,5 +1898,9 @@ path = "tests/recursive_generic_property_order_tests.rs"
 name = "optional_property_required_elaboration_tests"
 path = "tests/optional_property_required_elaboration_tests.rs"
 
+[[test]]
+name = "variadic_tuple_arity_inference_tests"
+path = "tests/variadic_tuple_arity_inference_tests.rs"
+
 [lints]
 workspace = true

--- a/crates/tsz-checker/tests/variadic_tuple_arity_inference_tests.rs
+++ b/crates/tsz-checker/tests/variadic_tuple_arity_inference_tests.rs
@@ -167,3 +167,26 @@ const bad: { head: string; mid: [string]; last: boolean } = r;
         "sandwich: wrong mid-type should fail",
     );
 }
+
+#[test]
+fn method_this_inference_does_not_treat_second_rest_as_fixed_suffix() {
+    let diagnostics = tsz_checker::test_utils::check_source_code_messages(
+        r#"
+interface Desc<A extends unknown[], T> {
+    readonly f: (...args: A) => T;
+    bind<T extends unknown[], U extends unknown[], R>(
+        this: Desc<[...T, ...U], R>,
+        ...args: T
+    ): Desc<[...U], R>;
+}
+
+declare const a: Desc<[string, number, boolean], object>;
+const b = a.bind("", 1);
+const ok: Desc<[boolean], object> = b;
+"#,
+    );
+    assert!(
+        diagnostics.is_empty(),
+        "consecutive variadic rest segments should preserve the remaining suffix, got {diagnostics:#?}",
+    );
+}

--- a/crates/tsz-checker/tests/variadic_tuple_arity_inference_tests.rs
+++ b/crates/tsz-checker/tests/variadic_tuple_arity_inference_tests.rs
@@ -1,0 +1,169 @@
+//! Checker integration tests for variadic tuple arity inference.
+//!
+//! Structural rule: when a generic function parameter is a variadic tuple
+//! `[H, ...Tail]`, `[...Init, L]`, or `[H, ...Mid, L]`, tsc aligns fixed
+//! elements from the front (prefix) and back (suffix) of the concrete argument
+//! tuple, then infers the rest type parameter from the middle slice.
+//!
+//! These tests verify that tsz infers the correct types and therefore accepts
+//! valid assignments and rejects only the deliberately wrong ones.
+
+use tsz_checker::test_utils::check_source_codes;
+
+fn assert_no_errors(source: &str, label: &str) {
+    let codes = check_source_codes(source);
+    assert!(
+        codes.is_empty(),
+        "{label}: expected no diagnostics, got {codes:?}"
+    );
+}
+
+fn assert_only_one_2322(source: &str, label: &str) {
+    let codes = check_source_codes(source);
+    assert_eq!(
+        codes,
+        vec![2322],
+        "{label}: expected exactly one TS2322, got {codes:?}"
+    );
+}
+
+// =============================================================================
+// Trailing-rest: [H, ...Tail]
+// =============================================================================
+
+#[test]
+fn head_and_tail_function_infers_correctly() {
+    assert_no_errors(
+        r#"
+declare function head<H, Tail extends unknown[]>(args: [H, ...Tail]): H;
+const h: string = head(["hello", 1, true]);
+"#,
+        "head function: H inferred as string",
+    );
+}
+
+#[test]
+fn tail_function_infers_rest_as_tuple() {
+    assert_no_errors(
+        r#"
+declare function tail<H, Tail extends unknown[]>(args: [H, ...Tail]): Tail;
+const t: [number, boolean] = tail(["hello", 1, true]);
+"#,
+        "tail function: Tail inferred as [number, boolean]",
+    );
+}
+
+#[test]
+fn tail_function_renamed_type_params() {
+    // Proves fix is not keyed on param name "Tail"
+    assert_no_errors(
+        r#"
+declare function tail2<X, Y extends unknown[]>(args: [X, ...Y]): Y;
+const t: [number, boolean] = tail2(["hello", 1, true]);
+"#,
+        "tail function with renamed params: Y = [number, boolean]",
+    );
+}
+
+#[test]
+fn tail_wrong_assignment_fails() {
+    assert_only_one_2322(
+        r#"
+declare function tail<H, Tail extends unknown[]>(args: [H, ...Tail]): Tail;
+const t: [string, boolean] = tail(["hello", 1, true]);
+"#,
+        "tail function: bad assignment must produce TS2322",
+    );
+}
+
+#[test]
+fn empty_tail_inferred_as_empty_tuple() {
+    assert_no_errors(
+        r#"
+declare function tail<H, Tail extends unknown[]>(args: [H, ...Tail]): Tail;
+const t: [] = tail(["only"]);
+"#,
+        "tail of single-element source is []",
+    );
+}
+
+// =============================================================================
+// Leading-rest: [...Init, L]
+// =============================================================================
+
+#[test]
+fn last_function_infers_correctly() {
+    assert_no_errors(
+        r#"
+declare function last<Init extends unknown[], L>(args: [...Init, L]): L;
+const l: boolean = last(["hello", 1, true]);
+"#,
+        "last function: L inferred as boolean",
+    );
+}
+
+#[test]
+fn init_function_infers_rest_as_tuple() {
+    assert_no_errors(
+        r#"
+declare function init<Init extends unknown[], L>(args: [...Init, L]): Init;
+const i: [string, number] = init(["hello", 1, true]);
+"#,
+        "init function: Init = [string, number]",
+    );
+}
+
+#[test]
+fn init_function_renamed_type_params() {
+    // Proves fix is not keyed on param name "Init"
+    assert_no_errors(
+        r#"
+declare function init2<P extends unknown[], Q>(args: [...P, Q]): P;
+const i: [string, number] = init2(["hello", 1, true]);
+"#,
+        "init function renamed: P = [string, number]",
+    );
+}
+
+#[test]
+fn last_wrong_assignment_fails() {
+    assert_only_one_2322(
+        r#"
+declare function last<Init extends unknown[], L>(args: [...Init, L]): L;
+const l: string = last(["hello", 1, true]);
+"#,
+        "last function: bad assignment must produce TS2322",
+    );
+}
+
+// =============================================================================
+// Fixed-prefix + rest + fixed-suffix: [H, ...Mid, L]
+// =============================================================================
+
+#[test]
+fn sandwich_function_infers_prefix_rest_suffix() {
+    assert_no_errors(
+        r#"
+declare function sandwich<H, Mid extends unknown[], L>(
+    args: [H, ...Mid, L]
+): { head: H; mid: Mid; last: L };
+const r = sandwich(["a", 1, true]);
+const ok: { head: string; mid: [number]; last: boolean } = r;
+"#,
+        "sandwich: H=string, Mid=[number], L=boolean",
+    );
+}
+
+#[test]
+fn sandwich_wrong_mid_fails() {
+    assert_only_one_2322(
+        r#"
+declare function sandwich<H, Mid extends unknown[], L>(
+    args: [H, ...Mid, L]
+): { head: H; mid: Mid; last: L };
+const r = sandwich(["a", 1, true]);
+const bad: { head: string; mid: [string]; last: boolean } = r;
+"#,
+        "sandwich: wrong mid-type should fail",
+    );
+}

--- a/crates/tsz-solver/src/inference/infer.rs
+++ b/crates/tsz-solver/src/inference/infer.rs
@@ -445,6 +445,31 @@ impl<'a> InferenceContext<'a> {
             .map(|(_, v, _)| *v)
     }
 
+    pub(crate) fn fixed_tuple_candidate_len_for_type(&mut self, ty: TypeId) -> Option<usize> {
+        let name = match self.interner.lookup(ty) {
+            Some(TypeData::TypeParameter(info) | TypeData::Infer(info)) => info.name,
+            _ => return None,
+        };
+        let var = self.find_type_param(name)?;
+        let root = self.table.find(var);
+        let info = self.table.probe_value(root);
+        info.candidates
+            .iter()
+            .chain(info.contra_candidates.iter())
+            .filter_map(|candidate| {
+                let TypeData::Tuple(list_id) = self.interner.lookup(candidate.type_id)? else {
+                    return None;
+                };
+                let elements = self.interner.tuple_list(list_id);
+                if elements.iter().any(|element| element.rest) {
+                    return None;
+                }
+                Some((candidate.priority, elements.len()))
+            })
+            .min_by_key(|(priority, len)| (*priority, *len))
+            .map(|(_, len)| len)
+    }
+
     /// Record the declared `extends` constraint for an inference variable.
     pub fn set_declared_constraint(&mut self, var: InferenceVar, constraint: TypeId) {
         self.declared_constraints.insert(var, constraint);

--- a/crates/tsz-solver/src/inference/infer_matching.rs
+++ b/crates/tsz-solver/src/inference/infer_matching.rs
@@ -1161,23 +1161,6 @@ impl<'a> InferenceContext<'a> {
         Ok(())
     }
 
-    /// Infer from tuple types
-    fn infer_tuples(
-        &mut self,
-        source_elems: TupleListId,
-        target_elems: TupleListId,
-        priority: InferencePriority,
-    ) -> Result<(), InferenceError> {
-        let source_list = self.interner.tuple_list(source_elems);
-        let target_list = self.interner.tuple_list(target_elems);
-
-        for (source_elem, target_elem) in source_list.iter().zip(target_list.iter()) {
-            self.infer_from_types(source_elem.type_id, target_elem.type_id, priority)?;
-        }
-
-        Ok(())
-    }
-
     /// Infer from callable types, handling signatures and properties
     fn infer_callables(
         &mut self,

--- a/crates/tsz-solver/src/inference/infer_matching_tuples.rs
+++ b/crates/tsz-solver/src/inference/infer_matching_tuples.rs
@@ -1,0 +1,151 @@
+//! Variadic tuple inference for `InferenceContext`.
+//!
+//! tsc's `inferFromTupleTypes` aligns fixed elements from the front (prefix)
+//! and the back (suffix), then collects the remaining "middle" source elements
+//! into a tuple and infers it against the target rest parameter. This module
+//! implements that algorithm so `infer_tuples` handles all variadic cases:
+//!
+//! - `[H, ...Tail]` — fixed prefix, trailing rest
+//! - `[...Init, L]` — leading rest, fixed suffix
+//! - `[H, ...Mid, L]` — fixed prefix, rest, fixed suffix
+//! - Both source and target contain rest elements
+//! - Concrete source tuple against concrete array-typed rest element
+
+use crate::types::{InferencePriority, TupleListId, TypeData, TypeId};
+
+use super::infer::{InferenceContext, InferenceError};
+
+impl<'a> InferenceContext<'a> {
+    /// Infer from tuple types, handling variadic (rest) elements.
+    ///
+    /// Structural rule: given source `[s₀,…,sₙ]` and target `[t₀…tₖ, ...R, tₘ…tₙ]`,
+    /// `R` is inferred from the tuple `[sₖ₊₁,…,sₙ₋ₘ]` (the middle slice).
+    pub(super) fn infer_tuples(
+        &mut self,
+        source_elems: TupleListId,
+        target_elems: TupleListId,
+        priority: InferencePriority,
+    ) -> Result<(), InferenceError> {
+        let source_list = self.interner.tuple_list(source_elems);
+        let target_list = self.interner.tuple_list(target_elems);
+
+        // Find the first rest-element index in each side.
+        let source_rest_idx = source_list.iter().position(|e| e.rest);
+        let target_rest_idx = target_list.iter().position(|e| e.rest);
+
+        // Neither side has a rest element — simple pairwise zip.
+        if source_rest_idx.is_none() && target_rest_idx.is_none() {
+            for (s, t) in source_list.iter().zip(target_list.iter()) {
+                self.infer_from_types(s.type_id, t.type_id, priority)?;
+            }
+            return Ok(());
+        }
+
+        // Fixed-element counts before/after the rest position.
+        let source_prefix = source_rest_idx.unwrap_or(source_list.len());
+        let target_prefix = target_rest_idx.unwrap_or(target_list.len());
+
+        // How many fixed elements to align from the front.
+        let prefix_count = source_prefix.min(target_prefix);
+
+        // How many fixed elements to align from the back.
+        // When source has no rest, all elements not consumed by the prefix are
+        // available for target's suffix. When source has a rest, only the source
+        // elements after the rest position are available.
+        let available_for_suffix = if let Some(src_rest) = source_rest_idx {
+            source_list.len() - src_rest - 1
+        } else {
+            source_list.len().saturating_sub(prefix_count)
+        };
+        let suffix_count =
+            available_for_suffix.min(target_rest_idx.map_or(0, |i| target_list.len() - i - 1));
+
+        // Prefix inference.
+        for i in 0..prefix_count {
+            self.infer_from_types(source_list[i].type_id, target_list[i].type_id, priority)?;
+        }
+
+        // Suffix inference (working backwards from the end).
+        for (s, t) in source_list
+            .iter()
+            .rev()
+            .zip(target_list.iter().rev())
+            .take(suffix_count)
+        {
+            self.infer_from_types(s.type_id, t.type_id, priority)?;
+        }
+
+        // Handle the variadic middle portion.
+        if let Some(target_rest_pos) = target_rest_idx {
+            let target_rest_type = target_list[target_rest_pos].type_id;
+
+            let rest_start = prefix_count;
+            let rest_end = source_list.len().saturating_sub(suffix_count);
+            let middle = &source_list[rest_start..rest_end];
+
+            // Single source rest element maps directly to the target rest parameter.
+            if middle.len() == 1 && middle[0].rest {
+                self.infer_from_types(middle[0].type_id, target_rest_type, priority)?;
+                return Ok(());
+            }
+
+            let is_target_type_param = matches!(
+                self.interner.lookup(target_rest_type),
+                Some(TypeData::TypeParameter(_) | TypeData::Infer(_))
+            );
+
+            if is_target_type_param {
+                // Collect middle source elements into a tuple and infer it
+                // against the type parameter (empty tuple included — it proves
+                // zero-arity and prevents the parameter defaulting to its
+                // constraint, which would hide arity mismatches).
+                let middle_tuple = self.interner.tuple(middle.to_vec());
+                self.infer_from_types(middle_tuple, target_rest_type, priority)?;
+            } else {
+                // Target rest is a concrete array type (e.g. `Array<X>`).
+                // Extract the element type and infer each source middle element
+                // individually against it.
+                let inner = self.tuple_infer_rest_elem_inner(target_rest_type);
+                for elem in middle {
+                    self.infer_from_types(elem.type_id, inner, priority)?;
+                }
+            }
+        } else if source_rest_idx.is_some() {
+            // Source has a rest element but target does not.
+            // Infer the source rest's element type against each target fixed
+            // element position that was not covered by the prefix.
+            // source_prefix == source_rest_idx.unwrap() when source_rest_idx.is_some().
+            let source_rest_type = source_list[source_prefix].type_id;
+            let inner = self.tuple_infer_rest_elem_inner(source_rest_type);
+            for i in prefix_count..target_prefix {
+                self.infer_from_types(inner, target_list[i].type_id, priority)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Extract the array element type from an array-like rest element type.
+    ///
+    /// For `T[]` / `Array<T>` returns `T`; for `readonly T[]` returns `T`;
+    /// for a single-arg generic application returns its argument; for anything
+    /// else returns the type itself so the caller falls back gracefully.
+    fn tuple_infer_rest_elem_inner(&self, rest_type: TypeId) -> TypeId {
+        match self.interner.lookup(rest_type) {
+            Some(TypeData::Array(elem)) => elem,
+            Some(TypeData::ReadonlyType(inner)) => match self.interner.lookup(inner) {
+                Some(TypeData::Array(elem)) => elem,
+                _ => rest_type,
+            },
+            Some(TypeData::Application(app_id)) => {
+                let app = self.interner.type_application(app_id);
+                if app.args.len() == 1 {
+                    app.args[0]
+                } else {
+                    rest_type
+                }
+            }
+            _ => rest_type,
+        }
+    }
+}

--- a/crates/tsz-solver/src/inference/infer_matching_tuples.rs
+++ b/crates/tsz-solver/src/inference/infer_matching_tuples.rs
@@ -49,16 +49,77 @@ impl<'a> InferenceContext<'a> {
         let prefix_count = source_prefix.min(target_prefix);
 
         // How many fixed elements to align from the back.
+        // Variadic rest segments after the first rest are still variable-length
+        // tuple parts; they must not be treated as one fixed suffix element.
+        let source_trailing_fixed = source_list.iter().rev().take_while(|e| !e.rest).count();
+        let target_trailing_fixed = target_list.iter().rev().take_while(|e| !e.rest).count();
+
         // When source has no rest, all elements not consumed by the prefix are
         // available for target's suffix. When source has a rest, only the source
-        // elements after the rest position are available.
-        let available_for_suffix = if let Some(src_rest) = source_rest_idx {
-            source_list.len() - src_rest - 1
+        // fixed elements after the last rest position are available.
+        let available_for_suffix = if source_rest_idx.is_some() {
+            source_trailing_fixed
         } else {
             source_list.len().saturating_sub(prefix_count)
         };
-        let suffix_count =
-            available_for_suffix.min(target_rest_idx.map_or(0, |i| target_list.len() - i - 1));
+        let suffix_count = available_for_suffix.min(target_trailing_fixed);
+
+        if let Some(target_rest_pos) = target_rest_idx
+            && let Some(next_rest_offset) = target_list[target_rest_pos + 1..]
+                .iter()
+                .position(|elem| elem.rest)
+            && let Some(prefix_len) =
+                self.fixed_tuple_candidate_len_for_type(target_list[target_rest_pos].type_id)
+        {
+            let next_rest_pos = target_rest_pos + 1 + next_rest_offset;
+            let prefix_end = target_rest_pos.saturating_add(prefix_len);
+            if prefix_end <= source_list.len() {
+                for i in 0..target_rest_pos {
+                    self.infer_from_types(
+                        source_list[i].type_id,
+                        target_list[i].type_id,
+                        priority,
+                    )?;
+                }
+
+                let suffix_count = source_trailing_fixed.min(
+                    target_list[next_rest_pos + 1..]
+                        .iter()
+                        .rev()
+                        .take_while(|elem| !elem.rest)
+                        .count(),
+                );
+                let end_index = source_list.len().saturating_sub(suffix_count);
+                if prefix_end <= end_index {
+                    for (s, t) in source_list
+                        .iter()
+                        .rev()
+                        .zip(target_list.iter().rev())
+                        .take(suffix_count)
+                    {
+                        self.infer_from_types(s.type_id, t.type_id, priority)?;
+                    }
+
+                    let middle = &source_list[prefix_end..end_index];
+                    let next_rest_type = target_list[next_rest_pos].type_id;
+                    if middle.len() == 1 && middle[0].rest {
+                        self.infer_from_types(middle[0].type_id, next_rest_type, priority)?;
+                    } else {
+                        let middle_tuple = self.interner.tuple(middle.to_vec());
+                        self.infer_from_types(middle_tuple, next_rest_type, priority)?;
+                    }
+                    return Ok(());
+                }
+            }
+        }
+
+        if let Some(target_rest_pos) = target_rest_idx
+            && target_list[target_rest_pos + 1..]
+                .iter()
+                .any(|elem| elem.rest)
+        {
+            return Ok(());
+        }
 
         // Prefix inference.
         for i in 0..prefix_count {

--- a/crates/tsz-solver/src/inference/mod.rs
+++ b/crates/tsz-solver/src/inference/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod infer;
 pub(crate) mod infer_bct;
 pub(crate) mod infer_candidate_kinds;
 pub(crate) mod infer_matching;
+pub(crate) mod infer_matching_tuples;
 #[allow(dead_code)]
 pub(crate) mod infer_resolve;
 pub(crate) mod infer_variance;

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -432,6 +432,9 @@ mod mapped_empty_keyspace_subtype_tests;
 #[path = "../tests/matching_tests.rs"]
 mod matching_tests;
 #[cfg(test)]
+#[path = "../tests/matching_variadic_tuple_tests.rs"]
+mod matching_variadic_tuple_tests;
+#[cfg(test)]
 #[path = "../tests/narrowing_comprehensive_tests.rs"]
 mod narrowing_comprehensive_tests;
 #[cfg(test)]

--- a/crates/tsz-solver/src/operations/constraints/signatures.rs
+++ b/crates/tsz-solver/src/operations/constraints/signatures.rs
@@ -1006,10 +1006,84 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         for (i, t_elem) in target.iter().enumerate() {
             if t_elem.rest {
                 if var_map.contains_key(&t_elem.type_id) {
+                    if let Some(next_rest_offset) =
+                        target[i + 1..].iter().position(|tail_elem| tail_elem.rest)
+                        && let Some(prefix_len) =
+                            ctx.fixed_tuple_candidate_len_for_type(t_elem.type_id)
+                    {
+                        let next_rest_index = i + 1 + next_rest_offset;
+                        let prefix_end = i.saturating_add(prefix_len);
+                        if prefix_end <= source.len() {
+                            let trailing_count = source
+                                .iter()
+                                .rev()
+                                .take_while(|elem| !elem.rest)
+                                .count()
+                                .min(
+                                    target[next_rest_index + 1..]
+                                        .iter()
+                                        .rev()
+                                        .take_while(|elem| !elem.rest)
+                                        .count(),
+                                );
+                            let end_index = source.len().saturating_sub(trailing_count);
+                            if prefix_end <= end_index {
+                                let tail = source[prefix_end..end_index]
+                                    .iter()
+                                    .map(|s_elem| TupleElement {
+                                        type_id: s_elem.type_id,
+                                        name: s_elem.name,
+                                        optional: s_elem.optional,
+                                        rest: s_elem.rest,
+                                    })
+                                    .collect::<Vec<_>>();
+                                let next_rest = &target[next_rest_index];
+                                if tail.len() == 1 && tail[0].rest {
+                                    self.constrain_types(
+                                        ctx,
+                                        var_map,
+                                        tail[0].type_id,
+                                        next_rest.type_id,
+                                        priority,
+                                    );
+                                } else {
+                                    let tail_tuple = self.interner.tuple(tail);
+                                    self.constrain_types(
+                                        ctx,
+                                        var_map,
+                                        tail_tuple,
+                                        next_rest.type_id,
+                                        priority,
+                                    );
+                                }
+                                for (s_suf, t_suf) in source
+                                    .iter()
+                                    .rev()
+                                    .zip(target.iter().rev())
+                                    .take(trailing_count)
+                                {
+                                    self.constrain_types(
+                                        ctx,
+                                        var_map,
+                                        s_suf.type_id,
+                                        t_suf.type_id,
+                                        priority,
+                                    );
+                                }
+                                return;
+                            }
+                        }
+                    }
+                    if target[i + 1..].iter().any(|tail_elem| tail_elem.rest) {
+                        return;
+                    }
                     let tail = &target[i + 1..];
                     let mut trailing_count = 0usize;
                     let mut source_index = source.len();
                     for tail_elem in tail.iter().rev() {
+                        if tail_elem.rest {
+                            break;
+                        }
                         if source_index <= i {
                             break;
                         }

--- a/crates/tsz-solver/src/operations/constraints/signatures.rs
+++ b/crates/tsz-solver/src/operations/constraints/signatures.rs
@@ -1052,6 +1052,19 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                         let tail_tuple = self.interner.tuple(tail);
                         self.constrain_types(ctx, var_map, tail_tuple, t_elem.type_id, priority);
                     }
+                    // Constrain each fixed suffix target element against its matching source
+                    // element. The reversed loop above identified `trailing_count` pairs
+                    // (last-of-target with last-of-source, working backwards), but only used
+                    // them to compute where the middle slice ends. We must still propagate
+                    // the actual type candidates for those positions (e.g. `L` in `[H, ...Mid, L]`).
+                    for (s_suf, t_suf) in source
+                        .iter()
+                        .rev()
+                        .zip(target.iter().rev())
+                        .take(trailing_count)
+                    {
+                        self.constrain_types(ctx, var_map, s_suf.type_id, t_suf.type_id, priority);
+                    }
                     return;
                 }
                 let rest_elem_type = self.rest_element_type(t_elem.type_id);

--- a/crates/tsz-solver/tests/matching_variadic_tuple_tests.rs
+++ b/crates/tsz-solver/tests/matching_variadic_tuple_tests.rs
@@ -1,0 +1,315 @@
+//! Tests for variadic tuple inference via `infer_from_types`.
+//!
+//! Structural rule: when inferring from a concrete source tuple against a
+//! variadic target tuple, tsc aligns fixed elements from the front (prefix)
+//! and from the back (suffix), then collects the middle source elements into a
+//! tuple type that is inferred against the rest type parameter.
+
+use super::*;
+use crate::inference::infer::InferenceContext;
+use crate::intern::TypeInterner;
+use crate::types::{InferencePriority, TupleElement, TypeData, TypeParamInfo};
+
+fn make_type_param(interner: &TypeInterner, name: &str) -> (tsz_common::interner::Atom, TypeId) {
+    let atom = interner.intern_string(name);
+    let ty = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: atom,
+        constraint: None,
+        default: None,
+        is_const: false,
+    }));
+    (atom, ty)
+}
+
+fn fixed(type_id: TypeId) -> TupleElement {
+    TupleElement {
+        type_id,
+        name: None,
+        optional: false,
+        rest: false,
+    }
+}
+
+fn rest(type_id: TypeId) -> TupleElement {
+    TupleElement {
+        type_id,
+        name: None,
+        optional: false,
+        rest: true,
+    }
+}
+
+// =============================================================================
+// Trailing-rest patterns: [H, ...Tail]
+// =============================================================================
+
+#[test]
+fn infer_trailing_rest_one_prefix_element() {
+    // Source: [string, number, boolean]   Target: [H, ...Tail]
+    // → H = string, Tail = [number, boolean]
+    let interner = TypeInterner::new();
+    let mut ctx = InferenceContext::new(&interner);
+    let (h_name, h_type) = make_type_param(&interner, "H");
+    let (tail_name, tail_type) = make_type_param(&interner, "Tail");
+    ctx.fresh_type_param(h_name, false);
+    ctx.fresh_type_param(tail_name, false);
+
+    let source = interner.tuple(vec![
+        fixed(TypeId::STRING),
+        fixed(TypeId::NUMBER),
+        fixed(TypeId::BOOLEAN),
+    ]);
+    let target = interner.tuple(vec![fixed(h_type), rest(tail_type)]);
+
+    ctx.infer_from_types(source, target, InferencePriority::NakedTypeVariable)
+        .unwrap();
+
+    let vh = ctx.find_type_param(h_name).unwrap();
+    let vt = ctx.find_type_param(tail_name).unwrap();
+    assert_eq!(
+        ctx.resolve_with_constraints(vh).unwrap(),
+        TypeId::STRING,
+        "H should be string"
+    );
+
+    let expected_tail = interner.tuple(vec![fixed(TypeId::NUMBER), fixed(TypeId::BOOLEAN)]);
+    assert_eq!(
+        ctx.resolve_with_constraints(vt).unwrap(),
+        expected_tail,
+        "Tail should be [number, boolean]"
+    );
+}
+
+#[test]
+fn infer_trailing_rest_renamed_params() {
+    // Same as above but with renamed type params (proves non-name-keyed)
+    // Source: [string, number, boolean]   Target: [X, ...Y]
+    // → X = string, Y = [number, boolean]
+    let interner = TypeInterner::new();
+    let mut ctx = InferenceContext::new(&interner);
+    let (x_name, x_type) = make_type_param(&interner, "X");
+    let (y_name, y_type) = make_type_param(&interner, "Y");
+    ctx.fresh_type_param(x_name, false);
+    ctx.fresh_type_param(y_name, false);
+
+    let source = interner.tuple(vec![
+        fixed(TypeId::STRING),
+        fixed(TypeId::NUMBER),
+        fixed(TypeId::BOOLEAN),
+    ]);
+    let target = interner.tuple(vec![fixed(x_type), rest(y_type)]);
+
+    ctx.infer_from_types(source, target, InferencePriority::NakedTypeVariable)
+        .unwrap();
+
+    let vx = ctx.find_type_param(x_name).unwrap();
+    let vy = ctx.find_type_param(y_name).unwrap();
+    assert_eq!(ctx.resolve_with_constraints(vx).unwrap(), TypeId::STRING);
+    let expected = interner.tuple(vec![fixed(TypeId::NUMBER), fixed(TypeId::BOOLEAN)]);
+    assert_eq!(ctx.resolve_with_constraints(vy).unwrap(), expected);
+}
+
+#[test]
+fn infer_trailing_rest_empty_middle() {
+    // Source: [string]   Target: [H, ...Tail]
+    // → H = string, Tail = [] (empty tuple)
+    let interner = TypeInterner::new();
+    let mut ctx = InferenceContext::new(&interner);
+    let (h_name, h_type) = make_type_param(&interner, "H");
+    let (tail_name, tail_type) = make_type_param(&interner, "Tail");
+    ctx.fresh_type_param(h_name, false);
+    ctx.fresh_type_param(tail_name, false);
+
+    let source = interner.tuple(vec![fixed(TypeId::STRING)]);
+    let target = interner.tuple(vec![fixed(h_type), rest(tail_type)]);
+
+    ctx.infer_from_types(source, target, InferencePriority::NakedTypeVariable)
+        .unwrap();
+
+    let vh = ctx.find_type_param(h_name).unwrap();
+    let vt = ctx.find_type_param(tail_name).unwrap();
+    assert_eq!(ctx.resolve_with_constraints(vh).unwrap(), TypeId::STRING);
+    let expected_empty = interner.tuple(vec![]);
+    assert_eq!(ctx.resolve_with_constraints(vt).unwrap(), expected_empty);
+}
+
+// =============================================================================
+// Leading-rest patterns: [...Init, L]
+// =============================================================================
+
+#[test]
+fn infer_leading_rest_one_suffix_element() {
+    // Source: [string, number, boolean]   Target: [...Init, L]
+    // → Init = [string, number], L = boolean
+    let interner = TypeInterner::new();
+    let mut ctx = InferenceContext::new(&interner);
+    let (init_name, init_type) = make_type_param(&interner, "Init");
+    let (l_name, l_type) = make_type_param(&interner, "L");
+    ctx.fresh_type_param(init_name, false);
+    ctx.fresh_type_param(l_name, false);
+
+    let source = interner.tuple(vec![
+        fixed(TypeId::STRING),
+        fixed(TypeId::NUMBER),
+        fixed(TypeId::BOOLEAN),
+    ]);
+    let target = interner.tuple(vec![rest(init_type), fixed(l_type)]);
+
+    ctx.infer_from_types(source, target, InferencePriority::NakedTypeVariable)
+        .unwrap();
+
+    let vi = ctx.find_type_param(init_name).unwrap();
+    let vl = ctx.find_type_param(l_name).unwrap();
+    assert_eq!(
+        ctx.resolve_with_constraints(vl).unwrap(),
+        TypeId::BOOLEAN,
+        "L should be boolean"
+    );
+    let expected_init = interner.tuple(vec![fixed(TypeId::STRING), fixed(TypeId::NUMBER)]);
+    assert_eq!(
+        ctx.resolve_with_constraints(vi).unwrap(),
+        expected_init,
+        "Init should be [string, number]"
+    );
+}
+
+#[test]
+fn infer_leading_rest_renamed_params() {
+    // Source: [string, number, boolean]   Target: [...P, Q]
+    // → P = [string, number], Q = boolean
+    let interner = TypeInterner::new();
+    let mut ctx = InferenceContext::new(&interner);
+    let (p_name, p_type) = make_type_param(&interner, "P");
+    let (q_name, q_type) = make_type_param(&interner, "Q");
+    ctx.fresh_type_param(p_name, false);
+    ctx.fresh_type_param(q_name, false);
+
+    let source = interner.tuple(vec![
+        fixed(TypeId::STRING),
+        fixed(TypeId::NUMBER),
+        fixed(TypeId::BOOLEAN),
+    ]);
+    let target = interner.tuple(vec![rest(p_type), fixed(q_type)]);
+
+    ctx.infer_from_types(source, target, InferencePriority::NakedTypeVariable)
+        .unwrap();
+
+    let vp = ctx.find_type_param(p_name).unwrap();
+    let vq = ctx.find_type_param(q_name).unwrap();
+    assert_eq!(ctx.resolve_with_constraints(vq).unwrap(), TypeId::BOOLEAN);
+    let expected = interner.tuple(vec![fixed(TypeId::STRING), fixed(TypeId::NUMBER)]);
+    assert_eq!(ctx.resolve_with_constraints(vp).unwrap(), expected);
+}
+
+#[test]
+fn infer_leading_rest_single_source_element() {
+    // Source: [boolean]   Target: [...Init, L]
+    // → Init = [], L = boolean
+    let interner = TypeInterner::new();
+    let mut ctx = InferenceContext::new(&interner);
+    let (init_name, init_type) = make_type_param(&interner, "Init");
+    let (l_name, l_type) = make_type_param(&interner, "L");
+    ctx.fresh_type_param(init_name, false);
+    ctx.fresh_type_param(l_name, false);
+
+    let source = interner.tuple(vec![fixed(TypeId::BOOLEAN)]);
+    let target = interner.tuple(vec![rest(init_type), fixed(l_type)]);
+
+    ctx.infer_from_types(source, target, InferencePriority::NakedTypeVariable)
+        .unwrap();
+
+    let vi = ctx.find_type_param(init_name).unwrap();
+    let vl = ctx.find_type_param(l_name).unwrap();
+    assert_eq!(ctx.resolve_with_constraints(vl).unwrap(), TypeId::BOOLEAN);
+    let expected_empty = interner.tuple(vec![]);
+    assert_eq!(ctx.resolve_with_constraints(vi).unwrap(), expected_empty);
+}
+
+// =============================================================================
+// Fixed-prefix + rest + fixed-suffix: [H, ...Mid, L]
+// =============================================================================
+
+#[test]
+fn infer_prefix_rest_suffix() {
+    // Source: [string, number, boolean, bigint]  Target: [H, ...Mid, L]
+    // → H = string, Mid = [number, boolean], L = bigint
+    let interner = TypeInterner::new();
+    let mut ctx = InferenceContext::new(&interner);
+    let (h_name, h_type) = make_type_param(&interner, "H");
+    let (mid_name, mid_type) = make_type_param(&interner, "Mid");
+    let (l_name, l_type) = make_type_param(&interner, "L");
+    ctx.fresh_type_param(h_name, false);
+    ctx.fresh_type_param(mid_name, false);
+    ctx.fresh_type_param(l_name, false);
+
+    let source = interner.tuple(vec![
+        fixed(TypeId::STRING),
+        fixed(TypeId::NUMBER),
+        fixed(TypeId::BOOLEAN),
+        fixed(TypeId::BIGINT),
+    ]);
+    let target = interner.tuple(vec![fixed(h_type), rest(mid_type), fixed(l_type)]);
+
+    ctx.infer_from_types(source, target, InferencePriority::NakedTypeVariable)
+        .unwrap();
+
+    let vh = ctx.find_type_param(h_name).unwrap();
+    let vm = ctx.find_type_param(mid_name).unwrap();
+    let vl = ctx.find_type_param(l_name).unwrap();
+    assert_eq!(ctx.resolve_with_constraints(vh).unwrap(), TypeId::STRING);
+    assert_eq!(ctx.resolve_with_constraints(vl).unwrap(), TypeId::BIGINT);
+    let expected_mid = interner.tuple(vec![fixed(TypeId::NUMBER), fixed(TypeId::BOOLEAN)]);
+    assert_eq!(ctx.resolve_with_constraints(vm).unwrap(), expected_mid);
+}
+
+// =============================================================================
+// Both sides have rest elements
+// =============================================================================
+
+#[test]
+fn infer_rest_to_rest_single() {
+    // Source: [...A]   Target: [...B]
+    // → B = A (rest-to-rest maps type-to-type)
+    let interner = TypeInterner::new();
+    let mut ctx = InferenceContext::new(&interner);
+    let (a_name, a_type) = make_type_param(&interner, "A");
+    let (b_name, b_type) = make_type_param(&interner, "B");
+    ctx.fresh_type_param(a_name, false);
+    ctx.fresh_type_param(b_name, false);
+
+    let source = interner.tuple(vec![rest(a_type)]);
+    let target = interner.tuple(vec![rest(b_type)]);
+
+    ctx.infer_from_types(source, target, InferencePriority::NakedTypeVariable)
+        .unwrap();
+
+    let vb = ctx.find_type_param(b_name).unwrap();
+    assert_eq!(ctx.resolve_with_constraints(vb).unwrap(), a_type);
+}
+
+// =============================================================================
+// Negative / fallback cases
+// =============================================================================
+
+#[test]
+fn infer_no_rest_preserves_zip_behavior() {
+    // Source: [string, number]   Target: [T, U]
+    // → T = string, U = number  (no variadic elements; falls through to zip)
+    let interner = TypeInterner::new();
+    let mut ctx = InferenceContext::new(&interner);
+    let (t_name, t_type) = make_type_param(&interner, "T");
+    let (u_name, u_type) = make_type_param(&interner, "U");
+    ctx.fresh_type_param(t_name, false);
+    ctx.fresh_type_param(u_name, false);
+
+    let source = interner.tuple(vec![fixed(TypeId::STRING), fixed(TypeId::NUMBER)]);
+    let target = interner.tuple(vec![fixed(t_type), fixed(u_type)]);
+
+    ctx.infer_from_types(source, target, InferencePriority::NakedTypeVariable)
+        .unwrap();
+
+    let vt = ctx.find_type_param(t_name).unwrap();
+    let vu = ctx.find_type_param(u_name).unwrap();
+    assert_eq!(ctx.resolve_with_constraints(vt).unwrap(), TypeId::STRING);
+    assert_eq!(ctx.resolve_with_constraints(vu).unwrap(), TypeId::NUMBER);
+}

--- a/crates/tsz-solver/tests/operations_tests_parts/part_04.rs
+++ b/crates/tsz-solver/tests/operations_tests_parts/part_04.rs
@@ -785,19 +785,18 @@ fn test_infer_generic_tuple_rest_in_tuple_param_from_rest_argument() {
     ]);
 
     let result = infer_generic_function(&interner, &mut subtype, &func, &[tuple_arg]);
-    // TODO: T should be inferred as the rest element type pattern from the
-    // tuple argument (a tuple with [...string[]]), but generic tuple rest
-    // inference is not fully implemented. Currently the result does not match
-    // the ideal expected tuple; verify the inference does not produce it.
+    // T should be inferred from the rest portion of the argument tuple.
+    // The source rest element is `string[]` so T = string[] (the interner normalises
+    // `[...string[]]` to `string[]`, so ideal_expected equals `string_array`).
     let ideal_expected = interner.tuple(vec![TupleElement {
         type_id: string_array,
         name: None,
         optional: false,
         rest: true,
     }]);
-    assert_ne!(
+    assert_eq!(
         result, ideal_expected,
-        "Generic tuple rest inference is not yet fully implemented"
+        "T should be inferred as string[] from the rest argument"
     );
 }
 


### PR DESCRIPTION
## Agent
AgentName: claude-sonnet-4-6 (busy-lamport); m5-pro-48g-gpt5

## Track
Solver / type inference, M4-C lane.

## Invariant
When inferring from a concrete argument tuple against a variadic parameter tuple such as `[H, ...Mid, L]`, tsc aligns fixed prefix elements from the front, fixed suffix elements from the back, and collects the middle slice into a tuple for the rest type parameter. Prefix, middle/rest, and suffix aligned pairs must all receive type candidates. Consecutive variadic rest segments like `[...T, ...U]` must not let the first rest greedily consume fixed suffix elements that belong to the later rest after round-one inference fixes `T`.

## Scope
- Fix tuple constraint walking in `crates/tsz-solver/src/operations/constraints/signatures.rs` so suffix target elements are constrained after the middle rest slice.
- Split tuple matching inference into `crates/tsz-solver/src/inference/infer_matching_tuples.rs` so direct `infer_from_types` handles trailing rest, leading rest, prefix+rest+suffix, both-sided rest, and concrete array rest targets.
- Avoid treating later rest segments as fixed suffix elements; when the first rest already has a fixed tuple candidate, consume that prefix and infer the remaining middle slice into the next rest.
- Add checker integration coverage in `crates/tsz-checker/tests/variadic_tuple_arity_inference_tests.rs` for the old `Desc.bind` / `variadicTuples1` repro.
- Add solver unit coverage in `crates/tsz-solver/tests/matching_variadic_tuple_tests.rs`.
- Update the previously documented not-yet-implemented tuple-rest test in `crates/tsz-solver/tests/operations_tests_parts/part_04.rs`.

## Project Corpus Impact
- Row: n/a
- Bug family: generic-call / variadic-tuple inference, issue #11587.
- Evidence: targeted checker coverage and focused conformance `variadicTuples1` exercise the reported inference family; no project fixture row has been identified for this PR.

## Verification
- Author-reported local `cargo test -p tsz-checker --test variadic_tuple_arity_inference_tests`: 11/11 pass.
- Author-reported local `cargo test -p tsz-solver -- matching_variadic`: 9/9 pass.
- Author-reported local `cargo clippy -p tsz-solver -p tsz-checker --all-targets -- -D warnings`: clean.
- m5-pro-48g-gpt5 local `cargo fmt --check`: pass.
- m5-pro-48g-gpt5 local `git diff --check`: pass.
- m5-pro-48g-gpt5 local `cargo nextest run -p tsz-checker --test variadic_tuple_arity_inference_tests`: 12/12 pass.
- m5-pro-48g-gpt5 local `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter variadicTuples1 --verbose`: 1/1 pass, fingerprint-only 0.
- Ready-review CI for `c70e8e3b3f66237b6816a65914016a384b2b440b` is green; m5-pro-48g-gpt5 is adding `merge-queue` on 2026-05-30.

## Coordination Notes
Claimed issue #11587 for variadic tuple inference. m5-pro-48g-gpt5 repaired the exact-head `conformance-aggregate` regression in `TypeScript/tests/cases/conformance/types/tuple/variadicTuples1.ts` by preventing greedy consecutive-rest inference in the initial `this` seed and preserving the round-one re-seed path. Labels remain `solver`, `type-inference`, and `agent:M4-C`; exact-head CI is green and m5-pro-48g-gpt5 is queueing the PR on 2026-05-30.