### PR TITLE
fix(module-resolver): resolve path mapping targets with explicit extensions

### DIFF
--- a/crates/tsz-core/src/module_resolver/mod.rs
+++ b/crates/tsz-core/src/module_resolver/mod.rs
@@ -553,8 +553,10 @@ impl ModuleResolver {
         // TypeScript treats `paths` mappings as requiring `baseUrl` to avoid surprising
         // absolute lookups that behave like relative resolution.
         let mut path_mapping_attempted = false;
-        if self.base_url.is_some() && !self.path_mappings.is_empty() {
-            let attempt = self.try_path_mappings(specifier, containing_dir);
+        if let Some(base_url) = self.base_url.as_deref()
+            && !self.path_mappings.is_empty()
+        {
+            let attempt = self.try_path_mappings(specifier, base_url);
             if let Some(resolved) = attempt.resolved {
                 return (Ok(resolved), path_mapping_attempted);
             }

--- a/crates/tsz-core/src/module_resolver/path_mapping.rs
+++ b/crates/tsz-core/src/module_resolver/path_mapping.rs
@@ -1,7 +1,7 @@
 //! Path mapping resolution from tsconfig `paths` and `baseUrl`.
 
 use super::{ModuleExtension, ModuleResolver, ResolvedModule};
-use crate::module_resolver_helpers::split_path_extension;
+use crate::resolution::helpers::apply_wildcard_substitution;
 use std::path::Path;
 
 pub(super) struct PathMappingAttempt {
@@ -10,44 +10,29 @@ pub(super) struct PathMappingAttempt {
 }
 
 impl ModuleResolver {
-    /// Try resolving through path mappings
-    pub(super) fn try_path_mappings(
-        &self,
-        specifier: &str,
-        _containing_dir: &Path,
-    ) -> PathMappingAttempt {
-        // Sort path mappings by specificity (most specific first)
-        let mut sorted_mappings: Vec<_> = self.path_mappings.iter().collect();
-        sorted_mappings.sort_by_key(|b| std::cmp::Reverse(b.specificity()));
-
+    /// Try resolving through path mappings.
+    ///
+    /// tsc resolves path mapping targets by probing the substituted path
+    /// (relative to `baseUrl`) with its normal file/directory lookup, regardless
+    /// of whether the substituted target already has an explicit extension.
+    /// Targets with explicit extensions (e.g. `"./foo.d.ts"`, `"./lib/*.ts"`)
+    /// are checked as-is; `try_file_or_directory` handles extension substitution
+    /// and declaration-sidecar probing the same way it does for any other path.
+    ///
+    /// `base` is the resolved `baseUrl` directory; callers must only invoke this
+    /// method when `base_url` is set (the type system enforces it via `&Path`).
+    pub(super) fn try_path_mappings(&self, specifier: &str, base: &Path) -> PathMappingAttempt {
+        // `self.path_mappings` is pre-sorted by specificity descending at
+        // construction time (`build_path_mappings` in config/mod.rs).
         let mut attempted = false;
-        for mapping in sorted_mappings {
+        for mapping in &self.path_mappings {
             if let Some(star_match) = mapping.match_specifier(specifier) {
                 attempted = true;
-                // Try each target path
                 for target in &mapping.targets {
-                    let substituted = if target.contains('*') {
-                        target.replace('*', &star_match)
-                    } else {
-                        target.clone()
-                    };
-                    if Self::has_path_mapping_target_extension(&substituted) {
-                        continue;
-                    }
-
-                    let base = self
-                        .base_url
-                        .as_deref()
-                        .expect("path mappings require baseUrl for attempted resolution");
+                    let substituted = apply_wildcard_substitution(target, &star_match, false);
                     let candidate = base.join(&substituted);
 
                     if let Some(resolved) = self.try_file_or_directory(&candidate) {
-                        // `candidate` has no extension here (we skipped
-                        // targets that already did on line 34), so classify
-                        // on the resolved path instead — otherwise the
-                        // extension is always `Unknown`, which desyncs path-
-                        // mapping-resolved modules from every other resolver
-                        // exit that sets this from the resolved file.
                         let extension = ModuleExtension::from_path(&resolved);
                         return PathMappingAttempt {
                             resolved: Some(ResolvedModule {
@@ -69,10 +54,5 @@ impl ModuleResolver {
             resolved: None,
             attempted,
         }
-    }
-
-    pub(super) fn has_path_mapping_target_extension(target: &str) -> bool {
-        let base_path = std::path::Path::new(target);
-        split_path_extension(base_path).is_some()
     }
 }

--- a/crates/tsz-core/src/module_resolver/tests.rs
+++ b/crates/tsz-core/src/module_resolver/tests.rs
@@ -18,6 +18,7 @@ mod module_extension;
 mod node16_modes;
 mod package_exports_imports;
 mod package_json_data;
+mod path_mapping;
 mod pattern_matching;
 mod resolution_failure;
 mod resolver_integration;

--- a/crates/tsz-core/src/module_resolver/tests/lookup_integration.rs
+++ b/crates/tsz-core/src/module_resolver/tests/lookup_integration.rs
@@ -1254,13 +1254,9 @@ fn test_lookup_path_mapping_failure_produces_ts2307_via_lookup() {
 #[test]
 fn test_path_mapping_extension_reflects_resolved_file() {
     // Regression: path-mapping previously classified the resolved module's
-    // extension from the pre-resolution candidate (which always has no
-    // extension at this point — targets with extensions are filtered
-    // earlier). That made every path-mapping-resolved module carry
-    // `ModuleExtension::Unknown` instead of the real `.ts` / `.d.ts` / etc.,
-    // drifting from every other resolver exit (relative, node_modules,
-    // exports, self-reference) which uses the resolved path. The fix
-    // classifies on the resolved path.
+    // extension from the pre-resolution candidate path instead of the
+    // actual resolved file, producing `ModuleExtension::Unknown` for every
+    // path-mapping result. The fix classifies on the resolved path.
     use std::fs;
     let dir = std::env::temp_dir().join("tsz_path_mapping_ext_regression");
     let _ = fs::remove_dir_all(&dir);

--- a/crates/tsz-core/src/module_resolver/tests/path_mapping.rs
+++ b/crates/tsz-core/src/module_resolver/tests/path_mapping.rs
@@ -1,0 +1,336 @@
+//! Path mapping resolution tests.
+//!
+//! Covers `paths` / `baseUrl` behavior:
+//!
+//! - Wildcard targets without extension (baseline, existing behavior)
+//! - Fixed declaration targets (`.d.ts`) with no wildcard in target
+//! - Wildcard targets with explicit extension suffix (`.d.ts`, `.ts`, `.js`)
+//! - Catch-all `"*"` pattern mapping to a fixed declaration file
+//! - Multiple fallback targets — first hit wins
+//! - Specificity ordering (longer prefix wins)
+//! - Nested sub-paths captured by wildcard (`"components/Button"`)
+
+use super::super::*;
+use super::fixtures::TempFixture;
+use crate::config::PathMapping;
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn make_options(dir: &std::path::Path, mappings: Vec<PathMapping>) -> ResolvedCompilerOptions {
+    ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Bundler),
+        base_url: Some(dir.to_path_buf()),
+        paths: Some(mappings),
+        module_suffixes: vec![String::new()],
+        ..Default::default()
+    }
+}
+
+/// Convenience constructor for a single `PathMapping` with no suffix.
+fn pm(pattern: &str, prefix: &str, targets: &[&str]) -> PathMapping {
+    PathMapping {
+        pattern: pattern.to_string(),
+        prefix: prefix.to_string(),
+        suffix: String::new(),
+        targets: targets.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+// ── wildcard extensionless target (baseline) ──────────────────────────────────
+
+#[test]
+fn test_path_mapping_wildcard_extensionless_target() {
+    let fx = TempFixture::new();
+    fx.write("src/widget.ts", "export const w = 1;");
+    fx.write("index.ts", "import '@app/widget';");
+
+    let options = make_options(fx.path(), vec![pm("@app/*", "@app/", &["src/*"])]);
+    let mut resolver = ModuleResolver::new(&options);
+    let result = resolver.resolve("@app/widget", &fx.join("index.ts"), Span::new(0, 11));
+    assert_eq!(
+        result
+            .expect("@app/widget should resolve to src/widget.ts")
+            .resolved_path,
+        fx.join("src/widget.ts"),
+    );
+}
+
+// ── fixed .d.ts target — previously broken ────────────────────────────────────
+
+#[test]
+fn test_path_mapping_exact_dts_target() {
+    // A fixed `.d.ts` target (no wildcard in the target string) must resolve.
+    // Previously `has_path_mapping_target_extension` silently skipped it.
+    let fx = TempFixture::new();
+    fx.write(
+        "external.d.ts",
+        "declare const value: any; export default value;",
+    );
+    fx.write("index.ts", "import 'next';");
+
+    let options = make_options(fx.path(), vec![pm("next", "next", &["./external.d.ts"])]);
+    let mut resolver = ModuleResolver::new(&options);
+    let result = resolver.resolve("next", &fx.join("index.ts"), Span::new(0, 6));
+    assert_eq!(
+        result
+            .expect("exact .d.ts target must resolve")
+            .resolved_path,
+        fx.join("external.d.ts"),
+    );
+}
+
+#[test]
+fn test_path_mapping_catch_all_wildcard_with_fixed_dts_target() {
+    // `"*": ["./external.d.ts"]` — a catch-all pattern mapping ALL specifiers
+    // to a single fixed declaration file. Models the nextjs guard config pattern.
+    let fx = TempFixture::new();
+    fx.write(
+        "external.d.ts",
+        "declare const defaultExport: any; export default defaultExport;",
+    );
+    fx.write("index.ts", "import 'some-pkg';");
+
+    let options = make_options(fx.path(), vec![pm("*", "", &["./external.d.ts"])]);
+    let mut resolver = ModuleResolver::new(&options);
+
+    for specifier in &["some-pkg", "react", "next/image", "lodash/fp"] {
+        let result = resolver.resolve(specifier, &fx.join("index.ts"), Span::new(0, 8));
+        assert_eq!(
+            result
+                .unwrap_or_else(|_| panic!("{specifier} should resolve via catch-all mapping"))
+                .resolved_path,
+            fx.join("external.d.ts"),
+            "{specifier} must map to external.d.ts"
+        );
+    }
+}
+
+#[test]
+fn test_path_mapping_wildcard_with_explicit_dts_suffix_in_target() {
+    // `"@types/*": ["./stubs/*.d.ts"]` — the target template itself ends in `.d.ts`.
+    // After substitution `"utils"` → `"./stubs/utils.d.ts"` the file must be found.
+    let fx = TempFixture::new();
+    fx.write("stubs/utils.d.ts", "export declare function util(): void;");
+    fx.write("index.ts", "import '@types/utils';");
+
+    let options = make_options(
+        fx.path(),
+        vec![pm("@types/*", "@types/", &["./stubs/*.d.ts"])],
+    );
+    let mut resolver = ModuleResolver::new(&options);
+    let result = resolver.resolve("@types/utils", &fx.join("index.ts"), Span::new(0, 14));
+    assert_eq!(
+        result
+            .expect("@types/utils should resolve to stubs/utils.d.ts")
+            .resolved_path,
+        fx.join("stubs/utils.d.ts"),
+    );
+}
+
+#[test]
+fn test_path_mapping_wildcard_with_explicit_ts_suffix_in_target() {
+    // `"@src/*": ["./source/*.ts"]` — explicit `.ts` extension in target template.
+    let fx = TempFixture::new();
+    fx.write("source/helpers.ts", "export const x = 1;");
+    fx.write("index.ts", "import '@src/helpers';");
+
+    let options = make_options(fx.path(), vec![pm("@src/*", "@src/", &["./source/*.ts"])]);
+    let mut resolver = ModuleResolver::new(&options);
+    let result = resolver.resolve("@src/helpers", &fx.join("index.ts"), Span::new(0, 14));
+    assert_eq!(
+        result
+            .expect("@src/helpers should resolve to source/helpers.ts")
+            .resolved_path,
+        fx.join("source/helpers.ts"),
+    );
+}
+
+#[test]
+fn test_path_mapping_wildcard_captures_nested_sub_path() {
+    // When the wildcard captures a multi-segment path like `"server/app-page"`,
+    // the substituted target `"./src/server/app-page"` must still resolve.
+    let fx = TempFixture::new();
+    fx.write("src/server/app-page.ts", "export type AppPage = {};");
+    fx.write("index.ts", "import 'next/dist/server/app-page';");
+
+    let options = make_options(
+        fx.path(),
+        vec![pm("next/dist/*", "next/dist/", &["./src/*"])],
+    );
+    let mut resolver = ModuleResolver::new(&options);
+    let result = resolver.resolve(
+        "next/dist/server/app-page",
+        &fx.join("index.ts"),
+        Span::new(0, 26),
+    );
+    assert_eq!(
+        result
+            .expect("nested sub-path should resolve via wildcard mapping")
+            .resolved_path,
+        fx.join("src/server/app-page.ts"),
+    );
+}
+
+// ── specificity ordering ──────────────────────────────────────────────────────
+
+#[test]
+fn test_path_mapping_more_specific_pattern_wins() {
+    // `"next/dist/compiled/*"` (prefix len 22) beats `"next/dist/*"` (prefix len 10)
+    // beats `"*"` (prefix len 0).  The external.d.ts is the expected result only
+    // for `"next/dist/compiled/..."` specifiers.
+    let fx = TempFixture::new();
+    fx.write("src/router.ts", "export {};");
+    fx.write("external.d.ts", "declare const v: any; export default v;");
+    fx.write("index.ts", "");
+
+    let options = make_options(
+        fx.path(),
+        vec![
+            pm(
+                "next/dist/compiled/*",
+                "next/dist/compiled/",
+                &["./external.d.ts"],
+            ),
+            pm("next/dist/*", "next/dist/", &["./src/*"]),
+            pm("*", "", &["./external.d.ts"]),
+        ],
+    );
+    let mut resolver = ModuleResolver::new(&options);
+
+    // Most specific: hits the compiled wildcard → external.d.ts
+    let compiled = resolver
+        .resolve(
+            "next/dist/compiled/react",
+            &fx.join("index.ts"),
+            Span::new(0, 1),
+        )
+        .expect("next/dist/compiled/* should map to external.d.ts");
+    assert_eq!(compiled.resolved_path, fx.join("external.d.ts"));
+
+    // Medium specificity: hits next/dist/* → src/router.ts
+    let server = resolver
+        .resolve("next/dist/router", &fx.join("index.ts"), Span::new(0, 1))
+        .expect("next/dist/* should map to src/router.ts");
+    assert_eq!(server.resolved_path, fx.join("src/router.ts"));
+
+    // Least specific: * catch-all → external.d.ts
+    let unrelated = resolver
+        .resolve("lodash", &fx.join("index.ts"), Span::new(0, 1))
+        .expect("* catch-all should map to external.d.ts");
+    assert_eq!(unrelated.resolved_path, fx.join("external.d.ts"));
+}
+
+// ── multiple fallback targets ─────────────────────────────────────────────────
+
+#[test]
+fn test_path_mapping_falls_through_missing_targets_to_first_existing() {
+    // When a mapping lists multiple targets, the first one that resolves on disk wins.
+    let fx = TempFixture::new();
+    // Only the second target file exists.
+    fx.write("fallback.d.ts", "export {};");
+    fx.write("index.ts", "import 'pkg';");
+
+    let options = make_options(
+        fx.path(),
+        vec![pm("pkg", "pkg", &["./missing.d.ts", "./fallback.d.ts"])],
+    );
+    let mut resolver = ModuleResolver::new(&options);
+    let result = resolver.resolve("pkg", &fx.join("index.ts"), Span::new(0, 5));
+    assert_eq!(
+        result
+            .expect("second fallback target should resolve when first is missing")
+            .resolved_path,
+        fx.join("fallback.d.ts"),
+    );
+}
+
+// ── extension classification ──────────────────────────────────────────────────
+
+#[test]
+fn test_path_mapping_explicit_dts_target_classifies_as_dts() {
+    let fx = TempFixture::new();
+    fx.write("stub.d.ts", "export declare const n: number;");
+    fx.write("index.ts", "import 'pkg';");
+
+    let options = make_options(fx.path(), vec![pm("pkg", "pkg", &["./stub.d.ts"])]);
+    let mut resolver = ModuleResolver::new(&options);
+    let module = resolver
+        .resolve("pkg", &fx.join("index.ts"), Span::new(0, 5))
+        .expect("explicit .d.ts target must resolve");
+
+    assert_eq!(module.resolved_path, fx.join("stub.d.ts"));
+    assert_eq!(
+        module.extension,
+        ModuleExtension::Dts,
+        "resolved extension must be Dts, not Unknown"
+    );
+}
+
+// ── nextjs-fixture pattern ────────────────────────────────────────────────────
+
+#[test]
+fn test_path_mapping_nextjs_guard_config_pattern() {
+    // Reproduces the nextjs guard tsconfig.tsz-guard.json path mapping:
+    //
+    //   "next/dist/compiled/*" → ["./external.d.ts"]
+    //   "next/dist/*"          → ["./src/*"]
+    //   "*"                    → ["./external.d.ts"]
+    //
+    // Before the fix, the first and third entries had `.d.ts` targets that
+    // `has_path_mapping_target_extension` skipped, so any import not matching
+    // `"next/dist/*"` silently fell through to bare-specifier resolution and
+    // produced TS2307 / no-module divergence from tsc.
+    let fx = TempFixture::new();
+    fx.write(
+        "external.d.ts",
+        "declare const defaultExport: any; export default defaultExport;",
+    );
+    fx.write("src/server/app-page.ts", "export type AppPage = {};");
+    fx.write("index.ts", "");
+
+    let options = make_options(
+        fx.path(),
+        vec![
+            pm(
+                "next/dist/compiled/*",
+                "next/dist/compiled/",
+                &["./external.d.ts"],
+            ),
+            pm("next/dist/*", "next/dist/", &["./src/*"]),
+            pm("*", "", &["./external.d.ts"]),
+        ],
+    );
+    let mut resolver = ModuleResolver::new(&options);
+
+    // "next/dist/compiled/react" → external.d.ts (most-specific fixed target)
+    let compiled = resolver
+        .resolve(
+            "next/dist/compiled/react",
+            &fx.join("index.ts"),
+            Span::new(0, 1),
+        )
+        .expect("next/dist/compiled/* must resolve to external.d.ts");
+    assert_eq!(compiled.resolved_path, fx.join("external.d.ts"));
+
+    // "next/dist/server/app-page" → src/server/app-page.ts (wildcard extensionless)
+    let server_page = resolver
+        .resolve(
+            "next/dist/server/app-page",
+            &fx.join("index.ts"),
+            Span::new(0, 1),
+        )
+        .expect("next/dist/* must resolve to src/server/app-page.ts");
+    assert_eq!(server_page.resolved_path, fx.join("src/server/app-page.ts"));
+
+    // "next" → external.d.ts (catch-all "*" pattern)
+    let next_root = resolver
+        .resolve("next", &fx.join("index.ts"), Span::new(0, 1))
+        .expect("\"*\" catch-all must resolve next to external.d.ts");
+    assert_eq!(next_root.resolved_path, fx.join("external.d.ts"));
+
+    // "react" → external.d.ts (catch-all "*" pattern)
+    let react = resolver
+        .resolve("react", &fx.join("index.ts"), Span::new(0, 1))
+        .expect("\"*\" catch-all must resolve react to external.d.ts");
+    assert_eq!(react.resolved_path, fx.join("external.d.ts"));
+}

--- a/crates/tsz-core/src/resolution/helpers.rs
+++ b/crates/tsz-core/src/resolution/helpers.rs
@@ -148,15 +148,17 @@ pub(crate) fn export_pattern_specificity(pattern: &str) -> (usize, usize) {
 /// specificity is largest. Equal-specificity ties resolve to the first entry in
 /// iteration order — callers must use an insertion-order map (`IndexMap`) to get
 /// deterministic JSON-source-order tie-breaking per the Node.js/TypeScript spec.
+type BestExportPatternEntry<'a> = ((usize, usize), &'a str, String, &'a PackageExports);
+
 pub(crate) fn find_best_export_pattern<'a>(
     patterns: impl Iterator<Item = (&'a String, &'a PackageExports)>,
     match_fn: impl Fn(&str) -> Option<String>,
 ) -> Option<(&'a str, String, &'a PackageExports)> {
-    let mut best: Option<((usize, usize), &'a str, String, &'a PackageExports)> = None;
+    let mut best: Option<BestExportPatternEntry<'a>> = None;
     for (pattern, value) in patterns {
         if let Some(matched) = match_fn(pattern) {
             let specificity = export_pattern_specificity(pattern);
-            if best.as_ref().map_or(true, |(s, _, _, _)| specificity > *s) {
+            if best.as_ref().is_none_or(|(s, _, _, _)| specificity > *s) {
                 best = Some((specificity, pattern.as_str(), matched, value));
             }
         }


### PR DESCRIPTION
AgentName: claude-sonnet-4-6

## Track
Module resolver / `tsconfig` paths-mapping parity

## Invariant
When a tsconfig `paths` target is an explicit-extension path (e.g. `"./foo.d.ts"`, `"./stubs/*.d.ts"`), TypeScript probes the substituted path relative to `baseUrl` with its normal file/directory lookup. tsz was skipping all such targets silently.

## Scope

### Bug fixed
`has_path_mapping_target_extension` checked whether a substituted target had a known TypeScript/JavaScript extension (`.ts`, `.d.ts`, `.js`, `.tsx`, …). If it did, the target was `continue`d — never probed — causing all fixed-extension `paths` targets to silently fail and fall through to bare-specifier resolution (TS2307 or wrong resolution).

This broke every tsconfig that uses the nextjs guard pattern:
```jsonc
"paths": {
  "next/dist/compiled/*": ["./external.d.ts"],   // ← was skipped
  "next/dist/*":          ["./src/*"],            // ← worked
  "*":                    ["./external.d.ts"]     // ← was skipped
}
```

### Additional improvements (all within the same file cluster)
- **Remove redundant per-call sort**: `build_path_mappings` already sorts by specificity at construction time; the O(n log n) + Vec alloc on every resolution call was wasted.
- **Use shared `apply_wildcard_substitution`**: replaced inline `contains('*')` + `replace` with the existing crate helper that uses `replacen` (first `*` only, per spec).
- **Pass `base: &Path` to `try_path_mappings`**: the call site already guards `base_url.is_some()`; passing the path makes the precondition part of the type signature instead of a distant-invariant `expect`.
- **10 new unit tests** using `TempFixture` (parallel-safe, RAII cleanup), covering: exact `.d.ts` target, wildcard `.d.ts`/`.ts` suffix targets, catch-all `"*"` → fixed file, specificity ordering, fallback targets, and the full nextjs guard config pattern.
- **Updated stale comment** in `lookup_integration.rs` that referenced the now-removed extension-filter behaviour.
- **Pre-existing clippy fixes** in `resolution/helpers.rs`: `map_or` → `is_none_or`, complex-type alias `BestExportPatternEntry`.

## Project Corpus Impact
- Row: nextjs-guard
- Bug family: paths-mapping silent drop of explicit-extension targets → TS2307 divergence on any specifier matched by a fixed-.d.ts target
- Evidence: 10 new unit tests reproduce the exact nextjs guard pattern and all pass locally; `cargo nextest run -p tsz-core -E 'test(module_resolver)'` → 217/217 pass; `cargo clippy -p tsz-core --all-targets --all-features -- -D warnings` → clean.

## Verification
```
cargo clippy -p tsz-core --all-targets --all-features -- -D warnings  # clean
cargo nextest run -p tsz-core -E 'test(module_resolver)'               # 217/217
```

## Coordination Notes
- Claimed from open issue pool. No overlapping open PR targets the `paths`-mapping extension-skip bug.
- The fix is structural (removes the bad guard entirely) rather than a special-case patch. Tests cover exact targets, wildcard suffix targets, catch-all patterns, and specificity ordering — not just the reported fixture.
- Ran `/simplify` 3× before opening; each round had actionable findings that were applied.