### PR TITLE
fix(checker): preserve lib type refs behind value locals

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/core.rs
+++ b/crates/tsz-checker/src/state/type_resolution/core.rs
@@ -720,7 +720,12 @@ impl<'a> CheckerState<'a> {
                         Some(sym_id)
                     }
                     TypeSymbolResolution::ValueOnly(_) => {
-                        if let Some(target_sym_id) = self
+                        let local_value_allows_global_type_fallback = has_libs
+                            && self.ctx.actual_lib_context_has_bare_name(name)
+                            && !self.ctx.file_local_type_shadow_for_lib_name(name);
+                        if local_value_allows_global_type_fallback {
+                            None
+                        } else if let Some(target_sym_id) = self
                             .resolve_type_symbol_for_lowering(type_name_idx)
                             .map(tsz_binder::SymbolId)
                             .or_else(|| self.resolve_type_only_import_alias_target_symbol(name))

--- a/crates/tsz-checker/src/types/queries/lib_resolution.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution.rs
@@ -1285,7 +1285,8 @@ mod tests {
 
 #[cfg(test)]
 mod integration_tests {
-    use crate::test_utils::check_source_codes;
+    use crate::CheckerOptions;
+    use crate::test_utils::{check_multi_file_with_libs, check_source_codes, load_lib_files};
 
     #[test]
     fn promise_type_annotation_no_error() {
@@ -1533,6 +1534,33 @@ mod integration_tests {
     #[test]
     fn readonly_utility_type_no_crash() {
         let _codes = check_source_codes("type R = Readonly<{ a: number; b: string }>;");
+    }
+
+    #[test]
+    fn value_only_local_does_not_shadow_global_readonly_type() {
+        let diagnostics = check_multi_file_with_libs(
+            &[(
+                "test.ts",
+                "export declare const Readonly: 1;\ntype R = Readonly<{ a: number }>;",
+            )],
+            "test.ts",
+            CheckerOptions::default(),
+            &load_lib_files(&["es5.d.ts"]),
+        );
+        let codes: Vec<u32> = diagnostics.iter().map(|diag| diag.code).collect();
+        assert!(
+            !codes.contains(&2749),
+            "value-only locals must not shadow global type-space aliases: {codes:?}"
+        );
+    }
+
+    #[test]
+    fn value_only_local_without_type_binding_still_reports_ts2749() {
+        let codes = check_source_codes("declare const OnlyValue: 1;\ntype T = OnlyValue<string>;");
+        assert!(
+            codes.contains(&2749),
+            "pure value-only references should still report TS2749: {codes:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
Tracks 8 and 10: semantic campaign / conformance strictness and rendered diagnostic debt.

## Invariant
When a type reference first resolves to a local value-only symbol but the actual lib context provides a type-space binding for the same bare name, `tsc` continues through type-space lookup instead of reporting TS2749; this PR makes tsz do the same through checker type-reference orchestration while preserving the normal TS2749 path for pure value-only references.

## Owner Layer
Checker orchestration owns this branch point because it is deciding whether a syntactic type reference should stop with TS2749 or continue to the existing lib/global type-space resolution path. The semantic construction and lib binding remain behind existing solver/checker query boundaries; this PR does not add type-shape traversal, rendered-string decisions, or new raw type interning in checker code.

## Adjacent Case Matrix
- Positive: a local `const Readonly` value does not shadow the global `Readonly<T>` type alias in type position when libs are loaded.
- Negative: a local value-only name with no available type-space binding still reports TS2749.
- Generalization: the fallback is keyed by namespace availability and lib-context type lookup, not by a specific conformance file or rendered diagnostic string.

## Scope
- `crates/tsz-checker/src/state/type_resolution/core.rs`
- `crates/tsz-checker/src/types/queries/lib_resolution.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: conformance strictness / type-value namespace lookup
- Evidence: focused conformance witness `deeplyNestedMappedTypes` no longer emits extra TS2749 diagnostics; it remains a TS2322 fingerprint-only display mismatch in the focused run. The current dashboard reports 12,582/12,582 and 0 accepted-regression entries on `origin/main`.

## Verification
- `cargo nextest run -p tsz-checker --lib 'value_only_local'`
- `scripts/safe-run.sh --limit 50% -- ./scripts/conformance/conformance.sh run --filter deeplyNestedMappedTypes --verbose`
- `git diff --check`
- `cargo fmt --check`
- `python3 scripts/conformance/query-conformance.py --dashboard`

## Coordination Notes
- Branch: `codex/m1-c-conformance-strictness-20260531`
- Rebasing/sync: rebased and force-pushed with lease onto `origin/main` at `ed1d676f30`; current reviewed head is `5b44f53f58`.
- The accepted-regression list is already empty on current main; this PR preserves the namespace strictness fix and regression tests rather than changing the accepted list.
- Adjacent main PR #11891 fixed core cross-file preservation for exported value shadows; this PR complements it in checker type-reference resolution.
- Fallback behavior: if lib context is absent, no global type binding exists, or the local file has a real type-space binding, tsz stays on the existing resolution path.
- AgentName: M1-C.