### PR TITLE
refactor(solver): route subtype cache keys through relation policy

### DIFF
--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -238,6 +238,27 @@ impl RelationPolicy {
     /// `config` field of a [`crate::types::RelationCacheKey`]. Every
     /// behavior-affecting field on `RelationPolicy` must be reflected here.
     pub const fn cache_config(self) -> RelationCacheConfig {
+        let any_mode = match self.any_propagation_mode {
+            AnyPropagationMode::All => CachedAnyMode::All,
+            // A policy does not know the current recursion depth, so it
+            // encodes the configured mode as "top-level" from the policy's
+            // perspective. The `SubtypeChecker` refines this to
+            // `TopLevelOnlyNested` at depth > 0 when it builds its own key.
+            AnyPropagationMode::TopLevelOnly => CachedAnyMode::TopLevelOnlyAtTop,
+        };
+        self.cache_config_with_cached_any_mode(any_mode)
+    }
+
+    /// Project this policy to a cache config with an already-resolved cached
+    /// `any` mode.
+    ///
+    /// `SubtypeChecker` uses this when `AnyPropagationMode::TopLevelOnly`
+    /// depends on current recursion depth, which is operation-local state not
+    /// stored on the policy itself.
+    pub(crate) const fn cache_config_with_cached_any_mode(
+        self,
+        any_mode: CachedAnyMode,
+    ) -> RelationCacheConfig {
         let field_owned_bits = RelationFlags::STRICT_SUBTYPE_CHECKING
             .union(RelationFlags::STRICT_ANY_PROPAGATION)
             .union(RelationFlags::SKIP_WEAK_TYPE_CHECKS)
@@ -263,14 +284,6 @@ impl RelationPolicy {
         if !self.erase_generics {
             bits = bits.union(RelationFlags::NO_ERASE_GENERICS);
         }
-        let any_mode = match self.any_propagation_mode {
-            AnyPropagationMode::All => CachedAnyMode::All,
-            // A policy does not know the current recursion depth, so it
-            // encodes the configured mode as "top-level" from the policy's
-            // perspective. The `SubtypeChecker` refines this to
-            // `TopLevelOnlyNested` at depth > 0 when it builds its own key.
-            AnyPropagationMode::TopLevelOnly => CachedAnyMode::TopLevelOnlyAtTop,
-        };
         RelationCacheConfig::new(bits, any_mode)
     }
 }

--- a/crates/tsz-solver/src/relations/subtype/helpers.rs
+++ b/crates/tsz-solver/src/relations/subtype/helpers.rs
@@ -6,12 +6,12 @@
 
 use crate::def::resolver::TypeResolver;
 use crate::objects::PropertyCollectionResult;
+use crate::relations::relation_queries::RelationPolicy;
 use crate::relations::subtype::{
     AnyPropagationMode, INTERSECTION_OBJECT_FAST_PATH_THRESHOLD, SubtypeChecker, SubtypeResult,
 };
 use crate::types::{
-    CachedAnyMode, ObjectFlags, ObjectShape, RelationCacheConfig, RelationCacheKey, RelationFlags,
-    TypeId, Visibility,
+    CachedAnyMode, ObjectFlags, ObjectShape, RelationCacheKey, RelationFlags, TypeId, Visibility,
 };
 use crate::visitor::{
     callable_shape_id, function_shape_id, index_access_parts, keyof_inner_type, literal_string,
@@ -269,7 +269,15 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             AnyPropagationMode::TopLevelOnly => CachedAnyMode::TopLevelOnlyNested,
         };
 
-        RelationCacheKey::for_subtype(source, target, RelationCacheConfig::new(flags, any_mode))
+        let policy = RelationPolicy::from_relation_flags(flags)
+            .with_any_propagation_mode(self.any_propagation)
+            .with_assume_related_on_cycle(self.assume_related_on_cycle);
+
+        RelationCacheKey::for_subtype(
+            source,
+            target,
+            policy.cache_config_with_cached_any_mode(any_mode),
+        )
     }
 
     /// Test-only accessor that exposes the cache key this checker would use

--- a/crates/tsz-solver/tests/relation_cache_config_tests/cache_agreement.rs
+++ b/crates/tsz-solver/tests/relation_cache_config_tests/cache_agreement.rs
@@ -353,6 +353,28 @@ fn query_cache_typed_policy_entrypoints_insert_policy_shaped_keys() {
 }
 
 #[test]
+fn subtype_checker_cache_key_uses_relation_policy_projection() {
+    let source = include_str!("../../src/relations/subtype/helpers.rs");
+    let make_key_start = source
+        .find("pub(crate) fn make_cache_key")
+        .expect("subtype helper must keep make_cache_key");
+    let debug_accessor_start = source[make_key_start..]
+        .find("pub fn debug_cache_key_for")
+        .map(|offset| make_key_start + offset)
+        .expect("debug accessor should follow make_cache_key");
+    let make_key_source = &source[make_key_start..debug_accessor_start];
+
+    assert!(
+        make_key_source.contains("RelationPolicy"),
+        "subtype cache-key construction must project through RelationPolicy",
+    );
+    assert!(
+        !make_key_source.contains("RelationCacheConfig::new"),
+        "subtype cache-key construction must not hand-roll RelationCacheConfig",
+    );
+}
+
+#[test]
 fn assignability_cache_strict_any_policy_matches_uncached_relation_query() {
     let interner = TypeInterner::new();
     let db = QueryCache::new(&interner);


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Solver relation policy/cache-key cleanup for #8207.

## Invariant
When subtype relation results are cached, cache keys must be derived from the same RelationPolicy projection that drives the relation answer. This PR routes subtype cache key construction through the policy projection without changing intended relation behavior.

## Scope
- crates/tsz-solver/src/relations/relation_queries.rs
- crates/tsz-solver/src/relations/subtype/helpers.rs
- crates/tsz-solver/tests/relation_cache_config_tests/cache_agreement.rs

## Project Corpus Impact
- Row: n/a
- Bug family: relation-cache correctness / solver policy protocol
- Evidence: solver-only cache-key refactor with targeted cache-enabled/cache-disabled agreement tests; no project corpus row claimed.

## Verification
- Current base: a379738fd4e43c1684f0cfbaf1c4873c74da664d
- Current head: 06f6038f232c6c19c449eaa0f9c7fa95c09e22f8
- cargo nextest run -p tsz-solver -E "test(subtype_checker_cache_key_uses_relation_policy_projection) | test(relation_policy_cache_agreement_tests)" (28 passed, 6414 skipped)
- cargo fmt --check
- git diff --check main..HEAD

## Coordination Notes
- Rebased onto current main a379738fd4e43c1684f0cfbaf1c4873c74da664d after #11965 landed.
- Ready/non-draft, but merge-queue is intentionally off until restarted exact-head PR-head CI completes green.
- Related issue: #8207.