### PR TITLE
fix(emit): recover private-name decorator and indexed-access cases

### DIFF
--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -19,6 +19,12 @@ use tsz_scanner::SyntaxKind;
 /// `trailing_comments`, `source_order`).
 pub(crate) type FieldInit = (String, NodeIndex, u32, Vec<String>, Vec<String>, u32);
 
+/// A private field constructor initializer entry:
+/// (`weakmap_name`, `has_initializer`, `initializer_node`, `leading_comments`,
+/// `trailing_comments`, `source_order`).
+pub(crate) type PrivateFieldConstructorInit =
+    (String, bool, NodeIndex, Vec<String>, Vec<String>, u32);
+
 /// A const enum entry scoped to a specific region of the source.
 /// File-level const enums use `(0, u32::MAX)` so they match any position.
 /// Function-scoped const enums use the enclosing function's `(pos, end)`.
@@ -52,10 +58,13 @@ pub(crate) struct PrivateMemberInfo {
 pub(crate) struct PrivateAccessorDef {
     /// The variable name (e.g., `_C_prop_get`).
     pub var_name: String,
-    /// The body node index.
-    pub body: NodeIndex,
+    /// The body node index, or `None` for invalid no-body accessors that `tsc`
+    /// recovers as empty extracted helpers.
+    pub body: Option<NodeIndex>,
     /// Optional setter parameter node index.
     pub param: Option<NodeIndex>,
+    /// Whether the extracted accessor function is async.
+    pub is_async: bool,
 }
 
 /// Info about a private method function to emit after the class body.
@@ -884,10 +893,9 @@ pub struct Printer<'a> {
 
     /// Private field constructor inits:
     /// (`weakmap_name`, `has_initializer`, `initializer_idx`,
-    /// `leading_comments`, `source_order`).
+    /// `leading_comments`, `trailing_comments`, `source_order`).
     /// Emitted as `_C_field.set(this, <init>)` at the start of the constructor.
-    pub(crate) pending_private_field_constructor_inits:
-        Vec<(String, bool, NodeIndex, Vec<String>, u32)>,
+    pub(crate) pending_private_field_constructor_inits: Vec<PrivateFieldConstructorInit>,
 
     /// `WeakSet` instance name for `_X_instances.add(this)` in the constructor.
     /// Set when the class has private instance methods or accessors.

--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -883,9 +883,11 @@ pub struct Printer<'a> {
     pub(crate) pending_private_class_alias: Option<(String, String)>,
 
     /// Private field constructor inits:
-    /// (`weakmap_name`, `has_initializer`, `initializer_idx`, `source_order`).
+    /// (`weakmap_name`, `has_initializer`, `initializer_idx`,
+    /// `leading_comments`, `source_order`).
     /// Emitted as `_C_field.set(this, <init>)` at the start of the constructor.
-    pub(crate) pending_private_field_constructor_inits: Vec<(String, bool, NodeIndex, u32)>,
+    pub(crate) pending_private_field_constructor_inits:
+        Vec<(String, bool, NodeIndex, Vec<String>, u32)>,
 
     /// `WeakSet` instance name for `_X_instances.add(this)` in the constructor.
     /// Set when the class has private instance methods or accessors.

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -1078,11 +1078,44 @@ impl<'a> Printer<'a> {
                 .iter()
                 .filter(|f| !f.is_static)
                 .map(|f| {
-                    let source_order = self.arena.get(f.member_idx).map_or(u32::MAX, |n| n.pos);
+                    let Some(member_pos) = class
+                        .members
+                        .nodes
+                        .iter()
+                        .position(|&member_idx| member_idx == f.member_idx)
+                    else {
+                        return (
+                            f.weakmap_name.clone(),
+                            f.has_initializer,
+                            f.initializer,
+                            Vec::new(),
+                            u32::MAX,
+                        );
+                    };
+                    let member_node = self.arena.get(f.member_idx);
+                    let source_order = member_node.map_or(u32::MAX, |n| n.pos);
+                    let leading_comments = if !self.ctx.options.remove_comments {
+                        let prev_end = if member_pos > 0 {
+                            class
+                                .members
+                                .nodes
+                                .get(member_pos - 1)
+                                .and_then(|&prev_idx| self.arena.get(prev_idx))
+                                .map_or(source_order, |prev| {
+                                    self.find_token_end_before_trivia(prev.pos, prev.end)
+                                })
+                        } else {
+                            source_order.saturating_sub(64)
+                        };
+                        self.collect_leading_comments_in_range(prev_end, source_order)
+                    } else {
+                        Vec::new()
+                    };
                     (
                         f.weakmap_name.clone(),
                         f.has_initializer,
                         f.initializer,
+                        leading_comments,
                         source_order,
                     )
                 })

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -923,12 +923,12 @@ impl<'a> Printer<'a> {
                                 continue;
                             }
                             if let Some(ref name) = accessor.get_var_name
-                                && accessor.getter_body.is_some()
+                                && accessor.has_getter
                             {
                                 var_names.push(name.clone());
                             }
                             if let Some(ref name) = accessor.set_var_name
-                                && accessor.setter_body.is_some()
+                                && accessor.has_setter
                             {
                                 var_names.push(name.clone());
                             }
@@ -1009,12 +1009,12 @@ impl<'a> Printer<'a> {
                         fn_ref: accessor
                             .get_var_name
                             .as_ref()
-                            .filter(|_| accessor.getter_body.is_some())
+                            .filter(|_| accessor.has_getter)
                             .cloned(),
                         setter_ref: accessor
                             .set_var_name
                             .as_ref()
-                            .filter(|_| accessor.setter_body.is_some())
+                            .filter(|_| accessor.has_setter)
                             .cloned(),
                         state_var: if accessor.is_static {
                             private_class_alias.clone()
@@ -1089,6 +1089,7 @@ impl<'a> Printer<'a> {
                             f.has_initializer,
                             f.initializer,
                             Vec::new(),
+                            Vec::new(),
                             u32::MAX,
                         );
                     };
@@ -1111,11 +1112,29 @@ impl<'a> Printer<'a> {
                     } else {
                         Vec::new()
                     };
+                    let trailing_comments = if !self.ctx.options.remove_comments {
+                        let skip_end = class
+                            .members
+                            .nodes
+                            .get(member_pos + 1)
+                            .and_then(|&next_idx| self.arena.get(next_idx))
+                            .map_or_else(
+                                || member_node.map_or(source_order, |n| n.end),
+                                |next| next.pos,
+                            );
+                        member_node.map_or_else(Vec::new, |node| {
+                            let actual_end = self.find_token_end_before_trivia(node.pos, skip_end);
+                            self.collect_trailing_comments_in_range(actual_end)
+                        })
+                    } else {
+                        Vec::new()
+                    };
                     (
                         f.weakmap_name.clone(),
                         f.has_initializer,
                         f.initializer,
                         leading_comments,
+                        trailing_comments,
                         source_order,
                     )
                 })
@@ -1146,25 +1165,27 @@ impl<'a> Printer<'a> {
             // Prepare private accessor function defs for after the class body
             // Both instance and static private accessors are extracted.
             for accessor in &private_accessors {
-                if let Some(body_idx) = accessor.getter_body
+                if accessor.has_getter
                     && let Some(ref var_name) = accessor.get_var_name
                 {
                     self.pending_private_accessor_defs.push(
                         crate::emitter::core::PrivateAccessorDef {
                             var_name: var_name.clone(),
-                            body: body_idx,
+                            body: accessor.getter_body,
                             param: None,
+                            is_async: accessor.getter_is_async,
                         },
                     );
                 }
-                if let Some(body_idx) = accessor.setter_body
+                if accessor.has_setter
                     && let Some(ref var_name) = accessor.set_var_name
                 {
                     self.pending_private_accessor_defs.push(
                         crate::emitter::core::PrivateAccessorDef {
                             var_name: var_name.clone(),
-                            body: body_idx,
+                            body: accessor.setter_body,
                             param: accessor.setter_param,
+                            is_async: accessor.setter_is_async,
                         },
                     );
                 }

--- a/crates/tsz-emitter/src/emitter/declarations/class/private_method_defs.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/private_method_defs.rs
@@ -1,6 +1,9 @@
 use super::super::super::Printer;
 use crate::emitter::core::{PrivateAccessorDef, PrivateMethodDef};
 use std::sync::Arc;
+use tsz_common::common::ScriptTarget;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
 
 impl<'a> Printer<'a> {
     pub(in crate::emitter) fn emit_private_method_function_def(
@@ -12,6 +15,44 @@ impl<'a> Printer<'a> {
     ) {
         self.write(&def.var_name);
         self.write(" = ");
+        if def.is_async
+            && def.is_generator
+            && (self.ctx.options.target as u32) < (ScriptTarget::ES2018 as u32)
+        {
+            let prev_self_alias = self.scoped_class_expression_self_alias.clone();
+            if private_member_def_needs_class_alias
+                && let Some(alias) = class_value_alias
+                && !class_name.is_empty()
+            {
+                self.scoped_class_expression_self_alias =
+                    Some((Arc::<str>::from(class_name), Arc::<str>::from(alias)));
+            }
+            self.emit_private_async_generator_function(def);
+            self.scoped_class_expression_self_alias = prev_self_alias;
+            return;
+        }
+        if def.is_async
+            && !def.is_generator
+            && (self.ctx.options.target as u32) < (ScriptTarget::ES2017 as u32)
+        {
+            let prev_self_alias = self.scoped_class_expression_self_alias.clone();
+            if private_member_def_needs_class_alias
+                && let Some(alias) = class_value_alias
+                && !class_name.is_empty()
+            {
+                self.scoped_class_expression_self_alias =
+                    Some((Arc::<str>::from(class_name), Arc::<str>::from(alias)));
+            }
+            self.emit_async_function_es5_body(
+                &def.var_name,
+                &def.params,
+                def.body,
+                "this",
+                NodeIndex::NONE,
+            );
+            self.scoped_class_expression_self_alias = prev_self_alias;
+            return;
+        }
         if def.is_async {
             self.write("async ");
         }
@@ -65,7 +106,31 @@ impl<'a> Printer<'a> {
         class_name: &str,
     ) {
         self.write(&def.var_name);
-        self.write(" = function ");
+        self.write(" = ");
+        let params = def.param.into_iter().collect::<Vec<_>>();
+        if def.is_async
+            && let Some(body) = def.body
+            && (self.ctx.options.target as u32) < (ScriptTarget::ES2017 as u32)
+        {
+            let prev_self_alias = self.scoped_class_expression_self_alias.clone();
+            if private_member_def_needs_class_alias
+                && let Some(alias) = class_value_alias
+                && !class_name.is_empty()
+            {
+                self.scoped_class_expression_self_alias =
+                    Some((Arc::<str>::from(class_name), Arc::<str>::from(alias)));
+            }
+            self.emit_async_function_es5_body(
+                &def.var_name,
+                &params,
+                body,
+                "this",
+                NodeIndex::NONE,
+            );
+            self.scoped_class_expression_self_alias = prev_self_alias;
+            return;
+        }
+        self.write("function ");
         self.write(&def.var_name);
         self.write("(");
         self.function_scope_depth += 1;
@@ -94,8 +159,12 @@ impl<'a> Printer<'a> {
         self.ctx.block_scope_state.enter_scope();
         self.push_temp_scope();
         let prev_declared = std::mem::take(&mut self.declared_namespace_names);
-        self.prepare_logical_assignment_value_temps(def.body);
-        self.emit_single_line_block(def.body);
+        if let Some(body) = def.body {
+            self.prepare_logical_assignment_value_temps(body);
+            self.emit_single_line_block(body);
+        } else {
+            self.write("{ }");
+        }
         self.declared_namespace_names = prev_declared;
         self.pop_temp_scope();
         self.ctx.block_scope_state.exit_scope();
@@ -103,5 +172,135 @@ impl<'a> Printer<'a> {
         self.emitting_function_body_block = prev_emitting_function_body_block;
         self.function_scope_depth -= 1;
         self.scoped_class_expression_self_alias = prev_self_alias;
+    }
+
+    fn emit_private_async_generator_function(&mut self, def: &PrivateMethodDef) {
+        self.push_temp_scope();
+        let move_params_to_generator = self.async_params_need_generator_forwarding(&def.params);
+        let inner_name = self.next_async_generator_inner_name(&def.var_name);
+        self.write("function ");
+        self.write(&def.var_name);
+        self.write("(");
+        if move_params_to_generator {
+            self.emit_async_outer_parameter_placeholders(&def.params);
+        } else {
+            self.emit_function_parameters_js(&def.params);
+        }
+        self.write(") {");
+
+        if self.ctx.target_es5 {
+            self.write_line();
+            self.increase_indent();
+            self.write("return ");
+            self.write_helper("__asyncGenerator");
+            self.write("(this, arguments, ");
+            self.emit_async_generator_es5_inner_function(
+                Some(inner_name),
+                &def.params,
+                def.body,
+                move_params_to_generator,
+            );
+            self.write(");");
+            self.write_line();
+            self.decrease_indent();
+            self.write("}");
+            self.pop_temp_scope();
+            return;
+        }
+
+        let body_is_single_line = self
+            .arena
+            .get(def.body)
+            .is_some_and(|node| self.is_single_line(node));
+        if body_is_single_line {
+            self.write(" return ");
+            self.write_helper("__asyncGenerator");
+            self.write("(this, arguments, function* ");
+            self.write(&inner_name);
+            self.write("(");
+            if move_params_to_generator {
+                let saved = self.ctx.emit_await_as_yield_await;
+                self.ctx.emit_await_as_yield_await = true;
+                self.emit_function_parameters_js(&def.params);
+                self.ctx.emit_await_as_yield_await = saved;
+            }
+            self.write(") {");
+            self.emit_private_async_generator_body_statements(def.body, true);
+            self.write(" }); }");
+            self.pop_temp_scope();
+            return;
+        }
+
+        self.write_line();
+        self.increase_indent();
+        self.write("return ");
+        self.write_helper("__asyncGenerator");
+        self.write("(this, arguments, function* ");
+        self.write(&inner_name);
+        self.write("(");
+        if move_params_to_generator {
+            let saved = self.ctx.emit_await_as_yield_await;
+            self.ctx.emit_await_as_yield_await = true;
+            self.emit_function_parameters_js(&def.params);
+            self.ctx.emit_await_as_yield_await = saved;
+        }
+        self.write(") {");
+        self.write_line();
+        self.increase_indent();
+        self.emit_private_async_generator_body_statements(def.body, false);
+        self.decrease_indent();
+        self.write("});");
+        self.write_line();
+        self.decrease_indent();
+        self.write("}");
+        self.pop_temp_scope();
+    }
+
+    fn emit_private_async_generator_body_statements(&mut self, body: NodeIndex, inline: bool) {
+        let saved = self.ctx.emit_await_as_yield_await;
+        self.ctx.emit_await_as_yield_await = true;
+        self.function_scope_depth += 1;
+        if let Some(body_node) = self.arena.get(body)
+            && let Some(block) = self.arena.get_block(body_node)
+        {
+            let statements = block.statements.clone();
+            if inline {
+                for &stmt in &statements.nodes {
+                    self.write(" ");
+                    self.emit_private_async_generator_statement(stmt);
+                }
+            } else if !self.emit_statement_list_with_using_scope(&statements) {
+                for &stmt in &statements.nodes {
+                    self.emit_private_async_generator_statement(stmt);
+                    self.write_line();
+                }
+            }
+        }
+        self.function_scope_depth -= 1;
+        self.ctx.emit_await_as_yield_await = saved;
+    }
+
+    fn emit_private_async_generator_statement(&mut self, stmt: NodeIndex) {
+        let Some(node) = self.arena.get(stmt) else {
+            return;
+        };
+        if node.kind != syntax_kind_ext::RETURN_STATEMENT {
+            self.emit(stmt);
+            return;
+        }
+        let Some(ret) = self.arena.get_return_statement(node) else {
+            self.emit(stmt);
+            return;
+        };
+        self.write("return");
+        if ret.expression.is_some() {
+            self.write(" yield ");
+            self.write_helper("__await");
+            self.write("(");
+            self.emit_expression(ret.expression);
+            self.write(")");
+        }
+        self.write_semicolon();
+        self.emit_trailing_comment_after_semicolon(node);
     }
 }

--- a/crates/tsz-emitter/src/emitter/declarations/class_members.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class_members.rs
@@ -1298,18 +1298,25 @@ impl<'a> Printer<'a> {
         while private_idx < private_inits.len() || public_idx < field_inits.len() {
             let next_private_order = private_inits
                 .get(private_idx)
-                .map_or(u32::MAX, |(_, _, _, _, source_order)| *source_order);
+                .map_or(u32::MAX, |(_, _, _, _, _, source_order)| *source_order);
             let next_public_order = field_inits
                 .get(public_idx)
                 .map_or(u32::MAX, |(_, _, _, _, _, source_order)| *source_order);
             if next_private_order <= next_public_order {
-                let (weakmap_name, has_initializer, initializer, leading_comments, _) =
-                    &private_inits[private_idx];
+                let (
+                    weakmap_name,
+                    has_initializer,
+                    initializer,
+                    leading_comments,
+                    trailing_comments,
+                    _,
+                ) = &private_inits[private_idx];
                 self.emit_private_field_constructor_init(
                     weakmap_name,
                     *has_initializer,
                     *initializer,
                     leading_comments,
+                    trailing_comments,
                 );
                 private_idx += 1;
             } else {
@@ -1335,6 +1342,7 @@ impl<'a> Printer<'a> {
         has_initializer: bool,
         initializer: NodeIndex,
         leading_comments: &[String],
+        trailing_comments: &[String],
     ) {
         for comment in leading_comments {
             self.write_comment(comment);
@@ -1348,6 +1356,10 @@ impl<'a> Printer<'a> {
             self.write("void 0");
         }
         self.write(");");
+        for comment in trailing_comments {
+            self.write_space();
+            self.write_comment(comment);
+        }
         self.write_line();
     }
 

--- a/crates/tsz-emitter/src/emitter/declarations/class_members.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class_members.rs
@@ -1298,16 +1298,18 @@ impl<'a> Printer<'a> {
         while private_idx < private_inits.len() || public_idx < field_inits.len() {
             let next_private_order = private_inits
                 .get(private_idx)
-                .map_or(u32::MAX, |(_, _, _, source_order)| *source_order);
+                .map_or(u32::MAX, |(_, _, _, _, source_order)| *source_order);
             let next_public_order = field_inits
                 .get(public_idx)
                 .map_or(u32::MAX, |(_, _, _, _, _, source_order)| *source_order);
             if next_private_order <= next_public_order {
-                let (weakmap_name, has_initializer, initializer, _) = &private_inits[private_idx];
+                let (weakmap_name, has_initializer, initializer, leading_comments, _) =
+                    &private_inits[private_idx];
                 self.emit_private_field_constructor_init(
                     weakmap_name,
                     *has_initializer,
                     *initializer,
+                    leading_comments,
                 );
                 private_idx += 1;
             } else {
@@ -1332,7 +1334,12 @@ impl<'a> Printer<'a> {
         weakmap_name: &str,
         has_initializer: bool,
         initializer: NodeIndex,
+        leading_comments: &[String],
     ) {
+        for comment in leading_comments {
+            self.write_comment(comment);
+            self.write_line();
+        }
         self.write(weakmap_name);
         self.write(".set(this, ");
         if has_initializer {

--- a/crates/tsz-emitter/src/emitter/declarations/core.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/core.rs
@@ -392,7 +392,14 @@ impl<'a> Printer<'a> {
         if let Some(name_node) = self.arena.get(decl.name) {
             self.emit_comments_before_pos(name_node.pos);
         }
-        self.emit_decl_name(decl.name);
+        if let Some(name_node) = self.arena.get(decl.name)
+            && name_node.kind == SyntaxKind::PrivateIdentifier as u16
+            && let Some(name) = self.arena.get_identifier(name_node)
+        {
+            self.write(&name.escaped_text);
+        } else {
+            self.emit_decl_name(decl.name);
+        }
 
         // Skip type annotation for JavaScript emit — consume any comments
         // inside the erased type annotation so they don't leak into output.

--- a/crates/tsz-emitter/src/emitter/source_file/legacy_decorator_computed_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/legacy_decorator_computed_tests.rs
@@ -81,3 +81,38 @@ fn legacy_decorated_computed_class_expressions_match_tsc_temp_order() {
         "A computed method should consume pending computed field entries without adding a class-expression wrapper.\nOutput:\n{output}"
     );
 }
+
+#[test]
+fn legacy_decorators_on_private_members_do_not_schedule_decorate_helper() {
+    let source = "declare function decorator(target: any, key: any): any;\nclass A {\n    @decorator #field = 1;\n    @decorator #method() {}\n    @decorator get #value() { return 1; }\n}\n";
+
+    let output = emit(source);
+
+    assert!(
+        !output.contains("__decorate"),
+        "Invalid legacy decorators on private members should not schedule runtime decorator helpers.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_A_field.set(this, 1);")
+            && output.contains("_A_instances = new WeakSet()")
+            && output.contains("_A_method = function _A_method() { }")
+            && output.contains("_A_value_get = function _A_value_get() { return 1; }"),
+        "Private field, method, and accessor state should still lower normally.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn legacy_public_member_decorators_still_schedule_decorate_helper() {
+    let source = "declare function decorator(target: any, key: any): any;\nclass A {\n    @decorator field = 1;\n    @decorator method() {}\n}\n";
+
+    let output = emit(source);
+
+    assert!(
+        output.contains("__decorate([") && output.contains("], A.prototype, \"field\", void 0);"),
+        "Public legacy field decorators should still schedule __decorate.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("], A.prototype, \"method\", null);"),
+        "Public legacy method decorators should still schedule __decorate.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/source_file/parser_recovery_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/parser_recovery_tests.rs
@@ -26,3 +26,14 @@ alpha = (beta = gamma === ) = 'value';
 ";
     assert_eq!(output, expected);
 }
+
+#[test]
+fn invalid_private_name_indexed_access_recovers_as_declarator_tail() {
+    let source = "const badForNow: C[#bar] = 3;";
+    let output = emit_es2015(source);
+    let expected = "\
+const badForNow, #bar;
+3;
+";
+    assert_eq!(output, expected);
+}

--- a/crates/tsz-emitter/src/emitter/source_file/private_field_helper_order_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/private_field_helper_order_tests.rs
@@ -178,6 +178,26 @@ class A {
 }
 
 #[test]
+fn private_field_trailing_comments_move_to_weakmap_initializers() {
+    let source = r#"
+class A {
+    #a = 1; // first
+    #b = 2; // second
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains("_A_a.set(this, 1); // first"),
+        "trailing comment for #a should move with the constructor WeakMap initializer.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_A_b.set(this, 2); // second"),
+        "trailing comment for #b should move with the constructor WeakMap initializer.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn private_accessor_helpers_follow_source_order() {
     let source = r#"
 class A {
@@ -204,6 +224,79 @@ class A {
     assert!(
         a_pos < b_pos && b_pos < c_pos,
         "Private accessor helper initialization order should match source order.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn no_body_private_accessors_emit_empty_extracted_helpers() {
+    let source = r#"
+class A {
+    declare get #value(): number;
+    declare set #value(value: number);
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains("_A_value_get = function _A_value_get() { }"),
+        "no-body private getter should recover as an empty extracted helper.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_A_value_set = function _A_value_set(value) { }"),
+        "no-body private setter should recover as an empty extracted helper.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("get ()") && !output.contains("set ("),
+        "recovered no-body private accessors should not be printed in the class body.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn private_async_helpers_downlevel_for_es2015_but_preserve_native_for_es2019() {
+    let source = r#"
+class A {
+    async #method() { return 1; }
+    async *#stream() { return 2; }
+    async get #value() { return 3; }
+    async set #value(value: number) { }
+}
+"#;
+    let es2015 = emit(source, ScriptTarget::ES2015);
+    assert!(
+        es2015.contains("_A_method = function _A_method()")
+            && es2015
+                .contains("return __awaiter(this, void 0, void 0, function* () { return 1; });"),
+        "private async methods should lower through __awaiter for ES2015.\nOutput:\n{es2015}"
+    );
+    assert!(
+        es2015.contains("_A_stream = function _A_stream() { return __asyncGenerator(this, arguments, function* _A_stream_1() { return yield __await(2); }); }"),
+        "private async generators should lower through __asyncGenerator for ES2015.\nOutput:\n{es2015}"
+    );
+    assert!(
+        es2015.contains("_A_value_get = function _A_value_get()")
+            && es2015
+                .contains("return __awaiter(this, void 0, void 0, function* () { return 3; });"),
+        "private async getters should lower through __awaiter for ES2015.\nOutput:\n{es2015}"
+    );
+    assert!(
+        es2015.contains("_A_value_set = function _A_value_set(value)")
+            && es2015.contains("return __awaiter(this, void 0, void 0, function* () { });"),
+        "private async setters should lower through __awaiter for ES2015.\nOutput:\n{es2015}"
+    );
+    assert!(
+        !es2015.contains("async function _A_method")
+            && !es2015.contains("async function* _A_stream"),
+        "ES2015 private helpers should not keep native async helper functions.\nOutput:\n{es2015}"
+    );
+
+    let es2019 = emit(source, ScriptTarget::ES2019);
+    assert!(
+        es2019.contains("_A_method = async function _A_method()"),
+        "ES2019 should preserve native async private method helpers.\nOutput:\n{es2019}"
+    );
+    assert!(
+        es2019.contains("_A_stream = async function* _A_stream()"),
+        "ES2019 should preserve native async-generator private method helpers.\nOutput:\n{es2019}"
     );
 }
 

--- a/crates/tsz-emitter/src/emitter/source_file/private_field_helper_order_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/private_field_helper_order_tests.rs
@@ -141,3 +141,94 @@ class Box {
         "instance-only class must not emit a static field assignment.\nOutput:\n{output}"
     );
 }
+
+#[test]
+fn private_field_leading_comments_move_to_weakmap_initializers() {
+    let source = r#"
+class A {
+    /**
+     * @public
+     */
+    #a = 1;
+    /**
+     * @private
+     */
+    #b = 2;
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    let public_comment = output
+        .find("* @public")
+        .unwrap_or_else(|| panic!("expected public JSDoc on lowered private field\n{output}"));
+    let public_init = output
+        .find("_A_a.set(this, 1);")
+        .unwrap_or_else(|| panic!("expected lowered private #a initializer\n{output}"));
+    let private_comment = output
+        .find("* @private")
+        .unwrap_or_else(|| panic!("expected private JSDoc on lowered private field\n{output}"));
+    let private_init = output
+        .find("_A_b.set(this, 2);")
+        .unwrap_or_else(|| panic!("expected lowered private #b initializer\n{output}"));
+
+    assert!(
+        public_comment < public_init && private_comment < private_init,
+        "Private field comments should move with constructor WeakMap initializers.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn private_accessor_helpers_follow_source_order() {
+    let source = r#"
+class A {
+    get #a() { return 1; }
+    set #a(value) { }
+    get #b() { return 2; }
+    set #b(value) { }
+    get #c() { return 3; }
+    set #c(value) { }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    let a_pos = output
+        .find("_A_a_get = function _A_a_get()")
+        .unwrap_or_else(|| panic!("expected #a getter helper\n{output}"));
+    let b_pos = output
+        .find("_A_b_get = function _A_b_get()")
+        .unwrap_or_else(|| panic!("expected #b getter helper\n{output}"));
+    let c_pos = output
+        .find("_A_c_get = function _A_c_get()")
+        .unwrap_or_else(|| panic!("expected #c getter helper\n{output}"));
+
+    assert!(
+        a_pos < b_pos && b_pos < c_pos,
+        "Private accessor helper initialization order should match source order.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn declare_and_abstract_private_fields_do_not_allocate_storage() {
+    let source = r#"
+class A {
+    declare #erased: number;
+    declare #method(): void;
+    #kept = 1;
+}
+abstract class B {
+    abstract #missing: number;
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains("_A_kept = new WeakMap()"),
+        "ordinary private field should still allocate storage.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("_A_erased")
+            && !output.contains("_A_method")
+            && !output.contains("_B_missing"),
+        "declare/abstract private members should not allocate runtime storage.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/lowering/helpers.rs
+++ b/crates/tsz-emitter/src/lowering/helpers.rs
@@ -462,6 +462,37 @@ impl<'a> LoweringPass<'a> {
             .any(|&mod_idx| self.arena.get(mod_idx).is_some_and(|n| n.kind == modifier))
     }
 
+    pub(super) fn legacy_private_member_decorators_are_invalid(&self, name: NodeIndex) -> bool {
+        self.ctx.options.legacy_decorators && is_private_identifier(self.arena, name)
+    }
+
+    pub(super) fn modifiers_have_decorator(&self, modifiers: &Option<NodeList>) -> bool {
+        modifiers.as_ref().is_some_and(|mods| {
+            mods.nodes.iter().any(|&mod_idx| {
+                self.arena
+                    .get(mod_idx)
+                    .is_some_and(|node| node.kind == syntax_kind_ext::DECORATOR)
+            })
+        })
+    }
+
+    pub(super) fn visit_modifiers(&mut self, modifiers: &Option<NodeList>, skip_decorators: bool) {
+        let Some(mods) = modifiers else {
+            return;
+        };
+        for &mod_idx in &mods.nodes {
+            if skip_decorators
+                && self
+                    .arena
+                    .get(mod_idx)
+                    .is_some_and(|node| node.kind == syntax_kind_ext::DECORATOR)
+            {
+                continue;
+            }
+            self.visit(mod_idx);
+        }
+    }
+
     /// Check if a class has any decorators (class-level or member-level)
     pub(super) fn class_has_decorators(
         &self,

--- a/crates/tsz-emitter/src/lowering/visit_children.rs
+++ b/crates/tsz-emitter/src/lowering/visit_children.rs
@@ -200,16 +200,13 @@ impl<'a> LoweringPass<'a> {
             }
             k if k == syntax_kind_ext::PROPERTY_DECLARATION => {
                 if let Some(prop) = self.arena.get_property_decl(node) {
+                    let skip_invalid_legacy_private_decorators =
+                        self.legacy_private_member_decorators_are_invalid(prop.name);
                     // Set __metadata helper when a decorated property exists
                     if self.ctx.options.legacy_decorators
                         && self.ctx.options.emit_decorator_metadata
-                        && prop.modifiers.as_ref().is_some_and(|m| {
-                            m.nodes.iter().any(|&mod_idx| {
-                                self.arena
-                                    .get(mod_idx)
-                                    .is_some_and(|n| n.kind == syntax_kind_ext::DECORATOR)
-                            })
-                        })
+                        && !skip_invalid_legacy_private_decorators
+                        && self.modifiers_have_decorator(&prop.modifiers)
                     {
                         self.transforms.helpers_mut().metadata = true;
                     }
@@ -221,11 +218,7 @@ impl<'a> LoweringPass<'a> {
                     {
                         self.transforms.helpers_mut().prop_key = true;
                     }
-                    if let Some(mods) = &prop.modifiers {
-                        for &mod_idx in &mods.nodes {
-                            self.visit(mod_idx);
-                        }
-                    }
+                    self.visit_modifiers(&prop.modifiers, skip_invalid_legacy_private_decorators);
                     self.visit(prop.name);
                     if prop.initializer.is_some() {
                         self.visit(prop.initializer);
@@ -260,13 +253,10 @@ impl<'a> LoweringPass<'a> {
                     // Parameter decorators also emit method metadata. Overload signatures
                     // (no body) are not emitted as __decorate targets.
                     let is_overload = !method.body.is_some();
-                    let has_method_decorator = method.modifiers.as_ref().is_some_and(|m| {
-                        m.nodes.iter().any(|&mod_idx| {
-                            self.arena
-                                .get(mod_idx)
-                                .is_some_and(|n| n.kind == syntax_kind_ext::DECORATOR)
-                        })
-                    });
+                    let skip_invalid_legacy_private_decorators =
+                        self.legacy_private_member_decorators_are_invalid(method.name);
+                    let has_method_decorator = !skip_invalid_legacy_private_decorators
+                        && self.modifiers_have_decorator(&method.modifiers);
                     let has_parameter_decorator =
                         method.parameters.nodes.iter().any(|&param_idx| {
                             self.arena
@@ -291,20 +281,16 @@ impl<'a> LoweringPass<'a> {
                     if method.body.is_some() {
                         self.mark_function_parameter_transform_helpers(&method.parameters);
                     }
-                    if let Some(mods) = &method.modifiers {
-                        // For overload signatures (no body), save/restore the decorate
-                        // flag to prevent decorator visits from triggering helper emission.
-                        let prev_decorate = if is_overload {
-                            Some(self.transforms.helpers().decorate)
-                        } else {
-                            None
-                        };
-                        for &mod_idx in &mods.nodes {
-                            self.visit(mod_idx);
-                        }
-                        if let Some(prev) = prev_decorate {
-                            self.transforms.helpers_mut().decorate = prev;
-                        }
+                    // For overload signatures (no body), save/restore the decorate
+                    // flag to prevent decorator visits from triggering helper emission.
+                    let prev_decorate = if is_overload {
+                        Some(self.transforms.helpers().decorate)
+                    } else {
+                        None
+                    };
+                    self.visit_modifiers(&method.modifiers, skip_invalid_legacy_private_decorators);
+                    if let Some(prev) = prev_decorate {
+                        self.transforms.helpers_mut().decorate = prev;
                     }
                     self.visit(method.name);
                     for &param_idx in &method.parameters.nodes {
@@ -363,23 +349,19 @@ impl<'a> LoweringPass<'a> {
             }
             k if k == syntax_kind_ext::GET_ACCESSOR || k == syntax_kind_ext::SET_ACCESSOR => {
                 if let Some(accessor) = self.arena.get_accessor(node) {
+                    let skip_invalid_legacy_private_decorators =
+                        self.legacy_private_member_decorators_are_invalid(accessor.name);
                     if self.ctx.options.legacy_decorators
                         && self.ctx.options.emit_decorator_metadata
-                        && accessor.modifiers.as_ref().is_some_and(|m| {
-                            m.nodes.iter().any(|&mod_idx| {
-                                self.arena
-                                    .get(mod_idx)
-                                    .is_some_and(|n| n.kind == syntax_kind_ext::DECORATOR)
-                            })
-                        })
+                        && !skip_invalid_legacy_private_decorators
+                        && self.modifiers_have_decorator(&accessor.modifiers)
                     {
                         self.transforms.helpers_mut().metadata = true;
                     }
-                    if let Some(mods) = &accessor.modifiers {
-                        for &mod_idx in &mods.nodes {
-                            self.visit(mod_idx);
-                        }
-                    }
+                    self.visit_modifiers(
+                        &accessor.modifiers,
+                        skip_invalid_legacy_private_decorators,
+                    );
                     if accessor.body.is_some() {
                         self.mark_function_parameter_transform_helpers(&accessor.parameters);
                     }

--- a/crates/tsz-emitter/src/transforms/class_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir.rs
@@ -513,35 +513,54 @@ impl<'a> ES5ClassTransformer<'a> {
         let Some(prop_node) = self.arena.get(prop_idx) else {
             return;
         };
+        let prop_name_pos = self
+            .arena
+            .get_property_decl(prop_node)
+            .and_then(|prop| self.arena.get(prop.name))
+            .map(|name| name.pos as usize);
         let Some(text) = self.source_text else {
             return;
         };
         let bytes = text.as_bytes();
-        let mut i = prop_node.pos as usize;
+        let scan_positions = prop_name_pos
+            .into_iter()
+            .chain(std::iter::once(prop_node.pos as usize));
+        for scan_pos in scan_positions {
+            if let Some(comment) = Self::property_leading_comment_before(text, bytes, scan_pos) {
+                body.push(IRNode::Raw(comment.into()));
+                return;
+            }
+        }
+    }
+
+    fn property_leading_comment_before(
+        text: &str,
+        bytes: &[u8],
+        scan_pos: usize,
+    ) -> Option<String> {
+        let mut i = scan_pos;
         if i > bytes.len() {
-            return;
+            return None;
         }
         while i > 0 && matches!(bytes[i - 1], b' ' | b'\t' | b'\n' | b'\r') {
             i -= 1;
         }
         let line_start = text[..i].rfind('\n').map_or(0, |idx| idx + 1);
         if text[line_start..i].trim_start().starts_with("//") {
-            body.push(IRNode::Raw(text[line_start..i].to_string().into()));
-            return;
+            return Some(text[line_start..i].to_string());
         }
         if i < 2 || &bytes[i - 2..i] != b"*/" {
-            return;
+            return None;
         }
         let comment_end = i;
         let mut start = i.saturating_sub(2);
         loop {
             if start + 2 <= bytes.len() && &bytes[start..start + 2] == b"/*" {
                 let comment_text = &text[start..comment_end];
-                body.push(IRNode::Raw(comment_text.to_string().into()));
-                return;
+                return Some(comment_text.to_string());
             }
             if start == 0 {
-                return;
+                return None;
             }
             start -= 1;
         }

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_constructor.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_constructor.rs
@@ -1396,6 +1396,7 @@ impl<'a> ES5ClassTransformer<'a> {
                 continue;
             }
 
+            self.emit_property_leading_comment(body, field.member_idx);
             let value = if field.has_initializer && field.initializer.is_some() {
                 self.convert_expression(field.initializer)
             } else {

--- a/crates/tsz-emitter/src/transforms/private_fields_es5.rs
+++ b/crates/tsz-emitter/src/transforms/private_fields_es5.rs
@@ -71,12 +71,20 @@ pub struct PrivateAccessorInfo {
     pub get_var_name: Option<String>,
     /// The `WeakMap` variable name for the setter (e.g., "_`C_value_set`")
     pub set_var_name: Option<String>,
+    /// Whether a getter declaration appeared for this private name.
+    pub has_getter: bool,
+    /// Whether a setter declaration appeared for this private name.
+    pub has_setter: bool,
     /// The node index of the getter body (if any)
     pub getter_body: Option<NodeIndex>,
     /// The node index of the setter body (if any)
     pub setter_body: Option<NodeIndex>,
     /// The node index of the setter parameter (if any)
     pub setter_param: Option<NodeIndex>,
+    /// Whether the getter declaration carried an `async` modifier.
+    pub getter_is_async: bool,
+    /// Whether the setter declaration carried an `async` modifier.
+    pub setter_is_async: bool,
     /// Whether this is a static private accessor
     pub is_static: bool,
 }
@@ -555,22 +563,31 @@ pub fn collect_private_accessors_with_reserved(
                             &format!("{}_set", private_helper_base(class_name, clean_name)),
                             used_names,
                         )),
+                        has_getter: false,
+                        has_setter: false,
                         getter_body: None,
                         setter_body: None,
                         setter_param: None,
+                        getter_is_async: false,
+                        setter_is_async: false,
                         is_static,
                     });
                     accessors.len() - 1
                 };
             let entry = &mut accessors[entry_idx];
             entry.member_indices.push(member_idx);
+            let is_async = arena.has_modifier(&accessor_data.modifiers, SyntaxKind::AsyncKeyword);
 
             // Update based on accessor type
             if member_node.kind == syntax_kind_ext::GET_ACCESSOR {
+                entry.has_getter = true;
+                entry.getter_is_async = is_async;
                 if accessor_data.body.is_some() {
                     entry.getter_body = Some(accessor_data.body);
                 }
             } else if member_node.kind == syntax_kind_ext::SET_ACCESSOR {
+                entry.has_setter = true;
+                entry.setter_is_async = is_async;
                 if accessor_data.body.is_some() {
                     entry.setter_body = Some(accessor_data.body);
                 }
@@ -583,11 +600,7 @@ pub fn collect_private_accessors_with_reserved(
         }
     }
 
-    // Convert to Vec, filtering out entries that have neither getter nor setter
     accessors
-        .into_iter()
-        .filter(|a| a.getter_body.is_some() || a.setter_body.is_some())
-        .collect()
 }
 
 /// Information about a private method in a class

--- a/crates/tsz-emitter/src/transforms/private_fields_es5.rs
+++ b/crates/tsz-emitter/src/transforms/private_fields_es5.rs
@@ -29,7 +29,7 @@
 //! as a shared utility to avoid circular dependencies. This module re-exports it
 //! for backward compatibility.
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 use tsz_parser::parser::node::{NodeAccess, NodeArena};
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
@@ -462,6 +462,12 @@ pub fn collect_private_fields_with_reserved(
 
             // Check if this is a private field
             if is_private_identifier(arena, prop_data.name) {
+                if arena.has_modifier(&prop_data.modifiers, SyntaxKind::AbstractKeyword)
+                    || arena.has_modifier(&prop_data.modifiers, SyntaxKind::DeclareKeyword)
+                {
+                    continue;
+                }
+
                 let field_name = get_private_field_name(arena, prop_data.name).unwrap_or_default();
                 let clean_name = field_name.strip_prefix('#').unwrap_or(&field_name);
                 let weakmap_name = make_unique_private_name(
@@ -502,7 +508,7 @@ pub fn collect_private_accessors_with_reserved(
     class_name: &str,
     used_names: &mut FxHashSet<String>,
 ) -> Vec<PrivateAccessorInfo> {
-    let mut accessors: FxHashMap<String, PrivateAccessorInfo> = FxHashMap::default();
+    let mut accessors: Vec<PrivateAccessorInfo> = Vec::new();
 
     let Some(class_node) = arena.get(class_idx) else {
         return Vec::new();
@@ -531,11 +537,14 @@ pub fn collect_private_accessors_with_reserved(
             let clean_name = field_name.strip_prefix('#').unwrap_or(&field_name);
             let is_static = arena.has_modifier(&accessor_data.modifiers, SyntaxKind::StaticKeyword);
 
-            // Get or create the accessor info for this name
-            let entry =
-                accessors
-                    .entry(clean_name.to_string())
-                    .or_insert_with(|| PrivateAccessorInfo {
+            // Get or create the accessor info for this name. Keep entries in
+            // source order so helper declaration/initialization order matches
+            // `tsc` for classes with several private accessor pairs.
+            let entry_idx =
+                if let Some(idx) = accessors.iter().position(|entry| entry.name == clean_name) {
+                    idx
+                } else {
+                    accessors.push(PrivateAccessorInfo {
                         member_indices: Vec::new(),
                         name: clean_name.to_string(),
                         get_var_name: Some(make_unique_private_name(
@@ -551,6 +560,9 @@ pub fn collect_private_accessors_with_reserved(
                         setter_param: None,
                         is_static,
                     });
+                    accessors.len() - 1
+                };
+            let entry = &mut accessors[entry_idx];
             entry.member_indices.push(member_idx);
 
             // Update based on accessor type
@@ -573,7 +585,7 @@ pub fn collect_private_accessors_with_reserved(
 
     // Convert to Vec, filtering out entries that have neither getter nor setter
     accessors
-        .into_values()
+        .into_iter()
         .filter(|a| a.getter_body.is_some() || a.setter_body.is_some())
         .collect()
 }
@@ -639,6 +651,10 @@ pub fn collect_private_methods_with_reserved(
 
             // Check if this is a private method
             if !is_private_identifier(arena, method_data.name) {
+                continue;
+            }
+
+            if method_data.body.is_none() {
                 continue;
             }
 

--- a/crates/tsz-parser/src/parser/state_statements.rs
+++ b/crates/tsz-parser/src/parser/state_statements.rs
@@ -1095,6 +1095,7 @@ impl ParserState {
             let can_start_decl = self.is_identifier_or_keyword()
                 || self.is_token(SyntaxKind::OpenBraceToken)
                 || self.is_token(SyntaxKind::OpenBracketToken)
+                || self.is_token(SyntaxKind::PrivateIdentifier)
                 || starts_recovered_invalid_unicode_identifier;
 
             if !can_start_decl {
@@ -1349,8 +1350,12 @@ impl ParserState {
                         && !self.is_reserved_word())
                         || self.is_token(SyntaxKind::OpenBraceToken)
                         || self.is_token(SyntaxKind::OpenBracketToken)
+                        || self.is_token(SyntaxKind::PrivateIdentifier)
                         || self.current_unknown_starts_invalid_unicode_identifier_debris();
-                    if !(decl_only_literal_value_errors && next_starts_declarator) {
+                    if !(next_starts_declarator
+                        && (decl_only_literal_value_errors
+                            || self.is_token(SyntaxKind::PrivateIdentifier)))
+                    {
                         break;
                     }
                 }
@@ -1416,7 +1421,8 @@ impl ParserState {
                     let can_continue = (self.is_identifier_or_keyword()
                         && !self.is_reserved_word())
                         || self.is_token(SyntaxKind::OpenBraceToken)
-                        || self.is_token(SyntaxKind::OpenBracketToken);
+                        || self.is_token(SyntaxKind::OpenBracketToken)
+                        || self.is_token(SyntaxKind::PrivateIdentifier);
                     if can_continue {
                         // Emit ',' expected directly, bypassing the distance-based
                         // suppression heuristic. tsc's parseDelimitedList always
@@ -1556,6 +1562,12 @@ impl ParserState {
                 // Example: `var a = q~;` → tsc emits `var a = q;\n~;`
                 if !self.is_statement_start() {
                     let unexpected_token = self.token();
+                    let decl_name_is_private_identifier = self
+                        .arena
+                        .get(decl)
+                        .and_then(|node| self.arena.get_variable_declaration(node))
+                        .and_then(|decl| self.arena.get(decl.name))
+                        .is_some_and(|name| name.kind == SyntaxKind::PrivateIdentifier as u16);
                     // When a `.` separates what looks like two declarations
                     // (e.g., `const x: "".typeof(...)`), tsc treats the `.` as
                     // a missing `,` and continues the declaration list. When the
@@ -1584,6 +1596,29 @@ impl ParserState {
                     } else if unexpected_token == SyntaxKind::CloseBracketToken
                         && self.is_token(SyntaxKind::EqualsToken)
                     {
+                        if decl_name_is_private_identifier {
+                            self.parse_error_at_current_token(
+                                "Variable declaration expected.",
+                                diagnostic_codes::VARIABLE_DECLARATION_EXPECTED,
+                            );
+                            let snapshot = self.scanner.save_state();
+                            let saved_token = self.current_token;
+                            self.next_token();
+                            if !matches!(
+                                self.token(),
+                                SyntaxKind::SemicolonToken
+                                    | SyntaxKind::CloseBraceToken
+                                    | SyntaxKind::EndOfFileToken
+                            ) {
+                                self.parse_error_at_current_token(
+                                    "Variable declaration expected.",
+                                    diagnostic_codes::VARIABLE_DECLARATION_EXPECTED,
+                                );
+                            }
+                            self.scanner.restore_state(snapshot);
+                            self.current_token = saved_token;
+                            break;
+                        }
                         // `const x: C[#bar] = 3;` is recovered as a malformed
                         // declaration tail after `]`, producing TS1134 at `=`
                         // and at the initializer start (matching tsc).
@@ -1694,7 +1729,8 @@ impl ParserState {
             // so `var a, return;` should be a trailing comma error, not a new declaration.
             let can_start_next = (self.is_identifier_or_keyword() && !self.is_reserved_word())
                 || self.is_token(SyntaxKind::OpenBraceToken)
-                || self.is_token(SyntaxKind::OpenBracketToken);
+                || self.is_token(SyntaxKind::OpenBracketToken)
+                || self.is_token(SyntaxKind::PrivateIdentifier);
 
             if !can_start_next {
                 // Trailing comma in variable declaration list — emit TS1009.

--- a/crates/tsz-parser/src/parser/state_types_advanced.rs
+++ b/crates/tsz-parser/src/parser/state_types_advanced.rs
@@ -1689,12 +1689,11 @@ impl ParserState {
                 );
             } else {
                 // Private identifiers are not currently valid as indexed-access
-                // type arguments (e.g. `C[#bar]`). Keep the malformed tail in the
-                // token stream so declaration-list recovery can emit the same
-                // follow-up diagnostics as tsc.
+                // type arguments (e.g. `C[#bar]`). Keep the malformed name in the
+                // token stream so declaration-list recovery can parse it as the
+                // next invalid declarator, matching tsc's emitted JS shape.
                 if self.is_token(SyntaxKind::PrivateIdentifier) {
                     self.parse_expected(SyntaxKind::CloseBracketToken);
-                    self.next_token(); // consume `#bar`, leave trailing `]` for caller recovery
                     break;
                 }
 

--- a/crates/tsz-parser/src/parser/state_variable_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_variable_declarations.rs
@@ -85,6 +85,8 @@ impl ParserState {
             self.parse_object_binding_pattern()
         } else if self.is_token(SyntaxKind::OpenBracketToken) {
             self.parse_array_binding_pattern()
+        } else if self.is_token(SyntaxKind::PrivateIdentifier) {
+            self.parse_private_identifier()
         } else if self.current_unknown_starts_invalid_unicode_identifier_debris() {
             self.parse_recovered_invalid_unicode_escape_identifier()
         } else if self.is_reserved_word() {


### PR DESCRIPTION
AgentName: Studio-C

## Track
Track 9 JavaScript emit parity.

## Invariant
When legacy decorators are attached to private class members, `tsc` treats those decorators as invalid and does not schedule runtime decorator helper emission for them; private member state still lowers normally through the emitter lowering plan.

When an indexed-access type contains an invalid private identifier such as `C[#bar]`, `tsc` leaves the private identifier for declaration-list recovery so JavaScript emit preserves the malformed second declarator shape (`const badForNow, #bar;`) and recovers the initializer tail as a separate statement. This PR keeps that rule in parser recovery / emitter declaration printing, not checker semantics or output surgery.

When private fields are lowered into constructor `WeakMap.set` initializers, leading and trailing field comments move with the generated initializer, private accessor helper declarations stay in source order, and `declare`/`abstract` private fields plus no-body private methods do not allocate runtime storage.

When private accessors are invalid but recoverable without bodies, `tsc` still extracts empty private helper functions and skips the broken class-body accessor spelling. When extracted private async methods/accessors are emitted below the native async target, tsz lowers them through `__awaiter`; extracted private async generators lower through `__asyncGenerator` below ES2018 while preserving native async helper functions for ES2019+.

## Scope
- Adds lowering helper predicates for decorator-bearing modifiers and invalid legacy private member decorators.
- Skips legacy decorator traversal and metadata helper scheduling for private fields, private methods, and private accessors.
- Keeps public legacy member decorators on the existing `__decorate` helper path.
- Keeps invalid private identifiers in indexed-access type tails available to declaration-list recovery.
- Emits invalid private identifiers when they are recovered variable declarator names.
- Carries leading and trailing comments on lowered private field constructor initializers.
- Preserves private accessor helper order by collecting accessor entries in source order.
- Skips runtime storage/extracted helpers for `declare`/`abstract` private fields and no-body private methods.
- Recovers no-body private accessors as empty extracted helper functions.
- Downlevels extracted private async method/accessor helpers with target-sensitive `__awaiter` / `__asyncGenerator` emission while preserving native helpers for ES2019+.
- Adds focused parser-recovery/emitter regression coverage for the indexed-access tail and private-field lowering invariants.

## Project Corpus Impact
- Row: n/a
- Bug family: class/private/accessor/decorator JS lowering; legacy decorator helper scheduling on invalid private members; parser recovery for invalid private-name indexed-access type tails; private field initializer trivia/helper ordering; private async/accessor helper lowering.
- Evidence: emit-only baseline fixes for `privateNamesAndDecorators`, `privateNamesAndIndexedAccess`, `privateNamesIncompatibleModifiersJs`, and `privateNamesIncompatibleModifiers`; no project corpus row is known to depend on these invalid private-member decorator or private-name recovery cases.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- `cargo nextest run -p tsz-emitter legacy_decorators_on_private_members_do_not_schedule_decorate_helper legacy_public_member_decorators_still_schedule_decorate_helper`
- `cargo nextest run -p tsz-emitter legacy_decorator_computed_tests` (pre-rebase; post-rebase rerun hit SIGKILL during nextest test discovery on an unrelated test binary while local disk was critically low)
- `cargo nextest run -p tsz-parser private` (post-rebase on `48048c0a5e`, 10/10)
- `cargo nextest run -p tsz-emitter invalid_private_name_indexed_access_recovers_as_declarator_tail` (pre-rebase)
- `cargo nextest run -p tsz-emitter private_field_helper_order_tests` (post-update on `ffe80da1f4`, 11/11; patch-equivalent to `e57f186d8a` after main sync)
- `scripts/safe-run.sh scripts/emit/run.sh --filter=privateNamesAndDecorators --js-only --verbose --timeout=30000 --json-out=/tmp/privateNamesAndDecorators-studio-c-fixed.json`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=privateNamesAndIndexedAccess --js-only --verbose --timeout=30000 --json-out=/tmp/privateNamesAndIndexedAccess-studio-c-fixed2.json`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=privateNamesIncompatibleModifiersJs --js-only --verbose --timeout=30000 --json-out=/tmp/privateNamesIncompatibleModifiersJs-studio-c-comments-order.json`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=privateNamesIncompatibleModifiers --js-only --verbose --timeout=30000 --json-out=/tmp/privateNamesIncompatibleModifiers-studio-c-async-accessors.json` (2/2)
- `scripts/safe-run.sh scripts/emit/run.sh --filter=privateName --js-only --verbose --timeout=30000 --json-out=/tmp/privateName-studio-c-after-async-accessors.json` (156/158; remaining two are duplicate private-name recovery buckets)

## Coordination Notes
- Parent #11989 merged; this PR is now rebased onto `main` through `5550c3faa2`.
- Claimed focused slices on #8506 before editing: `privateNamesAndDecorators`, `privateNamesAndIndexedAccess`, the comment/order/no-runtime-storage slice, and the no-body accessor/private async helper slice that fixes `privateNamesIncompatibleModifiers`.
- Current head is `e57f186d8a` on `codex/studio-c-private-decorator-helper-20260531`.
- Marked ready after fresh draft-light CI passed on head `e57f186d8a`: `CI Light Summary`, `unit`, `dist-binaries`, `lint`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, and `GitGuardian Security Checks` are green. Auto-merge remains off while ready-review heavy CI runs.
- Remaining `privateName` failures after this PR head: `privateNameDuplicateField` and `privateNamesUnique-3`; both are duplicate private-name recovery cases where `tsc` preserves invalid native private members in the class body while also emitting helper state.
