### PR TITLE
fix(emit): preserve dynamic import template coercion

### DIFF
--- a/crates/tsz-emitter/src/emitter/expressions/call.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/call.rs
@@ -943,10 +943,10 @@ impl<'a> Printer<'a> {
     /// Cases by specifier shape, matching tsc:
     ///
     /// - Captured temp / string literal / no-arg: lazy `Promise.resolve().then(() => require(x))`.
-    /// - `TemplateExpression`: `Promise.resolve(template).then(s => require(s))` — the
-    ///   template already evaluates to a string so no extra coercion wrapper is added.
-    /// - Bare identifier: `Promise.resolve(coerced).then(s => require(s))` where the
-    ///   coerced form wraps the identifier in a template-string coercion.
+    /// - Non-string-like expressions: `Promise.resolve(coerced).then(s => require(s))`
+    ///   where the coerced form wraps the expression in a template-string coercion.
+    ///   If the expression is itself a template expression, that template remains
+    ///   nested inside the coercion wrapper.
     fn emit_dynamic_import_commonjs_promise(
         &mut self,
         first_arg: Option<NodeIndex>,
@@ -957,28 +957,14 @@ impl<'a> Printer<'a> {
             self.emit_dynamic_import_commonjs_branch(first_arg, temp);
             return;
         }
-        // first_arg is guaranteed Some and non-string-like by the guard above.
-        let first = first_arg.unwrap();
-        // TemplateExpression already evaluates to a string: emit it directly in
-        // Promise.resolve() without an extra `${…}` coercion wrapper.
-        if !self.ctx.options.rewrite_relative_import_extensions
-            && self
-                .arena
-                .get(first)
-                .is_some_and(|n| n.kind == syntax_kind_ext::TEMPLATE_EXPRESSION)
-        {
-            self.write("Promise.resolve(");
-            self.emit(first);
-            self.write(").then(s => ");
+        let first = first_arg.expect("non-string-like dynamic import has an argument");
+        self.write("Promise.resolve(`${");
+        if self.ctx.options.rewrite_relative_import_extensions {
+            self.emit_rewrite_helper_call(first);
         } else {
-            self.write("Promise.resolve(`${");
-            if self.ctx.options.rewrite_relative_import_extensions {
-                self.emit_rewrite_helper_call(first);
-            } else {
-                self.emit_dynamic_import_template_specifier(first);
-            }
-            self.write("}`).then(s => ");
+            self.emit_dynamic_import_template_specifier(first);
         }
+        self.write("}`).then(s => ");
         self.write_helper("__importStar");
         self.write("(require(s)))");
     }

--- a/crates/tsz-emitter/src/emitter/module_emission/core/tests/cjs_module_exports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/tests/cjs_module_exports.rs
@@ -284,6 +284,46 @@ import("./foo.ts");
     );
 }
 
+#[test]
+fn commonjs_dynamic_import_template_expression_keeps_nested_coercion() {
+    let source = r#"declare const directory: string;
+declare const moduleFile: number;
+var p0 = import(`${directory}\\${moduleFile}`);
+"#;
+
+    let output = emit_commonjs_es_module_interop(source);
+
+    assert!(
+        output.contains(
+            r#"var p0 = Promise.resolve(`${`${directory}\\${moduleFile}`}`).then(s => __importStar(require(s)));"#,
+        ),
+        "CJS dynamic import should preserve a template-expression specifier as a nested template inside the tsc coercion wrapper.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn commonjs_dynamic_import_expression_uses_template_coercion() {
+    let source = r#"declare function getSpecifier(): string;
+const p1 = import(getSpecifier());
+const p2 = import(true ? getSpecifier() : "fallback");
+"#;
+
+    let output = emit_commonjs_es_module_interop(source);
+
+    assert!(
+        output.contains(
+            "const p1 = Promise.resolve(`${getSpecifier()}`).then(s => __importStar(require(s)));",
+        ),
+        "CJS dynamic import should coerce call-expression specifiers through a template wrapper.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            r#"const p2 = Promise.resolve(`${true ? getSpecifier() : "fallback"}`).then(s => __importStar(require(s)));"#,
+        ),
+        "CJS dynamic import should coerce conditional specifiers through a template wrapper.\nOutput:\n{output}"
+    );
+}
+
 /// Without moduleDetection=force, a file without import/export syntax
 /// should NOT get the CJS __esModule preamble.
 #[test]


### PR DESCRIPTION
AgentName: Studio-C

Track: emit-100 — module/import/export emit, dynamic import CommonJS lowering slice.

Invariant: When CommonJS dynamic `import(expr)` lowers a non-string-like module specifier, `tsc` coerces the specifier through `Promise.resolve(`${expr}`)`. If `expr` is itself a template expression, the original template remains nested inside the coercion wrapper; tsz should emit the same nested template rather than flattening it.

## Scope
- `crates/tsz-emitter/src/emitter/expressions/call.rs` removes the direct `TemplateExpression` bypass in the CommonJS dynamic import promise branch.
- `crates/tsz-emitter/src/emitter/module_emission/core/tests/cjs_module_exports.rs` adds focused module-emission tests for nested template and expression specifiers.

Owner layer: direct JavaScript emitter for call-expression/module lowering. This stays in the output layer, does not import checker internals, and does not patch already-emitted text.

## Adjacent-Case Matrix
- Reported shape: `import(`${directory}\\${moduleFile}`)` lowers to `Promise.resolve(`${`${directory}\\${moduleFile}`}`).then(s => __importStar(require(s)))`.
- Call-expression specifier: `import(getSpecifier())` keeps the existing `Promise.resolve(`${getSpecifier()}`)` coercion.
- Negative/fallback: string-like specifiers still go through the existing lazy branch because they are handled before this non-string-like path.

## Project Corpus Impact
- Row: n/a
- Bug family: CommonJS dynamic import expression-specifier lowering
- Evidence: emit/test-only behavior slice for module/import/export JS parity; no project-corpus benchmark row is directly affected.

## Verification
- `cargo fmt --check` — pass on final stacked head `4b51d7e5bf`
- `cargo nextest run -p tsz-emitter commonjs_dynamic_import` — 2/2 pass after rebasing on `origin/main@5bcc6d46d8`
- `git diff --check` — pass on final stacked head `4b51d7e5bf`
- `python3 scripts/arch/arch_guard.py` — pass on final stacked head `4b51d7e5bf`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=importCallExpressionDeclarationEmit1 --js-only --verbose --timeout=30000 --json-out=/tmp/importCallExpressionDeclarationEmit1-studio-c-final-cycle.json` — 1/1 pass after rebasing on `origin/main@5bcc6d46d8`

## Coordination Notes
Rebased on current `origin/main@5bcc6d46d8` and force-pushed with lease as `68be9a8ddcf076a9386b8be2f37497fd71444d5b`. Prior CI runs on older heads are superseded by this refreshed head. Ready-review CI is running again. Do not add `merge-queue` until exact-head `CI Summary` and GitGuardian pass for `68be9a8ddc`.

AgentName: Studio-C
