### PR TITLE
fix(solver): normalize relation policy cache overrides

### DIFF
--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -238,7 +238,13 @@ impl RelationPolicy {
     /// `config` field of a [`crate::types::RelationCacheKey`]. Every
     /// behavior-affecting field on `RelationPolicy` must be reflected here.
     pub const fn cache_config(self) -> RelationCacheConfig {
-        let mut bits = self.flags;
+        let field_owned_bits = RelationFlags::STRICT_SUBTYPE_CHECKING
+            .union(RelationFlags::STRICT_ANY_PROPAGATION)
+            .union(RelationFlags::SKIP_WEAK_TYPE_CHECKS)
+            .union(RelationFlags::ASSUME_RELATED_ON_CYCLE)
+            .union(RelationFlags::NO_ERASE_GENERICS);
+        let mut bits =
+            RelationFlags::from_bits_retain(self.flags.bits() & !field_owned_bits.bits());
         if self.strict_subtype_checking {
             bits = bits.union(RelationFlags::STRICT_SUBTYPE_CHECKING);
         }

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/policy_config.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/policy_config.rs
@@ -45,6 +45,49 @@ fn relation_policy_cache_config_unifies_equivalent_flag_and_builder_bits() {
 }
 
 #[test]
+fn relation_policy_builder_overrides_remove_prior_flag_bits_from_cache_config() {
+    let cases = [
+        (
+            "strict subtype checking",
+            RelationPolicy::from_relation_flags(RelationFlags::STRICT_SUBTYPE_CHECKING)
+                .with_strict_subtype_checking(false),
+            RelationFlags::STRICT_SUBTYPE_CHECKING,
+        ),
+        (
+            "strict any propagation",
+            RelationPolicy::from_relation_flags(RelationFlags::STRICT_ANY_PROPAGATION)
+                .with_strict_any_propagation(false),
+            RelationFlags::STRICT_ANY_PROPAGATION,
+        ),
+        (
+            "skip weak type checks",
+            RelationPolicy::from_relation_flags(RelationFlags::SKIP_WEAK_TYPE_CHECKS)
+                .with_skip_weak_type_checks(false),
+            RelationFlags::SKIP_WEAK_TYPE_CHECKS,
+        ),
+        (
+            "assume related on cycle",
+            RelationPolicy::from_relation_flags(RelationFlags::ASSUME_RELATED_ON_CYCLE)
+                .with_assume_related_on_cycle(false),
+            RelationFlags::ASSUME_RELATED_ON_CYCLE,
+        ),
+        (
+            "generic erasure",
+            RelationPolicy::from_relation_flags(RelationFlags::NO_ERASE_GENERICS)
+                .with_erase_generics(true),
+            RelationFlags::NO_ERASE_GENERICS,
+        ),
+    ];
+
+    for (name, policy, flag) in cases {
+        assert!(
+            !policy.cache_config().flags.contains(flag),
+            "{name} builder override must remove stale flag bits from the cache config",
+        );
+    }
+}
+
+#[test]
 fn assignability_cache_reuses_slot_for_flag_and_builder_strict_subtype_policy() {
     let interner = TypeInterner::new();
     let db = QueryCache::new(&interner);


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 4: semantic campaign / relation policy cache-key contract

## Invariant
When a `RelationPolicy` is built from flags and then a typed builder overrides one of the same behavior-affecting fields, the solver cache key must reflect the final typed field value. This PR keeps `RelationPolicy::cache_config` as the canonical projection by stripping field-owned bits from the packed flag payload before re-adding them from the typed fields.

## Scope
- `crates/tsz-solver/src/relations/relation_queries.rs`
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests/policy_config.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: relation policy/cache correctness
- Evidence: solver-only cache-key projection ratchet; no project fixture metadata or checker call-site changes.

## Verification
- RED before fix on branch head before production change: `cargo nextest run -p tsz-solver -E 'test(relation_policy_builder_overrides_remove_prior_flag_bits_from_cache_config)'` failed because `with_strict_subtype_checking(false)` left `STRICT_SUBTYPE_CHECKING` in `cache_config().flags`.
- GREEN on exact PR head `2a4369d712e527f6b595d7fd438ee5d698b0a12f`: `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'`: 27 passed, 6411 skipped.
- GREEN on exact PR head `2a4369d712e527f6b595d7fd438ee5d698b0a12f`: `cargo fmt --check`.
- GREEN on exact PR head `2a4369d712e527f6b595d7fd438ee5d698b0a12f`: `git diff --check origin/main..HEAD`.
- Base containment check: exact PR head is based on `origin/main` `65aad9b3ca180675d3f03d821a36cb3611796367`.
- File-size guard: `relation_queries.rs` 816 lines; `policy_config.rs` 186 lines.
- GREEN on exact PR head `2a4369d712e527f6b595d7fd438ee5d698b0a12f`: remote ready-review PR-head CI completed successfully, including `CI Summary` and `GitGuardian Security Checks`.

## Coordination Notes
Refs #8207. This is a narrow solver-only follow-up after #11885 landed. It does not touch M1-B checker RelationRequest routing, M4-C inference/evaluation work, or Studio-F generic helper splitting. Adjacent cases covered by the new ratchet: strict subtype checking, strict-any propagation, weak-type skipping, cycle-assumption mode, and generic-erasure mode. Direct flag-only modes such as callback parameter check, readonly identity, and erased-signature retry continue to pass through the packed typed flag set unchanged. Exact PR head `2a4369d712e527f6b595d7fd438ee5d698b0a12f` contains `origin/main` `65aad9b3ca180675d3f03d821a36cb3611796367`. No WIP label or auto-merge; M4-B added `merge-queue` after exact-head PR-head checks passed.

