### PR TITLE
fix(solver): default absent optional infer properties to constraint or undefined

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -551,6 +551,41 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         );
     }
 
+    /// Default each `infer` variable in `pattern` to its declared constraint, or
+    /// `undefined` when unconstrained, for any name not already bound in `bindings`.
+    ///
+    /// Used when an *optional* property of the conditional extends-pattern is absent
+    /// in the source type.  An absent optional property reads as `undefined`, so an
+    /// unconstrained `infer R` gets `undefined`.  A constrained `infer R extends C`
+    /// gets `C` directly (bypassing the constraint check), allowing the conditional
+    /// to take its **true** branch without a spurious `undefined` failing the
+    /// constraint.
+    ///
+    /// Note: the fast path (`eval_conditional_object_prop_infer`) uses `unknown`
+    /// when ALL candidates across ALL slots are absent (a single-object source with
+    /// no union). This function is called from the **general path** (tuple patterns,
+    /// union sources iterated member-by-member), where each absent optional member
+    /// should contribute `undefined` so the union of members is `<type> | undefined`.
+    pub(crate) fn fill_absent_optional_infer_defaults(
+        &self,
+        pattern: TypeId,
+        bindings: &mut FxHashMap<Atom, TypeId>,
+    ) {
+        let mut visited = FxHashSet::default();
+        self.for_each_infer(
+            pattern,
+            &mut |info| {
+                // A constrained `infer R extends C` defaults to C (true branch stays
+                // valid). An unconstrained `infer R` defaults to `undefined`, matching
+                // the value an absent optional property produces in a union member.
+                let default_ty = info.constraint.unwrap_or(TypeId::UNDEFINED);
+                bindings.entry(info.name).or_insert(default_ty);
+                true
+            },
+            &mut visited,
+        );
+    }
+
     /// Bind an inferred type to an infer parameter.
     ///
     /// Handles constraint checking and merging with existing bindings.

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_object_match.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_object_match.rs
@@ -37,18 +37,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 .find(|prop| prop.name == pattern_prop.name);
             let Some(source_prop) = source_prop else {
                 if pattern_prop.optional {
-                    if self.type_contains_infer(pattern_prop.type_id) {
-                        let mut visited = FxHashSet::default();
-                        if !self.match_infer_pattern(
-                            TypeId::UNDEFINED,
-                            pattern_prop.type_id,
-                            bindings,
-                            &mut visited,
-                            checker,
-                        ) {
-                            return false;
-                        }
-                    }
+                    self.fill_absent_optional_infer_defaults(pattern_prop.type_id, bindings);
                     continue;
                 }
                 return false;
@@ -126,10 +115,14 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     if !pattern_prop.optional {
                         return false;
                     }
-                    if !self.type_contains_infer(pattern_prop.type_id) {
-                        continue;
-                    }
-                    TypeId::UNDEFINED
+                    // Absent optional property: default each infer variable to its declared
+                    // constraint (or `undefined`), matching tsc's `inferFromProperties`.
+                    // A constrained `infer R extends C` gets C directly so the true branch
+                    // is taken without a spurious `undefined` failing the constraint check.
+                    // An unconstrained `infer R` gets `undefined` — the value of an absent
+                    // optional property — so union sources produce `<type> | undefined`.
+                    self.fill_absent_optional_infer_defaults(pattern_prop.type_id, &mut merged);
+                    continue;
                 }
             };
             let mut local = base.clone();
