### PR TITLE
chore(agents): expose owned work ok flag

### DIFF
--- a/scripts/agents/list-owned-work.sh
+++ b/scripts/agents/list-owned-work.sh
@@ -260,6 +260,7 @@ const totalOwnedCount = totalPrCount + totalIssueCount;
 const ownedWorkClear = totalOwnedCount === 0;
 
 const report = {
+  ok: ownedWorkClear,
   generated_by: "scripts/agents/list-owned-work.sh",
   repository: process.env.REPOSITORY,
   with_pr_state: process.env.WITH_PR_STATE === "true",

--- a/scripts/agents/test_list_owned_work.py
+++ b/scripts/agents/test_list_owned_work.py
@@ -74,6 +74,7 @@ exec "$@"
             self.assertEqual("scripts/agents/list-owned-work.sh", report["generated_by"])
             self.assertEqual("mohsen1/tsz", report["repository"])
             self.assertFalse(report["with_pr_state"])
+            self.assertFalse(report["ok"])
             self.assertFalse(report["owned_work_clear"])
             self.assertEqual("active", report["owned_work_status"])
             self.assertEqual(1, report["total_pr_count"])
@@ -103,6 +104,7 @@ exec "$@"
             self.run_list_owned_work(["Studio-F", "--json-report", str(report_path)])
 
             report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertTrue(report["ok"])
             self.assertTrue(report["owned_work_clear"])
             self.assertEqual("clear", report["owned_work_status"])
             self.assertEqual(0, report["total_pr_count"])


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Track 10 / launch infrastructure and cheap evidence plumbing.

## Invariant
When `scripts/agents/list-owned-work.sh --json-report` writes a machine-readable report, consumers can read a top-level boolean `ok` to determine whether the selected owned-work runway is clear instead of reinterpreting counters or string status.

## Scope
- `scripts/agents/list-owned-work.sh`
- `scripts/agents/test_list_owned_work.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: script-only launch-infra metadata; no checker, solver, parser, binder, emitter, LSP, WASM, or project corpus behavior changes.

## Verification
- `python3 scripts/agents/test_list_owned_work.py`
- `bash -n scripts/agents/list-owned-work.sh`
- `git diff --check`
- `scripts/agents/list-owned-work.sh Studio-F --json-report /tmp/tsz-owned-work-ok-smoke.json` plus JSON smoke confirmed `{ ok: true, status: "clear", total: 0 }`

## Coordination Notes
- Start-cycle owned work was clear for Studio-F before this branch.
- This follows #11969 and #11970 by aligning another start-cycle JSON artifact with a direct success boolean.
- Live label audit initially found #11972 missing an owner; Studio-F added canonical `agent:M4-D` based on binder/module-resolution ownership and reran the audit clean before opening this PR.
- Primary checkout had unrelated Studio-C dirty checker files and was left untouched; this PR was built in sibling worktree `/Users/mohsen/code/tsz-studio-f-owned-work-ok-20260531` from `origin/main`.
