### PR TITLE
fix(emit-tools): require aligned current detail

### DIFF
--- a/scripts/emit/query-emit.py
+++ b/scripts/emit/query-emit.py
@@ -269,6 +269,10 @@ def emit_freshness_status_line(data):
     return f"Emit detail freshness: {state}."
 
 
+def emit_detail_is_current(freshness_status):
+    return freshness_status.get("state") == "current"
+
+
 def emit_pass_rate(summary, prefix):
     passed = summary.get(f"{prefix}Pass")
     total = summary.get(f"{prefix}Total")
@@ -575,7 +579,7 @@ def main():
     parser.add_argument(
         "--require-current-detail",
         action="store_true",
-        help="Exit non-zero when README/public aggregate is ahead of emit-detail.json",
+        help="Exit non-zero unless README/public aggregate matches emit-detail.json",
     )
     args = parser.parse_args()
 
@@ -583,7 +587,7 @@ def main():
     filtered_data = filter_data_by_name(data, args.filter)
     freshness_status = emit_freshness_status(emit_summary(data), emit_summary_from_readme())
 
-    if args.require_current_detail and freshness_status["state"] == "stale":
+    if args.require_current_detail and not emit_detail_is_current(freshness_status):
         print(emit_freshness_status_line(data), file=sys.stderr)
         return 1
 

--- a/scripts/emit/test_query_emit_families.py
+++ b/scripts/emit/test_query_emit_families.py
@@ -150,6 +150,18 @@ after
         status = self.mod.emit_freshness_status(summary, dict(summary))
         self.assertEqual(status["state"], "current")
 
+    def test_current_detail_requirement_requires_matching_aggregates(self):
+        self.assertTrue(self.mod.emit_detail_is_current({"state": "current"}))
+        for state in (
+            "stale",
+            "detail-ahead",
+            "different-domain",
+            "unknown-public",
+            "missing-detail",
+        ):
+            with self.subTest(state=state):
+                self.assertFalse(self.mod.emit_detail_is_current({"state": state}))
+
     def test_stale_failure_family_heading_names_public_remaining_count(self):
         detail_summary = {
             "jsPass": 13094,


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 1 release metric truth; emit tooling guard fix.

## Invariant
When a caller requires current emit detail, the checked per-test detail must match the README/public aggregate exactly; stale, detail-ahead, incomparable, or missing-public states must fail the guard instead of being treated as current.

## Scope
- `scripts/emit/query-emit.py`
- `scripts/emit/test_query_emit_families.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: emit metric tooling only; no project-row fixture, benchmark row, checker, solver, parser, binder, emitter, or corpus behavior changes.

## Verification
- `python3 -m unittest scripts.emit.test_query_emit_families`
- `python3 scripts/emit/query-emit.py --require-current-detail` exits 1 on the current stale checked detail and reports the freshness mismatch
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Existing Studio-A PR runway was empty before opening this PR.
- Main checkout has unrelated dirty Studio-C checker files; this work was done in a fresh Studio-A worktree from `origin/main`.
- Code/test tooling only; no repository markdown/docs files edited.
