### PR TITLE
fix(emit-tools): apply query filters to failure views

### DIFF
--- a/scripts/emit/query-emit.py
+++ b/scripts/emit/query-emit.py
@@ -311,6 +311,16 @@ def show_dts_failures(data, top=40, paths_only=False):
     print_truncated_more(fails, top)
 
 
+def filter_data_by_name(data, pattern):
+    if not pattern:
+        return data
+
+    lower = pattern.lower()
+    filtered = dict(data)
+    filtered["results"] = [r for r in data["results"] if lower in r["name"].lower()]
+    return filtered
+
+
 def show_top_errors(data, top=20):
     results = data["results"]
 
@@ -445,21 +455,22 @@ def main():
     args = parser.parse_args()
 
     data = load_detail()
+    filtered_data = filter_data_by_name(data, args.filter)
 
     if args.js_failures:
-        show_js_failures(data, args.top, args.paths_only)
+        show_js_failures(filtered_data, args.top, args.paths_only)
     elif args.dts_failures:
-        show_dts_failures(data, args.top, args.paths_only)
+        show_dts_failures(filtered_data, args.top, args.paths_only)
     elif args.top_errors:
-        show_top_errors(data, args.top)
+        show_top_errors(filtered_data, args.top)
     elif args.families:
-        show_failure_families(data, args.top)
+        show_failure_families(filtered_data, args.top)
     elif args.close:
-        show_close(data, args.top)
+        show_close(filtered_data, args.top)
+    elif args.status:
+        show_status(filtered_data, args.status, args.top)
     elif args.filter:
         show_filter(data, args.filter, args.top, args.paths_only)
-    elif args.status:
-        show_status(data, args.status, args.top)
     else:
         show_overview(data)
 

--- a/scripts/emit/test_query_emit_families.py
+++ b/scripts/emit/test_query_emit_families.py
@@ -6,6 +6,8 @@ cases confirm that unsupported shapes still fall through to "other".
 """
 
 import importlib.util
+import contextlib
+import io
 import pathlib
 import sys
 import unittest
@@ -99,6 +101,45 @@ after
             },
         )
         self.assertIsNone(note)
+
+
+class TestQueryFilters(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = load_query_emit()
+
+    def test_name_filter_scopes_dts_failures(self):
+        data = {
+            "results": [
+                make_result("checkJsdocSatisfiesTag15", dts_error="+1/-1 lines"),
+                make_result("jsDeclarationsClasses", dts_error="+21/-17 lines"),
+            ]
+        }
+        filtered = self.mod.filter_data_by_name(data, "checkJsdoc")
+
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            self.mod.show_dts_failures(filtered)
+
+        text = out.getvalue()
+        self.assertIn("DTS failures: 1", text)
+        self.assertIn("checkJsdocSatisfiesTag15", text)
+        self.assertNotIn("jsDeclarationsClasses", text)
+
+    def test_name_filter_scopes_paths_only_failure_output(self):
+        data = {
+            "results": [
+                make_result("checkJsdocSatisfiesTag15", dts_error="+1/-1 lines"),
+                make_result("jsDeclarationsClasses", dts_error="+21/-17 lines"),
+            ]
+        }
+        filtered = self.mod.filter_data_by_name(data, "jsDeclarations")
+
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            self.mod.show_dts_failures(filtered, paths_only=True)
+
+        self.assertEqual(out.getvalue(), "jsDeclarationsClasses\n")
 
 
 class TestJSFamilyClassifier(unittest.TestCase):


### PR DESCRIPTION
## Agent
AgentName: Studio-E

## Track
Track 9 / emit tooling; supports JSDoc/JS declaration emit triage under #9333.

## Invariant
When an agent queries checked-in emit detail with `--filter` plus a failure, family, close, top-error, or status view, the view is scoped to the requested test-name substring; this PR changes the offline query tool only.

## Scope
- `scripts/emit/query-emit.py`
- `scripts/emit/test_query_emit_families.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: emit-triage tooling only; no compiler, benchmark fixture, emit runner, or project corpus behavior changes.

## Verification
- `python3 -m unittest scripts.emit.test_query_emit_families`
- `python3 scripts/emit/query-emit.py --dts-failures --filter checkJsdoc --top 80`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- AgentName: Studio-E
- Owned PR runway was clear before starting.
- This does not take over broad declaration-summary work in #8275.
- The live `checkJsdocSatisfiesTag15` DTS run is green on current main; this PR prevents filtered triage from printing unrelated DTS failures from stale checked-in detail.
- Ready for manager review/queue after PR-head checks.