### PR TITLE
fix(emit): recover stolen jsx closing tags

### DIFF
--- a/crates/tsz-emitter/src/emitter/jsx/emit.rs
+++ b/crates/tsz-emitter/src/emitter/jsx/emit.rs
@@ -102,6 +102,14 @@ impl<'a> Printer<'a> {
     // =========================================================================
 
     fn emit_jsx_element_preserve(&mut self, node: &Node) {
+        self.emit_jsx_element_preserve_with_recovered_close(node, false);
+    }
+
+    fn emit_jsx_element_preserve_with_recovered_close(
+        &mut self,
+        node: &Node,
+        recovered_empty_close: bool,
+    ) {
         let Some(jsx) = self.arena.get_jsx_element(node) else {
             return;
         };
@@ -115,6 +123,11 @@ impl<'a> Printer<'a> {
             self.writer.set_indent_level(saved_indent);
         }
         self.emit(jsx.opening_element);
+        let opening_tag_name = self
+            .arena
+            .get(jsx.opening_element)
+            .and_then(|opening_node| self.arena.get_jsx_opening(opening_node))
+            .map(|opening| opening.tag_name);
         let has_synthesized_empty_close = self
             .arena
             .get(jsx.closing_element)
@@ -142,9 +155,20 @@ impl<'a> Printer<'a> {
             {
                 continue;
             }
-            self.emit(child);
+            if let Some(parent_tag_name) = opening_tag_name
+                && self.jsx_child_stole_parent_closer(child, parent_tag_name)
+                && let Some(child_node) = self.arena.get(child)
+            {
+                self.emit_jsx_element_preserve_with_recovered_close(child_node, true);
+            } else {
+                self.emit(child);
+            }
         }
-        self.emit(jsx.closing_element);
+        if recovered_empty_close {
+            self.write("</>");
+        } else {
+            self.emit(jsx.closing_element);
+        }
     }
 
     fn jsx_node_contains_recovered_missing_false_conditional(&self, node: &Node) -> bool {

--- a/crates/tsz-emitter/src/emitter/jsx/mod.rs
+++ b/crates/tsz-emitter/src/emitter/jsx/mod.rs
@@ -1,4 +1,5 @@
 mod emit;
+mod recovery;
 mod transform;
 
 use std::borrow::Cow;
@@ -719,6 +720,32 @@ x = <foo>x</foo>, x = <foo/>;
         assert!(
             !output.contains("</div>"),
             "Conflict-marker JSX recovery should not mirror the opener tag.\nOutput: {output}"
+        );
+    }
+
+    #[test]
+    fn recovered_jsx_child_that_consumes_parent_close_emits_empty_close() {
+        let output = emit_jsx_preserve_es2015("var x = <root><leaf></root>;");
+        assert!(
+            output.contains("<root><leaf></></root>"),
+            "Recovered child close should be emitted as an empty JSX close.\nOutput: {output}"
+        );
+        assert!(
+            !output.contains("<root><leaf></root></root>"),
+            "Recovered child should not duplicate the parent closing tag.\nOutput: {output}"
+        );
+    }
+
+    #[test]
+    fn mismatched_jsx_close_without_parent_recovery_keeps_written_close() {
+        let output = emit_jsx_preserve_es2015("var x = <alpha></beta>;");
+        assert!(
+            output.contains("<alpha></beta>"),
+            "Plain mismatched JSX close should preserve the written close.\nOutput: {output}"
+        );
+        assert!(
+            !output.contains("<alpha></>"),
+            "Plain mismatched JSX close should not be treated as parent recovery.\nOutput: {output}"
         );
     }
 

--- a/crates/tsz-emitter/src/emitter/jsx/recovery.rs
+++ b/crates/tsz-emitter/src/emitter/jsx/recovery.rs
@@ -1,0 +1,89 @@
+use super::super::Printer;
+use tsz_common::interner::Atom;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
+
+impl<'a> Printer<'a> {
+    pub(in super::super) fn jsx_child_stole_parent_closer(
+        &self,
+        child: NodeIndex,
+        parent_tag_name: NodeIndex,
+    ) -> bool {
+        let Some(child_node) = self.arena.get(child) else {
+            return false;
+        };
+        if child_node.kind != syntax_kind_ext::JSX_ELEMENT {
+            return false;
+        }
+        let Some(child_element) = self.arena.get_jsx_element(child_node) else {
+            return false;
+        };
+        let Some(child_open_tag) = self
+            .arena
+            .get(child_element.opening_element)
+            .and_then(|opening_node| self.arena.get_jsx_opening(opening_node))
+            .map(|opening| opening.tag_name)
+        else {
+            return false;
+        };
+        let Some(child_close_tag) = self
+            .arena
+            .get(child_element.closing_element)
+            .and_then(|closing_node| self.arena.get_jsx_closing(closing_node))
+            .map(|closing| closing.tag_name)
+        else {
+            return false;
+        };
+
+        !self.jsx_tag_names_match(child_open_tag, child_close_tag)
+            && self.jsx_tag_names_match(child_close_tag, parent_tag_name)
+    }
+
+    fn jsx_tag_names_match(&self, a: NodeIndex, b: NodeIndex) -> bool {
+        if a == b {
+            return true;
+        }
+        let Some(node_a) = self.arena.get(a) else {
+            return false;
+        };
+        let Some(node_b) = self.arena.get(b) else {
+            return false;
+        };
+        if node_a.kind != node_b.kind {
+            return false;
+        }
+
+        if node_a.is_identifier() {
+            if let (Some(id_a), Some(id_b)) = (
+                self.arena.get_identifier(node_a),
+                self.arena.get_identifier(node_b),
+            ) {
+                if id_a.atom != Atom::NONE && id_b.atom != Atom::NONE {
+                    return id_a.atom == id_b.atom;
+                }
+                return id_a.escaped_text == id_b.escaped_text;
+            }
+        } else if node_a.kind == SyntaxKind::ThisKeyword as u16 {
+            return true;
+        } else if node_a.kind == syntax_kind_ext::JSX_NAMESPACED_NAME {
+            if let (Some(ns_a), Some(ns_b)) = (
+                self.arena.get_jsx_namespaced_name(node_a),
+                self.arena.get_jsx_namespaced_name(node_b),
+            ) {
+                return self.jsx_tag_names_match(ns_a.namespace, ns_b.namespace)
+                    && self.jsx_tag_names_match(ns_a.name, ns_b.name);
+            }
+        } else if node_a.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            && let (Some(acc_a), Some(acc_b)) = (
+                self.arena.get_access_expr(node_a),
+                self.arena.get_access_expr(node_b),
+            )
+        {
+            return self.jsx_tag_names_match(acc_a.expression, acc_b.expression)
+                && self.jsx_tag_names_match(acc_a.name_or_argument, acc_b.name_or_argument);
+        }
+
+        false
+    }
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Track 9: Emit/DTS parity recovery; JavaScript emit JSX parser recovery.

## Invariant
When a recovered unclosed JSX child consumes a closing tag whose parsed tag structure matches the parent opener, `tsc` emits an empty JSX close (`</>`) for the child and keeps the parent's real close; this PR makes tsz do that through the JSX preserve printer.

## Owner Layer
Output layer: direct JSX preserve printer/parser-recovery fact. The fix reads parsed JSX tag structure and does not add checker imports, semantic validation, or output surgery.

## Scope
- Detect child JSX elements whose mismatched closing tag structurally matches the parent opener.
- Emit that child's recovered close as `</>` in preserve mode.
- Preserve ordinary mismatched closes such as `<alpha></beta>`.
- Add focused unit coverage and keep the JSX preserve helper split below the 2000-line file-size guard.

## Adjacent-Case Matrix
- Reported-style recovered child/parent close consumption: child gets `</>`, parent keeps its close.
- Plain mismatched JSX close without parent recovery: printed as written.
- Preserve-mode JSX only; non-JSX statement recovery falls through to existing emit paths.

## Known Fallbacks
Unsupported or non-structural tag shapes fall back to normal JSX closing-element emit. The recovery is intentionally not keyed by a file name, baseline name, or a rendered output fragment.

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit JSX parser recovery (`jsxUnclosedParserRecovery`)
- Evidence: targeted emit filter `jsxUnclosedParserRecovery` passes 1/1 JS-only after rebasing onto current `origin/main`.

## Verification
- `cargo fmt --check`
- `cargo check -p tsz-emitter`
- `cargo nextest run -p tsz-emitter -E 'test(recovered_jsx_child_that_consumes_parent_close_emits_empty_close) | test(mismatched_jsx_close_without_parent_recovery_keeps_written_close)'`
- `CARGO_INCREMENTAL=0 scripts/emit/run.sh --filter=jsxUnclosedParserRecovery --js-only --verbose --timeout=30000 --json-out=/tmp/jsxUnclosedParserRecovery-studio-c-after-rebase-503.json`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check HEAD~1..HEAD`

## Coordination Notes
AgentName: Studio-C. Rebased onto current `origin/main` on 2026-05-31 after #11936, #11941, #11944, and #11945, and #11946 landed. Ready for heavy ready-for-review CI once exact-head draft checks complete. No roadmap update: this is a small Track 9 JS emit parity slice.

