### PR TITLE
fix(parser): use token_full_start() for satisfies/as expression end span

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -122,6 +122,9 @@ mod parser_improvement_primitive_type_recovery_tests;
 #[path = "../../tests/parser_improvement_regex_recovery_tests.rs"]
 mod parser_improvement_regex_recovery_tests;
 #[cfg(test)]
+#[path = "../../tests/parser_improvement_satisfies_generic_chain_tests.rs"]
+mod parser_improvement_satisfies_generic_chain_tests;
+#[cfg(test)]
 #[path = "../../tests/parser_improvement_template_recovery_tests.rs"]
 mod parser_improvement_template_recovery_tests;
 #[cfg(test)]

--- a/crates/tsz-parser/src/parser/state_expressions.rs
+++ b/crates/tsz-parser/src/parser/state_expressions.rs
@@ -427,6 +427,8 @@ impl ParserState {
         }
 
         let right = self.parse_binary_expression_rhs(left, op, precedence);
+        // TODO: should be token_full_start() to match tsc's finishNode default; token_end()
+        // overshoots by the lookahead token. Fix requires CI conformance verification.
         let end_pos = self.token_end();
         let final_right = if right.is_none() { left } else { right };
 
@@ -461,6 +463,8 @@ impl ParserState {
             self.error_expression_expected();
             when_false = self.create_missing_expression();
         }
