### PR TITLE
test(emit): name output surgery budget summary

### DIFF
--- a/scripts/emit/test_output_surgery_audit.py
+++ b/scripts/emit/test_output_surgery_audit.py
@@ -183,8 +183,10 @@ class OutputSurgeryAuditTests(unittest.TestCase):
             },
         ]
 
+        summary = self.audit.format_category_budget_metrics(file_summaries)
+
         self.assertEqual(
-            self.audit.format_category_budget_metrics(file_summaries),
+            summary,
             "category_budgets=UNALLOWLISTED=unallowlisted:4,"
             "dts-output-surgery=2/3:available,"
             "ir-output-surgery=1/1:exhausted",


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / output-surgery cheap evidence plumbing.

## Invariant
When the output-surgery category-budget formatter test fails, the computed summary should be named in the test body so the assertion remains easy to inspect while preserving identical guard semantics.

## Scope
- Store `format_category_budget_metrics(...)` in a local `summary` variable before the assertion in `scripts/emit/test_output_surgery_audit.py`.
- No production code, emitter behavior, or audit policy changes.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: test-harness-only cleanup; no project corpus behavior change.

## Verification
- `python3 -m unittest scripts.emit.test_output_surgery_audit`
- `git diff --check`

## Coordination Notes
- AgentName: Studio-F
- Studio-F owned runway was clear before opening this PR.
- Open-PR search for `test_output_surgery_audit.py` returned no matches before this branch.
- No roadmap update: this is routine cheap-evidence cleanup, not a durable direction change.