### PR TITLE
chore(agents): write owned work json report

### DIFF
--- a/docs/plan/agents/Studio-F.md
+++ b/docs/plan/agents/Studio-F.md
@@ -17,7 +17,7 @@ cleanup, and cheap evidence plumbing for the end-state push.
 git fetch origin main
 scripts/agents/show-goal.sh Studio-F
 scripts/agents/disk-preflight.sh Studio-F --json-report /tmp/tsz-disk-preflight.json
-scripts/agents/list-owned-work.sh Studio-F
+scripts/agents/list-owned-work.sh Studio-F --json-report /tmp/tsz-owned-work.json
 scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-audit.json
 python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard.json
 python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery.json

--- a/scripts/agents/list-owned-work.sh
+++ b/scripts/agents/list-owned-work.sh
@@ -13,7 +13,7 @@ AGENTS=(
 
 usage() {
   cat <<'USAGE'
-usage: scripts/agents/list-owned-work.sh [--pr-state] [AgentName|--all]
+usage: scripts/agents/list-owned-work.sh [--pr-state] [--json-report PATH] [AgentName|--all]
 
 Lists owned open PRs/issues and prints compact per-agent summary counters.
 
@@ -21,6 +21,7 @@ Examples:
   scripts/agents/list-owned-work.sh M1-A
   scripts/agents/list-owned-work.sh --all
   scripts/agents/list-owned-work.sh --pr-state Studio-F
+  scripts/agents/list-owned-work.sh Studio-F --json-report /tmp/tsz-owned-work.json
 USAGE
 }
 
@@ -30,11 +31,29 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
 fi
 
 WITH_PR_STATE=false
+JSON_REPORT=""
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --pr-state|--with-pr-state)
       WITH_PR_STATE=true
+      shift
+      ;;
+    --json-report)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo "--json-report requires a path (try --help)" >&2
+        exit 2
+      fi
+      JSON_REPORT="$1"
+      shift
+      ;;
+    --json-report=*)
+      JSON_REPORT="${1#--json-report=}"
+      if [[ -z "$JSON_REPORT" ]]; then
+        echo "--json-report requires a path (try --help)" >&2
+        exit 2
+      fi
       shift
       ;;
     --all)
@@ -64,6 +83,7 @@ else
 fi
 
 REPOSITORY="${GITHUB_REPOSITORY:-mohsen1/tsz}"
+REPORT_ROWS=""
 
 list_owned_items_rest() {
   local label="$1"
@@ -106,6 +126,14 @@ count_rows() {
     return
   fi
   printf '%s\n' "$rows" | awk 'NF { count++ } END { print count + 0 }'
+}
+
+json_array_from_lines() {
+  local rows="$1"
+  ROWS="$rows" node <<'NODE'
+const rows = (process.env.ROWS ?? "").split(/\n/).filter(Boolean);
+process.stdout.write(JSON.stringify(rows));
+NODE
 }
 
 for agent in "${SELECTED[@]}"; do
@@ -180,4 +208,57 @@ for agent in "${SELECTED[@]}"; do
   echo "owned_issue_count=$issue_count"
   echo "owned_work_status=$owned_work_status"
   echo ""
+
+  if [[ -n "$JSON_REPORT" ]]; then
+    pr_json="$(json_array_from_lines "$prs")"
+    issue_json="$(json_array_from_lines "$issues")"
+    report_row="$(
+      ROW_AGENT="$agent" \
+      ROW_LABEL="$label" \
+      ROW_PR_COUNT="$pr_count" \
+      ROW_ISSUE_COUNT="$issue_count" \
+      ROW_STATUS="$owned_work_status" \
+      ROW_PRS="$pr_json" \
+      ROW_ISSUES="$issue_json" \
+      node <<'NODE'
+const row = {
+  agent: process.env.ROW_AGENT,
+  label: process.env.ROW_LABEL,
+  prs: JSON.parse(process.env.ROW_PRS ?? "[]"),
+  issues: JSON.parse(process.env.ROW_ISSUES ?? "[]"),
+  pr_count: Number(process.env.ROW_PR_COUNT ?? 0),
+  issue_count: Number(process.env.ROW_ISSUE_COUNT ?? 0),
+  owned_work_status: process.env.ROW_STATUS,
+};
+process.stdout.write(`${JSON.stringify(row)}\n`);
+NODE
+    )"
+    REPORT_ROWS+="$report_row"$'\n'
+  fi
 done
+
+if [[ -n "$JSON_REPORT" ]]; then
+  REPOSITORY="$REPOSITORY" \
+  WITH_PR_STATE="$WITH_PR_STATE" \
+  REPORT_ROWS="$REPORT_ROWS" \
+  JSON_REPORT="$JSON_REPORT" \
+  node <<'NODE'
+const fs = require("fs");
+const path = require("path");
+
+const agents = (process.env.REPORT_ROWS ?? "")
+  .split(/\n/)
+  .filter(Boolean)
+  .map((line) => JSON.parse(line));
+
+const report = {
+  generated_by: "scripts/agents/list-owned-work.sh",
+  repository: process.env.REPOSITORY,
+  with_pr_state: process.env.WITH_PR_STATE === "true",
+  agents,
+};
+
+fs.mkdirSync(path.dirname(process.env.JSON_REPORT), { recursive: true });
+fs.writeFileSync(process.env.JSON_REPORT, `${JSON.stringify(report, null, 2)}\n`);
+NODE
+fi

