### PR TITLE
fix(emit): prototype-qualify super in nested-class computed names

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -31,6 +31,10 @@ name = "es5_super_object_literal_accessor_tests"
 path = "tests/es5_super_object_literal_accessor_tests.rs"
 
 [[test]]
+name = "es5_nested_class_computed_name_super_tests"
+path = "tests/es5_nested_class_computed_name_super_tests.rs"
+
+[[test]]
 name = "es5_super_arrow_this_capture_tests"
 path = "tests/es5_super_arrow_this_capture_tests.rs"
 

--- a/crates/tsz-emitter/src/transforms/class_es5.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5.rs
@@ -215,6 +215,11 @@ impl<'a> ClassES5Emitter<'a> {
         self.transformer.set_extends_this_captured(captured);
     }
 
+    pub fn set_inherited_computed_name_super(&mut self, super_name: String) {
+        self.transformer
+            .set_inherited_computed_name_super(super_name);
+    }
+
     pub const fn set_tc39_decorators(&mut self, enabled: bool) {
         self.tc39_decorators = enabled;
         self.transformer.set_tc39_decorators(enabled);

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
@@ -14,6 +14,8 @@ use tsz_parser::syntax::transform_utils::{
     contains_new_target_reference, contains_super_reference,
 };
 
+#[path = "class_es5_ast_to_ir_classes.rs"]
+mod classes;
 #[path = "class_es5_ast_to_ir_comments.rs"]
 mod comments;
 #[path = "class_es5_ast_to_ir_control_flow.rs"]
@@ -489,6 +491,16 @@ impl<'a> AstToIr<'a> {
                 self.convert_object_literal(idx)
             }
             k if k == syntax_kind_ext::FUNCTION_EXPRESSION => self.convert_function_expression(idx),
+            k if k == syntax_kind_ext::CLASS_EXPRESSION
+                && self.has_super
+                && !self.is_static.get()
+                && self.class_expression_has_computed_name_super(idx) =>
+            {
+                IRNode::ASTRefWithInheritedComputedNameSuper {
+                    node: idx,
+                    super_name: self.super_name.clone().into(),
+                }
+            }
             k if k == syntax_kind_ext::CLASS_EXPRESSION && self.this_captured.get() => {
                 IRNode::ASTRefWithCapturedClassHeritageThis(idx)
             }
@@ -703,149 +715,6 @@ impl<'a> AstToIr<'a> {
             name: name.into(),
             initializer,
         })
