### PR TITLE
fix(emit-tools): label stale detail counters

### DIFF
--- a/scripts/emit/query-emit.py
+++ b/scripts/emit/query-emit.py
@@ -347,6 +347,7 @@ def show_overview(data):
             "  Checked-detail Declaration: "
             f"{s['dtsPass']}/{s['dtsTotal']} ({s['dtsPassRate']}%)"
         )
+    detail_label = "Checked-detail " if headline_source != "checked detail" else ""
     print()
 
     results = data["results"]
@@ -354,18 +355,21 @@ def show_overview(data):
     dts_fails = [r for r in results if r["dtsStatus"] == "fail"]
     timeouts = [r for r in results if r["jsStatus"] == "timeout" or r["dtsStatus"] == "timeout"]
 
-    print(f"  JS failures: {len(js_fails)}")
-    print(f"  DTS failures: {len(dts_fails)}")
-    print(f"  Timeouts: {len(timeouts)}")
+    print(f"  {detail_label}JS failures: {len(js_fails)}")
+    print(f"  {detail_label}DTS failures: {len(dts_fails)}")
+    print(f"  {detail_label}Timeouts: {len(timeouts)}")
     print()
 
     # JS-pass but DTS-fail (close to full pass)
     js_pass_dts_fail = [r for r in results if r["jsStatus"] == "pass" and r["dtsStatus"] == "fail"]
-    print(f"  JS pass + DTS fail (close to full pass): {len(js_pass_dts_fail)}")
+    print(
+        f"  {detail_label}JS pass + DTS fail (close to full pass): "
+        f"{len(js_pass_dts_fail)}"
+    )
 
     # DTS-pass but JS-fail
     dts_pass_js_fail = [r for r in results if r["dtsStatus"] == "pass" and r["jsStatus"] == "fail"]
-    print(f"  DTS pass + JS fail: {len(dts_pass_js_fail)}")
+    print(f"  {detail_label}DTS pass + JS fail: {len(dts_pass_js_fail)}")
     print()
 
     # Top error messages

--- a/scripts/emit/test_query_emit_families.py
+++ b/scripts/emit/test_query_emit_families.py
@@ -220,6 +220,52 @@ after
         self.assertEqual(source, "checked detail")
         self.assertEqual(summary, detail_summary)
 
+    def test_stale_overview_labels_checked_detail_counters(self):
+        data = {
+            "summary": {
+                "jsPass": 13094,
+                "jsTotal": 13530,
+                "jsPassRate": 96.8,
+                "dtsPass": 1606,
+                "dtsTotal": 1669,
+                "dtsPassRate": 96.2,
+            },
+            "results": [
+                {
+                    "name": "jsOnlyFailure",
+                    "jsStatus": "fail",
+                    "dtsStatus": "pass",
+                    "jsError": "+1/-1 lines",
+                },
+                {
+                    "name": "dtsOnlyFailure",
+                    "jsStatus": "pass",
+                    "dtsStatus": "fail",
+                    "dtsError": "+1/-1 lines",
+                },
+            ],
+        }
+        original = self.mod.emit_summary_from_readme
+        self.mod.emit_summary_from_readme = lambda: {
+            "jsPass": 13459,
+            "jsTotal": 13530,
+            "dtsPass": 1644,
+            "dtsTotal": 1669,
+        }
+        try:
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                self.mod.show_overview(data)
+        finally:
+            self.mod.emit_summary_from_readme = original
+
+        text = out.getvalue()
+        self.assertIn("Source: README/public aggregate", text)
+        self.assertIn("JavaScript: 13459/13530 (99.5%)", text)
+        self.assertIn("Checked-detail JS failures: 1", text)
+        self.assertIn("Checked-detail DTS failures: 1", text)
+        self.assertIn("Checked-detail JS pass + DTS fail", text)
+
 
 class TestQueryFilters(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 1 release metric truth; emit tooling/reporting fix.

## Invariant
When README/public emit aggregate is the headline metric because checked per-test detail is stale, overview counters derived from checked per-test detail must be labeled as checked-detail counters instead of appearing as current aggregate truth.

## Scope
- `scripts/emit/query-emit.py`
- `scripts/emit/test_query_emit_families.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: emit-metric reporting only; no project-row fixture, benchmark row, checker, solver, parser, binder, emitter, or corpus behavior changes.

## Verification
- `python3 -m unittest scripts.emit.test_query_emit_families`
- `python3 scripts/emit/query-emit.py | sed -n '1,24p'`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Existing Studio-A PRs were clear before this branch.
- Disk guard is low on this machine (11 GB after cache-preserving cleanup), so local verification stayed in lightweight Python/script checks and avoided new build caches.
- This PR changes code/test tooling only; no repository markdown/docs files were edited.
