### PR TITLE
fix(emit): descend into template substitutions in ES5 block-scoping closure capture (latent correctness)

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -207,6 +207,10 @@ name = "loop_capture_labeled_var_recovery_tests"
 path = "tests/loop_capture_labeled_var_recovery_tests.rs"
 
 [[test]]
+name = "loop_capture_template_substitution_tests"
+path = "tests/loop_capture_template_substitution_tests.rs"
+
+[[test]]
 name = "loop_capture_continue_control_tests"
 path = "tests/loop_capture_continue_control_tests.rs"
 

--- a/crates/tsz-emitter/src/transforms/block_scoping_es5.rs
+++ b/crates/tsz-emitter/src/transforms/block_scoping_es5.rs
@@ -926,6 +926,71 @@ fn visit_children<F: FnMut(NodeIndex)>(arena: &NodeArena, node: &Node, mut visit
                 visitor(ret.expression);
             }
         }
+        // A labeled statement (`label: stmt`) is transparent to capture
+        // analysis: the labeled body can be a loop or block whose closures
+        // capture an outer loop variable, so we must descend into it.
+        k if k == syntax_kind_ext::LABELED_STATEMENT => {
+            if let Some(labeled) = arena.get_labeled_statement(node) {
+                visitor(labeled.statement);
+            }
+        }
+        // `new Expr(args)` shares the call-expression payload. A captured loop
+        // variable can appear in the callee or any argument
+        // (e.g. `new Foo(() => x)`), so descend like a call expression.
+        k if k == syntax_kind_ext::NEW_EXPRESSION => {
+            if let Some(new_expr) = arena.get_call_expr(node) {
+                visitor(new_expr.expression);
+                if let Some(ref args) = new_expr.arguments {
+                    for &arg_idx in &args.nodes {
+                        visitor(arg_idx);
+                    }
+                }
+            }
+        }
+        // Template substitutions (`${...}`) are real child expressions. A
+        // template head has no expression, but each `TemplateSpan` carries one
+        // (`\`a${expr}b\``), so a captured loop variable referenced only inside
+        // a substitution must be visited like any other expression.
+        k if k == syntax_kind_ext::TEMPLATE_EXPRESSION => {
+            if let Some(template) = arena.get_template_expr(node) {
+                for &span_idx in &template.template_spans.nodes {
+                    visitor(span_idx);
+                }
+            }
+        }
+        k if k == syntax_kind_ext::TEMPLATE_SPAN => {
+            if let Some(span) = arena.get_template_span(node) {
+                visitor(span.expression);
+            }
+        }
+        // A tagged template (`` tag`a${expr}b` ``) wraps both a tag expression
+        // and the template literal; closures capturing a loop variable can live
+        // in either, so descend into both.
+        k if k == syntax_kind_ext::TAGGED_TEMPLATE_EXPRESSION => {
+            if let Some(tagged) = arena.get_tagged_template(node) {
+                visitor(tagged.tag);
+                visitor(tagged.template);
+            }
+        }
+        // Unary operators (`-x`, `!x`, `x++`, `++x`) and the await/yield/
+        // non-null/spread family all wrap a single operand expression that may
+        // contain a capturing closure.
+        k if k == syntax_kind_ext::PREFIX_UNARY_EXPRESSION
+            || k == syntax_kind_ext::POSTFIX_UNARY_EXPRESSION =>
+        {
+            if let Some(unary) = arena.get_unary_expr(node) {
+                visitor(unary.operand);
+            }
+        }
+        k if k == syntax_kind_ext::AWAIT_EXPRESSION
+            || k == syntax_kind_ext::YIELD_EXPRESSION
+            || k == syntax_kind_ext::NON_NULL_EXPRESSION
+            || k == syntax_kind_ext::SPREAD_ELEMENT =>
+        {
+            if let Some(unary) = arena.get_unary_expr_ex(node) {
+                visitor(unary.expression);
+            }
+        }
         // Add more node types as needed
         _ => {}
     }

