### PR TITLE
fix(checker): preserve Kysely callback context

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/class.rs
+++ b/crates/tsz-checker/src/query_boundaries/class.rs
@@ -421,6 +421,83 @@ pub(crate) fn interface_overload_trailing_signature_assignable(
         || (allow_fresh_generic_retry && checker.assign_relation_outcome(source, target).related)
 }
 
+fn call_signature_function_type(
+    checker: &mut CheckerState<'_>,
+    sig: &tsz_solver::CallSignature,
+) -> TypeId {
+    checker
+        .ctx
+        .types
+        .factory()
+        .function(tsz_solver::FunctionShape {
+            type_params: sig.type_params.clone(),
+            params: sig.params.clone(),
+            this_type: sig.this_type,
+            return_type: sig.return_type,
+            type_predicate: sig.type_predicate,
+            is_constructor: false,
+            is_method: sig.is_method,
+        })
+}
+
+/// True when a single class implementation-style method covers an overloaded
+/// interface method. This mirrors `tsc`'s overload implementation compatibility:
+/// each exposed overload must be compatible with the implementation signature,
+/// rather than requiring the implementation signature to be a subtype of the
+/// whole overload set.
+pub(crate) fn implementation_signature_covers_interface_overloads(
+    checker: &mut CheckerState<'_>,
+    source: TypeId,
+    target: TypeId,
+) -> bool {
+    let source = unwrap_single_property_value_type(checker, source);
+    let target = unwrap_single_property_value_type(checker, target);
+    let source_sigs = member_call_signatures(checker.ctx.types, source);
+    let target_sigs = member_call_signatures(checker.ctx.types, target);
+    if source_sigs.len() != 1 || target_sigs.is_empty() {
+        return false;
+    }
+
+    let source_type = call_signature_function_type(checker, &source_sigs[0]);
+    if target_sigs.len() == 1 {
+        let target_type = call_signature_function_type(checker, &target_sigs[0]);
+        return overload_return_base_matches_and_params_cover(checker, source_type, target_type);
+    }
+
+    target_sigs.iter().all(|target_sig| {
+        let target_type = call_signature_function_type(checker, target_sig);
+        checker.is_implementation_compatible_with_overload(source_type, target_type)
+            || checker
+                .assign_relation_outcome(target_type, source_type)
+                .related
+            || overload_return_base_matches_and_params_cover(checker, source_type, target_type)
+    })
+}
+
+fn overload_return_base_matches_and_params_cover(
+    checker: &mut CheckerState<'_>,
+    source_type: TypeId,
+    target_type: TypeId,
+) -> bool {
+    let policy = tsz_solver::relations::relation_queries::RelationPolicy::from_flags(
+        checker.ctx.pack_relation_flags(),
+    );
+    let context = tsz_solver::relations::relation_queries::RelationContext {
+        query_db: Some(checker.ctx.types),
+        inheritance_graph: Some(&checker.ctx.inheritance_graph),
+        class_check: None,
+    };
+    tsz_solver::relations::relation_queries::query_erased_overload_params_with_matching_return_base(
+        checker.ctx.types.as_type_database(),
+        &checker.ctx,
+        source_type,
+        target_type,
+        policy,
+        context,
+    )
+    .is_related()
+}
+
 /// Check if a DIRECT (own) member type mismatch should be reported (TS2416).
 ///
 /// Unlike `should_report_member_type_mismatch`, this variant uses a targeted
@@ -443,6 +520,9 @@ pub(crate) fn should_report_own_member_type_mismatch(
         return false;
     }
     if checker.should_suppress_assignability_for_parse_recovery(node_idx, node_idx) {
+        return false;
+    }
+    if implementation_signature_covers_interface_overloads(checker, source, target) {
         return false;
     }
     if checker.is_assignable_to_no_erase_generics(source, target) {
@@ -635,6 +715,9 @@ pub(crate) fn should_report_member_type_mismatch_bivariant(
     target: TypeId,
     node_idx: NodeIndex,
 ) -> bool {
+    if implementation_signature_covers_interface_overloads(checker, source, target) {
+        return false;
+    }
     checker.should_report_assignability_mismatch_bivariant(source, target, node_idx)
 }
 

--- a/crates/tsz-checker/src/query_boundaries/class.rs
+++ b/crates/tsz-checker/src/query_boundaries/class.rs
@@ -466,11 +466,11 @@ pub(crate) fn implementation_signature_covers_interface_overloads(
 
     target_sigs.iter().all(|target_sig| {
         let target_type = call_signature_function_type(checker, target_sig);
-        checker.is_implementation_compatible_with_overload(source_type, target_type)
-            || checker
-                .assign_relation_outcome(target_type, source_type)
-                .related
-            || overload_return_base_matches_and_params_cover(checker, source_type, target_type)
+        // Do not reuse the broad overload-implementation relation here: Array's
+        // callback overload surface needs a real TS2416 when the implementation
+        // narrows callback returns. This helper is only for builder-style returns
+        // that share an application base after erasing local type params.
+        overload_return_base_matches_and_params_cover(checker, source_type, target_type)
     })
 }
 
@@ -715,9 +715,6 @@ pub(crate) fn should_report_member_type_mismatch_bivariant(
     target: TypeId,
     node_idx: NodeIndex,
 ) -> bool {
-    if implementation_signature_covers_interface_overloads(checker, source, target) {
-        return false;
-    }
     checker.should_report_assignability_mismatch_bivariant(source, target, node_idx)
 }
 

--- a/crates/tsz-checker/tests/class_implements_overloaded_method_ts2416_tests.rs
+++ b/crates/tsz-checker/tests/class_implements_overloaded_method_ts2416_tests.rs
@@ -135,6 +135,30 @@ class Impl implements Base {
     );
 }
 
