### PR TITLE
fix(checker): resolve type-parameter constraints during missing-name pre-pass

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -249,6 +249,9 @@ mod literal_application_alias_display_tests;
 #[path = "../tests/merged_symbol_tests.rs"]
 mod merged_symbol_tests;
 #[cfg(test)]
+#[path = "../tests/missing_name_pass_constrained_type_param_tests.rs"]
+mod missing_name_pass_constrained_type_param_tests;
+#[cfg(test)]
 #[path = "../tests/name_resolution_boundary_tests.rs"]
 mod name_resolution_boundary_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -706,8 +706,26 @@ impl<'a> CheckerState<'a> {
             return Vec::new();
         };
 
-        let factory = self.ctx.types.factory();
+        // Two-pass insertion mirrors `push_type_parameters`: the first pass
+        // binds every name unconstrained so the second pass can resolve each
+        // declared constraint against its sibling type parameters. Without
+        // the second pass the early "missing names" scan observes a parameter
+        // `K extends keyof T[U]` as if it were unconstrained, which causes
+        // downstream mapped-type validity checks (`{ [P in K]: ... }`) to
+        // incorrectly fire TS2322/TS2536. `tsc` resolves constraints lazily;
+        // tsz uses scope, so the scope must reflect the declared constraints
+        // before validation walks the signature.
+        struct Entry {
+            name: String,
+            atom: tsz_common::interner::Atom,
+            is_const: bool,
+            constraint_node: Option<NodeIndex>,
+        }
+        let mut entries: Vec<Entry> = Vec::new();
         let mut updates = Vec::new();
