### PR TITLE
fix(emit): recover invalid numeric declaration names

### DIFF
--- a/crates/tsz-emitter/src/emitter/source_file/emit.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/emit.rs
@@ -494,10 +494,7 @@ impl<'a> Printer<'a> {
         let has_invalid_export_recovery = source.statements.nodes.iter().any(|&idx| {
             self.arena
                 .get(idx)
-                .and_then(|node| self.arena.get_export_decl(node))
-                .is_some_and(|export| {
-                    export.export_clause.is_none() && export.module_specifier.is_none()
-                })
+                .is_some_and(|node| self.is_invalid_export_recovery_statement(node))
         });
         let needs_use_strict_invalid_export_recovery = has_invalid_export_recovery
             && (matches!(self.ctx.options.module, ModuleKind::None) || is_es_module_output)
@@ -1810,7 +1807,10 @@ impl<'a> Printer<'a> {
                 .nodes
                 .get(stmt_i + 1)
                 .and_then(|&next_idx| self.arena.get(next_idx));
-
+            if self.emit_recovered_invalid_numeric_declaration_name_statement(stmt_node) {
+                last_erased_was_shorthand_module = false;
+                continue;
+            }
             if is_erased {
                 if stmt_node.kind == syntax_kind_ext::INTERFACE_DECLARATION {
                     self.emit_recovered_interface_body_statements(stmt_node);

--- a/crates/tsz-emitter/src/emitter/source_file/invalid_numeric_declaration_recovery_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/invalid_numeric_declaration_recovery_tests.rs
@@ -1,0 +1,57 @@
+use crate::emitter::{ModuleKind, Printer as EmitterPrinter, PrinterOptions};
+use tsz_common::ScriptTarget;
+use tsz_parser::ParserState;
+
+fn emit_es2015(source: &str) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        target: ScriptTarget::ES2015,
+        module: ModuleKind::None,
+        ..Default::default()
+    };
+    let mut printer = EmitterPrinter::with_options(&parser.arena, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+#[test]
+fn invalid_numeric_declaration_names_recover_runtime_statements() {
+    let source = "\
+namespace 42 {}
+interface 7 {}
+type 9 {}
+
+export namespace 123 {}
+export interface 456 {}
+export type 789 {}
+";
+    let output = emit_es2015(source);
+    let expected = "\
+\"use strict\";
+namespace;
+42;
+{ }
+interface;
+7;
+{ }
+type;
+9;
+{ }
+namespace;
+123;
+{ }
+interface;
+456;
+{ }
+type;
+789;
+{ }
+";
+    assert_eq!(output, expected);
+    assert!(
+        !output.contains("export {};"),
+        "Invalid exported numeric declarations should not synthesize an empty export.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/source_file/mod.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/mod.rs
@@ -5,6 +5,8 @@ mod emit;
 mod import_helpers_class_scan;
 #[cfg(test)]
 mod import_helpers_class_scan_tests;
+#[cfg(test)]
+mod invalid_numeric_declaration_recovery_tests;
 mod recovery;
 #[cfg(test)]
 mod tc39_decorator_tests;

--- a/crates/tsz-emitter/src/emitter/source_file/recovery.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/recovery.rs
@@ -1,6 +1,7 @@
 use crate::emitter::Printer;
 use tsz_parser::parser::node::Node;
 use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
 
 impl<'a> Printer<'a> {
     pub(in crate::emitter) fn recovered_yield_call_statement_text(
@@ -69,6 +70,91 @@ impl<'a> Printer<'a> {
         let start = self.skip_trivia_forward(node.pos, node.end) as usize;
         let tail = text.get(start..)?;
         tail.starts_with("</>").then(|| " > ;".to_string())
+    }
+
+    pub(in crate::emitter) fn is_invalid_export_recovery_statement(&self, node: &Node) -> bool {
+        self.arena.get_export_decl(node).is_some_and(|export| {
+            export.export_clause.is_none() && export.module_specifier.is_none()
+        }) || self.is_recovered_invalid_numeric_export_declaration_name(node)
+    }
+
+    pub(in crate::emitter) fn emit_recovered_invalid_numeric_declaration_name_statement(
+        &mut self,
+        node: &Node,
+    ) -> bool {
+        let Some(statements) = self.recovered_invalid_numeric_declaration_name_statements(node)
+        else {
+            return false;
+        };
+
+        if !self.writer.is_at_line_start() {
+            self.write_line();
+        }
+        for statement in statements {
+            self.write(&statement);
+            self.write_line();
+        }
+        true
+    }
+
+    fn recovered_invalid_numeric_declaration_name_statements(
+        &self,
+        node: &Node,
+    ) -> Option<Vec<String>> {
+        let keywords: &[&str] = if node.kind == syntax_kind_ext::MODULE_DECLARATION {
+            &["namespace", "module"]
+        } else if node.kind == syntax_kind_ext::INTERFACE_DECLARATION {
+            &["interface"]
+        } else if node.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION {
+            &["type"]
+        } else if node.kind == syntax_kind_ext::EXPORT_DECLARATION {
+            &["namespace", "module", "interface", "type"]
+        } else {
+            return None;
+        };
+
+        let text = self.source_text?;
+        let start = self.skip_trivia_forward(node.pos, node.end) as usize;
+        let bytes = text.as_bytes();
+        let mut line_end = start;
+        while line_end < bytes.len() && !matches!(bytes[line_end], b'\n' | b'\r') {
+            line_end += 1;
+        }
+        let line = crate::safe_slice::slice(text, start, line_end)
+            .ok()?
+            .trim_start();
+        let line = strip_recovery_keyword(line, "export")
+            .map(str::trim_start)
+            .unwrap_or(line);
+
+        for keyword in keywords {
+            let Some(rest) = strip_recovery_keyword(line, keyword) else {
+                continue;
+            };
+            let rest = rest.trim_start();
+            let (number, after_number) = take_numeric_literal_prefix(rest)?;
+            if !is_empty_recovered_block(after_number) {
+                return None;
+            }
+            return Some(vec![
+                format!("{keyword};"),
+                format!("{number};"),
+                "{ }".to_string(),
+            ]);
+        }
+
+        None
+    }
+
+    pub(in crate::emitter) fn is_recovered_invalid_numeric_export_declaration_name(
+        &self,
+        node: &Node,
+    ) -> bool {
+        if !self.invalid_numeric_declaration_has_export_modifier(node) {
+            return false;
+        }
+        self.recovered_invalid_numeric_declaration_name_statements(node)
+            .is_some()
     }
 
     pub(in crate::emitter) fn recovered_ambient_class_parenthesized_tail_text(
@@ -275,6 +361,37 @@ impl<'a> Printer<'a> {
         Some(format!("{} => ", parts.join(" => ")))
     }
 
+    fn invalid_numeric_declaration_has_export_modifier(&self, node: &Node) -> bool {
+        if let Some(text) = self.source_text {
+            let start = self.skip_trivia_forward(node.pos, node.end) as usize;
+            if let Some(line) = text.get(start..) {
+                let line = line.trim_start();
+                if strip_recovery_keyword(line, "export").is_some() {
+                    return true;
+                }
+            }
+        }
+        if node.kind == syntax_kind_ext::MODULE_DECLARATION {
+            return self.arena.get_module(node).is_some_and(|module| {
+                self.arena
+                    .has_modifier(&module.modifiers, SyntaxKind::ExportKeyword)
+            });
+        }
+        if node.kind == syntax_kind_ext::INTERFACE_DECLARATION {
+            return self.arena.get_interface(node).is_some_and(|interface| {
+                self.arena
+                    .has_modifier(&interface.modifiers, SyntaxKind::ExportKeyword)
+            });
+        }
+        if node.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION {
+            return self.arena.get_type_alias(node).is_some_and(|alias| {
+                self.arena
+                    .has_modifier(&alias.modifiers, SyntaxKind::ExportKeyword)
+            });
+        }
+        false
+    }
+
     pub(in crate::emitter) fn recovered_debugger_namespace_line(
         &self,
         node: &Node,
@@ -303,4 +420,37 @@ impl<'a> Printer<'a> {
 
 const fn is_identifier_continue(byte: &u8) -> bool {
     byte.is_ascii_alphanumeric() || *byte == b'_' || *byte == b'$'
+}
+
+fn strip_recovery_keyword<'a>(text: &'a str, keyword: &str) -> Option<&'a str> {
+    let rest = text.strip_prefix(keyword)?;
+    if rest.as_bytes().first().is_some_and(is_identifier_continue) {
+        return None;
+    }
+    Some(rest)
+}
+
+fn take_numeric_literal_prefix(text: &str) -> Option<(&str, &str)> {
+    let bytes = text.as_bytes();
+    if !bytes.first().is_some_and(u8::is_ascii_digit) {
+        return None;
+    }
+    let mut end = 1;
+    while end < bytes.len()
+        && (bytes[end].is_ascii_alphanumeric() || matches!(bytes[end], b'.' | b'_' | b'+' | b'-'))
+    {
+        end += 1;
+    }
+    Some((&text[..end], &text[end..]))
+}
+
+fn is_empty_recovered_block(text: &str) -> bool {
+    let trimmed = text.trim_start();
+    let Some(after_open) = trimmed.strip_prefix('{') else {
+        return false;
+    };
+    let Some(close_pos) = after_open.find('}') else {
+        return false;
+    };
+    after_open[..close_pos].trim().is_empty() && after_open[close_pos + 1..].trim().is_empty()
 }


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Track 9: Emit/DTS parity recovery; JavaScript emit parser recovery.

## Invariant
When an erased `namespace`/`module`/`interface`/`type` declaration has an invalid numeric name and an empty recovered body, `tsc` emits recovered keyword, numeric literal, and empty block statements; an `export` prefix only triggers strict mode and must not synthesize `export {};`.

## Owner Layer
Output layer: source-file parser recovery in `tsz-emitter`. The fix uses declaration kind, numeric-literal spelling, and empty-block source shape as recovery facts; it does not ask the checker for semantics or rewrite already-emitted output.

## Scope
- Add source-file recovery for invalid numeric declaration names on `namespace`, `module`, `interface`, and `type` declarations.
- Keep the recovery structural: numeric literal plus empty block only, including recovered exported forms.
- Wire invalid exported numeric declarations into the existing strict-mode invalid-export recovery path.
- Add an emitter unit test with numeric names that differ from the TypeScript baseline spelling.

## Adjacent-Case Matrix
- Non-exported `namespace`, `interface`, and `type` numeric-name declarations recover runtime statements.
- Exported `namespace`, `interface`, and `type` numeric-name declarations recover the same runtime statements while only using `export` to trigger strict mode.
- The unit test varies numeric literal values from the baseline (`42`, `7`, `9`, `123`, `456`, `789`) to guard against single-spelling recovery.

## Known Fallbacks
Declarations without a numeric literal prefix or without an empty recovered block fall back to existing erased-declaration handling. This is parser-recovery output logic, not a semantic declaration validation rule.

## Project Corpus Impact
- Row: n/a
- Bug family: JavaScript emit parser/recovery (`parseInvalidNames`)
- Evidence: `CARGO_INCREMENTAL=0 scripts/emit/run.sh --filter=parseInvalidNames --js-only --verbose --timeout=30000 --json-out=/tmp/parseInvalidNames-studio-c-after-rebase-d7f.json` passes 1/1 after rebasing onto current `origin/main`.

## Verification
- `cargo fmt --check`
- `cargo check -p tsz-emitter`
- `cargo nextest run -p tsz-emitter -E 'test(invalid_numeric_declaration_names_recover_runtime_statements)'`
- `CARGO_INCREMENTAL=0 scripts/emit/run.sh --filter=parseInvalidNames --js-only --verbose --timeout=30000 --json-out=/tmp/parseInvalidNames-studio-c-after-rebase-d7f.json`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check HEAD~1..HEAD`

## Coordination Notes
AgentName: Studio-C. Rebased onto current `origin/main` on 2026-05-31 after #11936, #11941, #11944, #11945, and #11946 landed. Ready for heavy ready-for-review CI once exact-head draft checks complete. This slice avoids PR #11934's `jsxUnclosedParserRecovery` ownership. No roadmap update: this is a narrow parser-recovery emit parity fix.
