### PR TITLE
perf(checker): resolve lib refs in member batching

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct/interface_methods.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct/interface_methods.rs
@@ -139,7 +139,10 @@ impl<'a> CheckerState<'a> {
                         type_name,
                     );
                 }
-                self.resolve_entity_name_text_to_def_id_for_lowering(type_name)
+                (!self.ctx.file_local_type_shadow_for_lib_name(type_name))
+                    .then(|| self.resolve_actual_lib_name_to_def_id_for_lowering(type_name))
+                    .flatten()
+                    .or_else(|| self.resolve_entity_name_text_to_def_id_for_lowering(type_name))
             };
             let no_type_symbol = |_node_idx: NodeIndex| -> Option<u32> { None };
             let no_def_id = |_node_idx: NodeIndex| -> Option<tsz_solver::def::DefId> { None };

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use tsz_binder::{BinderState, symbol_flags};
 use tsz_common::perf_counters::CrossArenaSymbolMissSource;
 use tsz_parser::parser::ParserState;
+use tsz_parser::parser::node::NodeAccess;
 use tsz_solver::TypeId;
 
 #[test]
@@ -180,6 +181,95 @@ fn direct_cross_file_interface_lowering_handles_simple_builtin_dom_interfaces() 
             .contains_symbol_type(value_merged_sym_id),
         "declined value-merged dom interfaces should not populate lib delegation cache",
     );
