### PR TITLE
fix(dts): respect shadowed undefined guards

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_guards.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_guards.rs
@@ -377,7 +377,7 @@ impl<'a> DeclarationEmitter<'a> {
         let nullish_idx = self
             .arena
             .skip_parenthesized_and_assertions_and_comma(nullish_idx);
-        if self.get_identifier_text(nullish_idx).as_deref() == Some("undefined") {
+        if self.is_unbound_undefined_value_reference(nullish_idx) {
             return Some("undefined");
         }
         let nullish_node = self.arena.get(nullish_idx)?;
@@ -386,6 +386,21 @@ impl<'a> DeclarationEmitter<'a> {
             k if k == SyntaxKind::UndefinedKeyword as u16 => Some("undefined"),
             _ => None,
         }
+    }
+
+    fn is_unbound_undefined_value_reference(&self, expr_idx: NodeIndex) -> bool {
+        let Some(node) = self.arena.get(expr_idx) else {
+            return false;
+        };
+        if node.kind == SyntaxKind::UndefinedKeyword as u16 {
+            return true;
+        }
+        if self.get_identifier_text(expr_idx).as_deref() != Some("undefined") {
+            return false;
+        }
+
+        self.binder
+            .is_none_or(|_| self.value_reference_symbol(expr_idx).is_none())
     }
 
     fn nullish_guarded_return_type_text(

--- a/crates/tsz-emitter/src/declaration_emitter/tests/misc_inference_features.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/misc_inference_features.rs
@@ -193,6 +193,29 @@ function ensurePresent<Thing>(thing: Thing) {
 }
 
 #[test]
+fn generic_return_parameter_shadowed_undefined_does_not_narrow() {
+    let output = emit_dts_with_binding(
+        r#"
+function keepShadowed<Value>(value: Value, undefined: unknown) {
+    if (value === undefined) throw Error();
+    return value;
+}
+"#,
+    );
+
+    assert!(
+        output.contains(
+            "declare function keepShadowed<Value>(value: Value, undefined: unknown): Value;"
+        ),
+        "Expected shadowed undefined identifier to fall back to the declared generic surface: {output}"
+    );
+    assert!(
+        !output.contains("keepShadowed<Value>(value: Value, undefined: unknown): Value &"),
+        "Expected local undefined binding not to be treated as a nullish guard: {output}"
+    );
+}
+
+#[test]
 fn generic_return_parameter_after_nested_nullish_helpers_composes_flow_surface() {
     let output = emit_dts(
         r#"


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Declaration emit / public API summary boundary follow-up.

## Invariant
When a source-visible nullish guard compares a returned generic parameter with an identifier named `undefined`, tsz should only treat that identifier as the builtin undefined value when binder resolution does not prove it is a local value binding; shadowed user bindings must fall back to the normal declaration return surface.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_guards.rs`
- `crates/tsz-emitter/src/declaration_emitter/tests/misc_inference_features.rs`
- Replaces spelling-only `undefined` guard recognition with a binder-aware unbound-reference check.
- Adds a negative DTS test for a parameter named `undefined`.

## Project Corpus Impact
- Row: `unknownControlFlow`
- Bug family: DTS generic nullish control-flow return surfaces / shadowed undefined guard safety
- Evidence: `scripts/safe-run.sh scripts/emit/run.sh --filter=unknownControlFlow --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-unknownControlFlow-shadowed-undefined-pr-20260531.json` passes 1/1.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo nextest run -p tsz-emitter -E 'test(generic_return_parameter_after_nullish_throw_guard_keeps_flow_surface) or test(generic_return_parameter_shadowed_undefined_does_not_narrow) or test(generic_return_parameter_after_nested_nullish_helpers_composes_flow_surface)'`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=unknownControlFlow --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-unknownControlFlow-shadowed-undefined-pr-20260531.json`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-emitter --all-targets -- -D warnings`

## Coordination Notes
- AgentName: Studio-D
- Follow-up to merged #11850 and Reviewer comment on #11850: https://github.com/mohsen1/tsz/pull/11850#issuecomment-4586117659
- Owner layer remains declaration/source-structured return summary fallback. This does not add checker diagnostics, solver relation checks, raw `TypeData` matching, or output surgery.
- Conservative fallback: if binder resolves `undefined` to a local value symbol, the guard helper declines to narrow and the existing declaration emit path handles the return.
- #11850 merged before this review fix could be pushed, so this PR preserves the review fix as a small follow-up on current `main`.