### PR TITLE
fix(emit): scope nested private accessor helpers

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -2945,29 +2945,12 @@ impl<'a> Printer<'a> {
                     if !first {
                         self.write(", ");
                     }
-                    self.write(&def.var_name);
-                    self.write(" = function ");
-                    self.write(&def.var_name);
-                    self.write("(");
-                    if let Some(param_idx) = def.param
-                        && let Some(param_node) = self.arena.get(param_idx)
-                        && let Some(param_data) = self.arena.get_parameter(param_node)
-                    {
-                        self.emit(param_data.name);
-                    }
-                    self.write(") ");
-                    let prev_self_alias = self.scoped_class_expression_self_alias.clone();
-                    if private_member_def_needs_class_alias
-                        && let Some(alias) = class_value_alias.as_ref()
-                        && !class_name.is_empty()
-                    {
-                        self.scoped_class_expression_self_alias = Some((
-                            Arc::<str>::from(class_name.as_str()),
-                            Arc::<str>::from(alias.as_str()),
-                        ));
-                    }
-                    self.emit_single_line_block(def.body);
-                    self.scoped_class_expression_self_alias = prev_self_alias;
+                    self.emit_private_accessor_function_def(
+                        def,
+                        private_member_def_needs_class_alias,
+                        class_value_alias.as_deref(),
+                        &class_name,
+                    );
                     first = false;
                 }
                 for accessor in &private_auto_accessors {
@@ -3522,29 +3505,12 @@ impl<'a> Printer<'a> {
                 self.write(",");
                 self.write_line();
                 self.increase_indent();
-                self.write(&def.var_name);
-                self.write(" = function ");
-                self.write(&def.var_name);
-                self.write("(");
-                if let Some(param_idx) = def.param
-                    && let Some(param_node) = self.arena.get(param_idx)
-                    && let Some(param_data) = self.arena.get_parameter(param_node)
-                {
-                    self.emit(param_data.name);
-                }
-                self.write(") ");
-                let prev_self_alias = self.scoped_class_expression_self_alias.clone();
-                if private_member_def_needs_class_alias
-                    && let Some(alias) = class_value_alias.as_ref()
-                    && !class_name.is_empty()
-                {
-                    self.scoped_class_expression_self_alias = Some((
-                        Arc::<str>::from(class_name.as_str()),
-                        Arc::<str>::from(alias.as_str()),
-                    ));
-                }
-                self.emit_single_line_block(def.body);
-                self.scoped_class_expression_self_alias = prev_self_alias;
+                self.emit_private_accessor_function_def(
+                    def,
+                    private_member_def_needs_class_alias,
+                    class_value_alias.as_deref(),
+                    &class_name,
+                );
                 self.decrease_indent();
             }
 
@@ -3714,31 +3680,12 @@ impl<'a> Printer<'a> {
                 if !first {
                     self.write(", ");
                 }
-                self.write(&def.var_name);
-                self.write(" = function ");
-                self.write(&def.var_name);
-                self.write("(");
-                if let Some(param_idx) = def.param {
-                    // Emit setter parameter name
-                    if let Some(param_node) = self.arena.get(param_idx)
-                        && let Some(param_data) = self.arena.get_parameter(param_node)
-                    {
-                        self.emit(param_data.name);
-                    }
-                }
-                self.write(") ");
-                let prev_self_alias = self.scoped_class_expression_self_alias.clone();
-                if private_member_def_needs_class_alias
-                    && let Some(alias) = class_value_alias.as_ref()
-                    && !class_name.is_empty()
-                {
-                    self.scoped_class_expression_self_alias = Some((
-                        Arc::<str>::from(class_name.as_str()),
-                        Arc::<str>::from(alias.as_str()),
-                    ));
-                }
-                self.emit_single_line_block(def.body);
-                self.scoped_class_expression_self_alias = prev_self_alias;
+                self.emit_private_accessor_function_def(
+                    def,
+                    private_member_def_needs_class_alias,
+                    class_value_alias.as_deref(),
+                    &class_name,
+                );
                 first = false;
             }
 

--- a/crates/tsz-emitter/src/emitter/declarations/class/private_method_defs.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/private_method_defs.rs
@@ -1,5 +1,5 @@
 use super::super::super::Printer;
-use crate::emitter::core::PrivateMethodDef;
+use crate::emitter::core::{PrivateAccessorDef, PrivateMethodDef};
 use std::sync::Arc;
 
 impl<'a> Printer<'a> {
@@ -48,6 +48,54 @@ impl<'a> Printer<'a> {
         self.ctx.flags.in_generator = def.is_generator;
         self.emit(def.body);
         self.ctx.flags.in_generator = prev_in_generator;
+        self.declared_namespace_names = prev_declared;
+        self.pop_temp_scope();
+        self.ctx.block_scope_state.exit_scope();
+        self.pending_function_body_parameters = prev_pending_function_body_parameters;
+        self.emitting_function_body_block = prev_emitting_function_body_block;
+        self.function_scope_depth -= 1;
+        self.scoped_class_expression_self_alias = prev_self_alias;
+    }
+
+    pub(in crate::emitter) fn emit_private_accessor_function_def(
+        &mut self,
+        def: &PrivateAccessorDef,
+        private_member_def_needs_class_alias: bool,
+        class_value_alias: Option<&str>,
+        class_name: &str,
+    ) {
+        self.write(&def.var_name);
+        self.write(" = function ");
+        self.write(&def.var_name);
+        self.write("(");
+        self.function_scope_depth += 1;
+        if let Some(param_idx) = def.param
+            && let Some(param_node) = self.arena.get(param_idx)
+            && let Some(param_data) = self.arena.get_parameter(param_node)
+        {
+            self.emit(param_data.name);
+        }
+        self.write(") ");
+
+        let prev_self_alias = self.scoped_class_expression_self_alias.clone();
+        if private_member_def_needs_class_alias
+            && let Some(alias) = class_value_alias
+            && !class_name.is_empty()
+        {
+            self.scoped_class_expression_self_alias =
+                Some((Arc::<str>::from(class_name), Arc::<str>::from(alias)));
+        }
+        let prev_emitting_function_body_block = self.emitting_function_body_block;
+        self.emitting_function_body_block = true;
+        let prev_pending_function_body_parameters = std::mem::replace(
+            &mut self.pending_function_body_parameters,
+            def.param.into_iter().collect(),
+        );
+        self.ctx.block_scope_state.enter_scope();
+        self.push_temp_scope();
+        let prev_declared = std::mem::take(&mut self.declared_namespace_names);
+        self.prepare_logical_assignment_value_temps(def.body);
+        self.emit_single_line_block(def.body);
         self.declared_namespace_names = prev_declared;
         self.pop_temp_scope();
         self.ctx.block_scope_state.exit_scope();

--- a/crates/tsz-emitter/tests/private_element_naming_tests.rs
+++ b/crates/tsz-emitter/tests/private_element_naming_tests.rs
@@ -299,3 +299,83 @@ class Container {
          names.\nOutput:\n{output}"
     );
 }
+
+#[test]
+fn nested_class_private_getter_helpers_hoist_to_enclosing_constructor() {
+    let source = r#"
+class Outer {
+    get #value() { return 1; }
+    constructor() {
+        class Inner {
+            get #value() { return 2; }
+            read(other: Inner) {
+                return other.#value;
+            }
+        }
+    }
+}
+"#;
+    let output = parse_lower_emit(source, es2015_esnext());
+
+    let constructor_pos = output
+        .find("constructor() {")
+        .expect("constructor should be emitted");
+    let inner_decl_pos = output[constructor_pos..]
+        .find("var _Inner_instances, _Inner_value_get;")
+        .map(|pos| constructor_pos + pos)
+        .expect("nested class private helpers should be declared in the constructor");
+    let inner_class_pos = output[constructor_pos..]
+        .find("class Inner")
+        .map(|pos| constructor_pos + pos)
+        .expect("nested class should be emitted inside the constructor");
+    let inner_init_pos = output[constructor_pos..]
+        .find("_Inner_instances = new WeakSet(), _Inner_value_get = function _Inner_value_get()")
+        .map(|pos| constructor_pos + pos)
+        .expect("nested class private accessor helper should be initialized after the class");
+
+    assert!(
+        inner_decl_pos < inner_class_pos && inner_class_pos < inner_init_pos,
+        "Nested class private accessor declarations should be hoisted to the enclosing constructor before the class executes.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains(
+            "_Inner_value_get = function _Inner_value_get() { var _Inner_instances, _Inner_value_get;"
+        ),
+        "Outer private-helper declarations must not be inserted into the generated getter body.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn nested_class_private_setter_helpers_keep_their_own_function_scope() {
+    let source = r#"
+class Host {
+    set #score(value) { this.total = value; }
+    constructor() {
+        class Local {
+            set #score(value) { this.total = value; }
+            write(other: Local) {
+                other.#score = 1;
+            }
+        }
+    }
+}
+"#;
+    let output = parse_lower_emit(source, es2015_esnext());
+
+    assert!(
+        output.contains("var _Local_instances, _Local_score_set;"),
+        "Nested class private setter helpers should be declared in the enclosing constructor.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "_Local_score_set = function _Local_score_set(value) { this.total = value; };"
+        ),
+        "Generated setter helper should preserve its parameter and body.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains(
+            "_Local_score_set = function _Local_score_set(value) { var _Local_instances, _Local_score_set;"
+        ),
+        "Outer private-helper declarations must not be inserted into the generated setter body.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Emit/DTS parity: JavaScript emit private-name nested class family.

## Invariant
When a nested class with lowered private accessors is emitted inside an enclosing function or constructor body, `tsc` declares that nested class's private storage/helper temps in the enclosing body before the nested class executes; generated getter/setter helper function bodies get their own function temp scope and must not consume the enclosing body's private-helper declarations.

## Scope
- Factor private accessor helper-function emission through the same scoped helper pattern used by private method helper functions.
- Replace duplicated accessor helper emit paths in ES2015+ class/private lowering with the scoped helper.
- Add regression coverage for nested private getter and setter helpers with distinct class/member names.

## Project Corpus Impact
- Row: n/a
- Bug family: JavaScript emit private-name nested class accessor temp hoisting
- Evidence: targeted TypeScript emit baseline `privateNameNestedClassAccessorsShadowing` now passes, with adjacent `privateNameNestedClass*` JS filter green.

## Verification
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/tsz-studio-c-private-accessor-target cargo nextest run -p tsz-emitter --test private_element_naming_tests`
- `scripts/emit/run.sh --filter=privateNameNestedClass --js-only --verbose --timeout=30000 --json-out=/tmp/privateNameNestedClass-studio-c-private-accessor-main-sync.json`
- `CARGO_TARGET_DIR=/tmp/tsz-studio-c-private-accessor-target cargo check -p tsz-emitter`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check origin/main...HEAD`

## Coordination Notes
- AgentName: Studio-C
- Refs #8506; this is a focused class/private/accessor emit slice, not a full private-name family closure.
- PR #11909 merged on 2026-05-31 after merge-queue testing.
- No checker/solver semantic validation and no output surgery added; this stays in emitter helper scheduling/temp-scope ownership.
