### PR TITLE
chore(agents): summarize owned work status

### DIFF
--- a/scripts/agents/list-owned-work.sh
+++ b/scripts/agents/list-owned-work.sh
@@ -15,6 +15,8 @@ usage() {
   cat <<'USAGE'
 usage: scripts/agents/list-owned-work.sh [--pr-state] [AgentName|--all]
 
+Lists owned open PRs/issues and prints compact per-agent summary counters.
+
 Examples:
   scripts/agents/list-owned-work.sh M1-A
   scripts/agents/list-owned-work.sh --all
@@ -97,6 +99,15 @@ list_owned_items_rest() {
   fi
 }
 
+count_rows() {
+  local rows="$1"
+  if [[ -z "$rows" ]]; then
+    echo 0
+    return
+  fi
+  printf '%s\n' "$rows" | awk 'NF { count++ } END { print count + 0 }'
+}
+
 for agent in "${SELECTED[@]}"; do
   case "$agent" in
     M1-A|M1-B|M1-C|M1-D|M4-A|M4-B|M4-C|M4-D|Studio-A|Studio-B|Studio-C|Studio-D|Studio-E|Studio-F|Reviewer) ;;
@@ -143,6 +154,7 @@ for agent in "${SELECTED[@]}"; do
   else
     echo "- none"
   fi
+  pr_count="$(count_rows "$prs")"
   echo ""
   echo "Issues:"
   issues="$(
@@ -156,5 +168,16 @@ for agent in "${SELECTED[@]}"; do
   else
     echo "- none"
   fi
+  issue_count="$(count_rows "$issues")"
+  total_count=$(( pr_count + issue_count ))
+  if (( total_count == 0 )); then
+    owned_work_status="clear"
+  else
+    owned_work_status="active"
+  fi
+  echo ""
+  echo "owned_pr_count=$pr_count"
+  echo "owned_issue_count=$issue_count"
+  echo "owned_work_status=$owned_work_status"
   echo ""
 done

--- a/scripts/agents/test_list_owned_work.py
+++ b/scripts/agents/test_list_owned_work.py
@@ -1,0 +1,62 @@
+import os
+import pathlib
+import subprocess
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "agents" / "list-owned-work.sh"
+
+
+class ListOwnedWorkTests(unittest.TestCase):
+    def run_list_owned_work(self, args, prs="", issues=""):
+        env = {**os.environ, "FAKE_GH_PRS": prs, "FAKE_GH_ISSUES": issues}
+        bootstrap = r"""
+gh() {
+  case "$1 $2" in
+    "pr list") printf "%s" "${FAKE_GH_PRS:-}" ;;
+    "issue list") printf "%s" "${FAKE_GH_ISSUES:-}" ;;
+    *) echo "unexpected gh invocation: $*" >&2; return 99 ;;
+  esac
+}
+export -f gh
+exec "$@"
+"""
+        return subprocess.run(
+            ["/bin/bash", "-c", bootstrap, "bash", str(SCRIPT), *args],
+            cwd=ROOT,
+            env=env,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+        )
+
+    def test_clear_owned_work_prints_summary_counters(self):
+        result = self.run_list_owned_work(["Studio-F"])
+
+        self.assertIn("## agent:Studio-F", result.stdout)
+        self.assertIn("PRs:\n- none", result.stdout)
+        self.assertIn("Issues:\n- none", result.stdout)
+        self.assertIn("owned_pr_count=0", result.stdout)
+        self.assertIn("owned_issue_count=0", result.stdout)
+        self.assertIn("owned_work_status=clear", result.stdout)
+
+    def test_active_owned_work_prints_active_summary(self):
+        result = self.run_list_owned_work(
+            ["Studio-F"],
+            prs=(
+                "#1 ready first PR https://github.com/mohsen1/tsz/pull/1\n"
+                "#2 draft second PR https://github.com/mohsen1/tsz/pull/2\n"
+            ),
+            issues="#3 issue https://github.com/mohsen1/tsz/issues/3\n",
+        )
+
+        self.assertIn("owned_pr_count=2", result.stdout)
+        self.assertIn("owned_issue_count=1", result.stdout)
+        self.assertIn("owned_work_status=active", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure and cheap evidence plumbing.

## Invariant
Keep multi-agent coordination scripts small, deterministic, and cheap to run during every cycle.

## Scope
- Add compact owned-work summary counters to scripts/agents/list-owned-work.sh.
- Add focused unit coverage for clear and active owned-work summaries.

## Project Corpus Impact
Row: n/a
Bug family: n/a
Evidence: agent-script-only; no compiler, parser, checker, solver, emitter, benchmark, or project-corpus behavior changed.

## Verification
- python3 -m unittest scripts.agents.test_list_owned_work scripts.agents.test_disk_preflight scripts.agents.test_ensure_agent_labels scripts.agents.test_show_goal
- scripts/agents/list-owned-work.sh Studio-F
- scripts/agents/list-owned-work.sh --help
- git diff --check origin/main...HEAD

## Coordination Notes
This PR gives every agent cycle a machine-readable owned-work summary so lanes can quickly prove whether existing PRs/issues are clear before starting more work. Pruned stale remote refs/worktree metadata and only attempted safe deletion of local branches already merged into origin/main; active worktrees were skipped.

Signed-off-by: Studio-F