### PR TITLE
chore(ci): expose emit detail artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1135,6 +1135,15 @@ jobs:
         run: tar -xf node-harness.tar
       - name: Run emit suite
         run: scripts/ci/github-suite.sh emit-shard
+      - name: Upload emit details
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: emit-details
+          path: |
+            .ci-metrics/emit*.json
+            .ci-logs/emit/*.log
+          if-no-files-found: ignore
 
   fourslash:
     # Each matrix shard runs on its own 8-vCPU cloud runner. Run 25058599510

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -1538,7 +1538,8 @@ run_emit_shard() {
   export TSZ_BIN="$ROOT_DIR/.target/dist-fast/tsz"
   echo "Emit shard ${shard_index}/${shard_count}: offset=${offset} chunk=${chunk} workers=${EMIT_WORKERS} timeout_ms=${EMIT_TIMEOUT_MS}"
 
-  local detail_json="$METRICS_DIR/emit-shard-${shard_index}.json"
+  local detail_json="$METRICS_DIR/emit-detail-${shard_index}.json"
+  local shard_json="$METRICS_DIR/emit-shard-${shard_index}.json"
   local emit_args=(
     --skip-build
     --concurrency="$EMIT_WORKERS"
@@ -1574,12 +1575,12 @@ run_emit_shard() {
   local result_json
   result_json="$(printf '{"shard":%s,"rc":%s,"js_passed":%s,"js_total":%s,"js_skipped":%s,"js_timeouts":%s,"dts_passed":%s,"dts_total":%s,"dts_skipped":%s}' \
     "$shard_index" "$rc" "$js_p" "$js_t" "$js_s" "$js_to" "$dts_p" "$dts_t" "$dts_s")"
-  echo "$result_json" > "$METRICS_DIR/emit-shard-${shard_index}.json"
+  echo "$result_json" > "$shard_json"
   echo "EMIT_SHARD shard=${shard_index} rc=${rc} js=${js_p}/${js_t} skip=${js_s} timeout=${js_to} dts=${dts_p}/${dts_t}"
 
   if [[ -n "$bucket" && "$run_key" != "unknown" ]]; then
     local prefix="${bucket%/}/emit-runs/${run_key}"
-    gsutil cp "$METRICS_DIR/emit-shard-${shard_index}.json" "${prefix}/shard-${shard_index}.json" \
+    gsutil cp "$shard_json" "${prefix}/shard-${shard_index}.json" \
       && echo "Uploaded emit shard result: shard-${shard_index}.json" \
       || echo "warning: failed to upload emit shard result (non-fatal)" >&2
   fi

--- a/scripts/ci/gcp-summary.py
+++ b/scripts/ci/gcp-summary.py
@@ -350,7 +350,7 @@ def main() -> int:
     lines: list[str] = []
     append_env(lines, args.suite, args.exit_code)
 
-    if args.suite == "emit":
+    if args.suite in {"emit", "emit-shard", "emit-aggregate"}:
         emit_summary(metrics_dir, logs_dir, lines)
     elif args.suite == "fourslash":
         fourslash_summary(metrics_dir, logs_dir, lines)


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Emit/DTS parity tooling: expose current declaration emit failure evidence from CI.

## Invariant
When the GitHub emit shard runs, CI should preserve detailed emit runner results and surface emit failures through the existing summary/artifact path; this PR changes the CI/reporting surface only.

## Scope
- Preserve `emit-detail-<shard>.json` separately from compact `emit-shard-<shard>.json` in `scripts/ci/gcp-full-ci.sh`.
- Treat `emit-shard` and `emit-aggregate` as emit suites in `scripts/ci/gcp-summary.py`.
- Upload emit metrics and logs from the GitHub `emit` job, even when the suite fails.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI-tooling-only; no compiler, checker, solver, parser, emitter output, or project corpus behavior changes.

## Verification
- `bash -n scripts/ci/gcp-full-ci.sh`
- `python3 -m py_compile scripts/ci/gcp-summary.py`
- Synthetic `gcp-summary.py --suite emit-shard` run with `emit-detail-0.json` confirmed `Emit Aggregate`, `Emit Failures`, and the sample DTS failure appear.
- `git diff --check`
- Focused current-head DTS probe: `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target scripts/emit/run.sh --filter=nodeModuleReexportFromDottedPath --dts-only --verbose --json-out=/tmp/studio-d-node-module-reexport-dotted-current-main.json`

## Coordination Notes
- The checked-in `scripts/emit/emit-detail.json` is stale; focused Studio-D probes now cover all 63 stale-listed DTS failures as passing, so Studio-D needs fresh CI detail to continue the remaining DTS hunt without full local emit.
- No open PR currently claims this exact emit-detail artifact/summary exposure. Recent Studio-F work touched output-surgery reporting only.
