### PR TITLE
fix(checker): suppress spurious TS2322 for function-valued excess property on key-remapping mapped types

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -35,6 +35,10 @@ name = "closure_boundary_property_narrowing_tests"
 path = "tests/closure_boundary_property_narrowing_tests.rs"
 
 [[test]]
+name = "mapped_remapped_excess_function_property_tests"
+path = "tests/mapped_remapped_excess_function_property_tests.rs"
+
+[[test]]
 name = "cross_file_lib_generic_heritage_tests"
 path = "tests/cross_file_lib_generic_heritage_tests.rs"
 

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -350,6 +350,13 @@ impl<'a> CheckerState<'a> {
                     } else {
                         contextual_type
                     };
+                    // Set when the property is absent from the contextual type and we
+                    // fall back to a synthetic `never` contextual type purely to drive
+                    // function-parameter implicit-any handling (see below). Such a
+                    // property is excess (TS2353 territory), so the synthetic `never`
+                    // must never be used as an assignability *target* — doing so emits
+                    // a spurious TS2322 against `never`.
+                    let mut property_context_is_synthetic_absent_never = false;
                     let property_context_type = if let Some(ctx_type) =
                         function_property_lookup_context
                     {
@@ -393,6 +400,7 @@ impl<'a> CheckerState<'a> {
                             && !allows_callable_fallback
                         {
                             property_context_type = Some(TypeId::NEVER);
+                            property_context_is_synthetic_absent_never = true;
                         }
                         let needs_callable_fallback = property_context_type.is_none()
                             || matches!(property_context_type, Some(TypeId::ANY | TypeId::UNKNOWN));
@@ -724,6 +732,7 @@ impl<'a> CheckerState<'a> {
                             });
 
                         if (recheck_key_remapped_property || recheck_contextual_property)
+                            && !property_context_is_synthetic_absent_never
                             && let Some(check_target) = property_context_type
                             && value_type != TypeId::ERROR
                             && value_type != TypeId::ANY

--- a/crates/tsz-checker/tests/mapped_remapped_excess_function_property_tests.rs
+++ b/crates/tsz-checker/tests/mapped_remapped_excess_function_property_tests.rs
@@ -1,0 +1,170 @@
+//! Regression tests for a false-positive `TS2322` on object-literal assignment.
+//!
+//! Structural rule: when an object literal is assigned to a key-remapping mapped
+//! type (`{ [K in keyof T as <name-type>]: ... }`) and the literal carries an
+//! *excess* property — one that the remapping does not produce — whose value is
+//! a **function-like** expression (arrow, function expression, or method
+//! shorthand), `tsc` reports only `TS2353` (object literal may only specify
+//! known properties). It must not additionally report `TS2322` against `never`.
+//!
+//! tsz previously synthesized a `never` contextual type for absent function-like
+//! properties (used purely to drive parameter implicit-any handling) and then,
+//! for remapped mapped targets, re-checked the property value against that
+//! synthetic `never`, emitting a spurious `TS2322: Type '() => void' is not
+//! assignable to type 'never'`. The fix marks that `never` as a sentinel and
+//! skips the re-check for it.
+//!
+//! The rule is independent of the iteration-variable name, the filter style
+//! (value-based vs key-based vs rename), and the function-expression flavor.
+
+use tsz_checker::test_utils::check_source_strict_codes;
+
+fn codes_ignoring_lib_noise(source: &str) -> Vec<u32> {
+    // TS2318 (cannot find global type) is unrelated lib-loading noise in the
+    // unit harness; these fixtures reference no lib globals.
+    check_source_strict_codes(source)
+        .into_iter()
+        .filter(|&code| code != 2318)
+        .collect()
+}
+
+/// Reported repro shape: value-based filter (`T[K] extends X ? never : K`) with
+/// an excess arrow-function property. Only `TS2353` is expected.
+#[test]
+fn excess_arrow_property_on_value_filtered_mapped_target_is_only_ts2353() {
+    let source = r#"
+type DropNums<T> = { [K in keyof T as T[K] extends number ? never : K]: T[K] };
+interface M { a: number; s: string; }
+type R = DropNums<M>;
+const bad: R = { s: "x", fn: () => {} };
+"#;
+    let codes = codes_ignoring_lib_noise(source);
+    assert!(
+        !codes.contains(&2322),
+        "excess function-valued property must not produce a spurious TS2322 against `never`; got {codes:?}"
+    );
+    assert!(
+        codes.contains(&2353),
+        "excess property should still be reported as TS2353; got {codes:?}"
+    );
+}
+
+/// Same rule with a renamed iteration variable (`Prop` instead of `K`) — proves
+/// the fix is not keyed on a particular binder name.
+#[test]
+fn excess_arrow_property_renamed_binder_is_only_ts2353() {
+    let source = r#"
+type Filter<X> = { [Prop in keyof X as X[Prop] extends number ? never : Prop]: X[Prop] };
+interface M { a: number; s: string; }
+type R = Filter<M>;
+const bad: R = { s: "y", handler: () => {} };
+"#;
+    let codes = codes_ignoring_lib_noise(source);
+    assert!(!codes.contains(&2322), "got {codes:?}");
+    assert!(codes.contains(&2353), "got {codes:?}");
+}
+
+/// Key-based filter (`P extends Bad ? never : P`, the `Omit` shape) with an
+/// excess arrow property.
+#[test]
+fn excess_arrow_property_on_key_filtered_mapped_target_is_only_ts2353() {
+    let source = r#"
+type DropKey<T, Bad extends string> = { [P in keyof T as P extends Bad ? never : P]: T[P] };
+interface M { keep: string; }
+type R = DropKey<M, "x">;
+const bad: R = { keep: "z", cb: () => {} };
+"#;
+    let codes = codes_ignoring_lib_noise(source);
+    assert!(!codes.contains(&2322), "got {codes:?}");
+    assert!(codes.contains(&2353), "got {codes:?}");
+}
+
+/// Rename remap (`as `p_${K}``) — the remapped key space is entirely renamed, so
+/// any unprefixed function-valued property is excess.
+#[test]
+fn excess_arrow_property_on_rename_remapped_mapped_target_is_only_ts2353() {
+    let source = r#"
+type Prefix<T> = { [K in keyof T as `p_${string & K}`]: T[K] };
+interface M { a: number; }
+type R = Prefix<M>;
+const bad: R = { p_a: 1, extra: () => {} };
+"#;
+    let codes = codes_ignoring_lib_noise(source);
+    assert!(!codes.contains(&2322), "got {codes:?}");
+    assert!(codes.contains(&2353), "got {codes:?}");
+}
+
+/// Method-shorthand and function-expression excess properties exercise the same
+/// `initializer_is_function_like` path as arrows.
+#[test]
+fn excess_method_and_function_expression_properties_are_only_ts2353() {
+    let method = r#"
+type DropNums<T> = { [K in keyof T as T[K] extends number ? never : K]: T[K] };
+interface M { a: number; s: string; }
+type R = DropNums<M>;
+const bad: R = { s: "x", run() { return 1; } };
+"#;
+    let func_expr = r#"
+type DropNums<T> = { [K in keyof T as T[K] extends number ? never : K]: T[K] };
+interface M { a: number; s: string; }
+type R = DropNums<M>;
+const bad: R = { s: "x", run: function () {} };
+"#;
+    for source in [method, func_expr] {
+        let codes = codes_ignoring_lib_noise(source);
+        assert!(!codes.contains(&2322), "got {codes:?} for {source}");
+        assert!(codes.contains(&2353), "got {codes:?} for {source}");
+    }
+}
+
+/// Negative case: a mapped type that genuinely types every member as `never`
+/// (no remapping/filtering) must still reject a function-valued initializer
+/// with `TS2322` — the property is present, not excess.
+#[test]
+fn function_value_against_real_never_member_still_errors_ts2322() {
+    let source = r#"
+type AllNever<T> = { [K in keyof T]: never };
+interface M { a: number; }
+type R = AllNever<M>;
+const bad: R = { a: () => {} };
+"#;
+    let codes = codes_ignoring_lib_noise(source);
+    assert!(
+        codes.contains(&2322),
+        "assigning a function to a real `never`-typed member must still error TS2322; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2353),
+        "the property is present (not excess), so no TS2353 is expected; got {codes:?}"
+    );
+}
+
+/// Negative case: a remapped key that *survives* with an incompatible
+/// function-parameter type must still be re-checked and produce `TS2322`.
+#[test]
+fn surviving_remapped_function_property_with_wrong_signature_still_errors() {
+    let source = r#"
+type Wrap<T> = { [K in keyof T as `w_${string & K}`]: T[K] };
+interface P { fn: (x: number) => void; }
+type R = Wrap<P>;
+const bad: R = { w_fn: (x: string) => {} };
+"#;
+    let codes = codes_ignoring_lib_noise(source);
+    assert!(
+        codes.contains(&2322),
+        "a surviving remapped property with an incompatible signature must still error; got {codes:?}"
+    );
+}
+
+/// Valid assignment (only surviving keys, correct values) must be clean.
+#[test]
+fn valid_assignment_to_remapped_mapped_target_is_clean() {
+    let source = r#"
+type DropNums<T> = { [K in keyof T as T[K] extends number ? never : K]: T[K] };
+interface M { a: number; s: string; }
+type R = DropNums<M>;
+const ok: R = { s: "x" };
+"#;
+    let codes = codes_ignoring_lib_noise(source);
+    assert!(codes.is_empty(), "expected no diagnostics, got {codes:?}");
+}

--- a/crates/tsz-checker/tests/mapped_remapped_excess_function_property_tests.rs
+++ b/crates/tsz-checker/tests/mapped_remapped_excess_function_property_tests.rs
@@ -79,8 +79,8 @@ const bad: R = { keep: "z", cb: () => {} };
     assert!(codes.contains(&2353), "got {codes:?}");
 }
 
