### PR TITLE
perf(bench): incremental type-challenges-solutions fixture generation

### DIFF
--- a/scripts/bench/project-fixtures.sh
+++ b/scripts/bench/project-fixtures.sh
@@ -525,13 +525,46 @@ tsz_write_type_challenges_solutions_config() {
   local source_dir="$1"
   local compile_dir="$2"
 
-  rm -rf "$compile_dir"
+  # Preserve the existing manifest JSON across runs so that
+  # type-challenges-solutions-manifest.mjs can reuse cached outputSha256,
+  # declarations, and semanticFamilies for unchanged source entries.
+  # Only the solutions directory is selectively cleaned below.
   mkdir -p "$compile_dir/solutions"
 
   local generated=0
   local manifest_tsv="$compile_dir/type-challenges-solutions-manifest.tsv"
   local manifest_json="$compile_dir/type-challenges-solutions-manifest.json"
   printf 'output\tsource\tsourceSha256\tid\tlevel\ttitle\n' > "$manifest_tsv"
+
+  # Build a cache of sourceSha256 values from the existing manifest so we can
+  # skip re-extracting solution code for unchanged source files.
+  # The cache maps "sourceStem" -> "sourceSha256".
+  declare -A _tsz_source_sha_cache=()
+  if [[ -f "$manifest_json" ]] && command -v node >/dev/null 2>&1; then
+    local _cache_raw _cache_ref
+    # Single Node.js invocation: first line = source.ref, rest = stem<TAB>sha pairs.
+    # Two-call pattern avoided to halve process-start and JSON-parse overhead.
+    _cache_raw="$(
+      MANIFEST_FILE="$manifest_json" node --input-type=module <<'NODE'
+import fs from "node:fs";
+try {
+  const m = JSON.parse(fs.readFileSync(process.env.MANIFEST_FILE, "utf8"));
+  process.stdout.write((m.source?.ref ?? "") + "\n");
+  for (const e of (m.entries ?? [])) {
+    const stem = e.challenge?.sourceStem;
+    const sha = e.challenge?.sourceSha256;
+    if (stem && sha) process.stdout.write(stem + "\t" + sha + "\n");
+  }
+} catch {}
+NODE
+    )"
+    IFS= read -r _cache_ref <<< "$_cache_raw"
+    if [[ "$_cache_ref" == "$TYPE_CHALLENGES_SOLUTIONS_REF" ]]; then
+      while IFS=$'\t' read -r _stem _sha; do
+        [[ -n "$_stem" ]] && _tsz_source_sha_cache["$_stem"]="$_sha"
+      done <<< "${_cache_raw#*$'\n'}"
+    fi
+  fi
 
   local markdown
   while IFS= read -r markdown; do
