### PR TITLE
chore(agents): write show goal json report

### DIFF
--- a/scripts/agents/show-goal.sh
+++ b/scripts/agents/show-goal.sh
@@ -11,12 +11,13 @@ set -euo pipefail
 usage() {
   local stream="${1:-1}"
   cat >&"$stream" <<'USAGE'
-usage: scripts/agents/show-goal.sh <AgentName> [--no-fetch|--local]
+usage: scripts/agents/show-goal.sh [--json-report PATH] <AgentName> [--no-fetch|--local]
 
 Examples:
   scripts/agents/show-goal.sh M1-A
   scripts/agents/show-goal.sh Studio-F --no-fetch
   scripts/agents/show-goal.sh Studio-F --local
+  scripts/agents/show-goal.sh Studio-F --json-report /tmp/tsz-agent-goal.json
 USAGE
 }
 
@@ -25,26 +26,57 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   exit 0
 fi
 
-if [[ $# -lt 1 || $# -gt 2 ]]; then
-  usage 2
-  exit 1
-fi
-
-AGENT="$1"
-if [[ "$AGENT" == --* ]]; then
-  echo "unknown argument: $AGENT" >&2
-  usage 2
-  exit 1
-fi
-
 NO_FETCH=false
 LOCAL_ONLY=false
-if [[ $# -eq 2 ]]; then
-  case "$2" in
-    --no-fetch) NO_FETCH=true ;;
-    --local) LOCAL_ONLY=true ;;
-    *) echo "unknown argument: $2" >&2; usage 2; exit 1 ;;
+JSON_REPORT=""
+AGENT=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-fetch)
+      NO_FETCH=true
+      shift
+      ;;
+    --local)
+      LOCAL_ONLY=true
+      shift
+      ;;
+    --json-report)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo "--json-report requires a path (try --help)" >&2
+        exit 2
+      fi
+      JSON_REPORT="$1"
+      shift
+      ;;
+    --json-report=*)
+      JSON_REPORT="${1#--json-report=}"
+      if [[ -z "$JSON_REPORT" ]]; then
+        echo "--json-report requires a path (try --help)" >&2
+        exit 2
+      fi
+      shift
+      ;;
+    --*)
+      echo "unknown argument: $1" >&2
+      usage 2
+      exit 1
+      ;;
+    *)
+      if [[ -n "$AGENT" ]]; then
+        echo "unknown argument: $1" >&2
+        usage 2
+        exit 1
+      fi
+      AGENT="$1"
+      shift
+      ;;
   esac
+done
+
+if [[ -z "$AGENT" ]]; then
+  usage 2
+  exit 1
 fi
 
 case "$AGENT" in
@@ -56,22 +88,64 @@ ROOT="$(git rev-parse --show-toplevel)"
 GOAL_PATH="docs/plan/agents/${AGENT}.md"
 REMOTE_GOAL="$(mktemp "${TMPDIR:-/tmp}/tsz-agent-goal.XXXXXX")"
 trap 'rm -f "$REMOTE_GOAL"' EXIT
+FETCH_ATTEMPTED=false
+PRINTED_SOURCE=""
+BRANCH_LOCAL_DIFFERS=false
+
+write_json_report() {
+  [[ -n "$JSON_REPORT" ]] || return 0
+  AGENT="$AGENT" \
+  ROOT="$ROOT" \
+  GOAL_PATH="$GOAL_PATH" \
+  PRINTED_SOURCE="$PRINTED_SOURCE" \
+  FETCH_ATTEMPTED="$FETCH_ATTEMPTED" \
+  LOCAL_ONLY="$LOCAL_ONLY" \
+  NO_FETCH="$NO_FETCH" \
+  BRANCH_LOCAL_DIFFERS="$BRANCH_LOCAL_DIFFERS" \
+  JSON_REPORT="$JSON_REPORT" \
+  node <<'NODE'
+const fs = require("fs");
+const path = require("path");
+
+const bool = (value) => value === "true";
+const report = {
+  generated_by: "scripts/agents/show-goal.sh",
+  agent: process.env.AGENT,
+  repo: process.env.ROOT,
+  goal_path: process.env.GOAL_PATH,
+  printed_source: process.env.PRINTED_SOURCE,
+  fetch_attempted: bool(process.env.FETCH_ATTEMPTED),
+  local_only: bool(process.env.LOCAL_ONLY),
+  no_fetch: bool(process.env.NO_FETCH),
+  branch_local_differs: bool(process.env.BRANCH_LOCAL_DIFFERS),
+};
+
+fs.mkdirSync(path.dirname(process.env.JSON_REPORT), { recursive: true });
+fs.writeFileSync(process.env.JSON_REPORT, `${JSON.stringify(report, null, 2)}\n`);
+NODE
+}
 
 if [[ "$LOCAL_ONLY" == false && "$NO_FETCH" == false ]]; then
+  FETCH_ATTEMPTED=true
   git -C "$ROOT" fetch -q origin main || true
 fi
 
 if [[ "$LOCAL_ONLY" == false ]] \
   && git -C "$ROOT" show "origin/main:${GOAL_PATH}" >"$REMOTE_GOAL" 2>/dev/null; then
   if [[ -f "$ROOT/$GOAL_PATH" ]] && ! cmp -s "$REMOTE_GOAL" "$ROOT/$GOAL_PATH"; then
+    BRANCH_LOCAL_DIFFERS=true
     echo "warning: printed origin/main:${GOAL_PATH}; branch-local ${GOAL_PATH} differs. Use --local to inspect it." >&2
   fi
