### PR TITLE
docs(agents): record label audit json artifact

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -18,7 +18,7 @@ git fetch origin main
 scripts/agents/show-goal.sh M1-A
 scripts/agents/disk-preflight.sh M1-A
 scripts/agents/list-owned-work.sh M1-A
-scripts/agents/ensure-agent-labels.sh --audit
+scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-audit.json
 node scripts/ci/pr-ownership-report.mjs
 ```
 
@@ -42,7 +42,7 @@ node scripts/ci/pr-ownership-report.mjs
 
 - `scripts/agents/list-owned-work.sh --all`.
 - `node scripts/ci/pr-ownership-report.mjs`.
-- `scripts/agents/ensure-agent-labels.sh --audit`.
+- `scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-audit.json`.
 - Recent merged PRs touching `docs/plan/agents`, `scripts/ci/pr-ownership-report.mjs`,
   and label/WIP tooling.
 - Open issues with `bug`, `false-positive`, `false-negative`,
@@ -60,6 +60,6 @@ node scripts/ci/pr-ownership-report.mjs
 ## Verification
 
 - Use `scripts/ci/pr-ownership-report.mjs` for PR topology.
-- Use `scripts/agents/ensure-agent-labels.sh --audit` for label hygiene.
+- Use `scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-audit.json` for label hygiene.
 - Use `scripts/ci/check-wip-state-comments.mjs` when changing WIP state.
 - No compiler suite is needed for metadata-only cleanup.

--- a/docs/plan/agents/README.md
+++ b/docs/plan/agents/README.md
@@ -113,7 +113,7 @@ blocked.
 Useful live checks:
 
 ```bash
-scripts/agents/ensure-agent-labels.sh --audit
+scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-audit.json
 scripts/agents/list-owned-work.sh --all
 scripts/agents/list-owned-work.sh --pr-state Studio-F
 node scripts/ci/pr-ownership-report.mjs
@@ -215,7 +215,7 @@ smaller:
 
 | Debt Category | Owner | Gate Supported | Counter Or Command |
 | --- | --- | --- | --- |
-| Ownership and duplicate-work hygiene | `M1-A` | all gates | `node scripts/ci/pr-ownership-report.mjs`; `scripts/agents/ensure-agent-labels.sh --audit` |
+| Ownership and duplicate-work hygiene | `M1-A` | all gates | `node scripts/ci/pr-ownership-report.mjs`; `scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-audit.json` |
 | Checker relation gateway debt | `M1-B` | bug closure, conformance strictness | `scripts/arch/check-checker-boundaries.sh`; `python3 scripts/arch/arch_guard.py` |
 | Accepted-regression and diagnostic hardcoding debt | `M1-C` | conformance strictness | `python3 scripts/conformance/query-conformance.py --dashboard`; accepted-regression entry count |
 | Flow/narrowing boundary debt | `M1-D` | bug closure, project rows | focused checker/solver tests plus `python3 scripts/arch/arch_guard.py` |
@@ -236,7 +236,7 @@ smaller:
 1. Merge this coordination update or tell sessions to read this branch.
 2. Confirm live PR runway state, draft parking risks, and queue candidates with
    `node scripts/ci/pr-ownership-report.mjs`.
-3. Confirm labels with `scripts/agents/ensure-agent-labels.sh --audit`.
+3. Confirm labels with `scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-audit.json`.
 4. Confirm cheap release metrics with the owning lane commands:
    conformance dashboard, emit families, project row summary, and architecture
    guard.

--- a/docs/plan/agents/Reviewer.md
+++ b/docs/plan/agents/Reviewer.md
@@ -34,7 +34,7 @@ git fetch origin main
 scripts/agents/show-goal.sh Reviewer
 scripts/agents/disk-preflight.sh Reviewer
 scripts/agents/list-owned-work.sh Reviewer
-scripts/agents/ensure-agent-labels.sh --audit
+scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-audit.json
 gh pr list --state open --limit 100 --json number,title,isDraft,labels,updatedAt,url
 ```
 

--- a/docs/plan/agents/Studio-F.md
+++ b/docs/plan/agents/Studio-F.md
@@ -18,6 +18,7 @@ git fetch origin main
 scripts/agents/show-goal.sh Studio-F
 scripts/agents/disk-preflight.sh Studio-F
 scripts/agents/list-owned-work.sh Studio-F
+scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-audit.json
 python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard.json
 python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery.json
 ```


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / cheap evidence plumbing.

## Invariant
When launch lanes use agent-label hygiene as evidence, the documented command should preserve both human-readable output and a machine-readable JSON artifact.

## Scope
- Update launch guidance to use `scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-audit.json`.
- Add the JSON artifact command to Studio-F, M1-A, and Reviewer cycle guidance where label hygiene is part of coordination evidence.
- No script, compiler, or runtime behavior changes.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only launch coordination update; no project corpus, compiler, emit, checker, solver, parser, binder, LSP, or WASM behavior changes.

## Verification
- `scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-audit.json`
- `python3 -m json.tool /tmp/tsz-agent-label-audit.json`
- `git diff --check HEAD~1..HEAD`

## Coordination Notes
- AgentName: Studio-F
- Studio-F owned runway was clear before opening this PR.
- This follows merged #11935, which added the JSON-report flag.
- Checked open PRs before editing; no open PR is touching these agent guidance docs for the same command shape.
- No roadmap update: this is routine launch evidence plumbing, not a durable roadmap direction change.