### PR TITLE
fix(parser): JSDoc postfix `?`/`!` after array suffix emits TS17019

### DIFF
--- a/crates/tsz-parser/src/parser/state_types.rs
+++ b/crates/tsz-parser/src/parser/state_types.rs
@@ -607,6 +607,16 @@ impl ParserState {
             self.parse_primary_type_base(start_pos)
         };
 
+        // Bare `infer X` skips all postfix operators (`[]`, `?`, `!`), matching
+        // tsc's `parseTypeOperatorOrHigher` which returns `parseInferType()`
+        // directly instead of falling through to `parsePostfixTypeOrHigher`.
+        // The trailing tokens become the tuple-optional marker, the outer
+        // conditional `?`, or a stray-marker recovery via
+        // `bare_infer_has_stray_tuple_marker` at the tuple-element level.
+        if self.node_is_bare_infer_type(base_type) {
+            return base_type;
+        }
+
         self.parse_primary_type_array_suffix(start_pos, base_type)
     }
 
@@ -970,12 +980,20 @@ impl ParserState {
         start_pos: u32,
         base_type: NodeIndex,
     ) -> NodeIndex {
-        if self.is_token(SyntaxKind::OpenBracketToken) {
+        // Array/indexed-access suffix: T[], T[K], T[][], etc.
+        // `parse_array_type` itself loops over consecutive `[...]` chains so
+        // the postfix `?`/`!` handlers below run once on the fully-arrayed
+        // base type.  Falling through (rather than the previous early return)
+        // is what lets `T[]?` emit TS17019 like tsc instead of cascading into
+        // TS1005 / TS1110.
+        let base_type = if self.is_token(SyntaxKind::OpenBracketToken) {
             if self.look_ahead_is_computed_type_member_boundary() {
                 return base_type;
             }
-            return self.parse_array_type(start_pos, base_type);
-        }
+            self.parse_array_type(start_pos, base_type)
+        } else {
+            base_type
+        };
 
         // Handle JSDoc-style postfix `?` after a type (e.g., `string?`).
         // TSC emits TS17019: "'?' at the end of a type is not valid TypeScript syntax."
@@ -991,7 +1009,6 @@ impl ParserState {
         if self.is_token(SyntaxKind::QuestionToken)
             && !self.scanner.has_preceding_line_break()
             && (self.context_flags & crate::parser::state::CONTEXT_FLAG_IN_TUPLE_ELEMENT) == 0
-            && !self.node_is_bare_infer_type(base_type)
         {
             // Lookahead: if the token after `?` can start a type, this is a conditional
             // type's `?`, not a nullable suffix.
@@ -1006,21 +1023,13 @@ impl ParserState {
 
             if !next_can_start_type {
                 let q_end = self.token_end();
-                let (diag_start, suggested) = if let Some(node) = self.arena.get(base_type) {
-                    (
-                        node.pos,
-                        self.scanner
-                            .source_slice(node.pos as usize, node.end as usize)
-                            .to_string(),
-                    )
-                } else {
-                    (start_pos, String::from("T"))
-                };
+                let (diag_start, suggested) =
+                    self.postfix_jsdoc_type_diagnostic_anchor(start_pos, base_type);
                 self.next_token(); // consume '?'
                 // Simplify the suggestion for types that absorb undefined.
                 // TSC suggests just the type name when adding | undefined is redundant.
                 let suggestion = match suggested.as_str() {
-                    "any" | "unknown" | "never" | "void" | "undefined" => suggested.clone(),
+                    "any" | "unknown" | "never" | "void" | "undefined" => suggested,
                     _ => format!("{suggested} | undefined"),
                 };
                 let msg = format!(
@@ -1054,21 +1063,10 @@ impl ParserState {
             }
         }
 
-        if self.is_token(SyntaxKind::ExclamationToken)
-            && !self.scanner.has_preceding_line_break()
-            && !self.node_is_bare_infer_type(base_type)
-        {
+        if self.is_token(SyntaxKind::ExclamationToken) && !self.scanner.has_preceding_line_break() {
             let bang_end = self.token_end();
-            let (diag_start, suggested) = if let Some(node) = self.arena.get(base_type) {
-                (
-                    node.pos,
-                    self.scanner
-                        .source_slice(node.pos as usize, node.end as usize)
-                        .to_string(),
-                )
-            } else {
-                (start_pos, String::from("T"))
-            };
+            let (diag_start, suggested) =
+                self.postfix_jsdoc_type_diagnostic_anchor(start_pos, base_type);
             self.next_token(); // consume '!'
             let msg = format!(
                 "'!' at the end of a type is not valid TypeScript syntax. Did you mean to write '{suggested}'?"
@@ -1083,6 +1081,42 @@ impl ParserState {
         }
 
         base_type
+    }
+
+    /// Build the (diagnostic span start, suggestion text) pair used when a
+    /// trailing `?` / `!` JSDoc postfix is reported as TS17019.
+    ///
+    /// The diagnostic span anchors at the outer `base_type`'s position so the
+    /// underline runs from the typed-out cursor location. The suggestion text
+    /// mirrors the type's source but peels outer `PARENTHESIZED_TYPE` wrappers
+    /// to match tsc's display: `(string | number)?` should suggest
+    /// `string | number | undefined`, not `(string | number) | undefined`.
+    fn postfix_jsdoc_type_diagnostic_anchor(
+        &self,
+        start_pos: u32,
+        base_type: NodeIndex,
+    ) -> (u32, String) {
+        use super::syntax_kind_ext::PARENTHESIZED_TYPE;
+
+        let Some(anchor) = self.arena.get(base_type) else {
+            return (start_pos, String::from("T"));
+        };
+
+        // Walk through outer parens — `((T))?` should suggest `T | undefined`.
+        let mut suggestion_node = anchor;
+        while suggestion_node.kind == PARENTHESIZED_TYPE
+            && let Some(inner) = self.arena.get_wrapped_type(suggestion_node)
+            && inner.type_node != NodeIndex::NONE
+            && let Some(next) = self.arena.get(inner.type_node)
+        {
+            suggestion_node = next;
+        }
+
+        let suggestion = self
+            .scanner
+            .source_slice(suggestion_node.pos as usize, suggestion_node.end as usize)
+            .to_string();
+        (anchor.pos, suggestion)
     }
 
     // Parenthesized, tuple, literal, import, mapped, and type-argument parsing -> state_types_advanced.rs

--- a/crates/tsz-parser/tests/parser_improvement_nullable_type_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_nullable_type_recovery_tests.rs
@@ -1,6 +1,6 @@
 //! Tests for parser improvements to reduce TS1005 and TS2300 false positives — nullable type recovery.
 
-use crate::parser::test_fixture::{parse_source, parse_source_named};
+use crate::parser::test_fixture::{assert_no_errors, parse_source, parse_source_named};
 
 #[test]
 fn test_postfix_question_emits_ts17019() {
@@ -157,4 +157,206 @@ const b = 1 as !any;
         vec![17019, 17020, 17019, 17020],
         "Expected TS17019/TS17020 recovery for invalid non-nullable type syntax, got diagnostics: {diagnostics:?}"
     );
+}
+
+/// Postfix `?` after an array suffix (e.g., `string[]?`) must emit TS17019
+/// like a postfix on a bare type, not cascade into TS1005/TS1110. tsc treats
+/// `parsePostfixTypeOrHigher` as a loop over `[]` and `?`/`!`, so the JSDoc
+/// nullable applies to the array.
+#[test]
+fn postfix_question_after_array_emits_ts17019() {
+    for source in [
+        "type A = string[]?;",
+        "type B = number[]?;",
+        "type C = string[][]?;",
+        "type D = readonly string[]?;",
+    ] {
+        let (parser, _root) = parse_source(source);
+        let diagnostics = parser.get_diagnostics();
+        assert!(
+            diagnostics.iter().any(|d| d.code == 17019),
+            "Expected TS17019 for `{source}`, got {diagnostics:?}"
+        );
+        assert!(
+            diagnostics.iter().all(|d| d.code != 1005 && d.code != 1110),
+            "Postfix `?` after array should not cascade into TS1005/TS1110 for `{source}`, got {diagnostics:?}"
+        );
+    }
+}
+
+/// Same rule applies to postfix `!`: `string[]!` should report TS17019 once,
+/// not cascade.
+#[test]
+fn postfix_bang_after_array_emits_ts17019() {
+    let (parser, _root) = parse_source("type A = string[]!;");
+    let diagnostics = parser.get_diagnostics();
+    assert!(
+        diagnostics.iter().any(|d| d.code == 17019),
+        "Expected TS17019 for `string[]!`, got {diagnostics:?}"
+    );
+    assert!(
+        diagnostics.iter().all(|d| d.code != 1005 && d.code != 1110),
+        "Postfix `!` after array should not cascade for `string[]!`, got {diagnostics:?}"
+    );
+}
+
+/// Postfix `?` after indexed-access (`T['k']?`) follows the same rule as the
+/// array suffix path. Both share `parse_array_type` and must fall through to
+/// the JSDoc-nullable handler.
+#[test]
+fn postfix_question_after_indexed_access_emits_ts17019() {
+    let source = "type X = { abc: string }; type A = X['abc']?;";
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    assert!(
+        diagnostics.iter().any(|d| d.code == 17019),
+        "Expected TS17019 for `X['abc']?`, got {diagnostics:?}"
+    );
+}
+
+/// `(string | number)?` should drop the outer parens in the suggestion text
+/// — tsc displays `string | number | undefined`, not `(string | number) | undefined`.
+#[test]
+fn postfix_question_strips_outer_parens_in_suggestion() {
+    let (parser, _root) = parse_source("type A = (string | number)?;");
+    let diagnostics = parser.get_diagnostics();
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.code == 17019)
+        .expect("expected TS17019 for `(string | number)?`");
+    assert_eq!(
+        diag.message,
+        "'?' at the end of a type is not valid TypeScript syntax. Did you mean to write 'string | number | undefined'?",
+        "expected suggestion without outer parens, got {diagnostics:?}"
+    );
+}
+
+/// Nested parens are peeled iteratively: `((string))?` suggests `string |
+/// undefined`.
+#[test]
+fn postfix_question_peels_nested_parens_in_suggestion() {
+    let (parser, _root) = parse_source("type A = ((string))?;");
+    let diagnostics = parser.get_diagnostics();
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.code == 17019)
+        .expect("expected TS17019 for `((string))?`");
+    assert_eq!(
+        diag.message,
+        "'?' at the end of a type is not valid TypeScript syntax. Did you mean to write 'string | undefined'?",
+        "expected nested parens to be peeled, got {diagnostics:?}"
+    );
+}
+
+/// `[string[]?]` is a valid tuple-optional element and must not emit TS17019:
+/// the `?` belongs to the tuple, not to a JSDoc-nullable on `string[]`. This
+/// guards the `IN_TUPLE_ELEMENT` suppression when the array-suffix path now
+/// falls through to the postfix handler.
+#[test]
+fn array_optional_inside_tuple_is_tuple_optional_not_jsdoc_nullable() {
+    for source in [
+        "type A = [string[]?];",
+        "type B = [(string | number)?];",
+        "type C = [number[][]?];",
+    ] {
+        let (parser, _root) = parse_source(source);
+        let diagnostics = parser.get_diagnostics();
+        assert!(
+            diagnostics.iter().all(|d| d.code != 17019),
+            "Tuple-optional `[T[]?]` must not emit TS17019 for `{source}`, got {diagnostics:?}"
+        );
+        assert!(
+            diagnostics.iter().all(|d| d.code != 1005 && d.code != 1110),
+            "Tuple-optional `[T[]?]` must not cascade for `{source}`, got {diagnostics:?}"
+        );
+    }
+}
+
+/// `infer X extends T[]?` (postfix `?` on the constraint inside an `infer`
+/// extends clause) must produce TS17019 on the constraint, not roll back as
+/// an outer conditional `?`. Reported as the recovery surface for #11333
+/// (variadic tuple utility parser recovery).
+#[test]
+fn infer_extends_array_postfix_emits_ts17019_on_constraint() {
+    let source = "type A<T> = T extends [infer X extends string[]?, infer Y] ? [X, Y] : never;";
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    assert!(
+        diagnostics.iter().any(|d| d.code == 17019),
+        "Expected TS17019 for `infer X extends string[]?`, got {diagnostics:?}"
+    );
+    assert!(
+        diagnostics.iter().all(|d| d.code != 1110),
+        "Should not cascade into TS1110 `Type expected.` for the trailing element, got {diagnostics:?}"
+    );
+}
+
+/// Bare `infer X` must not absorb a postfix `[]` array suffix. tsc's
+/// `parseTypeOperatorOrHigher` returns `parseInferType()` directly without
+/// running postfix parsing, so `[infer X[]]` should recover as the
+/// stray-`[` pattern (TS1005 `,` expected), not silently parse as
+/// `[(infer X)[]]`.
+#[test]
+fn bare_infer_followed_by_array_suffix_does_not_absorb_brackets() {
+    let source = "type A<T> = T extends [infer X[]] ? X : never;";
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    assert!(
+        diagnostics.iter().any(|d| d.code == 1005),
+        "Expected TS1005 `',' expected.` for bare `infer X[]`, got {diagnostics:?}"
+    );
+}
+
+/// Parenthesized `infer` accepts the array suffix and should not regress —
+/// `(infer X)[]` is the documented way to write an array of an inferred type.
+#[test]
+fn parenthesized_infer_followed_by_array_suffix_parses() {
+    assert_no_errors("type A<T> = T extends (infer X)[] ? X : never;");
+}
+
+/// Bare `infer X` followed by a postfix `?` outside a tuple still leaves the
+/// `?` for the surrounding context (so `T extends infer U ? U : never` parses
+/// as a conditional type, not as a JSDoc nullable on the infer). This pins
+/// down the "bare infer skips postfix" rule across non-tuple contexts.
+#[test]
+fn bare_infer_question_in_conditional_extends_position_parses_as_conditional() {
+    assert_no_errors("type A<T> = T extends infer U ? U : never;");
+}
+
+/// The variadic-utility shape from issue #11333 should parse cleanly:
+/// `Tail<T>`, then a mapped type over `keyof Tail<T>`, then a function
+/// returning that. The parser must not cross-pollute state between the
+/// declarations.
+#[test]
+fn variadic_tuple_infer_mapped_chain_parses_cleanly() {
+    assert_no_errors(
+        r"
+type Tail<T extends any[]> = T extends [any, ...infer R] ? R : never;
+type MapTail<T extends any[]> = { [K in keyof Tail<T>]: Tail<T>[K] };
+function f<T extends any[]>(x: T, y: MapTail<T>) { return [x, y] as const; }
+",
+    );
+}
+
+/// Adjacent stress cases for the same rule: deeply nested infer + variadic +
+/// conditional + mapped. Varies type-parameter names so the fix is structural,
+/// not name-dependent (per CLAUDE.md §25 anti-hardcoding directive).
+#[test]
+fn variadic_tuple_infer_adjacent_shapes_parse_cleanly() {
+    for source in [
+        // Reverse via variadic + mapped recursion.
+        "type Reverse<T extends any[]> = T extends [...infer R, infer L] ? [L, ...Reverse<R>] : T;",
+        // Multi-position infer with `extends` constraint.
+        "type Head<U extends any[]> = U extends [infer H extends string, ...any[]] ? H : never;",
+        // Mapped + indexed access over a variadic alias.
+        "type M<P extends any[]> = { [K in keyof P]: P[K] };",
+        // Template-literal infer in a conditional cascade.
+        "type S<X> = X extends `${infer A}-${infer B}` ? [A, B] : never;",
+        // Conditional with `infer R extends string` constraint plus outer `?`.
+        "type C<T> = T extends infer R extends string ? R : never;",
+        // Variadic concat via recursive conditional.
+        "type Cat<A extends any[], B extends any[]> = A extends [infer Hd, ...infer Rs] ? [Hd, ...Cat<Rs, B>] : B;",
+    ] {
+        assert_no_errors(source);
+    }
 }


### PR DESCRIPTION
## Agent

AgentName: M4-D
Track: parser parity / TS17019 recovery
Invariant: tsc parity for postfix JSDoc nullable / non-nullable suffix recovery on array, indexed-access, and parenthesized types.

## Scope

Fixes #11333 (utility-types-project: parser parseTypeAlias recursion on variadic tuple utility) — but the actual bug class the issue surfaces is broader than the title suggests, so the fix is broader too.

`parse_primary_type_array_suffix` returned early after consuming a `[]` chain, so the postfix `?`/`!` handler never ran on arrayed or indexed-access types. That caused tsz to:

- emit TS1005 / TS1110 cascade for `string[]?` / `T['x']?` instead of TS17019;
- silently swallow `[]` after a bare `infer X` (so `[infer X[]]` accepted) instead of recovering as TS1005 like tsc;
- inside an `infer X extends T[]?` constraint, drag the `?` into the *outer* conditional and then complain about a missing true type at the trailing `,` — which is exactly what surfaced as "parseTypeAlias recursion on variadic tuple utility" downstream.

## Structural rule

> When a base type has accepted an array or indexed-access suffix and a postfix `?` or `!` follows, tsc emits TS17019. Bare `infer X` skips **all** postfix operators (`[]`, `?`, `!`) entirely.

Fix:

1. Fall through from the `[]` branch to the postfix `?`/`!` handler so `T[]?` reports JSDoc-nullable on the array.
2. Bare `infer X` early-return in `parse_primary_type` — mirrors tsc's `parseTypeOperatorOrHigher` which returns `parseInferType()` directly without entering `parsePostfixTypeOrHigher`.
3. Consolidate the duplicated `(diag_start, suggested)` block into a new `postfix_jsdoc_type_diagnostic_anchor` helper that also peels outer `PARENTHESIZED_TYPE` wrappers so `(T | U)?` suggests `T | U | undefined`, not `(T | U) | undefined`.

## Adjacent-case test matrix (per CLAUDE.md §25 / §26)

12 new tests under `parser_improvement_nullable_type_recovery_tests.rs`:

- **The bug class** — TS17019 fires for `T[]?`, `T[][]?`, `T[]!`, `T['k']?`.
- **Suggestion shaping** — outer parens stripped for `(T | U)?` and `((T))?`.
- **Tuple suppression preserved** — `[T[]?]` stays a tuple-optional element.
- **Constraint surface (issue #11333)** — `infer X extends T[]?` reports TS17019 on the constraint, not TS1110 cascade.
- **Bare-infer rule** — `[infer X[]]` recovers as TS1005, matching tsc.
- **Negative regressions guarded** — `(infer X)[]`, `T extends infer U ? U : never`, the full variadic + infer + mapped chain from the issue, and a name-varied matrix (`Reverse`/`Head`/`M`/`S`/`C`/`Cat`) all parse cleanly.

The matrix varies type-parameter names so the rule is structural, not name-dependent.

## Project Corpus Impact

- Row: utility-types-project
- Bug family: parser postfix-type recovery (TS17019 / TS1005 cascade)
- Evidence: local repro `type A = string[]?;` — tsc emits `TS17019`, tsz previously emitted `TS1005 ';' expected.`; both now match. Local repro `type A<T> = T extends [infer X extends string[]?, infer Y] ? [X, Y] : never;` — tsc emits `TS17019` at the constraint's `?` (1,40), tsz previously emitted `TS1110 Type expected.` at the trailing `,` (1,49); both now match exactly (file:line and code). Local repro `[infer X[]]` — tsc emits `TS1005 ',' expected.`, tsz previously accepted silently; both now match.

## Verification

- `cargo test -p tsz-parser` — 1182 passed; 0 failed (was 1170 before the new tests).
- `cargo clippy -p tsz-parser --tests -- -D warnings` — clean.
- Manual probes against `tsc` (TypeScript 6) for `string[]?`, `string[][]?`, `string[]!`, `number[]?`, `X['a']?`, `(string | number)?`, `((string))?`, `[infer X[]]`, `(infer X)[]`, `T extends infer U ? U : never`, `infer X extends string[]?` — all match tsc's diagnostic code and message.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` flags a pre-existing `clippy::duplicate-mod` in `crates/tsz-cli/src/driver/core.rs:3172` (loads `driver/tests.rs` both via `mod tests;` and via `#[path = "tests.rs"] mod tests;`). Unrelated to this PR; same failure reproduces on `origin/main`.

## Coordination Notes

- Runner alias: `claude-opus-4-7-confident-thompson` (Claude Code on the Web session). Canonical ownership lane is `agent:M4-D` (parser lane), matching the labels on issue #11333.
- Closes #11333. Same fix also resolves the practical surface behind sibling parser issues (`#11322`, `#11348`) — the underlying rule is "postfix suffix routing across array/indexed-access/parens", not "Awaited chain" or "mapped intersections" per se.
- Architecture-aligned (CLAUDE.md §25 anti-hardcoding): no user-chosen identifier names appear in the fix; the rule is keyed on `SyntaxKind::OpenBracketToken`, `node.kind == PARENTHESIZED_TYPE`, and `node_is_bare_infer_type`.