### PR TITLE
docs(plan): refresh output surgery metric

### DIFF
--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -58,7 +58,7 @@ denominators.
 | Declaration emit | `96.2%` (`1,606 / 1,669`) in checked-in emit snapshot and README |
 | Fourslash / language service | `99.9%` (`6,558 / 6,562`) |
 | Open bug issues | `37` open `bug` issues in live GitHub orientation |
-| Output-surgery audit | green: `0` unallowlisted calls, `0` stale allowlist entries; allowlist budget exhausted at `31 / 31` tracked calls |
+| Output-surgery audit | green: `0` unallowlisted calls, `0` stale allowlist entries; allowlist budget exhausted at `23 / 23` tracked calls |
 
 Conformance remains a hard regression gate. It is no longer the sole readiness
 signal. The primary readiness signal for this phase is whether tsz can
@@ -121,7 +121,7 @@ changes the picture.
    precomputed declaration/public-API summary.
 8. Output-surgery audit is green again: the current audit reports `0`
    unallowlisted calls and `0` stale allowlist entries. The allowlist budget is
-   still exhausted at `31 / 31` tracked calls, so Studio-C/D/F emit work should
+   still exhausted at `23 / 23` tracked calls, so Studio-C/D/F emit work should
    pay down or justify existing entries before adding new output-surgery calls.
 9. Conformance is no longer the dominant progress signal but it remains a hard
    regression gate. The current diagnostic gap is zero tests; broad


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Studio-F launch infrastructure and release-gate evidence plumbing.

## Invariant
When the live output-surgery audit reports an exhausted allowlist budget, the roadmap release-gate metric should quote the same tracked-call numerator and denominator; this PR updates only the stale roadmap number from current audit evidence.

## Scope
- `docs/plan/ROADMAP.md`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only roadmap metric refresh; no compiler, emit, checker, solver, parser, binder, LSP, WASM, or project corpus behavior changes.

## Verification
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery-roadmap-refresh.json`
- JSON spot-check confirmed `ok: true`, `status: "passed"`, `allowlisted_calls: 23`, `allowlist_cap: 23`, `allowlist_budget_status: "exhausted"`, `unallowlisted_calls: 0`, and `stale_allowlist_files: 0`
- `rg -n "31 / 31|23 / 23|Output-surgery audit" docs/plan/ROADMAP.md`
- `git diff --check HEAD~1..HEAD`

## Coordination Notes
- Studio-F owned work was clear before this branch.
- Start-cycle checks passed: disk preflight OK, label audit clean, architecture guardrails passed, and output-surgery audit passed.
- This is a public metric correction, not routine PR status bookkeeping; no roadmap direction changed.
