### PR TITLE
fix(dts): block NoInfer callback return inference

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs
@@ -768,12 +768,27 @@ impl<'a> DeclarationEmitter<'a> {
             else {
                 continue;
             };
+            let blocked_return_type_params = self
+                .no_infer_blocked_return_type_params_from_function_type(
+                    source_arena,
+                    param.type_annotation,
+                    type_param_names,
+                );
             Self::infer_function_type_substitutions(
                 &source_function_type,
                 &argument_function_type,
                 type_param_names,
+                &blocked_return_type_params,
                 &mut substitutions,
             );
+            for param_name in blocked_return_type_params {
+                if !substitutions
+                    .iter()
+                    .any(|(name, _)| name.as_str() == param_name)
+                {
+                    substitutions.push((param_name, "unknown".to_string()));
+                }
+            }
         }
 
         for (&param_idx, &arg_idx) in parameters.nodes.iter().zip(args.nodes.iter()) {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_no_infer.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_no_infer.rs
@@ -1,0 +1,197 @@
+//! Declaration emit helpers for generic calls constrained by builtin `NoInfer`.
+
+use super::super::DeclarationEmitter;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::{NodeAccess, NodeArena};
+use tsz_parser::parser::syntax_kind_ext;
+
+impl<'a> DeclarationEmitter<'a> {
+    pub(in crate::declaration_emitter) fn call_expression_uses_no_infer_return_block(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> bool {
+        let Some(expr_node) = self.arena.get(expr_idx) else {
+            return false;
+        };
+        let Some(call) = self.arena.get_call_expr(expr_node) else {
+            return false;
+        };
+        let Some(binder) = self.binder else {
+            return false;
+        };
+        let Some(raw_sym_id) = self.value_reference_symbol(call.expression) else {
+            return false;
+        };
+        let sym_id = self
+            .resolve_portability_import_alias(raw_sym_id, binder)
+            .unwrap_or_else(|| self.resolve_portability_symbol(raw_sym_id, binder));
+
+        self.with_symbol_declarations(sym_id, |source_arena, decl_idx| {
+            let decl_node = source_arena.get(decl_idx)?;
+            let callable = Self::callable_decl_parts_from_node(source_arena, decl_node)?;
+            if !callable.type_annotation.is_some()
+                || !self.function_signature_accepts_call_arguments(
+                    source_arena,
+                    callable.parameters,
+                    call,
+                )
+            {
+                return None;
+            }
+            let type_param_names = callable
+                .type_parameters?
+                .nodes
+                .iter()
+                .copied()
+                .filter_map(|param_idx| {
+                    let param_node = source_arena.get(param_idx)?;
+                    let param = source_arena.get_type_parameter(param_node)?;
+                    self.identifier_text_from_arena(source_arena, param.name)
+                })
+                .collect::<Vec<_>>();
+            for &param_idx in &callable.parameters.nodes {
+                let Some(param_node) = source_arena.get(param_idx) else {
+                    continue;
+                };
+                let Some(param) = source_arena.get_parameter(param_node) else {
+                    continue;
+                };
+                if !self
+                    .no_infer_blocked_return_type_params_from_function_type(
+                        source_arena,
+                        param.type_annotation,
+                        &type_param_names,
+                    )
+                    .is_empty()
+                {
+                    return Some(true);
+                }
+            }
+            None
+        })
+        .unwrap_or(false)
+    }
+
+    pub(in crate::declaration_emitter) fn no_infer_blocked_return_type_params_from_function_type(
+        &self,
+        source_arena: &NodeArena,
+        type_idx: NodeIndex,
+        type_param_names: &[String],
+    ) -> Vec<String> {
+        let type_idx = source_arena.skip_parenthesized(type_idx);
+        let Some(type_node) = source_arena.get(type_idx) else {
+            return Vec::new();
+        };
+        if type_node.kind != syntax_kind_ext::FUNCTION_TYPE {
+            return Vec::new();
+        }
+        let Some(function_type) = source_arena.get_function_type(type_node) else {
+            return Vec::new();
+        };
+        let Some(return_param) =
+            self.simple_type_node_name_from_arena(source_arena, function_type.type_annotation)
+        else {
+            return Vec::new();
+        };
+        if !type_param_names
+            .iter()
+            .any(|name| name.as_str() == return_param)
+        {
+            return Vec::new();
+        }
+        let blocked = function_type
+            .parameters
+            .nodes
+            .iter()
+            .copied()
+            .any(|param_idx| {
+                let Some(param_node) = source_arena.get(param_idx) else {
+                    return false;
+                };
+                let Some(param) = source_arena.get_parameter(param_node) else {
+                    return false;
+                };
+                self.type_node_contains_builtin_no_infer_of_type_param(
+                    source_arena,
+                    param.type_annotation,
+                    &return_param,
+                    0,
+                )
+            });
+        if blocked {
+            vec![return_param]
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn type_node_contains_builtin_no_infer_of_type_param(
+        &self,
+        source_arena: &NodeArena,
+        type_idx: NodeIndex,
+        type_param_name: &str,
+        depth: u8,
+    ) -> bool {
+        if depth > 64 || type_idx.is_none() {
+            return false;
+        }
+        let type_idx = source_arena.skip_parenthesized(type_idx);
+        if self.type_node_is_builtin_no_infer_of_type_param(source_arena, type_idx, type_param_name)
+        {
+            return true;
+        }
+        source_arena
+            .get_children(type_idx)
+            .into_iter()
+            .any(|child| {
+                self.type_node_contains_builtin_no_infer_of_type_param(
+                    source_arena,
+                    child,
+                    type_param_name,
+                    depth + 1,
+                )
+            })
+    }
+
+    fn type_node_is_builtin_no_infer_of_type_param(
+        &self,
+        source_arena: &NodeArena,
+        type_idx: NodeIndex,
+        type_param_name: &str,
+    ) -> bool {
+        let type_idx = source_arena.skip_parenthesized(type_idx);
+        let Some(type_node) = source_arena.get(type_idx) else {
+            return false;
+        };
+        if type_node.kind != syntax_kind_ext::TYPE_REFERENCE {
+            return false;
+        }
+        let Some(type_ref) = source_arena.get_type_ref(type_node) else {
+            return false;
+        };
+        let Some(type_args) = type_ref.type_arguments.as_ref() else {
+            return false;
+        };
+        let [arg_idx] = type_args.nodes.as_slice() else {
+            return false;
+        };
+        if self
+            .simple_type_node_name_from_arena(source_arena, *arg_idx)
+            .as_deref()
+            != Some(type_param_name)
+        {
+            return false;
+        }
+        let Some(binder) = self.binder else {
+            return false;
+        };
+        let Some(global_no_infer) = binder.get_global_type("NoInfer") else {
+            return false;
+        };
+        let Some(sym_id) = self.declaration_type_symbol_from_type_node(source_arena, type_idx)
+        else {
+            return false;
+        };
+        sym_id == global_no_infer && binder.lib_symbol_ids.contains(&sym_id)
+    }
+}

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs
@@ -262,6 +262,7 @@ mod emit_node;
 mod function_analysis;
 mod generic_call_literal;
 mod generic_call_mapped_inference;
+mod generic_call_no_infer;
 mod generic_call_variadic_tuple;
 mod js_exports;
 mod js_exports_local;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_function_text.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_function_text.rs
@@ -28,6 +28,7 @@ impl<'a> DeclarationEmitter<'a> {
         source: &FunctionTypeTextParts,
         argument: &FunctionTypeTextParts,
         type_param_names: &[String],
+        blocked_return_type_params: &[String],
         substitutions: &mut Vec<(String, String)>,
     ) {
         for (source_param_index, source_param) in source.parameters.iter().enumerate() {
@@ -119,6 +120,9 @@ impl<'a> DeclarationEmitter<'a> {
         if type_param_names
             .iter()
             .any(|name| name.as_str() == source.return_type)
+            && !blocked_return_type_params
+                .iter()
+                .any(|name| name.as_str() == source.return_type)
             && !substitutions
                 .iter()
                 .any(|(name, _)| name.as_str() == source.return_type)
@@ -452,6 +456,7 @@ mod tests {
             &source,
             &argument,
             &["A".to_string(), "B".to_string()],
+            &[],
             &mut substitutions,
         );
 
@@ -462,5 +467,26 @@ mod tests {
                 ("B".to_string(), "boolean".to_string()),
             ]
         );
+    }
+
+    #[test]
+    fn blocked_return_type_param_does_not_infer_from_callback_return() {
+        let source =
+            DeclarationEmitter::parse_function_type_text("(a: NoInfer<Shape>, b: number) => Shape")
+                .unwrap();
+        let argument =
+            DeclarationEmitter::parse_function_type_text("(a: unknown, b: number) => number")
+                .unwrap();
+        let mut substitutions = Vec::new();
+
+        DeclarationEmitter::infer_function_type_substitutions(
+            &source,
+            &argument,
+            &["Shape".to_string()],
+            &["Shape".to_string()],
+            &mut substitutions,
+        );
+
+        assert!(substitutions.is_empty());
     }
 }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
@@ -470,6 +470,7 @@ impl<'a> DeclarationEmitter<'a> {
                         if self.source_return_is_bare_type_parameter(source_arena, func)
                             && !self
                                 .call_expression_uses_partial_required_mapped_inference(expr_idx)
+                            && !self.call_expression_uses_no_infer_return_block(expr_idx)
                             && let Some(canonical_text) =
                                 self.fully_resolved_call_canonical_type_text(expr_idx)
                         {


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Declaration emit parity / DTS generic call inference.

## Invariant
Declaration emit must mirror `tsc` when a callback parameter surface contains the standard-library `NoInfer<T>` marker: that position blocks callback-return inference for returned `T`, so if no other inference source remains the emitted call result falls back to `unknown`.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_no_infer.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_function_text.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs`

## Project Corpus Impact
- Row: TypeScript conformance emit fixture `noInfer`
- Bug family: DTS generic call inference / builtin `NoInfer` inference blocking
- Evidence: `scripts/safe-run.sh scripts/emit/run.sh --filter=noInfer --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-noinfer-final-synced-main-20260531.json` passes 2/2 (`noInfer`, `noInferRedeclaration`) on the latest `origin/main`-rebased head.

## Generalization Gate
- Structural rule: a standard-library `NoInfer<T>` occurrence inside a function-typed callback parameter blocks inference into `T`; the callback return should not substitute `T` back into the declared call result.
- Adjacent-case matrix: positive builtin `NoInfer<Shape>` callback parameter unit, positive conformance lib `NoInfer<T>` (`noInfer`), negative local shadowed `type NoInfer<T>` (`noInferRedeclaration`), and retained rest callback inference unit.
- Fallback behavior: detection resolves the type reference to the standard-library binder symbol and requires that symbol to come from lib declarations; a local alias named `NoInfer` does not activate this path.
- Removal path: replace this AST-side detection once declaration/public API summaries expose `NoInfer` inference-block facts directly.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main..HEAD`
- `cargo nextest run -p tsz-emitter blocked_return_type_param_does_not_infer_from_callback_return --no-fail-fast`
- `cargo nextest run -p tsz-emitter rest_type_param_infers_rest_array_from_rest_callback --no-fail-fast`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=noInfer --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-noinfer-final-synced-main-20260531.json`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=mappedTypesArraysTuples --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-mapped-arrays-tuples-stack-final-20260531.json`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-emitter --all-targets -- -D warnings`

## Coordination Notes
- AgentName: Studio-D
- Rebased onto latest `origin/main` after #11872 merged; current head is the single NoInfer DTS commit on top of main.
- Checked open Studio-D work before starting; #11872 owns the now-merged Partial inverse slice, while this PR owns the next `noInfer` DTS fixture.
- Detection intentionally uses standard-library symbol identity for `NoInfer`; a local alias named `NoInfer` must not activate this path, covered by the `noInferRedeclaration` focused emit filter.