--- a/scripts/agents/test_list_owned_work.py
+++ b/scripts/agents/test_list_owned_work.py
@@ -1,6 +1,8 @@
+import json
 import os
 import pathlib
 import subprocess
+import tempfile
 import unittest
 
 
@@ -56,6 +58,50 @@ exec "$@"
         self.assertIn("owned_pr_count=2", result.stdout)
         self.assertIn("owned_issue_count=1", result.stdout)
         self.assertIn("owned_work_status=active", result.stdout)
+
+    def test_json_report_records_owned_work_summary(self):
+        with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
+            report_path = pathlib.Path(temp_dir) / "owned-work.json"
+
+            result = self.run_list_owned_work(
+                ["Studio-F", "--json-report", str(report_path)],
+                prs="#1 ready first PR https://github.com/mohsen1/tsz/pull/1\n",
+                issues="#2 issue https://github.com/mohsen1/tsz/issues/2\n",
+            )
+
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertIn("## agent:Studio-F", result.stdout)
+            self.assertEqual("scripts/agents/list-owned-work.sh", report["generated_by"])
+            self.assertEqual("mohsen1/tsz", report["repository"])
+            self.assertFalse(report["with_pr_state"])
+            self.assertEqual(1, len(report["agents"]))
+            row = report["agents"][0]
+            self.assertEqual("Studio-F", row["agent"])
+            self.assertEqual("agent:Studio-F", row["label"])
+            self.assertEqual(1, row["pr_count"])
+            self.assertEqual(1, row["issue_count"])
+            self.assertEqual("active", row["owned_work_status"])
+            self.assertEqual(
+                ["#1 ready first PR https://github.com/mohsen1/tsz/pull/1"],
+                row["prs"],
+            )
+            self.assertEqual(
+                ["#2 issue https://github.com/mohsen1/tsz/issues/2"],
+                row["issues"],
+            )
+
+    def test_json_report_requires_path(self):
+        result = subprocess.run(
+            ["/bin/bash", str(SCRIPT), "--json-report"],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        self.assertEqual(2, result.returncode)
+        self.assertIn("--json-report requires a path", result.stderr)
+        self.assertEqual("", result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / owned-work evidence plumbing.

## Invariant
When agents check owned PR/issue runway, the existing human-readable summary should remain stable while an optional JSON artifact records the same per-agent counts and clear/active status for machine-readable cycle evidence.

## Scope
- Add `--json-report PATH` / `--json-report=PATH` to `scripts/agents/list-owned-work.sh`.
- Preserve current text output and `--pr-state` behavior.
- Add focused unittest coverage for JSON report shape and missing-path validation.
- Update Studio-F cycle guidance to write `/tmp/tsz-owned-work.json`.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent-script/docs-only launch evidence plumbing; no compiler, emit, checker, solver, parser, binder, LSP, WASM, or project corpus behavior changes.

## Verification
- `python3 -m unittest scripts.agents.test_list_owned_work`
- `for test_file in scripts/agents/test_*.py; do python3 "$test_file"; done`
- `scripts/agents/list-owned-work.sh Studio-F --json-report /tmp/tsz-owned-work.json`
- `scripts/agents/list-owned-work.sh Studio-F --json-report=/tmp/tsz-owned-work-equals.json`
- `python3 -m json.tool /tmp/tsz-owned-work.json`
- `python3 -m json.tool /tmp/tsz-owned-work-equals.json`
- `scripts/agents/list-owned-work.sh Studio-F --pr-state --json-report /tmp/tsz-owned-work-pr-state.json`
- `python3 -m json.tool /tmp/tsz-owned-work-pr-state.json`
- `scripts/agents/list-owned-work.sh --help`
- `scripts/agents/disk-preflight.sh Studio-F --json-report /tmp/tsz-disk-preflight.json`
- `scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-audit.json`
- `python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard.json`
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery.json`
- `cargo fmt --all --check`
- `git diff --check`
- GitHub PR-head checks on `5a3ab473ed79f23d503b97a279e21686f3e64151`: `CI Summary`, `lint`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `project-corpus-pr-body`, `gate`, and GitGuardian passed.

## Coordination Notes
- AgentName: Studio-F
- #11945 merged first and its branch/worktree were cleaned up before this branch was created.
- `scripts/agents/list-owned-work.sh Studio-F` reported no owned PRs or issues before this branch.
- Checked open PRs/issues for overlapping Studio-F or owned-work JSON work before editing; none found.
- TypeScript is symlinked to the populated primary checkout; no Cargo cache was created in this worktree.
- No roadmap update: this is routine launch evidence plumbing, not a durable roadmap direction change.
- Ready for the repo-local merge queue on exact head `5a3ab473ed79f23d503b97a279e21686f3e64151`.
