### PR TITLE
fix(solver): skip class-context subtype cache sharing

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -325,12 +325,19 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // type whose method signatures carry `ThisType` return types.
         let has_this_type =
             contains_this_type(self.interner, source) || contains_this_type(self.interner, target);
+        // Class-symbol classification is also context-dependent: the callback
+        // can make the same object shape behave as a named class/interface in
+        // one checker and as a plain structural object in another. Since the
+        // relation cache key cannot encode an arbitrary predicate, avoid
+        // sharing those answers across checker instances.
+        let has_class_check_context = self.is_class_symbol.is_some();
+        let can_use_shared_relation_cache = !has_this_type && !has_class_check_context;
         // The `in_callback_param_check` state is encoded in
         // `RelationFlags::IN_CALLBACK_PARAM_CHECK` via `make_cache_key`, so
         // callback-mode results live in a separate cache slot from
         // non-callback-mode results and cannot poison each other.
         if !self.identity_cycle_check
-            && !has_this_type
+            && can_use_shared_relation_cache
             && let Some(db) = self.query_db
         {
             let key = self.make_cache_key(source, target);
@@ -777,7 +784,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     self.def_guard.leave(dp);
                 }
                 self.guard.leave(pair);
-                if !has_this_type && let Some(db) = self.query_db {
+                if can_use_shared_relation_cache && let Some(db) = self.query_db {
                     let key = self.make_cache_key(source, target);
                     cache_definitive!(db, key, result);
                 }
@@ -836,7 +843,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 self.def_guard.leave(dp);
             }
             self.guard.leave(pair);
-            if !has_this_type && let Some(db) = self.query_db {
+            if can_use_shared_relation_cache && let Some(db) = self.query_db {
                 let key = self.make_cache_key(source, target);
                 cache_definitive!(db, key, result);
             }
@@ -857,7 +864,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 self.def_guard.leave(dp);
             }
             self.guard.leave(pair);
