### PR TITLE
fix(emit): lower nested async function expressions in ES5

### DIFF
--- a/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
@@ -1134,8 +1134,8 @@ impl<'a> Printer<'a> {
         } else if type_name_node.kind == tsz_scanner::SyntaxKind::Identifier as u16 {
             let name = emit_utils::identifier_text_or_empty(self.arena, type_ref.type_name);
             if name.as_bytes().first().is_some_and(u8::is_ascii_uppercase)
-                && name != "Promise"
-                && name != "PromiseLike"
+                && !matches!(name.as_str(), "Promise" | "PromiseLike")
+                && !self.is_namespace_import_binding_name(&name)
                 && !self.is_type_only_declaration_name(&name)
             {
                 self.commonjs_named_import_substitutions

--- a/crates/tsz-emitter/src/emitter/es5/helpers_async_promise.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_async_promise.rs
@@ -1,0 +1,38 @@
+//! Async Promise-constructor helpers.
+//!
+//! Kept separate from `helpers_async.rs` so the main async emitter stays under
+//! the file-size ceiling.
+
+use super::super::*;
+use crate::transforms::emit_utils;
+
+impl<'a> Printer<'a> {
+    pub(in crate::emitter) fn is_namespace_import_binding_name(&self, name: &str) -> bool {
+        self.arena.nodes.iter().any(|node| {
+            if node.kind != syntax_kind_ext::IMPORT_DECLARATION {
+                return false;
+            }
+            let Some(import_decl) = self.arena.get_import_decl(node) else {
+                return false;
+            };
+            let Some(clause_node) = self.arena.get(import_decl.import_clause) else {
+                return false;
+            };
+            let Some(clause) = self.arena.get_import_clause(clause_node) else {
+                return false;
+            };
+            let Some(named_bindings_node) = self.arena.get(clause.named_bindings) else {
+                return false;
+            };
+            if named_bindings_node.kind != syntax_kind_ext::NAMESPACE_IMPORT {
+                return false;
+            }
+            self.arena
+                .get_named_imports(named_bindings_node)
+                .and_then(|namespace_import| {
+                    emit_utils::identifier_text(self.arena, namespace_import.name)
+                })
+                .is_some_and(|binding| binding == name)
+        })
+    }
+}

--- a/crates/tsz-emitter/src/emitter/es5/mod.rs
+++ b/crates/tsz-emitter/src/emitter/es5/mod.rs
@@ -15,6 +15,7 @@ mod for_of_destructure_prealloc;
 mod helpers;
 mod helpers_async;
 mod helpers_async_generator;
+mod helpers_async_promise;
 mod helpers_async_shadowing;
 mod helpers_class_expression_comments;
 mod helpers_class_expression_names;

--- a/crates/tsz-emitter/src/transforms/async_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir.rs
@@ -54,7 +54,7 @@ use std::cell::{Cell, RefCell};
 use crate::transforms::class_es5_ir::ES5ClassTransformer;
 use crate::transforms::helpers::HelpersNeeded;
 use crate::transforms::ir::{IRCatchClause, IRGeneratorCase, IRNode, IRParam};
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use tsz_common::common::ModuleKind;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeArena;
@@ -65,6 +65,8 @@ use tsz_parser::parser::syntax_kind_ext;
 mod bindings;
 #[path = "async_es5_ir_calls.rs"]
 mod calls;
+#[path = "async_es5_ir_cases.rs"]
+mod cases;
 #[path = "async_es5_ir_condition_await.rs"]
 mod condition_await;
 #[path = "async_es5_ir_discovery.rs"]
@@ -170,6 +172,10 @@ pub struct AsyncES5Transformer<'a> {
     /// the first `catch (e)` in the file becomes `e_1`, the second becomes
     /// `e_2`, and so on, regardless of function boundaries.
     pub(super) catch_binding_ordinals: RefCell<rustc_hash::FxHashMap<String, u32>>,
+    /// Catch-binding temps reserved for the async function body currently being
+    /// lowered. Reserving them before body conversion lets nested async function
+    /// expressions continue after the outer body's catch names.
+    pub(super) planned_catch_binding_temps: RefCell<FxHashMap<u32, String>>,
 }
 
 impl<'a> AsyncES5Transformer<'a> {
@@ -201,6 +207,7 @@ impl<'a> AsyncES5Transformer<'a> {
             labeled_break_targets: Vec::new(),
             catch_binding_renames: Vec::new(),
             catch_binding_ordinals: RefCell::new(rustc_hash::FxHashMap::default()),
+            planned_catch_binding_temps: RefCell::new(FxHashMap::default()),
         }
     }
 
@@ -410,6 +417,24 @@ impl<'a> AsyncES5Transformer<'a> {
         }
     }
 
