### PR TITLE
fix(checker): accept imported recursive iteration maps

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
@@ -27,7 +27,7 @@ impl<'a> CheckerState<'a> {
                         )
                     })?
                 });
-        let Some((_check_type, _extends_type, true_type, false_type)) = components else {
+        let Some((check_type, extends_type, true_type, false_type)) = components else {
             return false;
         };
         let db = self.ctx.types.as_type_database();
@@ -49,7 +49,26 @@ impl<'a> CheckerState<'a> {
                     .assign_relation_outcome(branch_evaluated, constraint)
                     .related
                 || self.indexed_object_map_branch_satisfies_constraint(branch, constraint)
+                || (branch == true_type
+                    && branch == check_type
+                    && self.conditional_extends_type_satisfies_constraint(extends_type, constraint))
         })
+    }
+
+    fn conditional_extends_type_satisfies_constraint(
+        &mut self,
+        extends_type: TypeId,
+        constraint: TypeId,
+    ) -> bool {
+        let extends_type = self.resolve_lazy_type(extends_type);
+        let extends_evaluated = self.evaluate_type_for_assignability(extends_type);
+        let constraint = self.resolve_lazy_type(constraint);
+        let constraint_evaluated = self.evaluate_type_for_assignability(constraint);
+        self.assign_relation_outcome(extends_type, constraint)
+            .related
+            || self
+                .assign_relation_outcome(extends_evaluated, constraint_evaluated)
+                .related
     }
 
     fn indexed_object_map_branch_satisfies_constraint(
@@ -98,6 +117,7 @@ impl<'a> CheckerState<'a> {
                 || self
                     .assign_relation_outcome(value_evaluated, constraint_evaluated)
                     .related
+                || self.conditional_result_branches_satisfy_constraint(value, constraint)
         })
     }
 
