### PR TITLE
chore(agents): expose disk preflight status

### DIFF
--- a/scripts/agents/disk-preflight.sh
+++ b/scripts/agents/disk-preflight.sh
@@ -346,6 +346,7 @@ const bool = (value) => value === "true";
 const diskOk = guard.disk_status === "ok";
 const report = {
   ok: diskOk,
+  status: diskOk ? "pass" : "fail",
   agent: process.env.AGENT,
   repo: process.env.ROOT,
   disk_guard: {

--- a/scripts/agents/test_disk_preflight.py
+++ b/scripts/agents/test_disk_preflight.py
@@ -112,6 +112,7 @@ class DiskPreflightTests(unittest.TestCase):
             report = json.loads(report_path.read_text(encoding="utf-8"))
             self.assertIn("agent=Studio-F", result.stdout)
             self.assertTrue(report["ok"])
+            self.assertEqual("pass", report["status"])
             self.assertEqual("Studio-F", report["agent"])
             self.assertEqual(str(fake_repo), report["repo"])
             self.assertEqual("populated-local-submodule", report["typescript"]["state"])
@@ -146,6 +147,7 @@ class DiskPreflightTests(unittest.TestCase):
 
             report = json.loads(report_path.read_text(encoding="utf-8"))
             self.assertFalse(report["ok"])
+            self.assertEqual("fail", report["status"])
             self.assertEqual("low", report["disk_guard"]["disk_status"])
             self.assertFalse(report["disk_guard"]["ok"])
 


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / disk-worktree evidence plumbing.

## Invariant
When disk-preflight writes machine-readable evidence, consumers can read both a boolean ok field and an explicit pass/fail status without inferring status from disk_guard internals.

## Scope
- scripts/agents/disk-preflight.sh
- scripts/agents/test_disk_preflight.py

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent preflight JSON report only; no compiler, checker, solver, parser, emitter, or project-corpus behavior changes.

## Verification
- python3 scripts/agents/test_disk_preflight.py
- scripts/agents/disk-preflight.sh Studio-F --json-report /tmp/tsz-disk-preflight-status.json
- git diff --check origin/main...HEAD

## Coordination Notes
- Owned by Studio-F as a small disk/worktree evidence-plumbing slice.
- Exact head: db91fe1e9e.
- Start-cycle label hygiene was repaired separately on #11981 before opening this PR.