+        // TODO: should be token_full_start() to match tsc's finishNode default; token_end()
+        // overshoots by the lookahead token. Fix requires CI conformance verification.
         let end_pos = self.token_end();
 
         self.arena.add_conditional_expr(
@@ -566,7 +570,9 @@ impl ParserState {
         } else {
             self.parse_non_predicate_type()
         };
-        let end_pos = self.token_end();
+        // token_full_start() matches tsc's finishNode default (scanner.getTokenFullStart()).
+        // token_end() overshoots: it returns the end of the *next* token, not the type.
+        let end_pos = self.token_full_start();
 
         let result = self.arena.add_type_assertion(
             if is_satisfies {

--- a/crates/tsz-parser/tests/parser_improvement_satisfies_generic_chain_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_satisfies_generic_chain_tests.rs
@@ -1,0 +1,244 @@
+//! Tests for `satisfies` / `as` expression spans and their interaction with
+//! generic call chains (issue: large-ts-repo parser-2-20).
+//!
+//! Structural rule: after `parse_non_predicate_type()` returns, the scanner
+//! sits on the first token that is NOT part of the type. The `end` field of
+//! a `satisfies` or `as` expression node must equal `token_full_start()` — the
+//! full start of that next token (matching tsc's `finishNode` default of
+//! `scanner.getTokenFullStart()`). Using `token_end()` overshoots and causes
+//! node text extraction to include the following token.
+
+use crate::parser::syntax_kind_ext;
+use crate::parser::test_fixture::{assert_no_errors, assert_span, assert_span_on, parse_source};
+
+// ---------------------------------------------------------------------------
+// satisfies expression span — does not overshoot into the following token
+// ---------------------------------------------------------------------------
+
+// Three different following-token contexts prove the rule is structural, not
+// tied to a specific delimiter.
+
+#[test]
+fn satisfies_span_excludes_trailing_semicolon() {
+    assert_span(
+        "const x = value satisfies string;",
+        syntax_kind_ext::SATISFIES_EXPRESSION,
+        "value satisfies string",
+    );
+}
+
+#[test]
+fn satisfies_span_excludes_trailing_comma() {
+    assert_span(
+        "const a = [value satisfies number, 1];",
+        syntax_kind_ext::SATISFIES_EXPRESSION,
+        "value satisfies number",
+    );
+}
+
+#[test]
+fn satisfies_span_excludes_trailing_close_paren() {
+    assert_span(
+        "fn(value satisfies boolean)",
+        syntax_kind_ext::SATISFIES_EXPRESSION,
+        "value satisfies boolean",
+    );
+}
+
+#[test]
+fn satisfies_span_generic_type_rhs_excludes_semicolon() {
+    // The `>` closes the type-argument list; the `;` must not be included.
+    assert_span(
+        "const x = value satisfies Array<number>;",
+        syntax_kind_ext::SATISFIES_EXPRESSION,
+        "value satisfies Array<number>",
+    );
+}
+
+#[test]
+fn satisfies_span_generic_type_two_args_excludes_semicolon() {
+    assert_span(
+        "const x = value satisfies Map<string, number>;",
+        syntax_kind_ext::SATISFIES_EXPRESSION,
+        "value satisfies Map<string, number>",
+    );
+}
+
+#[test]
+fn satisfies_span_nested_generic_type_excludes_semicolon() {
+    assert_span(
+        "const x = value satisfies ReadonlyArray<Map<string, number>>;",
+        syntax_kind_ext::SATISFIES_EXPRESSION,
+        "value satisfies ReadonlyArray<Map<string, number>>",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// as expression span — same structural rule
+// ---------------------------------------------------------------------------
+
+#[test]
+fn as_expression_span_excludes_trailing_semicolon() {
+    assert_span(
+        "const x = value as string;",
+        syntax_kind_ext::AS_EXPRESSION,
+        "value as string",
+    );
+}
+
+#[test]
+fn as_expression_span_generic_type_excludes_semicolon() {
+    assert_span(
+        "const x = value as Array<number>;",
+        syntax_kind_ext::AS_EXPRESSION,
+        "value as Array<number>",
+    );
+}
+
+#[test]
+fn as_expression_span_generic_two_args_excludes_semicolon() {
+    assert_span(
+        "const x = value as Map<string, number>;",
+        syntax_kind_ext::AS_EXPRESSION,
+        "value as Map<string, number>",
+    );
+}
+
+#[test]
+fn as_const_span_excludes_trailing_semicolon() {
+    assert_span(
+        "const x = value as const;",
+        syntax_kind_ext::AS_EXPRESSION,
+        "value as const",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// satisfies after a generic call chain — no parse errors
+// ---------------------------------------------------------------------------
+
+// Each source uses a different type-parameter spelling to prove the fix is
+// structural, not keyed to a single identifier name.
+
+#[test]
+fn satisfies_after_generic_call_no_errors() {
+    for source in [
+        "const x = factory<Item>() satisfies Item[];",
+        "const x = factory<Element>() satisfies Element[];",
+    ] {
+        assert_no_errors(source);
+    }
+}
+
+#[test]
+fn satisfies_after_chained_generic_calls_no_errors() {
+    assert_no_errors("const x = builder<K>().configure<V>() satisfies ReadonlyMap<K, V>;");
+}
+
+#[test]
+fn satisfies_after_deeply_chained_generic_calls_no_errors() {
+    assert_no_errors("const x = a<P>().b<Q>().c<R>() satisfies Triple<P, Q, R>;");
+}
+
+#[test]
+fn satisfies_generic_type_after_non_generic_call_no_errors() {
+    assert_no_errors("const x = create() satisfies Map<string, number>;");
+}
+
+#[test]
+fn satisfies_generic_type_after_member_call_chain_no_errors() {
+    assert_no_errors("const x = obj.method<T>().other() satisfies Result<T>;");
+}
+
+// Instantiation expressions (f<T> without a following call) are valid TS 4.7+.
+#[test]
+fn satisfies_after_instantiation_expression_no_errors() {
+    assert_no_errors("const x = fn<string> satisfies (() => string);");
+}
+
+// ---------------------------------------------------------------------------
+// satisfies span correctness after a generic call chain
+// ---------------------------------------------------------------------------
+
+#[test]
+fn satisfies_after_generic_call_span_correct() {
+    let source = "const x = factory<Item>() satisfies Item[];";
+    assert_span(
+        source,
+        syntax_kind_ext::SATISFIES_EXPRESSION,
+        "factory<Item>() satisfies Item[]",
+    );
+}
+
+#[test]
+fn satisfies_after_chained_generic_calls_span_correct() {
+    let source = "const x = builder<K>().configure<V>() satisfies ReadonlyMap<K, V>;";
+    assert_span(
+        source,
+        syntax_kind_ext::SATISFIES_EXPRESSION,
+        "builder<K>().configure<V>() satisfies ReadonlyMap<K, V>",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// chained as / satisfies — both outer and inner spans must not overshoot
+// ---------------------------------------------------------------------------
+
+#[test]
+fn chained_satisfies_then_as_const_spans_correct() {
+    let source = "const x = value satisfies Record<string, number> as const;";
+    let (parser, _) = parse_source(source);
+    // Outer as-expression wraps the whole chain.
+    assert_span_on(
+        &parser,
+        source,
+        syntax_kind_ext::AS_EXPRESSION,
+        "value satisfies Record<string, number> as const",
+    );
+    // Inner satisfies expression must also have the right span.
+    assert_span_on(
+        &parser,
+        source,
+        syntax_kind_ext::SATISFIES_EXPRESSION,
+        "value satisfies Record<string, number>",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Recovery: unusual type forms on the RHS must parse without errors
+// ---------------------------------------------------------------------------
+
+#[test]
+fn satisfies_with_union_type_rhs_no_errors() {
+    assert_no_errors("const x = value satisfies string | number;");
+}
+
+#[test]
+fn satisfies_with_intersection_type_rhs_no_errors() {
+    assert_no_errors("const x = value satisfies A & B;");
+}
+
+#[test]
+fn satisfies_with_function_type_rhs_no_errors() {
+    assert_no_errors("const x = value satisfies (x: number) => string;");
+}
+
+#[test]
+fn satisfies_with_conditional_type_rhs_no_errors() {
+    assert_no_errors("const x = value satisfies string extends number ? true : false;");
+}
+
+#[test]
+fn satisfies_inside_arrow_return_no_errors() {
+    assert_no_errors("const f = () => value satisfies string;");
+}
+
+#[test]
+fn satisfies_in_ternary_consequent_no_errors() {
+    assert_no_errors("const x = cond ? value satisfies string : fallback;");
+}
+
+#[test]
+fn satisfies_in_ternary_alternate_no_errors() {
+    assert_no_errors("const x = cond ? other : value satisfies number;");
+}

--- a/crates/tsz-parser/tests/state_type_tests.rs
+++ b/crates/tsz-parser/tests/state_type_tests.rs
@@ -1,6 +1,6 @@
 //! Tests for type expression parsing in the parser.
 use crate::parser::syntax_kind_ext;
-use crate::parser::test_fixture::{parse_source, parse_source_named};
+use crate::parser::test_fixture::{assert_span, assert_span_on, parse_source, parse_source_named};
 
 #[test]
 fn parse_complex_type_expressions_have_no_errors() {
@@ -384,46 +384,6 @@ fn parse_type_predicate_does_not_overshoot_into_following_arrow() {
         syntax_kind_ext::TYPE_PREDICATE,
         "x is string",
     );
-}
-
-/// Assert the first node of `kind` at `expected_text` has the correct span.
-/// Error messages include the full source for debugging.
-fn assert_span_on(
-    parser: &crate::parser::ParserState,
-    source: &str,
-    kind: u16,
-    expected_text: &str,
-) {
-    let arena = &parser.arena;
-    let expected_start = source
-        .find(expected_text)
-        .unwrap_or_else(|| panic!("expected_text {expected_text:?} not found in {source:?}"));
-    let expected_end = expected_start + expected_text.len();
-
-    let mut found = false;
-    for i in 0..arena.len() {
-        let Some(node) = arena.get(crate::parser::NodeIndex(i as u32)) else {
-            continue;
-        };
-        if node.kind == kind && node.pos as usize == expected_start {
-            assert_eq!(
-                node.end as usize, expected_end,
-                "span mismatch for kind={kind} in {source:?}: got [{}..{}], expected [{}..{}] ({expected_text:?})",
-                node.pos, node.end, expected_start, expected_end
-            );
-            found = true;
-            break;
-        }
-    }
-    assert!(
-        found,
-        "no node of kind={kind} found at offset {expected_start} in {source:?}"
-    );
-}
-
-fn assert_span(source: &str, kind: u16, expected_text: &str) {
-    let (parser, _) = parse_source(source);
-    assert_span_on(&parser, source, kind, expected_text);
 }
 
 // --- composite type node span tests ---

--- a/crates/tsz-parser/tests/test_fixture.rs
+++ b/crates/tsz-parser/tests/test_fixture.rs
@@ -26,6 +26,62 @@ pub(crate) fn parse_source_named(file_name: &str, source: &str) -> (ParserState,
     (parser, root)
 }
 
+/// Assert that no parse diagnostics were emitted for `source`.
+pub(crate) fn assert_no_errors(source: &str) {
+    let (parser, _) = parse_source(source);
+    assert!(
+        parser.get_diagnostics().is_empty(),
+        "expected no parse errors for {source:?}, got {:?}",
+        parser.get_diagnostics()
+    );
+}
+
+/// Assert that a node of the given `kind` starts at `expected_text` within
+/// `source` and its span ends exactly where `expected_text` ends — i.e. the
+/// node does not overshoot into a trailing token such as `;` or `,`.
+///
+/// Shared by all test files that check node span boundaries.
+pub(crate) fn assert_span(source: &str, kind: u16, expected_text: &str) {
+    let (parser, _) = parse_source(source);
+    assert_span_on(&parser, source, kind, expected_text);
+}
+
+/// Like `assert_span` but operates on an already-parsed `ParserState`, avoiding
+/// a second `parse_source` call when multiple spans are checked on the same input.
+pub(crate) fn assert_span_on(
+    parser: &crate::parser::ParserState,
+    source: &str,
+    kind: u16,
+    expected_text: &str,
+) {
+    let arena = parser.get_arena();
+    let expected_start = source.find(expected_text).unwrap_or_else(|| {
+        panic!("expected_text {expected_text:?} not found in source {source:?}")
+    });
+    let expected_end = expected_start + expected_text.len();
+
+    let mut found = false;
+    for node in &arena.nodes {
+        if node.kind == kind && node.pos as usize == expected_start {
+            assert_eq!(
+                node.end as usize,
+                expected_end,
+                "span mismatch for kind={kind} in {source:?}: \
+                 got [{pos}..{end}] = {got:?}, expected [{expected_start}..{expected_end}] = {expected_text:?}",
+                pos = node.pos,
+                end = node.end,
+                got = &source[node.pos as usize..node.end as usize],
+            );
+            found = true;
+            break;
+        }
+    }
+    assert!(
+        found,
+        "no node of kind={kind} starting at offset {expected_start} found in {source:?}"
+    );
+}
+
 /// Parse a source string under an explicit `ScriptTarget` language version,
 /// using the default `"test.ts"` file name. Used by tests that exercise
 /// target-version-sensitive scanner/parser behaviour (e.g. ES5 vs ES2015


### PR DESCRIPTION
## Summary

AgentName: claude-sonnet-4-6
**Track:** Parser
**Issue:** Fixes #11461 (large-ts-repo parser-2-20)

`parse_as_or_satisfies_expression` computed the node's `end` with `token_end()` after `parse_non_predicate_type()` returned. At that point the scanner sits on the first token **after** the type, so `token_end()` returned the end of that lookahead token — overshooting by one full token.

tsc's `finishNode` always uses `scanner.getTokenFullStart()` (= **start** of the lookahead) as the default `end`. The tsz equivalent is `token_full_start()`. The same convention is documented in `state_types.rs` lines 377–381 for union types.

## Invariant

> When `parse_as_or_satisfies_expression` closes the assertion node, the scanner sits on the first token not part of the type. The node's `end` must be `token_full_start()` — not `token_end()` — matching tsc's universal `finishNode(scanner.getTokenFullStart())` convention.

## Scope

**Parser only.** One-line change to `state_expressions.rs`. No checker, solver, emitter, or binder changes.

**Also in this PR:**
- Centralises `assert_span`, `assert_span_on`, `assert_no_errors` into `test_fixture.rs` (removes private copies from `state_type_tests.rs`)
- 26 new focused tests in `parser_improvement_satisfies_generic_chain_tests.rs` covering span correctness and generic call chain recovery

**Deferred (follow-up #11795):** The same `token_end()` overshoot exists in `parse_binary_expression_remainder` and `parse_conditional_expression`. Those sites are marked with TODO comments. Fixing them needs full CI conformance verification due to the wide blast radius of binary/conditional AST nodes.

## Project Corpus Impact

- Row: large-ts-repo
- Bug family: Parser node span overshoot (token_end vs token_full_start)
- Evidence: The fix makes `node_text(arena, src, satisfies_node)` return `"x satisfies T"` instead of `"x satisfies T;"`. The project corpus comparison diverged because wrong spans affected diagnostic position ranges and node text extraction for all `as`/`satisfies` expressions in the corpus.

## Verification

```bash
# All 1084 parser unit tests pass
cargo test -p tsz-parser --lib
# result: ok. 1084 passed; 0 failed

# Clippy clean
cargo clippy -p tsz-parser --all-targets -- -D warnings
# result: Finished with no warnings

# Workspace compiles cleanly
cargo check --workspace --all-targets
# result: Finished dev profile

# New tests exercise the exact failure mode
cargo test -p tsz-parser --lib parser_improvement_satisfies_generic_chain
# result: ok. 26 passed
```

Full conformance, emit, and fourslash suites run in CI.

## Coordination Notes

- Issue #11461 claimed with WIP label before work started.
- Follow-up issue #11795 filed for the binary/conditional `token_end()` sites.
- No overlap with other open draft PRs found.
- Three `/simplify` passes run; centralized test helpers, removed duplicate private copies, fixed double-parse in chained-span test.

---
_Generated by [Claude Code](https://claude.ai/code/session_017DSGT3shw2eNLgAsAn4ha4)_