### PR TITLE
fix(emit): hoist ES5 private storage before CJS marker

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
@@ -2,6 +2,10 @@ use super::super::super::{Printer, ScriptTarget};
 use super::class_has_self_references;
 use super::replace_identifier;
 use crate::emitter::core::PropertyNameEmit;
+use crate::transforms::private_fields_es5::{
+    collect_enclosing_source_binding_names, collect_private_accessors_with_reserved,
+    collect_private_fields_with_reserved,
+};
 use crate::transforms::{ClassDecoratorInfo, ClassES5Emitter};
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::ClassData;
@@ -1016,6 +1020,29 @@ impl<'a> Printer<'a> {
         }
 
         let mut decls = Vec::new();
+        let mut used_private_names = collect_enclosing_source_binding_names(self.arena, class_idx);
+        for field in collect_private_fields_with_reserved(
+            self.arena,
+            class_idx,
+            class_name,
+            &mut used_private_names,
+        ) {
+            decls.push(field.weakmap_name);
+        }
+        for accessor in collect_private_accessors_with_reserved(
+            self.arena,
+            class_idx,
+            class_name,
+            &mut used_private_names,
+        ) {
+            if let Some(name) = accessor.get_var_name {
+                decls.push(name);
+            }
+            if let Some(name) = accessor.set_var_name {
+                decls.push(name);
+            }
+        }
+
         let mut temp_name_index = self.ctx.destructuring_state.temp_var_counter;
         let mut auto_accessor_storage_reserved = false;
         for &member_idx in &class_data.members.nodes {

--- a/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
@@ -1235,6 +1235,43 @@ fn es2015_undeclared_private_recovery_does_not_request_helpers() {
 }
 
 #[test]
+fn es5_commonjs_exported_class_private_storage_hoists_before_es_module_marker() {
+    let source = "export class Box {\n    #value: unknown;\n}\n";
+
+    let (parser, root) = parse_test_source(source);
+    let options = PrinterOptions {
+        target: ScriptTarget::ES5,
+        module: ModuleKind::CommonJS,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    let storage_pos = output
+        .find("var _Box_value;")
+        .expect("private storage var should be emitted");
+    let marker_pos = output
+        .find("Object.defineProperty(exports, \"__esModule\", { value: true });")
+        .expect("CommonJS ES module marker should be emitted");
+    let export_init_pos = output
+        .find("exports.Box = void 0;")
+        .expect("CommonJS export initializer should be emitted");
+    let class_pos = output
+        .find("var Box = /** @class */")
+        .expect("ES5 class IIFE should be emitted");
+
+    assert!(
+        storage_pos < marker_pos && marker_pos < export_init_pos && export_init_pos < class_pos,
+        "Private storage declarations for exported ES5 classes should be hoisted before the CommonJS preamble.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn esnext_legacy_class_fields_hoist_auto_accessors_in_source_order() {
     let source = "// order comment\n\
 class C {\n\


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
JavaScript emit parity, class/private/accessor/decorator lowering.

## Invariant
When an exported ES5/CommonJS class owns private field or accessor storage, the generated storage var declarations must be in the source-file hoist slot before the CommonJS ES module marker; this PR changes ES5 class hoist planning and keeps the ClassES5Emitter responsible for removing duplicated in-IIFE declarations.

## Scope
- crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
- crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs

## Project Corpus Impact
- Row: n/a
- Bug family: class/private/accessor/decorator lowering
- Evidence: TypeScript baseline privateFieldAssignabilityFromUnknown(target=es5) now passes in the focused JS emit runner; no project-corpus row was run for this compiler-baseline slice.

## Verification
- cargo fmt --all --check
- cargo nextest run -p tsz-emitter es5_commonjs_exported_class_private_storage_hoists_before_es_module_marker
- scripts/emit/run.sh --filter=privateFieldAssignabilityFromUnknown --js-only --verbose --timeout=15000 --json-out=/tmp/privateFieldAssignabilityFromUnknown-after.json
- scripts/emit/run.sh --filter=private --js-only --timeout=15000 --json-out=/tmp/studio-c-private-main-20260531-after-hoist.json (295/310; +1 from main, remaining failures are pre-existing/private follow-ups)
- cargo check -p tsz-emitter
- git diff --check
- PR-head CI for `9bcf13ba72eef8b2079339fcef2501cad24c5f6f` is green, including CI Summary, emit, conformance, fourslash, dist-binaries, lint, unit, WASM, and GitGuardian.

## Coordination Notes
- AgentName: Studio-C
- Independent from #11853, which owns privateNameNestedMethodAccess/nested private aliasing.
- The local worktree also has unrelated unstaged output-surgery audit edits; this PR includes only the two emitter files above.
- Added `merge-queue` after exact-head PR checks passed; `Queue Tested` is queue-owned.