### PR TITLE
fix(dts): expand function-local type aliases in inferred return types (+1 declarationEmitInferredTypeAlias4)

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/portability_resolve.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/portability_resolve.rs
@@ -221,10 +221,6 @@ impl<'a> DeclarationEmitter<'a> {
         &self,
         printed_type_text: &str,
     ) -> bool {
-        if self.current_source_file_idx.is_none() {
-            return false;
-        }
-
         let mut visited_names = rustc_hash::FxHashSet::default();
         self.type_text_uses_non_emittable_local_alias_root(printed_type_text, &mut visited_names)
     }
@@ -319,6 +315,10 @@ impl<'a> DeclarationEmitter<'a> {
             return false;
         }
 
+        // A function-local alias is never module-visible (tsc expands it).
+        if self.name_is_function_local_type_alias(ident) {
+            return true;
+        }
         self.current_file_declaration_requires_serialization_guard(ident, visited_names)
     }
 

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
@@ -263,6 +263,13 @@ impl<'a> DeclarationEmitter<'a> {
         if !source_type_text.contains('<') {
             return false;
         }
+        // A name that is only visible inside a function body is not a real,
+        // module-visible reference for a `.d.ts`. Preserving it by name would
+        // emit an undeclared identifier; tsc expands the alias structurally
+        // instead. Reject so the inferred type id is printed (and expanded).
+        if self.type_text_starts_with_function_local_type_alias(source_type_text) {
+            return false;
+        }
         let printed = self.print_type_id(inferred_return_type);
         if printed == source_type_text || !printed.contains('<') {
             return false;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs
@@ -54,7 +54,10 @@ impl<'a> DeclarationEmitter<'a> {
             })
     }
 
