### PR TITLE
refactor(emitter): split enum ES5 wrapper

### DIFF
--- a/crates/tsz-emitter/src/transforms/enum_es5.rs
+++ b/crates/tsz-emitter/src/transforms/enum_es5.rs
@@ -39,11 +39,14 @@ use std::collections::{HashMap, HashSet};
 
 use crate::transforms::emit_utils::is_valid_identifier_name;
 use crate::transforms::ir::{IRNode, IRParam};
-use crate::transforms::ir_printer::IRPrinter;
 use tsz_parser::parser::node::NodeArena;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::parser::{NodeIndex, NodeList};
 use tsz_scanner::SyntaxKind;
+
+#[path = "enum_es5_emitter.rs"]
+mod enum_es5_emitter;
+pub use enum_es5_emitter::EnumES5Emitter;
 
 /// Enum ES5 transformer - produces IR for enum declarations
 pub struct EnumES5Transformer<'a> {
@@ -1906,106 +1909,6 @@ impl<'a> EnumES5Transformer<'a> {
             }
             _ => false,
         }
-    }
-}
-
-/// Enum ES5 emitter wrapping `EnumES5Transformer` + `IRPrinter`
-pub struct EnumES5Emitter<'a> {
-    indent_level: u32,
-    transformer: EnumES5Transformer<'a>,
-}
-
-impl<'a> EnumES5Emitter<'a> {
-    pub fn new(arena: &'a NodeArena) -> Self {
-        EnumES5Emitter {
-            indent_level: 0,
-            transformer: EnumES5Transformer::new(arena),
-        }
-    }
-
-    pub const fn set_indent_level(&mut self, level: u32) {
-        self.indent_level = level;
-    }
-
-    /// Set source text for raw expression extraction
-    pub const fn set_source_text(&mut self, text: &'a str) {
-        self.transformer.set_source_text(text);
-    }
-
-    /// Set whether the emit target downlevels block-scoped declarations to
-    /// `var` (ES5/ES3), enabling the `var E = void 0;` reset for block-scoped
-    /// enums.
-    pub const fn set_target_es5(&mut self, value: bool) {
-        self.transformer.set_target_es5(value);
-    }
-
-    /// Set whether const enums should be preserved (emitted instead of erased)
-    pub const fn set_preserve_const_enums(&mut self, value: bool) {
-        self.transformer.set_preserve_const_enums(value);
-    }
-
-    /// Set whether the enum should emit its own `var E;` declaration.
-    pub const fn set_emit_var_declaration(&mut self, value: bool) {
-        self.transformer.set_emit_var_declaration(value);
-    }
-
-    /// Fold a CommonJS export binding into the enum IIFE tail.
-    pub fn set_commonjs_export_fold(&mut self, export_name: &str) {
-        self.transformer.set_commonjs_export_fold(export_name);
-    }
-
-    pub fn set_commonjs_export_folds<'b>(
-        &mut self,
-        export_names: impl IntoIterator<Item = &'b str>,
-    ) {
-        self.transformer.set_commonjs_export_folds(export_names);
-    }
-
-    /// Fold a System export call into the enum IIFE tail.
-    pub fn set_system_export_fold(&mut self, export_name: &str) {
-        self.transformer.set_system_export_fold(export_name);
-    }
-
-    /// Fold multiple System export calls into the enum IIFE tail.
-    pub fn set_system_export_folds<'b>(&mut self, export_names: impl IntoIterator<Item = &'b str>) {
-        self.transformer.set_system_export_folds(export_names);
-    }
-
-    /// Emit an enum declaration
-    /// Returns empty string for const enums (they are erased)
-    pub fn emit_enum(&mut self, enum_idx: NodeIndex) -> String {
-        let ir = self.transformer.transform_enum(enum_idx);
-        let ir = match ir {
-            Some(ir) => ir,
-            None => return String::new(),
-        };
-
-        // ASTRef nodes (used for string literals to preserve source quote
-        // style) require both arena and source text to print; without them
-        // the printer falls back to "undefined".
-        let arena = self.transformer.arena;
-        let mut printer = match self.transformer.source_text {
-            Some(text) => IRPrinter::with_arena_and_source(arena, text),
-            None => IRPrinter::with_arena(arena),
-        };
-        printer.set_indent_level(self.indent_level);
-        // Propagate the ES5/ES3 target so `ASTRef` arrows inside enum member
-        // initializers (e.g. `(() => ...)()`) downlevel to function expressions,
-        // matching `emit_enum_declaration`; otherwise the nested AST printer
-        // defaults to native ES2015 arrow emission.
-        printer.set_target_es5(self.transformer.target_es5);
-        let result = printer.emit(&ir);
-        result.to_string()
-    }
-
-    /// Get the enum name without emitting anything
-    pub fn get_enum_name(&self, enum_idx: NodeIndex) -> String {
-        self.transformer.get_enum_name(enum_idx)
-    }
-
-    /// Check if enum is a const enum
-    pub fn is_const_enum_by_idx(&self, enum_idx: NodeIndex) -> bool {
-        self.transformer.is_const_enum_by_idx(enum_idx)
     }
 }
 