@@ -238,6 +258,9 @@ impl<'a> CheckerState<'a> {
         constraint: TypeId,
     ) -> bool {
         for _ in 0..8 {
+            if self.indexed_object_map_branch_satisfies_constraint(type_arg, constraint) {
+                return true;
+            }
             if let Some((check, extends_type, true_type, false_type)) =
                 query::full_conditional_type_components(self.ctx.types.as_type_database(), type_arg)
             {

--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
@@ -365,7 +365,9 @@ impl<'a> CheckerState<'a> {
                             type_arg,
                             inst_constraint,
                         ) || self
-                            .diagnostic_relation_boolean_guard(evaluated_arg, inst_constraint)
+                            .type_alias_application_filters_to_constraint(type_arg, inst_constraint)
+                            || self
+                                .diagnostic_relation_boolean_guard(evaluated_arg, inst_constraint)
                             || query::homomorphic_mapped_application_should_defer_constraint(
                                 self, type_arg,
                             )

--- a/crates/tsz-cli/tests/tsc_compat_tests_parts/part_02.rs
+++ b/crates/tsz-cli/tests/tsc_compat_tests_parts/part_02.rs
@@ -1010,3 +1010,171 @@ export type AutoPath<O extends any, P extends string, D extends string = '.'> =
          tsz output:\n{tsz_output}"
     );
 }
+
+#[test]
+fn imported_recursive_iteration_map_satisfies_iteration_constraint() {
+    let temp = TempDir::new("imported_recursive_iteration_map").expect("temp dir");
+    write_file(
+        &temp.path.join("Iteration/Iteration.ts"),
+        r#"
+export type Iteration = [
+  value: number,
+  sign: '-' | '0' | '+',
+  prev: keyof IterationMap,
+  next: keyof IterationMap,
+  oppo: keyof IterationMap,
+];
+export type IterationMap = {
+  '__': [number, '-' | '0' | '+', '__', '__', '__'],
+  '-1': [-1, '-', '__', '0', '1'],
+  '0': [0, '0', '-1', '1', '0'],
+  '1': [1, '+', '0', '__', '-1'],
+};
+"#,
+    );
+    write_file(
+        &temp.path.join("Iteration/IterationOf.ts"),
+        r#"
+import {IterationMap} from './Iteration'
+export type IterationOf<N extends number> =
+  `${N}` extends keyof IterationMap ? IterationMap[`${N}`] : IterationMap['__']
+"#,
+    );
+    write_file(
+        &temp.path.join("Iteration/Prev.ts"),
+        r#"
+import {Iteration, IterationMap} from './Iteration'
+export type Prev<I extends Iteration> = IterationMap[I[2]]
+"#,
+    );
+    write_file(
+        &temp.path.join("Iteration/Next.ts"),
+        r#"
+import {Iteration, IterationMap} from './Iteration'
+export type Next<I extends Iteration> = IterationMap[I[3]]
+"#,
+    );
+    write_file(
+        &temp.path.join("Iteration/Pos.ts"),
+        r#"
+import {Iteration} from './Iteration'
+export type Pos<I extends Iteration> = I[0]
+"#,
+    );
+    write_file(
+        &temp.path.join("Any/Cast.ts"),
+        r#"
+export type Cast<A1 extends any, A2 extends any> =
+  A1 extends A2 ? A1 : A2
+"#,
+    );
+    write_file(
+        &temp.path.join("Number/IsNegative.ts"),
+        r#"
+import {IterationOf} from '../Iteration/IterationOf'
+import {Iteration} from '../Iteration/Iteration'
+
+export type _IsNegative<N extends Iteration> = {
+  '-': 1
+  '+': 0
+  '0': 0
+}[N[1]]
+export type IsNegative<N extends number> = _IsNegative<IterationOf<N>>
+"#,
+    );
+    write_file(
+        &temp.path.join("Number/IsPositive.ts"),
+        r#"
+import {_IsNegative} from './IsNegative'
+import {IterationOf} from '../Iteration/IterationOf'
+import {Iteration} from '../Iteration/Iteration'
+
+export type _IsPositive<N extends Iteration> = {
+  '-': 0
+  '+': 1
+  '0': 0
+}[N[1]]
+export type IsPositive<N extends number> = _IsPositive<IterationOf<N>>
+"#,
+    );
+    write_file(
+        &temp.path.join("Number/Sub.ts"),
+        r#"
+import {Iteration} from '../Iteration/Iteration'
+import {Pos} from '../Iteration/Pos'
+import {Prev} from '../Iteration/Prev'
+import {Next} from '../Iteration/Next'
+import {_IsNegative} from './IsNegative'
+import {Cast} from '../Any/Cast'
+
+type SubPositive<N1 extends Iteration, N2 extends Iteration> = {
+  0: SubPositive<Prev<N1>, Prev<N2>>
+  1: N1
+  2: number
+}[Pos<N2> extends 0 ? 1 : number extends Pos<N2> ? 2 : 0] extends infer X
+  ? Cast<X, Iteration>
+  : never
+
+type SubNegative<N1 extends Iteration, N2 extends Iteration> = {
+  0: SubNegative<Next<N1>, Next<N2>>
+  1: N1
+  2: number
+}[Pos<N2> extends 0 ? 1 : number extends Pos<N2> ? 2 : 0] extends infer X
+  ? Cast<X, Iteration>
+  : never
+
+export type _Sub<N1 extends Iteration, N2 extends Iteration> = {
+  0: SubPositive<N1, N2>
+  1: SubNegative<N1, N2>
+}[_IsNegative<N2>]
+"#,
+    );
+    write_file(
+        &temp.path.join("Number/Greater.ts"),
+        r#"
+import {_Sub} from './Sub'
+import {_IsPositive} from './IsPositive'
+import {IterationOf} from '../Iteration/IterationOf'
+import {Iteration} from '../Iteration/Iteration'
+
+export type _Greater<N1 extends Iteration, N2 extends Iteration> =
+  _IsPositive<_Sub<N1, N2>>
+export type Greater<N1 extends number, N2 extends number> =
+  N1 extends unknown
+    ? N2 extends unknown
+      ? _Greater<IterationOf<N1>, IterationOf<N2>>
+      : never
+    : never
+"#,
+    );
+
+    let (tsc_code, tsc_output) = run_tsc_with_exit_code(
+        &temp.path,
+        &[
+            "--noEmit",
+            "--strict",
+            "--target",
+            "es2022",
+            "Number/Greater.ts",
+        ],
+    )
+    .expect("tsc should run");
+    assert_eq!(tsc_code, 0, "tsc accepted the imported iteration map: {tsc_output}");
+
+    let (tsz_code, tsz_output) = run_tsz_with_exit_code(
+        &temp.path,
+        &[
+            "--noEmit",
+            "--strict",
+            "--target",
+            "es2022",
+            "Number/Greater.ts",
+        ],
+    )
+    .expect("tsz should run");
+    assert_eq!(
+        tsz_code, 0,
+        "Imported recursive object-map aliases should satisfy the Iteration constraint like tsc.\n\
+         tsz output:\n{tsz_output}"
+    );
+}

--- a/scripts/bench/project-fixtures.sh
+++ b/scripts/bench/project-fixtures.sh
@@ -537,9 +537,12 @@ tsz_write_type_challenges_solutions_config() {
   printf 'output\tsource\tsourceSha256\tid\tlevel\ttitle\n' > "$manifest_tsv"
 
   # Build a cache of sourceSha256 values from the existing manifest so we can
-  # skip re-extracting solution code for unchanged source files.
-  # The cache maps "sourceStem" -> "sourceSha256".
-  declare -A _tsz_source_sha_cache=()
+  # skip re-extracting solution code for unchanged source files. Keep the cache
+  # in a TSV temp file instead of a Bash associative array so this script still
+  # runs under macOS Bash 3.2 in local lint.
+  local _tsz_source_sha_cache_tsv
+  _tsz_source_sha_cache_tsv="$(mktemp "${TMPDIR:-/tmp}/tsz-source-sha-cache.XXXXXX")"
+  : > "$_tsz_source_sha_cache_tsv"
   if [[ -f "$manifest_json" ]] && command -v node >/dev/null 2>&1; then
     local _cache_raw _cache_ref
     # Single Node.js invocation: first line = source.ref, rest = stem<TAB>sha pairs.
@@ -560,9 +563,7 @@ NODE
     )"
     IFS= read -r _cache_ref <<< "$_cache_raw"
     if [[ "$_cache_ref" == "$TYPE_CHALLENGES_SOLUTIONS_REF" ]]; then
-      while IFS=$'\t' read -r _stem _sha; do
-        [[ -n "$_stem" ]] && _tsz_source_sha_cache["$_stem"]="$_sha"
-      done <<< "${_cache_raw#*$'\n'}"
+      printf '%s\n' "${_cache_raw#*$'\n'}" > "$_tsz_source_sha_cache_tsv"
     fi
   fi
 
@@ -578,7 +579,12 @@ NODE
     source_sha256="$(perl -MDigest::SHA=sha256_hex -0777 -ne 'print sha256_hex($_)' "$markdown")"
 
     # Skip extraction when output is current: source SHA unchanged and file exists.
-    if [[ -f "$output" ]] && [[ "${_tsz_source_sha_cache["$base"]:-}" == "$source_sha256" ]]; then
+    local cached_source_sha256
+    cached_source_sha256="$(
+      awk -F '\t' -v stem="$base" '$1 == stem { print $2; exit }' \
+        "$_tsz_source_sha_cache_tsv"
+    )"
+    if [[ -f "$output" ]] && [[ "$cached_source_sha256" == "$source_sha256" ]]; then
       generated=$((generated + 1))
       printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
         "solutions/${base}.ts" \
