### PR TITLE
fix(solver): elaborate same-generic TS2322 failures by type argument

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -2133,6 +2133,26 @@ impl<'a> CheckerState<'a> {
             };
         }
 
+        // Same-generic application (`C<A..>` vs `C<B..>`): tsc elaborates the
+        // differing type arguments directly. The structural pipeline evaluates
+        // the applications to object shapes (losing the type-argument identity)
+        // and would emit a `Types of property 'x' are incompatible.` wrapper
+        // that tsc does not produce, so detect it on the raw operands first.
+        if let Some(reason) =
+            crate::query_boundaries::assignability::same_generic_application_failure_reason(
+                self.ctx.types,
+                &self.ctx,
+                &self.ctx,
+                source,
+                target,
+            )
+        {
+            return crate::query_boundaries::assignability::AssignabilityFailureAnalysis {
+                weak_union_violation: false,
+                failure_reason: Some(reason),
+            };
+        }
+
         let (prepared_source, prepared_target) = self.prepare_assignability_inputs(source, target);
 
         // Keep failure analysis on the same relation boundary as `is_assignable_to`

--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -12,90 +12,9 @@ use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
 mod display_types;
+mod explicit_any_annotations;
 
 impl<'a> CheckerState<'a> {
-    fn has_explicit_any_generic_variable_annotation(&self, diag_idx: NodeIndex) -> bool {
-        let Some(node) = self.ctx.arena.get(diag_idx) else {
-            return false;
-        };
-        if node.kind != syntax_kind_ext::VARIABLE_DECLARATION {
-            return false;
-        }
-        let Some(decl) = self.ctx.arena.get_variable_declaration(node) else {
-            return false;
-        };
-        if decl.type_annotation == NodeIndex::NONE {
-            return false;
-        }
-        self.type_annotation_contains_explicit_any_type_argument(decl.type_annotation)
-    }
-
-    fn type_annotation_contains_explicit_any_type_argument(
-        &self,
-        type_annotation: NodeIndex,
-    ) -> bool {
-        let mut stack = vec![type_annotation];
-        while let Some(current) = stack.pop() {
-            let Some(node) = self.ctx.arena.get(current) else {
-                continue;
-            };
-            if node.kind == syntax_kind_ext::TYPE_REFERENCE
-                && let Some(type_ref) = self.ctx.arena.get_type_ref(node)
-                && let Some(type_args) = &type_ref.type_arguments
-                && type_args
-                    .nodes
-                    .iter()
-                    .any(|&arg| self.type_node_contains_any_keyword(arg))
-            {
-                return true;
-            }
-            stack.extend(self.ctx.arena.get_children(current));
-        }
-        false
-    }
-
-    fn type_node_contains_any_keyword(&self, type_node: NodeIndex) -> bool {
-        let mut stack = vec![type_node];
-        while let Some(current) = stack.pop() {
-            let Some(node) = self.ctx.arena.get(current) else {
-                continue;
-            };
-            if node.kind == SyntaxKind::AnyKeyword as u16
-                || self.is_bare_any_keyword_type_reference(node)
-            {
-                return true;
-            }
-            stack.extend(self.ctx.arena.get_children(current));
-        }
-        false
-    }
-
-    fn is_bare_any_keyword_type_reference(&self, node: &tsz_parser::parser::node::Node) -> bool {
-        if node.kind != syntax_kind_ext::TYPE_REFERENCE {
-            return false;
-        }
-        let Some(type_ref) = self.ctx.arena.get_type_ref(node) else {
-            return false;
-        };
-        if type_ref
-            .type_arguments
-            .as_ref()
-            .is_some_and(|args| !args.nodes.is_empty())
-        {
-            return false;
-        }
-        let Some(name_node) = self.ctx.arena.get(type_ref.type_name) else {
-            return false;
-        };
-        if name_node.kind != SyntaxKind::Identifier as u16 {
-            return false;
-        }
-        self.ctx
-            .arena
-            .get_identifier(name_node)
-            .is_some_and(|ident| ident.escaped_text == "any")
-    }
-
     pub(crate) fn generic_indexed_access_argument_surface(&self, type_id: TypeId) -> bool {
         self.generic_indexed_access_argument_surface_inner(type_id)
             || self

--- a/crates/tsz-checker/src/assignability/assignability_diagnostics/explicit_any_annotations.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics/explicit_any_annotations.rs
@@ -1,0 +1,89 @@
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::NodeAccess;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
+
+impl<'a> CheckerState<'a> {
+    pub(super) fn has_explicit_any_generic_variable_annotation(&self, diag_idx: NodeIndex) -> bool {
+        let Some(node) = self.ctx.arena.get(diag_idx) else {
+            return false;
+        };
+        if node.kind != syntax_kind_ext::VARIABLE_DECLARATION {
+            return false;
+        }
+        let Some(decl) = self.ctx.arena.get_variable_declaration(node) else {
+            return false;
+        };
+        if decl.type_annotation == NodeIndex::NONE {
+            return false;
+        }
+        self.type_annotation_contains_explicit_any_type_argument(decl.type_annotation)
+    }
+
+    fn type_annotation_contains_explicit_any_type_argument(
+        &self,
+        type_annotation: NodeIndex,
+    ) -> bool {
+        let mut stack = vec![type_annotation];
+        while let Some(current) = stack.pop() {
+            let Some(node) = self.ctx.arena.get(current) else {
+                continue;
+            };
+            if node.kind == syntax_kind_ext::TYPE_REFERENCE
+                && let Some(type_ref) = self.ctx.arena.get_type_ref(node)
+                && let Some(type_args) = &type_ref.type_arguments
+                && type_args
+                    .nodes
+                    .iter()
+                    .any(|&arg| self.type_node_contains_any_keyword(arg))
+            {
+                return true;
+            }
+            stack.extend(self.ctx.arena.get_children(current));
+        }
+        false
+    }
+
+    fn type_node_contains_any_keyword(&self, type_node: NodeIndex) -> bool {
+        let mut stack = vec![type_node];
+        while let Some(current) = stack.pop() {
+            let Some(node) = self.ctx.arena.get(current) else {
+                continue;
+            };
+            if node.kind == SyntaxKind::AnyKeyword as u16
+                || self.is_bare_any_keyword_type_reference(node)
+            {
+                return true;
+            }
+            stack.extend(self.ctx.arena.get_children(current));
+        }
+        false
+    }
+
+    fn is_bare_any_keyword_type_reference(&self, node: &tsz_parser::parser::node::Node) -> bool {
+        if node.kind != syntax_kind_ext::TYPE_REFERENCE {
+            return false;
+        }
+        let Some(type_ref) = self.ctx.arena.get_type_ref(node) else {
+            return false;
+        };
+        if type_ref
+            .type_arguments
+            .as_ref()
+            .is_some_and(|args| !args.nodes.is_empty())
+        {
+            return false;
+        }
+        let Some(name_node) = self.ctx.arena.get(type_ref.type_name) else {
+            return false;
+        };
+        if name_node.kind != SyntaxKind::Identifier as u16 {
+            return false;
+        }
+        self.ctx
+            .arena
+            .get_identifier(name_node)
+            .is_some_and(|ident| ident.escaped_text == "any")
+    }
+}

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -554,6 +554,16 @@ impl<'a> CheckerState<'a> {
                 *target_return,
                 nested_reason.as_deref(),
             ),
+            SubtypeFailureReason::TypeArgumentMismatch {
+                source_arg,
+                target_arg,
+                nested_reason,
+            } => self.render_type_argument_mismatch(
+                &rctx,
+                *source_arg,
+                *target_arg,
+                nested_reason.as_ref(),
+            ),
             SubtypeFailureReason::TooManyParameters {
                 source_count,
                 target_count,

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -67,8 +67,8 @@ impl<'a> CheckerState<'a> {
             db: &dyn tsz_solver::construction::TypeDatabase,
             ty: TypeId,
         ) -> bool {
-            crate::query_boundaries::common::is_object_like_type(db, ty)
-                || crate::query_boundaries::common::is_callable_type(db, ty)
+            crate::query_boundaries::dispatch::is_object_like_type(db, ty)
+                || crate::query_boundaries::dispatch::is_callable_type(db, ty)
         }
 
         let source_eval = self.evaluate_type_for_assignability(source);

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -520,6 +520,68 @@ impl<'a> CheckerState<'a> {
         diag
     }
 
+    /// Render a same-generic type-argument mismatch (`C<A..>` vs `C<B..>`).
+    ///
+    /// Emits the top-level `Type 'C<A..>' is not assignable to type 'C<B..>'.`
+    /// line followed directly by the failing argument relation, with no
+    /// intermediate `Types of property 'x' are incompatible.` wrapper — tsc
+    /// elaborates same-generic argument failures straight into the differing
+    /// argument. Deeper argument failures (e.g. nested generic arguments) keep
+    /// elaborating through the structured `nested_reason`.
+    pub(super) fn render_type_argument_mismatch(
+        &mut self,
+        ctx: &RenderContext,
+        source_arg: TypeId,
+        target_arg: TypeId,
+        nested_reason: &tsz_solver::SubtypeFailureReason,
+    ) -> Diagnostic {
+        let source = ctx.source;
+        let target = ctx.target;
+        let idx = ctx.idx;
+        let depth = ctx.depth;
+        let start = ctx.start;
+        let length = ctx.length;
+        let file_name = ctx.file_name.clone();
+
+        let (source_str, target_str) = if depth == 0 {
+            self.format_top_level_assignability_message_types_at(source, target, idx)
+        } else {
+            (
+                self.format_type_diagnostic(source),
+                self.format_type_diagnostic(target),
+            )
+        };
+        let base = format_message(
+            diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            &[&source_str, &target_str],
+        );
+        let mut diag = Diagnostic::error(
+            file_name,
+            start,
+            length,
+            base,
+            diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+        );
+
+        // The failing argument relation is rendered as the immediate child of
+        // this line (no intermediate wrapper), so it sits at the current
+        // elaboration depth — one indent level beneath the application line.
+        if depth < 5 {
+            let (nested_source, nested_target) =
+                Self::nested_failure_display_types(nested_reason, source_arg, target_arg);
+            let nested_diag = self.render_failure_reason(
+                nested_reason,
+                nested_source,
+                nested_target,
+                idx,
+                depth + 1,
+            );
+            Self::push_nested_chain(&mut diag, nested_diag, depth);
+        }
+
+        diag
+    }
+
     /// Append the inner element failure line beneath a tuple element mismatch.
     ///
     /// Uses the structured `nested_reason` when present so deeply nested element

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -58,6 +58,25 @@ impl<'a> CheckerState<'a> {
         nested_base == enclosing_base
     }
 
+    fn same_generic_mismatch_keeps_application_top_level(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> bool {
+        fn structural_display_type(
+            db: &dyn tsz_solver::construction::TypeDatabase,
+            ty: TypeId,
+        ) -> bool {
+            crate::query_boundaries::common::is_object_like_type(db, ty)
+                || crate::query_boundaries::common::is_callable_type(db, ty)
+        }
+
+        let source_eval = self.evaluate_type_for_assignability(source);
+        let target_eval = self.evaluate_type_for_assignability(target);
+        structural_display_type(self.ctx.types, source_eval)
+            || structural_display_type(self.ctx.types, target_eval)
+    }
+
     const fn nested_reason_is_plain_type_mismatch(
         reason: &tsz_solver::SubtypeFailureReason,
     ) -> bool {
@@ -543,7 +562,16 @@ impl<'a> CheckerState<'a> {
         let length = ctx.length;
         let file_name = ctx.file_name.clone();
 
-        let (source_str, target_str) = if depth == 0 {
+        let (source_str, target_str) = if depth == 0
+            && !self.same_generic_mismatch_keeps_application_top_level(source, target)
+        {
+            let (source_str, _) =
+                self.format_top_level_assignability_message_types_at(source, target, idx);
+            (
+                source_str,
+                self.format_type_for_assignability_message_skip_application_alias(target_arg),
+            )
+        } else if depth == 0 {
             self.format_top_level_assignability_message_types_at(source, target, idx)
         } else {
             (
@@ -569,14 +597,33 @@ impl<'a> CheckerState<'a> {
         if depth < 5 {
             let (nested_source, nested_target) =
                 Self::nested_failure_display_types(nested_reason, source_arg, target_arg);
-            let nested_diag = self.render_failure_reason(
-                nested_reason,
-                nested_source,
-                nested_target,
-                idx,
-                depth + 1,
-            );
-            Self::push_nested_chain(&mut diag, nested_diag, depth);
+            if Self::nested_reason_is_plain_type_mismatch(nested_reason) {
+                let source_str = self
+                    .format_type_for_assignability_message_skip_application_alias(nested_source);
+                let target_str = self
+                    .format_type_for_assignability_message_skip_application_alias(nested_target);
+                diag.related_information.push(DiagnosticRelatedInformation {
+                    file: diag.file.clone(),
+                    start,
+                    length,
+                    message_text: format_message(
+                        diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+                        &[&source_str, &target_str],
+                    ),
+                    category: DiagnosticCategory::Message,
+                    code: diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+                    depth: depth.min(u8::MAX as u32) as u8,
+                });
+            } else {
+                let nested_diag = self.render_failure_reason(
+                    nested_reason,
+                    nested_source,
+                    nested_target,
+                    idx,
+                    depth + 1,
+                );
+                Self::push_nested_chain(&mut diag, nested_diag, depth);
+            }
         }
 
         diag

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -942,6 +942,9 @@ mod ts18048_unary_arithmetic_nullish_tests;
 #[path = "tests/ts2322_private_field_narrowing_write_tests.rs"]
 mod ts2322_private_field_narrowing_write_tests;
 #[cfg(test)]
+#[path = "tests/ts2322_same_generic_type_argument_elaboration_tests.rs"]
+mod ts2322_same_generic_type_argument_elaboration_tests;
+#[cfg(test)]
 #[path = "tests/ts2339_js_this_function_name_display_tests.rs"]
 mod ts2339_js_this_function_name_display_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -1793,6 +1793,30 @@ pub(crate) fn analyze_assignability_failure_with_context<
     }
 }
 
+/// Explain a same-generic application failure (`C<A..>` vs `C<B..>`) via the
+/// differing type arguments, mirroring tsc.
+///
+/// Must be called on the **raw** (unevaluated) operands so the application
+/// structure survives; returns `None` unless the failure reliably reduces to a
+/// concrete type argument, in which case the structural analysis should run.
+pub(crate) fn same_generic_application_failure_reason<
+    R: tsz_solver::relations::subtype::TypeResolver,
+>(
+    db: &dyn TypeDatabase,
+    ctx: &crate::context::CheckerContext<'_>,
+    resolver: &R,
+    source: TypeId,
+    target: TypeId,
+) -> Option<SubtypeFailureReason> {
+    tsz_solver::relations::relation_queries::explain_same_generic_application_with_resolver(
+        db,
+        resolver,
+        source,
+        target,
+        |checker| ctx.configure_compat_checker(checker),
+    )
+}
+
 /// Variance-aware Application-to-Application assignability check.
 ///
 /// When both source and target are Applications with the same base type,

--- a/crates/tsz-checker/src/query_boundaries/dispatch.rs
+++ b/crates/tsz-checker/src/query_boundaries/dispatch.rs
@@ -8,6 +8,10 @@ pub(crate) fn is_object_like_type(db: &dyn TypeDatabase, type_id: TypeId) -> boo
     tsz_solver::type_queries::is_object_like_type(db, type_id)
 }
 
+pub(crate) fn is_callable_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    tsz_solver::type_queries::is_callable_type(db, type_id)
+}
+
 pub(crate) fn get_index_access_types(
     db: &dyn TypeDatabase,
     type_id: TypeId,

--- a/crates/tsz-checker/src/query_boundaries/relation_types.rs
+++ b/crates/tsz-checker/src/query_boundaries/relation_types.rs
@@ -297,6 +297,17 @@ impl RelationFailure {
                 target_param,
                 target_constraint,
             },
+            // The same-generic argument failure is rendered directly from the
+            // solver reason; this checker-facing classification only needs the
+            // failing argument pair (used for drift/heuristic inspection).
+            SubtypeFailureReason::TypeArgumentMismatch {
+                source_arg,
+                target_arg,
+                ..
+            } => Self::TypeMismatch {
+                source_type: source_arg,
+                target_type: target_arg,
+            },
         }
     }
 }

--- a/crates/tsz-checker/src/tests/ts2322_same_generic_type_argument_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2322_same_generic_type_argument_elaboration_tests.rs
@@ -1,0 +1,192 @@
+//! Regression tests for the TS2322 same-generic type-argument elaboration.
+//!
+//! Structural rule: when the assignment source and target are applications of
+//! the **same generic target** (`C<A..>` vs `C<B..>`) whose variance reliably
+//! pins the failure to a concrete type argument, `tsc` elaborates the failure
+//! by comparing the differing type **arguments** directly — a single nested
+//! line `Type 'Ai' is not assignable to type 'Bi'.` — instead of recursing
+//! into a structural property comparison that emits an extra
+//! `Types of property 'x' are incompatible.` line.
+//!
+//! See issue #11778. The fix lives in the solver relation failure-reason
+//! generation (`SubtypeChecker::explain_same_generic_type_arguments`) so it
+//! applies to every same-generic mismatch, not the reported spelling.
+
+use crate::test_utils::check_source_diagnostics;
+
+/// Collect the TS2322 diagnostic's full elaboration text (main message plus all
+/// related-information lines, joined by newlines) for a single-error source.
+fn ts2322_elaboration(source: &str) -> String {
+    let diags = check_source_diagnostics(source);
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "Expected exactly one TS2322. Got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    let mut lines = vec![ts2322[0].message_text.clone()];
+    lines.extend(
+        ts2322[0]
+            .related_information
+            .iter()
+            .map(|info| info.message_text.clone()),
+    );
+    lines.join("\n")
+}
+
+/// The reported repro: a user class with a single covariant/invariant field.
+/// tsc elaborates the differing argument directly; no `Types of property`.
+#[test]
+fn same_generic_user_class_elaborates_type_argument_directly() {
+    let text = ts2322_elaboration(
+        r#"
+class Box<T> { v!: T }
+declare const b: Box<number>;
+const n: Box<string> = b;
+"#,
+    );
+    assert!(
+        text.contains("Type 'number' is not assignable to type 'string'."),
+        "Expected the differing type argument as the nested line. Got: {text:?}"
+    );
+    assert!(
+        !text.contains("Types of property"),
+        "Same-generic argument mismatch must not emit a `Types of property` line. Got: {text:?}"
+    );
+}
+
+/// Anti-hardcoding cover: the rule is about same-generic *applications*, not the
+/// type-parameter name. Renaming `T` to `K` and the property must not change the
+/// elaboration shape.
+#[test]
+fn same_generic_user_class_renamed_type_param() {
+    let text = ts2322_elaboration(
+        r#"
+class Holder<K> { value!: K }
+declare const h: Holder<number>;
+const h2: Holder<string> = h;
+"#,
+    );
+    assert!(
+        text.contains("Type 'number' is not assignable to type 'string'."),
+        "Renamed variant must still elaborate the type argument directly. Got: {text:?}"
+    );
+    assert!(
+        !text.contains("Types of property"),
+        "Renamed variant must not emit a `Types of property` line. Got: {text:?}"
+    );
+}
+
+/// Covariant container shape (type parameter only in a method return position)
+/// follows the same rule — proving the fix is variance-driven, not field-shaped.
+#[test]
+fn same_generic_covariant_container() {
+    let text = ts2322_elaboration(
+        r#"
+interface Producer<T> { get(): T }
+declare const p: Producer<number>;
+const p2: Producer<string> = p;
+"#,
+    );
+    assert!(
+        text.contains("Type 'number' is not assignable to type 'string'."),
+        "Covariant container must elaborate the argument directly. Got: {text:?}"
+    );
+    assert!(
+        !text.contains("Types of property"),
+        "Covariant container mismatch must not emit a `Types of property` line. Got: {text:?}"
+    );
+}
+
+/// Multi-parameter generic: only the *differing* (second) argument is reported,
+/// proving the fix selects the failing argument position rather than the first.
+#[test]
+fn same_generic_multi_parameter_selects_failing_argument() {
+    let text = ts2322_elaboration(
+        r#"
+interface Pair<A, B> { first: A; second: B }
+declare const pr: Pair<string, number>;
+const pr2: Pair<string, string> = pr;
+"#,
+    );
+    assert!(
+        text.contains("Type 'number' is not assignable to type 'string'."),
+        "Multi-parameter mismatch must elaborate the failing (second) argument. Got: {text:?}"
+    );
+    assert!(
+        !text.contains("Types of property"),
+        "Multi-parameter mismatch must not emit a `Types of property` line. Got: {text:?}"
+    );
+}
+
+/// Nested same-generic arguments keep elaborating: the outer application line,
+/// then the inner application line, then the leaf relation — each one indent
+/// level deeper, still without any `Types of property` wrapper.
+#[test]
+fn same_generic_nested_arguments_chain() {
+    let text = ts2322_elaboration(
+        r#"
+class Holder<K> { value!: K }
+class Wrap<T> { inner!: T }
+declare const w: Wrap<Holder<number>>;
+const w2: Wrap<Holder<string>> = w;
+"#,
+    );
+    assert!(
+        text.contains("Type 'Holder<number>' is not assignable to type 'Holder<string>'."),
+        "Outer argument (Holder<number> vs Holder<string>) must be elaborated. Got: {text:?}"
+    );
+    assert!(
+        text.contains("Type 'number' is not assignable to type 'string'."),
+        "Inner leaf argument must be elaborated. Got: {text:?}"
+    );
+    assert!(
+        !text.contains("Types of property"),
+        "Nested same-generic mismatch must not emit a `Types of property` line. Got: {text:?}"
+    );
+}
+
+/// Negative / fallback cover: *different* generic targets (`Foo<T>` vs `Bar<T>`)
+/// are not the same application, so tsc keeps the structural property
+/// elaboration. This locks the same-generic rule from over-firing.
+#[test]
+fn different_generic_targets_keep_property_elaboration() {
+    let text = ts2322_elaboration(
+        r#"
+class Foo<T> { v!: T }
+class Bar<T> { v!: T }
+declare const f: Foo<number>;
+const bar: Bar<string> = f;
+"#,
+    );
+    assert!(
+        text.contains("Types of property 'v' are incompatible."),
+        "Distinct generic targets must keep the structural property elaboration. Got: {text:?}"
+    );
+    assert!(
+        text.contains("Type 'number' is not assignable to type 'string'."),
+        "The leaf relation should still appear beneath the property line. Got: {text:?}"
+    );
+}
+
+/// Negative / fallback cover: a plain (non-generic) object property mismatch
+/// must still elaborate with `Types of property`, matching tsc.
+#[test]
+fn plain_object_property_mismatch_keeps_property_elaboration() {
+    let text = ts2322_elaboration(
+        r#"
+interface A { x: number }
+interface B { x: string }
+declare const a: A;
+const b: B = a;
+"#,
+    );
+    assert!(
+        text.contains("Types of property 'x' are incompatible."),
+        "Plain object property mismatch must keep `Types of property`. Got: {text:?}"
+    );
+}

--- a/crates/tsz-solver/src/diagnostics/core.rs
+++ b/crates/tsz-solver/src/diagnostics/core.rs
@@ -252,6 +252,24 @@ pub enum SubtypeFailureReason {
     /// target types come from the diagnostic context, so this variant carries
     /// no payload.
     AbstractConstructorAssignment,
+    /// Two applications of the **same generic target** (`C<A..>` vs `C<B..>`)
+    /// whose differing type **arguments** are the cause of the failure.
+    ///
+    /// tsc elaborates this by comparing the failing type argument directly,
+    /// emitting a single nested line (e.g. `Type 'number' is not assignable to
+    /// type 'string'.`) beneath the top-level TS2322/TS2345 message, with no
+    /// intermediate `Types of property 'x' are incompatible.` wrapper that a
+    /// structural-member walk would otherwise produce.
+    ///
+    /// `source_arg`/`target_arg` are the failing argument pair, already
+    /// oriented for the parameter's variance (for a contravariant parameter
+    /// these are the target/source arguments respectively). `nested_reason`
+    /// explains that argument relation and is rendered one level deeper.
+    TypeArgumentMismatch {
+        source_arg: TypeId,
+        target_arg: TypeId,
+        nested_reason: Box<Self>,
+    },
 }
 
 /// Diagnostic severity level.
@@ -575,6 +593,7 @@ impl SubtypeFailureReason {
             | Self::ParameterCountMismatch { .. }
             | Self::TooManyParameters { .. }
             | Self::IndexAccessTypeParameterMismatch { .. }
+            | Self::TypeArgumentMismatch { .. }
             | Self::AbstractConstructorAssignment => codes::TYPE_NOT_ASSIGNABLE,
             Self::NoCommonProperties { .. } => codes::NO_COMMON_PROPERTIES,
             Self::ExcessProperty { .. } => codes::EXCESS_PROPERTY,
@@ -945,6 +964,23 @@ impl SubtypeFailureReason {
                     codes::ABSTRACT_CONSTRUCTOR_ASSIGNMENT,
                     vec![],
                 ))
+            }
+            Self::TypeArgumentMismatch {
+                source_arg,
+                target_arg,
+                nested_reason,
+            } => {
+                // Top-level TS2322 for the application pair, then the failing
+                // type argument relation directly beneath it. tsc does not emit
+                // a `Types of property` wrapper for same-generic argument
+                // mismatches, so the nested argument failure is the only
+                // elaboration line.
+                let mut diag = PendingDiagnostic::error(
+                    codes::TYPE_NOT_ASSIGNABLE,
+                    vec![source.into(), target.into()],
+                );
+                diag = diag.with_related(nested_reason.to_diagnostic(*source_arg, *target_arg));
+                diag
             }
         }
     }

--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -1658,6 +1658,28 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         }
     }
 
