### PR TITLE
fix(parser): recover dotted interface names as trailing statements (matches tsc)

### DIFF
--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -124,23 +124,35 @@ impl ParserState {
             self.parse_identifier()
         };
 
-        // TS1434: Dotted names like `Foo.I1` are not valid interface names.
-        // tsc emits "Unexpected keyword or identifier" and "{  expected" at the dotted part.
+        // Dotted names like `Foo.I1` are not valid interface names. tsc parses
+        // `interface Foo`, then fails `parseExpected('{')` at the `.` (TS1005),
+        // terminates the interface with an empty body, and resumes statement
+        // parsing at the segment after the dot. The remaining `I1 { }` is then
+        // recovered as an expression statement (`I1;` with TS1434 "Unexpected
+        // keyword or identifier") followed by a block (`{ }`). Mirror that:
+        // emit TS1005 at the dot, consume only the dot, and return an
+        // empty-body interface so the trailing tokens re-enter statement
+        // recovery (matching tsc's emit and diagnostics).
         if self.is_token(SyntaxKind::DotToken) {
             use tsz_common::diagnostics::diagnostic_codes;
             // Emit '{' expected at the dot position (tsc expects { after the name)
             self.parse_error_at_current_token("'{' expected.", diagnostic_codes::EXPECTED);
-            // Skip over the dotted name segments (e.g., `.I1`)
-            while self.is_token(SyntaxKind::DotToken) {
-                self.next_token(); // skip '.'
-                if self.is_identifier_or_keyword() {
-                    self.parse_error_at_current_token(
-                        "Unexpected keyword or identifier.",
-                        diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER,
-                    );
-                    self.next_token(); // skip the identifier
-                }
-            }
+            // Consume only the dot; leave the following segment(s) for the
+            // statement loop so the recovered statement is preserved in emit.
+            self.next_token();
+            let end_pos = self.arena.get(name).map_or(start_pos, |node| node.end);
+            return self.arena.add_interface(
+                syntax_kind_ext::INTERFACE_DECLARATION,
+                start_pos,
+                end_pos,
+                crate::parser::node::InterfaceData {
+                    modifiers,
+                    name,
+                    type_parameters: None,
+                    heritage_clauses: None,
+                    members: self.make_node_list(vec![]),
+                },
+            );
         }
 
         // Parse type parameters: interface IList<T> {}

--- a/crates/tsz-parser/tests/state_declaration_tests.rs
+++ b/crates/tsz-parser/tests/state_declaration_tests.rs
@@ -1563,3 +1563,63 @@ fn unicode_escape_unknown_variable_name_reports_only_invalid_character() {
         "invalid escaped identifier should not cascade to TS1134, got {fingerprints:?}"
     );
 }
+
+/// `interface <Name>.<Rest> { }` is a malformed dotted interface name. tsc
+/// parses `interface <Name>` with an empty body, reports TS1005 `'{' expected.`
+/// at the dot, and resumes statement parsing at `<Rest>` — recovering it as an
+/// expression statement (TS1434 "Unexpected keyword or identifier") followed by
+/// the trailing `{ }` block. The recovered statements must survive into the AST
+/// so they are emitted, instead of being silently swallowed by the interface.
+///
+/// This check varies the chosen identifier names (`Foo.I1`, `Bar.Baz`) so the
+/// rule is keyed on the dotted-name grammar shape, not on a particular spelling.
+fn assert_dotted_interface_recovery(source: &str, dot_offset: u32, rest_offset: u32) {
+    use syntax_kind_ext::{BLOCK, EXPRESSION_STATEMENT, INTERFACE_DECLARATION};
+
+    let (parser, root) = parse_source(source);
+    let diags = parser.get_diagnostics();
+
+    const TS1005: u32 = diagnostic_codes::EXPECTED;
+    const TS1434: u32 = diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER;
+
+    // TS1005 `'{' expected.` reported at the dot that follows the interface name.
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.code == TS1005 && d.start == dot_offset && d.message.contains("'{'")),
+        "expected TS1005 `'{{' expected.` at the dot (offset {dot_offset}) for {source:?}, got {diags:?}"
+    );
+    // TS1434 reported at the segment after the dot, which re-enters statement
+    // recovery as an expression statement.
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.code == TS1434 && d.start == rest_offset),
+        "expected TS1434 at the post-dot identifier (offset {rest_offset}) for {source:?}, got {diags:?}"
+    );
+
+    // The recovered statement list must contain an empty interface, the
+    // expression statement for the trailing identifier, and the block.
+    let sf = parser.get_arena().get_source_file_at(root).unwrap();
+    let kinds: Vec<u16> = sf
+        .statements
+        .nodes
+        .iter()
+        .filter_map(|idx| parser.get_arena().get(*idx).map(|node| node.kind))
+        .collect();
+    assert!(
+        kinds.contains(&INTERFACE_DECLARATION)
+            && kinds.contains(&EXPRESSION_STATEMENT)
+            && kinds.contains(&BLOCK),
+        "dotted interface name should recover as interface + expression statement + block, got {kinds:?} for {source:?}"
+    );
+}
+
+#[test]
+fn parse_dotted_interface_name_recovers_trailing_statements() {
+    // `interface Foo.I1 { }`: dot at offset 13, `I1` at offset 14.
+    assert_dotted_interface_recovery("interface Foo.I1 { }\n", 13, 14);
+    // Renamed shape proves the rule is structural, not spelling-specific:
+    // `interface Bar.Baz { }`: dot at offset 13, `Baz` at offset 14.
+    assert_dotted_interface_recovery("interface Bar.Baz { }\n", 13, 14);
+}


