### PR TITLE
fix(parser): use token_full_start() for binary and conditional expression end spans

### DIFF
--- a/crates/tsz-parser/src/parser/state_expressions.rs
+++ b/crates/tsz-parser/src/parser/state_expressions.rs
@@ -427,9 +427,11 @@ impl ParserState {
         }
 
         let right = self.parse_binary_expression_rhs(left, op, precedence);
-        // TODO: should be token_full_start() to match tsc's finishNode default; token_end()
-        // overshoots by the lookahead token. Fix requires CI conformance verification.
-        let end_pos = self.token_end();
+        // Use token_full_start() (start of next lookahead token's trivia) rather than
+        // token_end() (end of that token). After parse_binary_expression_rhs returns, the
+        // scanner sits on the first token not part of this expression. token_full_start()
+        // matches tsc's finishNode(scanner.getTokenFullStart()) convention.
+        let end_pos = self.token_full_start();
         let final_right = if right.is_none() { left } else { right };
 
         self.arena.add_binary_expr(
@@ -463,9 +465,12 @@ impl ParserState {
             self.error_expression_expected();
             when_false = self.create_missing_expression();
         }
-        // TODO: should be token_full_start() to match tsc's finishNode default; token_end()
-        // overshoots by the lookahead token. Fix requires CI conformance verification.
-        let end_pos = self.token_end();
+        // Use token_full_start() rather than token_end(); same convention as
+        // parse_binary_expression_remainder and state_types.rs union/intersection
+        // types: after the last branch is parsed, the scanner sits on the first
+        // token not part of this expression, so token_full_start() gives the
+        // correct node end, matching tsc's finishNode(scanner.getTokenFullStart()).
+        let end_pos = self.token_full_start();
 
         self.arena.add_conditional_expr(
             syntax_kind_ext::CONDITIONAL_EXPRESSION,

--- a/crates/tsz-parser/tests/state_expression_tests.rs
+++ b/crates/tsz-parser/tests/state_expression_tests.rs
@@ -775,3 +775,134 @@ fn malformed_octal_literal_does_not_leak_ts1005_alongside_ts1178() {
         "TS1005 must NOT fire at the same position as TS1178. Got codes: {codes:?}"
     );
 }
+
+// ── binary / conditional span correctness ──────────────────────────────────
+//
+// After parse_binary_expression_rhs / parse_assignment_expression return, the
+// scanner sits on the first token NOT part of the expression (e.g. `;`).
+// token_full_start() gives the start of that lookahead token's trivia, which
+// is the correct node end matching tsc's finishNode(scanner.getTokenFullStart())
+// convention. token_end() overshoots by including the full lookahead token.
+
+fn binary_expr_end(source: &str) -> u32 {
+    let (parser, _) = parse_source(source);
+    let arena = parser.get_arena();
+    arena
+        .nodes
+        .iter()
+        .find(|node| node.kind == syntax_kind_ext::BINARY_EXPRESSION)
+        .expect("expected a BinaryExpression node")
+        .end
+}
+
+fn conditional_expr_end(source: &str) -> u32 {
+    let (parser, _) = parse_source(source);
+    let arena = parser.get_arena();
+    arena
+        .nodes
+        .iter()
+        .find(|node| node.kind == syntax_kind_ext::CONDITIONAL_EXPRESSION)
+        .expect("expected a ConditionalExpression node")
+        .end
+}
+
+#[test]
+fn binary_expression_end_does_not_overshoot_semicolon() {
+    // "a + b;" — binary expr is "a + b", semicolon is separate.
+    // end must point at `;` (offset 5), not past it (offset 6).
+    let source = "a + b;";
+    let semi_pos = source.find(';').unwrap() as u32;
+    let end = binary_expr_end(source);
+    assert_eq!(
+        end, semi_pos,
+        "BinaryExpression.end ({end}) must equal the start of ';' ({semi_pos}), not past it"
+    );
+    assert_eq!(
+        &source[..end as usize],
+        "a + b",
+        "source slice must be the expression text without the trailing semicolon"
+    );
+}
+
+#[test]
+fn binary_expression_end_does_not_overshoot_with_multiple_operators() {
+    // "a + b * c;" — nested binary, outermost end must not include ';'.
+    let source = "a + b * c;";
+    let semi_pos = source.find(';').unwrap() as u32;
+    let end = binary_expr_end(source);
+    assert_eq!(
+        end, semi_pos,
+        "BinaryExpression.end ({end}) must not include the trailing ';' at {semi_pos}"
+    );
+}
+
+#[test]
+fn binary_expression_end_does_not_overshoot_comparison_operator() {
+    // "x === y;" — strict-equality binary expression.
+    let source = "x === y;";
+    let semi_pos = source.find(';').unwrap() as u32;
+    let end = binary_expr_end(source);
+    assert_eq!(end, semi_pos, "BinaryExpression end must stop before ';'");
+}
+
+#[test]
+fn binary_expression_end_does_not_overshoot_logical_operator() {
+    // "a && b;" — logical-AND binary expression.
+    let source = "a && b;";
+    let semi_pos = source.find(';').unwrap() as u32;
+    let end = binary_expr_end(source);
+    assert_eq!(end, semi_pos, "BinaryExpression end must stop before ';'");
+}
+
+#[test]
+fn binary_expression_end_does_not_bleed_into_next_statement() {
+    // Two statements — the binary expr of the first must not reach into the second.
+    let source = "a + b;\nlet x = 1;";
+    let semi_pos = source.find(';').unwrap() as u32;
+    let end = binary_expr_end(source);
+    assert_eq!(
+        end, semi_pos,
+        "BinaryExpression.end must not bleed into the next statement (end={end}, semi={semi_pos})"
+    );
+}
+
+#[test]
+fn conditional_expression_end_does_not_overshoot_semicolon() {
+    // "a ? b : c;" — conditional expr is "a ? b : c", semicolon is separate.
+    let source = "a ? b : c;";
+    let semi_pos = source.find(';').unwrap() as u32;
+    let end = conditional_expr_end(source);
+    assert_eq!(
+        end, semi_pos,
+        "ConditionalExpression.end ({end}) must equal the start of ';' ({semi_pos}), not past it"
+    );
+    assert_eq!(
+        &source[..end as usize],
+        "a ? b : c",
+        "source slice must be the expression text without the trailing semicolon"
+    );
+}
+
+#[test]
+fn conditional_expression_end_does_not_overshoot_with_nested_binary() {
+    // "x > 0 ? y + 1 : z;" — conditional with binary branches.
+    let source = "x > 0 ? y + 1 : z;";
+    let semi_pos = source.find(';').unwrap() as u32;
+    let end = conditional_expr_end(source);
+    assert_eq!(
+        end, semi_pos,
+        "ConditionalExpression.end must not include ';' (end={end}, semi={semi_pos})"
+    );
+}
+
+#[test]
+fn conditional_expression_end_does_not_bleed_into_next_statement() {
+    // Two statements — conditional expr of the first must not reach into the second.
+    let source = "a ? b : c;\nlet x = 1;";
+    let semi_pos = source.find(';').unwrap() as u32;
+    let end = conditional_expr_end(source);
+    assert_eq!(
+        end, semi_pos,
+        "ConditionalExpression.end must not bleed into the next statement (end={end}, semi={semi_pos})"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: claude-sonnet-4-6 (dazzling-johnson-vA5Uo); m5-pro-48g-gpt5

## Track
Track 9 (Parser) — node-span correctness: binary and conditional expression end positions.

## Invariant

> After `parse_binary_expression_rhs` / `parse_assignment_expression` returns, the scanner sits on the first token **not** part of the expression (e.g. `;`). The node's `end` must be `token_full_start()` — start of that lookahead token's trivia — not `token_end()` — end of that lookahead token. This matches tsc's universal `finishNode(scanner.getTokenFullStart())` convention.

**Before (wrong):** `a + b;` → `BinaryExpression.end = 6` (past `;`), so `source[0..6] = "a + b;"`.

**After (correct):** `a + b;` → `BinaryExpression.end = 5` (start of `;`), so `source[0..5] = "a + b"`.

## Scope

One-line fix at two sites in `crates/tsz-parser/src/parser/state_expressions.rs`:
- `parse_binary_expression_remainder` line 430: `token_end()` → `token_full_start()`
- `parse_conditional_expression` line 464: `token_end()` → `token_full_start()`

8 new focused tests in `state_expression_tests.rs` covering:
1. `a + b;` — binary arithmetic
2. `a + b * c;` — nested binary (multiple operators)
3. `x === y;` — comparison operator
4. `a && b;` — logical operator
5. Two-statement source — no bleed into next statement
6. `a ? b : c;` — conditional basic
7. `x > 0 ? y + 1 : z;` — conditional with binary branches
8. Two-statement conditional — no bleed into next statement

## Owning layer

Parser only. No checker, solver, emitter, or binder changes.

## Adjacent cases verified

The same `token_full_start()` convention is already used for:
- Union/intersection types (`state_types.rs` lines 283, 341, 381, 425)
- As/satisfies expressions (fixed in #11796)
- Parameter ends (`state_types.rs` lines 750, 781)

## Known uncertainty

Binary and conditional expressions are foundational AST nodes used in hundreds of conformance tests. The fix is trivially correct by the tsc convention, but full conformance + emit + fourslash CI is required before landing. This PR is opened as ready (not draft) per issue #11795 to trigger heavy CI.

## Project Corpus Impact

- Row: large-ts-repo (any expression with binary/conditional followed by `;` had an inflated span)
- Bug family: Parser node span overshoot (`token_end` vs `token_full_start`)
- Evidence: 8/8 new span tests pass; 1066/1066 full tsz-parser unit tests pass (zero regressions); companion fix for as/satisfies landed in #11796

## Verification

```bash
cargo nextest run -p tsz-parser -E 'test(binary_expression_end) | test(conditional_expression_end)'
# 8/8 PASS

cargo nextest run -p tsz-parser
# 1066/1066 PASS

cargo clippy -p tsz-parser --all-targets -- -D warnings
# clean
```

Full conformance, emit, and fourslash suites run in CI (required for this PR per issue #11795).

## Coordination Notes

m5-pro-48g-gpt5 normalized this PR body for the project-corpus gate on 2026-05-30.

- Fixes #11795 (binary/conditional token_end overshoot — follow-up from #11796)
- Stacks on main; #11796 (as/satisfies fix) is the companion, not a dependency
- No overlap with open PRs checked before starting

https://claude.ai/code/session_01AhjhEWDifBur4L6PGcfi7b
