### PR TITLE
fix(emit): preserve annotation-position parens for primitives; normalize array-element parens by structure

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/tests/infer_paren_and_union_intersection.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/infer_paren_and_union_intersection.rs
@@ -146,30 +146,31 @@ fn template_literal_type_text_reescapes_backtick_and_dollar_brace() {
 }
 
 // ---------------------------------------------------------------------------
-// Fix C: a source-parenthesized array element keeps its parens verbatim in
-// the copied annotation (`(T)[]` stays `(T)[]`, not `T[]`). The fix keys on
-// the source `PARENTHESIZED_TYPE` array element, never on the element's name.
+// Fix C: a source-parenthesized array element has its parens stripped in the
+// .d.ts when the element type needs no structural grouping. Only composite
+// types (union, conditional, function, etc.) re-add parens structurally.
+// Reference types like `(Foo)[]` normalize to `Foo[]`, matching tsc 6.0.
 // ---------------------------------------------------------------------------
 
 #[test]
-fn parenthesized_array_element_keeps_parens() {
-    // `(Foo)[]` is a redundant-but-user-written grouping that tsc preserves
-    // verbatim in the .d.ts.
+fn parenthesized_array_element_reference_strips_parens() {
+    // `(Foo)[]` — source parens around a simple reference type are stripped;
+    // tsc 6.0 emits `Foo[]` in the .d.ts (no structural reason for grouping).
     let output = emit_dts("export type T = (Foo)[];");
     assert!(
-        output.contains("(Foo)[]"),
-        "source-parenthesized array element must keep parens: {output}"
+        output.contains("T = Foo[]") && !output.contains("(Foo)[]"),
+        "source-parenthesized reference element must strip parens: {output}"
     );
 }
 
 #[test]
-fn parenthesized_array_element_keeps_parens_renamed() {
-    // Same rule, different element spelling: proves the fix is not keyed on a
+fn parenthesized_array_element_reference_strips_parens_renamed() {
+    // Same rule, different element spelling: proves the rule is not keyed on a
     // particular type-reference name.
     let output = emit_dts("export type T = (Widget9)[];");
     assert!(
-        output.contains("(Widget9)[]"),
-        "source-parenthesized array element must keep parens (renamed): {output}"
+        output.contains("T = Widget9[]") && !output.contains("(Widget9)[]"),
+        "source-parenthesized reference element must strip parens (renamed): {output}"
     );
 }
 
@@ -341,12 +342,21 @@ fn function_return_parenthesized_infer_with_constraint_keeps_parens_renamed() {
 }
 
 #[test]
-fn annotation_redundant_parens_around_keyword_are_stripped() {
-    // #11687's win: `var x: (string)` → `string`.
+fn annotation_parens_around_keyword_are_preserved() {
+    // tsc 6.0 preserves source-level parens around keyword types in annotation
+    // position: `var x: (string)` stays `var x: (string)` in the .d.ts.
+    // Only function/constructor types and bare infer types (no constraint) have
+    // their annotation-position parens stripped.
     let output = emit_dts("export declare var x: (string);");
     assert!(
-        output.contains("var x: string;") && !output.contains("(string)"),
-        "redundant parens around a keyword type must be stripped: {output}"
+        output.contains("var x: (string);"),
+        "keyword type annotation parens must be preserved: {output}"
+    );
+    // Same rule for another keyword: prove it is not spelling-dependent.
+    let output2 = emit_dts("export declare var n: (number);");
+    assert!(
+        output2.contains("var n: (number);"),
+        "keyword type annotation parens must be preserved (number): {output2}"
     );
 }
 

--- a/crates/tsz-emitter/src/declaration_emitter/tests/type_formatting.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/type_formatting.rs
@@ -1761,26 +1761,26 @@ fn test_typeof_type() {
 // Parenthesized type preservation
 // =============================================================================
 
-/// tsc strips *redundant* parentheses around atomic/simple type annotations
-/// (`var x: (string)` → `string`) but *preserves* them around composite types
-/// such as unions, intersections, conditionals, and tuples (see the
-/// `parenthesized_*` tests below and
-/// `tests::infer_paren_and_union_intersection`).
+/// tsc 6.0 *preserves* source-level parentheses in annotation positions for
+/// all type forms except `FunctionType`, `ConstructorType`, and bare
+/// `InferType` (without a constraint). Primitive keywords like `(string)` and
+/// composite types like `(string | number)` both round-trip with their parens
+/// intact (see `tests::infer_paren_and_union_intersection`).
 
 #[test]
-fn parenthesized_simple_type_annotation_stripped() {
-    // Redundant parens around a primitive keyword are stripped:
-    // `var x: (string)` → `string`.
+fn parenthesized_simple_type_annotation_preserved() {
+    // tsc 6.0 preserves source-level parens around a primitive keyword in
+    // annotation position: `var x: (string)` stays `var x: (string)`.
     let output = emit_dts("export declare var x: (string);");
     assert!(
-        output.contains("x: string;") && !output.contains("(string)"),
-        "Expected redundant parens stripped around keyword type: {output}"
+        output.contains("x: (string);"),
+        "Expected parens preserved around keyword type: {output}"
     );
     // Renamed variable — prove the rule is not spelling-dependent.
     let output2 = emit_dts("export declare var value: (number);");
     assert!(
-        output2.contains("value: number;") && !output2.contains("(number)"),
-        "Expected redundant parens stripped around keyword type (renamed): {output2}"
+        output2.contains("value: (number);"),
+        "Expected parens preserved around keyword type (renamed): {output2}"
     );
 }
 

--- a/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
@@ -69,31 +69,37 @@ impl<'a> DeclarationEmitter<'a> {
     /// Whether a source `PARENTHESIZED_TYPE` reached directly by `emit_type`
     /// (an annotation-like position, not a structural caller that already
     /// peels) should keep its source parens around `inner` (the fully peeled
-    /// inner type), matching tsc.
+    /// inner type), matching tsc 6.0.
     ///
-    /// tsc strips redundant parens around atomic/simple operands and
-    /// function/constructor types in these positions, but preserves the source
-    /// grouping when the inner type is a composite that benefits from explicit
-    /// parentheses (union, intersection, conditional, mapped/type-literal,
-    /// tuple) or an `infer` carrying a constraint. The decision is purely
-    /// structural — keyed on the inner node kind, never on identifier names or
-    /// rendered output.
+    /// tsc preserves source-level parens verbatim in annotation positions for
+    /// all type forms **except**:
+    /// - `FunctionType` / `ConstructorType`: the surrounding `()` is implied
+    ///   by `=> Return` / `new` syntax and strips cleanly.
+    /// - bare `InferType` (no constraint): redundant grouping with nothing to
+    ///   capture, so the parens drop.  `(infer U extends X)` keeps its parens
+    ///   because the trailing `extends X` would otherwise re-absorb following
+    ///   tokens in the conditional grammar.
+    ///
+    /// Primitives (`string`, `number`, …), references, arrays, composites,
+    /// and everything else round-trip with their source parens intact.
+    ///
+    /// Structural-position callers (array element, union member, intersection
+    /// arm, conditional branch) call `peel_paren` first and manage parens by
+    /// precedence — those paths never reach this function.
     fn annotation_paren_keeps_source_parens(&self, inner: NodeIndex) -> bool {
         let Some(node) = self.arena.get(inner) else {
             return false;
         };
         let k = node.kind;
-        k == syntax_kind_ext::UNION_TYPE
-            || k == syntax_kind_ext::INTERSECTION_TYPE
-            || k == syntax_kind_ext::CONDITIONAL_TYPE
-            || k == syntax_kind_ext::MAPPED_TYPE
-            || k == syntax_kind_ext::TYPE_LITERAL
-            || k == syntax_kind_ext::TUPLE_TYPE
-            // A source-parenthesized `infer U extends C` keeps its parens: the
-            // trailing `extends` would otherwise re-absorb following tokens
-            // (e.g. an enclosing conditional's own clause). A bare `(infer U)`
-            // with no constraint drops the redundant parens.
-            || (k == syntax_kind_ext::INFER_TYPE && self.infer_type_has_constraint(inner))
+        if k == syntax_kind_ext::FUNCTION_TYPE || k == syntax_kind_ext::CONSTRUCTOR_TYPE {
+            return false;
+        }
+        // Bare infer (no constraint) in annotation position drops its redundant
+        // parens; constrained infer keeps them to avoid grammar ambiguity.
+        if k == syntax_kind_ext::INFER_TYPE {
+            return self.infer_type_has_constraint(inner);
+        }
+        true
     }
 
     pub(crate) fn emit_type(&mut self, type_idx: NodeIndex) {
@@ -181,28 +187,21 @@ impl<'a> DeclarationEmitter<'a> {
             // Array type
             k if k == syntax_kind_ext::ARRAY_TYPE => {
                 if let Some(arr) = self.arena.get_array_type(type_node) {
-                    // Preserve a source-level parenthesized array element so the
-                    // user's parens round-trip verbatim (e.g. `(T)[]` stays
-                    // `(T)[]`, not `T[]`). Detect the source `PARENTHESIZED_TYPE`
-                    // wrapper structurally on the array element, mirroring the
-                    // conditional-type arms. This only affects verbatim source
-                    // copy; synthesized array types print through the solver
-                    // TypePrinter, which normalizes parens independently.
-                    let element_source_was_parenthesized = self
-                        .arena
-                        .get(arr.element_type)
-                        .is_some_and(|n| n.kind == syntax_kind_ext::PARENTHESIZED_TYPE);
+                    // Peel source-level parens from the element type. Parens are
+                    // only re-emitted when structurally required (union, intersection,
+                    // conditional, function, constructor, type-operator, infer).
+                    // Primitive/reference types like `(string)[]` are normalized to
+                    // `string[]`; `(string | number)[]` keeps its parens.
                     let inner = self.peel_paren(arr.element_type);
-                    let needs_parens = element_source_was_parenthesized
-                        || self.arena.get(inner).is_some_and(|n| {
-                            n.kind == syntax_kind_ext::FUNCTION_TYPE
-                                || n.kind == syntax_kind_ext::CONSTRUCTOR_TYPE
-                                || n.kind == syntax_kind_ext::UNION_TYPE
-                                || n.kind == syntax_kind_ext::INTERSECTION_TYPE
-                                || n.kind == syntax_kind_ext::CONDITIONAL_TYPE
-                                || n.kind == syntax_kind_ext::TYPE_OPERATOR
-                                || n.kind == syntax_kind_ext::INFER_TYPE
-                        });
+                    let needs_parens = self.arena.get(inner).is_some_and(|n| {
+                        n.kind == syntax_kind_ext::FUNCTION_TYPE
+                            || n.kind == syntax_kind_ext::CONSTRUCTOR_TYPE
+                            || n.kind == syntax_kind_ext::UNION_TYPE
+                            || n.kind == syntax_kind_ext::INTERSECTION_TYPE
+                            || n.kind == syntax_kind_ext::CONDITIONAL_TYPE
+                            || n.kind == syntax_kind_ext::TYPE_OPERATOR
+                            || n.kind == syntax_kind_ext::INFER_TYPE
+                    });
                     if needs_parens {
                         self.write("(");
                     }


### PR DESCRIPTION
## Agent
AgentName: claude-sonnet-4-6 (dazzling-johnson); m5-pro-48g-gpt5

## Track
DTS emit parity — parenthesized type annotation and array-element parenthesis handling.

## Invariant
tsc 6.0 preserves source-level parens in annotation positions for all types except `FunctionType`, `ConstructorType`, and bare `InferType` without a constraint. In array-element position, parens are driven by structural need only.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/type_emission.rs`
- `crates/tsz-cli` / `tsz-emitter` parenthesized type tests.
- Rewrites `annotation_paren_keeps_source_parens` from opt-in to opt-out, preserving the `infer U extends ...` case.
- Removes source-parenthesized array elements from the array `needs_parens` decision so `(string)[]` normalizes to `string[]`, while structurally composite array element types keep grouping.

## Project Corpus Impact
- Row: DTS emit parity.
- Bug family: parenthesized-type round-trip in `.d.ts` output.
- Evidence: `declFileTypeAnnotationParenType(target=es2015)` and `(target=es5)` were cited from `emit-detail.json` as current DTS failures with +1/-1 lines each; this fix targets that family.

## Verification
- Author-reported local `cargo test -p tsz-cli parenthesized`: all 9 tests pass, including the 3 previously failing tests.
- Author-reported local `cargo test -p tsz-emitter --lib`: 13 pre-existing failures unchanged; all previously passing tests still pass.
- Draft CI for `06b4363107cb66cc2c2948e3e8d1174642e3fe17`: success.
- Ready-review CI is being triggered by m5-pro-48g-gpt5 on 2026-05-30; this PR must not enter `merge-queue` until exact-head ready CI is green.

## Coordination Notes
The prior ES5 `__setFunctionName` fix from PR #11789 has already merged. The three `tsz-cli` integration tests that drove this fix were added in commit `27b443e` without the implementation; this PR completes that work. m5-pro-48g-gpt5 normalized the draft PR body and marked it ready at the user's request so the heavy emit/conformance/fourslash gates can run.
