### PR TITLE
chore(emit-tools): show output-surgery category budgets

### DIFF
--- a/scripts/emit/audit-output-surgery.py
+++ b/scripts/emit/audit-output-surgery.py
@@ -314,6 +314,19 @@ def format_budget_metrics(budget: BudgetSummary) -> str:
     )
 
 
+def format_category_budget_metrics(file_summaries: list[dict[str, object]]) -> str:
+    parts: list[str] = []
+    for summary in build_category_summaries(file_summaries):
+        category = str(summary["category"])
+        count = int(summary["count"])
+        max_count = summary["max_count"]
+        if max_count is None:
+            parts.append(f"{category}=unallowlisted:{count}")
+        else:
+            parts.append(f"{category}={count}/{int(max_count)}")
+    return "category_budgets=" + ",".join(parts)
+
+
 def build_json_report(
     findings: list[Finding],
     allowlist: dict[str, AllowEntry],
@@ -372,12 +385,14 @@ def format_pass_summary(
     allowlist: dict[str, AllowEntry],
 ) -> str:
     summary = summarize_failures(failures)
-    budget = summarize_budget(build_file_summaries(grouped_counts(findings), allowlist))
+    file_summaries = build_file_summaries(grouped_counts(findings), allowlist)
+    budget = summarize_budget(file_summaries)
     return (
         "Output-surgery audit passed: "
         f"total_findings={len(findings)}, "
         f"files_with_findings={len(grouped_counts(findings))}, "
         f"{format_budget_metrics(budget)}, "
+        f"{format_category_budget_metrics(file_summaries)}, "
         f"unallowlisted_calls={summary.unallowlisted}, "
         f"over_allowlist_files={summary.over_allowlist_files}, "
         f"over_allowlist_excess_calls={summary.over_allowlist_excess_calls}, "
@@ -407,10 +422,12 @@ def main(argv: list[str] | None = None) -> int:
 
     if failures:
         summary = summarize_failures(failures)
-        budget = summarize_budget(build_file_summaries(grouped_counts(findings), allowlist))
+        file_summaries = build_file_summaries(grouped_counts(findings), allowlist)
+        budget = summarize_budget(file_summaries)
         print(
             "\nOutput-surgery audit summary: "
             f"{format_budget_metrics(budget)}, "
+            f"{format_category_budget_metrics(file_summaries)}, "
             f"unallowlisted_calls={summary.unallowlisted}, "
             f"unallowlisted_files={summary.unallowlisted_files}, "
             f"over_allowlist_files={summary.over_allowlist_files}, "

--- a/scripts/emit/test_output_surgery_audit.py
+++ b/scripts/emit/test_output_surgery_audit.py
@@ -144,10 +144,46 @@ class OutputSurgeryAuditTests(unittest.TestCase):
             "allowlist_cap=2, "
             "remaining_allowlist_capacity=0, "
             "allowlist_budget_status=exhausted, "
+            "category_budgets=semantic-output-surgery=2/2, "
             "unallowlisted_calls=0, "
             "over_allowlist_files=0, "
             "over_allowlist_excess_calls=0, "
             "stale_allowlist_files=0.",
+        )
+
+    def test_category_budget_metrics_names_each_category(self):
+        file_summaries = [
+            {
+                "path": "a.rs",
+                "count": 2,
+                "category": "dts-output-surgery",
+                "max_count": 3,
+                "reason": "existing debt",
+                "status": "allowlisted",
+            },
+            {
+                "path": "b.rs",
+                "count": 1,
+                "category": "ir-output-surgery",
+                "max_count": 1,
+                "reason": "existing debt",
+                "status": "allowlisted",
+            },
+            {
+                "path": "c.rs",
+                "count": 4,
+                "category": "UNALLOWLISTED",
+                "max_count": None,
+                "reason": None,
+                "status": "unallowlisted",
+            },
+        ]
+
+        self.assertEqual(
+            self.audit.format_category_budget_metrics(file_summaries),
+            "category_budgets=UNALLOWLISTED=unallowlisted:4,"
+            "dts-output-surgery=2/3,"
+            "ir-output-surgery=1/1",
         )
 
     def test_budget_status_classifies_budget_edges(self):


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Track 10 launch infrastructure / emit guardrail evidence

## Invariant
When the output-surgery audit budget is exhausted, the CLI summary should show which output-surgery categories own the budget pressure without requiring agents to open the JSON report. This PR changes audit reporting only.

## Scope
- Add category-level budget metrics to the output-surgery audit pass/fail summaries.
- Cover mixed category and unallowlisted formatting in the focused audit unit test.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: script-only guardrail reporting; no compiler behavior, emit output, or project corpus behavior changes.

## Verification
- python3 -m unittest scripts.emit.test_output_surgery_audit
- python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery-studio-f.json
- python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard-studio-f.json
- git diff --check origin/main..HEAD

## Coordination Notes
Existing Studio-F PR runway was clear before starting: scripts/agents/list-owned-work.sh Studio-F reported no PRs and no issues. #10620 was already merged before this branch. No roadmap update: this is routine cheap-evidence plumbing, not a durable direction change.