### PR TITLE
fix(binder): preserve namespace re-export alias partner when MODULE overwrites ALIAS

### DIFF
--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -1281,6 +1281,21 @@ impl BinderState {
                 // or `export` modifier. These may not be module/namespace symbols but
                 // need to be in module_exports for cross-file import resolution.
                 if symbol.is_exported || name == "export=" {
+                    // When a namespace MODULE symbol overwrites an existing `export * as N`
+                    // ALIAS in file_exports, preserve the import_module link via
+                    // alias_partners. The checker's member-resolution path already follows
+                    // alias_partners to bridge locally-declared namespace members with the
+                    // re-exported ones from the source module.
+                    if (symbol.flags & symbol_flags::MODULE) != 0
+                        && let Some(existing_id) = file_exports.get(name)
+                        && self.symbols.get(existing_id).is_some_and(|s| {
+                            (s.flags & symbol_flags::ALIAS) != 0
+                                && s.import_name.as_deref() == Some("*")
+                                && !s.is_umd_export
+                        })
+                    {
+                        Arc::make_mut(&mut self.alias_partners).insert(sym_id, existing_id);
+                    }
                     file_exports.set(name.clone(), sym_id);
                 }
             }

--- a/crates/tsz-binder/src/state/tests/exports_jsdoc.rs
+++ b/crates/tsz-binder/src/state/tests/exports_jsdoc.rs
@@ -915,6 +915,123 @@ let x: number | undefined;
     );
 }
 
