### PR TITLE
fix(emit): preserve private field init order

### DIFF
--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -13,8 +13,10 @@ use tsz_parser::parser::node::{Node, NodeArena};
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
-/// A class field initializer entry: (`field_name`, `initializer_node`, `init_end`, `leading_comments`, `trailing_comments`).
-pub(crate) type FieldInit = (String, NodeIndex, u32, Vec<String>, Vec<String>);
+/// A class field initializer entry:
+/// (`field_name`, `initializer_node`, `init_end`, `leading_comments`,
+/// `trailing_comments`, `source_order`).
+pub(crate) type FieldInit = (String, NodeIndex, u32, Vec<String>, Vec<String>, u32);
 
 /// A const enum entry scoped to a specific region of the source.
 /// File-level const enums use `(0, u32::MAX)` so they match any position.
@@ -864,9 +866,10 @@ pub struct Printer<'a> {
     /// Emitted as `_a = ClassName;` after the class body.
     pub(crate) pending_private_class_alias: Option<(String, String)>,
 
-    /// Private field constructor inits: (`weakmap_name`, `has_initializer`, `initializer_idx`).
+    /// Private field constructor inits:
+    /// (`weakmap_name`, `has_initializer`, `initializer_idx`, `source_order`).
     /// Emitted as `_C_field.set(this, <init>)` at the start of the constructor.
-    pub(crate) pending_private_field_constructor_inits: Vec<(String, bool, NodeIndex)>,
+    pub(crate) pending_private_field_constructor_inits: Vec<(String, bool, NodeIndex, u32)>,
 
     /// `WeakSet` instance name for `_X_instances.add(this)` in the constructor.
     /// Set when the class has private instance methods or accessors.

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -1039,7 +1039,15 @@ impl<'a> Printer<'a> {
             self.pending_private_field_constructor_inits = private_fields
                 .iter()
                 .filter(|f| !f.is_static)
-                .map(|f| (f.weakmap_name.clone(), f.has_initializer, f.initializer))
+                .map(|f| {
+                    let source_order = self.arena.get(f.member_idx).map_or(u32::MAX, |n| n.pos);
+                    (
+                        f.weakmap_name.clone(),
+                        f.has_initializer,
+                        f.initializer,
+                        source_order,
+                    )
+                })
                 .collect();
 
             // Prepare WeakSet instances.add(this) for constructor
@@ -1847,6 +1855,7 @@ impl<'a> Printer<'a> {
                             init_end,
                             leading_comments,
                             trailing_comments,
+                            member_node.pos,
                         ));
                     }
                 }
