### PR TITLE
refactor(checker): avoid array display text gate

### DIFF
--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -258,9 +258,7 @@ impl<'a> CheckerState<'a> {
             })
             .or_else(|| self.noinfer_call_parameter_mismatch_display(param_type, arg_type))
             .unwrap_or_else(|| self.format_type_diagnostic(param_type));
-        if target_display.contains("Array<") {
-            target_display = Self::normalize_array_generic_to_shorthand(&target_display);
-        }
+        target_display = Self::normalize_array_generic_to_shorthand(&target_display);
         if let Some((generic_actual_display, generic_target_display)) =
             self.generic_direct_primitive_mismatch_display(arg_type, param_type, arg_idx)
         {

--- a/crates/tsz-checker/tests/rendered_decision_debt_tests.rs
+++ b/crates/tsz-checker/tests/rendered_decision_debt_tests.rs
@@ -24,3 +24,30 @@ fn recursive_heritage_conflict_check_does_not_compare_rendered_types() {
         "recursive heritage conflict detection should route through the assignability boundary"
     );
 }
+
+#[test]
+fn call_parameter_array_display_normalization_is_not_gated_by_rendered_text() {
+    let source = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/types/computation/call_result.rs"
+    ))
+    .expect("call result source should be readable");
+
+    let start = source
+        .find("fn error_argument_not_assignable_preserving_param_display")
+        .expect("call argument diagnostic helper should exist");
+    let body = &source[start..];
+    let end = body
+        .find("\n    fn finite_mapped_parameter_display_type")
+        .expect("call argument diagnostic helper should end before next helper");
+    let helper_body = &body[..end];
+
+    assert!(
+        !helper_body.contains("target_display.contains(\"Array<\")"),
+        "call argument target display normalization must not branch on rendered Array<T> text"
+    );
+    assert!(
+        helper_body.contains("Self::normalize_array_generic_to_shorthand(&target_display)"),
+        "call argument target display should always route through the idempotent display normalizer"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
Tracks 8, 10: rendered diagnostic decision debt burn-down.

## Invariant
When call-argument diagnostics normalize target type display, the caller should not branch on rendered `Array<T>` text; this PR routes the already-rendered target string through the idempotent display normalizer and pins that guard with a focused debt test.

## Scope
- `crates/tsz-checker/src/types/computation/call_result.rs`
- `crates/tsz-checker/tests/rendered_decision_debt_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: diagnostic display-policy refactor and guardrail test only; no semantic checker behavior change intended.

## Verification
- Rebased onto `origin/main` (`5bcc6d46d8c500c2ed2126ca8dde592f174e8b86`) and pushed current head `664c370f301e9f52453946e5bc8e1766bd5583bc`.
- On #11932 branch after the earlier focused pass: `cargo fmt --check`, `git diff --check origin/main...HEAD`, and `cargo nextest run -p tsz-checker --test rendered_decision_debt_tests`.
- Final stack sync on the top branch after rebasing #11932/#11942/#11953: `cargo fmt --check`; `git diff --check origin/main...HEAD`; `cargo nextest run -p tsz-checker --test rendered_decision_debt_tests`; `cargo nextest run -p tsz-checker --lib test_multiline_rendered_type_decision_patterns_do_not_grow`; `cargo nextest run -p tsz-checker --test jsdoc_type_tag_tests test_js_constructor_instance_assignment_source_uses_constructor_name`; `python3 scripts/conformance/query-conformance.py --dashboard` => `12582/12582`, accepted-regression gate `0`.

## Coordination Notes
- Follow-up slice for #8775 rendered diagnostic decision debt.
- #11942 is stacked on this PR, and #11953 is stacked on #11942.
- Disk preflight initially reported low, but compact guard immediately reported `101 GiB` free; caches and TypeScript symlink were preserved.
- `merge-queue` is intentionally off after the rebase until exact-head PR-head checks for `664c370f301e9f52453946e5bc8e1766bd5583bc` complete green. `Queue Tested` is queue-owned and may remain pending/missing before enqueue.
