### PR TITLE
fix(checker): add index signature incompatibility chain to TS2430 interface extension errors

### DIFF
--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -1048,10 +1048,17 @@ impl<'a> CheckerState<'a> {
                                     // The later base's index signature conflicts with
                                     // what was inherited from earlier bases.
                                     // tsc reports TS2430 against the later base only.
+                                    let index_kind = if key_type == TypeId::NUMBER {
+                                        "number"
+                                    } else {
+                                        "string"
+                                    };
+                                    let prev_type_str = self.format_type(prev_val);
+                                    let value_type_str = self.format_type(value_type);
                                     self.error_at_node(
                                         iface_data.name,
                                         &format!(
-                                            "Interface '{derived_name}' incorrectly extends interface '{base_name}'."
+                                            "Interface '{derived_name}' incorrectly extends interface '{base_name}'.\n  '{index_kind}' index signatures are incompatible.\n    Type '{prev_type_str}' is not assignable to type '{value_type_str}'."
                                         ),
                                         diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE,
                                     );
@@ -1944,10 +1951,12 @@ impl<'a> CheckerState<'a> {
                     (derived_string_index_type, base_string_index_value)
                     && !self.index_value_assignable_for_interface_extends(derived_val, base_val)
                 {
+                    let derived_type_str = self.format_type(derived_val);
+                    let base_type_str = self.format_type(base_val);
                     self.error_at_node(
                         iface_data.name,
                         &format!(
-                            "Interface '{derived_name}' incorrectly extends interface '{base_name}'."
+                            "Interface '{derived_name}' incorrectly extends interface '{base_name}'.\n  'string' index signatures are incompatible.\n    Type '{derived_type_str}' is not assignable to type '{base_type_str}'."
                         ),
                         diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE,
                     );
@@ -1957,10 +1966,12 @@ impl<'a> CheckerState<'a> {
                     (derived_number_index_type, base_number_index_value)
                     && !self.index_value_assignable_for_interface_extends(derived_val, base_val)
                 {
+                    let derived_type_str = self.format_type(derived_val);
+                    let base_type_str = self.format_type(base_val);
                     self.error_at_node(
                         iface_data.name,
                         &format!(
-                            "Interface '{derived_name}' incorrectly extends interface '{base_name}'."
+                            "Interface '{derived_name}' incorrectly extends interface '{base_name}'.\n  'number' index signatures are incompatible.\n    Type '{derived_type_str}' is not assignable to type '{base_type_str}'."
                         ),
                         diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE,
                     );


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Checker diagnostics parity: TS2430 interface extension error chain.

## Invariant
When an interface extends a base with an incompatible index signature, either from a single base or a cross-base conflict, `tsc` includes the `index signatures are incompatible` chain in the TS2430 diagnostic. This PR makes tsz preserve that diagnostic chain without changing assignability semantics.

## Scope
- `crates/tsz-checker/src/classes/class_checker_compat.rs`: updates TS2430 error messages for single-base and cross-base index signature conflicts to include the full incompatibility chain.

## Project Corpus Impact
- Row: n/a
- Bug family: TS2430 diagnostic chain for index signature incompatibility
- Evidence: verified against `tsc` on single-base and cross-base interface-extension cases; no project-corpus row targeted.

## Verification
- Tested with `tsc` on a single-base case: `B extends A` with incompatible index signatures.
- Tested with `tsc` on a cross-base case: `C extends A, B` with conflicting index signatures.
- Both `tsc` and tsz now produce matching diagnostic chains.
- CI before the body repair: conformance, emit, fourslash, project compile guard, lint, unit, wasm, and snapshot gates passed for head `3e79cc4b99e89d9c51327ab3358ed5b71c609d05`; only `project-corpus-pr-body` failed on PR body shape.

## Coordination Notes
- Original AgentName in the PR body was `StudioDS4`; Studio-B repaired the required PR-body metadata on 2026-05-31 so the already-green head can re-enter the queue.
- Fixes #11336.