### PR TITLE
test(solver): route query trace cache fixture through policy

### DIFF
--- a/crates/tsz-solver/src/caches/query_trace.rs
+++ b/crates/tsz-solver/src/caches/query_trace.rs
@@ -202,18 +202,19 @@ mod tests {
 
     #[test]
     fn relation_cache_config_trace_fields_include_any_mode() {
-        let config = crate::types::RelationCacheConfig::new(
+        let config = crate::relations::relation_queries::RelationPolicy::from_relation_flags(
             crate::types::RelationFlags::STRICT_NULL_CHECKS,
-            crate::types::CachedAnyMode::TopLevelOnlyNested,
-        );
+        )
+        .with_any_propagation_mode(crate::relations::subtype::AnyPropagationMode::TopLevelOnly)
+        .cache_config();
 
         let fields = relation_cache_config_trace_fields(config);
 
-        assert_eq!(
-            fields.flags,
-            crate::types::RelationFlags::STRICT_NULL_CHECKS.bits()
+        assert!(
+            crate::types::RelationFlags::from_bits_retain(fields.flags)
+                .contains(crate::types::RelationFlags::STRICT_NULL_CHECKS)
         );
-        assert_eq!(fields.any_mode, "top_level_only_nested");
+        assert_eq!(fields.any_mode, "top_level_only_at_top");
     }
 
     #[test]

--- a/crates/tsz-solver/tests/relation_cache_config_tests.rs
+++ b/crates/tsz-solver/tests/relation_cache_config_tests.rs
@@ -126,6 +126,20 @@ fn relation_cache_config_does_not_expose_raw_constructor() {
 }
 
 #[test]
+fn query_trace_relation_cache_config_fixture_uses_policy_projection() {
+    let source = include_str!("../src/caches/query_trace.rs");
+
+    assert!(
+        source.contains("RelationPolicy::from_relation_flags"),
+        "query trace relation config fixtures should use the typed relation policy projection",
+    );
+    assert!(
+        !source.contains("RelationCacheConfig::new"),
+        "query trace should not hand-build relation cache configs; use RelationPolicy::cache_config()",
+    );
+}
+
+#[test]
 fn legacy_flag_constructor_stores_typed_relation_flags() {
     let policy = RelationPolicy::from_flags(
         RelationCacheKey::FLAG_STRICT_NULL_CHECKS


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Solver relation policy/cache-key cleanup for #8207.

## Invariant
When query trace tests need a RelationCacheConfig fixture, they should derive it through RelationPolicy so trace coverage cannot reintroduce direct raw cache configuration. This PR adds the ratchet and updates the fixture after #11922 landed.

## Scope
- crates/tsz-solver/src/caches/query_trace.rs
- crates/tsz-solver/tests/relation_cache_config_tests.rs

## Project Corpus Impact
- Row: n/a
- Bug family: relation-cache correctness / solver policy protocol
- Evidence: test fixture and solver ratchet only; no project corpus row claimed.

## Verification
- Current base: d98c418281deab68c071191a78c6cfc65a8a8f1f (origin/main)
- Current head: b4382d88ed609a87fd04f6dff63121a64ea464b7
- cargo nextest run -p tsz-solver -E 'test(relation_cache_config_tests)' (55 passed, 6391 skipped)
- cargo fmt --check
- git diff --check origin/main...HEAD

## Coordination Notes
- #11922 landed, so this PR was rebased from the stack branch onto current main and retargeted to main.
- Synced again after main advanced to d98c418281deab68c071191a78c6cfc65a8a8f1f.
- Ready for review/queue after exact-head PR checks complete green.
- Related issue: #8207.
