### PR TITLE
fix(dts): preserve defaulted optional parameter undefined

### DIFF
--- a/crates/tsz-emitter/src/emitter/types/printer/type_printing.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/type_printing.rs
@@ -393,6 +393,13 @@ impl<'a> TypePrinter<'a> {
         }
 
         if non_undefined.len() == 1
+            && visitor::type_param_info(self.interner, non_undefined[0])
+                .is_some_and(|info| info.default.is_some())
+        {
+            return type_id;
+        }
+
+        if non_undefined.len() == 1
             && visitor::function_shape_id(self.interner, non_undefined[0]).is_none()
             && visitor::callable_shape_id(self.interner, non_undefined[0]).is_none()
         {
@@ -1485,6 +1492,57 @@ mod tests {
             TypeId::VOID,
         );
         assert_eq!(printed, "set(value?: string | undefined): void");
+    }
+
+    #[test]
+    fn optional_param_display_strips_plain_type_param_undefined() {
+        let interner = TypeInterner::new();
+        let t_name = interner.intern_string("T");
+        let value = interner.intern_string("value");
+        let t_param = tsz_solver::types::TypeParamInfo {
+            name: t_name,
+            constraint: None,
+            default: None,
+            is_const: false,
+        };
+        let t_type = interner.type_param(t_param);
+        let ty = interner.union2(t_type, TypeId::UNDEFINED);
+        let printed = TypePrinter::new(&interner).print_method_signature(
+            "set",
+            false,
+            &[t_param],
+            &[tsz_solver::ParamInfo::optional(value, ty)],
+            None,
+            TypeId::VOID,
+        );
+        assert_eq!(printed, "set<T>(value?: T): void");
+    }
+
+    #[test]
+    fn optional_param_display_preserves_defaulted_type_param_undefined() {
+        let interner = TypeInterner::new();
+        let this_name = interner.intern_string("This");
+        let this_arg = interner.intern_string("thisArg");
+        let this_param = tsz_solver::types::TypeParamInfo {
+            name: this_name,
+            constraint: None,
+            default: Some(TypeId::UNDEFINED),
+            is_const: false,
+        };
+        let this_type = interner.type_param(this_param);
+        let ty = interner.union2(this_type, TypeId::UNDEFINED);
+        let printed = TypePrinter::new(&interner).print_method_signature(
+            "flatMap",
+            false,
+            &[this_param],
+            &[tsz_solver::ParamInfo::optional(this_arg, ty)],
+            None,
+            TypeId::VOID,
+        );
+        assert_eq!(
+            printed,
+            "flatMap<This = undefined>(thisArg?: This | undefined): void"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Declaration emit / public API type display parity.

## Invariant
When declaration emit prints an inferred public mapped type whose method signature has an optional parameter typed as a defaulted type parameter unioned with `undefined`, `tsc` preserves the `| undefined` branch. This PR keeps that display decision inside the declaration TypePrinter using existing `TypeParamInfo` facts, without adding checker diagnostics or fresh semantic validation in declaration printing.

## Scope
- `crates/tsz-emitter/src/emitter/types/printer/type_printing.rs`
- Adds focused TypePrinter tests for plain vs defaulted type-parameter optional parameter display.

## Project Corpus Impact
- Row: `mappedTypeWithAsClauseAndLateBoundProperty2`
- Bug family: DTS mapped key-remap public type display / optional defaulted type-parameter `undefined` preservation.
- Evidence: focused DTS row now passes with `scripts/safe-run.sh scripts/emit/run.sh --filter=mappedTypeWithAsClauseAndLateBoundProperty2 --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-mapped-as-late-bound-rebased-20260531.json`.

## Adjacent-Case Matrix
- Reported public API shape: mapped key-remap output over array members preserves `This | undefined` and `D | undefined` for defaulted type parameters.
- Positive equivalent shape: `flatMap<This = undefined>(thisArg?: This | undefined)` preserves the branch because the type parameter has a default.
- Negative/fallback shape: `set<T>(value?: T)` still strips synthesized optional-parameter `undefined` for a plain type parameter with no default.
- Existing preserved-origin shape: explicit union-origin optional parameters still print `string | undefined`.
- Existing synthesized primitive shape: optional primitive unions such as `separator?: string | undefined` still print as `separator?: string`.

## Fallback Behavior
Unsupported or unrelated parameter types continue through the existing optional-parameter display path. The new branch only checks solver-owned `TypeParamInfo.default` on the non-undefined union member and otherwise falls back to the previous rules for explicit union origins, callable/function members, primitives, and plain type parameters.

## Verification
- `cargo fmt --all --check`
- `git diff --check HEAD~1..HEAD`
- `cargo nextest run -p tsz-emitter -E 'test(optional_param_display_strips_plain_type_param_undefined) or test(optional_param_display_preserves_defaulted_type_param_undefined) or test(optional_param_display_omits_synthesized_primitive_undefined) or test(optional_param_display_preserves_explicit_union_origin)'`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=mappedTypeWithAsClauseAndLateBoundProperty2 --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-mapped-as-late-bound-rebased-20260531.json`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=mappedTypeAsClauses --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-mapped-as-clauses-after-20260531.json`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=mappedTypeUnionConstraintInferences --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-mapped-union-constraint-after-20260531.json`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-emitter --all-targets -- -D warnings`

## Coordination Notes
- #11862 has merged; this is a fresh Studio-D branch rebased onto current `origin/main`.
- No active open PR claimed this mapped key-remap type-display row during intake; adjacent JSDoc/private-name emit work is left to Studio-E/Studio-C.
- Ready for manager review/queue after PR-head CI is green. `Queue Tested` is queue-owned and expected to remain pending until `merge-queue` is applied.
