### PR TITLE
chore(agents): expose owned work report status

### DIFF
--- a/scripts/agents/list-owned-work.sh
+++ b/scripts/agents/list-owned-work.sh
@@ -261,6 +261,7 @@ const ownedWorkClear = totalOwnedCount === 0;
 
 const report = {
   ok: ownedWorkClear,
+  status: ownedWorkClear ? "clear" : "active",
   generated_by: "scripts/agents/list-owned-work.sh",
   repository: process.env.REPOSITORY,
   with_pr_state: process.env.WITH_PR_STATE === "true",

--- a/scripts/agents/test_list_owned_work.py
+++ b/scripts/agents/test_list_owned_work.py
@@ -75,6 +75,7 @@ exec "$@"
             self.assertEqual("mohsen1/tsz", report["repository"])
             self.assertFalse(report["with_pr_state"])
             self.assertFalse(report["ok"])
+            self.assertEqual("active", report["status"])
             self.assertFalse(report["owned_work_clear"])
             self.assertEqual("active", report["owned_work_status"])
             self.assertEqual(1, report["total_pr_count"])
@@ -105,6 +106,7 @@ exec "$@"
 
             report = json.loads(report_path.read_text(encoding="utf-8"))
             self.assertTrue(report["ok"])
+            self.assertEqual("clear", report["status"])
             self.assertTrue(report["owned_work_clear"])
             self.assertEqual("clear", report["owned_work_status"])
             self.assertEqual(0, report["total_pr_count"])


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Studio-F launch infrastructure and cheap evidence plumbing.

## Invariant
When `scripts/agents/list-owned-work.sh --json-report` writes machine-readable coordination state, consumers can read one top-level `status` field without re-deriving it from counters; this PR changes only the owned-work report surface.

## Scope
- `scripts/agents/list-owned-work.sh`
- `scripts/agents/test_list_owned_work.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent-script-only JSON report metadata; no compiler, emit, checker, solver, parser, binder, LSP, WASM, or project corpus behavior changes.

## Verification
- `python3 -m unittest scripts.agents.test_list_owned_work`
- `scripts/agents/list-owned-work.sh Studio-F --json-report /tmp/tsz-owned-work-status.json`
- `node -e 'const fs=require("fs"); const r=JSON.parse(fs.readFileSync("/tmp/tsz-owned-work-status.json","utf8")); console.log(JSON.stringify({ok:r.ok,status:r.status,owned_work_status:r.owned_work_status,total_owned_count:r.total_owned_count}, null, 2));'`
- `git diff --check`

## Coordination Notes
- No Studio-F owned PRs/issues were open before this branch.
- Start-cycle checks passed: disk preflight OK, label audit clean, architecture guardrails passed, and output-surgery audit passed.
- Primary checkout has unrelated Studio-C dirty files and was left untouched.
