### PR TITLE
fix(module-resolver): pick file probing extensions from target package's `package.json#type`

### DIFF
--- a/crates/tsz-core/src/module_resolver/exports_imports.rs
+++ b/crates/tsz-core/src/module_resolver/exports_imports.rs
@@ -86,6 +86,7 @@ impl ModuleResolver {
         containing_file: &str,
         specifier_span: Span,
         importing_module_kind: ImportingModuleKind,
+        importer_package_type: Option<super::PackageType>,
     ) -> Result<ResolvedModule, ResolutionFailure> {
         // Walk up directory tree looking for package.json with imports field
         let mut current = containing_dir.to_path_buf();
@@ -98,6 +99,12 @@ impl ModuleResolver {
                 && let Some(imports) = &package_json.imports
             {
                 let conditions = self.get_export_conditions(importing_module_kind);
+                // `#imports` always resolve inside the importer's own package,
+                // so use the package_json we just read to anchor the extension
+                // priority. The importer's own context is the fallback when
+                // this package.json has no `"type"` field.
+                let host_pt =
+                    self.target_package_type_from_json(&package_json, importer_package_type);
 
                 for (target, resolved_using_ts_extension) in
                     self.resolve_imports_subpath_candidates(imports, specifier, &conditions)
@@ -112,7 +119,8 @@ impl ModuleResolver {
                         else {
                             continue;
                         };
-                        if let Some(resolved) = self.try_file_or_directory(&resolved_path) {
+                        if let Some(resolved) = self.try_file_or_directory(&resolved_path, host_pt)
+                        {
                             return Ok(ResolvedModule {
                                 resolved_path: resolved.clone(),
                                 resolved_using_ts_extension,
@@ -339,6 +347,7 @@ impl ModuleResolver {
         subpath: &str,
         conditions: &[String],
         is_types_condition: bool,
+        target_package_type: Option<super::PackageType>,
     ) -> Option<(PathBuf, bool)> {
         match exports {
             PackageExports::String(s) => {
@@ -346,15 +355,13 @@ impl ModuleResolver {
                     let resolved = package_relative_target_path(package_dir, s)?;
                     if is_types_condition {
                         if let Some(r) = self
-                            .try_types_entry(&resolved)
-                            .or_else(|| self.try_export_target(&resolved))
+                            .try_types_entry(&resolved, target_package_type)
+                            .or_else(|| self.try_export_target(&resolved, target_package_type))
                         {
                             return Some((r, false));
                         }
-                    } else {
-                        if let Some(r) = self.try_export_target(&resolved) {
-                            return Some((r, false));
-                        }
+                    } else if let Some(r) = self.try_export_target(&resolved, target_package_type) {
+                        return Some((r, false));
                     }
                 }
                 None
@@ -372,6 +379,7 @@ impl ModuleResolver {
                             value,
                             conditions,
                             is_types_condition,
+                            target_package_type,
                         )
                         .map(|p| (p, key_uses_ts));
                 }
@@ -396,6 +404,7 @@ impl ModuleResolver {
                         &substituted_value,
                         conditions,
                         is_types_condition,
+                        target_package_type,
                     ) {
                         return Some((resolved, key_uses_ts));
                     }
@@ -418,6 +427,7 @@ impl ModuleResolver {
                             subpath,
                             conditions,
                             is_types,
+                            target_package_type,
                         ) {
                             return Some(resolved);
                         }
@@ -434,6 +444,7 @@ impl ModuleResolver {
                         subpath,
                         conditions,
                         is_types_condition,
+                        target_package_type,
                     ) {
                         return Some(resolved);
                     }
@@ -454,15 +465,16 @@ impl ModuleResolver {
         value: &PackageExports,
         conditions: &[String],
         is_types_condition: bool,
+        target_package_type: Option<super::PackageType>,
     ) -> Option<PathBuf> {
         match value {
             PackageExports::String(s) => {
                 let resolved = package_relative_target_path(package_dir, s)?;
                 if is_types_condition {
-                    self.try_types_entry(&resolved)
-                        .or_else(|| self.try_export_target(&resolved))
+                    self.try_types_entry(&resolved, target_package_type)
+                        .or_else(|| self.try_export_target(&resolved, target_package_type))
                 } else {
-                    self.try_export_target(&resolved)
+                    self.try_export_target(&resolved, target_package_type)
                 }
             }
             PackageExports::Conditional(cond_entries) => {
@@ -479,6 +491,7 @@ impl ModuleResolver {
                             nested,
                             conditions,
                             is_types,
+                            target_package_type,
                         ) {
                             return Some(resolved);
                         }
@@ -493,6 +506,7 @@ impl ModuleResolver {
                         element,
                         conditions,
                         is_types_condition,
+                        target_package_type,
                     ) {
                         return Some(resolved);
                     }
@@ -529,6 +543,7 @@ impl ModuleResolver {
         package_dir: &Path,
         subpath: &str,
         types_versions: &serde_json::Value,
+        target_package_type: Option<super::PackageType>,
     ) -> Option<PathBuf> {
         let compiler_version =
             types_versions_compiler_version(self.types_versions_compiler_version.as_deref());
@@ -540,7 +555,12 @@ impl ModuleResolver {
         //    iteration order is consistent with the wildcard pass below.
         for (key, value) in paths {
             if !key.contains('*') && key == subpath {
-                return self.apply_types_versions_targets(package_dir, value, "");
+                return self.apply_types_versions_targets(
+                    package_dir,
+                    value,
+                    "",
+                    target_package_type,
+                );
             }
         }
 
@@ -573,7 +593,7 @@ impl ModuleResolver {
         }
 
         let (_, value, wildcard) = best?;
-        self.apply_types_versions_targets(package_dir, value, &wildcard)
+        self.apply_types_versions_targets(package_dir, value, &wildcard, target_package_type)
     }
 
     /// Iterate the `value` of a `typesVersions` paths entry (a single string or
@@ -585,6 +605,7 @@ impl ModuleResolver {
         package_dir: &Path,
         value: &serde_json::Value,
         wildcard: &str,
+        target_package_type: Option<super::PackageType>,
     ) -> Option<PathBuf> {
         // tsc's `replaceFirstStar` substitutes only the first `*` in the
         // target string. `apply_wildcard_substitution` does the same when
@@ -595,7 +616,7 @@ impl ModuleResolver {
         let try_target = |target: &str| {
             let substituted = apply_wildcard_substitution(target, wildcard, false);
             let resolved = package_dir.join(substituted.trim_start_matches("./"));
-            self.try_file_or_directory(&resolved)
+            self.try_file_or_directory(&resolved, target_package_type)
         };
         match value {
             serde_json::Value::String(target) => try_target(target.as_str()),

--- a/crates/tsz-core/src/module_resolver/file_probing.rs
+++ b/crates/tsz-core/src/module_resolver/file_probing.rs
@@ -36,12 +36,15 @@ impl ModuleResolver {
     // File probing methods
     // =========================================================================
 
-    /// Try to resolve a file with various extensions
-    pub(super) fn try_file(&self, path: &Path) -> Option<PathBuf> {
-        self.try_file_with_package_type(path, self.current_package_type)
-    }
-
-    pub(super) fn try_file_with_package_type(
+    /// Try to resolve a file with various extensions.
+    ///
+    /// `package_type` is the type of the package CONTAINING `path` (the
+    /// target's `package.json#type` for external lookups, the importer's
+    /// own package type for in-tree lookups). For `Node16`/`NodeNext` this
+    /// drives whether `.mts`/`.d.mts` or `.cts`/`.d.cts` are tried first; in
+    /// other resolution modes it is ignored. Use `None` when no package
+    /// context applies (path mapping, baseUrl, classic, bundler bare).
+    pub(super) fn try_file(
         &self,
         path: &Path,
         package_type: Option<PackageType>,
@@ -111,14 +114,10 @@ impl ModuleResolver {
         None
     }
 
-    /// Like `try_file`, but does NOT try directory index resolution (path/index.{ext}).
-    /// Used for ESM packages in Node16/NodeNext where directory index resolution
-    /// is not allowed by Node.js.
-    pub(super) fn try_file_no_index(&self, path: &Path) -> Option<PathBuf> {
-        self.try_file_no_index_with_package_type(path, self.current_package_type)
-    }
-
-    pub(super) fn try_file_no_index_with_package_type(
+    /// Like [`Self::try_file`], but does NOT try directory index resolution
+    /// (`path/index.{ext}`). Used for ESM packages in Node16/NodeNext where
+    /// directory index resolution is not allowed by Node.js.
+    pub(super) fn try_file_no_index(
         &self,
         path: &Path,
         package_type: Option<PackageType>,
@@ -218,7 +217,7 @@ impl ModuleResolver {
         }
     }
 
-    pub(super) fn try_directory_with_package_type(
+    pub(super) fn try_directory(
         &self,
         path: &Path,
         package_type: Option<PackageType>,
@@ -238,6 +237,12 @@ impl ModuleResolver {
         if package_json_path.exists()
             && let Ok(pj) = self.read_package_json(&package_json_path)
         {
+            // The directory's own `package.json#type` determines the
+            // extension-candidate priority for `main` / `types` resolution
+            // inside this directory; the caller-supplied `package_type`
+            // only acts as an inherited fallback when this nested
+            // package.json has no `"type"` field.
+            let dir_package_type = self.target_package_type_from_json(&pj, package_type);
             let types = pj
                 .types
                 .clone()
@@ -252,51 +257,55 @@ impl ModuleResolver {
             // bypasses the redirect, producing a divergent resolution from tsc.
             if let Some(types_versions) = &pj.types_versions {
                 let subpath = types.as_deref().unwrap_or("index");
-                if let Some(resolved) = self.resolve_types_versions(path, subpath, types_versions) {
+                if let Some(resolved) =
+                    self.resolve_types_versions(path, subpath, types_versions, dir_package_type)
+                {
                     return Some(resolved);
                 }
             }
 
             if let Some(types) = types {
                 let types_path = path.join(&types);
-                if let Some(resolved) = self.try_types_entry(&types_path) {
+                if let Some(resolved) = self.try_types_entry(&types_path, dir_package_type) {
                     return Some(resolved);
                 }
             }
             if let Some(main) = &pj.main {
                 let main_path = path.join(main);
-                if let Some(resolved) = self.try_file_with_package_type(&main_path, package_type) {
+                if let Some(resolved) = self.try_file(&main_path, dir_package_type) {
                     return Some(resolved);
                 }
             }
+            let index = path.join("index");
+            return self.try_file(&index, dir_package_type);
         }
 
         let index = path.join("index");
-        self.try_file_with_package_type(&index, package_type)
+        self.try_file(&index, package_type)
     }
 
     /// Try to resolve a path as a file or directory
-    pub(super) fn try_file_or_directory(&self, path: &Path) -> Option<PathBuf> {
-        self.try_file_or_directory_with_package_type(path, self.current_package_type)
-    }
-
-    pub(super) fn try_file_or_directory_with_package_type(
+    pub(super) fn try_file_or_directory(
         &self,
         path: &Path,
         package_type: Option<PackageType>,
     ) -> Option<PathBuf> {
         // Try as file first
-        if let Some(resolved) = self.try_file_with_package_type(path, package_type) {
+        if let Some(resolved) = self.try_file(path, package_type) {
             return Some(resolved);
         }
 
-        self.try_directory_with_package_type(path, package_type)
+        self.try_directory(path, package_type)
     }
 
     /// Resolve an exports target without Node16 extension substitution.
     ///
     /// Explicit extensions must exist exactly; extensionless targets follow normal lookup.
-    pub(super) fn try_export_target(&self, path: &Path) -> Option<PathBuf> {
+    pub(super) fn try_export_target(
+        &self,
+        path: &Path,
+        package_type: Option<PackageType>,
+    ) -> Option<PathBuf> {
         if let Some(extension) = path.extension().and_then(|ext| ext.to_str()) {
             if split_path_extension(path).is_some() {
                 // For JS export targets, try declaration substitution first.
@@ -336,17 +345,21 @@ impl ModuleResolver {
             self.resolution_kind,
             ModuleResolutionKind::Node16 | ModuleResolutionKind::NodeNext
         );
-        if !skip_extension_probing && let Some(resolved) = self.try_file(path) {
+        if !skip_extension_probing && let Some(resolved) = self.try_file(path, package_type) {
             return Some(resolved);
         }
         if path.is_dir() {
             let index = path.join("index");
-            return self.try_file(&index);
+            return self.try_file(&index, package_type);
         }
         None
     }
 
-    pub(super) fn try_types_entry(&self, path: &Path) -> Option<PathBuf> {
+    pub(super) fn try_types_entry(
+        &self,
+        path: &Path,
+        package_type: Option<PackageType>,
+    ) -> Option<PathBuf> {
         if let Some(resolved) = resolve_explicit_unknown_extension(path) {
             return Some(resolved);
         }
@@ -382,6 +395,6 @@ impl ModuleResolver {
             return None;
         }
 
-        self.try_file_or_directory(path)
+        self.try_file_or_directory(path, package_type)
     }
 }

--- a/crates/tsz-core/src/module_resolver/mod.rs
+++ b/crates/tsz-core/src/module_resolver/mod.rs
@@ -208,8 +208,6 @@ pub struct ModuleResolver {
     /// repeated walks from sibling files do not need to re-stat the same
     /// ancestors.
     node_modules_dir_cache: std::cell::RefCell<FxHashMap<PathBuf, bool>>,
-    /// Cached package type for the current resolution
-    current_package_type: Option<PackageType>,
     /// Root directory for the project (used for TS2209 ambiguous root detection)
     root_dir: Option<PathBuf>,
     /// Out directory for the project (also used for TS2209 - if set, root is not ambiguous)
@@ -265,7 +263,6 @@ impl ModuleResolver {
             package_json_cache: std::cell::RefCell::new(FxHashMap::default()),
             skip_fallback_cache: std::cell::RefCell::new(FxHashMap::default()),
             node_modules_dir_cache: std::cell::RefCell::new(FxHashMap::default()),
-            current_package_type: None,
             root_dir: options.root_dir.clone(),
             out_dir: options.out_dir.clone(),
         }
@@ -307,7 +304,6 @@ impl ModuleResolver {
             package_json_cache: std::cell::RefCell::new(FxHashMap::default()),
             skip_fallback_cache: std::cell::RefCell::new(FxHashMap::default()),
             node_modules_dir_cache: std::cell::RefCell::new(FxHashMap::default()),
-            current_package_type: None,
             root_dir: None,
             out_dir: None,
         }
@@ -381,15 +377,12 @@ impl ModuleResolver {
                     _ => self.get_importing_module_kind(containing_file),
                 },
             });
-        self.current_package_type = match self.resolution_kind {
-            ModuleResolutionKind::Node16 | ModuleResolutionKind::NodeNext => {
-                Some(match importing_module_kind {
-                    ImportingModuleKind::Esm => PackageType::Module,
-                    ImportingModuleKind::CommonJs => PackageType::CommonJs,
-                })
-            }
-            _ => None,
-        };
+        // The IMPORTER's package type drives extension-priority choices for
+        // any file probing that lives in the importer's own package context
+        // (relative paths, baseUrl/path-mapping targets, classic walk-up).
+        // External-package lookups derive their own `package_type` from the
+        // target's `package.json` instead — see [`Self::resolve_package`].
+        let importer_package_type = self.importer_package_type(importing_module_kind);
         let cache_key = (
             containing_dir.clone(),
             specifier.to_string(),
@@ -409,6 +402,7 @@ impl ModuleResolver {
             specifier_span,
             importing_module_kind,
             import_kind,
+            importer_package_type,
         );
 
         if !self.allow_importing_ts_extensions
@@ -513,6 +507,7 @@ impl ModuleResolver {
         specifier_span: Span,
         importing_module_kind: ImportingModuleKind,
         import_kind: ImportKind,
+        importer_package_type: Option<PackageType>,
     ) -> (Result<ResolvedModule, ResolutionFailure>, bool) {
         // Step 1: Handle #-prefixed imports (package.json imports field)
         // This is a Node16/NodeNext feature for subpath imports
@@ -544,6 +539,7 @@ impl ModuleResolver {
                     containing_file,
                     specifier_span,
                     importing_module_kind,
+                    importer_package_type,
                 ),
                 false,
             );
@@ -556,7 +552,7 @@ impl ModuleResolver {
         if let Some(base_url) = self.base_url.as_deref()
             && !self.path_mappings.is_empty()
         {
-            let attempt = self.try_path_mappings(specifier, base_url);
+            let attempt = self.try_path_mappings(specifier, base_url, importer_package_type);
             if let Some(resolved) = attempt.resolved {
                 return (Ok(resolved), path_mapping_attempted);
             }
@@ -573,6 +569,7 @@ impl ModuleResolver {
                     specifier_span,
                     importing_module_kind,
                     import_kind,
+                    importer_package_type,
                 ),
                 path_mapping_attempted,
             );
@@ -581,7 +578,12 @@ impl ModuleResolver {
         // Step 4: Handle absolute imports (rare but valid)
         if specifier.starts_with('/') {
             return (
-                self.resolve_absolute(specifier, containing_file, specifier_span),
+                self.resolve_absolute(
+                    specifier,
+                    containing_file,
+                    specifier_span,
+                    importer_package_type,
+                ),
                 path_mapping_attempted,
             );
         }
@@ -589,7 +591,7 @@ impl ModuleResolver {
         // Step 5: Try baseUrl fallback for non-relative specifiers
         if let Some(base_url) = &self.base_url {
             let candidate = base_url.join(specifier);
-            if let Some(resolved) = self.try_file_or_directory(&candidate) {
+            if let Some(resolved) = self.try_file_or_directory(&candidate, importer_package_type) {
                 return (
                     Ok(ResolvedModule {
                         resolved_path: resolved.clone(),
@@ -1025,6 +1027,7 @@ impl ModuleResolver {
         let importing_module_kind = self.get_importing_module_kind(containing_file);
 
         self.allow_js = true;
+        let importer_package_type = self.importer_package_type(importing_module_kind);
         let (result, _) = self.resolve_uncached(
             specifier,
             &containing_dir,
@@ -1032,6 +1035,7 @@ impl ModuleResolver {
             specifier_span,
             importing_module_kind,
             import_kind,
+            importer_package_type,
         );
         self.allow_js = false;
 
@@ -1180,6 +1184,5 @@ fn is_arbitrary_extension_declaration(specifier: &str, resolved_path: &std::path
     resolved_name.ends_with(&expected_suffix)
 }
 
-/// Parse a package specifier into package name and subpath
 #[cfg(test)]
 mod tests;

--- a/crates/tsz-core/src/module_resolver/node_modules_resolution.rs
+++ b/crates/tsz-core/src/module_resolver/node_modules_resolution.rs
@@ -62,11 +62,12 @@ impl ModuleResolver {
         package_json: &PackageJson,
         original_specifier: &str,
     ) -> Option<PathBuf> {
+        let target_pt = self.target_package_type_from_json(package_json, None);
         let mut candidates = Vec::new();
 
         if let Some(types_versions) = &package_json.types_versions
             && let Some(resolved) =
-                self.resolve_types_versions(package_dir, "index", types_versions)
+                self.resolve_types_versions(package_dir, "index", types_versions, target_pt)
         {
             candidates.push(resolved);
         }
@@ -77,7 +78,7 @@ impl ModuleResolver {
             .or_else(|| package_json.typings.clone())
         {
             let types_path = package_dir.join(&types);
-            if let Some(resolved) = self.try_types_entry(&types_path)
+            if let Some(resolved) = self.try_types_entry(&types_path, target_pt)
                 && !candidates.contains(&resolved)
             {
                 candidates.push(resolved);
@@ -113,7 +114,9 @@ impl ModuleResolver {
         let mut current = containing_dir.to_path_buf();
         loop {
             let candidate = current.join(specifier);
-            if let Some(resolved) = self.try_file_or_directory(&candidate) {
+            // Classic resolution never uses Node16/NodeNext extension priorities;
+            // `extension_candidates_for_package_type` ignores `package_type` here.
+            if let Some(resolved) = self.try_file_or_directory(&candidate, None) {
                 return Ok(ResolvedModule {
                     resolved_path: resolved.clone(),
                     resolved_using_ts_extension: false,
@@ -276,8 +279,9 @@ impl ModuleResolver {
                     && subpath.is_none()
                 {
                     // In bundler mode, package specifiers may resolve directly to
-                    // files like `node_modules/foo.d.ts`.
-                    if let Some(resolved) = self.try_file_or_directory(&package_dir) {
+                    // files like `node_modules/foo.d.ts`. Bundler mode never uses
+                    // Node16/NodeNext extension priorities, so package_type is irrelevant.
+                    if let Some(resolved) = self.try_file_or_directory(&package_dir, None) {
                         return Ok(ResolvedModule {
                             resolved_path: resolved.clone(),
                             resolved_using_ts_extension: false,
@@ -371,6 +375,8 @@ impl ModuleResolver {
             Err(_) => return false,
         };
 
+        let target_pt = self.target_package_type_from_json(&package_json, None);
+
         let Some(exports) = package_json.exports else {
             return false;
         };
@@ -386,6 +392,7 @@ impl ModuleResolver {
             &subpath_key,
             conditions,
             false,
+            target_pt,
         )
         .is_none()
     }
@@ -532,6 +539,14 @@ impl ModuleResolver {
             PackageJson::default()
         };
 
+        // Every file probe inside this package walks the TARGET package's own
+        // extension priorities (.mts vs .cts vs .ts), not the importer's. This
+        // is the structural rule the resolver was leaking before: a `main`
+        // resolution for a `"type":"module"` package must try `.mts`/`.d.mts`
+        // first regardless of whether the importer happens to be CJS, and
+        // vice-versa.
+        let target_pt = self.target_package_type_from_json(&package_json, None);
+
         // If there's a subpath, resolve it directly
         if let Some(subpath) = subpath {
             let subpath_key = format!("./{subpath}");
@@ -547,6 +562,7 @@ impl ModuleResolver {
                         &subpath_key,
                         conditions,
                         false,
+                        target_pt,
                     )
                 {
                     return Ok(ResolvedModule {
@@ -560,7 +576,7 @@ impl ModuleResolver {
                 }
                 if let Some(types_versions) = &package_json.types_versions
                     && let Some(resolved) =
-                        self.resolve_types_versions(package_dir, subpath, types_versions)
+                        self.resolve_types_versions(package_dir, subpath, types_versions, target_pt)
                 {
                     return Ok(ResolvedModule {
                         resolved_path: resolved.clone(),
@@ -590,7 +606,7 @@ impl ModuleResolver {
             // Try typesVersions field
             if let Some(types_versions) = &package_json.types_versions
                 && let Some(resolved) =
-                    self.resolve_types_versions(package_dir, subpath, types_versions)
+                    self.resolve_types_versions(package_dir, subpath, types_versions, target_pt)
             {
                 return Ok(ResolvedModule {
                     resolved_path: resolved.clone(),
@@ -605,19 +621,17 @@ impl ModuleResolver {
             // Fall back to direct file resolution.
             // In Node16/NodeNext with ESM packages (no exports field), Node.js does
             // not perform directory index resolution. Only try file-based resolution
-            // to match tsc behavior.
+            // to match tsc behavior. `target_pt` already encodes both the
+            // Node16/NodeNext gate and the package.json `"type"` lookup, so
+            // checking it directly keeps the "is this an ESM package?"
+            // decision in one place instead of re-deriving it from the raw
+            // package.json field.
             let file_path = package_dir.join(subpath);
-            let is_esm_package = matches!(
-                self.resolution_kind,
-                ModuleResolutionKind::Node16 | ModuleResolutionKind::NodeNext
-            ) && package_json
-                .package_type
-                .as_deref()
-                .is_some_and(|t| t == "module");
+            let is_esm_package = target_pt == Some(super::PackageType::Module);
             let resolved = if is_esm_package {
-                self.try_file_no_index(&file_path)
+                self.try_file_no_index(&file_path, target_pt)
             } else {
-                self.try_file_or_directory(&file_path)
+                self.try_file_or_directory(&file_path, target_pt)
             };
             if let Some(resolved) = resolved {
                 return Ok(ResolvedModule {
@@ -665,6 +679,7 @@ impl ModuleResolver {
                     ".",
                     conditions,
                     false,
+                    target_pt,
                 )
             {
                 return Ok(ResolvedModule {
@@ -695,7 +710,7 @@ impl ModuleResolver {
         // Try typesVersions field for index
         if let Some(types_versions) = &package_json.types_versions
             && let Some(resolved) =
-                self.resolve_types_versions(package_dir, "index", types_versions)
+                self.resolve_types_versions(package_dir, "index", types_versions, target_pt)
         {
             return Ok(ResolvedModule {
                 resolved_path: resolved.clone(),
@@ -715,7 +730,7 @@ impl ModuleResolver {
             .or_else(|| package_json.typings.clone())
         {
             let types_path = package_dir.join(&types);
-            if let Some(resolved) = self.try_types_entry(&types_path) {
+            if let Some(resolved) = self.try_types_entry(&types_path, target_pt) {
                 return Ok(ResolvedModule {
                     resolved_path: resolved.clone(),
                     resolved_using_ts_extension: false,
@@ -752,8 +767,9 @@ impl ModuleResolver {
                     extension: ModuleExtension::from_path(&declaration),
                 });
             }
-            // Try the main path as a file (with extension probing)
-            if let Some(resolved) = self.try_file(&main_path) {
+            // Try the main path as a file (with extension probing) — using the
+            // TARGET package's type, not the importer's.
+            if let Some(resolved) = self.try_file(&main_path, target_pt) {
                 return Ok(ResolvedModule {
                     resolved_path: resolved.clone(),
                     resolved_using_ts_extension: false,
@@ -767,7 +783,7 @@ impl ModuleResolver {
             // Do NOT read nested package.json — main field resolution is non-recursive.
             if main_path.is_dir() {
                 let index = main_path.join("index");
-                if let Some(resolved) = self.try_file(&index) {
+                if let Some(resolved) = self.try_file(&index, target_pt) {
                     return Ok(ResolvedModule {
                         resolved_path: resolved.clone(),
                         resolved_using_ts_extension: false,

--- a/crates/tsz-core/src/module_resolver/package_json.rs
+++ b/crates/tsz-core/src/module_resolver/package_json.rs
@@ -3,12 +3,76 @@
 //! Handles reading/parsing package.json files and determining the
 //! package type (ESM vs CommonJS) for a given directory.
 
-use super::{ModuleResolver, PackageType};
+use super::{ImportingModuleKind, ModuleResolver, PackageType};
+use crate::config::ModuleResolutionKind;
 use std::path::Path;
 
 use crate::module_resolver_helpers::PackageJson;
 
+/// Parse `package.json#type` into a [`PackageType`], or `None` when the
+/// field is missing or an unknown value. Shared by both
+/// [`ModuleResolver::target_package_type_from_json`] (which defaults the
+/// unknown/missing case to `CommonJs` for `Node16`/`NodeNext`) and
+/// [`ModuleResolver::get_package_type_for_dir`] (which leaves the unknown
+/// case as `None` so the directory walk-up can keep climbing).
+fn parse_package_type_field(field: Option<&str>) -> Option<PackageType> {
+    match field {
+        Some("module") => Some(PackageType::Module),
+        Some("commonjs") => Some(PackageType::CommonJs),
+        _ => None,
+    }
+}
+
 impl ModuleResolver {
+    /// Map the importer's [`ImportingModuleKind`] to the
+    /// `Option<PackageType>` that should drive extension-priority choices
+    /// for file probing in the importer's own package context (relative
+    /// paths, baseUrl/path mappings, classic walk-up). Only
+    /// `Node16`/`NodeNext` distinguish ESM vs CJS extension order; every
+    /// other mode treats all extensions equally and so returns `None`.
+    pub(super) const fn importer_package_type(
+        &self,
+        importing_module_kind: ImportingModuleKind,
+    ) -> Option<PackageType> {
+        match self.resolution_kind {
+            ModuleResolutionKind::Node16 | ModuleResolutionKind::NodeNext => {
+                Some(match importing_module_kind {
+                    ImportingModuleKind::Esm => PackageType::Module,
+                    ImportingModuleKind::CommonJs => PackageType::CommonJs,
+                })
+            }
+            _ => None,
+        }
+    }
+
+    /// Compute the target [`PackageType`] for file probing inside a package
+    /// whose `package.json` has already been read.
+    ///
+    /// The extension-priority axis (`.mts`/`.d.mts` first vs `.cts`/`.d.cts`
+    /// first) only applies under `Node16`/`NodeNext`; other resolution kinds
+    /// return `None` so the helper always agrees with
+    /// [`Self::extension_candidates_for_package_type`].
+    ///
+    /// `inherit_from` is the caller's fallback hint when the target's
+    /// `package.json` has no `"type"` field or declares an unknown value;
+    /// it lets nested directories (e.g. `try_directory`) inherit their
+    /// enclosing package's mode under `Node16`/`NodeNext` instead of
+    /// silently snapping back to `CommonJs`.
+    pub(super) fn target_package_type_from_json(
+        &self,
+        pj: &PackageJson,
+        inherit_from: Option<PackageType>,
+    ) -> Option<PackageType> {
+        match self.resolution_kind {
+            ModuleResolutionKind::Node16 | ModuleResolutionKind::NodeNext => Some(
+                parse_package_type_field(pj.package_type.as_deref())
+                    .or(inherit_from)
+                    .unwrap_or(PackageType::CommonJs),
+            ),
+            _ => None,
+        }
+    }
+
     /// Get the package type for a directory by walking up to find package.json
     pub(super) fn get_package_type_for_dir(&self, dir: &Path) -> Option<PackageType> {
         let mut current = dir.to_path_buf();
@@ -34,11 +98,7 @@ impl ModuleResolver {
             if package_json_path.is_file()
                 && let Ok(pj) = self.read_package_json(&package_json_path)
             {
-                let package_type = pj.package_type.as_deref().and_then(|t| match t {
-                    "module" => Some(PackageType::Module),
-                    "commonjs" => Some(PackageType::CommonJs),
-                    _ => None,
-                });
+                let package_type = parse_package_type_field(pj.package_type.as_deref());
                 // Cache all visited paths
                 let mut cache = self.package_type_cache.borrow_mut();
                 for path in visited {

--- a/crates/tsz-core/src/module_resolver/path_mapping.rs
+++ b/crates/tsz-core/src/module_resolver/path_mapping.rs
@@ -1,6 +1,6 @@
 //! Path mapping resolution from tsconfig `paths` and `baseUrl`.
 
-use super::{ModuleExtension, ModuleResolver, ResolvedModule};
+use super::{ModuleExtension, ModuleResolver, PackageType, ResolvedModule};
 use crate::resolution::helpers::apply_wildcard_substitution;
 use std::path::Path;
 
@@ -21,7 +21,12 @@ impl ModuleResolver {
     ///
     /// `base` is the resolved `baseUrl` directory; callers must only invoke this
     /// method when `base_url` is set (the type system enforces it via `&Path`).
-    pub(super) fn try_path_mappings(&self, specifier: &str, base: &Path) -> PathMappingAttempt {
+    pub(super) fn try_path_mappings(
+        &self,
+        specifier: &str,
+        base: &Path,
+        importer_package_type: Option<PackageType>,
+    ) -> PathMappingAttempt {
         // `self.path_mappings` is pre-sorted by specificity descending at
         // construction time (`build_path_mappings` in config/mod.rs).
         let mut attempted = false;
@@ -32,7 +37,9 @@ impl ModuleResolver {
                     let substituted = apply_wildcard_substitution(target, &star_match, false);
                     let candidate = base.join(&substituted);
 
-                    if let Some(resolved) = self.try_file_or_directory(&candidate) {
+                    if let Some(resolved) =
+                        self.try_file_or_directory(&candidate, importer_package_type)
+                    {
                         let extension = ModuleExtension::from_path(&resolved);
                         return PathMappingAttempt {
                             resolved: Some(ResolvedModule {

--- a/crates/tsz-core/src/module_resolver/relative_resolution.rs
+++ b/crates/tsz-core/src/module_resolver/relative_resolution.rs
@@ -62,6 +62,7 @@ impl ModuleResolver {
         specifier_span: Span,
         importing_module_kind: ImportingModuleKind,
         import_kind: ImportKind,
+        importer_package_type: Option<PackageType>,
     ) -> Result<ResolvedModule, ResolutionFailure> {
         let candidate = containing_dir.join(specifier);
         let mut candidates = vec![candidate];
@@ -89,12 +90,12 @@ impl ModuleResolver {
                         .unwrap_or(PackageType::CommonJs),
                 )
             } else {
-                self.current_package_type
+                importer_package_type
             };
             if prefer_directory {
-                self.try_directory_with_package_type(path, package_type)
+                self.try_directory(path, package_type)
             } else {
-                self.try_file_or_directory_with_package_type(path, package_type)
+                self.try_file_or_directory(path, package_type)
             }
         };
 
@@ -309,10 +310,11 @@ impl ModuleResolver {
         specifier: &str,
         containing_file: &str,
         specifier_span: Span,
+        importer_package_type: Option<PackageType>,
     ) -> Result<ResolvedModule, ResolutionFailure> {
         let path = std::path::PathBuf::from(specifier);
 
-        if let Some(resolved) = self.try_file_or_directory(&path) {
+        if let Some(resolved) = self.try_file_or_directory(&path, importer_package_type) {
             return Ok(ResolvedModule {
                 resolved_path: resolved.clone(),
                 resolved_using_ts_extension: false,

--- a/crates/tsz-core/src/module_resolver/self_reference.rs
+++ b/crates/tsz-core/src/module_resolver/self_reference.rs
@@ -68,6 +68,7 @@ impl ModuleResolver {
                             None => ".".to_string(),
                         };
 
+                        let target_pt = self.target_package_type_from_json(&package_json, None);
                         if let Some((resolved, resolved_using_ts_extension)) = self
                             .resolve_package_exports_with_conditions(
                                 &current,
@@ -75,6 +76,7 @@ impl ModuleResolver {
                                 &subpath_key,
                                 conditions,
                                 false,
+                                target_pt,
                             )
                         {
                             // Self-reference resolved successfully via exports.

--- a/crates/tsz-core/src/module_resolver/tests.rs
+++ b/crates/tsz-core/src/module_resolver/tests.rs
@@ -23,3 +23,4 @@ mod pattern_matching;
 mod resolution_failure;
 mod resolver_integration;
 mod specifier_parsing;
+mod target_package_type;

--- a/crates/tsz-core/src/module_resolver/tests/target_package_type.rs
+++ b/crates/tsz-core/src/module_resolver/tests/target_package_type.rs
@@ -1,0 +1,248 @@
+//! Tests for the structural rule "external package file probing uses the
+//! TARGET package's `package.json#type`, not the importer's".
+//!
+//! These cover the bug class fixed by removing the resolver's
+//! `current_package_type` shared state in favour of explicitly threading
+//! the target package's type into every probe inside
+//! [`ModuleResolver::resolve_package`] and friends. The rule:
+//!
+//! > In Node16/NodeNext, when an external `node_modules/<pkg>` package's
+//! > `main`, `types`, `typesVersions`, exports/imports, or extensionless
+//! > subpath fallback is being probed, the `(.mts vs .cts vs .ts)`
+//! > priority is taken from the TARGET package's own `package.json#type`.
+//! > The importer's ESM/CJS mode is irrelevant once the resolver has
+//! > stepped inside the target package.
+//!
+//! Variants tested:
+//! 1. ESM importer + CJS target main field: must prefer `.cts`/`.d.cts`
+//!    even though the importer is ESM.
+//! 2. CJS importer + ESM target main field: must prefer `.mts`/`.d.mts`
+//!    even though the importer is CJS.
+//! 3. Renaming an importer ESM → CJS without touching the target keeps
+//!    the resolved file stable (proves the choice depends on target, not
+//!    importer).
+//! 4. The same rule extends to `types` field resolution.
+
+use super::super::*;
+use std::fs;
+
+/// Standard Node16 resolver options used by every test in this module.
+/// Every test in this file exercises the `Node16`/`NodeNext` extension-
+/// priority rule, so the resolver and emitter both need to be in Node16
+/// mode; factoring this out keeps each test focused on its target-package
+/// shape rather than option boilerplate.
+fn node16_options() -> ResolvedCompilerOptions {
+    ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node16),
+        module_suffixes: vec![String::new()],
+        printer: crate::emitter::PrinterOptions {
+            module: crate::emitter::ModuleKind::Node16,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// ESM importer reaches into a CJS target whose `main` is extensionless.
+/// Pre-fix tsz used the importer's ESM extension order
+/// (`.mts`/`.d.mts` first), so a sibling `lib/index.mts` placeholder would
+/// have shadowed the real `lib/index.cts`. The rule says the target's
+/// `package.json` decides, and this target declares no `"type"` (CJS by
+/// default), so `.cts`/`.d.cts` must win.
+#[test]
+fn esm_importer_cjs_target_main_picks_cts_first() {
+    let dir = std::env::temp_dir().join("tsz_target_pt_esm_importer_cjs_main");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("node_modules/pkg/lib")).unwrap();
+    fs::create_dir_all(dir.join("src")).unwrap();
+
+    // Target package is CJS (no "type" field → defaults to CommonJS in
+    // Node16). Its main is extensionless, so the resolver must probe
+    // extensions. Both .mts and .cts files exist; tsc picks .cts.
+    fs::write(
+        dir.join("node_modules/pkg/package.json"),
+        r#"{ "name": "pkg", "main": "./lib/index" }"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.join("node_modules/pkg/lib/index.mts"),
+        "export declare const which: 'mts';",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("node_modules/pkg/lib/index.cts"),
+        "export declare const which: 'cts';",
+    )
+    .unwrap();
+
+    // ESM importer (package marks src as ESM).
+    fs::write(dir.join("src/package.json"), r#"{"type":"module"}"#).unwrap();
+    fs::write(dir.join("src/app.ts"), "import { which } from 'pkg';").unwrap();
+
+    let mut resolver = ModuleResolver::new(&node16_options());
+    let resolved = resolver
+        .resolve("pkg", &dir.join("src/app.ts"), Span::new(0, 5))
+        .expect("pkg should resolve");
+
+    assert!(
+        resolved.resolved_path.ends_with("lib/index.cts"),
+        "ESM importer reaching into a CJS target must still pick the \
+         target's CJS extension priority (.cts), got {}",
+        resolved.resolved_path.display(),
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// CJS importer reaches into an ESM target whose `main` is extensionless.
+/// Pre-fix tsz used the importer's CJS extension order, so a sibling
+/// `lib/index.cts` placeholder would have shadowed the real
+/// `lib/index.mts`. With the target's `"type":"module"` driving the
+/// probe, `.mts`/`.d.mts` must come first.
+#[test]
+fn cjs_importer_esm_target_main_picks_mts_first() {
+    let dir = std::env::temp_dir().join("tsz_target_pt_cjs_importer_esm_main");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("node_modules/pkg/lib")).unwrap();
+    fs::create_dir_all(dir.join("src")).unwrap();
+
+    fs::write(
+        dir.join("node_modules/pkg/package.json"),
+        r#"{ "name": "pkg", "type": "module", "main": "./lib/index" }"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.join("node_modules/pkg/lib/index.mts"),
+        "export declare const which: 'mts';",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("node_modules/pkg/lib/index.cts"),
+        "export declare const which: 'cts';",
+    )
+    .unwrap();
+
+    // CJS importer (no type=module in src, .cts extension forces CJS).
+    fs::write(dir.join("src/app.cts"), "import { which } from 'pkg';").unwrap();
+
+    let mut resolver = ModuleResolver::new(&node16_options());
+    let resolved = resolver
+        .resolve("pkg", &dir.join("src/app.cts"), Span::new(0, 5))
+        .expect("pkg should resolve");
+
+    assert!(
+        resolved.resolved_path.ends_with("lib/index.mts"),
+        "CJS importer reaching into an ESM target must still pick the \
+         target's ESM extension priority (.mts), got {}",
+        resolved.resolved_path.display(),
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// Two importers (one ESM, one CJS) in the same project; the target
+/// package's resolution must be IDENTICAL because the target's
+/// `package.json#type` is what drives probing — not the importer mode.
+/// This is the cross-row leakage symptom from the originating issue:
+/// pre-fix, swapping the importer would shadow one extension with the
+/// other and the cache would echo the wrong file across files.
+#[test]
+fn target_resolution_is_independent_of_importer_mode() {
+    let dir = std::env::temp_dir().join("tsz_target_pt_importer_independence");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("node_modules/pkg/lib")).unwrap();
+    fs::create_dir_all(dir.join("esm_src")).unwrap();
+    fs::create_dir_all(dir.join("cjs_src")).unwrap();
+
+    fs::write(
+        dir.join("node_modules/pkg/package.json"),
+        r#"{ "name": "pkg", "type": "module", "main": "./lib/index" }"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.join("node_modules/pkg/lib/index.mts"),
+        "export declare const x: 'mts';",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("node_modules/pkg/lib/index.cts"),
+        "export declare const x: 'cts';",
+    )
+    .unwrap();
+
+    // ESM importer side (type=module).
+    fs::write(dir.join("esm_src/package.json"), r#"{"type":"module"}"#).unwrap();
+    fs::write(dir.join("esm_src/app.ts"), "import { x } from 'pkg';").unwrap();
+
+    // CJS importer side (no type, .cts file).
+    fs::write(dir.join("cjs_src/app.cts"), "import { x } from 'pkg';").unwrap();
+
+    let mut resolver = ModuleResolver::new(&node16_options());
+    let esm_resolved = resolver
+        .resolve("pkg", &dir.join("esm_src/app.ts"), Span::new(0, 5))
+        .expect("pkg resolves from ESM importer");
+    let cjs_resolved = resolver
+        .resolve("pkg", &dir.join("cjs_src/app.cts"), Span::new(0, 5))
+        .expect("pkg resolves from CJS importer");
+
+    assert_eq!(
+        esm_resolved.resolved_path,
+        cjs_resolved.resolved_path,
+        "Target package resolution must depend on the target's package.json#type, \
+         not the importer's mode. ESM importer got {}, CJS importer got {}",
+        esm_resolved.resolved_path.display(),
+        cjs_resolved.resolved_path.display(),
+    );
+    assert!(
+        esm_resolved.resolved_path.ends_with("lib/index.mts"),
+        "ESM target should resolve to .mts regardless of importer, got {}",
+        esm_resolved.resolved_path.display(),
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// The `types` field falls back to the same extension-priority pass, so
+/// the target-package-type rule extends to it. CJS target with a
+/// declaration-less extensionless `types` entry must prefer `.d.cts` over
+/// `.d.mts` even when imported from an ESM file.
+#[test]
+fn esm_importer_cjs_target_types_field_picks_d_cts_first() {
+    let dir = std::env::temp_dir().join("tsz_target_pt_types_field");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("node_modules/pkg/types")).unwrap();
+    fs::create_dir_all(dir.join("src")).unwrap();
+
+    fs::write(
+        dir.join("node_modules/pkg/package.json"),
+        r#"{ "name": "pkg", "types": "./types/index" }"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.join("node_modules/pkg/types/index.d.mts"),
+        "export declare const x: 'mts';",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("node_modules/pkg/types/index.d.cts"),
+        "export declare const x: 'cts';",
+    )
+    .unwrap();
+
+    fs::write(dir.join("src/package.json"), r#"{"type":"module"}"#).unwrap();
+    fs::write(dir.join("src/app.ts"), "import { x } from 'pkg';").unwrap();
+
+    let mut resolver = ModuleResolver::new(&node16_options());
+    let resolved = resolver
+        .resolve("pkg", &dir.join("src/app.ts"), Span::new(0, 5))
+        .expect("pkg should resolve via types field");
+
+    assert!(
+        resolved.resolved_path.ends_with("types/index.d.cts"),
+        "ESM importer + CJS target should still pick .d.cts for the \
+         target's types field, got {}",
+        resolved.resolved_path.display(),
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## Summary

Fixes #11201 (kysely-project: module-resolution package exports mapping misroutes mixed ESM/CJS subpaths).

The resolver held a mutable `current_package_type: Option<PackageType>` set from the IMPORTER's mode, and every implicit file-probing wrapper (`try_file`, `try_file_no_index`, `try_file_or_directory`) defaulted to it. So every probe inside `resolve_package` — `main`, extensionless subpath fallback, typesVersions targets, the `types` field — consulted the importer's mode instead of the target package's own `"type"`. This is the "exports condition cache leaks package mode across rows" symptom from the issue.

**Structural rule (matches `tsc`):** under `Node16`/`NodeNext`, once the resolver steps into a target package, the `(.mts/.d.mts` first vs `.cts/.d.cts` first) extension priority is taken from the target's own `package.json#type`. The importer's mode never overrides that choice from the outside, and a sibling `.mts`/`.cts` placeholder in a mixed package must not shadow the real entry just because the importer happens to be in the opposite mode.

## Track

`module-resolution`

## Invariant

External package file probing under `Node16`/`NodeNext` selects its extension-candidate set from the target package's own `package.json#type`. The importer's mode only controls probing for paths that live in the importer's own package (relative, baseUrl, classic walk-up, path mappings).

## Scope

- Remove `current_package_type` shared state from `ModuleResolver`.
- Thread `Option<PackageType>` explicitly through every file-probing call site (`try_file`, `try_file_no_index`, `try_file_or_directory`, `try_directory`, `try_export_target`, `try_types_entry`, `resolve_types_versions`, `apply_types_versions_targets`, `resolve_package_exports_with_conditions`, `resolve_export_value_with_conditions`, `resolve_package_imports`, `try_path_mappings`, `resolve_relative`, `resolve_absolute`, `resolve_uncached`).
- Add `ModuleResolver::importer_package_type` (importer-side) and `ModuleResolver::target_package_type_from_json(pj, inherit_from)` (target-side) helpers in `package_json.rs`, plus a shared `parse_package_type_field` free fn that dedupes the `"module"`/`"commonjs"` string → enum mapping.
- `resolve_package` computes `target_pt` once from the just-read `package.json` and reuses it everywhere inside, including the `is_esm_package` decision in the subpath fallback (so the "is this ESM?" rule lives in one place).
- `apply_types_versions_targets` takes `target_package_type` directly so it no longer re-reads `package.json` on every call.

## Project Corpus Impact

- Row: `kysely-project` (and any other project corpus row that surfaces the same target-vs-importer mode mismatch — issue #11201 names `kysely-project` explicitly; the structural rule applies to every Node16/NodeNext bench row).
- Bug family: module-resolution, package.json `"type"` field handling.
- Evidence: New tests under `crates/tsz-core/src/module_resolver/tests/target_package_type.rs` cover the four shapes of the rule (ESM importer + CJS target main; CJS importer + ESM target main; importer-mode independence of target resolution; same rule on the `types` field). All four fail pre-fix and pass post-fix.

## Verification

- `cargo test -p tsz-core module_resolver --no-fail-fast` — 220 passed, 0 failed (216 pre-existing + 4 new). (Note: `cargo nextest` is not installed in this sandbox; `cargo test` is the local fallback per §19.5. CI runs the full nextest suite.)
- `cargo test --workspace --no-fail-fast` — exit 0.
- `cargo clippy -p tsz-core --tests --all-features -- -D warnings` — clean.

## Test plan

- [x] New regression: `tests/target_package_type.rs` (4 tests covering ESM importer + CJS target main, CJS importer + ESM target main, importer-mode independence, and the `types` field).
- [x] All existing `module_resolver` tests still pass.
- [x] Workspace `cargo test` clean.
- [x] Workspace `cargo clippy -D warnings` clean.
- [ ] CI: lint, dist-fast build, conformance, emit, fourslash, WASM.

## Coordination Notes

AgentName: `M4-D` (runner identity: `claude-opus-4-7-bSOpG`). The originating issue (#11201) had `agent:M4-D`; this PR continues that lane and now carries the canonical `agent:M4-D` label as well. The fix generalizes well beyond the kysely-project row hypothesis — it is the underlying class of "cross-importer package-mode leakage" bug. None of the other auto-generated issues are claimed by this PR (no extra `Fixes #`) because their fingerprints have not been individually validated against the new rule yet; follow-up triage can close them if they are subsumed.

https://claude.ai/code/session_01BmA1TeegUHyA9SJCYckoa9