### PR TITLE
chore(arch): write guard json reports atomically

### DIFF
--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -29,6 +29,16 @@ def scan_project_config_writers(fixture_path, compile_guard_path, bench_path):
     )
 
 
+def write_json_report(report_path: Path, payload: dict) -> None:
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = report_path.with_name(f".{report_path.name}.tmp")
+    temp_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temp_path.replace(report_path)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Run TSZ architecture guardrails"
@@ -291,10 +301,7 @@ def main() -> int:
     }
 
     if args.json_report:
-        report_path = Path(args.json_report)
-        if report_path.parent != Path("."):
-            report_path.parent.mkdir(parents=True, exist_ok=True)
-        report_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        write_json_report(Path(args.json_report), payload)
 
     if args.json:
         print(json.dumps(payload, indent=2))

--- a/scripts/arch/test_arch_guard.py
+++ b/scripts/arch/test_arch_guard.py
@@ -1,7 +1,24 @@
+import json
+
 from test_arch_guard_support import ROOT, load_arch_guard_module, pathlib, tempfile, unittest
 from test_arch_guard_counts import *
 from test_arch_guard_policy import *
 from test_arch_guard_projects import *
+
+
+class ArchGuardJsonReportTests(unittest.TestCase):
+    def setUp(self):
+        self.arch_guard = load_arch_guard_module()
+
+    def test_write_json_report_is_atomic_and_stable(self):
+        payload = {"total_hits": 0, "status": "passed", "failures": []}
+        with tempfile.TemporaryDirectory() as tmp:
+            report_path = pathlib.Path(tmp) / "nested" / "arch_guard.json"
+            self.arch_guard.write_json_report(report_path, payload)
+
+            self.assertEqual(json.loads(report_path.read_text(encoding="utf-8")), payload)
+            self.assertTrue(report_path.read_text(encoding="utf-8").endswith("\n"))
+            self.assertFalse(report_path.with_name(".arch_guard.json.tmp").exists())
 
 
 class ArchGuardCompatCheckerBoundaryTests(unittest.TestCase):


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Tooling/guardrail evidence plumbing.

## Invariant
When `arch_guard.py --json-report` writes release-gate evidence, the report should be valid, stable JSON and should not leave a partial file behind if the writer is interrupted; this PR makes the arch guard use the same temp-and-replace pattern already used by output-surgery evidence.

## Scope
- `scripts/arch/arch_guard.py`: route JSON report writes through an atomic helper with stable key ordering.
- `scripts/arch/test_arch_guard.py`: add focused coverage for parent creation, valid JSON, trailing newline, and no leftover temp file.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: tooling-only guardrail evidence plumbing; no compiler behavior path.

## Verification
- `python3 scripts/arch/test_arch_guard.py` (227 tests passed)
- `python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard-studio-f-atomic.json` (passed; report status `passed`, `total_hits=0`, no temp file left)
- `git diff --check`
- PR-head checks on `64be31c828d382caa16797c792e90810e3e351b7`: `CI Summary`, `arch-tool-smoke`, `project-corpus-pr-body`, `queue-one-pr`, `gate`, and GitGuardian passed.

## Coordination Notes
- AgentName: Studio-F
- Owned Studio-F PR runway was clear before starting (`scripts/agents/list-owned-work.sh Studio-F` reported no PRs/issues).
- Open PR scan showed other lanes are draft/WIP/blocked/stacked; this PR does not touch their code paths.
- Current checkout used for edits is a fresh Studio-F worktree from `origin/main`; dirty Studio-C checker files in `/Users/mohsen/code/tsz` were left untouched.
- Enqueued with `merge-queue` after exact-head PR-head checks passed; waiting for queue-owned `Queue Tested` and final merge verification.
