### PR TITLE
fix(emit-tools): headline public aggregate when detail is stale

### DIFF
--- a/scripts/emit/query-emit.py
+++ b/scripts/emit/query-emit.py
@@ -269,6 +269,21 @@ def emit_freshness_status_line(data):
     return f"Emit detail freshness: {state}."
 
 
+def emit_pass_rate(summary, prefix):
+    passed = summary.get(f"{prefix}Pass")
+    total = summary.get(f"{prefix}Total")
+    if passed is None or total is None or total <= 0:
+        return "N/A"
+    return f"{(passed / total) * 100:.1f}"
+
+
+def emit_headline_summary(detail_summary, public_summary):
+    status = emit_freshness_status(detail_summary, public_summary)
+    if status["state"] == "stale":
+        return public_summary, "README/public aggregate"
+    return detail_summary, "checked detail"
+
+
 def emit_remaining_failures(summary, surface):
     prefix = "js" if surface == "js" else "dts"
     passed = summary.get(f"{prefix}Pass")
@@ -308,10 +323,30 @@ def print_emit_freshness_note(data):
 
 def show_overview(data):
     s = data["summary"]
+    public_summary = emit_summary_from_readme()
+    headline_summary, headline_source = emit_headline_summary(emit_summary(data), public_summary)
     print(f"Emit Test Results")
     print_emit_freshness_note(data)
-    print(f"  JavaScript: {s['jsPass']}/{s['jsTotal']} ({s['jsPassRate']}%)")
-    print(f"  Declaration: {s['dtsPass']}/{s['dtsTotal']} ({s['dtsPassRate']}%)")
+    print(f"  Source: {headline_source}")
+    print(
+        "  JavaScript: "
+        f"{headline_summary['jsPass']}/{headline_summary['jsTotal']} "
+        f"({emit_pass_rate(headline_summary, 'js')}%)"
+    )
+    print(
+        "  Declaration: "
+        f"{headline_summary['dtsPass']}/{headline_summary['dtsTotal']} "
+        f"({emit_pass_rate(headline_summary, 'dts')}%)"
+    )
+    if headline_source != "checked detail":
+        print(
+            "  Checked-detail JavaScript: "
+            f"{s['jsPass']}/{s['jsTotal']} ({s['jsPassRate']}%)"
+        )
+        print(
+            "  Checked-detail Declaration: "
+            f"{s['dtsPass']}/{s['dtsTotal']} ({s['dtsPassRate']}%)"
+        )
     print()
 
     results = data["results"]

--- a/scripts/emit/test_query_emit_families.py
+++ b/scripts/emit/test_query_emit_families.py
@@ -186,6 +186,40 @@ after
 
         self.assertEqual(heading, "Declaration: 25 failures/timeouts")
 
+    def test_stale_headline_summary_uses_public_aggregate(self):
+        detail_summary = {
+            "jsPass": 13094,
+            "jsTotal": 13530,
+            "dtsPass": 1606,
+            "dtsTotal": 1669,
+        }
+        public_summary = {
+            "jsPass": 13459,
+            "jsTotal": 13530,
+            "dtsPass": 1644,
+            "dtsTotal": 1669,
+        }
+
+        summary, source = self.mod.emit_headline_summary(detail_summary, public_summary)
+
+        self.assertEqual(source, "README/public aggregate")
+        self.assertEqual(summary["jsPass"], 13459)
+        self.assertEqual(summary["dtsPass"], 1644)
+
+    def test_current_headline_summary_uses_checked_detail(self):
+        detail_summary = {
+            "jsPass": 13459,
+            "jsTotal": 13530,
+            "dtsPass": 1644,
+            "dtsTotal": 1669,
+        }
+        public_summary = dict(detail_summary)
+
+        summary, source = self.mod.emit_headline_summary(detail_summary, public_summary)
+
+        self.assertEqual(source, "checked detail")
+        self.assertEqual(summary, detail_summary)
+
 
 class TestQueryFilters(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 1 release metric truth; emit tooling/reporting fix.

## Invariant
When README/public emit aggregate and checked per-test emit detail cover the same totals but the public aggregate has more passes, the public aggregate is the current headline metric while checked detail remains the failure-family evidence source.

## Scope
- `scripts/emit/query-emit.py`
- `scripts/emit/test_query_emit_families.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: emit-metric reporting only; no project-row fixture, benchmark row, checker, solver, parser, binder, emitter, or corpus behavior changes.

## Verification
- `python3 -m unittest scripts.emit.test_query_emit_families`
- `python3 scripts/emit/query-emit.py | sed -n '1,40p'`
- `python3 scripts/emit/query-emit.py --families | sed -n '1,36p'`
- `python3 scripts/emit/query-emit.py --freshness`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Existing Studio-A PRs were clear before this branch.
- Fixed label hygiene on WIP PR #11959 by adding the canonical `agent:Studio-C` label and leaving its WIP/draft state untouched.
- This PR changes code/test tooling only; no repository markdown/docs files were edited.
