### PR TITLE
fix(bench): add required green artifact gate

### DIFF
--- a/scripts/bench/check-artifact-readiness.mjs
+++ b/scripts/bench/check-artifact-readiness.mjs
@@ -4,7 +4,8 @@
  *
  * Exit codes:
  *   0 — artifact present, all required rows included
- *   1 — artifact present, one or more required rows are missing
+ *   1 — artifact present, one or more required rows are missing or the
+ *       --require-green release gate found non-green required rows
  *   2 — artifact file absent or unparseable
  *
  * Without --json: writes a markdown report to stdout (and GITHUB_STEP_SUMMARY
@@ -15,7 +16,7 @@
  * is absent (exit 2) so callers reliably get machine-readable status in all cases.
  *
  * Usage:
- *   node scripts/bench/check-artifact-readiness.mjs [--json] <artifact.json>
+ *   node scripts/bench/check-artifact-readiness.mjs [--json] [--require-green] <artifact.json>
  */
 
 import fs from "node:fs";
@@ -31,6 +32,7 @@ import {
 
 const args = process.argv.slice(2);
 const jsonOutput = args.includes("--json");
+const requireGreen = args.includes("--require-green");
 const filePath = args.find((a) => !a.startsWith("-")) ?? null;
 
 function loadArtifact() {
@@ -206,8 +208,26 @@ function analyzeArtifact(artifact) {
   };
 }
 
+function uniqueRowsByName(rows) {
+  const byName = new Map();
+  for (const row of rows) {
+    if (!row?.name || byName.has(row.name)) continue;
+    byName.set(row.name, row);
+  }
+  return [...byName.values()];
+}
+
 function buildJson({ artifactAbsent, parseError, artifact, measurementProfile, validationWarnings, rows, missing, red, yellow, gray, green, duplicates }) {
   const missingNames = missing?.map((r) => r.name) ?? REQUIRED_PROJECT_ROWS;
+  const nonGreenRows = rows
+    ? uniqueRowsByName([
+      ...(red ?? []),
+      ...(yellow ?? []),
+      ...(gray ?? []),
+      ...(missing ?? []),
+      ...(duplicates ?? []),
+    ])
+    : missingNames.map((name) => ({ name, state: "missing" }));
   return {
     artifact_absent: artifactAbsent,
     parse_error: parseError ?? null,
@@ -228,6 +248,13 @@ function buildJson({ artifactAbsent, parseError, artifact, measurementProfile, v
     missing: missingNames.length,
     missing_rows: missingNames,
     duplicate_rows: duplicates?.map((r) => ({ name: r.name, count: r.duplicate_count })) ?? [],
+    all_required_rows_green: rows
+      ? nonGreenRows.length === 0 && green?.length === rows.length
+      : false,
+    non_green_required_rows: nonGreenRows.map((r) => ({
+      name: r.name,
+      state: r.state,
+    })),
     red_rows: red?.map((r) => r.name) ?? [],
     yellow_rows: yellow?.map((r) => r.name) ?? [],
     rows: rows?.map((r) => ({
@@ -471,6 +498,15 @@ if (missing.length > 0 || duplicates.length > 0) {
         missing.map((r) => r.name).join(", ") + "\n",
     );
   }
+  process.exit(1);
+}
+
+if (requireGreen && (red.length > 0 || yellow.length > 0 || gray.length > 0)) {
+  const nonGreen = [...red, ...yellow, ...gray];
+  process.stderr.write(
+    `bench-artifact-readiness: ${nonGreen.length} required row(s) are not green: ` +
+      nonGreen.map((r) => `${r.name} (${r.state})`).join(", ") + "\n",
+  );
   process.exit(1);
 }
 

--- a/scripts/bench/test-check-artifact-readiness.mjs
+++ b/scripts/bench/test-check-artifact-readiness.mjs
@@ -158,12 +158,15 @@ withTempDir((dir) => {
   const file = path.join(dir, "bench.json");
   const rows = REQUIRED_PROJECT_ROWS.map((name) => makeRow(name, "green"));
   writeJson(file, makeArtifact(rows, { measurement_profile: SAMPLE_MEASUREMENT_PROFILE }));
-  const result = run(file);
+  const result = run(file, ["--json", "--require-green"]);
   assert.equal(result.status, 0, `all-green artifact should exit 0, got:\n${result.stderr}`);
-  assert.match(result.stdout, new RegExp(`green.*\\| ${REQUIRED_PROJECT_ROWS.length}`), "should show all green count");
-  assert.match(result.stdout, /Measurement profile.*release-pgo/, "should show measurement profile mode");
-  assert.match(result.stdout, /PGO profile.*abcdef123456/, "should show PGO profile fingerprint");
-  assert.match(result.stdout, /PGO training.*123456abcdef/, "should show PGO training fingerprint");
+  const parsed = JSON.parse(result.stdout.trim());
+  assert.equal(parsed.all_required_rows_green, true, "all-green JSON should mark release gate ready");
+  assert.deepEqual(parsed.non_green_required_rows, [], "all-green JSON should not report non-green rows");
+  assert.match(result.stderr, new RegExp(`green.*\\| ${REQUIRED_PROJECT_ROWS.length}`), "should show all green count");
+  assert.match(result.stderr, /Measurement profile.*release-pgo/, "should show measurement profile mode");
+  assert.match(result.stderr, /PGO profile.*abcdef123456/, "should show PGO profile fingerprint");
+  assert.match(result.stderr, /PGO training.*123456abcdef/, "should show PGO training fingerprint");
 });
 console.log("✅ complete all-green artifact exits 0");
 
@@ -273,6 +276,29 @@ withTempDir((dir) => {
 console.log("✅ red row present in artifact exits 0 (not missing)");
 
 // ---------------------------------------------------------------------------
+// Test: --require-green fails when any present required row is red.
+// ---------------------------------------------------------------------------
+withTempDir((dir) => {
+  const file = path.join(dir, "bench.json");
+  const redName = REQUIRED_PROJECT_ROWS[0];
+  const rows = REQUIRED_PROJECT_ROWS.map((name, i) =>
+    i === 0 ? makeRow(name, "red", { errorStatus: "tsz crashed" }) : makeRow(name, "green"),
+  );
+  writeJson(file, makeArtifact(rows));
+  const result = run(file, ["--json", "--require-green"]);
+  assert.equal(result.status, 1, "--require-green should fail when a required row is red");
+  const parsed = JSON.parse(result.stdout.trim());
+  assert.equal(parsed.all_required_rows_green, false, "JSON should mark release gate not ready");
+  assert.deepEqual(
+    parsed.non_green_required_rows,
+    [{ name: redName, state: "red" }],
+    "JSON should name the red required row",
+  );
+  assert.match(result.stderr, new RegExp(`${redName} \\(red\\)`));
+});
+console.log("✅ --require-green fails on red required rows");
+
+// ---------------------------------------------------------------------------
 // Test: yellow row → exit 0
 // ---------------------------------------------------------------------------
 withTempDir((dir) => {
@@ -287,6 +313,38 @@ withTempDir((dir) => {
   assert.match(result.stdout, /some failure/, "should name the first failure class for yellow rows");
 });
 console.log("✅ yellow row present exits 0");
+
+// ---------------------------------------------------------------------------
+// Test: --require-green fails when required rows are yellow or gray.
+// ---------------------------------------------------------------------------
+withTempDir((dir) => {
+  const file = path.join(dir, "bench.json");
+  const yellowName = REQUIRED_PROJECT_ROWS[0];
+  const grayName = REQUIRED_PROJECT_ROWS[1];
+  const partialGreen = makeRow(grayName, "green");
+  delete partialGreen.compatibility.phase;
+  const rows = REQUIRED_PROJECT_ROWS.map((name, i) => {
+    if (i === 0) return makeRow(name, "yellow");
+    if (i === 1) return partialGreen;
+    return makeRow(name, "green");
+  });
+  writeJson(file, makeArtifact(rows));
+  const result = run(file, ["--json", "--require-green"]);
+  assert.equal(result.status, 1, "--require-green should fail on yellow/gray rows");
+  const parsed = JSON.parse(result.stdout.trim());
+  assert.equal(parsed.all_required_rows_green, false, "JSON should mark release gate not ready");
+  assert.deepEqual(
+    parsed.non_green_required_rows,
+    [
+      { name: yellowName, state: "yellow" },
+      { name: grayName, state: "gray" },
+    ],
+    "JSON should name yellow and gray required rows",
+  );
+  assert.match(result.stderr, new RegExp(`${yellowName} \\(yellow\\)`));
+  assert.match(result.stderr, new RegExp(`${grayName} \\(gray\\)`));
+});
+console.log("✅ --require-green fails on yellow or gray required rows");
 
 // ---------------------------------------------------------------------------
 // Test: partial compatibility metadata cannot be reported as green.
@@ -459,6 +517,8 @@ withTempDir((dir) => {
   }
   assert.equal(parsed.artifact_absent, true, "JSON should have artifact_absent: true");
   assert.equal(parsed.missing, REQUIRED_PROJECT_ROWS.length, "all rows should be missing");
+  assert.equal(parsed.all_required_rows_green, false, "absent artifact is not release-ready");
+  assert.equal(parsed.non_green_required_rows.length, REQUIRED_PROJECT_ROWS.length, "all missing rows are non-green");
 });
 console.log("✅ --json with absent artifact emits artifact_absent: true");
 


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 1 release metric truth; benchmark artifact guard fix.

## Invariant
When release automation needs a fully green required project-corpus benchmark artifact, artifact presence alone is not enough; `--require-green` must fail on any red, yellow, gray, missing, or duplicate required row and report the exact non-green rows in JSON.

## Scope
- `scripts/bench/check-artifact-readiness.mjs`
- `scripts/bench/test-check-artifact-readiness.mjs`

## Project Corpus Impact
- Row: all required benchmark rows
- Bug family: benchmark artifact truth / project-corpus release gate
- Evidence: tooling-only guard over existing benchmark artifacts; no fixture, compiler, checker, solver, parser, binder, emitter, or corpus behavior changes. Current public artifact is present with 7 green and 4 red required rows, and `--require-green` now fails while naming `ts-toolbelt-project`, `zod-project`, `kysely-project`, and `large-ts-repo`.

## Verification
- `node scripts/bench/test-check-artifact-readiness.mjs`
- `node scripts/bench/check-artifact-readiness.mjs --json --require-green crates/tsz-website/bench-snapshot.json` exits 1 and reports the 4 red required rows
- `node scripts/bench/validate-project-metadata.mjs`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Existing Studio-A PR runway was empty before opening this PR.
- This is code/test tooling only; no repository markdown/docs files edited.
- Default artifact-readiness behavior remains artifact completeness: red/yellow/gray rows still exit 0 unless `--require-green` is passed.
