### PR TITLE
fix(solver): preserve full nested elaboration chain in TypeFormatter::render

### DIFF
--- a/crates/tsz-solver/src/diagnostics/builders.rs
+++ b/crates/tsz-solver/src/diagnostics/builders.rs
@@ -697,7 +697,7 @@ impl TypeDiagnostic {
                 message_text: rel.message.clone(),
                 category: DiagnosticCategory::Message,
                 code: 0,
-                depth: 0,
+                depth: rel.depth,
             })
             .collect();
 

--- a/crates/tsz-solver/src/diagnostics/core.rs
+++ b/crates/tsz-solver/src/diagnostics/core.rs
@@ -401,6 +401,12 @@ impl SourceSpan {
 pub struct RelatedInformation {
     pub span: SourceSpan,
     pub message: String,
+    /// Nesting depth within the parent diagnostic's elaboration chain.
+    /// `0` is the first elaboration line (rendered at 2 spaces of indent);
+    /// each deeper level adds 2 more spaces. Non-chain related entries (e.g.
+    /// genuine cross-location pointers like "see declaration here") stay at
+    /// `0`.
+    pub depth: u8,
 }
 
 /// A type checking diagnostic.
@@ -436,11 +442,12 @@ impl TypeDiagnostic {
         self
     }
 
-    /// Add related information.
+    /// Add related information at depth 0.
     pub fn with_related(mut self, span: SourceSpan, message: impl Into<String>) -> Self {
         self.related.push(RelatedInformation {
             span,
             message: message.into(),
+            depth: 0,
         });
         self
     }

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -958,12 +958,14 @@ impl<'a> TypeFormatter<'a> {
         // surface every level instead of being silently truncated after the
         // first. Depth carries the nesting level so the reporter can render
         // tsc-style progressive 2-space indentation.
-        let fallback_span = pending
-            .span
-            .clone()
-            .unwrap_or_else(|| SourceSpan::new("<unknown>", 0, 0));
-        for related in &pending.related {
-            self.render_related_chain(related, 0, &fallback_span, &mut diag.related);
+        if !pending.related.is_empty() {
+            let fallback_span = pending
+                .span
+                .clone()
+                .unwrap_or_else(|| SourceSpan::new("<unknown>", 0, 0));
+            for related in &pending.related {
+                self.render_related_chain(related, 0, &fallback_span, &mut diag.related);
+            }
         }
 
         diag

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -953,24 +953,43 @@ impl<'a> TypeFormatter<'a> {
         };
 
         // Render related diagnostics, falling back to the primary span.
+        // Recursively walk the elaboration tree so nested chains built via
+        // `with_related` (e.g. `PropertyTypeMismatch { nested_reason: ... }`)
+        // surface every level instead of being silently truncated after the
+        // first. Depth carries the nesting level so the reporter can render
+        // tsc-style progressive 2-space indentation.
         let fallback_span = pending
             .span
             .clone()
             .unwrap_or_else(|| SourceSpan::new("<unknown>", 0, 0));
         for related in &pending.related {
-            let related_msg =
-                self.render_template(get_message_template(related.code), &related.args);
-            let span = related
-                .span
-                .clone()
-                .unwrap_or_else(|| fallback_span.clone());
-            diag.related.push(RelatedInformation {
-                span,
-                message: related_msg,
-            });
+            self.render_related_chain(related, 0, &fallback_span, &mut diag.related);
         }
 
         diag
+    }
+
+    /// Recursively flatten a nested `PendingDiagnostic` elaboration chain into
+    /// `RelatedInformation` entries with monotonically increasing depth so the
+    /// reporter can render tsc-style progressive indentation.
+    fn render_related_chain(
+        &mut self,
+        pending: &PendingDiagnostic,
+        depth: u8,
+        fallback_span: &SourceSpan,
+        out: &mut Vec<RelatedInformation>,
+    ) {
+        let message = self.render_template(get_message_template(pending.code), &pending.args);
+        let span = pending.span.as_ref().unwrap_or(fallback_span).clone();
+        out.push(RelatedInformation {
+            span,
+            message,
+            depth,
+        });
+        let next_depth = depth.saturating_add(1);
+        for child in &pending.related {
+            self.render_related_chain(child, next_depth, fallback_span, out);
+        }
     }
 
     /// Render a message template with arguments.

--- a/crates/tsz-solver/tests/diagnostics_tests.rs
+++ b/crates/tsz-solver/tests/diagnostics_tests.rs
@@ -268,6 +268,112 @@ fn test_union_member_mismatch_diagnostic_includes_related_members() {
 }
 
 #[test]
+fn test_render_preserves_nested_property_mismatch_chain() {
+    // Structural rule: when a `PendingDiagnostic` carries a nested elaboration
+    // chain built via `with_related`, `TypeFormatter::render` must flatten the
+    // full chain with monotonically increasing depth — not silently truncate
+    // after the first level (the previous behavior dropped every "Types of
+    // property 'X' are incompatible" line below the outermost one).
+    let interner = TypeInterner::new();
+    let inner = SubtypeFailureReason::PropertyTypeMismatch {
+        property_name: interner.intern_string("b"),
+        source_property_type: TypeId::NUMBER,
+        target_property_type: TypeId::STRING,
+        nested_reason: None,
+    };
+    let outer = SubtypeFailureReason::PropertyTypeMismatch {
+        property_name: interner.intern_string("a"),
+        source_property_type: TypeId::NUMBER, // placeholder; the chain uses the inner pair
+        target_property_type: TypeId::STRING,
+        nested_reason: Some(Box::new(inner)),
+    };
+
+    let pending = outer
+        .to_diagnostic(TypeId::NUMBER, TypeId::STRING)
+        .with_span(SourceSpan::new("test.ts", 0, 1));
+
+    // `to_diagnostic` builds a sibling+nested elaboration tree under the top
+    // diagnostic. Before the recursive-flatten fix, the renderer dropped every
+    // child of a non-top-level entry, so the inner "Types of property 'b' are
+    // incompatible." helper-name line vanished entirely — exactly the
+    // "truncates helper names and loses context" symptom.
+    let mut formatter = TypeFormatter::new(&interner);
+    let diag = formatter.render(&pending);
+
+    let messages: Vec<(u8, &str)> = diag
+        .related
+        .iter()
+        .map(|r| (r.depth, r.message.as_str()))
+        .collect();
+
+    assert!(
+        messages
+            .iter()
+            .any(|(_, m)| m.contains("'a'") && m.contains("incompatible")),
+        "outer property mismatch line missing: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|(_, m)| m.contains("'b'") && m.contains("incompatible")),
+        "inner property mismatch line is truncated and helper name 'b' is lost: {messages:?}"
+    );
+
+    // Depth must strictly increase as the walker descends from a parent into
+    // its children. The 'a' elaboration is a direct sibling of the top diag
+    // (depth 0); the 'b' elaboration hangs off the nested TS2322 wrapper, so
+    // it sits at least one level deeper.
+    let outer_a = diag
+        .related
+        .iter()
+        .find(|r| r.message.contains("'a'"))
+        .expect("outer 'a' line");
+    let inner_b = diag
+        .related
+        .iter()
+        .find(|r| r.message.contains("'b'"))
+        .expect("inner 'b' line");
+    assert_eq!(outer_a.depth, 0);
+    assert!(
+        inner_b.depth > outer_a.depth,
+        "inner 'b' should be rendered deeper than outer 'a' (got outer={}, inner={})",
+        outer_a.depth,
+        inner_b.depth
+    );
+}
+
+#[test]
+fn test_render_related_chain_depth_does_not_overflow_on_pathological_depth() {
+    // Recursion safety: even a chain longer than u8::MAX must not panic. The
+    // walker saturates `depth` at u8::MAX so deeper levels still emit (just at
+    // the same maximum-indent level the reporter clamps to).
+    let interner = TypeInterner::new();
+    // Build a 300-level chain by nesting PropertyTypeMismatch reasons.
+    let mut reason: Option<Box<SubtypeFailureReason>> = None;
+    for i in 0..300 {
+        let name = format!("p{i}");
+        reason = Some(Box::new(SubtypeFailureReason::PropertyTypeMismatch {
+            property_name: interner.intern_string(&name),
+            source_property_type: TypeId::NUMBER,
+            target_property_type: TypeId::STRING,
+            nested_reason: reason,
+        }));
+    }
+    let outermost = *reason.expect("at least one level");
+    let pending = outermost
+        .to_diagnostic(TypeId::NUMBER, TypeId::STRING)
+        .with_span(SourceSpan::new("test.ts", 0, 1));
+
+    let mut formatter = TypeFormatter::new(&interner);
+    let diag = formatter.render(&pending);
+
+    // The chain renders without panic; max depth saturates at u8::MAX.
+    let max_depth = diag.related.iter().map(|r| r.depth).max().unwrap_or(0);
+    assert_eq!(max_depth, u8::MAX);
+    assert!(diag.related.len() >= 300);
+}
+
+#[test]
 fn test_property_missing_diagnostic() {
     let interner = TypeInterner::new();
     let mut builder = DiagnosticBuilder::new(&interner);


### PR DESCRIPTION
AgentName: cloud-opus47-1m-confident-thompson-yev4t

## Track

Diagnostics — solver elaboration rendering.

## Invariant

When a `PendingDiagnostic` carries a nested `related` chain built via `with_related`, the rendered chain preserves every level with monotonically increasing depth so the reporter can produce tsc-style progressive 2-space indentation. Independent of which subtype-failure variant produced the chain, property names, or target.

## Scope

`crates/tsz-solver/src/diagnostics/{core,builders,format/mod}.rs` and a focused unit-test file. No checker, binder, or emitter logic changes.

### Root cause

`crates/tsz-solver/src/diagnostics/format/mod.rs::TypeFormatter::render` walked only `pending.related` at the top level, dropping every child of a non-top-level entry. Subtype-failure variants that built chains via `with_related(nested_pending)` — including `PropertyTypeMismatch`, `TypeArgumentMismatch`, `TupleElementTypeMismatch`, `ReturnTypeMismatch`, `ParameterTypeMismatch`, `IndexSignatureMismatch`, `ArrayElementMismatch`, and `AbstractConstructorAssignment` — silently lost their inner "Types of property 'X' are incompatible." helper-name lines and their innermost intrinsic mismatch. That's the diagnostics-36-20 bench fingerprint (#11494) and a class of broken elaborations across many fixtures.

Compounding this, `TypeDiagnostic::to_checker_diagnostic` hardcoded `depth: 0` for every flattened entry. The downstream `DiagnosticRelatedInformation` and the CLI reporter (`crates/tsz-cli/src/reporting/reporter.rs::format_related_plain` — `indent = 2 * (depth + 1)`) already supported progressive indentation; the solver just never populated depth, so progressive indentation could never engage.

### Structural rule

> When a `PendingDiagnostic` carries a nested `related` chain (built via `with_related`), tsc renders the full chain with progressive 2-space indentation per nesting level. This change makes tsz's solver-driven elaboration chain do the same — independent of which subtype-failure variant produced the chain, which property names appear, or which target.

### Fix

- Add `depth: u8` to solver `RelatedInformation`.
- `TypeFormatter::render` now recursively walks `pending.related` through a new `render_related_chain` helper, pushing each node with `depth.saturating_add(1)` as it descends. Saturation protects against pathological depths.
- `TypeDiagnostic::to_checker_diagnostic` passes `rel.depth` through instead of hardcoding 0.

The chain construction shape in `SubtypeFailureReason::to_diagnostic` (the `outer.with_related(elaboration).with_related(nested)` sibling pattern) is intentionally untouched — it's a real architectural smell and worth a follow-up, but restructuring every reason variant is out of scope for an elaboration-truncation fix. The recursive flatten handles siblings and children uniformly, so today both render correctly.

## Project Corpus Impact

- Row: diagnostics-36-20 (nextjs-fresh-app, #11494) and the wider class of TS2322/TS2345 chained elaborations across project corpora.
- Bug family: solver elaboration chain truncation.
- Evidence: two new solver unit tests (`test_render_preserves_nested_property_mismatch_chain`, `test_render_related_chain_depth_does_not_overflow_on_pathological_depth`) plus the existing `test_union_member_mismatch_diagnostic_includes_related_members` continues to pass. Heavy CI runs conformance/emit/fourslash on the ready PR.

## Adjacent-case test matrix

- The reported recursive-failure shape: `{a:{b:number}}` vs `{a:{b:string}}` (covered by `test_render_preserves_nested_property_mismatch_chain`).
- Renamed-property variation: applies automatically — the helper is name-independent (interner uses Atom IDs).
- Sibling case where `pending.related` is single-level (existing `test_union_member_mismatch_diagnostic_includes_related_members` still passes — three members at depth 0).
- Pathological-depth fallback: `test_render_related_chain_depth_does_not_overflow_on_pathological_depth` builds a 300-level chain and proves `saturating_add` clamps at `u8::MAX` without panic.

## Verification

- `cargo build --workspace`: green.
- `cargo test -p tsz-solver test_render`: 2 new tests + existing nested-chain tests pass.
- `cargo test -p tsz-solver --lib`: 6185 passed, 1 pre-existing-on-main flaky failure (`template_literal_with_any_is_string`, unrelated to this diff — verified by stash-and-rerun on main).
- Draft CI: green (unit, unit-cloudbuild, cargo-deny, cargo-shear, project-row-drift, lint, gate, GitGuardian all success).

## Coordination Notes

Issue #11494 is labeled `agent:M1-C` upstream but had no draft PR, no claim comment, and no WIP label when picked. A `WIP` label and signed claim comment were added before coding. Branch: `claude/confident-thompson-yev4t`. AgentName signed in every commit and on the issue.

The sibling-vs-nested chain shape in `SubtypeFailureReason::to_diagnostic` (`crates/tsz-solver/src/diagnostics/core.rs` lines 600–990) is a deferred follow-up — restructuring every reason variant to nest the inner chain UNDER the elaboration (rather than as its sibling) would touch all chain-carrying variants and is not required for the truncation fix to be correct.

https://claude.ai/code/session_01BMXttjKrwPerAU6XWEbBdV