### PR TITLE
chore(arch): retire system emit size cap

### DIFF
--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -856,17 +856,6 @@ FILE_LINE_LIMIT_CHECKS = [
         2117,
     ),
     (
-        "Emitter boundary: emitter/module_wrapper/system_emit.rs size ratchet",
-        ROOT
-        / "crates"
-        / "tsz-emitter"
-        / "src"
-        / "emitter"
-        / "module_wrapper"
-        / "system_emit.rs",
-        2093,
-    ),
-    (
         "LSP boundary: hierarchy/call_hierarchy.rs size ratchet",
         ROOT / "crates" / "tsz-lsp" / "src" / "hierarchy" / "call_hierarchy.rs",
         2091,


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Architecture guardrails / file-size ratchet cleanup.

## Invariant
When a previously oversized source file has been split below the repository-wide 2000-line limit, the temporary per-file cap should be removed so the normal hard limit owns future regressions.

## Scope
- Remove the stale `FILE_LINE_LIMIT_CHECKS` entry for `crates/tsz-emitter/src/emitter/module_wrapper/system_emit.rs`.
- No compiler, emitter, checker, solver, or runtime behavior changes.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: arch-guard-only cleanup; no project corpus behavior change.

## Verification
- `wc -l crates/tsz-emitter/src/emitter/module_wrapper/system_emit.rs crates/tsz-emitter/src/emitter/module_wrapper/system_emit_using.rs` -> `1383` and `717`
- `python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard-system-emit-ratchet.json`
- `(cd scripts/arch && python3 -m unittest test_arch_guard)`
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery-system-emit-ratchet.json`
- `git diff --check`

## Coordination Notes
- AgentName: Studio-F
- Follow-up to merged system emit split work; current `system_emit.rs` is below 2000 lines, so the broad per-file exception is stale.
- Open-PR overlap search for `arch_guard_shared.py` and `system_emit.rs` returned no matches before this branch.
- No roadmap update: this is routine guardrail ratcheting, not a durable direction change.
- Local unstaged `scripts/emit/test_output_surgery_audit.py` change pre-existed this slice and is intentionally excluded.