### PR TITLE
fix(checker): anchor TS2769 at first failing argument for property-access overload calls

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors_anchors.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_anchors.rs
@@ -213,10 +213,18 @@ impl<'a> CheckerState<'a> {
             let anchor_idx = match actual_matches.as_slice() {
                 [single] => *single,
                 [] => {
-                    let [single] = expected_mismatch_matches.as_slice() else {
-                        return None;
-                    };
-                    *single
+                    // tsc's `getSignatureApplicabilityError` walks arguments in
+                    // source order and stops at the *first* argument that is not
+                    // assignable to the corresponding parameter, anchoring the
+                    // overload's diagnostic there. When the solver's reported
+                    // `actual_type` cannot be matched to a single argument by
+                    // type identity — e.g. a generic argument whose type
+                    // parameter (`a: T` in `Object.assign(a, b)`) is a distinct
+                    // `TypeId` from the one cached for the argument node — fall
+                    // back to that first-failing-argument rule. `arg_nodes` is in
+                    // source order and mismatches are pushed in order, so the
+                    // first entry is the first failing argument.
+                    *expected_mismatch_matches.first()?
                 }
                 _ => return None,
             };

--- a/crates/tsz-checker/tests/ts2769_anchor_disagreeing_overloads_tests.rs
+++ b/crates/tsz-checker/tests/ts2769_anchor_disagreeing_overloads_tests.rs
@@ -105,10 +105,8 @@ fn assert_first_argument_anchored(type_param_a: &str, type_param_b: &str) {
 }}
 interface Holder {{ asn: Asn; }}
 declare var h: Holder;
-const wrap = <{a}, {b}>(x: {a}, y: {b}) => h.asn(x, y);
+const wrap = <{type_param_a}, {type_param_b}>(x: {type_param_a}, y: {type_param_b}) => h.asn(x, y);
 "#,
-        a = type_param_a,
-        b = type_param_b,
     );
     let diags = get_diagnostics(&source);
     let ts2769: Vec<_> = diags.iter().filter(|(code, _, _)| *code == 2769).collect();

--- a/crates/tsz-checker/tests/ts2769_anchor_disagreeing_overloads_tests.rs
+++ b/crates/tsz-checker/tests/ts2769_anchor_disagreeing_overloads_tests.rs
@@ -80,3 +80,63 @@ f(42);
         "TS2769 should stay at argument when overloads produce identical failure messages"
     );
 }
+
+/// Structural rule: when an overloaded *property-access* call fails with
+/// argument-type mismatches that all point at the same source-order argument,
+/// tsc anchors the TS2769 at that first failing argument — never at the callee
+/// property name. This mirrors `getSignatureApplicabilityError`, which stops at
+/// the first argument that is not assignable to the parameter.
+///
+/// The regression this guards against: a generic argument (`a: T`) whose
+/// type-parameter `TypeId` differs from the one the solver reports in the
+/// failure. Type-identity matching cannot pick the argument, so the anchor
+/// previously collapsed to the callee for property-access calls with more than
+/// one argument (the `Object.assign(a, b)` shape from
+/// `unionAndIntersectionInference1`).
+///
+/// `assert_arg_anchored` is run with two different type-parameter name choices
+/// to prove the fix is name-agnostic (§25): renaming `T`/`U` to `K`/`V` must
+/// not change the anchor.
+fn assert_first_argument_anchored(type_param_a: &str, type_param_b: &str) {
+    let source = format!(
+        r#"interface Asn {{
+    (target: {{}}, source: string): {{}};
+    (target: object, source: number): number;
+}}
+interface Holder {{ asn: Asn; }}
+declare var h: Holder;
+const wrap = <{a}, {b}>(x: {a}, y: {b}) => h.asn(x, y);
+"#,
+        a = type_param_a,
+        b = type_param_b,
+    );
+    let diags = get_diagnostics(&source);
+    let ts2769: Vec<_> = diags.iter().filter(|(code, _, _)| *code == 2769).collect();
+    assert_eq!(ts2769.len(), 1, "expected one TS2769, got {diags:#?}");
+
+    // The first argument `x` inside `h.asn(x, y)`.
+    let call_open = source.find("h.asn(").expect("call must exist");
+    let first_arg_start = (call_open + "h.asn(".len()) as u32;
+    // The callee property name `asn` — the position the bug anchored at.
+    let property_name_start = (source.find("h.asn(").unwrap() + "h.".len()) as u32;
+
+    assert_ne!(
+        ts2769[0].1, property_name_start,
+        "TS2769 must not anchor at the callee property name `asn`; got start={}",
+        ts2769[0].1
+    );
+    assert_eq!(
+        ts2769[0].1, first_arg_start,
+        "TS2769 should anchor at the first failing argument for a property-access \
+         overloaded call; got start={}",
+        ts2769[0].1
+    );
+}
+
+#[test]
+fn ts2769_anchored_at_first_generic_argument_for_property_access_call() {
+    // Default `T`/`U` spelling.
+    assert_first_argument_anchored("T", "U");
+    // Renamed bound variables must produce the same anchor (name-agnostic).
+    assert_first_argument_anchored("K", "V");
+}

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -5,4 +5,3 @@
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
-TypeScript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference1.ts