@@ -543,6 +576,20 @@ tsz_write_type_challenges_solutions_config() {
     output="$compile_dir/solutions/${base}.ts"
     tmp="$compile_dir/solutions/.${base}.tmp"
     source_sha256="$(perl -MDigest::SHA=sha256_hex -0777 -ne 'print sha256_hex($_)' "$markdown")"
+
+    # Skip extraction when output is current: source SHA unchanged and file exists.
+    if [[ -f "$output" ]] && [[ "${_tsz_source_sha_cache["$base"]:-}" == "$source_sha256" ]]; then
+      generated=$((generated + 1))
+      printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "solutions/${base}.ts" \
+        "en/${base}.md" \
+        "$source_sha256" \
+        "$id" \
+        "$level" \
+        "${title//$'\t'/ }" \
+        >> "$manifest_tsv"
+      continue
+    fi
 
     perl -0ne '
       my ($solution) = /## Solution\n(.*?)(?:\n## References|\z)/s;
@@ -598,6 +645,20 @@ tsz_write_type_challenges_solutions_config() {
       "${title//$'\t'/ }" \
       >> "$manifest_tsv"
   done < <(find "$source_dir/en" -maxdepth 1 -name '*.md' ! -name 'index.md' | sort)
+
+  # Remove stale solution files from sources that no longer exist.
+  # Build an in-memory set from the TSV so we avoid one grep per .ts file.
+  declare -A _tsz_current_outputs=()
+  local _tsv_output
+  while IFS=$'\t' read -r _tsv_output _rest; do
+    [[ -n "$_tsv_output" && "$_tsv_output" != "output" ]] && \
+      _tsz_current_outputs["$_tsv_output"]=1
+  done < "$manifest_tsv"
+  local _ts_file
+  while IFS= read -r _ts_file; do
+    local _ts_rel="solutions/$(basename "$_ts_file")"
+    [[ -z "${_tsz_current_outputs["$_ts_rel"]:-}" ]] && rm -f "$_ts_file"
+  done < <(find "$compile_dir/solutions" -maxdepth 1 -name '*.ts' 2>/dev/null)
 
   if [[ "$generated" -eq 0 ]]; then
     echo "error: no Type Challenges solution sources were generated from $source_dir/en" >&2

--- a/scripts/ci/test-type-challenges-solutions-manifest.mjs
+++ b/scripts/ci/test-type-challenges-solutions-manifest.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -476,5 +477,159 @@ withTempDir((dir) => {
   assert.match(
     sourceResult.stderr,
     /duplicate Type Challenges solution source en\/alpha\.md/,
+  );
+});
+
+// Cache hit: when sourceSha256 and source.ref are unchanged on a second run,
+// the manifest script reuses outputSha256/declarations/semanticFamilies from
+// the existing manifest without re-reading the output file.
+withTempDir((dir) => {
+  const compileDir = path.join(dir, "compile");
+  const manifestPath = path.join(compileDir, "type-challenges-solutions-manifest.json");
+  fs.mkdirSync(path.join(compileDir, "solutions"), { recursive: true });
+  fs.writeFileSync(path.join(compileDir, "solutions", "gamma.ts"), "type Gamma = string;\n");
+
+  const tsvPath = path.join(compileDir, "gamma.tsv");
+  const SOURCE_SHA_GAMMA = "a".repeat(64);
+  fs.writeFileSync(
+    tsvPath,
+    manifestRows([["solutions/gamma.ts", "en/gamma.md", SOURCE_SHA_GAMMA, "3", "easy", "Gamma"]]),
+    "utf8",
+  );
+
+  // First run: manifest written from scratch.
+  const firstResult = runManifest(tsvPath, manifestPath);
+  assert.equal(firstResult.status, 0, firstResult.stderr || firstResult.stdout);
+  const firstManifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  const firstOutputSha = firstManifest.entries[0].outputSha256;
+  assert.match(firstOutputSha, /^[0-9a-f]{64}$/);
+
+  // Corrupt the output file between runs (same sourceSha256 in TSV).
+  fs.writeFileSync(
+    path.join(compileDir, "solutions", "gamma.ts"),
+    "// corrupted content that changes the file hash\ntype Gamma = never;\n",
+  );
+
+  // Second run with same TSV: the cached outputSha256 from the first manifest
+  // must be reused, not the corrupted file's hash.
+  const secondResult = runManifest(tsvPath, manifestPath);
+  assert.equal(secondResult.status, 0, secondResult.stderr || secondResult.stdout);
+  const secondManifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  assert.equal(
+    secondManifest.entries[0].outputSha256,
+    firstOutputSha,
+    "cache hit: outputSha256 must equal first-run value when sourceSha256 is unchanged",
+  );
+  assert.deepEqual(
+    secondManifest.entries[0].declarations,
+    firstManifest.entries[0].declarations,
+    "cache hit: declarations must equal first-run value",
+  );
+});
+
+// Cache miss: when sourceSha256 changes, the manifest script re-reads the
+// output file and computes a fresh outputSha256.
+withTempDir((dir) => {
+  const compileDir = path.join(dir, "compile");
+  const manifestPath = path.join(compileDir, "type-challenges-solutions-manifest.json");
+  fs.mkdirSync(path.join(compileDir, "solutions"), { recursive: true });
+  fs.writeFileSync(path.join(compileDir, "solutions", "delta.ts"), "type Delta = string;\n");
+
+  const INITIAL_SOURCE_SHA = "b".repeat(64);
+  const tsvPath = path.join(compileDir, "delta.tsv");
+  fs.writeFileSync(
+    tsvPath,
+    manifestRows([["solutions/delta.ts", "en/delta.md", INITIAL_SOURCE_SHA, "4", "easy", "Delta"]]),
+    "utf8",
+  );
+
+  // First run: establish the manifest with INITIAL_SOURCE_SHA.
+  const firstResult = runManifest(tsvPath, manifestPath);
+  assert.equal(firstResult.status, 0, firstResult.stderr || firstResult.stdout);
+  const firstManifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  const firstOutputSha = firstManifest.entries[0].outputSha256;
+
+  // Update the output file AND change the sourceSha256 in the TSV (simulating
+  // a changed source that was re-extracted).
+  const newContent = "type Delta = number; // regenerated\n";
+  fs.writeFileSync(path.join(compileDir, "solutions", "delta.ts"), newContent);
+  const CHANGED_SOURCE_SHA = "c".repeat(64);
+  fs.writeFileSync(
+    tsvPath,
+    manifestRows([["solutions/delta.ts", "en/delta.md", CHANGED_SOURCE_SHA, "4", "easy", "Delta"]]),
+    "utf8",
+  );
+
+  // Second run: cache key (sourceSha256) changed so the file is re-read.
+  const secondResult = runManifest(tsvPath, manifestPath);
+  assert.equal(secondResult.status, 0, secondResult.stderr || secondResult.stdout);
+  const secondManifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  const expectedFreshSha = crypto.createHash("sha256").update(newContent).digest("hex");
+  assert.equal(
+    secondManifest.entries[0].outputSha256,
+    expectedFreshSha,
+    "cache miss: outputSha256 must be freshly computed when sourceSha256 changes",
+  );
+  assert.notEqual(
+    secondManifest.entries[0].outputSha256,
+    firstOutputSha,
+    "cache miss: outputSha256 must differ from first-run value after source change",
+  );
+});
+
+// Cache invalidation: when source.ref changes, the entire cache is discarded
+// because the generated .ts header comment includes the ref.
+withTempDir((dir) => {
+  const compileDir = path.join(dir, "compile");
+  const manifestPath = path.join(compileDir, "type-challenges-solutions-manifest.json");
+  fs.mkdirSync(path.join(compileDir, "solutions"), { recursive: true });
+  const outputContent = "type Epsilon = string;\n";
+  fs.writeFileSync(path.join(compileDir, "solutions", "epsilon.ts"), outputContent);
+
+  const EPSILON_SOURCE_SHA = "d".repeat(64);
+  const tsvPath = path.join(compileDir, "epsilon.tsv");
+  fs.writeFileSync(
+    tsvPath,
+    manifestRows([["solutions/epsilon.ts", "en/epsilon.md", EPSILON_SOURCE_SHA, "5", "easy", "Epsilon"]]),
+    "utf8",
+  );
+
+  // First run with ref "ref-v1".
+  const firstResult = spawnSync(process.execPath, [MANIFEST_SCRIPT, tsvPath, manifestPath], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      TYPE_CHALLENGES_SOLUTIONS_REPO: "https://example.invalid/type-challenges-solutions.git",
+      TYPE_CHALLENGES_SOLUTIONS_REF: "ref-v1",
+      TYPE_CHALLENGES_SOLUTIONS_EXPECTED_GENERATED: "1",
+    },
+  });
+  assert.equal(firstResult.status, 0, firstResult.stderr || firstResult.stdout);
+  const firstManifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  const firstOutputSha = firstManifest.entries[0].outputSha256;
+
+  // Second run with a different ref — same sourceSha256 but different ref.
+  // The cache must be invalidated so the output file is re-read.
+  const secondResult = spawnSync(process.execPath, [MANIFEST_SCRIPT, tsvPath, manifestPath], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      TYPE_CHALLENGES_SOLUTIONS_REPO: "https://example.invalid/type-challenges-solutions.git",
+      TYPE_CHALLENGES_SOLUTIONS_REF: "ref-v2",
+      TYPE_CHALLENGES_SOLUTIONS_EXPECTED_GENERATED: "1",
+    },
+  });
+  assert.equal(secondResult.status, 0, secondResult.stderr || secondResult.stdout);
+  const secondManifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+
+  // With a ref change the cache is cleared; the manifest script re-reads the
+  // file and computes a fresh hash equal to the actual file content's hash.
+  const expectedSha = crypto.createHash("sha256").update(outputContent).digest("hex");
+  assert.equal(
+    secondManifest.entries[0].outputSha256,
+    expectedSha,
+    "ref-change invalidation: outputSha256 must be freshly computed",
   );
 });

