### PR TITLE
fix(emit): widen non-ASCII chars in JSX identifier-derived JS string literals

### DIFF
--- a/crates/tsz-emitter/src/emitter/jsx/emit.rs
+++ b/crates/tsz-emitter/src/emitter/jsx/emit.rs
@@ -1071,6 +1071,13 @@ impl<'a> Printer<'a> {
         self.write(factory);
     }
 
+    /// Emit `text` as a double-quoted JS string with JSX-name escaping.
+    fn emit_jsx_double_quoted_js_string(&mut self, text: &str) {
+        self.write("\"");
+        self.write(&escape_jsx_text_for_js_with_quote(text, '"'));
+        self.write("\"");
+    }
+
     /// Emit a JSX tag name as a function argument.
     /// Intrinsic elements (lowercase) -> string literal.
     /// Component elements (uppercase/dotted/namespaced) -> identifier/expression.
@@ -1085,9 +1092,7 @@ impl<'a> Printer<'a> {
             if let Some(ident) = self.arena.get_identifier(node) {
                 let text = self.arena.resolve_identifier_text(ident);
                 if text.starts_with(|c: char| c.is_ascii_lowercase()) {
-                    self.write("\"");
-                    self.write(text);
-                    self.write("\"");
+                    self.emit_jsx_double_quoted_js_string(text);
                 } else {
                     self.emit(tag_name);
                 }
@@ -1112,9 +1117,9 @@ impl<'a> Printer<'a> {
                 .map(|i| self.arena.resolve_identifier_text(i))
                 .unwrap_or("");
             self.write("\"");
-            self.write(ns_text);
+            self.write(&escape_jsx_text_for_js_with_quote(ns_text, '"'));
             self.write(":");
-            self.write(name_text);
+            self.write(&escape_jsx_text_for_js_with_quote(name_text, '"'));
             self.write("\"");
             return;
         }
@@ -1713,9 +1718,7 @@ impl<'a> Printer<'a> {
         {
             let processed = process_jsx_text(&text.text);
             let decoded = decode_jsx_entities(&processed);
-            self.write("\"");
-            self.write(&escape_jsx_text_for_js_with_quote(&decoded, '"'));
-            self.write("\"");
+            self.emit_jsx_double_quoted_js_string(&decoded);
             return;
         }
 
@@ -1806,12 +1809,12 @@ impl<'a> Printer<'a> {
         self.write(" }");
     }
 
-    /// Emit a property name, quoting if needed.
+    /// Emit a property name, quoting (with JS-escape) if it isn't a valid JS
+    /// identifier; otherwise pass through verbatim to preserve any source
+    /// `\uXXXX` spelling.
     pub(in super::super) fn emit_jsx_prop_name(&mut self, name: &str) {
         if needs_quoting(name) {
-            self.write("\"");
-            self.write(name);
-            self.write("\"");
+            self.emit_jsx_double_quoted_js_string(name);
         } else {
             self.write(name);
         }

--- a/crates/tsz-emitter/src/emitter/jsx/mod.rs
+++ b/crates/tsz-emitter/src/emitter/jsx/mod.rs
@@ -1,6 +1,7 @@
 mod emit;
 mod transform;
 
+use std::borrow::Cow;
 use tsz_parser::parser::NodeIndex;
 
 // =============================================================================
@@ -199,17 +200,24 @@ pub(super) fn process_jsx_text(text: &str) -> String {
     parts.join(" ")
 }
 
-/// Escape a string for JS string literal context with entity decoding and Unicode escaping.
-/// `quote` is the surrounding quote char (' or ") so we know which to escape.
-pub(super) fn escape_jsx_text_for_js_with_quote(s: &str, quote: char) -> String {
+/// Escape for JS string-literal context (CR/LF/TAB, backslash, matching quote,
+/// non-ASCII -> `\uXXXX`). Borrows on the no-escape fast path.
+pub(super) fn escape_jsx_text_for_js_with_quote(s: &str, quote: char) -> Cow<'_, str> {
+    let quote_byte = quote as u8;
+    let needs_escape = s.bytes().any(|b| {
+        b == b'\\' || b == b'\r' || b == b'\n' || b == b'\t' || b == quote_byte || b > 0x7E
+    });
+    if !needs_escape {
+        return Cow::Borrowed(s);
+    }
+
+    use std::fmt::Write as _;
     let mut result = String::with_capacity(s.len());
     let mut chars = s.chars().peekable();
     while let Some(c) = chars.next() {
         match c {
             '\\' => result.push_str("\\\\"),
-            // tsc rebuilds JSX string content as a fresh JS string literal with
-            // line terminators normalized to LF, so a raw `CRLF` or lone `CR` in
-            // a JSX attribute value (or text child) is emitted as `\n`, never `\r`.
+            // Normalize CRLF/CR -> \n per tsc's JSX string-rebuild behavior.
             '\r' => {
                 if chars.peek() == Some(&'\n') {
                     chars.next();
@@ -222,22 +230,20 @@ pub(super) fn escape_jsx_text_for_js_with_quote(s: &str, quote: char) -> String 
                 result.push('\\');
                 result.push(c);
             }
-            // Non-ASCII chars get \uXXXX escaping (or surrogate pairs for > U+FFFF)
             c if c as u32 > 0x7E => {
                 let cp = c as u32;
                 if cp > 0xFFFF {
-                    // UTF-16 surrogate pair
                     let hi = 0xD800 + ((cp - 0x10000) >> 10);
                     let lo = 0xDC00 + ((cp - 0x10000) & 0x3FF);
-                    result.push_str(&format!("\\u{hi:04X}\\u{lo:04X}"));
+                    write!(result, "\\u{hi:04X}\\u{lo:04X}").unwrap();
                 } else {
-                    result.push_str(&format!("\\u{cp:04X}"));
+                    write!(result, "\\u{cp:04X}").unwrap();
                 }
             }
             _ => result.push(c),
         }
     }
-    result
+    Cow::Owned(result)
 }
 
 /// Decode HTML/XML entities in JSX text.
@@ -977,6 +983,108 @@ const f = <a-\u{0063}/>;"#;
             output.contains(r#"React.createElement(Comp\u{0061}, { x: 12 })"#),
             "Component tag identifier extended-escape spelling should be preserved in expression emit.\nOutput: {output}"
         );
+    }
+
+    #[test]
+    fn jsx_classic_intrinsic_tag_name_escapes_non_ascii_chars() {
+        let source = "const a = <a-\u{00E9}/>;\nconst b = <a-\u{00F1}/>;\nconst c = <a-\u{00FC}/>;";
+        let output = emit_jsx_react(source);
+        for (label, fragment) in [
+            (
+                "U+00E9 tail",
+                r#"const a = React.createElement("a-\u00E9", null)"#,
+            ),
+            (
+                "U+00F1 tail",
+                r#"const b = React.createElement("a-\u00F1", null)"#,
+            ),
+            (
+                "U+00FC tail",
+                r#"const c = React.createElement("a-\u00FC", null)"#,
+            ),
+        ] {
+            assert!(
+                output.contains(fragment),
+                "Intrinsic JSX tag with non-ASCII tail ({label}) should JS-escape the non-ASCII codepoint.\nOutput: {output}"
+            );
+        }
+        for raw in ["\"a-\u{00E9}\"", "\"a-\u{00F1}\"", "\"a-\u{00FC}\""] {
+            assert!(
+                !output.contains(raw),
+                "Raw non-ASCII codepoint {raw:?} should not appear inside an emitted JSX intrinsic tag string.\nOutput: {output}"
+            );
+        }
+    }
+
+    #[test]
+    fn jsx_classic_non_bmp_attribute_value_emits_surrogate_pair() {
+        let source = "const a = <input value=\"\u{1F600}\"/>;";
+        let output = emit_jsx_react(source);
+        assert!(
+            output.contains(r#"value: "\uD83D\uDE00""#),
+            "Non-BMP codepoint in a JSX attribute string value should emit as a UTF-16 surrogate pair.\nOutput: {output}"
+        );
+        assert!(
+            !output.contains("\u{1F600}"),
+            "Raw non-BMP codepoint should not appear inside an emitted JSX attribute string.\nOutput: {output}"
+        );
+    }
+
+    #[test]
+    fn jsx_classic_namespaced_tag_name_escapes_non_ascii_chars() {
+        let source = "const a = <\u{00E9}:path/>;\nconst b = <svg:\u{00E9}/>;\nconst c = <\u{00E9}:\u{00F1}/>;";
+        let output = emit_jsx_react(source);
+        for (label, fragment) in [
+            (
+                "non-ASCII namespace",
+                r#"const a = React.createElement("\u00E9:path", null)"#,
+            ),
+            (
+                "non-ASCII local name",
+                r#"const b = React.createElement("svg:\u00E9", null)"#,
+            ),
+            (
+                "both halves non-ASCII",
+                r#"const c = React.createElement("\u00E9:\u00F1", null)"#,
+            ),
+        ] {
+            assert!(
+                output.contains(fragment),
+                "Namespaced JSX tag with non-ASCII parts ({label}) should JS-escape each half.\nOutput: {output}"
+            );
+        }
+        for raw in [
+            "\"\u{00E9}:path\"",
+            "\"svg:\u{00E9}\"",
+            "\"\u{00E9}:\u{00F1}\"",
+        ] {
+            assert!(
+                !output.contains(raw),
+                "Raw non-ASCII codepoint {raw:?} should not appear inside an emitted namespaced JSX tag string.\nOutput: {output}"
+            );
+        }
+    }
+
+    #[test]
+    fn jsx_classic_quoted_attribute_key_escapes_non_ascii_chars() {
+        let source = "const a = <div data-\u{00E9}=\"x\" data-\u{00F1}={1} ns:\u{00E9}=\"y\" />;";
+        let output = emit_jsx_react(source);
+        for (label, fragment) in [
+            ("hyphenated, string value", r#""data-\u00E9": "x""#),
+            ("hyphenated, expression value", r#""data-\u00F1": 1"#),
+            ("namespaced", r#""ns:\u00E9": "y""#),
+        ] {
+            assert!(
+                output.contains(fragment),
+                "Quoted JSX attribute key with non-ASCII ({label}) should JS-escape the non-ASCII codepoint.\nOutput: {output}"
+            );
+        }
+        for raw in ["\"data-\u{00E9}\"", "\"data-\u{00F1}\"", "\"ns:\u{00E9}\""] {
+            assert!(
+                !output.contains(raw),
+                "Raw non-ASCII codepoint {raw:?} should not appear inside an emitted JSX attribute key string.\nOutput: {output}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
AgentName: cloud-opus47-1m-confident-thompson-80zfP

## Track
Track 9 — JavaScript emit parity (JSX/react emit family, issue #8512)

## Invariant
When tsz emits an identifier-derived JSX name as the **content of a JS string literal** in the classic `React.createElement(...)` transform, the content must follow the JS string-literal grammar — `tsc` rebuilds the argument as a fresh JS string with non-ASCII codepoints widened to `\uXXXX` (surrogate pairs for non-BMP). Pure-ASCII names round-trip byte-identical to existing emit baselines via a zero-alloc fast path.

## Scope

Three identifier positions previously wrote cooked text raw and now route through the same chokepoint (`escape_jsx_text_for_js_with_quote`) that JSX text and attribute string values already use:

- **intrinsic tag-name argument** (lowercase identifier) — `crates/tsz-emitter/src/emitter/jsx/emit.rs:emit_jsx_tag_name_as_argument`
- **namespaced tag-name argument** (`"ns:name"` — both halves) — same function, JSX_NAMESPACED_NAME arm
- **quoted attribute key** (hyphenated, namespaced, digit-start) — `emit_jsx_prop_name`

### Drive-by simplification (from `/simplify` ×3)

- New `Printer::emit_jsx_double_quoted_js_string` helper collapses the `write("\"") / escape / write("\"")` triplet used at 4 emit sites (intrinsic tag, prop name, JSX text child, and re-used by the helper)
- `escape_jsx_text_for_js_with_quote` returns `Cow<'_, str>` and borrows on the no-escape path — zero-alloc ASCII fast path keyed on a byte-scan (`s.bytes().any(...)`)
- Replaced `format!` with `write!` for surrogate-pair hex output (no intermediate `String`)
- Trimmed doc comments and fixed `quote as u32 as u8` → `quote as u8`, `let _ = write!` → `.unwrap()` for infallible `String` writes

## Project Corpus Impact

- Row: n/a (emit parity)
- Bug family: JSX classic-runtime identifier-as-string-literal emit
- Evidence: local repro showed `<a-é/>` emitting `React.createElement("a-é", null)` (raw bytes); after fix emits `React.createElement("a-é", null)` matching `tsc`'s fresh-string-literal rebuild. Same pattern applies to namespaced tag halves and quoted attribute keys with non-ASCII content. Issue: #8512 (JSX/react emit family).

## Verification

- `cargo test -p tsz-emitter --lib jsx::tests` — **49 passed, 0 failed** (4 new tests added, all pass)
- `cargo test -p tsz-emitter --lib` — **3416 passed** (4 more than the 3412-passing baseline on `main`), 8 pre-existing failures unchanged (confirmed via `git stash` + retest)
- `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings` — clean
- CI will run conformance, emit, fourslash, and WASM gates after ready-for-review

## Adjacent-case test matrix (Anti-hardcoding §25, Generalization §26)

The structural rule is *"identifier-derived content in a JS string-literal position must be JS-escaped"* — not test-name-specific, not spelling-specific.

- `jsx_classic_intrinsic_tag_name_escapes_non_ascii_chars`: U+00E9, U+00F1, U+00FC tails — three renamed codepoints, anchored to distinct `const a/b/c` bindings so a single-spelling regression can't pass.
- `jsx_classic_namespaced_tag_name_escapes_non_ascii_chars`: non-ASCII namespace half / non-ASCII local half / both halves non-ASCII — three renamed shapes.
- `jsx_classic_quoted_attribute_key_escapes_non_ascii_chars`: hyphenated-string-valued, hyphenated-expression-valued, namespaced — three distinct attribute shapes.
- `jsx_classic_non_bmp_attribute_value_emits_surrogate_pair`: non-BMP codepoint emits as UTF-16 surrogate pair (😀).
- Pure-ASCII coverage stays intact via the existing `jsx_classic_unicode_escape_intrinsic_tag_name_is_cooked` and `jsx_classic_unicode_escape_attribute_identifier_names_are_preserved` tests, which assert byte-identical output for ASCII names — so the new `Cow::Borrowed` fast path is exercised by the pre-existing suite.

Each non-ASCII test also asserts the **negative** form: the raw codepoint must not appear inside the emitted JSX string at that position.

## Coordination Notes

- Issue #8512 was claimed via `WIP` label and signed claim comment.
- Slice does not overlap any open PR: `git log` and PR inventory showed no JSX identifier-as-string-literal work in flight. Previous WIP claims on `jsxMultilineAttributeValuesReact` (CRLF normalization) and `jsxNamespacePrefixInName` had been cleaned up; the CRLF fix has already landed and is the existing chokepoint this PR extends.
- Auto-merge (squash) is enabled — PR will land once required checks pass.

---
_Generated by [Claude Code](https://claude.ai/code)_