### PR TITLE
fix(solver): propagate class context into assignability

### DIFF
--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -8,7 +8,8 @@ use crate::operations::AssignabilityChecker;
 use crate::relations::lawyer::AnyPropagationRules;
 use crate::relations::subtype::{NoopResolver, SubtypeChecker, TypeResolver};
 use crate::types::{
-    IntrinsicKind, LiteralValue, MappedModifier, MappedType, PropertyInfo, TypeData, TypeId,
+    IntrinsicKind, LiteralValue, MappedModifier, MappedType, PropertyInfo, SymbolRef, TypeData,
+    TypeId,
 };
 use crate::visitor::{
     TypeVisitor, application_id, array_element_type, index_access_parts, intrinsic_kind,
@@ -667,6 +668,11 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
     pub fn set_query_db(&mut self, db: &'a dyn QueryDatabase) {
         self.query_db = Some(db);
         self.subtype.query_db = Some(db);
+    }
+
+    /// Set the class-symbol classifier used by nested subtype checks.
+    pub fn set_class_check(&mut self, check: &'a dyn Fn(SymbolRef) -> bool) {
+        self.subtype.is_class_symbol = Some(check);
     }
 
     /// Set the inheritance graph for nominal class subtype checking.

--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -518,6 +518,9 @@ pub(crate) fn configured_compat_checker<'a, R: TypeResolver>(
     if let Some(query_db) = context.query_db {
         checker.set_query_db(query_db);
     }
+    if let Some(class_check) = context.class_check {
+        checker.set_class_check(class_check);
+    }
     checker
 }
 

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/class_context_partitioning.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/class_context_partitioning.rs
@@ -3,6 +3,9 @@
 use crate::caches::db::QueryDatabase;
 use crate::caches::query_cache::QueryCache;
 use crate::intern::TypeInterner;
+use crate::relations::relation_queries::{
+    RelationContext, RelationKind, RelationPolicy, query_relation,
+};
 use crate::relations::subtype::SubtypeChecker;
 use crate::types::{IndexSignature, ObjectFlags, ObjectShape, PropertyInfo, TypeId};
 
@@ -67,5 +70,81 @@ fn subtype_cache_skips_class_check_context() {
     assert!(
         structural_cached.is_subtype_of(source, target),
         "a class-context result must not be reused by a structural checker without class context",
+    );
+}
+
+#[test]
+fn assignability_relation_context_propagates_class_check_without_shared_cache() {
+    use tsz_binder::SymbolId;
+
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let source_symbol = SymbolId(43);
+    let class_ref = crate::SymbolRef(source_symbol.0);
+    let is_class = |symbol: crate::SymbolRef| symbol == class_ref;
+
+    let source = interner.object_with_flags_and_symbol(
+        vec![
+            PropertyInfo::new(interner.intern_string("a"), TypeId::NUMBER),
+            PropertyInfo::new(interner.intern_string("b"), TypeId::NUMBER),
+        ],
+        ObjectFlags::empty(),
+        Some(source_symbol),
+    );
+    let target = interner.object_with_index(ObjectShape {
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::NUMBER,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+    });
+    let class_context = RelationContext {
+        query_db: Some(&db),
+        class_check: Some(&is_class),
+        ..RelationContext::default()
+    };
+
+    let class_key = SubtypeChecker::new(&interner)
+        .with_query_db(&db)
+        .with_class_check(&is_class)
+        .debug_cache_key_for(source, target);
+
+    assert!(
+        !query_relation(
+            &interner,
+            source,
+            target,
+            RelationKind::Assignable,
+            RelationPolicy::default(),
+            class_context,
+        )
+        .is_related(),
+        "assignability relation context must preserve class/interface index-signature rules",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(class_key),
+        None,
+        "class-check assignability context must not populate a shared class-agnostic subtype slot",
+    );
+
+    assert!(
+        query_relation(
+            &interner,
+            source,
+            target,
+            RelationKind::Assignable,
+            RelationPolicy::default(),
+            RelationContext {
+                query_db: Some(&db),
+                ..RelationContext::default()
+            },
+        )
+        .is_related(),
+        "without class-symbol context the same shape remains structurally assignable",
     );
 }


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Solver relation policy/cache correctness; #8207 relation policy cache-key and context cleanup.

## Invariant
When assignability is evaluated with a RelationContext::class_check predicate, tsz must apply the same named class/interface index-signature rules as subtype checking, and must not share those context-dependent answers through the class-agnostic relation cache. This belongs in solver relation setup because class context changes the boolean relation answer.

## Scope
- crates/tsz-solver/src/relations/compat.rs
- crates/tsz-solver/src/relations/relation_queries.rs
- crates/tsz-solver/tests/relation_policy_cache_agreement_tests/class_context_partitioning.rs

## Project Corpus Impact
- Row: n/a
- Bug family: solver relation policy / class-context assignability
- Evidence: targeted solver unit coverage; no project corpus row was run locally. This can affect class/interface assignability paths by preserving existing subtype class-context semantics through the assignability facade.

## Structural Rule
When a relation query supplies a class-symbol classifier, compatibility/assignability must propagate that classifier to nested subtype checks; structural assignability without the classifier remains unchanged.

## Adjacent Case Matrix
- Class-context subtype already rejects a named class/interface source without an explicit string index signature.
- Class-context assignability now follows that same rejection through RelationKind::Assignable.
- Structural assignability without class context still accepts the same object shape.
- Shared subtype cache remains unpopulated for class-context answers because the predicate is not cache-keyable.

## Verification
- Current base: a379738fd4e43c1684f0cfbaf1c4873c74da664d
- Current head: c099901ea0949a8a024e43c3d409562e89bd61c9
- RED: cargo nextest run -p tsz-solver -E "test(assignability_relation_context_propagates_class_check_without_shared_cache)" failed before the fix with the expected class-context assertion.
- cargo nextest run -p tsz-solver -E "test(relation_policy_cache_agreement_tests)" (28 passed, 6414 skipped)
- cargo fmt --check
- git diff --check main..HEAD
- python3 scripts/arch/arch_guard.py

## Coordination Notes
- Fresh worktree: /Users/mohsen/code/tsz-m4b-assignability-class-context-20260531.
- Rebased onto current main a379738fd4e43c1684f0cfbaf1c4873c74da664d after #11965 landed.
- Independent of #11920/#11922/#11947, which cover relation cache config constructor/projection cleanup.
- Related issue: #8207.