### PR TITLE
fix(emit): recover unparsed equality assignment

### DIFF
--- a/crates/tsz-emitter/src/emitter/source_file/emit.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/emit.rs
@@ -1569,6 +1569,7 @@ impl<'a> Printer<'a> {
         let mut has_non_empty_runtime_export = has_synthesized_esm_import;
         let mut has_deferred_empty_export = false;
         let mut skip_recovered_yield_operand_statement = false;
+        let mut skip_recovered_unparsed_token_assignment_statement = false;
         let mut skip_recovered_debugger_namespace_until: Option<u32> = None;
         if source.statements.nodes.is_empty()
             && self
@@ -1588,21 +1589,21 @@ impl<'a> Printer<'a> {
             if stmt_i < cjs_pre_preamble_prologue_count {
                 continue;
             }
-
             if skip_recovered_yield_operand_statement {
                 skip_recovered_yield_operand_statement = false;
                 if self.is_recovered_yield_operand_statement(stmt_node) {
                     continue;
                 }
             }
-
+            if std::mem::take(&mut skip_recovered_unparsed_token_assignment_statement) {
+                continue;
+            }
             if let Some(skip_until) = skip_recovered_debugger_namespace_until {
                 if stmt_node.pos < skip_until {
                     continue;
                 }
                 skip_recovered_debugger_namespace_until = None;
             }
-
             if let Some((line_end, trailing_comment)) =
                 self.recovered_debugger_namespace_line(stmt_node)
             {
@@ -1947,7 +1948,9 @@ impl<'a> Printer<'a> {
                 .map(|next_node| next_node.pos);
 
             let before_len = self.writer.len();
-            if let Some(recovered_jsx_closing) =
+            if self.emit_recovered_unparsed_token_assignment_statement(stmt_node, next_stmt_node) {
+                skip_recovered_unparsed_token_assignment_statement = true;
+            } else if let Some(recovered_jsx_closing) =
                 self.recovered_invalid_jsx_closing_fragment_statement_text(stmt_node)
             {
                 self.write(&recovered_jsx_closing);
@@ -1989,9 +1992,7 @@ impl<'a> Printer<'a> {
                 } else {
                     None
                 };
-
                 self.emit(stmt_idx);
-
                 if use_deferred_nested_cjs_exports {
                     if use_deferred_single_cjs_exports {
                         self.deferred_local_export_bindings = prev_deferred_local_export_bindings;
@@ -2002,7 +2003,6 @@ impl<'a> Printer<'a> {
             }
             let emitted_output = self.writer.len() > before_len;
             let mut handled_legacy_decorated_deferred_export = false;
-
             if emitted_output
                 && is_top_level_cjs
                 && self.ctx.options.legacy_decorators

--- a/crates/tsz-emitter/src/emitter/source_file/mod.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/mod.rs
@@ -7,6 +7,8 @@ mod import_helpers_class_scan;
 mod import_helpers_class_scan_tests;
 #[cfg(test)]
 mod invalid_numeric_declaration_recovery_tests;
+#[cfg(test)]
+mod parser_recovery_tests;
 mod recovery;
 #[cfg(test)]
 mod tc39_decorator_tests;

--- a/crates/tsz-emitter/src/emitter/source_file/parser_recovery_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/parser_recovery_tests.rs
@@ -1,0 +1,28 @@
+use crate::emitter::{ModuleKind, Printer as EmitterPrinter, PrinterOptions};
+use tsz_common::ScriptTarget;
+use tsz_parser::ParserState;
+
+fn emit_es2015(source: &str) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        target: ScriptTarget::ES2015,
+        module: ModuleKind::None,
+        ..Default::default()
+    };
+    let mut printer = EmitterPrinter::with_options(&parser.arena, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+#[test]
+fn unparsed_equality_token_recovers_following_assignment_operand() {
+    let source = "} alpha = ( beta = gamma ==== 'value') {";
+    let output = emit_es2015(source);
+    let expected = "\
+alpha = (beta = gamma === ) = 'value';
+{ }
+";
+    assert_eq!(output, expected);
+}

--- a/crates/tsz-emitter/src/emitter/source_file/recovery.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/recovery.rs
@@ -157,6 +157,40 @@ impl<'a> Printer<'a> {
             .is_some()
     }
 
+    pub(in crate::emitter) fn emit_recovered_unparsed_token_assignment_statement(
+        &mut self,
+        node: &Node,
+        next: Option<&Node>,
+    ) -> bool {
+        let Some(next) = next else {
+            return false;
+        };
+        let Some(expr_stmt) = self.arena.get_expression_statement(node) else {
+            return false;
+        };
+        let Some(next_expr_stmt) = self.arena.get_expression_statement(next) else {
+            return false;
+        };
+        let Some(expr_node) = self.arena.get(expr_stmt.expression) else {
+            return false;
+        };
+        let Some(next_expr_node) = self.arena.get(next_expr_stmt.expression) else {
+            return false;
+        };
+        if expr_node.end <= node.end || next_expr_node.pos >= expr_node.end {
+            return false;
+        }
+        if !self.has_trailing_recovered_equality_token(node) {
+            return false;
+        }
+
+        self.emit_expression_in_statement_position(expr_stmt.expression);
+        self.write(" = ");
+        self.emit_expression_in_statement_position(next_expr_stmt.expression);
+        self.write_semicolon();
+        true
+    }
+
     pub(in crate::emitter) fn recovered_ambient_class_parenthesized_tail_text(
         &self,
         node: &Node,
@@ -204,6 +238,29 @@ impl<'a> Printer<'a> {
 
         let recovered = crate::safe_slice::slice(text, start, end).ok()?.trim_end();
         Some(format!("{recovered};"))
+    }
+
+    fn has_trailing_recovered_equality_token(&self, node: &Node) -> bool {
+        let text = match self.source_text {
+            Some(text) => text,
+            None => return false,
+        };
+        let start = self.skip_trivia_forward(node.pos, node.end) as usize;
+        let end = (node.end as usize).min(text.len());
+        let current = match text.get(start..end) {
+            Some(current) => current.trim_end(),
+            None => return false,
+        };
+        if current.contains('\n') || current.contains('\r') {
+            return false;
+        }
+        current
+            .as_bytes()
+            .iter()
+            .rev()
+            .take_while(|&&byte| byte == b'=')
+            .count()
+            >= 4
     }
 
     pub(in crate::emitter) fn is_recovered_yield_operand_statement(&self, node: &Node) -> bool {


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Track 9: Emit/DTS parity recovery; JavaScript emit parser recovery.

## Invariant
When parser recovery splits an invalid equality run across adjacent expression statements while the current expression span structurally covers the following operand, `tsc` emits the current expression plus the following operand as one recovered assignment statement instead of emitting the following operand separately.

## Owner Layer
Output layer: source-file parser recovery in `tsz-emitter`. The fix consumes an adjacent expression statement only when AST spans and the recovered equality-token run prove the parser-recovery shape; it does not perform checker semantic validation or patch already-emitted text.

## Scope
- Add source-file recovery for the unparsed equality-token assignment shape used by `parserUnparsedTokenCrash2`.
- Consume the following expression statement only when the current expression span structurally covers it and the source statement ends in a recovered equality run.
- Add a focused emitter unit test with different identifiers/literal text from the TypeScript fixture.
- Conflict-resolution rebase keeps the merged invalid-numeric declaration recovery and the unparsed equality recovery together.

## Adjacent-Case Matrix
- Reported fixture `parserUnparsedTokenCrash2` passes 1/1 through the TypeScript baseline-style emit runner.
- Unit coverage varies identifiers and literal text (`alpha`, `beta`, `gamma`, `'value'`) to prove the rule is not keyed to fixture spelling.
- Negative/fallback behavior is structural: no following expression covered by the current expression span, or no recovered equality run, falls through to normal statement emission.

## Known Fallbacks
This PR deliberately handles only the adjacent-expression recovery shape where the parser already exposes the following operand inside the current expression span. Other malformed binary-expression recoveries continue through existing emit paths.

## Project Corpus Impact
- Row: n/a
- Bug family: JavaScript emit parser/recovery (`parserUnparsedTokenCrash2`)
- Evidence: emit harness only; no project-corpus fixture metadata or benchmark row changes.

## Verification
- `cargo fmt --check`
- `cargo nextest run -p tsz-emitter -E 'test(unparsed_equality_token_recovers_following_assignment_operand) | test(invalid_numeric_declaration_names_recover_runtime_statements)'` -> 2 passed after conflict resolution
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh scripts/emit/run.sh --filter=parserUnparsedTokenCrash2 --js-only --verbose --timeout=30000 --json-out=/tmp/parserUnparsedTokenCrash2-studio-c-after-conflict-rebase-4610.json` -> 1/1 JS passed
- `python3 scripts/arch/arch_guard.py`
- `git diff --check HEAD~1..HEAD`

## Coordination Notes
AgentName: Studio-C. Rebased onto current `origin/main` after #11939 merged; conflict resolution preserves both `invalid_numeric_declaration_recovery_tests` and `parser_recovery_tests`. Current head is `4610f0a38f`. CI restarted on the rebased head, so this PR is not queued until exact-head PR checks are green. No roadmap update: this is a narrow parser-recovery emit parity fix.