+    /// Explain a same-generic application failure (`C<A..>` vs `C<B..>`) by the
+    /// differing type arguments, mirroring tsc. Returns `None` unless the inputs
+    /// are applications of the same generic target whose variance reliably
+    /// pins the failure to a concrete type argument (see
+    /// [`SubtypeChecker::explain_same_generic_type_arguments`]).
+    ///
+    /// Must be called on the **raw** (unevaluated) operands so the application
+    /// structure is still present; once the applications are expanded to object
+    /// shapes the type-argument identity is lost and the structural path runs.
+    pub fn explain_same_generic_type_arguments(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> Option<SubtypeFailureReason> {
+        if source == target {
+            return None;
+        }
+        self.configure_subtype(self.strict_function_types);
+        self.subtype
+            .explain_same_generic_type_arguments(source, target)
+    }
+
     const fn configure_subtype(&mut self, strict_function_types: bool) {
         self.subtype.strict_function_types = strict_function_types;
         self.subtype.allow_void_return = true;

--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -336,6 +336,28 @@ where
     }
 }
 
+/// Explain a same-generic application failure (`C<A..>` vs `C<B..>`) via the
+/// differing type arguments, mirroring tsc's elaboration.
+///
+/// Returns `Some` only when `source`/`target` are applications of the same
+/// generic target whose variance reliably pins the failure to a concrete type
+/// argument; otherwise `None` so the caller falls back to the structural
+/// failure analysis. Must be called on the **raw** (unevaluated) operands.
+pub fn explain_same_generic_application_with_resolver<'a, R: TypeResolver, F>(
+    interner: &'a dyn TypeDatabase,
+    resolver: &'a R,
+    source: TypeId,
+    target: TypeId,
+    configure: F,
+) -> Option<crate::SubtypeFailureReason>
+where
+    F: FnOnce(&mut CompatChecker<'a, R>),
+{
+    let mut checker = CompatChecker::with_resolver(interner, resolver);
+    configure(&mut checker);
+    checker.explain_same_generic_type_arguments(source, target)
+}
+
 /// Query a relation using a no-op resolver and no overrides.
 pub fn query_relation(
     interner: &dyn TypeDatabase,

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -217,6 +217,18 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         resolved_source = self.resolve_type_query_for_explain(resolved_source);
         resolved_target = self.resolve_type_query_for_explain(resolved_target);
 
+        // Same-generic application (`C<A..>` vs `C<B..>`): tsc elaborates the
+        // differing type arguments directly rather than recursing into a
+        // structural property comparison. Detect this before expanding the
+        // applications below — expansion would replace them with object shapes
+        // and route into the `Types of property 'x' are incompatible.` path
+        // that tsc does not emit for same-generic argument mismatches.
+        if let Some(reason) =
+            self.explain_same_generic_type_arguments(resolved_source, resolved_target)
+        {
+            return Some(reason);
+        }
+
         // Expand applications (like Array<number>, MyGeneric<string>) to structural forms
         if let Some(app_id) = crate::visitor::application_id(self.interner, resolved_source)
             && let Some(expanded) = self.try_expand_application(app_id)

--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -10,15 +10,17 @@
 use super::super::{SubtypeChecker, SubtypeResult, TypeResolver};
 pub(crate) use super::mapped_chain::flatten_mapped_chain;
 use crate::def::DefId;
+use crate::diagnostics::SubtypeFailureReason;
 use crate::instantiation::instantiate::fill_application_defaults;
 use crate::types::{MappedModifier, MappedType, TypeData, TypeParamInfo};
-use crate::types::{MappedTypeId, SymbolRef, TypeApplicationId, TypeId};
+use crate::types::{MappedTypeId, SymbolRef, TypeApplicationId, TypeId, Variance};
 use crate::visitor::{
     application_id, array_element_type, contains_type_parameter_named, index_access_parts,
     intersection_list_id, is_empty_object_type, keyof_inner_type, mapped_type_id, object_shape_id,
     object_with_index_shape_id, tuple_list_id, type_param_info, union_list_id,
 };
 use crate::visitors::visitor_predicates::is_primitive_type;
+use std::sync::Arc;
 
 /// Maximum nesting depth, per generic `DefId`, for the one-sided application
 /// expansion relation paths (`App <: T` and `T <: App`).
@@ -164,6 +166,152 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             }
             _ => None,
         }
