### PR TITLE
fix(core): preserve lib type fallback for exported value shadows

### DIFF
--- a/crates/tsz-checker/tests/lib_global_namespace_shadowing_tests.rs
+++ b/crates/tsz-checker/tests/lib_global_namespace_shadowing_tests.rs
@@ -283,3 +283,42 @@ type X = Readonly<Partial<{ a: number }>>;
         "TS2749 must not fire for nested lib types Readonly<Partial<T>> with local unique-symbol shadow; got: {codes:?}"
     );
 }
+
+#[test]
+fn exported_unique_symbol_shadow_does_not_hide_lib_type_alias() {
+    // `deeplyNestedMappedTypes.ts` exports its unique-symbol values. Exporting
+    // the VALUE-only declaration must still leave the global TYPE alias
+    // reachable in type position.
+    let codes = diagnostic_codes(
+        r#"
+export declare const Readonly: unique symbol;
+export declare const Optional: unique symbol;
+export interface TSchema {
+    [Readonly]?: string;
+    [Optional]?: string;
+    static: unknown;
+}
+export type TReadonly<T extends TSchema> = T & { [Readonly]: "Readonly" };
+export type TOptional<T extends TSchema> = T & { [Optional]: "Optional" };
+export type TProperties = Record<string | number, TSchema>;
+export type ReadonlyPropertyKeys<T extends TProperties> = {
+    [K in keyof T]: T[K] extends TReadonly<TSchema>
+        ? (T[K] extends TOptional<T[K]> ? never : K)
+        : never
+}[keyof T];
+export type OptionalPropertyKeys<T extends TProperties> = {
+    [K in keyof T]: T[K] extends TOptional<TSchema>
+        ? (T[K] extends TReadonly<T[K]> ? never : K)
+        : never
+}[keyof T];
+export type R<T extends TProperties, V extends Record<keyof any, unknown>> =
+    Readonly<Partial<Pick<V, ReadonlyPropertyKeys<T>>>> &
+    Partial<Pick<V, OptionalPropertyKeys<T>>>;
+"#,
+    );
+    assert!(
+        !codes.contains(&2749),
+        "TS2749 must not fire when exported unique-symbol consts shadow only VALUE; \
+         lib type aliases must remain visible in type position; got: {codes:?}"
+    );
+}

--- a/crates/tsz-cli/tests/tsc_compat_tests_parts/part_02.rs
+++ b/crates/tsz-cli/tests/tsc_compat_tests_parts/part_02.rs
@@ -776,3 +776,53 @@ if (container.hasValue()) {
         "`this is ...` predicates must narrow receiver properties, got: {output}"
     );
 }
+
+#[test]
+fn exported_value_only_lib_type_shadow_in_mapped_reducer_has_no_ts2749() {
+    let temp = TempDir::new("exported_value_only_lib_type_shadow").expect("temp dir");
+    write_file(
+        &temp.path.join("test.ts"),
+        r#"
+export declare const Readonly: unique symbol;
+export declare const Optional: unique symbol;
+export interface TSchema {
+  [Readonly]?: string
+  [Optional]?: string
+  params: unknown[]
+  static: unknown
+}
+export type TReadonly<T extends TSchema> = T & { [Readonly]: 'Readonly' }
+export type TOptional<T extends TSchema> = T & { [Optional]: 'Optional' }
+export type TPropertyKey = string | number
+export type TProperties = Record<TPropertyKey, TSchema>
+export type ReadonlyPropertyKeys<T extends TProperties> = {
+  [K in keyof T]: T[K] extends TReadonly<TSchema>
+    ? (T[K] extends TOptional<T[K]> ? never : K)
+    : never
+}[keyof T]
+export type OptionalPropertyKeys<T extends TProperties> = {
+  [K in keyof T]: T[K] extends TOptional<TSchema>
+    ? (T[K] extends TReadonly<T[K]> ? never : K)
+    : never
+}[keyof T]
+export type PropertiesReducer<T extends TProperties, R extends Record<keyof any, unknown>> =
+  Readonly<Partial<Pick<R, ReadonlyPropertyKeys<T>>>> &
+  Partial<Pick<R, OptionalPropertyKeys<T>>>
+export type PropertiesReduce<T extends TProperties> = PropertiesReducer<T, {
+  [K in keyof T]: T[K]['static']
+}>
+"#,
+    );
+
+    let (tsz_code, tsz_output) = run_tsz_with_exit_code(
+        &temp.path,
+        &["--noEmit", "--strict", "--target", "es2015", "test.ts"],
+    )
+    .expect("tsz should run");
+
+    assert_eq!(
+        tsz_code, 0,
+        "tsz must not emit TS2749 for VALUE-only exported Readonly shadowing lib type alias\n\
+         tsz output:\n{tsz_output}"
+    );
+}