### PR DESCRIPTION
AgentName: opus48-emit100

## Track
Emit → 100% (JavaScript emit parity). Parser error-recovery for dotted interface names.

## Invariant
A dotted name (`interface Foo.I1`) is not a valid interface name. tsc parses
`interface Foo` with an empty body, fails `parseExpected('{')` at the `.` (TS1005
`'{' expected.`), terminates the interface, and resumes statement parsing at the
segment after the dot — recovering `I1 { }` as an expression statement (`I1;` with
TS1434 "Unexpected keyword or identifier") followed by a block. tsz previously
skipped all dotted segments and parsed a body, dropping the trailing statement
from emit. This change mirrors tsc: emit TS1005 at the dot, consume only the dot,
return an empty-body interface so the trailing tokens re-enter statement recovery
— matching tsc's emit AND diagnostics.

## Scope
Parser error-recovery (`tsz-parser`). Keyed on token KIND (`DotToken` after the
interface name), never on a spelling.
- `state_declarations.rs` — dotted-interface-name recovery (replace skip-loop with
  TS1005 + single-dot-consume + empty-body interface return).
- `state_declaration_tests.rs` — focused two-shape test (`Foo.I1` and renamed `Bar.Baz`).

## Project Corpus Impact
- Row: n/a — TypeScript conformance/emit fixture parser-recovery fix, not a project-corpus benchmark row.
- Bug family: dotted-interface-name parser error recovery (recovered AST → emit + recovery diagnostics).
- Evidence: local `scripts/emit/run.sh --js-only` Failed **56 → 55** (−1; fixes `interfaceDeclaration4` + variant `parserInterfaceDeclaration4`; `comm`-diff shows zero new failures vs freshly-built origin/main baseline); `--dts-only` unchanged; `cargo nextest -p tsz-parser` 1123/1123 (+1 new). **Conformance PRE-CHECKED locally**: `interfaceDeclaration4` `.errors.txt` PASS, `InterfaceDeclaration` family 13/13, broader `interface` filter 116/116 — diagnostics unchanged (TS1005 at the dot + TS1434 post-dot).

## Verification
- Net `--js-only`: 56 → 55, zero regressions. Targeted: interfaceDeclaration4 + parserInterfaceDeclaration4 PASS.
- Conformance verified locally on the fixed test + adjacent family (the recovery-diagnostic
  pre-check from the [[dts-shared-path]] lesson) — so ready CI's conformance-aggregate should
  hold (unlike #11869/#11874 which needed a post-hoc narrow; this one was pre-checked).
- clippy clean.

## Coordination Notes
- 5th recovery fix this campaign (after #11851/#11854/#11869/#11874). Sibling lanes own
  privateName (#11849/#11853/#11856), dts, and tsx-recovery (Studio-C) — not touched.
- The other 9 candidates in this batch were triaged as broad/multi-bug/scanner-deep and
  deliberately left as follow-ups (no hack shipped). AgentName: opus48-emit100. Reviews welcome.
