### PR TITLE
fix(parser): recover template-literal object-literal property as tagged-template tail (matches tsc)

### DIFF
--- a/crates/tsz-parser/src/parser/speculation.rs
+++ b/crates/tsz-parser/src/parser/speculation.rs
@@ -34,6 +34,7 @@ pub(crate) struct ParserCheckpoint {
     import_attribute_tail_recovered: bool,
     suppress_object_literal_comma_once: bool,
     abort_object_literal_recovery_once: bool,
+    recovered_template_literal_property_in_object: bool,
     suppress_next_missing_close_paren_error_once: bool,
     saw_arrow_parameter_recovery: bool,
 }
@@ -58,6 +59,8 @@ impl ParserState {
             import_attribute_tail_recovered: self.import_attribute_tail_recovered,
             suppress_object_literal_comma_once: self.suppress_object_literal_comma_once,
             abort_object_literal_recovery_once: self.abort_object_literal_recovery_once,
+            recovered_template_literal_property_in_object: self
+                .recovered_template_literal_property_in_object,
             suppress_next_missing_close_paren_error_once: self
                 .suppress_next_missing_close_paren_error_once,
             saw_arrow_parameter_recovery: self.saw_arrow_parameter_recovery,
@@ -81,6 +84,7 @@ impl ParserState {
             import_attribute_tail_recovered,
             suppress_object_literal_comma_once,
             abort_object_literal_recovery_once,
+            recovered_template_literal_property_in_object,
             suppress_next_missing_close_paren_error_once,
             saw_arrow_parameter_recovery,
         } = checkpoint;
@@ -99,6 +103,8 @@ impl ParserState {
         self.import_attribute_tail_recovered = import_attribute_tail_recovered;
         self.suppress_object_literal_comma_once = suppress_object_literal_comma_once;
         self.abort_object_literal_recovery_once = abort_object_literal_recovery_once;
+        self.recovered_template_literal_property_in_object =
+            recovered_template_literal_property_in_object;
         self.suppress_next_missing_close_paren_error_once =
             suppress_next_missing_close_paren_error_once;
         self.saw_arrow_parameter_recovery = saw_arrow_parameter_recovery;

--- a/crates/tsz-parser/src/parser/state.rs
+++ b/crates/tsz-parser/src/parser/state.rs
@@ -227,6 +227,12 @@ pub struct ParserState {
     /// appear. Abort the object-literal member list so the return-token tail is
     /// recovered as ordinary statements.
     pub(crate) abort_object_literal_recovery_once: bool,
+    /// An object literal aborted because a template literal appeared where a
+    /// property name was expected (e.g. `{ \`b\`: 321 }`). The object closes at
+    /// the template, the template becomes a tagged-template tail, and the
+    /// variable-declaration-list recovery should treat a following `:` as a
+    /// missing comma between declarators rather than a type annotation.
+    pub(crate) recovered_template_literal_property_in_object: bool,
     /// Recovery already reported a missing `)` at a later synchronized position,
     /// so the immediate caller should suppress its fallback `parse_expected(')')`.
     pub(crate) suppress_next_missing_close_paren_error_once: bool,
@@ -388,6 +394,7 @@ impl ParserState {
             import_attribute_tail_recovered: false,
             suppress_object_literal_comma_once: false,
             abort_object_literal_recovery_once: false,
+            recovered_template_literal_property_in_object: false,
             suppress_next_missing_close_paren_error_once: false,
             suppress_next_missing_class_close_brace_error_once: false,
             non_block_close_brace_statement_errors_remaining: 0,
@@ -442,6 +449,7 @@ impl ParserState {
         self.import_attribute_tail_recovered = false;
         self.suppress_object_literal_comma_once = false;
         self.abort_object_literal_recovery_once = false;
+        self.recovered_template_literal_property_in_object = false;
         self.suppress_next_missing_close_paren_error_once = false;
         self.suppress_next_missing_class_close_brace_error_once = false;
         self.non_block_close_brace_statement_errors_remaining = 0;

--- a/crates/tsz-parser/src/parser/state.rs
+++ b/crates/tsz-parser/src/parser/state.rs
@@ -228,10 +228,11 @@ pub struct ParserState {
     /// recovered as ordinary statements.
     pub(crate) abort_object_literal_recovery_once: bool,
     /// An object literal aborted because a template literal appeared where a
-    /// property name was expected (e.g. `{ \`b\`: 321 }`). The object closes at
-    /// the template, the template becomes a tagged-template tail, and the
-    /// variable-declaration-list recovery should treat a following `:` as a
-    /// missing comma between declarators rather than a type annotation.
+    /// property name was expected (a template literal used as a key). The
+    /// object closes at the template, the template becomes a tagged-template
+    /// tail, and the variable-declaration-list recovery should treat a
+    /// following `:` as a missing comma between declarators rather than a type
+    /// annotation.
     pub(crate) recovered_template_literal_property_in_object: bool,
     /// Recovery already reported a missing `)` at a later synchronized position,
     /// so the immediate caller should suppress its fallback `parse_expected(')')`.

--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -1845,6 +1845,11 @@ impl ParserState {
                 diagnostic_codes::PROPERTY_ASSIGNMENT_EXPECTED,
             );
             self.abort_object_literal_recovery_once = true;
+            // Signal the variable-declaration-list recovery that a `:` after
+            // this object-literal initializer is a misplaced separator, not a
+            // type annotation, so a trailing `\`tpl\`: value` recovers as a
+            // tagged template plus a separate statement (matching tsc).
+            self.recovered_template_literal_property_in_object = true;
             return NodeIndex::NONE;
         }
 

--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -1829,69 +1829,23 @@ impl ParserState {
         if self.is_token(SyntaxKind::NoSubstitutionTemplateLiteral)
             || self.is_token(SyntaxKind::TemplateHead)
         {
+            // A template literal cannot be a property name. tsc's
+            // `parsePropertyName` does not accept template literals, so
+            // `parseObjectLiteralElement` reports TS1136 and aborts the
+            // member list *without consuming the template*. The object
+            // literal then closes (synthetic `}`), and the surrounding
+            // expression/statement parser handles the template as a tagged
+            // template tail on the object expression, with anything after it
+            // parsed as separate statements. Mirror that recovery here so the
+            // recovered AST — and therefore emit — matches tsc, instead of
+            // absorbing the template (and a trailing value) as a property.
             use tsz_common::diagnostics::diagnostic_codes;
             self.parse_error_at_current_token(
                 "Property assignment expected.",
                 diagnostic_codes::PROPERTY_ASSIGNMENT_EXPECTED,
             );
-            let name = self.parse_template_literal();
-            // tsc emits cascading errors when a template literal is used
-            // as a property name with `: value` following:
-            //   TS1136 on the template, TS1005 "',' expected" at `:`,
-            //   TS1134 "Variable declaration expected." at the value.
-            // We emit these inline to match tsc's diagnostic output.
-            let initializer = if self.is_token(SyntaxKind::ColonToken) {
-                let colon_pos = self.token_pos();
-                let colon_len = self.token_end() - colon_pos;
-                self.parse_error_at(
-                    colon_pos,
-                    colon_len,
-                    "',' expected.",
-                    diagnostic_codes::EXPECTED,
-                );
-                self.next_token(); // consume `:`
-                // Emit TS1134 at the value position
-                if !self.is_token(SyntaxKind::CloseBraceToken)
-                    && !self.is_token(SyntaxKind::EndOfFileToken)
-                {
-                    let val_pos = self.token_pos();
-                    let val_len = self.token_end() - val_pos;
-                    self.parse_error_at(
-                        val_pos,
-                        val_len,
-                        "Variable declaration expected.",
-                        diagnostic_codes::VARIABLE_DECLARATION_EXPECTED,
-                    );
-                }
-                let expr = self.parse_assignment_expression();
-                // Emit TS1128 at the next token (typically `}` or next line)
-                // tsc sees the closing `}` in statement context, not as
-                // the object literal closer.
-                if !self.is_token(SyntaxKind::EndOfFileToken) {
-                    let next_pos = self.token_pos();
-                    let next_len = self.token_end() - next_pos;
-                    self.parse_error_at(
-                        next_pos,
-                        next_len,
-                        "Declaration or statement expected.",
-                        diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED,
-                    );
-                }
-                expr
-            } else {
-                name
-            };
-            let end_pos = self.token_end();
-            return self.arena.add_property_assignment(
-                syntax_kind_ext::PROPERTY_ASSIGNMENT,
-                start_pos,
-                end_pos,
-                crate::parser::node::PropertyAssignmentData {
-                    modifiers: None,
-                    name,
-                    initializer,
-                },
-            );
+            self.abort_object_literal_recovery_once = true;
+            return NodeIndex::NONE;
         }
 
         // Check if the property name requires `:` syntax (can't be a shorthand property).

--- a/crates/tsz-parser/src/parser/state_statements.rs
+++ b/crates/tsz-parser/src/parser/state_statements.rs
@@ -1191,6 +1191,37 @@ impl ParserState {
                 if self.is_token(SyntaxKind::ColonToken) {
                     use tsz_common::diagnostics::diagnostic_codes;
 
+                    // A `:` that follows a declarator which already has an
+                    // initializer (`var x = INIT :`) is never a type
+                    // annotation — type annotations precede `=`. tsc therefore
+                    // treats the `:` as a missing comma between declarators,
+                    // reports TS1005 at the `:`, and retries the declarator
+                    // list at the next token rather than parsing a type. The
+                    // next token then either starts a new declarator or, when
+                    // it cannot (e.g. a numeric literal), yields TS1134 and is
+                    // left for the surrounding statement parser. This recovers
+                    // shapes like `var x = {} \`tpl\` : 321` the way tsc does
+                    // (tagged-template initializer + a separate `321;`
+                    // statement) instead of swallowing `321` as a type.
+                    let decl_has_initializer = self
+                        .arena
+                        .get(decl)
+                        .and_then(|node| self.arena.get_variable_declaration(node))
+                        .is_some_and(|decl| decl.initializer.is_some());
+                    if decl_has_initializer {
+                        // Bypass the distance-based suppression gate (the `:`
+                        // can sit within `ERROR_SUPPRESSION_DISTANCE` of a
+                        // prior TS1136 from a recovered template-literal
+                        // property name); tsc dedups only on exact position,
+                        // and the `:` is at a distinct position.
+                        self.parse_error_at_current_token(
+                            "',' expected.",
+                            diagnostic_codes::EXPECTED,
+                        );
+                        self.next_token(); // consume `:`
+                        continue;
+                    }
+
                     let recover_invalid_jsx_namespace_head =
                         self.recover_jsx_invalid_namespace_head_tail;
                     if self.recover_jsx_closing_tag_extra_namespace_tail

--- a/crates/tsz-parser/src/parser/state_statements.rs
+++ b/crates/tsz-parser/src/parser/state_statements.rs
@@ -1191,27 +1191,27 @@ impl ParserState {
                 if self.is_token(SyntaxKind::ColonToken) {
                     use tsz_common::diagnostics::diagnostic_codes;
 
-                    // A `:` that follows a declarator which already has an
-                    // initializer (`var x = INIT :`) is never a type
-                    // annotation — type annotations precede `=`. tsc therefore
-                    // treats the `:` as a missing comma between declarators,
-                    // reports TS1005 at the `:`, and retries the declarator
-                    // list at the next token rather than parsing a type. The
-                    // next token then either starts a new declarator or, when
-                    // it cannot (e.g. a numeric literal), yields TS1134 and is
-                    // left for the surrounding statement parser. This recovers
-                    // shapes like `var x = {} \`tpl\` : 321` the way tsc does
-                    // (tagged-template initializer + a separate `321;`
-                    // statement) instead of swallowing `321` as a type.
-                    let decl_has_initializer = self
-                        .arena
-                        .get(decl)
-                        .and_then(|node| self.arena.get_variable_declaration(node))
-                        .is_some_and(|decl| decl.initializer.is_some());
-                    if decl_has_initializer {
+                    // A `:` that follows an initializer recovered from a
+                    // template-literal-as-property-name object literal (e.g.
+                    // `var x = {} \`tpl\` : 321`) is never a type annotation.
+                    // tsc closes the object literal at the template, attaches
+                    // the template as a tagged-template tail, then treats the
+                    // `:` as a missing comma between declarators: it reports
+                    // TS1005 at the `:` and retries the declarator list at the
+                    // next token. That next token then either starts a new
+                    // declarator or, when it cannot (e.g. a numeric literal),
+                    // yields TS1134 and is left for the surrounding statement
+                    // parser. Recover the same way here so the AST — and emit
+                    // — match tsc (tagged-template initializer plus a separate
+                    // trailing statement) instead of swallowing the value as a
+                    // type. Gated on the dedicated recovery flag so it does not
+                    // perturb other `:`-after-initializer shapes such as
+                    // failed-arrow recovery (`var y = x:number => x*x`).
+                    if self.recovered_template_literal_property_in_object {
+                        self.recovered_template_literal_property_in_object = false;
                         // Bypass the distance-based suppression gate (the `:`
-                        // can sit within `ERROR_SUPPRESSION_DISTANCE` of a
-                        // prior TS1136 from a recovered template-literal
+                        // can sit within `ERROR_SUPPRESSION_DISTANCE` of the
+                        // prior TS1136 from the recovered template-literal
                         // property name); tsc dedups only on exact position,
                         // and the `:` is at a distinct position.
                         self.parse_error_at_current_token(
@@ -1758,6 +1758,12 @@ impl ParserState {
     pub(crate) fn parse_variable_declaration_with_flags(&mut self, flags: u16) -> NodeIndex {
         let start_pos = self.token_pos();
         self.parse_variable_declaration_with_flags_pre_checks(flags);
+
+        // Clear any stale template-literal-property recovery signal so that it
+        // can only reflect *this* declarator's initializer (e.g. an object
+        // literal in a non-declaration context must not leak into a later
+        // `var`).
+        self.recovered_template_literal_property_in_object = false;
 
         let name = self.parse_variable_declaration_name();
         let exclamation_token = self.parse_optional(SyntaxKind::ExclamationToken);

--- a/crates/tsz-parser/tests/parser_improvement_template_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_template_recovery_tests.rs
@@ -1,6 +1,89 @@
 //! Tests for parser improvements to reduce TS1005 and TS2300 false positives — template recovery.
 
+use crate::parser::syntax_kind_ext;
 use crate::parser::test_fixture::parse_source;
+
+/// Structural rule: when a template literal appears where an object-literal
+/// property name is expected, tsc closes the object literal at the template,
+/// recovers the template as a tagged-template tail on the object expression,
+/// and parses anything after the bogus `: value` as separate statements. The
+/// recovered AST must therefore contain a tagged-template expression (not a
+/// property assignment whose name is the template), and the diagnostics must
+/// be the TS1136 / TS1005 / TS1134 / TS1128 cascade.
+fn assert_template_property_recovers_as_tagged_template(source: &str) {
+    let (parser, _root) = parse_source(source);
+    let codes: Vec<u32> = parser.get_diagnostics().iter().map(|d| d.code).collect();
+    assert_eq!(
+        codes,
+        vec![1136, 1005, 1134, 1128],
+        "expected the TS1136/TS1005/TS1134/TS1128 cascade for {source:?}, got {:?}",
+        parser.get_diagnostics()
+    );
+
+    // The template must have recovered as a tagged template on the object
+    // expression, proving the object literal closed before it. If the parser
+    // instead absorbed the template as a property name, no tagged-template
+    // node would exist.
+    let arena = parser.get_arena();
+    let has_tagged_template = arena
+        .nodes
+        .iter()
+        .any(|n| n.kind == syntax_kind_ext::TAGGED_TEMPLATE_EXPRESSION);
+    assert!(
+        has_tagged_template,
+        "expected a tagged-template expression in the recovered AST for {source:?}; \
+         the object literal should close at the template, not absorb it as a property name"
+    );
+}
+
+#[test]
+fn template_literal_property_name_recovers_as_tagged_template_short() {
+    // `templateStringInPropertyName1`-style: the only member is a template.
+    assert_template_property_recovers_as_tagged_template("var x = {\n    `a`: 321\n}\n");
+}
+
+#[test]
+fn template_literal_property_name_recovers_as_tagged_template_after_member() {
+    // `templateStringInObjectLiteral`-style: a valid member precedes the
+    // template member. Use a different iteration-variable-free shape and a
+    // different template spelling to prove the rule is structural, not keyed
+    // on the `b` spelling.
+    assert_template_property_recovers_as_tagged_template(
+        "var x = {\n    a: `abc${ 123 }def`,\n    `b`: 321\n}\n",
+    );
+}
+
+#[test]
+fn template_literal_property_name_recovers_as_tagged_template_with_substitutions() {
+    // `templateStringInPropertyName2`-style: a substitution template head/tail
+    // (TemplateHead, not NoSubstitutionTemplateLiteral). The `:` is now far
+    // from the TS1136 position, exercising the non-suppressed path.
+    assert_template_property_recovers_as_tagged_template(
+        "var x = {\n    `abc${ 123 }def${ 456 }ghi`: 321\n}\n",
+    );
+}
+
+#[test]
+fn template_literal_property_name_recovery_does_not_leak_into_later_declaration() {
+    // A template-literal property name inside a non-declaration object literal
+    // (a call argument) must not flip the recovery flag for a subsequent,
+    // well-formed `var ... : Type` declaration. If the flag leaked, the later
+    // `:` would be misreported as a missing comma (TS1005) instead of being a
+    // valid type annotation.
+    let source = "foo({ `a`: 1 });\nvar y: number = 2;\n";
+    let (parser, _root) = parse_source(source);
+    let later_decl_errors: Vec<u32> = parser
+        .get_diagnostics()
+        .iter()
+        .filter(|d| (d.start as usize) >= source.find("var y").unwrap())
+        .map(|d| d.code)
+        .collect();
+    assert!(
+        later_decl_errors.is_empty(),
+        "well-formed `var y: number = 2;` must not inherit template-property recovery; \
+         got {later_decl_errors:?}"
+    );
+}
 
 #[test]
 fn test_ts1125_tagged_template_does_not_emit_errors() {


### PR DESCRIPTION
AgentName: opus48-emit100

## Track
Emit → 100% (JavaScript emit parity). Root cause turned out to be **parser
error-recovery**, not emit formatting.

## Invariant
A template literal cannot be an object-literal property name. tsc's
`parsePropertyName` rejects it: `parseObjectLiteralElement` reports TS1136 and
aborts the member list **without consuming the template**; the object literal
closes (synthetic `}`), the template is recovered as a **tagged-template tail**
on the object expression, and a trailing `: value` is recovered as a
missing-comma-between-declarators (TS1005 at `:`) plus a separate statement.
Previously tsz absorbed the template (and the trailing value) as a synthetic
property assignment with a hand-rolled TS1136/1005/1134/1128 cascade, building
the wrong AST and therefore the wrong emit. This change makes tsz build tsc's
recovered AST, so emit matches.

## Scope
Parser error-recovery (`tsz-parser`). No checker/solver/emitter logic changed —
the emit fix is a downstream consequence of the corrected AST.
- `state_expressions_literals.rs` — template-as-property-name: emit TS1136, set
  `abort_object_literal_recovery_once` + the new
  `recovered_template_literal_property_in_object` flag, return `NodeIndex::NONE`
  without consuming the template (replaces the old inline diagnostic cascade;
  net **−** lines in this file).
- `state_statements.rs` — var-decl-list `:`-recovery: when the dedicated flag is
  set, report TS1005 at the `:` and retry the declarator at the next token;
  flag cleared at each declarator start to prevent leakage.
- `state.rs`, `speculation.rs` — declare/init/reset/checkpoint the flag.
- `parser_improvement_template_recovery_tests.rs` — 4 structural tests (no-subst,
  after-member, substitution `` `abc${}` ``, and a leak-prevention case proving
  the flag does not perturb a later unrelated `var`).

## Project Corpus Impact
- Row: n/a — TypeScript conformance/emit fixture fix, not a project-corpus benchmark row.
- Bug family: template-literal-as-object-literal-property parser error recovery (AST shape → emit + recovery diagnostics).
- Evidence: local `scripts/emit/run.sh --js-only` Failed **71 → 69** (−2; both `templateStringInObjectLiteral{,ES6}` fixed, +4 `templateStringInPropertyName*` also corrected, zero new failures, diffed vs a freshly-built origin/main baseline); `--dts-only` unchanged at 25; `cargo nextest -p tsz-parser` 1096/1096 (+4 new); clippy clean.

## Verification
- Targeted: `templateStringInObjectLiteral`, `templateStringInObjectLiteralES6` — PASS.
- Full `--js-only`: 71 → 69, only delta is the fixed tests, no new failures.
- A first attempt that gated on "declarator has an initializer" regressed 5
  arrow-recovery tests (`asyncArrowFunction9_*`, `fatarrowfunctionsErrors`);
  resolved by narrowing the trigger to the dedicated flag, leaving generic `:`
  recovery untouched. Final run: zero new failures.
- **Conformance is the real gate here**: this alters recovery DIAGNOSTIC emission
  (TS1136/TS1005/TS1134), which the emit-only local gate cannot see. Opened ready
  so conformance/emit/fourslash/WASM run; will narrow/revert on any conformance regression.

## Coordination Notes
- Part of the re-grounded emit-100 push (HEAD failing set 71 JS / 25 DTS).
- Sibling lanes own adjacent clusters: privateName (#11849) and dts-nullish (#11850) — not touched here.
- Parser-recovery is the §25 "conformance-gated" category; this is a real
  recovery fix (no emitter band-aid). AgentName: opus48-emit100. Reviews welcome.
