### PR TITLE
fix(checker): guard iterable constraint element recursion

### DIFF
--- a/crates/tsz-checker/src/checkers/iterable_checker.rs
+++ b/crates/tsz-checker/src/checkers/iterable_checker.rs
@@ -467,6 +467,19 @@ impl<'a> CheckerState<'a> {
     /// When `is_async` is true (`for await...of`), the element type is awaited,
     /// so `Iterable<Promise<T>>` yields `T` instead of `Promise<T>`.
     pub fn for_of_element_type(&mut self, iterable_type: TypeId, is_async: bool) -> TypeId {
+        self.for_of_element_type_with_depth(iterable_type, is_async, 0)
+    }
+
+    fn for_of_element_type_with_depth(
+        &mut self,
+        iterable_type: TypeId,
+        is_async: bool,
+        depth: usize,
+    ) -> TypeId {
+        if depth > 100 {
+            return TypeId::ANY;
+        }
+
         if iterable_type == TypeId::ANY || iterable_type == TypeId::ERROR {
             return iterable_type;
         }
@@ -489,7 +502,9 @@ impl<'a> CheckerState<'a> {
             classify_for_of_element_type(self.ctx.types, iterable_type)
         {
             return constraint
-                .map(|constraint| self.for_of_element_type(constraint, is_async))
+                .map(|constraint| {
+                    self.for_of_element_type_with_depth(constraint, is_async, depth + 1)
+                })
                 .unwrap_or(TypeId::ANY);
         }
 

--- a/crates/tsz-checker/tests/async_iterable_type_param_element_tests.rs
+++ b/crates/tsz-checker/tests/async_iterable_type_param_element_tests.rs
@@ -82,3 +82,20 @@ async function g<Stream extends AsyncIterableIterator<boolean>>(source: Stream) 
         "for-await element type must follow the constraint yield type, got {codes:?}",
     );
 }
+
+#[test]
+fn circular_type_parameter_constraint_does_not_recurse_forever() {
+    let codes = strict_codes(
+        r#"
+async function h<Outer extends Inner, Inner extends Outer>(source: Outer) {
+  for await (const item of source) {
+    const bad: string = item;
+  }
+}
+"#,
+    );
+    assert!(
+        !codes.is_empty(),
+        "circular constraints should still produce diagnostics or a safe fallback, got {codes:?}",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Semantic campaign follow-up / async iterable element typing robustness

## Invariant
When a `for await...of` operand is a type parameter with cyclic or deeply nested constraints, `tsc` reports diagnostics or falls back without unbounded recursion; this PR keeps tsz's async-aware element extraction on a depth-limited checker path.

## Scope
- Carry a recursion depth through `CheckerState::for_of_element_type` so type-parameter constraint recursion shares the existing `ANY` fallback guard.
- Add a circular constrained type-parameter regression beside the async iterable element tests.

## Project Corpus Impact
- Row: kysely-project
- Bug family: async iterable classification / TS2504-family robustness after #11950
- Evidence: follow-up to Reviewer finding on merged #11950; focused test covers circular constraints while preserving constrained async iterable element typing.

## Verification
- `cargo fmt --check`
- `CARGO_BUILD_JOBS=1 cargo nextest run -p tsz-checker --test async_iterable_type_param_element_tests`
- `git diff --cached --check`
- `python3 scripts/arch/arch_guard.py`

## Coordination Notes
- #11950 merged before its amended review fix landed; this PR contains only that missing two-file guard follow-up on current `origin/main`.
- No markdown/docs changes.
- Disk is low on this machine, so verification stayed focused and did not run broad local suites.
