### PR TITLE
fix(emit): downlevel arrows in ES5 enum member initializers (+1 methodContainingLocalFunction)

### DIFF
--- a/crates/tsz-emitter/src/transforms/enum_es5.rs
+++ b/crates/tsz-emitter/src/transforms/enum_es5.rs
@@ -1989,6 +1989,11 @@ impl<'a> EnumES5Emitter<'a> {
             None => IRPrinter::with_arena(arena),
         };
         printer.set_indent_level(self.indent_level);
+        // Propagate the ES5/ES3 target so `ASTRef` arrows inside enum member
+        // initializers (e.g. `(() => ...)()`) downlevel to function expressions,
+        // matching `emit_enum_declaration`; otherwise the nested AST printer
+        // defaults to native ES2015 arrow emission.
+        printer.set_target_es5(self.transformer.target_es5);
         let result = printer.emit(&ir);
         result.to_string()
     }

--- a/crates/tsz-emitter/tests/enum_es5.rs
+++ b/crates/tsz-emitter/tests/enum_es5.rs
@@ -842,6 +842,65 @@ fn empty_string_literal_member_name_emits_when_first() {
     );
 }
 
+/// At an ES5/ES3 target, an arrow-function expression that appears inside an
+/// enum member initializer (e.g. an immediately-invoked arrow `(() => ...)()`)
+/// must be downleveled to function-expression form, exactly like the
+/// `emit_enum_declaration` path does. The `EnumES5Emitter` previously built its
+/// `IRPrinter` without propagating the ES5 target, so the nested AST printer
+/// used for `ASTRef` arrow nodes defaulted to native ES2015 arrow emission.
+#[test]
+fn enum_member_arrow_iife_downlevels_to_function_expression_at_es5() {
+    let source = "enum E { A = (() => 5)() }";
+    let output = emit_enum_legacy_configured(source, |emitter| {
+        emitter.set_source_text(source);
+        emitter.set_target_es5(true);
+    });
+    assert!(
+        output.contains("(function () { return 5; })()"),
+        "arrow IIFE in enum initializer must downlevel to a function expression at es5, got:\n{output}"
+    );
+    assert!(
+        !output.contains("=>"),
+        "no arrow syntax should survive at es5, got:\n{output}"
+    );
+}
+
+/// Same rule, different identifier spellings and a nested arrow, proving the
+/// downleveling keys on the arrow-function node kind rather than any specific
+/// identifier name or rendered text (§25/§26 anti-hardcoding).
+#[test]
+fn enum_member_arrow_iife_downlevels_with_renamed_identifiers_at_es5() {
+    let source = "enum Renamed { Member = (() => [1].map(q => q + 1))() }";
+    let output = emit_enum_legacy_configured(source, |emitter| {
+        emitter.set_source_text(source);
+        emitter.set_target_es5(true);
+    });
+    assert!(
+        !output.contains("=>"),
+        "no arrow syntax (outer or nested) should survive at es5, got:\n{output}"
+    );
+    assert!(
+        output.contains("function () {") && output.contains("function (q) {"),
+        "both the outer IIFE arrow and the nested `q => ...` callback must downlevel, got:\n{output}"
+    );
+}
+
+/// Negative case: at an ES2015+ target the same arrow IIFE must be preserved
+/// verbatim — the downleveling is gated on the ES5 target, not applied
+/// unconditionally.
+#[test]
+fn enum_member_arrow_iife_preserved_at_es2015() {
+    let source = "enum E { A = (() => 5)() }";
+    let output = emit_enum_legacy_configured(source, |emitter| {
+        emitter.set_source_text(source);
+        emitter.set_target_es5(false);
+    });
+    assert!(
+        output.contains("(() => 5)()"),
+        "arrow IIFE must be preserved at es2015, got:\n{output}"
+    );
+}
+
 #[test]
 fn empty_string_member_emits_but_invalid_char_member_is_skipped() {
     // The empty-string literal member (legitimate, name node = StringLiteral)


### PR DESCRIPTION
AgentName: m3-max-64g-opus48

## Track
Emit parity → 100% (JS emit). ES5 enum member-initializer arrow downleveling.

## Invariant
When `EnumES5Emitter::emit_enum` builds an `IRPrinter` to print the enum IIFE,
it must propagate its ES5/ES3 target flag to that printer (as the sibling
`emit_enum_declaration` already does), so `ASTRef` arrow-function nodes inside
enum member initializers downlevel to function-expression form instead of being
printed as native ES2015 arrows. Keyed on the arrow AST node kind under an
ES5 target fact, not on identifier names.

## Scope
- `crates/tsz-emitter/src/transforms/enum_es5.rs` (+5): add the
  `printer.set_target_es5(...)` call the nested printer was missing.
- `crates/tsz-emitter/tests/enum_es5.rs` (+59): 3 tests.

## Bug
`EnumES5Emitter::emit_enum` stored `target_es5` on its inner transformer but
never called `printer.set_target_es5(...)` when constructing the `IRPrinter`,
so a nested arrow in an enum member initializer (`enum E { A = (() => {...})() }`)
defaulted to ES2015 emission at `--target es5`.

## Project Corpus Impact
- Row: emit (`--js-only`)
- Bug family: ES5 enum member-initializer arrow not downleveled (nested IRPrinter missing target_es5)
- Evidence: `--js-only -j4` 72→71 (flips `methodContainingLocalFunction(target=es5)`, zero new). `--dts-only` 24→24. Before: `E[E["A"] = (() => {...})()]`; after: `E[E["A"] = (function () {...})()]`; es2015 unchanged. `node --check` OK.

## Verification
- arch guard `Architecture guardrails passed`; clippy `-D warnings` clean.
- 3 new tests: witness, a renamed+nested-arrow variant (proves keying on arrow node kind not names), and an es2015 negative (arrow preserved).

## Coordination Notes
Emit is OUTPUT — aligns the enum IIFE printer's target fact with the sibling
declaration path; no output surgery, no semantic validation. NOTE: `enum_es5.rs`
is 2014 lines (pre-existing §19 oversize — 2009 lines on origin/main before this
+5; the arch gate's 2000-LOC scan only covers `tsz-checker/src` so it isn't
flagged). Tracking a follow-up split issue separately rather than bundling a
refactor into this narrow fix (§20.2).
