### PR TITLE
chore(agents): expose label audit ok flag

### DIFF
--- a/scripts/agents/ensure-agent-labels.sh
+++ b/scripts/agents/ensure-agent-labels.sh
@@ -201,6 +201,7 @@ const findingCount =
   missingIssues.length +
   multipleIssues.length +
   noncanonicalIssues.length;
+const ok = findingCount === 0;
 const metrics = {
   missing_canonical_labels: missingCanonicalLabels.length,
   noncanonical_agent_labels: noncanonicalLabels.length,
@@ -214,7 +215,7 @@ const metrics = {
   agent_label_audit_findings: findingCount,
 };
 console.log(`agent_label_audit_findings=${findingCount}`);
-console.log(`agent_label_audit_status=${findingCount === 0 ? "pass" : "fail"}`);
+console.log(`agent_label_audit_status=${ok ? "pass" : "fail"}`);
 
 const summarizeWorkItem = (item) => ({
   number: item.number,
@@ -227,7 +228,8 @@ const summarizeLabeledWorkItem = (item) => ({
 });
 if (process.env.JSON_REPORT) {
   const report = {
-    status: findingCount === 0 ? "pass" : "fail",
+    ok,
+    status: ok ? "pass" : "fail",
     metrics,
     missing_canonical_labels: missingCanonicalLabels,
     noncanonical_agent_labels: noncanonicalLabels,

--- a/scripts/agents/test_ensure_agent_labels.py
+++ b/scripts/agents/test_ensure_agent_labels.py
@@ -283,6 +283,7 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
             report = json.loads(report_path.read_text(encoding="utf-8"))
 
         self.assertEqual("fail", report["status"])
+        self.assertFalse(report["ok"])
         self.assertEqual(2, report["metrics"]["agent_label_audit_findings"])
         self.assertEqual(1, report["metrics"]["open_prs_missing_agent_label"])
         self.assertEqual(1, report["metrics"]["open_prs_noncanonical_agent_label"])
@@ -307,6 +308,29 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
             ],
             report["open_prs_noncanonical_agent_label"],
         )
+
+    def test_json_report_records_ok_for_clean_audit(self):
+        with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
+            report_path = pathlib.Path(temp_dir) / "reports" / "agent-labels.json"
+            result = self.run_audit_result(
+                [
+                    {
+                        "number": 32,
+                        "title": "fix: owned",
+                        "labels": [{"name": "agent:Studio-F"}],
+                        "body": "AgentName: Studio-F",
+                        "url": "https://github.com/mohsen1/tsz/pull/32",
+                    }
+                ],
+                args=["--audit", "--json-report", str(report_path)],
+            )
+
+            self.assertIn("agent_label_audit_status=pass", result.stdout)
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+
+        self.assertTrue(report["ok"])
+        self.assertEqual("pass", report["status"])
+        self.assertEqual(0, report["metrics"]["agent_label_audit_findings"])
 
     def test_json_report_requires_audit_mode(self):
         result = self.run_audit_result(


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Track 10 / launch infrastructure and cheap evidence plumbing.

## Invariant
When `scripts/agents/ensure-agent-labels.sh --audit --json-report` writes a machine-readable report, consumers can read a top-level boolean `ok` instead of reinterpreting string status or finding counters.

## Scope
- `scripts/agents/ensure-agent-labels.sh`
- `scripts/agents/test_ensure_agent_labels.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: script-only launch-infra metadata; no checker, solver, parser, binder, emitter, LSP, WASM, or project corpus behavior changes.

## Verification
- `python3 scripts/agents/test_ensure_agent_labels.py`
- `bash -n scripts/agents/ensure-agent-labels.sh`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-ok-smoke.json` plus JSON smoke confirmed `{ ok: true, status: "pass", findings: 0 }`

## Coordination Notes
- Start-cycle owned work was clear for Studio-F.
- Initial label-audit race on #11968 resolved externally before editing; rerun audit passed.
- Primary checkout had unrelated Studio-C dirty checker files and was left untouched; this PR was built in sibling worktree `/Users/mohsen/code/tsz-studio-f-agent-label-ok-20260531` from `origin/main`.
