### PR TITLE
chore(agents): summarize disk preflight cache reuse

### DIFF
--- a/scripts/agents/disk-preflight.sh
+++ b/scripts/agents/disk-preflight.sh
@@ -60,13 +60,20 @@ PRIMARY_TS="$PRIMARY_REPO/TypeScript"
 
 echo ""
 echo "== local cargo cache presence =="
+LOCAL_CARGO_CACHE_COUNT=0
 for dir in .target .target-bench target; do
   if [[ -d "$ROOT/$dir" ]]; then
     echo "$dir=present"
+    LOCAL_CARGO_CACHE_COUNT=$((LOCAL_CARGO_CACHE_COUNT + 1))
   else
     echo "$dir=missing"
   fi
 done
+if (( LOCAL_CARGO_CACHE_COUNT > 0 )); then
+  echo "cargo_cache_status=present"
+else
+  echo "cargo_cache_status=missing"
+fi
 
 echo ""
 echo "== TypeScript reuse sources =="
@@ -97,6 +104,22 @@ if [[ "$COMMON_REAL" != "$GIT_REAL" && ! -e "$ROOT/TypeScript/tests/cases" ]]; t
   else
     echo "hint=no populated TypeScript source found; run scripts/setup/setup-ts-submodule.sh in the primary checkout first"
   fi
+fi
+
+CARGO_CACHE_SOURCE_COUNT=0
+while IFS= read -r wt; do
+  [[ -n "$wt" ]] || continue
+  [[ "$wt" != "$ROOT" ]] || continue
+  if [[ -d "$wt/.target" || -d "$wt/.target-bench" || -d "$wt/target" ]]; then
+    CARGO_CACHE_SOURCE_COUNT=$((CARGO_CACHE_SOURCE_COUNT + 1))
+  fi
+done < <(git -C "$ROOT" worktree list --porcelain | awk '/^worktree / { print substr($0, 10) }')
+
+echo ""
+echo "== cargo cache reuse summary =="
+echo "cargo_cache_reuse_sources=$CARGO_CACHE_SOURCE_COUNT"
+if (( LOCAL_CARGO_CACHE_COUNT == 0 && CARGO_CACHE_SOURCE_COUNT > 0 )); then
+  echo "hint=reuse an existing cached worktree before creating a new build cache"
 fi
 
 echo ""

--- a/scripts/agents/test_disk_preflight.py
+++ b/scripts/agents/test_disk_preflight.py
@@ -71,12 +71,15 @@ class DiskPreflightTests(unittest.TestCase):
             self.assertIn("typescript=populated-local-submodule", result.stdout)
             self.assertIn(f"primary={fake_repo} ts-populated", result.stdout)
             self.assertIn("target=present", result.stdout)
+            self.assertIn("cargo_cache_status=present", result.stdout)
+            self.assertIn("cargo_cache_reuse_sources=0", result.stdout)
 
     def test_worktree_without_typescript_points_to_link_helper(self):
         with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
             temp_root = pathlib.Path(temp_dir).resolve()
             fake_repo, fake_script = self.make_fake_repo(temp_root)
             (fake_repo / "TypeScript" / "tests" / "cases").mkdir(parents=True)
+            (fake_repo / ".target").mkdir()
 
             linked_worktree = temp_root / "tsz-linked"
             self.run_git(
@@ -90,6 +93,12 @@ class DiskPreflightTests(unittest.TestCase):
             self.assertIn("typescript=missing", result.stdout)
             self.assertIn(f"primary={fake_repo} ts-populated", result.stdout)
             self.assertIn("hint=run scripts/setup/link-ts-submodule.sh", result.stdout)
+            self.assertIn("cargo_cache_status=missing", result.stdout)
+            self.assertIn("cargo_cache_reuse_sources=1", result.stdout)
+            self.assertIn(
+                "hint=reuse an existing cached worktree before creating a new build cache",
+                result.stdout,
+            )
 
     def test_unknown_agent_fails_before_preflight(self):
         with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / disk and worktree hygiene / cheap evidence plumbing.

## Invariant
When a worktree lacks local Cargo caches but sibling worktrees already have reusable cache state, `disk-preflight.sh` should expose that as compact machine-readable evidence instead of making agents infer it from the long worktree list.

## Scope
- `scripts/agents/disk-preflight.sh`
- `scripts/agents/test_disk_preflight.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent-script-only change; no compiler, emit, conformance, benchmark, LSP, or WASM behavior changes.

## Verification
- `python3 -m unittest scripts.agents.test_disk_preflight`
- `python3 -m unittest scripts.agents.test_disk_preflight scripts.agents.test_ensure_agent_labels scripts.agents.test_show_goal`
- `scripts/agents/disk-preflight.sh --help`
- `scripts/agents/disk-preflight.sh Studio-F | sed -n '1,44p'`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Owned Studio-F runway was clear before this branch (`scripts/agents/list-owned-work.sh Studio-F`: no PRs, no issues).
- Checked open PR overlap for disk preflight, disk worktree, cache reuse, and Studio-F; no overlapping Studio-F infrastructure PR was found.
- This does not delete worktrees, clean caches, create worktrees, or change cleanup policy; it only adds summary lines so agents can preserve and reuse existing caches more reliably.
