### PR TITLE
fix(checker): suppress cascading TS2322 after TS2769 on variable declarations

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -198,7 +198,15 @@ impl<'a> CheckerState<'a> {
         )
     }
 
-    fn should_suppress_assignment_after_overload_failure(&self, anchor_idx: NodeIndex) -> bool {
+    fn should_suppress_assignment_after_overload_failure(
+        &self,
+        source: TypeId,
+        anchor_idx: NodeIndex,
+    ) -> bool {
+        if source != TypeId::NEVER && source != TypeId::ERROR {
+            return false;
+        }
+
         let Some(anchor_node) = self.ctx.arena.get(anchor_idx) else {
             return false;
         };
@@ -529,7 +537,7 @@ impl<'a> CheckerState<'a> {
             }
             return;
         }
-        if self.should_suppress_assignment_after_overload_failure(anchor_idx) {
+        if self.should_suppress_assignment_after_overload_failure(source, anchor_idx) {
             return;
         }
 

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -233,11 +233,7 @@ impl<'a> CheckerState<'a> {
             {
                 return false;
             }
-            return self.ctx.diagnostics.iter().any(|diag| {
-                diag.code == diagnostic_codes::NO_OVERLOAD_MATCHES_THIS_CALL
-                    && diag.start >= rhs_node.pos
-                    && diag.start < rhs_node.end
-            });
+            return self.call_or_new_expr_emitted_no_overload_failure(rhs_idx, rhs_node);
         }
 
         // Case 2: `const x: T = fn(true);` — anchor is the variable name IDENTIFIER.
@@ -268,14 +264,23 @@ impl<'a> CheckerState<'a> {
             {
                 return false;
             }
-            return self.ctx.diagnostics.iter().any(|diag| {
-                diag.code == diagnostic_codes::NO_OVERLOAD_MATCHES_THIS_CALL
-                    && diag.start >= init_node.pos
-                    && diag.start < init_node.end
-            });
+            return self.call_or_new_expr_emitted_no_overload_failure(init_idx, init_node);
         }
 
         false
+    }
+
+    fn call_or_new_expr_emitted_no_overload_failure(
+        &self,
+        expr_idx: NodeIndex,
+        expr_node: &tsz_parser::parser::node::Node,
+    ) -> bool {
+        self.ctx.no_overload_call_nodes.contains(&expr_idx.0)
+            && self.ctx.diagnostics.iter().any(|diag| {
+                diag.code == diagnostic_codes::NO_OVERLOAD_MATCHES_THIS_CALL
+                    && diag.start >= expr_node.pos
+                    && diag.start < expr_node.end
+            })
     }
 
     pub(super) fn private_or_protected_member_missing_display(

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -202,42 +202,80 @@ impl<'a> CheckerState<'a> {
         let Some(anchor_node) = self.ctx.arena.get(anchor_idx) else {
             return false;
         };
-        if anchor_node.kind != syntax_kind_ext::EXPRESSION_STATEMENT {
-            return false;
+
+        // Case 1: `x = fn(true);` — anchor is EXPRESSION_STATEMENT
+        if anchor_node.kind == syntax_kind_ext::EXPRESSION_STATEMENT {
+            let Some(expr_stmt) = self.ctx.arena.get_expression_statement(anchor_node) else {
+                return false;
+            };
+            let expr_idx = self.ctx.arena.skip_parenthesized(expr_stmt.expression);
+            let Some(expr_node) = self.ctx.arena.get(expr_idx) else {
+                return false;
+            };
+            if expr_node.kind != syntax_kind_ext::BINARY_EXPRESSION {
+                return false;
+            }
+            let Some(binary) = self.ctx.arena.get_binary_expr(expr_node) else {
+                return false;
+            };
+            if !self.is_assignment_operator(binary.operator_token) {
+                return false;
+            }
+            let rhs_idx = self
+                .ctx
+                .arena
+                .skip_parenthesized_and_assertions(binary.right);
+            let Some(rhs_node) = self.ctx.arena.get(rhs_idx) else {
+                return false;
+            };
+            if rhs_node.kind != syntax_kind_ext::CALL_EXPRESSION
+                && rhs_node.kind != syntax_kind_ext::NEW_EXPRESSION
+            {
+                return false;
+            }
+            return self.ctx.diagnostics.iter().any(|diag| {
+                diag.code == diagnostic_codes::NO_OVERLOAD_MATCHES_THIS_CALL
+                    && diag.start >= rhs_node.pos
+                    && diag.start < rhs_node.end
+            });
         }
-        let Some(expr_stmt) = self.ctx.arena.get_expression_statement(anchor_node) else {
-            return false;
-        };
-        let expr_idx = self.ctx.arena.skip_parenthesized(expr_stmt.expression);
-        let Some(expr_node) = self.ctx.arena.get(expr_idx) else {
-            return false;
-        };
-        if expr_node.kind != syntax_kind_ext::BINARY_EXPRESSION {
-            return false;
+
+        // Case 2: `const x: T = fn(true);` — anchor is the variable name IDENTIFIER.
+        // Walk up to the VARIABLE_DECLARATION and check the initializer.
+        if anchor_node.kind == tsz_scanner::SyntaxKind::Identifier as u16 {
+            let Some(ext) = self.ctx.arena.get_extended(anchor_idx) else {
+                return false;
+            };
+            let parent_idx = ext.parent;
+            let Some(parent_node) = self.ctx.arena.get(parent_idx) else {
+                return false;
+            };
+            if parent_node.kind != syntax_kind_ext::VARIABLE_DECLARATION {
+                return false;
+            }
+            let Some(vd) = self.ctx.arena.get_variable_declaration(parent_node) else {
+                return false;
+            };
+            let init_idx = self
+                .ctx
+                .arena
+                .skip_parenthesized_and_assertions(vd.initializer);
+            let Some(init_node) = self.ctx.arena.get(init_idx) else {
+                return false;
+            };
+            if init_node.kind != syntax_kind_ext::CALL_EXPRESSION
+                && init_node.kind != syntax_kind_ext::NEW_EXPRESSION
+            {
+                return false;
+            }
+            return self.ctx.diagnostics.iter().any(|diag| {
+                diag.code == diagnostic_codes::NO_OVERLOAD_MATCHES_THIS_CALL
+                    && diag.start >= init_node.pos
+                    && diag.start < init_node.end
+            });
         }
-        let Some(binary) = self.ctx.arena.get_binary_expr(expr_node) else {
-            return false;
-        };
-        if !self.is_assignment_operator(binary.operator_token) {
-            return false;
-        }
-        let rhs_idx = self
-            .ctx
-            .arena
-            .skip_parenthesized_and_assertions(binary.right);
-        let Some(rhs_node) = self.ctx.arena.get(rhs_idx) else {
-            return false;
-        };
-        if rhs_node.kind != syntax_kind_ext::CALL_EXPRESSION
-            && rhs_node.kind != syntax_kind_ext::NEW_EXPRESSION
-        {
-            return false;
-        }
-        self.ctx.diagnostics.iter().any(|diag| {
-            diag.code == diagnostic_codes::NO_OVERLOAD_MATCHES_THIS_CALL
-                && diag.start >= rhs_node.pos
-                && diag.start < rhs_node.end
-        })
+
+        false
     }
 
     pub(super) fn private_or_protected_member_missing_display(

--- a/crates/tsz-checker/src/error_reporter/call_errors_overload_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_overload_tests.rs
@@ -782,15 +782,10 @@ const result: string[] = map(["a", "b"], x => x);
     );
 }
 
-/// When ALL overloads return the same type (e.g. both return `string`), the
-/// intersection fallback is `string`.  After TS2769, tsc does NOT also emit
-/// TS2322 on the declaration because the call's return type is `errorType` —
-/// it is not a concrete `string` the assignability check can see.
-///
-/// This tests that tsz likewise does NOT cascade TS2322 when all overloads
-/// share a return type and the declared annotation is incompatible.
+/// When all overloads return the same type, overload-failure recovery remains
+/// that type. tsc still reports the real downstream declaration TS2322.
 #[test]
-fn overload_same_return_type_ts2769_no_cascading_ts2322() {
+fn overload_same_return_type_ts2769_reports_decl_ts2322() {
     let source = r#"
 function fn(x: string): string;
 function fn(x: number): string;
@@ -802,16 +797,18 @@ const n: number = fn(true);
         diagnostics.iter().any(|d| d.code == 2769),
         "expected TS2769 for fn(true), got: {diagnostics:?}"
     );
-    let ts2322_count = diagnostics.iter().filter(|d| d.code == 2322).count();
-    assert_eq!(
-        ts2322_count, 0,
-        "tsc does not cascade TS2322 after TS2769 even when all overloads return same type; got: {diagnostics:?}"
+    let n_pos = source.find("const n").unwrap() as u32 + "const ".len() as u32;
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == 2322 && d.start == n_pos),
+        "same-return overload recovery should keep the real declaration TS2322 at `n`, got: {diagnostics:?}"
     );
 }
 
 /// Same as above but using assignment statement form rather than declaration.
 #[test]
-fn overload_same_return_type_ts2769_no_cascading_ts2322_assignment_stmt() {
+fn overload_same_return_type_ts2769_reports_assignment_ts2322() {
     let source = r#"
 function fn(x: string): string;
 function fn(x: number): string;
@@ -824,10 +821,12 @@ n = fn(true);
         diagnostics.iter().any(|d| d.code == 2769),
         "expected TS2769, got: {diagnostics:?}"
     );
-    let ts2322_count = diagnostics.iter().filter(|d| d.code == 2322).count();
-    assert_eq!(
-        ts2322_count, 0,
-        "tsc does not cascade TS2322 after TS2769 in assignment stmt when overloads share return type; got: {diagnostics:?}"
+    let assignment_pos = source.rfind("n =").unwrap() as u32;
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == 2322 && d.start == assignment_pos),
+        "same-return overload recovery should keep the real assignment TS2322, got: {diagnostics:?}"
     );
 }
 
@@ -875,5 +874,41 @@ n = outer(inner(true));
             .iter()
             .any(|d| d.code == 2322 && d.start == assignment_pos),
         "nested overload failures must not suppress the real outer assignment TS2322, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn overload_failure_initializer_preserves_real_ts2322() {
+    let source = r#"
+type Pick<T, K extends keyof T> = { [P in K]: T[P] };
+type Exclude<T, U> = T extends U ? never : T;
+type Assign<T, U> = Omit<T, keyof U> & U;
+type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+declare const Object: {
+    assign<T extends {}, U>(target: T, source: U): T & U;
+    assign(target: object, ...sources: any[]): any;
+};
+
+class Base<T> {
+    constructor(public t: T) { }
+}
+
+export class Foo<T> extends Base<T> {
+    update(): Foo<Assign<T, { x: number }>> {
+        const v: Assign<T, { x: number }> = Object.assign(this.t, { x: 1 });
+        return new Foo(v);
+    }
+}
+"#;
+    let diagnostics = check_source_with_strict_null(source);
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2769),
+        "expected TS2769 for Object.assign(this.t, ...), got: {diagnostics:?}"
+    );
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2322
+            && d.message_text
+                .contains("not assignable to type 'Assign<T, { x: number; }>'")),
+        "the initializer overload failure must not hide the real TS2322, got: {diagnostics:?}"
     );
 }

