### PR TITLE
chore(emit-tools): label output-surgery category status

### DIFF
--- a/scripts/emit/audit-output-surgery.py
+++ b/scripts/emit/audit-output-surgery.py
@@ -263,11 +263,20 @@ def build_category_summaries(file_summaries: list[dict[str, object]]) -> list[di
 
     result: list[dict[str, object]] = []
     for entry in sorted(categories.values(), key=lambda item: str(item["category"])):
+        count = int(entry["count"])
+        max_count = entry["max_count"]
+        remaining_capacity = None
+        budget_status = "unallowlisted"
+        if max_count is not None:
+            remaining_capacity = max(0, int(max_count) - count)
+            budget_status = classify_budget_status(count, int(max_count))
         result.append(
             {
                 "category": entry["category"],
-                "count": entry["count"],
-                "max_count": entry["max_count"],
+                "count": count,
+                "max_count": max_count,
+                "remaining_capacity": remaining_capacity,
+                "budget_status": budget_status,
                 "files": entry["files"],
                 "statuses": dict(sorted(entry["statuses"].items())),
             }
@@ -323,7 +332,8 @@ def format_category_budget_metrics(file_summaries: list[dict[str, object]]) -> s
         if max_count is None:
             parts.append(f"{category}=unallowlisted:{count}")
         else:
-            parts.append(f"{category}={count}/{int(max_count)}")
+            budget_status = str(summary["budget_status"])
+            parts.append(f"{category}={count}/{int(max_count)}:{budget_status}")
     return "category_budgets=" + ",".join(parts)
 
 

--- a/scripts/emit/test_output_surgery_audit.py
+++ b/scripts/emit/test_output_surgery_audit.py
@@ -100,6 +100,8 @@ class OutputSurgeryAuditTests(unittest.TestCase):
                     "category": "UNALLOWLISTED",
                     "count": 1,
                     "max_count": None,
+                    "remaining_capacity": None,
+                    "budget_status": "unallowlisted",
                     "files": 1,
                     "statuses": {"unallowlisted": 1},
                 },
@@ -107,6 +109,8 @@ class OutputSurgeryAuditTests(unittest.TestCase):
                     "category": "semantic-output-surgery",
                     "count": 1,
                     "max_count": 2,
+                    "remaining_capacity": 1,
+                    "budget_status": "available",
                     "files": 2,
                     "statuses": {"allowlisted": 1, "stale_allowlist": 1},
                 },
@@ -144,7 +148,7 @@ class OutputSurgeryAuditTests(unittest.TestCase):
             "allowlist_cap=2, "
             "remaining_allowlist_capacity=0, "
             "allowlist_budget_status=exhausted, "
-            "category_budgets=semantic-output-surgery=2/2, "
+            "category_budgets=semantic-output-surgery=2/2:exhausted, "
             "unallowlisted_calls=0, "
             "over_allowlist_files=0, "
             "over_allowlist_excess_calls=0, "
@@ -182,8 +186,8 @@ class OutputSurgeryAuditTests(unittest.TestCase):
         self.assertEqual(
             self.audit.format_category_budget_metrics(file_summaries),
             "category_budgets=UNALLOWLISTED=unallowlisted:4,"
-            "dts-output-surgery=2/3,"
-            "ir-output-surgery=1/1",
+            "dts-output-surgery=2/3:available,"
+            "ir-output-surgery=1/1:exhausted",
         )
 
     def test_budget_status_classifies_budget_edges(self):


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Track 10 launch infrastructure / emit guardrail evidence

## Invariant
When the output-surgery audit budget is exhausted, category-level output should expose which categories are exhausted and how much capacity remains. This PR changes audit reporting only.

## Scope
- Add per-category remaining_capacity and budget_status fields to the output-surgery JSON report.
- Include per-category status in the CLI category_budgets summary.
- Update focused audit unit expectations for category budget status.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: script-only guardrail reporting; no compiler behavior, emit output, or project corpus behavior changes.

## Verification
- python3 -m unittest scripts.emit.test_output_surgery_audit
- python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery-category-status.json
- python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard-category-status.json
- git diff --check

## Coordination Notes
Existing Studio-F runway was clear before starting: #11846 and #11857 are merged, and scripts/agents/list-owned-work.sh Studio-F reported no PRs or issues. Open PR overlap was checked; no open PR touches scripts/emit/audit-output-surgery.py or its focused test. Studio-E #11859 touches the allowlist, which is complementary to this reporting-only change. No roadmap update: this is routine cheap-evidence plumbing, not a durable direction change.