### PR TITLE
test(checker): cover defaulted recursive alias declarations

### DIFF
--- a/crates/tsz-checker/tests/generic_default_recursive_alias_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/generic_default_recursive_alias_diagnostics_tests.rs
@@ -34,6 +34,38 @@ type A = Solve29<string>;
 }
 
 #[test]
+fn defaulted_recursive_alias_wrapper_declaration_reports_ts2589_without_use_site() {
+    let codes = semantic_codes(
+        r#"
+type Link28<T, D extends number = 4> = [D] extends [0] ? T : Link28<T[]>;
+type Solve28<T> = Link28<T> extends infer U ? U : never;
+"#,
+    );
+
+    assert_eq!(
+        codes,
+        vec![2589, 2589],
+        "tsc reports the recursive alias boundary and wrapper alias even without a concrete use; got {codes:?}"
+    );
+}
+
+#[test]
+fn renamed_defaulted_recursive_alias_wrapper_declaration_reports_ts2589_without_use_site() {
+    let codes = semantic_codes(
+        r#"
+type Path<X, N extends number = 4> = [N] extends [0] ? X : Path<X[]>;
+type Resolve<X> = Path<X> extends infer Y ? Y : never;
+"#,
+    );
+
+    assert_eq!(
+        codes,
+        vec![2589, 2589],
+        "renamed aliases and params should report declaration-time TS2589 without a use site; got {codes:?}"
+    );
+}
+
+#[test]
 fn renamed_defaulted_recursive_alias_does_not_cascade_ts2589_to_use_alias() {
     let codes = semantic_codes(
         r#"


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
M4-A project corpus regression guard; checker diagnostic parity test-only PR.

## Invariant
When a defaulted recursive conditional alias omits its defaulted parameter in the recursive branch, tsz must report TS2589 at the recursive alias boundary and at a wrapper alias declaration even when there is no later concrete use site. This PR changes test coverage only.

## Scope
- `crates/tsz-checker/tests/generic_default_recursive_alias_diagnostics_tests.rs`

## Project Corpus Impact
- Row: ts-toolbelt-project
- Bug family: solver infer placeholder constraints/defaulted recursive conditional alias depth, issue #11129
- Evidence: fresh dist-fast CLI witness now matches `tsc` for the declaration-only `Link28`/`Solve28` repro; this PR preserves that behavior with a renamed structural guard.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --test generic_default_recursive_alias_diagnostics_tests`
- `scripts/safe-run.sh cargo build --profile dist-fast -p tsz-cli --bin tsz`
- `node TypeScript/lib/tsc.js --noEmit --strict --target es2022 /tmp/m4a-issue-11129.ts` and `.target/dist-fast/tsz --noEmit --strict --target es2022 /tmp/m4a-issue-11129.ts` both report TS2589 at lines 1 and 2.

## Coordination Notes
- Resolves #11129 by adding focused regression coverage; behavior is already fixed on current `main`, and the earlier failing CLI witness came from a stale dist-fast binary.
- Overlap checked against open PRs on 2026-05-31: M4-B relation/cache PRs #11913/#11917 and M4-C Kysely PR #11910 do not touch this test surface.
- AgentName: M4-A; ready for CI and manager/queue-owner review.
