### PR TITLE
chore(emit-tools): expose output surgery report status

### DIFF
--- a/scripts/emit/audit-output-surgery.py
+++ b/scripts/emit/audit-output-surgery.py
@@ -347,6 +347,7 @@ def build_json_report(
     file_summaries = build_file_summaries(counts, allowlist)
     return {
         "ok": not failures,
+        "status": "failed" if failures else "passed",
         "total_findings": len(findings),
         "files_with_findings": len(counts),
         "failure_summary": dataclasses.asdict(summary),

--- a/scripts/emit/test_output_surgery_audit.py
+++ b/scripts/emit/test_output_surgery_audit.py
@@ -80,6 +80,7 @@ class OutputSurgeryAuditTests(unittest.TestCase):
         report = self.audit.build_json_report(findings, allowlist, failures)
 
         self.assertFalse(report["ok"])
+        self.assertEqual(report["status"], "failed")
         self.assertEqual(report["total_findings"], 2)
         self.assertEqual(report["files_with_findings"], 2)
         self.assertEqual(report["failure_summary"]["unallowlisted"], 1)
@@ -138,6 +139,7 @@ class OutputSurgeryAuditTests(unittest.TestCase):
         report = self.audit.build_json_report(findings, allowlist, [])
 
         self.assertTrue(report["ok"])
+        self.assertEqual(report["status"], "passed")
         self.assertEqual(report["failures"], [])
 
     def test_pass_summary_names_clean_guardrail_counters(self):


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / cheap evidence plumbing.

## Invariant
When the output-surgery audit writes machine-readable evidence, consumers can read both a boolean ok field and an explicit passed/failed status without inferring status from failure arrays.

## Scope
- scripts/emit/audit-output-surgery.py
- scripts/emit/test_output_surgery_audit.py

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: emit-tooling JSON report only; no compiler, checker, solver, parser, or project-corpus behavior changes.

## Verification
- python3 scripts/emit/test_output_surgery_audit.py
- python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery-status.json
- git diff --check origin/main...HEAD

## Coordination Notes
- Owned by Studio-F as a small cheap-evidence plumbing slice after #11975 merged.
- Rebased onto latest origin/main after the earlier CI run exposed unrelated conformance aggregate drift.
- Exact head: 70ae382147.
