### PR TITLE
fix(emit-tools): flag stale emit detail snapshots

### DIFF
--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -427,6 +427,7 @@ run_lint() {
   python3 scripts/ci/test_gcp_full_ci_emit_metrics.py || return $?
   python3 scripts/ci/test_refresh_readme.py || return $?
   python3 scripts/conformance/test_query_conformance.py || return $?
+  python3 scripts/emit/test_query_emit_families.py || return $?
   # Use the dedicated ci-lint profile (debug=false, incremental=false,
   # codegen-units=256). Workspace clippy artifacts go to .target/ci-lint/
   # — separate cache key from .target/debug so dev incrementals on a

--- a/scripts/emit/query-emit.py
+++ b/scripts/emit/query-emit.py
@@ -34,6 +34,7 @@ Usage:
 import os
 import sys
 import argparse
+import re
 from collections import Counter
 from pathlib import Path
 
@@ -41,6 +42,8 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from lib.query_snapshot import load_snapshot, print_top_counter, print_truncated_more
 
 DETAIL_FILE = Path(__file__).parent / "emit-detail.json"
+ROOT_DIR = Path(__file__).resolve().parents[2]
+README_FILE = ROOT_DIR / "README.md"
 
 
 JS_FAMILY_RULES = [
@@ -154,9 +157,85 @@ def load_detail():
     return load_snapshot(DETAIL_FILE, "Run: ./scripts/emit/run.sh --json-out")
 
 
+def emit_summary(data):
+    summary = data.get("summary", {})
+    return {
+        "jsPass": summary.get("jsPass"),
+        "jsTotal": summary.get("jsTotal"),
+        "dtsPass": summary.get("dtsPass"),
+        "dtsTotal": summary.get("dtsTotal"),
+    }
+
+
+def emit_summary_from_readme_text(text):
+    section = text.split("<!-- EMIT_START -->", 1)
+    if len(section) != 2:
+        return None
+    section = section[1].split("<!-- EMIT_END -->", 1)[0]
+
+    summary = {}
+    for line in section.splitlines():
+        if "JavaScript" in line:
+            prefix = "js"
+        elif "Declaration" in line:
+            prefix = "dts"
+        else:
+            continue
+
+        match = re.search(r"\(([\d,]+)\s*/\s*([\d,]+)", line)
+        if not match:
+            continue
+        summary[f"{prefix}Pass"] = int(match.group(1).replace(",", ""))
+        summary[f"{prefix}Total"] = int(match.group(2).replace(",", ""))
+
+    required = {"jsPass", "jsTotal", "dtsPass", "dtsTotal"}
+    return summary if required.issubset(summary) else None
+
+
+def emit_summary_from_readme(path=README_FILE):
+    try:
+        return emit_summary_from_readme_text(path.read_text())
+    except OSError:
+        return None
+
+
+def emit_freshness_note(detail_summary, public_summary):
+    if not detail_summary or not public_summary:
+        return None
+
+    same_domain = (
+        detail_summary.get("jsTotal") == public_summary.get("jsTotal")
+        and detail_summary.get("dtsTotal") == public_summary.get("dtsTotal")
+    )
+    public_ahead = (
+        public_summary.get("jsPass", 0) > detail_summary.get("jsPass", 0)
+        or public_summary.get("dtsPass", 0) > detail_summary.get("dtsPass", 0)
+    )
+    if not same_domain or not public_ahead:
+        return None
+
+    return (
+        "Note: README/public emit aggregate is newer than "
+        "scripts/emit/emit-detail.json "
+        f"(JS {public_summary['jsPass']:,}/{public_summary['jsTotal']:,} vs "
+        f"{detail_summary['jsPass']:,}/{detail_summary['jsTotal']:,}; "
+        f"DTS {public_summary['dtsPass']:,}/{public_summary['dtsTotal']:,} vs "
+        f"{detail_summary['dtsPass']:,}/{detail_summary['dtsTotal']:,}). "
+        "Failure-family rows below still use checked-in per-test detail."
+    )
+
+
+def print_emit_freshness_note(data):
+    note = emit_freshness_note(emit_summary(data), emit_summary_from_readme())
+    if note:
+        print(note)
+        print()
+
+
 def show_overview(data):
     s = data["summary"]
     print(f"Emit Test Results")
+    print_emit_freshness_note(data)
     print(f"  JavaScript: {s['jsPass']}/{s['jsTotal']} ({s['jsPassRate']}%)")
     print(f"  Declaration: {s['dtsPass']}/{s['dtsTotal']} ({s['dtsPassRate']}%)")
     print()
@@ -286,6 +365,7 @@ def collect_failures_by_family(data, surface):
 def show_failure_families(data, top=20):
     print("Emit failure families")
     print()
+    print_emit_freshness_note(data)
     for surface, title in (("js", "JavaScript"), ("dts", "Declaration")):
         families = collect_failures_by_family(data, surface)
         rows = sorted(

--- a/scripts/emit/test_query_emit_families.py
+++ b/scripts/emit/test_query_emit_families.py
@@ -35,6 +35,72 @@ def make_result(name, js_error="", dts_error="", test_path="", baseline_file="")
     }
 
 
+class TestEmitFreshnessNote(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = load_query_emit()
+
+    def test_readme_emit_summary_parses_progress_block(self):
+        summary = self.mod.emit_summary_from_readme_text(
+            """
+before
+<!-- EMIT_START -->
+```
+JavaScript:  [####################] 99.5% (13,459 / 13,530 tests)
+Declaration: [####################] 98.5% (1,644 / 1,669 tests)
+```
+<!-- EMIT_END -->
+after
+"""
+        )
+        self.assertEqual(
+            summary,
+            {
+                "jsPass": 13459,
+                "jsTotal": 13530,
+                "dtsPass": 1644,
+                "dtsTotal": 1669,
+            },
+        )
+
+    def test_freshness_note_reports_public_aggregate_ahead(self):
+        note = self.mod.emit_freshness_note(
+            {
+                "jsPass": 13094,
+                "jsTotal": 13530,
+                "dtsPass": 1606,
+                "dtsTotal": 1669,
+            },
+            {
+                "jsPass": 13459,
+                "jsTotal": 13530,
+                "dtsPass": 1644,
+                "dtsTotal": 1669,
+            },
+        )
+        self.assertIsNotNone(note)
+        self.assertIn("README/public emit aggregate is newer", note)
+        self.assertIn("JS 13,459/13,530 vs 13,094/13,530", note)
+        self.assertIn("DTS 1,644/1,669 vs 1,606/1,669", note)
+
+    def test_freshness_note_ignores_different_emit_domains(self):
+        note = self.mod.emit_freshness_note(
+            {
+                "jsPass": 13094,
+                "jsTotal": 13530,
+                "dtsPass": 1606,
+                "dtsTotal": 1669,
+            },
+            {
+                "jsPass": 13459,
+                "jsTotal": 14000,
+                "dtsPass": 1644,
+                "dtsTotal": 1669,
+            },
+        )
+        self.assertIsNone(note)
+
+
 class TestJSFamilyClassifier(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 10 / release metric truth: emit dashboard freshness guard for the offline failure-family query.

## Invariant
When public README/site emit aggregate metrics are newer than the checked-in per-test emit detail, `query-emit.py` should say that its family breakdown is using stale per-test detail instead of presenting those counts as the current aggregate truth.

## Scope
- Teach `scripts/emit/query-emit.py` to parse the README emit block and print a freshness note when README/public aggregate counts are ahead of `scripts/emit/emit-detail.json` for the same JS/DTS totals.
- Cover the parser and note decision in `scripts/emit/test_query_emit_families.py`.
- Wire that emit query test into the CI lint suite.

## Project Corpus Impact
- Row: n/a.
- Bug family: public release metric reporting / stale emit detail snapshot guard.
- Evidence: `python3 scripts/emit/query-emit.py --families` now reports that README/public emit aggregate is newer (`13,459 / 13,530` JS and `1,644 / 1,669` DTS) while failure-family rows still come from checked-in per-test detail (`13,094 / 13,530` JS and `1,606 / 1,669` DTS).

## Verification
- `python3 -m py_compile scripts/emit/query-emit.py scripts/emit/test_query_emit_families.py`
- `python3 scripts/emit/test_query_emit_families.py`
- `python3 scripts/emit/query-emit.py --families`
- `python3 scripts/emit/query-emit.py`
- `bash -n scripts/ci/gcp-full-ci.sh`
- `git diff --check`

## Coordination Notes
- No open PRs are labeled `agent:Studio-A`.
- This does not refresh markdown or snapshots; it makes the code reporting surface explicit about the current aggregate-vs-detail mismatch until a fresh per-test emit detail artifact is checked in.