### PR TITLE
perf(checker): admit lib self refs in simple interfaces

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/computed/simple_local_interface.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/simple_local_interface.rs
@@ -3,6 +3,7 @@ use crate::state::CheckerState;
 use crate::symbol_resolver::TypeSymbolResolution;
 use tsz_binder::SymbolId;
 use tsz_common::perf_counters::{
+    ComputeTypeOfSymbolInterfaceSimpleObjectActualLibTypeReferenceOutcome as ActualLibTypeReferenceOutcome,
     ComputeTypeOfSymbolInterfaceSimpleObjectNonPrimitiveAnnotationKind as AnnotationKind,
     ComputeTypeOfSymbolInterfaceSimpleObjectOutcome as Outcome,
     ComputeTypeOfSymbolInterfaceSimpleObjectTypeReferenceRejectOutcome as TypeReferenceOutcome,
@@ -297,11 +298,16 @@ impl<'a> CheckerState<'a> {
         type_idx: NodeIndex,
         allow_actual_lib_type_references: bool,
     ) -> Option<TypeId> {
+        let record = |outcome: ActualLibTypeReferenceOutcome| {
+            tsz_common::perf_counters::record_compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcome(outcome);
+        };
         if !allow_actual_lib_type_references {
+            record(ActualLibTypeReferenceOutcome::Disabled);
             return None;
         }
         let node = self.ctx.arena.get(type_idx)?;
         if node.kind != syntax_kind_ext::TYPE_REFERENCE {
+            record(ActualLibTypeReferenceOutcome::NotTypeReference);
             return None;
         }
         let type_ref = self.ctx.arena.get_type_ref(node)?;
@@ -310,27 +316,44 @@ impl<'a> CheckerState<'a> {
             .as_ref()
             .is_some_and(|args| !args.nodes.is_empty())
         {
+            record(ActualLibTypeReferenceOutcome::HasTypeArguments);
             return None;
         }
         let type_name_node = self.ctx.arena.get(type_ref.type_name)?;
-        let ident = self.ctx.arena.get_identifier(type_name_node)?;
+        let Some(ident) = self.ctx.arena.get_identifier(type_name_node) else {
+            record(ActualLibTypeReferenceOutcome::NonIdentifierName);
+            return None;
+        };
         let name = ident.escaped_text.as_str();
-        if is_compiler_managed_type(name) || self.ctx.file_local_type_shadow_for_lib_name(name) {
+        if is_compiler_managed_type(name) {
+            record(ActualLibTypeReferenceOutcome::CompilerManagedType);
+            return None;
+        }
+        if self.ctx.file_local_type_shadow_for_lib_name(name)
+            && !crate::state_type_analysis::cross_file_direct::is_builtin_lib_declaration_arena(
+                self.ctx.arena,
+            )
+        {
+            record(ActualLibTypeReferenceOutcome::FileLocalShadow);
             return None;
         }
         let TypeSymbolResolution::Type(sym_id) =
             self.resolve_identifier_symbol_in_type_position_without_tracking(type_ref.type_name)
         else {
+            record(ActualLibTypeReferenceOutcome::SymbolNotType);
             return None;
         };
         let actual_lib_def_id = self.resolve_actual_lib_name_to_def_id_for_lowering(name);
         if !self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id) && actual_lib_def_id.is_none() {
+            record(ActualLibTypeReferenceOutcome::NotActualLibSymbol);
             return None;
         }
         if !self.get_type_params_for_symbol(sym_id).is_empty() {
+            record(ActualLibTypeReferenceOutcome::GenericSymbol);
             return None;
         }
         let def_id = actual_lib_def_id.unwrap_or_else(|| self.ctx.get_or_create_def_id(sym_id));
+        record(ActualLibTypeReferenceOutcome::Success);
         Some(self.ctx.types.lazy(def_id))
     }
 
@@ -536,6 +559,8 @@ mod tests {
     use crate::query_boundaries::common::{lazy_def_id, raw_property_type};
     use crate::test_utils::load_lib_files;
     use std::sync::Arc;
+    use tsz_binder::BinderState;
+    use tsz_parser::parser::ParserState;
 
     #[test]
     fn simple_actual_lib_interface_lowers_bare_lib_type_reference_property() {
@@ -602,6 +627,96 @@ mod tests {
                 },
             )
             .expect("simple DOM interface should lower with a bare lib type reference");
+        let href = state.ctx.types.intern_string("href");
+        let href_type = raw_property_type(state.ctx.types.as_type_database(), interface_type, href)
+            .expect("href property should be present");
+        let expected_def_id = state
+            .resolve_actual_lib_name_to_def_id_for_lowering("SVGAnimatedString")
+            .expect("SVGAnimatedString should have actual-lib identity");
+
+        assert_eq!(
+            lazy_def_id(state.ctx.types.as_type_database(), href_type),
+            Some(expected_def_id),
+        );
+    }
+
+    #[test]
+    fn simple_actual_lib_interface_does_not_treat_lib_decl_as_source_shadow() {
+        let lib_files = load_lib_files(&["es5.d.ts", "dom.d.ts"]);
+        let dom = lib_files
+            .iter()
+            .find(|lib| {
+                lib.arena
+                    .source_files
+                    .first()
+                    .is_some_and(|source_file| source_file.file_name.ends_with("dom.d.ts"))
+            })
+            .expect("dom lib should be loaded");
+        let mut parser = ParserState::new(
+            "fixture.ts".to_string(),
+            "import './side-effect';\nlet value;".to_string(),
+        );
+        let root = parser.parse_source_file();
+        let mut binder = BinderState::new();
+        binder.bind_source_file_with_libs(parser.get_arena(), root, &lib_files);
+        assert!(
+            binder.is_external_module(),
+            "fixture should exercise external-module shadow logic"
+        );
+        let types = TypeInterner::new();
+        let ctx = CheckerContext::new(
+            dom.arena.as_ref(),
+            &binder,
+            &types,
+            "dom.d.ts".to_string(),
+            CheckerOptions::default(),
+        );
+        let mut state = CheckerState { ctx };
+        let lib_contexts: Vec<LibContext> = lib_files
+            .iter()
+            .map(|lib| LibContext {
+                arena: Arc::clone(&lib.arena),
+                binder: Arc::clone(&lib.binder),
+            })
+            .collect();
+        state.ctx.set_lib_contexts(lib_contexts);
+        state.ctx.set_actual_lib_file_count(lib_files.len());
+
+        let sym_id = state
+            .ctx
+            .binder
+            .file_locals
+            .get("SVGURIReference")
+            .expect("SVGURIReference should be merged into the source binder");
+        assert!(
+            state
+                .ctx
+                .file_local_type_shadow_for_lib_name("SVGAnimatedString"),
+            "external-module source binder reports the merged lib declaration as a local shadow"
+        );
+        let declarations = state
+            .ctx
+            .binder
+            .get_symbol(sym_id)
+            .expect("SVGURIReference symbol should exist")
+            .declarations
+            .clone();
+
+        let interface_type = state
+            .try_lower_simple_local_interface_object(
+                sym_id,
+                &declarations,
+                SimpleLocalInterfaceFacts {
+                    has_out_of_arena_decl: false,
+                    has_cross_file_same_index: false,
+                    has_local_interface_decl: true,
+                    has_local_interface_heritage_extends: false,
+                    has_local_computed_property_name: false,
+                    suppress_missing_interface_decl_reject: false,
+                    allow_actual_lib_type_references: true,
+                },
+            )
+            .expect("actual-lib declaration should not be rejected as its own source shadow");
         let href = state.ctx.types.intern_string("href");
         let href_type = raw_property_type(state.ctx.types.as_type_database(), interface_type, href)
             .expect("href property should be present");

--- a/crates/tsz-common/src/perf_counters/definitions.rs
+++ b/crates/tsz-common/src/perf_counters/definitions.rs
@@ -799,6 +799,51 @@ impl ComputeTypeOfSymbolInterfaceSimpleObjectTypeReferenceRejectOutcome {
     }
 }
 
+/// Fine-grained outcome buckets for
+/// `try_lower_simple_actual_lib_type_reference`.
+///
+/// The broader `type_reference` reject counters say whether a reference was
+/// syntactically resolvable. These buckets say why the actual-lib lazy-ref
+/// lowering helper did or did not accept it.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub enum ComputeTypeOfSymbolInterfaceSimpleObjectActualLibTypeReferenceOutcome {
+    Success = 0,
+    Disabled = 1,
+    NotTypeReference = 2,
+    HasTypeArguments = 3,
+    NonIdentifierName = 4,
+    CompilerManagedType = 5,
+    FileLocalShadow = 6,
+    SymbolNotType = 7,
+    NotActualLibSymbol = 8,
+    GenericSymbol = 9,
+}
+
+pub const COMPUTE_TYPE_OF_SYMBOL_INTERFACE_SIMPLE_OBJECT_ACTUAL_LIB_TYPE_REFERENCE_OUTCOME_COUNT:
+    usize = 10;
+
+pub const COMPUTE_TYPE_OF_SYMBOL_INTERFACE_SIMPLE_OBJECT_ACTUAL_LIB_TYPE_REFERENCE_OUTCOME_NAMES:
+    [&str; COMPUTE_TYPE_OF_SYMBOL_INTERFACE_SIMPLE_OBJECT_ACTUAL_LIB_TYPE_REFERENCE_OUTCOME_COUNT] = [
+    "success",
+    "disabled",
+    "not_type_reference",
+    "has_type_arguments",
+    "non_identifier_name",
+    "compiler_managed_type",
+    "file_local_shadow",
+    "symbol_not_type",
+    "not_actual_lib_symbol",
+    "generic_symbol",
+];
+
+impl ComputeTypeOfSymbolInterfaceSimpleObjectActualLibTypeReferenceOutcome {
+    #[inline(always)]
+    pub const fn as_index(self) -> usize {
+        self as usize
+    }
+}
+
 /// Why a cross-file cache reader (`cached_cross_file_*` in
 /// `crates/tsz-checker/src/context/cross_file_query.rs`) returned `None`.
 ///

--- a/crates/tsz-common/src/perf_counters/dump.rs
+++ b/crates/tsz-common/src/perf_counters/dump.rs
@@ -182,6 +182,11 @@ impl PerfCounters {
             .iter()
             .map(load)
             .sum();
+        let interface_simple_object_actual_lib_type_reference_outcome_total: u64 = c
+            .compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcome
+            .iter()
+            .map(load)
+            .sum();
         if source_total == 0
             && kind_total == 0
             && interface_fastpath_total == 0
@@ -189,6 +194,7 @@ impl PerfCounters {
             && interface_simple_object_total == 0
             && interface_simple_object_non_primitive_annotation_kind_total == 0
             && interface_simple_object_type_reference_reject_outcome_total == 0
+            && interface_simple_object_actual_lib_type_reference_outcome_total == 0
         {
             return String::new();
         }
@@ -280,6 +286,24 @@ impl PerfCounters {
             {
                 let count = load(
                     &c.compute_type_of_symbol_interface_simple_object_type_reference_reject_outcome
+                        [idx],
+                );
+                if count > 0 {
+                    out.push_str(&format!("  {name:<28} {count:>12}\n"));
+                }
+            }
+        }
+        if interface_simple_object_actual_lib_type_reference_outcome_total > 0 {
+            out.push_str(
+                "\ncompute_type_of_symbol interface simple-object actual-lib type-reference outcomes:\n",
+            );
+            for (idx, name) in
+                COMPUTE_TYPE_OF_SYMBOL_INTERFACE_SIMPLE_OBJECT_ACTUAL_LIB_TYPE_REFERENCE_OUTCOME_NAMES
+                    .iter()
+                    .enumerate()
+            {
+                let count = load(
+                    &c.compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcome
                         [idx],
                 );
                 if count > 0 {

--- a/crates/tsz-common/src/perf_counters/runtime.rs
+++ b/crates/tsz-common/src/perf_counters/runtime.rs
@@ -148,6 +148,9 @@ pub struct PerfCounters {
         COMPUTE_TYPE_OF_SYMBOL_INTERFACE_SIMPLE_OBJECT_NON_PRIMITIVE_ANNOTATION_KIND_COUNT],
     pub compute_type_of_symbol_interface_simple_object_type_reference_reject_outcome: [AtomicU64;
         COMPUTE_TYPE_OF_SYMBOL_INTERFACE_SIMPLE_OBJECT_TYPE_REFERENCE_REJECT_OUTCOME_COUNT],
+    pub compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcome:
+        [AtomicU64;
+            COMPUTE_TYPE_OF_SYMBOL_INTERFACE_SIMPLE_OBJECT_ACTUAL_LIB_TYPE_REFERENCE_OUTCOME_COUNT],
     pub property_classification_calls: AtomicU64,
     pub property_classification_string_fallback_source_lookups: AtomicU64,
     pub property_classification_string_fallback_target_names: AtomicU64,
@@ -255,6 +258,9 @@ impl PerfCounters {
                 AtomicU64::new(0)
             };
                 COMPUTE_TYPE_OF_SYMBOL_INTERFACE_SIMPLE_OBJECT_TYPE_REFERENCE_REJECT_OUTCOME_COUNT],
+            compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcome:
+                [const { AtomicU64::new(0) };
+                    COMPUTE_TYPE_OF_SYMBOL_INTERFACE_SIMPLE_OBJECT_ACTUAL_LIB_TYPE_REFERENCE_OUTCOME_COUNT],
             property_classification_calls: AtomicU64::new(0),
             property_classification_string_fallback_source_lookups: AtomicU64::new(0),
             property_classification_string_fallback_target_names: AtomicU64::new(0),
@@ -1065,6 +1071,21 @@ pub fn record_compute_type_of_symbol_interface_simple_object_type_reference_reje
             },
         );
     }
+}
+
+/// Record why the actual-lib lazy-ref lowering helper accepted or rejected a
+/// property-signature type reference inside the simple local-interface shortcut.
+#[inline]
+pub fn record_compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcome(
+    outcome: ComputeTypeOfSymbolInterfaceSimpleObjectActualLibTypeReferenceOutcome,
+) {
+    if !enabled_fast() {
+        return;
+    }
+    counters()
+        .compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcome
+        [outcome.as_index()]
+    .fetch_add(1, Ordering::Relaxed);
 }
 
 pub fn record_property_classification_call() {

--- a/crates/tsz-common/src/perf_counters/snapshot.rs
+++ b/crates/tsz-common/src/perf_counters/snapshot.rs
@@ -141,6 +141,16 @@ pub struct PerfCounterSnapshot {
     /// order.
     pub compute_type_of_symbol_interface_simple_object_type_reference_reject_outcomes:
         Vec<NamedCount>,
+    /// Fine-grained accept/reject split for the helper that lowers simple
+    /// actual-lib type references to lazy `DefId` references.
+    ///
+    /// Always
+    /// `COMPUTE_TYPE_OF_SYMBOL_INTERFACE_SIMPLE_OBJECT_ACTUAL_LIB_TYPE_REFERENCE_OUTCOME_COUNT`
+    /// long, in
+    /// `COMPUTE_TYPE_OF_SYMBOL_INTERFACE_SIMPLE_OBJECT_ACTUAL_LIB_TYPE_REFERENCE_OUTCOME_NAMES`
+    /// order.
+    pub compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcomes:
+        Vec<NamedCount>,
     /// Bounded name-level attribution for `type_reference` rows within
     /// `compute_type_of_symbol_interface_simple_object_outcomes.reject_non_primitive_annotation`.
     ///
@@ -629,6 +639,16 @@ impl PerfCounters {
                     name: COMPUTE_TYPE_OF_SYMBOL_INTERFACE_SIMPLE_OBJECT_TYPE_REFERENCE_REJECT_OUTCOME_NAMES[i],
                     count: load(
                         &c.compute_type_of_symbol_interface_simple_object_type_reference_reject_outcome
+                            [i],
+                    ),
+                })
+                .collect(),
+            compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcomes: (0
+                ..COMPUTE_TYPE_OF_SYMBOL_INTERFACE_SIMPLE_OBJECT_ACTUAL_LIB_TYPE_REFERENCE_OUTCOME_COUNT)
+                .map(|i| NamedCount {
+                    name: COMPUTE_TYPE_OF_SYMBOL_INTERFACE_SIMPLE_OBJECT_ACTUAL_LIB_TYPE_REFERENCE_OUTCOME_NAMES[i],
+                    count: load(
+                        &c.compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcome
                             [i],
                     ),
                 })

--- a/crates/tsz-common/src/perf_counters/tests.rs
+++ b/crates/tsz-common/src/perf_counters/tests.rs
@@ -37,6 +37,7 @@ mod json_tests {
             "compute_type_of_symbol_interface_simple_object_non_primitive_annotation_residues",
             "compute_type_of_symbol_interface_simple_object_declaration_provenance_residues",
             "compute_type_of_symbol_interface_simple_object_type_reference_reject_outcomes",
+            "compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcomes",
             "compute_type_of_symbol_interface_simple_object_type_reference_reject_residues",
             "direct_interface_lowering_outcomes",
             "direct_actual_lib_alias_body_outcomes",
@@ -923,6 +924,37 @@ mod json_tests {
     }
 
     #[test]
+    fn compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcomes_locks_to_names_array(
+    ) {
+        let snap = PerfCounters::snapshot();
+        let json = serde_json::to_value(&snap).expect("serializes");
+        let rows = json
+            ["compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcomes"]
+            .as_array()
+            .expect(
+                "compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcomes is array",
+            );
+        assert_eq!(
+            rows.len(),
+            COMPUTE_TYPE_OF_SYMBOL_INTERFACE_SIMPLE_OBJECT_ACTUAL_LIB_TYPE_REFERENCE_OUTCOME_COUNT,
+            "compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcomes length must match \
+             COMPUTE_TYPE_OF_SYMBOL_INTERFACE_SIMPLE_OBJECT_ACTUAL_LIB_TYPE_REFERENCE_OUTCOME_NAMES",
+        );
+        for (i, row) in rows.iter().enumerate() {
+            assert_eq!(
+                row["name"],
+                COMPUTE_TYPE_OF_SYMBOL_INTERFACE_SIMPLE_OBJECT_ACTUAL_LIB_TYPE_REFERENCE_OUTCOME_NAMES
+                    [i],
+                "compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcomes[{i}] is out of declaration order",
+            );
+            assert!(
+                row["count"].is_u64(),
+                "compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcomes[{i}].count should be a number",
+            );
+        }
+    }
+
+    #[test]
     fn compute_type_of_symbol_interface_simple_object_non_primitive_annotation_residues_lock_field_shape(
     ) {
         let unique_interface = format!(
@@ -1553,6 +1585,9 @@ mod json_tests {
         let ctos_simple_object_type_reference_reject_outcome_idx =
             ComputeTypeOfSymbolInterfaceSimpleObjectTypeReferenceRejectOutcome::IdentifierNotFoundSymbol
                 .as_index();
+        let ctos_simple_object_actual_lib_type_reference_outcome_idx =
+            ComputeTypeOfSymbolInterfaceSimpleObjectActualLibTypeReferenceOutcome::Success
+                .as_index();
 
         let before_source =
             c.delegate_cross_arena_symbol_miss_by_source[source_idx].load(Ordering::Relaxed);
@@ -1606,6 +1641,10 @@ mod json_tests {
             .compute_type_of_symbol_interface_simple_object_type_reference_reject_outcome
             [ctos_simple_object_type_reference_reject_outcome_idx]
             .load(Ordering::Relaxed);
+        let before_ctos_simple_object_actual_lib_type_reference_outcome = c
+            .compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcome
+            [ctos_simple_object_actual_lib_type_reference_outcome_idx]
+            .load(Ordering::Relaxed);
 
         c.delegate_cross_arena_symbol_miss_by_source[source_idx].fetch_add(1, Ordering::Relaxed);
         c.delegate_cross_arena_symbol_miss_by_kind[kind_idx].fetch_add(1, Ordering::Relaxed);
@@ -1630,6 +1669,9 @@ mod json_tests {
             .fetch_add(1, Ordering::Relaxed);
         c.compute_type_of_symbol_interface_simple_object_type_reference_reject_outcome
             [ctos_simple_object_type_reference_reject_outcome_idx]
+            .fetch_add(1, Ordering::Relaxed);
+        c.compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcome
+            [ctos_simple_object_actual_lib_type_reference_outcome_idx]
             .fetch_add(1, Ordering::Relaxed);
         c.compute_type_of_symbol_interface_simple_object_fastpath_hits
             .fetch_add(1, Ordering::Relaxed);
@@ -1814,6 +1856,27 @@ mod json_tests {
                 .unwrap_or(0)
                 > before_ctos_simple_object_type_reference_reject_outcome,
             "compute_type_of_symbol_interface_simple_object_type_reference_reject_outcomes[identifier_not_found_symbol] did not reflect the bump",
+        );
+
+        let ctos_simple_object_actual_lib_type_reference_outcomes = json
+            ["compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcomes"]
+            .as_array()
+            .expect(
+                "compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcomes is array",
+            );
+        let ctos_simple_object_actual_lib_type_reference_outcome_row =
+            &ctos_simple_object_actual_lib_type_reference_outcomes
+                [ctos_simple_object_actual_lib_type_reference_outcome_idx];
+        assert_eq!(
+            ctos_simple_object_actual_lib_type_reference_outcome_row["name"],
+            "success"
+        );
+        assert!(
+            ctos_simple_object_actual_lib_type_reference_outcome_row["count"]
+                .as_u64()
+                .unwrap_or(0)
+                > before_ctos_simple_object_actual_lib_type_reference_outcome,
+            "compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcomes[success] did not reflect the bump",
         );
 
         assert!(


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 7/9 generated app lib/module identity; green-row speed/cache-counter slice for Vite DOM simple-interface lowering.

## Invariant
When a builtin lib declaration is lowered through an external-module source binder, the lib declaration's own bare lib type names are not user source shadows; this PR makes tsz preserve actual-lib lazy identity for unshadowed no-type-argument references through checker type-analysis orchestration and the existing actual-lib resolver.

## Scope
- `crates/tsz-checker/src/state/type_analysis/computed/simple_local_interface.rs`
- `crates/tsz-common/src/perf_counters/definitions.rs`
- `crates/tsz-common/src/perf_counters/dump.rs`
- `crates/tsz-common/src/perf_counters/runtime.rs`
- `crates/tsz-common/src/perf_counters/snapshot.rs`
- `crates/tsz-common/src/perf_counters/tests.rs`

## Project Corpus Impact
- Row: `vite-vanilla-ts-app`
- Bug family: generated app lib/module identity; checker cross-arena delegation/simple DOM interface lowering.
- Evidence: before artifacts `/private/tmp/studio-b-vite-dom-member-batch-20260531.perf.json` and `/private/tmp/studio-b-vite-dom-member-batch-20260531.tsgo-winners.json`; after artifacts `/private/tmp/studio-b-vite-lib-shadow-guard-20260531.perf.json`, `/private/tmp/studio-b-vite-lib-shadow-guard-20260531.json`, and `/private/tmp/studio-b-vite-lib-shadow-guard-20260531.tsgo-winners.json`.
- Counter movement: simple-object hits 8 -> 58; `reject_non_primitive_annotation` 92 -> 32; `type_reference` rejects 63 -> 3; actual-lib helper success 148; diagnostics remained 0.
- Timing sample: row still below target; factor moved 1.44 -> 1.41 in the quick sample (`tsz_ms` 105.14 -> 104.55, `tsgo_ms` 72.93 -> 74.13), with target gap factor still about 2.82.

## Adjacent Case Matrix
- Covered: builtin DOM interface property with a bare actual-lib reference lowers to lazy actual-lib identity.
- Covered: the same lowering path under an external-module source binder does not treat the lib declaration's own name as a source shadow.
- Covered: direct builtin DOM member batching keeps actual-lib property refs resolved.
- Covered fallback: value-merged builtin DOM interface with type arguments keeps inherited members on the normal path.
- Unsupported shapes still fall back: type arguments, generic symbols, compiler-managed types, non-identifiers, source-file shadows, and non-actual-lib symbols.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-common perf_counters`
- `cargo nextest run -p tsz-checker --lib simple_actual_lib_interface_lowers_bare_lib_type_reference_property simple_actual_lib_interface_does_not_treat_lib_decl_as_source_shadow direct_builtin_dom_member_batch_resolves_actual_lib_property_refs value_merged_builtin_dom_interface_type_argument_keeps_inherited_members`
- `CARGO_TARGET_DIR=.target-bench scripts/safe-run.sh --limit 75% -- cargo build --release -p tsz-cli --features perf-tools`
- `TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh --limit 75% -- .target-bench/release/tsz --extendedDiagnostics --perf-counters-json /private/tmp/studio-b-vite-lib-shadow-guard-20260531.perf.json --noEmit -p .target-bench/external/vite-vanilla-ts-live/tsconfig.json`
- `BENCH_PGO=0 TSC_NPM_SPEC=6.0.3 scripts/safe-run.sh --limit 75% -- scripts/bench/bench-vs-tsgo.sh --quick --rebuild --filter '^vite-vanilla-ts-app$' --json-file /private/tmp/studio-b-vite-lib-shadow-guard-20260531.json`
- `node scripts/bench/tsgo-winner-report.mjs /private/tmp/studio-b-vite-lib-shadow-guard-20260531.json /private/tmp/studio-b-vite-lib-shadow-guard-20260531.tsgo-winners.json`

## Coordination Notes
- Existing Studio-B PRs were merged first; `scripts/agents/list-owned-work.sh Studio-B` reported `owned_pr_count=0` before this PR was opened.
- Based on latest `origin/main` after rebase; ready for PR-head CI and manager/queue-owner review once checks are green.
- This captures a structural guard fix plus the counter that exposed it. Vite remains below the 2x target, so the Studio-B performance objective is still active.
