### PR TITLE
fix(checker): derive async iterator element from constraint

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -59,6 +59,10 @@ name = "for_await_type_parameter_iterability_tests"
 path = "tests/for_await_type_parameter_iterability_tests.rs"
 
 [[test]]
+name = "async_iterable_type_param_element_tests"
+path = "tests/async_iterable_type_param_element_tests.rs"
+
+[[test]]
 name = "array_element_naked_inference_tests"
 path = "tests/array_element_naked_inference_tests.rs"
 

--- a/crates/tsz-checker/src/checkers/iterable_checker.rs
+++ b/crates/tsz-checker/src/checkers/iterable_checker.rs
@@ -485,6 +485,14 @@ impl<'a> CheckerState<'a> {
             return TypeId::ANY;
         }
 
+        if let ForOfElementKind::TypeParameter { constraint } =
+            classify_for_of_element_type(self.ctx.types, iterable_type)
+        {
+            return constraint
+                .map(|constraint| self.for_of_element_type(constraint, is_async))
+                .unwrap_or(TypeId::ANY);
+        }
+
         if is_async {
             // For for-await-of: try async iterator protocol first (AsyncIterable<T> → T),
             // then fall back to sync iterator + Promise unwrapping (Iterable<Promise<T>> → T)
@@ -641,6 +649,9 @@ impl<'a> CheckerState<'a> {
                 // Unwrap readonly wrapper and compute element type for inner
                 self.for_of_element_type_classified(inner, depth + 1)
             }
+            ForOfElementKind::TypeParameter { constraint } => constraint
+                .map(|constraint| self.for_of_element_type_classified(constraint, depth + 1))
+                .unwrap_or(TypeId::ANY),
             ForOfElementKind::String => TypeId::STRING,
             ForOfElementKind::Other => {
                 // For custom iterators, Application types (Map, Set), etc.,

--- a/crates/tsz-checker/tests/async_iterable_type_param_element_tests.rs
+++ b/crates/tsz-checker/tests/async_iterable_type_param_element_tests.rs
@@ -1,0 +1,84 @@
+use tsz_checker::test_utils::check_source_strict_codes;
+
+const ASYNC_ITERABLE_PRELUDE: &str = r#"
+declare const Symbol: { readonly asyncIterator: unique symbol };
+
+interface PromiseLike<T> {
+  then<TResult>(onfulfilled: (value: T) => TResult | PromiseLike<TResult>): PromiseLike<TResult>;
+}
+
+interface Promise<T> extends PromiseLike<T> {}
+
+interface IteratorYieldResult<TYield> {
+  done?: false;
+  value: TYield;
+}
+
+interface IteratorReturnResult<TReturn> {
+  done: true;
+  value: TReturn;
+}
+
+type IteratorResult<TYield, TReturn = any> =
+  IteratorYieldResult<TYield> | IteratorReturnResult<TReturn>;
+
+interface AsyncIterator<T, TReturn = any, TNext = unknown> {
+  next(...args: [] | [TNext]): Promise<IteratorResult<T, TReturn>>;
+}
+
+interface AsyncIterable<T> {
+  [Symbol.asyncIterator](): AsyncIterator<T>;
+}
+
+interface AsyncIterableIterator<T> extends AsyncIterator<T> {
+  [Symbol.asyncIterator](): AsyncIterableIterator<T>;
+}
+"#;
+
+fn strict_codes(source: &str) -> Vec<u32> {
+    check_source_strict_codes(&format!("{ASYNC_ITERABLE_PRELUDE}\n{source}"))
+}
+
+#[test]
+fn for_await_type_parameter_constraint_provides_element_type() {
+    let codes = strict_codes(
+        r#"
+async function f<T extends AsyncIterableIterator<number>>(iter: T) {
+  for await (const value of iter) {
+    const ok: number = value;
+    const bad: string = value;
+  }
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&2504),
+        "constrained async-iterable type parameter must not emit TS2504, got {codes:?}",
+    );
+    assert!(
+        codes.contains(&2322),
+        "for-await element type must be number rather than any, got {codes:?}",
+    );
+}
+
+#[test]
+fn for_await_renamed_type_parameter_constraint_provides_element_type() {
+    let codes = strict_codes(
+        r#"
+async function g<Stream extends AsyncIterableIterator<boolean>>(source: Stream) {
+  for await (const item of source) {
+    const ok: boolean = item;
+    const bad: number = item;
+  }
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&2504),
+        "renamed constrained async-iterable parameter must not emit TS2504, got {codes:?}",
+    );
+    assert!(
+        codes.contains(&2322),
+        "for-await element type must follow the constraint yield type, got {codes:?}",
+    );
+}

--- a/crates/tsz-solver/src/type_queries/iterable.rs
+++ b/crates/tsz-solver/src/type_queries/iterable.rs
@@ -181,6 +181,8 @@ pub enum ForOfElementKind {
     Intersection(Vec<TypeId>),
     /// Readonly wrapper - unwrap and compute
     Readonly(TypeId),
+    /// Type parameter - compute element type from the apparent type constraint
+    TypeParameter { constraint: Option<TypeId> },
     /// String type - iteration yields string
     String,
     /// Other types - resolve via iterator protocol or return ANY as fallback
@@ -213,6 +215,9 @@ pub fn classify_for_of_element_type(db: &dyn TypeDatabase, type_id: TypeId) -> F
         TypeData::ReadonlyType(inner) | TypeData::NoInfer(inner) => {
             ForOfElementKind::Readonly(inner)
         }
+        TypeData::TypeParameter(info) | TypeData::Infer(info) => ForOfElementKind::TypeParameter {
+            constraint: info.constraint,
+        },
         // String literals iterate to produce `string`
         TypeData::Literal(crate::LiteralValue::String(_)) => ForOfElementKind::String,
         _ => ForOfElementKind::Other,

--- a/crates/tsz-solver/tests/iterable_classifier_tests.rs
+++ b/crates/tsz-solver/tests/iterable_classifier_tests.rs
@@ -736,6 +736,22 @@ fn for_of_no_infer_unwraps_via_readonly_arm() {
 }
 
 #[test]
+fn for_of_type_parameter_carries_constraint() {
+    let interner = TypeInterner::new();
+    let constraint = interner.lazy(DefId(23));
+    let tp = interner.type_param(TypeParamInfo {
+        name: interner.intern_string("Item"),
+        constraint: Some(constraint),
+        default: None,
+        is_const: false,
+    });
+    match classify_for_of_element_type(&interner, tp) {
+        ForOfElementKind::TypeParameter { constraint: c } => assert_eq!(c, Some(constraint)),
+        other => panic!("expected TypeParameter, got {other:?}"),
+    }
+}
+
+#[test]
 fn for_of_string_literal_returns_string_kind() {
     let interner = TypeInterner::new();
     let lit = interner.literal_string("hello");


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Semantic campaign / async iterable element typing

## Invariant
When a `for await...of` operand is a type parameter constrained to an async iterable, `tsc` computes the loop element from the parameter's apparent constraint. This PR routes tsz element typing through the solver iterable classifier's constraint fact, then lets the checker reuse its existing async element extraction path.

## Scope
- Add a solver classifier arm for constrained type parameters and infer variables.
- Recurse through type-parameter constraints before async/sync element extraction in the checker.
- Add solver and checker regression coverage, including a renamed type parameter to prove the rule is structural.

## Project Corpus Impact
- Row: kysely-project
- Bug family: async iterable classification / TS2504-family; element type from generic async-generator constraints
- Evidence: related to #10667. Focused tests assert no TS2504 and require TS2322 on wrong loop-variable assignments, preventing fallback to `any`.

## Verification
- `cargo nextest run -p tsz-solver for_of_type_parameter_carries_constraint`
- `CARGO_BUILD_JOBS=1 cargo nextest run -p tsz-checker --test async_iterable_type_param_element_tests`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`

## Coordination Notes
- Open PR sweep before publishing found no Studio-A PR and no overlap with active checker/solver lanes.
- Agent label audit passed before publishing.
- Disk was low on this machine (~9-10 GiB free after cache-preserving cleanup), so the checker verification was run as a single explicit test target instead of preparing all checker integration binaries.