--- a/crates/tsz-emitter/src/transforms/enum_es5_emitter.rs
+++ b/crates/tsz-emitter/src/transforms/enum_es5_emitter.rs
@@ -1,0 +1,104 @@
+use super::EnumES5Transformer;
+use crate::transforms::ir_printer::IRPrinter;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::NodeArena;
+
+/// Enum ES5 emitter wrapping `EnumES5Transformer` + `IRPrinter`
+pub struct EnumES5Emitter<'a> {
+    indent_level: u32,
+    transformer: EnumES5Transformer<'a>,
+}
+
+impl<'a> EnumES5Emitter<'a> {
+    pub fn new(arena: &'a NodeArena) -> Self {
+        EnumES5Emitter {
+            indent_level: 0,
+            transformer: EnumES5Transformer::new(arena),
+        }
+    }
+
+    pub const fn set_indent_level(&mut self, level: u32) {
+        self.indent_level = level;
+    }
+
+    /// Set source text for raw expression extraction
+    pub const fn set_source_text(&mut self, text: &'a str) {
+        self.transformer.set_source_text(text);
+    }
+
+    /// Set whether the emit target downlevels block-scoped declarations to
+    /// `var` (ES5/ES3), enabling the `var E = void 0;` reset for block-scoped
+    /// enums.
+    pub const fn set_target_es5(&mut self, value: bool) {
+        self.transformer.set_target_es5(value);
+    }
+
+    /// Set whether const enums should be preserved (emitted instead of erased)
+    pub const fn set_preserve_const_enums(&mut self, value: bool) {
+        self.transformer.set_preserve_const_enums(value);
+    }
+
+    /// Set whether the enum should emit its own `var E;` declaration.
+    pub const fn set_emit_var_declaration(&mut self, value: bool) {
+        self.transformer.set_emit_var_declaration(value);
+    }
+
+    /// Fold a CommonJS export binding into the enum IIFE tail.
+    pub fn set_commonjs_export_fold(&mut self, export_name: &str) {
+        self.transformer.set_commonjs_export_fold(export_name);
+    }
+
+    pub fn set_commonjs_export_folds<'b>(
+        &mut self,
+        export_names: impl IntoIterator<Item = &'b str>,
+    ) {
+        self.transformer.set_commonjs_export_folds(export_names);
+    }
+
+    /// Fold a System export call into the enum IIFE tail.
+    pub fn set_system_export_fold(&mut self, export_name: &str) {
+        self.transformer.set_system_export_fold(export_name);
+    }
+
+    /// Fold multiple System export calls into the enum IIFE tail.
+    pub fn set_system_export_folds<'b>(&mut self, export_names: impl IntoIterator<Item = &'b str>) {
+        self.transformer.set_system_export_folds(export_names);
+    }
+
+    /// Emit an enum declaration
+    /// Returns empty string for const enums (they are erased)
+    pub fn emit_enum(&mut self, enum_idx: NodeIndex) -> String {
+        let ir = self.transformer.transform_enum(enum_idx);
+        let ir = match ir {
+            Some(ir) => ir,
+            None => return String::new(),
+        };
+
+        // ASTRef nodes (used for string literals to preserve source quote
+        // style) require both arena and source text to print; without them
+        // the printer falls back to "undefined".
+        let arena = self.transformer.arena;
+        let mut printer = match self.transformer.source_text {
+            Some(text) => IRPrinter::with_arena_and_source(arena, text),
+            None => IRPrinter::with_arena(arena),
+        };
+        printer.set_indent_level(self.indent_level);
+        // Propagate the ES5/ES3 target so `ASTRef` arrows inside enum member
+        // initializers (e.g. `(() => ...)()`) downlevel to function expressions,
+        // matching `emit_enum_declaration`; otherwise the nested AST printer
+        // defaults to native ES2015 arrow emission.
+        printer.set_target_es5(self.transformer.target_es5);
+        let result = printer.emit(&ir);
+        result.to_string()
+    }
+
+    /// Get the enum name without emitting anything
+    pub fn get_enum_name(&self, enum_idx: NodeIndex) -> String {
+        self.transformer.get_enum_name(enum_idx)
+    }
+
+    /// Check if enum is a const enum
+    pub fn is_const_enum_by_idx(&self, enum_idx: NodeIndex) -> bool {
+        self.transformer.is_const_enum_by_idx(enum_idx)
+    }
+}