--- a/crates/tsz-core/src/parallel/core/merge_support.rs
+++ b/crates/tsz-core/src/parallel/core/merge_support.rs
@@ -515,9 +515,10 @@ impl MergedProgram {
     /// Build the `lib_type_namespace` map for a reconstructed binder.
     ///
     /// Scans only the per-file locals for `file_idx` (not merged globals) for
-    /// VALUE-only user symbols whose names also appear as TYPE symbols in
-    /// `self.globals`. This lets the checker's symbol resolver fall back to
-    /// the lib TYPE symbol when a local VALUE-only symbol would otherwise block it.
+    /// VALUE-only user symbols whose names also appear as TYPE symbols in the
+    /// merged lib namespace. This lets the checker's symbol resolver fall back
+    /// to the lib TYPE symbol when a local VALUE-only symbol would otherwise
+    /// block it.
     #[must_use]
     pub fn build_lib_type_namespace(&self, file_idx: usize) -> FxHashMap<String, SymbolId> {
         use crate::binder::symbol_flags;
@@ -530,14 +531,34 @@ impl MergedProgram {
             if (sym_flags & symbol_flags::VALUE) == 0 || (sym_flags & symbol_flags::TYPE) != 0 {
                 continue;
             }
-            if let Some(global_id) = self.globals.get(name) {
-                let global_flags = self.symbols.get(global_id).map_or(0, |s| s.flags);
-                if (global_flags & symbol_flags::TYPE) != 0 {
-                    result.insert(name.clone(), global_id);
-                }
+            if let Some(lib_type_id) = self.find_lib_type_symbol(name) {
+                result.insert(name.clone(), lib_type_id);
             }
         }
         result
+    }
+
+    fn find_lib_type_symbol(&self, name: &str) -> Option<SymbolId> {
+        use crate::binder::symbol_flags;
+
+        if let Some(global_id) = self.globals.get(name) {
+            let global_flags = self.symbols.get(global_id).map_or(0, |s| s.flags);
+            if (global_flags & symbol_flags::TYPE) != 0 {
+                return Some(global_id);
+            }
+        }
+
+        self.symbols
+            .find_all_by_name(name)
+            .iter()
+            .copied()
+            .find(|candidate_id| {
+                self.lib_symbol_ids.contains(candidate_id)
+                    && self
+                        .symbols
+                        .get(*candidate_id)
+                        .is_some_and(|sym| (sym.flags & symbol_flags::TYPE) != 0)
+            })
     }
 }
 


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
M4-A advanced type evaluation / accepted-regression false-positive cleanup.

## Invariant
When an external module exports a VALUE-only declaration whose spelling matches a lib TYPE alias, type-position resolution must still be able to reach the lib TYPE symbol; this PR changes reconstructed per-file binder state so project/CLI checking preserves that namespace split.

## Scope
- `crates/tsz-core/src/parallel/core/merge_support.rs`: recover lib-origin type symbols by name when building reconstructed `lib_type_namespace`.
- `crates/tsz-cli/tests/tsc_compat_tests_parts/part_02.rs`: add a project/CLI regression for an exported `Readonly` unique-symbol shadow inside a mapped reducer.
- `crates/tsz-checker/tests/lib_global_namespace_shadowing_tests.rs`: keep adjacent single-file checker coverage for exported unique-symbol shadows.

## Project Corpus Impact
- Row: accepted-regression / conformance `deeplyNestedMappedTypes.ts`
- Bug family: false-positive TS2749 from exported value-only declarations shadowing lib type aliases.
- Evidence: narrow conformance filter no longer reports TS2749 for `deeplyNestedMappedTypes.ts`; remaining drift is the pre-existing TS2322 fingerprint-only mismatch.

## Verification
- `cargo nextest run -p tsz-cli --test tsc_compat_tests exported_value_only_lib_type_shadow_in_mapped_reducer_has_no_ts2749`
- `cargo nextest run -p tsz-checker --test lib_global_namespace_shadowing_tests exported_unique_symbol_shadow_does_not_hide_lib_type_alias`
- `cargo fmt --check`
- `git diff --check HEAD`
- `scripts/safe-run.sh cargo build -p tsz-cli --bin tsz --profile dist-fast`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter deeplyNestedMappedTypes --verbose` (still fingerprint-only TS2322; TS2749 removed)

## Coordination Notes
- M4-A owned open PR check before publishing: none.
- This is not WIP and is intended for ready-review CI.
- No roadmap update: this is a focused false-positive fix with regression coverage, not a durable roadmap direction change.
