### PR TITLE
fix(binder,checker): emit TS2300 on duplicate `export { X } from "mod"` specifiers

### DIFF
--- a/crates/tsz-binder/src/modules/import_export.rs
+++ b/crates/tsz-binder/src/modules/import_export.rs
@@ -665,9 +665,24 @@ impl BinderState {
                                 }
                             }
 
-                            // Create symbols for re-export specifiers so they can be tracked
-                            // in the compilation cache for incremental invalidation
+                            // Duplicate `export { X } from "mod"` specifiers share one slot in
+                            // the file's exports table — tsc reports TS2300 on each. The default
+                            // ALIAS+ALIAS path in `declare_symbol` allocates a shadowing symbol,
+                            // leaving the duplicate-identifier checker with two single-decl
+                            // symbols and no TS2300. Append the second spec to the existing
+                            // re-export alias's declarations instead so the checker sees both.
                             for (exported, original, spec_idx) in &export_mappings {
+                                if let Some(existing_id) =
+                                    self.existing_reexport_alias_for_name(arena, exported)
+                                {
+                                    let span = Self::declaration_span(arena, *spec_idx);
+                                    if let Some(sym) = self.symbols.get_mut(existing_id) {
+                                        sym.add_declaration(*spec_idx, span);
+                                    }
+                                    Arc::make_mut(&mut self.node_symbols)
+                                        .insert(spec_idx.0, existing_id);
+                                    continue;
+                                }
                                 let sym_id = self.declare_symbol(
                                     arena,
                                     exported,
@@ -679,12 +694,8 @@ impl BinderState {
                                     sym.is_exported = true;
                                     sym.is_type_only = export_type_only;
                                     sym.import_module = Some(source_module.clone());
-                                    sym.import_name = Some(
-                                        original
-                                            .as_ref()
-                                            .cloned()
-                                            .unwrap_or_else(|| exported.clone()),
-                                    );
+                                    sym.import_name =
+                                        Some(original.clone().unwrap_or_else(|| exported.clone()));
                                 }
                                 Arc::make_mut(&mut self.node_symbols).insert(spec_idx.0, sym_id);
                             }
@@ -820,6 +831,29 @@ impl BinderState {
                 }
             }
         }
+    }
+
+    /// Existing re-export alias for `name` in the current scope, if any.
+    ///
+    /// `import { X } from "m"`, `export { X } from "m"`, and `export import X =
+    /// require("m")` all set `ALIAS` + `import_module`; only an `EXPORT_SPECIFIER`
+    /// first declaration identifies the file's exports-table slot we want to
+    /// merge into.
+    fn existing_reexport_alias_for_name(
+        &self,
+        arena: &NodeArena,
+        name: &str,
+    ) -> Option<crate::SymbolId> {
+        let candidate = self.current_scope.get(name)?;
+        let sym = self.symbols.get(candidate)?;
+        if (sym.flags & symbol_flags::ALIAS) == 0 || sym.import_module.is_none() {
+            return None;
+        }
+        let first_decl = sym.declarations.first().copied()?;
+        arena
+            .get(first_decl)
+            .is_some_and(|n| n.kind == syntax_kind_ext::EXPORT_SPECIFIER)
+            .then_some(candidate)
     }
 
     /// Check if a node kind is a declaration that should be bound

--- a/crates/tsz-binder/src/state/tests/exports_jsdoc.rs
+++ b/crates/tsz-binder/src/state/tests/exports_jsdoc.rs
@@ -84,6 +84,104 @@ namespace M {
     );
 }
 
