### PR TITLE
fix(parser): add ASI guard and multi_line detection to parse_import_attributes

### DIFF
--- a/crates/tsz-parser/src/parser/state_declarations_modules.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_modules.rs
@@ -642,8 +642,12 @@ impl ParserState {
     /// Parse optional import attributes: `with { type: "json" }` or `assert { type: "json" }`
     /// Returns `NodeIndex::NONE` if no attributes are present.
     pub(crate) fn parse_import_attributes(&mut self) -> NodeIndex {
-        // Check for 'with' or 'assert' keyword (not on a new line to avoid ASI issues)
         if !self.is_token(SyntaxKind::WithKeyword) && !self.is_token(SyntaxKind::AssertKeyword) {
+            return NodeIndex::NONE;
+        }
+        // ASI: 'with'/'assert' on a new line starts a new statement, not import attributes.
+        // Matches tsc's `!scanner.hasPrecedingLineBreak()` check before parseImportAttributes.
+        if self.scanner.has_preceding_line_break() {
             return NodeIndex::NONE;
         }
 
@@ -657,6 +661,8 @@ impl ParserState {
         }
 
         self.parse_expected(SyntaxKind::OpenBraceToken);
+        // multi_line is true when the first attribute (or closing brace) is on a new line after '{'.
+        let multi_line = self.scanner.has_preceding_line_break();
 
         let mut elements = Vec::new();
         while !self.is_token(SyntaxKind::CloseBraceToken)
@@ -700,7 +706,7 @@ impl ParserState {
             crate::parser::node::ImportAttributesData {
                 token,
                 elements: node_list,
-                multi_line: false,
+                multi_line,
             },
         )
     }

--- a/crates/tsz-parser/tests/parser_improvement_import_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_import_recovery_tests.rs
@@ -637,3 +637,189 @@ fn test_import_type_from_equals_still_routes_to_import_equals() {
         "Expected no parse errors for `import type from = require(...)`, got {parse_errors:?}"
     );
 }