--- a/crates/tsz-emitter/tests/enum_es5.rs
+++ b/crates/tsz-emitter/tests/enum_es5.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::transforms::ir_printer::IRPrinter;
 use tsz_parser::parser::ParserState;
 
 fn transform_enum(source: &str) -> String {

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -533,11 +533,6 @@ FILE_LINE_LIMIT_CHECKS = [
         2072,
     ),
     (
-        "Emitter boundary: transforms/enum_es5.rs size ratchet",
-        ROOT / "crates" / "tsz-emitter" / "src" / "transforms" / "enum_es5.rs",
-        2014,
-    ),
-    (
         "Emitter boundary: transforms/ir_printer.rs size ratchet",
         ROOT / "crates" / "tsz-emitter" / "src" / "transforms" / "ir_printer.rs",
         2008,


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Architecture guardrails / emitter file-size debt.

## Invariant
`enum_es5.rs` should stay below the §19 2000-line hard limit without carrying a temporary per-file cap. This PR moves the thin `EnumES5Emitter` wrapper into a sibling module and re-exports it from the original path, preserving behavior while retiring the stale `FILE_LINE_LIMIT_CHECKS` entry.

## Scope
- Extract `EnumES5Emitter` from `crates/tsz-emitter/src/transforms/enum_es5.rs` into `crates/tsz-emitter/src/transforms/enum_es5_emitter.rs`.
- Preserve the public `transforms::enum_es5::EnumES5Emitter` and `transforms::EnumES5Emitter` paths.
- Keep the existing enum transform tests compiling after the split by importing `IRPrinter` directly.
- Remove the `transforms/enum_es5.rs` size ratchet cap from `scripts/arch/arch_guard_shared.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: pure code-motion emitter refactor; no parser, checker, solver, emit-output policy, benchmark, or project-corpus behavior changed.

## Verification
- cargo fmt --check
- cargo check -p tsz-emitter
- cargo check -p tsz-emitter --tests
- cargo clippy -p tsz-emitter --all-targets -- -D warnings
- python3 -m unittest test_arch_guard test_arch_guard_policy test_arch_guard_counts test_arch_guard_misc (from scripts/arch)
- python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard-enum-es5-split-rerun.json
- python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery-enum-es5-split.json
- git diff --check
- wc -l crates/tsz-emitter/src/transforms/enum_es5.rs crates/tsz-emitter/src/transforms/enum_es5_emitter.rs (`1917`, `104`)

## Coordination Notes
- Partial follow-up for #11882: this removes one of the four temporary over-2000 production-file caps from #11881. It intentionally does not close #11882 because `generics.rs`, `ir_printer.rs`, and `type_inference_return_normalization.rs` still need splits.
- Checked open PR overlap before editing. Active DTS/parser/module-wrapper PRs do not touch `transforms/enum_es5.rs`.
- No roadmap update needed; this is routine §19 debt burn-down.

Signed-off-by: Studio-F