--- a/scripts/ci/type-challenges-solutions-manifest.mjs
+++ b/scripts/ci/type-challenges-solutions-manifest.mjs
@@ -13,6 +13,64 @@ if (!tsvPath || !manifestPath) {
   process.exit(2);
 }
 
+/**
+ * Load content-addressed cache from an existing manifest file.
+ *
+ * When the same source content (identified by `sourceSha256`) was processed in
+ * a prior run against the same repository ref, the derived output values
+ * (`outputSha256`, `declarations`, `semanticFamilies`) are deterministic and do
+ * not need to be recomputed.  This avoids re-reading and re-hashing every
+ * generated `.ts` file when most sources are unchanged between runs.
+ *
+ * The cache is keyed by `sourceSha256` alone (not by file path), because the
+ * content hash fully identifies the source content.  Two different source paths
+ * with the same content would share a cache entry, but that is harmless — they
+ * would produce identical output anyway.
+ *
+ * Cache validity conditions (both must hold):
+ *   1. The existing manifest's `source.ref` equals the current ref env var.
+ *   2. The entry's `challenge.sourceSha256` matches the TSV row's value.
+ *
+ * @param {string} existingManifestPath - Path that will be overwritten; read
+ *   before processing starts so the old content is still available.
+ * @param {string} currentRef - Current `TYPE_CHALLENGES_SOLUTIONS_REF` value.
+ * @returns {Map<string, {outputSha256: string, declarations: string[], semanticFamilies: string[]}>}
+ */
+function loadManifestCache(existingManifestPath, currentRef) {
+  let oldManifest;
+  try {
+    oldManifest = JSON.parse(fs.readFileSync(existingManifestPath, "utf8"));
+  } catch {
+    return new Map();
+  }
+  if (oldManifest.source?.ref !== currentRef) return new Map();
+  if (!Array.isArray(oldManifest.entries)) return new Map();
+
+  const cache = new Map();
+  for (const entry of oldManifest.entries) {
+    const sourceSha256 = entry.challenge?.sourceSha256;
+    if (
+      !/^[0-9a-f]{64}$/.test(sourceSha256) ||
+      cache.has(sourceSha256)
+    ) {
+      continue;
+    }
+    if (
+      typeof entry.outputSha256 !== "string" ||
+      !Array.isArray(entry.declarations) ||
+      !Array.isArray(entry.semanticFamilies)
+    ) {
+      continue;
+    }
+    cache.set(sourceSha256, {
+      outputSha256: entry.outputSha256,
+      declarations: entry.declarations,
+      semanticFamilies: entry.semanticFamilies,
+    });
+  }
+  return cache;
+}
+
 const repository = process.env.TYPE_CHALLENGES_SOLUTIONS_REPO;
 const ref = process.env.TYPE_CHALLENGES_SOLUTIONS_REF;
 const expectedGenerated = Number(
@@ -94,6 +152,11 @@ const {
   manifestRoot,
   resolvedManifestPath,
 } = validateManifestOutputPath(tsvPath, manifestPath);
+
+// Load the old manifest before we start writing so we can reuse cached
+// outputSha256/declarations/semanticFamilies for unchanged source entries.
+const manifestCache = loadManifestCache(resolvedManifestPath, ref);
+
 const lines = fs.readFileSync(tsvPath, "utf8").trimEnd().split(/\r?\n/);
 const header = lines.shift();
 
@@ -102,7 +165,15 @@ if (header !== "output\tsource\tsourceSha256\tid\tlevel\ttitle") {
   process.exit(1);
 }
 
-function readOutputMetadata(outputPath) {
+function readOutputMetadata(outputPath, sourceSha256) {
+  // Reuse cached metadata when the source content is unchanged.  The output
+  // `.ts` content is deterministically derived from the source markdown, so
+  // unchanged source => unchanged output => all derived values are stable.
+  const cached = manifestCache.get(sourceSha256);
+  if (cached !== undefined) {
+    return cached;
+  }
+
   const text = fs.readFileSync(outputPath, "utf8");
   const names = [];
   const seen = new Set();
@@ -236,7 +307,7 @@ const entries = lines
       declarations,
       semanticFamilies,
       outputSha256,
-    } = readOutputMetadata(outputPath);
+    } = readOutputMetadata(outputPath, sourceSha256);
     if (declarations.length === 0) {
       console.error(`error: manifest output has no declarations: ${output}`);
       process.exit(1);


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
`perf` — benchmark fixture pipeline efficiency

## Invariant
When source markdown is unchanged between runs, tsz re-hashes all generated `.ts` files every time; this PR makes tsz skip that I/O by caching `outputSha256`, `declarations`, and `semanticFamilies` keyed by `sourceSha256` in the manifest JSON.

## Scope
- `scripts/bench/project-fixtures.sh` — `tsz_write_type_challenges_solutions_config` only
- `scripts/ci/type-challenges-solutions-manifest.mjs` — `loadManifestCache` + `readOutputMetadata`
- `scripts/ci/test-type-challenges-solutions-manifest.mjs` — 3 new test blocks

No Rust, no checker/solver, no conformance paths touched.

## Project Corpus Impact
- Row: `type-challenges-solutions-project` (generated category)
- Bug family: n/a — performance-only change; manifest content is invariant-identical
- Evidence: `node scripts/ci/test-type-challenges-solutions-manifest.mjs` exits 0; cache-hit test verifies `outputSha256` is reused when `sourceSha256` is unchanged; cache-miss test verifies fresh computation on source change; ref-change test verifies full invalidation.

## Verification
- `node scripts/ci/test-type-challenges-solutions-manifest.mjs` — exits 0, all existing + 3 new tests pass

## Coordination Notes
- Runner identity: claude-sonnet-4-6
- Claimed from issue #11619 (previously labeled `agent:Studio-B`); continuing under Studio-B ownership lane.
- Fixes: type-challenges-solutions fixture re-hashes all 78 output `.ts` files on every run even when sources are unchanged.
