### PR TITLE
fix(checker): accept conditional object-map string filters

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
@@ -48,6 +48,56 @@ impl<'a> CheckerState<'a> {
                 || self
                     .assign_relation_outcome(branch_evaluated, constraint)
                     .related
+                || self.indexed_object_map_branch_satisfies_constraint(branch, constraint)
+        })
+    }
+
+    fn indexed_object_map_branch_satisfies_constraint(
+        &mut self,
+        branch: TypeId,
+        constraint: TypeId,
+    ) -> bool {
+        let Some((object_type, _index_type)) =
+            query::index_access_components(self.ctx.types.as_type_database(), branch)
+        else {
+            return false;
+        };
+        let object_type = self.resolve_lazy_type(object_type);
+        let value_types = {
+            let Some(shape) =
+                query::get_object_shape(self.ctx.types.as_type_database(), object_type)
+            else {
+                return false;
+            };
+            let mut values: Vec<TypeId> = shape
+                .properties
+                .iter()
+                .map(|property| property.type_id)
+                .collect();
+            if let Some(index) = &shape.string_index {
+                values.push(index.value_type);
+            }
+            if let Some(index) = &shape.number_index {
+                values.push(index.value_type);
+            }
+            values
+        };
+        if value_types.is_empty() {
+            return false;
+        }
+
+        let constraint = self.resolve_lazy_type(constraint);
+        let constraint_evaluated = self.evaluate_type_for_assignability(constraint);
+        value_types.into_iter().all(|value| {
+            if value == TypeId::NEVER {
+                return true;
+            }
+            let value = self.resolve_lazy_type(value);
+            let value_evaluated = self.evaluate_type_for_assignability(value);
+            self.assign_relation_outcome(value, constraint).related
+                || self
+                    .assign_relation_outcome(value_evaluated, constraint_evaluated)
+                    .related
         })
     }
 
