### PR TITLE
fix(emit-tools): label stale family totals

### DIFF
--- a/scripts/emit/query-emit.py
+++ b/scripts/emit/query-emit.py
@@ -269,6 +269,32 @@ def emit_freshness_status_line(data):
     return f"Emit detail freshness: {state}."
 
 
+def emit_remaining_failures(summary, surface):
+    prefix = "js" if surface == "js" else "dts"
+    passed = summary.get(f"{prefix}Pass")
+    total = summary.get(f"{prefix}Total")
+    if passed is None or total is None:
+        return None
+    return total - passed
+
+
+def failure_family_surface_heading(surface, title, detail_total, detail_summary, public_summary):
+    status = emit_freshness_status(detail_summary, public_summary)
+    if status["state"] != "stale":
+        return f"{title}: {detail_total} failures/timeouts"
+
+    public_remaining = emit_remaining_failures(public_summary, surface)
+    detail_remaining = emit_remaining_failures(detail_summary, surface)
+    if public_remaining is None or detail_remaining is None:
+        return f"{title} checked-detail: {detail_total} failures/timeouts"
+
+    return (
+        f"{title} checked-detail: {detail_total} failures/timeouts "
+        f"(public aggregate remaining: {public_remaining:,}; "
+        f"detail aggregate remaining: {detail_remaining:,})"
+    )
+
+
 def print_emit_freshness_status(data):
     print(emit_freshness_status_line(data))
 
@@ -424,6 +450,8 @@ def show_failure_families(data, top=20):
     print("Emit failure families")
     print()
     print_emit_freshness_note(data)
+    detail_summary = emit_summary(data)
+    public_summary = emit_summary_from_readme()
     for surface, title in (("js", "JavaScript"), ("dts", "Declaration")):
         families = collect_failures_by_family(data, surface)
         rows = sorted(
@@ -431,7 +459,11 @@ def show_failure_families(data, top=20):
             key=lambda item: (-len(item[1]), item[0]),
         )
         total = sum(len(results) for _, results in rows)
-        print(f"{title}: {total} failures/timeouts")
+        print(
+            failure_family_surface_heading(
+                surface, title, total, detail_summary, public_summary
+            )
+        )
         for family, results in rows[:top]:
             examples = ", ".join(
                 r["name"] for r in sorted(results, key=lambda r: r["name"])[:3]

--- a/scripts/emit/test_query_emit_families.py
+++ b/scripts/emit/test_query_emit_families.py
@@ -150,6 +150,42 @@ after
         status = self.mod.emit_freshness_status(summary, dict(summary))
         self.assertEqual(status["state"], "current")
 
+    def test_stale_failure_family_heading_names_public_remaining_count(self):
+        detail_summary = {
+            "jsPass": 13094,
+            "jsTotal": 13530,
+            "dtsPass": 1606,
+            "dtsTotal": 1669,
+        }
+        public_summary = {
+            "jsPass": 13459,
+            "jsTotal": 13530,
+            "dtsPass": 1644,
+            "dtsTotal": 1669,
+        }
+
+        heading = self.mod.failure_family_surface_heading(
+            "js", "JavaScript", 436, detail_summary, public_summary
+        )
+
+        self.assertIn("JavaScript checked-detail: 436 failures/timeouts", heading)
+        self.assertIn("public aggregate remaining: 71", heading)
+        self.assertIn("detail aggregate remaining: 436", heading)
+
+    def test_current_failure_family_heading_keeps_plain_count(self):
+        summary = {
+            "jsPass": 13459,
+            "jsTotal": 13530,
+            "dtsPass": 1644,
+            "dtsTotal": 1669,
+        }
+
+        heading = self.mod.failure_family_surface_heading(
+            "dts", "Declaration", 25, summary, dict(summary)
+        )
+
+        self.assertEqual(heading, "Declaration: 25 failures/timeouts")
+
 
 class TestQueryFilters(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Release metric truth / emit tooling.

## Invariant
When the public README emit aggregate is newer than `scripts/emit/emit-detail.json`, failure-family rows are checked-detail snapshot counts, not current public remaining counts; this PR makes `query-emit.py --families` label that distinction at the reporting layer.

## Scope
- `scripts/emit/query-emit.py`: show stale family headings as checked-detail counts and include public aggregate remaining counts for JS/DTS.
- `scripts/emit/test_query_emit_families.py`: cover stale and current heading behavior.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: emit-tooling/reporting-only change; no compiler, checker, emitter, benchmark fixture, or project compatibility behavior changes.

## Verification
- `python3 scripts/emit/test_query_emit_families.py`
- `python3 scripts/emit/query-emit.py --families`
- `git diff --check`
- Branch sync: rebased onto `origin/main` `65aad9b3ca180675d3f03d821a36cb3611796367`; `origin/main` is an ancestor of `052c24bb8d7fbc6426b48d5a1262f1d538226298`.

## Coordination Notes
- Code/script-only PR; no repo markdown or docs files changed.
- #11919 and #11915 were merged before opening this new Studio-A PR.
- Draft CI passed on the previous head before `origin/main` advanced; this head is a rebase-only update of the same script changes with fresh local verification.
- This does not refresh `emit-detail.json`; it prevents stale detail-family totals from being mistaken for the newer public aggregate totals while emit-owner PRs continue reducing the underlying failures.
