### PR TITLE
chore(arch): expose guard failure counts

### DIFF
--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -41,10 +41,13 @@ def write_json_report(report_path: Path, payload: dict) -> None:
 
 def build_json_payload(failures: list[tuple[str, list[str]]], total_hits: int) -> dict:
     ok = not failures
+    failed_hit_count = sum(len(hits) for _, hits in failures)
     return {
         "ok": ok,
         "status": "failed" if failures else "passed",
         "total_hits": total_hits,
+        "failure_count": len(failures),
+        "failed_hit_count": failed_hit_count,
         "failures": [{"name": name, "hits": hits} for name, hits in failures],
     }
 

--- a/scripts/arch/test_arch_guard.py
+++ b/scripts/arch/test_arch_guard.py
@@ -13,20 +13,41 @@ class ArchGuardJsonReportTests(unittest.TestCase):
     def test_json_payload_includes_boolean_ok_status(self):
         self.assertEqual(
             self.arch_guard.build_json_payload([], 0),
-            {"ok": True, "status": "passed", "total_hits": 0, "failures": []},
+            {
+                "ok": True,
+                "status": "passed",
+                "total_hits": 0,
+                "failure_count": 0,
+                "failed_hit_count": 0,
+                "failures": [],
+            },
         )
         self.assertEqual(
-            self.arch_guard.build_json_payload([("Rule", ["src/lib.rs:1"])], 1),
+            self.arch_guard.build_json_payload(
+                [("Rule", ["src/lib.rs:1", "src/lib.rs:2"])],
+                2,
+            ),
             {
                 "ok": False,
                 "status": "failed",
-                "total_hits": 1,
-                "failures": [{"name": "Rule", "hits": ["src/lib.rs:1"]}],
+                "total_hits": 2,
+                "failure_count": 1,
+                "failed_hit_count": 2,
+                "failures": [
+                    {"name": "Rule", "hits": ["src/lib.rs:1", "src/lib.rs:2"]}
+                ],
             },
         )
 
     def test_write_json_report_is_atomic_and_stable(self):
-        payload = {"ok": True, "total_hits": 0, "status": "passed", "failures": []}
+        payload = {
+            "ok": True,
+            "total_hits": 0,
+            "status": "passed",
+            "failure_count": 0,
+            "failed_hit_count": 0,
+            "failures": [],
+        }
         with tempfile.TemporaryDirectory() as tmp:
             report_path = pathlib.Path(tmp) / "nested" / "arch_guard.json"
             self.arch_guard.write_json_report(report_path, payload)


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / architecture guardrail evidence.

## Invariant
Architecture guard JSON reports should expose direct failure counters so agents and automation do not need to infer failing rule count or failing hit count from free-form failure arrays.

## Scope
- Add `failure_count` and `failed_hit_count` to `scripts/arch/arch_guard.py` JSON payloads.
- Update `scripts/arch/test_arch_guard.py` JSON contract coverage while preserving existing `ok`, `status`, `total_hits`, and `failures` keys.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: arch-script-only report-shape change; no compiler, checker, solver, emitter, or project corpus behavior changes.

## Verification
- `python3 -m unittest test_arch_guard.ArchGuardJsonReportTests` from `scripts/arch`
- `python3 -m unittest discover -p 'test_arch_guard*.py'` from `scripts/arch` (472 tests)
- `python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard-arch-report.json`
- `git diff --check origin/main...HEAD`

## Coordination Notes
- Started after Studio-F owned work was clear and #11960 merged.
- No overlap with active emit/checker/solver PRs; this touches only arch guard evidence plumbing.
- The dirty primary checkout currently trips an arch size ratchet in Studio-C WIP files, but this branch is clean on current `origin/main` and the live arch guard passes here.
- Opened as draft for light CI and coordination.
