### PR TITLE
fix(emit): delay private lhs receiver temp allocation

### DIFF
--- a/crates/tsz-common/src/source_map/mod.rs
+++ b/crates/tsz-common/src/source_map/mod.rs
@@ -77,6 +77,47 @@ impl SourceMapGenerator {
         }
     }
 
+    /// Create a `SourceMapGenerator` with the same source/name tables but no
+    /// generated mappings.
+    #[must_use]
+    pub fn clone_for_inline_capture(&self) -> Self {
+        Self {
+            file: self.file.clone(),
+            source_root: self.source_root.clone(),
+            sources: self.sources.clone(),
+            sources_content: self.sources_content.clone(),
+            names: self.names.clone(),
+            mappings: Vec::new(),
+            prev_generated_column: 0,
+            prev_original_line: 0,
+            prev_original_column: 0,
+            prev_source_index: 0,
+            prev_name_index: 0,
+        }
+    }
+
+    /// Return generated mappings accumulated so far.
+    #[must_use]
+    pub fn mappings(&self) -> &[Mapping] {
+        &self.mappings
+    }
+
+    /// Append any names added while writing an inline capture.
+    ///
+    /// The capture generator is created from `clone_for_inline_capture`, so its
+    /// existing name prefix must match the main generator. New names are appended
+    /// in order to keep captured mapping name indices valid when mappings are
+    /// copied back to the main generator.
+    pub fn sync_names_from_inline_capture(&mut self, capture: &Self) {
+        for (index, name) in capture.names.iter().enumerate() {
+            if let Some(existing) = self.names.get(index) {
+                debug_assert_eq!(existing, name);
+            } else {
+                self.names.push(name.clone());
+            }
+        }
+    }
+
     /// Set the source root
     pub fn set_source_root(&mut self, root: String) {
         self.source_root = root;

--- a/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
@@ -647,6 +647,18 @@ impl<'a> Printer<'a> {
         }
     }
 
