### PR TITLE
chore(arch): expose guard json ok status

### DIFF
--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -39,6 +39,16 @@ def write_json_report(report_path: Path, payload: dict) -> None:
     temp_path.replace(report_path)
 
 
+def build_json_payload(failures: list[tuple[str, list[str]]], total_hits: int) -> dict:
+    ok = not failures
+    return {
+        "ok": ok,
+        "status": "failed" if failures else "passed",
+        "total_hits": total_hits,
+        "failures": [{"name": name, "hits": hits} for name, hits in failures],
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Run TSZ architecture guardrails"
@@ -294,11 +304,7 @@ def main() -> int:
             )
         )
 
-    payload = {
-        "status": "failed" if failures else "passed",
-        "total_hits": total_hits,
-        "failures": [{"name": name, "hits": hits} for name, hits in failures],
-    }
+    payload = build_json_payload(failures, total_hits)
 
     if args.json_report:
         write_json_report(Path(args.json_report), payload)

--- a/scripts/arch/test_arch_guard.py
+++ b/scripts/arch/test_arch_guard.py
@@ -10,8 +10,23 @@ class ArchGuardJsonReportTests(unittest.TestCase):
     def setUp(self):
         self.arch_guard = load_arch_guard_module()
 
+    def test_json_payload_includes_boolean_ok_status(self):
+        self.assertEqual(
+            self.arch_guard.build_json_payload([], 0),
+            {"ok": True, "status": "passed", "total_hits": 0, "failures": []},
+        )
+        self.assertEqual(
+            self.arch_guard.build_json_payload([("Rule", ["src/lib.rs:1"])], 1),
+            {
+                "ok": False,
+                "status": "failed",
+                "total_hits": 1,
+                "failures": [{"name": "Rule", "hits": ["src/lib.rs:1"]}],
+            },
+        )
+
     def test_write_json_report_is_atomic_and_stable(self):
-        payload = {"total_hits": 0, "status": "passed", "failures": []}
+        payload = {"ok": True, "total_hits": 0, "status": "passed", "failures": []}
         with tempfile.TemporaryDirectory() as tmp:
             report_path = pathlib.Path(tmp) / "nested" / "arch_guard.json"
             self.arch_guard.write_json_report(report_path, payload)


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Tooling/guardrail evidence plumbing.

## Invariant
When `arch_guard.py` emits machine-readable release-gate evidence, consumers should be able to check success with the same boolean `ok` field used by output-surgery evidence instead of parsing the string `status`; this PR adds that explicit boolean while keeping the existing status/failure fields.

## Scope
- `scripts/arch/arch_guard.py`: factor JSON payload construction and include `ok` for both `--json` and `--json-report`.
- `scripts/arch/test_arch_guard.py`: cover pass/fail payloads and keep atomic report coverage aligned with the new schema.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: tooling-only guardrail evidence plumbing; no compiler behavior path.

## Verification
- `python3 scripts/arch/test_arch_guard.py` (228 tests passed)
- `python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard-studio-f-ok-rebased.json` (passed; report `ok=true`, `status=passed`, `total_hits=0`)
- `python3 scripts/arch/arch_guard.py --json > /tmp/tsz-arch-guard-studio-f-ok-stdout-rebased.json` (passed; stdout JSON included `ok=true`, `status=passed`, `total_hits=0`)
- `git diff --check`
- PR-head checks on `ca9cf65f8ceb7cd4636e3bb2aac2d1c420b24fe7`: `CI Summary`, `arch-tool-smoke`, `project-corpus-pr-body`, `queue-one-pr`, `gate`, and GitGuardian passed.

## Coordination Notes
- AgentName: Studio-F
- Owned Studio-F runway was clear before starting (`scripts/agents/list-owned-work.sh Studio-F` reported no PRs/issues).
- Open PR scan showed other active lanes own their current PRs; this PR only touches arch tooling JSON evidence.
- Current checkout used for edits is a fresh Studio-F worktree from `origin/main`; dirty Studio-C checker files in `/Users/mohsen/code/tsz` were left untouched.
- Enqueued with `merge-queue` after exact-head PR-head checks passed; waiting for queue-owned `Queue Tested` and final merge verification.
