### PR TITLE
fix(bench): ignore Cloud Build cpu model drift

### DIFF
--- a/scripts/bench/merge-results.mjs
+++ b/scripts/bench/merge-results.mjs
@@ -126,7 +126,17 @@ function validateRunnerEnvironmentConsistency(environments) {
   const warnings = [];
   for (const { file, environment } of environments.slice(1)) {
     const current = runnerHardwareSignature(environment);
-    const mismatchedFields = Object.keys(baseline).filter((key) => baseline[key] !== current[key]);
+    const mismatchedFields = Object.keys(baseline).filter((key) => {
+      if (baseline[key] === current[key]) return false;
+      if (
+        key === "cpu_model"
+        && baseline.cloud_build_machine_type
+        && baseline.cloud_build_machine_type === current.cloud_build_machine_type
+      ) {
+        return false;
+      }
+      return true;
+    });
     if (mismatchedFields.length > 0) {
       warnings.push({
         file: path.basename(file),

--- a/scripts/bench/test-merge-results.mjs
+++ b/scripts/bench/test-merge-results.mjs
@@ -558,7 +558,82 @@ withTempDir((dir) => {
   assert.equal(merged.validation.runner_environment_warnings[0].file, "bench-results-b.json");
   assert.deepEqual(
     merged.validation.runner_environment_warnings[0].mismatched_fields,
-    ["cpu_model", "total_memory_bytes"],
+    ["total_memory_bytes"],
+  );
+});
+
+withTempDir((dir) => {
+  const changedRunnerEnvironment = {
+    ...SAMPLE_RUNNER_ENVIRONMENT,
+    cpu_model: "AMD EPYC 7B12",
+  };
+  const first = writeInput(
+    dir,
+    "bench-results-a.json",
+    [projectRow("first")],
+    {
+      ...SAMPLE_RUN_METADATA,
+      runner_environment: SAMPLE_RUNNER_ENVIRONMENT,
+      shard: { label: "first", filter: "first" },
+      filter: "first",
+    },
+  );
+  const second = writeInput(
+    dir,
+    "bench-results-b.json",
+    [projectRow("second")],
+    {
+      ...SAMPLE_RUN_METADATA,
+      runner_environment: changedRunnerEnvironment,
+      shard: { label: "second", filter: "second" },
+      filter: "second",
+    },
+  );
+  const result = runMergeInputs(dir, [first, second], ["--require-runner-signature"]);
+  assert.equal(result.status, 0, result.stderr);
+  const merged = JSON.parse(fs.readFileSync(result.output, "utf8"));
+  assert.equal(merged.validation.runner_signature_required, true);
+  assert.deepEqual(merged.validation.runner_environment_warnings, []);
+});
+
+withTempDir((dir) => {
+  const localRunnerEnvironment = { ...SAMPLE_RUNNER_ENVIRONMENT };
+  delete localRunnerEnvironment.cloud_build;
+  const changedRunnerEnvironment = {
+    ...localRunnerEnvironment,
+    cpu_model: "AMD EPYC 7B12",
+  };
+  const first = writeInput(
+    dir,
+    "bench-results-a.json",
+    [projectRow("first")],
+    {
+      ...SAMPLE_RUN_METADATA,
+      runner_environment: localRunnerEnvironment,
+      shard: { label: "first", filter: "first" },
+      filter: "first",
+    },
+  );
+  const second = writeInput(
+    dir,
+    "bench-results-b.json",
+    [projectRow("second")],
+    {
+      ...SAMPLE_RUN_METADATA,
+      runner_environment: changedRunnerEnvironment,
+      shard: { label: "second", filter: "second" },
+      filter: "second",
+    },
+  );
+  const result = runMergeInputs(dir, [first, second], ["--require-runner-signature"]);
+  assert.equal(result.status, 0, result.stderr);
+  const merged = JSON.parse(fs.readFileSync(result.output, "utf8"));
+  assert.equal(merged.validation.runner_signature_required, true);
+  assert.equal(merged.validation.runner_environment_warnings.length, 1);
+  assert.equal(merged.validation.runner_environment_warnings[0].file, "bench-results-b.json");
+  assert.deepEqual(
+    merged.validation.runner_environment_warnings[0].mismatched_fields,
+    ["cpu_model"],
   );
 });
 


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Benchmark/project-corpus metric truth; runner-signature validation fix.

## Invariant
When benchmark shards run under the same Cloud Build machine type, host CPU model may vary without changing the benchmark runner class; this PR keeps runner metadata warnings focused on durable runner-signature changes while preserving warnings for local or non-Cloud-Build CPU model drift.

## Scope
- `scripts/bench/merge-results.mjs`
- `scripts/bench/test-merge-results.mjs`

## Project Corpus Impact
- Row: project-corpus benchmark artifact metadata
- Bug family: runner signature validation / benchmark artifact readiness
- Evidence: current artifact `crates/tsz-website/bench-snapshot.json` from workflow run `26707914493` has one runner metadata warning for `bench-results-algorithmic-mapped.json` on `cpu_model` despite matching Cloud Build machine type `e2-highcpu-32`; this PR prevents that spurious warning in future merged artifacts.

## Verification
- `node scripts/bench/test-merge-results.mjs`
- `node scripts/bench/test-check-artifact-readiness.mjs`
- `node scripts/bench/validate-project-metadata.mjs`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Existing Studio-A PRs were clear before starting this branch.
- Scope is bench JavaScript plus tests only; no repo markdown/docs changes.
- Issue #10649 remains the live artifact-truth tracker; this PR addresses the Cloud Build CPU-model warning class for future artifacts.