+    fn capture_private_receiver_inline(
+        &mut self,
+        expression: NodeIndex,
+        clean_name: &str,
+    ) -> String {
+        let scratch = self.writer.inline_capture_from(128);
+        let main_writer = std::mem::replace(&mut self.writer, scratch);
+        self.emit_private_receiver(expression, clean_name);
+        let scratch = std::mem::replace(&mut self.writer, main_writer);
+        scratch.take_output()
+    }
+
     /// Emit the state variable (WeakMap/WeakSet) for a private field.
     fn emit_private_state_var(&mut self, weakmap_name: &str, clean_name: &str) {
         let info = self.private_member_info.get(clean_name).cloned();
@@ -894,6 +906,11 @@ impl<'a> Printer<'a> {
                 };
 
                 let needs_receiver_temp = !self.receiver_is_simple(pfa.expression);
+                let captured_receiver = if needs_receiver_temp {
+                    Some(self.capture_private_receiver_inline(pfa.expression, &pfa.clean_name))
+                } else {
+                    None
+                };
                 let receiver_temp = if needs_receiver_temp {
                     Some(self.make_unique_name_hoisted())
                 } else {
@@ -905,7 +922,13 @@ impl<'a> Printer<'a> {
 
                 self.write_helper("__classPrivateFieldSet");
                 self.write("(");
-                self.emit_receiver_or_temp_assign(expression, receiver_temp.as_deref());
+                if let Some(receiver) = captured_receiver.as_deref() {
+                    self.write(receiver_temp.as_deref().expect("receiver temp"));
+                    self.write(" = ");
+                    self.write(receiver);
+                } else {
+                    self.emit_receiver_or_temp_assign(expression, receiver_temp.as_deref());
+                }
                 self.write(", ");
                 self.emit_private_state_var(&weakmap_name, &clean_name);
                 self.write(", ");

--- a/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
@@ -651,12 +651,12 @@ impl<'a> Printer<'a> {
         &mut self,
         expression: NodeIndex,
         clean_name: &str,
-    ) -> String {
+    ) -> (String, Option<tsz_common::source_map::SourceMapGenerator>) {
         let scratch = self.writer.inline_capture_from(128);
         let main_writer = std::mem::replace(&mut self.writer, scratch);
         self.emit_private_receiver(expression, clean_name);
         let scratch = std::mem::replace(&mut self.writer, main_writer);
-        scratch.take_output()
+        scratch.take_output_and_source_map()
     }
 
     /// Emit the state variable (WeakMap/WeakSet) for a private field.
@@ -922,10 +922,17 @@ impl<'a> Printer<'a> {
 
                 self.write_helper("__classPrivateFieldSet");
                 self.write("(");
-                if let Some(receiver) = captured_receiver.as_deref() {
+                if let Some(receiver) = captured_receiver.as_ref() {
                     self.write(receiver_temp.as_deref().expect("receiver temp"));
                     self.write(" = ");
-                    self.write(receiver);
+                    let receiver_line = self.writer.current_line();
+                    let receiver_column = self.writer.current_column();
+                    self.write(&receiver.0);
+                    self.writer.add_inline_capture_mappings(
+                        receiver_line,
+                        receiver_column,
+                        receiver.1.as_ref(),
+                    );
                 } else {
                     self.emit_receiver_or_temp_assign(expression, receiver_temp.as_deref());
                 }

--- a/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
@@ -221,6 +221,33 @@ class A3 {
 }
 
 #[test]
+fn private_compound_assignment_allocates_nested_receiver_temps_first() {
+    let source = r#"
+class Test {
+    #y = 123;
+    static something(obj) {
+        obj[(new class { #x = 1; s = "prop"; }).s].#y = 1;
+        obj[(new class { #x = 1; s = "prop"; }).s].#y += 1;
+    }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains("static something(obj) {\n        var _x, _a, _x_1, _b, _c;"),
+        "Nested receiver temps should be declared before the compound assignment receiver temp.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("__classPrivateFieldSet(_c = obj[(new (_b = class {"),
+        "Compound private-field assignment should allocate the receiver temp after rendering nested receiver temps.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("__classPrivateFieldGet(_c, _Test_y, \"f\") + 1"),
+        "Compound private-field assignment should reuse the delayed receiver temp for the GET helper.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn static_private_method_receiver_respects_local_class_name_shadow() {
     let source = r#"
 class X {

--- a/crates/tsz-emitter/src/output/source_writer.rs
+++ b/crates/tsz-emitter/src/output/source_writer.rs
@@ -123,13 +123,16 @@ impl SourceWriter {
     pub(crate) fn inline_capture_from(&self, capacity: usize) -> Self {
         Self {
             output: String::with_capacity(capacity),
-            line: self.line,
-            column: self.column,
+            line: 0,
+            column: 0,
             indent_level: self.indent_level,
             at_line_start: false,
             indent_str: self.indent_str.clone(),
             new_line: self.new_line.clone(),
-            source_map: None,
+            source_map: self
+                .source_map
+                .as_ref()
+                .map(SourceMapGenerator::clone_for_inline_capture),
             current_source_index: self.current_source_index,
             #[cfg(debug_assertions)]
             delimiter_stack: Vec::new(),
@@ -524,6 +527,16 @@ impl SourceWriter {
         self.output
     }
 
+    /// Take captured text and its relative source-map state.
+    pub(crate) fn take_output_and_source_map(self) -> (String, Option<SourceMapGenerator>) {
+        let unclosed_delimiter_count = self.unclosed_delimiter_count();
+        debug_assert!(
+            self.delimiters_balanced(),
+            "structured delimiter helpers left {unclosed_delimiter_count} unclosed delimiter(s)"
+        );
+        (self.output, self.source_map)
+    }
+
     /// Get the output length in bytes
     pub const fn len(&self) -> usize {
         self.output.len()
@@ -612,6 +625,39 @@ impl SourceWriter {
         };
 
         for mapping in mappings {
+            let line = base_line + mapping.generated_line;
+            let column = if mapping.generated_line == 0 {
+                base_column + mapping.generated_column
+            } else {
+                mapping.generated_column
+            };
+            sm.add_mapping(
+                line,
+                column,
+                mapping.source_index,
+                mapping.original_line,
+                mapping.original_column,
+                mapping.name_index,
+            );
+        }
+    }
+
+    /// Add mappings produced by an inline capture at the current splice point.
+    pub(crate) fn add_inline_capture_mappings(
+        &mut self,
+        base_line: u32,
+        base_column: u32,
+        capture_map: Option<&SourceMapGenerator>,
+    ) {
+        let Some(ref mut sm) = self.source_map else {
+            return;
+        };
+        let Some(capture_map) = capture_map else {
+            return;
+        };
+
+        sm.sync_names_from_inline_capture(capture_map);
+        for mapping in capture_map.mappings() {
             let line = base_line + mapping.generated_line;
             let column = if mapping.generated_line == 0 {
                 base_column + mapping.generated_column

--- a/crates/tsz-emitter/src/output/source_writer.rs
+++ b/crates/tsz-emitter/src/output/source_writer.rs
@@ -118,6 +118,26 @@ impl SourceWriter {
         }
     }
 
+    /// Create a scratch writer for rendering text that will be spliced into the
+    /// current inline position.
+    pub(crate) fn inline_capture_from(&self, capacity: usize) -> Self {
+        Self {
+            output: String::with_capacity(capacity),
+            line: self.line,
+            column: self.column,
+            indent_level: self.indent_level,
+            at_line_start: false,
+            indent_str: self.indent_str.clone(),
+            new_line: self.new_line.clone(),
+            source_map: None,
+            current_source_index: self.current_source_index,
+            #[cfg(debug_assertions)]
+            delimiter_stack: Vec::new(),
+            #[cfg(debug_assertions)]
+            delimiter_mismatch_count: 0,
+        }
+    }
+
     /// Create a `SourceWriter` with source map generation enabled
     pub fn with_source_map(output_file: String) -> Self {
         let mut writer = Self::new();

--- a/crates/tsz-emitter/tests/source_writer.rs
+++ b/crates/tsz-emitter/tests/source_writer.rs
@@ -96,6 +96,50 @@ fn test_insert_line_at_shifts_output_and_source_maps() {
     assert!(map.mappings.matches(';').count() >= 2);
 }
 
+#[test]
+fn inline_capture_mappings_are_spliced_at_actual_column() {
+    let mut writer = SourceWriter::with_source_map("out.js".to_string());
+    writer.add_source("input.ts".to_string(), Some("receiver.value".to_string()));
+    writer.write("__classPrivateFieldSet(_a = ");
+
+    let mut capture = writer.inline_capture_from(32);
+    capture.write_node_with_name(
+        "receiver",
+        SourcePosition {
+            pos: 0,
+            line: 0,
+            column: 0,
+        },
+        "receiver",
+    );
+    let (captured_text, captured_map) = capture.take_output_and_source_map();
+
+    let splice_line = writer.current_line();
+    let splice_column = writer.current_column();
+    writer.write(&captured_text);
+    writer.add_inline_capture_mappings(splice_line, splice_column, captured_map.as_ref());
+
+    assert_eq!(writer.get_output(), "__classPrivateFieldSet(_a = receiver");
+
+    let mut generator = writer
+        .take_source_map()
+        .expect("source map should be enabled");
+    let mappings = generator.mappings();
+    assert!(
+        mappings.iter().any(|mapping| {
+            mapping.generated_line == splice_line
+                && mapping.generated_column == splice_column
+                && mapping.original_line == 0
+                && mapping.original_column == 0
+                && mapping.name_index.is_some()
+        }),
+        "captured receiver mapping should be offset to the actual splice column"
+    );
+
+    let source_map = generator.generate();
+    assert_eq!(source_map.names, vec!["receiver"]);
+}
+
 // =============================================================================
 // SourceWriter - constructors and defaults
 // =============================================================================


### PR DESCRIPTION
AgentName: Studio-C

## Track
Track 9 JavaScript emit parity.

## Invariant
When a private-field compound assignment has a side-effecting receiver expression, nested temps produced while evaluating that receiver must be allocated before the outer receiver temp shared by `__classPrivateFieldSet` and `__classPrivateFieldGet`, matching `tsc` temp declaration order. Captured inline receiver output must preserve source-map writer state when it is spliced back into the main writer.

## Scope
- Adds an inline scratch-writer capture path for private receivers so nested emit can allocate temps before the compound-assignment receiver temp is created.
- Applies that capture only to private-field compound assignment receivers that already require a temp.
- Preserves captured receiver source-map position state when restoring the main writer.
- Adds focused emitter/source-writer regression coverage.

## Project Corpus Impact
- Row: n/a
- Bug family: class/private/accessor/decorator JS lowering; private-field compound assignment receiver temp planning.
- Evidence: emit-only targeted parity change; no project corpus row is known to depend on this private-name conformance baseline.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- `cargo nextest run -p tsz-emitter private_compound_assignment_allocates_nested_receiver_temps_first`
- `cargo nextest run -p tsz-emitter private_tagged_template_tests`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=privateNameInLhsReceiverExpression --js-only --verbose --timeout=30000 --json-out=/tmp/privateNameInLhsReceiverExpression-studio-c-be6ea25109.json`
- Earlier broad sample: `scripts/safe-run.sh scripts/emit/run.sh --filter=privateName --js-only --verbose --timeout=30000 --json-out=/tmp/privateName-studio-c-rebased-after-lhs.json` (152/158 after rebasing on #11974; remaining six are pre-existing private-name buckets)

## Coordination Notes
- Claimed focused slice on #8506 before editing: `privateNameInLhsReceiverExpression`.
- Current head is `5431f1e4feb05715454e51ad9dde410903536b0a` on `codex/studio-c-private-name-lhs-temp-20260531`; #11993 is stacked on this branch.
- Ready-review CI is still running for the exact head; `merge-queue` stays off until exact-head `CI Summary` and `GitGuardian Security Checks` are green.