+/// Negative: the erased-return fallback is only valid when the top-level
+/// generic application family matches. Sharing a nested generic application is
+/// not enough to ignore incompatible outer return families.
+#[test]
+fn overloaded_interface_method_nested_shared_return_application_still_ts2416() {
+    let source = r#"
+interface Box<T> { value: T; }
+interface SourceWrap<T> { source: T; }
+interface TargetWrap<T> { target: T; }
+interface Base {
+  make(x: "target"): TargetWrap<Box<string>>;
+}
+class Impl implements Base {
+  make(x: string): SourceWrap<Box<number>> {
+    return undefined as any;
+  }
+}
+"#;
+    assert!(
+        ts2416_count(source) >= 1,
+        "A nested shared return application base must not erase incompatible outer returns"
+    );
+}
+
 /// Negative for overloads specifically: with multiple overloads, tsc compares
 /// parameters *contravariantly* (not bivariantly), so an impl whose parameter
 /// is narrower than an overload's parameter is rejected.

--- a/crates/tsz-checker/tests/generic_call_inference_tests_parts/part_02.rs
+++ b/crates/tsz-checker/tests/generic_call_inference_tests_parts/part_02.rs
@@ -1277,3 +1277,390 @@ const bad: string = postUserId;
         "builder-chain contextual instantiation should not lose table keys or callback context. Got: {diags:#?}"
     );
 }