+}
+
+#[test]
+fn direct_builtin_dom_member_batch_resolves_actual_lib_property_refs() {
+    let lib_files = load_lib_files(&["es5.d.ts", "dom.d.ts"]);
+    let mut parser = ParserState::new("fixture.ts".to_string(), "let value;".to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file_with_libs(parser.get_arena(), root, &lib_files);
+    let arena = Arc::new(parser.get_arena().clone());
+    let binder = Arc::new(binder);
+    let types = TypeInterner::new();
+    let ctx = CheckerContext::new(
+        arena.as_ref(),
+        binder.as_ref(),
+        &types,
+        "fixture.ts".to_string(),
+        CheckerOptions::default(),
+    );
+    let mut state = CheckerState { ctx };
+    let lib_contexts: Vec<LibContext> = lib_files
+        .iter()
+        .map(|lib| LibContext {
+            arena: Arc::clone(&lib.arena),
+            binder: Arc::clone(&lib.binder),
+        })
+        .collect();
+    state.ctx.set_lib_contexts(lib_contexts);
+    state.ctx.set_actual_lib_file_count(lib_files.len());
+
+    let dom = lib_files
+        .iter()
+        .find(|lib| {
+            lib.arena
+                .source_files
+                .first()
+                .is_some_and(|source_file| source_file.file_name.ends_with("dom.d.ts"))
+        })
+        .expect("dom lib should be loaded");
+    let sym_id = dom
+        .binder
+        .file_locals
+        .get("SVGURIReference")
+        .expect("SVGURIReference should resolve to a dom lib symbol");
+    let interface_idx = dom
+        .binder
+        .get_symbol(sym_id)
+        .expect("SVGURIReference symbol should exist")
+        .declarations[0];
+    let interface = dom
+        .arena
+        .get(interface_idx)
+        .and_then(|node| dom.arena.get_interface(node))
+        .expect("SVGURIReference should have an interface declaration");
+    let href_member = interface
+        .members
+        .nodes
+        .iter()
+        .copied()
+        .find(|&member_idx| {
+            dom.arena
+                .get(member_idx)
+                .and_then(|member| dom.arena.get_signature(member))
+                .and_then(|sig| dom.arena.get_identifier_text(sig.name))
+                == Some("href")
+        })
+        .expect("SVGURIReference.href should exist");
+
+    let results = state
+        .direct_cross_file_interface_member_simple_types(
+            interface_idx,
+            &[href_member],
+            dom.arena.as_ref(),
+            dom.binder.as_ref(),
+            None,
+            false,
+        )
+        .expect("DOM member batch should lower actual-lib property references");
+    let href_type = results
+        .get(&href_member)
+        .copied()
+        .expect("href member should lower directly");
+    let expected_def_id = state
+        .resolve_actual_lib_name_to_def_id_for_lowering("SVGAnimatedString")
+        .expect("SVGAnimatedString should have actual-lib identity");
+    let actual_def_id =
+        crate::query_boundaries::common::lazy_def_id(state.ctx.types.as_type_database(), href_type);
+
+    assert_eq!(actual_def_id, Some(expected_def_id));
 }
 
 #[test]


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 7/9 generated app lib/module identity; green-row speed slice for Vite DOM/lib delegation.

## Invariant
When batched cross-file interface member lowering sees an unshadowed actual-lib type reference, it resolves that name through actual-lib `DefId` identity before falling back to local entity resolution. Source-file member lowering still uses the delegate file's local name resolver, and shadowed lib names still fall back to the existing path.

## Scope
- `crates/tsz-checker/src/state/type_analysis/cross_file_direct/interface_methods.rs`
- `crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs`

## Project Corpus Impact
- Row: `vite-vanilla-ts-app`
- Bug family: generated app lib/module identity; checker cross-arena delegation on DOM member/type-reference paths
- Evidence: focused quick run stayed diagnostic-clean and improved the Vite timing sample to `tsz_ms=105.14`, `tsgo_ms=72.93`, `winner=tsgo`, `factor=1.44`; standard report still shows this row below the 2x tsz-vs-tsgo target with `target_gap_factor=2.883312765665707`, so this is progress, not lane completion.
- Artifacts: `/private/tmp/studio-b-vite-dom-member-batch-20260531.json`, `/private/tmp/studio-b-vite-dom-member-batch-20260531.perf.json`, `/private/tmp/studio-b-vite-dom-member-batch-20260531.tsgo-winners.json`

## Verification
- `git diff --check`
- `cargo fmt --check`
- `cargo nextest run -p tsz-checker --lib direct_builtin_dom_member_batch_resolves_actual_lib_property_refs value_merged_builtin_dom_interface_type_argument_keeps_inherited_members`
- `BENCH_PGO=0 TSC_NPM_SPEC=6.0.3 scripts/safe-run.sh --limit 75% -- scripts/bench/bench-vs-tsgo.sh --quick --rebuild --filter '^vite-vanilla-ts-app$' --json-file /private/tmp/studio-b-vite-dom-member-batch-20260531.json`
- `CARGO_TARGET_DIR=.target-bench scripts/safe-run.sh --limit 75% -- cargo build --release -p tsz-cli --features perf-tools`
- `TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh --limit 75% -- .target-bench/release/tsz --extendedDiagnostics --perf-counters-json /private/tmp/studio-b-vite-dom-member-batch-20260531.perf.json --noEmit -p .target-bench/external/vite-vanilla-ts-live/tsconfig.json`
- `node scripts/bench/tsgo-winner-report.mjs /private/tmp/studio-b-vite-dom-member-batch-20260531.json /private/tmp/studio-b-vite-dom-member-batch-20260531.tsgo-winners.json`
- After rebase onto current `origin/main` (`d2cbcd1d3a`): `git diff --check origin/main...HEAD`, `cargo fmt --check`, `cargo nextest run -p tsz-checker --lib direct_builtin_dom_member_batch_resolves_actual_lib_property_refs value_merged_builtin_dom_interface_type_argument_keeps_inherited_members`

## Coordination Notes
- Existing Studio-B PRs were merged first: #11902 and #11907.
- Rebased from `280ae6cc83` to current `origin/main` at `d2cbcd1d3a` after the first ready-review CI run reported conformance aggregate drift on the stale merge ref (`deeplyNestedMappedTypes.ts`, `intersectionsOfLargeUnions2.ts`, `importAttributes11.ts`). New head is `f1245729a9`.
- Open PR overlap check and `scripts/agents/ensure-agent-labels.sh --audit` were clean before publishing; this PR uses the canonical `agent:Studio-B` label.
- Disk note: the first broad `nextest` invocation exhausted disk while linking unrelated checker integration-test binaries; I recovered by deleting only this branch's fresh failed-build `.target` cache, then reran the focused `--lib` test successfully.
- Ready for exact-head CI/queue handling once the rebased head is green; no auto-merge requested by Studio-B.
