### PR TITLE
fix(emit): preserve exported anonymous private helper names

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -8,7 +8,7 @@ use crate::transforms::private_fields_es5::{
     PrivateAccessorInfo, PrivateFieldInfo, PrivateMethodInfo,
     collect_enclosing_source_binding_names, collect_private_accessors_with_reserved,
     collect_private_fields_with_reserved, collect_private_methods_with_reserved,
-    get_private_field_name, is_private_identifier, make_unique_private_name,
+    get_private_field_name, is_private_identifier, make_unique_private_name, private_helper_base,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::Arc;
@@ -601,9 +601,48 @@ impl<'a> Printer<'a> {
         let emit_auto_accessor_instance_inits_after_class =
             auto_accessor_instance_storage_inits_in_computed_key.is_empty();
 
+        let is_class_expression = node.kind == syntax_kind_ext::CLASS_EXPRESSION;
+
         // Private field lowering: when target < ES2022, transform #fields to WeakMap pattern
         let needs_private_field_lowering = !self.ctx.options.target.supports_es2022()
             && self.ctx.options.target != ScriptTarget::ESNext;
+        let anonymous_class_expression_has_static_private = class.name.is_none()
+            && is_class_expression
+            && class.members.nodes.iter().any(|&member_idx| {
+                let Some(member_node) = self.arena.get(member_idx) else {
+                    return false;
+                };
+                let (modifiers, name_idx) = match member_node.kind {
+                    k if k == syntax_kind_ext::PROPERTY_DECLARATION => self
+                        .arena
+                        .get_property_decl(member_node)
+                        .map(|prop| (&prop.modifiers, prop.name)),
+                    k if k == syntax_kind_ext::METHOD_DECLARATION => self
+                        .arena
+                        .get_method_decl(member_node)
+                        .map(|method| (&method.modifiers, method.name)),
+                    k if k == syntax_kind_ext::GET_ACCESSOR
+                        || k == syntax_kind_ext::SET_ACCESSOR =>
+                    {
+                        self.arena
+                            .get_accessor(member_node)
+                            .map(|accessor| (&accessor.modifiers, accessor.name))
+                    }
+                    _ => None,
+                }
+                .unwrap_or((&None, NodeIndex::NONE));
+
+                self.arena.is_static(modifiers) && is_private_identifier(self.arena, name_idx)
+            });
+        let private_helper_class_name = if class.name.is_none()
+            && is_class_expression
+            && !anonymous_class_expression_has_static_private
+            && (class_name.is_empty() || self.class_expr_is_exported_variable_initializer(_idx))
+        {
+            ""
+        } else {
+            &class_name
+        };
         // Generated private-helper names are uniquified against a single file-wide
         // set so nested or sibling classes that reuse a class name receive
         // `_N`-suffixed helpers instead of colliding (matches tsc's per-file name
@@ -620,7 +659,7 @@ impl<'a> Printer<'a> {
             collect_private_fields_with_reserved(
                 self.arena,
                 _idx,
-                &class_name,
+                private_helper_class_name,
                 &mut used_private_names,
             )
         } else {
@@ -630,7 +669,7 @@ impl<'a> Printer<'a> {
             collect_private_methods_with_reserved(
                 self.arena,
                 _idx,
-                &class_name,
+                private_helper_class_name,
                 &mut used_private_names,
             )
         } else {
@@ -640,7 +679,7 @@ impl<'a> Printer<'a> {
             collect_private_accessors_with_reserved(
                 self.arena,
                 _idx,
-                &class_name,
+                private_helper_class_name,
                 &mut used_private_names,
             )
         } else {
@@ -651,7 +690,7 @@ impl<'a> Printer<'a> {
                 collect_private_auto_accessors_with_reserved(
                     self,
                     class,
-                    &class_name,
+                    private_helper_class_name,
                     &mut used_private_names,
                 )
             } else {
@@ -676,7 +715,7 @@ impl<'a> Printer<'a> {
             || private_auto_accessors.iter().any(|a| !a.is_static);
         let instances_weakset_name = if has_instance_methods_or_accessors {
             Some(make_unique_private_name(
-                &format!("_{class_name}_instances"),
+                &private_helper_base(private_helper_class_name, "instances"),
                 &mut used_private_names,
             ))
         } else {
@@ -692,8 +731,6 @@ impl<'a> Printer<'a> {
 
         let target_needs_static_block_lowering =
             (self.ctx.options.target as u32) < (ScriptTarget::ES2022 as u32);
-        let is_class_expression = node.kind == syntax_kind_ext::CLASS_EXPRESSION;
-
         let static_initializer_alias_source_nodes: Vec<NodeIndex> =
             if target_needs_static_block_lowering {
                 class

--- a/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
@@ -158,6 +158,85 @@ impl<'a> Printer<'a> {
         false
     }
 
+    pub(in crate::emitter) fn class_expr_is_exported_variable_initializer(
+        &self,
+        class_idx: NodeIndex,
+    ) -> bool {
+        let mut current = class_idx;
+        let mut hops = 0;
+
+        while hops < 8 {
+            let Some(parent_idx) = self
+                .arena
+                .get_extended(current)
+                .map(|ext| ext.parent)
+                .filter(|p| !p.is_none())
+            else {
+                return false;
+            };
+            let Some(parent_node) = self.arena.get(parent_idx) else {
+                return false;
+            };
+
+            match parent_node.kind {
+                syntax_kind_ext::PARENTHESIZED_EXPRESSION
+                | syntax_kind_ext::TYPE_ASSERTION
+                | syntax_kind_ext::AS_EXPRESSION
+                | syntax_kind_ext::SATISFIES_EXPRESSION
+                | syntax_kind_ext::NON_NULL_EXPRESSION => {
+                    current = parent_idx;
+                    hops += 1;
+                }
+                syntax_kind_ext::VARIABLE_DECLARATION => {
+                    let Some(decl) = self.arena.get_variable_declaration(parent_node) else {
+                        return false;
+                    };
+                    if decl.initializer != current {
+                        return false;
+                    }
+                    let Some(list_idx) = self
+                        .arena
+                        .get_extended(parent_idx)
+                        .map(|ext| ext.parent)
+                        .filter(|p| !p.is_none())
+                    else {
+                        return false;
+                    };
+                    let Some(list_node) = self.arena.get(list_idx) else {
+                        return false;
+                    };
+                    if list_node.kind != syntax_kind_ext::VARIABLE_DECLARATION_LIST {
+                        return false;
+                    }
+                    let Some(statement_idx) = self
+                        .arena
+                        .get_extended(list_idx)
+                        .map(|ext| ext.parent)
+                        .filter(|p| !p.is_none())
+                    else {
+                        return false;
+                    };
+                    let Some(statement_node) = self.arena.get(statement_idx) else {
+                        return false;
+                    };
+                    if statement_node.kind != syntax_kind_ext::VARIABLE_STATEMENT {
+                        return false;
+                    }
+                    return self
+                        .arena
+                        .get_variable(statement_node)
+                        .is_some_and(|variable| {
+                            self.arena
+                                .has_modifier(&variable.modifiers, SyntaxKind::ExportKeyword)
+                        });
+                }
+                _ => return false,
+            }
+        }
+
+        false
+    }
+
     fn identifier_binding_name(&self, name_idx: NodeIndex) -> Option<String> {
         let name_node = self.arena.get(name_idx)?;
         if name_node.kind != SyntaxKind::Identifier as u16 {

--- a/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
@@ -1301,6 +1301,45 @@ fn es2015_nested_class_expression_inherits_enclosing_private_self_alias() {
 }
 
 #[test]
+fn es2015_anonymous_class_expression_private_helper_names_follow_static_private_state() {
+    let source = "export const Alpha = class {\n    #value = 1;\n    #read() { return this.#value; }\n    public x = 2;\n};\nexport const Delta = (class {\n    #value = 4;\n    #read() { return this.#value; }\n});\nexport const Beta = class {\n    static #secret = 1;\n    #value = 2;\n    public y = 3;\n};\nconst Gamma = class {\n    #value = 3;\n    #read() { return this.#value; }\n};\n";
+
+    let (parser, root) = parse_test_source(source);
+    let options = PrinterOptions {
+        target: ScriptTarget::ES2015,
+        module: ModuleKind::ESNext,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert!(
+        output.contains("var _instances, _value, _read")
+            && output.contains("_Beta_secret")
+            && output.contains("_Beta_value"),
+        "Private helper declarations should use bare stems for instance-only anonymous class expressions and binding stems when static private state needs named evaluation.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("_Alpha_value")
+            && !output.contains("_Alpha_instances")
+            && !output.contains("_Delta_value")
+            && !output.contains("_Delta_instances"),
+        "Instance-only exported anonymous class expression private helpers should not be named from direct or wrapped bindings.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_Gamma_instances")
+            && output.contains("_Gamma_value")
+            && output.contains("_Gamma_read"),
+        "Unexported variable class expressions should keep binding-derived private helper stems.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn esnext_legacy_class_fields_hoist_auto_accessors_in_source_order() {
     let source = "// order comment\n\
 class C {\n\

--- a/crates/tsz-emitter/src/transforms/private_fields_es5.rs
+++ b/crates/tsz-emitter/src/transforms/private_fields_es5.rs
@@ -245,6 +245,14 @@ pub fn make_unique_private_name(base: &str, used_names: &mut FxHashSet<String>) 
     }
 }
 
+pub fn private_helper_base(class_name: &str, clean_name: &str) -> String {
+    if class_name.is_empty() {
+        format!("_{clean_name}")
+    } else {
+        format!("_{class_name}_{clean_name}")
+    }
+}
+
 fn collect_statement_binding_names(
     arena: &NodeArena,
     stmt_idx: NodeIndex,
@@ -456,8 +464,10 @@ pub fn collect_private_fields_with_reserved(
             if is_private_identifier(arena, prop_data.name) {
                 let field_name = get_private_field_name(arena, prop_data.name).unwrap_or_default();
                 let clean_name = field_name.strip_prefix('#').unwrap_or(&field_name);
-                let weakmap_name =
-                    make_unique_private_name(&format!("_{class_name}_{clean_name}"), used_names);
+                let weakmap_name = make_unique_private_name(
+                    &private_helper_base(class_name, clean_name),
+                    used_names,
+                );
                 let is_static = arena.has_modifier(&prop_data.modifiers, SyntaxKind::StaticKeyword);
 
                 fields.push(PrivateFieldInfo {
@@ -529,11 +539,11 @@ pub fn collect_private_accessors_with_reserved(
                         member_indices: Vec::new(),
                         name: clean_name.to_string(),
                         get_var_name: Some(make_unique_private_name(
-                            &format!("_{class_name}_{clean_name}_get"),
+                            &format!("{}_get", private_helper_base(class_name, clean_name)),
                             used_names,
                         )),
                         set_var_name: Some(make_unique_private_name(
-                            &format!("_{class_name}_{clean_name}_set"),
+                            &format!("{}_set", private_helper_base(class_name, clean_name)),
                             used_names,
                         )),
                         getter_body: None,
@@ -635,7 +645,7 @@ pub fn collect_private_methods_with_reserved(
             let field_name = get_private_field_name(arena, method_data.name).unwrap_or_default();
             let clean_name = field_name.strip_prefix('#').unwrap_or(&field_name);
             let fn_var_name =
-                make_unique_private_name(&format!("_{class_name}_{clean_name}"), used_names);
+                make_unique_private_name(&private_helper_base(class_name, clean_name), used_names);
             let is_static = arena.has_modifier(&method_data.modifiers, SyntaxKind::StaticKeyword);
             let is_async = arena.has_modifier(&method_data.modifiers, SyntaxKind::AsyncKeyword);
 


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Emit / JavaScript parity: class/private/accessor/decorator lowering.

## Invariant
When an exported variable initializer contains an anonymous class expression without static private state, `tsc` uses bare private-helper stems for instance private state even when the class expression is wrapped; this PR makes tsz choose those helper stems in the emitter's private-field lowering path without semantic validation or output surgery.

## Structural Rule
Anonymous class-expression private helper naming is an output-layer named-evaluation fact. Exported variable initializers with instance-only private state use bare helper stems, exported class expressions with static private state keep binding-derived stems, and ordinary unexported variable class expressions keep binding-derived stems.

## Owner Layer
Emitter only. The change adds a parent-chain predicate over parser AST parents and variable-statement modifiers, then routes helper-name construction through the ES5 private-field lowering helpers. It does not import checker/solver internals, inspect semantic types, or patch already-emitted output.

## Adjacent Case Matrix
- Direct exported anonymous class expression: `export const Alpha = class { #value; #read() {} }` uses bare `_value`, `_read`, and `_instances` helper stems.
- Wrapped exported anonymous class expression: `export const Delta = (class { #value; #read() {} })` also uses bare helper stems, covering parenthesized wrapper traversal.
- Exported anonymous class expression with static private state: `export const Beta = class { static #secret; #value; }` keeps binding-derived `_Beta_secret` and `_Beta_value` stems.
- Unexported variable class expression: `const Gamma = class { #value; #read() {} }` keeps binding-derived `_Gamma_value`, `_Gamma_read`, and `_Gamma_instances` stems.

## Known Unsupported Shapes / Fallback
The new predicate only recognizes wrappers already handled by class-expression named-evaluation resolution: parentheses, type assertions, `as`, `satisfies`, and non-null expressions. Other shapes fall back to the existing binding-derived helper naming path.

## Scope
- `crates/tsz-emitter/src/emitter/declarations/class/helpers.rs`: adds the exported variable-initializer parent-chain predicate.
- `crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs`: chooses the private helper class stem from the structural predicate and static-private state.
- `crates/tsz-emitter/src/transforms/private_fields_es5.rs`: centralizes helper base construction so empty class stems do not produce doubled underscores.
- `crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs`: covers direct exported, wrapped exported, static-private exported, and unexported variable class-expression helper names.

## Project Corpus Impact
- Row: n/a
- Bug family: class/private/accessor/decorator lowering
- Evidence: `scripts/emit/run.sh --filter=privateFieldsInClassExpressionDeclaration --js-only --verbose --timeout=30000 --json-out=/tmp/privateFieldsInClassExpressionDeclaration-after-rebase-ec3e.json` passes 1/1 on head `ffceac0508` rebased onto `origin/main` `ec3e69c181`; earlier private-family verification on this slice reported 296/310 in `/tmp/studio-c-private-main-20260531-after-rebase-class-expression-names.json`.

## Verification
- `cargo fmt --all --check`
- `CARGO_TARGET_DIR=/tmp/tsz-studio-c-check-target cargo check -p tsz-emitter`
- `CARGO_TARGET_DIR=/tmp/tsz-studio-c-check-target cargo nextest run -p tsz-emitter es2015_anonymous_class_expression_private_helper_names_follow_static_private_state es2015_nested_class_expression_inherits_enclosing_private_self_alias`
- `scripts/emit/run.sh --filter=privateFieldsInClassExpressionDeclaration --js-only --verbose --timeout=30000 --json-out=/tmp/privateFieldsInClassExpressionDeclaration-after-rebase-ec3e.json`
- `scripts/emit/run.sh --filter=private --js-only --timeout=15000 --json-out=/tmp/studio-c-private-main-20260531-after-rebase-class-expression-names.json`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`

## Coordination Notes
- AgentName: Studio-C
- Ready PR refreshed onto current `origin/main`; exact-head CI is rerunning after the force-push.
- Rebased onto `origin/main` at `ec3e69c181` and pushed head `ffceac0508`.
- Local unstaged `scripts/emit/test_output_surgery_audit.py` changes pre-existed this slice and remain intentionally excluded.



