### PR TITLE
refactor(solver): retire raw relation cache flag constructor

### DIFF
--- a/crates/tsz-solver/src/types.rs
+++ b/crates/tsz-solver/src/types.rs
@@ -380,15 +380,6 @@ impl RelationCacheConfig {
         Self { flags, any_mode }
     }
 
-    /// Build a config that only encodes boolean flags (any-mode defaults
-    /// to `All`, matching tsc's default).
-    pub const fn from_flags(flags: RelationFlags) -> Self {
-        Self {
-            flags,
-            any_mode: CachedAnyMode::All,
-        }
-    }
-
     /// Fluent builder override.
     pub const fn with_any_mode(mut self, any_mode: CachedAnyMode) -> Self {
         self.any_mode = any_mode;

--- a/crates/tsz-solver/tests/relation_cache_config_tests.rs
+++ b/crates/tsz-solver/tests/relation_cache_config_tests.rs
@@ -94,6 +94,16 @@ fn unflagged_compatibility_policy_matches_empty_legacy_flags() {
 }
 
 #[test]
+fn relation_cache_config_does_not_expose_raw_flags_constructor() {
+    let source = include_str!("../src/types.rs");
+
+    assert!(
+        !source.contains("pub const fn from_flags(flags: RelationFlags) -> Self"),
+        "RelationCacheConfig must not expose a raw flags constructor; use RelationPolicy::from_relation_flags(...).cache_config() so typed policy defaults and overrides stay canonical",
+    );
+}
+
+#[test]
 fn legacy_flag_constructor_stores_typed_relation_flags() {
     let policy = RelationPolicy::from_flags(
         RelationCacheKey::FLAG_STRICT_NULL_CHECKS

--- a/crates/tsz-solver/tests/subtype_cache_tests.rs
+++ b/crates/tsz-solver/tests/subtype_cache_tests.rs
@@ -473,7 +473,7 @@ fn relation_cache_key_different_flags_different_key() {
     let key_strict = RelationCacheKey::for_subtype(
         TypeId::STRING,
         TypeId::NUMBER,
-        RelationCacheConfig::from_flags(RelationFlags::STRICT_NULL_CHECKS),
+        RelationPolicy::from_relation_flags(RelationFlags::STRICT_NULL_CHECKS).cache_config(),
     );
 
     assert_ne!(


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 4: semantic campaign / relation policy cache-key contract for #8207.

## Invariant
When solver code needs a relation cache config from relation flags, the config is produced through `RelationPolicy::from_relation_flags(...).cache_config()`; this PR removes the raw `RelationCacheConfig::from_flags` bypass so typed policy defaults and overrides stay canonical.

## Scope
- `crates/tsz-solver/src/types.rs`
- `crates/tsz-solver/tests/relation_cache_config_tests.rs`
- `crates/tsz-solver/tests/subtype_cache_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: relation policy/cache correctness
- Evidence: solver-only API ratchet; no project fixture metadata, checker routing, or relation semantics changed.

## Verification
- RED before fix: `cargo nextest run -p tsz-solver -E 'test(relation_cache_config_does_not_expose_raw_flags_constructor)'` failed because `RelationCacheConfig` still exposed `pub const fn from_flags(flags: RelationFlags) -> Self`.
- GREEN on exact PR head `e69062825f3490ed938c2905bdaa78eaab772f38`: `cargo nextest run -p tsz-solver -E 'test(relation_cache_config_tests)'`: 52 passed, 6386 skipped.
- GREEN on exact PR head `e69062825f3490ed938c2905bdaa78eaab772f38`: `cargo nextest run -p tsz-solver -E 'test(relation_cache_key_different_flags_different_key)'`: 1 passed, 6437 skipped.
- GREEN on exact PR head `e69062825f3490ed938c2905bdaa78eaab772f38`: `cargo fmt --check`.
- GREEN on exact PR head `e69062825f3490ed938c2905bdaa78eaab772f38`: `git diff --check origin/main..HEAD`.
- Base containment check: exact PR head is based on `origin/main` `65aad9b3ca180675d3f03d821a36cb3611796367`.
- Search ratchet on exact PR head `e69062825f3490ed938c2905bdaa78eaab772f38`: `rg -n 'RelationCacheConfig::from_flags|pub const fn from_flags\(flags: RelationFlags\) -> Self' crates/tsz-solver/src crates/tsz-solver/tests -g '!relation_cache_config_tests.rs'` returned no matches (exit 1).
- File-size guard: `types.rs` 1932 lines; `relation_cache_config_tests.rs` 1162 lines; `subtype_cache_tests.rs` 795 lines.
- GREEN on exact PR head `e69062825f3490ed938c2905bdaa78eaab772f38`: remote ready-review PR-head CI completed successfully, including `CI Summary` and `GitGuardian Security Checks`.

## Coordination Notes
- Refs #8207.
- This is independent of ready PR #11913; #11913 tightens typed `RelationPolicy` override projection, while this PR removes a raw `RelationCacheConfig` constructor bypass.
- Avoids M1-B draft #11890 checker routing paths entirely.
- Exact PR head `e69062825f3490ed938c2905bdaa78eaab772f38` contains `origin/main` `65aad9b3ca180675d3f03d821a36cb3611796367`.
- No WIP label or auto-merge; M4-B added `merge-queue` after exact-head PR-head checks passed.

