### PR TITLE
fix(checker): report TS2339 for concrete objects indexed by a missing literal key

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -943,6 +943,10 @@ name = "enum_indexed_access_tests"
 path = "tests/enum_indexed_access_tests.rs"
 
 [[test]]
+name = "indexed_access_concrete_missing_key_ts2536_tests"
+path = "tests/indexed_access_concrete_missing_key_ts2536_tests.rs"
+
+[[test]]
 name = "enum_member_cache_tests"
 path = "tests/enum_member_cache_tests.rs"
 

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -1598,6 +1598,55 @@ impl<'a> CheckerState<'a> {
                 return;
             }
 
+            // tsc emits TS2536 ("Type 'X' cannot be used to index type 'Y'") only
+            // when the index type is itself a type parameter (or the object type is
+            // generic/deferred). For a *concrete* object type indexed by a *missing
+            // literal* key, tsc instead reports the property as missing (TS2339) —
+            // uniformly across object literals, interfaces, classes, unions,
+            // intersections, function/callable types, and `unknown`. When the index
+            // is not a type parameter, the object type carries no type parameters
+            // (so type-parameter-like, generic index-access/conditional/application
+            // objects are all excluded), and the index resolves to a literal key,
+            // emit TS2339 so anonymous object literals and union/function-typed
+            // accesses match tsc instead of falling through to a spurious TS2536.
+            // Dedup merges this with any TS2339 the property path already produced
+            // for the same key and location.
+            if !original_index_is_type_param
+                && !crate::query_boundaries::common::contains_type_parameters(
+                    self.ctx.types,
+                    object_type_for_check,
+                )
+                && let Some(key_atom) =
+                    crate::query_boundaries::type_computation::access::literal_property_name(
+                        self.ctx.types,
+                        index_type_for_check,
+                    )
+            {
+                let key_name = self.ctx.types.resolve_atom(key_atom);
+                // Only report the key as missing if it genuinely does not resolve
+                // to a property. Some valid accesses (e.g. an enum member via
+                // `(typeof Enum)["Member"]`) can reach this fallback through
+                // unrelated resolution gaps; emitting here would turn a valid
+                // access into a spurious error. Either way, a concrete object
+                // indexed by a concrete literal key is never a TS2536 in tsc, so do
+                // not fall through to the TS2536 emission below.
+                if !matches!(
+                    self.resolve_property_access_with_env(object_type_for_check, &key_name),
+                    tsz_solver::operations::property::PropertyAccessResult::Success { .. }
+                ) {
+                    let message = format_message(
+                        diagnostic_messages::PROPERTY_DOES_NOT_EXIST_ON_TYPE,
+                        &[key_name.as_str(), &obj_type_str],
+                    );
+                    self.error_at_node(
+                        concrete_error_anchor,
+                        &message,
+                        diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE,
+                    );
+                }
+                return;
+            }
+
             let message_2536 = format_message(
                 diagnostic_messages::TYPE_CANNOT_BE_USED_TO_INDEX_TYPE,
                 &[&index_type_str, &obj_type_str],
@@ -1645,7 +1694,6 @@ impl<'a> CheckerState<'a> {
             concrete_object_type,
         );
         let object_has_shape = object_shape.is_some();
-        let object_has_named_shape = object_shape.and_then(|shape| shape.symbol).is_some();
         let object_is_array_like =
             crate::query_boundaries::common::is_array_type(self.ctx.types, concrete_object_type)
                 || crate::query_boundaries::common::tuple_elements(
@@ -1807,7 +1855,7 @@ impl<'a> CheckerState<'a> {
             ) && self.get_index_key_kind(index_type) == Some((true, false))
                 && !self.is_element_indexable(concrete_object_type, true, false)
                 && !object_is_type_parameter_ref
-                && (object_has_named_shape || object_is_array_like)
+                && (object_has_shape || object_is_array_like)
             {
                 let object_type_str = self.format_type(object_type);
                 let message = format_message(

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -1606,12 +1606,14 @@ impl<'a> CheckerState<'a> {
             // intersections, function/callable types, and `unknown`. When the index
             // is not a type parameter, the object type carries no type parameters
             // (so type-parameter-like, generic index-access/conditional/application
-            // objects are all excluded), and the index resolves to a literal key,
-            // emit TS2339 so anonymous object literals and union/function-typed
-            // accesses match tsc instead of falling through to a spurious TS2536.
+            // objects are all excluded), the original object node is not itself a
+            // type parameter, and the index resolves to a literal key, emit TS2339
+            // so anonymous object literals and union/function-typed accesses match
+            // tsc instead of falling through to a spurious TS2536.
             // Dedup merges this with any TS2339 the property path already produced
             // for the same key and location.
             if !original_index_is_type_param
+                && !self.type_node_refers_to_type_parameter(data.object_type)
                 && !crate::query_boundaries::common::contains_type_parameters(
                     self.ctx.types,
                     object_type_for_check,

--- a/crates/tsz-checker/tests/indexed_access_concrete_missing_key_ts2536_tests.rs
+++ b/crates/tsz-checker/tests/indexed_access_concrete_missing_key_ts2536_tests.rs
@@ -1,0 +1,281 @@
+//! A concrete object type indexed by a missing literal key reports the property
+//! as missing (TS2339), never "Type 'X' cannot be used to index type 'Y'"
+//! (TS2536).
+//!
+//! Structural rule: tsc reserves TS2536 for indexed accesses whose index type is
+//! a type parameter (or whose object type is generic/deferred). When the object
+//! type is fully concrete — an anonymous object literal, an interface/class, a
+//! union or intersection of such, a function/callable type, or `unknown` — and
+//! the index is a concrete literal that is absent, tsc emits TS2339 for the
+//! missing property and does *not* additionally emit TS2536. Previously tsz
+//! emitted a spurious TS2536 alongside the TS2339 for anonymous object-literal
+//! aliases (and emitted only the spurious TS2536 for unions/function types),
+//! diverging from interfaces/classes which already reached the property path.
+//!
+//! These tests pin the rule structurally (varying type names, iteration-variable
+//! names, and shapes) so the fix cannot be a spelling-specific point patch, and
+//! include negative controls proving the legitimate TS2536 (type-parameter index)
+//! and valid accesses are unaffected.
+
+use tsz_common::diagnostics::Diagnostic;
+
+fn check(source: &str) -> Vec<Diagnostic> {
+    tsz_checker::test_utils::check_source_diagnostics(source)
+}
+
+fn codes(diags: &[Diagnostic]) -> Vec<u32> {
+    diags.iter().map(|d| d.code).collect()
+}
+
+fn has_code(diags: &[Diagnostic], code: u32) -> bool {
+    diags.iter().any(|d| d.code == code)
+}
+
+fn missing_property_messages(diags: &[Diagnostic]) -> Vec<String> {
+    diags
+        .iter()
+        .filter(|d| d.code == 2339)
+        .map(|d| d.message_text.clone())
+        .collect()
+}
+
+/// Reported repro: a type alias to an anonymous object literal, indexed by a
+/// missing string literal, must report TS2339 only — no spurious TS2536.
+#[test]
+fn anonymous_object_alias_missing_string_literal_is_ts2339_only() {
+    let diags = check(
+        r#"
+type TA = { a: number };
+type R = TA["b"];
+"#,
+    );
+    assert!(
+        !has_code(&diags, 2536),
+        "anonymous object alias must not emit TS2536, got: {:?}",
+        codes(&diags)
+    );
+    assert!(
+        missing_property_messages(&diags)
+            .iter()
+            .any(|m| m.contains("'b'") && m.contains("type 'TA'")),
+        "expected TS2339 for missing 'b', got: {:?}",
+        missing_property_messages(&diags)
+    );
+}
+
+/// Same rule with a different alias name and property spelling — proves the fix
+/// is structural, not keyed to `TA`/`b`.
+#[test]
+fn anonymous_object_alias_missing_key_is_name_agnostic() {
+    let diags = check(
+        r#"
+type Shape = { width: number; height: number };
+type R = Shape["depth"];
+"#,
+    );
+    assert!(
+        !has_code(&diags, 2536),
+        "must not emit TS2536, got: {:?}",
+        codes(&diags)
+    );
+    assert!(
+        missing_property_messages(&diags)
+            .iter()
+            .any(|m| m.contains("'depth'") && m.contains("type 'Shape'")),
+        "expected TS2339 for missing 'depth', got: {:?}",
+        missing_property_messages(&diags)
+    );
+}
+
+/// An inline anonymous object literal (no alias) indexed by a missing literal.
+#[test]
+fn inline_anonymous_object_missing_literal_is_ts2339_only() {
+    let diags = check(
+        r#"
+type R = { a: number }["b"];
+"#,
+    );
+    assert!(
+        !has_code(&diags, 2536),
+        "inline object literal must not emit TS2536, got: {:?}",
+        codes(&diags)
+    );
+    assert!(
+        has_code(&diags, 2339),
+        "expected TS2339, got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// A union of concrete object types indexed by a key missing from one member.
+#[test]
+fn union_of_objects_missing_member_is_ts2339_only() {
+    let diags = check(
+        r#"
+type U = { a: number } | { a: number; b: string };
+type R = U["b"];
+"#,
+    );
+    assert!(
+        !has_code(&diags, 2536),
+        "union of objects must not emit TS2536, got: {:?}",
+        codes(&diags)
+    );
+    assert!(
+        has_code(&diags, 2339),
+        "expected TS2339, got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// An intersection of concrete object types indexed by an absent key.
+#[test]
+fn intersection_of_objects_missing_key_is_ts2339_only() {
+    let diags = check(
+        r#"
+type In = { a: number } & { c: string };
+type R = In["b"];
+"#,
+    );
+    assert!(
+        !has_code(&diags, 2536),
+        "intersection of objects must not emit TS2536, got: {:?}",
+        codes(&diags)
+    );
+    assert!(
+        has_code(&diags, 2339),
+        "expected TS2339, got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// A function type indexed by a missing member: tsc reports TS2339, not TS2536.
+#[test]
+fn function_type_missing_member_is_ts2339_only() {
+    let diags = check(
+        r#"
+type Fn = (x: number) => string;
+type R = Fn["nope"];
+"#,
+    );
+    assert!(
+        !has_code(&diags, 2536),
+        "function type must not emit TS2536, got: {:?}",
+        codes(&diags)
+    );
+    assert!(
+        has_code(&diags, 2339),
+        "expected TS2339, got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// The result of a (key-remapping-free) mapped type is a concrete object; an
+/// absent key reported through it must be TS2339, not TS2536, regardless of the
+/// mapped-type iteration variable name.
+#[test]
+fn mapped_type_result_missing_literal_is_ts2339_only() {
+    for iter_var in ["P", "Key"] {
+        let src = format!(
+            r#"
+type Mapped = {{ [{iter_var} in "a" | "b"]: number }};
+type R = Mapped["c"];
+"#
+        );
+        let diags = check(&src);
+        assert!(
+            !has_code(&diags, 2536),
+            "mapped-type result (iter var {iter_var}) must not emit TS2536, got: {:?}",
+            codes(&diags)
+        );
+        assert!(
+            has_code(&diags, 2339),
+            "expected TS2339 (iter var {iter_var}), got: {:?}",
+            codes(&diags)
+        );
+    }
+}
+
+/// Union-of-literals index over an anonymous object: the valid member is
+/// suppressed, the missing member reports TS2339, and no TS2536 appears.
+#[test]
+fn union_literal_index_over_anonymous_object_is_ts2339_only() {
+    let diags = check(
+        r#"
+type TA = { a: number };
+type R = TA["a" | "b"];
+"#,
+    );
+    assert!(
+        !has_code(&diags, 2536),
+        "union-literal index over anonymous object must not emit TS2536, got: {:?}",
+        codes(&diags)
+    );
+    let msgs = missing_property_messages(&diags);
+    assert!(
+        msgs.iter().any(|m| m.contains("'b'")),
+        "expected TS2339 for missing 'b', got: {msgs:?}"
+    );
+    assert!(
+        !msgs.iter().any(|m| m.contains("'a'")),
+        "valid member 'a' must not report, got: {msgs:?}"
+    );
+}
+
+/// Negative control / generalization gate: the *legitimate* TS2536 — a concrete
+/// object indexed by a type parameter that is not constrained to that object's
+/// keyof — must be preserved. Exercised with two distinct type-parameter names
+/// to prove the preserved path is not name-based.
+#[test]
+fn legitimate_ts2536_type_parameter_index_is_preserved() {
+    for param in ["K", "Idx"] {
+        let src = format!(
+            r#"
+type Target = {{ a: number; b: string }};
+type Other = {{ z: number }};
+type R<{param} extends keyof Other> = Target[{param}];
+"#
+        );
+        let diags = check(&src);
+        assert!(
+            has_code(&diags, 2536),
+            "legitimate TS2536 (type param {param}) must be preserved, got: {:?}",
+            codes(&diags)
+        );
+    }
+}
+
+/// Negative control: a valid access into a concrete object type must stay clean.
+#[test]
+fn valid_concrete_object_access_is_clean() {
+    let diags = check(
+        r#"
+type O = { a: number; b: string };
+type R1 = O["a"];
+type R2 = O["a" | "b"];
+type R3 = O[keyof O];
+"#,
+    );
+    assert!(
+        !has_code(&diags, 2536) && !has_code(&diags, 2339),
+        "valid concrete-object accesses must be clean, got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// Negative control: a string index signature accepts any string key, so an
+/// anonymous object literal carrying one must not report a missing property.
+#[test]
+fn anonymous_object_with_string_index_signature_is_clean() {
+    let diags = check(
+        r#"
+type Dict = { [k: string]: number };
+type R = Dict["anything"];
+"#,
+    );
+    assert!(
+        !has_code(&diags, 2536) && !has_code(&diags, 2339),
+        "string index signature must accept the key, got: {:?}",
+        codes(&diags)
+    );
+}

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -225,7 +225,14 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         # `object_shape_for_type`, `types_are_comparable_for_assertion`).
         # All routes are existing request-shaped boundaries — no new
         # quarantine entry — so the count rises by the expected delta.
-        3277,
+        #
+        # Bumped by 1 for the concrete indexed-access TS2536→TS2339 parity fix:
+        # the missing-literal-key guard in `check_indexed_access_type` adds one
+        # `contains_type_parameters` concreteness check (the literal key name is
+        # derived through `query_boundaries::type_computation::access`, not the
+        # `common` barrel). It is an existing request-shaped helper already used
+        # throughout this file — no new quarantine entry.
+        3278,
     ),
 ]
 

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1165,7 +1165,14 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         # route through existing `query_boundaries::common` wrappers; no new
         # quarantine entry — `contains_keyof_type` reuses the existing
         # `contains_*` one-liner pattern in `common.rs`.
-        3280,
+        #
+        # Bumped by 1 for the concrete indexed-access TS2536→TS2339 parity fix:
+        # the missing-literal-key guard in `check_indexed_access_type` adds one
+        # `contains_type_parameters` concreteness check (the literal key name is
+        # derived through `query_boundaries::type_computation::access`, not the
+        # `common` barrel). It is an existing request-shaped helper already used
+        # throughout this file — no new quarantine entry.
+        3281,
     ),
 ]
 


### PR DESCRIPTION
## Agent
AgentName: PensiveWright-SXZyY (Claude Code, remote execution / claude/pensive-wright-SXZyY)

## Track

Checker / conformance — indexed-access type diagnostics (`TS2536` / `TS2339`
parity with `tsc`). Family of the `keyofAndIndexedAccessErrors` accepted
regression and the kysely indexed-access false-positive cluster.

## Invariant / Structural rule

> When an indexed-access type `T[K]` has an index that is **not** a type
> parameter and an object type `T` that carries **no type parameters** (fully
> concrete), an absent literal key is a missing-property error — `tsc` reports
> `TS2339` ("Property 'k' does not exist on type 'T'") and never `TS2536`
> ("Type 'K' cannot be used to index type 'T'"). `TS2536` is reserved for
> type-parameter indices and generic/deferred object types.

## Problem

`tsc` 6.0.2 reports `TS2339` (not `TS2536`) for a concrete object indexed by a
missing literal key, uniformly across object literals, interfaces, classes,
unions, intersections, function/callable types, and `unknown`. tsz diverged for
**anonymous** object types:

```ts
type TA = { a: number };
type R1 = TA["b"];        // tsc: TS2339 only — tsz also emitted spurious TS2536
type U  = { a: number } | { a: number; b: string };
type R2 = U["b"];         // tsc: TS2339 only — tsz emitted *only* the spurious TS2536
type Fn = () => void;
type R3 = Fn["nope"];     // tsc: TS2339 only — tsz emitted *only* the spurious TS2536
```

Named interfaces/classes already reached the property path and reported `TS2339`
only; anonymous object-literal aliases, unions of objects, and function types
fell through to a spurious `TS2536` because the concrete-missing-property branch
was gated to *named* object shapes, and the final fallback always emitted
`TS2536`.

## Root cause (owner layer: checker)

In `crates/tsz-checker/src/types/type_checking/indexed_access.rs`
(`check_indexed_access_type`):

1. `try_emit_concrete_index_access_error`'s missing-property branch was gated on
   `object_has_named_shape`, so anonymous object literals (no symbol) never
   emitted `TS2339` and returned `false`.
2. The function's final fallback unconditionally emitted `TS2536` for any
   concrete object reaching it — diverging from `tsc` and from tsz's own named
   path.

## Fix

- Generalize the missing-property gate from `object_has_named_shape` to
  `object_has_shape` so anonymous object literals are handled exactly like named
  interfaces/classes (one-token structural generalization).
- Before the final `TS2536` fallback, when the index is not a type parameter and
  the object type carries no type parameters, derive the literal key name via the
  shared `query_boundaries::type_computation::access::literal_property_name`
  helper (string / number / enum members) and emit `TS2339` when the property
  does not resolve. A `resolve_property_access` guard prevents valid accesses
  that reach the fallback through unrelated resolution gaps from being turned
  into spurious errors. Dedup merges this with any `TS2339` the property path
  already produces.

The legitimate `TS2536` (a concrete object indexed by a *type-parameter* index,
e.g. `Target[K]` where `K extends keyof Other`) is preserved, gated by
`!original_index_is_type_param`.

## Scope

`crates/tsz-checker/` only:
- `src/types/type_checking/indexed_access.rs` — the fallback `TS2339` guard and
  the `object_has_named_shape` → `object_has_shape` generalization.
- `tests/indexed_access_concrete_missing_key_ts2536_tests.rs` — new regression
  suite (+ `[[test]]` registration in `Cargo.toml`).
- `scripts/arch/arch_guard_{shared,config}.py` — `#8225` query-boundary cap
  bumped by 1 (single new `contains_type_parameters` reference; the key-name
  helper routes through `query_boundaries::type_computation::access`, not the
  `common` barrel).

## Adjacent-case test matrix (name-agnostic)

- anonymous object alias + missing string literal (two name choices);
- inline anonymous object literal;
- union and intersection of concrete objects;
- function type;
- mapped-type result (two iteration-variable names);
- union-of-literals index (valid member suppressed, missing member reports);
- **negative**: legitimate type-parameter-index `TS2536` preserved (two param names);
- **negative**: valid concrete-object access stays clean;
- **negative**: string index signature accepts the key.

## Project Corpus Impact

- Row: `keyofAndIndexedAccessErrors.ts` family (accepted-regression in
  `scripts/conformance/conformance-accepted-regressions.txt`); kysely
  indexed-access false-positive cluster.
- Bug family: spurious `TS2536` over-reporting on concrete object indexed-access
  types (`tsz` emits an error `tsc` does not).
- Evidence: differential check against `tsc` 6.0.2 (the repo-pinned compiler) on
  8 hand-written probe files — every concrete-object case now matches `tsc`
  exactly (`split`/`wide`/`edge`/`valid` byte-identical), valid code stays clean,
  the legitimate type-parameter `TS2536` is preserved; new owning-crate unit
  tests (11) pass.

## Verification

- `cargo test -p tsz-checker --test indexed_access_concrete_missing_key_ts2536_tests` → 11 passed.
- Focused indexed-access / keyof sweep (ts2536/ts7053/tuple/union/homomorphic/element-access/deferred-keyof) → all green.
- `cargo clippy -p tsz-checker --tests -- -D warnings` → clean.
- `python3 scripts/arch/arch_guard.py` → guardrails pass (cap bumped +1 with justification).
- Differential vs `tsc` 6.0.2 on the probe matrix → concrete-object cases match.

## Coordination Notes

- Signed: PensiveWright-SXZyY. Discovered while triaging the `keyof`/indexed-access
  accepted-regression family (random-issue selection landed on already-fixed
  #10443, which was closed with evidence pointing to merged #10752; the
  reproducible, verifiable divergence in this family is the `TS2536` over-report
  fixed here).
- Pre-existing, **unrelated** local unit failures observed on `main` (identical
  with/without this change, confirmed by stashing): `enum_indexed_access_tests`
  (3 — a separate `(typeof Enum)["Member"]` resolution gap) and one case in
  `ts2344_keyof_bare_tparam_defer_tests` (computed unique-symbol-prefix `keyof`).
  These are different root causes and out of scope; this PR does not touch or
  regress them.
- Known out-of-scope follow-ups in the same surface (separate root causes, not
  addressed here): the missed *generic* `TS2536` for `t[k]` with an unconstrained
  type-parameter index (false negative), `TS7053` elaboration sub-messages, and
  the structural-alias type-display naming.
- `/simplify` run (3 passes): pass 1 replaced hand-rolled string/number literal
  extraction with the existing `literal_property_name` query boundary (which also
  fixed an enum-index case and reduced the `#8225` cap delta from +3 to +1) and
  inlined a single-use binding into a let-chain; passes 2–3 confirmed clean.

https://claude.ai/code/session_01NCbecacWH87hSvTmAnTgXd

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCbecacWH87hSvTmAnTgXd)_
