### PR TITLE
chore(agents): add strict label audit mode

### DIFF
--- a/scripts/agents/ensure-agent-labels.sh
+++ b/scripts/agents/ensure-agent-labels.sh
@@ -15,7 +15,7 @@ COLOR="ededed"
 
 usage() {
   cat <<'USAGE'
-usage: scripts/agents/ensure-agent-labels.sh [--audit]
+usage: scripts/agents/ensure-agent-labels.sh [--audit] [--strict]
 
 Create or refresh the GitHub labels used by multi-agent sessions.
 
@@ -24,6 +24,8 @@ agent ownership labels are missing, duplicated, or noncanonical; and open
 release-triage issues whose agent ownership labels are missing, duplicated, or
 noncanonical. Open PRs whose body explicitly says no canonical agent lane was
 assigned are reported separately. The audit does not edit labels.
+
+With --audit --strict, exit nonzero when the audit has actionable findings.
 USAGE
 }
 
@@ -33,10 +35,25 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
 fi
 
 AUDIT=false
-if [[ $# -eq 1 && "${1:-}" == "--audit" ]]; then
-  AUDIT=true
-elif [[ $# -ne 0 ]]; then
-  echo "Unknown option: $1 (try --help)" >&2
+STRICT_AUDIT=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --audit)
+      AUDIT=true
+      ;;
+    --strict)
+      STRICT_AUDIT=true
+      ;;
+    *)
+      echo "Unknown option: $1 (try --help)" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [[ "$STRICT_AUDIT" == true && "$AUDIT" != true ]]; then
+  echo "--strict requires --audit (try --help)" >&2
   exit 2
 fi
 
@@ -66,7 +83,7 @@ if [[ "$AUDIT" == true ]]; then
       process.stdout.write(JSON.stringify(fs.readFileSync(0, "utf8").trim().split(/\n/).filter(Boolean)));
     '
   )"
-  AGENTS_JSON="$agents_json" LABELS_TEXT="$existing" PRS_JSON="$prs_json" ISSUES_JSON="$issues_json" node <<'NODE'
+  AGENTS_JSON="$agents_json" LABELS_TEXT="$existing" PRS_JSON="$prs_json" ISSUES_JSON="$issues_json" STRICT_AUDIT="$STRICT_AUDIT" node <<'NODE'
 const canonical = new Set(JSON.parse(process.env.AGENTS_JSON).map((agent) => `agent:${agent}`));
 const labels = process.env.LABELS_TEXT.split(/\n/).filter(Boolean);
 const prs = JSON.parse(process.env.PRS_JSON);
@@ -150,6 +167,17 @@ console.log(`open_prs_noncanonical_agent_label=${noncanonicalPrs.length}`);
 console.log(`open_release_issues_missing_agent_label=${missingIssues.length}`);
 console.log(`open_issues_multiple_agent_labels=${multipleIssues.length}`);
 console.log(`open_issues_noncanonical_agent_label=${noncanonicalIssues.length}`);
+const findingCount =
+  missingCanonicalLabels.length +
+  noncanonicalLabels.length +
+  missingPrs.length +
+  multiplePrs.length +
+  noncanonicalPrs.length +
+  missingIssues.length +
+  multipleIssues.length +
+  noncanonicalIssues.length;
+console.log(`agent_label_audit_findings=${findingCount}`);
+console.log(`agent_label_audit_status=${findingCount === 0 ? "pass" : "fail"}`);
 
 printRows("Missing Canonical Labels", missingCanonicalLabels, (label) => `- ${label}`);
 printRows("Noncanonical Agent Labels", noncanonicalLabels, (label) => `- ${label}`);
@@ -182,6 +210,9 @@ printRows(
   noncanonicalIssues,
   (issue) => `- #${issue.number} ${issue.agentLabels.join(", ")} ${issue.title}${issue.url ? ` ${issue.url}` : ""}`,
 );
+if (process.env.STRICT_AUDIT === "true" && findingCount > 0) {
+  process.exitCode = 1;
+}
 NODE
   exit 0
 fi