--- a/crates/tsz-checker/src/error_reporter/call_errors_overload_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_overload_tests.rs
@@ -529,3 +529,304 @@ class Box {
         "multi-overload nullable mismatch should stay TS2769, got: {diagnostics:?}"
     );
 }
+
+#[test]
+fn overload_impl_sig_excluded_bool_arg_errors_at_call_site() {
+    // The implementation signature (x: any) must never be included in the
+    // overload candidate set. If it were, `foo(true)` would silently succeed
+    // because `true` is assignable to `any`. The error must be TS2769 anchored
+    // at the call site (argument or callee), not inside the implementation.
+    let source = r#"
+function foo(x: string): string;
+function foo(x: number): number;
+function foo(x: any): any { return x; }
+foo(true);
+"#;
+    let diagnostics = check_source_with_strict_null(source);
+    let impl_start = source.find("function foo(x: any)").unwrap() as u32;
+    let impl_end = impl_start + "function foo(x: any): any { return x; }".len() as u32;
+    for diag in &diagnostics {
+        assert!(
+            diag.start < impl_start || diag.start >= impl_end,
+            "error must not be anchored inside the implementation signature, got: {diag:?}"
+        );
+    }
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2769),
+        "expected TS2769 for foo(true) — impl sig must not be an overload candidate, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn overload_impl_sig_excluded_class_method() {
+    // Class method variant: the implementation method `(x: any)` must not
+    // appear as a callable overload from the outside.
+    let source = r#"
+class C {
+    method(x: string): string;
+    method(x: number): number;
+    method(x: any): any { return x; }
+}
+const c = new C();
+c.method(true);
+"#;
+    let diagnostics = check_source_with_strict_null(source);
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2769),
+        "expected TS2769 for c.method(true), got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn overload_single_mismatch_reports_at_arg_not_impl_span() {
+    // When exactly one overload has arity-compatible mismatches the checker
+    // may take a single-mismatch fast path. The diagnostic must still be
+    // anchored at the argument, not at any declaration inside the function.
+    let source = r#"
+declare function fn(value: string): string;
+declare function fn(value: string, extra: number): number;
+const x = fn(42);
+"#;
+    let diagnostics = check_source_with_strict_null(source);
+    let arg_start = source.rfind("42").unwrap() as u32;
+    let overload1_start = source.find("fn(value: string)").unwrap() as u32;
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| { (d.code == 2769 || d.code == 2345) && d.start == arg_start }),
+        "error must be at the argument `42` (position {arg_start}), overload start: {overload1_start}, got: {diagnostics:?}"
+    );
+}
+
+// ── Assignment-context + overloads ────────────────────────────────────────────────
+
+/// `const s: string = fn(42)` — overload 2 returns number, assigning to string
+/// should give TS2322 at `s`, NOT inside the implementation body.
+#[test]
+fn overload_return_mismatch_ts2322_anchored_at_variable() {
+    let source = r#"
+function fn(x: string): string;
+function fn(x: number): number;
+function fn(x: any): any { return x; }
+const s: string = fn(42);
+"#;
+    let diagnostics = check_source_with_strict_null(source);
+    // fn(42) matches overload 2 returning number; `const s: string` triggers TS2322.
+    let ts2322: Vec<_> = diagnostics.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "expected exactly one TS2322, got: {diagnostics:?}"
+    );
+    // The anchor must be at `s` — find its position.
+    let s_pos = source.find("const s").unwrap() as u32 + "const ".len() as u32;
+    assert_eq!(
+        ts2322[0].start, s_pos,
+        "TS2322 must be anchored at `s`, not inside the implementation; got: {:?}",
+        ts2322[0]
+    );
+}
+
+/// `const b: boolean = fn(true)` — no overload matches boolean, so TS2769 fires.
+/// After TS2769, there should be NO cascading TS2322 for the declaration.
+/// (tsc suppresses the assignment error when the call already failed.)
+#[test]
+fn overload_no_match_ts2769_no_cascading_ts2322_on_decl() {
+    let source = r#"
+function fn(x: string): string;
+function fn(x: number): number;
+function fn(x: any): any { return x; }
+const b: boolean = fn(true);
+"#;
+    let diagnostics = check_source_with_strict_null(source);
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2769),
+        "expected TS2769 for fn(true), got: {diagnostics:?}"
+    );
+    // tsc does NOT cascade TS2322 on a variable declaration when the assigned
+    // expression already produced TS2769. Verify we do not double-report.
+    let ts2322_count = diagnostics.iter().filter(|d| d.code == 2322).count();
+    assert_eq!(
+        ts2322_count, 0,
+        "TS2322 must not cascade after TS2769 on a variable declaration, got: {diagnostics:?}"
+    );
+}
+
+/// Assignment-statement form: `x = fn(true)` — TS2769 fires; no cascading TS2322.
+#[test]
+fn overload_no_match_ts2769_no_cascading_ts2322_on_assignment_stmt() {
+    let source = r#"
+function fn(x: string): string;
+function fn(x: number): number;
+function fn(x: any): any { return x; }
+let x: string;
+x = fn(true);
+"#;
+    let diagnostics = check_source_with_strict_null(source);
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2769),
+        "expected TS2769, got: {diagnostics:?}"
+    );
+    let ts2322_count = diagnostics.iter().filter(|d| d.code == 2322).count();
+    assert_eq!(
+        ts2322_count, 0,
+        "TS2322 must not cascade after TS2769 in assignment statement, got: {diagnostics:?}"
+    );
+}
+
+/// Overloaded generic: contextual return type should help select overload.
+/// `const n: number = fnG("hello")` — overload 1 returns T=number when annotated.
+#[test]
+fn overload_generic_contextual_return_type_selects_correct_overload() {
+    let source = r#"
+function fnG<T>(x: string): T;
+function fnG<T>(x: number): T;
+function fnG<T>(x: any): T { return x; }
+const n: number = fnG("hello");
+"#;
+    let diagnostics = check_source_with_strict_null(source);
+    // With contextual type `number`, T=number should be inferred.
+    // fn("hello") should succeed (string matches string param) and return number.
+    // If contextual type is missing, T=unknown and string->number gives TS2322.
+    // We accept both zero errors OR a single TS2322 at `n`.
+    // Key invariant: no error inside the implementation body.
+    let impl_start = source.find("function fnG<T>(x: any)").unwrap() as u32;
+    let impl_end = impl_start + "function fnG<T>(x: any): T { return x; }".len() as u32;
+    for d in &diagnostics {
+        assert!(
+            d.start < impl_start || d.start >= impl_end,
+            "error must not be inside the implementation body, got: {d:?}"
+        );
+    }
+}
+
+/// Implementation-site diagnostic guard: class method overload.
+/// Call that fails TS2769 must anchor at the call site, not inside the
+/// implementation method's body or its declaring class span.
+#[test]
+fn overload_class_method_ts2769_anchored_at_call_not_impl_body() {
+    let source = r#"
+class Processor {
+    run(x: string): string;
+    run(x: number): number;
+    run(x: any): any { return x; }
+}
+const p = new Processor();
+p.run(true);
+"#;
+    let diagnostics = check_source_with_strict_null(source);
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2769),
+        "expected TS2769 for p.run(true), got: {diagnostics:?}"
+    );
+    // Anchor must be at the call `p.run(true)`, specifically at `true`.
+    let impl_start = source.find("run(x: any)").unwrap() as u32;
+    let impl_end = impl_start + "run(x: any): any { return x; }".len() as u32;
+    for d in diagnostics.iter().filter(|d| d.code == 2769) {
+        assert!(
+            d.start < impl_start || d.start >= impl_end,
+            "TS2769 anchor inside implementation body, got: {d:?}"
+        );
+    }
+}
+
+/// Overload with impl having no return annotation: the impl is invisible to
+/// callers. TS2769 must NOT include the implementation in failure list.
+#[test]
+fn overload_impl_no_return_annotation_excluded_from_failures() {
+    let source = r#"
+function transform(x: string): string;
+function transform(x: number): number;
+function transform(x: any) { return x; }
+transform({});
+"#;
+    let diagnostics = check_source_with_strict_null(source);
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2769),
+        "expected TS2769 for transform(object), got: {diagnostics:?}"
+    );
+    // Count related info: should have exactly 2 entries (one per overload, not 3).
+    let ts2769: Vec<_> = diagnostics.iter().filter(|d| d.code == 2769).collect();
+    assert_eq!(ts2769.len(), 1, "expected one TS2769, got: {diagnostics:?}");
+    // The implementation starts at:
+    let impl_start = source.find("function transform(x: any)").unwrap() as u32;
+    let impl_end = impl_start + "function transform(x: any) { return x; }".len() as u32;
+    for d in &diagnostics {
+        assert!(
+            d.start < impl_start || d.start >= impl_end,
+            "no error should be anchored inside the implementation, got: {d:?}"
+        );
+    }
+}
+
+/// Assignment context propagates to narrow overload return when contextual type
+/// is explicit: `const s: string[] = map(["a","b"], x => x)` should work.
+/// (Array.map has overloads; the context string[] guides T inference.)
+#[test]
+fn overload_contextual_return_type_propagates_to_generic_arg_inference() {
+    let source = r#"
+function map<T, U>(arr: T[], fn: (x: T) => U): U[];
+function map<T>(arr: T[]): T[];
+function map<T, U>(arr: T[], fn?: (x: T) => U): (T | U)[] { return arr as any; }
+const result: string[] = map(["a", "b"], x => x);
+"#;
+    let diagnostics = check_source_with_strict_null(source);
+    // The call should succeed cleanly with correct contextual type propagation.
+    let non_trivial: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code == 2322 || d.code == 2345 || d.code == 2769)
+        .collect();
+    assert!(
+        non_trivial.is_empty(),
+        "expected no type errors for map with contextual string[] return, got: {non_trivial:?}"
+    );
+}
+
+/// When ALL overloads return the same type (e.g. both return `string`), the
+/// intersection fallback is `string`.  After TS2769, tsc does NOT also emit
+/// TS2322 on the declaration because the call's return type is `errorType` —
+/// it is not a concrete `string` the assignability check can see.
+///
+/// This tests that tsz likewise does NOT cascade TS2322 when all overloads
+/// share a return type and the declared annotation is incompatible.
+#[test]
+fn overload_same_return_type_ts2769_no_cascading_ts2322() {
+    let source = r#"
+function fn(x: string): string;
+function fn(x: number): string;
+function fn(x: any): any { return ""; }
+const n: number = fn(true);
+"#;
+    let diagnostics = check_source_with_strict_null(source);
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2769),
+        "expected TS2769 for fn(true), got: {diagnostics:?}"
+    );
+    let ts2322_count = diagnostics.iter().filter(|d| d.code == 2322).count();
+    assert_eq!(
+        ts2322_count, 0,
+        "tsc does not cascade TS2322 after TS2769 even when all overloads return same type; got: {diagnostics:?}"
+    );
+}
+
+/// Same as above but using assignment statement form rather than declaration.
+#[test]
+fn overload_same_return_type_ts2769_no_cascading_ts2322_assignment_stmt() {
+    let source = r#"
+function fn(x: string): string;
+function fn(x: number): string;
+function fn(x: any): any { return ""; }
+let n: number;
+n = fn(true);
+"#;
+    let diagnostics = check_source_with_strict_null(source);
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2769),
+        "expected TS2769, got: {diagnostics:?}"
+    );
+    let ts2322_count = diagnostics.iter().filter(|d| d.code == 2322).count();
+    assert_eq!(
+        ts2322_count, 0,
+        "tsc does not cascade TS2322 after TS2769 in assignment stmt when overloads share return type; got: {diagnostics:?}"
+    );
+}

