### PR TITLE
fix(checker): elide `export { X }` of type-only-imported locals from emit preamble

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -31,6 +31,10 @@ web-time = { workspace = true }
 stacker = "0.1.23"
 
 [[test]]
+name = "type_only_import_reexport_tests"
+path = "tests/type_only_import_reexport_tests.rs"
+
+[[test]]
 name = "closure_boundary_property_narrowing_tests"
 path = "tests/closure_boundary_property_narrowing_tests.rs"
 

--- a/crates/tsz-checker/src/declarations/module_checker.rs
+++ b/crates/tsz-checker/src/declarations/module_checker.rs
@@ -1051,24 +1051,41 @@ impl<'a> CheckerState<'a> {
             }
 
             // Mark local re-export specifiers for emit elision when the re-exported
-            // local binding resolves to a type-only symbol (interface, type alias,
-            // uninstantiated namespace, or a const enum without preserveConstEnums).
-            // This covers `import { I1 as I } from "mod"; export { I }` — the import
-            // checker marks the import specifier, but the export specifier has a
-            // different NodeIndex that the emitter checks separately.
+            // local binding has no runtime form. Three sources:
             //
-            // For import-alias bindings, use `import_binding_is_type_only` which has
-            // full const-enum awareness. For other local symbols, `is_local_symbol_type_only`
-            // handles interfaces, type aliases, and uninstantiated namespaces.
+            // 1. The local binding was introduced as a type-only import
+            //    (`import type { X }`, `import { type X }`, `import type X`,
+            //    `import type * as N`). The binder sets `sym.is_type_only`
+            //    regardless of whether the source-module export is a value:
+            //    the local form has no runtime slot. tsc emits no
+            //    `exports.X = void 0;` and no CommonJS re-export binding.
+            // 2. The local binding is an import alias and the source-module
+            //    export is itself type-only (interface, type alias,
+            //    uninstantiated namespace, or const enum without
+            //    `preserveConstEnums`). `import_binding_is_type_only` has the
+            //    full const-enum and `export =` awareness here.
+            // 3. The local binding is a non-alias declaration that is purely
+            //    a type entity (interface, type alias, uninstantiated
+            //    namespace). `is_local_symbol_type_only` handles that.
             if is_local && !enclosing_export_is_type_only && !specifier.is_type_only {
                 use tsz_binder::symbol_flags;
-                let is_type_only = if let Some(sym_id) = self.ctx.binder.file_locals.get(&name_str)
-                    && let Some(sym) = self.ctx.binder.get_symbol(sym_id)
-                    && sym.has_any_flags(symbol_flags::ALIAS)
-                    && let Some(ref module_spec) = sym.import_module
-                {
-                    let import_name = sym.import_name.as_deref().unwrap_or(&name_str);
-                    self.import_binding_is_type_only(module_spec, import_name)
+                let sym_lookup = self
+                    .ctx
+                    .binder
+                    .file_locals
+                    .get(&name_str)
+                    .and_then(|sym_id| self.ctx.binder.get_symbol(sym_id).map(|sym| (sym_id, sym)));
+                let is_type_only = if let Some((_, sym)) = sym_lookup {
+                    if sym.is_type_only {
+                        true
+                    } else if sym.has_any_flags(symbol_flags::ALIAS)
+                        && let Some(ref module_spec) = sym.import_module
+                    {
+                        let import_name = sym.import_name.as_deref().unwrap_or(&name_str);
+                        self.import_binding_is_type_only(module_spec, import_name)
+                    } else {
+                        self.is_local_symbol_type_only(&name_str)
+                    }
                 } else {
                     self.is_local_symbol_type_only(&name_str)
                 };

--- a/crates/tsz-checker/src/declarations/module_checker.rs
+++ b/crates/tsz-checker/src/declarations/module_checker.rs
@@ -1051,13 +1051,9 @@ impl<'a> CheckerState<'a> {
             }
 
             // Mark local re-export specifiers for emit elision when the local
-            // binding has no runtime form. `sym.is_type_only` catches type-only
-            // imports (`import type { X }` etc.) regardless of whether the
-            // source-module export is itself a runtime value. The alias branch
-            // handles `import { X } from "m"` where `X` is type-only in `m`;
-            // `import_binding_is_type_only` adds const-enum and `export =`
-            // awareness over the plain specifier-side query. The fallback
-            // covers non-alias declarations that are purely type entities.
+            // binding has no runtime form. The alias branch follows the import
+            // through the source module (covers const-enum and `export =`
+            // shapes that the plain specifier-side query misses).
             if is_local && !enclosing_export_is_type_only && !specifier.is_type_only {
                 use tsz_binder::symbol_flags;
                 let sym = self

--- a/crates/tsz-checker/src/declarations/module_checker.rs
+++ b/crates/tsz-checker/src/declarations/module_checker.rs
@@ -1050,10 +1050,14 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
 
-            // Mark local re-export specifiers for emit elision when the local
-            // binding has no runtime form. The alias branch follows the import
-            // through the source module (covers const-enum and `export =`
-            // shapes that the plain specifier-side query misses).
+            // Rule: when `export { X }` re-exports a local binding whose
+            // source has no runtime form — type-only import, type-only
+            // declaration, or alias to a type-only / const-enum / `export =`
+            // module export — tsc elides the specifier from JS emit; mark
+            // the specifier so the emitter matches. The alias branch follows
+            // the import through the source module, which is what catches
+            // the const-enum / `export =` shapes the plain specifier-side
+            // query misses.
             if is_local && !enclosing_export_is_type_only && !specifier.is_type_only {
                 use tsz_binder::symbol_flags;
                 let sym = self

--- a/crates/tsz-checker/src/declarations/module_checker.rs
+++ b/crates/tsz-checker/src/declarations/module_checker.rs
@@ -1050,42 +1050,32 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
 
-            // Mark local re-export specifiers for emit elision when the re-exported
-            // local binding has no runtime form. Three sources:
-            //
-            // 1. The local binding was introduced as a type-only import
-            //    (`import type { X }`, `import { type X }`, `import type X`,
-            //    `import type * as N`). The binder sets `sym.is_type_only`
-            //    regardless of whether the source-module export is a value:
-            //    the local form has no runtime slot. tsc emits no
-            //    `exports.X = void 0;` and no CommonJS re-export binding.
-            // 2. The local binding is an import alias and the source-module
-            //    export is itself type-only (interface, type alias,
-            //    uninstantiated namespace, or const enum without
-            //    `preserveConstEnums`). `import_binding_is_type_only` has the
-            //    full const-enum and `export =` awareness here.
-            // 3. The local binding is a non-alias declaration that is purely
-            //    a type entity (interface, type alias, uninstantiated
-            //    namespace). `is_local_symbol_type_only` handles that.
+            // Mark local re-export specifiers for emit elision when the local
+            // binding has no runtime form. `sym.is_type_only` catches type-only
+            // imports (`import type { X }` etc.) regardless of whether the
+            // source-module export is itself a runtime value. The alias branch
+            // handles `import { X } from "m"` where `X` is type-only in `m`;
+            // `import_binding_is_type_only` adds const-enum and `export =`
+            // awareness over the plain specifier-side query. The fallback
+            // covers non-alias declarations that are purely type entities.
             if is_local && !enclosing_export_is_type_only && !specifier.is_type_only {
                 use tsz_binder::symbol_flags;
-                let sym_lookup = self
+                let sym = self
                     .ctx
                     .binder
                     .file_locals
                     .get(&name_str)
-                    .and_then(|sym_id| self.ctx.binder.get_symbol(sym_id).map(|sym| (sym_id, sym)));
-                let is_type_only = if let Some((_, sym)) = sym_lookup {
-                    if sym.is_type_only {
-                        true
-                    } else if sym.has_any_flags(symbol_flags::ALIAS)
-                        && let Some(ref module_spec) = sym.import_module
-                    {
-                        let import_name = sym.import_name.as_deref().unwrap_or(&name_str);
-                        self.import_binding_is_type_only(module_spec, import_name)
-                    } else {
-                        self.is_local_symbol_type_only(&name_str)
-                    }
+                    .and_then(|sym_id| self.ctx.binder.get_symbol(sym_id));
+                let is_type_only = if let Some(sym) = sym
+                    && sym.is_type_only
+                {
+                    true
+                } else if let Some(sym) = sym
+                    && sym.has_any_flags(symbol_flags::ALIAS)
+                    && let Some(ref module_spec) = sym.import_module
+                {
+                    let import_name = sym.import_name.as_deref().unwrap_or(&name_str);
+                    self.import_binding_is_type_only(module_spec, import_name)
                 } else {
                     self.is_local_symbol_type_only(&name_str)
                 };

--- a/crates/tsz-checker/tests/type_only_import_reexport_tests.rs
+++ b/crates/tsz-checker/tests/type_only_import_reexport_tests.rs
@@ -42,9 +42,6 @@ fn check_two_files_collect_export_specifiers(
     let mut binder_b = BinderState::new();
     binder_b.bind_source_file(parser_b.get_arena(), root_b);
 
-    let arena_a = Arc::new(parser_a.get_arena().clone());
-    let arena_b = Arc::new(parser_b.get_arena().clone());
-
     // `import_binding_is_type_only` follows the module specifier into
     // `binder_a`'s export table, so seed `binder_b.module_exports` for the
     // re-export path. No `register_symbol_file_target` is needed: the
@@ -55,13 +52,18 @@ fn check_two_files_collect_export_specifiers(
             .insert(module_specifier.to_string(), exports);
     }
 
-    let all_arenas = Arc::new(vec![Arc::clone(&arena_a), Arc::clone(&arena_b)]);
-    let all_binders = Arc::new(vec![Arc::new(binder_a), Arc::new(binder_b)]);
+    let arena_b = Arc::new(parser_b.get_arena().clone());
+    let all_arenas = Arc::new(vec![
+        Arc::new(parser_a.get_arena().clone()),
+        Arc::clone(&arena_b),
+    ]);
+    let binder_b = Arc::new(binder_b);
+    let all_binders = Arc::new(vec![Arc::new(binder_a), Arc::clone(&binder_b)]);
 
     let types = TypeInterner::new();
     let mut checker = CheckerState::new(
         arena_b.as_ref(),
-        all_binders[1].as_ref(),
+        binder_b.as_ref(),
         &types,
         entry_name.to_string(),
         CheckerOptions {

--- a/crates/tsz-checker/tests/type_only_import_reexport_tests.rs
+++ b/crates/tsz-checker/tests/type_only_import_reexport_tests.rs
@@ -1,0 +1,292 @@
+//! Tests that `export { X }` of a local `import type` (or `import { type X }`)
+//! binding marks the export specifier for emit elision.
+//!
+//! Structural rule: when `export { X }` references a local name `X` whose
+//! binder symbol has `is_type_only = true` (declared via `import type`,
+//! `import { type X }`, `import type default`, or `import type * as X`),
+//! the local binding has no runtime form. The export specifier must land in
+//! `ctx.type_only_nodes` so the CommonJS / preserve emitter elides it from
+//! the `exports.X = void 0` preamble and from any `Object.defineProperty`
+//! re-export wiring — matching tsc's behavior of dropping the binding from
+//! emit even though the source module's export may itself be a runtime value.
+//!
+//! Each test varies the binding spelling and import shape to verify the rule
+//! lives at the structural level, not on a specific identifier name.
+
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::sync::Arc;
+use tsz_binder::BinderState;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::state::CheckerState;
+use tsz_parser::parser::{NodeIndex, ParserState, syntax_kind_ext};
+use tsz_solver::construction::TypeInterner;
+
+/// Run the checker over a two-file project (`./mod` and `entry.ts`) and
+/// return the set of export-specifier `NodeIndex` values inside `entry.ts`
+/// along with the checker's `type_only_nodes` set.
+fn check_two_files_collect_export_specifiers(
+    mod_source: &str,
+    entry_source: &str,
+) -> (Vec<(String, NodeIndex)>, FxHashSet<NodeIndex>) {
+    let mod_name = "mod.ts";
+    let entry_name = "entry.ts";
+    let module_specifier = "./mod";
+
+    let mut parser_a = ParserState::new(mod_name.to_string(), mod_source.to_string());
+    let root_a = parser_a.parse_source_file();
+    let mut binder_a = BinderState::new();
+    binder_a.bind_source_file(parser_a.get_arena(), root_a);
+
+    let mut parser_b = ParserState::new(entry_name.to_string(), entry_source.to_string());
+    let root_b = parser_b.parse_source_file();
+    let mut binder_b = BinderState::new();
+    binder_b.bind_source_file(parser_b.get_arena(), root_b);
+
+    let arena_a = Arc::new(parser_a.get_arena().clone());
+    let arena_b = Arc::new(parser_b.get_arena().clone());
+
+    let file_a_exports = binder_a.module_exports.get(mod_name).cloned();
+    if let Some(exports) = &file_a_exports {
+        std::sync::Arc::make_mut(&mut binder_b.module_exports)
+            .insert(module_specifier.to_string(), exports.clone());
+    }
+
+    let mut cross_file_targets = FxHashMap::default();
+    if let Some(exports) = &file_a_exports {
+        for (_name, &sym_id) in exports.iter() {
+            cross_file_targets.insert(sym_id, 0usize);
+        }
+    }
+
+    let all_arenas = Arc::new(vec![Arc::clone(&arena_a), Arc::clone(&arena_b)]);
+    let binder_a = Arc::new(binder_a);
+    let binder_b = Arc::new(binder_b);
+    let all_binders = Arc::new(vec![Arc::clone(&binder_a), Arc::clone(&binder_b)]);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        arena_b.as_ref(),
+        binder_b.as_ref(),
+        &types,
+        entry_name.to_string(),
+        CheckerOptions {
+            no_lib: true,
+            module: tsz_common::common::ModuleKind::CommonJS,
+            ..Default::default()
+        },
+    );
+
+    checker.ctx.set_all_arenas(Arc::clone(&all_arenas));
+    checker.ctx.set_all_binders(Arc::clone(&all_binders));
+    checker.ctx.set_current_file_idx(1);
+    for (sym_id, file_idx) in &cross_file_targets {
+        checker.ctx.register_symbol_file_target(*sym_id, *file_idx);
+    }
+
+    let mut resolved_module_paths: FxHashMap<(usize, String), usize> = FxHashMap::default();
+    resolved_module_paths.insert((1, module_specifier.to_string()), 0);
+    checker
+        .ctx
+        .set_resolved_module_paths(Arc::new(resolved_module_paths));
+
+    let mut resolved_modules: FxHashSet<String> = FxHashSet::default();
+    resolved_modules.insert(module_specifier.to_string());
+    checker.ctx.set_resolved_modules(resolved_modules);
+
+    checker.check_source_file(root_b);
+
+    let mut specifiers: Vec<(String, NodeIndex)> = Vec::new();
+    let arena = arena_b.as_ref();
+    if let Some(sf_node) = arena.get(root_b)
+        && let Some(sf) = arena.get_source_file(sf_node)
+    {
+        for &stmt_idx in &sf.statements.nodes {
+            let Some(stmt) = arena.get(stmt_idx) else {
+                continue;
+            };
+            if stmt.kind != syntax_kind_ext::EXPORT_DECLARATION {
+                continue;
+            }
+            let Some(export_decl) = arena.get_export_decl(stmt) else {
+                continue;
+            };
+            let Some(clause_node) = arena.get(export_decl.export_clause) else {
+                continue;
+            };
+            let Some(named_exports) = arena.get_named_imports(clause_node) else {
+                continue;
+            };
+            for &spec_idx in &named_exports.elements.nodes {
+                let Some(spec_node) = arena.get(spec_idx) else {
+                    continue;
+                };
+                let Some(spec) = arena.get_specifier(spec_node) else {
+                    continue;
+                };
+                let name_node_idx = spec.name;
+                let Some(name_node) = arena.get(name_node_idx) else {
+                    continue;
+                };
+                let Some(ident) = arena.get_identifier(name_node) else {
+                    continue;
+                };
+                specifiers.push((ident.escaped_text.clone(), spec_idx));
+            }
+        }
+    }
+
+    (specifiers, checker.ctx.type_only_nodes.clone())
+}
+
+fn assert_spec_marked(specs: &[(String, NodeIndex)], type_only: &FxHashSet<NodeIndex>, name: &str) {
+    let Some((_, idx)) = specs.iter().find(|(n, _)| n == name) else {
+        panic!("export specifier {name:?} not found; got {specs:?}");
+    };
+    assert!(
+        type_only.contains(idx),
+        "export {{ {name} }} should be marked type-only, but was not. \
+         Specs={specs:?} type_only={type_only:?}"
+    );
+}
+
+fn assert_spec_not_marked(
+    specs: &[(String, NodeIndex)],
+    type_only: &FxHashSet<NodeIndex>,
+    name: &str,
+) {
+    let Some((_, idx)) = specs.iter().find(|(n, _)| n == name) else {
+        panic!("export specifier {name:?} not found; got {specs:?}");
+    };
+    assert!(
+        !type_only.contains(idx),
+        "export {{ {name} }} should NOT be marked type-only, but was. \
+         Specs={specs:?} type_only={type_only:?}"
+    );
+}
+
+// ── Type-only IMPORT, value SOURCE ──────────────────────────────────────────
+//
+// In each of these cases the source module's export is a runtime value
+// (`class K {}`), but the local binding is decorated as type-only. tsc drops
+// the re-export from emit because the local has no runtime slot.
+
+/// `import type { K } from "./mod"; export { K };`
+/// Bound variable name `K`.
+#[test]
+fn type_only_named_import_reexport_marks_specifier_k() {
+    let mod_src = "export class K {}\n";
+    let entry_src = "import type { K } from \"./mod\";\nexport { K };\n";
+    let (specs, type_only) = check_two_files_collect_export_specifiers(mod_src, entry_src);
+    assert_spec_marked(&specs, &type_only, "K");
+}
+
+/// Same rule, different identifier spelling: `Widget`.
+/// Verifies the fix is not gated on a specific name.
+#[test]
+fn type_only_named_import_reexport_marks_specifier_widget() {
+    let mod_src = "export class Widget {}\n";
+    let entry_src = "import type { Widget } from \"./mod\";\nexport { Widget };\n";
+    let (specs, type_only) = check_two_files_collect_export_specifiers(mod_src, entry_src);
+    assert_spec_marked(&specs, &type_only, "Widget");
+}
+
+/// `import { type K } from "./mod"; export { K };`
+/// Specifier-level `type` modifier — the binder also flips `sym.is_type_only`.
+#[test]
+fn inline_type_named_import_reexport_marks_specifier() {
+    let mod_src = "export class K {}\n";
+    let entry_src = "import { type K } from \"./mod\";\nexport { K };\n";
+    let (specs, type_only) = check_two_files_collect_export_specifiers(mod_src, entry_src);
+    assert_spec_marked(&specs, &type_only, "K");
+}
+
+/// `import type { Origin as Local } from "./mod"; export { Local };`
+/// Renaming on the import side — the local name `Local` is what `export`
+/// references; the binder still flags `Local` as type-only.
+#[test]
+fn renamed_type_only_import_reexport_marks_specifier() {
+    let mod_src = "export class Origin {}\n";
+    let entry_src = "import type { Origin as Local } from \"./mod\";\nexport { Local };\n";
+    let (specs, type_only) = check_two_files_collect_export_specifiers(mod_src, entry_src);
+    assert_spec_marked(&specs, &type_only, "Local");
+}
+
+/// `import type { K } from "./mod"; export { K as Out };`
+/// Renaming on the export side — the local-name lookup still resolves to the
+/// type-only-imported `K`, so the rule should fire.
+#[test]
+fn type_only_import_with_renaming_export_marks_specifier() {
+    let mod_src = "export class K {}\n";
+    let entry_src = "import type { K } from \"./mod\";\nexport { K as Out };\n";
+    let (specs, type_only) = check_two_files_collect_export_specifiers(mod_src, entry_src);
+    assert_spec_marked(&specs, &type_only, "Out");
+}
+
+/// `import type * as N from "./mod"; export { N };`
+/// Namespace import is also type-only.
+#[test]
+fn type_only_namespace_import_reexport_marks_specifier() {
+    let mod_src = "export class A {}\nexport class B {}\n";
+    let entry_src = "import type * as N from \"./mod\";\nexport { N };\n";
+    let (specs, type_only) = check_two_files_collect_export_specifiers(mod_src, entry_src);
+    assert_spec_marked(&specs, &type_only, "N");
+}
+
+/// `import type Default from "./mod"; export { Default };`
+/// Default import is also type-only.
+#[test]
+fn type_only_default_import_reexport_marks_specifier() {
+    let mod_src = "export default class M {}\n";
+    let entry_src = "import type Default from \"./mod\";\nexport { Default };\n";
+    let (specs, type_only) = check_two_files_collect_export_specifiers(mod_src, entry_src);
+    assert_spec_marked(&specs, &type_only, "Default");
+}
+
+// ── Mixed type-only + value imports re-exported together ────────────────────
+
+/// `import type { T } from "./mod"; import { V } from "./mod";`
+/// `export { T }; export { V };`
+/// `T` is elided; `V` survives. Two separate export clauses.
+#[test]
+fn mixed_type_and_value_imports_two_export_clauses() {
+    let mod_src = "export class T {}\nexport class V {}\n";
+    let entry_src = "import type { T } from \"./mod\";\nimport { V } from \"./mod\";\nexport { T };\nexport { V };\n";
+    let (specs, type_only) = check_two_files_collect_export_specifiers(mod_src, entry_src);
+    assert_spec_marked(&specs, &type_only, "T");
+    assert_spec_not_marked(&specs, &type_only, "V");
+}
+
+/// Same as above but inside a single export clause:
+/// `import { type T, V } from "./mod"; export { T, V };`
+#[test]
+fn mixed_inline_type_and_value_single_export_clause() {
+    let mod_src = "export class T {}\nexport class V {}\n";
+    let entry_src = "import { type T, V } from \"./mod\";\nexport { T, V };\n";
+    let (specs, type_only) = check_two_files_collect_export_specifiers(mod_src, entry_src);
+    assert_spec_marked(&specs, &type_only, "T");
+    assert_spec_not_marked(&specs, &type_only, "V");
+}
+
+// ── Negative cases ──────────────────────────────────────────────────────────
+
+/// A plain value import is NOT type-only, even when the consumer never uses
+/// it locally. `export { V }` must survive emit as a real re-export.
+#[test]
+fn plain_value_import_reexport_not_marked() {
+    let mod_src = "export class V {}\n";
+    let entry_src = "import { V } from \"./mod\";\nexport { V };\n";
+    let (specs, type_only) = check_two_files_collect_export_specifiers(mod_src, entry_src);
+    assert_spec_not_marked(&specs, &type_only, "V");
+}
+
+/// An `export type { X }` declaration is itself fully erased by the emitter
+/// based on the declaration-level marker; the per-specifier marking in
+/// `type_only_nodes` is allowed but not required here. We only assert that
+/// a plain value re-export sitting next to it survives.
+#[test]
+fn explicit_export_type_does_not_mark_neighboring_value_export() {
+    let mod_src = "export class V {}\nexport class T {}\n";
+    let entry_src = "export type { T } from \"./mod\";\nexport { V } from \"./mod\";\n";
+    let (specs, type_only) = check_two_files_collect_export_specifiers(mod_src, entry_src);
+    assert_spec_not_marked(&specs, &type_only, "V");
+}

--- a/crates/tsz-checker/tests/type_only_import_reexport_tests.rs
+++ b/crates/tsz-checker/tests/type_only_import_reexport_tests.rs
@@ -45,28 +45,23 @@ fn check_two_files_collect_export_specifiers(
     let arena_a = Arc::new(parser_a.get_arena().clone());
     let arena_b = Arc::new(parser_b.get_arena().clone());
 
-    let file_a_exports = binder_a.module_exports.get(mod_name).cloned();
-    if let Some(exports) = &file_a_exports {
+    // `import_binding_is_type_only` follows the module specifier into
+    // `binder_a`'s export table, so seed `binder_b.module_exports` for the
+    // re-export path. No `register_symbol_file_target` is needed: the
+    // assertion only inspects `ctx.type_only_nodes`, which is populated
+    // before any cross-file type construction.
+    if let Some(exports) = binder_a.module_exports.get(mod_name).cloned() {
         std::sync::Arc::make_mut(&mut binder_b.module_exports)
-            .insert(module_specifier.to_string(), exports.clone());
-    }
-
-    let mut cross_file_targets = FxHashMap::default();
-    if let Some(exports) = &file_a_exports {
-        for (_name, &sym_id) in exports.iter() {
-            cross_file_targets.insert(sym_id, 0usize);
-        }
+            .insert(module_specifier.to_string(), exports);
     }
 
     let all_arenas = Arc::new(vec![Arc::clone(&arena_a), Arc::clone(&arena_b)]);
-    let binder_a = Arc::new(binder_a);
-    let binder_b = Arc::new(binder_b);
-    let all_binders = Arc::new(vec![Arc::clone(&binder_a), Arc::clone(&binder_b)]);
+    let all_binders = Arc::new(vec![Arc::new(binder_a), Arc::new(binder_b)]);
 
     let types = TypeInterner::new();
     let mut checker = CheckerState::new(
         arena_b.as_ref(),
-        binder_b.as_ref(),
+        all_binders[1].as_ref(),
         &types,
         entry_name.to_string(),
         CheckerOptions {
@@ -79,9 +74,6 @@ fn check_two_files_collect_export_specifiers(
     checker.ctx.set_all_arenas(Arc::clone(&all_arenas));
     checker.ctx.set_all_binders(Arc::clone(&all_binders));
     checker.ctx.set_current_file_idx(1);
-    for (sym_id, file_idx) in &cross_file_targets {
-        checker.ctx.register_symbol_file_target(*sym_id, *file_idx);
-    }
 
     let mut resolved_module_paths: FxHashMap<(usize, String), usize> = FxHashMap::default();
     resolved_module_paths.insert((1, module_specifier.to_string()), 0);


### PR DESCRIPTION
AgentName: opus47-claim-thompson
Track: emit parity (checker → emitter `type_only_nodes` contract)
Invariant: `tsc` parity for CommonJS / preserve / system / amd / umd / esnext emit of mixed type / value re-exports.
Scope: `crates/tsz-checker/src/declarations/module_checker.rs` (local-named-export classifier) + new `crates/tsz-checker/tests/type_only_import_reexport_tests.rs`.

## Structural rule

> When `export { X }` re-exports a local binding whose source has no runtime form — type-only import (`import type { X }`, `import { type X }`, `import type X`, `import type * as X`), type-only declaration (interface, type alias, uninstantiated namespace), or alias to a const-enum / `export =` module export — `tsc` elides the specifier from JS emit; this change makes `tsz` mark the export-specifier `NodeIndex` so the emitter matches.

## Root cause

The checker's local-named-export classifier in `module_checker.rs` previously dispatched the alias path through `import_binding_is_type_only(source_module, import_name)`, which only inspects the source-module export. For `import type { Kysely } from './mod'; export { Kysely };` where `Kysely` is a `class` in `./mod`, the source-side check returns false even though the *local* binding has no runtime form. The export specifier was not added to `ctx.type_only_nodes`, so the CJS emitter wrote `exports.Kysely = void 0;` and an `Object.defineProperty(exports, "Kysely", ...)` re-export wire, while `tsc` correctly emits neither.

Fix: short-circuit on the binder's `sym.is_type_only` flag (set for all type-only import shapes), keep the existing `import_binding_is_type_only` alias path for source-side const-enum / `export =` shapes, fall back to `is_local_symbol_type_only` for non-alias local declarations.

## Coverage matrix (11 checker tests, structural assertions on `ctx.type_only_nodes`)

| # | Shape | Identifier | Result |
|---|-------|-----------|--------|
| 1 | `import type { K } from "m"; export { K };` | `K` | marked |
| 2 | same rule, different name | `Widget` | marked |
| 3 | `import { type K } from "m"; export { K };` (inline `type`) | `K` | marked |
| 4 | `import type { Origin as Local }; export { Local };` (rename on import) | `Local` | marked |
| 5 | `import type { K }; export { K as Out };` (rename on export) | `Out` | marked |
| 6 | `import type * as N from "m"; export { N };` | `N` | marked |
| 7 | `import type Default from "m"; export { Default };` | `Default` | marked |
| 8 | `import type { T }; import { V }; export { T }; export { V };` | `T`, `V` | `T` marked, `V` not |
| 9 | `import { type T, V } from "m"; export { T, V };` | `T`, `V` | `T` marked, `V` not |
| 10 | `import { V } from "m"; export { V };` (plain value, negative) | `V` | not marked |
| 11 | `export type { T } from "m"; export { V } from "m";` (neighboring) | `V` | not marked |

Two name choices for the core shape (`K`/`Widget`) per `.claude/CLAUDE.md` §25 review checklist item 3.

## Manual CLI parity verification

Built `tsz` debug and compared rendered emit against `tsc` 6.0.2 across module targets for the canonical repro and three adjacent shapes — `MATCH` in every case after the fix:

```
edge1..edge5 + edge_ns + edge_def + edge_inline + edge_rename1 + edge_rename2: 10/10 MATCH
modules tested: commonjs, esnext, preserve, node16, system, amd, umd
```

The reported issue's two-line repro (`export type { Kysely }; export { Kysely };` from the same module) already matched pre-fix because the duplicate-identifier shape goes through the declaration-level type-only marker; the genuine divergence in this family is the local type-only import case, which is what this PR fixes.

## Project Corpus Impact

- Row: kysely-project, type-challenges-solutions-project, vite-vanilla-ts-app, nextjs (and any project corpus row with a CJS preamble for re-exports of type-only-imported locals).
- Bug family: emit / helper-wiring / void-0 preamble for mixed type-only + value re-exports.
- Evidence: 11 new structural unit tests in `crates/tsz-checker/tests/type_only_import_reexport_tests.rs`; manual CLI tsc-parity sweep across 7 module targets (commonjs / esnext / preserve / node16 / system / amd / umd).

## Verification

- `cargo test -p tsz-checker --test type_only_import_reexport_tests` → 11/11 pass.
- `cargo test -p tsz-checker --lib` → no new failures (49 pre-existing baseline failures verified present without this PR via `git stash` + re-run).
- `cargo test -p tsz-checker --lib export` → 126/0.
- `cargo test -p tsz-checker --lib reexport` → 12/0.
- `cargo test -p tsz-checker --lib type_only` → 23/0.
- `cargo test -p tsz-checker --test commonjs_module_export_alias_tests` → 21/0.
- `cargo test -p tsz-checker --test js_export_surface_tests` → 78/0.
- `cargo test -p tsz-checker --test ts2300_reexport_augmentation_tests` → 15/0.
- `cargo test -p tsz-emitter --lib type_only` → 64/0.
- `cargo test -p tsz-emitter --lib reexport` → 34/0.
- `cargo clippy -p tsz-checker --lib --tests -- -D warnings` → clean.
- Three `/simplify` passes applied (flat sym lookup, dropped unused test plumbing, inlined `arena_a`, held `binder_b` Arc directly, tightened doc comment, added explicit §26 rule statement).

## Coordination Notes

Issue #11342 carries the in-progress label for the lifetime of this PR; the label is removed on merge via the issue close hook. No overlapping draft PRs found for the type-only re-export family (`search_pull_requests "type-only re-export"`). The deferred altitude finding (collapse the call site to `is_local_symbol_type_only` after upgrading its alias branch to `import_binding_is_type_only`) is out of scope here — it has 2 other callers in `verbatim_module_syntax.rs` and warrants its own change with conformance triage.

Closes #11342.

---
_Generated by [Claude Code](https://claude.ai/code/session_016LEv31xyArTDVimnyhkU3b)_