### PR TITLE
fix(emit): schedule private class-expression state before static fields

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -1,9 +1,10 @@
 use super::super::super::core::PropertyNameEmit;
 use super::super::super::{Printer, ScriptTarget};
+use super::private_comma_items::PrivateCommaItems;
 use super::replace_identifier;
 use super::static_field_erasure::static_no_init_field_is_erased;
 use super::{AutoAccessorEmitOptions, AutoAccessorInfo, StaticFieldInit};
-use crate::emitter::core::{PrivateMemberInfo, PrivateMethodDef};
+use crate::emitter::core::{PrivateAccessorDef, PrivateMemberInfo, PrivateMethodDef};
 use crate::transforms::private_fields_es5::{
     PrivateAccessorInfo, PrivateFieldInfo, PrivateMethodInfo,
     collect_enclosing_source_binding_names, collect_private_accessors_with_reserved,
@@ -21,14 +22,14 @@ use tsz_parser::syntax::transform_utils::{
 use tsz_scanner::SyntaxKind;
 
 #[derive(Debug, Clone)]
-struct PrivateAutoAccessorInfo {
-    member_idx: NodeIndex,
-    name: String,
-    get_var_name: String,
-    set_var_name: String,
-    storage_name: String,
-    initializer: Option<NodeIndex>,
-    is_static: bool,
+pub(super) struct PrivateAutoAccessorInfo {
+    pub(super) member_idx: NodeIndex,
+    pub(super) name: String,
+    pub(super) get_var_name: String,
+    pub(super) set_var_name: String,
+    pub(super) storage_name: String,
+    pub(super) initializer: Option<NodeIndex>,
+    pub(super) is_static: bool,
 }
 
 fn collect_private_auto_accessors_with_reserved(
@@ -143,7 +144,7 @@ impl<'a> Printer<'a> {
         name == "constructor"
     }
 
-    fn emit_private_auto_accessor_function_def(
+    pub(in crate::emitter) fn emit_private_auto_accessor_function_def(
         &mut self,
         var_name: &str,
         storage_name: &str,
@@ -1290,6 +1291,7 @@ impl<'a> Printer<'a> {
         // Allocate the class-expression temp after computed-name temps so the
         // generated `_a`, `_b`, `_c` ordering matches tsc.
         let has_static_field_comma_expr = target_needs_field_lowering
+            && target_needs_static_block_lowering
             && class.members.nodes.iter().any(|&member_idx| {
                 let Some(member) = self.arena.get(member_idx) else {
                     return false;
@@ -1930,6 +1932,55 @@ impl<'a> Printer<'a> {
                 || has_private_field_inits
                 || has_instances_weakset);
 
+        let prev_scoped_class_expression_self_alias =
+            self.scoped_class_expression_self_alias.take();
+        let scoped_class_expression_self_alias_ancestor_len =
+            self.scoped_class_expression_self_alias_ancestors.len();
+        if let Some((prev_class_name, prev_class_alias)) =
+            prev_scoped_class_expression_self_alias.clone()
+        {
+            let shadows_prev_alias = class_name_is_real
+                && !class_name.is_empty()
+                && class_name == prev_class_name.as_ref();
+            if !shadows_prev_alias {
+                self.scoped_class_expression_self_alias_ancestors
+                    .push((prev_class_name, prev_class_alias));
+            }
+        }
+        if let Some(alias) = assignment_alias {
+            if class_name_is_real && !class_name.is_empty() && class_name != alias {
+                self.scoped_class_expression_self_alias = Some((
+                    Arc::<str>::from(class_name.as_str()),
+                    Arc::<str>::from(alias),
+                ));
+            }
+        } else if let Some(temp) = class_expr_temp.as_ref() {
+            if class_name_is_real && !class_name.is_empty() && class_name != *temp {
+                self.scoped_class_expression_self_alias = Some((
+                    Arc::<str>::from(class_name.as_str()),
+                    Arc::<str>::from(temp.as_str()),
+                ));
+            }
+        } else if let Some(alias) = class_value_alias.as_ref() {
+            if class_name_is_real && !class_name.is_empty() && class_name != *alias {
+                self.scoped_class_expression_self_alias = Some((
+                    Arc::<str>::from(class_name.as_str()),
+                    Arc::<str>::from(alias.as_str()),
+                ));
+            }
+        } else if let Some((static_class_name, static_class_alias)) =
+            self.private_static_class_alias.clone()
+            && class_name_is_real
+            && !class_name.is_empty()
+            && class_name == static_class_name
+            && class_name != static_class_alias
+        {
+            self.scoped_class_expression_self_alias = Some((
+                Arc::<str>::from(class_name.as_str()),
+                Arc::<str>::from(static_class_alias.as_str()),
+            ));
+        }
+
         if synthesize_constructor {
             // Increment function_scope_depth so async arrow functions inside
             // the synthesized constructor use `this` instead of `void 0` as
@@ -2052,54 +2103,6 @@ impl<'a> Printer<'a> {
             .unwrap_or(node.end);
 
         let mut field_init_comment_idx = 0usize;
-        let prev_scoped_class_expression_self_alias =
-            self.scoped_class_expression_self_alias.take();
-        let scoped_class_expression_self_alias_ancestor_len =
-            self.scoped_class_expression_self_alias_ancestors.len();
-        if let Some((prev_class_name, prev_class_alias)) =
-            prev_scoped_class_expression_self_alias.clone()
-        {
-            let shadows_prev_alias = class_name_is_real
-                && !class_name.is_empty()
-                && class_name == prev_class_name.as_ref();
-            if !shadows_prev_alias {
-                self.scoped_class_expression_self_alias_ancestors
-                    .push((prev_class_name, prev_class_alias));
-            }
-        }
-        if let Some(alias) = assignment_alias {
-            if class_name_is_real && !class_name.is_empty() && class_name != alias {
-                self.scoped_class_expression_self_alias = Some((
-                    Arc::<str>::from(class_name.as_str()),
-                    Arc::<str>::from(alias),
-                ));
-            }
-        } else if let Some(temp) = class_expr_temp.as_ref() {
-            if class_name_is_real && !class_name.is_empty() && class_name != *temp {
-                self.scoped_class_expression_self_alias = Some((
-                    Arc::<str>::from(class_name.as_str()),
-                    Arc::<str>::from(temp.as_str()),
-                ));
-            }
-        } else if let Some(alias) = class_value_alias.as_ref() {
-            if class_name_is_real && !class_name.is_empty() && class_name != *alias {
-                self.scoped_class_expression_self_alias = Some((
-                    Arc::<str>::from(class_name.as_str()),
-                    Arc::<str>::from(alias.as_str()),
-                ));
-            }
-        } else if let Some((static_class_name, static_class_alias)) =
-            self.private_static_class_alias.clone()
-            && class_name_is_real
-            && !class_name.is_empty()
-            && class_name == static_class_name
-            && class_name != static_class_alias
-        {
-            self.scoped_class_expression_self_alias = Some((
-                Arc::<str>::from(class_name.as_str()),
-                Arc::<str>::from(static_class_alias.as_str()),
-            ));
-        }
         for (member_i, &member_idx) in class.members.nodes.iter().enumerate() {
             // Skip private field declarations entirely when lowering to WeakMap pattern
             if !private_fields.is_empty()
@@ -2997,8 +3000,34 @@ impl<'a> Printer<'a> {
                 }
             }
         }
+        // Private helper/state initialization can be part of a class-expression
+        // comma list. Gather it before static element scheduling so lowered
+        // private state can be emitted before static field/block work observes it.
+        let weakmap_inits = std::mem::take(&mut self.pending_weakmap_inits);
+        let has_weakmap_inits = !weakmap_inits.is_empty();
+        let static_private_inits = std::mem::take(&mut self.pending_static_private_inits);
+        let private_class_alias_pair = self.pending_private_class_alias.take();
+        let instances_ws = self.pending_instances_weakset_add.clone();
+        let method_defs: Vec<PrivateMethodDef> =
+            std::mem::take(&mut self.pending_private_method_defs);
+        let accessor_defs: Vec<PrivateAccessorDef> =
+            std::mem::take(&mut self.pending_private_accessor_defs);
+        let private_auto_instance_storage_inits: Vec<String> = private_auto_accessors
+            .iter()
+            .filter(|_| !emitted_private_auto_accessors_pre_static)
+            .filter(|a| !a.is_static)
+            .map(|a| format!("{} = new WeakMap()", a.storage_name))
+            .collect();
+        let has_post_class_inits = private_class_alias_pair.is_some()
+            || has_weakmap_inits
+            || instances_ws.is_some()
+            || !method_defs.is_empty()
+            || !accessor_defs.is_empty()
+            || !private_auto_instance_storage_inits.is_empty();
+
         let class_expr_static_comma_had_scheduled_elements =
             !static_field_inits.is_empty() || !deferred_static_blocks.is_empty();
+        let mut emitted_private_comma_items_before_static_items = false;
         if !static_field_inits.is_empty()
             && let Some(temp) = class_expr_static_temp.as_ref()
         {
@@ -3042,9 +3071,33 @@ impl<'a> Printer<'a> {
             }
             comma_items.sort_by_key(|(pos, _)| *pos);
 
+            if needs_private_comma_expr && has_post_class_inits {
+                emitted_private_comma_items_before_static_items = true;
+                self.emit_private_comma_items(PrivateCommaItems {
+                    weakmap_inits: &weakmap_inits,
+                    instances_ws: instances_ws.as_deref(),
+                    private_auto_instance_storage_inits: &private_auto_instance_storage_inits,
+                    method_defs: &method_defs,
+                    accessor_defs: &accessor_defs,
+                    private_member_def_needs_class_alias,
+                    class_value_alias: class_value_alias.as_deref(),
+                    class_name: &class_name,
+                    emitted_private_auto_accessors_pre_static,
+                    private_auto_accessors: &private_auto_accessors,
+                    private_class_alias_pair: private_class_alias_pair.as_ref(),
+                    set_function_name: class_expr_set_function_name
+                        .as_deref()
+                        .map(|name| (temp.as_str(), name)),
+                    static_private_inits: &static_private_inits,
+                });
+            }
+
             for (_pos, item) in comma_items {
                 match item {
                     CommaItem::SetFunctionName(name) => {
+                        if emitted_private_comma_items_before_static_items {
+                            continue;
+                        }
                         self.emit_class_expr_set_function_name_comma_item(temp, &name);
                     }
                     CommaItem::Field((
@@ -3419,32 +3472,6 @@ impl<'a> Printer<'a> {
             }
         }
 
-        // Emit private field WeakMap initializations after class body:
-        // _C_field1 = new WeakMap();
-        let has_weakmap_inits = !self.pending_weakmap_inits.is_empty();
-        let static_private_inits = std::mem::take(&mut self.pending_static_private_inits);
-        let private_class_alias_pair = self.pending_private_class_alias.take();
-
-        // Emit combined initialization line after class body.
-        // tsc joins class alias, WeakMap inits, WeakSet init, and private method/accessor defs
-        // with commas on a single line, e.g.:
-        // _a = A, _A_foo = new WeakMap(), _A_instances = new WeakSet(), _A_m = function _A_m() { };
-        let instances_ws = self.pending_instances_weakset_add.clone();
-        let method_defs = std::mem::take(&mut self.pending_private_method_defs);
-        let accessor_defs = std::mem::take(&mut self.pending_private_accessor_defs);
-        let private_auto_instance_storage_inits: Vec<String> = private_auto_accessors
-            .iter()
-            .filter(|_| !emitted_private_auto_accessors_pre_static)
-            .filter(|a| !a.is_static)
-            .map(|a| format!("{} = new WeakMap()", a.storage_name))
-            .collect();
-        let has_post_class_inits = private_class_alias_pair.is_some()
-            || has_weakmap_inits
-            || instances_ws.is_some()
-            || !method_defs.is_empty()
-            || !accessor_defs.is_empty()
-            || !private_auto_instance_storage_inits.is_empty();
-
         // For class expressions with private field lowering, emit the WeakMap/WeakSet/method
         // initializations as comma-separated items inside the wrapping expression:
         //   (_a = class C { ... },
@@ -3453,137 +3480,33 @@ impl<'a> Printer<'a> {
         //       _C_method = function _C_method() { },
         //       _a)
         // For class declarations, emit as separate statements after the class body.
-        if needs_private_comma_expr && has_post_class_inits {
-            // Emit comma-separated inits inline. tsc orders them as:
-            // instance-member helpers (WeakMap/WeakSet/private method+accessor
-            // functions) first, then `__setFunctionName`, then static value
-            // inits. The named-evaluation step is emitted below, after helpers.
-            // WeakMap inits: _X_field = new WeakMap()
-            let weakmap_inits = self.pending_weakmap_inits.clone();
-            for init in &weakmap_inits {
-                self.write(",");
-                self.write_line();
-                self.increase_indent();
-                self.write(init);
-                self.decrease_indent();
-            }
-
-            // WeakSet: _X_instances = new WeakSet()
-            if let Some(ref ws_name) = instances_ws {
-                self.write(",");
-                self.write_line();
-                self.increase_indent();
-                self.write(ws_name);
-                self.write(" = new WeakSet()");
-                self.decrease_indent();
-            }
-
-            for init in &private_auto_instance_storage_inits {
-                self.write(",");
-                self.write_line();
-                self.increase_indent();
-                self.write(init);
-                self.decrease_indent();
-            }
-
-            // Private method function definitions
-            for def in &method_defs {
-                self.write(",");
-                self.write_line();
-                self.increase_indent();
-                self.emit_private_method_function_def(
-                    def,
-                    private_member_def_needs_class_alias,
-                    class_value_alias.as_deref(),
-                    &class_name,
-                );
-                self.decrease_indent();
-            }
-
-            // Private accessor function definitions
-            for def in &accessor_defs {
-                self.write(",");
-                self.write_line();
-                self.increase_indent();
-                self.emit_private_accessor_function_def(
-                    def,
-                    private_member_def_needs_class_alias,
-                    class_value_alias.as_deref(),
-                    &class_name,
-                );
-                self.decrease_indent();
-            }
-
-            if !emitted_private_auto_accessors_pre_static {
-                for accessor in &private_auto_accessors {
-                    self.write(",");
-                    self.write_line();
-                    self.increase_indent();
-                    self.emit_private_auto_accessor_function_def(
-                        &accessor.get_var_name,
-                        &accessor.storage_name,
-                        accessor.is_static,
-                        true,
-                        private_class_alias_pair
-                            .as_ref()
-                            .map(|(alias, _)| alias.as_str())
-                            .or(class_value_alias.as_deref()),
-                    );
-                    self.write(",");
-                    self.write_line();
-                    self.emit_private_auto_accessor_function_def(
-                        &accessor.set_var_name,
-                        &accessor.storage_name,
-                        accessor.is_static,
-                        false,
-                        private_class_alias_pair
-                            .as_ref()
-                            .map(|(alias, _)| alias.as_str())
-                            .or(class_value_alias.as_deref()),
-                    );
-                    self.decrease_indent();
-                }
-            }
-
-            // Named-evaluation step: after instance helpers, before static
-            // value inits, matching tsc.
-            if (!needs_static_comma_expr || class_expr_static_comma_has_no_scheduled_elements)
-                && let Some(temp) = class_expr_temp.as_ref()
-                && let Some(name) = class_expr_set_function_name.as_ref()
-            {
-                self.emit_class_expr_set_function_name_comma_item(temp, name);
-            }
-
-            // Emit static private field value initializations as comma items
-            // (e.g., `_D_field = { value: __classPrivateFieldGet(...) }`)
-            for (var_name, init_idx) in &static_private_inits {
-                self.write(",");
-                self.write_line();
-                self.increase_indent();
-                self.write(var_name);
-                self.write(" = { value: ");
-                if init_idx.is_some() {
-                    self.emit_expression(*init_idx);
+        if needs_private_comma_expr
+            && has_post_class_inits
+            && !emitted_private_comma_items_before_static_items
+        {
+            self.emit_private_comma_items(PrivateCommaItems {
+                weakmap_inits: &weakmap_inits,
+                instances_ws: instances_ws.as_deref(),
+                private_auto_instance_storage_inits: &private_auto_instance_storage_inits,
+                method_defs: &method_defs,
+                accessor_defs: &accessor_defs,
+                private_member_def_needs_class_alias,
+                class_value_alias: class_value_alias.as_deref(),
+                class_name: &class_name,
+                emitted_private_auto_accessors_pre_static,
+                private_auto_accessors: &private_auto_accessors,
+                private_class_alias_pair: private_class_alias_pair.as_ref(),
+                set_function_name: if !needs_static_comma_expr
+                    || class_expr_static_comma_has_no_scheduled_elements
+                {
+                    class_expr_temp
+                        .as_deref()
+                        .zip(class_expr_set_function_name.as_deref())
                 } else {
-                    self.write("void 0");
-                }
-                self.write(" }");
-                self.decrease_indent();
-            }
-            for accessor in private_auto_accessors.iter().filter(|a| a.is_static) {
-                self.write(",");
-                self.write_line();
-                self.increase_indent();
-                self.write(&accessor.storage_name);
-                self.write(" = { value: ");
-                if let Some(init) = accessor.initializer {
-                    self.emit_expression(init);
-                } else {
-                    self.write("void 0");
-                }
-                self.write(" }");
-                self.decrease_indent();
-            }
+                    None
+                },
+                static_private_inits: &static_private_inits,
+            });
 
             if !target_supports_native_private_names && has_legacy_private_name_member_decorators {
                 self.write(",");
@@ -3618,7 +3541,7 @@ impl<'a> Printer<'a> {
                     self.write(";");
                 }
             }
-        } else if has_post_class_inits {
+        } else if has_post_class_inits && !emitted_private_comma_items_before_static_items {
             self.write_line();
             let mut first = true;
 
@@ -3631,7 +3554,6 @@ impl<'a> Printer<'a> {
             }
 
             // WeakMap inits first (tsc order): _X_field = new WeakMap()
-            let weakmap_inits = self.pending_weakmap_inits.clone();
             for init in &weakmap_inits {
                 if !first {
                     self.write(", ");

--- a/crates/tsz-emitter/src/emitter/declarations/class/mod.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/mod.rs
@@ -4,6 +4,7 @@ mod decorators;
 mod emit_declaration;
 mod emit_es6;
 mod helpers;
+mod private_comma_items;
 mod private_method_defs;
 mod static_block_self_alias;
 mod static_field_erasure;

--- a/crates/tsz-emitter/src/emitter/declarations/class/private_comma_items.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/private_comma_items.rs
@@ -1,0 +1,140 @@
+use super::emit_es6::PrivateAutoAccessorInfo;
+use crate::emitter::Printer;
+use crate::emitter::core::{PrivateAccessorDef, PrivateMethodDef};
+use tsz_parser::parser::NodeIndex;
+
+pub(super) struct PrivateCommaItems<'a> {
+    pub(super) weakmap_inits: &'a [String],
+    pub(super) instances_ws: Option<&'a str>,
+    pub(super) private_auto_instance_storage_inits: &'a [String],
+    pub(super) method_defs: &'a [PrivateMethodDef],
+    pub(super) accessor_defs: &'a [PrivateAccessorDef],
+    pub(super) private_member_def_needs_class_alias: bool,
+    pub(super) class_value_alias: Option<&'a str>,
+    pub(super) class_name: &'a str,
+    pub(super) emitted_private_auto_accessors_pre_static: bool,
+    pub(super) private_auto_accessors: &'a [PrivateAutoAccessorInfo],
+    pub(super) private_class_alias_pair: Option<&'a (String, String)>,
+    pub(super) set_function_name: Option<(&'a str, &'a str)>,
+    pub(super) static_private_inits: &'a [(String, NodeIndex)],
+}
+
+impl<'a> Printer<'a> {
+    pub(super) fn emit_private_comma_items(&mut self, items: PrivateCommaItems<'_>) {
+        for init in items.weakmap_inits {
+            self.write(",");
+            self.write_line();
+            self.increase_indent();
+            self.write(init);
+            self.decrease_indent();
+        }
+
+        if let Some(ws_name) = items.instances_ws {
+            self.write(",");
+            self.write_line();
+            self.increase_indent();
+            self.write(ws_name);
+            self.write(" = new WeakSet()");
+            self.decrease_indent();
+        }
+
+        for init in items.private_auto_instance_storage_inits {
+            self.write(",");
+            self.write_line();
+            self.increase_indent();
+            self.write(init);
+            self.decrease_indent();
+        }
+
+        for def in items.method_defs {
+            self.write(",");
+            self.write_line();
+            self.increase_indent();
+            self.emit_private_method_function_def(
+                def,
+                items.private_member_def_needs_class_alias,
+                items.class_value_alias,
+                items.class_name,
+            );
+            self.decrease_indent();
+        }
+
+        for def in items.accessor_defs {
+            self.write(",");
+            self.write_line();
+            self.increase_indent();
+            self.emit_private_accessor_function_def(
+                def,
+                items.private_member_def_needs_class_alias,
+                items.class_value_alias,
+                items.class_name,
+            );
+            self.decrease_indent();
+        }
+
+        if !items.emitted_private_auto_accessors_pre_static {
+            for accessor in items.private_auto_accessors {
+                self.write(",");
+                self.write_line();
+                self.increase_indent();
+                self.emit_private_auto_accessor_function_def(
+                    &accessor.get_var_name,
+                    &accessor.storage_name,
+                    accessor.is_static,
+                    true,
+                    items
+                        .private_class_alias_pair
+                        .map(|(alias, _)| alias.as_str())
+                        .or(items.class_value_alias),
+                );
+                self.write(",");
+                self.write_line();
+                self.emit_private_auto_accessor_function_def(
+                    &accessor.set_var_name,
+                    &accessor.storage_name,
+                    accessor.is_static,
+                    false,
+                    items
+                        .private_class_alias_pair
+                        .map(|(alias, _)| alias.as_str())
+                        .or(items.class_value_alias),
+                );
+                self.decrease_indent();
+            }
+        }
+
+        if let Some((temp, name)) = items.set_function_name {
+            self.emit_class_expr_set_function_name_comma_item(temp, name);
+        }
+
+        for (var_name, init_idx) in items.static_private_inits {
+            self.write(",");
+            self.write_line();
+            self.increase_indent();
+            self.write(var_name);
+            self.write(" = { value: ");
+            if init_idx.is_some() {
+                self.emit_expression(*init_idx);
+            } else {
+                self.write("void 0");
+            }
+            self.write(" }");
+            self.decrease_indent();
+        }
+
+        for accessor in items.private_auto_accessors.iter().filter(|a| a.is_static) {
+            self.write(",");
+            self.write_line();
+            self.increase_indent();
+            self.write(&accessor.storage_name);
+            self.write(" = { value: ");
+            if let Some(init) = accessor.initializer {
+                self.emit_expression(init);
+            } else {
+                self.write("void 0");
+            }
+            self.write(" }");
+            self.decrease_indent();
+        }
+    }
+}

--- a/crates/tsz-emitter/src/emitter/source_file/class_expr_private_static_scheduling_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/class_expr_private_static_scheduling_tests.rs
@@ -1,0 +1,87 @@
+//! Structural emit tests for class expressions that combine private names with
+//! static-field lowering.
+//!
+//! Structural rule: when the target supports native static blocks, a class
+//! expression whose fields lower to static blocks can stay in direct class
+//! expression position. When private names lower to helper storage, the helper
+//! storage is part of the class-expression comma list and must be scheduled
+//! before lowered static elements that can observe it.
+
+use crate::context::emit::EmitContext;
+use crate::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use crate::lowering::LoweringPass;
+use tsz_common::ScriptTarget;
+use tsz_parser::ParserState;
+
+fn emit(source: &str, target: ScriptTarget, use_define_for_class_fields: bool) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        target,
+        use_define_for_class_fields,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+#[test]
+fn esnext_class_expression_static_field_keeps_native_private_self_reference() {
+    let source = "class Host {\n    #prop = 0;\n    static box = class Inner {\n        #foo = 1;\n        static child = class {\n            m() { new Inner().#foo; }\n        };\n    };\n}\n";
+    let output = emit(source, ScriptTarget::ESNext, false);
+
+    assert!(
+        output.contains("static { this.box = class Inner {"),
+        "ESNext useDefine=false should lower the static field to a static block without wrapping the class expression.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("new Inner().#foo;"),
+        "Native private-name emit should keep the named class expression self-reference.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("(_a = class Inner") && !output.contains("new _a().#foo"),
+        "Native private names must not synthesize a temp alias solely for the class-expression self-reference.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es2020_class_expression_private_storage_precedes_lowered_static_field() {
+    let source = "class Host {\n    #prop = 0;\n    static box = class Inner {\n        #foo = 1;\n        static child = class {\n            m() { new Inner().#foo; }\n        };\n    };\n}\n";
+    let output = emit(source, ScriptTarget::ES2020, false);
+
+    let private_storage = output
+        .find("_Inner_foo = new WeakMap()")
+        .unwrap_or_else(|| {
+            panic!("Expected lowered private storage for the nested class.\nOutput:\n{output}")
+        });
+    let static_child = output.find("_a.child = class").unwrap_or_else(|| {
+        panic!(
+            "Expected the lowered static field to use the class-expression temp.\nOutput:\n{output}"
+        )
+    });
+
+    assert!(
+        private_storage < static_child,
+        "Lowered private storage must be scheduled before static field work that can observe it.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("__classPrivateFieldGet(new _a(), _Inner_foo, \"f\")"),
+        "Lowered references to the class-expression private field should use the class-expression temp.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn lowered_private_access_preserves_asi_trailing_comment() {
+    let source = "class C {\n    #x = 1;\n    m() {\n        new C().#x // keep\n    }\n}\n";
+    let output = emit(source, ScriptTarget::ES2020, false);
+
+    assert!(
+        output.contains("__classPrivateFieldGet(new C(), _C_x, \"f\"); // keep"),
+        "Lowering a private access expression statement must preserve same-line trailing comments even when the source used ASI.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/source_file/mod.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/mod.rs
@@ -24,6 +24,8 @@ mod class_expr_es5_interior_comment_tests;
 #[cfg(test)]
 mod class_expr_object_property_static_naming_tests;
 #[cfg(test)]
+mod class_expr_private_static_scheduling_tests;
+#[cfg(test)]
 mod class_expression_decorator_tests;
 #[cfg(test)]
 mod class_static_alias_tests;

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -1369,6 +1369,28 @@ impl<'a> Printer<'a> {
         if self.emit_recovered_jsx_unary_trailing_less_than(node, expr_stmt.expression) {
             self.write_line();
         }
+        let has_source_statement_semicolon = self.source_text.is_some_and(|text| {
+            let bytes = text.as_bytes();
+            let start = node.pos as usize;
+            let end = (node.end as usize).min(bytes.len());
+            let mut depth: i32 = 0;
+            let mut i = start;
+            while i < end {
+                match bytes[i] {
+                    b'{' => depth += 1,
+                    b'}' => {
+                        depth -= 1;
+                        if depth < 0 {
+                            break;
+                        }
+                    }
+                    b';' if depth == 0 => return true,
+                    _ => {}
+                }
+                i += 1;
+            }
+            false
+        });
         self.map_trailing_semicolon(node);
         if !self.output_ends_with_semicolon() {
             self.write_semicolon();
@@ -1379,7 +1401,13 @@ impl<'a> Printer<'a> {
             self.write_line();
             self.write_semicolon();
         }
-        self.emit_trailing_comment_after_semicolon(node);
+        if has_source_statement_semicolon {
+            self.emit_trailing_comment_after_semicolon(node);
+        } else if expression_trailing_comment_range.is_none()
+            && let Some(expr_node) = self.arena.get(expr_stmt.expression)
+        {
+            self.emit_trailing_comments(expr_node.end);
+        }
         if let Some((comment_start, comment_end)) = expression_trailing_comment_range {
             self.emit_comments_after_deferred_semicolon(comment_start, comment_end);
         }


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
JavaScript emit parity, class/private/accessor/decorator lowering.

## Invariant
When class expressions combine private names, static-field lowering, class-expression temps, and ASI trailing comments, `tsc` preserves helper-state ordering, self-alias visibility, and trailing comments. This PR makes tsz match that behavior in the emitter output layer without checker or solver semantic validation.

## Scope
- Keep class expressions with static fields in direct class-expression position when the target supports native static blocks.
- Emit lowered private helper state inside class-expression comma lists before lowered static field/block work that can observe that state.
- Preserve class-expression self aliases while synthesized constructors emit instance field initializers.
- Preserve same-line trailing comments on ASI expression statements after private-access lowering.
- Split shared private comma-item emission into a class emitter helper to stay under the architecture size ratchet; helper arguments are grouped in `PrivateCommaItems` to keep CI clippy clean.

## Project Corpus Impact
- Row: n/a
- Bug family: class/private/accessor/decorator lowering
- Evidence: targeted emit parity filter `privateNameWhenNotUseDefineForClassFieldsInEsNext` passes 2/2 JS cases; this is a TypeScript baseline parity fix rather than a project-corpus row-specific change.

## Verification
- `cargo fmt --check` - pass on rebased head `2524ea13b0`
- `cargo nextest run -p tsz-emitter -E 'test(commonjs_dynamic_import) | test(class_expr_private_static_scheduling)'` - 5/5 pass on rebased head `2524ea13b0`
- `git diff --check` - pass on rebased head `2524ea13b0`
- `python3 scripts/arch/arch_guard.py` - pass on rebased head `2524ea13b0`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=privateNameWhenNotUseDefineForClassFieldsInEsNext --js-only --verbose --timeout=30000 --json-out=/tmp/privateNameWhenNotUseDefineForClassFieldsInEsNext-studio-c-rebased-2524ea13b0.json` - 2/2 pass on rebased head `2524ea13b0`
- Earlier verification on prior head `0826b3aabf`: `cargo nextest run -p tsz-emitter commonjs_dynamic_import` passed 2/2; `cargo nextest run -p tsz-emitter class_expr_private_static_scheduling` passed 3/3; `scripts/safe-run.sh scripts/emit/run.sh --filter=privateNameWhenNotUseDefineForClassFieldsInEsNext --js-only --verbose --timeout=30000 --json-out=/tmp/privateNameWhenNotUseDefineForClassFieldsInEsNext-studio-c-final-after-base-merged.json` passed 2/2.
- Earlier in this cycle, `scripts/safe-run.sh scripts/emit/run.sh --filter=importCallExpressionDeclarationEmit1 --js-only --verbose --timeout=30000 --json-out=/tmp/importCallExpressionDeclarationEmit1-studio-c-rebased-latest-cycle.json` passed 1/1 for the now-merged base slice.

## Coordination Notes
- #11967 has merged, so this PR is retargeted directly to `main`.
- Rebased and force-pushed on `origin/main@2434798405486d8b920fb45cedd1d301956bf343` after #11978 and #11979 landed.
- Current head is `2524ea13b09b09782dfb9d2c6a668870cb9267d7`.
- The local dirty checker edits predate this slice and are intentionally excluded from this PR.