### PR TITLE
perf(checker): avoid cache detach on absent removals

### DIFF
--- a/crates/tsz-checker/src/context/caches.rs
+++ b/crates/tsz-checker/src/context/caches.rs
@@ -68,6 +68,9 @@ impl NodeTypeCache {
 
     #[inline]
     pub fn remove(&mut self, key: &u32) -> Option<TypeId> {
+        if !self.data.contains_key(key) {
+            return None;
+        }
         Arc::make_mut(&mut self.data).remove(key)
     }
 
@@ -232,6 +235,9 @@ impl SymbolTypeCache {
 
     #[inline]
     pub fn remove(&mut self, key: &SymbolId) -> Option<TypeId> {
+        if !self.data.contains_key(key) {
+            return None;
+        }
         Arc::make_mut(&mut self.data).remove(key)
     }
 
@@ -278,5 +284,41 @@ impl SymbolTypeCache {
 impl Default for SymbolTypeCache {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_type_cache_absent_remove_does_not_detach_shared_snapshot() {
+        let mut parent = NodeTypeCache::new();
+        parent.insert(1, TypeId::STRING);
+        let mut child = parent.clone();
+
+        assert!(child.remove(&2).is_none());
+        assert!(Arc::ptr_eq(&parent.data, &child.data));
+
+        assert_eq!(child.remove(&1), Some(TypeId::STRING));
+        assert!(!Arc::ptr_eq(&parent.data, &child.data));
+        assert_eq!(parent.get(&1), Some(&TypeId::STRING));
+        assert_eq!(child.get(&1), None);
+    }
+
+    #[test]
+    fn symbol_type_cache_absent_remove_does_not_detach_shared_snapshot() {
+        let sym = SymbolId(1);
+        let mut parent = SymbolTypeCache::new();
+        parent.insert(sym, TypeId::STRING);
+        let mut child = parent.clone();
+
+        assert!(child.remove(&SymbolId(2)).is_none());
+        assert!(Arc::ptr_eq(&parent.data, &child.data));
+
+        assert_eq!(child.remove(&sym), Some(TypeId::STRING));
+        assert!(!Arc::ptr_eq(&parent.data, &child.data));
+        assert_eq!(parent.get(&sym), Some(&TypeId::STRING));
+        assert_eq!(child.get(&sym), None);
     }
 }


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 performance/residency - micro-allocation/cache-residency

## Invariant
When a sparse Arc-backed checker cache is shared with a child checker and a missing key is removed, the removal is a no-op and must not detach/copy the shared snapshot. Present-key removals still detach the child cache and leave the parent snapshot unchanged.

## Scope
- `crates/tsz-checker/src/context/caches.rs`
- Avoid unnecessary `Arc::make_mut` in `NodeTypeCache::remove` and `SymbolTypeCache::remove` for absent keys.
- Add focused cache snapshot tests for absent-remove no-detach behavior.

## Project Corpus Impact
- Row: `vite-vanilla-ts-app`
- Bug family: generated app dependency/config sanity; child-checker/project skeleton residency (#7378)
- Evidence: fresh timing-mode quick runs on exact current head after rebasing:
  - Before current-main row: `/private/tmp/studio-b-vite-current-main-20260531b.json`, `tsz=114.03ms`, `tsgo=79.10ms`, `tsgo` wins 1.44x.
  - After final exact-head row: `/private/tmp/studio-b-vite-after-absent-remove-final-20260531.json`, `tsz=107.78ms`, `tsgo=74.55ms`, `tsgo` wins 1.45x; companion report `/private/tmp/studio-b-vite-after-absent-remove-final-20260531.tsgo-winners.json` still reports one 2x target gap.
  - `utility-types-project` remains above target after the patch: `/private/tmp/studio-b-utility-types-after-absent-remove-20260531.json`, `tsz=35.88ms`, `tsgo=82.00ms`, `tsz` wins 2.29x.

## Verification
- `cargo nextest run -p tsz-checker --lib -E 'test(node_type_cache_absent_remove_does_not_detach_shared_snapshot) | test(symbol_type_cache_absent_remove_does_not_detach_shared_snapshot)'`
- `cargo check -p tsz-checker --lib`
- `git diff --check origin/main..HEAD`
- `BENCH_PGO=0 TSC_NPM_SPEC=6.0.3 scripts/safe-run.sh --limit 75% -- scripts/bench/bench-vs-tsgo.sh --quick --rebuild --filter '^vite-vanilla-ts-app$' --json-file /private/tmp/studio-b-vite-after-absent-remove-final-20260531.json`
- `node scripts/bench/tsgo-winner-report.mjs /private/tmp/studio-b-vite-after-absent-remove-final-20260531.json /private/tmp/studio-b-vite-after-absent-remove-final-20260531.tsgo-winners.json`
- `BENCH_PGO=0 TSC_NPM_SPEC=6.0.3 scripts/safe-run.sh --limit 75% -- scripts/bench/bench-vs-tsgo.sh --quick --filter '^utility-types-project$' --json-file /private/tmp/studio-b-utility-types-after-absent-remove-20260531.json`
- `node scripts/bench/tsgo-winner-report.mjs /private/tmp/studio-b-utility-types-after-absent-remove-20260531.json /private/tmp/studio-b-utility-types-after-absent-remove-20260531.tsgo-winners.json`

## Coordination Notes
- Existing Studio-B PR #11860 was merged first before this branch was opened.
- Owned-work scan found no other open Studio-B PRs at cycle start.
- Open PR overlap was checked; no active PR claims checker cache absent-remove/COW behavior.
- This is a small residency slice, not the Vite row closure. Leave merge-queue/auto-merge to the manager after exact-head checks are complete.
