### PR TITLE
fix(parser): preserve bare hash private recovery

### DIFF
--- a/crates/tsz-emitter/tests/private_identifier_recovery_tests.rs
+++ b/crates/tsz-emitter/tests/private_identifier_recovery_tests.rs
@@ -24,3 +24,36 @@ fn private_identifier_in_array_assignment_recovery_is_preserved() {
         "array assignment recovery must not erase the private identifier; output:\n{output}"
     );
 }
+
+#[test]
+fn bare_hash_private_name_recovery_drives_downlevel_private_emit() {
+    let source = r"
+#
+
+class C {
+    #
+
+    m() {
+        this.#
+    }
+}
+";
+    let output = print_es2015(source);
+
+    assert!(
+        output.contains("#;\nclass C"),
+        "top-level recovered bare hash should still print as `#;`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("var _C_;"),
+        "class-body recovered bare hash should allocate the blank private field helper.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("__classPrivateFieldGet(this, _C_, \"f\")"),
+        "property access `this.#` should lower through the recovered private helper.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("this.\n"),
+        "bare hash property access must not print as a dangling `this.`.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-parser/src/parser/state_expressions.rs
+++ b/crates/tsz-parser/src/parser/state_expressions.rs
@@ -1132,13 +1132,9 @@ impl ParserState {
                     let name = if is_private_identifier {
                         self.parse_private_identifier()
                     } else if self.is_token(SyntaxKind::HashToken) {
-                        // Bare `#` after `.` — emit TS1127 like tsc's scanner does.
-                        self.parse_error_at_current_token(
-                            tsz_common::diagnostics::diagnostic_messages::INVALID_CHARACTER,
-                            tsz_common::diagnostics::diagnostic_codes::INVALID_CHARACTER,
-                        );
-                        self.next_token();
-                        NodeIndex::NONE
+                        // Bare `#` after `.` recovers as a private-name-shaped node
+                        // so downlevel private-field emit can preserve tsc's tree.
+                        self.parse_recovered_bare_hash_private_identifier()
                     } else if self.is_identifier_or_keyword() {
                         // When there's a line break after the dot and the current token
                         // starts a declaration (e.g. `foo.\nvar y = 1;`), don't consume

--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -2882,8 +2882,8 @@ impl ParserState {
                 SyntaxKind::DotToken => {
                     self.next_token();
                     let diag_count_before = self.parse_diagnostics.len();
-                    let name = if self.is_token(SyntaxKind::PrivateIdentifier) {
-                        self.parse_private_identifier()
+                    let name = if let Some(name) = self.parse_private_identifier_or_bare_hash() {
+                        name
                     } else if self.is_identifier_or_keyword() {
                         self.parse_identifier_name()
                     } else {

--- a/crates/tsz-parser/src/parser/state_expressions_tail.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_tail.rs
@@ -32,6 +32,80 @@ impl ParserState {
         }
     }
 
+    pub(crate) fn bare_hash_is_followed_by_statement_boundary(&mut self) -> bool {
+        let snapshot = self.scanner.save_state();
+        let current = self.current_token;
+
+        self.next_token();
+        let boundary = self.scanner.has_preceding_line_break()
+            || matches!(
+                self.token(),
+                SyntaxKind::SemicolonToken
+                    | SyntaxKind::CloseBraceToken
+                    | SyntaxKind::EndOfFileToken
+            );
+
+        self.scanner.restore_state(snapshot);
+        self.current_token = current;
+        boundary
+    }
+
+    pub(crate) fn report_bare_hash_invalid_character(&mut self) {
+        self.parse_error_at_current_token(
+            tsz_common::diagnostics::diagnostic_messages::INVALID_CHARACTER,
+            diagnostic_codes::INVALID_CHARACTER,
+        );
+    }
+
+    pub(crate) fn parse_recovered_bare_hash_identifier(&mut self) -> NodeIndex {
+        let start_pos = self.token_pos();
+        let end_pos = self.token_end();
+        self.report_bare_hash_invalid_character();
+        self.next_token();
+        self.arena.add_identifier(
+            SyntaxKind::Identifier as u16,
+            start_pos,
+            end_pos,
+            IdentifierData {
+                atom: Atom::NONE,
+                escaped_text: String::from("#"),
+                original_text: None,
+                type_arguments: None,
+            },
+        )
+    }
+
+    pub(crate) fn parse_recovered_bare_hash_private_identifier(&mut self) -> NodeIndex {
+        let start_pos = self.token_pos();
+        let end_pos = self.token_end();
+        self.report_bare_hash_invalid_character();
+        self.next_token();
+        self.arena.add_identifier(
+            SyntaxKind::PrivateIdentifier as u16,
+            start_pos,
+            end_pos,
+            IdentifierData {
+                atom: Atom::NONE,
+                escaped_text: String::from("#"),
+                original_text: None,
+                type_arguments: None,
+            },
+        )
+    }
+
+    pub(crate) fn parse_private_identifier_or_bare_hash(&mut self) -> Option<NodeIndex> {
+        if self.is_token(SyntaxKind::HashToken) {
+            self.current_token = self.scanner.re_scan_hash_token();
+        }
+        if self.is_token(SyntaxKind::PrivateIdentifier) {
+            Some(self.parse_private_identifier())
+        } else if self.is_token(SyntaxKind::HashToken) {
+            Some(self.parse_recovered_bare_hash_private_identifier())
+        } else {
+            None
+        }
+    }
+
     // Parse argument list
     pub(crate) fn parse_argument_list(&mut self) -> NodeList {
         let mut args = Vec::new();
@@ -218,6 +292,7 @@ impl ParserState {
         match self.token() {
             SyntaxKind::Identifier => self.parse_identifier(),
             SyntaxKind::PrivateIdentifier => self.parse_private_identifier(),
+            SyntaxKind::HashToken => self.parse_recovered_bare_hash_identifier(),
             SyntaxKind::NumericLiteral => self.parse_numeric_literal(),
             SyntaxKind::BigIntLiteral => self.parse_bigint_literal(),
             SyntaxKind::StringLiteral => self.parse_string_literal(),

--- a/crates/tsz-parser/src/parser/state_statements.rs
+++ b/crates/tsz-parser/src/parser/state_statements.rs
@@ -300,13 +300,12 @@ impl ParserState {
                     // Got a valid private identifier — let the normal statement
                     // parser handle it (it will likely fail with a meaningful error).
                     self.current_token = rescanned;
+                } else if self.bare_hash_is_followed_by_statement_boundary() {
+                    // Preserve a standalone invalid `#` as a statement expression.
+                    // tsc still emits `#;` for this recovery shape.
                 } else {
                     // Bare `#` — emit TS1127 and skip, matching tsc.
-                    use tsz_common::diagnostics::diagnostic_codes;
-                    self.parse_error_at_current_token(
-                        tsz_common::diagnostics::diagnostic_messages::INVALID_CHARACTER,
-                        diagnostic_codes::INVALID_CHARACTER,
-                    );
+                    self.report_bare_hash_invalid_character();
                     self.next_token();
                     previous_statement_was_block = false;
                     continue;

--- a/crates/tsz-parser/src/parser/state_statements_class_members.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_members.rs
@@ -1339,20 +1339,20 @@ impl ParserState {
         }
 
         // Handle bare `#` that can't become a PrivateIdentifier.
-        // In tsc, the scanner emits TS1127 for a standalone `#` (e.g., `# name` with a
-        // space, or `#` followed by a non-identifier char). Rescan; if still HashToken,
-        // emit TS1127 and skip to avoid cascading TS1003/TS1005/TS1068/TS1128.
+        // Preserve standalone `#` as a recovered private name at boundaries.
         if self.is_token(SyntaxKind::HashToken) {
             let rescanned = self.scanner.re_scan_hash_token();
             if rescanned != SyntaxKind::PrivateIdentifier {
-                self.parse_error_at_current_token(
-                    tsz_common::diagnostics::diagnostic_messages::INVALID_CHARACTER,
-                    diagnostic_codes::INVALID_CHARACTER,
-                );
-                self.next_token();
-                return NodeIndex::NONE;
+                self.report_bare_hash_invalid_character();
+                if self.bare_hash_is_followed_by_statement_boundary() {
+                    self.current_token = SyntaxKind::PrivateIdentifier;
+                } else {
+                    self.next_token();
+                    return NodeIndex::NONE;
+                }
+            } else {
+                self.current_token = rescanned;
             }
-            self.current_token = rescanned;
         }
 
         let decorators = self.parse_decorators();

--- a/crates/tsz-parser/src/parser/state_switch_recovery.rs
+++ b/crates/tsz-parser/src/parser/state_switch_recovery.rs
@@ -327,7 +327,9 @@ impl ParserState {
             // This prevents TS1109 from being emitted for tokens that are obviously not expressions
             // (e.g., }, ], ), etc.) when we fall through to parse_expression_statement() from
             // parse_statement()'s wildcard match.
-            if !self.is_expression_start() {
+            let recoverable_bare_hash_expression = self.is_token(SyntaxKind::HashToken)
+                && self.bare_hash_is_followed_by_statement_boundary();
+            if !self.is_expression_start() && !recoverable_bare_hash_expression {
                 // Don't emit error here - let the statement-level error handling deal with it
                 // Just return NONE to indicate failure
                 self.jsx_missing_brace_semicolon_window_start = None;

--- a/crates/tsz-parser/tests/parser_improvement_class_member_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_class_member_recovery_tests.rs
@@ -161,6 +161,46 @@ class C {
 }
 
 #[test]
+fn test_standalone_bare_hash_in_class_recovers_private_field_name() {
+    let source = r"
+class C {
+    #
+
+    m() {
+        this.#
+    }
+}
+";
+    let (parser, root) = parse_source(source);
+
+    let diagnostics = parser.get_diagnostics();
+    assert!(
+        diagnostics.iter().any(|d| d.code == 1127),
+        "Expected TS1127 for recovered bare '#', got diagnostics: {diagnostics:?}"
+    );
+
+    let arena = parser.get_arena();
+    let source_file = arena.get_source_file_at(root).unwrap();
+    let class_idx = source_file.statements.nodes[0];
+    let class_node = arena.get(class_idx).unwrap();
+    let class_data = arena.get_class(class_node).unwrap();
+    let member_node = arena.get(class_data.members.nodes[0]).unwrap();
+    assert_eq!(
+        member_node.kind,
+        crate::parser::syntax_kind_ext::PROPERTY_DECLARATION,
+        "standalone class-body '#' should recover as a property declaration"
+    );
+    let prop = arena.get_property_decl(member_node).unwrap();
+    let name_node = arena.get(prop.name).unwrap();
+    assert_eq!(
+        name_node.kind,
+        tsz_scanner::SyntaxKind::PrivateIdentifier as u16
+    );
+    let ident = arena.get_identifier(name_node).unwrap();
+    assert_eq!(ident.escaped_text, "#");
+}
+
+#[test]
 fn test_valid_private_name_no_ts1127() {
     // Valid private names should not emit TS1127
     let source = r"


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Emit / parser recovery: invalid private-name syntax that still affects JavaScript output.

## Invariant
A standalone bare `#` that appears at a statement/class-member boundary remains an invalid-character parse diagnostic, but the recovered syntax tree must preserve the same shape `tsc` emits from: top-level `#;`, class-body recovered private fields, and `this.#` private access lowering through the downlevel private-field emitter.

## Structural Rule
Boundary-only bare `#` tokens are preserved as recovered identifiers/private identifiers with TS1127. Non-boundary bare hashes continue to skip through the existing invalid-character recovery path to avoid cascading parser noise. The emitter still consumes parser structure only; this PR does not add semantic validation or output surgery.

## Scope
- `crates/tsz-parser/src/parser/state_expressions_tail.rs`: adds shared bare-hash recovery helpers and primary-expression preservation.
- `crates/tsz-parser/src/parser/state_statements.rs`: lets standalone top-level `#` reach expression-statement parsing only at statement boundaries.
- `crates/tsz-parser/src/parser/state_statements_class_members.rs`: recovers boundary-only class-body `#` as a private-name-shaped member.
- `crates/tsz-parser/src/parser/state_expressions.rs` and `state_expressions_literals.rs`: recovers `this.#`/member-access bare hash as a private identifier node.
- `crates/tsz-parser/src/parser/state_switch_recovery.rs`: lets the expression-statement early rejection admit only boundary bare-hash recovery.
- Parser and emitter unit tests cover the recovered tree and downlevel private-field output.

## Project Corpus Impact
- Row: n/a
- Bug family: parser recovery feeding private-name emit
- Evidence: targeted emit fixture `privateNameHashCharName` now passes 1/1 in JS-only mode; no project corpus row identified for this syntax-recovery fixture.

## Verification
- `cargo fmt --all --check`
- `CARGO_TARGET_DIR=/tmp/tsz-studio-c-check-target cargo check -p tsz-parser -p tsz-emitter`
- `CARGO_TARGET_DIR=/tmp/tsz-studio-c-check-target cargo nextest run -p tsz-parser test_standalone_bare_hash_in_class_recovers_private_field_name test_bare_hash_at_top_level_emits_ts1127 test_bare_hash_in_class_emits_ts1127`
- `CARGO_TARGET_DIR=/tmp/tsz-studio-c-check-target cargo nextest run -p tsz-emitter bare_hash_private_name_recovery_drives_downlevel_private_emit private_identifier_in_array_assignment_recovery_is_preserved`
- `scripts/emit/run.sh --filter=privateNameHashCharName --js-only --verbose --timeout=30000 --json-out=/tmp/privateNameHashCharName-after-rebase-70a6.json`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`

## Coordination Notes
- AgentName: Studio-C
- Head: `dd7fd25c86` rebased onto `origin/main` `70a6bc2c76`.
- Overlap check: `gh search prs/issues "privateNameHashCharName"` returned no open matches.
- This is independent of #11865; that PR has been marked ready after exact-head draft checks passed.
- Local unstaged `scripts/emit/test_output_surgery_audit.py` changes pre-existed this slice and remain intentionally excluded.


