### PR TITLE
refactor(checker): name legacy relation policy edge

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -9,6 +9,8 @@ use tsz_solver::{
 
 use crate::state::CheckerState;
 
+use super::relation_policy;
+
 pub(crate) use super::common::{contains_type_parameters, object_shape_for_type};
 
 pub(crate) fn are_types_structurally_identical<R: TypeResolver>(
@@ -753,7 +755,7 @@ pub(crate) const fn assignability_cache_key(
     RelationCacheKey::for_assignability(
         source,
         target,
-        tsz_solver::relations::relation_queries::RelationPolicy::from_flags(flags).cache_config(),
+        relation_policy::from_checker_flags_u16(flags).cache_config(),
     )
 }
 
@@ -766,7 +768,7 @@ pub(crate) const fn subtype_cache_key(
     RelationCacheKey::for_subtype(
         source,
         target,
-        tsz_solver::relations::relation_queries::RelationPolicy::from_flags(flags).cache_config(),
+        relation_policy::from_checker_flags_u16(flags).cache_config(),
     )
 }
 pub(crate) use tsz_solver::type_queries::{
@@ -915,7 +917,7 @@ pub(crate) fn are_types_overlapping_with_env(
         flags |= RelationFlags::STRICT_NULL_CHECKS;
     }
 
-    let policy = tsz_solver::relations::relation_queries::RelationPolicy::from_flags(flags);
+    let policy = relation_policy::from_checker_flags_u16(flags);
     tsz_solver::relations::relation_queries::query_relation_with_resolver(
         db,
         env,
@@ -948,7 +950,7 @@ pub(crate) fn is_assignable_with_overrides<R: tsz_solver::relations::subtype::Ty
         inheritance_graph,
         sound_mode,
     } = *inputs;
-    let policy = tsz_solver::relations::relation_queries::RelationPolicy::from_flags(flags)
+    let policy = relation_policy::from_checker_flags_u16(flags)
         .with_strict_subtype_checking(sound_mode)
         .with_strict_any_propagation(sound_mode);
     let context = tsz_solver::relations::relation_queries::RelationContext {
@@ -987,7 +989,7 @@ pub(crate) fn is_assignable_no_weak_checks<R: tsz_solver::relations::subtype::Ty
         inheritance_graph,
         sound_mode,
     } = *inputs;
-    let policy = tsz_solver::relations::relation_queries::RelationPolicy::from_flags(flags)
+    let policy = relation_policy::from_checker_flags_u16(flags)
         .with_strict_subtype_checking(sound_mode)
         .with_strict_any_propagation(sound_mode)
         .with_skip_weak_type_checks(true);
@@ -1033,7 +1035,7 @@ pub(crate) fn is_assignable_bivariant_with_resolver<
     inheritance_graph: &InheritanceGraph,
     sound_mode: bool,
 ) -> tsz_solver::relations::relation_queries::RelationResult {
-    let policy = tsz_solver::relations::relation_queries::RelationPolicy::from_flags(flags)
+    let policy = relation_policy::from_checker_flags_u16(flags)
         .with_strict_subtype_checking(sound_mode)
         .with_strict_any_propagation(sound_mode);
     let context = tsz_solver::relations::relation_queries::RelationContext {
@@ -1061,7 +1063,7 @@ pub(crate) fn is_subtype_with_resolver<R: tsz_solver::relations::subtype::TypeRe
     inheritance_graph: &InheritanceGraph,
     class_check: Option<&dyn Fn(tsz_solver::SymbolRef) -> bool>,
 ) -> tsz_solver::relations::relation_queries::RelationResult {
-    let policy = tsz_solver::relations::relation_queries::RelationPolicy::from_flags(flags);
+    let policy = relation_policy::from_checker_flags_u16(flags);
     let context = tsz_solver::relations::relation_queries::RelationContext {
         query_db: Some(db),
         inheritance_graph: Some(inheritance_graph),
@@ -1089,7 +1091,7 @@ pub(crate) fn is_redeclaration_identical_with_resolver<
     inheritance_graph: &InheritanceGraph,
     sound_mode: bool,
 ) -> bool {
-    let policy = tsz_solver::relations::relation_queries::RelationPolicy::from_flags(flags)
+    let policy = relation_policy::from_checker_flags_u16(flags)
         .with_strict_subtype_checking(sound_mode)
         .with_strict_any_propagation(sound_mode);
     let context = tsz_solver::relations::relation_queries::RelationContext {
@@ -1838,7 +1840,7 @@ pub(crate) fn check_application_variance_assignability<
         inheritance_graph,
         sound_mode,
     } = *inputs;
-    let policy = tsz_solver::relations::relation_queries::RelationPolicy::from_flags(flags)
+    let policy = relation_policy::from_checker_flags_u16(flags)
         .with_strict_subtype_checking(sound_mode)
         .with_strict_any_propagation(sound_mode);
     let context = tsz_solver::relations::relation_queries::RelationContext {

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -2,7 +2,7 @@ use tsz_solver::TypeId;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 use tsz_solver::narrowing::{GuardSense, TypeGuard};
 
-use super::assignability::RelationFlags;
+use super::{assignability::RelationFlags, relation_policy};
 
 pub(crate) use super::common::{
     LiteralValueKind, PredicateSignatureKind, TypeResolver,
@@ -536,9 +536,7 @@ pub(crate) fn is_assignable_strict_null(
         source,
         target,
         tsz_solver::relations::relation_queries::RelationKind::Assignable,
-        tsz_solver::relations::relation_queries::RelationPolicy::from_flags(
-            RelationFlags::STRICT_NULL_CHECKS,
-        ),
+        relation_policy::from_checker_flags_u16(RelationFlags::STRICT_NULL_CHECKS),
         tsz_solver::relations::relation_queries::RelationContext::default(),
     )
     .is_related()
@@ -616,7 +614,7 @@ pub(crate) fn is_assignable_with_env(
         source,
         target,
         tsz_solver::relations::relation_queries::RelationKind::Assignable,
-        tsz_solver::relations::relation_queries::RelationPolicy::from_flags(flags),
+        relation_policy::from_checker_flags_u16(flags),
         tsz_solver::relations::relation_queries::RelationContext::default(),
     )
     .is_related()
@@ -727,7 +725,7 @@ fn types_are_subtype_with_env(
         source,
         target,
         tsz_solver::relations::relation_queries::RelationKind::Subtype,
-        tsz_solver::relations::relation_queries::RelationPolicy::from_flags(flags),
+        relation_policy::from_checker_flags_u16(flags),
         tsz_solver::relations::relation_queries::RelationContext::default(),
     )
     .is_related()

--- a/crates/tsz-checker/src/query_boundaries/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/mod.rs
@@ -40,6 +40,7 @@ pub(crate) mod operator_wrappers;
 pub(crate) mod optional_chain;
 pub(crate) mod property_access;
 pub(crate) mod recursive_alias;
+pub(crate) mod relation_policy;
 pub(crate) mod relation_types;
 pub(crate) mod spread;
 pub(crate) mod state;

--- a/crates/tsz-checker/src/query_boundaries/relation_policy.rs
+++ b/crates/tsz-checker/src/query_boundaries/relation_policy.rs
@@ -1,0 +1,11 @@
+//! Checker-side relation policy compatibility edges.
+
+use tsz_solver::relations::relation_queries::RelationPolicy;
+
+/// Decode checker-owned packed relation flags into the solver policy type.
+///
+/// New checker relation paths should keep this conversion at the query-boundary
+/// edge and pass typed [`RelationPolicy`] values inward.
+pub(crate) const fn from_checker_flags_u16(flags: u16) -> RelationPolicy {
+    RelationPolicy::from_flags(flags)
+}

--- a/crates/tsz-checker/src/tests/relation_flags_boundary_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/relation_flags_boundary_contract_tests.rs
@@ -8,7 +8,7 @@ fn flow_analysis_uses_boundary_relation_flags_surface() {
         .expect("failed to read query_boundaries/flow_analysis.rs");
 
     assert!(
-        source.contains("use super::assignability::RelationFlags;"),
+        source.contains("assignability::RelationFlags"),
         "flow_analysis relation helpers must import boundary-owned RelationFlags"
     );
 
@@ -21,4 +21,26 @@ fn flow_analysis_uses_boundary_relation_flags_surface() {
         !source.contains("RelationCacheKey::FLAG_STRICT_NULL_CHECKS"),
         "flow_analysis relation helpers must not reach directly into RelationCacheKey bits"
     );
+}
+
+/// Checker relation helpers are the compatibility edge for packed `u16`
+/// relation flags. Keep that edge explicit so new code does not treat the
+/// packed protocol as an ordinary solver policy constructor.
+#[test]
+fn checker_boundaries_use_explicit_legacy_relation_policy_constructor() {
+    for path in [
+        "src/query_boundaries/assignability.rs",
+        "src/query_boundaries/flow_analysis.rs",
+    ] {
+        let source = fs::read_to_string(path).expect("failed to read checker query boundary");
+
+        assert!(
+            source.contains("relation_policy::from_checker_flags_u16"),
+            "{path} must name the packed-flag compatibility edge explicitly",
+        );
+        assert!(
+            !source.contains("RelationPolicy::from_flags"),
+            "{path} must not use the ambiguous packed-flag constructor name",
+        );
+    }
 }


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 10 / #8207 relation policy/cache protocol cleanup. Checker-boundary ratchet following merged #11979.

## Invariant
When checker query boundaries receive packed `u16` relation flags from compiler-option plumbing, tsz converts them through a named checker-side compatibility edge before passing typed `RelationPolicy` values inward; solver relation/cache internals remain on typed policy/config APIs.

## Scope
- Add `query_boundaries::relation_policy::from_checker_flags_u16` as the checker-owned packed-flag adapter.
- Route assignability and flow-analysis relation helpers through that adapter instead of spelling `RelationPolicy::from_flags` at each call site.
- Add a boundary contract test that keeps the explicit checker adapter in `assignability.rs` and `flow_analysis.rs`.

## Project Corpus Impact
- Row: n/a
- Bug family: relation policy/cache-key protocol cleanup
- Evidence: refactor-only checker query-boundary naming; no relation semantics changed. Focused checker tests, architecture guard, and draft-light CI passed on the current head.

## Verification
- RED: `cargo nextest run -p tsz-checker -E 'test(checker_boundaries_use_explicit_legacy_relation_policy_constructor)'` failed before implementation because `assignability.rs` still used `RelationPolicy::from_flags` directly.
- GREEN: `cargo nextest run -p tsz-checker --lib -E 'test(checker_boundaries_use_explicit_legacy_relation_policy_constructor)'` passed.
- GREEN after rebase onto `origin/main` (`e51854029481b077bbee13605f86965ac32ccf0d`): `cargo nextest run -p tsz-checker --lib -E 'test(relation_flags_boundary_contract_tests)'` passed.
- GREEN after rebase: `cargo fmt --check` passed.
- GREEN after rebase: `git diff --check origin/main...HEAD` passed.
- GREEN after rebase: `python3 scripts/arch/arch_guard.py` passed.
- GREEN exact-head draft-light CI on `681e4b74aa005080b2fba41d876fe2d9b67040c4`: `CI Light Summary`, `lint`, `unit`, `dist-binaries`, `cargo-shear`, `cargo-deny`, `project-row-drift`, and `unit-cloudbuild` passed.
- File-size audit: `assignability.rs` is 1999 lines, under the 2000-line hard limit.

## Coordination Notes
- #11979 merged on 2026-05-31; this PR is based on `main`.
- Rebasing note: branch was rebased onto `origin/main` at `e51854029481b077bbee13605f86965ac32ccf0d` after #11983 landed; current head is `681e4b74aa005080b2fba41d876fe2d9b67040c4`.
- Ready for review after exact-head draft-light CI completed green. Leaving `merge-queue` off until ready-review PR-head gates complete for this same head.
- This is intentionally checker-boundary-only after `arch_guard.py` confirmed adding a new solver-side packed-flag constructor would violate the #8207 legacy bridge cap.