-/// Rename remap (`as `p_${K}``) — the remapped key space is entirely renamed, so
-/// any unprefixed function-valued property is excess.
+/// Rename remap (template-literal name type `p_${K}`) — the remapped key space
+/// is entirely renamed, so any unprefixed function-valued property is excess.
 #[test]
 fn excess_arrow_property_on_rename_remapped_mapped_target_is_only_ts2353() {
     let source = r#"


### PR DESCRIPTION
AgentName: PensiveWright-opus48

Closes #11827.

## Track

Checker / object-literal contextual typing — `tsc` parity for object literals
assigned to key-remapping mapped types. Contributes to the kysely `TS2322`
false-positive family (#10663).

## Invariant / Structural rule

> When an object-literal property's key is **absent** from a key-remapping
> mapped contextual type (`{ [K in keyof T as <name-type>]: ... }`) — i.e. the
> property is excess — its (function-like) value must not be re-checked against
> the synthetic `never` contextual type that tsz uses internally to drive
> function-parameter implicit-any handling. The property is excess (`TS2353`
> only), matching `tsc`. A genuine `never`-typed member and a *surviving*
> remapped key with an incompatible value are unaffected and still error
> (`TS2322`).

## Problem

```ts
type NonFns<T> = { [K in keyof T as T[K] extends Function ? never : K]: T[K] };
interface M { a: number; b(): void; c: string; }
type R = NonFns<M>;
const bad: R = { a: 1, c: "x", b: () => {} };
```

- **tsc 6.0.2**: `TS2353` only (`b` does not exist in `NonFns<M>`).
- **tsz before**: `TS2353` **and** spurious `TS2322: Type '() => void' is not assignable to type 'never'`.

`r.b` (TS2339) and `keyof R` already correctly exclude `b`; the divergence was
confined to the object-literal assignment path and only for function-valued
excess properties.

## Root cause (owner layer: checker)

In `get_type_of_object_literal_with_request`
(`crates/tsz-checker/src/types/computation/object_literal/computation.rs`):

1. For a **function-like** initializer whose property is **absent** from the
   contextual type, the code sets `property_context_type = Some(TypeId::NEVER)`
   as a *sentinel* used only to drive function-parameter implicit-any handling
   (it is not a real contextual type).
2. For a **remapped** mapped target (`recheck_key_remapped_property`), the code
   then re-checks the property value against `property_context_type` — for a
   filtered-out key that target is the synthetic `never`, producing the spurious
   `TS2322`.

## Fix

Track the synthetic `never` with a sentinel flag
(`property_context_is_synthetic_absent_never`) and skip the remapped-mapped
re-check for it. The other downstream consumers of the synthetic `never`
(`apply_contextual_type`, `should_widen_object_property_literal`) already treat
`never` as a permissive/no-op context, so the suppression is correctly scoped to
the single diagnostic-emitting re-check.

## Scope

`crates/tsz-checker/` only:
- `src/types/computation/object_literal/computation.rs` — sentinel flag + guard (9 lines).
- `tests/mapped_remapped_excess_function_property_tests.rs` — new regression tests.
- `Cargo.toml` — register the new test target (`autotests = false`).

## Project Corpus Impact

- Row: kysely-project (contributes to the `TS2322` false-positive family, #10663).
- Bug family: false-positive `TS2322` against `never` for function-valued excess properties on key-remapping mapped types.
- Evidence: differential check against `tsc` 6.0.2 on the repro and 9 adjacent shapes (all now match); new owning-crate unit tests; 12 related checker test binaries (211 tests) pass with no regressions.

## Adjacent-case test matrix (name-agnostic)

- value-based filter (`T[K] extends … ? never : K`), arrow excess;
- renamed iteration variable (`Prop` / `X`);
- key-based filter (`P extends Bad ? never : P`, the `Omit` shape);
- rename remap (`` as `p_${K}` ``);
- method-shorthand and function-expression excess;
- **negative**: real `never` member still errors `TS2322` (and no `TS2353`);
- **negative**: surviving remapped key with wrong signature still errors;
- valid assignment stays clean.

## Verification

- `cargo test -p tsz-checker --test mapped_remapped_excess_function_property_tests` → 8 passed.
- Focused regression set (12 mapped/object-literal/contextual test binaries) → 211 passed, 0 failed.
- `cargo clippy -p tsz-checker --tests` → clean.
- Differential vs `tsc` 6.0.2 on the repro + adjacent shapes → all match.

## Coordination Notes

Discovered while investigating the kysely `TS2322` false-positive cluster
(#10663). The reported kysely diagnostics only reproduce in the full library
context (no fixtures available locally); this PR fixes a distinct, minimal,
synthetically reproducible sub-bug fundamentally at the checker boundary rather
than patching a fixture. No open PR targets this path. `/simplify` reviewed the
change (4 cleanup angles) — no findings; code confirmed right-altitude.

Signed: PensiveWright-opus48.