### PR TITLE
fix(emit): erase no-initializer static fields under useDefineForClassFields (+1 staticPropertyNameConflicts)

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -91,6 +91,10 @@ name = "computed_name_no_init_define_field_tests"
 path = "tests/computed_name_no_init_define_field_tests.rs"
 
 [[test]]
+name = "static_no_init_field_erasure_tests"
+path = "tests/static_no_init_field_erasure_tests.rs"
+
+[[test]]
 name = "jsx_spread_tests"
 path = "tests/jsx_spread_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -1,6 +1,7 @@
 use super::super::super::core::PropertyNameEmit;
 use super::super::super::{Printer, ScriptTarget};
 use super::replace_identifier;
+use super::static_field_erasure::static_no_init_field_is_erased;
 use super::{AutoAccessorEmitOptions, AutoAccessorInfo, StaticFieldInit};
 use crate::emitter::core::{PrivateMemberInfo, PrivateMethodDef};
 use crate::transforms::private_fields_es5::{
@@ -1812,12 +1813,12 @@ impl<'a> Printer<'a> {
                     };
 
                     if self.has_effective_static_modifier_js(&prop.modifiers) {
-                        // At ES2022+, static fields are emitted as `static { this.f = v; }`
-                        // blocks inside the class body, not as external assignments.
-                        if !needs_static_block_lowering {
-                            // Don't collect for external emission; these will be
-                            // emitted inline as static initialization blocks.
-                        } else {
+                        // `tsc` erases a no-init static field (see `static_field_erasure`).
+                        let erased = static_no_init_field_is_erased(
+                            prop.initializer.is_none(),
+                            self.ctx.options.use_define_for_class_fields,
+                        );
+                        if needs_static_block_lowering && !erased {
                             static_field_inits.push((
                                 name_emit,
                                 prop.initializer,

--- a/crates/tsz-emitter/src/emitter/declarations/class/mod.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/mod.rs
@@ -6,6 +6,7 @@ mod emit_es6;
 mod helpers;
 mod private_method_defs;
 mod static_block_self_alias;
+mod static_field_erasure;
 
 use super::super::core::PropertyNameEmit;
 use tsz_parser::parser::NodeIndex;

--- a/crates/tsz-emitter/src/emitter/declarations/class/static_field_erasure.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/static_field_erasure.rs
@@ -1,0 +1,66 @@
+//! Structural predicate for `useDefineForClassFields` erasure of
+//! no-initializer **static** class fields.
+//!
+//! `tsc`'s `transformPropertyWorker` (in `transformers/classFields.ts`) returns
+//! no statement for a property when it has a `static` modifier (or is a private
+//! name) *and* has no initializer:
+//!
+//! ```ts
+//! if ((isPrivateIdentifier(name) || hasStaticModifier(property)) && !property.initializer) {
+//!     return undefined;
+//! }
+//! ```
+//!
+//! So a static field declared without an initializer is never materialized as
+//! `Object.defineProperty(C, <name>, { ... value: void 0 })`. Materializing one
+//! produced a `defineProperty` descriptor with an empty `value:` (invalid JS)
+//! and would clobber the constructor function's own non-writable slots
+//! (`name`, `length`, `prototype`, `caller`, `arguments`).
+//!
+//! The rule keys purely on structural facts — `no initializer` + `define
+//! semantics enabled`, evaluated at a call site that has already established the
+//! `static`-modifier half of the condition — never on the chosen field name. A
+//! no-initializer *instance* field is unaffected and still materializes with
+//! `value: void 0`; an *initialized* static field is unaffected and still emits
+//! its define. The computed-name temp hoisting for an erased field still happens
+//! independently, matching `tsc`'s retained `_a = expr` capture.
+
+/// Returns `true` when a static class field should be erased from
+/// `useDefineForClassFields` runtime field-lowering, given:
+///
+/// * `no_initializer` — the property declaration has no initializer expression.
+/// * `use_define_for_class_fields` — define-field semantics are enabled.
+///
+/// Callers invoke this only after establishing the field carries a `static`
+/// modifier (the enclosing `static` branch), which is the other half of `tsc`'s
+/// `(isPrivateIdentifier(name) || hasStaticModifier(property)) && !initializer`
+/// condition.
+pub(in crate::emitter::declarations::class) const fn static_no_init_field_is_erased(
+    no_initializer: bool,
+    use_define_for_class_fields: bool,
+) -> bool {
+    no_initializer && use_define_for_class_fields
+}
+
+#[cfg(test)]
+mod tests {
+    use super::static_no_init_field_is_erased;
+
+    #[test]
+    fn no_init_with_define_is_erased() {
+        assert!(static_no_init_field_is_erased(true, true));
+    }
+
+    #[test]
+    fn initialized_static_field_is_not_erased() {
+        assert!(!static_no_init_field_is_erased(false, true));
+    }
+
+    #[test]
+    fn no_init_without_define_is_not_erased() {
+        // Without define semantics a bare typed static field has no runtime
+        // form anyway; the caller filters it earlier, but the predicate must
+        // not claim erasure on its own.
+        assert!(!static_no_init_field_is_erased(true, false));
+    }
+}

--- a/crates/tsz-emitter/tests/static_no_init_field_erasure_tests.rs
+++ b/crates/tsz-emitter/tests/static_no_init_field_erasure_tests.rs
@@ -1,0 +1,193 @@
+//! Tests for `useDefineForClassFields` erasure of no-initializer **static**
+//! class fields.
+//!
+//! Structural rule: when a class field has no initializer **and** carries a
+//! `static` modifier, `tsc`'s field-lowering (`transformPropertyWorker`) emits
+//! no runtime statement for it:
+//!
+//! ```ts
+//! if ((isPrivateIdentifier(name) || hasStaticModifier(property)) && !property.initializer) {
+//!     return undefined;
+//! }
+//! ```
+//!
+//! So such a field is never materialized as
+//! `Object.defineProperty(C, <name>, { ... value: void 0 })`. Emitting one
+//! produced a define with an empty `value:` (invalid JS) and would clobber the
+//! constructor function's own non-writable slots (`name`, `length`,
+//! `prototype`, ...). A no-initializer **instance** field is unaffected and
+//! still materializes with `value: void 0`. An initialized static field is also
+//! unaffected and still emits its define.
+//!
+//! Witness: `staticPropertyNameConflicts(target=es2015,usedefineforclassfields=true)`.
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_print_with_opts;
+use tsz_emitter::output::printer::PrintOptions;
+
+/// ES2015 (or ES5) options with `useDefineForClassFields` enabled, which is the
+/// only configuration where bare no-init fields are lowered to define calls.
+fn es2015_udfcf() -> PrintOptions {
+    PrintOptions {
+        use_define_for_class_fields: true,
+        ..PrintOptions::es6()
+    }
+}
+
+fn es5_udfcf() -> PrintOptions {
+    PrintOptions {
+        use_define_for_class_fields: true,
+        ..PrintOptions::es5()
+    }
+}
+
+/// No emit site may ever produce a `defineProperty` descriptor whose `value:`
+/// is empty. This is the concrete invalid-JS defect the fix eliminates.
+fn assert_no_empty_value(output: &str) {
+    for line in output.lines() {
+        let trimmed = line.trim_end();
+        assert!(
+            !(trimmed.ends_with("value:") || trimmed.ends_with("value: ")),
+            "emitted a defineProperty descriptor with an empty `value:`\nOutput:\n{output}"
+        );
+    }
+}
+
+// ── Reported witness: no-init static field with a reserved Function name ──────
+
+/// `static name;` (no initializer) conflicts with `Function.name`. `tsc` erases
+/// the static define entirely; only the instance field materializes.
+#[test]
+fn static_no_init_reserved_name_field_is_erased() {
+    let source = "class StaticName {\n    static name: number;\n    name: string;\n}\n";
+    let output = parse_and_print_with_opts(source, es2015_udfcf());
+    assert_no_empty_value(&output);
+    // No static define for the conflicting static field.
+    assert!(
+        !output.contains("Object.defineProperty(StaticName, \"name\""),
+        "no-init static field must not be materialized\nOutput:\n{output}"
+    );
+    // The instance field IS still materialized (`this`, not the class).
+    assert!(
+        output.contains("Object.defineProperty(this, \"name\""),
+        "no-init instance field must still materialize with value: void 0\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("value: void 0"),
+        "instance field materializes value: void 0\nOutput:\n{output}"
+    );
+}
+
+/// Same rule with a DIFFERENT Function own-property key (`length`). Proves the
+/// rule is the static-no-init family, not the literal `name`.
+#[test]
+fn static_no_init_reserved_length_field_is_erased() {
+    let source = "class StaticLength {\n    static length: number;\n    length: string;\n}\n";
+    let output = parse_and_print_with_opts(source, es2015_udfcf());
+    assert_no_empty_value(&output);
+    assert!(
+        !output.contains("Object.defineProperty(StaticLength, \"length\""),
+        "no-init static `length` field must not be materialized\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("Object.defineProperty(this, \"length\""),
+        "no-init instance `length` field must still materialize\nOutput:\n{output}"
+    );
+}
+
+/// The rule is keyed on `static` + `no initializer`, not on reserved names: a
+/// non-conflicting user-chosen no-init static field is erased exactly the same
+/// way (this is `tsc`'s general rule, line 2579). Renamed to prove no
+/// name-string dependence.
+#[test]
+fn static_no_init_nonconflicting_user_name_field_is_erased() {
+    let source = "class Widget {\n    static notReserved: number;\n    inst: string;\n}\n";
+    let output = parse_and_print_with_opts(source, es2015_udfcf());
+    assert_no_empty_value(&output);
+    assert!(
+        !output.contains("Object.defineProperty(Widget, \"notReserved\""),
+        "no-init static field is erased regardless of name\nOutput:\n{output}"
+    );
+    // The instance field still materializes.
+    assert!(
+        output.contains("Object.defineProperty(this, \"inst\""),
+        "no-init instance field still materializes\nOutput:\n{output}"
+    );
+}
+
+// ── Computed-name variant: temp still captured, define still erased ───────────
+
+/// A no-init static field with a *computed* name still has its computed-name
+/// temp hoisted (matching `tsc`'s retained `_a = expr`), but the runtime define
+/// is erased. Renamed key proves no name-string dependence.
+#[test]
+fn static_no_init_computed_name_field_erases_define_keeps_temp() {
+    let source = "const Keys = { k: 'k' } as const;\nclass C {\n    static [Keys.k]: number;\n    [Keys.k]: string;\n}\n";
+    let output = parse_and_print_with_opts(source, es2015_udfcf());
+    assert_no_empty_value(&output);
+    // The computed-name capture temp is still emitted (instance field needs it,
+    // and tsc retains the static one too).
+    assert!(
+        output.contains("Keys.k"),
+        "computed-name temp capture must be retained\nOutput:\n{output}"
+    );
+    // The instance field materializes via the captured temp on `this`.
+    assert!(
+        output.contains("Object.defineProperty(this, _"),
+        "instance computed field materializes via temp\nOutput:\n{output}"
+    );
+    // No static-class define using the captured temp.
+    assert!(
+        !output.contains("Object.defineProperty(C, _"),
+        "no-init static computed field define must be erased\nOutput:\n{output}"
+    );
+}
+
+// ── Negative / fallback cases: must keep correct (non-erased) emission ────────
+
+/// An *initialized* static field whose name conflicts with a Function own
+/// property is NOT erased: it still emits its define with the real value.
+/// Proves the predicate keys on initializer-presence, not on the name.
+#[test]
+fn static_initialized_reserved_name_field_is_kept() {
+    let source = "class InitConflict {\n    static name = 123;\n}\n";
+    let output = parse_and_print_with_opts(source, es2015_udfcf());
+    assert_no_empty_value(&output);
+    assert!(
+        output.contains("Object.defineProperty(InitConflict, \"name\""),
+        "initialized static field must still emit its define\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("value: 123"),
+        "initialized static field keeps its real value\nOutput:\n{output}"
+    );
+}
+
+/// A no-init *instance* field with a reserved name is materialized (only the
+/// `static` modifier triggers erasure). Negative control for the static rule.
+#[test]
+fn instance_no_init_reserved_name_field_is_materialized() {
+    let source = "class OnlyInstance {\n    name: string;\n}\n";
+    let output = parse_and_print_with_opts(source, es2015_udfcf());
+    assert_no_empty_value(&output);
+    assert!(
+        output.contains("Object.defineProperty(this, \"name\""),
+        "no-init instance field must materialize on `this`\nOutput:\n{output}"
+    );
+}
+
+/// The same erasure holds at the ES5 target (different class-IIFE form), so the
+/// fix is not target-specific. The ES5 emitter must not produce an empty-value
+/// static define for a no-init static field.
+#[test]
+fn static_no_init_reserved_name_field_is_erased_es5() {
+    let source = "class StaticName {\n    static name: number;\n    name: string;\n}\n";
+    let output = parse_and_print_with_opts(source, es5_udfcf());
+    assert_no_empty_value(&output);
+    assert!(
+        !output.contains("Object.defineProperty(StaticName, \"name\""),
+        "no-init static field must not be materialized at ES5\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
AgentName: m3-max-64g-opus48

## Track
Emit parity → 100% (JS emit). Static class-field define-for-class-fields lowering.

## Invariant
When a class field has NO initializer AND carries a `static` modifier, tsc's
`useDefineForClassFields` field-lowering erases it entirely (emits no
`Object.defineProperty(C, …)`). A no-init *instance* field still materializes
with `value: void 0`; an *initialized* static field still emits its define.
Keyed structurally on initializer-presence + static-modifier + define
semantics — NOT on the field name.

## Scope
- `crates/tsz-emitter/src/emitter/declarations/class/static_field_erasure.rs`
  (new, 66 lines): `static_no_init_field_is_erased(no_initializer, use_define_for_class_fields)`
  predicate + 3 unit tests.
- `declarations/class/emit_es6.rs`: call-site at the static-field collection
  branch (kept at its 4191-line ratchet by housing the predicate in the new module).
- `declarations/class/mod.rs`: module registration.
- `crates/tsz-emitter/tests/static_no_init_field_erasure_tests.rs` (new, 193 lines): 7 tests; registered in Cargo.toml.

## Bug
tsz emitted `Object.defineProperty(C, <name>, { … value: })` with an EMPTY
value expression (invalid JS) for no-init static fields. The earlier
"Function own-property name conflict" framing was a red herring — the real tsc
rule erases ALL no-init static fields regardless of name (the test merely used
reserved names because those are the ones that would conflict if defined).

## Project Corpus Impact
- Row: emit (`--js-only`)
- Bug family: no-initializer static field emitted as empty-`value:` Object.defineProperty instead of erased (useDefineForClassFields)
- Evidence: `--js-only -j4` 72→71 (flips `staticPropertyNameConflicts(target=es2015,useDefineForClassFields=true)`, zero new). `--dts-only` 24→24. `node --check` passes; zero empty-`value:` lines remain.

## Verification
- arch guard `Architecture guardrails passed`; clippy `-D warnings` clean.
- 10 new tests: witness (`static name;`), renamed (`static length;`),
  non-conflicting user name (`static notReserved;` — also erased, proving it's
  the static-no-init family not the name), computed-name (define erased, temp
  still hoisted), negatives (initialized static reserved-name kept; no-init
  instance field materialized), es5 erasure.

## Coordination Notes
Emit is OUTPUT — a structural erasure predicate, no name-string matching, no
output surgery, no semantic validation. STOP-scoped: `staticPropertyNameConflicts(target=es5)`
left failing — its remaining diff is computed-name temp PLACEMENT (the broad
static-member capture-phase / temp-model track, Stages A–C), explicitly out of
scope; this change does not regress it. No creep into typeOfThisInStaticMembers/
thisAndSuperInStaticMembers.
