### PR TITLE
test(solver): ratchet legacy relation flag constants

### DIFF
--- a/crates/tsz-solver/tests/relation_cache_config_tests/cache_agreement.rs
+++ b/crates/tsz-solver/tests/relation_cache_config_tests/cache_agreement.rs
@@ -98,14 +98,66 @@ fn legacy_flag_constants_match_typed_bitflags() {
     // External callers still depend on the `FLAG_*` `u16` constants being
     // numerically stable. Guarantee they line up with the typed layout so
     // that bridges like `pack_relation_flags()` keep working.
-    assert_eq!(
-        u32::from(RelationCacheKey::FLAG_STRICT_NULL_CHECKS),
-        RelationFlags::STRICT_NULL_CHECKS.bits()
-    );
-    assert_eq!(
-        u32::from(RelationCacheKey::FLAG_NO_ERASE_GENERICS),
-        RelationFlags::NO_ERASE_GENERICS.bits()
-    );
+    let cases = [
+        (
+            "strict null checks",
+            RelationCacheKey::FLAG_STRICT_NULL_CHECKS,
+            RelationFlags::STRICT_NULL_CHECKS,
+        ),
+        (
+            "strict function types",
+            RelationCacheKey::FLAG_STRICT_FUNCTION_TYPES,
+            RelationFlags::STRICT_FUNCTION_TYPES,
+        ),
+        (
+            "exact optional property types",
+            RelationCacheKey::FLAG_EXACT_OPTIONAL_PROPERTY_TYPES,
+            RelationFlags::EXACT_OPTIONAL_PROPERTY_TYPES,
+        ),
+        (
+            "no unchecked indexed access",
+            RelationCacheKey::FLAG_NO_UNCHECKED_INDEXED_ACCESS,
+            RelationFlags::NO_UNCHECKED_INDEXED_ACCESS,
+        ),
+        (
+            "disable method bivariance",
+            RelationCacheKey::FLAG_DISABLE_METHOD_BIVARIANCE,
+            RelationFlags::DISABLE_METHOD_BIVARIANCE,
+        ),
+        (
+            "allow void return",
+            RelationCacheKey::FLAG_ALLOW_VOID_RETURN,
+            RelationFlags::ALLOW_VOID_RETURN,
+        ),
+        (
+            "allow bivariant rest",
+            RelationCacheKey::FLAG_ALLOW_BIVARIANT_REST,
+            RelationFlags::ALLOW_BIVARIANT_REST,
+        ),
+        (
+            "allow bivariant parameter count",
+            RelationCacheKey::FLAG_ALLOW_BIVARIANT_PARAM_COUNT,
+            RelationFlags::ALLOW_BIVARIANT_PARAM_COUNT,
+        ),
+        (
+            "disable generic erasure",
+            RelationCacheKey::FLAG_NO_ERASE_GENERICS,
+            RelationFlags::NO_ERASE_GENERICS,
+        ),
+        (
+            "allow erased generic signature retry",
+            RelationCacheKey::FLAG_ALLOW_ERASED_GENERIC_SIGNATURE_RETRY,
+            RelationFlags::ALLOW_ERASED_GENERIC_SIGNATURE_RETRY,
+        ),
+    ];
+
+    for (name, legacy, typed) in cases {
+        assert_eq!(
+            u32::from(legacy),
+            typed.bits(),
+            "{name} legacy flag constant must match the typed RelationFlags bit",
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 10 / #8207 relation policy/cache correctness. Test-only cache-key protocol ratchet.

## Invariant
When a legacy packed `RelationCacheKey::FLAG_*` constant remains public, its numeric bit must match the typed `RelationFlags` bit consumed by `RelationPolicy`; this PR strengthens the solver test contract at the compatibility edge.

## Scope
- Expand `legacy_flag_constants_match_typed_bitflags` to cover every remaining public legacy relation `FLAG_*` constant.
- No production solver behavior changes.

## Project Corpus Impact
- Row: n/a
- Bug family: relation policy/cache-key protocol cleanup
- Evidence: test-only boundary-contract ratchet for legacy flag constants; no project-row fixture run.

## Verification
- GREEN: `cargo nextest run -p tsz-solver -E 'test(legacy_flag_constants_match_typed_bitflags)'` passed, 1 test.
- GREEN after latest rebase: `cargo nextest run -p tsz-solver -E 'test(relation_cache_config_tests)'` passed, 55 tests.
- GREEN after latest rebase: `cargo fmt --check` passed.
- GREEN after latest rebase: `git diff --check` passed.
- GREEN after latest rebase: `python3 scripts/arch/arch_guard.py` passed.
- File-size audit after rebase onto `origin/main` `af7cea8385`: `relation_cache_config_tests/cache_agreement.rs` is 1399 lines and `relation_policy_cache_agreement_tests/cache_agreement.rs` is 1935 lines, both under the 2000-line hard limit.
- GREEN exact-head draft-light CI on `e7fafeb8d62f17fc16755622fa12ddc5e56481f1`: `CI Light Summary`, `project-row-drift`, `cargo-shear`, `unit-cloudbuild`, `unit`, `dist-binaries`, `cargo-deny`, `lint`, `gate`, `queue-one-pr`, and `GitGuardian Security Checks` passed.

## Coordination Notes
- Non-overlap: this is a test-only #8207 ratchet for the legacy constant/typed flag boundary. It does not touch M1-B checker relation-routing or #11988's solver relation-policy propagation code.
- #11988 landed through the merge queue before this branch was published; this branch is rebased onto current `origin/main` after #11988, #11989, and #11994.
- Current head is `e7fafeb8d6`.
- Marked ready after exact-head draft-light CI completed green; `merge-queue` remains off until ready-review PR-head gates complete for this head.
