### PR TITLE
test(emit-tools): guard output surgery ok report

### DIFF
--- a/scripts/emit/test_output_surgery_audit.py
+++ b/scripts/emit/test_output_surgery_audit.py
@@ -127,6 +127,19 @@ class OutputSurgeryAuditTests(unittest.TestCase):
             ],
         )
 
+    def test_json_report_records_ok_for_clean_audit(self):
+        findings = [
+            self.audit.Finding("a.rs", 1, "replacen", "output = output.replacen(&a, &b, 1);"),
+        ]
+        allowlist = {
+            "a.rs": self.audit.AllowEntry("semantic-output-surgery", 1, "existing debt"),
+        }
+
+        report = self.audit.build_json_report(findings, allowlist, [])
+
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["failures"], [])
+
     def test_pass_summary_names_clean_guardrail_counters(self):
         findings = [
             self.audit.Finding("a.rs", 1, "replacen", "output = output.replacen(&a, &b, 1);"),


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Track 10 / launch infrastructure and cheap evidence plumbing.

## Invariant
When `scripts/emit/audit-output-surgery.py --json-report` has no guardrail failures, the report's top-level `ok` field stays true so start-cycle consumers can read the release-gate state without reinterpreting failure arrays.

## Scope
- `scripts/emit/test_output_surgery_audit.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: test-only emit-tool guardrail coverage; no checker, solver, parser, binder, emitter runtime, LSP, WASM, or project corpus behavior changes.

## Verification
- `python3 scripts/emit/test_output_surgery_audit.py`
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery-ok-test.json` plus JSON smoke confirmed `{ ok: true, total_findings: 23, failures: 0, budget_status: "exhausted" }`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard-output-surgery-ok.json`
- `scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-audit-output-surgery-ok.json`

## Coordination Notes
- Studio-F owned work was clear before opening this PR.
- This complements the recent start-cycle JSON evidence work by locking the output-surgery success `ok` contract in a focused unit test.
- Disk was below guard at cycle start; Studio-F removed merged #11965's clean detached worktree and the inactive Studio-B `.target` cache after cache-preserving cleanup failed, restoring disk to ~50 GiB free while preserving active source worktrees.
