### PR TITLE
chore(dts): account object member output surgery

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs
@@ -368,11 +368,12 @@ impl<'a> DeclarationEmitter<'a> {
         if !negative_numeric_computed_names.is_empty() {
             for line in &mut lines {
                 for (key_text, source_name_text) in &negative_numeric_computed_names {
-                    if Self::replace_object_literal_property_line_name(
+                    if let Some(rewritten) = Self::object_literal_property_line_with_name(
                         line,
                         key_text,
                         source_name_text,
                     ) {
+                        *line = rewritten;
                         break;
                     }
                 }
@@ -952,7 +953,11 @@ impl<'a> DeclarationEmitter<'a> {
             {
                 continue;
             }
-            *line = line.replacen(existing_union, source_union, 1);
+            if let Some(rewritten) =
+                Self::object_index_signature_line_with_value_type(line, source_union)
+            {
+                *line = rewritten;
+            }
         }
     }
 
@@ -1213,11 +1218,13 @@ impl<'a> DeclarationEmitter<'a> {
         name_text.trim().strip_prefix('[')?.strip_suffix(']')
     }
 
-    fn replace_object_literal_property_line_name(
-        line: &mut String,
+    fn object_literal_property_line_with_name(
+        line: &str,
         key_text: &str,
         replacement_name: &str,
-    ) -> bool {
+    ) -> Option<String> {
+        // OUTPUT_SURGERY_DEBT: rebuilds a DTS member line after type printing;
+        // migrate to declaration summary member spelling facts.
         let leading_len = line.len() - line.trim_start().len();
         let trimmed = &line[leading_len..];
         let candidates = [
@@ -1228,11 +1235,16 @@ impl<'a> DeclarationEmitter<'a> {
         for candidate in candidates {
             if trimmed.starts_with(&candidate) {
                 let replacement = format!("{replacement_name}:");
-                line.replace_range(leading_len..leading_len + candidate.len(), &replacement);
-                return true;
+                let suffix = &trimmed[candidate.len()..];
+                let mut rewritten =
+                    String::with_capacity(leading_len + replacement.len() + suffix.len());
+                rewritten.push_str(&line[..leading_len]);
+                rewritten.push_str(&replacement);
+                rewritten.push_str(suffix);
+                return Some(rewritten);
             }
         }
-        false
+        None
     }
 
     fn object_index_signature_line_with_key(line: &str, replacement_key: &str) -> Option<String> {
@@ -1252,6 +1264,50 @@ impl<'a> DeclarationEmitter<'a> {
             rewritten.push_str("readonly ");
         }
         rewritten.push_str(replacement_key);
+        rewritten.push_str(suffix);
+        Some(rewritten)
+    }
+
+    fn object_index_signature_line_with_value_type(
+        line: &str,
+        replacement_value_type: &str,
+    ) -> Option<String> {
+        // OUTPUT_SURGERY_DEBT: rebuilds a DTS index-signature line after type
+        // printing; migrate to structured declaration member facts.
+        let trimmed = line.trim_start();
+        let without_readonly = trimmed
+            .strip_prefix("readonly ")
+            .unwrap_or(trimmed)
+            .trim_start();
+        if !(without_readonly.starts_with("[x: string]:")
+            || without_readonly.starts_with("[x: number]:")
+            || without_readonly.starts_with("[x: symbol]:"))
+        {
+            return None;
+        }
+
+        let signature_start = line.len() - without_readonly.len();
+        let bracket_end = without_readonly.find(']')?;
+        let colon_relative = without_readonly.get(bracket_end + 1..)?.find(':')? + bracket_end + 1;
+        let after_colon = signature_start + colon_relative + 1;
+        let value_tail = &line[after_colon..];
+        let value_leading_len = value_tail.len() - value_tail.trim_start().len();
+        let value_start = after_colon + value_leading_len;
+        let value_and_suffix = &line[value_start..];
+        let trimmed_value_len = value_and_suffix.trim_end().len();
+        let suffix_start = if value_and_suffix[..trimmed_value_len].ends_with(';') {
+            trimmed_value_len.saturating_sub(1)
+        } else {
+            trimmed_value_len
+        };
+
+        let prefix = &line[..value_start];
+        let suffix = &value_and_suffix[suffix_start..];
+        let replacement_value_type = replacement_value_type.trim();
+        let mut rewritten =
+            String::with_capacity(prefix.len() + replacement_value_type.len() + suffix.len());
+        rewritten.push_str(prefix);
+        rewritten.push_str(replacement_value_type);
         rewritten.push_str(suffix);
         Some(rewritten)
     }
@@ -1579,5 +1635,72 @@ mod object_index_signature_rewrite_tests {
     fn ignores_non_string_index_lines() {
         assert_eq!(rewrite("    [x: number]: boolean;"), None);
         assert_eq!(rewrite("    value: boolean;"), None);
+    }
+
+    #[test]
+    fn rewrites_index_signature_value_type_without_changing_key() {
+        assert_eq!(
+            DeclarationEmitter::object_index_signature_line_with_value_type(
+                "    [x: string]: Beta | Alpha;",
+                "Alpha | Beta",
+            )
+            .as_deref(),
+            Some("    [x: string]: Alpha | Beta;")
+        );
+        assert_eq!(
+            DeclarationEmitter::object_index_signature_line_with_value_type(
+                "    readonly [x: number]: Second | First;",
+                "First | Second",
+            )
+            .as_deref(),
+            Some("    readonly [x: number]: First | Second;")
+        );
+    }
+
+    #[test]
+    fn preserves_index_signature_spacing_and_suffix() {
+        assert_eq!(
+            DeclarationEmitter::object_index_signature_line_with_value_type(
+                "\t[x: symbol]:   Old | New;  ",
+                "New | Old",
+            )
+            .as_deref(),
+            Some("\t[x: symbol]:   New | Old;  ")
+        );
+    }
+}
+
+#[cfg(test)]
+mod object_property_name_rewrite_tests {
+    use super::DeclarationEmitter;
+
+    fn rewrite(line: &str, key: &str, replacement: &str) -> Option<String> {
+        DeclarationEmitter::object_literal_property_line_with_name(line, key, replacement)
+    }
+
+    #[test]
+    fn rewrites_quoted_property_prefix_to_source_name() {
+        assert_eq!(
+            rewrite("    \"-1\": string;", "-1", "[-1]").as_deref(),
+            Some("    [-1]: string;")
+        );
+        assert_eq!(
+            rewrite("    '-2': number;", "-2", "[-2]").as_deref(),
+            Some("    [-2]: number;")
+        );
+    }
+
+    #[test]
+    fn rewrites_bare_property_prefix_and_preserves_suffix() {
+        assert_eq!(
+            rewrite("\t-3: boolean;  ", "-3", "[-3]").as_deref(),
+            Some("\t[-3]: boolean;  ")
+        );
+    }
+
+    #[test]
+    fn ignores_non_matching_property_lines() {
+        assert_eq!(rewrite("    other: boolean;", "-1", "[-1]"), None);
+        assert_eq!(rewrite("    method(): boolean;", "-1", "[-1]"), None);
     }
 }

--- a/scripts/emit/audit-output-surgery.py
+++ b/scripts/emit/audit-output-surgery.py
@@ -25,6 +25,7 @@ SOURCE_ROOT = ROOT / "crates" / "tsz-emitter" / "src"
 ALLOWLIST_PATH = ROOT / "scripts" / "emit" / "output-surgery-allowlist.txt"
 
 REPLACE_CALL_RE = re.compile(r"(?:\.\s*)?(replace|replacen|replace_range)\s*\(")
+MANUAL_DEBT_MARKER_RE = re.compile(r"OUTPUT_SURGERY_DEBT\b")
 UNALLOWLISTED_FAILURE_RE = re.compile(
     r": (?P<count>\d+) unallowlisted output-surgery call\(s\)"
 )
@@ -123,6 +124,15 @@ def scan(base: pathlib.Path = SOURCE_ROOT) -> list[Finding]:
     for path in iter_rust_files(base):
         rel = path.relative_to(ROOT).as_posix()
         for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if MANUAL_DEBT_MARKER_RE.search(line):
+                findings.append(
+                    Finding(
+                        path=rel,
+                        line_no=line_no,
+                        call="manual",
+                        text=line.strip(),
+                    )
+                )
             for match in REPLACE_CALL_RE.finditer(line):
                 if is_auto_allowed_data_cleanup(rel, line):
                     continue

--- a/scripts/emit/output-surgery-allowlist.txt
+++ b/scripts/emit/output-surgery-allowlist.txt
@@ -3,7 +3,7 @@
 # counts may go down as plan/IR/declaration-summary work removes debt; new or
 # increased counts require an explicit category and removal reason.
 crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs|dts-output-surgery|1|inferred type text parameter rewrite; migrate to declaration display request facts
-crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs|dts-output-surgery|2|object member inferred text rewrites; migrate to declaration summary member facts
+crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs|dts-output-surgery|2|manual object member line rebuilds after type printing; migrate to declaration summary member facts
 crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs|dts-output-surgery|3|return type text normalization rewrites; migrate to structured return declaration display
 crates/tsz-emitter/src/emitter/source_file/top_level_using.rs|resource-region-output-surgery|16|top-level using region rewrites emitted strings; migrate to disposable-region plan
 crates/tsz-emitter/src/transforms/ir_printer.rs|ir-output-surgery|1|IR printer patches emitted class wrapper text; migrate to structured IR node/chunk

--- a/scripts/emit/test_output_surgery_audit.py
+++ b/scripts/emit/test_output_surgery_audit.py
@@ -39,6 +39,19 @@ class OutputSurgeryAuditTests(unittest.TestCase):
             )
         )
 
+    def test_manual_debt_marker_is_tracked(self):
+        with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
+            base = pathlib.Path(temp_dir)
+            src = base / "demo.rs"
+            src.write_text(
+                "// OUTPUT_SURGERY_DEBT: manual DTS line rebuild\n",
+                encoding="utf-8",
+            )
+            findings = self.audit.scan(base)
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].call, "manual")
+
     def test_allowlist_ratchets_counts(self):
         findings = [
             self.audit.Finding("a.rs", 1, "replacen", "output = output.replacen(&a, &b, 1);"),
@@ -332,14 +345,16 @@ class OutputSurgeryAuditTests(unittest.TestCase):
                 "\n".join(
                     [
                         "let escaped = s.replace('\\\\', \"\\\\\\\\\");",
+                        "// OUTPUT_SURGERY_DEBT: manual DTS line rebuild",
                         "output = output.replacen(&from, &to, 1);",
                     ]
                 ),
                 encoding="utf-8",
             )
             findings = self.audit.scan(base)
-        self.assertEqual(len(findings), 1)
+        self.assertEqual(len(findings), 2)
         self.assertEqual(findings[0].line_no, 2)
+        self.assertEqual(findings[1].line_no, 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Agent
AgentName: Studio-E

## Track
Track 9 / emit-DTS tech-debt guardrail under #9333.

## Invariant
When object-literal DTS recovery has already identified a broad index-signature value or a negative numeric property prefix to repair, tsz rebuilds that declaration line from parsed prefix/value spans instead of broad output-surgery replacement APIs, while the manual line rebuilds remain counted as DTS output-surgery debt until declaration-summary/member facts own the spelling and value-type decisions.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs`
- `scripts/emit/audit-output-surgery.py`
- `scripts/emit/output-surgery-allowlist.txt`
- `scripts/emit/test_output_surgery_audit.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: DTS output-surgery guardrail/accounting debt only; no checker, solver, benchmark fixture, emit runner, or project corpus behavior change.

## Structural Rule
Owner layer: declaration-emitter object-literal DTS recovery helper plus emit guardrail audit.

When object-literal recovery preserves source member ordering or source computed property spelling, the repair operates on the already-selected declaration line by reconstructing the known line segment. Unsupported lines fall back unchanged. Because these are still late DTS line rebuilds after type printing, the audit tracks explicit `OUTPUT_SURGERY_DEBT` markers rather than treating removal of broad replacement APIs as debt retirement.

## Adjacent-Case Matrix
- String/number/symbol broad index signatures preserve their key and rewrite only the value type text.
- `readonly` index signatures keep their modifier and source spacing.
- Quoted and bare negative numeric property names rewrite to the source computed spelling while non-matching lines are ignored.
- Manual line rebuild markers are counted by `audit-output-surgery.py` so output-surgery totals remain stable until the debt moves to structured declaration facts.

## Verification
- `cargo fmt --check`
- `python3 scripts/emit/test_output_surgery_audit.py`
- `python3 scripts/emit/audit-output-surgery.py` (`total_findings=23`, `dts-output-surgery=6/6`)
- `cargo nextest run -p tsz-emitter object_index_signature_rewrite_tests object_property_name_rewrite_tests`
- `git diff --check origin/main...HEAD`
- Earlier full scoped DTS evidence: `scripts/safe-run.sh scripts/emit/run.sh --filter=jsDeclarations --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-e-object-member-jsDeclarations-20260531.json`

## Coordination Notes
- AgentName: Studio-E
- Follows #11906 and #9333 by narrowing two object-member DTS rewrites from broad replacement APIs to parsed prefix/value line rebuilds without reducing the output-surgery debt counter.
- Keeps `dts-output-surgery` exhausted at `6/6` and total output-surgery findings at `23/23`; removal condition is migration to declaration summary/member facts.
- Addresses Reviewer blocker from 2026-06-01 by keeping the manual line rebuilds counted and documenting the removal condition.
- Rebased onto current `origin/main` (`0ac6d659f0`) after ready-review aggregate failed on stale synthetic merge; pushed refreshed head `bb0e1ba965d4d95b499d2481e4b350f896b02c21`.
- Does not overlap #8275 declaration-summary work, which is separately claimed.
- Draft light CI restarted for head `bb0e1ba965d4d95b499d2481e4b350f896b02c21`; keep merge-queue off until exact-head ready-review CI is green.