### PR TITLE
fix(emit): honor invalid jsdoc template aliases

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc/function_facts.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc/function_facts.rs
@@ -55,7 +55,9 @@ impl<'a> DeclarationEmitter<'a> {
             .is_none_or(|raw| raw.contains('\n'))
     }
 
-    fn parse_jsdoc_overload_signatures(jsdoc: &str) -> Vec<JsdocOverloadSignature> {
+    pub(in crate::declaration_emitter) fn parse_jsdoc_overload_signatures(
+        jsdoc: &str,
+    ) -> Vec<JsdocOverloadSignature> {
         let lines = Self::normalized_jsdoc_lines(jsdoc);
         let overload_positions: Vec<usize> = lines
             .iter()
@@ -95,16 +97,21 @@ impl<'a> DeclarationEmitter<'a> {
         lines: &[String],
     ) -> Option<JsdocOverloadSignature> {
         let mut type_params = global_type_params.to_vec();
+        let mut has_invalid_segment_template = false;
         let mut params = Vec::new();
         let mut return_type = None;
         let mut seen_return = false;
+        let mut seen_segment_template = false;
 
         for line in lines {
             if let Some(rest) = Self::jsdoc_tag_rest(line, "template") {
-                Self::push_jsdoc_type_params_unique(
-                    &mut type_params,
-                    &Self::parse_jsdoc_template_params(&format!("@template {rest}")),
-                );
+                let parsed = Self::parse_jsdoc_template_params(&format!("@template {rest}"));
+                if seen_segment_template {
+                    Self::push_jsdoc_type_params_unique(&mut type_params, &parsed);
+                } else {
+                    has_invalid_segment_template = !parsed.is_empty();
+                    seen_segment_template = true;
+                }
                 continue;
             }
 
@@ -135,8 +142,16 @@ impl<'a> DeclarationEmitter<'a> {
         Some(JsdocOverloadSignature {
             comment: jsdoc.to_string(),
             type_params,
-            params,
-            return_type: return_type.unwrap_or_else(|| "any".to_string()),
+            params: if has_invalid_segment_template {
+                Vec::new()
+            } else {
+                params
+            },
+            return_type: if has_invalid_segment_template {
+                "any".to_string()
+            } else {
+                return_type.unwrap_or_else(|| "any".to_string())
+            },
         })
     }
 
@@ -225,7 +240,10 @@ impl<'a> DeclarationEmitter<'a> {
             .collect()
     }
 
-    fn jsdoc_tag_rest<'b>(line: &'b str, tag: &str) -> Option<&'b str> {
+    pub(in crate::declaration_emitter) fn jsdoc_tag_rest<'b>(
+        line: &'b str,
+        tag: &str,
+    ) -> Option<&'b str> {
         let rest = line.strip_prefix('@')?.strip_prefix(tag)?;
         if rest
             .chars()
@@ -250,7 +268,10 @@ impl<'a> DeclarationEmitter<'a> {
         params
     }
 
-    fn push_jsdoc_type_params_unique(params: &mut Vec<String>, additions: &[String]) {
+    pub(in crate::declaration_emitter) fn push_jsdoc_type_params_unique(
+        params: &mut Vec<String>,
+        additions: &[String],
+    ) {
         for param in additions {
             let key = Self::jsdoc_template_param_name_key(param).to_string();
             if params

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc/type_aliases.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc/type_aliases.rs
@@ -1,5 +1,14 @@
 use super::*;
 
+#[derive(Clone)]
+struct JsdocPropertyAliasMember {
+    name: String,
+    optional: bool,
+    type_text: String,
+    description_lines: Vec<String>,
+    children: Vec<JsdocPropertyAliasMember>,
+}
+
 impl<'a> DeclarationEmitter<'a> {
     pub(in crate::declaration_emitter) fn parse_jsdoc_callback_alias(
         jsdoc: &str,
@@ -157,6 +166,93 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         params
+    }
+
+    fn parse_jsdoc_template_params_before_tag(jsdoc: &str, tag: &str) -> Vec<String> {
+        let mut params = Vec::new();
+        for raw_line in jsdoc.lines() {
+            let line = raw_line.trim_start_matches('*').trim();
+            if Self::jsdoc_tag_rest(line, tag).is_some() {
+                break;
+            }
+            if let Some(rest) = Self::jsdoc_tag_rest(line, "template") {
+                Self::push_jsdoc_type_params_unique(
+                    &mut params,
+                    &Self::parse_jsdoc_template_params(&format!("@template {rest}")),
+                );
+            }
+        }
+        params
+    }
+
+    fn jsdoc_template_param_names_after_tag(jsdoc: &str, tag: &str) -> Vec<String> {
+        let mut names = Vec::new();
+        let mut seen = FxHashSet::default();
+        let mut after_tag = false;
+        for raw_line in jsdoc.lines() {
+            let line = raw_line.trim_start_matches('*').trim();
+            if !after_tag {
+                if Self::jsdoc_tag_rest(line, tag).is_some() {
+                    after_tag = true;
+                }
+                continue;
+            }
+            if let Some(rest) = Self::jsdoc_tag_rest(line, "template") {
+                for param in Self::parse_jsdoc_template_params(&format!("@template {rest}")) {
+                    let name = Self::jsdoc_template_param_name_key(&param).to_string();
+                    if seen.insert(name.clone()) {
+                        names.push(name);
+                    }
+                }
+            }
+        }
+        names
+    }
+
+    pub(in crate::declaration_emitter) fn jsdoc_type_text_references_any_template_param(
+        type_text: &str,
+        param_names: &[String],
+    ) -> bool {
+        if param_names.is_empty() {
+            return false;
+        }
+
+        let mut start = None;
+        for (idx, ch) in type_text.char_indices() {
+            if start.is_none() {
+                if Self::is_jsdoc_identifier_start(ch) {
+                    start = Some(idx);
+                }
+                continue;
+            }
+
+            if Self::is_jsdoc_identifier_continue(ch) {
+                continue;
+            }
+
+            if let Some(word_start) = start.take()
+                && param_names
+                    .iter()
+                    .any(|name| name == &type_text[word_start..idx])
+            {
+                return true;
+            }
+        }
+
+        if let Some(word_start) = start {
+            return param_names
+                .iter()
+                .any(|name| name == &type_text[word_start..]);
+        }
+        false
+    }
+
+    const fn is_jsdoc_identifier_start(ch: char) -> bool {
+        ch == '_' || ch == '$' || ch.is_ascii_alphabetic()
+    }
+
+    const fn is_jsdoc_identifier_continue(ch: char) -> bool {
+        Self::is_jsdoc_identifier_start(ch) || ch.is_ascii_digit()
     }
 
     fn split_jsdoc_template_param_segments(text: &str) -> Vec<&str> {
@@ -465,29 +561,118 @@ impl<'a> DeclarationEmitter<'a> {
             return None;
         }
 
-        let mut type_text = String::from("{\n");
+        let mut members = Vec::new();
         for (property_name, optional, property_type, description_lines) in properties {
-            if !description_lines.is_empty() {
-                type_text.push_str("    /**\n");
-                for line in description_lines {
-                    type_text.push_str("     * ");
-                    type_text.push_str(&line);
-                    type_text.push('\n');
-                }
-                type_text.push_str("     */\n");
-            }
-            type_text.push_str("    ");
-            type_text.push_str(&Self::render_jsdoc_property_name(&property_name));
-            if optional {
-                type_text.push('?');
-            }
-            type_text.push_str(": ");
-            type_text.push_str(&property_type);
-            type_text.push_str(";\n");
+            let path = Self::split_jsdoc_property_path(&property_name);
+            Self::insert_jsdoc_property_alias_member(
+                &mut members,
+                &path,
+                optional,
+                property_type,
+                description_lines,
+            );
         }
+
+        let mut type_text = String::from("{\n");
+        Self::render_jsdoc_property_alias_members(&members, 4, &mut type_text);
         type_text.push('}');
 
         Some((name, type_text))
+    }
+
+    fn split_jsdoc_property_path(name: &str) -> Vec<String> {
+        if Self::is_quoted_jsdoc_property_name(name) {
+            return vec![name.to_string()];
+        }
+        let path = name
+            .split('.')
+            .filter(|part| !part.is_empty())
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        if path.is_empty() {
+            vec![name.to_string()]
+        } else {
+            path
+        }
+    }
+
+    fn insert_jsdoc_property_alias_member(
+        members: &mut Vec<JsdocPropertyAliasMember>,
+        path: &[String],
+        optional: bool,
+        type_text: String,
+        description_lines: Vec<String>,
+    ) {
+        let Some((head, tail)) = path.split_first() else {
+            return;
+        };
+
+        let member_idx = members
+            .iter()
+            .position(|member| member.name == *head)
+            .unwrap_or_else(|| {
+                members.push(JsdocPropertyAliasMember {
+                    name: head.clone(),
+                    optional: false,
+                    type_text: "object".to_string(),
+                    description_lines: Vec::new(),
+                    children: Vec::new(),
+                });
+                members.len() - 1
+            });
+
+        let member = &mut members[member_idx];
+        if tail.is_empty() {
+            member.optional = optional;
+            member.type_text = type_text;
+            member.description_lines = description_lines;
+            return;
+        }
+
+        Self::insert_jsdoc_property_alias_member(
+            &mut member.children,
+            tail,
+            optional,
+            type_text,
+            description_lines,
+        );
+    }
+
+    fn render_jsdoc_property_alias_members(
+        members: &[JsdocPropertyAliasMember],
+        indent: usize,
+        type_text: &mut String,
+    ) {
+        let pad = " ".repeat(indent);
+        for member in members {
+            if !member.description_lines.is_empty() {
+                type_text.push_str(&pad);
+                type_text.push_str("/**\n");
+                for line in &member.description_lines {
+                    type_text.push_str(&pad);
+                    type_text.push_str(" * ");
+                    type_text.push_str(line);
+                    type_text.push('\n');
+                }
+                type_text.push_str(&pad);
+                type_text.push_str(" */\n");
+            }
+            type_text.push_str(&pad);
+            type_text.push_str(&Self::render_jsdoc_property_name(&member.name));
+            if member.optional {
+                type_text.push('?');
+            }
+            type_text.push_str(": ");
+            if member.children.is_empty() {
+                type_text.push_str(&member.type_text);
+                type_text.push_str(";\n");
+            } else {
+                type_text.push_str("{\n");
+                Self::render_jsdoc_property_alias_members(&member.children, indent + 4, type_text);
+                type_text.push_str(&pad);
+                type_text.push_str("};\n");
+            }
+        }
     }
 
     fn parse_jsdoc_name_only_typedef_alias(jsdoc: &str) -> Option<(String, String)> {
@@ -563,28 +748,50 @@ impl<'a> DeclarationEmitter<'a> {
     pub(in crate::declaration_emitter) fn parse_jsdoc_type_alias_decl(
         jsdoc: &str,
     ) -> Option<JsdocTypeAliasDecl> {
-        let type_params = Self::parse_jsdoc_template_params(jsdoc);
         let mut description_lines = Self::jsdoc_description_lines(jsdoc);
         description_lines.extend(Self::jsdoc_typedef_trailing_description_lines(jsdoc));
 
         if Self::jsdoc_has_property_tags(jsdoc) {
+            let type_params = Self::parse_jsdoc_template_params_before_tag(jsdoc, "typedef");
+            let invalid_type_param_names =
+                Self::jsdoc_template_param_names_after_tag(jsdoc, "typedef");
             let (name, type_text) = Self::parse_jsdoc_property_type_alias(jsdoc)?;
             if name == "default" {
                 return None;
             }
+            let (type_text, render_verbatim) =
+                if Self::jsdoc_type_text_references_any_template_param(
+                    &type_text,
+                    &invalid_type_param_names,
+                ) {
+                    ("any".to_string(), false)
+                } else {
+                    (type_text, true)
+                };
             return Some(JsdocTypeAliasDecl {
                 name,
                 type_params,
                 type_text,
                 description_lines,
-                render_verbatim: true,
+                render_verbatim,
             });
         }
 
         if let Some((name, type_text)) = Self::parse_jsdoc_typedef_alias(jsdoc) {
+            let type_params = Self::parse_jsdoc_template_params_before_tag(jsdoc, "typedef");
+            let invalid_type_param_names =
+                Self::jsdoc_template_param_names_after_tag(jsdoc, "typedef");
             if name == "default" {
                 return None;
             }
+            let type_text = if Self::jsdoc_type_text_references_any_template_param(
+                &type_text,
+                &invalid_type_param_names,
+            ) {
+                "any".to_string()
+            } else {
+                type_text
+            };
             return Some(JsdocTypeAliasDecl {
                 name,
                 type_params,
@@ -597,6 +804,17 @@ impl<'a> DeclarationEmitter<'a> {
         if let Some((name, type_text, description_lines)) =
             Self::parse_jsdoc_callback_alias_parts(jsdoc)
         {
+            let type_params = Self::parse_jsdoc_template_params_before_tag(jsdoc, "callback");
+            let invalid_type_param_names =
+                Self::jsdoc_template_param_names_after_tag(jsdoc, "callback");
+            let type_text = if Self::jsdoc_type_text_references_any_template_param(
+                &type_text,
+                &invalid_type_param_names,
+            ) {
+                "() => any".to_string()
+            } else {
+                type_text
+            };
             return Some(JsdocTypeAliasDecl {
                 name,
                 type_params,
@@ -613,7 +831,8 @@ impl<'a> DeclarationEmitter<'a> {
         jsdoc: &str,
         alias_name: &str,
     ) -> Option<JsdocTypeAliasDecl> {
-        let type_params = Self::parse_jsdoc_template_params(jsdoc);
+        let type_params = Self::parse_jsdoc_template_params_before_tag(jsdoc, "typedef");
+        let invalid_type_param_names = Self::jsdoc_template_param_names_after_tag(jsdoc, "typedef");
         let (name, type_text) = if Self::jsdoc_has_property_tags(jsdoc) {
             Self::parse_jsdoc_property_type_alias(jsdoc)?
         } else {
@@ -622,13 +841,21 @@ impl<'a> DeclarationEmitter<'a> {
         if name != "default" {
             return None;
         }
+        let uses_invalid_template_param = Self::jsdoc_type_text_references_any_template_param(
+            &type_text,
+            &invalid_type_param_names,
+        );
 
         Some(JsdocTypeAliasDecl {
             name: alias_name.to_string(),
             type_params,
-            type_text,
+            type_text: if uses_invalid_template_param {
+                "any".to_string()
+            } else {
+                type_text
+            },
             description_lines: Vec::new(),
-            render_verbatim: Self::jsdoc_has_property_tags(jsdoc),
+            render_verbatim: Self::jsdoc_has_property_tags(jsdoc) && !uses_invalid_template_param,
         })
     }
 

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc_tests.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc_tests.rs
@@ -135,6 +135,83 @@ fn typedef_alias_renders_constrained_template_default_with_description() {
 }
 
 #[test]
+fn typedef_alias_ignores_template_after_typedef_tag() {
+    let jsdoc = "\
+@typedef Box
+@template T
+@property {T} value
+";
+
+    let decl = DeclarationEmitter::parse_jsdoc_type_alias_decl(jsdoc)
+        .expect("expected JSDoc typedef alias");
+    assert_eq!(decl.name, "Box");
+    assert!(decl.type_params.is_empty());
+
+    let rendered = DeclarationEmitter::render_jsdoc_type_alias_decl(&decl, false)
+        .expect("expected rendered type alias");
+    assert_eq!(rendered, "type Box = any;\n");
+}
+
+#[test]
+fn callback_alias_ignores_template_after_callback_tag() {
+    let jsdoc = "\
+@callback Fn
+@template T
+@param {T} value
+@returns {T}
+";
+
+    let decl = DeclarationEmitter::parse_jsdoc_type_alias_decl(jsdoc)
+        .expect("expected JSDoc callback alias");
+    assert_eq!(decl.name, "Fn");
+    assert!(decl.type_params.is_empty());
+
+    let rendered = DeclarationEmitter::render_jsdoc_type_alias_decl(&decl, false)
+        .expect("expected rendered type alias");
+    assert_eq!(rendered, "type Fn = () => any;\n");
+}
+
+#[test]
+fn property_alias_nests_dotted_property_paths() {
+    let jsdoc = "\
+@typedef Nested
+@property {Object} outer
+@template T
+@property {number} outer.value
+@property {string} outer.label
+";
+
+    let decl = DeclarationEmitter::parse_jsdoc_type_alias_decl(jsdoc)
+        .expect("expected JSDoc property alias");
+    assert_eq!(decl.name, "Nested");
+    assert!(decl.type_params.is_empty());
+
+    let rendered = DeclarationEmitter::render_jsdoc_type_alias_decl(&decl, false)
+        .expect("expected rendered type alias");
+    assert_eq!(
+        rendered,
+        "type Nested = {\n    outer: {\n        value: number;\n        label: string;\n    };\n};\n"
+    );
+}
+
+#[test]
+fn overload_template_after_overload_collapses_signature_surface() {
+    let jsdoc = "\
+@overload
+@template T
+@template U
+@param {U} value
+@returns {U}
+";
+
+    let signatures = DeclarationEmitter::parse_jsdoc_overload_signatures(jsdoc);
+    assert_eq!(signatures.len(), 1);
+    assert_eq!(signatures[0].type_params, vec!["U"]);
+    assert!(signatures[0].params.is_empty());
+    assert_eq!(signatures[0].return_type, "any");
+}
+
+#[test]
 fn satisfies_param_facts_require_real_tag_boundary() {
     let jsdoc = "\
 @satisfiesx {(bad: number) => void}


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Declaration emit / JS JSDoc declaration facts.

## Invariant
JSDoc declaration emit must follow TypeScript tag-order semantics before printing: template tags that occur after `@typedef`, `@callback`, or the first post-`@overload` template boundary are invalid for the declaration surface, and dotted `@property` paths are nested as declaration facts rather than repaired from rendered output.

## Scope
- Split JSDoc alias template collection into valid pre-alias templates and invalid post-alias names.
- Collapse typedef/callback alias surfaces that reference invalid template names to TypeScript-compatible `any` / `() => any` output.
- Build nested property-alias facts for dotted `@property` paths.
- Match TypeScript overload behavior where the first template tag after `@overload` invalidates the parameter/return surface while later template tags may still be listed.
- Add focused emitter unit tests for the structural JSDoc cases.

## Project Corpus Impact
- Row: n/a (declaration emit conformance row: `templateInsideCallback`)
- Bug family: JS/JSDoc declaration fact ordering for invalid template tags and dotted property aliases.
- Evidence: `scripts/safe-run.sh scripts/emit/run.sh --filter=templateInsideCallback --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-templateInsideCallback-rebased.json` passed 1/1 on `b007572d47c067c47cb360c4e90e249b4597c08f`.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `cargo nextest run -p tsz-emitter jsdoc`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-emitter --all-targets -- -D warnings`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=templateInsideCallback --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-templateInsideCallback-rebased.json`

## Coordination Notes
- AgentName: Studio-D.
- Opened after refreshing Studio-D owned runway: #11903 and #11923 are separate ready declaration-emit PRs with CI pending/continuing.
- This PR is intentionally scoped to `templateInsideCallback` / JSDoc alias and overload declaration facts.
- Checked overlap with #11916 (Studio-E object-member output-surgery cleanup); this change does not touch that output-surgery path and keeps the rule in parsed JSDoc facts.