+/// Duplicate `export { X } from "mod"` re-export specifiers must end up sharing
+/// a single symbol with multiple declarations so the checker's duplicate-
+/// identifier pass can emit TS2300 on each spec node.
+///
+/// Structural rule: two re-export specs that bind the same *exported* name —
+/// independent of source module, original name, or type-only-ness — collide.
+#[test]
+fn duplicate_reexport_specifiers_share_one_symbol_with_multiple_declarations() {
+    let source = r"
+export { Foo } from './a';
+export type { Foo } from './a';
+";
+    let (binder, _parser) = parse_and_bind(source);
+
+    let foo_sym_id = binder
+        .file_locals
+        .get("Foo")
+        .expect("expected re-export alias for Foo in file_locals");
+    let foo_sym = binder
+        .symbols
+        .get(foo_sym_id)
+        .expect("expected symbol data for Foo");
+
+    assert_ne!(foo_sym.flags & symbol_flags::ALIAS, 0);
+    assert_eq!(
+        foo_sym.declarations.len(),
+        2,
+        "expected two spec declarations on the shared re-export symbol, got: {:?}",
+        foo_sym.declarations
+    );
+
+    // The visible binding keeps the first-bound spec's metadata so downstream
+    // import resolution still routes through the original module specifier.
+    assert_eq!(foo_sym.import_module.as_deref(), Some("./a"));
+    assert_eq!(foo_sym.import_name.as_deref(), Some("Foo"));
+    assert!(
+        !foo_sym.is_type_only,
+        "first-bound spec was value-only — the merge must not escalate to type-only"
+    );
+}
+
+/// Same merging behavior when the duplicate uses a different original name
+/// (`Foo as X` + `Bar as X`) — the EXPORTED name is the keying axis, not the
+/// source identifier.
+#[test]
+fn duplicate_reexport_specifiers_with_distinct_originals_share_one_symbol() {
+    let source = r"
+export { Foo as X } from './a';
+export { Bar as X } from './a';
+";
+    let (binder, _parser) = parse_and_bind(source);
+
+    let x_sym_id = binder
+        .file_locals
+        .get("X")
+        .expect("expected re-export alias for X in file_locals");
+    let x_sym = binder
+        .symbols
+        .get(x_sym_id)
+        .expect("expected symbol data for X");
+
+    assert_eq!(
+        x_sym.declarations.len(),
+        2,
+        "expected two spec declarations on the shared re-export symbol, got: {:?}",
+        x_sym.declarations
+    );
+    assert_eq!(x_sym.import_name.as_deref(), Some("Foo"));
+}
+
+/// Aliased re-exports with DISTINCT exported names must remain separate
+/// symbols (no merge). Guards the literal repro from issue #11334.
+#[test]
+fn distinct_exported_names_remain_separate_re_export_symbols() {
+    let source = r"
+export * from './a';
+export { Foo as Bar } from './a';
+export type { Foo } from './a';
+";
+    let (binder, _parser) = parse_and_bind(source);
+
+    let bar = binder.file_locals.get("Bar").expect("expected Bar symbol");
+    let foo = binder.file_locals.get("Foo").expect("expected Foo symbol");
+    assert_ne!(
+        bar, foo,
+        "Bar and Foo must remain distinct re-export symbols"
+    );
+
+    let bar_sym = binder.symbols.get(bar).expect("Bar symbol data");
+    let foo_sym = binder.symbols.get(foo).expect("Foo symbol data");
+    assert_eq!(bar_sym.declarations.len(), 1);
+    assert_eq!(foo_sym.declarations.len(), 1);
+    assert_eq!(bar_sym.import_name.as_deref(), Some("Foo"));
+    assert_eq!(foo_sym.import_name.as_deref(), Some("Foo"));
+    assert!(foo_sym.is_type_only);
+    assert!(!bar_sym.is_type_only);
+}
+
 #[test]
 fn records_import_metadata_for_exported_reexports() {
     let source = r"

--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -379,6 +379,10 @@ name = "ts2300_reexport_augmentation_tests"
 path = "tests/ts2300_reexport_augmentation_tests.rs"
 
 [[test]]
+name = "ts2300_duplicate_reexport_tests"
+path = "tests/ts2300_duplicate_reexport_tests.rs"
+
+[[test]]
 name = "ts2304_tests"
 path = "tests/ts2304_tests.rs"
 

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -1310,20 +1310,18 @@ impl<'a> CheckerState<'a> {
                         continue;
                     }
 
-                    // Import specifiers and re-export specifiers with the same name
-                    // do not conflict. In tsc, `export { A } from "mod"` creates a
-                    // symbol in the file's exports table, not in file locals, so it
-                    // never collides with `import { A } from "mod"`. Our binder
-                    // merges both into the same symbol, so we suppress the false
-                    // TS2300 here when at least one declaration is a re-export
-                    // specifier (export specifier whose parent ExportDeclaration
-                    // has a module specifier).
+                    // In tsc, `import { A } from "m"` lives in file locals and
+                    // `export { A } from "m"` lives in the file's exports table —
+                    // different slots, no collision. Our binder merges both into
+                    // the same symbol, so suppress TS2300 only when exactly one
+                    // side is a re-export specifier; two re-exports of the same
+                    // exported name share the exports slot and DO collide.
                     let both_aliases = (decl_flags & symbol_flags::ALIAS) != 0
                         && (other_flags & symbol_flags::ALIAS) != 0;
                     if both_aliases {
                         let decl_is_reexport = self.is_reexport_specifier(decl_idx);
                         let other_is_reexport = self.is_reexport_specifier(other_idx);
-                        if decl_is_reexport || other_is_reexport {
+                        if decl_is_reexport != other_is_reexport {
                             continue;
                         }
                     }

--- a/crates/tsz-checker/tests/ts2300_duplicate_reexport_tests.rs
+++ b/crates/tsz-checker/tests/ts2300_duplicate_reexport_tests.rs
@@ -1,0 +1,178 @@
+//! TS2300 for duplicate `export { ... } from "..."` re-export specifiers.
+//!
+//! Structural rule: two specs that bind the same EXPORTED name share the file's
+//! exports-table slot — independent of type-only-ness, renaming, or source
+//! module — and tsc emits TS2300 on each. The `no_ts2300` tests guard against
+//! over-firing on the adjacent shapes (aliased rename, wildcard + explicit,
+//! import + re-export).
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::diagnostic_count;
+use tsz_common::common::ModuleKind;
+
+fn check_diags(files: &[(&str, &str)], entry_file: &str) -> Vec<(u32, String)> {
+    tsz_checker::test_utils::check_multi_file(
+        files,
+        entry_file,
+        CheckerOptions {
+            module: ModuleKind::CommonJS,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .map(|d| (d.code, d.message_text))
+    .collect()
+}
+
+const SOURCE: &str = "export class Foo { x: number = 0; }\n";
+const SOURCE_B: &str = "export class Foo { y: string = \"\"; }\n";
+
+// ─── duplicate same-name value re-exports ─────────────────────────────────────
+
+#[test]
+fn duplicate_value_reexport_emits_ts2300() {
+    let test = "export { Foo } from './a';\nexport { Foo } from './a';\n";
+    let diags = check_diags(&[("a.ts", SOURCE), ("test.ts", test)], "test.ts");
+    assert_eq!(
+        diagnostic_count(&diags, 2300),
+        2,
+        "expected TS2300 on each duplicate re-export spec, got: {diags:?}"
+    );
+}
+
+#[test]
+fn duplicate_type_reexport_emits_ts2300() {
+    let test = "export type { Foo } from './a';\nexport type { Foo } from './a';\n";
+    let diags = check_diags(&[("a.ts", SOURCE), ("test.ts", test)], "test.ts");
+    assert_eq!(
+        diagnostic_count(&diags, 2300),
+        2,
+        "expected TS2300 on each duplicate type-only re-export, got: {diags:?}"
+    );
+}
+
+#[test]
+fn value_then_type_reexport_emits_ts2300() {
+    let test = "export { Foo } from './a';\nexport type { Foo } from './a';\n";
+    let diags = check_diags(&[("a.ts", SOURCE), ("test.ts", test)], "test.ts");
+    assert_eq!(
+        diagnostic_count(&diags, 2300),
+        2,
+        "expected TS2300 on both value + type-only re-exports of same name, got: {diags:?}"
+    );
+}
+
+#[test]
+fn type_then_value_reexport_emits_ts2300() {
+    let test = "export type { Foo } from './a';\nexport { Foo } from './a';\n";
+    let diags = check_diags(&[("a.ts", SOURCE), ("test.ts", test)], "test.ts");
+    assert_eq!(
+        diagnostic_count(&diags, 2300),
+        2,
+        "expected TS2300 on both type-only + value re-exports of same name, got: {diags:?}"
+    );
+}
+
+// ─── renamed export-as collisions ─────────────────────────────────────────────
+
+#[test]
+fn duplicate_renamed_export_emits_ts2300() {
+    // Both specs export the same name `X`; the `Foo as X` rename does not
+    // sidestep the duplicate.
+    let test = "export { Foo as X } from './a';\nexport { Foo as X } from './a';\n";
+    let diags = check_diags(&[("a.ts", SOURCE), ("test.ts", test)], "test.ts");
+    assert_eq!(
+        diagnostic_count(&diags, 2300),
+        2,
+        "expected TS2300 on duplicate aliased re-export name, got: {diags:?}"
+    );
+}
+
+#[test]
+fn duplicate_exported_name_via_different_aliases_emits_ts2300() {
+    // Same exported name `X`, different original names — still a duplicate of `X`.
+    let a_two = "export class Foo { x: number = 0; }\nexport class Bar { y: string = \"\"; }\n";
+    let test = "export { Foo as X } from './a';\nexport { Bar as X } from './a';\n";
+    let diags = check_diags(&[("a.ts", a_two), ("test.ts", test)], "test.ts");
+    assert_eq!(
+        diagnostic_count(&diags, 2300),
+        2,
+        "expected TS2300 on `X` exported via two different sources, got: {diags:?}"
+    );
+}
+
+// ─── duplicate across different source modules ───────────────────────────────
+
+#[test]
+fn duplicate_same_name_different_sources_emits_ts2300() {
+    let test = "export { Foo } from './a';\nexport type { Foo } from './b';\n";
+    let diags = check_diags(
+        &[("a.ts", SOURCE), ("b.ts", SOURCE_B), ("test.ts", test)],
+        "test.ts",
+    );
+    assert_eq!(
+        diagnostic_count(&diags, 2300),
+        2,
+        "expected TS2300 even when sources differ — name space collision is on the exported name, got: {diags:?}"
+    );
+}
+
+// ─── no false-positives ──────────────────────────────────────────────────────
+
+#[test]
+fn aliased_reexports_with_distinct_names_no_ts2300() {
+    let test = "export { Foo as Bar } from './a';\nexport type { Foo } from './a';\n";
+    let diags = check_diags(&[("a.ts", SOURCE), ("test.ts", test)], "test.ts");
+    assert_eq!(
+        diagnostic_count(&diags, 2300),
+        0,
+        "distinct exported names (Bar vs Foo) must not collide, got: {diags:?}"
+    );
+}
+
+#[test]
+fn wildcard_plus_explicit_reexport_no_ts2300() {
+    // The literal repro from issue #11334: `export *` brings Foo in implicitly,
+    // an explicit `export { Foo as Bar }` adds the renamed binding, and an
+    // explicit `export type { Foo }` adds the type-only binding for `Foo`.
+    // Explicit names override the wildcard silently — no duplicate.
+    let test = "export * from './a';
+export { Foo as Bar } from './a';
+export type { Foo } from './a';
+";
+    let diags = check_diags(&[("a.ts", SOURCE), ("test.ts", test)], "test.ts");
+    assert_eq!(
+        diagnostic_count(&diags, 2300),
+        0,
+        "wildcard + explicit re-exports of distinct names must not collide, got: {diags:?}"
+    );
+}
+
+#[test]
+fn import_plus_reexport_no_ts2300() {
+    // tsc places `import { X }` in file locals and `export { X } from "mod"`
+    // in the file's exports table — different slots, no collision.
+    let test = "import { Foo } from './a';\nexport { Foo } from './a';\nconst _: Foo = { x: 1 };\n";
+    let diags = check_diags(&[("a.ts", SOURCE), ("test.ts", test)], "test.ts");
+    assert_eq!(
+        diagnostic_count(&diags, 2300),
+        0,
+        "import + same-name re-export must not collide, got: {diags:?}"
+    );
+}
+
+#[test]
+fn three_explicit_reexports_all_emit_ts2300() {
+    // Each adjacent pair contributes a diagnostic. tsc emits TS2300 on every
+    // spec node that participates in the duplicate set (3 here).
+    let test = "export { Foo } from './a';
+export type { Foo } from './a';
+export { Foo } from './a';
+";
+    let diags = check_diags(&[("a.ts", SOURCE), ("test.ts", test)], "test.ts");
+    assert_eq!(
+        diagnostic_count(&diags, 2300),
+        3,
+        "expected TS2300 on each of three duplicate re-export specs, got: {diags:?}"
+    );
+}


### PR DESCRIPTION
AgentName: cloud-opus47-1m-confident-thompson

## Track
Conformance / module-resolution / parity — fixes a class of silently-dropped duplicate re-export diagnostics across user code.

## Invariant
**When two `export { X } from "m"` specifiers in the same module declare the same EXPORTED name, they share the file's exports-table slot — independent of type-only-ness, renaming, or source module — and `tsc` reports TS2300 on each.** Import-aliases (`import { X } from "m"`) continue to occupy a separate slot from re-export specifiers, and `export *` continues to be silently shadowed by explicit named re-exports.

## Scope
- Binder: in the named re-export path (`bind_export_declaration`), recognize that a same-name re-export alias already exists in the current scope (discriminated by `ALIAS + import_module + first_decl_kind == EXPORT_SPECIFIER`), and append the new spec to its declarations instead of allocating a shadow symbol.
- Checker: in `check_duplicate_identifiers`, tighten the `both_aliases` suppression from `decl_is_reexport || other_is_reexport` to `decl_is_reexport != other_is_reexport`. Two re-exports of the same exported name now fall through to TS2300; mixed import + re-export pairings remain suppressed.

## Project Corpus Impact
- Row: type-fest-project (issue #11334), and broadly any project that exposes barrel `index.ts` files with overlapping re-export declarations (kysely-project, utility-types-project, and similar barrel-heavy projects).
- Bug family: silently-dropped TS2300 on duplicate re-export specifiers.
- Evidence: `cargo test -p tsz-checker --test ts2300_duplicate_reexport_tests` (11 new tests, 11 passing) — covers value/type/mixed value-then-type/type-then-value/renamed/cross-source/three-way duplicates plus negative cases (aliased-distinct, wildcard+explicit, import+reexport).

## Verification
- `cargo test -p tsz-binder` → 360 + 7 + 40 + 8 + 35 + 52 passing (all pre-existing binder tests plus 2 new duplicate-reexport tests + 1 new distinct-exported-names test).
- `cargo test -p tsz-checker --test ts2300_duplicate_reexport_tests` → 11 passing.
- `cargo test -p tsz-checker --test ts2300_tests --test ts2300_reexport_augmentation_tests --test jsdoc_import_runtime_duplicate_tests` → all pass.
- Hand-verified against `tsc 6.0.2` on the structural matrix in `/tmp/reexport-bug/idx{1..14}.ts`:
  - Cases that should emit `TS2300 Duplicate identifier 'X'` (value+value, type+type, value+type, type+value, renamed-as duplicates, cross-source duplicates) now match `tsc` byte-for-byte on both diagnostic codes and line/column anchors.
  - Cases that should NOT collide (aliased re-exports with distinct names, import+reexport pairings, wildcard+explicit named re-exports) continue to produce no diagnostics.

## Coordination Notes
- Out-of-scope follow-ups for future PRs:
  1. Generalize the duplicate-alias merge to ALL `declare_symbol` ALIAS+ALIAS pairings inside `declare_symbol` itself (so `import M = X.A; import M = X.B;` and other duplicate-alias classes share the rule). Today's tsz already reports TS2300 for that specific case via a different code path, but a unified slot model would be cleaner.
  2. Promote the local `check_diags` test helper into `tsz_checker::test_utils` so `ts2300_reexport_augmentation_tests` and the new test file share it.
  3. Local-export-vs-reexport collisions (TS2323 + TS2484, e.g. `export const Foo = 1; export type { Foo } from './a';`) are still silently dropped — they're a different diagnostic family and out of this PR's scope.

Three rounds of `/simplify` were applied (inlined helper, dropped redundant binder test, switched to `tsz_checker::test_utils::diagnostic_count`, early-`continue` in the merge loop, trimmed doc/test headers, fixed a stale test comment).

Closes #11334