### PR TITLE
chore(emit-tools): expose output surgery budget counters

### DIFF
--- a/scripts/emit/audit-output-surgery.py
+++ b/scripts/emit/audit-output-surgery.py
@@ -345,13 +345,22 @@ def build_json_report(
     counts = grouped_counts(findings)
     summary = summarize_failures(failures)
     file_summaries = build_file_summaries(counts, allowlist)
+    budget = summarize_budget(file_summaries)
     return {
         "ok": not failures,
         "status": "failed" if failures else "passed",
         "total_findings": len(findings),
         "files_with_findings": len(counts),
+        "allowlisted_calls": budget.allowlisted_calls,
+        "allowlist_cap": budget.allowlist_cap,
+        "remaining_allowlist_capacity": budget.remaining_allowlist_capacity,
+        "allowlist_budget_status": budget.budget_status,
+        "unallowlisted_calls": summary.unallowlisted,
+        "over_allowlist_files": summary.over_allowlist_files,
+        "over_allowlist_excess_calls": summary.over_allowlist_excess_calls,
+        "stale_allowlist_files": summary.stale_allowlist_files,
         "failure_summary": dataclasses.asdict(summary),
-        "budget_summary": dataclasses.asdict(summarize_budget(file_summaries)),
+        "budget_summary": dataclasses.asdict(budget),
         "failures": failures,
         "categories": build_category_summaries(file_summaries),
         "files": file_summaries,

--- a/scripts/emit/test_output_surgery_audit.py
+++ b/scripts/emit/test_output_surgery_audit.py
@@ -83,6 +83,14 @@ class OutputSurgeryAuditTests(unittest.TestCase):
         self.assertEqual(report["status"], "failed")
         self.assertEqual(report["total_findings"], 2)
         self.assertEqual(report["files_with_findings"], 2)
+        self.assertEqual(report["allowlisted_calls"], 1)
+        self.assertEqual(report["allowlist_cap"], 2)
+        self.assertEqual(report["remaining_allowlist_capacity"], 1)
+        self.assertEqual(report["allowlist_budget_status"], "available")
+        self.assertEqual(report["unallowlisted_calls"], 1)
+        self.assertEqual(report["over_allowlist_files"], 0)
+        self.assertEqual(report["over_allowlist_excess_calls"], 0)
+        self.assertEqual(report["stale_allowlist_files"], 0)
         self.assertEqual(report["failure_summary"]["unallowlisted"], 1)
         self.assertEqual(
             report["budget_summary"],


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Emit tooling / output-surgery release-gate evidence.

## Invariant
When `scripts/emit/audit-output-surgery.py --json-report` writes the audit artifact, the existing nested `failure_summary` and `budget_summary` remain stable while key pass/fail counters are also available at the JSON root.

## Scope
- Expose top-level output-surgery budget and failure counters in `scripts/emit/audit-output-surgery.py`.
- Extend the focused output-surgery audit unit test coverage for the top-level aliases.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: test-harness/tooling-only; does not change compiler, emit output, project corpus fixtures, or TypeScript parity behavior.

## Verification
- `python3 -m unittest scripts.emit.test_output_surgery_audit`
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-budget-status-report.json`
- `git diff --check HEAD~1 HEAD`
- `scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-audit.json`

## Coordination Notes
- Studio-F slice after #11990; no open Studio-F PR overlap at publication time.
- Existing nested JSON fields are preserved for compatibility; top-level fields mirror current summary values for easier release-gate consumption.
