### PR TITLE
fix(emit): hoist system for-await temps

### DIFF
--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -270,6 +270,12 @@ pub(crate) struct TempScopeState {
     pub(crate) hoisted_for_of_temps: Vec<String>,
 }
 
+pub(crate) struct SystemForAwaitTempPlan {
+    pub(crate) loop_done_name: String,
+    pub(crate) return_temp_name: String,
+    pub(crate) value_temp_name: String,
+}
+
 impl ParamTransformPlan {
     pub(crate) const fn has_transforms(&self) -> bool {
         !self.params.is_empty() || self.rest.is_some()
@@ -692,6 +698,10 @@ pub struct Printer<'a> {
     /// Legacy-decorated class self-reference aliases planned while collecting
     /// `SystemJS` wrapper hoists and consumed when emitting the matching class.
     pub(crate) preplanned_legacy_decorated_class_aliases: FxHashMap<NodeIndex, String>,
+
+    /// Top-level `for await...of` temps planned for a `System.register`
+    /// `execute` body before the wrapper's hoisted `var` list is printed.
+    pub(crate) system_for_await_temp_plans: FxHashMap<NodeIndex, SystemForAwaitTempPlan>,
 
     /// Byte offset where CJS destructuring export temps should be inserted.
     pub(crate) cjs_destr_hoist_byte_offset: usize,

--- a/crates/tsz-emitter/src/emitter/core_setup.rs
+++ b/crates/tsz-emitter/src/emitter/core_setup.rs
@@ -351,6 +351,7 @@ impl<'a> Printer<'a> {
             system_object_rest_export_temps: FxHashMap::default(),
             system_binding_pattern_temps: FxHashMap::default(),
             preplanned_legacy_decorated_class_aliases: FxHashMap::default(),
+            system_for_await_temp_plans: FxHashMap::default(),
             cjs_destr_hoist_byte_offset: 0,
             cjs_destr_hoist_line: 0_u32,
             preallocated_temp_names: VecDeque::new(),

--- a/crates/tsz-emitter/src/emitter/es5/bindings_param_patterns.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings_param_patterns.rs
@@ -1206,11 +1206,23 @@ impl<'a> Printer<'a> {
         // - For loop: _d (guard)
         // Catch: e_N_1 (error value, not pre-declared)
         let error_container_name = format!("e_{}", counter + 1);
-        let loop_done_name = self.get_temp_var_name();
-        let return_temp_name = self
-            .reserved_iterator_return_temps
-            .remove(&for_of_idx)
-            .unwrap_or_else(|| self.get_temp_var_name()); // _a, _b, ...
+        let system_temp_plan = if self.in_system_execute_body && self.temp_scope_stack.is_empty() {
+            self.system_for_await_temp_plans.remove(&for_of_idx)
+        } else {
+            None
+        };
+        let loop_done_name = system_temp_plan.as_ref().map_or_else(
+            || self.get_temp_var_name(),
+            |plan| plan.loop_done_name.clone(),
+        );
+        let return_temp_name = system_temp_plan.as_ref().map_or_else(
+            || {
+                self.reserved_iterator_return_temps
+                    .remove(&for_of_idx)
+                    .unwrap_or_else(|| self.get_temp_var_name())
+            },
+            |plan| plan.return_temp_name.clone(),
+        ); // _a, _b, ...
         let is_nested_iterator_for_of = self.iterator_for_of_depth > 0;
         self.iterator_for_of_depth += 1;
 
@@ -1218,8 +1230,15 @@ impl<'a> Printer<'a> {
         // allocating this loop's iterator/result vars.
         self.preallocate_nested_iterator_return_temps(for_in_of.statement);
 
-        let value_temp_name = self.get_temp_var_name();
-        let loop_guard_name = self.get_temp_var_name();
+        let value_temp_name = system_temp_plan.as_ref().map_or_else(
+            || self.get_temp_var_name(),
+            |plan| plan.value_temp_name.clone(),
+        );
+        let loop_guard_name = if system_temp_plan.is_some() {
+            loop_done_name.clone()
+        } else {
+            self.get_temp_var_name()
+        };
         let (loop_iterator_name, loop_result_name) = if let Some(expr_node) =
             self.arena.get(for_in_of.expression)
             && expr_node.is_identifier()

--- a/crates/tsz-emitter/src/emitter/module_emission/exports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/exports.rs
@@ -805,7 +805,7 @@ impl<'a> Printer<'a> {
                 // export const/let/var x = ...
                 k if k == syntax_kind_ext::VARIABLE_STATEMENT => {
                     if self.in_system_execute_body {
-                        self.emit_system_variable_initializers(clause_node);
+                        self.emit_system_variable_initializers(clause_node, node.pos);
                         return;
                     }
                     if !self.ctx.module_state.has_export_assignment {

--- a/crates/tsz-emitter/src/emitter/module_wrapper/system_emit.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/system_emit.rs
@@ -336,14 +336,17 @@ impl<'a> Printer<'a> {
         }
         self.emit_system_import_binding_exports(source, system_plan);
 
+        let mut previous_stmt_end = source_node.pos;
         for &stmt_idx in &source.statements.nodes {
+            let Some(stmt_node) = self.arena.get(stmt_idx) else {
+                continue;
+            };
+            let leading_comment_start = previous_stmt_end;
+            previous_stmt_end = stmt_node.end;
             // Skip function declarations that were already hoisted to the outer scope
             if hoisted_func_stmts.contains(&stmt_idx) {
                 continue;
             }
-            let Some(stmt_node) = self.arena.get(stmt_idx) else {
-                continue;
-            };
             // Skip "use strict" prologue directives — the System.register callback
             // already emits "use strict" at the module scope (line 315 above), so
             // re-emitting the source's own directive inside execute() would duplicate it.
@@ -408,7 +411,7 @@ impl<'a> Printer<'a> {
             }
 
             if stmt_node.kind == syntax_kind_ext::VARIABLE_STATEMENT {
-                self.emit_system_variable_initializers(stmt_node);
+                self.emit_system_variable_initializers(stmt_node, leading_comment_start);
             } else if stmt_node.kind == syntax_kind_ext::CLASS_DECLARATION {
                 // Non-exported class declarations: var is hoisted, emit as assignment
                 self.emit_system_class_as_expression(stmt_node, stmt_idx);
@@ -668,7 +671,7 @@ impl<'a> Printer<'a> {
         }
 
         if clause_node.kind == syntax_kind_ext::VARIABLE_STATEMENT {
-            self.emit_system_variable_initializers(clause_node);
+            self.emit_system_variable_initializers(clause_node, node.pos);
             return true;
         }
 
@@ -1050,10 +1053,22 @@ impl<'a> Printer<'a> {
     pub(in crate::emitter) fn emit_system_variable_initializers(
         &mut self,
         node: &tsz_parser::parser::node::Node,
+        leading_comment_start: u32,
     ) {
         let Some(var_stmt) = self.arena.get_variable(node) else {
             return;
         };
+        let actual_start = self.skip_trivia_forward(node.pos, node.end);
+        let before_comments_len = self.writer.len();
+        self.emit_comments_before_pos(actual_start);
+        if self.writer.len() == before_comments_len {
+            self.emit_comments_in_range_untracked(
+                leading_comment_start,
+                actual_start,
+                false,
+                false,
+            );
+        }
         let is_exported = self
             .arena
             .has_modifier(&var_stmt.modifiers, SyntaxKind::ExportKeyword);

--- a/crates/tsz-emitter/src/emitter/module_wrapper/system_emit_using.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/system_emit_using.rs
@@ -106,7 +106,7 @@ impl<'a> Printer<'a> {
             }
 
             if stmt_node.kind == syntax_kind_ext::VARIABLE_STATEMENT {
-                self.emit_system_variable_initializers(stmt_node);
+                self.emit_system_variable_initializers(stmt_node, stmt_node.pos);
             } else {
                 self.emit(stmt_idx);
             }

--- a/crates/tsz-emitter/src/emitter/module_wrapper/system_hoist.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/system_hoist.rs
@@ -1,5 +1,6 @@
 use super::super::{JsxEmit, Printer};
 use super::{SystemDependencyAction, SystemDependencyPlan};
+use crate::emitter::core::SystemForAwaitTempPlan;
 use std::collections::HashSet;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -14,6 +15,7 @@ impl<'a> Printer<'a> {
         self.system_empty_binding_temps.clear();
         self.system_object_rest_export_temps.clear();
         self.system_binding_pattern_temps.clear();
+        self.system_for_await_temp_plans.clear();
         let mut names = Vec::new();
         let mut deferred_named_export_names = Vec::new();
         let mut seen_deferred_named_export_names = HashSet::new();
@@ -55,6 +57,8 @@ impl<'a> Printer<'a> {
         {
             names.push("_jsxFileName".to_string());
         }
+
+        self.collect_system_for_await_hoisted_temps(source, &mut names, &mut seen);
 
         for &stmt_idx in &source.statements.nodes {
             let Some(stmt_node) = self.arena.get(stmt_idx) else {
@@ -563,6 +567,201 @@ impl<'a> Printer<'a> {
         }
 
         names
+    }
+
+    fn collect_system_for_await_hoisted_temps(
+        &mut self,
+        source: &tsz_parser::parser::node::SourceFileData,
+        names: &mut Vec<String>,
+        seen: &mut HashSet<String>,
+    ) {
+        let mut for_of_counter = self.ctx.destructuring_state.for_of_counter;
+        for &stmt_idx in &source.statements.nodes {
+            self.collect_system_for_await_hoisted_temps_from_node(
+                stmt_idx,
+                names,
+                seen,
+                &mut for_of_counter,
+            );
+        }
+    }
+
+    fn collect_system_for_await_hoisted_temps_from_node(
+        &mut self,
+        idx: NodeIndex,
+        names: &mut Vec<String>,
+        seen: &mut HashSet<String>,
+        for_of_counter: &mut u32,
+    ) {
+        if idx.is_none() {
+            return;
+        }
+        let Some(node) = self.arena.get(idx) else {
+            return;
+        };
+
+        match node.kind {
+            k if k == syntax_kind_ext::FOR_OF_STATEMENT => {
+                if let Some(for_in_of) = self.arena.get_for_in_of(node) {
+                    if for_in_of.await_modifier {
+                        let loop_done_name = self.make_unique_name();
+                        let error_container_name = format!("e_{}", *for_of_counter + 1);
+                        let return_temp_name = self.make_unique_name();
+                        let value_temp_name = self.make_unique_name();
+                        *for_of_counter += 1;
+
+                        for name in [
+                            &loop_done_name,
+                            &error_container_name,
+                            &return_temp_name,
+                            &value_temp_name,
+                        ] {
+                            if seen.insert(name.clone()) {
+                                names.push(name.clone());
+                            }
+                        }
+                        self.system_for_await_temp_plans.insert(
+                            idx,
+                            SystemForAwaitTempPlan {
+                                loop_done_name,
+                                return_temp_name,
+                                value_temp_name,
+                            },
+                        );
+                    }
+                    self.collect_system_for_await_hoisted_temps_from_node(
+                        for_in_of.statement,
+                        names,
+                        seen,
+                        for_of_counter,
+                    );
+                }
+            }
+            k if k == syntax_kind_ext::BLOCK || k == syntax_kind_ext::CASE_BLOCK => {
+                if let Some(block) = self.arena.get_block(node) {
+                    for &stmt in &block.statements.nodes {
+                        self.collect_system_for_await_hoisted_temps_from_node(
+                            stmt,
+                            names,
+                            seen,
+                            for_of_counter,
+                        );
+                    }
+                }
+            }
+            k if k == syntax_kind_ext::IF_STATEMENT => {
+                if let Some(if_stmt) = self.arena.get_if_statement(node) {
+                    self.collect_system_for_await_hoisted_temps_from_node(
+                        if_stmt.then_statement,
+                        names,
+                        seen,
+                        for_of_counter,
+                    );
+                    self.collect_system_for_await_hoisted_temps_from_node(
+                        if_stmt.else_statement,
+                        names,
+                        seen,
+                        for_of_counter,
+                    );
+                }
+            }
+            k if k == syntax_kind_ext::TRY_STATEMENT => {
+                if let Some(try_stmt) = self.arena.get_try(node) {
+                    self.collect_system_for_await_hoisted_temps_from_node(
+                        try_stmt.try_block,
+                        names,
+                        seen,
+                        for_of_counter,
+                    );
+                    self.collect_system_for_await_hoisted_temps_from_node(
+                        try_stmt.catch_clause,
+                        names,
+                        seen,
+                        for_of_counter,
+                    );
+                    self.collect_system_for_await_hoisted_temps_from_node(
+                        try_stmt.finally_block,
+                        names,
+                        seen,
+                        for_of_counter,
+                    );
+                }
+            }
+            k if k == syntax_kind_ext::CATCH_CLAUSE => {
+                if let Some(catch_clause) = self.arena.get_catch_clause(node) {
+                    self.collect_system_for_await_hoisted_temps_from_node(
+                        catch_clause.block,
+                        names,
+                        seen,
+                        for_of_counter,
+                    );
+                }
+            }
+            k if k == syntax_kind_ext::FOR_STATEMENT
+                || k == syntax_kind_ext::FOR_IN_STATEMENT
+                || k == syntax_kind_ext::WHILE_STATEMENT
+                || k == syntax_kind_ext::DO_STATEMENT =>
+            {
+                if let Some(loop_data) = self.arena.get_loop(node) {
+                    self.collect_system_for_await_hoisted_temps_from_node(
+                        loop_data.statement,
+                        names,
+                        seen,
+                        for_of_counter,
+                    );
+                } else if let Some(for_in_of) = self.arena.get_for_in_of(node) {
+                    self.collect_system_for_await_hoisted_temps_from_node(
+                        for_in_of.statement,
+                        names,
+                        seen,
+                        for_of_counter,
+                    );
+                }
+            }
+            k if k == syntax_kind_ext::SWITCH_STATEMENT => {
+                if let Some(sw) = self.arena.get_switch(node) {
+                    self.collect_system_for_await_hoisted_temps_from_node(
+                        sw.case_block,
+                        names,
+                        seen,
+                        for_of_counter,
+                    );
+                }
+            }
+            k if k == syntax_kind_ext::CASE_CLAUSE || k == syntax_kind_ext::DEFAULT_CLAUSE => {
+                if let Some(clause) = self.arena.get_case_clause(node) {
+                    for &stmt in &clause.statements.nodes {
+                        self.collect_system_for_await_hoisted_temps_from_node(
+                            stmt,
+                            names,
+                            seen,
+                            for_of_counter,
+                        );
+                    }
+                }
+            }
+            k if k == syntax_kind_ext::LABELED_STATEMENT => {
+                if let Some(labeled) = self.arena.get_labeled_statement(node) {
+                    self.collect_system_for_await_hoisted_temps_from_node(
+                        labeled.statement,
+                        names,
+                        seen,
+                        for_of_counter,
+                    );
+                }
+            }
+            k if k == syntax_kind_ext::WITH_STATEMENT => {
+                if let Some(with_stmt) = self.arena.get_with_statement(node) {
+                    self.collect_system_for_await_hoisted_temps_from_node(
+                        with_stmt.then_statement,
+                        names,
+                        seen,
+                        for_of_counter,
+                    );
+                }
+            }
+            _ => {}
+        }
     }
 
     fn system_hoist_legacy_decorated_class_alias(

--- a/crates/tsz-emitter/src/emitter/module_wrapper/tests/system_top_level_await.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/tests/system_top_level_await.rs
@@ -106,7 +106,7 @@ fn system_for_await_of_downlevel_makes_execute_async_es2015() {
     // `for await...of` downleveled to ES2015 emits `await iterator.next()` /
     // `await iterator.return()` inside execute, which requires async.
     let output = emit_system_lowered(
-        "export {};\nconst arr = [Promise.resolve()];\nfor await (const item of arr) {\n    item;\n}\n",
+        "export {};\n// for-await-of\nconst arr = [Promise.resolve()];\nfor await (const item of arr) {\n    item;\n}\n",
         ScriptTarget::ES2015,
     );
     assert!(
@@ -116,6 +116,18 @@ fn system_for_await_of_downlevel_makes_execute_async_es2015() {
     assert!(
         output.contains("await "),
         "downleveled for-await-of should emit await operators.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("var _a, e_1, _b, _c, arr;"),
+        "System wrapper must hoist for-await temps before execute.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("// for-await-of\n            arr = [Promise.resolve()];"),
+        "System variable initializer emit must preserve leading comments.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("for (var _a = true, arr_1 = __asyncValues(arr), arr_1_1;"),
+        "System top-level for-await should reuse the planned done temp as the loop guard.\nOutput:\n{output}"
     );
 }
 
@@ -130,6 +142,10 @@ fn system_for_await_of_renamed_binder_makes_execute_async_es2015() {
     assert!(
         output.contains("execute: async function () {"),
         "renamed for-await-of binder must still mark execute async.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("var _a, e_1, _b, _c, xs;"),
+        "renamed for-await-of source must still plan wrapper hoists structurally.\nOutput:\n{output}"
     );
 }
 

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -1052,7 +1052,7 @@ impl<'a> Printer<'a> {
                 Vec::new()
             };
 
-            self.emit_system_variable_initializers(node);
+            self.emit_system_variable_initializers(node, node.pos);
 
             for (local_name, export_name) in deferred_exports {
                 self.write_line();


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Studio-C JavaScript emit parity: System module/top-level-await transform slice.

## Invariant
When a `System.register` module inlines top-level `for await...of` into `execute`, the downlevel iterator temps must be planned into the wrapper hoist list before `execute`, and leading comments on the transformed top-level variable initializer must remain in the `execute` body. This PR changes the emitter/module-wrapper temp planning path only.

## Scope
- Plan top-level System `for await...of` temps while collecting wrapper hoists.
- Let the ES5 async-iterator lowerer consume the planned System temp names and reuse the planned done temp as the loop guard for `execute` output.
- Preserve leading comments for custom System variable-initializer emission.
- Extend System top-level-await unit coverage for temp hoists, renamed binders, and comment preservation.

## Project Corpus Impact
- Row: n/a
- Bug family: JavaScript emit System module top-level-await / downlevel `for await...of` temp hoisting
- Evidence: conformance emit filter `topLevelAwait.1` passes 6/6 locally on current-main head `4cb80d3eb6b3f65fe693d822ede7bf0071891859`, including `module=system,target=es2015` and `module=system,target=es2017`.

## Verification
- `cargo fmt --check`
- `cargo check -p tsz-emitter`
- `cargo nextest run -p tsz-emitter -E 'test(system_top_level_await)'` -> 7/7 passed
- `CARGO_INCREMENTAL=0 scripts/emit/run.sh --filter=topLevelAwait.1 --js-only --verbose --timeout=30000 --json-out=/tmp/topLevelAwait1-studio-c-system-for-await-c03-sync.json` -> 6/6 passed
- `python3 scripts/arch/arch_guard.py`
- `git diff --check HEAD~1..HEAD`

## Coordination Notes
- AgentName: Studio-C.
- Rebased and force-pushed onto observed current `origin/main` at `c03cb81882 perf(checker): resolve lib refs in member batching (#11924)`.
- Open PR overlap checked with `gh pr list --state open --limit 100 ...`; no active module-wrapper/top-level-await emit PR found.
- `scripts/agents/ensure-agent-labels.sh --audit` passed this cycle.
- Ready for manager review/queue consideration after exact-head PR checks complete. I did not add merge-queue or enable auto-merge.