### PR TITLE
fix(emit): gate namespace-import elision on usage + strip multi-line generic type headers (--noCheck correctness)

### DIFF
--- a/crates/tsz-emitter/src/emitter/module_emission/core/tests/esm_class_namespace.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/tests/esm_class_namespace.rs
@@ -1477,3 +1477,103 @@ export {};
         "verbatimModuleSyntax must preserve the original import clause.\nOutput:\n{output}"
     );
 }
+
+fn emit_esnext(source: &str, opts_init: impl FnOnce(&mut PrinterOptions)) -> String {
+    let mut parser = ParserState::new("main.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut options = PrinterOptions {
+        module: ModuleKind::ESNext,
+        ..Default::default()
+    };
+    opts_init(&mut options);
+    let mut printer = Printer::with_options(&parser.arena, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+/// `import Foo, * as ns from "x"; Foo();` - an unused namespace binding beside
+/// a used default must drop only the namespace, mirroring the unused-default
+/// elision rule.
+#[test]
+fn esnext_unused_namespace_beside_used_default_is_elided() {
+    let output = emit_esnext(
+        "import Foo, * as ns from \"./dep\";\nFoo();\nexport {};\n",
+        |_| {},
+    );
+    assert!(
+        output.contains("import Foo from \"./dep\""),
+        "Used default binding must be preserved without the unused namespace.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("* as ns"),
+        "Unused namespace binding should be elided.\nOutput:\n{output}"
+    );
+}
+
+/// Negative: a USED namespace binding beside a used default must be kept.
+#[test]
+fn esnext_used_namespace_beside_used_default_is_kept() {
+    let output = emit_esnext(
+        "import Foo, * as ns from \"./dep\";\nFoo();\nns.bar();\nexport {};\n",
+        |_| {},
+    );
+    assert!(
+        output.contains("import Foo, * as ns from \"./dep\""),
+        "Both used bindings must be preserved.\nOutput:\n{output}"
+    );
+}
+
+/// Bound-name choice must not matter - the namespace elision is name-agnostic.
+#[test]
+fn esnext_unused_namespace_elision_is_name_agnostic() {
+    let output = emit_esnext(
+        "import Defaulted, * as everything from \"./dep\";\nDefaulted();\nexport {};\n",
+        |_| {},
+    );
+    assert!(
+        output.contains("import Defaulted from \"./dep\""),
+        "Used default must be preserved under a renamed namespace.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("everything"),
+        "Unused namespace binding should be elided regardless of its name.\nOutput:\n{output}"
+    );
+}
+
+/// Negative: verbatimModuleSyntax must keep the source clause exactly - the
+/// unused namespace binding must NOT be elided.
+#[test]
+fn esnext_verbatim_module_syntax_keeps_unused_namespace() {
+    let output = emit_esnext(
+        "import Foo, * as ns from \"./dep\";\nFoo();\nexport {};\n",
+        |o| o.verbatim_module_syntax = true,
+    );
+    assert!(
+        output.contains("import Foo, * as ns from \"./dep\""),
+        "verbatimModuleSyntax must preserve the original import clause.\nOutput:\n{output}"
+    );
+}
+
+/// Negative: a namespace binding named like the classic JSX factory root is
+/// referenced implicitly by JSX and must NOT be elided when the file has JSX.
+#[test]
+fn esnext_jsx_factory_namespace_binding_is_kept() {
+    let source = "import * as React from \"react\";\nconst el = <div />;\nexport {};\n";
+    // JSX requires a `.tsx` source for the parser to enable JSX parsing.
+    let mut parser = ParserState::new("main.tsx".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        module: ModuleKind::ESNext,
+        jsx: crate::emitter::JsxEmit::Preserve,
+        ..Default::default()
+    };
+    let mut printer = Printer::with_options(&parser.arena, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+    assert!(
+        output.contains("import * as React from \"react\""),
+        "JSX-factory namespace binding must be preserved when the file uses JSX.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/module_emission/imports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/imports.rs
@@ -363,6 +363,48 @@ impl<'a> Printer<'a> {
             && self.async_return_type_uses_imported_promise_constructor(&[local_name])
     }
 
+    /// Whether the namespace binding of an import clause (`import * as ns`) is
+    /// referenced as a value in the rest of the file. Mirrors
+    /// `default_binding_has_value_usage` for the namespace binding so that an
+    /// unused namespace beside a surviving default or named binding is elided
+    /// (matching tsc). The full module is scanned (issue #3597) so a use BEFORE
+    /// the import still keeps the binding.
+    fn namespace_binding_has_value_usage(
+        &self,
+        import_node: &Node,
+        namespace_name_idx: NodeIndex,
+    ) -> bool {
+        let local_name = self.get_identifier_text_idx(namespace_name_idx);
+        if local_name.is_empty() {
+            return true;
+        }
+        let Some(source_text) = self.source_text else {
+            return true;
+        };
+        let Some(import_data) = self.arena.get_import_decl(import_node) else {
+            return true;
+        };
+        let haystack =
+            Self::source_excluding_import_decl(source_text, import_node, import_data, self.arena);
+        let value_haystack = crate::import_usage::strip_type_only_content(&haystack);
+        let value_haystack = crate::import_usage::strip_qualified_accesses_for_names(
+            &value_haystack,
+            &self.ctx.options.external_const_enum_bindings,
+        );
+        if crate::import_usage::contains_identifier_occurrence(&value_haystack, &local_name) {
+            return true;
+        }
+        // Under `--emitDecoratorMetadata`, decorated-member type annotations are
+        // *value* references; preserve the namespace whose name appears there.
+        if self.ctx.options.emit_decorator_metadata
+            && crate::import_usage::name_appears_in_decorator_metadata_type(&haystack, &local_name)
+        {
+            return true;
+        }
+        self.ctx.target_es5
+            && self.async_return_type_uses_imported_promise_constructor(&[local_name])
+    }
+
     /// Filter named import specifiers to only those with value-level usage
     /// in the rest of the file. Used in --noCheck mode.
     fn filter_value_specs_by_usage(
@@ -720,7 +762,23 @@ impl<'a> Printer<'a> {
         {
             if let Some(named_imports) = self.arena.get_named_imports(bindings_node) {
                 if named_imports.name.is_some() && named_imports.elements.nodes.is_empty() {
-                    namespace_name = Some(named_imports.name);
+                    // A namespace binding (`import * as ns`) is kept only when it
+                    // has a value-level use. In --noCheck mode (type_only_nodes
+                    // empty) apply the same text-based usage gate used by the
+                    // default and named-specifier paths so an unused namespace
+                    // binding beside a surviving default (`import Foo, * as ns`)
+                    // is elided. JSX-factory namespace names are exempt because
+                    // they are referenced implicitly by JSX elements.
+                    let gate_namespace = self.ctx.options.type_only_nodes.is_empty()
+                        && !self.source_is_js_file
+                        && !self.ctx.options.verbatim_module_syntax
+                        && !preserve_invalid_module_syntax
+                        && !self.is_jsx_factory_import_clause(clause);
+                    if !gate_namespace
+                        || self.namespace_binding_has_value_usage(node, named_imports.name)
+                    {
+                        namespace_name = Some(named_imports.name);
+                    }
                 } else {
                     value_specs = self.collect_value_specifiers(&named_imports.elements);
                     // In --noCheck mode (type_only_nodes empty), apply text-based

--- a/crates/tsz-emitter/src/import_usage.rs
+++ b/crates/tsz-emitter/src/import_usage.rs
@@ -320,42 +320,62 @@ fn strip_non_code_text(line: &str, in_block_comment: &mut bool) -> String {
 /// - Other `import`/`export` statements (identifiers in other imports are not value usages)
 pub fn strip_type_only_content(source: &str) -> String {
     let mut result = String::with_capacity(source.len());
-    // Track brace depth to skip multi-line type declaration bodies
-    // (interface, type alias, declare blocks)
-    let mut type_brace_depth: u32 = 0;
+    // Tracks the span of a multi-line type-only declaration that is still
+    // being consumed. A declaration's header (`type X<...>`), its type-
+    // parameter list, and its body (`= {...}` / `interface X {...}`) can all
+    // span multiple lines, so we follow brace and angle-bracket depth and the
+    // statement terminator rather than assuming the opening brace shares the
+    // first line.
+    let mut pending: Option<TypeDeclSpan> = None;
     let mut in_block_comment = false;
     for line in source.lines() {
         let code_line = strip_non_code_text(line, &mut in_block_comment);
         let trimmed = code_line.trim();
 
-        // If we're inside a type declaration body, count braces to find the end
-        if type_brace_depth > 0 {
-            for ch in trimmed.chars() {
-                match ch {
-                    '{' => type_brace_depth += 1,
-                    '}' => type_brace_depth -= 1,
-                    _ => {}
-                }
-                if type_brace_depth == 0 {
-                    break;
-                }
+        // If we're inside a multi-line type declaration, keep consuming lines
+        // until the statement terminates (brace body closes or an alias `;`
+        // lands at top level).
+        if let Some(span) = pending.as_mut() {
+            if span.consume(trimmed) {
+                pending = None;
             }
             result.push('\n');
             continue;
         }
 
-        // Check if this line starts a type-only declaration (possibly multi-line)
-        let is_type_only_start = trimmed.starts_with("declare ")
-            || trimmed.starts_with("import type ")
-            || trimmed.starts_with("import type{")
+        // Type declarations (`type`/`interface`/`declare` families) may carry a
+        // multi-line `<...>` type-parameter header and a multi-line body, so
+        // they terminate on a balanced statement end, not merely a balanced
+        // brace on the opening line.
+        let is_type_decl_start = trimmed.starts_with("declare ")
             || trimmed.starts_with("export type ")
             || trimmed.starts_with("export type{")
             || trimmed.starts_with("export interface ")
             || trimmed.starts_with("export declare ")
             || trimmed.starts_with("type ")
-            || trimmed.starts_with("interface ")
-            // Other import statements - identifiers from other
-            // imports should not count as value usages of *this* import.
+            || trimmed.starts_with("interface ");
+
+        if is_type_decl_start {
+            let mut span = TypeDeclSpan::default();
+            let terminated = span.consume(trimmed);
+            // Only carry the declaration onto following lines when its `<...>`
+            // type-parameter header or `{...}` body is genuinely still open.
+            // A declaration that is balanced on its opening line is complete
+            // even without a trailing `;` (`type X = Foo`), so it must not
+            // consume the next statement.
+            if !terminated && (span.brace_depth > 0 || span.angle_depth > 0) {
+                pending = Some(span);
+            }
+            result.push('\n');
+            continue;
+        }
+
+        // Import/re-export statements never carry a `<...>` type-parameter
+        // header; identifiers from *other* imports/re-exports are not value
+        // usages of *this* import, so strip them with simple brace tracking
+        // (multi-line named-import/export lists use braces).
+        let is_import_export_start = trimmed.starts_with("import type ")
+            || trimmed.starts_with("import type{")
             // But `import X = Y` (namespace aliases) reference identifiers as
             // values and must be kept — only strip module-style imports.
             || (trimmed.starts_with("import ") && !is_namespace_alias_import(trimmed))
@@ -369,16 +389,26 @@ pub fn strip_type_only_content(source: &str) -> String {
             || (trimmed.starts_with("export {") && is_reexport_from(trimmed))
             || (trimmed.starts_with("export import ") && !is_namespace_alias_import(&trimmed["export ".len()..]));
 
-        if is_type_only_start {
-            // Check if this line opens a brace block (multi-line declaration)
+        if is_import_export_start {
+            // Import/re-export statements span multiple lines only when their
+            // named-binding `{...}` list is unbalanced on the opening line
+            // (e.g. `import {\n a,\n b\n} from "m"`). A statement without an
+            // open brace is single-line, even when it lacks a trailing `;`
+            // (`import * as ns from "m"`), so it must NOT become pending.
+            let mut depth: i32 = 0;
             for ch in trimmed.chars() {
                 match ch {
-                    '{' => type_brace_depth += 1,
-                    '}' => {
-                        type_brace_depth = type_brace_depth.saturating_sub(1);
-                    }
+                    '{' => depth += 1,
+                    '}' => depth -= 1,
                     _ => {}
                 }
+            }
+            if depth > 0 {
+                pending = Some(TypeDeclSpan {
+                    brace_depth: depth as u32,
+                    angle_depth: 0,
+                    body_opened: true,
+                });
             }
             result.push('\n');
             continue;
@@ -389,6 +419,51 @@ pub fn strip_type_only_content(source: &str) -> String {
         result.push('\n');
     }
     result
+}
+
+/// Tracks the in-progress span of a multi-line type-only declaration so the
+/// stripper consumes the full statement — its `<...>` type-parameter header,
+/// its `= {...}` / block body, and its terminating `;` — instead of stopping at
+/// the first brace-balanced line.
+#[derive(Default)]
+struct TypeDeclSpan {
+    brace_depth: u32,
+    angle_depth: u32,
+    /// Whether a brace body (`{`) has been opened anywhere in this declaration.
+    body_opened: bool,
+}
+
+impl TypeDeclSpan {
+    /// Feed one line of comment/string-stripped code. Returns `true` when the
+    /// declaration statement has terminated on this line.
+    fn consume(&mut self, code: &str) -> bool {
+        for ch in code.chars() {
+            match ch {
+                '{' => {
+                    self.brace_depth += 1;
+                    self.body_opened = true;
+                }
+                '}' => {
+                    self.brace_depth = self.brace_depth.saturating_sub(1);
+                    // A block body that closes back to top level ends the
+                    // statement (interfaces have no trailing `;`).
+                    if self.brace_depth == 0 && self.angle_depth == 0 && self.body_opened {
+                        return true;
+                    }
+                }
+                '<' => self.angle_depth += 1,
+                '>' => self.angle_depth = self.angle_depth.saturating_sub(1),
+                ';' => {
+                    // A `;` at top level ends an alias declaration (`type X = ...;`).
+                    if self.brace_depth == 0 && self.angle_depth == 0 {
+                        return true;
+                    }
+                }
+                _ => {}
+            }
+        }
+        false
+    }
 }
 
 pub fn strip_qualified_accesses_for_names<'a>(

--- a/crates/tsz-emitter/tests/import_usage.rs
+++ b/crates/tsz-emitter/tests/import_usage.rs
@@ -147,6 +147,81 @@ fn strip_type_only_content_drops_type_alias_block_multiline() {
     assert!(contains_identifier_occurrence(&stripped, "z"));
 }
 
+// Issue: a `type X<...> = {...}` whose `<...>` type-parameter header spans
+// multiple lines must be fully stripped. The header continuation lines
+// previously leaked into the haystack because the stripper only entered skip
+// mode on a brace-balanced opening line.
+#[test]
+fn strip_type_only_content_drops_multiline_type_param_header() {
+    let src = "type Wrapper<\n  TKey,\n  TVal\n> = {\n  k: TKey;\n  v: TVal;\n};\nconst z = 1;\n";
+    let stripped = strip_type_only_content(src);
+    assert!(!contains_identifier_occurrence(&stripped, "Wrapper"));
+    // Type-parameter names and body identifiers in the multi-line header/body
+    // must NOT survive as value usages.
+    assert!(!contains_identifier_occurrence(&stripped, "TKey"));
+    assert!(!contains_identifier_occurrence(&stripped, "TVal"));
+    assert!(!contains_identifier_occurrence(&stripped, "k"));
+    assert!(contains_identifier_occurrence(&stripped, "z"));
+}
+
+// Renamed bound variables prove the fix keys on structure, not on the names
+// `T`/`U`/`Wrapper`.
+#[test]
+fn strip_type_only_content_drops_multiline_type_param_header_renamed() {
+    let src = "type Box<\n  A,\n  B\n> = {\n  first: A;\n  second: B;\n};\nconst kept = 1;\n";
+    let stripped = strip_type_only_content(src);
+    assert!(!contains_identifier_occurrence(&stripped, "Box"));
+    assert!(!contains_identifier_occurrence(&stripped, "A"));
+    assert!(!contains_identifier_occurrence(&stripped, "B"));
+    assert!(!contains_identifier_occurrence(&stripped, "first"));
+    assert!(contains_identifier_occurrence(&stripped, "kept"));
+}
+
+// An `interface` with a multi-line type-parameter header must also be fully
+// stripped (same header-spanning shape, different declaration keyword).
+#[test]
+fn strip_type_only_content_drops_multiline_interface_header() {
+    let src = "interface Holder<\n  Item\n> {\n  value: Item;\n}\nconst z = 1;\n";
+    let stripped = strip_type_only_content(src);
+    assert!(!contains_identifier_occurrence(&stripped, "Holder"));
+    assert!(!contains_identifier_occurrence(&stripped, "Item"));
+    assert!(!contains_identifier_occurrence(&stripped, "value"));
+    assert!(contains_identifier_occurrence(&stripped, "z"));
+}
+
+// Negative (over-consume guard): a brace-less single-line statement that lacks
+// a trailing `;` (`import * as ns from "m"`) must consume ONLY its own line and
+// must NOT swallow a following braced declaration. A later value reference
+// (`c2` inside `class C extends c2.C`) must survive so its import is kept.
+#[test]
+fn strip_type_only_content_braceless_import_does_not_consume_following_class() {
+    let src = "import * as ns from \"module\"\nimport { c2 } from \"module\"\nclass C extends c2.C {\n}\nlet y = ns.value;\n";
+    let stripped = strip_type_only_content(src);
+    // `c2` is used as a value in the extends clause and must remain visible.
+    assert!(contains_identifier_occurrence(&stripped, "c2"));
+    assert!(contains_identifier_occurrence(&stripped, "ns"));
+}
+
+// Negative: a balanced single-line alias without a trailing `;` is complete on
+// its own line and must not over-consume the following value statement.
+#[test]
+fn strip_type_only_content_braceless_alias_without_semicolon_keeps_following_value() {
+    let src = "type X = Foo\nconst keepMe = 1;\nkeepMe;\n";
+    let stripped = strip_type_only_content(src);
+    assert!(!contains_identifier_occurrence(&stripped, "Foo"));
+    assert!(contains_identifier_occurrence(&stripped, "keepMe"));
+}
+
+// Negative: a generic single-line alias still terminates on its own line and
+// the following value usage survives (no over-consumption of later lines).
+#[test]
+fn strip_type_only_content_singleline_generic_alias_keeps_following_value() {
+    let src = "type Id<T> = T;\nconst usedValue = 1;\nusedValue;\n";
+    let stripped = strip_type_only_content(src);
+    assert!(!contains_identifier_occurrence(&stripped, "Id"));
+    assert!(contains_identifier_occurrence(&stripped, "usedValue"));
+}
+
 #[test]
 fn strip_type_only_content_drops_other_module_imports() {
     // Identifiers from *other* imports should not count as value usages


### PR DESCRIPTION
AgentName: m3-max-64g-opus48

## Track
Emit correctness (bugs-on-top) — `--noCheck` unused-import elision. JS emit.

## Invariant
(1) A namespace import binding (`import * as ns`) is elided when the text-heuristic
usage scan finds no value-use of the namespace name — the SAME usage gate the
default and named-specifier paths already apply. (2) The type-only-content
stripper must consume a `type X<...> = {...}` declaration's full header
(type-param `<...>` list + `{...}` body), not just brace-balanced opening lines.

## Scope
- `module_emission/imports.rs`: add `namespace_binding_has_value_usage` (mirrors
  `default_binding_has_value_usage`) and gate the namespace binding with the same
  type-only/js-file/verbatim/jsx-factory conditions as the sibling paths.
- `import_usage.rs::strip_type_only_content`: `TypeDeclSpan` tracks brace + angle
  depth so multi-line `type X<...>` headers go pending only when `<...>`/`{...}`
  is genuinely open; import/re-export keep simple brace tracking.
- tests: `module_emission/core/tests/esm_class_namespace.rs`, `tests/import_usage.rs`.

## Bug
(1) The namespace branch set `namespace_name` unconditionally, so an unused
`import Foo, * as ns from "x"; Foo();` wrongly kept `ns`. (2) A `type X<\n...\n> = {...}`
header's continuation lines leaked into the value-usage haystack.

## Project Corpus Impact
- Row: n/a (emit CORRECTNESS fix — `--noCheck` unused-import over-retention; latent, no currently-failing corpus test exercises both shapes)
- Bug family: unused namespace import kept + multi-line generic `type` header leaks into usage scan
- Evidence: `--js-only -j4` 72→72 / `--dts-only` 24→24 (net-zero, ZERO regressions). Witnesses are unit tests (unused-namespace-elided + multiline-type-header-stripped, name-agnostic). `node --check` valid on CJS + ESM outputs.

## Verification
- arch `Architecture guardrails passed`; clippy `-D warnings` clean; files under 2000-line ratchet.
- Over-elide NEGATIVES added: USED namespace kept; verbatimModuleSyntax keeps unused ns; JSX-factory `import * as React` kept; brace-less `import * as ns` does NOT consume a following `class`; brace-less `type X = Foo` (no `;`) does not over-consume.

## Coordination Notes
Emit is OUTPUT — text-heuristic elision gates, no checker/binder real-usage info
needed, no output surgery. Mid-task self-corrected a regression
(`isolatedModulesImportExportElision` — over-consume from brace-less pending);
fixed by gating pending on open braces/angles only + 2 negative tests. Net-zero
on metric but a genuine `--noCheck` correctness improvement.
