### PR TITLE
test(checker): cover branch assignment merge narrowing

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -39,6 +39,10 @@ name = "closure_boundary_property_narrowing_tests"
 path = "tests/closure_boundary_property_narrowing_tests.rs"
 
 [[test]]
+name = "assignment_branch_merge_narrowing_tests"
+path = "tests/assignment_branch_merge_narrowing_tests.rs"
+
+[[test]]
 name = "mapped_remapped_excess_function_property_tests"
 path = "tests/mapped_remapped_excess_function_property_tests.rs"
 

--- a/crates/tsz-checker/tests/assignment_branch_merge_narrowing_tests.rs
+++ b/crates/tsz-checker/tests/assignment_branch_merge_narrowing_tests.rs
@@ -1,0 +1,53 @@
+use tsz_checker::test_utils::check_source_strict_codes;
+
+const TS2322: u32 = 2322;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_strict_codes(source)
+}
+
+#[test]
+fn branch_assignment_preserves_defined_local_after_intervening_read() {
+    let diagnostics = codes(
+        r#"
+declare const arr: (number | undefined)[];
+declare function maybeNumber(): number | undefined;
+
+function f() {
+    let value = maybeNumber();
+    if (!value) {
+        value = 5;
+        arr.push(value);
+    }
+    const z: number = value;
+}
+"#,
+    );
+
+    assert!(
+        !diagnostics.contains(&TS2322),
+        "branch assignment should narrow value to number after the merge, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn branch_without_assignment_still_keeps_possibly_undefined() {
+    let diagnostics = codes(
+        r#"
+declare function maybeNumber(): number | undefined;
+
+function f() {
+    let value = maybeNumber();
+    if (!value) {
+        value;
+    }
+    const z: number = value;
+}
+"#,
+    );
+
+    assert!(
+        diagnostics.contains(&TS2322),
+        "without a branch assignment the value can still be undefined, got {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Benchmark blocker regression coverage for Kysely strict-null flow narrowing.

## Invariant
When a local `let` value starts as `T | undefined` and every reachable branch either proves it present or assigns a present value before a later read, `tsc` treats the merged read as present; this PR locks that behavior in checker flow tests.

## Scope
- `crates/tsz-checker/tests/assignment_branch_merge_narrowing_tests.rs`
- `crates/tsz-checker/Cargo.toml`

## Project Corpus Impact
- Row: `kysely-project`
- Bug family: strictNullChecks branch-assignment flow narrowing from #10669
- Evidence: the reduced follow-up witness from #10669 is now covered by a checker integration test, including the negative branch-without-assignment case.

## Verification
- `cargo nextest run -p tsz-checker --test assignment_branch_merge_narrowing_tests`
- `cargo fmt --check --package tsz-checker`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- No repo markdown changes.
- The reduced #10669 follow-up already passes on current `main`; this PR adds regression coverage so the Kysely row does not lose that behavior again.
- Opened after confirming Studio-A had no open PRs and no active PR claimed this exact flow-regression coverage.