-    fn symbol_is_function_local_type_alias(&self, symbol: &tsz_binder::Symbol) -> bool {
+    pub(in crate::declaration_emitter) fn symbol_is_function_local_type_alias(
+        &self,
+        symbol: &tsz_binder::Symbol,
+    ) -> bool {
         symbol.declarations.iter().copied().any(|decl_idx| {
             let mut current = decl_idx;
             for _ in 0..32 {
@@ -180,12 +183,24 @@ impl<'a> DeclarationEmitter<'a> {
         let Some(alias_name) = Self::leading_type_reference_name_for_emit(type_text) else {
             return false;
         };
+        self.name_is_function_local_type_alias(alias_name)
+    }
+
+    /// True when `name` resolves to a type alias whose declaration lives inside
+    /// a function body. Such an alias is not visible at module scope, so it
+    /// cannot be referenced by name in a `.d.ts`; the inferred type must be
+    /// expanded structurally (with recursive arms elided) instead. Keyed on the
+    /// structural function-local fact, never on the spelling of `name`.
+    pub(in crate::declaration_emitter) fn name_is_function_local_type_alias(
+        &self,
+        name: &str,
+    ) -> bool {
         let Some(binder) = self.binder else {
             return false;
         };
 
         binder.symbols.iter().any(|symbol| {
-            symbol.escaped_name == alias_name
+            symbol.escaped_name == name
                 && symbol.flags & symbol_flags::TYPE_ALIAS != 0
                 && self.symbol_is_function_local_type_alias(symbol)
         })

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs
@@ -59,6 +59,13 @@ impl<'a> DeclarationEmitter<'a> {
         symbol: &tsz_binder::Symbol,
     ) -> bool {
         symbol.declarations.iter().copied().any(|decl_idx| {
+            let Some(decl_node) = self.arena.get(decl_idx) else {
+                return false;
+            };
+            if decl_node.kind != syntax_kind_ext::TYPE_ALIAS_DECLARATION {
+                return false;
+            }
+
             let mut current = decl_idx;
             for _ in 0..32 {
                 let Some(parent_idx) = self.arena.parent_of(current) else {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl_function_initializers.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl_function_initializers.rs
@@ -366,20 +366,39 @@ impl<'a> DeclarationEmitter<'a> {
                 if self.referenced_declared_annotation_is_multiline_object_type(returned_identifier)
                     && let Some(type_id) = self.reference_declared_type_id(returned_identifier)
                 {
-                    return Some(self.print_type_id_for_inferred_declaration(type_id));
+                    return Some(self.print_inferred_declaration_in_function_scope(func, type_id));
                 }
                 let type_text =
                     self.reference_declared_source_type_annotation_text(returned_identifier)?;
                 if let Some(type_id) = self.reference_declared_type_id(returned_identifier)
                     && self.printed_type_uses_non_emittable_local_alias_root(&type_text)
                 {
-                    return Some(self.print_type_id_for_inferred_declaration(type_id));
+                    return Some(self.print_inferred_declaration_in_function_scope(func, type_id));
                 }
                 Some(type_text)
             })?;
         let (type_text, _) =
             self.function_source_return_type_text_for_declaration_scope(func, &type_text);
         Some(type_text)
+    }
+
+    /// Print an inferred declaration type while keeping the enclosing function's
+    /// type parameters nameable. When the function is generic, the inferred type
+    /// can legitimately reference an outer type parameter (e.g. expanding a
+    /// function-local alias `Foo<T>` instantiated with `A[]` keeps `A`), so the
+    /// outer-type-param-aware printer must be used; otherwise the parameter would
+    /// widen to `unknown`. Non-generic functions use the plain inferred printer.
+    fn print_inferred_declaration_in_function_scope(
+        &self,
+        func: &tsz_parser::parser::node::FunctionData,
+        type_id: tsz_solver::types::TypeId,
+    ) -> String {
+        match func.type_parameters.as_ref() {
+            Some(type_params) if !type_params.nodes.is_empty() => {
+                self.print_type_id_with_outer_type_params(type_id, type_params)
+            }
+            _ => self.print_type_id_for_inferred_declaration(type_id),
+        }
     }
 
     pub(in crate::declaration_emitter) fn function_return_identifier_declared_type_id(

--- a/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
@@ -1416,3 +1416,18 @@ fn module_level_type_alias_is_not_function_local() {
         "a module-level non-generic alias must not be treated as function-local"
     );
 }
+
+#[test]
+fn unresolved_function_body_type_reference_is_not_function_local_alias() {
+    // A missing global type reference inside a function body may still have a
+    // binder symbol, but it is not a type-alias declaration. The function-local
+    // detector must not treat unresolved references as local aliases or
+    // transpileDeclaration emits a spurious TS7056.
+    assert!(
+        !function_local_alias_detector_for(
+            "export const fn = (a: MissingGlobalType) => null! as MissingGlobalType;\n",
+            "MissingGlobalType",
+        ),
+        "unresolved type references inside a function are not local aliases"
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
@@ -1326,3 +1326,93 @@ export class C2 extends Probe {
         "Expected a non-class same-named member to not be treated as a class constructor: {with_value}"
     );
 }
+
+// =============================================================================
+// Function-local type-alias nameability for inferred declaration emit.
+//
+// Rule: a type alias declared inside a function body is not visible at module
+// scope, so it can never be referenced by name in a `.d.ts`. When such an alias
+// appears in an inferred return type, tsc expands it structurally (eliding any
+// recursive arm to `/*elided*/ any`) rather than printing the bare local name.
+// The fix keys on this structural function-local fact, not on the spelling of
+// the alias or any enclosing type parameter. These tests exercise the structural
+// detector directly; the full inferred-emit pipeline is covered by the emit
+// corpus baseline `declarationEmitInferredTypeAlias4`.
+// =============================================================================
+
+fn function_local_alias_detector_for(source: &str, alias_name: &str) -> bool {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+
+    let interner = TypeInterner::new();
+    let type_cache = crate::type_cache_view::TypeCacheView::default();
+    let mut emitter =
+        DeclarationEmitter::with_type_info(&parser.arena, type_cache, &interner, &binder);
+    // `name_is_function_local_type_alias` only depends on the binder symbol table
+    // and AST parentage, so it does not require an emit pass; still drive `emit`
+    // so the emitter is in the same configured state as production callers.
+    let _ = emitter.emit(root);
+    emitter.name_is_function_local_type_alias(alias_name)
+}
+
+#[test]
+fn function_local_type_alias_is_detected_for_inferred_emit() {
+    // Alias declared inside a function body -> function-local -> must expand.
+    assert!(
+        function_local_alias_detector_for(
+            "function f<A>() {\n    type Foo<T> = T | { x: Foo<T> };\n    var x: Foo<A[]>;\n    return x;\n}\n",
+            "Foo",
+        ),
+        "a type alias declared inside a function body must be flagged function-local"
+    );
+}
+
+#[test]
+fn function_local_type_alias_detection_keys_on_scope_not_name() {
+    // Same structural scenario with every binder-bound name changed
+    // (Q/Bar/U/z instead of A/Foo/T/x). If the detector were keyed on the
+    // spelling `Foo`, this renamed variant would slip through.
+    assert!(
+        function_local_alias_detector_for(
+            "function g<Q>() {\n    type Bar<U> = U | { y: Bar<U> };\n    var z: Bar<Q[]>;\n    return z;\n}\n",
+            "Bar",
+        ),
+        "renaming the alias/type-parameter must not change the function-local verdict"
+    );
+}
+
+#[test]
+fn function_local_non_generic_type_alias_is_detected() {
+    // Non-generic function-local alias used in an inferred return must also be
+    // flagged so it is expanded structurally rather than named.
+    assert!(
+        function_local_alias_detector_for(
+            "export function makeWidget() {\n  type Local = { kind: \"widget\"; size: number };\n  const w: Local = { kind: \"widget\", size: 3 };\n  return w;\n}\n",
+            "Local",
+        ),
+        "a non-generic function-local alias must be flagged function-local"
+    );
+}
+
+#[test]
+fn module_level_type_alias_is_not_function_local() {
+    // Negative case: an identically shaped alias declared at module scope IS
+    // nameable in the `.d.ts` and must be preserved by name, so the detector
+    // must report it as NOT function-local.
+    assert!(
+        !function_local_alias_detector_for(
+            "type Foo<T> = T | { x: Foo<T> };\nexport function f<A>() {\n    var x: Foo<A[]>;\n    return x;\n}\n",
+            "Foo",
+        ),
+        "a module-level alias must not be treated as function-local"
+    );
+    assert!(
+        !function_local_alias_detector_for(
+            "type Widget = { kind: \"widget\"; size: number };\nexport function makeWidget() {\n  const w: Widget = { kind: \"widget\", size: 3 };\n  return w;\n}\n",
+            "Widget",
+        ),
+        "a module-level non-generic alias must not be treated as function-local"
+    );
+}


### PR DESCRIPTION
AgentName: m3-max-64g-opus48; m5-pro-48g-gpt5

## Track
Emit parity → 100% (DTS emit). Inferred-return function-local type-alias nameability.

## Invariant
When a function's inferred return type leads with a type-reference name that
resolves to a type alias declared INSIDE a function body (function-local, not
module-visible), it cannot be named in the `.d.ts`, so it is expanded
structurally (eliding recursive arms to `/*elided*/ any`) — exactly as tsc does.
The nameability gates must check REAL (module-visible) nameability, not mere
name presence. Keyed on the structural function-local fact, never the spelling.

## Scope
- `declaration_emitter/helpers/portability_resolve.rs`: `local_identifier_requires_serialization_guard`
  now fires for function-local aliases (prior guard only matched top-level decls);
  removed an over-broad `current_source_file_idx.is_none()` early-return that
  suppressed the guard in scratch/cloned-emitter contexts. Net-zero lines (kept ratchet).
- `helpers/type_inference_return_normalization.rs`: `source_return_type_preserves_named_application`
  rejects a leading function-local alias (text-preferring path).
- `helpers/variable_decl_function_initializers.rs`: inferred-decl fallbacks route through
  new `print_inferred_declaration_in_function_scope` (outer-type-param-aware printer so
  generic `A` stays nameable instead of widening to `unknown`).
- `helpers/type_printing.rs`: visibility + new `name_is_function_local_type_alias`.
- `declaration_emitter/tests/generics_and_ambient.rs`: 4 new tests.

## Bug
tsz's nameability gates checked only name PRESENCE, so a function-local alias
name leaked into the `.d.ts` (`declare function f<A>(): ... LocalAlias ...`)
instead of being expanded/elided.

## Project Corpus Impact
- Row: dts (`--dts-only`)
- Bug family: inferred-return type referencing a function-local type alias is preserved by name instead of expanded/elided
- Evidence: `--dts-only -j4` flips `declarationEmitInferredTypeAlias4` FAIL→PASS (now emits `declare function f<A>(): A[] | { x: A[] | /*elided*/ any; };` matching tsc), zero regressions. `--js-only` 72→72 unaffected (DTS-path only). Solver TypeId was already correct — pure emitter gate fix (confirms the endgame-triage reclassification from "solver-tail" to emitter-contained).

## Verification
- m5-pro-48g-gpt5 local `cargo fmt --check`: pass.
- m5-pro-48g-gpt5 local `git diff --check`: pass.
- m5-pro-48g-gpt5 local `cargo nextest run -p tsz-emitter unresolved_function_body_type_reference_is_not_function_local_alias`: pass.
- m5-pro-48g-gpt5 local `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter declarationUnresolvedTypeReference2 --verbose`: 1/1 pass.
- m5-pro-48g-gpt5 local `cargo clippy -p tsz-emitter --all-targets -- -D warnings`: pass.
- arch `Architecture guardrails passed`; clippy `-D warnings` clean.
- 4 new tests (witness, renamed `g<Q>`/`Bar<U>` proving scope-keying not name, non-generic local, module-level negatives still preserved by name).

## Coordination Notes
m5-pro-48g-gpt5 repaired the exact-head conformance regression on 2026-05-30 by rejecting unresolved type-reference nodes in the function-local alias detector; ready-review CI is rerunning on `3046ea2e47`.

Emit is OUTPUT — DTS nameability gate fix, no solver/checker change, no output
surgery. STOP-noted: `typeParametersAvailableInNestedScope3` is a separate
pre-existing type-param-shadow cluster, untouched. portability_resolve.rs is
also the dts-heritage-base-alias item's file — sequence dts-heritage after this lands.