+
+#[test]
+fn contextual_kysely_select_array_preserves_aliased_expression_factory_param() {
+    // Kysely-style reduction from #10683/#10677: the overload returns a mapped
+    // selection over the inferred `SE`, but the arrow element inside the
+    // readonly selection array still needs the contextual
+    // `ExpressionBuilder<DB, TB>` parameter before `noImplicitAny`.
+    let source = r#"
+type SelectType<T> = T;
+type DrainOuterGeneric<T> = [T] extends [unknown] ? T : never;
+type Nullable<T> = { [K in keyof T]: T[K] | null };
+type ShallowRecord<K extends keyof any, T> = DrainOuterGeneric<{ [P in K]: T }>;
+
+type AnyColumn<DB, TB extends keyof DB> = {
+  [T in TB]: keyof DB[T]
+}[TB] & string;
+
+type ExtractColumnType<DB, TB extends keyof DB, C> = {
+  [T in TB]: C extends keyof DB[T] ? DB[T][C] : never
+}[TB];
+
+type AnyColumnWithTable<DB, TB extends keyof DB> = {
+  [T in TB]: `${T & string}.${keyof DB[T] & string}`
+}[TB];
+
+type AnyAliasedColumn<DB, TB extends keyof DB> =
+  `${AnyColumn<DB, TB>} as ${string}`;
+
+type AnyAliasedColumnWithTable<DB, TB extends keyof DB> =
+  `${AnyColumnWithTable<DB, TB>} as ${string}`;
+
+interface AliasedExpression<T, A extends string> {
+  expressionType?: T;
+  alias: A;
+}
+
+interface ExpressionWrapper<DB, TB extends keyof DB, T> {
+  $castTo<C>(): ExpressionWrapper<DB, TB, C>;
+  as<A extends string>(alias: A): AliasedExpression<T, A>;
+}
+
+interface ExpressionBuilder<DB, TB extends keyof DB> {
+  ref<RE extends StringReference<DB, TB>>(
+    reference: RE,
+  ): ExpressionWrapper<DB, TB, ExtractTypeFromReferenceExpression<DB, TB, RE>>;
+}
+
+type StringReference<DB, TB extends keyof DB> =
+  | AnyColumn<DB, TB>
+  | AnyColumnWithTable<DB, TB>;
+
+type ExtractTypeFromReferenceExpression<DB, TB extends keyof DB, RE> =
+  SelectType<ExtractTypeFromStringReference<DB, TB, RE>>;
+
+type ExtractTypeFromStringReference<DB, TB extends keyof DB, RE> =
+  RE extends `${infer T}.${infer C}`
+    ? T extends TB
+      ? C extends keyof DB[T]
+        ? DB[T][C]
+        : never
+      : never
+    : RE extends AnyColumn<DB, TB>
+      ? ExtractColumnType<DB, TB, RE>
+      : unknown;
+
+type AliasedExpressionFactory<DB, TB extends keyof DB> = (
+  eb: ExpressionBuilder<DB, TB>,
+) => AliasedExpression<any, any>;
+
+type AliasedExpressionOrFactory<DB, TB extends keyof DB> =
+  | AliasedExpression<any, any>
+  | AliasedExpressionFactory<DB, TB>;
+
+type DynamicReferenceBuilder<RA> = { dynamicReference: RA };
+
+type TableExpression<DB, TB extends keyof DB> =
+  | AnyAliasedTable<DB>
+  | AnyTable<DB>
+  | AliasedExpressionOrFactory<DB, TB>;
+
+type TableExpressionOrList<DB, TB extends keyof DB> =
+  | TableExpression<DB, TB>
+  | ReadonlyArray<TableExpression<DB, TB>>;
+
+type AnyAliasedTable<DB> = `${AnyTable<DB>} as ${string}`;
+type AnyTable<DB> = keyof DB & string;
+
+type ExtractTableAlias<DB, TE> = TE extends `${string} as ${infer TA}`
+  ? TA extends keyof DB
+    ? TA
+    : never
+  : TE extends keyof DB
+    ? TE
+    : never;
+
+type ExtractAliasFromTableExpression<DB, TE> = TE extends string
+  ? TE extends `${string} as ${infer TA}`
+    ? TA
+    : TE extends keyof DB
+      ? TE
+      : never
+  : TE extends AliasedExpression<any, infer QA>
+    ? QA
+    : TE extends (qb: any) => AliasedExpression<any, infer QA>
+      ? QA
+      : never;
+
+type ExtractRowTypeFromTableExpression<DB, TE, A extends keyof any> =
+  TE extends `${infer T} as ${infer TA}`
+    ? TA extends A
+      ? T extends keyof DB
+        ? DB[T]
+        : never
+      : never
+    : TE extends A
+      ? TE extends keyof DB
+        ? DB[TE]
+        : never
+      : TE extends AliasedExpression<infer O, infer QA>
+        ? QA extends A
+          ? O
+          : never
+        : TE extends (qb: any) => AliasedExpression<infer O, infer QA>
+          ? QA extends A
+            ? O
+            : never
+          : never;
+
+type From<DB, TE> = DrainOuterGeneric<{
+  [C in keyof DB | ExtractAliasFromTableExpression<DB, TE>]:
+    C extends ExtractAliasFromTableExpression<DB, TE>
+      ? ExtractRowTypeFromTableExpression<DB, TE, C>
+      : C extends keyof DB
+        ? DB[C]
+        : never
+}>;
+
+type FromTables<DB, TB extends keyof DB, TE> = DrainOuterGeneric<
+  TB | ExtractAliasFromTableExpression<DB, TE>
+>;
+
+type SelectFrom<
+  DB,
+  TB extends keyof DB,
+  TE extends TableExpressionOrList<DB, TB>,
+> = [TE] extends [keyof DB]
+  ? SelectQueryBuilder<DB, TB | ExtractTableAlias<DB, TE>, {}>
+  : [TE] extends [`${infer T} as ${infer A}`]
+    ? T extends keyof DB
+      ? SelectQueryBuilder<DB & ShallowRecord<A, DB[T]>, TB | A, {}>
+      : never
+    : TE extends ReadonlyArray<infer T>
+      ? SelectQueryBuilder<From<DB, T>, FromTables<DB, TB, T>, {}>
+      : SelectQueryBuilder<From<DB, TE>, FromTables<DB, TB, TE>, {}>;
+
+type SelectExpression<DB, TB extends keyof DB> =
+  | AnyAliasedColumnWithTable<DB, TB>
+  | AnyAliasedColumn<DB, TB>
+  | AnyColumnWithTable<DB, TB>
+  | AnyColumn<DB, TB>
+  | DynamicReferenceBuilder<any>
+  | AliasedExpressionOrFactory<DB, TB>;
+
+type SelectArg<DB, TB extends keyof DB, SE extends SelectExpression<DB, TB>> =
+  | SE
+  | ReadonlyArray<SE>
+  | ((eb: ExpressionBuilder<DB, TB>) => ReadonlyArray<SE>);
+
+type SelectCallback<DB, TB extends keyof DB> = (
+  eb: ExpressionBuilder<DB, TB>,
+) => ReadonlyArray<SelectExpression<DB, TB>>;
+
+type FlattenSelectExpression<SE> =
+  SE extends DynamicReferenceBuilder<infer RA>
+    ? { [R in RA]: DynamicReferenceBuilder<R> }[RA]
+    : SE;
+
+type ExtractAliasFromSelectExpression<SE> = SE extends string
+  ? ExtractAliasFromStringSelectExpression<SE>
+  : SE extends AliasedExpression<any, infer EA>
+    ? EA
+    : SE extends (qb: any) => AliasedExpression<any, infer EA>
+      ? EA
+      : SE extends DynamicReferenceBuilder<infer RA>
+        ? ExtractAliasFromStringSelectExpression<RA>
+        : never;
+
+type ExtractAliasFromStringSelectExpression<SE extends string> =
+  SE extends `${string}.${infer C} as ${infer A}`
+    ? A
+    : SE extends `${string}.${infer C}`
+      ? C
+      : SE;
+
+type ExtractTypeFromSelectExpression<DB, TB extends keyof DB, SE> =
+  SE extends string
+    ? ExtractTypeFromStringSelectExpression<DB, TB, SE>
+    : SE extends (eb: any) => AliasedExpression<infer O, any>
+      ? O
+      : SE extends AliasedExpression<infer O, any>
+        ? O
+        : never;
+
+type ExtractTypeFromStringSelectExpression<DB, TB extends keyof DB, SE> =
+  SE extends `${infer T}.${infer C} as ${string}`
+    ? T extends TB
+      ? C extends keyof DB[T]
+        ? DB[T][C]
+        : never
+      : never
+    : SE extends `${infer C} as ${string}`
+      ? C extends AnyColumn<DB, TB>
+        ? ExtractColumnType<DB, TB, C>
+        : never
+      : SE extends `${infer T}.${infer C}`
+        ? T extends TB
+          ? C extends keyof DB[T]
+            ? DB[T][C]
+            : never
+          : never
+        : SE extends AnyColumn<DB, TB>
+          ? ExtractColumnType<DB, TB, SE>
+          : never;
+
+type KyselySelection<DB, TB extends keyof DB, SE> = [DB] extends [unknown]
+  ? {
+      [E in FlattenSelectExpression<SE> as ExtractAliasFromSelectExpression<E>]:
+        SelectType<ExtractTypeFromSelectExpression<DB, TB, E>>
+    }
+  : {};
+
+type CallbackSelection<DB, TB extends keyof DB, CB> =
+  CB extends (eb: any) => ReadonlyArray<infer SE>
+    ? KyselySelection<DB, TB, SE>
+    : never;
+
+interface SelectQueryBuilder<DB, TB extends keyof DB, O> {
+  leftJoin<
+    TE extends TableExpression<DB, TB>,
+    K1 extends JoinReferenceExpression<DB, TB, TE>,
+    K2 extends JoinReferenceExpression<DB, TB, TE>,
+  >(
+    table: TE,
+    k1: K1,
+    k2: K2,
+  ): SelectQueryBuilderWithLeftJoin<DB, TB, O, TE>;
+
+  innerJoin<
+    TE extends TableExpression<DB, TB>,
+    K1 extends JoinReferenceExpression<DB, TB, TE>,
+    K2 extends JoinReferenceExpression<DB, TB, TE>,
+  >(
+    table: TE,
+    k1: K1,
+    k2: K2,
+  ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>;
+
+  where(lhs: string, op: string, rhs: unknown): SelectQueryBuilder<DB, TB, O>;
+
+  select<SE extends SelectExpression<DB, TB>>(
+    selections: ReadonlyArray<SE>,
+  ): SelectQueryBuilder<DB, TB, O & KyselySelection<DB, TB, SE>>;
+  select<CB extends SelectCallback<DB, TB>>(
+    callback: CB,
+  ): SelectQueryBuilder<DB, TB, O & CallbackSelection<DB, TB, CB>>;
+  select<SE extends SelectExpression<DB, TB>>(
+    selection: SE,
+  ): SelectQueryBuilder<DB, TB, O & KyselySelection<DB, TB, SE>>;
+}
+
+type JoinReferenceExpression<DB, TB extends keyof DB, TE> = DrainOuterGeneric<
+  AnyColumn<From<DB, TE>, FromTables<DB, TB, TE>>
+    | AnyColumnWithTable<From<DB, TE>, FromTables<DB, TB, TE>>
+>;
+
+type SelectQueryBuilderWithInnerJoin<
+  DB,
+  TB extends keyof DB,
+  O,
+  TE extends TableExpression<DB, TB>,
+> = TE extends `${infer T} as ${infer A}`
+  ? T extends keyof DB
+    ? InnerJoinedBuilder<DB, TB, O, A, DB[T]>
+    : never
+  : TE extends keyof DB
+    ? SelectQueryBuilder<DB, TB | TE, O>
+    : never;
+
+type InnerJoinedBuilder<DB, TB extends keyof DB, O, A extends string, R> =
+  A extends keyof DB
+    ? SelectQueryBuilder<InnerJoinedDB<DB, A, R>, TB | A, O>
+    : SelectQueryBuilder<DB & ShallowRecord<A, R>, TB | A, O>;
+
+type InnerJoinedDB<DB, A extends string, R> = DrainOuterGeneric<{
+  [C in keyof DB | A]: C extends A ? R : C extends keyof DB ? DB[C] : never
+}>;
+
+type SelectQueryBuilderWithLeftJoin<
+  DB,
+  TB extends keyof DB,
+  O,
+  TE extends TableExpression<DB, TB>,
+> = TE extends `${infer T} as ${infer A}`
+  ? T extends keyof DB
+    ? LeftJoinedBuilder<DB, TB, O, A, DB[T]>
+    : never
+  : TE extends keyof DB
+    ? LeftJoinedBuilder<DB, TB, O, TE, DB[TE]>
+    : never;
+
+type LeftJoinedBuilder<DB, TB extends keyof DB, O, A extends keyof any, R> =
+  A extends keyof DB
+    ? SelectQueryBuilder<LeftJoinedDB<DB, A, R>, TB | A, O>
+    : SelectQueryBuilder<DB & ShallowRecord<A, Nullable<R>>, TB | A, O>;
+
+type LeftJoinedDB<DB, A extends keyof any, R> = DrainOuterGeneric<{
+  [C in keyof DB | A]: C extends A
+    ? Nullable<R>
+    : C extends keyof DB
+      ? DB[C]
+      : never
+}>;
+
+class SelectQueryBuilderImpl<DB, TB extends keyof DB, O>
+  implements SelectQueryBuilder<DB, TB, O>
+{
+  leftJoin(...args: any): any {
+    return new SelectQueryBuilderImpl();
+  }
+
+  innerJoin(...args: any): any {
+    return new SelectQueryBuilderImpl();
+  }
+
+  where(...args: any): any {
+    return new SelectQueryBuilderImpl();
+  }
+
+  select<SE extends SelectExpression<DB, TB>>(
+    selection: SelectArg<DB, TB, SE>,
+  ): SelectQueryBuilder<DB, TB, O & KyselySelection<DB, TB, SE>> {
+    return new SelectQueryBuilderImpl<DB, TB, O & KyselySelection<DB, TB, SE>>();
+  }
+}
+
+class QueryCreator<DB> {
+  selectFrom<TE extends TableExpressionOrList<DB, never>>(
+    from: TE,
+  ): SelectFrom<DB, never, TE> {
+    return new SelectQueryBuilderImpl() as SelectFrom<DB, never, TE>;
+  }
+}
+
+class Kysely<DB> extends QueryCreator<DB> {}
+
+type MssqlSysTables = {
+  "sys.tables": { name: string; object_id: number; schema_id: number; type: "U" };
+  "sys.views": { name: string; type: "V" };
+  "sys.schemas": { name: string; schema_id: number };
+  "sys.columns": { name: string; object_id: number; user_type_id: number };
+  "sys.types": { name: string; user_type_id: number };
+};
+
+const db = new Kysely<MssqlSysTables>();
+
+db.selectFrom("sys.tables as tables")
+  .leftJoin("sys.schemas as table_schemas", "table_schemas.schema_id", "tables.schema_id")
+  .innerJoin("sys.columns as columns", "columns.object_id", "tables.object_id")
+  .innerJoin("sys.types as types", "types.user_type_id", "columns.user_type_id")
+  .select([
+    "tables.name as table_name",
+    (eb) =>
+      eb
+        .ref("tables.type")
+        .$castTo<MssqlSysTables["sys.tables"]["type"] | MssqlSysTables["sys.views"]["type"]>()
+        .as("table_type"),
+    "table_schemas.name as table_schema_name",
+    "columns.name as column_name",
+    "types.name as type_name",
+  ]);
+"#;
+    let diags = relevant_strict_default_lib_diagnostics(source);
+    assert!(
+        lacks_any_diagnostic_code(&diags, &[7006, 2347, 2322, 2394, 2416]),
+        "Kysely-style selection callback should keep its builder context. Got: {diags:#?}"
+    );
+}

--- a/crates/tsz-checker/tests/overload_modifier_tests.rs
+++ b/crates/tsz-checker/tests/overload_modifier_tests.rs
@@ -513,3 +513,26 @@ class Store<X, Y> {
 "#;
     assert!(!has_error(source, 2394));
 }
+
+#[test]
+fn overload_assignment_missing_literal_overload_still_ts2322() {
+    let source = r#"
+function f(x: "foo"): number;
+function f(x: string): number;
+function f(x: string): number {
+    return 0;
+}
+
+function g(x: "foo"): number;
+function g(x: string): number {
+    return 0;
+}
+
+let a = f;
+let b = g;
+
+a = b;
+b = a;
+"#;
+    assert!(has_error(source, 2322));
+}

--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -502,6 +502,28 @@ pub fn query_relation_with_overrides<
     }
 }
 