-    }
-
-    fn convert_class_declaration(&self, idx: NodeIndex) -> IRNode {
-        let mut transformer = ES5ClassTransformer::new(self.arena);
-        transformer.set_module_kind(self.module_kind);
-        transformer.set_dynamic_import_promise_counter(self.dynamic_import_promise_counter.get());
-        transformer.set_indent_base(self.class_transformer_indent_base);
-        transformer.set_downlevel_iteration(self.downlevel_iteration);
-        if let Some(transforms) = self.transforms.clone() {
-            transformer.set_transforms(transforms);
-        }
-        if !self.has_tc39_decorator_directive(idx) {
-            let class_decorators = self.collect_class_decorators(idx);
-            let has_member_decorators = self.class_has_member_decorators(idx);
-            if !class_decorators.is_empty() || has_member_decorators {
-                transformer.set_class_decorators(class_decorators);
-                transformer.set_legacy_decorators(has_member_decorators);
-            }
-        }
-        if let Some(source_text) = self.source_text {
-            transformer.set_source_text(source_text);
-        }
-        if self.this_captured.get() {
-            transformer.set_extends_this_captured(true);
-        }
-
-        if let Some(ir) = transformer.transform_class_to_ir(idx) {
-            self.dynamic_import_promise_counter
-                .set(transformer.dynamic_import_promise_counter());
-            return ir;
-        }
-
-        IRNode::ASTRef(idx)
-    }
-
-    fn has_tc39_decorator_directive(&self, idx: NodeIndex) -> bool {
-        self.transforms
-            .as_ref()
-            .and_then(|transforms| transforms.get(idx))
-            .is_some_and(Self::directive_is_tc39_decorators)
-    }
-
-    fn directive_is_tc39_decorators(directive: &TransformDirective) -> bool {
-        match directive {
-            TransformDirective::TC39Decorators { .. } => true,
-            TransformDirective::Chain(items) => {
-                items.iter().any(Self::directive_is_tc39_decorators)
-            }
-            _ => false,
-        }
-    }
-
-    fn collect_class_decorators(&self, idx: NodeIndex) -> Vec<NodeIndex> {
-        let Some(node) = self.arena.get(idx) else {
-            return Vec::new();
-        };
-        let Some(class_data) = self.arena.get_class(node) else {
-            return Vec::new();
-        };
-        Self::collect_decorators_from_modifiers(self.arena, class_data.modifiers.as_ref())
-    }
-
-    fn class_has_member_decorators(&self, idx: NodeIndex) -> bool {
-        let Some(node) = self.arena.get(idx) else {
-            return false;
-        };
-        let Some(class_data) = self.arena.get_class(node) else {
-            return false;
-        };
-        class_data
-            .members
-            .nodes
-            .iter()
-            .any(|&member_idx| self.member_has_decorator(member_idx))
-    }
-
-    fn member_has_decorator(&self, member_idx: NodeIndex) -> bool {
-        let Some(member_node) = self.arena.get(member_idx) else {
-            return false;
-        };
-
-        let modifiers = match member_node.kind {
-            k if k == syntax_kind_ext::METHOD_DECLARATION => self
-                .arena
-                .get_method_decl(member_node)
-                .and_then(|method| method.modifiers.as_ref()),
-            k if k == syntax_kind_ext::PROPERTY_DECLARATION => self
-                .arena
-                .get_property_decl(member_node)
-                .and_then(|property| property.modifiers.as_ref()),
-            k if k == syntax_kind_ext::GET_ACCESSOR || k == syntax_kind_ext::SET_ACCESSOR => self
-                .arena
-                .get_accessor(member_node)
-                .and_then(|accessor| accessor.modifiers.as_ref()),
-            _ => None,
-        };
-        if !Self::collect_decorators_from_modifiers(self.arena, modifiers).is_empty() {
-            return true;
-        }
-
-        let parameters = match member_node.kind {
-            k if k == syntax_kind_ext::METHOD_DECLARATION => self
-                .arena
-                .get_method_decl(member_node)
-                .map(|method| &method.parameters),
-            k if k == syntax_kind_ext::CONSTRUCTOR => self
-                .arena
-                .get_constructor(member_node)
-                .map(|ctor| &ctor.parameters),
-            _ => None,
-        };
-
-        parameters.is_some_and(|params| {
-            params.nodes.iter().any(|&param_idx| {
-                let Some(param_node) = self.arena.get(param_idx) else {
-                    return false;
-                };
-                let Some(param) = self.arena.get_parameter(param_node) else {
-                    return false;
-                };
-                !Self::collect_decorators_from_modifiers(self.arena, param.modifiers.as_ref())
-                    .is_empty()
-            })
-        })
-    }
-
-    fn collect_decorators_from_modifiers(
-        arena: &NodeArena,
-        modifiers: Option<&NodeList>,
-    ) -> Vec<NodeIndex> {
-        modifiers
-            .map(|m| {
-                m.nodes
-                    .iter()
-                    .copied()
-                    .filter(|&mod_idx| {
-                        arena
-                            .get(mod_idx)
-                            .is_some_and(|node| node.kind == syntax_kind_ext::DECORATOR)
-                    })
-                    .collect()
-            })
-            .unwrap_or_default()
     }
 
     fn convert_function_declaration(&self, idx: NodeIndex) -> IRNode {

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_classes.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_classes.rs
@@ -1,0 +1,193 @@
+//! Class declaration conversion helpers for the ES5 class `AstToIr` bridge.
+
+use super::*;
+
+impl<'a> AstToIr<'a> {
+    pub(super) fn convert_class_declaration(&self, idx: NodeIndex) -> IRNode {
+        let mut transformer = ES5ClassTransformer::new(self.arena);
+        transformer.set_module_kind(self.module_kind);
+        transformer.set_dynamic_import_promise_counter(self.dynamic_import_promise_counter.get());
+        transformer.set_indent_base(self.class_transformer_indent_base);
+        transformer.set_downlevel_iteration(self.downlevel_iteration);
+        if let Some(transforms) = self.transforms.clone() {
+            transformer.set_transforms(transforms);
+        }
+        if !self.has_tc39_decorator_directive(idx) {
+            let class_decorators = self.collect_class_decorators(idx);
+            let has_member_decorators = self.class_has_member_decorators(idx);
+            if !class_decorators.is_empty() || has_member_decorators {
+                transformer.set_class_decorators(class_decorators);
+                transformer.set_legacy_decorators(has_member_decorators);
+            }
+        }
+        if let Some(source_text) = self.source_text {
+            transformer.set_source_text(source_text);
+        }
+        if self.this_captured.get() {
+            transformer.set_extends_this_captured(true);
+        }
+        if self.has_super && !self.is_static.get() {
+            transformer.set_inherited_computed_name_super(self.super_name.clone());
+        }
+
+        if let Some(ir) = transformer.transform_class_to_ir(idx) {
+            self.dynamic_import_promise_counter
+                .set(transformer.dynamic_import_promise_counter());
+            return ir;
+        }
+
+        IRNode::ASTRef(idx)
+    }
+
+    pub(super) fn class_expression_has_computed_name_super(&self, idx: NodeIndex) -> bool {
+        let Some(node) = self.arena.get(idx) else {
+            return false;
+        };
+        let Some(class_data) = self.arena.get_class(node) else {
+            return false;
+        };
+        class_data.members.nodes.iter().any(|&member_idx| {
+            let Some(member_node) = self.arena.get(member_idx) else {
+                return false;
+            };
+            let name = match member_node.kind {
+                k if k == syntax_kind_ext::METHOD_DECLARATION => self
+                    .arena
+                    .get_method_decl(member_node)
+                    .map(|method| method.name),
+                k if k == syntax_kind_ext::PROPERTY_DECLARATION => self
+                    .arena
+                    .get_property_decl(member_node)
+                    .map(|property| property.name),
+                k if k == syntax_kind_ext::GET_ACCESSOR || k == syntax_kind_ext::SET_ACCESSOR => {
+                    self.arena
+                        .get_accessor(member_node)
+                        .map(|accessor| accessor.name)
+                }
+                _ => None,
+            };
+            let Some(name) = name else {
+                return false;
+            };
+            let Some(name_node) = self.arena.get(name) else {
+                return false;
+            };
+            if name_node.kind != syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+                return false;
+            }
+            self.arena
+                .get_computed_property(name_node)
+                .is_some_and(|computed| contains_super_reference(self.arena, computed.expression))
+        })
+    }
+
+    fn has_tc39_decorator_directive(&self, idx: NodeIndex) -> bool {
+        self.transforms
+            .as_ref()
+            .and_then(|transforms| transforms.get(idx))
+            .is_some_and(Self::directive_is_tc39_decorators)
+    }
+
+    fn directive_is_tc39_decorators(directive: &TransformDirective) -> bool {
+        match directive {
+            TransformDirective::TC39Decorators { .. } => true,
+            TransformDirective::Chain(items) => {
+                items.iter().any(Self::directive_is_tc39_decorators)
+            }
+            _ => false,
+        }
+    }
+
+    fn collect_class_decorators(&self, idx: NodeIndex) -> Vec<NodeIndex> {
+        let Some(node) = self.arena.get(idx) else {
+            return Vec::new();
+        };
+        let Some(class_data) = self.arena.get_class(node) else {
+            return Vec::new();
+        };
+        Self::collect_decorators_from_modifiers(self.arena, class_data.modifiers.as_ref())
+    }
+
+    fn class_has_member_decorators(&self, idx: NodeIndex) -> bool {
+        let Some(node) = self.arena.get(idx) else {
+            return false;
+        };
+        let Some(class_data) = self.arena.get_class(node) else {
+            return false;
+        };
+        class_data
+            .members
+            .nodes
+            .iter()
+            .any(|&member_idx| self.member_has_decorator(member_idx))
+    }
+
+    fn member_has_decorator(&self, member_idx: NodeIndex) -> bool {
+        let Some(member_node) = self.arena.get(member_idx) else {
+            return false;
+        };
+
+        let modifiers = match member_node.kind {
+            k if k == syntax_kind_ext::METHOD_DECLARATION => self
+                .arena
+                .get_method_decl(member_node)
+                .and_then(|method| method.modifiers.as_ref()),
+            k if k == syntax_kind_ext::PROPERTY_DECLARATION => self
+                .arena
+                .get_property_decl(member_node)
+                .and_then(|property| property.modifiers.as_ref()),
+            k if k == syntax_kind_ext::GET_ACCESSOR || k == syntax_kind_ext::SET_ACCESSOR => self
+                .arena
+                .get_accessor(member_node)
+                .and_then(|accessor| accessor.modifiers.as_ref()),
+            _ => None,
+        };
+        if !Self::collect_decorators_from_modifiers(self.arena, modifiers).is_empty() {
+            return true;
+        }
+
+        let parameters = match member_node.kind {
+            k if k == syntax_kind_ext::METHOD_DECLARATION => self
+                .arena
+                .get_method_decl(member_node)
+                .map(|method| &method.parameters),
+            k if k == syntax_kind_ext::CONSTRUCTOR => self
+                .arena
+                .get_constructor(member_node)
+                .map(|ctor| &ctor.parameters),
+            _ => None,
+        };
+
+        parameters.is_some_and(|params| {
+            params.nodes.iter().any(|&param_idx| {
+                let Some(param_node) = self.arena.get(param_idx) else {
+                    return false;
+                };
+                let Some(param) = self.arena.get_parameter(param_node) else {
+                    return false;
+                };
+                !Self::collect_decorators_from_modifiers(self.arena, param.modifiers.as_ref())
+                    .is_empty()
+            })
+        })
+    }
+
+    fn collect_decorators_from_modifiers(
+        arena: &NodeArena,
+        modifiers: Option<&NodeList>,
+    ) -> Vec<NodeIndex> {
+        modifiers
+            .map(|m| {
+                m.nodes
+                    .iter()
+                    .copied()
+                    .filter(|&mod_idx| {
+                        arena
+                            .get(mod_idx)
+                            .is_some_and(|node| node.kind == syntax_kind_ext::DECORATOR)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}

--- a/crates/tsz-emitter/src/transforms/class_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir.rs
@@ -216,6 +216,14 @@ pub struct ES5ClassTransformer<'a> {
     /// identifier references in class property initializers use the renamed form
     /// when an outer `let`/`const` was renamed during ES5 lowering.
     outer_rename_map: FxHashMap<String, String>,
+    /// Super name of an enclosing *instance* member when this class is lowered
+    /// inside that member's body. A computed property name in such a nested
+    /// class is evaluated inside the enclosing instance method, so a `super`
+    /// reference in the name binds to the outer class's prototype home and must
+    /// lower to `<super>.prototype.m.call(this)` rather than the default
+    /// static-context `<super>.m`. `None` for a top-level/static definition
+    /// site, where computed names keep static-like super access.
+    inherited_computed_name_super: Option<String>,
 }
 
 impl<'a> ES5ClassTransformer<'a> {
@@ -260,6 +268,7 @@ impl<'a> ES5ClassTransformer<'a> {
             extra_hoisted_temps: RefCell::new(Vec::new()),
             emit_computed_props_outside: Cell::new(false),
             outer_rename_map: FxHashMap::default(),
+            inherited_computed_name_super: None,
         }
     }
 
@@ -267,6 +276,14 @@ impl<'a> ES5ClassTransformer<'a> {
     /// variables renamed during ES5 lowering in enclosing scopes).
     pub fn set_outer_rename_map(&mut self, map: FxHashMap<String, String>) {
         self.outer_rename_map = map;
+    }
+
+    /// Record the super name of an enclosing *instance* member when this nested
+    /// class is lowered inside that member's body. Enables prototype-qualified
+    /// `super` lowering for `super` references that appear in this class's
+    /// computed property names.
+    pub fn set_inherited_computed_name_super(&mut self, super_name: String) {
+        self.inherited_computed_name_super = Some(super_name);
     }
 
     pub const fn set_use_define_for_class_fields(&mut self, enable: bool) {
@@ -1019,6 +1036,26 @@ impl<'a> ES5ClassTransformer<'a> {
     /// Convert an AST expression to IR in static context
     fn convert_expression_static(&self, idx: NodeIndex) -> IRNode {
         let converter = self.make_converter().with_static(true);
+        let result = converter.convert_expression(idx);
+        self.collect_from_converter(&converter);
+        result
+    }
+
+    /// Convert a computed-property-name expression that is evaluated inside an
+    /// enclosing *instance* member body. A `super` reference here binds to the
+    /// outer class's prototype home, so super access lowers in instance context
+    /// (`<super>.prototype.m.call(this)`) using the inherited outer super name,
+    /// instead of the default class-definition static context.
+    fn convert_computed_name_expression_instance_super(
+        &self,
+        idx: NodeIndex,
+        outer_super_name: &str,
+    ) -> IRNode {
+        let converter = self
+            .make_converter()
+            .with_super(true)
+            .with_super_name(outer_super_name.to_string())
+            .with_static(false);
         let result = converter.convert_expression(idx);
         self.collect_from_converter(&converter);
         result

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
@@ -369,6 +369,27 @@ impl<'a> ES5ClassTransformer<'a> {
 
         if name_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME {
             if let Some(computed) = self.arena.get_computed_property(name_node) {
+                // A computed property name in a class nested inside an enclosing
+                // *instance* member body evaluates its expression in that member.
+                // A `super` reference there binds to the outer class's prototype
+                // home, so it must lower in instance super context
+                // (`<super>.prototype.m.call(this)`) rather than the default
+                // class-definition static context (`<super>.m`). Only divert
+                // when the name actually references `super`; all other computed
+                // names keep the established static-like behavior.
+                if let Some(outer_super) = self.inherited_computed_name_super.as_ref()
+                    && tsz_parser::syntax::transform_utils::contains_super_reference(
+                        self.arena,
+                        computed.expression,
+                    )
+                {
+                    return IRMethodName::Computed(Box::new(
+                        self.convert_computed_name_expression_instance_super(
+                            computed.expression,
+                            outer_super,
+                        ),
+                    ));
+                }
                 return IRMethodName::Computed(Box::new(
                     self.convert_computed_property_expression(computed.expression, true),
                 ));

--- a/crates/tsz-emitter/src/transforms/ir.rs
+++ b/crates/tsz-emitter/src/transforms/ir.rs
@@ -553,6 +553,14 @@ pub enum IRNode {
     /// should be evaluated in a captured constructor receiver context.
     ASTRefWithCapturedClassHeritageThis(NodeIndex),
 
+    /// Reference to an original class expression whose computed property names
+    /// should inherit an enclosing instance `super` home while the nested
+    /// printer applies normal ES5 class-expression lowering.
+    ASTRefWithInheritedComputedNameSuper {
+        node: NodeIndex,
+        super_name: Cow<'static, str>,
+    },
+
     /// Reference to an original AST node with constrained source range.
     /// Used when the parser's node.end extends into a parent block's closing brace.
     ASTRefRange(NodeIndex, u32),
@@ -1228,6 +1236,7 @@ impl IRNode {
             | Self::ASTRef(_)
             | Self::ASTRefWithGeneratorThis { .. }
             | Self::ASTRefWithCapturedClassHeritageThis(_)
+            | Self::ASTRefWithInheritedComputedNameSuper { .. }
             | Self::ASTRefRange(..)
             | Self::UseStrict
             | Self::EsesModuleMarker => false,

--- a/crates/tsz-emitter/src/transforms/ir_printer.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer.rs
@@ -35,6 +35,7 @@ use ir_printer_namespace::NamespaceIifeContext;
 
 use crate::context::transform::TransformContext;
 use crate::emitter::{Printer as AstPrinter, PrinterOptions};
+use crate::transforms::ClassES5Emitter;
 use crate::transforms::ir::{
     EnumMember, EnumMemberValue, IRMethodName, IRNode, IRParam, IRProperty, IRPropertyKey,
     IRPropertyKind, IRSwitchCase,
@@ -1704,6 +1705,43 @@ impl<'a> IRPrinter<'a> {
                     printer.emit_expression(*idx);
                     self.merge_ast_printer_block_scope_reserved_names(&printer);
                     let output = printer.get_output();
+                    if !output.trim().is_empty() {
+                        self.write_embedded_output(output.trim());
+                        return;
+                    }
+                }
+                self.write("undefined");
+            }
+
+            IRNode::ASTRefWithInheritedComputedNameSuper { node, super_name } => {
+                if let Some(arena) = self.arena {
+                    let mut es5_emitter = ClassES5Emitter::new(arena);
+                    es5_emitter.set_indent_level(0);
+                    es5_emitter.set_remove_comments(self.remove_comments);
+                    es5_emitter.set_tslib_prefix(self.tslib_prefix);
+                    es5_emitter.set_tslib_import_binding(self.tslib_import_binding.clone());
+                    es5_emitter.set_inherited_computed_name_super(super_name.to_string());
+                    es5_emitter.set_printer_options(self.make_ast_printer_options());
+                    if let Some(source_text) = self.source_text {
+                        es5_emitter.set_source_text(source_text);
+                    }
+                    if let Some(transforms) = self.transforms.clone() {
+                        es5_emitter.set_transforms(transforms);
+                    }
+                    let class_name = arena
+                        .get(*node)
+                        .and_then(|class_node| arena.get_class(class_node))
+                        .and_then(|class_data| {
+                            arena
+                                .get(class_data.name)
+                                .and_then(|name_node| arena.get_identifier(name_node))
+                                .map(|name| name.escaped_text.clone())
+                        });
+                    let output = if let Some(class_name) = class_name {
+                        es5_emitter.emit_class_as_iife_expr(*node, &class_name).0
+                    } else {
+                        es5_emitter.emit_class_as_iife_expr(*node, "class_1").0
+                    };
                     if !output.trim().is_empty() {
                         self.write_embedded_output(output.trim());
                         return;

--- a/crates/tsz-emitter/tests/es5_nested_class_computed_name_super_tests.rs
+++ b/crates/tsz-emitter/tests/es5_nested_class_computed_name_super_tests.rs
@@ -1,0 +1,204 @@
+//! ES5 `super` lowering inside a nested class's computed property name.
+//!
+//! Structural rule: when a class is declared inside an enclosing *instance*
+//! member body of a derived class, a `super` reference that appears in that
+//! nested class's computed property name is evaluated in the enclosing member,
+//! so it binds to the outer class's prototype home. At ES5 such a `super`
+//! method call must lower to `_super.prototype.m.call(this)`, the instance
+//! super form — not the class-definition static form `_super.m.call(this)`.
+//!
+//! A nested class declared inside a *static* member (or at a class-definition
+//! site with no enclosing instance super home) keeps the established
+//! static-like computed-name super access. The behaviour is keyed on the
+//! structural instance-vs-static enclosing-member distinction, not on any
+//! identifier spelling, so the tests vary the super method name, the outer and
+//! nested class names, and the member name.
+
+use tsz_common::common::ScriptTarget;
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_lower_print;
+
+fn emit_es5(source: &str) -> String {
+    let opts = PrintOptions {
+        target: ScriptTarget::ES5,
+        ..Default::default()
+    };
+    parse_and_lower_print(source, opts)
+}
+
+/// Reported shape: a nested class declaration inside an instance method whose
+/// computed name calls `super.m()` lowers in instance super context.
+#[test]
+fn nested_class_decl_computed_name_super_call_is_prototype_qualified() {
+    let source = r#"class A {
+    foo() { return 1; }
+}
+class B extends A {
+    foo() { return 2; }
+    bar() {
+        class Local {
+            [super.foo()]() { return 100; }
+        }
+        return Local;
+    }
+}"#;
+    let output = emit_es5(source);
+    assert!(
+        output.contains("_super.prototype.foo.call(this)"),
+        "super method call in a nested class's computed name (enclosing instance \
+         method) must be prototype-qualified.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("[_super.foo.call(this)]"),
+        "must NOT use the static-context base for the instance-home super.\nOutput:\n{output}"
+    );
+}
+
+/// Same rule with the super method, classes, and member names all renamed:
+/// proves the behaviour is structural, not keyed on `foo`/`A`/`B`/`Local`.
+#[test]
+fn nested_class_decl_computed_name_super_call_renamed_members() {
+    let source = r#"class Base {
+    ping(): number { return 1; }
+}
+class Derived extends Base {
+    ping(): number { return 2; }
+    make() {
+        class Inner {
+            [super.ping()]() { return 7; }
+        }
+        return Inner;
+    }
+}"#;
+    let output = emit_es5(source);
+    assert!(
+        output.contains("_super.prototype.ping.call(this)"),
+        "renamed super method must still lower prototype-qualified.\nOutput:\n{output}"
+    );
+}
+
+/// `super[expr]()` element-access form in the nested computed name lowers the
+/// same way.
+#[test]
+fn nested_class_decl_computed_name_super_element_call_is_prototype_qualified() {
+    let source = r#"class A {
+    foo() { return 1; }
+}
+class B extends A {
+    foo() { return 2; }
+    bar() {
+        class Local {
+            [super["foo"]()]() { return 100; }
+        }
+        return Local;
+    }
+}"#;
+    let output = emit_es5(source);
+    assert!(
+        output.contains("_super.prototype[\"foo\"].call(this)"),
+        "super element-access call in a nested computed name (enclosing instance \
+         method) must be prototype-qualified.\nOutput:\n{output}"
+    );
+}
+
+/// Negative / fallback case: when the nested class is declared inside a
+/// *static* member, there is no enclosing instance super home, so the computed
+/// name keeps the static-like base (`_super.foo`), never `_super.prototype.foo`.
+#[test]
+fn nested_class_decl_in_static_member_keeps_static_super_base() {
+    let source = r#"class A {
+    static foo() { return 1; }
+}
+class B extends A {
+    static foo() { return 2; }
+    static bar() {
+        class Local {
+            [super.foo()]() { return 100; }
+        }
+        return Local;
+    }
+}"#;
+    let output = emit_es5(source);
+    assert!(
+        !output.contains("_super.prototype.foo.call(this)"),
+        "a nested class in a static member must not gain an instance-home super \
+         base for its computed name.\nOutput:\n{output}"
+    );
+}
+
+/// Same instance-home rule for the deferred class-expression path: the
+/// returned anonymous class is emitted by a nested printer, but its computed
+/// name still evaluates in the enclosing instance method.
+#[test]
+fn nested_class_expr_computed_name_super_call_is_prototype_qualified() {
+    let source = r#"class A {
+    foo() { return 1; }
+}
+class B extends A {
+    foo() { return 2; }
+    bar() {
+        return class {
+            [super.foo()]() { return 100; }
+        };
+    }
+}"#;
+    let output = emit_es5(source);
+    assert!(
+        output.contains("_super.prototype.foo.call(this)"),
+        "super method call in a nested class expression's computed name must \
+         inherit the enclosing instance super home.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("[_super.foo.call(this)]"),
+        "deferred class-expression lowering must not fall back to the static \
+         super base for an enclosing instance member.\nOutput:\n{output}"
+    );
+}
+
+/// The deferred class-expression path also handles element access without
+/// depending on a particular property spelling.
+#[test]
+fn nested_class_expr_computed_name_super_element_call_is_prototype_qualified() {
+    let source = r#"class Parent {
+    label() { return "ok"; }
+}
+class Child extends Parent {
+    make() {
+        return class {
+            [super["label"]()]() { return 1; }
+        };
+    }
+}"#;
+    let output = emit_es5(source);
+    assert!(
+        output.contains("_super.prototype[\"label\"].call(this)"),
+        "super element access in a deferred nested class expression's computed \
+         name must inherit the enclosing instance super home.\nOutput:\n{output}"
+    );
+}
+
+/// Static enclosing members do not provide an instance super home to deferred
+/// class expressions.
+#[test]
+fn nested_class_expr_in_static_member_keeps_static_super_base() {
+    let source = r#"class A {
+    static foo() { return 1; }
+}
+class B extends A {
+    static make() {
+        return class {
+            [super.foo()]() { return 100; }
+        };
+    }
+}"#;
+    let output = emit_es5(source);
+    assert!(
+        !output.contains("_super.prototype.foo.call(this)"),
+        "a class expression inside a static member must not inherit an instance \
+         super home.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
AgentName: Studio-C

Track: emit-100 — outer-this/super capture-phase for static and nested class member lowering.

Invariant: ES5 `super` lowering must match tsc. A `super` reference in a nested class computed property name binds to the lexical home where that name is evaluated, not to the nested class itself.

## Structural Rule
When a class declaration or class expression is evaluated inside an enclosing derived **instance** member, and one of the nested class's computed member names contains `super`, the computed-name evaluation inherits the outer instance super home. At ES5, that lowers method calls as `_super.prototype.m.call(this)` or element access as `_super.prototype[expr].call(this)`.

Static enclosing members keep the established static base (`_super.m.call(this)`), and class expressions without computed-name `super` stay on the normal deferred emit path. The gate is structural (`contains_super_reference` over the computed name plus an enclosing instance super home), with no identifier spelling or printer-output matching.

## Scope
Owner layer: ES5 class emit transform and IR printing. The checker is not involved.

- `class_es5_ast_to_ir.rs` now recognizes nested class expressions whose computed member names contain `super`, and carries the inherited super home across the IR boundary.
- `class_es5_ast_to_ir_classes.rs` splits class declaration and decorator conversion out of the large AST-to-IR transform shard, keeping the touched files under the 2000-line rule.
- `ir.rs` adds a focused IR node for deferred AST class-expression emission with inherited computed-name super context.
- `ir_printer.rs` emits that node through `ClassES5Emitter` rather than string surgery or checker-side state.
- `class_es5.rs` exposes a narrow setter for inherited computed-name super context.
- `es5_nested_class_computed_name_super_tests.rs` covers declaration, expression, element access, renamed members, and static negative cases.

## Adjacent-Case Matrix
- Nested class declaration, reported shape: `super.foo()` becomes `_super.prototype.foo.call(this)`.
- Nested class declaration, renamed outer/nested names: structural coverage, not spelling-keyed.
- Nested class declaration, element access: `super["foo"]()` becomes `_super.prototype["foo"].call(this)`.
- Static method negative: keeps static super base.
- Nested class expression, reported ES5 conformance witness shape: passes.
- Nested class expression, element access: passes.
- Static class expression negative: keeps static super base.
- `derivedClassSuperProperties` collateral guard: unchanged pass after tightening the class-expression gate.

## Project Corpus Impact
- Row: n/a
- Bug family: ES5 `super` lowering in nested-class computed property names
- Evidence: emit/test-only behavior slice; targeted emit witness `superPropertyAccessInComputedPropertiesOfNestedType_ES5` is now 2/2 for js-only output; no project-corpus benchmark row is affected.

## Verification
- `cargo fmt --check`
- `cargo nextest run -p tsz-emitter --test es5_nested_class_computed_name_super_tests` — 7/7 pass
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh scripts/emit/run.sh --filter=superPropertyAccessInComputedPropertiesOfNestedType_ES5 --js-only --verbose --timeout=30000 --json-out=/tmp/superPropertyAccessInComputedPropertiesOfNestedType_ES5-studio-c-class-expr-tight-final.json` — 2/2 pass
- `scripts/safe-run.sh scripts/emit/run.sh --filter=superProperty --js-only --skip-build --timeout=30000 --json-out=/tmp/superProperty-family-studio-c-tight-final.json` — 22/22 pass
- `scripts/safe-run.sh scripts/emit/run.sh --filter=derivedClassSuperProperties --js-only --skip-build --verbose --timeout=30000 --json-out=/tmp/derivedClassSuperProperties-studio-c-tight-final.json` — 2/2 pass
- `scripts/safe-run.sh scripts/emit/run.sh --filter=class --js-only --skip-build --timeout=10000 --json-out=/tmp/class-family-studio-c-tight-final.json` — 1474/1480 pass; remaining residual failures observed in this branch: `jsDeclarationsClasses(target=es5)`, `nestedClassDeclaration`, `nestedGlobalNamespaceInClass`, `privateNameWhenNotUseDefineForClassFieldsInEsNext(target=esnext)`, `privateNameWhenNotUseDefineForClassFieldsInEsNext(target=es2020)`, `staticPropertyNameConflicts(target=es5,usedefineforclassfields=true)`.

## Coordination Notes
Rebased on current `origin/main` and pushed as `8c8c2cd862`. The earlier class-expression deferred-ASTRef gap is fixed: the reported class-expression witness and adjacent expression element-access case now pass. `nestedClassDeclaration` in the broader class smoke remains covered by the separate Studio-C PR #11957, so this PR stays focused on computed-name `super` home inheritance.

AgentName: Studio-C




