### PR TITLE
fix(emitter): emit TemplateExpression specifiers directly in CJS dynamic import Promise.resolve()

### DIFF
--- a/crates/tsz-emitter/src/emitter/expressions/call.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/call.rs
@@ -940,11 +940,13 @@ impl<'a> Printer<'a> {
 
     /// Emit the CommonJS branch of a downlevel dynamic import as a Promise.
     ///
-    /// A captured temp, a string literal, or the no-argument case lets the
-    /// `require` reference the value directly via
-    /// `Promise.resolve().then(() => require(x))`. A bare identifier specifier
-    /// (never captured) is coerced through a template so the runtime `require`
-    /// receives a string: `Promise.resolve(`${id}`).then(s => require(s))`.
+    /// Cases by specifier shape, matching tsc:
+    ///
+    /// - Captured temp / string literal / no-arg: lazy `Promise.resolve().then(() => require(x))`.
+    /// - `TemplateExpression`: `Promise.resolve(template).then(s => require(s))` — the
+    ///   template already evaluates to a string so no extra coercion wrapper is added.
+    /// - Bare identifier: `Promise.resolve(coerced).then(s => require(s))` where the
+    ///   coerced form wraps the identifier in a template-string coercion.
     fn emit_dynamic_import_commonjs_promise(
         &mut self,
         first_arg: Option<NodeIndex>,
@@ -955,15 +957,28 @@ impl<'a> Printer<'a> {
             self.emit_dynamic_import_commonjs_branch(first_arg, temp);
             return;
         }
-        self.write("Promise.resolve(`${");
-        if self.ctx.options.rewrite_relative_import_extensions {
-            if let Some(first) = first_arg {
+        // first_arg is guaranteed Some and non-string-like by the guard above.
+        let first = first_arg.unwrap();
+        // TemplateExpression already evaluates to a string: emit it directly in
+        // Promise.resolve() without an extra `${…}` coercion wrapper.
+        if !self.ctx.options.rewrite_relative_import_extensions
+            && self
+                .arena
+                .get(first)
+                .is_some_and(|n| n.kind == syntax_kind_ext::TEMPLATE_EXPRESSION)
+        {
+            self.write("Promise.resolve(");
+            self.emit(first);
+            self.write(").then(s => ");
+        } else {
+            self.write("Promise.resolve(`${");
+            if self.ctx.options.rewrite_relative_import_extensions {
                 self.emit_rewrite_helper_call(first);
+            } else {
+                self.emit_dynamic_import_template_specifier(first);
             }
-        } else if let Some(first) = first_arg {
-            self.emit_dynamic_import_template_specifier(first);
+            self.write("}`).then(s => ");
         }
-        self.write("}`).then(s => ");
         self.write_helper("__importStar");
         self.write("(require(s)))");
     }

--- a/crates/tsz-emitter/tests/dynamic_import_amd_umd_parity_tests.rs
+++ b/crates/tsz-emitter/tests/dynamic_import_amd_umd_parity_tests.rs
@@ -1,10 +1,10 @@
 //! Parity tests for downlevel dynamic `import()` emit under CommonJS / AMD / UMD / System.
 //!
 //! Structural rules matched to tsc:
-//! - **TemplateExpression** specifiers (`` `./s/${id}` ``) evaluate to a string
+//! - **`TemplateExpression`** specifiers (`` `./s/${id}` ``) evaluate to a string
 //!   and are emitted directly in `Promise.resolve(<template>).then(s => ...)` for
 //!   CJS/AMD/System — no extra `` `${…}` `` coercion wrapper is added.
-//! - **Identifier** specifiers are coerced via `` `${id}` `` in the CJS/UMD CJS branch.
+//! - **`Identifier`** specifiers are coerced via `` `${id}` `` in the CJS/UMD CJS branch.
 //! - **UMD** captures non-string, non-identifier specifiers (including template
 //!   expressions) into a temp so both branches share the evaluated value.
 //! - **AMD** and **System** always inline the specifier without a temp.

--- a/crates/tsz-emitter/tests/dynamic_import_amd_umd_parity_tests.rs
+++ b/crates/tsz-emitter/tests/dynamic_import_amd_umd_parity_tests.rs
@@ -1,13 +1,15 @@
-//! Parity tests for downlevel dynamic `import()` emit under AMD / UMD / System.
+//! Parity tests for downlevel dynamic `import()` emit under CommonJS / AMD / UMD / System.
 //!
-//! Structural rule: when a downlevel dynamic `import()` lowers to a low-
-//! precedence substitution (a UMD `__syncRequire ? ... : ...` conditional, or a
-//! `_a = spec, ...` comma sequence when a complex specifier is captured), tsz
-//! must parenthesize it exactly where `tsc` does — based on the parent
-//! expression, not on a fixed wrap — and must capture a temp only for the
-//! specifier shapes `tsc` captures (UMD, non-string, non-identifier). System
-//! modules emit `context_1.import(<specifier>)` and drop the options/attributes
-//! argument. Verified against `tsc` 6.x.
+//! Structural rules matched to tsc:
+//! - **TemplateExpression** specifiers (`` `./s/${id}` ``) evaluate to a string
+//!   and are emitted directly in `Promise.resolve(<template>).then(s => ...)` for
+//!   CJS/AMD/System — no extra `` `${…}` `` coercion wrapper is added.
+//! - **Identifier** specifiers are coerced via `` `${id}` `` in the CJS/UMD CJS branch.
+//! - **UMD** captures non-string, non-identifier specifiers (including template
+//!   expressions) into a temp so both branches share the evaluated value.
+//! - **AMD** and **System** always inline the specifier without a temp.
+//! - **UMD conditional** parenthesization follows parent-expression binding, not a
+//!   fixed rule — verified against `tsc` 6.x.
 //!
 //! Owner layer: emitter (`crates/tsz-emitter/src/emitter/expressions/call.rs`).
 
@@ -18,6 +20,17 @@ use tsz_emitter::output::printer::PrintOptions;
 mod test_support;
 
 use test_support::parse_and_lower_print as emit;
+
+fn cjs(source: &str) -> String {
+    emit(
+        source,
+        PrintOptions {
+            target: ScriptTarget::ES2022,
+            module: ModuleKind::CommonJS,
+            ..Default::default()
+        },
+    )
+}
 
 fn umd(source: &str) -> String {
     emit(
@@ -279,5 +292,111 @@ fn system_dynamic_import_inlines_identifier_specifier() {
     assert!(
         out.contains("context_1.import(p)"),
         "System dynamic import inlines the identifier specifier.\nOutput:\n{out}"
+    );
+}
+
+// --- Template expression specifier: no double-wrapping ----------------------
+//
+// Rule: a TemplateExpression (`` `./s/${id}` ``) already evaluates to a string.
+// tsc emits it directly in Promise.resolve() for CJS — no extra `${…}` wrapper.
+// For identifiers, tsc adds the `${…}` coercion; for templates it does not.
+
+#[test]
+fn cjs_template_specifier_emits_directly_in_promise_resolve() {
+    // Structural rule: Promise.resolve(`./widgets/${id}`) — not Promise.resolve(`${`./widgets/${id}`}`)
+    let out = cjs("async function load(id: string) { return await import(`./widgets/${id}`); }");
+    assert!(
+        out.contains("Promise.resolve(`./widgets/${id}`).then(s => "),
+        "template specifier must be emitted directly in Promise.resolve() without an extra wrapper.\nOutput:\n{out}"
+    );
+    assert!(
+        out.contains("__importStar(require(s))"),
+        "template specifier path must still wrap require() with __importStar.\nOutput:\n{out}"
+    );
+    assert!(
+        !out.contains("Promise.resolve(`${`"),
+        "template specifier must not be double-wrapped in another template literal.\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn cjs_template_specifier_multi_span_emits_directly() {
+    // Two substitutions: rule holds regardless of the number of template spans.
+    let out = cjs(
+        "async function load(prefix: string, id: string) { return await import(`${prefix}/${id}.js`); }",
+    );
+    assert!(
+        out.contains("Promise.resolve(`${prefix}/${id}.js`).then(s => "),
+        "multi-span template must be emitted directly in Promise.resolve().\nOutput:\n{out}"
+    );
+    assert!(
+        !out.contains("Promise.resolve(`${`"),
+        "multi-span template must not be double-wrapped.\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn cjs_template_specifier_rule_is_independent_of_variable_name() {
+    // The fix is structural (TemplateExpression kind), not name-specific.
+    let out = cjs(
+        "async function load(routeSegment: string) { return await import(`./routes/${routeSegment}/page`); }",
+    );
+    assert!(
+        out.contains("Promise.resolve(`./routes/${routeSegment}/page`).then(s => "),
+        "template form must not depend on the bound variable name.\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn cjs_identifier_specifier_still_uses_coercion_wrapper() {
+    // Identifier specifiers are NOT templates and still need the `${…}` coercion.
+    // This is the existing behaviour — verify it is unchanged by the template fix.
+    let out = cjs("async function load(p: string) { return await import(p); }");
+    assert!(
+        out.contains("Promise.resolve(`${p}`).then(s => "),
+        "identifier specifier must still use the backtick-coercion form.\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn amd_template_specifier_inlines_in_require_array() {
+    // AMD never captures; template expression must be inlined in require([...]).
+    let out = amd("async function load(id: string) { return await import(`./widgets/${id}`); }");
+    assert!(
+        out.contains("require([`./widgets/${id}`]"),
+        "AMD must inline the template specifier in require([...]).\nOutput:\n{out}"
+    );
+    assert!(
+        !out.contains("_a = "),
+        "AMD must not capture the template specifier into a temp.\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn system_template_specifier_inlines_in_context_import() {
+    // System module: template expression passed directly to context_1.import().
+    let out = system("async function load(id: string) { return await import(`./widgets/${id}`); }");
+    assert!(
+        out.contains("context_1.import(`./widgets/${id}`)"),
+        "System must inline the template specifier in context_1.import().\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn umd_template_specifier_captured_into_temp() {
+    // UMD has two branches; a TemplateExpression is not string-like or identifier,
+    // so it is captured into a temp that both branches share.
+    let out = umd("async function load(id: string) { return await import(`./widgets/${id}`); }");
+    assert!(
+        out.contains("_a = `./widgets/${id}`"),
+        "UMD must capture the template specifier into a temp.\nOutput:\n{out}"
+    );
+    assert!(
+        out.contains("__syncRequire ? Promise.resolve().then("),
+        "UMD CJS branch with captured temp must use the lazy Promise.resolve().then() form.\nOutput:\n{out}"
+    );
+    assert!(
+        out.contains("__importStar(require(_a))"),
+        "UMD CJS branch must wrap require() with __importStar.\nOutput:\n{out}"
     );
 }


### PR DESCRIPTION
AgentName: Studio-C

## Track
emit — dynamic `import()` specifier lowering, CJS branch

## Invariant
When `tsc` lowers a dynamic `import()` to CommonJS, a `TemplateExpression` specifier (e.g. `` `./widgets/${id}` ``) is emitted directly into `Promise.resolve(template).then(s => __importStar(require(s)))` — the template is NOT wrapped in an extra `` `${…}` `` coercion because it already evaluates to a string. Bare identifier specifiers still use the coercion wrapper. tsz was incorrectly applying the coercion wrapper to template expressions.

## Scope

**Root cause:** `emit_dynamic_import_commonjs_promise` in `crates/tsz-emitter/src/emitter/expressions/call.rs` treated `TemplateExpression` nodes identically to bare identifiers — both were wrapped in `` Promise.resolve(`${...}`) ``. tsc distinguishes them: identifiers need coercion; templates do not.

**Structural rule:** When the specifier is a `TemplateExpression` AND `rewrite_relative_import_extensions` is not active, emit `Promise.resolve(template).then(s => __importStar(require(s)))`. For all other non-string-like specifiers, keep the coercion wrapper form.

**Adjacent cases verified (no name-keyed logic):**
- Single-substitution template: `` `./widgets/${id}` ``
- Multi-substitution template: `` `${prefix}/${id}.js` ``
- Renamed variable: `` `./routes/${routeSegment}/page` ``
- Identifier regression guard: `p` still uses `` `${p}` `` coercion (unchanged)

**Other module formats (all correct, no change needed):**
- **AMD**: always inlines the specifier raw into `require([...])` — templates inlined without capture (confirmed)
- **System**: passes the specifier directly to `context_1.import(...)` — templates inlined (confirmed)
- **UMD**: has two branches; templates are captured into a temp so both branches share the evaluated value (correct, unchanged — `dynamic_import_arg_is_string_like` deliberately excludes `TemplateExpression` for UMD)

## Project Corpus Impact
- Row: emit / dynamic import CJS specifier lowering
- Bug family: CJS `import()` TemplateExpression specifier double-wrapped in coercion — `Promise.resolve(\`\${template}\`)` emitted instead of `Promise.resolve(template)`
- Evidence: 7 new parity tests added covering CJS/AMD/System/UMD template specifier shapes; all pass locally. Pre-existing 13 failures in tsz-emitter are unrelated (declaration emitter, private fields).

## Verification
```
cargo nextest run -p tsz-emitter -E 'test(template_specifier) + test(cjs_identifier) + test(amd_template) + test(system_template) + test(umd_template)'
# 8 passed, 0 failed

cargo clippy -p tsz-emitter --lib --tests -- -D warnings
# clean
```

Three `/simplify` passes applied before committing. Round 3 confirmed no actionable findings.

## Coordination Notes
- Runner: claude-sonnet-4-6 / busy-lamport-V0vor
- Claimed from open issue backlog; branch `claude/busy-lamport-V0vor`
- ES5 async path (`async_es5_ir_convert.rs:convert_dynamic_import_call`) has a parallel template-capture behavior for ES5 generator lowering — noted as future work, out of scope here
- Pre-existing 13 failures in tsz-emitter are unrelated to this change