+/// Query the overload implementation fallback that compares erased parameter
+/// lists only when return types share a generic application base.
+pub fn query_erased_overload_params_with_matching_return_base<'a, R: TypeResolver>(
+    interner: &'a dyn TypeDatabase,
+    resolver: &'a R,
+    source: TypeId,
+    target: TypeId,
+    policy: RelationPolicy,
+    context: RelationContext<'a>,
+) -> RelationResult {
+    let mut checker = configured_subtype_checker(interner, resolver, policy, context);
+    let related = checker
+        .check_erased_function_type_params_with_matching_return_base(source, target)
+        .is_true();
+    RelationResult {
+        kind: RelationKind::Subtype,
+        related,
+        depth_exceeded: checker.depth_exceeded(),
+        iteration_exceeded: checker.iteration_exceeded(),
+    }
+}
+
 /// Bundled inputs for relation queries.
 pub struct RelationQueryInputs<'a, R: TypeResolver, P: AssignabilityOverrideProvider + ?Sized> {
     pub interner: &'a dyn TypeDatabase,

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -13,8 +13,9 @@ use crate::types::{
 use crate::visitor::callable_shape_id;
 
 use super::super::super::{SubtypeChecker, SubtypeResult, TypeResolver};
-use super::{erase_call_sig_to_any, erase_fn_shape_to_any, erase_type_params_to_constraints};
+use super::erase_type_params_to_constraints;
 
+mod overloads;
 mod params;
 
 type HoistedTypeParams = (Vec<TypeParamInfo>, Vec<(TypeId, TypeId)>);
@@ -1484,7 +1485,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // erasing type params to `any` before rejecting. This matches tsc's
                 // `signaturesRelatedTo` which uses `erase = true` for the N×M case.
                 if has_multiple_target_sigs {
-                    if !self.check_erased_fn_subtype_to_sig(&s_fn, t_sig).is_true() {
+                    if !self.check_erased_fn_subtype_to_sig(&s_fn, t_sig).is_true()
+                        && !self
+                            .check_erased_fn_params_to_sig_with_matching_return_base(&s_fn, t_sig)
+                            .is_true()
+                    {
                         return SubtypeResult::False;
                     }
                 } else {
@@ -1645,34 +1650,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         SubtypeResult::False
     }
 
-    /// Compare a function type against a call signature after erasing both signatures'
-    /// type parameters to `any`. Matches tsc's N×M `signaturesRelatedTo` path.
-    fn check_erased_fn_subtype_to_sig(
-        &mut self,
-        s_fn: &FunctionShape,
-        t_sig: &CallSignature,
-    ) -> SubtypeResult {
-        let s_erased = erase_fn_shape_to_any(s_fn, self.interner);
-        let t_erased = erase_call_sig_to_any(t_sig, self.interner);
-        self.check_function_subtype(&s_erased, &t_erased)
-    }
-
-    /// Compare a call signature against a function type after erasing both signatures'
-    /// type parameters to `any`. Matches tsc's N×M `signaturesRelatedTo` path.
-    fn check_erased_signature_subtype_to_fn(
-        &mut self,
-        s_sig: &CallSignature,
-        t_fn: &FunctionShape,
-    ) -> SubtypeResult {
-        let mut s_erased = erase_call_sig_to_any(s_sig, self.interner);
-        // Preserve constructor-vs-callable intent from the target function shape.
-        // `erase_call_sig_to_any` always returns `is_constructor = false`, which
-        // would immediately fail `check_function_subtype` on constructor targets.
-        s_erased.is_constructor = t_fn.is_constructor;
-        let t_erased = erase_fn_shape_to_any(t_fn, self.interner);
-        self.check_function_subtype(&s_erased, &t_erased)
-    }
-
     /// Try to instantiate a generic callable signature to match a concrete function type.
     /// This handles cases like: `declare function box<V>(x: V): {value: V}; const f: (x: number) => {value: number} = box;`
     fn try_instantiate_generic_callable_to_function(
@@ -1764,6 +1741,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     if self
                         .check_erased_call_signature_subtype(s_sig, t_sig)
                         .is_true()
+                        || self
+                            .check_erased_call_signature_params_with_matching_return_base(
+                                s_sig, t_sig,
+                            )
+                            .is_true()
                     {
                         found_match = true;
                         break;
@@ -1968,49 +1950,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         target: &CallSignature,
     ) -> SubtypeResult {
         self.check_call_signature_subtype_impl(source, target, false)
-    }
-
-    /// Compare two call signatures after erasing both signatures' type parameters
-    /// to `any`. Used in the N×M callable subtype path to match tsc's behavior.
-    fn check_erased_call_signature_subtype(
-        &mut self,
-        source: &CallSignature,
-        target: &CallSignature,
-    ) -> SubtypeResult {
-        let s_erased = erase_call_sig_to_any(source, self.interner);
-        let t_erased = erase_call_sig_to_any(target, self.interner);
-        self.check_function_subtype(&s_erased, &t_erased)
-    }
-
-    /// Compare constructor signatures after erasing type parameters to `any`.
-    /// Used in N×M constructor-signature comparison to match tsc behavior.
-    fn check_erased_call_signature_subtype_as_constructor(
-        &mut self,
-        source: &CallSignature,
-        target: &CallSignature,
-    ) -> SubtypeResult {
-        // Guard against over-erasing higher-order callable modality differences.
-        // If a source parameter is constructor-like while the target parameter is
-        // call-like (or vice versa), erasing both sides to `any` would mask a real
-        // incompatibility (e.g. `{ new (...) }` vs `(x) => ...`).
-        for (s_param, t_param) in source.params.iter().zip(target.params.iter()) {
-            let (s_has_call, s_has_construct) =
-                self.callable_modality_flags_for_type(s_param.type_id);
-            let (t_has_call, t_has_construct) =
-                self.callable_modality_flags_for_type(t_param.type_id);
-            let modality_mismatch =
-                (s_has_construct != t_has_construct) || (s_has_call != t_has_call);
-            if modality_mismatch && (s_has_call || s_has_construct || t_has_call || t_has_construct)
-            {
-                return SubtypeResult::False;
-            }
-        }
-
-        let mut s_erased = erase_call_sig_to_any(source, self.interner);
-        let mut t_erased = erase_call_sig_to_any(target, self.interner);
-        s_erased.is_constructor = true;
-        t_erased.is_constructor = true;
-        self.check_function_subtype(&s_erased, &t_erased)
     }
 
     pub(crate) fn callable_modality_flags_for_type(&mut self, type_id: TypeId) -> (bool, bool) {

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/overloads.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/overloads.rs
@@ -69,9 +69,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         source_return: TypeId,
         target_return: TypeId,
     ) -> bool {
-        if source_return == target_return {
-            return true;
-        }
         let source_bases = self.application_bases_including_root(source_return);
         !source_bases.is_empty()
             && self

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/overloads.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/overloads.rs
@@ -1,0 +1,183 @@
+use crate::types::{CallSignature, FunctionShape, TypeId};
+use crate::visitor::function_shape_id;
+
+use super::super::super::super::{SubtypeChecker, SubtypeResult, TypeResolver};
+use super::super::{erase_call_sig_to_any, erase_fn_shape_to_any};
+
+impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
+    /// Compare a function type against a call signature after erasing both signatures'
+    /// type parameters to `any`. Matches tsc's N x M `signaturesRelatedTo` path.
+    pub(super) fn check_erased_fn_subtype_to_sig(
+        &mut self,
+        s_fn: &FunctionShape,
+        t_sig: &CallSignature,
+    ) -> SubtypeResult {
+        let s_erased = erase_fn_shape_to_any(s_fn, self.interner);
+        let t_erased = erase_call_sig_to_any(t_sig, self.interner);
+        self.check_function_subtype(&s_erased, &t_erased)
+    }
+
+    pub(super) fn check_erased_fn_params_to_sig_with_matching_return_base(
+        &mut self,
+        s_fn: &FunctionShape,
+        t_sig: &CallSignature,
+    ) -> SubtypeResult {
+        let s_erased = erase_fn_shape_to_any(s_fn, self.interner);
+        let t_erased = erase_call_sig_to_any(t_sig, self.interner);
+        self.check_erased_function_shapes_params_with_matching_return_base(
+            s_erased, t_erased, false,
+        )
+    }
+
+    pub fn check_erased_function_type_params_with_matching_return_base(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> SubtypeResult {
+        let Some(s_fn_id) = function_shape_id(self.interner, source) else {
+            return SubtypeResult::False;
+        };
+        let Some(t_fn_id) = function_shape_id(self.interner, target) else {
+            return SubtypeResult::False;
+        };
+        let s_shape = self.interner.function_shape(s_fn_id);
+        let t_shape = self.interner.function_shape(t_fn_id);
+        let s_erased = erase_fn_shape_to_any(&s_shape, self.interner);
+        let t_erased = erase_fn_shape_to_any(&t_shape, self.interner);
+        self.check_erased_function_shapes_params_with_matching_return_base(s_erased, t_erased, true)
+    }
+
+    fn check_erased_function_shapes_params_with_matching_return_base(
+        &mut self,
+        mut source: FunctionShape,
+        mut target: FunctionShape,
+        reject_exact_params: bool,
+    ) -> SubtypeResult {
+        if !self.return_application_bases_overlap(source.return_type, target.return_type) {
+            return SubtypeResult::False;
+        }
+        source.return_type = TypeId::ANY;
+        target.return_type = TypeId::ANY;
+        if reject_exact_params && function_params_match_exactly(&source, &target) {
+            return SubtypeResult::False;
+        }
+        self.check_function_subtype_either_direction(&source, &target)
+    }
+
+    fn return_application_bases_overlap(
+        &self,
+        source_return: TypeId,
+        target_return: TypeId,
+    ) -> bool {
+        if source_return == target_return {
+            return true;
+        }
+        let source_bases = self.application_bases_including_root(source_return);
+        !source_bases.is_empty()
+            && self
+                .application_bases_including_root(target_return)
+                .into_iter()
+                .any(|target_base| source_bases.contains(&target_base))
+    }
+
+    fn application_bases_including_root(&self, type_id: TypeId) -> Vec<TypeId> {
+        let mut types = vec![type_id];
+        types.extend(crate::visitor::collect_all_types(self.interner, type_id));
+        types
+            .into_iter()
+            .filter_map(|ty| {
+                crate::type_queries::get_application_info(self.interner, ty).map(|(base, _)| base)
+            })
+            .collect()
+    }
+
+    /// Compare a call signature against a function type after erasing both signatures'
+    /// type parameters to `any`. Matches tsc's N x M `signaturesRelatedTo` path.
+    pub(super) fn check_erased_signature_subtype_to_fn(
+        &mut self,
+        s_sig: &CallSignature,
+        t_fn: &FunctionShape,
+    ) -> SubtypeResult {
+        let mut s_erased = erase_call_sig_to_any(s_sig, self.interner);
+        // Preserve constructor-vs-callable intent from the target function shape.
+        s_erased.is_constructor = t_fn.is_constructor;
+        let t_erased = erase_fn_shape_to_any(t_fn, self.interner);
+        self.check_function_subtype(&s_erased, &t_erased)
+    }
+
+    /// Compare two call signatures after erasing both signatures' type parameters
+    /// to `any`. Used in the N x M callable subtype path to match tsc's behavior.
+    pub(super) fn check_erased_call_signature_subtype(
+        &mut self,
+        source: &CallSignature,
+        target: &CallSignature,
+    ) -> SubtypeResult {
+        let s_erased = erase_call_sig_to_any(source, self.interner);
+        let t_erased = erase_call_sig_to_any(target, self.interner);
+        self.check_function_subtype(&s_erased, &t_erased)
+    }
+
+    pub(super) fn check_erased_call_signature_params_with_matching_return_base(
+        &mut self,
+        source: &CallSignature,
+        target: &CallSignature,
+    ) -> SubtypeResult {
+        let s_erased = erase_call_sig_to_any(source, self.interner);
+        let t_erased = erase_call_sig_to_any(target, self.interner);
+        self.check_erased_function_shapes_params_with_matching_return_base(
+            s_erased, t_erased, false,
+        )
+    }
+
+    /// Compare constructor signatures after erasing type parameters to `any`.
+    /// Used in N x M constructor-signature comparison to match tsc behavior.
+    pub(super) fn check_erased_call_signature_subtype_as_constructor(
+        &mut self,
+        source: &CallSignature,
+        target: &CallSignature,
+    ) -> SubtypeResult {
+        for (s_param, t_param) in source.params.iter().zip(target.params.iter()) {
+            let (s_has_call, s_has_construct) =
+                self.callable_modality_flags_for_type(s_param.type_id);
+            let (t_has_call, t_has_construct) =
+                self.callable_modality_flags_for_type(t_param.type_id);
+            let modality_mismatch =
+                (s_has_construct != t_has_construct) || (s_has_call != t_has_call);
+            if modality_mismatch && (s_has_call || s_has_construct || t_has_call || t_has_construct)
+            {
+                return SubtypeResult::False;
+            }
+        }
+
+        let mut s_erased = erase_call_sig_to_any(source, self.interner);
+        let mut t_erased = erase_call_sig_to_any(target, self.interner);
+        s_erased.is_constructor = true;
+        t_erased.is_constructor = true;
+        self.check_function_subtype(&s_erased, &t_erased)
+    }
+
+    fn check_function_subtype_either_direction(
+        &mut self,
+        source: &FunctionShape,
+        target: &FunctionShape,
+    ) -> SubtypeResult {
+        let forward = self.check_function_subtype(source, target);
+        if forward.is_true() {
+            return forward;
+        }
+        self.check_function_subtype(target, source)
+    }
+}
+
+fn function_params_match_exactly(source: &FunctionShape, target: &FunctionShape) -> bool {
+    source.params.len() == target.params.len()
+        && source
+            .params
+            .iter()
+            .zip(target.params.iter())
+            .all(|(source_param, target_param)| {
+                source_param.type_id == target_param.type_id
+                    && source_param.optional == target_param.optional
+                    && source_param.rest == target_param.rest
+            })
+}

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/overloads.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/overloads.rs
@@ -53,7 +53,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         mut target: FunctionShape,
         reject_exact_params: bool,
     ) -> SubtypeResult {
-        if !self.return_application_bases_overlap(source.return_type, target.return_type) {
+        if !self.return_application_bases_match(source.return_type, target.return_type) {
             return SubtypeResult::False;
         }
         source.return_type = TypeId::ANY;
@@ -64,28 +64,18 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         self.check_function_subtype_either_direction(&source, &target)
     }
 
-    fn return_application_bases_overlap(
-        &self,
-        source_return: TypeId,
-        target_return: TypeId,
-    ) -> bool {
-        let source_bases = self.application_bases_including_root(source_return);
-        !source_bases.is_empty()
-            && self
-                .application_bases_including_root(target_return)
-                .into_iter()
-                .any(|target_base| source_bases.contains(&target_base))
-    }
-
-    fn application_bases_including_root(&self, type_id: TypeId) -> Vec<TypeId> {
-        let mut types = vec![type_id];
-        types.extend(crate::visitor::collect_all_types(self.interner, type_id));
-        types
-            .into_iter()
-            .filter_map(|ty| {
-                crate::type_queries::get_application_info(self.interner, ty).map(|(base, _)| base)
-            })
-            .collect()
+    fn return_application_bases_match(&self, source_return: TypeId, target_return: TypeId) -> bool {
+        let Some((source_base, _)) =
+            crate::type_queries::get_application_info(self.interner, source_return)
+        else {
+            return false;
+        };
+        let Some((target_base, _)) =
+            crate::type_queries::get_application_info(self.interner, target_return)
+        else {
+            return false;
+        };
+        source_base == target_base
     }
 
     /// Compare a call signature against a function type after erasing both signatures'


### PR DESCRIPTION
## Agent
AgentName: M4-C

## Track
Track 3 inference/session/contextual typing — Kysely callback context and overload relation parity.

## Invariant
When a generic builder implementation covers callback and array-selection overloads whose returns share the same builder application base, tsz should preserve callback contextual typing and avoid false class/interface member incompatibility while still reporting predicate and stricter-generic TS2416 mismatches.

## Scope
- Adds a focused Kysely-style reduction covering chained table aliases, array selections, callback selections, `$castTo`, and aliased expression factories.
- Routes callable overload relation fallback through solver-owned erased signature comparison with a shared return application base guard.
- Keeps TS2416 class-member suppression narrow: single-signature fallback only covers differing parameter surfaces with matching return application bases; predicate and stricter generic constraint mismatches remain reported.
- Splits erased overload helper methods into `checking/overloads.rs` to satisfy the solver size ratchet.

## Project Corpus Impact
- Row: `kysely-project`
- Bug family: contextual callback inference / builder callback implicit-any (#10683, #10677, #8773)
- Evidence: rebased commit `3aa744c2aa` adds an in-repo Kysely-style regression that previously produced TS2322/TS2416 and now passes without TS7006/TS2347/TS2322/TS2394/TS2416. A temporary direct Kysely fixture repro was clean under `tsc` and, after this fix, the local tsz run produced no diagnostics before being stopped as an inconclusive slow real-project run; CI remains the project-row authority.

## Verification
- Rebased PR head `3aa744c2aa` onto `origin/main` `dc248538fc`; `origin/main` is an ancestor of the PR head.
- `cargo nextest run -p tsz-checker --test generic_call_inference_tests contextual_kysely_select_array_preserves_aliased_expression_factory_param` -> pass
- `cargo nextest run -p tsz-checker --test overload_modifier_tests --test abstract_method_overload_ts2416_tests --test class_implements_overloaded_method_ts2416_tests --test generic_method_override_constraint_ts2416_tests --test class_implements_predicate_inference_tests` -> 75 passed
- `python3 scripts/arch/arch_guard.py` -> pass
- `scripts/arch/check-checker-boundaries.sh` -> pass
- `cargo fmt --all --check` -> pass
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets --all-features -- -D warnings` -> pass
- `git diff --check` -> pass
- ReviewHelper follow-up `3aa744c2aa`: `cargo nextest run -p tsz-checker overloaded_interface_method_nested_shared_return_application_still_ts2416` -> pass before rebase; `cargo nextest run -p tsz-checker overloaded_interface_method` -> 12 passed before rebase. Post-rebase: `cargo fmt --check` and `git diff --check origin/codex/m4c-kysely-callback-context-20260531..HEAD` -> pass. A repeated post-rebase nextest runner invocation stalled after build with no test child process, so exact-head CI remains authoritative.
- `cargo nextest run -p tsz-checker --test conformance_issues_modules test_implement_array_interface_ts2416_not_ts2420` -> pass
- `cargo nextest run -p tsz-checker --test class_implements_overloaded_method_ts2416_tests overloaded_interface_method_nested_shared_return_application_still_ts2416` -> pass
- `scripts/safe-run.sh --limit 50% -- ./scripts/conformance/conformance.sh run --filter implementArrayInterface --verbose` -> 1/1 passed

## Coordination Notes
- Draft PR was opened early to claim #10683/#10677; this commit is the implemented slice.
- #10677 is treated as downstream fallout of #10683.
- Direct real Kysely repro remains too slow for a useful local loop; I stopped it rather than waiting, per repo guidance. The durable evidence is the focused regression plus CI.
- Remote PR body verified after the rebase/body-check refresh; ready for CI review on head `3aa744c2aa`.
- Reviewer architecture blocker addressed on head `3aa744c2aa`: TS2416 suppression now consumes `query_erased_overload_params_with_matching_return_base` instead of walking return application bases and parameter-only relation locally; follow-up `3aa744c2aa` restricts the erased-return fallback to matching top-level return application bases so nested shared generic applications cannot erase incompatible outer return families.