@@ -68,6 +118,7 @@ impl<'a> CheckerState<'a> {
                     branch == TypeId::NEVER
                         || (!query::contains_free_type_parameters(self.ctx.types, branch)
                             && !query::is_infer_type(self.ctx.types.as_type_database(), branch))
+                        || self.is_indexed_object_map_branch(branch)
                 };
                 if branch_is_simple(true_type) && branch_is_simple(false_type) {
                     return Some(components);
@@ -97,6 +148,18 @@ impl<'a> CheckerState<'a> {
             type_arg = instantiated;
         }
         None
+    }
+
+    fn is_indexed_object_map_branch(&self, branch: TypeId) -> bool {
+        query::index_access_components(self.ctx.types.as_type_database(), branch)
+            .and_then(|(object_type, _index_type)| {
+                query::get_object_shape(self.ctx.types.as_type_database(), object_type)
+            })
+            .is_some_and(|shape| {
+                !shape.properties.is_empty()
+                    || shape.string_index.is_some()
+                    || shape.number_index.is_some()
+            })
     }
 
     pub(crate) fn type_alias_application_infer_result_conditional_components(
@@ -194,6 +257,8 @@ impl<'a> CheckerState<'a> {
                     || self
                         .assign_relation_outcome(true_resolved, constraint)
                         .related
+                    || self
+                        .indexed_object_map_branch_satisfies_constraint(true_resolved, constraint)
                 {
                     return true;
                 }

--- a/crates/tsz-cli/tests/tsc_compat_tests_parts/part_02.rs
+++ b/crates/tsz-cli/tests/tsc_compat_tests_parts/part_02.rs
@@ -826,3 +826,187 @@ export type PropertiesReduce<T extends TProperties> = PropertiesReducer<T, {
          tsz output:\n{tsz_output}"
     );
 }
+
+#[test]
+fn imported_conditional_select_object_map_satisfies_string_constraint() {
+    let temp = TempDir::new("imported_conditional_select_object_map").expect("temp dir");
+    write_file(&temp.path.join("Any/Key.ts"), "export type Key = string | number | symbol\n");
+    write_file(
+        &temp.path.join("Any/_Internal.ts"),
+        "export type Match = 'default' | 'contains->' | 'extends->' | '<-contains' | '<-extends' | 'equals'\n",
+    );
+    write_file(
+        &temp.path.join("Any/Extends.ts"),
+        r#"
+export type Extends<A1 extends any, A2 extends any> =
+  [A1] extends [never] ? 0 : A1 extends A2 ? 1 : 0
+"#,
+    );
+    write_file(
+        &temp.path.join("Any/Contains.ts"),
+        r#"
+import {Extends} from './Extends'
+export type Contains<A1 extends any, A2 extends any> =
+  Extends<A1, A2> extends 1 ? 1 : 0
+"#,
+    );
+    write_file(
+        &temp.path.join("Any/Equals.ts"),
+        r#"
+export type Equals<A1 extends any, A2 extends any> =
+  (<A>() => A extends A2 ? 1 : 0) extends (<A>() => A extends A1 ? 1 : 0)
+    ? 1
+    : 0
+"#,
+    );
+    write_file(
+        &temp.path.join("Any/Is.ts"),
+        r#"
+import {Match} from './_Internal'
+import {Extends} from './Extends'
+import {Equals} from './Equals'
+import {Contains} from './Contains'
+
+export type Is<A extends any, A1 extends any, match extends Match = 'default'> = {
+  'default': Extends<A, A1>
+  'contains->': Contains<A, A1>
+  'extends->': Extends<A, A1>
+  '<-contains': Contains<A1, A>
+  '<-extends': Extends<A1, A>
+  'equals': Equals<A1, A>
+}[match]
+"#,
+    );
+    write_file(
+        &temp.path.join("List/List.ts"),
+        "export type List<A = any> = ReadonlyArray<A>\n",
+    );
+    write_file(
+        &temp.path.join("List/Head.ts"),
+        r#"
+import {List} from './List'
+export type Head<L extends List> = L extends readonly [] ? never : L[0]
+"#,
+    );
+    write_file(
+        &temp.path.join("List/Tail.ts"),
+        r#"
+import {List} from './List'
+export type Tail<L extends List> =
+  L extends readonly [] ? L : L extends readonly [any?, ...infer LTail] ? LTail : L
+"#,
+    );
+    write_file(
+        &temp.path.join("List/Pop.ts"),
+        r#"
+import {List} from './List'
+export type Pop<L extends List> =
+  L extends (readonly [...infer LBody, any] | readonly [...infer LBody, any?]) ? LBody : L
+"#,
+    );
+    write_file(
+        &temp.path.join("Object/Path.ts"),
+        r#"
+import {Key} from '../Any/Key'
+import {List} from '../List/List'
+
+export type Path<O, P extends List<Key>> =
+  P extends readonly []
+    ? O
+    : P extends readonly [infer K, ...infer R]
+      ? K extends keyof O ? Path<O[K], Extract<R, List<Key>>> : never
+      : O
+"#,
+    );
+    write_file(
+        &temp.path.join("Object/UnionOf.ts"),
+        r#"
+export type UnionOf<O extends object> =
+  O extends unknown ? O[keyof O] : never
+"#,
+    );
+    write_file(
+        &temp.path.join("Union/Select.ts"),
+        r#"
+import {Is} from '../Any/Is'
+import {Match} from '../Any/_Internal'
+
+export type Select<U extends any, M extends any, match extends Match = 'default'> =
+  U extends unknown ? {1: U & M, 0: never}[Is<U, M, match>] : never
+"#,
+    );
+    write_file(
+        &temp.path.join("String/Join.ts"),
+        r#"
+import {List} from '../List/List'
+export type Join<T extends List, D extends string = ''> = string
+"#,
+    );
+    write_file(
+        &temp.path.join("String/Split.ts"),
+        "export type Split<S extends string, D extends string = ''> = string[]\n",
+    );
+    write_file(
+        &temp.path.join("Function/AutoPath.ts"),
+        r#"
+import {Key} from '../Any/Key'
+import {Head} from '../List/Head'
+import {List} from '../List/List'
+import {Pop} from '../List/Pop'
+import {Tail} from '../List/Tail'
+import {Path} from '../Object/Path'
+import {UnionOf} from '../Object/UnionOf'
+import {Select} from '../Union/Select'
+import {Join} from '../String/Join'
+import {Split} from '../String/Split'
+
+type Index = number | string;
+type KeyToIndex<K extends Key, SP extends List<Index>> =
+  number extends K ? Head<SP> : K & Index;
+type MetaPath<O, D extends string, SP extends List<Index> = [], P extends List<Index> = []> = {
+  [K in keyof O]:
+    | MetaPath<O[K], D, Tail<SP>, [...P, KeyToIndex<K, SP>]>
+    | Join<[...P, KeyToIndex<K, SP>], D>;
+};
+type NextPath<OP> = Select<UnionOf<Exclude<OP, string> & {}>, string>;
+type ExecPath<A, SP extends List<Index>, Delimiter extends string> =
+  NextPath<Path<MetaPath<A, Delimiter, SP>, SP>>;
+type HintPath<A, P extends string, SP extends List<Index>, Exec extends string, D extends string> =
+  [Exec] extends [never] ? ExecPath<A, Pop<SP>, D> : Exec | P;
+type _AutoPath<A, P extends string, D extends string, SP extends List<Index> = Split<P, D>> =
+  HintPath<A, P, SP, ExecPath<A, SP, D>, D>;
+export type AutoPath<O extends any, P extends string, D extends string = '.'> =
+  _AutoPath<O, P, D>;
+"#,
+    );
+
+    let (tsc_code, tsc_output) = run_tsc_with_exit_code(
+        &temp.path,
+        &[
+            "--noEmit",
+            "--strict",
+            "--target",
+            "es2022",
+            "Function/AutoPath.ts",
+        ],
+    )
+    .expect("tsc should run");
+    assert_eq!(tsc_code, 0, "tsc accepted the imported Select shape: {tsc_output}");
+
+    let (tsz_code, tsz_output) = run_tsz_with_exit_code(
+        &temp.path,
+        &[
+            "--noEmit",
+            "--strict",
+            "--target",
+            "es2022",
+            "Function/AutoPath.ts",
+        ],
+    )
+    .expect("tsz should run");
+    assert_eq!(
+        tsz_code, 0,
+        "Conditional object-map filters must satisfy the string constraint like tsc.\n\
+         tsz output:\n{tsz_output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
checker/solver TS2344 parity for advanced conditional/indexed-access evaluation

## Invariant
When a distributive conditional returns an indexed finite object map whose values are all `never` or satisfy a primitive constraint, tsc accepts the alias result across import boundaries. tsz should prove that through the existing TS2344 conditional-filter path instead of evaluating the indexed branch to `undefined`.

## Scope
- `crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs`
- `crates/tsz-cli/tests/tsc_compat_tests_parts/part_02.rs`

## Project Corpus Impact
- Row: ts-toolbelt-project
- Bug family: imported conditional `Select`/indexed object-map filter false TS2344 in `Function/AutoPath.ts`
- Evidence: fresh dist-fast `tsz` now matches `tsc` exit 0 for `.target/project-compile-guard/ts-toolbelt/sources/Function/AutoPath.ts`.

## Verification
- RED before fix: `cargo nextest run -p tsz-cli --test tsc_compat_tests imported_conditional_select_object_map_satisfies_string_constraint` -> failed with TS2344 `Type 'undefined' does not satisfy the constraint 'string'`
- `cargo nextest run -p tsz-cli --test tsc_compat_tests imported_conditional_select_object_map_satisfies_string_constraint` -> 1 passed
- `cargo nextest run -p tsz-checker --test ts2344_generic_ref_scoped_param_concrete_constraint` -> 9 passed
- `cargo fmt --check` -> pass
- `git diff --check` -> pass
- `scripts/arch/check-checker-boundaries.sh` -> pass
- `scripts/safe-run.sh cargo build -p tsz-cli --bin tsz --profile dist-fast` -> pass
- `node TypeScript/lib/tsc.js --noEmit --strict --target es2022 .target/project-compile-guard/ts-toolbelt/sources/Function/AutoPath.ts` -> exit 0
- `.target/dist-fast/tsz --noEmit --strict --target es2022 .target/project-compile-guard/ts-toolbelt/sources/Function/AutoPath.ts` -> exit 0

## Coordination Notes
- Owned PR check at cycle start: no open M4-A PRs.
- Open overlap checked before coding; M4-B owns relation/cache work and M4-C owns recursive default diagnostic anchoring, neither overlaps this imported conditional object-map TS2344 proof.
- No roadmap or accepted-regression file changes.
