### PR TITLE
fix(dts): preserve Partial inverse undefined stripping

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs
@@ -1,6 +1,7 @@
 //! Correlated union and generic call substitution helpers for DTS emit.
 
 use super::super::DeclarationEmitter;
+use std::cell::Cell;
 use tsz_parser::parser::node::{MappedTypeData, NodeArena, TypeAliasData};
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::parser::{NodeIndex, NodeList};
@@ -799,6 +800,120 @@ impl<'a> DeclarationEmitter<'a> {
         substitutions
     }
 
+    pub(in crate::declaration_emitter) fn partial_required_call_reused_type_should_replace_preferred(
+        &self,
+        expr_idx: NodeIndex,
+        reused_type_text: &str,
+        preferred_type_text: &str,
+    ) -> bool {
+        if !self.call_expression_uses_partial_required_mapped_inference(expr_idx) {
+            return false;
+        }
+        Self::partial_required_object_text_matches_preferred(reused_type_text, preferred_type_text)
+            .unwrap_or(false)
+    }
+
+    pub(in crate::declaration_emitter) fn call_expression_uses_partial_required_mapped_inference(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> bool {
+        let Some(expr_node) = self.arena.get(expr_idx) else {
+            return false;
+        };
+        let Some(call) = self.arena.get_call_expr(expr_node) else {
+            return false;
+        };
+        let Some(binder) = self.binder else {
+            return false;
+        };
+        let Some(raw_sym_id) = self.value_reference_symbol(call.expression) else {
+            return false;
+        };
+        let sym_id = self
+            .resolve_portability_import_alias(raw_sym_id, binder)
+            .unwrap_or_else(|| self.resolve_portability_symbol(raw_sym_id, binder));
+
+        self.with_symbol_declarations(sym_id, |source_arena, decl_idx| {
+            let decl_node = source_arena.get(decl_idx)?;
+            let callable = Self::callable_decl_parts_from_node(source_arena, decl_node)?;
+            if !callable.type_annotation.is_some()
+                || !self.function_signature_accepts_call_arguments(
+                    source_arena,
+                    callable.parameters,
+                    call,
+                )
+            {
+                return None;
+            }
+            let return_type_param =
+                self.simple_type_node_name_from_arena(source_arena, callable.type_annotation)?;
+            let type_params = callable.type_parameters?;
+            let declares_return_param = type_params.nodes.iter().copied().any(|param_idx| {
+                source_arena
+                    .get(param_idx)
+                    .and_then(|node| source_arena.get_type_parameter(node))
+                    .and_then(|param| self.identifier_text_from_arena(source_arena, param.name))
+                    .is_some_and(|name| name == return_type_param)
+            });
+            if !declares_return_param {
+                return None;
+            }
+
+            for &param_idx in &callable.parameters.nodes {
+                let Some(param_node) = source_arena.get(param_idx) else {
+                    continue;
+                };
+                let Some(param) = source_arena.get_parameter(param_node) else {
+                    continue;
+                };
+                let Some((param_inner, inference)) = self
+                    .mapped_argument_inference_from_param_type(source_arena, param.type_annotation)
+                else {
+                    continue;
+                };
+                if param_inner == return_type_param
+                    && matches!(inference, MappedArgumentInference::PartialRequired)
+                {
+                    return Some(true);
+                }
+            }
+            None
+        })
+        .unwrap_or(false)
+    }
+
+    fn partial_required_object_text_matches_preferred(
+        reused_type_text: &str,
+        preferred_type_text: &str,
+    ) -> Option<bool> {
+        let reused_members = Self::object_type_members(reused_type_text)?;
+        let preferred_members = Self::object_type_members(preferred_type_text)?;
+        if reused_members.len() != preferred_members.len() {
+            return Some(false);
+        }
+
+        let mut removed_undefined = false;
+        for (reused_member, preferred_member) in reused_members.iter().zip(preferred_members.iter())
+        {
+            let (reused_name, reused_optional, reused_type) =
+                Self::object_member_parts(reused_member)?;
+            let (preferred_name, preferred_optional, preferred_type) =
+                Self::object_member_parts(preferred_member)?;
+            if reused_name != preferred_name || reused_optional || preferred_optional {
+                return Some(false);
+            }
+            if reused_type == preferred_type {
+                continue;
+            }
+            if Self::remove_undefined_union_member(preferred_type) != reused_type {
+                return Some(false);
+            }
+            removed_undefined = true;
+        }
+
+        Some(removed_undefined)
+    }
+
     fn mapped_argument_inference_from_param_type(
         &self,
         source_arena: &NodeArena,
@@ -815,17 +930,36 @@ impl<'a> DeclarationEmitter<'a> {
             return None;
         };
         let param_inner = self.simple_type_node_name_from_arena(source_arena, *type_arg_idx)?;
-        let sym_id = self
-            .declaration_type_symbol_from_type_node(source_arena, param_type_idx)
-            .or_else(|| {
-                let name = self.simple_type_node_name_from_arena(source_arena, param_type_idx)?;
-                self.binder?.get_global_type(&name)
-            })?;
-        let inference = self.with_symbol_declarations(sym_id, |alias_arena, decl_idx| {
-            let alias_node = alias_arena.get(decl_idx)?;
-            let alias = alias_arena.get_type_alias(alias_node)?;
-            self.mapped_argument_inference_from_alias(alias_arena, alias)
-        })?;
+        let mut saw_declared_symbol = false;
+        let inference = if let Some(sym_id) =
+            self.declaration_type_symbol_from_type_node(source_arena, param_type_idx)
+        {
+            let saw_declaration = Cell::new(false);
+            let inference = self.with_symbol_declarations(sym_id, |alias_arena, decl_idx| {
+                saw_declaration.set(true);
+                let alias_node = alias_arena.get(decl_idx)?;
+                let alias = alias_arena.get_type_alias(alias_node)?;
+                self.mapped_argument_inference_from_alias(alias_arena, alias)
+            });
+            saw_declared_symbol = saw_declaration.get();
+            inference
+        } else {
+            None
+        };
+        let inference = if let Some(inference) = inference {
+            inference
+        } else {
+            if saw_declared_symbol {
+                return None;
+            }
+            let name = self.simple_type_node_name_from_arena(source_arena, param_type_idx)?;
+            let sym_id = self.binder?.get_global_type(&name)?;
+            self.with_symbol_declarations(sym_id, |alias_arena, decl_idx| {
+                let alias_node = alias_arena.get(decl_idx)?;
+                let alias = alias_arena.get_type_alias(alias_node)?;
+                self.mapped_argument_inference_from_alias(alias_arena, alias)
+            })?
+        };
         Some((param_inner, inference))
     }
 

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
@@ -468,6 +468,8 @@ impl<'a> DeclarationEmitter<'a> {
                         // (`D & M`, `T | U`, `Foo<T>`) on the text path so their
                         // tsc-faithful source structure is preserved.
                         if self.source_return_is_bare_type_parameter(source_arena, func)
+                            && !self
+                                .call_expression_uses_partial_required_mapped_inference(expr_idx)
                             && let Some(canonical_text) =
                                 self.fully_resolved_call_canonical_type_text(expr_idx)
                         {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
@@ -836,6 +836,40 @@ let y = complete(value);
 }
 
 #[test]
+fn partial_required_call_surface_can_replace_preferred_optional_undefined_object() {
+    let source = r#"
+type OptionalShape<Shape> = { [Field in keyof Shape]?: Shape[Field] };
+declare function complete<Shape>(x: OptionalShape<Shape>): Shape;
+declare let value: { a: number | undefined, b?: string[] };
+let y = complete(value);
+"#;
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+    let interner = TypeInterner::new();
+    let type_cache = crate::type_cache_view::TypeCacheView::default();
+    let emitter = DeclarationEmitter::with_type_info(&parser.arena, type_cache, &interner, &binder);
+    let call_idx = parser
+        .arena
+        .nodes
+        .iter()
+        .enumerate()
+        .find_map(|(idx, node)| {
+            (node.kind == syntax_kind_ext::CALL_EXPRESSION).then_some(NodeIndex(idx as u32))
+        })
+        .expect("missing call expression");
+
+    assert!(
+        emitter.partial_required_call_reused_type_should_replace_preferred(
+            call_idx,
+            "{\n    a: number;\n    b: string[];\n}",
+            "{\n    a: number | undefined;\n    b: string[];\n}",
+        )
+    );
+}
+
+#[test]
 fn call_reused_type_inverts_reverse_mapped_handler_parameters() {
     let source = r#"
 type Callbacks<Shape> = { [Field in keyof Shape]: (value: Shape[Field]) => void };

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -560,6 +560,11 @@ impl<'a> DeclarationEmitter<'a> {
                             && (text.contains("=>")
                                 || text.starts_with('[')
                                 || type_text.contains("unknown")
+                                || self.partial_required_call_reused_type_should_replace_preferred(
+                                    initializer,
+                                    text,
+                                    &type_text,
+                                )
                                 || (keyword == "const"
                                     && Self::is_literal_type_text_for_const_call(text)))
                     })


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Declaration emit parity / DTS mapped utility inference.

## Invariant
When a generic call returns the same type parameter accepted through a structural `Partial`-like mapped alias, declaration emit must reconstruct the required public surface that `tsc` emits. This PR changes declaration emit call-surface selection so the `Partial<T>` inverse can remove optionalization-added top-level `undefined` instead of being preempted by the checker canonical object type.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs`

## Project Corpus Impact
- Row: TypeScript conformance emit fixture `mappedTypesArraysTuples`
- Bug family: DTS reverse mapped `Partial<T>` inference for declared call returns
- Evidence: `scripts/safe-run.sh scripts/emit/run.sh --filter=mappedTypesArraysTuples --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-mapped-arrays-tuples-rebased-20260531.json` passes 1/1 after the fix.

## Generalization Gate
- Structural rule: a call returning bare `T` from a parameter shaped as `{ [K in keyof T]?: T[K] }` should prefer the reconstructed declaration surface over the canonical checker object when the only object-member difference is top-level `undefined` introduced by optionalization.
- Adjacent-case matrix: positive renamed alias/type parameter (`OptionalShape<Shape>`), positive conformance lib `Partial<T>` (`mappedTypesArraysTuples`), negative shadowed `type Partial<T> = T`, and retained isomorphic mapped tuple call behavior.
- Fallback behavior: if the parameter alias is not structurally partial-like, the reusable object surface is not used; if a local declared symbol shadows the utility name, global fallback is blocked.
- Removal path: replace this text comparison once declaration/public API summaries expose optionalization-origin facts directly.

## Verification
- `cargo fmt --all --check`
- `git diff --check HEAD~1..HEAD`
- `cargo nextest run -p tsz-emitter -E 'test(declared_call_return_inverts_structural_partial_like_mapped_alias) or test(partial_required_call_surface_can_replace_preferred_optional_undefined_object) or test(declared_call_return_does_not_treat_shadowed_partial_name_as_builtin) or test(declared_call_return_inverts_isomorphic_mapped_tuple_argument)' --no-fail-fast`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=mappedTypesArraysTuples --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-mapped-arrays-tuples-rebased-20260531.json`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-emitter --all-targets -- -D warnings`

## Coordination Notes
- AgentName: Studio-D
- Built on current `origin/main` after PR #11867 merged.
- Open PR overlap checked before publishing; no open PR claims `mappedTypesArraysTuples` or this `Partial<T>` inverse surface.
- `scripts/agents/ensure-agent-labels.sh --audit` still reports pre-existing unrelated label hygiene findings on other PRs/issues; this PR will receive one canonical `agent:Studio-D` label.
