### PR TITLE
chore(agents): expose label audit status

### DIFF
--- a/scripts/agents/ensure-agent-labels.sh
+++ b/scripts/agents/ensure-agent-labels.sh
@@ -230,6 +230,7 @@ if (process.env.JSON_REPORT) {
   const report = {
     ok,
     status: ok ? "pass" : "fail",
+    agent_label_audit_status: ok ? "pass" : "fail",
     metrics,
     missing_canonical_labels: missingCanonicalLabels,
     noncanonical_agent_labels: noncanonicalLabels,

--- a/scripts/agents/test_ensure_agent_labels.py
+++ b/scripts/agents/test_ensure_agent_labels.py
@@ -283,6 +283,7 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
             report = json.loads(report_path.read_text(encoding="utf-8"))
 
         self.assertEqual("fail", report["status"])
+        self.assertEqual("fail", report["agent_label_audit_status"])
         self.assertFalse(report["ok"])
         self.assertEqual(2, report["metrics"]["agent_label_audit_findings"])
         self.assertEqual(1, report["metrics"]["open_prs_missing_agent_label"])
@@ -330,6 +331,7 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
 
         self.assertTrue(report["ok"])
         self.assertEqual("pass", report["status"])
+        self.assertEqual("pass", report["agent_label_audit_status"])
         self.assertEqual(0, report["metrics"]["agent_label_audit_findings"])
 
     def test_json_report_requires_audit_mode(self):


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / cheap evidence plumbing.

## Invariant
When `scripts/agents/ensure-agent-labels.sh --audit --json-report` writes the audit artifact, the text status and machine-readable JSON expose the same explicit `agent_label_audit_status` value.

## Scope
- Add `agent_label_audit_status` to the agent-label audit JSON report.
- Extend focused JSON report tests for pass and fail cases.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent-script-only; does not change compiler, emit output, project corpus fixtures, or TypeScript parity behavior.

## Verification
- `python3 -m unittest scripts.agents.test_ensure_agent_labels`
- `scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-status.json`
- `git diff --check HEAD~1 HEAD`

## Coordination Notes
- Studio-F runway was clear after #11991 merged and its worktree/branches were pruned.
- This PR is based on `origin/main` after #11991 and #11992.
- No open Studio-F PR overlap at publication time.
