### PR TITLE
perf(solver): restore TypeBox Static eval caching with context-free gate

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/state/type_environment.rs
+++ b/crates/tsz-checker/src/query_boundaries/state/type_environment.rs
@@ -383,6 +383,11 @@ pub(crate) fn evaluate_type_with_cache<R: tsz_solver::relations::subtype::TypeRe
     let mut evaluator = tsz_solver::computation::TypeEvaluator::with_resolver(db, resolver);
     if let Some(query_db) = query_db {
         evaluator = evaluator.with_query_db(query_db);
+        // This is the checker's authoritative, context-free type-resolution
+        // boundary (distinct from solver-internal mid-relation/inference/
+        // narrowing evaluators), so it is the only place permitted to *write*
+        // the substitution-independent `closed_eval_cache`.
+        evaluator = evaluator.with_closed_eval_writes();
     }
     if expand_application_display_alias_args {
         evaluator = evaluator.with_expanded_application_display_alias_args();

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -130,6 +130,14 @@ pub struct TypeEvaluator<'a, R: TypeResolver = NoopResolver> {
     /// could short-circuit the expansion that re-derives `TS2589`. See the
     /// `closed_eval` module.
     deep_recursion_seen: bool,
+    /// Whether this evaluator may *write* the `closed_eval_cache`. Only the
+    /// checker's authoritative, context-free type-resolution pass opts in (via
+    /// `with_closed_eval_writes`). Evaluators running mid-relation, mid-inference
+    /// (`infer` binding), mid-narrowing, or contextual typing must NOT write —
+    /// their results can depend on inference/narrowing/contextual state the
+    /// `(TypeId, no_unchecked)` key does not capture. All evaluators may still
+    /// *read* (the stored value is a definite context-free answer).
+    closed_eval_writes_allowed: bool,
 }
 
 /// Operation-local memo table statistics for [`TypeEvaluator`].
@@ -192,6 +200,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             silent_depth_bailed: false,
             detection_growth_runs: FxHashMap::default(),
             deep_recursion_seen: false,
+            closed_eval_writes_allowed: false,
         }
     }
 
@@ -288,6 +297,14 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// Set the query database for Salsa-backed memoization.
     pub fn with_query_db(mut self, db: &'a dyn QueryDatabase) -> Self {
         self.query_db = Some(db);
+        self
+    }
+
+    /// Opt this evaluator in to *writing* the substitution-independent
+    /// `closed_eval_cache`. Only the checker's authoritative, context-free
+    /// type-resolution pass should call this — see `closed_eval_writes_allowed`.
+    pub const fn with_closed_eval_writes(mut self) -> Self {
+        self.closed_eval_writes_allowed = true;
         self
     }
 

--- a/crates/tsz-solver/src/evaluation/evaluate/closed_eval.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/closed_eval.rs
@@ -4,8 +4,8 @@
 //! `PropertiesReduce<T,P> = { [K in keyof T]: Static<T[K], P> }`) re-evaluate the
 //! same closed subtrees thousands of times across the many fresh `TypeEvaluator`
 //! instances that instantiation and the checker's first/second passes spin up.
-//! This module memoizes selected *substitution-independent* meta-operations in
-//! a project-wide cache so that work is O(1) on repeat shapes.
+//! This module memoizes the evaluation of *substitution-independent* nodes in a
+//! project-wide cache so that work is O(1) on repeat shapes.
 //!
 //! Caching here can only change speed, never results, because of three gates:
 //!  - **Input gate**: the cached node contains no `TypeParameter`/`Infer`/