+
+// =============================================================================
+// ASI guard for import attributes (with/assert on new line = new statement)
+// =============================================================================
+
+// Helpers shared across the ASI tests below.
+
+fn parse_first_import_has_attributes(source: &str) -> bool {
+    let (parser, root) = parse_source(source);
+    let arena = parser.get_arena();
+    let sf = arena.get_source_file_at(root).unwrap();
+    let stmt_node = arena.get(sf.statements.nodes[0]).unwrap();
+    arena
+        .get_import_decl(stmt_node)
+        .is_some_and(|i| i.attributes.is_some())
+}
+
+fn parse_first_export_has_attributes(source: &str) -> bool {
+    let (parser, root) = parse_source(source);
+    let arena = parser.get_arena();
+    let sf = arena.get_source_file_at(root).unwrap();
+    let stmt_node = arena.get(sf.statements.nodes[0]).unwrap();
+    arena
+        .get_export_decl(stmt_node)
+        .is_some_and(|e| e.attributes.is_some())
+}
+
+fn parse_first_import_attributes_multi_line(source: &str) -> bool {
+    let (parser, root) = parse_source(source);
+    let arena = parser.get_arena();
+    let sf = arena.get_source_file_at(root).unwrap();
+    let stmt_node = arena.get(sf.statements.nodes[0]).unwrap();
+    let import = arena.get_import_decl(stmt_node).unwrap();
+    let attr_node = arena
+        .get(import.attributes)
+        .expect("should have attributes");
+    arena
+        .get_import_attributes_data(attr_node)
+        .expect("should have attributes data")
+        .multi_line
+}
+
+#[test]
+fn test_import_attributes_same_line_extensionless_parsed() {
+    // `import './foo' with { type: 'json' }` — extensionless path, same line:
+    // 'with' is on the same line as the module specifier, so it IS import attributes.
+    let (parser, root) = parse_source(r#"import './foo' with { type: 'json' };"#);
+    let arena = parser.get_arena();
+    let sf = arena.get_source_file_at(root).unwrap();
+    let stmt_node = arena.get(sf.statements.nodes[0]).unwrap();
+    assert!(
+        arena
+            .get_import_decl(stmt_node)
+            .is_some_and(|i| i.attributes.is_some()),
+        "extensionless same-line 'with' must be parsed as import attributes"
+    );
+    let parse_errors: Vec<_> = parser
+        .get_diagnostics()
+        .iter()
+        .filter(|d| d.code < 2000)
+        .collect();
+    assert!(
+        parse_errors.is_empty(),
+        "Expected no parse errors for extensionless with-attributes, got {parse_errors:?}"
+    );
+}
+
+#[test]
+fn test_import_attributes_newline_extensionless_not_parsed_as_attributes() {
+    // When 'with' appears on a new line after the module specifier, ASI applies:
+    // the import declaration ends and 'with' starts a new statement (tsc behavior).
+    // The fix: `has_preceding_line_break()` guard in `parse_import_attributes`.
+    assert!(
+        !parse_first_import_has_attributes("import './foo'\nwith { type: 'json' };"),
+        "newline before 'with' must not be parsed as import attributes (ASI rule)"
+    );
+}
+
+#[test]
+fn test_import_attributes_same_line_with_extension_parsed() {
+    // Same-line attributes work with extension-bearing paths too.
+    assert!(
+        parse_first_import_has_attributes(r#"import './data.json' with { type: 'json' };"#),
+        "extension-bearing same-line 'with' must be parsed as import attributes"
+    );
+}
+
+#[test]
+fn test_import_attributes_newline_with_extension_not_parsed_as_attributes() {
+    // New-line guard applies regardless of whether the path has an extension.
+    assert!(
+        !parse_first_import_has_attributes("import './data.json'\nwith { type: 'json' };"),
+        "newline before 'with' must not be parsed as import attributes (extension-bearing path)"
+    );
+}
+
+#[test]
+fn test_import_assert_same_line_parsed() {
+    // 'assert' clause (deprecated TS 4.5–5.2 syntax) on the same line is still parsed.
+    assert!(
+        parse_first_import_has_attributes(r#"import './data.json' assert { type: 'json' };"#),
+        "same-line 'assert' clause must be parsed as import attributes"
+    );
+}
+
+#[test]
+fn test_import_assert_newline_not_parsed_as_attributes() {
+    // 'assert' on a new line must not be parsed as import attributes.
+    assert!(
+        !parse_first_import_has_attributes("import './data.json'\nassert { type: 'json' };"),
+        "newline before 'assert' must not be parsed as import attributes"
+    );
+}
+
+#[test]
+fn test_export_attributes_same_line_parsed() {
+    // Export declarations also support 'with' attributes on the same line.
+    let (parser, root) = parse_source(r#"export * from './foo' with { type: 'json' };"#);
+    let arena = parser.get_arena();
+    let sf = arena.get_source_file_at(root).unwrap();
+    let stmt_node = arena.get(sf.statements.nodes[0]).unwrap();
+    assert!(
+        arena
+            .get_export_decl(stmt_node)
+            .is_some_and(|e| e.attributes.is_some()),
+        "same-line 'with' on export must be parsed as import attributes"
+    );
+    let parse_errors: Vec<_> = parser
+        .get_diagnostics()
+        .iter()
+        .filter(|d| d.code < 2000)
+        .collect();
+    assert!(
+        parse_errors.is_empty(),
+        "Expected no parse errors for export with-attributes, got {parse_errors:?}"
+    );
+}
+
+#[test]
+fn test_export_attributes_newline_not_parsed_as_attributes() {
+    // 'with' on a new line after export's module specifier = new statement (ASI).
+    assert!(
+        !parse_first_export_has_attributes("export * from './foo'\nwith { type: 'json' };"),
+        "newline before 'with' on export must not be parsed as import attributes"
+    );
+}
+
+#[test]
+fn test_import_attributes_multi_line_sets_multi_line_flag() {
+    // When the attribute block spans multiple lines, `multi_line` should be true.
+    assert!(
+        parse_first_import_attributes_multi_line("import './foo' with {\n  type: 'json'\n};"),
+        "multi_line must be true when attribute block spans multiple lines"
+    );
+}
+
+#[test]
+fn test_import_attributes_single_line_clears_multi_line_flag() {
+    // When attributes are on one line, `multi_line` should be false.
+    assert!(
+        !parse_first_import_attributes_multi_line(r#"import './foo' with { type: 'json' };"#),
+        "multi_line must be false for single-line attribute block"
+    );
+}
+
+#[test]
+fn test_import_attributes_named_import_extensionless_same_line() {
+    // Named import with extensionless path and same-line attributes.
+    assert!(
+        parse_first_import_has_attributes(
+            r#"import { foo } from './module' with { type: 'json' };"#
+        ),
+        "named import with extensionless path: same-line 'with' must be attributes"
+    );
+}
+
+#[test]
+fn test_import_attributes_named_import_extensionless_newline() {
+    // Named import with extensionless path and new-line 'with' — ASI applies.
+    assert!(
+        !parse_first_import_has_attributes(
+            "import { foo } from './module'\nwith { type: 'json' };"
+        ),
+        "named import with extensionless path: newline 'with' must not be attributes"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Parser conformance — ASI handling for import/export attribute clauses (fixes #11560)

## Invariant
When `with` or `assert` appears after an import/export module specifier with a preceding line break, `tsc` applies ASI and treats the keyword as the start of a new statement; this PR makes tsz return `NodeIndex::NONE` from `parse_import_attributes` when `has_preceding_line_break()` is true, ending the import/export declaration without attributes and leaving the keyword to begin the next statement. The `multi_line` flag is also now set correctly from the scanner's line-break state after the opening brace.

## Scope
- `crates/tsz-parser/src/parser/state_declarations_modules.rs` — `parse_import_attributes()`: 2 guard statements + `multi_line` detection
- `crates/tsz-parser/tests/parser_improvement_import_recovery_tests.rs` — 12 new tests + 3 local helpers

The fix is inside `parse_import_attributes()` so all three call sites benefit: import declarations, export-star declarations, and named export declarations.

## Project Corpus Impact
- Row: vite-vanilla-ts-app (case parser-4-20)
- Bug family: parser-ASI — `with`/`assert` after module specifier on new line incorrectly parsed as import attributes instead of new statement
- Evidence: 1116/1116 `cargo test -p tsz-parser` pass; 22/22 `cargo test -p tsz-checker --test import_attributes_resolution_mode_tests` pass; `cargo clippy -p tsz-parser --all-targets -- -D warnings` clean.

## Verification
- `cargo test -p tsz-parser` — 1116/1116 ok (includes 12 new ASI tests)
- `cargo test -p tsz-checker --test import_attributes_resolution_mode_tests` — 22/22 ok
- `cargo clippy -p tsz-parser --all-targets --all-features -- -D warnings` — clean

Test matrix: `with`/`assert` keywords, same-line/newline, import/export, extensionless/extension-bearing paths, named/bare imports, single-line/multi-line `multi_line` flag.

## Coordination Notes
- Original runner identity: claude-sonnet-4-6 (busy-lamport-44Zg5)
- Fixes #11560 (vite-vanilla-ts-app parser-4-20). Issue WIP label added with signed comment before work began.
- Picked via random number generator from non-WIP open issues.
- Merged from origin/main before implementing — no conflicts.
- Independent of open parser PRs (#11874 JSX recovery, #11869 object-literal recovery) — different parser subsystem.
- Ownership transferred to Studio-C lane per Reviewer coordination comment.