### PR TITLE
fix(bench): wait for prep artifacts after cloudbuild success

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -704,6 +704,8 @@ jobs:
           cloudbuild_id="${{ needs.bench-prepare.outputs.build_id }}"
 
           deadline=$((SECONDS + 9000))
+          success_seen_at=""
+          success_grace_seconds=600
           while true; do
             rm -f bench-prep.env bench-prep.tar
             if storage_cp \
@@ -720,6 +722,10 @@ jobs:
 
             status="$(cloudbuild_status "$cloudbuild_id")"
             if [[ "$status" == "SUCCESS" ]]; then
+              if [[ -z "$success_seen_at" ]]; then
+                success_seen_at="$SECONDS"
+                echo "Cloud Build benchmark prep ${cloudbuild_id} succeeded; waiting up to ${success_grace_seconds}s for prep artifacts to become visible."
+              fi
               if copy_from_latest_prep_artifact; then
                 exit 0
               fi
@@ -727,11 +733,12 @@ jobs:
                 if validate_downloaded_prep_artifact; then
                   exit 0
                 fi
-                echo "Cloud Build benchmark prep ${cloudbuild_id} succeeded, but its manifest artifact is for ${manifest_target_sha:-unknown} / PGO=${manifest_pgo_optimized:-0}; expected ${target_sha} / PGO=1."
+                echo "Cloud Build benchmark prep ${cloudbuild_id} manifest artifact is for ${manifest_target_sha:-unknown} / PGO=${manifest_pgo_optimized:-0}; waiting for ${target_sha} / PGO=1."
+              fi
+              if (( SECONDS - success_seen_at >= success_grace_seconds )); then
+                echo "Cloud Build benchmark prep ${cloudbuild_id} succeeded, but neither SHA-scoped, latest, nor manifest artifacts exposed valid bench-prep env/tar for ${target_sha} after ${success_grace_seconds}s."
                 exit 1
               fi
-              echo "Cloud Build benchmark prep ${cloudbuild_id} succeeded, but neither SHA-scoped, latest, nor manifest artifacts exposed valid bench-prep env/tar for ${target_sha}."
-              exit 1
             fi
             case "$status" in
               FAILURE|INTERNAL_ERROR|TIMEOUT|CANCELLED|EXPIRED)
@@ -881,6 +888,8 @@ jobs:
           target_sha="${{ env.BENCH_TARGET_SHA }}"
 
           deadline=$((SECONDS + 9000))
+          success_seen_at=""
+          success_grace_seconds=600
           while true; do
             if storage_cp \
               "gs://tsz-ci_cloudbuild/bench-prep/${target_sha}/bench-prep.env" \
@@ -896,6 +905,10 @@ jobs:
 
             status="$(cloudbuild_status "$cloudbuild_id")"
             if [[ "$status" == "SUCCESS" ]]; then
+              if [[ -z "$success_seen_at" ]]; then
+                success_seen_at="$SECONDS"
+                echo "Cloud Build benchmark prep ${cloudbuild_id} succeeded; waiting up to ${success_grace_seconds}s for prep artifacts to become visible."
+              fi
               if copy_from_latest_prep_artifact; then
                 exit 0
               fi
@@ -903,11 +916,12 @@ jobs:
                 if validate_downloaded_prep_artifact; then
                   exit 0
                 fi
-                echo "Cloud Build benchmark prep ${cloudbuild_id} succeeded, but its manifest artifact is for ${manifest_target_sha:-unknown} / PGO=${manifest_pgo_optimized:-0}; expected ${target_sha} / PGO=1."
+                echo "Cloud Build benchmark prep ${cloudbuild_id} manifest artifact is for ${manifest_target_sha:-unknown} / PGO=${manifest_pgo_optimized:-0}; waiting for ${target_sha} / PGO=1."
+              fi
+              if (( SECONDS - success_seen_at >= success_grace_seconds )); then
+                echo "Cloud Build benchmark prep ${cloudbuild_id} succeeded, but neither SHA-scoped, latest, nor manifest artifacts exposed valid bench-prep env/tar for ${target_sha} after ${success_grace_seconds}s."
                 exit 1
               fi
