### PR TITLE
fix(emit): preserve private aliases in nested classes

### DIFF
--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -3,6 +3,7 @@ use crate::context::plan::EmitPlan;
 use crate::context::transform::{TransformContext, TransformDirective};
 use crate::enums::evaluator::EnumValue;
 use crate::output::source_writer::{LineMap, SourcePosition, SourceWriter};
+use crate::transforms::ClassES5Emitter;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -963,6 +964,32 @@ pub struct Printer<'a> {
 }
 
 impl<'a> Printer<'a> {
+    pub(in crate::emitter) fn configure_nested_es5_class_aliases(
+        &self,
+        es5_emitter: &mut ClassES5Emitter<'a>,
+    ) {
+        if let Some((_, alias)) = &self.scoped_class_expression_self_alias {
+            es5_emitter.set_outer_reserved_for_generator_state(vec![alias.as_ref().to_string()]);
+        }
+
+        let mut outer_rename_map = self.ctx.block_scope_state.visible_outer_rename_map();
+        for (class_name, class_alias) in &self.scoped_class_expression_self_alias_ancestors {
+            outer_rename_map.insert(
+                class_name.as_ref().to_string(),
+                class_alias.as_ref().to_string(),
+            );
+        }
+        if let Some((class_name, class_alias)) = &self.scoped_class_expression_self_alias {
+            outer_rename_map.insert(
+                class_name.as_ref().to_string(),
+                class_alias.as_ref().to_string(),
+            );
+        }
+        if !outer_rename_map.is_empty() {
+            es5_emitter.set_outer_rename_map(outer_rename_map);
+        }
+    }
+
     /// Emit a node.
     pub(in crate::emitter) fn emit_node(&mut self, node: &Node, idx: NodeIndex) {
         // Recursion depth check to prevent infinite loops

--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -945,6 +945,9 @@ pub struct Printer<'a> {
     /// Temporary alias for named class expressions that are wrapped in a comma
     /// expression, e.g. `(_a = class Foo { m() { return _a; } }, _a.x = 1, _a)`.
     pub(crate) scoped_class_expression_self_alias: Option<(Arc<str>, Arc<str>)>,
+    /// Enclosing class-value aliases still visible inside nested class bodies
+    /// whose names do not shadow the outer class binding.
+    pub(crate) scoped_class_expression_self_alias_ancestors: Vec<(Arc<str>, Arc<str>)>,
 
     /// Named-evaluation context for the next TC39-decorated anonymous class
     /// expression. The boolean is true when the name is a runtime expression

--- a/crates/tsz-emitter/src/emitter/core_setup.rs
+++ b/crates/tsz-emitter/src/emitter/core_setup.rs
@@ -410,6 +410,7 @@ impl<'a> Printer<'a> {
             scoped_static_super_index_value_access: false,
             scoped_static_super_assignment_target: false,
             scoped_class_expression_self_alias: None,
+            scoped_class_expression_self_alias_ancestors: Vec::new(),
             pending_tc39_class_expression_name: None,
             es5_class_expression_extends_this_captured: false,
             tagged_template_var_map: FxHashMap::default(),

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -2017,6 +2017,19 @@ impl<'a> Printer<'a> {
         let mut field_init_comment_idx = 0usize;
         let prev_scoped_class_expression_self_alias =
             self.scoped_class_expression_self_alias.take();
+        let scoped_class_expression_self_alias_ancestor_len =
+            self.scoped_class_expression_self_alias_ancestors.len();
+        if let Some((prev_class_name, prev_class_alias)) =
+            prev_scoped_class_expression_self_alias.clone()
+        {
+            let shadows_prev_alias = class_name_is_real
+                && !class_name.is_empty()
+                && class_name == prev_class_name.as_ref();
+            if !shadows_prev_alias {
+                self.scoped_class_expression_self_alias_ancestors
+                    .push((prev_class_name, prev_class_alias));
+            }
+        }
         if let Some(alias) = assignment_alias {
             if class_name_is_real && !class_name.is_empty() && class_name != alias {
                 self.scoped_class_expression_self_alias = Some((
@@ -2029,6 +2042,13 @@ impl<'a> Printer<'a> {
                 self.scoped_class_expression_self_alias = Some((
                     Arc::<str>::from(class_name.as_str()),
                     Arc::<str>::from(temp.as_str()),
+                ));
+            }
+        } else if let Some(alias) = class_value_alias.as_ref() {
+            if class_name_is_real && !class_name.is_empty() && class_name != *alias {
+                self.scoped_class_expression_self_alias = Some((
+                    Arc::<str>::from(class_name.as_str()),
+                    Arc::<str>::from(alias.as_str()),
                 ));
             }
         } else if let Some((static_class_name, static_class_alias)) =
@@ -2614,6 +2634,8 @@ impl<'a> Printer<'a> {
                 }
             }
         }
+        self.scoped_class_expression_self_alias_ancestors
+            .truncate(scoped_class_expression_self_alias_ancestor_len);
         self.scoped_class_expression_self_alias = prev_scoped_class_expression_self_alias;
 
         if !emitted_any_member && let Some(text) = self.source_text {

--- a/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
@@ -1392,6 +1392,22 @@ impl<'a> Printer<'a> {
         if let Some((_, alias)) = &self.scoped_class_expression_self_alias {
             es5_emitter.set_outer_reserved_for_generator_state(vec![alias.as_ref().to_string()]);
         }
+        let mut outer_rename_map = self.ctx.block_scope_state.visible_outer_rename_map();
+        for (class_name, class_alias) in &self.scoped_class_expression_self_alias_ancestors {
+            outer_rename_map.insert(
+                class_name.as_ref().to_string(),
+                class_alias.as_ref().to_string(),
+            );
+        }
+        if let Some((class_name, class_alias)) = &self.scoped_class_expression_self_alias {
+            outer_rename_map.insert(
+                class_name.as_ref().to_string(),
+                class_alias.as_ref().to_string(),
+            );
+        }
+        if !outer_rename_map.is_empty() {
+            es5_emitter.set_outer_rename_map(outer_rename_map);
+        }
         if self.es5_class_expression_extends_this_captured {
             es5_emitter.set_extends_this_captured(true);
         }

--- a/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
@@ -1389,25 +1389,7 @@ impl<'a> Printer<'a> {
             es5_emitter.set_tslib_import_binding(self.commonjs_tslib_import_binding.clone());
         }
         es5_emitter.set_use_define_for_class_fields(self.ctx.options.use_define_for_class_fields);
-        if let Some((_, alias)) = &self.scoped_class_expression_self_alias {
-            es5_emitter.set_outer_reserved_for_generator_state(vec![alias.as_ref().to_string()]);
-        }
-        let mut outer_rename_map = self.ctx.block_scope_state.visible_outer_rename_map();
-        for (class_name, class_alias) in &self.scoped_class_expression_self_alias_ancestors {
-            outer_rename_map.insert(
-                class_name.as_ref().to_string(),
-                class_alias.as_ref().to_string(),
-            );
-        }
-        if let Some((class_name, class_alias)) = &self.scoped_class_expression_self_alias {
-            outer_rename_map.insert(
-                class_name.as_ref().to_string(),
-                class_alias.as_ref().to_string(),
-            );
-        }
-        if !outer_rename_map.is_empty() {
-            es5_emitter.set_outer_rename_map(outer_rename_map);
-        }
+        self.configure_nested_es5_class_aliases(&mut es5_emitter);
         if self.es5_class_expression_extends_this_captured {
             es5_emitter.set_extends_this_captured(true);
         }

--- a/crates/tsz-emitter/src/emitter/literals/core.rs
+++ b/crates/tsz-emitter/src/emitter/literals/core.rs
@@ -1,4 +1,5 @@
 use std::fmt::Write;
+use std::sync::Arc;
 
 use crate::context::transform::IdentifierId;
 use crate::emitter::Printer;
@@ -40,6 +41,26 @@ impl<'a> Printer<'a> {
                 self.writer.write(class_alias.as_ref());
             }
             return;
+        }
+        if !self.suppress_ns_qualification && self.private_static_class_alias_shadow_depth == 0 {
+            let ancestor_alias = self
+                .scoped_class_expression_self_alias_ancestors
+                .iter()
+                .rev()
+                .find(|(class_name, _)| original_text == class_name.as_ref())
+                .map(|(_, class_alias)| Arc::clone(class_alias));
+            if let Some(class_alias) = ancestor_alias {
+                if let Some(source_pos) = self.take_pending_source_pos() {
+                    self.writer.write_node_with_name(
+                        class_alias.as_ref(),
+                        source_pos,
+                        original_text,
+                    );
+                } else {
+                    self.writer.write(class_alias.as_ref());
+                }
+                return;
+            }
         }
 
         // tsc preserves unicode escape sequences in identifiers verbatim.

--- a/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
@@ -1272,6 +1272,35 @@ fn es5_commonjs_exported_class_private_storage_hoists_before_es_module_marker() 
 }
 
 #[test]
+fn es2015_nested_class_expression_inherits_enclosing_private_self_alias() {
+    let source = "class Outer {\n    #value = 1;\n    #method() { return new Outer().#value; }\n    make() {\n        return class Inner {\n            #own() {}\n            read() {\n                new Outer().#value;\n                new Inner().#own;\n            }\n        };\n    }\n}\n";
+
+    let (parser, root) = parse_test_source(source);
+    let options = PrinterOptions {
+        target: ScriptTarget::ES2015,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert!(
+        output.contains(
+            "read() {\n                    __classPrivateFieldGet(new _a(), _Outer_value, \"f\");"
+        ),
+        "Nested class-expression bodies should rewrite enclosing class self-references through the private class-value alias.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("__classPrivateFieldGet(new _b(), _Inner_instances, \"m\", _Inner_own);"),
+        "Nested class self-references should still use the nested class expression alias.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn esnext_legacy_class_fields_hoist_auto_accessors_in_source_order() {
     let source = "// order comment\n\
 class C {\n\


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Emit / JavaScript parity: private field lowering.

## Invariant
When private member extraction creates a class-value alias for an enclosing class, `tsc` preserves that alias for references inside nested class bodies unless the nested class shadows the same class name; this PR makes tsz preserve the same alias through direct ES2015 class-body emit and nested ES5 class-expression lowering.

## Structural Rule
Class-value alias substitution is a lexical emit fact. Nested class bodies inherit enclosing aliases when their class name does not shadow the alias source name, and their own class self-alias remains the innermost match.

## Owner Layer
Emitter only. The change updates identifier emission and class body alias scope tracking; it does not add parser, checker, solver, or semantic validation behavior.

## Adjacent Case Matrix
- Checked-in witness: `privateNameNestedMethodAccess` now emits `new _a()` for `new C()` references inside nested class `D` while preserving `new _b()` for `D` self-access.
- Added unit witness: `es2015_nested_class_expression_inherits_enclosing_private_self_alias` uses `Outer`/`Inner` names so the rule is not tied to the checked-in `C`/`D` spelling.
- ES5 class-expression lowering receives the same inherited alias map so class-expression sub-emitters do not drop the enclosing alias boundary.
- Shadow behavior: alias ancestors are not installed when a nested class declares the same class name as the enclosing alias source.

## Scope
- `crates/tsz-emitter/src/emitter/core.rs`: tracks and configures enclosing class-value alias ancestors for nested emitters.
- `crates/tsz-emitter/src/emitter/core_setup.rs`: initializes the alias ancestor stack.
- `crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs`: preserves class-value alias ancestors across nested class bodies unless shadowed.
- `crates/tsz-emitter/src/emitter/es5/helpers_async.rs`: delegates nested ES5 class alias setup while staying under the file-size ratchet.
- `crates/tsz-emitter/src/emitter/literals/core.rs`: resolves current and ancestor class-value aliases while emitting identifiers.
- `crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs`: adds focused regression coverage for nested alias inheritance.

## Project Corpus Impact
- Row: JavaScript emit conformance.
- Bug family: class/private/accessor/decorator lowering.
- Evidence: `scripts/emit/run.sh --filter=privateNameNestedMethodAccess --js-only --verbose --timeout=15000 --json-out=/tmp/privateNameNestedMethodAccess-ratchet-fix.json` passed 1/1.
- Evidence: Earlier on the same patch before the final rebase, `scripts/emit/run.sh --filter=private --js-only --timeout=15000 --json-out=/tmp/studio-c-private-live-20260531-after-nested-alias.json` improved the private JS slice from 294/310 to 295/310.

## Verification
- `cargo fmt --all --check`
- `cargo check -p tsz-emitter`
- `cargo nextest run -p tsz-emitter es2015_nested_class_expression_inherits_enclosing_private_self_alias`
- `scripts/emit/run.sh --filter=privateNameNestedMethodAccess --js-only --verbose --timeout=15000 --json-out=/tmp/privateNameNestedMethodAccess-ratchet-fix.json`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py` now reports only the unrelated checker file `crates/tsz-checker/src/classes/class_checker_compat.rs:2006`; the owned emitter file `crates/tsz-emitter/src/emitter/es5/helpers_async.rs` is 2261 lines under its 2263 ratchet.

## Coordination Notes
- AgentName: Studio-C
- Follow-up split from #11849 because #11849 merged while this nested-alias fix was being prepared.
- Commit `411fd11e1f` moves nested ES5 class alias setup into `Printer::configure_nested_es5_class_aliases`, preserving behavior while clearing the owned emitter size ratchet.
- PR-head checks reran after the push; do not add `merge-queue` until exact-head checks are green.