@@ -1913,135 +1922,15 @@ impl<'a> Printer<'a> {
             // scope and capture the insertion anchor for the `var` line.
             self.push_temp_scope();
             let synth_ctor_hoist_anchor = self.capture_hoist_anchor();
-            // Emit _X_instances.add(this) for private methods/accessors
-            if let Some(ref ws_name) = self.pending_instances_weakset_add.clone() {
-                self.write(ws_name);
-                self.write(".add(this);");
-                self.write_line();
-            }
-            // Private field WeakMap.set inits first (before non-private field inits)
-            for field in &private_fields {
-                if !field.is_static {
-                    self.write(&field.weakmap_name);
-                    self.write(".set(this, ");
-                    if field.has_initializer {
-                        self.emit_expression(field.initializer);
-                    } else {
-                        self.write("void 0");
-                    }
-                    self.write(");");
-                    self.write_line();
-                }
-            }
-            if lower_auto_accessors_to_weakmap {
-                for (storage_name, init_idx) in &constructor_auto_accessor_instance_inits {
-                    self.write(storage_name);
-                    self.write(".set(this, ");
-                    match init_idx {
-                        Some(init) => {
-                            self.with_scoped_static_initializer_context_cleared(|this| {
-                                this.emit_expression(*init);
-                            });
-                        }
-                        None => self.write("void 0"),
-                    }
-                    self.write(");");
-                    self.write_line();
-                }
-            }
-            // Non-private field inits after WeakMap.set calls
-            for (name, init_idx, init_end, leading, trailing) in &field_inits {
-                // Emit leading comments from the original property declaration
-                for comment in leading {
-                    self.write_comment(comment);
-                    self.write_line();
-                }
-                if self.ctx.options.use_define_for_class_fields {
-                    self.write("Object.defineProperty(this, ");
-                    if name.starts_with('[') && name.ends_with(']') {
-                        self.write(&name[1..name.len() - 1]);
-                    } else {
-                        self.emit_string_literal_text(name);
-                    }
-                    self.write(", {");
-                    self.write_line();
-                    self.increase_indent();
-                    self.write("enumerable: true,");
-                    self.write_line();
-                    self.write("configurable: true,");
-                    self.write_line();
-                    self.write("writable: true,");
-                    self.write_line();
-                    self.write("value: ");
-                    if init_idx.is_none() {
-                        self.write("void 0");
-                    } else {
-                        if let Some(init_node) = self.arena.get(*init_idx) {
-                            while self.comment_emit_idx < self.all_comments.len()
-                                && self.all_comments[self.comment_emit_idx].end <= init_node.pos
-                            {
-                                self.comment_emit_idx += 1;
-                            }
-                        }
-                        self.with_scoped_static_initializer_context_cleared(|this| {
-                            this.emit_expression(*init_idx);
-                        });
-                    }
-                    self.write_line();
-                    self.decrease_indent();
-                    self.write("});");
+            self.emit_constructor_prologue(
+                &[],
+                &field_inits,
+                if lower_auto_accessors_to_weakmap {
+                    &constructor_auto_accessor_instance_inits
                 } else {
-                    if name.starts_with('[') {
-                        self.write("this");
-                        self.write(name);
-                    } else {
-                        self.write("this.");
-                        self.write(name);
-                    }
-                    self.write(" = ");
-                    if init_idx.is_none() {
-                        self.write("void 0");
-                    } else {
-                        if let Some(init_node) = self.arena.get(*init_idx) {
-                            while self.comment_emit_idx < self.all_comments.len()
-                                && self.all_comments[self.comment_emit_idx].end <= init_node.pos
-                            {
-                                self.comment_emit_idx += 1;
-                            }
-                        }
-                        let arrow_comment_scan_end =
-                            self.source_text.map_or(*init_end, |text| text.len() as u32);
-                        let arrow_comment_range = self
-                            .rightmost_concise_arrow_deferred_comment_range(
-                                *init_idx,
-                                arrow_comment_scan_end,
-                            );
-                        self.with_scoped_static_initializer_context_cleared(|this| {
-                            if let Some((comment_start, comment_end)) = arrow_comment_range {
-                                this.with_arrow_concise_body_trailing_comments_deferred(
-                                    comment_start,
-                                    comment_end,
-                                    |this| {
-                                        this.emit_expression(*init_idx);
-                                    },
-                                );
-                            } else {
-                                this.emit_expression(*init_idx);
-                            }
-                        });
-                    }
-                    self.write(";");
-                    if !trailing.is_empty() {
-                        for comment in trailing {
-                            self.write_space();
-                            self.write_comment(comment);
-                        }
-                    } else {
-                        self.emit_trailing_comments(*init_end);
-                    }
-                }
-                self.write_line();
-            }
+                    &[]
+                },
+            );
             // Insert any temps hoisted while emitting field initializers (e.g.
             // `_a` for a class expression lowered inside a private-field init, or
             // a `??=` read-cache temp) at the top of this synthesized constructor

--- a/crates/tsz-emitter/src/emitter/declarations/class_members.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class_members.rs
@@ -1238,7 +1238,7 @@ impl<'a> Printer<'a> {
     }
 
     /// Emit parameter property and field initializer assignments (constructor prologue).
-    fn emit_constructor_prologue(
+    pub(in crate::emitter) fn emit_constructor_prologue(
         &mut self,
         param_props: &[String],
         field_inits: &[crate::emitter::core::FieldInit],
@@ -1283,114 +1283,31 @@ impl<'a> Printer<'a> {
             }
             self.write_line();
         }
-        // Emit private field WeakMap.set inits after parameter properties. They
-        // are instance field initializers for ordering purposes.
+        // Emit private and public instance field initializers in source order
+        // after parameter properties. Both are field initializers for ordering
+        // purposes even though private fields lower to `WeakMap.set`.
         let private_inits = self.pending_private_field_constructor_inits.clone();
-        for (weakmap_name, has_initializer, initializer) in &private_inits {
-            self.write(weakmap_name);
-            self.write(".set(this, ");
-            if *has_initializer {
-                self.emit_expression(*initializer);
+        let mut private_idx = 0;
+        let mut public_idx = 0;
+        while private_idx < private_inits.len() || public_idx < field_inits.len() {
+            let next_private_order = private_inits
+                .get(private_idx)
+                .map_or(u32::MAX, |(_, _, _, source_order)| *source_order);
+            let next_public_order = field_inits
+                .get(public_idx)
+                .map_or(u32::MAX, |(_, _, _, _, _, source_order)| *source_order);
+            if next_private_order <= next_public_order {
+                let (weakmap_name, has_initializer, initializer, _) = &private_inits[private_idx];
+                self.emit_private_field_constructor_init(
+                    weakmap_name,
+                    *has_initializer,
+                    *initializer,
+                );
+                private_idx += 1;
             } else {
-                self.write("void 0");
+                self.emit_public_field_constructor_init(&field_inits[public_idx]);
+                public_idx += 1;
             }
-            self.write(");");
-            self.write_line();
-        }
-        for (name, init_idx, init_end, leading_comments, trailing_comments) in field_inits {
-            // Emit leading comments from the original property declaration
-            for comment in leading_comments {
-                self.write_comment(comment);
-                self.write_line();
-            }
-            if self.ctx.options.use_define_for_class_fields {
-                self.write("Object.defineProperty(this, ");
-                if name.starts_with('[') && name.ends_with(']') {
-                    self.write(&name[1..name.len() - 1]);
-                } else {
-                    self.emit_string_literal_text(name);
-                }
-                self.write(", {");
-                self.write_line();
-                self.increase_indent();
-                self.write("enumerable: true,");
-                self.write_line();
-                self.write("configurable: true,");
-                self.write_line();
-                self.write("writable: true,");
-                self.write_line();
-                self.write("value: ");
-                if init_idx.is_none() {
-                    self.write("void 0");
-                } else {
-                    if let Some(init_node) = self.arena.get(*init_idx) {
-                        while self.comment_emit_idx < self.all_comments.len()
-                            && self.all_comments[self.comment_emit_idx].end <= init_node.pos
-                        {
-                            self.comment_emit_idx += 1;
-                        }
-                    }
-                    self.with_scoped_static_initializer_context_cleared(|this| {
-                        this.emit_expression(*init_idx);
-                    });
-                }
-                self.write_line();
-                self.decrease_indent();
-                self.write("});");
-            } else {
-                // Bracket names (e.g., `["constructor"]`) are encoded with `[` prefix
-                if name.starts_with('[') {
-                    self.write("this");
-                    self.write(name);
-                } else {
-                    self.write("this.");
-                    self.write(name);
-                }
-                self.write(" = ");
-                if init_idx.is_none() {
-                    self.write("void 0");
-                } else {
-                    if let Some(init_node) = self.arena.get(*init_idx) {
-                        while self.comment_emit_idx < self.all_comments.len()
-                            && self.all_comments[self.comment_emit_idx].end <= init_node.pos
-                        {
-                            self.comment_emit_idx += 1;
-                        }
-                    }
-                    let arrow_comment_scan_end =
-                        self.source_text.map_or(*init_end, |text| text.len() as u32);
-                    let arrow_comment_range = self.rightmost_concise_arrow_deferred_comment_range(
-                        *init_idx,
-                        arrow_comment_scan_end,
-                    );
-                    self.with_scoped_static_initializer_context_cleared(|this| {
-                        if let Some((comment_start, comment_end)) = arrow_comment_range {
-                            this.with_arrow_concise_body_trailing_comments_deferred(
-                                comment_start,
-                                comment_end,
-                                |this| {
-                                    this.emit_expression(*init_idx);
-                                },
-                            );
-                        } else {
-                            this.emit_expression(*init_idx);
-                        }
-                    });
-                }
-                self.write(";");
-                // Emit trailing comments from the original class field.
-                // If pre-collected (field appeared before constructor in source), use them.
-                // Otherwise fall back to position-based lookup (field after constructor).
-                if !trailing_comments.is_empty() {
-                    for comment in trailing_comments {
-                        self.write_space();
-                        self.write_comment(comment);
-                    }
-                } else {
-                    self.emit_trailing_comments(*init_end);
-                }
-            }
-            self.write_line();
         }
         for (name, init_idx) in auto_accessor_inits {
             self.write(name);
@@ -1402,6 +1319,120 @@ impl<'a> Printer<'a> {
             self.write(");");
             self.write_line();
         }
+    }
+
+    fn emit_private_field_constructor_init(
+        &mut self,
+        weakmap_name: &str,
+        has_initializer: bool,
+        initializer: NodeIndex,
+    ) {
+        self.write(weakmap_name);
+        self.write(".set(this, ");
+        if has_initializer {
+            self.emit_expression(initializer);
+        } else {
+            self.write("void 0");
+        }
+        self.write(");");
+        self.write_line();
+    }
+
+    fn emit_public_field_constructor_init(&mut self, field_init: &crate::emitter::core::FieldInit) {
+        let (name, init_idx, init_end, leading_comments, trailing_comments, _) = field_init;
+        // Emit leading comments from the original property declaration.
+        for comment in leading_comments {
+            self.write_comment(comment);
+            self.write_line();
+        }
+        if self.ctx.options.use_define_for_class_fields {
+            self.write("Object.defineProperty(this, ");
+            if name.starts_with('[') && name.ends_with(']') {
+                self.write(&name[1..name.len() - 1]);
+            } else {
+                self.emit_string_literal_text(name);
+            }
+            self.write(", {");
+            self.write_line();
+            self.increase_indent();
+            self.write("enumerable: true,");
+            self.write_line();
+            self.write("configurable: true,");
+            self.write_line();
+            self.write("writable: true,");
+            self.write_line();
+            self.write("value: ");
+            if init_idx.is_none() {
+                self.write("void 0");
+            } else {
+                if let Some(init_node) = self.arena.get(*init_idx) {
+                    while self.comment_emit_idx < self.all_comments.len()
+                        && self.all_comments[self.comment_emit_idx].end <= init_node.pos
+                    {
+                        self.comment_emit_idx += 1;
+                    }
+                }
+                self.with_scoped_static_initializer_context_cleared(|this| {
+                    this.emit_expression(*init_idx);
+                });
+            }
+            self.write_line();
+            self.decrease_indent();
+            self.write("});");
+        } else {
+            // Bracket names (e.g., `["constructor"]`) are encoded with `[` prefix.
+            if name.starts_with('[') {
+                self.write("this");
+                self.write(name);
+            } else {
+                self.write("this.");
+                self.write(name);
+            }
+            self.write(" = ");
+            if init_idx.is_none() {
+                self.write("void 0");
+            } else {
+                if let Some(init_node) = self.arena.get(*init_idx) {
+                    while self.comment_emit_idx < self.all_comments.len()
+                        && self.all_comments[self.comment_emit_idx].end <= init_node.pos
+                    {
+                        self.comment_emit_idx += 1;
+                    }
+                }
+                let arrow_comment_scan_end =
+                    self.source_text.map_or(*init_end, |text| text.len() as u32);
+                let arrow_comment_range = self.rightmost_concise_arrow_deferred_comment_range(
+                    *init_idx,
+                    arrow_comment_scan_end,
+                );
+                self.with_scoped_static_initializer_context_cleared(|this| {
+                    if let Some((comment_start, comment_end)) = arrow_comment_range {
+                        this.with_arrow_concise_body_trailing_comments_deferred(
+                            comment_start,
+                            comment_end,
+                            |this| {
+                                this.emit_expression(*init_idx);
+                            },
+                        );
+                    } else {
+                        this.emit_expression(*init_idx);
+                    }
+                });
+            }
+            self.write(";");
+            // Emit trailing comments from the original class field. If
+            // pre-collected (field appeared before constructor in source), use
+            // them. Otherwise fall back to position-based lookup.
+            if !trailing_comments.is_empty() {
+                for comment in trailing_comments {
+                    self.write_space();
+                    self.write_comment(comment);
+                }
+            } else {
+                self.emit_trailing_comments(*init_end);
+            }
+        }
+        self.write_line();
     }
 
     pub(in crate::emitter) fn emit_get_accessor(&mut self, node: &Node, accessor_node: NodeIndex) {

--- a/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
@@ -1183,6 +1183,58 @@ fn es2015_constructor_private_destructuring_keeps_prologue_order() {
 }
 
 #[test]
+fn es2015_synthesized_constructor_preserves_public_private_field_order() {
+    let source = "class C {\n    foo = 1;\n    #bar = 2;\n    baz = 3;\n}\n";
+
+    let (parser, root) = parse_test_source(source);
+    let options = PrinterOptions {
+        target: ScriptTarget::ES2015,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert!(
+        output.contains(
+            "constructor() {\n        this.foo = 1;\n        _C_bar.set(this, 2);\n        this.baz = 3;\n    }"
+        ),
+        "Synthesized constructors must preserve source order across public fields and private WeakMap initializers.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es2015_undeclared_private_recovery_does_not_request_helpers() {
+    let source = "class C {\n    #real = 1;\n    m(other: object) {\n        this.#missing = 2;\n        #ghost in other;\n    }\n}\n";
+
+    let (parser, root) = parse_test_source(source);
+    let options = PrinterOptions {
+        target: ScriptTarget::ES2015,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert!(
+        !output.contains("__classPrivateFieldSet") && !output.contains("__classPrivateFieldIn"),
+        "Undeclared private-name recovery must not request private helper declarations.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_C_real = new WeakMap()"),
+        "Declared private fields should still lower to WeakMap storage.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn esnext_legacy_class_fields_hoist_auto_accessors_in_source_order() {
     let source = "// order comment\n\
 class C {\n\

--- a/crates/tsz-emitter/src/lowering/helpers_private_fields.rs
+++ b/crates/tsz-emitter/src/lowering/helpers_private_fields.rs
@@ -157,22 +157,6 @@ impl<'a> LoweringPass<'a> {
         }
     }
 
-    /// Check if a property access expression accesses a private identifier.
-    fn is_private_field_access(&self, node_idx: NodeIndex) -> bool {
-        let Some(node) = self.arena.get(node_idx) else {
-            return false;
-        };
-        if node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
-            return false;
-        }
-        let Some(access) = self.arena.get_access_expr(node) else {
-            return false;
-        };
-        self.arena
-            .get(access.name_or_argument)
-            .is_some_and(|name_n| name_n.kind == SyntaxKind::PrivateIdentifier as u16)
-    }
-
     fn private_field_access_name(&self, node_idx: NodeIndex) -> Option<&str> {
         let node = self.arena.get(node_idx)?;
         if node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
@@ -237,85 +221,6 @@ impl<'a> LoweringPass<'a> {
     ) -> bool {
         self.private_field_access_name(node_idx)
             .is_some_and(|name| private_names.contains(name))
-    }
-
-    fn assignment_pattern_contains_private_field_access(
-        &self,
-        pattern_idx: NodeIndex,
-        needle: NodeIndex,
-    ) -> bool {
-        let pattern_idx = self.unwrap_parens_and_types(pattern_idx);
-        if pattern_idx == needle && self.is_private_field_access(pattern_idx) {
-            return true;
-        }
-
-        let Some(node) = self.arena.get(pattern_idx) else {
-            return false;
-        };
-        match node.kind {
-            k if k == syntax_kind_ext::BINARY_EXPRESSION => {
-                self.arena.get_binary_expr(node).is_some_and(|binary| {
-                    binary.operator_token == SyntaxKind::EqualsToken as u16
-                        && self
-                            .assignment_pattern_contains_private_field_access(binary.left, needle)
-                })
-            }
-            k if k == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
-                || k == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION =>
-            {
-                self.arena.get_literal_expr(node).is_some_and(|literal| {
-                    literal.elements.nodes.iter().any(|&element| {
-                        self.assignment_pattern_contains_private_field_access(element, needle)
-                    })
-                })
-            }
-            k if k == syntax_kind_ext::OBJECT_BINDING_PATTERN
-                || k == syntax_kind_ext::ARRAY_BINDING_PATTERN =>
-            {
-                self.arena.get_binding_pattern(node).is_some_and(|pattern| {
-                    pattern.elements.nodes.iter().any(|&element| {
-                        self.assignment_pattern_contains_private_field_access(element, needle)
-                    })
-                })
-            }
-            k if k == syntax_kind_ext::PROPERTY_ASSIGNMENT => self
-                .arena
-                .get_property_assignment(node)
-                .is_some_and(|prop| {
-                    self.assignment_pattern_contains_private_field_access(prop.initializer, needle)
-                }),
-            k if k == syntax_kind_ext::SPREAD_ELEMENT
-                || k == syntax_kind_ext::SPREAD_ASSIGNMENT =>
-            {
-                self.arena.get_spread(node).is_some_and(|spread| {
-                    self.assignment_pattern_contains_private_field_access(spread.expression, needle)
-                })
-            }
-            _ => false,
-        }
-    }
-
-    fn assignment_pattern_has_private_field_access(&self, pattern_idx: NodeIndex) -> bool {
-        let Some(node) = self.arena.get(pattern_idx) else {
-            return false;
-        };
-        let start = node.pos;
-        let end = node.end;
-        for i in 0..self.arena.len() {
-            let nidx = NodeIndex(i as u32);
-            let Some(candidate) = self.arena.get(nidx) else {
-                continue;
-            };
-            if candidate.pos < start || candidate.end > end {
-                continue;
-            }
-            if self.is_private_field_access(nidx)
-                && self.assignment_pattern_contains_private_field_access(pattern_idx, nidx)
-            {
-                return true;
-            }
-        }
-        false
     }
 
     fn assignment_pattern_contains_declared_private_field_access(
@@ -504,29 +409,33 @@ impl<'a> LoweringPass<'a> {
         &self,
         class_data: &tsz_parser::parser::node::ClassData,
     ) -> bool {
+        let private_names = self.class_private_member_names(class_data);
         for &member_idx in &class_data.members.nodes {
             let Some(member_node) = self.arena.get(member_idx) else {
                 continue;
             };
             if self.ctx.options.legacy_decorators
-                && self.member_decorator_expressions_have_private_field_read(member_node)
+                && self.member_decorator_expressions_have_private_field_read(
+                    member_node,
+                    &private_names,
+                )
             {
                 return true;
             }
             // Static blocks: scan the block itself (its pos..end covers all statements)
             if member_node.kind == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION {
-                if self.subtree_has_private_field_read(member_idx) {
+                if self.subtree_has_private_field_read(member_idx, &private_names) {
                     return true;
                 }
                 continue;
             }
             if let Some(name) = self.get_member_name(member_node)
-                && self.subtree_has_private_field_read(name)
+                && self.subtree_has_private_field_read(name, &private_names)
             {
                 return true;
             }
             if let Some(body) = self.get_member_body(member_node)
-                && self.subtree_has_private_field_read(body)
+                && self.subtree_has_private_field_read(body, &private_names)
             {
                 return true;
             }
@@ -539,29 +448,33 @@ impl<'a> LoweringPass<'a> {
         &self,
         class_data: &tsz_parser::parser::node::ClassData,
     ) -> bool {
+        let private_names = self.class_private_member_names(class_data);
         for &member_idx in &class_data.members.nodes {
             let Some(member_node) = self.arena.get(member_idx) else {
                 continue;
             };
             if self.ctx.options.legacy_decorators
-                && self.member_decorator_expressions_have_private_field_write(member_node)
+                && self.member_decorator_expressions_have_private_field_write(
+                    member_node,
+                    &private_names,
+                )
             {
                 return true;
             }
             // Static blocks: scan the block itself
             if member_node.kind == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION {
-                if self.subtree_has_private_field_write(member_idx) {
+                if self.subtree_has_private_field_write(member_idx, &private_names) {
                     return true;
                 }
                 continue;
             }
             if let Some(name) = self.get_member_name(member_node)
-                && self.subtree_has_private_field_write(name)
+                && self.subtree_has_private_field_write(name, &private_names)
             {
                 return true;
             }
             if let Some(body) = self.get_member_body(member_node)
-                && self.subtree_has_private_field_write(body)
+                && self.subtree_has_private_field_write(body, &private_names)
             {
                 return true;
             }
@@ -574,28 +487,32 @@ impl<'a> LoweringPass<'a> {
         &self,
         class_data: &tsz_parser::parser::node::ClassData,
     ) -> bool {
+        let private_names = self.class_private_member_names(class_data);
         for &member_idx in &class_data.members.nodes {
             let Some(member_node) = self.arena.get(member_idx) else {
                 continue;
             };
             if self.ctx.options.legacy_decorators
-                && self.member_decorator_expressions_have_private_in_expression(member_node)
+                && self.member_decorator_expressions_have_private_in_expression(
+                    member_node,
+                    &private_names,
+                )
             {
                 return true;
             }
             if member_node.kind == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION {
-                if self.subtree_has_private_in_expression(member_idx) {
+                if self.subtree_has_private_in_expression(member_idx, &private_names) {
                     return true;
                 }
                 continue;
             }
             if let Some(name) = self.get_member_name(member_node)
-                && self.subtree_has_private_in_expression(name)
+                && self.subtree_has_private_in_expression(name, &private_names)
             {
                 return true;
             }
             if let Some(body) = self.get_member_body(member_node)
-                && self.subtree_has_private_in_expression(body)
+                && self.subtree_has_private_in_expression(body, &private_names)
             {
                 return true;
             }
@@ -606,27 +523,30 @@ impl<'a> LoweringPass<'a> {
     fn member_decorator_expressions_have_private_field_read(
         &self,
         member_node: &tsz_parser::parser::node::Node,
+        private_names: &rustc_hash::FxHashSet<String>,
     ) -> bool {
         self.member_decorator_expressions_match(member_node, |this, expr| {
-            this.subtree_has_private_field_read(expr)
+            this.subtree_has_private_field_read(expr, private_names)
         })
     }
 
     fn member_decorator_expressions_have_private_field_write(
         &self,
         member_node: &tsz_parser::parser::node::Node,
+        private_names: &rustc_hash::FxHashSet<String>,
     ) -> bool {
         self.member_decorator_expressions_match(member_node, |this, expr| {
-            this.subtree_has_private_field_write(expr)
+            this.subtree_has_private_field_write(expr, private_names)
         })
     }
 
     fn member_decorator_expressions_have_private_in_expression(
         &self,
         member_node: &tsz_parser::parser::node::Node,
+        private_names: &rustc_hash::FxHashSet<String>,
     ) -> bool {
         self.member_decorator_expressions_match(member_node, |this, expr| {
-            this.subtree_has_private_in_expression(expr)
+            this.subtree_has_private_in_expression(expr, private_names)
         })
     }
 
@@ -705,7 +625,11 @@ impl<'a> LoweringPass<'a> {
     }
 
     /// Scan a subtree for `#field in obj` expressions.
-    fn subtree_has_private_in_expression(&self, idx: NodeIndex) -> bool {
+    fn subtree_has_private_in_expression(
+        &self,
+        idx: NodeIndex,
+        private_names: &rustc_hash::FxHashSet<String>,
+    ) -> bool {
         let Some(root) = self.arena.get(idx) else {
             return false;
         };
@@ -724,9 +648,8 @@ impl<'a> LoweringPass<'a> {
                 && let Some(bin) = self.arena.get_binary_expr(n)
                 && bin.operator_token == SyntaxKind::InKeyword as u16
                 && self
-                    .arena
-                    .get(bin.left)
-                    .is_some_and(|l| l.kind == SyntaxKind::PrivateIdentifier as u16)
+                    .private_identifier_name(bin.left)
+                    .is_some_and(|name| private_names.contains(name))
             {
                 return true;
             }
@@ -735,7 +658,11 @@ impl<'a> LoweringPass<'a> {
     }
 
     /// Scan a subtree for expressions that write to private fields.
-    fn subtree_has_private_field_write(&self, idx: NodeIndex) -> bool {
+    fn subtree_has_private_field_write(
+        &self,
+        idx: NodeIndex,
+        private_names: &rustc_hash::FxHashSet<String>,
+    ) -> bool {
         let Some(root) = self.arena.get(idx) else {
             return false;
         };
@@ -761,8 +688,11 @@ impl<'a> LoweringPass<'a> {
                         continue;
                     }
                     let left = self.unwrap_parens_and_types(bin.left);
-                    if self.is_private_field_access(left)
-                        || self.assignment_pattern_has_private_field_access(bin.left)
+                    if self.is_declared_private_field_access(left, private_names)
+                        || self.assignment_pattern_has_declared_private_field_access(
+                            bin.left,
+                            private_names,
+                        )
                     {
                         return true;
                     }
@@ -777,7 +707,7 @@ impl<'a> LoweringPass<'a> {
                         || unary.operator == SyntaxKind::MinusMinusToken as u16
                     {
                         let operand = self.unwrap_parens_and_types(unary.operand);
-                        if self.is_private_field_access(operand) {
+                        if self.is_declared_private_field_access(operand, private_names) {
                             return true;
                         }
                     }
@@ -789,7 +719,11 @@ impl<'a> LoweringPass<'a> {
     }
 
     /// Scan a subtree for expressions that read from private fields.
-    fn subtree_has_private_field_read(&self, idx: NodeIndex) -> bool {
+    fn subtree_has_private_field_read(
+        &self,
+        idx: NodeIndex,
+        private_names: &rustc_hash::FxHashSet<String>,
+    ) -> bool {
         let Some(root) = self.arena.get(idx) else {
             return false;
         };
@@ -804,7 +738,7 @@ impl<'a> LoweringPass<'a> {
             if n.pos < start || n.end > end {
                 continue;
             }
-            if !self.is_private_field_access(nidx) {
+            if !self.is_declared_private_field_access(nidx, private_names) {
                 continue;
             }
             // Check if this access is exclusively a write target (LHS of plain `=`).
@@ -825,7 +759,11 @@ impl<'a> LoweringPass<'a> {
                         // Unwrap parens AND type assertions to find the actual LHS
                         let left = self.unwrap_parens_and_types(bin.left);
                         if left == nidx
-                            || self.assignment_pattern_contains_private_field_access(bin.left, nidx)
+                            || self.assignment_pattern_contains_declared_private_field_access(
+                                bin.left,
+                                nidx,
+                                private_names,
+                            )
                         {
                             is_write_only = true;
                             break;


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Emit / JavaScript parity: private field lowering and helper discovery.

## Invariant
`tsz` emit must preserve TypeScript private-field runtime semantics without adding helpers that `tsc` would not emit. Instance field initialization order follows source order after constructor parameter properties; recovery syntax for undeclared private names must not request private-field helpers for names that are not class-declared; nested class bodies must inherit enclosing class-value aliases when their own class name does not shadow the enclosing class name.

## Structural Rule
- Synthesized ES2015 constructors and existing constructors both route public field initializers and private `WeakMap.set` initializers through the same constructor prologue order, keyed by member source order.
- Private helper discovery counts reads, writes, and `#x in obj` expressions only when `#x` is a private name declared by the containing class.
- When private member extraction creates a class-value alias, direct ES2015 class-body emit and nested ES5 class-expression lowering carry that alias through nested class bodies unless the nested class shadows the same class name.

## Owner Layer
Emitter/lowering only. The patch does not change parser, binder, checker, solver, or diagnostics behavior.

## Adjacent Case Matrix
- Public/private field order: added `es2015_synthesized_constructor_preserves_public_private_field_order` to cover interleaved public fields, private fields, and methods when no constructor exists.
- Existing constructor prologue: reused the shared constructor prologue so parameter properties still run before generated field initialization.
- Helper discovery recovery: added `es2015_undeclared_private_recovery_does_not_request_helpers` with declared `#real`, undeclared `#missing`, and undeclared `#ghost` to avoid name-specific behavior.
- Nested class self-aliases: added `es2015_nested_class_expression_inherits_enclosing_private_self_alias` using `Outer`/`Inner` names to cover enclosing alias inheritance and nested class self-alias preservation separately from the checked-in `C`/`D` baseline.
- Checked-in baselines: `constructorWithParameterPropertiesAndPrivateFields.es2015`, `privateNameAndIndexSignature`, and `privateNameNestedMethodAccess` now pass locally on this branch.

## Scope
- `crates/tsz-emitter/src/emitter/core.rs`: carries source order for pending private field constructor initializers and tracks enclosing class-value alias ancestors.
- `crates/tsz-emitter/src/emitter/core_setup.rs`: initializes the alias ancestor stack.
- `crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs`: records public/private field initializer order, synthesizes constructors through the common prologue path, and preserves enclosing class-value aliases across nested class bodies unless shadowed.
- `crates/tsz-emitter/src/emitter/declarations/class_members.rs`: merges constructor parameter properties, public field initialization, and private field initialization in TypeScript order.
- `crates/tsz-emitter/src/emitter/es5/helpers_async.rs`: passes enclosing alias substitutions into nested ES5 class-expression sub-emitters.
- `crates/tsz-emitter/src/emitter/literals/core.rs`: resolves current and ancestor class-value aliases while emitting identifiers.
- `crates/tsz-emitter/src/lowering/helpers_private_fields.rs`: filters private helper discovery through declared private names.
- `crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs`: adds focused regression coverage for constructor ordering, undeclared private-name helper recovery, and nested alias inheritance.

## Project Corpus Impact
- Row: JavaScript emit conformance.
- Bug family: class/private/accessor/decorator lowering.
- Evidence: `scripts/emit/run.sh --filter=constructorWithParameterPropertiesAndPrivateFields --js-only --verbose --timeout=15000 --json-out=/tmp/constructorWithParameterPropertiesAndPrivateFields-current.json` passed 1/1.
- Evidence: `scripts/emit/run.sh --filter=privateNameAndIndexSignature --js-only --verbose --timeout=15000 --json-out=/tmp/privateNameAndIndexSignature-after-helper.json` passed 1/1.
- Evidence: `scripts/emit/run.sh --filter=privateNameNestedMethodAccess --js-only --verbose --timeout=15000 --json-out=/tmp/privateNameNestedMethodAccess-after-rebase.json` passed 1/1.
- Evidence: `scripts/emit/run.sh --filter=private --js-only --timeout=15000 --json-out=/tmp/studio-c-private-live-20260531-after-nested-alias.json` improved the private JS slice from 293/310 to 295/310.
- Evidence: `scripts/emit/run.sh --filter=privateNamesAndIndexedAccess --js-only --verbose --timeout=15000 --json-out=/tmp/privateNamesAndIndexedAccess-after.json` still fails on an independent invalid private identifier indexed-access recovery issue.

## Verification
- `cargo check -p tsz-emitter`
- `cargo nextest run -p tsz-emitter es2015_synthesized_constructor_preserves_public_private_field_order`
- `cargo nextest run -p tsz-emitter es2015_undeclared_private_recovery_does_not_request_helpers`
- `cargo nextest run -p tsz-emitter es2015_nested_class_expression_inherits_enclosing_private_self_alias`
- `scripts/emit/run.sh --filter=constructorWithParameterPropertiesAndPrivateFields --js-only --verbose --timeout=15000 --json-out=/tmp/constructorWithParameterPropertiesAndPrivateFields-current.json`
- `scripts/emit/run.sh --filter=privateNameAndIndexSignature --js-only --verbose --timeout=15000 --json-out=/tmp/privateNameAndIndexSignature-after-helper.json`
- `scripts/emit/run.sh --filter=privateNameNestedMethodAccess --js-only --verbose --timeout=15000 --json-out=/tmp/privateNameNestedMethodAccess-after-rebase.json`
- `scripts/emit/run.sh --filter=private --js-only --timeout=15000 --json-out=/tmp/studio-c-private-live-20260531-after-nested-alias.json` (expected nonzero; 295/310 private JS slice)
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

## Coordination Notes
- Rebased on `origin/main` at `bd7f88480c` and force-pushed with lease.
- The PR is intentionally ready for CI. Do not add `merge-queue` until required PR-head checks are green for head `7514350718`.
- AgentName: Studio-C
