### PR TITLE
fix(dts): preserve strict function inference in declarations

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs
@@ -1707,7 +1707,10 @@ impl<'a> DeclarationEmitter<'a> {
             || Self::contains_whole_word_in_text(constraint, "bigint")
     }
 
-    fn primitive_literal_argument_type_text(&self, arg_idx: NodeIndex) -> Option<String> {
+    pub(in crate::declaration_emitter) fn primitive_literal_argument_type_text(
+        &self,
+        arg_idx: NodeIndex,
+    ) -> Option<String> {
         let arg_idx = self.skip_parenthesized_expression(arg_idx)?;
         let arg_node = self.arena.get(arg_idx)?;
         (arg_node.kind == SyntaxKind::StringLiteral as u16

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_function_text.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_function_text.rs
@@ -39,19 +39,18 @@ impl<'a> DeclarationEmitter<'a> {
             {
                 continue;
             }
-            if substitutions
-                .iter()
-                .any(|(name, _)| name.as_str() == source_param.type_text)
-            {
-                continue;
-            }
             if let Some(argument_param) = argument.parameters.get(source_param_index) {
-                substitutions.push((
-                    source_param.type_text.clone(),
-                    Self::parenthesize_generic_function_type_argument(&argument_param.type_text),
-                ));
+                Self::merge_function_param_substitution(
+                    substitutions,
+                    &source_param.type_text,
+                    &argument_param.type_text,
+                );
             } else if source_param.optional {
-                substitutions.push((source_param.type_text.clone(), "unknown".to_string()));
+                Self::merge_function_param_substitution(
+                    substitutions,
+                    &source_param.type_text,
+                    "unknown",
+                );
             }
         }
 
@@ -138,6 +137,81 @@ impl<'a> DeclarationEmitter<'a> {
         }
     }
 
+    fn merge_function_param_substitution(
+        substitutions: &mut Vec<(String, String)>,
+        name: &str,
+        candidate: &str,
+    ) {
+        if let Some((_, existing)) = substitutions
+            .iter_mut()
+            .find(|(known, _)| known.as_str() == name)
+        {
+            if Self::type_text_is_stricter_function_parameter_candidate(candidate, existing) {
+                *existing = Self::parenthesize_generic_function_type_argument(candidate);
+            }
+            return;
+        }
+        substitutions.push((
+            name.to_string(),
+            Self::parenthesize_generic_function_type_argument(candidate),
+        ));
+    }
+
+    fn type_text_is_stricter_function_parameter_candidate(candidate: &str, existing: &str) -> bool {
+        let candidate = candidate.trim();
+        let existing = existing.trim();
+        if candidate == existing {
+            return false;
+        }
+        if Self::literal_type_text_narrows_type_text(candidate, existing) {
+            return true;
+        }
+        if Self::literal_type_text_narrows_type_text(existing, candidate) {
+            return false;
+        }
+        if Self::primitive_type_text_narrows_type_text(candidate, existing) {
+            return true;
+        }
+        false
+    }
+
+    fn literal_type_text_narrows_type_text(literal: &str, target: &str) -> bool {
+        let Some(primitive) = Self::literal_type_text_primitive_kind(literal) else {
+            return false;
+        };
+        target.trim() == primitive
+            || Self::primitive_type_text_narrows_type_text(primitive, target)
+            || Self::split_top_level_union_type_parts(target)
+                .iter()
+                .any(|part| part.trim() == primitive)
+    }
+
+    fn primitive_type_text_narrows_type_text(candidate: &str, existing: &str) -> bool {
+        matches!(candidate.trim(), "string" | "number" | "boolean" | "bigint")
+            && matches!(existing.trim(), "Object" | "object" | "{}" | "unknown")
+    }
+
+    fn literal_type_text_primitive_kind(type_text: &str) -> Option<&'static str> {
+        let trimmed = type_text.trim();
+        if trimmed == "true" || trimmed == "false" {
+            return Some("boolean");
+        }
+        if trimmed.starts_with('"') || trimmed.starts_with('\'') {
+            return Some("string");
+        }
+        if trimmed.ends_with('n')
+            && tsz_solver::utils::is_numeric_literal_name(
+                &trimmed[..trimmed.len().saturating_sub(1)],
+            )
+        {
+            return Some("bigint");
+        }
+        if tsz_solver::utils::is_numeric_literal_name(trimmed) {
+            return Some("number");
+        }
+        None
+    }
+
     fn infer_argument_function_type_param_substitution(
         argument_param: &FunctionTypeParamText,
         source_type_text: &str,
@@ -154,7 +228,11 @@ impl<'a> DeclarationEmitter<'a> {
         {
             return;
         }
-        substitutions.push((argument_type_text.to_string(), source_type_text.to_string()));
+        Self::merge_function_param_substitution(
+            substitutions,
+            argument_type_text,
+            source_type_text,
+        );
     }
 
     fn tuple_item_text_for_function_param(param: &FunctionTypeParamText) -> String {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_call.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_call.rs
@@ -242,6 +242,10 @@ impl<'a> DeclarationEmitter<'a> {
             type_param_names.push(name_text);
         }
 
+        let return_type_param_name = type_param_names
+            .iter()
+            .find(|name| type_text.trim() == name.as_str())
+            .cloned();
         let explicit_type_args = self.type_argument_list_source_text(call.type_arguments.as_ref());
         let mut substitutions = if explicit_type_args.is_empty() {
             self.infer_call_type_param_substitutions_from_arguments(
@@ -258,6 +262,17 @@ impl<'a> DeclarationEmitter<'a> {
                 .map(|(name_text, arg_text)| (name_text.clone(), arg_text.clone()))
                 .collect()
         };
+        if explicit_type_args.is_empty()
+            && let Some(name_text) = return_type_param_name.as_deref()
+            && let Some(literal_text) = self.literal_direct_type_parameter_argument_substitution(
+                source_arena,
+                func,
+                call,
+                name_text,
+            )
+        {
+            Self::replace_or_push_substitution(&mut substitutions, name_text, literal_text);
+        }
         for (name_text, default_text) in type_param_defaults {
             if substitutions
                 .iter()
@@ -289,6 +304,86 @@ impl<'a> DeclarationEmitter<'a> {
             return None;
         }
         Some(type_text)
+    }
+
+    pub(in crate::declaration_emitter) fn literal_direct_type_parameter_argument_substitution(
+        &self,
+        source_arena: &NodeArena,
+        func: &tsz_parser::parser::node::FunctionData,
+        call: &tsz_parser::parser::node::CallExprData,
+        type_param_name: &str,
+    ) -> Option<String> {
+        let args = call.arguments.as_ref()?;
+        for (&param_idx, &arg_idx) in func.parameters.nodes.iter().zip(args.nodes.iter()) {
+            let param_node = source_arena.get(param_idx)?;
+            let param = source_arena.get_parameter(param_node)?;
+            if param.dot_dot_dot_token {
+                continue;
+            }
+            let param_type_text = self
+                .emit_type_node_text_from_arena(source_arena, param.type_annotation)
+                .or_else(|| self.source_slice_from_arena(source_arena, param.type_annotation))?;
+            if param_type_text.trim() != type_param_name {
+                continue;
+            }
+            if let Some(literal_text) = self.primitive_literal_argument_type_text(arg_idx) {
+                return Some(literal_text);
+            }
+        }
+        None
+    }
+
+    fn replace_or_push_substitution(
+        substitutions: &mut Vec<(String, String)>,
+        name: &str,
+        value: String,
+    ) {
+        if let Some((_, existing)) = substitutions
+            .iter_mut()
+            .find(|(known, _)| known.as_str() == name)
+        {
+            *existing = value;
+            return;
+        }
+        substitutions.push((name.to_string(), value));
+    }
+
+    pub(in crate::declaration_emitter) fn function_has_higher_order_type_parameter_parameter(
+        &self,
+        source_arena: &NodeArena,
+        func: &tsz_parser::parser::node::FunctionData,
+        type_param_name: &str,
+    ) -> bool {
+        if type_param_name.is_empty() {
+            return false;
+        }
+        for &param_idx in &func.parameters.nodes {
+            let Some(param_node) = source_arena.get(param_idx) else {
+                continue;
+            };
+            let Some(param) = source_arena.get_parameter(param_node) else {
+                continue;
+            };
+            let Some(param_type_text) = self
+                .emit_type_node_text_from_arena(source_arena, param.type_annotation)
+                .or_else(|| self.source_slice_from_arena(source_arena, param.type_annotation))
+            else {
+                continue;
+            };
+            if !Self::contains_whole_word_in_text(&param_type_text, type_param_name) {
+                continue;
+            }
+            let Some(parts) = Self::parse_function_type_text(&param_type_text) else {
+                continue;
+            };
+            if parts.parameters.iter().any(|param| {
+                Self::contains_whole_word_in_text(&param.type_text, type_param_name)
+                    && Self::parse_function_type_text(&param.type_text).is_some()
+            }) {
+                return true;
+            }
+        }
+        false
     }
 
     fn expand_literal_key_mapped_type_text(type_text: &str) -> Option<String> {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
@@ -471,10 +471,27 @@ impl<'a> DeclarationEmitter<'a> {
                             && !self
                                 .call_expression_uses_partial_required_mapped_inference(expr_idx)
                             && !self.call_expression_uses_no_infer_return_block(expr_idx)
-                            && let Some(canonical_text) =
-                                self.fully_resolved_call_canonical_type_text(expr_idx)
                         {
-                            return Some(canonical_text);
+                            let literal_direct_substitution = self
+                                .literal_direct_type_parameter_argument_substitution(
+                                    source_arena,
+                                    func,
+                                    call,
+                                    type_text.trim(),
+                                );
+                            let has_higher_order_type_param_param = self
+                                .function_has_higher_order_type_parameter_parameter(
+                                    source_arena,
+                                    func,
+                                    type_text.trim(),
+                                );
+                            if (literal_direct_substitution.is_none()
+                                || has_higher_order_type_param_param)
+                                && let Some(canonical_text) =
+                                    self.fully_resolved_call_canonical_type_text(expr_idx)
+                            {
+                                return Some(canonical_text);
+                            }
                         }
                         if let Some(evaluated) = self
                             .evaluate_source_template_infer_conditional_call(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
@@ -805,6 +805,91 @@ let y10 = unboxify(x10);
 }
 
 #[test]
+fn declared_call_return_refines_callback_parameter_inference_from_later_arguments() {
+    let source = r#"
+declare function merge<A>(left: (value: A) => void, right: (value: A) => void): (value: A) => void;
+declare function acceptObject(value: Object): void;
+declare function acceptString(value: string): void;
+declare function acceptLiteral(value: "lit"): void;
+export const first = merge(acceptObject, acceptString);
+export const reversed = merge(acceptString, acceptObject);
+export const literal = merge(acceptObject, acceptLiteral);
+"#;
+    let output = emit_test_dts_with_binding(source);
+
+    assert!(
+        output.contains("export declare const first: (value: string) => void;"),
+        "{output}"
+    );
+    assert!(
+        output.contains("export declare const reversed: (value: string) => void;"),
+        "{output}"
+    );
+    assert!(
+        output.contains("export declare const literal: (value: \"lit\") => void;"),
+        "{output}"
+    );
+}
+
+#[test]
+fn declared_call_return_preserves_bare_type_parameter_literal_argument() {
+    let source = r#"
+declare function valueMerge<A>(value: A, left: (value: A) => void, right: (value: A) => void): A;
+declare function acceptObject(value: Object): void;
+declare function acceptString(value: string): void;
+const text = valueMerge("abc", acceptObject, acceptString);
+const number = valueMerge(123, (value: number | string) => {}, (value: 123) => {});
+"#;
+    let output = emit_test_dts_with_binding(source);
+
+    assert!(output.contains("declare const text = \"abc\";"), "{output}");
+    assert!(output.contains("declare const number = 123;"), "{output}");
+}
+
+#[test]
+fn higher_order_type_parameter_parameter_blocks_direct_literal_initializer_reuse() {
+    let source = r#"
+declare function direct<A>(value: A, callback: (value: A) => void): A;
+declare function higher<A>(value: A, callback: (inner: (value: A) => void) => void): A;
+declare function unrelated<A>(value: A, callback: (inner: (value: string) => void) => void): A;
+"#;
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+    let interner = TypeInterner::new();
+    let type_cache = crate::type_cache_view::TypeCacheView::default();
+    let emitter = DeclarationEmitter::with_type_info(&parser.arena, type_cache, &interner, &binder);
+
+    let find_function = |name: &str| {
+        parser.arena.nodes.iter().find_map(|node| {
+            let func = parser.arena.get_function(node)?;
+            (emitter
+                .identifier_text_from_arena(&parser.arena, func.name)
+                .as_deref()
+                == Some(name))
+            .then_some(func)
+        })
+    };
+
+    assert!(!emitter.function_has_higher_order_type_parameter_parameter(
+        &parser.arena,
+        find_function("direct").expect("direct function"),
+        "A",
+    ));
+    assert!(emitter.function_has_higher_order_type_parameter_parameter(
+        &parser.arena,
+        find_function("higher").expect("higher function"),
+        "A",
+    ));
+    assert!(!emitter.function_has_higher_order_type_parameter_parameter(
+        &parser.arena,
+        find_function("unrelated").expect("unrelated function"),
+        "A",
+    ));
+}
+
+#[test]
 fn declared_call_return_inverts_structural_partial_like_mapped_alias() {
     let source = r#"
 type OptionalShape<T> = { [Key in keyof T]?: T[Key] };

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -636,6 +636,15 @@ impl<'a> DeclarationEmitter<'a> {
                         initializer,
                         &type_text,
                     );
+                if keyword == "const"
+                    && !self.variable_declaration_has_effective_export(decl_idx)
+                    && Self::is_literal_type_text_for_const_call(&type_text)
+                    && self.call_expression_has_primitive_literal_argument(initializer)
+                {
+                    self.write(" = ");
+                    self.write(&type_text);
+                    return;
+                }
                 self.write(": ");
                 if fallback_to_any_for_types_versions_self_reference {
                     self.write("any");
@@ -1751,5 +1760,23 @@ impl<'a> DeclarationEmitter<'a> {
     ) -> Option<tsz_solver::types::LiteralValue> {
         let (_def_id, member_type) = tsz_solver::visitor::enum_components(interner, type_id)?;
         tsz_solver::visitor::literal_value(interner, member_type)
+    }
+
+    fn call_expression_has_primitive_literal_argument(&self, initializer: NodeIndex) -> bool {
+        let Some(init_node) = self.arena.get(initializer) else {
+            return false;
+        };
+        if init_node.kind != syntax_kind_ext::CALL_EXPRESSION {
+            return false;
+        }
+        let Some(call) = self.arena.get_call_expr(init_node) else {
+            return false;
+        };
+        call.arguments.as_ref().is_some_and(|args| {
+            args.nodes
+                .iter()
+                .copied()
+                .any(|arg| self.primitive_literal_argument_type_text(arg).is_some())
+        })
     }
 }


### PR DESCRIPTION
AgentName: Studio-D

## Track
Emit/DTS parity

## Invariant
Declaration emit must preserve `tsc`'s generic call inference surfaces for strict function types: callback-parameter inference should keep the stricter compatible parameter candidate, bare type-parameter returns may preserve direct primitive literal arguments for local const declarations, and higher-order callback parameters should fall back to the canonical widened call type.

## Scope
- Refine declaration source-call type-parameter substitution for function parameter candidates.
- Preserve direct primitive literal substitutions for bare type-parameter returns where `tsc` emits a const initializer.
- Keep higher-order callback cases on canonical call-type printing so widened results like `string` are preserved.
- Add focused emitter unit coverage for renamed type parameters, reversed callback order, literal arguments, and the higher-order fallback guard.

## Project Corpus Impact
- Row: n/a
- Bug family: declaration emit generic strict-function inference
- Evidence: emit/DTS-only conformance filter `strictFunctionTypes1` now passes locally.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `cargo nextest run -p tsz-emitter declared_call_return_refines_callback_parameter_inference_from_later_arguments declared_call_return_preserves_bare_type_parameter_literal_argument higher_order_type_parameter_parameter_blocks_direct_literal_initializer_reuse`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=strictFunctionTypes1 --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-strict-function-types1-postmerge.json`

## Coordination Notes
- AgentName: Studio-D
- Built on current `origin/main` after merging `280ae6cc83` into this branch.
- Non-overlapping with #11903, which remains open/ready while exact-head CI is still incomplete.
- No merge queue or auto-merge state is requested by this PR.