--- a/crates/tsz-checker/src/error_reporter/call_errors_overload_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_overload_tests.rs
@@ -830,3 +830,50 @@ n = fn(true);
         "tsc does not cascade TS2322 after TS2769 in assignment stmt when overloads share return type; got: {diagnostics:?}"
     );
 }
+
+#[test]
+fn nested_overload_failure_does_not_suppress_outer_decl_ts2322() {
+    let source = r#"
+function inner(x: string): string;
+function inner(x: number): string;
+function inner(x: any): any { return ""; }
+function outer(value: any): string { return ""; }
+const n: number = outer(inner(true));
+"#;
+    let diagnostics = check_source_with_strict_null(source);
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2769),
+        "expected nested TS2769 for inner(true), got: {diagnostics:?}"
+    );
+    let n_pos = source.find("const n").unwrap() as u32 + "const ".len() as u32;
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == 2322 && d.start == n_pos),
+        "nested overload failures must not suppress the real outer assignment TS2322 at `n`, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn nested_overload_failure_does_not_suppress_outer_assignment_ts2322() {
+    let source = r#"
+function inner(x: string): string;
+function inner(x: number): string;
+function inner(x: any): any { return ""; }
+function outer(value: any): string { return ""; }
+let n: number;
+n = outer(inner(true));
+"#;
+    let diagnostics = check_source_with_strict_null(source);
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2769),
+        "expected nested TS2769 for inner(true), got: {diagnostics:?}"
+    );
+    let assignment_pos = source.rfind("n =").unwrap() as u32;
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == 2322 && d.start == assignment_pos),
+        "nested overload failures must not suppress the real outer assignment TS2322, got: {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
Checker/diagnostics: utility-types-project overload/assignment diagnostic cascade cleanup.