@@ -647,18 +653,15 @@ NODE
   done < <(find "$source_dir/en" -maxdepth 1 -name '*.md' ! -name 'index.md' | sort)
 
   # Remove stale solution files from sources that no longer exist.
-  # Build an in-memory set from the TSV so we avoid one grep per .ts file.
-  declare -A _tsz_current_outputs=()
-  local _tsv_output
-  while IFS=$'\t' read -r _tsv_output _rest; do
-    [[ -n "$_tsv_output" && "$_tsv_output" != "output" ]] && \
-      _tsz_current_outputs["$_tsv_output"]=1
-  done < "$manifest_tsv"
+  local _tsz_current_outputs_tsv
+  _tsz_current_outputs_tsv="$(mktemp "${TMPDIR:-/tmp}/tsz-current-outputs.XXXXXX")"
+  awk -F '\t' 'NR > 1 && $1 != "" { print $1 }' "$manifest_tsv" > "$_tsz_current_outputs_tsv"
   local _ts_file
   while IFS= read -r _ts_file; do
     local _ts_rel="solutions/$(basename "$_ts_file")"
-    [[ -z "${_tsz_current_outputs["$_ts_rel"]:-}" ]] && rm -f "$_ts_file"
+    grep -Fxq "$_ts_rel" "$_tsz_current_outputs_tsv" || rm -f "$_ts_file"
   done < <(find "$compile_dir/solutions" -maxdepth 1 -name '*.ts' 2>/dev/null)