+// ----- namespace + `export * as N` coexistence (issue #11331) ---------------
+
+/// Asserts that after binding `source`, `module_exports["test.ts"][ns_name]`
+/// is a MODULE symbol and `alias_partners[MODULE]` points to an ALIAS with
+/// `import_module = "./mod"` and `import_name = "*"`.
+fn assert_ns_module_alias_partner(source: &str, ns_name: &str) {
+    let (binder, _parser) = parse_and_bind(source);
+
+    let ns_exported_id = binder
+        .module_exports
+        .get("test.ts")
+        .and_then(|e| e.get(ns_name))
+        .unwrap_or_else(|| panic!("expected {ns_name} in module_exports"));
+    let ns_sym = binder
+        .symbols
+        .get(ns_exported_id)
+        .unwrap_or_else(|| panic!("expected symbol data for exported {ns_name}"));
+    assert_ne!(
+        ns_sym.flags & symbol_flags::MODULE,
+        0,
+        "exported {ns_name} should be the namespace MODULE symbol"
+    );
+
+    let alias_id = binder
+        .alias_partners
+        .get(&ns_exported_id)
+        .copied()
+        .unwrap_or_else(|| panic!("expected alias_partners entry for {ns_name} MODULE"));
+    let alias_sym = binder
+        .symbols
+        .get(alias_id)
+        .unwrap_or_else(|| panic!("expected alias partner symbol data for {ns_name}"));
+    assert_ne!(alias_sym.flags & symbol_flags::ALIAS, 0);
+    assert_eq!(alias_sym.import_module.as_deref(), Some("./mod"));
+    assert_eq!(alias_sym.import_name.as_deref(), Some("*"));
+}
+
+/// `export * as N from './mod'` followed by `namespace N { ... }`:
+/// `module_exports` should hold the MODULE symbol and `alias_partners` should link
+/// MODULE → ALIAS so the checker can resolve members from both the local
+/// namespace and the re-exported source module.
+#[test]
+fn namespace_reexport_alias_before_local_namespace_links_alias_partners() {
+    assert_ns_module_alias_partner(
+        r"
+export * as Ns from './mod';
+export namespace Ns { export const x = 1; }
+",
+        "Ns",
+    );
+}
+
+/// `namespace N { ... }` followed by `export * as N from './mod'` (reversed
+/// source order): same invariants must hold — the fix must be order-insensitive.
+#[test]
+fn namespace_reexport_local_namespace_before_alias_links_alias_partners() {
+    assert_ns_module_alias_partner(
+        r"
+export namespace Ns { export const x = 1; }
+export * as Ns from './mod';
+",
+        "Ns",
+    );
+}
+
+/// Verify the fix is name-agnostic: use `K` and `M` as namespace names.
+#[test]
+fn namespace_reexport_alias_partner_is_name_agnostic() {
+    for (source, name) in [
+        (
+            r"
+export * as K from './mod';
+export namespace K { export const y = 2; }
+",
+            "K",
+        ),
+        (
+            r"
+export namespace M { export const z = 3; }
+export * as M from './mod';
+",
+            "M",
+        ),
+    ] {
+        assert_ns_module_alias_partner(source, name);
+    }
+}
+
+/// A plain `export * as N from './mod'` without a companion `namespace N`
+/// must NOT create a spurious `alias_partners` entry — only the ALIAS should
+/// be in `module_exports`, no MODULE to pair it with.
+#[test]
+fn namespace_reexport_without_local_namespace_has_no_alias_partner() {
+    let source = r"
+export * as Ns from './mod';
+";
+    let (binder, _parser) = parse_and_bind(source);
+
+    let ns_id = binder
+        .module_exports
+        .get("test.ts")
+        .and_then(|e| e.get("Ns"))
+        .expect("expected Ns in module_exports");
+    let ns_sym = binder
+        .symbols
+        .get(ns_id)
+        .expect("expected symbol data for Ns");
+    // Should be ALIAS, not MODULE
+    assert_ne!(ns_sym.flags & symbol_flags::ALIAS, 0);
+    assert_eq!(ns_sym.import_module.as_deref(), Some("./mod"));
+    // No alias_partners entry for a lone ALIAS
+    assert!(
+        !binder.alias_partners.contains_key(&ns_id),
+        "lone export-* alias should not have an alias_partners entry"
+    );
+}
+
 #[test]
 fn arrow_iife_no_flow_start_node() {
     // Arrow function IIFE should also be treated as inline (no FlowStart).


### PR DESCRIPTION
## Agent
AgentName: M4-D

## Track
Binder correctness — cross-file namespace re-export resolution

## Invariant
When `export * as N from './mod'` and `namespace N { ... }` coexist in the same file, `tsc` resolves `N.memberFromMod` through the re-exported source module; this PR makes tsz do the same by preserving the `alias_partners[MODULE] = ALIAS` link through the binder's post-processing step.

## Scope
Single change in `populate_module_exports_from_file_symbols` (`crates/tsz-binder/src/state/core.rs`). When a namespace MODULE symbol is about to overwrite an existing namespace re-export ALIAS in `file_exports`, record `alias_partners[MODULE] = ALIAS` before overwriting. No checker changes. No new data structures. The checker's existing `alias_partner_for` + `resolve_alias_import_member` path handles `MODULE → ALIAS` generically.

Fixes #11331.

## Project Corpus Impact
- Row: kysely-project
- Bug family: binder symbol merge — MODULE overwrites ALIAS, losing `import_module` link for deep namespace export maps
- Evidence: 4 new unit tests in `exports_jsdoc.rs` cover both declaration orderings and prove the fix is name-agnostic; checker `alias_partner_for` is key-generic and already follows MODULE→ALIAS entries.

## Verification
```
cargo test -p tsz-binder --lib namespace_reexport  # 6 pass
cargo test -p tsz-binder --lib                     # 367 pass
cargo clippy -p tsz-binder --all-targets -- -D warnings  # clean
```

## Coordination Notes
- Claimed issue #11331 (WIP label added); canonical owner label `agent:M4-D` added by M1-B.
- Runner: claude-sonnet-4-6 (busy-lamport session).
- 3× `/simplify` passes applied: flattened nesting to `if && let &&` guard, extracted shared test helper, explicit tuple iteration, removed redundant `.as_str()`, fixed `clippy::doc_markdown`.
- Altitude note: a bind-time approach (mirroring `crates/tsz-binder/src/binding/declaration.rs` lines ~1113–1159) would be architecturally cleaner but requires changes in two files; the post-processing fix handles both orderings in one place and is equally correct.