### PR DESCRIPTION
## Agent
AgentName: M1Opus48-ts2769

## Track
Track 8 — diagnostics (TS2769 anchor parity)

## Invariant
When an overloaded call fails with argument-type mismatches that all point at the same source-order argument, `tsc` anchors the TS2769 "No overload matches this call." diagnostic at the first failing argument (via `getSignatureApplicabilityError`, which stops at the first argument not assignable to the parameter) — regardless of whether the callee is an identifier or a property access. This PR makes tsz do the same through the checker's call-error anchor helper (`shared_overload_argument_anchor`).

## Scope
- `crates/tsz-checker/src/error_reporter/call_errors_anchors.rs`: in `shared_overload_argument_anchor`, when type-identity matching cannot single out the failing argument (empty `actual_matches`) but multiple arguments mismatch the expected parameter type, fall back to the first source-order mismatching argument instead of bailing to the callee anchor.
- `crates/tsz-checker/tests/ts2769_anchor_disagreeing_overloads_tests.rs`: add a name-agnostic regression test (`T`/`U` and `K`/`V`) for the property-access generic-first-argument shape.
- `scripts/conformance/conformance-accepted-regressions.txt`: remove `unionAndIntersectionInference1.ts` (now fingerprint-clean).

## Root cause
`Object.assign(a, b)` in `unionAndIntersectionInference1` (`const assign = <T, U>(a: T, b: U) => Object.assign(a, b)`) produced a TS2769 whose failures are `Argument of type 'T' is not assignable to parameter of type '{}'` / `object` plus arity mismatches. The solver-reported `actual_type` (`T`) is a different `TypeId` than the one cached for the argument node `a`, so `actual_matches` was empty; both args mismatch `{}`/`object`, so the old `[single]`-only branch bailed and the anchor collapsed to the callee property name `assign` (col 45). tsc anchors at the first failing argument `a` (col 52).

## Project Corpus Impact
- Row: n/a
- Bug family: TS2769 overload diagnostic anchor position (fingerprint-only)
- Evidence: `./scripts/conformance/conformance.sh run --filter unionAndIntersectionInference1 --verbose` now `1/1 passed`, `Fingerprint-only: 0` (was missing `:52` / extra `:45`). Broad TS2769 sweep clean (see Verification).

## Verification
- Target: `unionAndIntersectionInference1` 1/1 passed, fingerprint matches tsc (`:96:52`).
- All 19 conformance tests with TS2769 baselines pass, including substring-expanded batches: `overloadResolution` 9/9, `unionTypeCallSignatures` 7/7, `taggedTemplateStringsWithOverloadResolution` 6/6, `genericCall*`, `strictBindCallApply1`, `controlFlowIterationErrors`, `iterableArrayPattern28`, `iteratorSpreadInArray6`, `overloadResolutionClassConstructors`, `overloadResolutionConstructors`, `unionTypeConstructSignatures`.
- Broad regression sweep (all 100%, 0 fingerprint-only): `overload` 62/62, `taggedTemplate` 53/53, `spread` 71/71, `functionOverload` 58/58, `genericCall` 50/50, `tsxSpread` 21/21, `instanceof` 14/14, `callOverload` 7/7, `callWithSpread` 6/6, `tsxStatelessFunctionComponentOverload` 6/6, `promisePermutations` 3/3, `objectAssign` 1/1.
- Unit: `ts2769_anchor_disagreeing_overloads_tests` 3/3 (new name-agnostic test + the two pre-existing tests that lock callee-anchor-when-disagreeing and argument-anchor-when-agreeing). Adjacent overload-anchor test files (`jsx_overload_anchor_literal_attr_tests`, `jsx_multi_construct_overload_tests`, `overload_inference_literal_preservation_tests`) all pass — 18/18 combined.
- `cargo clippy -p tsz-checker --tests -- -D warnings`: clean for changed files. (One pre-existing `clippy::question_mark` lint at `crates/tsz-checker/src/query_boundaries/class.rs:785` is unrelated, already committed on `main`, and surfaces only under a newer local nightly; left untouched to keep this PR narrow — see Coordination Notes.)
- `python3 scripts/arch/arch_guard.py`: Architecture guardrails passed.

## Coordination Notes
- AgentName: M1Opus48-ts2769. Own worktree, branched off `origin/main`.
- Structural rule covered with two type-parameter name choices (`T`/`U`, `K`/`V`) to satisfy the anti-hardcoding directive; the fix uses the assignability relation + source order, never identifier names or printer output.
- The disagreeing-overloads object-literal path (callee anchor for `v({s,n})`) is preserved: a single object-literal argument resolves to that one argument, and the downstream `shared_argument_is_object_literal` / `shared_excess_property_name` gate in `error_emission.rs` still decides callee-vs-argument. Locked in by `ts2769_anchored_at_callee_when_overloads_disagree`.
- Pre-existing unrelated lint at `query_boundaries/class.rs:785` (`clippy::question_mark`) noticed during local clippy; not bundled here to keep the bug fix narrow. Worth a separate trivial cleanup PR/issue if CI's clippy ever flags it.