--- a/crates/tsz-emitter/tests/loop_capture_template_substitution_tests.rs
+++ b/crates/tsz-emitter/tests/loop_capture_template_substitution_tests.rs
@@ -1,0 +1,136 @@
+//! Regression coverage for ES5 block-scoping closure-capture analysis that must
+//! descend into template-literal substitutions (`${...}`).
+//!
+//! A block-scoped variable declared in a loop body and referenced only inside a
+//! template-literal substitution expression that is captured by a closure must
+//! still trigger the per-iteration loop-function (IIFE) lowering. Previously the
+//! capture analyzer's child-walk swallowed `TEMPLATE_EXPRESSION` /
+//! `TEMPLATE_SPAN` / `TAGGED_TEMPLATE_EXPRESSION` nodes via a catch-all arm, so
+//! captures buried in `${...}` were never detected.
+//!
+//! The rule is keyed on AST node KIND, not identifier spelling, so every test
+//! varies the captured binding name to prove generality (§25/§26).
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_lower_print;
+use tsz_common::common::ScriptTarget;
+use tsz_emitter::output::printer::PrintOptions;
+
+fn emit_es5(source: &str) -> String {
+    parse_and_lower_print(
+        source,
+        PrintOptions {
+            target: ScriptTarget::ES5,
+            ..Default::default()
+        },
+    )
+}
+
+/// Witness: a body-declared block-scoped variable referenced only inside a
+/// template substitution captured by an arrow must produce a per-iteration
+/// loop function.
+#[test]
+fn for_of_template_substitution_capture_emits_loop_function() {
+    let output = emit_es5(
+        r#"
+declare const items: string[];
+declare function sink(s: () => string): void;
+for (const fontType of items) {
+    sink(() => `color: ${fontType};`);
+}
+"#,
+    );
+
+    assert!(
+        output.contains("var _loop_1 = function"),
+        "capture inside a template substitution must trigger the loop-function lowering.\nOutput:\n{output}"
+    );
+}
+
+/// Same structure, different binding name. If the fix were keyed on the
+/// identifier spelling, renaming the binding would silently bypass it.
+#[test]
+fn for_of_template_substitution_capture_renamed_binding() {
+    let output = emit_es5(
+        r#"
+declare const list: string[];
+declare function sink(s: () => string): void;
+for (const widgetKind of list) {
+    sink(() => `border: ${widgetKind};`);
+}
+"#,
+    );
+
+    assert!(
+        output.contains("var _loop_1 = function"),
+        "renamed binding captured in a template substitution must still trigger the loop-function lowering.\nOutput:\n{output}"
+    );
+}
+
+/// A `while` loop where the captured binding lives inside a template span of a
+/// multi-substitution template literal.
+#[test]
+fn while_template_multi_span_capture_emits_loop_function() {
+    let output = emit_es5(
+        r#"
+declare function next(): boolean;
+declare function sink(s: () => string): void;
+while (next()) {
+    let cellValue = 1;
+    let rowName = "r";
+    sink(() => `cell ${rowName}=${cellValue} done`);
+}
+"#,
+    );
+
+    assert!(
+        output.contains("var _loop_1 = function"),
+        "captures inside multiple template spans must trigger the loop-function lowering.\nOutput:\n{output}"
+    );
+}
+
+/// Tagged template variant: the captured binding sits inside a substitution of
+/// a tagged template literal. The analyzer must descend into both the tag and
+/// the template.
+#[test]
+fn for_of_tagged_template_substitution_capture_emits_loop_function() {
+    let output = emit_es5(
+        r#"
+declare const rows: string[];
+declare function tag(strings: TemplateStringsArray, ...vals: any[]): string;
+declare function sink(s: () => string): void;
+for (const tileId of rows) {
+    sink(() => tag`tile-${tileId}-end`);
+}
+"#,
+    );
+
+    assert!(
+        output.contains("var _loop_1 = function"),
+        "capture inside a tagged-template substitution must trigger the loop-function lowering.\nOutput:\n{output}"
+    );
+}
+
+/// Negative: a template literal that captures nothing block-scoped from the
+/// loop must NOT produce a loop-function. Only an outer (non-loop) binding is
+/// referenced inside the substitution, so no per-iteration capture is needed.
+#[test]
+fn for_of_template_substitution_without_capture_is_unchanged() {
+    let output = emit_es5(
+        r#"
+declare const items: string[];
+declare function sink(s: string): void;
+const prefix = "p";
+for (const item of items) {
+    sink(`color: ${prefix}-${item};`);
+}
+"#,
+    );
+
+    assert!(
+        !output.contains("_loop_1"),
+        "a template literal with no captured block-scoped loop binding must not introduce a loop function.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
AgentName: m3-max-64g-opus48

## Track
Emit correctness (bugs-on-top) — ES5 block-scoping closure-capture analysis.

## Invariant
When the ES5 block-scoping capture analyzer walks an expression's children,
template-literal substitution expressions (`TEMPLATE_EXPRESSION` head +
`TEMPLATE_SPAN` expressions, `TAGGED_TEMPLATE_EXPRESSION` tag + template) — and
the other unary/new/spread/labeled child positions — are real child nodes and
must be visited, so a loop binding referenced only inside `${...}` is detected
and gets correct per-iteration `_loop_N` IIFE capture. Keyed on AST node KIND.

## Scope
- `crates/tsz-emitter/src/transforms/block_scoping_es5.rs` (+65): replace the
  `_ => {}` catch-all in `visit_children` with real arms for
  TEMPLATE_EXPRESSION / TEMPLATE_SPAN / TAGGED_TEMPLATE_EXPRESSION /
  NEW_EXPRESSION / PREFIX+POSTFIX_UNARY / AWAIT+YIELD+NON_NULL+SPREAD /
  LABELED_STATEMENT (each verified genuinely unvisited before adding).
- `crates/tsz-emitter/tests/loop_capture_template_substitution_tests.rs` (new, 5 tests); Cargo.toml registration.

## Bug
The ES5 block-scoping closure-capture child-walk swallowed template-substitution
(and several other) node kinds via a `_ => {}` catch-all, so a loop variable
referenced only inside a `${...}` captured by a closure was never detected → a
plain `for` loop emitted instead of the correct `_loop_N` per-iteration IIFE
(wrong runtime capture semantics at ES5).

## Project Corpus Impact
- Row: n/a (emit CORRECTNESS fix — latent ES5 closure-capture bug; well-formed inputs were mis-lowered)
- Bug family: ES5 block-scoping capture analysis does not descend into template-literal substitutions / other child positions
- Evidence: `--js-only -j4` 72→72, `--dts-only` 24→24 (net-zero, zero regressions). The originally-clustered `labeledStatementDeclarationListInLoopNoCrash3/4` witnesses do NOT flip — their residual diff is an INDEPENDENT malformed-unterminated-template parser/scanner error-recovery confound (the es2015 variant, which has no block-scoping transform, fails identically), so those are re-routed to the parser-recovery lane. This fix is proven on WELL-FORMED inputs: 5 new unit tests + CLI ES5 emit producing correct `_loop_1(fontType)` / tagged-template `__makeTemplateObject` capture; `node --check` OK.

## Verification
- arch guard `Architecture guardrails passed`; clippy `-D warnings` clean; file 1027 lines.
- 5 new tests (for-of capture, while multi-span, tagged template, renamed binding proving no name-keying, negative no-capture) pass; full `cargo nextest -p tsz-emitter` = only the 13 pre-existing unrelated failures (confirmed on origin/main).

## Coordination Notes
Emit is OUTPUT — pure traversal completeness fix, no semantic validation, no
output surgery. Net-zero on the metric but fixes a real latent ES5 capture bug.
Re-routes the `labeledStatementDeclarationListInLoopNoCrash` cluster to
parser-error-recovery (conformance-gated) in the endgame plan — it was
mis-clustered as block-scoping-traversal.