+
+        // Pass 1: insert unconstrained provisional bindings so constraint
+        // resolution in pass 2 can see all sibling type parameters.
         for &param_idx in &list.nodes {
             let Some(param_node) = self.ctx.arena.get(param_idx) else {
                 continue;
@@ -727,14 +745,46 @@ impl<'a> CheckerState<'a> {
                 .ctx
                 .arena
                 .has_modifier(&param.modifiers, SyntaxKind::ConstKeyword);
-            let type_id = factory.type_param(TypeParamInfo {
+            let constraint_node = (param.constraint != NodeIndex::NONE).then_some(param.constraint);
+            let type_id = self.ctx.types.factory().type_param(TypeParamInfo {
                 name: atom,
                 constraint: None,
                 default: None,
                 is_const,
             });
             let previous = self.ctx.type_parameter_scope.insert(name.clone(), type_id);
-            updates.push((name, previous, false));
+            updates.push((name.clone(), previous, false));
+            entries.push(Entry {
+                name,
+                atom,
+                is_const,
+                constraint_node,
+            });
+        }
+
+        // Pass 2: refine each binding with its resolved constraint. Resolution
+        // runs against the now-populated scope so transitive references like
+        // `<K extends keyof T[TB]>` (where `TB` is a prior type parameter)
+        // bind to the constrained type, not the provisional placeholder.
+        // Resolution errors fall back to the unconstrained placeholder so
+        // TS2304 / cycle handling is preserved.
+        for entry in entries {
+            let Some(constraint_node_idx) = entry.constraint_node else {
+                continue;
+            };
+            let resolved = self.get_type_from_type_node(constraint_node_idx);
+            if resolved == TypeId::ERROR {
+                continue;
+            }
+            let constrained_type_id = self.ctx.types.factory().type_param(TypeParamInfo {
+                name: entry.atom,
+                constraint: Some(resolved),
+                default: None,
+                is_const: entry.is_const,
+            });
+            self.ctx
+                .type_parameter_scope
+                .insert(entry.name, constrained_type_id);
         }
 
         updates

--- a/crates/tsz-checker/tests/missing_name_pass_constrained_type_param_tests.rs
+++ b/crates/tsz-checker/tests/missing_name_pass_constrained_type_param_tests.rs
@@ -1,0 +1,170 @@
+//! Regression coverage for the early `check_type_for_missing_names` pre-pass.
+//!
+//! When a method or callable signature declares
+//! `<K extends keyof T[U]>` and returns a self-referential generic that
+//! threads `K` through a mapped type (`Q<U, { [P in K]: T[U][P] }>` or any
+//! other position that triggers mapped-type-constraint validation), the
+//! pre-pass used to push `K` into `type_parameter_scope` without its
+//! declared constraint. Subsequent eager validation of the type-argument
+//! subtree would then see `K`'s constraint as `None` and incorrectly report:
+//!
+//! - TS2322 "Type 'K' is not assignable to type 'string | number | symbol'"
+//! - TS2536 "Type 'P' cannot be used to index type 'T[U]'"
+//!
+//! Genuinely unconstrained type parameters (`<T>` with no `extends` clause)
+//! must still report TS2322 — the fix is about preserving the **declared**
+//! constraint, not silencing the diagnostic for unconstrained params.
+//!
+//! Structural rule: any `push_*_type_parameters` helper that runs validation
+//! against the AST subtree must resolve declared constraints before the
+//! validation walk so the scope reflects the user-written extends clauses.
+
+use tsz_checker::context::CheckerOptions;
+
+fn check(source: &str) -> Vec<(u32, String)> {
+    tsz_checker::test_utils::check_source(source, "test.ts", CheckerOptions::default())
+        .into_iter()
+        .map(|d| (d.code, d.message_text))
+        .collect()
+}
+
+fn count_with_code(diags: &[(u32, String)], code: u32) -> usize {
+    diags.iter().filter(|(c, _)| *c == code).count()
+}
+
+#[test]
+fn recursive_self_returning_generic_with_indexed_keyof_constraint_passes() {
+    // The kysely-style minimal repro. The mapped key `K` is constrained by
+    // `keyof T[TB]`, where `TB` is the surrounding interface's type
+    // parameter. Both diagnostics must be silent — `K`'s constraint is a
+    // keyof, which is always a subtype of `string | number | symbol`.
+    let source = r#"
+interface T { user: { id: number; name: string } }
+interface Q<TB extends keyof T, R> {
+  select<K extends keyof T[TB]>(): Q<TB, { [P in K]: T[TB][P] }>;
+}
+"#;
+    let diags = check(source);
+    assert_eq!(
+        count_with_code(&diags, 2322),
+        0,
+        "TS2322 must not fire for K constrained by keyof T[TB]: {diags:?}"
+    );
+    assert_eq!(
+        count_with_code(&diags, 2536),
+        0,
+        "TS2536 must not fire for P indexing T[TB]: {diags:?}"
+    );
+}
+
+#[test]
+fn intersection_in_return_type_does_not_trip_mapped_key_validation() {
+    // Variant from kysely's `select(['id'])` shape — `R & { [P in K]: ... }`.
+    let source = r#"
+interface DB { user: { id: number; name: string } }
+
+interface Q<DB, TB extends keyof DB, R> {
+  select<K extends keyof DB[TB]>(cols: K[]): Q<DB, TB, R & { [P in K]: DB[TB][P] }>;
+}
+
+declare const q: Q<DB, 'user', {}>;
+const r = q.select(['id']);
+"#;
+    let diags = check(source);
+    assert_eq!(
+        count_with_code(&diags, 2322),
+        0,
+        "TS2322 must not fire on the return-type mapped key: {diags:?}"
+    );
+    assert_eq!(
+        count_with_code(&diags, 2536),
+        0,
+        "TS2536 must not fire on the mapped property type: {diags:?}"
+    );
+}
+
+#[test]
+fn renamed_type_parameters_still_pass() {
+    // Anti-hardcoding guard: the fix must not depend on identifier
+    // spellings. Rename every bound name and the result must be identical.
+    let source = r#"
+interface Records { account: { id: number; label: string } }
+interface View<Table extends keyof Records, Acc> {
+  pick<Col extends keyof Records[Table]>(): View<Table, Acc & { [Field in Col]: Records[Table][Field] }>;
+}
+"#;
+    let diags = check(source);
+    assert_eq!(
+        count_with_code(&diags, 2322),
+        0,
+        "renamed type parameters must not regress: {diags:?}"
+    );
+    assert_eq!(
+        count_with_code(&diags, 2536),
+        0,
+        "renamed mapped key must not regress: {diags:?}"
+    );
+}
+
+#[test]
+fn genuinely_unconstrained_type_param_used_as_mapped_key_still_reports() {
+    // Negative case: an unconstrained type parameter is not a valid mapped
+    // key — TS2322 must still fire. The fix preserves declared
+    // constraints; it must not silence missing ones.
+    let source = r#"
+type X<T> = { [P in T]: any };
+"#;
+    let diags = check(source);
+    assert!(
+        count_with_code(&diags, 2322) >= 1,
+        "unconstrained type parameter must still emit TS2322: {diags:?}"
+    );
+}
+
+#[test]
+fn function_type_with_indexed_keyof_constraint_returning_mapped_type() {
+    // Pure function-type variant (no enclosing interface). Forces the same
+    // pre-pass path through `push_missing_name_type_parameters` from a
+    // function-type literal context.
+    let source = r#"
+interface DB { user: { id: number; name: string } }
+type Pick2<TB extends keyof DB> = <K extends keyof DB[TB]>(cols: K[]) => { [P in K]: DB[TB][P] };
+declare const f: Pick2<'user'>;
+const v = f(['id']);
+"#;
+    let diags = check(source);
+    assert_eq!(
+        count_with_code(&diags, 2322),
+        0,
+        "function-type variant must not emit TS2322: {diags:?}"
+    );
+    assert_eq!(
+        count_with_code(&diags, 2536),
+        0,
+        "function-type variant must not emit TS2536: {diags:?}"
+    );
+}
+
+#[test]
+fn two_dependent_method_type_parameters_resolve_each_others_constraints() {
+    // Sibling type parameter chain: K1 constrains K2. Both must be resolved
+    // by pass-2 of the missing-name push so mapped-type validation against
+    // K2's constraint sees a real constraint type, not a provisional `None`.
+    let source = r#"
+interface DB { user: { id: number; name: string } }
+interface Q<TB extends keyof DB> {
+  combine<K1 extends keyof DB[TB], K2 extends K1>(): { [P in K2]: DB[TB][P] };
+}
+"#;
+    let diags = check(source);
+    assert_eq!(
+        count_with_code(&diags, 2322),
+        0,
+        "sibling type-param chain must not emit TS2322: {diags:?}"
+    );
+    assert_eq!(
+        count_with_code(&diags, 2536),
+        0,
+        "sibling type-param chain must not emit TS2536: {diags:?}"
+    );
+}


### PR DESCRIPTION
AgentName: cloud-opus47-1m-confident-thompson

## Track

Checker boundary / type-parameter scope management.

## Invariant

A `push_*_type_parameters` helper that runs validation against the AST
subtree must resolve declared constraints before the validation walk so
the scope reflects the user-written `extends` clauses. `tsc` resolves
constraints lazily; tsz uses scope, so the scope must carry the same
information.

## Scope

The "missing names" pre-pass in `push_missing_name_type_parameters`
inserted method/signature type parameters into the scope **without**
resolving their declared `extends` clauses. The pre-pass then ran
`check_type_node` on each generic type argument (via
`validate_type_args_against_params`), which descends into mapped types
and triggers `check_mapped_type_constraint`. Because the
provisionally-inserted `K extends keyof T[U]` looked unconstrained, the
mapped-key validity check (`is_valid_mapped_type_key_type`) returned
`false` and the checker emitted spurious TS2322 / TS2536 errors for
declarations like:

```ts
interface T { user: { id: number; name: string } }
interface Q<TB extends keyof T, R> {
  select<K extends keyof T[TB]>(): Q<TB, { [P in K]: T[TB][P] }>;
}
```

Both diagnostics — `TS2322: Type 'K' is not assignable to type 'string | number | symbol'`
and `TS2536: Type 'P' cannot be used to index type 'T[TB]'` — fired
on tsz while `tsc` accepts the program. Tracing showed
`check_mapped_type_constraint` running three times for the same node:
once during the missing-name walk (seeing `K` provisionally with
`constraint=None`, firing the spurious errors), then twice more during
the normal walk with `K` fully constrained (passing). The error from
the first call leaked to user output.

### Structural rule

The fix mirrors `push_type_parameters`'s established 2-pass pattern in
`push_missing_name_type_parameters`:

- **Pass 1** inserts every type parameter unconstrained so siblings can
  see each other (a constraint like `<K extends keyof T[TB]>` references
  the prior parameter `TB`).
- **Pass 2** resolves each declared constraint against the now-populated
  scope and upgrades the binding. Resolution failures fall back to the
  unconstrained placeholder so TS2304 and cycle handling stay intact.

After the fix, the same mapped-type validity walk sees `K` with its
declared `keyof T[U]` constraint, so the keyof-→-PropertyKey check
returns `true` and the false positives are gone.

Genuinely unconstrained type parameters still report TS2322 — this fix
preserves declared constraints, it does not silence missing ones
(`type X<T> = { [P in T]: any }` still emits TS2322, verified by
test).

### Adjacent cases covered

New file `crates/tsz-checker/tests/missing_name_pass_constrained_type_param_tests.rs`:

1. **Self-returning generic interface** (the kysely-style minimal repro).
2. **Intersection in the return type** — `R & { [P in K]: ... }`.
3. **Function-type variant** — `type Pick2<TB> = <K extends keyof DB[TB]>(...) => ...`
   triggers the same pre-pass through a different entry point.
4. **Sibling chain** — `combine<K1 extends keyof DB[TB], K2 extends K1>()`
   exercises pass-2 transitive resolution.
5. **Renamed type parameters** — anti-hardcoding guard; the fix must
   not depend on the spellings `K`, `P`, `TB`.
6. **Negative**: `type X<T> = { [P in T]: any }` must still emit TS2322.

## Project Corpus Impact

- Row: kysely-project
- Bug family: false TS2322 / TS2536 on mapped-type return positions in generic interface methods (subfamily of kysely false-positive map #10663; companion to #10683)
- Evidence: minimal repro reproduces locally with `tsz --strict --noEmit` and is fixed by this change; the fix is the canonical "missing-name pre-pass uses the same scope rules as the proper pass" cleanup, not a kysely-specific shim. Heavy project-corpus rerun belongs to CI per AGENTS.md §19.5.

## Verification

- `cargo build -p tsz-cli --bin tsz` — clean.
- `cargo test -p tsz-checker --lib missing_name_pass` — all 6 new tests
  pass.
- `cargo test -p tsz-checker --lib` — 5493 passed, 49 failed (all 49
  failures are pre-existing on `main` per a clean baseline run; the
  failure set is byte-identical before and after this change).
- `cargo test -p tsz-solver --lib` — 9 failures, all pre-existing on
  `main`.
- `cargo clippy -p tsz-checker --all-targets` — clean (exit 0, no
  warnings).
- Minimal repro `interface Q<TB extends keyof T, R> { select<K extends keyof T[TB]>(): Q<TB, { [P in K]: T[TB][P] }>; }`:
  - `tsc --strict --noEmit` — clean.
  - `tsz --strict --noEmit` before fix — TS2322 + TS2536.
  - `tsz --strict --noEmit` after fix — clean.
- Heavy suites (conformance, fourslash, emit, WASM) are CI's job.

## Coordination Notes

- Related to the kysely false-positive family tracked in #10663,
  #10677, #10683 (the picked issue for this PR). The kysely-specific
  symptoms additionally need the contextual-typing fix outlined in
  #8773; this PR closes the orthogonal false positive that any
  builder-shaped declaration would hit independent of contextual
  typing.
- No anti-hardcoding violations: the fix keys on a structural rule
  (scope must reflect declared constraints), tests vary names, and the
  unconstrained case still fails.

https://claude.ai/code/session_01EkRpseNHHwhV9bTRezapLW