### PR TITLE
refactor(emitter): split IR printer recovery helpers

### DIFF
--- a/crates/tsz-emitter/src/transforms/ir_printer.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer.rs
@@ -29,6 +29,8 @@ mod ir_printer_generator_state;
 mod ir_printer_helpers;
 #[path = "ir_printer_namespace.rs"]
 mod ir_printer_namespace;
+#[path = "ir_printer_recovery.rs"]
+mod ir_printer_recovery;
 use ir_printer_namespace::NamespaceIifeContext;
 
 use crate::context::transform::TransformContext;
@@ -39,7 +41,6 @@ use crate::transforms::ir::{
 };
 use tsz_parser::parser::base::NodeIndex;
 use tsz_parser::parser::node::NodeArena;
-use tsz_parser::syntax_kind_ext;
 
 /// IR Printer - converts IR nodes to JavaScript strings
 pub struct IRPrinter<'a> {
@@ -1925,81 +1926,6 @@ impl<'a> IRPrinter<'a> {
                 self.write(";");
             }
         }
-    }
-
-    fn is_recovered_empty_property_access(&self, node: &IRNode) -> bool {
-        match node {
-            IRNode::PropertyAccess { property, .. } => property.is_empty(),
-            IRNode::Raw(text) => text.trim_end().ends_with('.'),
-            IRNode::ASTRef(idx) => self.arena.is_some_and(|arena| {
-                arena.get(*idx).is_some_and(|node| {
-                    if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
-                        && arena.get_access_expr(node).is_some_and(|access| {
-                            arena.is_missing_recovery_identifier(access.name_or_argument)
-                        })
-                    {
-                        return true;
-                    }
-
-                    self.source_text.is_some_and(|source_text| {
-                        let start = (node.pos as usize).min(source_text.len());
-                        let end = (node.end as usize).min(source_text.len());
-                        if start < end {
-                            let span = &source_text[start..end];
-                            span.trim_end().ends_with('.')
-                                || Self::source_span_has_recovered_property_boundary(span)
-                                || Self::source_has_recovered_property_boundary(source_text, end)
-                        } else {
-                            Self::source_has_recovered_property_boundary(source_text, end)
-                        }
-                    })
-                })
-            }),
-            _ => false,
-        }
-    }
-
-    fn source_has_recovered_property_boundary(source_text: &str, end: usize) -> bool {
-        let bytes = source_text.as_bytes();
-        if bytes.get(end) != Some(&b'.') {
-            return false;
-        }
-
-        let mut i = end + 1;
-        while let Some(byte) = bytes.get(i) {
-            match byte {
-                b' ' | b'\t' | b'\r' => i += 1,
-                b'\n' | b';' | b'}' => return true,
-                _ => return false,
-            }
-        }
-        true
-    }
-
-    fn source_span_has_recovered_property_boundary(span: &str) -> bool {
-        let bytes = span.as_bytes();
-        for dot in bytes
-            .iter()
-            .enumerate()
-            .filter_map(|(i, byte)| (*byte == b'.').then_some(i))
-        {
-            let mut i = dot + 1;
-            while let Some(byte) = bytes.get(i) {
-                match byte {
-                    b' ' | b'\t' | b'\r' => i += 1,
-                    b'\n' => {
-                        i += 1;
-                        while matches!(bytes.get(i), Some(b' ' | b'\t' | b'\r' | b'\n')) {
-                            i += 1;
-                        }
-                        return bytes.get(i).is_none_or(|byte| matches!(byte, b';' | b'}'));
-                    }
-                    b';' | b'}' => return true,
-                    _ => break,
-                }
-            }
-        }
-        false
     }
 }
 

--- a/crates/tsz-emitter/src/transforms/ir_printer_helpers.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer_helpers.rs
@@ -4,6 +4,7 @@
 //! parameters, multiline comment formatting, and arrow function ES5 emission.
 
 use super::*;
