### PR TITLE
fix(emit): keep function name→paren seam comments after the name (+1 parserharness)

### DIFF
--- a/crates/tsz-emitter/src/emitter/comments/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/comments/helpers.rs
@@ -1,4 +1,5 @@
 use crate::emitter::Printer;
+use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::Node;
 
 /// Scan `bytes[start_pos..end_pos]` and return two boundary markers for the
@@ -1198,6 +1199,113 @@ impl<'a> Printer<'a> {
                 break;
             }
         }
+    }
+
+    /// Find the source position of the first `<` (type-parameter list) or `(`
+    /// (parameter list) at or after `start`, skipping characters that appear
+    /// inside line/block comments or string/template literals. Returns `None`
+    /// when no such token is found before `limit`.
+    ///
+    /// This is the structural boundary between a function-like's name and its
+    /// type-parameter/parameter list, used to bound the name → `(` comment seam.
+    /// Skipping comment and string contents avoids matching a `<` or `(` that
+    /// merely appears inside a seam comment (e.g. `foo /* (x) */(a)`).
+    fn find_name_seam_boundary(&self, start: u32, limit: u32) -> Option<u32> {
+        let text = self.source_text?;
+        let bytes = text.as_bytes();
+        let end = (limit as usize).min(bytes.len());
+        let mut i = start as usize;
+        while i < end {
+            match bytes[i] {
+                b'<' | b'(' => return Some(i as u32),
+                b'/' if i + 1 < end && bytes[i + 1] == b'/' => {
+                    i += 2;
+                    while i < end && bytes[i] != b'\n' && bytes[i] != b'\r' {
+                        i += 1;
+                    }
+                }
+                b'/' if i + 1 < end && bytes[i + 1] == b'*' => {
+                    i += 2;
+                    while i + 1 < end && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                        i += 1;
+                    }
+                    i += 2;
+                }
+                b'\'' | b'"' | b'`' => {
+                    let quote = bytes[i];
+                    i += 1;
+                    while i < end && bytes[i] != quote {
+                        if bytes[i] == b'\\' {
+                            i += 1;
+                        }
+                        i += 1;
+                    }
+                    i += 1;
+                }
+                _ => i += 1,
+            }
+        }
+        None
+    }
+
+    /// Emit comments that sit in the source seam between a function-like's name
+    /// and the first structural token that follows it — the type-parameter list
+    /// `<` or the parameter-list `(`
+    /// (e.g. `function clone /* <T> */(a, b)` or `generic /* keep */<T>(a)`).
+    ///
+    /// `tsc` keeps such a comment attached to the name — emitted right after the
+    /// name and before `(` — rather than letting it drift into the parameter
+    /// list. `skip_comments_in_range(node.pos, open_paren)` cannot do this: it
+    /// narrows the range to the last code token (the name), so a comment that
+    /// starts *after* the name end is never consumed there and later leaks into
+    /// the first parameter's leading comments.
+    ///
+    /// `name_idx` is the function-like's name node and `search_limit` bounds the
+    /// forward scan (use the function-like node's `end`). The seam runs from the
+    /// name's real token end up to the first non-trivia token after it — the `<`
+    /// of a type-parameter list or the parameter-list `(`. Stopping at `<` means
+    /// only the comment *before* `<` is emitted here; comments *inside* `<...>`
+    /// are erased separately. Comments in that span are emitted with their
+    /// source-faithful spacing and `comment_emit_idx` is advanced past them so
+    /// the parameter-list emit no longer re-emits them.
+    ///
+    /// This deliberately re-derives the boundary from source instead of trusting
+    /// a precomputed `(` position: the parser can extend a name's `end` past the
+    /// real `(` (e.g. empty-parameter methods), which would make a precomputed
+    /// `map_token_after(name.end, ..)` skip the real `(` and match a later `(`
+    /// inside the body, dragging body comments into the seam.
+    ///
+    /// Shared by function declarations, function expressions, methods, and
+    /// accessors, which all expose the same name → `(` seam.
+    pub(in crate::emitter) fn emit_name_to_paren_seam_comments(
+        &mut self,
+        name_idx: NodeIndex,
+        search_limit: u32,
+    ) {
+        if self.ctx.options.remove_comments {
+            return;
+        }
+        let Some(name_node) = self.arena.get(name_idx) else {
+            return;
+        };
+        // The parser's identifier `end` can extend over trailing trivia (the
+        // seam comment) up to the next token, so recover the real token end.
+        // The seam ends at the first `<` (type-parameter list) or `(`
+        // (parameter list) after the name, ignoring such characters that appear
+        // inside comments or strings. This is the structural boundary: a comment
+        // before it is a name seam comment; a comment after it lives inside
+        // `<...>` (erased) or the parameter list.
+        let Some(boundary) = self.find_name_seam_boundary(name_node.pos, search_limit) else {
+            return;
+        };
+        // The name's real text ends at the last code token before the boundary;
+        // the parser's `name.end` can over-extend past `<`/`(`, so clamp the
+        // scan to the boundary rather than trusting `name.end`.
+        let name_end = self.find_token_end_before_trivia(name_node.pos, boundary);
+        if name_end >= boundary {
+            return;
+        }
+        self.emit_comments_in_range(name_end, boundary, false, false);
     }
 
     /// Skip (suppress) all comments that belong to an erased declaration (interface, type alias).

