### PR TITLE
fix(emit): emit __read for empty array binding declarations under downlevelIteration

### DIFF
--- a/crates/tsz-emitter/src/emitter/es5/bindings.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings.rs
@@ -87,9 +87,11 @@ impl<'a> Printer<'a> {
                 }
                 first = false;
                 self.write(&temp_name);
-                let is_empty = self.binding_pattern_is_empty(decl.name);
-                let downlevel_array_binding = !is_empty
-                    && self.ctx.options.downlevel_iteration
+                // An array binding pattern in a variable declaration runs the
+                // iterator protocol under downlevelIteration even when empty:
+                // `var [];` emits `_a = __read(void 0, 0)`. (Empty *object*
+                // patterns just assign `void 0`.)
+                let downlevel_array_binding = self.ctx.options.downlevel_iteration
                     && self
                         .arena
                         .get(decl.name)
@@ -748,14 +750,19 @@ impl<'a> Printer<'a> {
             return;
         };
 
-        // Empty patterns — zero bindings, no rest — skip __read entirely.
-        // When a pattern has nothing to extract, tsc assigns the initializer
-        // directly to a temp (`_a = x`) regardless of downlevelIteration; calling
-        // `__read(x, 0)` to trigger the iterator protocol is incorrect for this case.
+        // Empty patterns assign the initializer directly to a temp (`_a = x`)
+        // instead of destructuring, because there is nothing to extract.
+        //
+        // The one exception is an empty *array* binding pattern in a variable
+        // declaration under downlevelIteration: tsc still runs the iterator
+        // protocol on the initializer, emitting `_a = __read(x, 0)`. (This is a
+        // declaration-only quirk; empty array *assignment* patterns like
+        // `([] = x)` are handled separately and assign `x` directly.) Empty
+        // object patterns never call `__read`.
         let is_empty = self.binding_pattern_is_empty(decl.name);
         let needs_downlevel_read = self.ctx.options.downlevel_iteration
             && pattern_node.kind == syntax_kind_ext::ARRAY_BINDING_PATTERN;
