### PR TITLE
fix(flow): preserve guard assignment through push calls

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -151,12 +151,8 @@ const fn flow_step_budget(flow_node_count: usize) -> usize {
     }
 }
 
-/// Schedule `ant` to be processed before `current_flow` by pushing it to the
-/// front of the worklist and re-enqueuing `current_flow` at the back.
-///
-/// Used by the BFS traversal when a node must defer until an antecedent's
-/// narrowing result is available. Caller must still `continue` after invoking
-/// this — the helper only manages the shared buffers.
+/// Re-enqueue `current_flow` after an antecedent whose narrowing result is needed.
+/// Caller must still `continue`; the helper only manages shared buffers.
 fn defer_to_antecedent(
     worklist: &mut VecDeque<(FlowNodeId, TypeId)>,
     in_worklist: &mut FxHashSet<FlowNodeId>,
@@ -2105,17 +2101,12 @@ impl<'a> FlowAnalyzer<'a> {
                     }
                 };
 
-                // Check if this array mutation affects our reference
                 let affects_ref = self.array_mutation_affects_reference(call, reference);
-
-                // For affected references, ARRAY_MUTATION acts as a merge point to preserve narrowing
                 let needs_antecedent = affects_ref && !flow.antecedent.is_empty();
 
                 if needs_antecedent {
-                    // Check if antecedent is ready (similar to merge point logic)
                     if let Some(&ant) = flow.antecedent.first() {
                         if !visited.contains(&ant) && !results.contains_key(&ant) {
-                            // Antecedent not ready - schedule it and defer self
                             defer_to_antecedent(
                                 worklist,
                                 in_worklist,
@@ -2125,7 +2116,6 @@ impl<'a> FlowAnalyzer<'a> {
                             );
                             continue;
                         }
-                        // Antecedent is ready - get its result
                         let antecedent_type = *results.get(&ant).unwrap_or(&current_type);
                         let (evolved_type, complete) =
                             self.array_mutation_evolved_type(antecedent_type, call, reference);
@@ -2137,9 +2127,15 @@ impl<'a> FlowAnalyzer<'a> {
                         current_type
                     }
                 } else if affects_ref {
-                    // For local variables, TypeScript preserves narrowing across method calls
                     current_type
                 } else if let Some(&ant) = flow.antecedent.first() {
+                    if self.antecedent_requires_defer(ant, reference, symbol_id)
+                        && !visited.contains(&ant)
+                        && !results.contains_key(&ant)
+                    {
+                        defer_to_antecedent(worklist, in_worklist, ant, current_flow, current_type);
+                        continue;
+                    }
                     if !in_worklist.contains(&ant) && !visited.contains(&ant) {
                         worklist.push_back((ant, current_type));
                         in_worklist.insert(ant);
@@ -2149,7 +2145,14 @@ impl<'a> FlowAnalyzer<'a> {
                     current_type
                 }
             } else if flow.has_any_flags(flow_flags::CALL) {
-                // Call expression - check for type predicates
+                if let Some(&ant) = flow.antecedent.first()
+                    && self.antecedent_requires_defer(ant, reference, symbol_id)
+                    && !visited.contains(&ant)
+                    && !results.contains_key(&ant)
+                {
+                    defer_to_antecedent(worklist, in_worklist, ant, current_flow, current_type);
+                    continue;
+                }
                 self.handle_call_iterative(reference, current_type, flow, results)
             } else if flow.has_any_flags(flow_flags::START) {
                 // Start node - check if we're crossing a closure boundary.
@@ -2554,20 +2557,14 @@ impl<'a> FlowAnalyzer<'a> {
             return pre_type;
         };
 
-        // Check if the call expression returns `never`. If so, this branch
-        // is dead — no control flow continues past a never-returning call.
-        // Return UNREACHABLE_NEVER (not TypeId::NEVER) to distinguish from
-        // legitimate narrowing to never (e.g., exhaustive type checks).
-        // This matches tsc's getTypeAtFlowCall which returns unreachableNeverType
-        // when getReturnTypeOfSignature(signature).flags & TypeFlags.Never.
+        // A never-returning call makes this branch dead; keep it distinct from
+        // legitimate narrowing to `never` (for example exhaustive type checks).
         if let Some(&call_return_type) = node_types.get(&flow.node.0) {
             if call_return_type == TypeId::NEVER {
                 return Self::UNREACHABLE_NEVER;
             }
-            // When the cached call return type is `any`, it may be stale from early
-            // type environment building (where `this` wasn't fully resolved yet).
-            // Fall back to checking the callee's signature for a `never` return type,
-            // first via node_types, then via binder declaration lookup.
+            // Stale early `any` call caches still need the callee/binder fallback
+            // for explicit `never` returns.
             if call_return_type == TypeId::ANY {
                 if let Some(&callee_type) = node_types.get(&call.expression.0)
                     && callee_type != TypeId::ANY
@@ -2577,10 +2574,7 @@ impl<'a> FlowAnalyzer<'a> {
                 {
                     return Self::UNREACHABLE_NEVER;
                 }
-                // When both the call and callee types are stale `any` (common for
-                // `this.method()` during early type env building), resolve the callee
-                // through the binder's symbol table and check its declaration's return
-                // type annotation directly. This avoids relying on the stale cache.
+                // When both caches are stale, use binder declarations directly.
                 if self.callee_declaration_returns_never(call.expression) {
                     return Self::UNREACHABLE_NEVER;
                 }

--- a/crates/tsz-checker/src/tests/constraint_position_nullable_access_tests.rs
+++ b/crates/tsz-checker/src/tests/constraint_position_nullable_access_tests.rs
@@ -135,6 +135,50 @@ function f<T extends (() => void) | undefined>(fn: T) {
 }
 
 // ---------------------------------------------------------------------------
+// Assignment-based narrowing through guarded branches.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reassignment_in_guard_branch_survives_intervening_read_at_join() {
+    let source = r#"
+declare function maybe(): number | undefined;
+declare const sink: { push(value: number | undefined): void };
+
+let table = maybe();
+if (table === undefined) {
+    table = 5;
+    sink.push(table);
+}
+const value: number = table;
+"#;
+    let c = codes(source);
+    assert!(
+        !c.iter().any(|code| matches!(*code, 2322 | 18048)),
+        "reassigned guard branch should make `table` definitely number at the join; got {c:?}"
+    );
+}
+
+#[test]
+fn reassignment_in_guard_branch_survives_intervening_plain_call_at_join() {
+    let source = r#"
+declare function maybe(): number | undefined;
+declare const sink: (value: number | undefined) => void;
+
+let table = maybe();
+if (table === undefined) {
+    table = 5;
+    sink(table);
+}
+const value: number = table;
+"#;
+    let c = codes(source);
+    assert!(
+        !c.iter().any(|code| matches!(*code, 2322 | 18048)),
+        "plain calls that only read `table` should preserve guard-branch assignment; got {c:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Guard narrows the constraint: no diagnostic after `=== undefined` return.
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Benchmark blocker / Kysely strict-null flow false positive (#10669).

## Structural Rule
When a variable is assigned a non-nullish value inside a guard branch and a following call only reads that variable as an argument, the call-flow node must preserve the assignment-narrowed type at the join.

## Owner Layer
Checker flow orchestration owns this change. The solver relation/type semantics are unchanged; the checker already tracks flow-node ordering and must defer call nodes until narrowing-carrying antecedents have produced their flow type.

## Invariant
This PR fixes checker flow orchestration for non-affecting array-mutation-style calls and ordinary calls, so a read-only call between a guard-branch assignment and the join does not erase the assignment-narrowed type.

## Adjacent-Case Test Matrix
- Reported shape: guarded reassignment followed by `.push(table)` before the join.
- Equivalent call shape: guarded reassignment followed by a plain `sink(table)` call before the join.
- Negative/fallback shape covered by the existing nullable constraint tests: generic nullable constraint accesses still report before guards and narrow only after valid guards.

## Scope
- `crates/tsz-checker/src/flow/control_flow/core.rs`: defer call flow nodes to narrowing-carrying antecedents before falling back to the current type.
- `crates/tsz-checker/src/tests/constraint_position_nullable_access_tests.rs`: add Kysely-shaped regressions for guarded reassignment followed by `.push(value)` and a plain `sink(value)` call.

## Project Corpus Impact
- Row: `kysely-project`
- Bug family: strictNullChecks / assignment-based flow narrowing, false TS2322/TS18048 tail from #10669.
- Evidence: local focused repro previously emitted false TS2322 after `sink.push(table)`; targeted checker module now passes both mutation-call and plain-call regressions.

## Known Unsupported Shapes / Fallback
- This is not a broad Kysely-row fix and does not claim to clear all #10669 diagnostics.
- Unsupported or unrelated call effects fall back to the existing call-flow/type-predicate handling; the change only forces antecedent flow facts to be available before that handling runs.

## Verification
- `cargo fmt --check`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`
- `CARGO_BUILD_JOBS=2 CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/mohsen/code/tsz-studio-a-kysely-flow-20260531/target cargo nextest run -p tsz-checker --lib constraint_position_nullable_access_tests`
- Branch sync: rebased onto `origin/main` `8af00cde5587375e3801c1e43774b82dc54538c8`; `origin/main` is an ancestor of `78b49ab922a44e655022006124cda16559e942b1`.
- Previous draft head `76eb79c4b6a96ea1c8dec7db73d6db9126708a8a` passed `CI Light Summary`; this head only rebases the same code onto newer `origin/main` and has fresh local focused verification above.

## Coordination Notes
- Code-only PR; no repo markdown/documentation files changed.
- #11915 merged first via merge queue at `2026-05-31T13:29:43Z`.
- A first local nextest attempt using the shared target failed with `No space left on device`; after cache-preserving cleanup, the focused run above passed in the PR worktree target.