--- a/crates/tsz-emitter/src/emitter/comments/mod.rs
+++ b/crates/tsz-emitter/src/emitter/comments/mod.rs
@@ -1,6 +1,9 @@
 mod core;
 mod helpers;
 
+#[cfg(test)]
+mod name_paren_seam_tests;
+
 pub use self::core::{
     CommentKind, CommentRange, get_leading_comment_ranges, get_trailing_comment_ranges,
 };

--- a/crates/tsz-emitter/src/emitter/comments/name_paren_seam_tests.rs
+++ b/crates/tsz-emitter/src/emitter/comments/name_paren_seam_tests.rs
@@ -1,0 +1,166 @@
+//! A comment in the source seam between a function-like's name and its
+//! parameter-list `(` belongs immediately after the emitted name (before `(`),
+//! not inside the parameter list. `tsc` emits `function clone /* <T> */(a, b)`,
+//! keeping the comment attached to the name. These tests cover the shared
+//! name → `(` seam across function declarations, function expressions, methods,
+//! and accessors, and verify the rule is structural (not keyed on identifier
+//! names) and does not drag body / type-parameter-internal comments into the
+//! seam.
+
+use crate::output::printer::{PrintOptions, Printer};
+use tsz_common::ScriptTarget;
+use tsz_parser::ParserState;
+
+fn emit(source: &str) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrintOptions {
+        target: ScriptTarget::ES2017,
+        ..Default::default()
+    };
+    let mut printer = Printer::new(&parser.arena, options);
+    printer.set_source_text(source);
+    printer.print(root);
+    printer.finish().code
+}
+
+#[test]
+fn function_declaration_seam_comment_stays_after_name() {
+    // Vary the function name and parameter names to prove the rule is structural.
+    for (name, p0, p1) in [("clone", "source", "target"), ("renamed", "m", "n")] {
+        let source = format!("function {name} /* c */({p0}, {p1}) {{ return {p0}; }}\n");
+        let output = emit(&source);
+        assert!(
+            output.contains(&format!("function {name} /* c */({p0}, {p1})")),
+            "[{name}] seam comment must sit after the name, before `(`.\nOutput:\n{output}",
+        );
+        // It must NOT have leaked into the parameter list.
+        assert!(
+            !output.contains("(/* c */"),
+            "[{name}] seam comment must not leak into the parameter list.\nOutput:\n{output}",
+        );
+    }
+}
+
+#[test]
+fn function_expression_seam_comment_stays_after_name() {
+    for name in ["copy", "fnExpr"] {
+        let source = format!("const f = function {name} /* c */(a, b) {{ return a; }};\n");
+        let output = emit(&source);
+        assert!(
+            output.contains(&format!("function {name} /* c */(a, b)")),
+            "[{name}] function-expression seam comment must sit after the name.\nOutput:\n{output}",
+        );
+    }
+}
+
+#[test]
+fn method_seam_comment_stays_after_name() {
+    for name in ["duplicate", "renamedMethod"] {
+        let source = format!("class C {{ {name} /* c */(x, y) {{ return x; }} }}\n");
+        let output = emit(&source);
+        assert!(
+            output.contains(&format!("{name} /* c */(x, y)")),
+            "[{name}] method seam comment must sit after the name.\nOutput:\n{output}",
+        );
+        assert!(
+            !output.contains("(/* c */"),
+            "[{name}] method seam comment must not leak into the parameter list.\nOutput:\n{output}",
+        );
+    }
+}
+
+#[test]
+fn object_method_seam_comment_stays_after_name() {
+    let source = "const o = { meth /* c */(a, b) { return a; } };\n";
+    let output = emit(source);
+    assert!(
+        output.contains("meth /* c */(a, b)"),
+        "object-method seam comment must sit after the name.\nOutput:\n{output}",
+    );
+}
+
+#[test]
+fn accessor_seam_comment_stays_after_name() {
+    let source = "class D {\n    get val /* g */() { return 1; }\n    set val /* s */(v) { }\n}\n";
+    let output = emit(source);
+    assert!(
+        output.contains("get val /* g */()"),
+        "getter seam comment must sit after the name.\nOutput:\n{output}",
+    );
+    assert!(
+        output.contains("set val /* s */(v)"),
+        "setter seam comment must sit after the name.\nOutput:\n{output}",
+    );
+    assert!(
+        !output.contains("(/* s */"),
+        "setter seam comment must not leak into the parameter list.\nOutput:\n{output}",
+    );
+}
+
+#[test]
+fn comment_before_type_parameter_list_is_kept_at_name() {
+    // `tsc` keeps a comment that sits between the name and the `<` of an erased
+    // type-parameter list, attaching it to the name (the `<...>` is erased).
+    for var in ["T", "K"] {
+        let source = format!("function generic /* keep */<{var}>(a) {{ return a; }}\n");
+        let output = emit(&source);
+        assert!(
+            output.contains("function generic /* keep */(a)"),
+            "[{var}] pre-`<` seam comment must be kept at the name.\nOutput:\n{output}",
+        );
+    }
+}
+
+#[test]
+fn comment_inside_type_parameter_list_is_erased() {
+    // A comment *inside* the erased `<...>` must NOT be dragged into the seam:
+    // vary the iteration variable name to prove the rule is structural.
+    for var in ["T", "X"] {
+        let source = format!("function tp<{var} /* drop */>(a) {{ return a; }}\n");
+        let output = emit(&source);
+        assert!(
+            !output.contains("/* drop */"),
+            "[{var}] type-parameter-internal comment must be erased.\nOutput:\n{output}",
+        );
+        assert!(
+            output.contains("function tp(a)"),
+            "[{var}] type parameters must be erased from JS output.\nOutput:\n{output}",
+        );
+    }
+}
+
+#[test]
+fn empty_parameter_method_body_comment_is_not_dragged_into_seam() {
+    // Regression guard: an empty-parameter method whose body holds a comment
+    // containing `(` (e.g. `Echo("bar1")`). The parser can extend the name's
+    // `end` past the real `(`; a naive `(` search would then match the body
+    // comment's `(` and drag the body comment into the seam, corrupting the
+    // method header into `bar1() { /*Echo("bar1");*/() { }`. The header must
+    // stay structurally intact: name immediately followed by the real `()`.
+    for name in ["bar1", "method"] {
+        let source = format!("class Foo {{ {name}() {{ /*Echo(\"{name}\");*/ }} }}\n");
+        let output = emit(&source);
+        assert!(
+            output.contains(&format!("{name}() ")),
+            "[{name}] method header must stay intact: name then `()`.\nOutput:\n{output}",
+        );
+        // No body comment dragged in front of the real `(`.
+        assert!(
+            !output.contains(&format!("{name} /*")) && !output.contains("*/()"),
+            "[{name}] body comment must not be dragged into the seam.\nOutput:\n{output}",
+        );
+    }
+}
+
+#[test]
+fn no_seam_comment_leaves_output_unchanged() {
+    // Negative case: when there is no inter-seam comment, the output is the
+    // plain function with no spurious spacing or comments.
+    let source = "function noSeam(p, q) { return p; }\n";
+    let output = emit(source);
+    assert!(
+        output.contains("function noSeam(p, q)"),
+        "function without a seam comment must emit normally.\nOutput:\n{output}",
+    );
+}