+  PRINTED_SOURCE="origin/main"
   cat "$REMOTE_GOAL"
+  write_json_report
   exit 0
 fi
 
 if [[ -f "$ROOT/$GOAL_PATH" ]]; then
+  PRINTED_SOURCE="local"
   cat "$ROOT/$GOAL_PATH"
+  write_json_report
   exit 0
 fi
 

--- a/scripts/agents/test_show_goal.py
+++ b/scripts/agents/test_show_goal.py
@@ -1,3 +1,4 @@
+import json
 import os
 import pathlib
 import stat
@@ -109,6 +110,59 @@ class ShowGoalTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertEqual(calls, ["rev-parse --show-toplevel"])
         self.assertEqual(temp_files, [])
+
+    def test_json_report_records_remote_goal_source(self):
+        with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
+            report_path = pathlib.Path(temp_dir) / "goal.json"
+
+            output, stderr, calls, temp_files = self.run_show_goal(
+                ["Studio-F", "--no-fetch", "--json-report", str(report_path)]
+            )
+
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertEqual(output, "# remote goal\n")
+            self.assertIn("branch-local docs/plan/agents/Studio-F.md differs", stderr)
+            self.assertEqual("scripts/agents/show-goal.sh", report["generated_by"])
+            self.assertEqual("Studio-F", report["agent"])
+            self.assertEqual("docs/plan/agents/Studio-F.md", report["goal_path"])
+            self.assertEqual("origin/main", report["printed_source"])
+            self.assertFalse(report["fetch_attempted"])
+            self.assertFalse(report["local_only"])
+            self.assertTrue(report["no_fetch"])
+            self.assertTrue(report["branch_local_differs"])
+            self.assertIn("-C", calls[1])
+            self.assertEqual(temp_files, [])
+
+    def test_json_report_records_local_goal_source(self):
+        with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
+            report_path = pathlib.Path(temp_dir) / "goal.json"
+
+            output, stderr, calls, temp_files = self.run_show_goal(
+                ["--json-report", str(report_path), "Studio-F", "--local"]
+            )
+
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertEqual(output, "# local goal\n")
+            self.assertEqual(stderr, "")
+            self.assertEqual("local", report["printed_source"])
+            self.assertFalse(report["fetch_attempted"])
+            self.assertTrue(report["local_only"])
+            self.assertFalse(report["branch_local_differs"])
+            self.assertEqual(calls, ["rev-parse --show-toplevel"])
+            self.assertEqual(temp_files, [])
+
+    def test_json_report_requires_path(self):
+        result = subprocess.run(
+            [str(SCRIPT), "Studio-F", "--json-report"],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        self.assertEqual(2, result.returncode)
+        self.assertIn("--json-report requires a path", result.stderr)
+        self.assertEqual("", result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / goal-source evidence plumbing.

## Invariant
When agents read their lane goal, the existing markdown output should remain stable while an optional JSON artifact records which source was printed, whether fetch was attempted, and whether the branch-local goal differed from `origin/main`.

## Scope
- Add `--json-report PATH` / `--json-report=PATH` to `scripts/agents/show-goal.sh`.
- Preserve current markdown output, remote-first behavior, `--no-fetch`, and `--local` modes.
- Add focused unittest coverage for remote-source JSON, local-source JSON, and missing-path validation.
- Keep the Studio-F goal command unchanged so the explicit `scripts/agents/show-goal.sh Studio-F` cycle instruction remains valid.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent-script/test-only launch evidence plumbing; no compiler, emit, checker, solver, parser, binder, LSP, WASM, or project corpus behavior changes.

## Verification
- `python3 -m unittest scripts.agents.test_show_goal`
- `scripts/agents/show-goal.sh Studio-F --no-fetch --json-report /tmp/tsz-agent-goal.json >/tmp/tsz-agent-goal.md`
- `python3 -m json.tool /tmp/tsz-agent-goal.json`
- `scripts/agents/show-goal.sh --help`
- `for test_file in scripts/agents/test_*.py; do python3 "$test_file"; done`
- `scripts/agents/disk-preflight.sh Studio-F --json-report /tmp/tsz-disk-preflight.json`
- `scripts/agents/list-owned-work.sh Studio-F --json-report /tmp/tsz-owned-work.json`
- `scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-audit.json`
- `python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard.json`
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery.json`
- `python3 -m json.tool /tmp/tsz-disk-preflight.json`
- `python3 -m json.tool /tmp/tsz-owned-work.json`
- `python3 -m json.tool /tmp/tsz-agent-label-audit.json`
- `python3 -m json.tool /tmp/tsz-arch-guard.json`
- `python3 -m json.tool /tmp/tsz-output-surgery.json`
- `cargo fmt --all --check`
- `git diff --check`
- GitHub PR-head checks on `ac3759180bd2f6af12015f8bf13aab0545b66751`: `CI Summary`, `lint`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `project-corpus-pr-body`, `gate`, and GitGuardian passed.

## Coordination Notes
- AgentName: Studio-F
- #11946 merged and was cleaned up before this branch was created.
- `scripts/agents/list-owned-work.sh Studio-F` reported no owned PRs or issues before this branch.
- Checked open PRs for overlapping Studio-F or `show-goal` JSON work before editing; none found.
- TypeScript is symlinked to the populated primary checkout; no Cargo cache was created in this worktree.
- No roadmap update: this is routine launch evidence plumbing, not a durable roadmap direction change.
- Ready for the repo-local merge queue on exact head `ac3759180bd2f6af12015f8bf13aab0545b66751`.
