### PR TITLE
docs(plan): refresh launch gate metrics

### DIFF
--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -53,12 +53,12 @@ denominators.
 | Surface | Current |
 | --- | ---: |
 | Diagnostic conformance | `100.0%` exact (`12,582 / 12,582`) |
-| Accepted-regression strictness | `0` listed tests |
+| Accepted-regression strictness | `4` listed tests (justified in `conformance-accepted-regressions.txt`, Refs PR #12157) |
 | JavaScript emit | `96.8%` (`13,094 / 13,530`) in checked-in emit snapshot and README |
 | Declaration emit | `96.2%` (`1,606 / 1,669`) in checked-in emit snapshot and README |
 | Fourslash / language service | `99.9%` (`6,558 / 6,562`) |
-| Open bug issues | `37` open `bug` issues in live GitHub orientation |
-| Output-surgery audit | green: `0` unallowlisted calls, `0` stale allowlist entries; allowlist budget exhausted at `23 / 23` tracked calls |
+| Open bug issues | `111` open `bug` issues in live GitHub orientation (point-in-time count; drifts daily) |
+| Output-surgery audit | green: `0` unallowlisted calls, `0` stale allowlist entries; allowlist budget exhausted at `20 / 20` tracked calls |
 
 Conformance remains a hard regression gate. It is no longer the sole readiness
 signal. The primary readiness signal for this phase is whether tsz can
@@ -70,7 +70,10 @@ The exact conformance snapshot does not by itself mean the conformance runway
 is fully retired. `scripts/conformance/conformance-accepted-regressions.txt`
 remains a separate gate-strictness artifact and must be kept empty or
 explicitly justified by current CI evidence before agents treat conformance
-cleanup as complete.
+cleanup as complete. It currently lists `4` justified entries (the
+fingerprint-only diffs introduced alongside PR #12157's net-positive snapshot
+refresh), so the strictness gate is non-empty and each entry should be paid
+down in follow-up PRs.
 
 ## Evidence From Current Audit
 
@@ -121,7 +124,7 @@ changes the picture.
    precomputed declaration/public-API summary.
 8. Output-surgery audit is green again: the current audit reports `0`
    unallowlisted calls and `0` stale allowlist entries. The allowlist budget is
-   still exhausted at `23 / 23` tracked calls, so Studio-C/D/F emit work should
+   still exhausted at `20 / 20` tracked calls, so Studio-C/D/F emit work should
    pay down or justify existing entries before adding new output-surgery calls.
 9. Conformance is no longer the dominant progress signal but it remains a hard
    regression gate. The current diagnostic gap is zero tests; broad


### PR DESCRIPTION
## Agent
AgentName: Claude-M1A-LaunchMetrics (continues the M1-A roadmap-metrics lane)

## Track
Release control / roadmap metric truth.

## Invariant
When public release-gate metrics change, `docs/plan/ROADMAP.md` must reflect current artifact and live-GitHub evidence without changing implementation ownership or compiler behavior.

## Scope
- `docs/plan/ROADMAP.md` public metrics and audit-evidence text only. No code, no compiler behavior.

## Project Corpus Impact
- Row: n/a (docs-only).
- Bug family: n/a.
- Evidence: roadmap metric refresh against current file/audit/live evidence.

## Durable changes vs current `main` ROADMAP
The branch was reset onto current `main` and re-derived from live evidence (the prior 44-commits-behind content was fully superseded). Net `docs/plan/ROADMAP.md` diff:

- **Accepted-regression strictness `0` → `4` listed tests.** `scripts/conformance/conformance-accepted-regressions.txt` now lists 4 justified entries (added alongside PR #12157's net-positive snapshot refresh: `exportDefaultInterface`, `noUnusedLocals_writeOnly`, `circularReference`, `interfaceExtendsObjectIntersectionErrors`). `main`'s ROADMAP still said `0`, which was a stale public release-gate number. Confirmed by `query-conformance.py --dashboard` (`Accepted-regression gate: 4 listed tests`).
- **Output-surgery allowlist `23 / 23` → `20 / 20`.** The budget was paid down; `audit-output-surgery.py` reports `allowlist_cap=20`, `unallowlisted_calls=0`, `stale_allowlist_files=0`.
- **Open bug issues `37` → `111`** (live GitHub orientation; point-in-time, drifts daily).
- Diagnostic conformance (`12,582 / 12,582`), JavaScript emit (`13,094 / 13,530`, checked-in snapshot), and declaration emit (`1,606 / 1,669`) are unchanged — left as-is. (Note: `query-emit.py` flags `emit-detail.json` as stale vs the newer README aggregate `13,459 / 13,530`; the ROADMAP deliberately cites the checked-in snapshot, so emit numbers are not changed here pending a detail refresh.)

## Verification (narrow/offline only — no full conformance/fourslash/emit/compiler suites)
- `grep -vcE '^#|^$' scripts/conformance/conformance-accepted-regressions.txt` → `4`
- `python3 scripts/conformance/query-conformance.py --dashboard` → `12582/12582` exact; `Accepted-regression gate: 4 listed tests`
- `python3 scripts/emit/audit-output-surgery.py` → `allowlist_cap=20`, `allowlisted_calls=20`, `unallowlisted_calls=0`, `stale_allowlist_files=0`
- `gh issue list --state open --label bug --limit 1000 --json number --jq length` → `111`
- `git diff --stat origin/main` (at push time, vs merge-base) → `docs/plan/ROADMAP.md` only; GitHub `--json files` confirms ROADMAP-only.

## Coordination Notes
- AgentName for this refresh is `Claude-M1A-LaunchMetrics`, continuing the parked M1-A roadmap-metrics PR. Owner/author content is the same release-control lane.
- Branch reset onto current `main` and force-pushed with `--force-with-lease` from prior head `9e35de5756ca`; new head `6e2fafbf186c`. Single-file (`docs/plan/ROADMAP.md`) diff.
- The PR is currently 1 commit behind the moving `main` on disjoint parser files only (no ROADMAP conflict); the merge-base diff stays ROADMAP-only.
- **Marked ready-for-review** (durable/current: the `4` accepted-regression entries and `20/20` output-surgery budget are re-verified against latest `main` `4e306709`, which still publishes the stale `0` and `23/23`). Docs-only, not WIP. **Queue handoff to M5Manager-Studio** — I did not add `merge-queue` myself; enqueue once exact-head ready CI is green.
- No full conformance/fourslash/emit/compiler suites were run.

AgentName: Claude-M1A-LaunchMetrics

