### PR TITLE
test(solver): guard callback relation cache partition

### DIFF
--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -4,6 +4,9 @@
 #[path = "relation_policy_cache_agreement_tests/cache_agreement.rs"]
 mod cache_agreement;
 
+#[path = "relation_policy_cache_agreement_tests/callback_kind_partitioning.rs"]
+mod callback_kind_partitioning;
+
 #[path = "relation_policy_cache_agreement_tests/any_mode_partitioning.rs"]
 mod any_mode_partitioning;
 

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/callback_kind_partitioning.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/callback_kind_partitioning.rs
@@ -1,0 +1,86 @@
+//! Callback-relation cache partitioning tests.
+
+use crate::caches::db::QueryDatabase;
+use crate::caches::query_cache::QueryCache;
+use crate::intern::TypeInterner;
+use crate::relations::relation_queries::{
+    RelationContext, RelationKind, RelationPolicy, query_relation,
+};
+use crate::types::{
+    FunctionShape, ParamInfo, PropertyInfo, RelationCacheKey, RelationFlags, TypeId,
+};
+
+#[test]
+fn bivariant_callback_kind_does_not_populate_strict_assignability_slot() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let name = interner.intern_string("name");
+    let breed = interner.intern_string("breed");
+
+    let animal = interner.object(vec![PropertyInfo::new(name, TypeId::STRING)]);
+    let dog = interner.object(vec![
+        PropertyInfo::new(name, TypeId::STRING),
+        PropertyInfo::new(breed, TypeId::STRING),
+    ]);
+    let source = interner.function(FunctionShape::new(
+        vec![ParamInfo::unnamed(dog)],
+        TypeId::VOID,
+    ));
+    let target = interner.function(FunctionShape::new(
+        vec![ParamInfo::unnamed(animal)],
+        TypeId::VOID,
+    ));
+
+    let strict_policy = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_NULL_CHECKS | RelationFlags::STRICT_FUNCTION_TYPES,
+    );
+    let strict_assignability_key =
+        RelationCacheKey::for_assignability(source, target, strict_policy.cache_config());
+
+    let strict_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        strict_policy,
+        RelationContext::default(),
+    )
+    .is_related();
+    assert!(
+        !strict_uncached,
+        "strict assignability should reject contravariant callback parameter narrowing",
+    );
+
+    let bivariant_with_cache = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::AssignableBivariantCallbacks,
+        strict_policy,
+        RelationContext {
+            query_db: Some(&db),
+            ..RelationContext::default()
+        },
+    )
+    .is_related();
+    assert!(
+        bivariant_with_cache,
+        "callback-bivariant relation should accept the same parameter comparison",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(strict_assignability_key),
+        None,
+        "callback mode must not populate the ordinary strict assignability slot",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, strict_policy),
+        strict_uncached,
+        "ordinary strict assignability must still match direct query_relation after callback mode",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(strict_assignability_key),
+        Some(strict_uncached),
+        "ordinary strict assignability should populate its own cache slot after lookup",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 4 solver relation policy/cache-key contracts; refactor-only/test guard.

## Invariant
When callback-bivariant assignability relaxes function parameter variance for a one-off relation query, that result must not populate the ordinary strict assignability cache slot.

## Scope
- Add a focused solver relation policy cache-agreement test shard.
- Register the shard without growing the existing near-limit cache agreement file.

## Project Corpus Impact
- Row: n/a
- Bug family: relation cache-key policy / callback variance guard
- Evidence: test-only guard for solver cache partitioning; no compiler behavior changes.

## Verification
- cargo fmt --check
- cargo nextest run -p tsz-solver bivariant_callback_kind_does_not_populate_strict_assignability_slot
- Current base: a379738fd4e43c1684f0cfbaf1c4873c74da664d
- Current head: 2de09d077eb6d6a042f045f0103edab08ff57973

## Coordination Notes
- Independent M4-B slice for #8207; does not modify production solver behavior.
- Existing ready M4-B PRs #11920, #11922, and #11952 remain unqueued while refreshed exact-head CI runs.
- #11947 remains draft/stacked on #11922.