### PR TITLE
fix(solver): propagate strict readonly relation policy

### DIFF
--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -583,6 +583,7 @@ fn configure_compat_checker_policy_bits<R: TypeResolver>(
     checker.subtype.allow_erased_generic_signature_retry =
         policy.allow_erased_generic_signature_retry();
     checker.subtype.in_callback_param_check = policy.in_callback_param_check();
+    checker.subtype.strict_readonly_identity = policy.strict_readonly_identity();
 }
 
 const fn configure_subtype_checker_policy_bits<'a, R: TypeResolver>(

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/cache_agreement.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/cache_agreement.rs
@@ -979,6 +979,89 @@ fn subtype_cache_strict_readonly_identity_matches_uncached_property_policy() {
 }
 
 #[test]
+fn assignability_cache_strict_readonly_identity_matches_uncached_property_policy() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let x = interner.intern_string("x");
+
+    let source = interner.object(vec![PropertyInfo::readonly(x, TypeId::NUMBER)]);
+    let target = interner.object(vec![PropertyInfo::new(x, TypeId::NUMBER)]);
+
+    let permissive_policy = RelationPolicy::unflagged_compatibility();
+    let strict_policy =
+        RelationPolicy::from_relation_flags(RelationFlags::STRICT_READONLY_IDENTITY);
+    let permissive_key =
+        RelationCacheKey::for_assignability(source, target, permissive_policy.cache_config());
+    let strict_key =
+        RelationCacheKey::for_assignability(source, target, strict_policy.cache_config());
+
+    assert_ne!(
+        permissive_key, strict_key,
+        "strict readonly identity must partition assignability cache entries",
+    );
+
+    let permissive_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        permissive_policy,
+        RelationContext::default(),
+    )
+    .is_related();
+    let strict_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        strict_policy,
+        RelationContext::default(),
+    )
+    .is_related();
+
+    assert!(
+        permissive_uncached,
+        "permissive readonly assignability should allow a readonly property to satisfy a mutable target",
+    );
+    assert!(
+        !strict_uncached,
+        "strict readonly identity assignability must reject readonly-to-mutable property comparison",
+    );
+
+    let strict_cached = db.is_assignable_to_with_policy(source, target, strict_policy);
+    assert_eq!(
+        strict_cached, strict_uncached,
+        "cached strict readonly assignability must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(strict_key),
+        Some(strict_cached),
+        "strict readonly assignability result must be stored in the strict policy slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(permissive_key),
+        None,
+        "permissive lookup must not hit the strict readonly slot",
+    );
+
+    let permissive_cached = db.is_assignable_to_with_policy(source, target, permissive_policy);
+    assert_eq!(
+        permissive_cached, permissive_uncached,
+        "cached permissive readonly assignability must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(permissive_key),
+        Some(permissive_cached),
+        "permissive readonly assignability result must be stored in the permissive policy slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(strict_key),
+        Some(strict_cached),
+        "strict readonly assignability slot must remain intact after permissive lookup",
+    );
+}
+
+#[test]
 fn assignability_cache_disable_method_bivariance_matches_uncached_method_policy() {
     let interner = TypeInterner::new();
     let db = QueryCache::new(&interner);


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 10 / #8207 relation policy/cache correctness. Solver relation policy propagation fix.

## Invariant
When `RelationPolicy` enables `STRICT_READONLY_IDENTITY`, assignability must apply the readonly-identity rule through the compat/subtype relation engine and store the answer under the strict-readonly cache slot; permissive readonly assignability remains in its own cache slot.

## Scope
- Propagate `RelationPolicy::strict_readonly_identity()` into the nested `SubtypeChecker` configured for `CompatChecker` relation queries.
- Add a cache-enabled/cache-disabled assignability agreement test for readonly-to-mutable property comparison under permissive and strict readonly policies.

## Project Corpus Impact
- Row: n/a
- Bug family: relation policy/cache-key protocol cleanup
- Evidence: focused solver policy/cache invariant; no project-row fixture run. The change affects only relation policy propagation for an already cache-keyed policy bit.

## Verification
- RED: `cargo nextest run -p tsz-solver -E 'test(assignability_cache_strict_readonly_identity_matches_uncached_property_policy)'` failed before implementation because strict readonly assignability still accepted readonly-to-mutable property comparison.
- GREEN: `cargo nextest run -p tsz-solver -E 'test(assignability_cache_strict_readonly_identity_matches_uncached_property_policy)'` passed after the fix.
- GREEN: `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'` passed, 32 tests.
- GREEN: `cargo fmt --check` passed.
- GREEN: `git diff --check` passed.
- GREEN: `python3 scripts/arch/arch_guard.py` passed.
- GREEN: `cargo clippy -p tsz-solver --lib -- -D warnings` passed.
- Earlier after rebase onto `origin/main` (`97d8e436a40378d46e53b345154eae2120c2d9a3`): `cargo nextest run -p tsz-solver -E 'test(assignability_cache_strict_readonly_identity_matches_uncached_property_policy)'` passed.
- Earlier after rebase onto `origin/main` (`0f7759ffc9014bdf910a37b4be5b87dc5ca243e2`, includes #11982): `cargo nextest run -p tsz-solver -E 'test(assignability_cache_strict_readonly_identity_matches_uncached_property_policy)'` passed.
- Earlier rebase onto `origin/main` (`a8b8222085366d427f2eb15aab01b05f21f2e5eb`): `cargo nextest run -p tsz-solver -E 'test(assignability_cache_strict_readonly_identity_matches_uncached_property_policy)'` passed.
- Current rebase onto `origin/main` (`af6478cbf72abe6a5fb1090eadccd9171ce82d14`): `cargo nextest run -p tsz-solver -E 'test(assignability_cache_strict_readonly_identity_matches_uncached_property_policy)'` passed.
- Current rebase: `cargo fmt --check` passed.
- Exact-head draft-light CI on `2cea8ff40a87eaa4b7b8f7f7309bc2677f027038`: `CI Light Summary` passed, with `lint`, `unit`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `unit-cloudbuild`, `gate`, and `GitGuardian Security Checks` successful.
- File-size audit: `relation_queries.rs` is 833 lines and `cache_agreement.rs` is 1935 lines, both under the 2000-line hard limit.

## Coordination Notes
- Non-overlap: this is solver-side policy propagation and cache agreement coverage. It does not touch #11982's checker-boundary relation flag adapter files.
- #11982 merged on 2026-05-31. This PR was rebased on top of that merge, then again on current `origin/main` after the roadmap-only `a8b8222085366d427f2eb15aab01b05f21f2e5eb` fast-forward, then again after `origin/main` advanced to `af6478cbf72abe6a5fb1090eadccd9171ce82d14`.
- Current head is `2cea8ff40a87eaa4b7b8f7f7309bc2677f027038`.
- Marked ready after exact-head draft-light CI completed green. `merge-queue` intentionally remains off until ready-review PR-head gates complete for this same head.