## Invariant
When a typed assignment target receives a call/new expression whose failed overload recovery collapses to `never` or `error`, tsc suppresses the non-actionable cascading TS2322 for that assignment target; when overload recovery preserves a concrete return type or a later assignment/return mismatch is real, TS2322 must remain. This PR keeps that decision in checker diagnostic orchestration and keys it by exact call/new `NodeIndex`, not a broad diagnostic span search.

## Scope
- `crates/tsz-checker/src/error_reporter/assignability.rs`
- `crates/tsz-checker/src/error_reporter/call_errors_overload_tests.rs`

## Project Corpus Impact
- Row: utility-types-project
- Bug family: TS2769 cascading TS2322 on variable declarations / overload selection diagnostics
- Evidence: focused overload diagnostic tests cover direct declaration suppression, assignment-statement suppression, same-return overloads that preserve TS2322, nested-overload negative cases, and an Object.assign-style initializer that must not hide the real TS2322.

## Verification
- Rebased directly onto `origin/main` `3bff65092f36afb2456d792f5c844d32f6ca72bf` on 2026-06-01; current head `ef2a3fa65650e0e9abe61a84e1e01a6df49cd9e2`.
- `git diff --check origin/main..HEAD`.
- `cargo fmt --all --check`.
- `CARGO_BUILD_JOBS=2 cargo nextest run -p tsz-checker --lib -E 'test(error_reporter::call_errors::overload_tests::)'` => 31 passed.
- `CARGO_BUILD_JOBS=2 scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult --verbose` => 1/1 passed, fingerprint-only 0.
- `CARGO_BUILD_JOBS=2 scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter deeplyNestedMappedTypes --verbose` => 1/1 passed, fingerprint-only 0.
- `CARGO_BUILD_JOBS=2 scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter intersectionsOfLargeUnions2 --verbose` => 1/1 passed, fingerprint-only 0.
- `CARGO_BUILD_JOBS=2 scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter checkJsxChildrenCanBeTupleType --verbose` => 1/1 passed, fingerprint-only 0.
- `python3 scripts/conformance/query-conformance.py --dashboard` => local checked detail `12582/12582 (100.0%)`, accepted-regression gate `0`, with snapshot freshness warning `delta +3`.
- Exact-head ready-review CI on `ef2a3fa65650e0e9abe61a84e1e01a6df49cd9e2` is green: `CI Summary`, conformance aggregate, emit, fourslash aggregate, WASM, `lint`, `unit`, `dist-binaries`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, and `GitGuardian Security Checks` passed.

## Coordination Notes
- Fixes the blocker found on the rebased local head where `inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult` produced actual `[TS2769]` instead of `[TS2322, TS2769]`.
- Also fixes the earlier Reviewer concern on old head `cc1132e05cb27a8d878886c5f3d9dbe54a5beb6a`: the broad initializer span predicate over-suppressed TS2322 when a nested call inside the initializer emitted TS2769.
- The previous ready-review aggregate witnesses from head `997678be4406` were rechecked locally on this head with narrow filters: `deeplyNestedMappedTypes`, `inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult`, `intersectionsOfLargeUnions2`, and `checkJsxChildrenCanBeTupleType` all pass.
- Ready for merge queue on `ef2a3fa65650e0e9abe61a84e1e01a6df49cd9e2`; exact-head ready-review checks completed successfully.
- Agent label audit shows #11980 has the correct single `agent:M1-C` label; unrelated missing-label findings remain on other PRs/issues.