### PR TITLE
fix(dts): format returned parameter type literals

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_parameter_return.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_parameter_return.rs
@@ -25,13 +25,28 @@ impl<'a> DeclarationEmitter<'a> {
             return None;
         }
 
-        self.emit_type_node_text(type_annotation).map(|type_text| {
-            type_text
-                .trim()
-                .trim_end_matches(';')
-                .trim_end()
-                .to_string()
-        })
+        self.type_literal_annotation_text(type_annotation)
+    }
+
+    pub(in crate::declaration_emitter) fn type_literal_annotation_text(
+        &self,
+        type_annotation: NodeIndex,
+    ) -> Option<String> {
+        let type_node = self.arena.get(type_annotation)?;
+        if type_node.kind != syntax_kind_ext::TYPE_LITERAL {
+            return None;
+        }
+
+        self.emit_type_node_text(type_annotation)
+            .map(|type_text| Self::trim_trailing_type_literal_annotation_punctuation(&type_text))
+    }
+
+    fn trim_trailing_type_literal_annotation_punctuation(type_text: &str) -> String {
+        type_text
+            .trim()
+            .trim_end_matches(';')
+            .trim_end()
+            .to_string()
     }
 
     pub(in crate::declaration_emitter) fn function_body_spread_array_return_type_text(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_parameter_return.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_parameter_return.rs
@@ -14,8 +14,24 @@ impl<'a> DeclarationEmitter<'a> {
         let type_annotation = self.function_parameter_type_annotation(func, returned_identifier)?;
         let type_text = self
             .single_line_mapped_type_annotation_text(type_annotation)
+            .or_else(|| self.returned_parameter_type_literal_text(type_annotation))
             .or_else(|| self.function_parameter_type_text(func, returned_identifier))?;
         (!type_text.trim().is_empty()).then_some(type_text)
+    }
+
+    fn returned_parameter_type_literal_text(&self, type_annotation: NodeIndex) -> Option<String> {
+        let type_node = self.arena.get(type_annotation)?;
+        if type_node.kind != syntax_kind_ext::TYPE_LITERAL {
+            return None;
+        }
+
+        self.emit_type_node_text(type_annotation).map(|type_text| {
+            type_text
+                .trim()
+                .trim_end_matches(';')
+                .trim_end()
+                .to_string()
+        })
     }
 
     pub(in crate::declaration_emitter) fn function_body_spread_array_return_type_text(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl_function_initializers.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl_function_initializers.rs
@@ -425,7 +425,8 @@ impl<'a> DeclarationEmitter<'a> {
                 continue;
             }
             let type_text = self
-                .source_slice_from_arena(self.arena, param.type_annotation)
+                .type_literal_annotation_text(param.type_annotation)
+                .or_else(|| self.source_slice_from_arena(self.arena, param.type_annotation))
                 .or_else(|| self.preferred_annotation_name_text(param.type_annotation))
                 .or_else(|| self.emit_type_node_text(param.type_annotation))?;
             let trimmed = type_text.trim_end();

--- a/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
@@ -187,6 +187,10 @@ fn test_inferred_return_preserves_mapped_parameter_annotation() {
     export function makeLookup<Value>(source: { [name: string]: Value }) {
         return source;
     }
+
+    export function makeMethod<Value>(source: { method(input: Value): void }) {
+        return source;
+    }
     "#,
     );
 
@@ -205,6 +209,10 @@ fn test_inferred_return_preserves_mapped_parameter_annotation() {
     assert!(
         output.contains("): {\n    [name: string]: Value;\n};"),
         "Expected renamed index signature parameter annotation to keep object return layout: {output}"
+    );
+    assert!(
+        output.contains("): {\n    method(input: Value): void;\n};"),
+        "Expected method-signature parameter annotation to keep object return layout: {output}"
     );
 }
 

--- a/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
@@ -183,6 +183,10 @@ fn test_inferred_return_preserves_mapped_parameter_annotation() {
     export function makeRecordRenamed<Value, Key extends string>(obj: { [X in Key]: Value }) {
         return obj;
     }
+
+    export function makeLookup<Value>(source: { [name: string]: Value }) {
+        return source;
+    }
     "#,
     );
 
@@ -197,6 +201,10 @@ fn test_inferred_return_preserves_mapped_parameter_annotation() {
     assert!(
         output.contains("): { [X in Key]: Value; };"),
         "Expected renamed mapped variables to use the same return annotation rule: {output}"
+    );
+    assert!(
+        output.contains("): {\n    [name: string]: Value;\n};"),
+        "Expected renamed index signature parameter annotation to keep object return layout: {output}"
     );
 }
 


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Emit/DTS parity: generic/type-display declarations and unique-symbol declaration returns.

## Invariant
When an unannotated generic function returns a parameter whose source annotation is an object type literal, `tsc` emits the structured parameter object type as the declaration return type; this PR makes tsz do the same through declaration parameter-return summary helpers before falling back to raw source slices.

## Scope
- Prefer structured type-node text for returned parameter type literals before falling back to raw source slices.
- Reuse the same structured type-literal annotation path in the source-backed parameter type fallback so method signatures do not inherit parser/source-span trailing tokens.
- Extend focused `tsz-emitter` unit coverage with renamed mapped-type, index-signature, and method-signature parameter shapes.
- Fix live `isomorphicMappedTypeInference` and `uniqueSymbolsDeclarationsErrors` DTS rows without checker diagnostics, solver reach-through, fresh type evaluation during printing, or output surgery.
- Latest pushed head is `8fabd74bbd` after rebasing onto current `origin/main` `5bcc6d46d8` including #11947 and #11972.

## Owner Layer
Declaration emit source-backed parameter return summaries in `tsz-emitter`.

## Adjacent-Case Matrix
- Reported row: `isomorphicMappedTypeInference` preserves the index-signature return layout.
- Live adjacent row: `uniqueSymbolsDeclarationsErrors` preserves method-signature object return layout with `typeof` parameter references.
- Equivalent mapped shape: `{ [P in K]: T }` continues to emit as a single-line mapped return.
- Renamed mapped shape: `{ [X in Key]: Value }` continues to use renamed binder names.
- Renamed index-signature shape: `{ [name: string]: Value }` emits with object return layout.
- Method-signature shape: `{ method(input: Value): void }` emits with object return layout.
- Fallback shape: non-type-literal parameter annotations continue through the existing `function_parameter_type_text` fallback.

## Known Unsupported Shapes / Fallbacks
Unsupported returned-parameter annotations continue through the existing source-slice/name/type-node fallback. This PR only changes object type literal parameter returns where structured type-node emission is already available.

## Project Corpus Impact
- Row: n/a
- Bug family: declaration emit generic/type-display declarations and unique-symbol declaration returns
- Evidence: emit/DTS-only change; verified with focused `tsz-emitter` unit coverage and narrow DTS filters before the latest main rebase, with exact-head CI now rerunning on `8fabd74bbd`.

## Verification
- `git diff --check origin/main...HEAD` (exact head `8fabd74bbd`)
- Previous focused local verification before the latest main rebase:
  - `cargo fmt --all --check` (head `4f3fbbc586`)
  - `cargo nextest run -p tsz-emitter test_inferred_return_preserves_mapped_parameter_annotation` (head `4f3fbbc586`: 1 passed, 3989 skipped)
  - `scripts/emit/run.sh --filter=uniqueSymbolsDeclarations --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-unique-symbols-declarations-exact-4f3fbbc586.json` (2/2 on head `4f3fbbc586`)
  - `scripts/emit/run.sh --filter=isomorphicMappedTypeInference --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-isomorphic-mapped-type-inference-exact-4f3fbbc586.json` (1/1 on head `4f3fbbc586`)
  - Mechanical coverage check: all 63 checked-in stale DTS failure names were covered by passing local JSON results on head `4f3fbbc586`.
- Exact-head ready CI is rerunning after rebasing onto `origin/main` `5bcc6d46d8` including #11947 and #11972.

## Coordination Notes
- AgentName: Studio-D
- PR #11903 and #11928 have merged; this is the current Studio-D DTS runway.
- Checked open PRs before publishing; no open Studio-D PRs and no overlapping generic/type-display DTS PR found.
- Synced with current `origin/main` `5bcc6d46d8` after #11947 and #11972 merged; ready for review/CI from Studio-D's side at head `8fabd74bbd`.
- No merge queue or auto-merge state requested until exact-head ready CI is green.