+  rm -f "$_tsz_source_sha_cache_tsv" "$_tsz_current_outputs_tsv"
 
   if [[ "$generated" -eq 0 ]]; then
     echo "error: no Type Challenges solution sources were generated from $source_dir/en" >&2


### PR DESCRIPTION
AgentName: M4-A

## Track
Project corpus compatibility / TS2344 constraint parity

## Invariant
When an imported generic alias application resolves to a finite indexed object map and every reachable map value is provably the constraint, including conditional true branches narrowed by `X extends Constraint`, `tsc` accepts the alias result at the generic constraint boundary. tsz should prove that through the TS2344 constraint helper instead of reporting an evaluated `undefined` artifact.

## Scope
- Extends the generic constraint helper to inspect type-alias applications whose instantiated body is an indexed finite object map.
- Reuses existing assignability/evaluation checks for direct map values, evaluated map values, and conditional branch proofs such as `Cast<X, Iteration>`.
- Adds a CLI compatibility regression for the imported recursive `IterationMap` pattern behind ts-toolbelt `Number/Greater.ts`.
- Fixes a CI lint blocker in the Type Challenges fixture generator by replacing Bash 4 associative arrays with TSV temp-file lookups so the harness works under macOS Bash 3.2 and CI lint.

## Project Corpus Impact
- Row: ts-toolbelt-project
- Bug family: imported recursive indexed object-map false TS2344 in `Number/Greater.ts`
- Evidence: final-head `tsc` and `.target/dist-fast/tsz` both exit 0 on `.target/project-compile-guard/ts-toolbelt/sources/Number/Greater.ts`; filtered ts-toolbelt project guard no longer lists `Number/Greater.ts` and now reports only `Function/Curry.ts`, `List/HasPath.ts`, and `Object/Invert.ts`.

## Verification
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `node scripts/ci/test-project-compile-guard-readiness-artifacts.mjs`
- `cargo nextest run -p tsz-cli --test tsc_compat_tests imported_recursive_iteration_map_satisfies_iteration_constraint`
- `cargo nextest run -p tsz-cli --test tsc_compat_tests imported_conditional_select_object_map_satisfies_string_constraint`
- `cargo nextest run -p tsz-checker --test ts2344_generic_ref_scoped_param_concrete_constraint`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh scripts/ci/github-suite.sh lint`
- `scripts/safe-run.sh cargo build -p tsz-cli --bin tsz --profile dist-fast`
- `node TypeScript/lib/tsc.js --noEmit --strict --target es2022 .target/project-compile-guard/ts-toolbelt/sources/Number/Greater.ts ; echo tsc_exit=$?` -> `tsc_exit=0`
- `.target/dist-fast/tsz --noEmit --strict --target es2022 .target/project-compile-guard/ts-toolbelt/sources/Number/Greater.ts ; echo tsz_exit=$?` -> `tsz_exit=0`
- `TSZ_PROJECT_COMPILE_FILTER="ts-toolbelt-project" TSZ_PROJECT_COMPILE_SET=all TSZ_PROJECT_COMPILE_ALLOW_FAILURES=1 scripts/safe-run.sh scripts/ci/project-compile-guard.sh` -> allowed failure; remaining diagnostics are `Function/Curry.ts`, `List/HasPath.ts`, and `Object/Invert.ts` only.

## Coordination Notes
- AgentName: M4-A
- Based on current `origin/main` before push.
- M4-A had no open owned PRs when this branch was prepared.
- Earlier CI on the previous head failed `project-corpus-pr-body` because the body used non-validator heading syntax; the remote body now includes both `AgentName: M4-A` and `## Project Corpus Impact`.
- Earlier lint exposed the Bash 3.2 fixture-generator issue fixed in this head; local full lint now passes.
- This is not overlapping with M4-B relation/cache work or M4-C contextual/defaults work; it is a TS2344 constraint-boundary proof for imported recursive indexed object maps plus a CI harness unblocker required to merge the PR.