+use tsz_parser::syntax_kind_ext;
 
 impl<'a> IRPrinter<'a> {
     /// Check if a body source range represents a single-line block in the source text.

--- a/crates/tsz-emitter/src/transforms/ir_printer_recovery.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer_recovery.rs
@@ -1,0 +1,80 @@
+use super::IRPrinter;
+use crate::transforms::ir::IRNode;
+use tsz_parser::syntax_kind_ext;
+
+impl<'a> IRPrinter<'a> {
+    pub(super) fn is_recovered_empty_property_access(&self, node: &IRNode) -> bool {
+        match node {
+            IRNode::PropertyAccess { property, .. } => property.is_empty(),
+            IRNode::Raw(text) => text.trim_end().ends_with('.'),
+            IRNode::ASTRef(idx) => self.arena.is_some_and(|arena| {
+                arena.get(*idx).is_some_and(|node| {
+                    if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                        && arena.get_access_expr(node).is_some_and(|access| {
+                            arena.is_missing_recovery_identifier(access.name_or_argument)
+                        })
+                    {
+                        return true;
+                    }
+
+                    self.source_text.is_some_and(|source_text| {
+                        let start = (node.pos as usize).min(source_text.len());
+                        let end = (node.end as usize).min(source_text.len());
+                        if start < end {
+                            let span = &source_text[start..end];
+                            span.trim_end().ends_with('.')
+                                || Self::source_span_has_recovered_property_boundary(span)
+                                || Self::source_has_recovered_property_boundary(source_text, end)
+                        } else {
+                            Self::source_has_recovered_property_boundary(source_text, end)
+                        }
+                    })
+                })
+            }),
+            _ => false,
+        }
+    }
+
+    fn source_has_recovered_property_boundary(source_text: &str, end: usize) -> bool {
+        let bytes = source_text.as_bytes();
+        if bytes.get(end) != Some(&b'.') {
+            return false;
+        }
+
+        let mut i = end + 1;
+        while let Some(byte) = bytes.get(i) {
+            match byte {
+                b' ' | b'\t' | b'\r' => i += 1,
+                b'\n' | b';' | b'}' => return true,
+                _ => return false,
+            }
+        }
+        true
+    }
+
+    fn source_span_has_recovered_property_boundary(span: &str) -> bool {
+        let bytes = span.as_bytes();
+        for dot in bytes
+            .iter()
+            .enumerate()
+            .filter_map(|(i, byte)| (*byte == b'.').then_some(i))
+        {
+            let mut i = dot + 1;
+            while let Some(byte) = bytes.get(i) {
+                match byte {
+                    b' ' | b'\t' | b'\r' => i += 1,
+                    b'\n' => {
+                        i += 1;
+                        while matches!(bytes.get(i), Some(b' ' | b'\t' | b'\r' | b'\n')) {
+                            i += 1;
+                        }
+                        return bytes.get(i).is_none_or(|byte| matches!(byte, b';' | b'}'));
+                    }
+                    b';' | b'}' => return true,
+                    _ => break,
+                }
+            }
+        }
+        false
+    }
+}

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -533,11 +533,6 @@ FILE_LINE_LIMIT_CHECKS = [
         2072,
     ),
     (
-        "Emitter boundary: transforms/ir_printer.rs size ratchet",
-        ROOT / "crates" / "tsz-emitter" / "src" / "transforms" / "ir_printer.rs",
-        2008,
-    ),
-    (
         "Emitter boundary: declaration_emitter/helpers/type_inference_return_normalization.rs size ratchet",
         ROOT
         / "crates"


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Architecture guardrails / emitter file-size debt.

## Invariant
`ir_printer.rs` should stay below the §19 2000-line hard limit without carrying a temporary per-file cap. This PR moves the recovered-property-access helper logic into a sibling IR-printer module, preserving behavior while retiring the stale `FILE_LINE_LIMIT_CHECKS` entry.

## Scope
- Extract recovered empty property-access detection helpers from `crates/tsz-emitter/src/transforms/ir_printer.rs` into `crates/tsz-emitter/src/transforms/ir_printer_recovery.rs`.
- Make `ir_printer_helpers.rs` import `syntax_kind_ext` directly instead of relying on the parent module's import.
- Remove the `transforms/ir_printer.rs` size ratchet cap from `scripts/arch/arch_guard_shared.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: pure code-motion emitter refactor; no parser, checker, solver, emit-output policy, benchmark, or project-corpus behavior changed.

## Verification
- Current head `ed8e7245e5651ba5f51dbbf41da6bef73dafb2f4`, after syncing with `origin/main` at `530a7a7a2113a666d99fd3e474af800896b7ed71`:
- `cargo fmt --check`
- `cargo check -p tsz-emitter`
- `python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard-ir-printer-split-rebased4.json`
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery-ir-printer-split-rebased4.json`
- `git diff --check origin/main...HEAD`
- `wc -l crates/tsz-emitter/src/transforms/ir_printer.rs crates/tsz-emitter/src/transforms/ir_printer_recovery.rs` (`1934`, `80`)
- Earlier same-slice verification before final main syncs: `cargo check -p tsz-emitter --tests`, `cargo clippy -p tsz-emitter --all-targets -- -D warnings`, and `python3 -m unittest test_arch_guard test_arch_guard_policy test_arch_guard_counts test_arch_guard_misc` (from `scripts/arch`).

## Coordination Notes
- Follow-up for #11882: this removes the temporary `ir_printer.rs` over-2000 production-file cap after #11886 removed the `enum_es5.rs` cap. `generics.rs` and `type_inference_return_normalization.rs` remain as separate debt.
- Checked open PR overlap before editing. Active DTS/parser/solver PRs do not touch `transforms/ir_printer.rs`.
- Reopened #11882 after finding it closed while remaining caps still existed; GitHub rate-limited the explanatory issue comment earlier, so the evidence is recorded here too.
- Synced with current `origin/main` after #11897 landed; awaiting exact-head PR CI before merge-queue.
- No roadmap update needed; this is routine §19 debt burn-down.

Signed-off-by: Studio-F