+    pub fn transform_async_function_expression(&mut self, func_idx: NodeIndex) -> IRNode {
+        match self.transform_async_function(func_idx) {
+            IRNode::FunctionDecl {
+                name,
+                parameters,
+                body,
+                ..
+            } => IRNode::FunctionExpr {
+                name: Some(name),
+                parameters,
+                body,
+                is_expression_body: false,
+                body_source_range: None,
+            },
+            node => node,
+        }
+    }
+
     pub fn transform_async_generator_inner_function(
         &mut self,
         name: Option<String>,
@@ -579,73 +604,6 @@ impl<'a> AsyncES5Transformer<'a> {
         self.state.in_async_body = false;
 
         IRNode::GeneratorBody { has_await, cases }
-    }
-
-    /// Build generator cases for the state machine
-    fn build_generator_cases(
-        &mut self,
-        body_idx: NodeIndex,
-        _has_await: bool,
-        skipped_statements: &[NodeIndex],
-    ) -> Vec<IRGeneratorCase> {
-        self.reset_temp_name_reservations(body_idx);
-        let mut cases = Vec::new();
-        let mut current_statements = Vec::new();
-        let mut current_label = self.state.next_label();
-
-        // Process the function body
-        self.process_async_body(
-            body_idx,
-            &mut cases,
-            &mut current_statements,
-            &mut current_label,
-            skipped_statements,
-        );
-
-        // Add final case if there are remaining statements
-        if !current_statements.is_empty() {
-            // Only add implicit return if the last statement isn't already a return
-            let needs_implicit_return =
-                !matches!(current_statements.last(), Some(IRNode::ReturnStatement(_)));
-            if needs_implicit_return {
-                current_statements.push(IRNode::ReturnStatement(Some(Box::new(
-                    IRNode::GeneratorOp {
-                        opcode: opcodes::RETURN,
-                        value: None,
-                        comment: Some("return".to_string().into()),
-                    },
-                ))));
-            }
-            cases.push(IRGeneratorCase {
-                label: current_label,
-                statements: current_statements,
-            });
-        } else if !cases.is_empty() {
-            cases.push(IRGeneratorCase {
-                label: current_label,
-                statements: vec![IRNode::ReturnStatement(Some(Box::new(
-                    IRNode::GeneratorOp {
-                        opcode: opcodes::RETURN,
-                        value: None,
-                        comment: Some("return".to_string().into()),
-                    },
-                )))],
-            });
-        } else if cases.is_empty() {
-            // Empty async body - still need a return case
-            cases.push(IRGeneratorCase {
-                label: 0,
-                statements: vec![IRNode::ReturnStatement(Some(Box::new(
-                    IRNode::GeneratorOp {
-                        opcode: opcodes::RETURN,
-                        value: None,
-                        comment: Some("return".to_string().into()),
-                    },
-                )))],
-            });
-        }
-
-        cases
     }
 
     fn process_async_body(
@@ -2364,6 +2322,21 @@ impl<'a> AsyncES5Transformer<'a> {
 
             k if k == syntax_kind_ext::EXPRESSION_STATEMENT => {
                 if let Some(expr_stmt) = self.arena.get_expression_statement(node) {
+                    if self.is_suspension_expression(expr_stmt.expression) {
+                        let trailing_comment = self.extract_trailing_line_comment_in_node(idx);
+                        self.process_await_expression(
+                            expr_stmt.expression,
+                            cases,
+                            current_statements,
+                            current_label,
+                        );
+                        current_statements
+                            .push(IRNode::ExpressionStatement(Box::new(IRNode::GeneratorSent)));
+                        if let Some(comment) = trailing_comment {
+                            current_statements.push(IRNode::TrailingComment(comment.into()));
+                        }
+                        return;
+                    }
                     self.process_expression_in_async(
                         expr_stmt.expression,
                         cases,
@@ -4822,8 +4795,20 @@ impl<'a> AsyncES5Transformer<'a> {
                     let catch_var_name =
                         self.get_catch_variable_name(catch_data.variable_declaration);
                     if !catch_var_name.is_empty() {
-                        let catch_temp =
-                            self.fresh_catch_binding_temp(&catch_var_name, try_data.catch_clause);
+                        let catch_temp = self
+                            .planned_catch_binding_temps
+                            .borrow()
+                            .get(&try_data.catch_clause.0)
+                            .cloned()
+                            .unwrap_or_else(|| {
+                                self.fresh_catch_binding_temp(
+                                    &catch_var_name,
+                                    try_data.catch_clause,
+                                )
+                            });
+                        self.blocked_temp_names
+                            .borrow_mut()
+                            .insert(catch_temp.clone());
                         current_statements.push(IRNode::VarDecl {
                             name: catch_temp.clone().into(),
                             initializer: None,

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_cases.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_cases.rs
@@ -1,0 +1,108 @@
+use crate::transforms::async_es5_ir::{AsyncES5Transformer, opcodes};
+use crate::transforms::ir::{IRGeneratorCase, IRNode};
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::NodeAccess;
+use tsz_parser::parser::syntax_kind_ext;
+
+impl AsyncES5Transformer<'_> {
+    /// Build generator cases for the state machine.
+    pub(super) fn build_generator_cases(
+        &mut self,
+        body_idx: NodeIndex,
+        _has_await: bool,
+        skipped_statements: &[NodeIndex],
+    ) -> Vec<IRGeneratorCase> {
+        let previous_planned_catches =
+            std::mem::take(&mut *self.planned_catch_binding_temps.borrow_mut());
+        self.reset_temp_name_reservations(body_idx);
+        self.plan_catch_binding_temps(body_idx);
+        let mut cases = Vec::new();
+        let mut current_statements = Vec::new();
+        let mut current_label = self.state.next_label();
+
+        self.process_async_body(
+            body_idx,
+            &mut cases,
+            &mut current_statements,
+            &mut current_label,
+            skipped_statements,
+        );
+
+        if !current_statements.is_empty() {
+            let needs_implicit_return =
+                !matches!(current_statements.last(), Some(IRNode::ReturnStatement(_)));
+            if needs_implicit_return {
+                current_statements.push(Self::async_return_none());
+            }
+            cases.push(IRGeneratorCase {
+                label: current_label,
+                statements: current_statements,
+            });
+        } else if !cases.is_empty() {
+            cases.push(IRGeneratorCase {
+                label: current_label,
+                statements: vec![Self::async_return_none()],
+            });
+        } else {
+            cases.push(IRGeneratorCase {
+                label: 0,
+                statements: vec![Self::async_return_none()],
+            });
+        }
+
+        *self.planned_catch_binding_temps.borrow_mut() = previous_planned_catches;
+        cases
+    }
+
+    fn async_return_none() -> IRNode {
+        IRNode::ReturnStatement(Some(Box::new(IRNode::GeneratorOp {
+            opcode: opcodes::RETURN,
+            value: None,
+            comment: Some("return".to_string().into()),
+        })))
+    }
+
+    fn plan_catch_binding_temps(&self, idx: NodeIndex) {
+        let Some(node) = self.arena.get(idx) else {
+            return;
+        };
+
+        if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
+            || node.is_function_expression_or_arrow()
+        {
+            return;
+        }
+
+        if node.kind == syntax_kind_ext::CLASS_DECLARATION
+            || node.kind == syntax_kind_ext::CLASS_EXPRESSION
+        {
+            return;
+        }
+
+        if node.kind == syntax_kind_ext::TRY_STATEMENT
+            && let Some(try_data) = self.arena.get_try(node)
+        {
+            let try_has_await = self.contains_await_recursive(try_data.try_block);
+            let catch_has_await = self.contains_await_recursive(try_data.catch_clause);
+            let finally_has_await = self.contains_await_recursive(try_data.finally_block);
+            if (try_has_await || catch_has_await || finally_has_await)
+                && let Some(catch_node) = self.arena.get(try_data.catch_clause)
+                && let Some(catch_data) = self.arena.get_catch_clause(catch_node)
+                && catch_data.variable_declaration.is_some()
+            {
+                let catch_var_name = self.get_catch_variable_name(catch_data.variable_declaration);
+                if !catch_var_name.is_empty() {
+                    let catch_temp =
+                        self.fresh_catch_binding_temp(&catch_var_name, try_data.catch_clause);
+                    self.planned_catch_binding_temps
+                        .borrow_mut()
+                        .insert(try_data.catch_clause.0, catch_temp);
+                }
+            }
+        }
+
+        for child in self.arena.get_children(idx) {
+            self.plan_catch_binding_temps(child);
+        }
+    }
+}

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_convert.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_convert.rs
@@ -620,6 +620,25 @@ impl<'a> AsyncES5Transformer<'a> {
         };
 
         if func.is_async
+            && !crate::transforms::emit_utils::source_header_has_async_generator_asterisk(
+                self.source_text,
+                node.pos,
+                self.arena.get(func.body).map_or(node.end, |body| body.pos),
+            )
+        {
+            let mut transformer = AsyncES5Transformer::new(self.arena);
+            if let Some(text) = self.source_text {
+                transformer.set_source_text(text);
+            }
+            transformer.downlevel_iteration = self.downlevel_iteration;
+            transformer.module_kind = self.module_kind;
+            transformer.set_catch_binding_ordinals(self.catch_binding_ordinals.borrow().clone());
+            let ir = transformer.transform_async_function_expression(idx);
+            self.set_catch_binding_ordinals(transformer.take_catch_binding_ordinals());
+            return ir;
+        }
+
+        if func.is_async
             && crate::transforms::emit_utils::source_header_has_async_generator_asterisk(
                 self.source_text,
                 node.pos,

--- a/crates/tsz-emitter/tests/async_es5_ir_parts/part_01.rs
+++ b/crates/tsz-emitter/tests/async_es5_ir_parts/part_01.rs
@@ -519,3 +519,34 @@ fn generator_switch_with_yield_lowers_like_async() {
         "Generator-mode dispatch must compare the resumed value identically to async mode.\nOutput:\n{output}"
     );
 }
+
+#[test]
+fn nested_async_function_expression_lowers_own_awaiter_body() {
+    let output = transform_and_print(
+        "async function f() { try { var b = async function b() { try { await g(); // keep\n} catch (error) {} }; await b(); // done\n} catch (error) {} }",
+    );
+
+    assert!(
+        output.contains("b = function b()"),
+        "A nested async function expression should stay an expression with its original name.\nOutput:\n{output}"
+    );
+    assert!(
+        output
+            .matches("return __awaiter(this, void 0, void 0, function ()")
+            .count()
+            >= 2,
+        "The outer and nested async functions should each lower to their own awaiter wrapper.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("await g()"),
+        "The nested async function body must not leak raw await into ES5 output.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("var b, error_1;") && output.contains("var error_2;"),
+        "Outer catch temps should be reserved before nested async function expression temps.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a.sent(); // keep") && output.contains("_a.sent(); // done"),
+        "Trailing comments after direct await expression statements should stay on the resumed sent expression.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/tests/es5_transforms_e2e_parts/part_01.rs
+++ b/crates/tsz-emitter/tests/es5_transforms_e2e_parts/part_01.rs
@@ -23,6 +23,24 @@ fn async_arrow_import_meta_hoisted_locals_share_var_statement() {
 }
 
 #[test]
+fn async_namespace_import_return_type_does_not_become_promise_constructor() {
+    let output = emit_es5_with_module(
+        "import * as Bluebird from \"bluebird\";\n\
+         async function a(): Bluebird<void> { await Bluebird.resolve(); }\n",
+        ModuleKind::CommonJS,
+    );
+
+    assert!(
+        output.contains("return __awaiter(this, void 0, void 0, function ()"),
+        "A namespace import object should not be passed as the awaiter Promise constructor.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("return __awaiter(this, void 0, Bluebird, function ()"),
+        "Namespace imports are module objects, not Promise constructors for `__awaiter`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn system_import_meta_file_is_wrapped_as_module() {
     let output = emit_es5_with_module(
         "(async () => {\n\


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Emit/DTS parity: JavaScript emit, ES5 async transform family.

## Invariant
When an async ES5 body contains a nested async function expression, `tsc` lowers the nested function expression as its own `__awaiter`/`__generator` boundary while the outer body keeps its own suspension discovery; this PR lowers that nested expression through the async ES5 IR owner without checker/solver semantics or output surgery.

## Scope
- Lower async function expressions in `async_es5_ir_convert` using a nested async IR transformer.
- Reserve outer async catch-binding temps before nested async expression lowering so catch suffixes match `tsc`.
- Preserve trailing comments after direct `await` expression statements on the resumed `_a.sent()` statement.
- Keep namespace import objects out of `__awaiter` Promise constructor inference.
- Split new case planning and Promise-constructor helpers into small modules to satisfy file-size ratchets.

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit ES5 async nested function expression lowering
- Evidence: focused TypeScript emit baseline `transformNestedGeneratorsWithTry(target=es5)` now passes locally.

## Verification
- `CARGO_TARGET_DIR=/tmp/tsz-studio-c-async-check-target cargo check -p tsz-emitter`
- `CARGO_TARGET_DIR=/tmp/tsz-studio-c-async-check-target cargo nextest run -p tsz-emitter -E 'test(nested_async_function_expression_lowers_own_awaiter_body) | test(async_namespace_import_return_type_does_not_become_promise_constructor)'`
- `scripts/emit/run.sh --filter=transformNestedGeneratorsWithTry --js-only --verbose --timeout=30000 --json-out=/tmp/transformNestedGeneratorsWithTry-studio-c-async-nested-final-head.json`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check origin/main...HEAD`

## Coordination Notes
- Addresses the `transformNestedGeneratorsWithTry(target=es5)` part of #11894.
- Does not attempt the separate `operationsAvailableOnPromisedType` ES5 spread/temp-name gaps from #11894.
- PR #11901 was a separate Studio-C private-method ES5 slice and is now merged; this branch was started from `origin/main` in a separate worktree and does not depend on it.
