### PR TITLE
test(checker): guard DOM literal alias delegation

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_declaration_alias_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_declaration_alias_tests.rs
@@ -83,7 +83,11 @@ fn direct_declaration_file_type_alias_lowers_builtin_dom_alias_body() {
         );
     }
 
-    for literal_union_alias in ["DocumentReadyState", "XMLHttpRequestResponseType"] {
+    for literal_union_alias in [
+        "DocumentReadyState",
+        "MutationRecordType",
+        "XMLHttpRequestResponseType",
+    ] {
         let sym_id = state
             .ctx
             .binder


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 7/9 green-row performance safety guard for DOM/lib identity work.

## Invariant
When a built-in declaration-file type alias is a DOM string-literal union, the direct declaration-file alias fast path must decline it so the normal cross-file path preserves TypeScript apparent string behavior and conformance fingerprints.

## Scope
- `crates/tsz-checker/src/state/type_analysis/cross_file_direct_declaration_alias_tests.rs`

## Project Corpus Impact
- Row: `vite-vanilla-ts-app`
- Bug family: guardrail for DOM builtin literal-alias delegation while pursuing Vite green-row residency work.
- Evidence: test-only guard; no compiler behavior change. The earlier direct-literal implementation was removed after ready-review CI reported conformance aggregate regressions on #11948.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `CARGO_BUILD_JOBS=4 cargo nextest run -p tsz-checker --lib -E "test(direct_declaration_file_type_alias_lowers_builtin_dom_alias_body)"`
- `scripts/safe-run.sh --limit 75% -- ./scripts/conformance/conformance.sh run --filter "coAndContraVariantInferences3" --verbose`

## Coordination Notes
- Prior Studio-B PR #11940 merged before this branch started.
- Original #11948 implementation tried to preserve builtin DOM literal aliases directly, but ready-review CI found unlisted conformance regressions. This update intentionally narrows the PR to a guard test by adding `MutationRecordType` to the existing DOM string-literal alias non-direct-path coverage.
- This PR is no longer a performance win and does not claim progress toward the Vite 2x target; it preserves the lesson for the next Studio-B slice.