### PR TITLE
chore(emit): parse legacy JSDoc generics without output surgery

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc.rs
@@ -1459,8 +1459,7 @@ impl<'a> DeclarationEmitter<'a> {
     }
 
     pub(in crate::declaration_emitter) fn normalize_jsdoc_type_expr(type_expr: &str) -> String {
-        let normalized_legacy_generics = type_expr.trim().replace(".<", "<");
-        let trimmed = normalized_legacy_generics.as_str();
+        let trimmed = type_expr.trim();
         if trimmed.is_empty() {
             return "any".to_string();
         }
@@ -1519,7 +1518,10 @@ impl<'a> DeclarationEmitter<'a> {
             return None;
         }
 
-        let base = type_expr[..open].trim();
+        let base_end = type_expr[..open]
+            .strip_suffix('.')
+            .map_or(open, |base| base.len());
+        let base = type_expr[..base_end].trim();
         if base.is_empty()
             || !base
                 .chars()
@@ -1530,7 +1532,11 @@ impl<'a> DeclarationEmitter<'a> {
 
         let args = type_expr[open + 1..type_expr.len() - 1].trim();
         if args.is_empty() {
-            return None;
+            return Some(match base {
+                "Array" => "any[]".to_string(),
+                "Promise" => "Promise<any>".to_string(),
+                _ => format!("{base}<>"),
+            });
         }
 
         let normalized_args = Self::split_jsdoc_params(args)
@@ -1723,12 +1729,9 @@ impl<'a> DeclarationEmitter<'a> {
             "Null" => "null".to_string(),
             "function" => "Function".to_string(),
             "event" => "Event".to_string(),
-            // `Array<>` is the form after `normalize_jsdoc_type_expr` strips
-            // the legacy `.<` → `<` so both `Array` and `Array.<>` reach this
-            // arm. tsc treats empty-args generic JSDoc references as
-            // implicit-any (`Array.<>` → `any[]`); without the `Array<>` arm
-            // the DTS surfaces a literal `Array<>` token that is not valid
-            // TypeScript.
+            // tsc treats empty-args generic JSDoc references as implicit-any
+            // (`Array.<>` → `any[]`); without the empty generic arms the DTS
+            // surfaces literal `Array<>` tokens that are not valid TypeScript.
             "array" | "Array" | "Array.<>" | "Array<>" => "any[]".to_string(),
             "promise" | "Promise" | "Promise.<>" | "Promise<>" => "Promise<any>".to_string(),
             _ => s.to_string(),

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc_tests.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc_tests.rs
@@ -90,6 +90,18 @@ fn bracket_default_segment_can_be_followed_by_another_param() {
 }
 
 #[test]
+fn legacy_jsdoc_generic_dot_is_normalized_by_generic_parser() {
+    assert_eq!(
+        DeclarationEmitter::normalize_jsdoc_type_expr("Array.<Object.<string, number>>"),
+        "Array<{\n    [x: string]: number;\n}>"
+    );
+    assert_eq!(
+        DeclarationEmitter::normalize_jsdoc_type_expr("(Array.<> | null)"),
+        "(any[] | null)"
+    );
+}
+
+#[test]
 fn jsdoc_type_attaches_through_trailing_line_comment() {
     assert!(DeclarationEmitter::jsdoc_attaches_through_var_prefix(
         " // explanation\nconst "

--- a/scripts/emit/output-surgery-allowlist.txt
+++ b/scripts/emit/output-surgery-allowlist.txt
@@ -3,7 +3,6 @@
 # counts may go down as plan/IR/declaration-summary work removes debt; new or
 # increased counts require an explicit category and removal reason.
 crates/tsz-emitter/src/declaration_emitter/helpers/computed_declarations.rs|dts-output-surgery|1|computed declaration text patch; migrate to structured declaration node emission
-crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc.rs|dts-output-surgery|1|legacy JSDoc type text normalization; migrate to structured JSDoc parser facts
 crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs|dts-output-surgery|1|inferred type text parameter rewrite; migrate to declaration display request facts
 crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_imported_calls.rs|dts-output-surgery|1|imported-call inferred text indentation patch; migrate to structured type display formatting
 crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs|dts-output-surgery|4|object member inferred text rewrites; migrate to declaration summary member facts


### PR DESCRIPTION
## Agent
AgentName: Studio-E

## Track
JSDoc / JavaScript declaration emit debt reduction

## Invariant
Declaration emit should preserve current JSDoc DTS surfaces while moving legacy generic normalization into the parser-local JSDoc type path instead of broad string replacement.

## Scope
- Teach `normalize_jsdoc_generic_type_reference` to accept legacy `Array.<T>` syntax directly.
- Preserve existing empty legacy generic behavior such as `Array.<>` -> `any[]` and `Promise.<>` -> `Promise<any>`.
- Remove the stale JSDoc `dts-output-surgery` allowlist entry after the broad `.replace(".<", "<")` call is gone.

## Project Corpus Impact
- Row: n/a
- Bug family: JSDoc legacy generic declaration emit normalization / output-surgery guardrail debt.
- Evidence: behavior-preserving emitter helper change; `jsDeclarations --dts-only` passed 134/134 and `checkJsdoc --dts-only` passed 1/1 on the latest rebased PR head.

## Verification
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target CARGO_INCREMENTAL=0 cargo nextest run -p tsz-emitter legacy_jsdoc_generic_dot_is_normalized_by_generic_parser`
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/studio-e-output-surgery-rebased-main7-11859.json`
- `python3 -m unittest scripts.emit.test_output_surgery_audit`
- `env CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target CARGO_INCREMENTAL=0 scripts/safe-run.sh scripts/emit/run.sh --filter=checkJsdoc --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-e-checkJsdoc-generic-normalize-rebased-main7.json`
- `env CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target CARGO_INCREMENTAL=0 scripts/safe-run.sh scripts/emit/run.sh --filter=jsDeclarations --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-e-jsDeclarations-generic-normalize-rebased-main7.json`
- `git diff --check origin/main..HEAD`

## Coordination Notes
Started from a fresh Studio-E worktree at `/Users/mohsen/code/tsz-studio-e-jsdoc-generic-normalize-20260531` on current `origin/main`. Checked overlap with open PRs before coding; later rebases kept the branch diff scoped to the JSDoc helper/test plus allowlist row. Disk pressure during early verification left a partial Cargo artifact; I removed this worktree generated `.target`, ran cache-preserving cleanup, cleaned only the affected shared Cargo packages, and reran verification green. Refreshed again onto latest `origin/main` after #11867, #11860, and #11868 landed and pushed head `6aa8a7a623`. No roadmap update: this is a routine ratchet of an existing guardrail debt item, not a durable direction change.