### PR TITLE
fix(cli): match leading globstar excludes from include roots

### DIFF
--- a/crates/tsz-cli/src/project/fs.rs
+++ b/crates/tsz-cli/src/project/fs.rs
@@ -341,6 +341,9 @@ fn expand_exclude_patterns(patterns: &[String]) -> Vec<String> {
     let mut expanded = Vec::new();
     for pattern in patterns {
         expanded.push(pattern.clone());
+        if let Some(root_relative) = pattern.strip_prefix("**/") {
+            expanded.push(root_relative.to_string());
+        }
         if !contains_glob_meta(pattern) && !pattern.ends_with("/**") {
             let base = pattern.trim_end_matches('/');
             expanded.push(format!("{base}/**"));
@@ -653,6 +656,51 @@ mod tests {
         assert!(patterns.contains(&"**/node_modules/**".to_string()));
         assert!(patterns.contains(&"dist".to_string()));
         assert!(patterns.contains(&"dist/**".to_string()));
+    }
+
+    #[test]
+    fn test_leading_globstar_exclude_matches_include_root_relative_path() {
+        let dir = unique_temp_dir("leading_globstar_exclude");
+        fs::create_dir_all(dir.join("src/dialect/mssql")).unwrap();
+        fs::create_dir_all(dir.join("src/dialect/mysql")).unwrap();
+        fs::write(
+            dir.join("src/dialect/mssql/skip.ts"),
+            "export const skip = 1;",
+        )
+        .unwrap();
+        fs::write(
+            dir.join("src/dialect/mysql/keep.ts"),
+            "export const keep = 1;",
+        )
+        .unwrap();
+
+        let options = FileDiscoveryOptions {
+            base_dir: dir.clone(),
+            files: Vec::new(),
+            files_explicitly_set: false,
+            include: Some(vec!["src/**/*.ts".to_string()]),
+            exclude: Some(vec!["**/dialect/mssql/**".to_string()]),
+            out_dir: None,
+            follow_links: false,
+            allow_js: false,
+            resolve_json_module: false,
+        };
+
+        let result = discover_ts_files(&options).unwrap();
+        assert!(
+            result
+                .iter()
+                .any(|path| path.ends_with("src/dialect/mysql/keep.ts")),
+            "expected non-excluded mysql file, got: {result:?}"
+        );
+        assert!(
+            !result
+                .iter()
+                .any(|path| path.ends_with("src/dialect/mssql/skip.ts")),
+            "leading globstar exclude should match paths relative to the include root, got: {result:?}"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
AgentName: Studio-A

## Track
project compile guard / CLI file discovery

## Invariant
When an exclude pattern begins with a leading globstar segment, tsconfig root-file discovery must match it both from the config root and from include-root-relative candidate paths; this PR makes tsz normalize that discovery pattern in the CLI project loader.

## Owner Layer
CLI project file discovery. This is not checker/solver type semantics; the change only affects which configured root files enter the project before imports are followed.

## Scope
- Expands leading `**/` exclude patterns to also match the same pattern relative to the include root.
- Adds a focused file-discovery unit test for `src/**/*.ts` plus `**/dialect/mssql/**`.

## Adjacent Case Matrix
- Nested include root: `src/**/*.ts` with `**/dialect/mssql/**` excludes `src/dialect/mssql/skip.ts`.
- Sibling positive case: the same include still keeps `src/dialect/mysql/keep.ts`.
- Fallback behavior: patterns without a leading `**/` continue through the existing expansion path unchanged.

## Project Corpus Impact
- Row: Kysely
- Bug family: project root discovery exclude matching
- Evidence: `cargo nextest run -p tsz-cli project::fs::tests::test_leading_globstar_exclude_matches_include_root_relative_path` passed after rebasing onto current `origin/main`. A filtered Kysely project check still reports imported mssql files and existing TS2504/TS2339/TS2322 blockers, so this does not claim the row is green.

## Verification
- `cargo nextest run -p tsz-cli project::fs::tests::test_leading_globstar_exclude_matches_include_root_relative_path`
- `git diff --check origin/main...HEAD`

## Coordination Notes
- No open Studio-A PRs were found before starting; this is now the only open Studio-A PR.
- Rebased onto `origin/main` at `97d8e436a40378d46e53b345154eae2120c2d9a3`; PR head is `efd14e4c6a1915afc0e5953e7ebea5b698506bd6`.
- Kysely semantic blockers remain; this PR only covers root-file discovery behavior.