--- a/crates/tsz-emitter/src/emitter/declarations/class_members.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class_members.rs
@@ -234,6 +234,12 @@ impl<'a> Printer<'a> {
                 .map(|source_pos| source_pos.pos)
                 .unwrap_or(search_start)
         };
+        // A comment in the source seam between the method name and `(`
+        // (e.g. `duplicate /* <V> */(x, y)`) belongs right after the name,
+        // before `(`. Emit it here so it does not leak into the parameter list.
+        if !self.ctx.flags.in_declaration_emit && method.name.is_some() {
+            self.emit_name_to_paren_seam_comments(method.name, node.end);
+        }
         // Skip comments inside the type parameter list
         if !self.ctx.flags.in_declaration_emit && method.type_parameters.is_some() {
             let tp_skip_start = if method.name.is_some() {
@@ -1413,6 +1419,12 @@ impl<'a> Printer<'a> {
         self.write("get ");
         self.emit_class_member_name_preserving_class_expression_name(accessor.name);
 
+        // A comment in the source seam between the accessor name and `(`
+        // (e.g. `get val /* g */()`) belongs right after the name, before `(`.
+        if !self.ctx.flags.in_declaration_emit && accessor.name.is_some() {
+            self.emit_name_to_paren_seam_comments(accessor.name, node.end);
+        }
+
         // Emit type parameters for error recovery (e.g., `get foo<T>() {}`)
         // Getters cannot legally have type parameters, but tsc preserves them in JS output.
         if let Some(ref type_params) = accessor.type_parameters
@@ -1448,6 +1460,12 @@ impl<'a> Printer<'a> {
 
         self.write("set ");
         self.emit_class_member_name_preserving_class_expression_name(accessor.name);
+
+        // A comment in the source seam between the accessor name and `(`
+        // (e.g. `set val /* s */(v)`) belongs right after the name, before `(`.
+        if !self.ctx.flags.in_declaration_emit && accessor.name.is_some() {
+            self.emit_name_to_paren_seam_comments(accessor.name, node.end);
+        }
 
         // Emit type parameters for error recovery (e.g., `set foo<T>(v) {}`)
         // Setters cannot legally have type parameters, but tsc preserves them in JS output.

--- a/crates/tsz-emitter/src/emitter/declarations/core.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/core.rs
@@ -132,6 +132,13 @@ impl<'a> Printer<'a> {
                 .map(|source_pos| source_pos.pos)
                 .unwrap_or(search_start)
         };
+        // A comment in the source seam between the function name and `(`
+        // (e.g. `function clone /* <T> */(a, b)`) belongs right after the name,
+        // before `(`. Emit it here so it is not later re-emitted inside the
+        // parameter list.
+        if func.name.is_some() {
+            self.emit_name_to_paren_seam_comments(func.name, node.end);
+        }
         // Skip comments inside the type parameter list
         if func.type_parameters.is_some() {
             let tp_skip_start = if func.name.is_some() {

--- a/crates/tsz-emitter/src/emitter/functions.rs
+++ b/crates/tsz-emitter/src/emitter/functions.rs
@@ -96,6 +96,12 @@ impl<'a> Printer<'a> {
                 .map(|source_pos| source_pos.pos)
                 .unwrap_or(search_start)
         };
+        // A comment in the source seam between the function name and `(`
+        // (e.g. `function copy /* <U> */(a, b)`) belongs right after the name,
+        // before `(`. Emit it here so it does not leak into the parameter list.
+        if func.name.is_some() {
+            self.emit_name_to_paren_seam_comments(func.name, node.end);
+        }
         self.open_paren();
         let search_start = func
             .parameters


### PR DESCRIPTION
AgentName: m3-max-64g-opus48

## Track
Emit parity → 100% (JS emit). Function name→paren seam comment placement.

## Invariant
A comment in the source span between a function-like's name and its
parameter-list `(` belongs immediately after the emitted name (before `(`);
emit it there and advance the comment cursor so it is not re-emitted inside the
parameter list. The seam boundary is RE-DERIVED from source (first `<` or `(`,
skipping comment/string contents), not from a precomputed `(` position — the
parser can extend a name's `end` past the real `(`. Keyed on source trivia structure.

## Scope
- `crates/tsz-emitter/src/emitter/comments/helpers.rs` (+108): `emit_name_to_paren_seam_comments` + `find_name_seam_boundary`.
- `comments/name_paren_seam_tests.rs` (new, 166): 9 tests; `comments/mod.rs` registration.
- `declarations/core.rs` (+7, function declaration), `functions.rs` (+6, function expression), `declarations/class_members.rs` (+18, method + get/set accessor) — all JS-emit only, `!in_declaration_emit` guarded where shared.

## Bug
`skip_comments_in_range(node.pos, open_paren_pos)` no-opped for an inter-name
`/* <T> */` comment (the boundary clamped to the name end), which then leaked
into the parameter list (`clone(/* <T> */ source, target)` instead of
`clone /* <T> */(source, target)`).

## Project Corpus Impact
- Row: emit (`--js-only`)
- Bug family: comment between a function name and its `(` leaks into the parameter list instead of staying after the name
- Evidence: `--js-only -j4` 72→71 (flips `parserharness`, zero regressions). `--dts-only` 24→24 neutral. `node --check` clean.

## Verification
- arch `Architecture guardrails passed`; clippy `-D warnings` clean.
- 9 new tests (§26 matrix: name/var-name variations, decl/expr/method/object-method/accessor, pre-`<` keep vs inside-`<>` erase, empty-param body-comment regression guard, negative no-seam).

## Coordination Notes
Emit is OUTPUT — comment-placement fix, no semantic validation, no output
surgery. Mid-task the naive precomputed-paren approach caused +49 regressions
(matched a `(` inside a body comment via the parser's inflated name.end) — fixed
by re-deriving the boundary from source and stopping at the first `<`/`(`
(keeps type-parameter-internal comments, which are erased separately, out of the seam).