-              echo "Cloud Build benchmark prep ${cloudbuild_id} succeeded, but neither SHA-scoped, latest, nor manifest artifacts exposed valid bench-prep env/tar for ${target_sha}."
-              exit 1
             fi
             case "$status" in
               FAILURE|INTERNAL_ERROR|TIMEOUT|CANCELLED|EXPIRED)

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -17,28 +17,40 @@ const BENCH_SHARD_CLOUDBUILD = path.join(
 const workflow = fs.readFileSync(BENCH_WORKFLOW, "utf8");
 const shardCloudbuild = fs.readFileSync(BENCH_SHARD_CLOUDBUILD, "utf8");
 
-const failFastMessages = workflow.match(
-  /Cloud Build benchmark prep \$\{cloudbuild_id\} succeeded, but its manifest artifact is for/g,
+const successGraceWindows = workflow.match(
+  /success_seen_at=""[\s\S]+?success_grace_seconds=600/g,
 ) ?? [];
 assert.equal(
-  failFastMessages.length,
+  successGraceWindows.length,
   2,
-  "both Cloud Build prep artifact paths should fail fast on stale manifest artifacts after build success",
+  "both Cloud Build prep artifact paths should use a bounded post-success artifact visibility grace window",
 );
 
-assert.doesNotMatch(
-  workflow,
-  /Cloud Build manifest artifact is for .*waiting for/,
-  "successful Cloud Build prep with a stale manifest artifact must not wait until the 150 minute deadline",
+const postSuccessMessages = workflow.match(
+  /Cloud Build benchmark prep \$\{cloudbuild_id\} succeeded; waiting up to \$\{success_grace_seconds\}s for prep artifacts to become visible\./g,
+) ?? [];
+assert.equal(
+  postSuccessMessages.length,
+  2,
+  "both Cloud Build prep artifact paths should log when entering the post-success artifact visibility grace window",
+);
+
+const staleManifestWaits = workflow.match(
+  /Cloud Build benchmark prep \$\{cloudbuild_id\} manifest artifact is for \$\{manifest_target_sha:-unknown\} \/ PGO=\$\{manifest_pgo_optimized:-0\}; waiting for \$\{target_sha\} \/ PGO=1\./g,
+) ?? [];
+assert.equal(
+  staleManifestWaits.length,
+  2,
+  "successful Cloud Build prep with a stale manifest artifact should keep polling during the post-success grace window",
 );
 
 const unusableArtifactMessages = workflow.match(
-  /Cloud Build benchmark prep \$\{cloudbuild_id\} succeeded, but neither SHA-scoped, latest, nor manifest artifacts exposed valid bench-prep env\/tar for/g,
+  /Cloud Build benchmark prep \$\{cloudbuild_id\} succeeded, but neither SHA-scoped, latest, nor manifest artifacts exposed valid bench-prep env\/tar for \$\{target_sha\} after \$\{success_grace_seconds\}s\./g,
 ) ?? [];
 assert.equal(
   unusableArtifactMessages.length,
   2,
-  "both Cloud Build prep artifact paths should fail fast when a successful build exposes no usable prep artifacts",
+  "both Cloud Build prep artifact paths should fail after the bounded post-success grace window when no usable prep artifacts appear",
 );
 
 assert.match(
@@ -55,14 +67,14 @@ assert.match(
 
 assert.match(
   workflow,
-  /expected \$\{target_sha\} \/ PGO=1\."\s*\n\s+exit 1/,
-  "PGO prep path should report the expected target and exit immediately",
+  /waiting for \$\{target_sha\} \/ PGO=1\."\s*\n\s+fi\s*\n\s+if \(\( SECONDS - success_seen_at >= success_grace_seconds \)\)/,
+  "PGO prep path should report the expected target and wait until the post-success grace deadline",
 );
 
 assert.match(
   workflow,
-  /expected \$\{target_sha\} \/ PGO=1\."\s*\n\s+exit 1/,
-  "benchmark prep path should report the expected target and PGO marker before exiting immediately",
+  /waiting for \$\{target_sha\} \/ PGO=1\."\s*\n\s+fi\s*\n\s+if \(\( SECONDS - success_seen_at >= success_grace_seconds \)\)/,
+  "benchmark prep path should report the expected target and PGO marker before the post-success grace deadline",
 );
 
 assert.match(

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -404,6 +404,7 @@ run_lint() {
   node scripts/bench/test-check-artifact-readiness.mjs || return $?
   node scripts/bench/test-benchmark-artifact-selection.mjs || return $?
   node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs || return $?
+  node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs || return $?
   for script in scripts/ci/*type-challenges*.mjs; do
     node --check "$script" || return $?
   done


### PR DESCRIPTION
AgentName: Studio-A

## Track
Bench / project-corpus release metric truth

## Invariant
Bench prep artifacts must be validated against the target SHA and PGO marker, while successful Cloud Build completion must not race GCS/manifest artifact visibility.

## Scope
- Keep both `bench-prep-artifact` Cloud Build download paths polling after Cloud Build reports `SUCCESS`.
- Add a bounded 600s post-success artifact visibility window before failing the job.
- Preserve immediate failure for terminal Cloud Build failure states.
- Wire the existing bench workflow Cloud Build prep guard into `gcp-full-ci.sh` lint.

## Project Corpus Impact
- Row: benchmark artifact publication / public benchmark freshness
- Bug family: Cloud Build prep artifact readiness race after successful producer build
- Evidence: recent Bench run 26685920580 failed in `bench-prep-artifact` immediately after Cloud Build success because SHA-scoped/latest/manifest prep artifacts were not visible on the first post-success read.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `bash -n scripts/ci/gcp-full-ci.sh`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/bench.yml"); puts "bench.yml yaml ok"'`

## Coordination Notes
- Related to #10649; this fixes the current full Bench blocker without editing roadmap or public metric markdown.
- Open PR overlap check found no active bench/artifact PR already owning this path.
