### PR TITLE
fix(emit): recover object class member tails

### DIFF
--- a/crates/tsz-emitter/src/emitter/expressions/literals.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/literals.rs
@@ -517,6 +517,8 @@ impl<'a> Printer<'a> {
         let has_trailing_comma = obj.elements.nodes.last().copied()
             == emitted_properties.last().copied()
             && self.has_trailing_comma_in_source(node, &emitted_properties);
+        let has_recovered_class_member_tail =
+            self.object_literal_has_recovered_class_member_tail(node, &emitted_properties);
 
         // Preserve single-line formatting from source by looking only at separators
         // between properties (not inside member bodies).
@@ -730,6 +732,9 @@ impl<'a> Printer<'a> {
                 self.write(",");
             }
             self.write(" }");
+            if has_recovered_class_member_tail {
+                self.write(", {}");
+            }
         } else {
             // Multi-line format: preserve original line layout from source
             // TSC keeps properties that are on the same line together
@@ -894,7 +899,76 @@ impl<'a> Printer<'a> {
             }
             self.decrease_indent();
             self.write("}");
+            if has_recovered_class_member_tail {
+                self.write(", {}");
+            }
         }
+    }
+
+    fn object_literal_has_recovered_class_member_tail(
+        &self,
+        object_node: &Node,
+        properties: &[NodeIndex],
+    ) -> bool {
+        let Some(source) = self.source_text else {
+            return false;
+        };
+
+        properties.iter().enumerate().any(|(prop_i, &prop_idx)| {
+            let Some(prop_node) = self.arena.get(prop_idx) else {
+                return false;
+            };
+            if prop_node.kind != syntax_kind_ext::PROPERTY_ASSIGNMENT {
+                return false;
+            }
+            let Some(prop) = self.arena.get_property_assignment(prop_node) else {
+                return false;
+            };
+            if prop.name == prop.initializer {
+                return false;
+            }
+            let Some(name_node) = self.arena.get(prop.name) else {
+                return false;
+            };
+            let name_is_class_keyword = name_node.kind == SyntaxKind::ClassKeyword as u16
+                || self
+                    .arena
+                    .get_identifier(name_node)
+                    .is_some_and(|ident| ident.escaped_text == "class");
+            if !name_is_class_keyword {
+                return false;
+            }
+
+            let Some(init_node) = self.arena.get(prop.initializer) else {
+                return false;
+            };
+            let start = std::cmp::min(prop_node.pos as usize, source.len());
+            let end = std::cmp::min(init_node.pos as usize, source.len());
+            if start >= end {
+                return false;
+            }
+            let Ok(between) = crate::safe_slice::slice(source, start, end) else {
+                return false;
+            };
+            if between.contains(':') {
+                return false;
+            }
+
+            let body_start = std::cmp::min(init_node.end as usize, source.len());
+            let body_end = properties
+                .get(prop_i + 1)
+                .and_then(|&next_prop| self.arena.get(next_prop))
+                .map_or(object_node.end, |next_node| next_node.pos);
+            let body_end = std::cmp::min(body_end as usize, source.len());
+            if body_start >= body_end {
+                return false;
+            }
+            let Ok(after_initializer) = crate::safe_slice::slice(source, body_start, body_end)
+            else {
+                return false;
+            };
+            after_initializer.contains('{') && after_initializer.contains('}')
+        })
     }
 
     fn object_literal_shorthand_continuation_tail(
@@ -967,36 +1041,25 @@ impl<'a> Printer<'a> {
                 Some(format!(": {tail}"))
             }
             b'[' => {
-                let computed_name_idx = if next_node.kind == syntax_kind_ext::PROPERTY_ASSIGNMENT {
-                    let assignment = self.arena.get_property_assignment(next_node)?;
-                    if assignment.initializer != assignment.name {
-                        return None;
+                let mut depth = 0_i32;
+                let mut tail_end = cursor;
+                while tail_end < search_end {
+                    match bytes[tail_end] {
+                        b'[' => depth += 1,
+                        b']' => {
+                            depth -= 1;
+                            if depth == 0 {
+                                tail_end += 1;
+                                break;
+                            }
+                        }
+                        b'\n' | b'\r' => return None,
+                        _ => {}
                     }
-                    assignment.name
-                } else if next_node.kind == syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT {
-                    let next_shorthand = self.arena.get_shorthand_property(next_node)?;
-                    if next_shorthand.equals_token
-                        || next_shorthand.object_assignment_initializer != NodeIndex::NONE
-                    {
-                        return None;
-                    }
-                    next_shorthand.name
-                } else {
+                    tail_end += 1;
+                }
+                if depth != 0 {
                     return None;
-                };
-                let computed_name = self.arena.get(computed_name_idx)?;
-                if computed_name.kind != syntax_kind_ext::COMPUTED_PROPERTY_NAME {
-                    return None;
-                }
-                let mut tail_end = std::cmp::min(computed_name.end as usize, source.len());
-                while tail_end > cursor && matches!(bytes[tail_end - 1], b' ' | b'\t') {
-                    tail_end -= 1;
-                }
-                if tail_end > cursor && bytes[tail_end - 1] == b',' {
-                    tail_end -= 1;
-                }
-                while tail_end > cursor && matches!(bytes[tail_end - 1], b' ' | b'\t') {
-                    tail_end -= 1;
                 }
                 if source[cursor..tail_end].contains('\n') {
                     return None;
@@ -1664,6 +1727,9 @@ impl<'a> Printer<'a> {
 }
 
 #[cfg(test)]
+mod object_recovery_tests;
+
+#[cfg(test)]
 mod tests {
     use crate::emitter::{Printer, PrinterOptions};
     use tsz_common::ScriptTarget;
@@ -1787,60 +1853,6 @@ mod tests {
         assert!(
             output.contains("1, /* trailing */"),
             "Block comment should stay on same line after comma.\nOutput:\n{output}"
-        );
-    }
-
-    #[test]
-    fn object_literal_recovery_keeps_property_access_tail_with_shorthand() {
-        let source = "var h = {\n    alpha.beta,\n    renamed.gamma,\n};\n";
-
-        let (parser, root) = parse_test_source(source);
-
-        let mut printer = Printer::with_options(
-            &parser.arena,
-            PrinterOptions {
-                target: ScriptTarget::ES2015,
-                ..Default::default()
-            },
-        );
-        printer.set_source_text(source);
-        printer.emit(root);
-        let output = printer.get_output().to_string();
-
-        assert!(
-            output.contains("alpha, : .beta,"),
-            "Recovered property-access member should stay attached to its shorthand base.\nOutput:\n{output}"
-        );
-        assert!(
-            output.contains("renamed, : .gamma,"),
-            "Recovery should not depend on a specific identifier spelling.\nOutput:\n{output}"
-        );
-    }
-
-    #[test]
-    fn object_literal_recovery_keeps_element_access_tail_with_shorthand() {
-        let source = "var h = {\n    alpha[\"beta\"],\n    renamed[1],\n};\n";
-
-        let (parser, root) = parse_test_source(source);
-
-        let mut printer = Printer::with_options(
-            &parser.arena,
-            PrinterOptions {
-                target: ScriptTarget::ES2015,
-                ..Default::default()
-            },
-        );
-        printer.set_source_text(source);
-        printer.emit(root);
-        let output = printer.get_output().to_string();
-
-        assert!(
-            output.contains("alpha, [\"beta\"]: ,"),
-            "Recovered element-access member should stay attached to its shorthand base.\nOutput:\n{output}"
-        );
-        assert!(
-            output.contains("renamed, [1]: ,"),
-            "Recovery should also handle numeric computed names without name-specific logic.\nOutput:\n{output}"
         );
     }
 

--- a/crates/tsz-emitter/src/emitter/expressions/literals/object_recovery_tests.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/literals/object_recovery_tests.rs
@@ -1,0 +1,139 @@
+use crate::emitter::{Printer, PrinterOptions};
+use tsz_common::ScriptTarget;
+
+fn parse_test_source(source: &str) -> (tsz_parser::ParserState, tsz_parser::parser::NodeIndex) {
+    let mut parser = tsz_parser::ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    (parser, root)
+}
+
+#[test]
+fn object_literal_recovered_class_member_emits_empty_object_tail() {
+    let source = "var box = {\n    class Renamed {\n    }\n}\n";
+
+    let (parser, root) = parse_test_source(source);
+
+    let mut printer = Printer::with_options(
+        &parser.arena,
+        PrinterOptions {
+            target: ScriptTarget::ES2015,
+            ..Default::default()
+        },
+    );
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert!(
+        output.contains("var box = {\n    class: Renamed\n}, {};"),
+        "Recovered object class member should keep tsc's trailing empty object.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn object_literal_real_class_property_does_not_emit_empty_object_tail() {
+    let source = "var box = {\n    class: Renamed\n};\n";
+
+    let (parser, root) = parse_test_source(source);
+
+    let mut printer = Printer::with_options(
+        &parser.arena,
+        PrinterOptions {
+            target: ScriptTarget::ES2015,
+            ..Default::default()
+        },
+    );
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert!(
+        output.contains("var box = {\n    class: Renamed\n};"),
+        "Ordinary class-named properties should not use recovery tail emit.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("}, {};"),
+        "Ordinary class-named properties must not get the recovery empty object.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn object_literal_bare_class_shorthand_does_not_emit_empty_object_tail() {
+    let source = "var box = { class };\n";
+
+    let (parser, root) = parse_test_source(source);
+
+    let mut printer = Printer::with_options(
+        &parser.arena,
+        PrinterOptions {
+            target: ScriptTarget::ES2015,
+            ..Default::default()
+        },
+    );
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert!(
+        output.contains("var box = { class:  };"),
+        "Bare invalid class shorthand should recover as a class-named property.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("}, {};"),
+        "Bare invalid class shorthand must not get the recovered class-body tail.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn object_literal_recovery_keeps_property_access_tail_with_shorthand() {
+    let source = "var h = {\n    alpha.beta,\n    renamed.gamma,\n};\n";
+
+    let (parser, root) = parse_test_source(source);
+
+    let mut printer = Printer::with_options(
+        &parser.arena,
+        PrinterOptions {
+            target: ScriptTarget::ES2015,
+            ..Default::default()
+        },
+    );
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert!(
+        output.contains("alpha, : .beta,"),
+        "Recovered property-access member should stay attached to its shorthand base.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("renamed, : .gamma,"),
+        "Recovery should not depend on a specific identifier spelling.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn object_literal_recovery_keeps_element_access_tail_with_shorthand() {
+    let source = "var h = {\n    alpha[\"beta\"],\n    renamed[1],\n};\n";
+
+    let (parser, root) = parse_test_source(source);
+
+    let mut printer = Printer::with_options(
+        &parser.arena,
+        PrinterOptions {
+            target: ScriptTarget::ES2015,
+            ..Default::default()
+        },
+    );
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert!(
+        output.contains("alpha, [\"beta\"]: ,"),
+        "Recovered element-access member should stay attached to its shorthand base.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("renamed, [1]: ,"),
+        "Recovery should also handle numeric computed names without name-specific logic.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Track 9: JavaScript emit parity - class/private/accessor/decorator parser recovery.

## Invariant
When an object-literal parser recovery shape represents invalid `class Name {}` syntax as a `class` property assignment with no source colon before the recovered initializer and a recovered class body follows in the source, `tsc` emits the object literal followed by the recovered empty-object tail; this PR makes tsz emit the same through the emitter parser-recovery output layer.

## Owner Layer
Emitter output recovery for syntax/parser recovery shapes only. The change does not import checker internals, ask solver questions, perform semantic validation, or patch already-emitted text.

## Scope
- Detect object-literal parser recovery where an invalid `class Name {}` member is represented as a `class` property assignment without a colon before the recovered initializer.
- Require recovered class-body braces after the initializer before adding `tsc`'s trailing empty-object tail, so bare invalid `{ class }` shorthand and `class,` recovery do not get the class-body tail.
- Preserve recovered property-access and computed element-access tails for malformed shorthand members by parsing the balanced tail from source instead of relying on the next recovered property node.
- Add adjacent tests proving the recovery case emits `}, {};`, ordinary `class: Renamed` properties do not, bare invalid `class` shorthand does not, and property/element access tails stay attached.
- Keep touched emitter shards under the 2000-line hard limit by moving recovery tests into a child test module.

## Adjacent-Case Matrix
- Recovered object member: `var box = { class Renamed {} }` emits the trailing empty object tail expected by `nestedClassDeclaration`.
- Ordinary property: `var box = { class: Renamed };` does not receive the recovery tail.
- Bare invalid shorthand: `var box = { class };` recovers as a class-named property without adding `}, {};`.
- Element/property access recovery: malformed shorthand members such as `alpha.beta` and `alpha["beta"]` keep the recovered source tail without identifier-specific logic.
- Class-family smoke after the change remains at 1475/1480; remaining failures are `jsDeclarationsClasses(target=es5)`, `nestedGlobalNamespaceInClass`, `privateNameWhenNotUseDefineForClassFieldsInEsNext(target=esnext)`, `privateNameWhenNotUseDefineForClassFieldsInEsNext(target=es2020)`, and `staticPropertyNameConflicts(target=es5,usedefineforclassfields=true)`.

## Known Fallbacks
The recovery gate still consumes source text because the parser does not expose a direct recovery fact for this class-member-in-object-literal shape. The gate is intentionally limited to the built-in `class` token/identifier, non-shorthand property assignments, no source colon before the initializer, and source class-body braces after the initializer.

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit class/private/accessor/decorator parser recovery
- Evidence: emit harness only; no project-corpus fixture metadata or benchmark row changes.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `wc -l crates/tsz-emitter/src/emitter/expressions/literals.rs crates/tsz-emitter/src/emitter/expressions/literals/object_recovery_tests.rs` -> `literals.rs` 1943 lines, test shard 139 lines
- `python3 scripts/arch/arch_guard.py`
- `cargo nextest run -p tsz-emitter -E 'test(object_literal_recovered_class_member_emits_empty_object_tail) | test(object_literal_real_class_property_does_not_emit_empty_object_tail) | test(object_literal_bare_class_shorthand_does_not_emit_empty_object_tail) | test(object_literal_recovery_keeps_element_access_tail_with_shorthand) | test(object_literal_recovery_keeps_property_access_tail_with_shorthand)'` -> 5 passed
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh scripts/emit/run.sh --filter=objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier --js-only --verbose --timeout=30000 --json-out=/tmp/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier-studio-c-after-bracket-recovery.json` -> 1/1 JS passed
- `scripts/safe-run.sh scripts/emit/run.sh --filter=nestedClassDeclaration --js-only --verbose --skip-build --timeout=30000 --json-out=/tmp/nestedClassDeclaration-studio-c-after-tighten.json` -> 1/1 JS passed
- `scripts/safe-run.sh scripts/emit/run.sh --filter=using --js-only --skip-build --timeout=10000 --json-out=/tmp/using-family-studio-c-after-object-recovery-tighten.json` -> 467/467 JS passed
- `scripts/safe-run.sh scripts/emit/run.sh --filter=class --js-only --skip-build --timeout=10000 --json-out=/tmp/class-family-studio-c-after-object-recovery-tighten.json` -> 1475/1480 JS passed; expected remaining five failures listed above

## Coordination Notes
- AgentName: Studio-C
- Based on current `origin/main`; head commit `c52f092497`.
- Amended after live `using` orientation found that the earlier class-tail gate also matched bare invalid `class` shorthand; the amended head tightens the gate and keeps `using` green.
- Ready-review CI restarted on the amended head. Do not enqueue until exact-head PR checks are green.
- #11939 and #11934 have merged. #11943 was rebased after #11939 and is running exact-head CI. No overlap with this object-literal recovery slice.
- No roadmap update: this is a narrow emit parity recovery slice, not a durable direction or release-gate change.