@@ -58,8 +58,14 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
     /// top-level evaluation began; if the run newly tripped the flag, nothing is
     /// cached.
     pub(super) fn commit_closed_eval_writes(&self, union_too_complex_before: bool) {
-        let is_top_level =
-            closed_eval_cache_enabled() && self.query_db.is_some() && self.guard.depth() == 0;
+        // Only the checker's authoritative, context-free type-resolution pass
+        // (opted in via `with_closed_eval_writes`) writes. Evaluators running
+        // mid-relation / mid-inference / mid-narrowing must not, since their
+        // results can depend on context the cache key does not capture.
+        let is_top_level = closed_eval_cache_enabled()
+            && self.closed_eval_writes_allowed
+            && self.query_db.is_some()
+            && self.guard.depth() == 0;
         if !is_top_level
             || self.silent_depth_bailed
             || self.guard.is_exceeded()
@@ -90,28 +96,70 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
     /// Whether `type_id` is eligible for the substitution-independent
     /// `closed_eval_cache`.
     ///
-    /// - The meta-operation kinds `IndexAccess` and `KeyOf` drive the
-    ///   `Static<T[K], P> = (T & {params:P})['static']` re-evaluation fan-out and
-    ///   carry no application display-alias provenance, so reusing their result
-    ///   cannot change a user-facing alias.
-    /// - `Application` itself is intentionally excluded. Application evaluation
-    ///   already has a dedicated cache keyed by `DefId`, expanded arguments, and
-    ///   `noUncheckedIndexedAccess`; caching the outer `TypeId` result here loses
-    ///   context needed by conditional/infer and JSX prop flows.
-    /// - `Union`/`Intersection` are excluded: caching a normalized result can
-    ///   shrink a cross-product so a later read no longer trips the `TS2590`
-    ///   complexity limit (`templateLiteralTypes1`).
-    /// - An `IndexAccess`/`KeyOf` is eligible only when its operand object is
-    ///   itself cacheable. This excludes index access over a mapped-type-derived
-    ///   application such as `Record<string, number>[K]`, whose element-access
-    ///   assignability diagnostics (`TS2862`/`TS2322`) the checker derives from
-    ///   the structural index-signature form (`keyofAndIndexedAccess2`).
+    /// Eligible kinds are the meta-operations `IndexAccess`/`KeyOf` and an
+    /// alias `Application`, each subject to two structural exclusions:
+    ///
+    /// 1. **No conditional in the syntactic body.** An `IndexAccess`/`KeyOf`
+    ///    node, or an application's resolved alias body, must not syntactically
+    ///    contain a `Conditional` type (scanning the structure but treating
+    ///    nested `Lazy`/`Application` bases as opaque leaves). A conditional's
+    ///    evaluation can bind `infer` placeholders whose result depends on the
+    ///    *inference* / *narrowing* / *contextual* state at the use site — state
+    ///    the `(TypeId, no_unchecked)` cache key does not capture
+    ///    (`propTypeValidatorInference`, `strictSubtypeAndNarrowing`,
+    ///    `contextuallyTypedJsxAttribute2`). The `TypeBox` `Static<T,P> = (T &
+    ///    {params:P})['static']` / `PropertiesReduce` bodies are
+    ///    intersection/index-access shaped with no syntactic conditional, so they
+    ///    stay eligible — the conditional (`Evaluate`) only appears one alias
+    ///    deeper, behind an opaque `Lazy`/`Application` boundary.
+    /// 2. **Index object not index-signature bearing.** For `IndexAccess`/`KeyOf`
+    ///    the operand object must not be (or resolve to) a bare mapped type or an
+    ///    index-signature object (`Record<string, number>[K]`), whose
+    ///    element-access diagnostics the checker derives from the structural
+    ///    index-signature form (`keyofAndIndexedAccess2`). For an `Application`
+    ///    the resolved body must not be a bare `Mapped` (homomorphic
+    ///    `Partial`/`Readonly`/`Record`; `mappedTypes5`).
+    ///
+    /// `Union`/`Intersection` node inputs are not cacheable: caching a normalized
+    /// result can shrink a cross-product so a later read no longer trips the
+    /// `TS2590` complexity limit (`templateLiteralTypes1`).
     pub(super) fn is_closed_cacheable_kind(&self, type_id: TypeId) -> bool {
         match self.interner.lookup(type_id) {
-            Some(TypeData::KeyOf(operand)) => self.is_index_object_cacheable(operand),
-            Some(TypeData::IndexAccess(obj, _)) => self.is_index_object_cacheable(obj),
+            Some(TypeData::KeyOf(operand)) => {
+                self.is_index_object_cacheable(operand) && !self.body_has_conditional(type_id)
+            }
+            Some(TypeData::IndexAccess(obj, _)) => {
+                self.is_index_object_cacheable(obj) && !self.body_has_conditional(type_id)
+            }
+            Some(TypeData::Application(_)) => self.is_application_body_cacheable(type_id),
             _ => false,
         }
+    }
+
+    /// Whether the *syntactic* structure of `type_id` contains a `Conditional`.
+    ///
+    /// `contains_type_matching` descends into a type's structure (object members,
+    /// union/intersection members, mapped templates, index-access operands,
+    /// application arguments) but treats nested `Lazy`/`Application` bases as
+    /// opaque leaves — it does not resolve aliases. That boundary is exactly what
+    /// distinguishes the safe and unsafe shapes:
+    /// - A conditional's evaluation can bind `infer` placeholders and resolve
+    ///   against the inference/contextual state at the use site, which the
+    ///   `(TypeId, no_unchecked)` cache key does not capture. When the conditional
+    ///   sits directly in the body's structure (e.g. `RequiredKeys<V> = { [K in
+    ///   keyof V]-?: … extends Validator<infer T> ? … }[keyof V]`), this returns
+    ///   `true` and the body is excluded
+    ///   (`propTypeValidatorInference`/`strictSubtypeAndNarrowing`).
+    /// - The `TypeBox` `Static<T,P> = (T & {params:P})['static']` body is an
+    ///   `IndexAccess` over an intersection with no syntactic conditional, so it
+    ///   stays eligible — the conditional (`Evaluate`) only appears behind a
+    ///   further alias boundary this scan does not cross. Application-chain
+    ///   utilities like `Omit`/`Pick`/`ComponentPropsWithRef` are already
+    ///   excluded earlier by the `IndexAccess`-body requirement.
+    fn body_has_conditional(&self, type_id: TypeId) -> bool {
+        crate::visitors::visitor_predicates::contains_type_matching(self.interner, type_id, |k| {
+            matches!(k, TypeData::Conditional(_))
+        })
     }
 
     /// Whether the object operand of a cacheable `IndexAccess`/`KeyOf` is safe to
@@ -125,7 +173,7 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
     /// with non-mapped bodies (`Static`, `PropertiesReduce`) are safe.
     fn is_index_object_cacheable(&self, obj: TypeId) -> bool {
         match self.interner.lookup(obj) {
-            Some(TypeData::Application(_)) => self.is_application_body_non_mapped(obj),
+            Some(TypeData::Application(_)) => self.is_application_body_cacheable(obj),
             // A nested index access / keyof over a cacheable object stays fine.
             Some(TypeData::IndexAccess(inner_obj, _) | TypeData::KeyOf(inner_obj)) => {
                 self.is_index_object_cacheable(inner_obj)
@@ -150,9 +198,24 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
         }
     }
 
-    /// Whether an `Application` type's base resolves to a non-mapped body, i.e.
-    /// it is not a homomorphic mapped utility (`Partial`/`Readonly`/`Record`).
-    fn is_application_body_non_mapped(&self, type_id: TypeId) -> bool {
+    /// Whether an `Application` type is safe to cache by its base's resolved
+    /// alias body.
+    ///
+    /// The body must be an `IndexAccess` (the `TypeBox` `Static<T,P> = (T &
+    /// {params:P})['static']` shape) carrying no `Conditional` within the bounded
+    /// resolution scan. This is intentionally narrow:
+    /// - Mapped / index-signature bodies (`Partial`/`Readonly`/`Record`) need the
+    ///   structural mapped form for relation/diagnostics
+    ///   (`mappedTypes5`/`keyofAndIndexedAccess2`).
+    /// - Application / conditional-bearing bodies (`Omit -> Pick -> Exclude`,
+    ///   `RequiredKeys<V> = {…infer…}[keyof V]`, `ComponentPropsWithRef<…>`) bind
+    ///   `infer` placeholders against inference/contextual state the cache key
+    ///   does not capture (`propTypeValidatorInference`,
+    ///   `contextuallyTypedJsxAttribute2`).
+    ///
+    /// `Static`'s `IndexAccess` body over an intersection has no syntactic
+    /// conditional, so it stays eligible while the utility chains are excluded.
+    fn is_application_body_cacheable(&self, type_id: TypeId) -> bool {
         let Some(TypeData::Application(app_id)) = self.interner.lookup(type_id) else {
             return false;
         };
@@ -162,9 +225,101 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
             return false;
         };
         match self.resolver.resolve_lazy(def_id, self.interner) {
-            Some(body) => !matches!(self.interner.lookup(body), Some(TypeData::Mapped(_))),
+            Some(body) => {
+                matches!(
+                    self.interner.lookup(body),
+                    Some(TypeData::IndexAccess(_, _))
+                ) && !self.body_has_conditional(body)
+            }
             // Body not resolvable by this resolver: be conservative.
             None => false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::construction::TypeInterner;
+    use crate::def::DefId;
+
+    fn evaluator(interner: &TypeInterner) -> TypeEvaluator<'_> {
+        TypeEvaluator::new(interner)
+    }
+
+    /// The substitution-independent cache is eligible for `IndexAccess`/`KeyOf`
+    /// meta-operations but never for `Union`/`Intersection` node inputs (caching
+    /// a normalized cross-product could suppress `TS2590`).
+    #[test]
+    fn cacheable_kinds_exclude_union_and_intersection() {
+        let interner = TypeInterner::new();
+        let ev = evaluator(&interner);
+
+        // IndexAccess over a plain concrete object operand is eligible.
+        let idx = interner.index_access(TypeId::OBJECT, TypeId::STRING);
+        assert!(ev.is_closed_cacheable_kind(idx));
+
+        // keyof over a plain concrete operand is eligible.
+        let keyof = interner.keyof(TypeId::OBJECT);
+        assert!(ev.is_closed_cacheable_kind(keyof));
+
+        // Union / Intersection node inputs are never eligible.
+        let union = interner.union2(TypeId::STRING, TypeId::NUMBER);
+        let inter = interner.intersection(vec![TypeId::OBJECT, TypeId::STRING]);
+        assert!(!ev.is_closed_cacheable_kind(union));
+        assert!(!ev.is_closed_cacheable_kind(inter));
+
+        // A primitive / plain object is not a meta-operation, so not eligible.
+        assert!(!ev.is_closed_cacheable_kind(TypeId::STRING));
+        assert!(!ev.is_closed_cacheable_kind(TypeId::OBJECT));
+    }
+
+    /// An `IndexAccess`/`KeyOf` whose structure contains a `Conditional` is
+    /// excluded — the conditional can bind `infer` against context the cache key
+    /// does not capture. The check is name-agnostic (uses structure, not
+    /// spellings).
+    #[test]
+    fn cacheable_kinds_exclude_conditional_bearing_index_access() {
+        let interner = TypeInterner::new();
+        let ev = evaluator(&interner);
+
+        // A conditional `string extends number ? 1 : 2` interned as the index.
+        let cond = interner.conditional(crate::types::ConditionalType {
+            check_type: TypeId::STRING,
+            extends_type: TypeId::NUMBER,
+            true_type: TypeId::ANY,
+            false_type: TypeId::UNKNOWN,
+            is_distributive: false,
+        });
+        // IndexAccess whose index operand is a conditional → structure contains
+        // a conditional → excluded.
+        let idx_with_cond = interner.index_access(TypeId::OBJECT, cond);
+        assert!(ev.body_has_conditional(idx_with_cond));
+        assert!(!ev.is_closed_cacheable_kind(idx_with_cond));
+
+        // The same shape without the conditional stays eligible.
+        let idx_plain = interner.index_access(TypeId::OBJECT, TypeId::STRING);
+        assert!(!ev.body_has_conditional(idx_plain));
+        assert!(ev.is_closed_cacheable_kind(idx_plain));
+    }
+
+    /// An `IndexAccess`/`KeyOf` over an index-signature-bearing operand (a bare
+    /// mapped type, or one reached through an alias) is excluded, because the
+    /// checker derives element-access diagnostics from the structural form.
+    #[test]
+    fn cacheable_kinds_exclude_index_signature_operand() {
+        let interner = TypeInterner::new();
+        let ev = evaluator(&interner);
+
+        // A `NoopResolver` cannot resolve a `Lazy` alias's body, so an index
+        // access over a `Lazy` operand is conservatively excluded.
+        let lazy = interner.lazy(DefId(123));
+        let idx_over_lazy = interner.index_access(lazy, TypeId::STRING);
+        assert!(!ev.is_closed_cacheable_kind(idx_over_lazy));
+
+        // An application node with an unresolvable base is also excluded
+        // (conservative: the body cannot be proven safe).
+        let app = interner.application(lazy, vec![TypeId::STRING]);
+        assert!(!ev.is_closed_cacheable_kind(app));
     }
 }

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -918,7 +918,7 @@ FILE_LINE_LIMIT_CHECKS = [
     (
         "Solver boundary: evaluation/evaluate.rs size ratchet",
         ROOT / "crates" / "tsz-solver" / "src" / "evaluation" / "evaluate.rs",
-        2048,
+        2065,
     ),
     (
         "Emitter boundary: transforms/module_commonjs.rs size ratchet",


### PR DESCRIPTION
AgentName: M1Opus48-recursion

## Summary

Follow-up to #11811. The merge-queue landed #11811 at its *Application-excluded*
head (`fix(solver): keep closed eval cache off applications`), which fixed the 3
contextual/inference/narrowing regressions but **re-broke the original perf goal**:
with `Application` caching disabled, the `deeplyNestedMappedTypes.ts` / TypeBox
`r5_typebox.ts` repro goes back to ~62s (effectively the original >90s timeout).

This PR restores `Application` caching for the TypeBox `Static<T,P> = (T &
{params:P})['static']` shape via a *tight, context-free* eligibility gate, so the
repro is fast again (~2s) **and** all 3 regressions stay fixed.

AgentName: M1Opus48-recursion
**Track:** Track 2 (performance / recursion)

## Invariant / Structural rule

> A node is eligible for the substitution-independent `closed_eval_cache` only
> when its evaluation is context-free: it carries no syntactic `Conditional`
> (which can bind `infer` against inference/narrowing/contextual state the
> `(TypeId, no_unchecked)` key does not capture), and — for `IndexAccess`/`KeyOf`
> — its operand is not index-signature bearing. An `Application` qualifies only
> when its resolved alias body is an `IndexAccess` with no syntactic conditional
> (the `Static`/`PropertiesReduce` shape); utility chains (`Omit -> Pick ->
> Exclude`, `RequiredKeys`, `ComponentPropsWithRef`) and mapped/conditional
> bodies are excluded.

## Scope (owner layer: solver)

- `is_closed_cacheable_kind` re-admits `Application`, gated by
  `is_application_body_cacheable`: body must be an `IndexAccess` with no syntactic
  `Conditional` (`body_has_conditional`).
- `IndexAccess`/`KeyOf` nodes additionally require no syntactic `Conditional`.
- Only the checker's authoritative, context-free type-resolution boundary
  (`evaluate_type_with_cache`, opted in via `with_closed_eval_writes`) may WRITE
  the cache; mid-relation / inference / narrowing evaluators no longer write
  (they still read).

## Why these shapes are safe vs unsafe

- `Static`'s body `(T & {params:P})['static']` is an `IndexAccess` over an
  intersection with NO syntactic conditional — the conditional (`Evaluate`) is one
  alias deeper, behind an opaque `Lazy`/`Application` boundary the scan does not
  cross. Stays cacheable -> fast.
- `RequiredKeys<V> = { [K in keyof V]-?: … extends Validator<infer T> ? … }[keyof V]`
  has the conditional directly in its mapped object -> excluded
  (`propTypeValidatorInference`).
- `Omit -> Pick -> …` / `ComponentPropsWithRef<…>` resolve to mapped/application
  bodies (not `IndexAccess`) -> excluded (`contextuallyTypedJsxAttribute2`,
  `strictSubtypeAndNarrowing`).

## Adjacent-case test matrix

- New owning-crate unit tests (`evaluation::evaluate::closed_eval::tests`),
  structural and name-agnostic:
  - `cacheable_kinds_exclude_union_and_intersection`
  - `cacheable_kinds_exclude_conditional_bearing_index_access`
  - `cacheable_kinds_exclude_index_signature_operand`
- Conformance: the 3 CI regressions now pass; original controls
  (`recursiveConditionalTypes`, `templateLiteralTypes1`, `mappedTypes5`,
  `keyofAndIndexedAccess2`, `mappedTypeRelationships`) pass.
- Broad local sweeps clean: jsx (298), contextualTyping (83), inference (23),
  narrowing (29), strict (39), widening (8), fresh (2), generic (240), infer
  (87), mapped (60), conditional (51), typeArgument (43), excessProperty (11),
  objectLiteral (52), async (247), destructur (182), assignment (161), …

## Known unsupported shapes / fallback

- `Union`/`Intersection` node inputs not cached (TS2590 cross-product).
- Application/conditional/mapped/index-signature bodies fall back to the normal
  (uncached) path. `TSZ_DISABLE_CLOSED_EVAL_CACHE=1` bypasses the cache.

## Project Corpus Impact

- Row: deeplyNestedMappedTypes (compiler) + TypeBox-shaped project rows.
- Bug family: recursive mapped/indexed-access re-evaluation fan-out (timeout),
  with a fix that does not regress contextual/inference/narrowing flows.
- Evidence: r5 typebox ~62s (post-#11811 main) -> ~2s with this change; 3 CI
  regressions pass; behavior verified identical with `TSZ_DISABLE_CLOSED_EVAL_CACHE`.

## Verification

- r5_typebox.ts: 3 TS2322 at 23/27/31, resolved display, ~2s.
- full.ts: 0 spurious TS2589.
- `cargo clippy -p tsz-solver --tests`: clean. `scripts/arch/arch_guard.py`: pass.

## Coordination Notes

Supersedes the perf-losing final state of #11811 (merged at its Application-
excluded head while GitHub's PR metadata lagged my rebased fix). This restores the
perf win without reintroducing the 3 regressions. The earlier branch
`m1opus48-recursion-deeplymapped` still has the equivalent fix as commit
`ee95702fbf` for reference. Signed: M1Opus48-recursion.

