### PR TITLE
chore(agents): summarize owned work report

### DIFF
--- a/scripts/agents/list-owned-work.sh
+++ b/scripts/agents/list-owned-work.sh
@@ -228,6 +228,7 @@ const row = {
   issues: JSON.parse(process.env.ROW_ISSUES ?? "[]"),
   pr_count: Number(process.env.ROW_PR_COUNT ?? 0),
   issue_count: Number(process.env.ROW_ISSUE_COUNT ?? 0),
+  owned_work_clear: process.env.ROW_STATUS === "clear",
   owned_work_status: process.env.ROW_STATUS,
 };
 process.stdout.write(`${JSON.stringify(row)}\n`);
@@ -250,11 +251,23 @@ const agents = (process.env.REPORT_ROWS ?? "")
   .split(/\n/)
   .filter(Boolean)
   .map((line) => JSON.parse(line));
+const totalPrCount = agents.reduce((sum, agent) => sum + Number(agent.pr_count ?? 0), 0);
+const totalIssueCount = agents.reduce(
+  (sum, agent) => sum + Number(agent.issue_count ?? 0),
+  0,
+);
+const totalOwnedCount = totalPrCount + totalIssueCount;
+const ownedWorkClear = totalOwnedCount === 0;
 
 const report = {
   generated_by: "scripts/agents/list-owned-work.sh",
   repository: process.env.REPOSITORY,
   with_pr_state: process.env.WITH_PR_STATE === "true",
+  owned_work_clear: ownedWorkClear,
+  owned_work_status: ownedWorkClear ? "clear" : "active",
+  total_pr_count: totalPrCount,
+  total_issue_count: totalIssueCount,
+  total_owned_count: totalOwnedCount,
   agents,
 };
 

--- a/scripts/agents/test_list_owned_work.py
+++ b/scripts/agents/test_list_owned_work.py
@@ -74,12 +74,18 @@ exec "$@"
             self.assertEqual("scripts/agents/list-owned-work.sh", report["generated_by"])
             self.assertEqual("mohsen1/tsz", report["repository"])
             self.assertFalse(report["with_pr_state"])
+            self.assertFalse(report["owned_work_clear"])
+            self.assertEqual("active", report["owned_work_status"])
+            self.assertEqual(1, report["total_pr_count"])
+            self.assertEqual(1, report["total_issue_count"])
+            self.assertEqual(2, report["total_owned_count"])
             self.assertEqual(1, len(report["agents"]))
             row = report["agents"][0]
             self.assertEqual("Studio-F", row["agent"])
             self.assertEqual("agent:Studio-F", row["label"])
             self.assertEqual(1, row["pr_count"])
             self.assertEqual(1, row["issue_count"])
+            self.assertFalse(row["owned_work_clear"])
             self.assertEqual("active", row["owned_work_status"])
             self.assertEqual(
                 ["#1 ready first PR https://github.com/mohsen1/tsz/pull/1"],
@@ -89,6 +95,21 @@ exec "$@"
                 ["#2 issue https://github.com/mohsen1/tsz/issues/2"],
                 row["issues"],
             )
+
+    def test_json_report_marks_clear_runway(self):
+        with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
+            report_path = pathlib.Path(temp_dir) / "owned-work.json"
+
+            self.run_list_owned_work(["Studio-F", "--json-report", str(report_path)])
+
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertTrue(report["owned_work_clear"])
+            self.assertEqual("clear", report["owned_work_status"])
+            self.assertEqual(0, report["total_pr_count"])
+            self.assertEqual(0, report["total_issue_count"])
+            self.assertEqual(0, report["total_owned_count"])
+            self.assertTrue(report["agents"][0]["owned_work_clear"])
+            self.assertEqual("clear", report["agents"][0]["owned_work_status"])
 
     def test_json_report_requires_path(self):
         result = subprocess.run(


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / owned-work runway evidence.

## Invariant
Owned-work JSON reports should expose direct aggregate runway status so agents and automation do not need to infer whether selected work is clear from per-agent arrays.

## Scope
- Add top-level `owned_work_clear`, `owned_work_status`, and total PR/issue/owned counters to `scripts/agents/list-owned-work.sh` JSON reports.
- Add per-agent `owned_work_clear` alongside the existing `owned_work_status` row field.
- Cover active and clear JSON report states in `scripts/agents/test_list_owned_work.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent-script-only report-shape change; no compiler, checker, solver, emitter, or project corpus behavior changes.

## Verification
- `python3 scripts/agents/test_list_owned_work.py`
- `bash -n scripts/agents/list-owned-work.sh`
- `git diff --check origin/main...HEAD`
- `scripts/agents/list-owned-work.sh Studio-F --json-report /tmp/tsz-owned-work-owned-report.json`

## Coordination Notes
- Started after Studio-F owned work was clear and #11963 had merged.
- No overlap with active emit/checker/solver PRs; this touches only agent owned-work evidence plumbing.
- The primary checkout has another lane's dirty files; this PR was prepared in a clean worktree from current `origin/main`.
- Opened as draft for light CI and coordination.
