### PR TITLE
perf(checker): skip declaration overlay inheritance

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -940,12 +940,18 @@ impl<'a> CheckerState<'a> {
             // Copy all cross-file state: arenas, binders, all 6 global indices,
             // resolved_module_paths, and module_specifiers.
             checker.ctx.copy_cross_file_state_from(&self.ctx);
-            // Copy cross-file symbol targets (local overlay only; global index
-            // is already shared via copy_cross_file_state_from)
-            self.ctx.copy_symbol_file_targets_to_attributed(
-                &mut checker.ctx,
-                tsz_common::perf_counters::CheckerCreationReason::DelegateCrossArenaSymbol,
-            );
+            if super::cross_file_overlay_gate::symbol_delegation_needs_parent_targets(
+                delegate_arena_source,
+                symbol_arena,
+                needs_cross_file_delegation,
+            ) {
+                // Copy cross-file symbol targets (local overlay only; global index
+                // is already shared via copy_cross_file_state_from).
+                self.ctx.copy_symbol_file_targets_to_attributed(
+                    &mut checker.ctx,
+                    tsz_common::perf_counters::CheckerCreationReason::DelegateCrossArenaSymbol,
+                );
+            }
             checker.ctx.current_file_idx = delegate_file_idx.unwrap_or(self.ctx.current_file_idx);
             // The parent cache is cloned into the child for performance, but raw
             // SymbolIds can still collide across binders in direct multi-file tests.

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_cache_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_cache_tests.rs
@@ -3,6 +3,7 @@ use crate::context::{CheckerContext, CheckerOptions};
 use std::sync::Arc;
 use tsz_binder::BinderState;
 use tsz_parser::parser::NodeArena;
+use tsz_parser::parser::ParserState;
 use tsz_solver::TypeParamInfo;
 use tsz_solver::construction::TypeInterner;
 use tsz_solver::def::DefinitionStore;
@@ -109,5 +110,55 @@ fn non_generic_source_file_symbol_arena_results_stay_stable() {
             state.ctx.current_file_idx as u32,
         ),
         None,
+    );
+}
+
+#[test]
+fn declaration_symbol_arena_delegation_does_not_need_parent_symbol_targets() {
+    let mut declaration_parser = ParserState::new(
+        "lib.dom.d.ts".to_string(),
+        "interface Declared { value: string }".to_string(),
+    );
+    declaration_parser.parse_source_file();
+    let declaration_arena = declaration_parser.get_arena();
+
+    let mut source_parser = ParserState::new(
+        "source.ts".to_string(),
+        "interface Local { value: string }".to_string(),
+    );
+    source_parser.parse_source_file();
+    let source_arena = source_parser.get_arena();
+
+    assert!(
+        !super::super::cross_file_overlay_gate::symbol_delegation_needs_parent_targets(
+            CrossArenaSymbolMissSource::SymbolArena,
+            declaration_arena,
+            false,
+        ),
+        "declaration-file symbol arena children already inherit shared cross-file indices",
+    );
+    assert!(
+        super::super::cross_file_overlay_gate::symbol_delegation_needs_parent_targets(
+            CrossArenaSymbolMissSource::SymbolArena,
+            source_arena,
+            false,
+        ),
+        "source-file symbol arena children still need parent overlay discoveries",
+    );
+    assert!(
+        super::super::cross_file_overlay_gate::symbol_delegation_needs_parent_targets(
+            CrossArenaSymbolMissSource::DeclarationArena,
+            declaration_arena,
+            false,
+        ),
+        "non-symbol-arena delegation keeps the existing overlay behavior",
+    );
+    assert!(
+        super::super::cross_file_overlay_gate::symbol_delegation_needs_parent_targets(
+            CrossArenaSymbolMissSource::SymbolArena,
+            declaration_arena,
+            true,
+        ),
+        "explicit symbol-file target delegation keeps the existing overlay behavior",
     );
 }

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_overlay_gate.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_overlay_gate.rs
@@ -1,0 +1,19 @@
+use tsz_common::perf_counters::CrossArenaSymbolMissSource;
+use tsz_parser::NodeArena;
+
+pub(super) fn symbol_delegation_needs_parent_targets(
+    delegate_arena_source: CrossArenaSymbolMissSource,
+    symbol_arena: &NodeArena,
+    needs_cross_file_delegation: bool,
+) -> bool {
+    if needs_cross_file_delegation
+        || delegate_arena_source != CrossArenaSymbolMissSource::SymbolArena
+    {
+        return true;
+    }
+
+    !symbol_arena
+        .source_files
+        .first()
+        .is_some_and(|source_file| source_file.is_declaration_file)
+}