@@ -222,17 +215,10 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         .find(|prop| prop.name == pattern_prop.name);
                     let Some(source_prop) = source_prop else {
                         if pattern_prop.optional {
-                            if self.type_contains_infer(pattern_prop.type_id)
-                                && !self.match_infer_pattern(
-                                    TypeId::UNDEFINED,
-                                    pattern_prop.type_id,
-                                    bindings,
-                                    visited,
-                                    checker,
-                                )
-                            {
-                                return false;
-                            }
+                            self.fill_absent_optional_infer_defaults(
+                                pattern_prop.type_id,
+                                bindings,
+                            );
                             continue;
                         }
                         return false;
@@ -291,17 +277,10 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
                     let Some(source_type) = merged_type else {
                         if pattern_prop.optional {
-                            if self.type_contains_infer(pattern_prop.type_id)
-                                && !self.match_infer_pattern(
-                                    TypeId::UNDEFINED,
-                                    pattern_prop.type_id,
-                                    bindings,
-                                    visited,
-                                    checker,
-                                )
-                            {
-                                return false;
-                            }
+                            self.fill_absent_optional_infer_defaults(
+                                pattern_prop.type_id,
+                                bindings,
+                            );
                             continue;
                         }
                         return false;
@@ -359,17 +338,10 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         self.implicit_sequence_property_type(source, pattern_prop.name)
                     else {
                         if pattern_prop.optional {
-                            if self.type_contains_infer(pattern_prop.type_id)
-                                && !self.match_infer_pattern(
-                                    TypeId::UNDEFINED,
-                                    pattern_prop.type_id,
-                                    bindings,
-                                    visited,
-                                    checker,
-                                )
-                            {
-                                return false;
-                            }
+                            self.fill_absent_optional_infer_defaults(
+                                pattern_prop.type_id,
+                                bindings,
+                            );
                             continue;
                         }
                         return false;

--- a/crates/tsz-solver/tests/evaluate_tests.rs
+++ b/crates/tsz-solver/tests/evaluate_tests.rs
@@ -22,6 +22,21 @@ fn test_infer_param_from_name(interner: &TypeInterner, name: Atom) -> TypeId {
     interner.intern(TypeData::Infer(TypeParamInfo::simple(name)))
 }
 
+fn test_constrained_infer_param(
+    interner: &TypeInterner,
+    name: &str,
+    constraint: TypeId,
+) -> (Atom, TypeId) {
+    let name = interner.intern_string(name);
+    let id = interner.intern(TypeData::Infer(TypeParamInfo {
+        name,
+        constraint: Some(constraint),
+        default: None,
+        is_const: false,
+    }));
+    (name, id)
+}
+
 fn assert_evaluates_to(interner: &TypeInterner, input: TypeId, expected: TypeId) {
     let result = evaluate_type(interner, input);
     assert_eq!(result, expected);

--- a/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_objects.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_objects.rs
@@ -1431,3 +1431,175 @@ fn test_conditional_infer_optional_property_non_distributive_union_branch() {
 
     assert_eq!(result, TypeId::NEVER);
 }
+
+// =============================================================================
+// Absent optional property infer tests — general path (tuple-wrapped to prevent
+// the fast path from handling it, proving the fix covers the general pattern).
+// =============================================================================
+
+#[test]
+fn test_conditional_infer_absent_optional_renamed_var_union_input() {
+    // Same as test_conditional_infer_optional_property_non_distributive_union_input
+    // but with infer variable named `K` instead of `R` to verify the fix is not
+    // hardcoded to a specific identifier.
+    let interner = TypeInterner::new();
+
+    let (t_name, t_param) = test_type_param(&interner, "T");
+
+    let (_, infer_k) = test_infer_param(&interner, "K");
+
+    // [T] extends [{ v?: infer K }] ? K : never, with T = { v: number } | {} (no distribution).
+    let extends_obj = interner.object(vec![PropertyInfo::opt(
+        interner.intern_string("v"),
+        infer_k,
+    )]);
+    let cond = ConditionalType {
+        check_type: interner.tuple(vec![TupleElement {
+            type_id: t_param,
+            name: None,
+            optional: false,
+            rest: false,
+        }]),
+        extends_type: interner.tuple(vec![TupleElement {
+            type_id: extends_obj,
+            name: None,
+            optional: false,
+            rest: false,
+        }]),
+        true_type: infer_k,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+
+    let cond_type = interner.conditional(cond);
+    let mut subst = TypeSubstitution::new();
+    let obj_number = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("v"),
+        TypeId::NUMBER,
+    )]);
+    let empty_obj = interner.object(Vec::new());
+    subst.insert(t_name, interner.union(vec![obj_number, empty_obj]));
+
+    let instantiated = instantiate_type(&interner, cond_type, &subst);
+    let result = evaluate_type(&interner, instantiated);
+    let expected = interner.union(vec![TypeId::NUMBER, TypeId::UNDEFINED]);
+
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn test_conditional_infer_absent_optional_constrained_union_true_branch() {
+    // [T] extends [{ a?: infer R extends string }] ? R : "nope", with
+    // T = { a: string } | {} (no distribution).
+    // The {} member has absent a: tsc uses the constraint (string) so the
+    // true branch is taken for that member too — result is string | string = string.
+    let interner = TypeInterner::new();
+
+    let (t_name, t_param) = test_type_param(&interner, "T");
+
+    let (_, infer_r) = test_constrained_infer_param(&interner, "R", TypeId::STRING);
+
+    let extends_obj = interner.object(vec![PropertyInfo::opt(
+        interner.intern_string("a"),
+        infer_r,
+    )]);
+    let nope = interner.literal_string("nope");
+    let cond = ConditionalType {
+        check_type: interner.tuple(vec![TupleElement {
+            type_id: t_param,
+            name: None,
+            optional: false,
+            rest: false,
+        }]),
+        extends_type: interner.tuple(vec![TupleElement {
+            type_id: extends_obj,
+            name: None,
+            optional: false,
+            rest: false,
+        }]),
+        true_type: infer_r,
+        false_type: nope,
+        is_distributive: false,
+    };
+
+    let cond_type = interner.conditional(cond);
+    let mut subst = TypeSubstitution::new();
+    let obj_string = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("a"),
+        TypeId::STRING,
+    )]);
+    let empty_obj = interner.object(Vec::new());
+    subst.insert(t_name, interner.union(vec![obj_string, empty_obj]));
+
+    let instantiated = instantiate_type(&interner, cond_type, &subst);
+    let result = evaluate_type(&interner, instantiated);
+
+    // Both members take the true branch: { a: string } → R = string, {} → R = string (constraint).
+    assert_eq!(result, TypeId::STRING);
+}
+
+#[test]
+fn test_conditional_infer_absent_optional_multiple_props_union_input() {
+    // [T] extends [{ a?: infer R; b?: infer S }] ? [R, S] : never, with
+    // T = { a: string; b: number } | {} (no distribution).
+    // {} member: a absent → R = undefined, b absent → S = undefined.
+    // Result: [string, number] | [undefined, undefined].
+    let interner = TypeInterner::new();
+
+    let (t_name, t_param) = test_type_param(&interner, "T");
+
+    let (_, infer_r) = test_infer_param(&interner, "R");
+    let (_, infer_s) = test_infer_param(&interner, "S");
+
+    let extends_obj = interner.object(vec![
+        PropertyInfo::opt(interner.intern_string("a"), infer_r),
+        PropertyInfo::opt(interner.intern_string("b"), infer_s),
+    ]);
+    let true_tuple = interner.tuple(vec![
+        TupleElement { type_id: infer_r, name: None, optional: false, rest: false },
+        TupleElement { type_id: infer_s, name: None, optional: false, rest: false },
+    ]);
+    let cond = ConditionalType {
+        check_type: interner.tuple(vec![TupleElement {
+            type_id: t_param,
+            name: None,
+            optional: false,
+            rest: false,
+        }]),
+        extends_type: interner.tuple(vec![TupleElement {
+            type_id: extends_obj,
+            name: None,
+            optional: false,
+            rest: false,
+        }]),
+        true_type: true_tuple,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+
+    let cond_type = interner.conditional(cond);
+    let mut subst = TypeSubstitution::new();
+    let obj_full = interner.object(vec![
+        PropertyInfo::new(interner.intern_string("a"), TypeId::STRING),
+        PropertyInfo::new(interner.intern_string("b"), TypeId::NUMBER),
+    ]);
+    let empty_obj = interner.object(Vec::new());
+    subst.insert(t_name, interner.union(vec![obj_full, empty_obj]));
+
+    let instantiated = instantiate_type(&interner, cond_type, &subst);
+    let result = evaluate_type(&interner, instantiated);
+
+    // Non-distributive evaluation: infer bindings are merged across union members.
+    // { a: string; b: number } contributes R=string, S=number.
+    // {} contributes R=undefined, S=undefined.
+    // Merged: R = string | undefined, S = number | undefined.
+    // true_type [R, S] → [string | undefined, number | undefined].
+    let r_ty = interner.union(vec![TypeId::STRING, TypeId::UNDEFINED]);
+    let s_ty = interner.union(vec![TypeId::NUMBER, TypeId::UNDEFINED]);
+    let expected = interner.tuple(vec![
+        TupleElement { type_id: r_ty, name: None, optional: false, rest: false },
+        TupleElement { type_id: s_ty, name: None, optional: false, rest: false },
+    ]);
+
+    assert_eq!(result, expected);
+}


### PR DESCRIPTION
## Agent
AgentName: claude-sonnet-4-6-remote; m5-pro-48g-gpt5

## Track
Solver / conditional type inference.

## Invariant
When a conditional type pattern has an absent optional property such as `{ v?: infer R extends C }`, the general inference path must bind `R` to `C` for constrained `infer` variables, or to `undefined` for unconstrained `infer` variables. A real present `undefined` value must still flow through the normal constraint-checking match path.

## Scope
- `crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs`
- `crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_object_match.rs`
- `crates/tsz-solver/tests/evaluate_tests.rs`
- `crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_objects.rs`
- Adds `fill_absent_optional_infer_defaults`, routes four absent-optional object/callable-property call sites through it, and adds focused conditional-infer tests.

## Project Corpus Impact
- Row: nextjs
- Bug family: constrained-infer-absent-optional; `infer R extends C` over absent optional properties silently takes the false branch in non-distributive conditionals when source union members lack the property.
- Evidence: 3 new solver unit tests pass; author-reported `cargo test -p tsz-solver conditional_infer` produced 173 passed / 0 failed. Fixes #11588.

## Verification
- Author-reported `cargo test -p tsz-solver conditional_infer`: 173 passed, 0 failed.
- Author-reported `cargo test -p tsz-solver conditional_infer_absent_optional`: 3 passed, 0 failed.
- Ready-review CI for `a31d2fefb9908906c1812fa2522fee0e8caac76f` is green after m5-pro-48g-gpt5 reran the normalized project-corpus body gate; m5-pro-48g-gpt5 is adding `merge-queue` on 2026-05-30.

## Coordination Notes
Fixes #11588. The absent-optional fast path (`eval_conditional_object_prop_infer`) uses `unknown` for single-object no-union sources; this PR only fixes the general path used for tuple patterns and union-source member iteration. The fast-path `unknown` versus `undefined` behavior is documented in the function doc comment and is intentionally left out of scope. m5-pro-48g-gpt5 normalized the PR body for the project-corpus gate and added solver labels on 2026-05-30.