### PR TITLE
chore(arch): expose guard report status

### DIFF
--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -45,6 +45,7 @@ def build_json_payload(failures: list[tuple[str, list[str]]], total_hits: int) -
     return {
         "ok": ok,
         "status": "failed" if failures else "passed",
+        "arch_guard_status": "failed" if failures else "passed",
         "total_hits": total_hits,
         "failure_count": len(failures),
         "failed_hit_count": failed_hit_count,

--- a/scripts/arch/test_arch_guard.py
+++ b/scripts/arch/test_arch_guard.py
@@ -16,6 +16,7 @@ class ArchGuardJsonReportTests(unittest.TestCase):
             {
                 "ok": True,
                 "status": "passed",
+                "arch_guard_status": "passed",
                 "total_hits": 0,
                 "failure_count": 0,
                 "failed_hit_count": 0,
@@ -30,6 +31,7 @@ class ArchGuardJsonReportTests(unittest.TestCase):
             {
                 "ok": False,
                 "status": "failed",
+                "arch_guard_status": "failed",
                 "total_hits": 2,
                 "failure_count": 1,
                 "failed_hit_count": 2,
@@ -44,6 +46,7 @@ class ArchGuardJsonReportTests(unittest.TestCase):
             "ok": True,
             "total_hits": 0,
             "status": "passed",
+            "arch_guard_status": "passed",
             "failure_count": 0,
             "failed_hit_count": 0,
             "failures": [],


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Architecture guardrails / cheap evidence plumbing.

## Invariant
When `python3 scripts/arch/arch_guard.py --json-report` writes the architecture guard artifact, the generic `status` remains stable and the JSON root also exposes explicit `arch_guard_status` for release-gate consumers.

## Scope
- Add `arch_guard_status` to the arch guard JSON payload.
- Extend focused arch guard JSON tests for pass/fail payloads and report writing.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: arch-tooling-only; does not change compiler, emit output, project corpus fixtures, or TypeScript parity behavior.

## Verification
- `python3 -m unittest test_arch_guard.ArchGuardJsonReportTests` from `scripts/arch`
- `python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-status.json`
- `git diff --check HEAD~1 HEAD`
- `scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-audit.json`

## Coordination Notes
- Studio-F owned runway was clear before this branch.
- Primary checkout had unrelated Studio-C conflicts; this PR was built in a fresh worktree from `origin/main`.
- While publishing, Studio-F fixed label-audit coordination for #11996 by marking it as no canonical agent lane assigned instead of creating a generated agent label.