-            if !has_this_type && let Some(db) = self.query_db {
+            if can_use_shared_relation_cache && let Some(db) = self.query_db {
                 let key = self.make_cache_key(source, target);
                 cache_definitive!(db, key, result);
             }
@@ -936,8 +943,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         self.guard.leave(pair);
 
         // Cache definitive results for cross-checker memoization.
-        // Skip ThisType: results are context-dependent (see lookup guard above).
-        if !has_this_type && let Some(db) = self.query_db {
+        // Skip context-dependent results (see lookup guard above).
+        if can_use_shared_relation_cache && let Some(db) = self.query_db {
             let key = self.make_cache_key(source, target);
             cache_definitive!(db, key, result);
         }

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -7,6 +7,9 @@ mod cache_agreement;
 #[path = "relation_policy_cache_agreement_tests/any_mode_partitioning.rs"]
 mod any_mode_partitioning;
 
+#[path = "relation_policy_cache_agreement_tests/class_context_partitioning.rs"]
+mod class_context_partitioning;
+
 #[path = "relation_policy_cache_agreement_tests/kind_partitioning.rs"]
 mod kind_partitioning;
 

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/class_context_partitioning.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/class_context_partitioning.rs
@@ -1,0 +1,71 @@
+//! Context-dependent class-check cache tests.
+
+use crate::caches::db::QueryDatabase;
+use crate::caches::query_cache::QueryCache;
+use crate::intern::TypeInterner;
+use crate::relations::subtype::SubtypeChecker;
+use crate::types::{IndexSignature, ObjectFlags, ObjectShape, PropertyInfo, TypeId};
+
+#[test]
+fn subtype_cache_skips_class_check_context() {
+    use tsz_binder::SymbolId;
+
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let source_symbol = SymbolId(42);
+    let class_ref = crate::SymbolRef(source_symbol.0);
+    let is_class = |symbol: crate::SymbolRef| symbol == class_ref;
+
+    let source = interner.object_with_flags_and_symbol(
+        vec![
+            PropertyInfo::new(interner.intern_string("a"), TypeId::NUMBER),
+            PropertyInfo::new(interner.intern_string("b"), TypeId::NUMBER),
+        ],
+        ObjectFlags::empty(),
+        Some(source_symbol),
+    );
+    let target = interner.object_with_index(ObjectShape {
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::NUMBER,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+    });
+
+    let mut class_uncached = SubtypeChecker::new(&interner).with_class_check(&is_class);
+    assert!(
+        !class_uncached.is_subtype_of(source, target),
+        "named class/interface sources need an explicit string index signature",
+    );
+
+    let mut structural_uncached = SubtypeChecker::new(&interner);
+    assert!(
+        structural_uncached.is_subtype_of(source, target),
+        "without class-symbol context the same shape is an ordinary structural object",
+    );
+
+    let mut class_cached = SubtypeChecker::new(&interner)
+        .with_query_db(&db)
+        .with_class_check(&is_class);
+    let class_key = class_cached.debug_cache_key_for(source, target);
+    assert!(
+        !class_cached.is_subtype_of(source, target),
+        "cached class-context relation should preserve the uncached class-context answer",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(class_key),
+        None,
+        "class-check context is behavior-affecting and must not populate a shared class-agnostic slot",
+    );
+
+    let mut structural_cached = SubtypeChecker::new(&interner).with_query_db(&db);
+    assert!(
+        structural_cached.is_subtype_of(source, target),
+        "a class-context result must not be reused by a structural checker without class context",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 4: semantic campaign / relation policy cache-key contract

## Invariant
When subtype checking depends on caller-provided class-symbol context, the solver must not share that result through a class-agnostic relation cache slot. This PR keeps the behavior in the solver subtype cache layer by skipping shared subtype cache lookup/write for `SubtypeChecker::with_class_check` contexts.

## Scope
- `crates/tsz-solver/src/relations/subtype/cache.rs`
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs`
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests/class_context_partitioning.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: relation policy/cache correctness
- Evidence: solver cache-context invariant; no project fixture metadata change. Compiler behavior should only change by preventing stale cross-checker subtype cache answers.

## Verification
- RED before fix: `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'` failed in `class_context_partitioning::subtype_cache_skips_class_check_context` because the class-context check populated `Some(false)` in the shared subtype cache.
- GREEN on current head `74d9fa92fcdce680a1b601c136fc06ca8b0b4a83` / base `feda6bd71c3f854df2070f5545651d7f664c0169`: `cargo nextest run -p tsz-solver -E 'test(subtype_cache_skips_class_check_context)'`: 1 passed, 6436 skipped.
- GREEN on current head `74d9fa92fcdce680a1b601c136fc06ca8b0b4a83` / base `feda6bd71c3f854df2070f5545651d7f664c0169`: `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'`: 26 passed, 6411 skipped.
- GREEN on current head `74d9fa92fcdce680a1b601c136fc06ca8b0b4a83` / base `feda6bd71c3f854df2070f5545651d7f664c0169`: `cargo fmt --check`.
- GREEN on current head `74d9fa92fcdce680a1b601c136fc06ca8b0b4a83` / base `feda6bd71c3f854df2070f5545651d7f664c0169`: `git diff --check origin/main..HEAD`.
- Fresh base check: `git merge-base --is-ancestor origin/main HEAD` exited 0 after fetching `origin/main`.
- File-size guard: `subtype/cache.rs` 1046 lines; relation-policy test root 17 lines; `class_context_partitioning.rs` 71 lines.
- Disk check on 2026-05-31: `scripts/agents/disk-preflight.sh M4-B` reported `disk_free_gb=55` and `disk_status=ok`; no cache-destructive cleanup was run this cycle.
- Current-head CI for `74d9fa92fcdce680a1b601c136fc06ca8b0b4a83` is green: `CI Summary` and `GitGuardian Security Checks` passed on 2026-05-31 in https://github.com/mohsen1/tsz/actions/runs/26712204525.

## Coordination Notes
Refs #8207. This is a small follow-up after #11786 landed. It does not overlap the prior policy-bit/any-mode/key-kind ratchets: those partition cache keys by explicit policy state, while this slice handles callback-owned class-symbol context that cannot be represented safely in a shared key. Branch is currently cleanly based on `origin/main` `feda6bd71c3f854df2070f5545651d7f664c0169`. `merge-queue` was added on current head `74d9fa92fcdce680a1b601c136fc06ca8b0b4a83` after exact-head `CI Summary` and `GitGuardian Security Checks` passed; `Queue Tested` is queue-owned. No WIP or auto-merge state requested by M4-B.