+    }
+
+    /// Resolve the per-type-parameter variance mask for a generic definition,
+    /// preferring declared/cached variances and computing (and caching) them
+    /// only when missing. Shared by the variance-aware relation fast path and
+    /// the same-generic error-elaboration path so both observe identical
+    /// variance facts.
+    pub(crate) fn resolve_application_variances(&self, def_id: DefId) -> Option<Arc<[Variance]>> {
+        use crate::caches::db::QueryDatabase;
+        self.resolver
+            .get_type_param_variance(def_id)
+            .or_else(|| {
+                self.query_db
+                    .and_then(|db| QueryDatabase::get_type_param_variance(db, def_id))
+            })
+            .or_else(|| {
+                let computed =
+                    crate::relations::variance::compute_type_param_variances_with_resolver(
+                        self.interner,
+                        self.resolver,
+                        def_id,
+                    );
+                if let (Some(db), Some(variances)) = (self.query_db, computed.as_ref()) {
+                    db.insert_type_param_variance(def_id, variances.clone());
+                }
+                computed
+            })
+    }
+
+    /// Explain a same-generic application failure (`C<A..>` vs `C<B..>`) by
+    /// comparing the differing type **arguments** directly, mirroring tsc.
+    ///
+    /// Structural rule: when source and target are applications of the same
+    /// generic target whose variances are reliably measured (no mapped-modifier
+    /// structural fallback, no unreliable rejection) and whose arguments are
+    /// concrete (no embedded type parameters), tsc reports the first
+    /// variance-failing type argument as a direct nested line — e.g.
+    /// `Type 'number' is not assignable to type 'string'.` — without the
+    /// `Types of property 'x' are incompatible.` wrapper that structural
+    /// expansion would produce.
+    ///
+    /// Returns `None` (so the caller falls back to structural elaboration)
+    /// whenever the relation itself would fall through to structural
+    /// comparison, keeping the existing property-based elaboration for those
+    /// shapes. This mirrors the conclusive-rejection conditions in
+    /// [`Self::check_application_to_application_subtype`].
+    pub(crate) fn explain_same_generic_type_arguments(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> Option<SubtypeFailureReason> {
+        // Callers may pass raw (lazy) references or already-resolved types;
+        // resolve lazy aliases so a `Lazy(DefId)` wrapping an application is
+        // recognised, while leaving direct applications untouched.
+        let resolved_source = self.resolve_lazy_type(source);
+        let resolved_target = self.resolve_lazy_type(target);
+        let s_app_id = application_id(self.interner, resolved_source)?;
+        let t_app_id = application_id(self.interner, resolved_target)?;
+        let s_app = self.interner.type_application(s_app_id);
+        let t_app = self.interner.type_application(t_app_id);
+
+        if s_app.base != t_app.base || s_app.args.len() != t_app.args.len() {
+            return None;
+        }
+
+        // Type-parameter arguments make a variance rejection inconclusive: the
+        // expanded structural forms can introduce implicit index signatures
+        // (homomorphic mapped types) that change the outcome. The relation
+        // falls through to structural comparison for these, so the explanation
+        // must do the same.
+        if args_contain_type_parameters(self.interner, &s_app.args) {
+            return None;
+        }
+
+        let def_id = self.application_base_def_id(s_app.base)?;
+        let variances = self.resolve_application_variances(def_id)?;
+        if variances.len() != s_app.args.len() {
+            return None;
+        }
+
+        // Mapped-modifier (`needs_structural_fallback`) and indexed-access /
+        // intersection-normalization (`rejection_unreliable`) variances make a
+        // variance-based rejection unreliable; tsc reports those structurally
+        // (its variance carries the structural-fallback marker), so keep the
+        // property-based elaboration for them.
+        if variances
+            .iter()
+            .any(|v| v.needs_structural_fallback() || v.rejection_unreliable())
+        {
+            return None;
+        }
+
+        // `s_app`/`t_app` are owned `Arc`s, independent of `self`, so the
+        // arguments can be indexed directly across the `&mut self` relation
+        // calls below without cloning the argument vectors.
+        for (i, variance) in variances.iter().enumerate() {
+            let s_arg = s_app.args[i];
+            let t_arg = t_app.args[i];
+
+            // Orient the failing relation by the parameter's variance, matching
+            // the per-argument direction used by the relation fast path.
+            let failing_pair = if variance.is_invariant() {
+                if !self.check_subtype(s_arg, t_arg).is_true() {
+                    Some((s_arg, t_arg))
+                } else if !self.check_subtype(t_arg, s_arg).is_true() {
+                    Some((t_arg, s_arg))
+                } else {
+                    None
+                }
+            } else if variance.is_covariant() {
+                (!self.check_subtype(s_arg, t_arg).is_true()).then_some((s_arg, t_arg))
+            } else if variance.is_contravariant() {
+                (!self.check_subtype(t_arg, s_arg).is_true()).then_some((t_arg, s_arg))
+            } else {
+                // Independent: argument does not constrain the relation.
+                None
+            };
+
+            if let Some((fail_src, fail_tgt)) = failing_pair {
+                // The type-argument elaboration is only reliable when this
+                // parameter's variance comes from a *direct* usage (a property,
+                // function parameter, or return type). Variances synthesized
+                // purely from mapped-type / indexed-access positions lack
+                // `DIRECT_USAGE`: there the differing arguments can normalize to
+                // structurally distinct shapes, and tsc reports the structural
+                // member difference (e.g. a missing property) rather than the
+                // raw argument relation. Fall back to structural elaboration for
+                // those, matching tsc.
+                if !variance.has_direct_usage() {
+                    return None;
+                }
+                let nested = self.explain_failure(fail_src, fail_tgt).unwrap_or(
+                    SubtypeFailureReason::TypeMismatch {
+                        source_type: fail_src,
+                        target_type: fail_tgt,
+                    },
+                );
+                return Some(SubtypeFailureReason::TypeArgumentMismatch {
+                    source_arg: fail_src,
+                    target_arg: fail_tgt,
+                    nested_reason: Box::new(nested),
+                });
+            }
+        }
+
+        None
     }
 
     /// Helper for resolving two Ref/TypeQuery symbols and checking subtype.
@@ -507,26 +655,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             let def_id = variance_def_id;
 
             if let Some(def_id) = def_id {
-                use crate::caches::db::QueryDatabase;
-                let variances = self
-                    .resolver
-                    .get_type_param_variance(def_id)
-                    .or_else(|| {
-                        self.query_db
-                            .and_then(|db| QueryDatabase::get_type_param_variance(db, def_id))
-                    })
-                    .or_else(|| {
-                        let computed =
-                            crate::relations::variance::compute_type_param_variances_with_resolver(
-                                self.interner,
-                                self.resolver,
-                                def_id,
-                            );
-                        if let (Some(db), Some(variances)) = (self.query_db, computed.as_ref()) {
-                            db.insert_type_param_variance(def_id, variances.clone());
-                        }
-                        computed
-                    });
+                let variances = self.resolve_application_variances(def_id);
                 if let Some(variances) = variances {
                     // Ensure variance count matches arg count (may differ with defaults)
                     if variances.len() == s_app.args.len() {


### PR DESCRIPTION
## Agent
AgentName: cloud-opus48-vXAgb; m5-pro-48g-gpt5

## Track
Checker/solver diagnostics parity — TS2322 same-generic type-argument elaboration.

## Invariant
When source and target are applications of the same generic target (`C<A>` vs `C<B>`) whose variance reliably pins the failure to a concrete type argument, tsc elaborates via the differing type argument without an intermediate `Types of property` wrapper. Assignability decisions must remain unchanged; only failure-reason elaboration changes.

## Scope
- Solver relation failure-reason generation adds `SubtypeFailureReason::TypeArgumentMismatch` through `SubtypeChecker::explain_same_generic_type_arguments`.
- The firing conditions mirror the conclusive-rejection path of `check_application_to_application_subtype`: same application base, equal arity, concrete arguments, reliable `DIRECT_USAGE` variance, and no structural-fallback markers.
- Checker invokes detection on raw operands in `analyze_assignability_failure` before evaluated applications become object shapes, then renders the reason at the right elaboration depth.
- Shared variance-resolution helper extraction keeps the relation fast path and explain path aligned.
- Deliberately out of scope: unifying the full variance-orientation dispatch with the hot relation fast path.

## Project Corpus Impact
- Row: n/a.
- Bug family: TS2322 same-generic type-argument elaboration; structural-property over-elaboration.
- Evidence: diagnostic-elaboration parity fix only. `is_assignable` is unaffected. Author-reported unit tests and identical base/branch lib-suite failure sets cover the behavior; ready-review CI will confirm conformance.

## Verification
- m5-pro-48g-gpt5 local `cargo fmt --check`: pass.
- m5-pro-48g-gpt5 local `git diff --check`: pass.
- m5-pro-48g-gpt5 local `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter varianceReferences --verbose`: 1/1 pass.
- m5-pro-48g-gpt5 local `cargo clippy -p tsz-checker --all-targets --all-features -- -D warnings`: pass.
- Author-reported new unit tests: 7/7 pass.
- Author-reported solver lib suite: failure set identical to base, 10 pre-existing failures and 0 new.
- Author-reported checker lib suite: failure set identical to base, 47 pre-existing failures and 0 new.
- Author-reported `cargo clippy -p tsz-solver -p tsz-checker --all-targets --all-features -- -D warnings`: clean.
- Author-reported CLI parity spot-checks against the issue repro and `Promise` / `Map` / nested cases.
- Ready-review CI for `5802bba3e1` is rerunning after m5-pro-48g-gpt5's conformance repair; this PR must not enter `merge-queue` until exact-head CI is green.

## Coordination Notes
Fixes #11778. Mapped/indexed-access-derived generics with unreliable variance, type-parameter arguments, and different-base applications deliberately fall back to the existing structural elaboration. m5-pro-48g-gpt5 normalized this PR body for the project-corpus gate on 2026-05-30.