### PR TITLE
test(checker): ratchet source-text anchor debt

### DIFF
--- a/crates/tsz-checker/tests/track8_debt_contract_tests.rs
+++ b/crates/tsz-checker/tests/track8_debt_contract_tests.rs
@@ -5,6 +5,7 @@ const SOURCE_FILE_CHECKING: &str = "src/state/state_checking/source_file.rs";
 
 const MAX_SOURCE_FILE_REWRITE_FINGERPRINT_HELPERS: usize = 6;
 const MAX_SOURCE_FILE_SOURCE_TEXT_CONTAINS_DECISIONS: usize = 23;
+const MAX_SOURCE_FILE_SOURCE_TEXT_FIND_DECISIONS: usize = 7;
 const MAX_SOURCE_FILE_RENDERED_MESSAGE_DECISIONS: usize = 15;
 
 #[test]
@@ -23,6 +24,11 @@ fn test_source_file_fingerprint_debt_does_not_increase() {
             "source_text.contains decisions",
             source.matches("source_text.contains(").count(),
             MAX_SOURCE_FILE_SOURCE_TEXT_CONTAINS_DECISIONS,
+        ),
+        (
+            "source_text.find decisions",
+            source.matches("source_text.find(").count(),
+            MAX_SOURCE_FILE_SOURCE_TEXT_FIND_DECISIONS,
         ),
         (
             "rendered diagnostic message decisions",


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
Tracks 8, 10: conformance strictness and diagnostic hardcoding burn-down.

## Invariant
When source-file diagnostic fingerprint debt is measured, both source-text fixture gates and source-text anchor searches should be budgeted; this PR changes only the Track 8 guard so new `source_text.find(` anchor decisions cannot be added silently.

## Scope
- `crates/tsz-checker/tests/track8_debt_contract_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: test-only Track 8 debt guard; no compiler behavior changes.

## Verification
- `cargo nextest run -p tsz-checker --test track8_debt_contract_tests`
- `git diff --check origin/main..HEAD`
- `cargo fmt --check`
- `python3 scripts/conformance/query-conformance.py --dashboard` => `12582/12582`, accepted-regression gate `0`
- `scripts/agents/ensure-agent-labels.sh --audit`
- Rebased onto `origin/main` (`8af00cde5587375e3801c1e43774b82dc54538c8`) and re-ran the same local checks on head `62d5d14dc2f91bd8c12a5a272783c2302c829fc5`. PR-head CI is running on this exact head.

## Coordination Notes
- Related to #8286 and #8775 diagnostic hardcoding burn-down.
- No open PR overlap found for Track 8 source-file diagnostic debt guard changes.
- Ready for review; no `merge-queue` label added by M1-C. Queue ownership can add it after exact-head PR-head checks are green.
- AgentName: M1-C