--- a/scripts/agents/test_ensure_agent_labels.py
+++ b/scripts/agents/test_ensure_agent_labels.py
@@ -31,9 +31,11 @@ CANONICAL_AGENT_LABELS = [
 
 
 class EnsureAgentLabelsAuditTests(unittest.TestCase):
-    def run_audit_with_prs(self, prs, issues=None):
+    def run_audit_result(self, prs, issues=None, args=None, check=True):
         if issues is None:
             issues = []
+        if args is None:
+            args = ["--audit"]
         with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
             fake_gh = pathlib.Path(temp_dir) / "gh"
             fake_gh.write_text(
@@ -82,14 +84,17 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
             }
 
             return subprocess.run(
-                [str(SCRIPT), "--audit"],
+                [str(SCRIPT), *args],
                 cwd=ROOT,
                 env=env,
-                check=True,
+                check=check,
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-            ).stdout
+            )
+
+    def run_audit_with_prs(self, prs, issues=None):
+        return self.run_audit_result(prs, issues=issues).stdout
 
     def test_audit_separates_intentionally_unassigned_prs(self):
         output = self.run_audit_with_prs(
@@ -113,6 +118,8 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
 
         self.assertIn("open_prs_missing_agent_label=0", output)
         self.assertIn("open_prs_intentionally_unassigned=1", output)
+        self.assertIn("agent_label_audit_findings=0", output)
+        self.assertIn("agent_label_audit_status=pass", output)
         self.assertIn("Open PRs Intentionally Unassigned", output)
         self.assertIn(
             "#1 chore: intentionally unassigned https://github.com/mohsen1/tsz/pull/1",
@@ -134,10 +141,51 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
 
         self.assertIn("open_prs_missing_agent_label=1", output)
         self.assertIn("open_prs_intentionally_unassigned=0", output)
+        self.assertIn("agent_label_audit_findings=1", output)
+        self.assertIn("agent_label_audit_status=fail", output)
         self.assertIn(
             "#3 fix: missing label https://github.com/mohsen1/tsz/pull/3",
             output,
         )
+
+    def test_strict_audit_fails_on_actionable_findings(self):
+        result = self.run_audit_result(
+            [
+                {
+                    "number": 4,
+                    "title": "fix: missing label",
+                    "labels": [],
+                    "body": "AgentName: Studio-F",
+                    "url": "https://github.com/mohsen1/tsz/pull/4",
+                }
+            ],
+            args=["--audit", "--strict"],
+            check=False,
+        )
+
+        self.assertEqual(1, result.returncode, result.stderr)
+        self.assertIn("open_prs_missing_agent_label=1", result.stdout)
+        self.assertIn("agent_label_audit_findings=1", result.stdout)
+        self.assertIn("agent_label_audit_status=fail", result.stdout)
+
+    def test_strict_audit_allows_intentionally_unassigned_prs(self):
+        result = self.run_audit_result(
+            [
+                {
+                    "number": 5,
+                    "title": "chore: intentionally unassigned",
+                    "labels": [],
+                    "body": "Coordination Notes\n- No canonical agent lane was assigned.",
+                    "url": "https://github.com/mohsen1/tsz/pull/5",
+                }
+            ],
+            args=["--audit", "--strict"],
+        )
+
+        self.assertEqual(0, result.returncode)
+        self.assertIn("open_prs_intentionally_unassigned=1", result.stdout)
+        self.assertIn("agent_label_audit_findings=0", result.stdout)
+        self.assertIn("agent_label_audit_status=pass", result.stdout)
 
     def test_audit_flags_release_issues_missing_agent_labels(self):
         output = self.run_audit_with_prs(


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / cheap evidence plumbing.

## Invariant
When label-hygiene debt is present, the human audit remains readable and automation can opt into a nonzero status through `--audit --strict`; this PR changes only the agent coordination script surface.

## Scope
- `scripts/agents/ensure-agent-labels.sh`
- `scripts/agents/test_ensure_agent_labels.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent-script-only change; no compiler, emit, conformance, benchmark, LSP, or WASM behavior changes.

## Verification
- `python3 -m unittest scripts.agents.test_ensure_agent_labels`
- `python3 -m unittest scripts.agents.test_ensure_agent_labels scripts.agents.test_disk_preflight scripts.agents.test_show_goal`
- `scripts/agents/ensure-agent-labels.sh --help`
- `scripts/agents/ensure-agent-labels.sh --strict` exits 2 because `--strict` requires `--audit`
- `scripts/agents/ensure-agent-labels.sh --audit` live audit prints `agent_label_audit_findings=24` and `agent_label_audit_status=fail`
- `scripts/agents/ensure-agent-labels.sh --audit --strict` live audit exits 1 with the same findings
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Owned Studio-F runway was clear before this branch (`scripts/agents/list-owned-work.sh Studio-F`: no PRs, no issues).
- Checked open PR overlap for `ensure-agent-labels`, agent label audit, label hygiene, and Studio-F; no overlapping infrastructure PR was found.
- This does not relabel or take ownership of unrelated PRs/issues; it only makes the existing audit output easier to gate when a queue/manager lane chooses to do so.
