### PR TITLE
fix(bench): preserve workflow provenance in merged artifacts

### DIFF
--- a/scripts/bench/merge-results.mjs
+++ b/scripts/bench/merge-results.mjs
@@ -414,6 +414,14 @@ function firstNonEmpty(...values) {
   return null;
 }
 
+function firstNonLocal(...values) {
+  for (const value of values) {
+    const normalized = String(value ?? "").trim();
+    if (normalized && normalized !== "local") return normalized;
+  }
+  return firstNonEmpty(...values);
+}
+
 function githubRunUrl(runId) {
   if (!runId || runId === "local") return null;
   const serverUrl = firstNonEmpty(process.env.GITHUB_SERVER_URL, "https://github.com");
@@ -424,20 +432,20 @@ function githubRunUrl(runId) {
 
 function mergedArtifactMetadata(payloads, generatedAt) {
   const payloadMetadata = payloads.find(({ payload }) => payload?.source_commit)?.payload;
-  const runId = firstNonEmpty(payloadMetadata?.workflow_run_id, process.env.GITHUB_RUN_ID, "local");
+  const runId = firstNonLocal(payloadMetadata?.workflow_run_id, process.env.GITHUB_RUN_ID, "local");
   return {
     generated_at: generatedAt,
-    source_commit: firstNonEmpty(
+    source_commit: firstNonLocal(
       payloadMetadata?.source_commit,
       process.env.BENCH_TARGET_SHA,
       process.env.GITHUB_SHA,
       "local",
     ),
-    workflow_name: firstNonEmpty(payloadMetadata?.workflow_name, process.env.GITHUB_WORKFLOW, "local"),
+    workflow_name: firstNonLocal(payloadMetadata?.workflow_name, process.env.GITHUB_WORKFLOW, "local"),
     workflow_run_id: runId,
-    workflow_run_url: firstNonEmpty(payloadMetadata?.workflow_run_url, githubRunUrl(runId)),
+    workflow_run_url: firstNonLocal(payloadMetadata?.workflow_run_url, githubRunUrl(runId)),
     workflow_run_attempt: firstNonEmpty(payloadMetadata?.workflow_run_attempt, process.env.GITHUB_RUN_ATTEMPT),
-    run_status: firstNonEmpty(
+    run_status: firstNonLocal(
       payloadMetadata?.run_status,
       process.env.GITHUB_ACTIONS === "true" ? "completed" : "local",
     ),

--- a/scripts/bench/test-merge-results.mjs
+++ b/scripts/bench/test-merge-results.mjs
@@ -150,7 +150,7 @@ function writeInput(dir, name, results, extraPayload = {}) {
   return input;
 }
 
-function runMergeInputs(dir, inputs, mergeArgs = []) {
+function runMergeInputs(dir, inputs, mergeArgs = [], envOverrides = {}) {
   const output = path.join(dir, "merged.json");
   const result = spawnSync(process.execPath, [MERGE_SCRIPT, output, ...mergeArgs, ...inputs], {
     cwd: ROOT,
@@ -164,6 +164,7 @@ function runMergeInputs(dir, inputs, mergeArgs = []) {
       GITHUB_SERVER_URL: "",
       GITHUB_SHA: "",
       GITHUB_WORKFLOW: "",
+      ...envOverrides,
     },
     encoding: "utf8",
   });
@@ -196,6 +197,34 @@ withTempDir((dir) => {
   assert.equal(merged.workflow_run_id, "local");
   assert.equal(merged.run_status, "local");
   assert.equal(merged.validation.project_compatibility_required_fields, true);
+});
+
+withTempDir((dir) => {
+  const input = writeInput(dir, "bench-results-local-shard.json", [projectRow("standalone")], {
+    generated_at: "2026-05-19T01:02:03.000Z",
+    source_commit: "local",
+    workflow_name: "local",
+    workflow_run_id: "local",
+    workflow_run_url: null,
+    run_status: "local",
+  });
+  const result = runMergeInputs(dir, [input], [], {
+    BENCH_TARGET_SHA: "feedface1234567890",
+    GITHUB_ACTIONS: "true",
+    GITHUB_REPOSITORY: "mohsen1/tsz",
+    GITHUB_RUN_ATTEMPT: "2",
+    GITHUB_RUN_ID: "67890",
+    GITHUB_SERVER_URL: "https://github.com",
+    GITHUB_SHA: "badcafe1234567890",
+    GITHUB_WORKFLOW: "Bench",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const merged = JSON.parse(fs.readFileSync(result.output, "utf8"));
+  assert.equal(merged.source_commit, "feedface1234567890");
+  assert.equal(merged.workflow_name, "Bench");
+  assert.equal(merged.workflow_run_id, "67890");
+  assert.equal(merged.workflow_run_url, "https://github.com/mohsen1/tsz/actions/runs/67890");
+  assert.equal(merged.run_status, "completed");
 });
 
 withTempDir((dir) => {


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Benchmark blocker / release metric truth.

## Invariant
When benchmark shards carry local placeholder provenance but the GitHub publish job has real workflow metadata, the merged benchmark artifact should cite the public workflow run; this PR fixes the benchmark merge reporting surface.

## Scope
- `scripts/bench/merge-results.mjs`
- `scripts/bench/test-merge-results.mjs`

## Project Corpus Impact
- Row: n/a
- Bug family: benchmark artifact provenance / public metric truth
- Evidence: affects merged benchmark artifact metadata only; project row definitions and compatibility row results are unchanged.

## Verification
- `node scripts/bench/test-merge-results.mjs`
- `node scripts/bench/test-check-artifact-readiness.mjs`
- `node scripts/bench/validate-project-metadata.mjs`
- `git diff --check`

## Coordination Notes
- No open `agent:Studio-A` PRs existed before this branch.
- Related tracker: #10649.
- No markdown/docs changes; this is a focused code/test fix for future benchmark artifacts.