-        if is_empty {
+        if is_empty && !needs_downlevel_read {
             self.emit_es5_destructuring_fallback(pattern_node, decl.initializer, first, true);
             return;
         }

--- a/crates/tsz-emitter/src/emitter/es5/bindings_patterns.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings_patterns.rs
@@ -66,10 +66,27 @@ impl<'a> Printer<'a> {
             self.write(", ");
         }
 
+        // A nested *empty array* binding pattern in a variable declaration still
+        // runs the iterator protocol on its source under downlevelIteration, so
+        // tsc extracts `__read(source, 0)`. A nested empty *object* pattern reads
+        // the source property directly. (Empty array *assignment* patterns are a
+        // separate path and never call `__read`.)
+        let is_empty_array = self
+            .arena
+            .get(elem.name)
+            .is_some_and(|node| node.kind == syntax_kind_ext::ARRAY_BINDING_PATTERN);
+
         let value_name = self.get_temp_var_name();
         self.write(&value_name);
         self.write(" = ");
-        self.emit_assignment_target_es5_with_computed(key_idx, temp_name, computed_key_temp);
+        if is_empty_array && self.ctx.options.downlevel_iteration && elem.initializer.is_none() {
+            self.write_helper("__read");
+            self.write("(");
+            self.emit_assignment_target_es5_with_computed(key_idx, temp_name, computed_key_temp);
+            self.write(", 0)");
+        } else {
+            self.emit_assignment_target_es5_with_computed(key_idx, temp_name, computed_key_temp);
+        }
 
         if elem.initializer.is_some() {
             let defaulted_name = self.get_temp_var_name();
@@ -86,7 +103,14 @@ impl<'a> Printer<'a> {
             self.write(", ");
             self.write(&empty_name);
             self.write(" = ");
-            self.write(&defaulted_name);
+            if is_empty_array && self.ctx.options.downlevel_iteration {
+                self.write_helper("__read");
+                self.write("(");
+                self.write(&defaulted_name);
+                self.write(", 0)");
+            } else {
+                self.write(&defaulted_name);
+            }
         }
     }
 

--- a/crates/tsz-emitter/src/lowering/visit_children.rs
+++ b/crates/tsz-emitter/src/lowering/visit_children.rs
@@ -61,25 +61,22 @@ impl<'a> LoweringPass<'a> {
                             TransformDirective::ES5VariableDeclarationList { decl_list: idx },
                         );
 
+                        // Under downlevelIteration, any *array* binding pattern in
+                        // a variable declaration runs the iterator protocol and
+                        // emits `__read`, even when the pattern is empty
+                        // (`var [];` → `__read(void 0, 0)`, `var [] = x;` →
+                        // `__read(x, 0)`). Object binding patterns never read.
                         let need_downlevel_read = self.ctx.options.downlevel_iteration
                             && decl_list.declarations.nodes.iter().any(|&decl_idx| {
-                                if let Some(decl_node) = self.arena.get(decl_idx) {
-                                    if let Some(decl) =
+                                self.arena
+                                    .get(decl_idx)
+                                    .and_then(|decl_node| {
                                         self.arena.get_variable_declaration(decl_node)
-                                    {
-                                        self.arena.get(decl.name).is_some_and(|name_node| {
-                                            name_node.kind == syntax_kind_ext::ARRAY_BINDING_PATTERN
-                                                && self
-                                                    .arena
-                                                    .get_binding_pattern(name_node)
-                                                    .is_some_and(|p| !p.elements.nodes.is_empty())
-                                        })
-                                    } else {
-                                        false
-                                    }
-                                } else {
-                                    false
-                                }
+                                    })
+                                    .and_then(|decl| self.arena.get(decl.name))
+                                    .is_some_and(|name_node| {
+                                        name_node.kind == syntax_kind_ext::ARRAY_BINDING_PATTERN
+                                    })
                             });
 
                         if need_downlevel_read {

--- a/crates/tsz-emitter/tests/destructuring_downlevel_iteration_read_tests.rs
+++ b/crates/tsz-emitter/tests/destructuring_downlevel_iteration_read_tests.rs
@@ -92,7 +92,7 @@ fn empty_assignment_patterns_commonjs_do_not_schedule_read_helpers() {
 }
 
 #[test]
-fn empty_array_binding_patterns_without_initializers_skip_read_helpers() {
+fn empty_array_binding_declarations_without_initializers_read_void_0() {
     let output = emit_es5_downlevel_iteration(
         "(function () {\n\
              var [];\n\
@@ -101,16 +101,18 @@ fn empty_array_binding_patterns_without_initializers_skip_read_helpers() {
          })();\n",
     );
 
-    // Empty array binding patterns have nothing to extract, so tsc assigns the
-    // initializer directly to a temp without invoking the iterator protocol.
+    // An *array* binding pattern in a variable declaration runs the iterator
+    // protocol under downlevelIteration even when empty: tsc emits
+    // `_a = __read(void 0, 0)` for `var [];`. (Empty *object* patterns assign
+    // `void 0` directly; empty array *assignment* patterns assign directly too.)
     assert!(
-        !output.contains("__read("),
-        "Empty array binding patterns must not schedule `__read` — no elements to read.\nOutput:\n{output}"
+        output.contains("var __read"),
+        "Empty array binding declarations must schedule the `__read` helper.\nOutput:\n{output}"
     );
     assert_eq!(
-        output.matches("void 0").count(),
+        output.matches("__read(void 0, 0)").count(),
         3,
-        "Each empty array binding pattern should emit a direct `void 0` assignment.\nOutput:\n{output}"
+        "Each empty array binding declaration without an initializer should read `void 0`.\nOutput:\n{output}"
     );
 }
 
@@ -162,7 +164,7 @@ fn for_of_sequential_empty_bindings_allocate_return_temps_before_body_temps() {
 }
 
 #[test]
-fn empty_binding_declarations_evaluate_rhs_without_reading_empty_arrays() {
+fn empty_array_binding_declarations_read_rhs_but_empty_objects_assign_directly() {
     let output = emit_es5_downlevel_iteration(
         "(function () {\n\
              var a: any;\n\
@@ -171,24 +173,39 @@ fn empty_binding_declarations_evaluate_rhs_without_reading_empty_arrays() {
          })();\n",
     );
 
-    // Empty patterns — both top-level and nested — must assign the source directly
-    // to a temp without calling `__read`. There are no elements to extract, so
-    // the iterator protocol adds no value.
+    // In a variable declaration under downlevelIteration, an empty *array*
+    // binding pattern still runs the iterator protocol (`__read(source, 0)`),
+    // while an empty *object* pattern assigns the source directly. This holds
+    // at the top level and for nested object properties.
     assert!(
-        output.contains("var _a = a, _b = a;"),
-        "Sibling empty object/array bindings should evaluate the same RHS with direct assignment.\nOutput:\n{output}"
+        output.contains("var _a = a, _b = __read(a, 0);"),
+        "Empty object binding assigns directly; sibling empty array binding reads via `__read`.\nOutput:\n{output}"
     );
     assert!(
-        output.contains("var _c = a.p1, _d = a.p2;"),
-        "Nested empty array bindings should copy the selected property directly, not through `__read`.\nOutput:\n{output}"
+        output.contains("var _c = a.p1, _d = __read(a.p2, 0);"),
+        "Nested empty object property assigns directly; nested empty array property reads via `__read`.\nOutput:\n{output}"
     );
     assert!(
-        !output.contains("__read("),
-        "Empty binding declarations must not emit any `__read` calls.\nOutput:\n{output}"
+        output.contains("var __read"),
+        "Empty array binding declarations must schedule the `__read` helper.\nOutput:\n{output}"
     );
+}
+
+#[test]
+fn nested_empty_array_binding_read_rule_is_not_keyed_on_property_names() {
+    // Same structural rule with different property spellings: the empty array
+    // property reads via `__read`, the empty object property does not — proving
+    // the behavior is keyed on pattern shape, not on `p1`/`p2`.
+    let output = emit_es5_downlevel_iteration(
+        "(function () {\n\
+             var a: any;\n\
+             var { alpha: {}, beta: [] } = a;\n\
+         })();\n",
+    );
+
     assert!(
-        !output.contains("a_b ="),
-        "Empty binding declaration temps must stay comma-separated.\nOutput:\n{output}"
+        output.contains("var _a = a.alpha, _b = __read(a.beta, 0);"),
+        "Nested empty array property reads via `__read` regardless of property name.\nOutput:\n{output}"
     );
 }
 


