### PR TITLE
test(solver): ratchet relation policy cache builders

### DIFF
--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/policy_config.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/policy_config.rs
@@ -6,6 +6,7 @@ use crate::intern::TypeInterner;
 use crate::relations::relation_queries::{
     RelationContext, RelationKind, RelationPolicy, query_relation,
 };
+use crate::relations::subtype::AnyPropagationMode;
 use crate::types::{
     FunctionShape, ParamInfo, PropertyInfo, RelationCacheKey, RelationFlags, TypeId,
 };
@@ -85,6 +86,74 @@ fn relation_policy_builder_overrides_remove_prior_flag_bits_from_cache_config() 
             "{name} builder override must remove stale flag bits from the cache config",
         );
     }
+}
+
+#[test]
+fn relation_policy_behavior_builders_partition_cache_config() {
+    let base = RelationPolicy::default();
+    let cases = [
+        (
+            "disable generic erasure",
+            base.with_erase_generics(false).cache_config(),
+        ),
+        (
+            "strict subtype checking",
+            base.with_strict_subtype_checking(true).cache_config(),
+        ),
+        (
+            "strict any propagation",
+            base.with_strict_any_propagation(true).cache_config(),
+        ),
+        (
+            "top-level-only any propagation",
+            base.with_any_propagation_mode(AnyPropagationMode::TopLevelOnly)
+                .cache_config(),
+        ),
+        (
+            "reject cycles instead of assuming related",
+            base.with_assume_related_on_cycle(false).cache_config(),
+        ),
+        (
+            "skip weak type checks",
+            base.with_skip_weak_type_checks(true).cache_config(),
+        ),
+    ];
+
+    for (name, config) in cases {
+        assert_ne!(
+            base.cache_config(),
+            config,
+            "{name} must occupy a distinct relation cache config",
+        );
+    }
+}
+
+#[test]
+fn relation_policy_builder_cache_matrix_covers_current_behavior_builders() {
+    let source = include_str!("../../src/relations/relation_queries.rs");
+    let builders: Vec<&str> = source
+        .lines()
+        .filter_map(|line| {
+            line.trim()
+                .strip_prefix("pub const fn ")
+                .and_then(|rest| rest.split_once('('))
+                .map(|(name, _)| name)
+                .filter(|name| name.starts_with("with_"))
+        })
+        .collect();
+
+    assert_eq!(
+        builders,
+        [
+            "with_erase_generics",
+            "with_strict_subtype_checking",
+            "with_strict_any_propagation",
+            "with_any_propagation_mode",
+            "with_assume_related_on_cycle",
+            "with_skip_weak_type_checks",
+        ],
+        "new behavior-affecting RelationPolicy builders must update the cache-config partition matrix",
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Solver relation policy/cache-key tech debt (#8207); test-only ratchet.

## Invariant
When a `RelationPolicy` builder changes behavior that can affect a relation answer, the projected `RelationCacheConfig` must change too; this PR adds solver tests that keep the policy-builder matrix aligned with cache-key partitioning.

## Scope
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests/policy_config.rs`
- Adds cache-config partition coverage for current behavior-affecting `RelationPolicy::with_*` builders.
- Adds a source-level matrix guard so new policy builders must update the cache-config partition test intentionally.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: solver test-harness-only ratchet; no production compiler behavior changed.

## Verification
- `cargo fmt --check`
- `cargo nextest run -p tsz-solver -E 'test(policy_config)'` (5 passed, 6443 skipped)
- `git diff --check origin/main...HEAD`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Fresh worktree: `/Users/mohsen/code/tsz-m4b-policy-cache-ratchet-20260531`
- Rebased after #11947 landed; current base: `5bcc6d46d8c500c2ed2126ca8dde592f174e8b86`
- Head reviewed/pushed: `ec036189a9b65a1999bee85cbf940069e0fafaeb`
- Non-overlap: #11947 has landed; this PR is a separate test-only #8207 ratchet and does not touch production relation code or checker routing.
- Draft/off queue while exact-head light CI completes.
