### PR TITLE
test(checker): guard DOM method interface fallback

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib.rs
@@ -133,6 +133,10 @@ impl<'a> CheckerState<'a> {
         if self.lib_name_locally_augmented(&name) {
             return None;
         }
+        // DOM value/interface pairs with declared methods can depend on
+        // inherited interface members and contextual callback parameter types.
+        // The direct type-position Lazy path below is safe only for body shapes
+        // that do not need the mature child/interface heritage path.
         if symbol.declarations.iter().any(|&decl_idx| {
             let arena = self
                 .ctx

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs
@@ -452,6 +452,9 @@ fn value_merged_builtin_dom_interface_type_argument_keeps_inherited_members() {
 const app = document.querySelector<HTMLDivElement>("#app");
 if (app) {
   app.innerHTML = "";
+  app.addEventListener("click", ev => {
+    ev.preventDefault();
+  });
 }
 "##,
         "fixture.ts",


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 performance guardrail / checker lib identity.

## Invariant
When an actual DOM builtin symbol is both a value and an interface and its interface declares methods, tsz must keep the mature child/interface path unless a direct path can prove inherited interface members and contextual callback parameter types are preserved. This PR does not add a new fast path; it codifies the correctness guard found while investigating the Vite green-row target gap.

## Scope
- Documents the DOM value/interface method guard in `cross_file_direct_actual_lib.rs`.
- Extends the Vite-style `document.querySelector<HTMLDivElement>` test to cover inherited `innerHTML` plus contextual `addEventListener` callback typing.

## Project Corpus Impact
- Row: `vite-vanilla-ts-app`
- Bug family: green-row speed gap, DOM/lib cross-arena delegation, value-merged DOM interface method fallback
- Evidence: Before artifact `/private/tmp/studio-b-vite-main-after-11930-20260531.tsgo-winners.json` shows Vite still green but below target (`tsz_ms=112.73`, `tsgo_ms=80.30`, `target_gap_factor=2.8077`) with attribution dominated by `checker:cross-arena-delegation`. During this investigation, broad admission of DOM method interfaces to the direct Lazy path caused TS2339 for `HTMLDivElement.innerHTML` and TS7006 for the event callback, so the next speed slice must preserve inherited/interface callback semantics rather than bypassing the fallback.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib -E 'test(value_merged_builtin_dom_interface_type_argument_keeps_inherited_members)'`

## Coordination Notes
- AgentName: Studio-B
- No owned Studio-B PRs were open at cycle start.
- Open overlap checked: M4-D #11931 owns alias/export cache; this PR is a DOM/lib method fallback guard and does not overlap its alias cache scope.
- This is intentionally a guardrail PR, not a speed claim. It preserves the failed-path evidence for the next DOM/lib cross-arena performance slice.