### PR DESCRIPTION
AgentName: opus48-emit100

## Track
Emit → 100% (JavaScript emit parity). ES5 downlevel destructuring.

## Invariant
An **array** binding pattern in a variable **declaration** runs the iterator
protocol under `downlevelIteration` and emits `__read(source, 0)` **even when
the pattern is empty** (`var [];` → `__read(void 0, 0)`, `var [] = x;` →
`__read(x, 0)`). Empty **object** patterns assign the source directly and never
call `__read`; empty array **assignment** patterns (`([] = x)`) are a separate
path that also assigns directly. PR #11790 over-generalized "empty array
patterns skip `__read`" onto the declaration path; this restores tsc parity
there. As a structural side effect, marking `__read` at its true first-use point
restores the correct helper emission order (`__read` precedes `__values`).

## Scope
Emitter (OUTPUT layer) only. No checker/solver semantic changes, no output
surgery (uses the `write_helper` API + helper scheduling, never string rewrites).
- `crates/tsz-emitter/src/emitter/es5/bindings.rs` — declaration paths emit the
  downlevel array read for empty patterns; object patterns unchanged.
- `crates/tsz-emitter/src/emitter/es5/bindings_patterns.rs` — nested empty
  *array* pattern reads `__read(source, 0)`; nested empty *object* reads directly.
- `crates/tsz-emitter/src/lowering/visit_children.rs` — helper scheduling marks
  `__read` for any array-binding-pattern declaration under downlevel (matches the
  emit paths); also simplifies a nested `if let` pyramid into an `and_then` chain.
- `crates/tsz-emitter/tests/destructuring_downlevel_iteration_read_tests.rs` —
  rewrote two stale PR-#11790 anti-tests to assert tsc-correct behavior (not
  suppress), and added a renamed-property (`alpha`/`beta`) variant proving the
  rule is keyed on pattern **shape**, not property names (§25).

## Project Corpus Impact
- Row: n/a — TypeScript conformance emit fixture fix, not a project-corpus benchmark row.
- Bug family: ES5 empty-array-binding-pattern `__read` under `downlevelIteration` (helper ordering).
- Evidence: local `scripts/emit/run.sh --js-only` Failed **71 → 69** (−2, zero new failures); `--dts-only` unchanged at 25; `cargo nextest run -p tsz-emitter` 439/439; clippy clean.

## Verification
- `emptyVariableDeclarationBindingPatterns01_ES5iterable(target=es5)` — PASS
- `emptyVariableDeclarationBindingPatterns02_ES5iterable(target=es5)` — PASS
- Full `--js-only`: 71 → 69 fails, only delta is the two fixed tests, no new failures.
- `--dts-only`: 25 (unchanged). `cargo nextest -p tsz-emitter`: 439/439. clippy: clean.
- Ready CI runs conformance/emit/fourslash/WASM as the real gate (this partially
  reverts #11790's declaration-path behavior; conformance-aggregate confirms no regression).

## Coordination Notes
- Re-grounded the emit-100 failing set first (71 JS / 25 DTS at main 44508c3792);
  the previously-planned for-await-temp item was already fixed by a sibling, so it
  was dropped. This PR is the contained empty-binding win from that re-grounding.
- Does NOT fix `sourceMapValidationDestructuringForArrayBindingPatternDefaultValues2`
  — that is a separate, pre-existing block-scoped `let [...]` for-initializer temp
  **numbering/allocation-order** divergence (verified on the pre-change binary),
  deliberately left out of scope to keep this fix narrow.
- AgentName: opus48-emit100. Reviews welcome.
