### PR TITLE
fix(checker): report default-omitted recursive alias wrappers

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/core.rs
+++ b/crates/tsz-checker/src/state/type_resolution/core.rs
@@ -399,15 +399,40 @@ impl<'a> CheckerState<'a> {
                         && self.type_alias_has_same_input_recursive_conditional_union_body(sym_id);
                     let default_reset_recursive_alias = is_type_alias
                         && self.type_alias_has_default_reset_recursive_conditional_body(sym_id);
-                    let default_reset_dependency_alias = is_type_alias
+                    let default_omitting_recursive_alias = is_type_alias
                         && !default_reset_recursive_alias
+                        && self.type_alias_has_default_omitting_recursive_conditional_body(sym_id);
+                    let defaulted_recursive_alias =
+                        default_reset_recursive_alias || default_omitting_recursive_alias;
+                    let default_reset_dependency_alias = is_type_alias
+                        && !defaulted_recursive_alias
                         && self.type_alias_body_references_default_reset_recursive_alias(sym_id);
                     let default_reset_conditional_check_alias = is_type_alias
-                        && !default_reset_recursive_alias
+                        && !defaulted_recursive_alias
                         && self
                             .type_alias_conditional_check_references_defaulted_alias_with_omitted_args(sym_id);
                     let should_check_depth =
-                        is_class || !args_have_type_params || default_reset_recursive_alias;
+                        is_class || !args_have_type_params || defaulted_recursive_alias;
+                    if default_omitting_recursive_alias
+                        && args_have_type_params
+                        && self.type_reference_omits_defaulted_alias_arg(sym_id, type_ref)
+                        && self.type_node_is_outside_symbol_declarations(idx, sym_id)
+                    {
+                        use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+                        self.error_at_node(
+                            idx,
+                            diagnostic_messages::TYPE_INSTANTIATION_IS_EXCESSIVELY_DEEP_AND_POSSIBLY_INFINITE,
+                            diagnostic_codes::TYPE_INSTANTIATION_IS_EXCESSIVELY_DEEP_AND_POSSIBLY_INFINITE,
+                        );
+                        if let Some(base_def_id) =
+                            query::get_application_info(self.ctx.types, type_id)
+                                .and_then(|(base, _)| query::get_lazy_def_id(self.ctx.types, base))
+                        {
+                            self.ctx.definition_store.mark_depth_poisoned(base_def_id);
+                            self.ctx.clear_type_evaluation_caches_for_def(base_def_id);
+                        }
+                        return TypeId::ANY;
+                    }
                     if should_check_depth {
                         // During symbol resolution, ensure_relation_input_ready is skipped,
                         // leaving the alias body unregistered in the TypeEnvironment. Without
@@ -428,9 +453,12 @@ impl<'a> CheckerState<'a> {
                         // Use the regular evaluator for ordinary type-reference
                         // probes. The TS2589-specific evaluator treats any repeated
                         // Application cycle as overflow, which is too aggressive for
-                        // bounded recursive conditional aliases.
+                        // bounded recursive conditional aliases. Default-reset
+                        // recursive aliases are already known to be unbounded, so
+                        // their wrapper references need the stronger probe too.
                         let (exceeded, tuple_too_large) = if (computed_recursive_alias
-                            || same_input_recursive_union_alias)
+                            || same_input_recursive_union_alias
+                            || defaulted_recursive_alias)
                             && let Some(base_def_id) = base_def_id
                         {
                             (
@@ -472,7 +500,7 @@ impl<'a> CheckerState<'a> {
                         let suppress_depth_cascade = exceeded
                             && (default_reset_dependency_alias
                                 || default_reset_conditional_check_alias
-                                || (!default_reset_recursive_alias
+                                || (!defaulted_recursive_alias
                                     && base_def_id.is_some_and(|def_id| {
                                         self.def_body_involves_depth_poisoned_def(def_id)
                                     })));
@@ -507,7 +535,7 @@ impl<'a> CheckerState<'a> {
 
                             if code
                                 == diagnostic_codes::TYPE_INSTANTIATION_IS_EXCESSIVELY_DEEP_AND_POSSIBLY_INFINITE
-                                && default_reset_recursive_alias
+                                && defaulted_recursive_alias
                                 && self.type_node_is_outside_symbol_declarations(idx, sym_id)
                                 && let Some(base_def_id) = base_def_id
                             {
@@ -1294,24 +1322,53 @@ impl<'a> CheckerState<'a> {
                             self.type_alias_has_same_input_recursive_conditional_union_body(sym_id);
                         let default_reset_recursive_alias =
                             self.type_alias_has_default_reset_recursive_conditional_body(sym_id);
-                        let default_reset_dependency_alias = !default_reset_recursive_alias
+                        let default_omitting_recursive_alias = !default_reset_recursive_alias
+                            && self
+                                .type_alias_has_default_omitting_recursive_conditional_body(sym_id);
+                        let defaulted_recursive_alias =
+                            default_reset_recursive_alias || default_omitting_recursive_alias;
+                        let default_reset_dependency_alias = !defaulted_recursive_alias
                             && self
                                 .type_alias_body_references_default_reset_recursive_alias(sym_id);
-                        let default_reset_conditional_check_alias = !default_reset_recursive_alias
+                        let default_reset_conditional_check_alias = !defaulted_recursive_alias
                             && self
                                 .type_alias_conditional_check_references_defaulted_alias_with_omitted_args(sym_id);
-                        if !args_have_type_params || default_reset_recursive_alias {
+                        if default_omitting_recursive_alias
+                            && args_have_type_params
+                            && self.type_reference_omits_defaulted_alias_arg(sym_id, type_ref)
+                            && self.type_node_is_outside_symbol_declarations(idx, sym_id)
+                        {
+                            use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+                            self.error_at_node(
+                                idx,
+                                diagnostic_messages::TYPE_INSTANTIATION_IS_EXCESSIVELY_DEEP_AND_POSSIBLY_INFINITE,
+                                diagnostic_codes::TYPE_INSTANTIATION_IS_EXCESSIVELY_DEEP_AND_POSSIBLY_INFINITE,
+                            );
+                            if let Some(app_def_id) =
+                                query::get_application_info(self.ctx.types, result).and_then(
+                                    |(base, _)| query::get_lazy_def_id(self.ctx.types, base),
+                                )
+                            {
+                                self.ctx.definition_store.mark_depth_poisoned(app_def_id);
+                                self.ctx.clear_type_evaluation_caches_for_def(app_def_id);
+                            }
+                            return TypeId::ANY;
+                        }
+                        if !args_have_type_params || defaulted_recursive_alias {
                             // Clear overflow flags before probing.
                             self.ctx.types.take_tuple_too_large();
                             self.ctx.depth_exceeded.set(false);
                             // Use the regular evaluator for ordinary type-reference
                             // probes. The TS2589-specific evaluator treats any repeated
                             // Application cycle as overflow, which is too aggressive for
-                            // bounded recursive conditional aliases.
+                            // bounded recursive conditional aliases. Default-reset
+                            // recursive aliases are already known to be unbounded, so
+                            // their wrapper references need the stronger probe too.
                             let app_def_id = query::get_application_info(self.ctx.types, result)
                                 .and_then(|(base, _)| query::get_lazy_def_id(self.ctx.types, base));
                             let (exceeded, tuple_too_large) = if (computed_recursive_alias
-                                || same_input_recursive_union_alias)
+                                || same_input_recursive_union_alias
+                                || defaulted_recursive_alias)
                                 && let Some(app_def_id) = app_def_id
                             {
                                 (
@@ -1357,7 +1414,7 @@ impl<'a> CheckerState<'a> {
                             let suppress_depth_cascade = exceeded
                                 && (default_reset_dependency_alias
                                     || default_reset_conditional_check_alias
-                                    || (!default_reset_recursive_alias
+                                    || (!defaulted_recursive_alias
                                         && app_def_id.is_some_and(|def_id| {
                                             self.def_body_involves_depth_poisoned_def(def_id)
                                         })));
@@ -1390,7 +1447,7 @@ impl<'a> CheckerState<'a> {
 
                                 if code
                                     == diagnostic_codes::TYPE_INSTANTIATION_IS_EXCESSIVELY_DEEP_AND_POSSIBLY_INFINITE
-                                    && default_reset_recursive_alias
+                                    && defaulted_recursive_alias
                                     && self.type_node_is_outside_symbol_declarations(idx, sym_id)
                                     && let Some(app_def_id) = app_def_id
                                 {

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -383,6 +383,21 @@ impl<'a> CheckerState<'a> {
                 diagnostic_codes::EXPRESSION_PRODUCES_A_UNION_TYPE_THAT_IS_TOO_COMPLEX_TO_REPRESENT,
             );
         }
+        if let Some(alias_sid) = alias_sym_id
+            && let Some(body_node) = self.ctx.arena.get(alias.type_node)
+            && let Some(conditional) = self.ctx.arena.get_conditional_type(body_node)
+            && self.type_node_references_defaulted_alias_with_omitted_args(
+                conditional.check_type,
+                alias_sid,
+            )
+        {
+            use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+            self.error_at_node(
+                conditional.check_type,
+                diagnostic_messages::TYPE_INSTANTIATION_IS_EXCESSIVELY_DEEP_AND_POSSIBLY_INFINITE,
+                diagnostic_codes::TYPE_INSTANTIATION_IS_EXCESSIVELY_DEEP_AND_POSSIBLY_INFINITE,
+            );
+        }
 
         // TS2589: detect excessively deep type instantiation at definition time.
         // tsc emits TS2589 for type aliases whose body contains conditional types

--- a/crates/tsz-checker/src/types/type_checking/type_alias_depth_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_depth_helpers.rs
@@ -321,7 +321,7 @@ impl<'a> CheckerState<'a> {
         })
     }
 
-    fn type_node_references_defaulted_alias_with_omitted_args(
+    pub(crate) fn type_node_references_defaulted_alias_with_omitted_args(
         &mut self,
         node_idx: NodeIndex,
         owner_alias_sid: tsz_binder::SymbolId,
@@ -354,7 +354,7 @@ impl<'a> CheckerState<'a> {
             })
     }
 
-    fn type_reference_omits_defaulted_alias_arg(
+    pub(crate) fn type_reference_omits_defaulted_alias_arg(
         &self,
         alias_sid: tsz_binder::SymbolId,
         type_ref: &tsz_parser::parser::node::TypeRefData,
@@ -426,7 +426,7 @@ impl<'a> CheckerState<'a> {
             })
     }
 
-    fn type_alias_has_default_omitting_recursive_conditional_body(
+    pub(crate) fn type_alias_has_default_omitting_recursive_conditional_body(
         &mut self,
         alias_sid: tsz_binder::SymbolId,
     ) -> bool {


### PR DESCRIPTION
## Agent
AgentName: M4-C

## Track
checker/solver TS2589 parity; M4-C defaulted recursive alias diagnostics

## Invariant
When a default-omitting recursive alias is used as a conditional check type through omitted defaults, TS 6.0.3 emits TS2589 both at recursive transform references and wrapper references. This PR changes checker/type-resolution anchoring so tsz reports the same wrapper diagnostics while preserving downstream cascade recovery.

## Scope
- `crates/tsz-checker/src/types/type_checking/type_alias_depth_helpers.rs`
- `crates/tsz-checker/src/types/type_checking/type_alias_checking.rs`
- `crates/tsz-checker/src/state/type_resolution/core.rs`

## Project Corpus Impact
- Row: kysely-project, large-ts-repo
- Bug family: solver-26-20 / default-omitted recursive alias TS2589 anchoring
- Evidence: focused TS2589 checker tests pass; aligned with issue #11211/#11297 minimal family without touching overload TS2394 work.

## Verification
- `CARGO_INCREMENTAL=0 RUSTFLAGS='-C debuginfo=0' cargo nextest run -p tsz-checker --lib recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589` -> 1 passed
- `CARGO_INCREMENTAL=0 RUSTFLAGS='-C debuginfo=0' cargo nextest run -p tsz-checker --test generic_default_recursive_alias_diagnostics_tests` -> 4 passed
- `CARGO_INCREMENTAL=0 RUSTFLAGS='-C debuginfo=0' cargo nextest run -p tsz-checker --lib -E 'test(bounded_recursive_conditional_no_ts2589_at_definition) | test(bounded_recursive_alias_with_indexed_type_parameter_arg_no_ts2589) | test(recursive_conditional_alias_with_parameter_dependent_helper_args_no_definition_ts2589)'` -> 3 passed
- `scripts/arch/check-checker-boundaries.sh` -> pass
- `git diff --check` -> pass
- `cargo fmt --check` -> pass

## Coordination Notes
- Rebased onto `origin/main` at `fe84f960e4ede7df4fe5a1faa5cd9e70aea872db`; current head is `e3799a185c15c94a2307ab77ca3bb0051f0f0bec`.
- No open PR overlap found for solver-26-20 before coding.
- Avoided active overload/Kysely TS2394 overlap in #11831 and recent #11866.
- Local disk pressure required `CARGO_INCREMENTAL=0 RUSTFLAGS='-C debuginfo=0'` for focused Rust test runs; no full conformance/emit/fourslash suite was run locally per TSZ policy.
