### PR TITLE
fix(emit): scope classic JSX factory import roots

### DIFF
--- a/crates/tsz-emitter/src/emitter/module_emission/core/tests/esm_class_namespace.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/tests/esm_class_namespace.rs
@@ -1577,3 +1577,70 @@ fn esnext_jsx_factory_namespace_binding_is_kept() {
         "JSX-factory namespace binding must be preserved when the file uses JSX.\nOutput:\n{output}"
     );
 }
+
+#[test]
+fn esnext_custom_jsx_factory_elides_unused_default_fragment_import_without_fragments() {
+    let source = r#"import React from "react";
+
+declare const jsx: typeof React.createElement;
+declare const Comp: (p: { css?: string }) => null;
+<Comp css="color:hotpink;" />;
+"#;
+
+    let mut parser = ParserState::new("main.tsx".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        module: ModuleKind::ESNext,
+        jsx: crate::emitter::JsxEmit::React,
+        jsx_factory: Some("jsx".to_string()),
+        ..Default::default()
+    };
+    let mut printer = Printer::with_options(&parser.arena, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert!(
+        !output.contains("from \"react\""),
+        "Default fragment factory root must not keep an otherwise type-only import alive when the file has no fragments.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("jsx(Comp, { css: \"color:hotpink;\" });"),
+        "Custom element factory should still emit the JSX call.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("export {};"),
+        "Eliding the only import should keep the file as an external module.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn esnext_custom_jsx_factory_keeps_default_fragment_import_for_fragments() {
+    let source = r#"import React from "react";
+
+declare const jsx: typeof React.createElement;
+<></>;
+"#;
+
+    let mut parser = ParserState::new("main.tsx".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        module: ModuleKind::ESNext,
+        jsx: crate::emitter::JsxEmit::React,
+        jsx_factory: Some("jsx".to_string()),
+        ..Default::default()
+    };
+    let mut printer = Printer::with_options(&parser.arena, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert!(
+        output.contains("import React from \"react\""),
+        "Default fragment factory root should keep the import when fragments emit React.Fragment.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("jsx(React.Fragment"),
+        "Fragment JSX should still reference the configured element factory and default fragment factory.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/module_emission/imports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/imports.rs
@@ -310,6 +310,8 @@ impl<'a> Printer<'a> {
         self.jsx_pragmas.classic_factory_roots(
             self.ctx.options.jsx_factory.as_deref(),
             self.ctx.options.jsx_fragment_factory.as_deref(),
+            usage.needs_jsx || usage.needs_jsxs || usage.needs_create_element,
+            usage.needs_fragment,
         )
     }
 

--- a/crates/tsz-emitter/src/jsx_pragmas.rs
+++ b/crates/tsz-emitter/src/jsx_pragmas.rs
@@ -128,12 +128,16 @@ impl JsxPragmaFacts {
         &self,
         jsx_factory: Option<&str>,
         jsx_fragment_factory: Option<&str>,
+        needs_factory: bool,
+        needs_fragment_factory: bool,
     ) -> Vec<String> {
         classic_jsx_factory_roots_from_facts(
             self.factory.as_deref(),
             self.fragment_factory.as_deref(),
             jsx_factory,
             jsx_fragment_factory,
+            needs_factory,
+            needs_fragment_factory,
         )
     }
 }
@@ -154,6 +158,8 @@ fn classic_jsx_factory_roots_from_facts(
     pragma_fragment_factory: Option<&str>,
     jsx_factory: Option<&str>,
     jsx_fragment_factory: Option<&str>,
+    needs_factory: bool,
+    needs_fragment_factory: bool,
 ) -> Vec<String> {
     let jsx_factory = pragma_factory
         .or(jsx_factory)
@@ -165,7 +171,13 @@ fn classic_jsx_factory_roots_from_facts(
         .to_string();
 
     let mut roots = Vec::new();
-    for factory in [jsx_factory, jsx_fragment_factory] {
+    for factory in [
+        needs_factory.then_some(jsx_factory),
+        needs_fragment_factory.then_some(jsx_fragment_factory),
+    ]
+    .into_iter()
+    .flatten()
+    {
         let Some(root) = factory.split('.').next() else {
             continue;
         };

--- a/crates/tsz-emitter/src/lowering/import_usage.rs
+++ b/crates/tsz-emitter/src/lowering/import_usage.rs
@@ -4,6 +4,12 @@ use super::*;
 use crate::emitter::JsxEmit;
 use crate::jsx_pragmas::JsxRuntimePragma;
 
+#[derive(Default)]
+struct ClassicJsxSyntaxUsage {
+    needs_factory: bool,
+    needs_fragment_factory: bool,
+}
+
 impl<'a> LoweringPass<'a> {
     pub(super) fn visit_import_declaration(&mut self, node: &Node, _idx: NodeIndex) {
         let Some(import_decl) = self.arena.get_import_decl(node) else {
@@ -177,24 +183,35 @@ impl<'a> LoweringPass<'a> {
         if !uses_classic_factory {
             return Vec::new();
         }
-        if !self.has_jsx_syntax() {
+        let usage = self.classic_jsx_syntax_usage();
+        if !usage.needs_factory && !usage.needs_fragment_factory {
             return Vec::new();
         }
 
         self.current_jsx_pragmas.classic_factory_roots(
             self.ctx.options.jsx_factory.as_deref(),
             self.ctx.options.jsx_fragment_factory.as_deref(),
+            usage.needs_factory,
+            usage.needs_fragment_factory,
         )
     }
 
-    fn has_jsx_syntax(&self) -> bool {
-        (0..self.arena.len()).any(|idx| {
-            self.arena.get(NodeIndex(idx as u32)).is_some_and(|node| {
-                node.kind == syntax_kind_ext::JSX_ELEMENT
-                    || node.kind == syntax_kind_ext::JSX_SELF_CLOSING_ELEMENT
-                    || node.kind == syntax_kind_ext::JSX_FRAGMENT
-            })
-        })
+    fn classic_jsx_syntax_usage(&self) -> ClassicJsxSyntaxUsage {
+        let mut usage = ClassicJsxSyntaxUsage::default();
+        for idx in 0..self.arena.len() {
+            let Some(node) = self.arena.get(NodeIndex(idx as u32)) else {
+                continue;
+            };
+            if node.kind == syntax_kind_ext::JSX_ELEMENT
+                || node.kind == syntax_kind_ext::JSX_SELF_CLOSING_ELEMENT
+            {
+                usage.needs_factory = true;
+            } else if node.kind == syntax_kind_ext::JSX_FRAGMENT {
+                usage.needs_factory = true;
+                usage.needs_fragment_factory = true;
+            }
+        }
+        usage
     }
 
     pub(super) fn import_has_value_usage_after_node(


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
JavaScript emit parity; JSX/react emit import elision.

## Invariant
When classic JSX emits through a custom element factory, import liveness tracks only factory roots actually referenced by emitted output; default fragment factory roots are live only for JSX fragments. This PR changes emitter import usage/factory-root planning only.

## Scope
- `crates/tsz-emitter/src/jsx_pragmas.rs`: roots can be requested separately for element and fragment factories.
- `crates/tsz-emitter/src/emitter/module_emission/imports.rs`: use scanned JSX output usage to decide root liveness.
- `crates/tsz-emitter/src/lowering/import_usage.rs`: mirror the same split for CommonJS helper planning.
- `crates/tsz-emitter/src/emitter/module_emission/core/tests/esm_class_namespace.rs`: regression coverage.

## Project Corpus Impact
- Row: n/a
- Bug family: JSX/react emit
- Evidence: Targeted emit baseline `jsxLibraryManagedAttributesUnusedGeneric` passes locally on current-main head `4254a4ce3c667006582dc89005072ca61cc66115`; broader `--filter=jsx` improved from 208/211 to 209/211 before earlier rebase. No project-corpus row was run.

## Verification
- `cargo fmt --check`
- `cargo check -p tsz-emitter`
- `cargo nextest run -p tsz-emitter -E 'test(esnext_custom_jsx_factory)'` -> 2/2 passed
- `CARGO_INCREMENTAL=0 scripts/emit/run.sh --filter=jsxLibraryManagedAttributesUnusedGeneric --js-only --verbose --timeout=30000 --json-out=/tmp/jsxLibraryManagedAttributesUnusedGeneric-studio-c-fix-c03-sync.json` -> 1/1 passed
- `CARGO_INCREMENTAL=0 scripts/emit/run.sh --filter=jsx --js-only --verbose --timeout=30000 --json-out=/tmp/jsx-studio-c-after-fix.json` (earlier broad check: 209/211; remaining failures `jsxReactTestSuite`, `jsxUnclosedParserRecovery`)
- `git diff --check HEAD~1..HEAD`
- `scripts/arch/arch_guard.py`

## Coordination Notes
- AgentName: Studio-C.
- Rebased and force-pushed onto observed current `origin/main` at `c03cb81882 perf(checker): resolve lib refs in member batching (#11924)`.
- Non-overlap: separate from PR #11921 (`fix(emit): hoist system for-await temps`); this slice is JSX factory import liveness only.
- Ready for manager review/queue consideration after exact-head PR checks complete. I did not add merge-queue or enable auto-merge.