### PR TITLE
fix(bench): gate clean artifact metadata

### DIFF
--- a/scripts/bench/check-artifact-readiness.mjs
+++ b/scripts/bench/check-artifact-readiness.mjs
@@ -4,8 +4,9 @@
  *
  * Exit codes:
  *   0 — artifact present, all required rows included
- *   1 — artifact present, one or more required rows are missing or the
- *       --require-green release gate found non-green required rows
+ *   1 — artifact present, one or more required rows are missing, the
+ *       --require-green release gate found non-green required rows, or the
+ *       --require-clean-metadata gate found artifact metadata warnings
  *   2 — artifact file absent or unparseable
  *
  * Without --json: writes a markdown report to stdout (and GITHUB_STEP_SUMMARY
@@ -16,7 +17,7 @@
  * is absent (exit 2) so callers reliably get machine-readable status in all cases.
  *
  * Usage:
- *   node scripts/bench/check-artifact-readiness.mjs [--json] [--require-green] <artifact.json>
+ *   node scripts/bench/check-artifact-readiness.mjs [--json] [--require-green] [--require-clean-metadata] <artifact.json>
  */
 
 import fs from "node:fs";
@@ -33,6 +34,7 @@ import {
 const args = process.argv.slice(2);
 const jsonOutput = args.includes("--json");
 const requireGreen = args.includes("--require-green");
+const requireCleanMetadata = args.includes("--require-clean-metadata");
 const filePath = args.find((a) => !a.startsWith("-")) ?? null;
 
 function loadArtifact() {
@@ -219,6 +221,7 @@ function uniqueRowsByName(rows) {
 
 function buildJson({ artifactAbsent, parseError, artifact, measurementProfile, validationWarnings, rows, missing, red, yellow, gray, green, duplicates }) {
   const missingNames = missing?.map((r) => r.name) ?? REQUIRED_PROJECT_ROWS;
+  const metadataWarningsList = metadataWarnings(measurementProfile, validationWarnings);
   const nonGreenRows = rows
     ? uniqueRowsByName([
       ...(red ?? []),
@@ -240,6 +243,8 @@ function buildJson({ artifactAbsent, parseError, artifact, measurementProfile, v
       measurement_profile: [],
       total: 0,
     },
+    metadata_clean: metadataWarningsList.length === 0,
+    metadata_warnings_total: metadataWarningsList.length,
     required_row_count: rows?.length ?? REQUIRED_PROJECT_ROWS.length,
     green: green?.length ?? 0,
     yellow: yellow?.length ?? 0,
@@ -322,6 +327,23 @@ function measurementProfileReportWarnings(profile, validationWarnings) {
     });
   }
   return warnings;
+}
+
+function metadataWarnings(profile, validationWarnings) {
+  const runnerWarnings = (validationWarnings?.runner_environment ?? []).map((warning) => ({
+    kind: "runner metadata",
+    file: warning.file ?? "unknown input",
+    message: fmtWarningFields(warning),
+  }));
+  const measurementWarnings = measurementProfileReportWarnings(
+    profile ?? { warning: "measurement_profile missing" },
+    validationWarnings ?? { measurement_profile: [] },
+  ).map((warning) => ({
+    kind: "measurement profile",
+    file: warning.file,
+    message: warning.message,
+  }));
+  return [...runnerWarnings, ...measurementWarnings];
 }
 
 function artifactAge(generatedAt) {
@@ -508,6 +530,17 @@ if (requireGreen && (red.length > 0 || yellow.length > 0 || gray.length > 0)) {
       nonGreen.map((r) => `${r.name} (${r.state})`).join(", ") + "\n",
   );
   process.exit(1);
+}
+
+if (requireCleanMetadata) {
+  const warnings = metadataWarnings(measurementProfile, validationWarnings);
+  if (warnings.length > 0) {
+    process.stderr.write(
+      `bench-artifact-readiness: ${warnings.length} metadata warning(s) present: ` +
+        warnings.map((warning) => `${warning.kind} ${warning.file}: ${warning.message}`).join("; ") + "\n",
+    );
+    process.exit(1);
+  }
 }
 
 process.exit(0);

--- a/scripts/bench/test-check-artifact-readiness.mjs
+++ b/scripts/bench/test-check-artifact-readiness.mjs
@@ -162,6 +162,8 @@ withTempDir((dir) => {
   assert.equal(result.status, 0, `all-green artifact should exit 0, got:\n${result.stderr}`);
   const parsed = JSON.parse(result.stdout.trim());
   assert.equal(parsed.all_required_rows_green, true, "all-green JSON should mark release gate ready");
+  assert.equal(parsed.metadata_clean, true, "all-green artifact should be metadata-clean");
+  assert.equal(parsed.metadata_warnings_total, 0, "all-green artifact should not report metadata warnings");
   assert.deepEqual(parsed.non_green_required_rows, [], "all-green JSON should not report non-green rows");
   assert.match(result.stderr, new RegExp(`green.*\\| ${REQUIRED_PROJECT_ROWS.length}`), "should show all green count");
   assert.match(result.stderr, /Measurement profile.*release-pgo/, "should show measurement profile mode");
@@ -185,6 +187,22 @@ withTempDir((dir) => {
   assert.match(result.stdout, /artifact measurement_profile.*measurement_profile missing/);
 });
 console.log("✅ missing measurement profile is reported without failing readiness");
+
+// ---------------------------------------------------------------------------
+// Test: --require-clean-metadata fails when measurement_profile is missing.
+// ---------------------------------------------------------------------------
+withTempDir((dir) => {
+  const file = path.join(dir, "bench.json");
+  const rows = REQUIRED_PROJECT_ROWS.map((name) => makeRow(name, "green"));
+  writeJson(file, makeArtifact(rows));
+  const result = run(file, ["--json", "--require-clean-metadata"]);
+  assert.equal(result.status, 1, "missing measurement profile should fail clean metadata gate");
+  const parsed = JSON.parse(result.stdout.trim());
+  assert.equal(parsed.metadata_clean, false, "JSON should mark missing measurement profile as unclean");
+  assert.equal(parsed.metadata_warnings_total, 1, "JSON should count missing measurement profile warning");
+  assert.match(result.stderr, /measurement profile artifact measurement_profile: measurement_profile missing/);
+});
+console.log("✅ --require-clean-metadata fails on missing measurement profile");
 
 // ---------------------------------------------------------------------------
 // Test: merged artifact validation warnings are surfaced in readiness output so
@@ -217,6 +235,8 @@ withTempDir((dir) => {
   const result = run(file, ["--json"]);
   assert.equal(result.status, 0, `validation warnings should not fail readiness:\n${result.stderr}`);
   const parsed = JSON.parse(result.stdout.trim());
+  assert.equal(parsed.metadata_clean, false, "JSON should mark validation warnings as unclean");
+  assert.equal(parsed.metadata_warnings_total, 2, "JSON should count all metadata warnings");
   assert.equal(parsed.validation_warnings.total, 2, "JSON should count validation warnings");
   assert.deepEqual(
     parsed.validation_warnings.runner_environment[0].mismatched_fields,
@@ -232,6 +252,34 @@ withTempDir((dir) => {
   assert.match(result.stderr, /Measurement profile warnings \(1\)/);
 });
 console.log("✅ validation warnings are surfaced in readiness output");
+
+// ---------------------------------------------------------------------------
+// Test: --require-clean-metadata fails when merged validation warnings exist.
+// ---------------------------------------------------------------------------
+withTempDir((dir) => {
+  const file = path.join(dir, "bench.json");
+  const rows = REQUIRED_PROJECT_ROWS.map((name) => makeRow(name, "green"));
+  writeJson(file, makeArtifact(rows, {
+    measurement_profile: SAMPLE_MEASUREMENT_PROFILE,
+    validation: {
+      runner_environment_warnings: [
+        {
+          file: "bench-results-b.json",
+          mismatched_fields: ["cpu_model"],
+          expected: { cpu_model: "Intel Xeon" },
+          actual: { cpu_model: "AMD EPYC" },
+        },
+      ],
+    },
+  }));
+  const result = run(file, ["--json", "--require-clean-metadata"]);
+  assert.equal(result.status, 1, "runner metadata warnings should fail clean metadata gate");
+  const parsed = JSON.parse(result.stdout.trim());
+  assert.equal(parsed.metadata_clean, false, "JSON should mark runner warning artifact as unclean");
+  assert.equal(parsed.metadata_warnings_total, 1, "JSON should count the runner warning");
+  assert.match(result.stderr, /runner metadata bench-results-b\.json: cpu_model/);
+});
+console.log("✅ --require-clean-metadata fails on runner metadata warnings");
 
 // ---------------------------------------------------------------------------
 // Test: artifact missing one required row → exit 1


### PR DESCRIPTION
AgentName: Studio-A

## Track
benchmark artifact truth / reporting gate

## Invariant
When a benchmark artifact carries runner-environment or measurement-profile metadata warnings, release-truth checks must be able to fail explicitly instead of only printing warnings in a human-readable report.

## Owner Layer
Benchmark tooling in `scripts/bench/check-artifact-readiness.mjs`. This does not change compiler semantics or benchmark measurements; it only changes artifact-readiness reporting/gating.

## Scope
- Adds `--require-clean-metadata` to fail readiness when runner or measurement metadata warnings are present.
- Adds JSON fields `metadata_clean` and `metadata_warnings_total` for machine-readable artifact truth.
- Extends the readiness script test for missing measurement profiles, runner metadata warnings, and default warning-only behavior.

## Project Corpus Impact
- Row: n/a
- Bug family: benchmark artifact metadata truth
- Evidence: The current checked-in benchmark snapshot is fresh and linked to workflow run `26707914493`, but strict clean-metadata mode reports the known historical `bench-results-algorithmic-mapped.json: cpu_model` warning. This PR adds a gate to make that state machine-readable and fail-fast when a clean artifact is required.

## Verification
- `node scripts/bench/test-check-artifact-readiness.mjs`
- `node scripts/bench/validate-project-metadata.mjs`
- `node scripts/bench/check-artifact-readiness.mjs --json --require-clean-metadata crates/tsz-website/bench-snapshot.json > /tmp/bench-readiness.json` exits 1 and reports `metadata_warnings_total: 1` for the known current warning
- `git diff --check`

## Coordination Notes
- Follows issue #10649 after #11958: the current public snapshot is fresh but still contains the historical runner warning, so Studio-A needs an explicit clean-metadata gate before treating the next artifact as fully clean truth.
- No open Studio-A PRs existed before this branch was opened.
