### PR TITLE
fix(solver): unwrap NoInfer in async iterable classification

### DIFF
--- a/crates/tsz-solver/src/type_queries/iterable.rs
+++ b/crates/tsz-solver/src/type_queries/iterable.rs
@@ -161,7 +161,9 @@ pub fn classify_async_iterable_type(
                 constraint: info.constraint,
             }
         }
-        TypeData::ReadonlyType(inner) => AsyncIterableTypeKind::Readonly(inner),
+        TypeData::ReadonlyType(inner) | TypeData::NoInfer(inner) => {
+            AsyncIterableTypeKind::Readonly(inner)
+        }
         _ => AsyncIterableTypeKind::NotAsyncIterable,
     }
 }

--- a/crates/tsz-solver/tests/iterable_classifier_tests.rs
+++ b/crates/tsz-solver/tests/iterable_classifier_tests.rs
@@ -531,6 +531,17 @@ fn async_iterable_readonly_returns_inner() {
 }
 
 #[test]
+fn async_iterable_no_infer_returns_inner() {
+    let interner = TypeInterner::new();
+    let inner = interner.lazy(DefId(21));
+    let no_infer = interner.intern(TypeData::NoInfer(inner));
+    match classify_async_iterable_type(&interner, no_infer) {
+        AsyncIterableTypeKind::Readonly(t) => assert_eq!(t, inner),
+        other => panic!("expected Readonly (NoInfer arm), got {other:?}"),
+    }
+}
+
+#[test]
 fn async_iterable_array_is_not_async_iterable() {
     // `Array<T>` is sync iterable, NOT async iterable. The classifier must
     // explicitly NOT short-circuit Array into Object.


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Semantic campaign / solver classifier fix

## Invariant
When an async iterable candidate is wrapped in `NoInfer<T>`, `tsc` checks the apparent inner type; this PR makes tsz unwrap `NoInfer` through the solver iterable classifier, matching the existing sync iterable path.

## Scope
- `crates/tsz-solver/src/type_queries/iterable.rs`
- `crates/tsz-solver/tests/iterable_classifier_tests.rs`

## Project Corpus Impact
- Row: `kysely-project`
- Bug family: async iterable classification / TS2504-family wrappers
- Evidence: related to #10667; local solver classifier coverage verifies the structural wrapper rule. This does not claim to close the full Kysely tracker by itself.

## Verification
- `cargo fmt --check`
- `cargo nextest run -p tsz-solver async_iterable_no_infer_returns_inner`
- `cargo nextest run -p tsz-solver async_iterable`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Open PR sweep showed no current PR claiming this exact `NoInfer` async iterable classifier gap.
- Existing async type-parameter constraint handling is already present on `main`; this PR fixes the adjacent wrapper mismatch without touching repo docs.