--- a/crates/tsz-checker/src/state/type_analysis/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/mod.rs
@@ -26,6 +26,7 @@ mod cross_file_direct_functions;
 mod cross_file_env_merge;
 mod cross_file_globals;
 mod cross_file_import_alias_pin;
+mod cross_file_overlay_gate;
 pub(crate) mod cross_file_query_types;
 mod cross_file_residue;
 mod cross_file_shared_cache;


### PR DESCRIPTION
AgentName: Studio-B

## Track

`perf` — checker cross-arena delegation residency/counter slice for green-row speed work.

## Invariant

When cross-arena symbol delegation targets a declaration-file arena through `symbol_arenas`, the child checker already inherits shared cross-file state and the global symbol-file index; this PR skips inheriting the parent local symbol-file overlay for that structural case while preserving overlay inheritance for source-file symbol arenas, declaration-arena misses, and explicit symbol-file-target delegation.

## Scope

- `crates/tsz-checker/src/state/type_analysis/cross_file.rs` — guards `DelegateCrossArenaSymbol` overlay inheritance.
- `crates/tsz-checker/src/state/type_analysis/cross_file_overlay_gate.rs` — keeps the predicate outside the near-limit cross-file module.
- `crates/tsz-checker/src/state/type_analysis/cross_file_cache_tests.rs` — covers declaration/source/explicit-target overlay decisions.
- `crates/tsz-checker/src/state/type_analysis/mod.rs` — registers the helper module.

## Project Corpus Impact

- Row: `vite-vanilla-ts-app`
- Bug family: checker cross-arena delegation overlay residency; target gap remains open
- Evidence: attribution mode on the Vite project stayed diagnostic-clean and reduced `copy_symbol_file_targets` from 395 calls / 1,732 visible entries to 4 calls / 19 visible entries. Timing mode still reports a 2x target gap (`tsgo` 1.44x faster), so this PR claims counter/residency progress rather than row closure.

## Verification

- `cargo fmt --check`
- `cargo nextest run -p tsz-checker --lib -E 'test(declaration_symbol_arena_delegation_does_not_need_parent_symbol_targets) | test(direct_cross_file_interface_lowering_handles_simple_builtin_dom_interfaces) | test(value_merged_builtin_dom_interface_type_argument_keeps_inherited_members)'`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh --limit 75% -- .target/release/tsz --extendedDiagnostics --perf-counters-json /private/tmp/studio-b-vite-overlay-skip-final-20260531.perf.json --noEmit -p /Users/mohsen/code/tsz-pr11869/.target-bench/external/vite-vanilla-ts-live/tsconfig.json`
- `python3 scripts/perf/query-perf-counters.py --json /private/tmp/studio-b-vite-overlay-skip-final-20260531.perf.json --baseline /private/tmp/studio-b-vite-current-main-after-11887.perf.json --by-reason`
- `BENCH_PGO=0 TSC_NPM_SPEC=6.0.3 scripts/safe-run.sh --limit 75% -- scripts/bench/bench-vs-tsgo.sh --quick --rebuild --filter '^vite-vanilla-ts-app$' --json-file /private/tmp/studio-b-vite-overlay-skip-20260531.json`
- `node scripts/bench/tsgo-winner-report.mjs /private/tmp/studio-b-vite-overlay-skip-20260531.json /private/tmp/studio-b-vite-overlay-skip-20260531.tsgo-winners.json`

## Coordination Notes

- Existing Studio-B PR #11902 was merged first at 2026-05-31T11:50:57Z.
- Opened as draft so light CI can validate the rebased head before any ready/queue action.
- No fixture-name fast path; the guard is keyed by declaration-file arena provenance and delegation source.
