### PR TITLE
fix(bench): attach row sidecar attribution reports

### DIFF
--- a/scripts/bench/test-tsgo-winner-report.mjs
+++ b/scripts/bench/test-tsgo-winner-report.mjs
@@ -484,6 +484,76 @@ withTempDir((dir) => {
 withTempDir((dir) => {
   const input = path.join(dir, "bench.json");
   const output = path.join(dir, "report.json");
+  const perfPath = path.join(dir, "bench.ts-essentials-project.perf.json");
+  writeJson(input, {
+    results: [
+      {
+        name: "ts-essentials-project",
+        winner: "tsgo",
+        factor: 1.2,
+        tsz_ms: 120,
+        tsgo_ms: 100,
+        compatibility: {
+          state: "green",
+          exit_class: "exit success",
+          phase: "check",
+          last_successful_phase: "check",
+          diagnostic_status: "none",
+          semantic_owner_family: "utility types plus recursive JSON shapes",
+        },
+      },
+      {
+        name: "vite-vanilla-ts-app",
+        winner: "tsgo",
+        factor: 1.5,
+        tsz_ms: 150,
+        tsgo_ms: 100,
+        compatibility: {
+          state: "green",
+          exit_class: "exit success",
+          phase: "check",
+          last_successful_phase: "check",
+          diagnostic_status: "none",
+          semantic_owner_family: "generated app dependency/config sanity",
+        },
+      },
+    ],
+  });
+  writeJson(perfPath, {
+    mode: "attribution",
+    delegate: { misses: 0 },
+    checker: { with_parent_cache_constructed: 0 },
+    slow_check_file_timings: [
+      { file: "ts-essentials/lib/xor/index.ts", elapsed_ms: 150, diagnostics: 0 },
+    ],
+  });
+
+  const result = spawnSync(process.execPath, [SCRIPT, input, output], {
+    cwd: ROOT,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /2x target gaps with attribution: 1\/2/);
+
+  const report = JSON.parse(fs.readFileSync(output, "utf8"));
+  assert.equal(report.two_x_target.rows_below_target, 2);
+  assert.equal(report.two_x_target.rows_with_attribution, 1);
+  assert.deepEqual(report.two_x_target.missing_attribution_rows, ["vite-vanilla-ts-app"]);
+  const tsEssentials = report.target_gaps.find((row) => row.name === "ts-essentials-project");
+  assert.deepEqual(tsEssentials.attribution_status, {
+    present: true,
+    path: path.relative(ROOT, perfPath).split(path.sep).join("/"),
+    url: null,
+    generated_at: tsEssentials.attribution_status.generated_at,
+    mode: "attribution",
+    dominant_subsystem: "checker:semantic-check",
+    warning: null,
+  });
+});
+
+withTempDir((dir) => {
+  const input = path.join(dir, "bench.json");
+  const output = path.join(dir, "report.json");
   const perfPath = path.join(dir, "bench.perf.json");
   writeJson(input, {
     results: [

--- a/scripts/bench/tsgo-winner-report.mjs
+++ b/scripts/bench/tsgo-winner-report.mjs
@@ -154,37 +154,51 @@ function sidecarPerfPath(inputPath) {
   return inputPath.replace(/\.json$/, ".perf.json");
 }
 
-function singleRowSidecarAttribution(rows, inputPath) {
-  if (rows.length !== 1) return new Map();
+function rowSidecarPerfPath(inputPath, rowName) {
+  if (typeof inputPath !== "string" || !inputPath.endsWith(".json")) return null;
+  if (typeof rowName !== "string" || rowName.length === 0) return null;
+  const slug = rowName.replace(/[^A-Za-z0-9._-]+/g, "_");
+  return inputPath.replace(/\.json$/, `.${slug}.perf.json`);
+}
 
-  const perfPath = sidecarPerfPath(inputPath);
-  if (!perfPath || !fs.existsSync(perfPath)) return new Map();
+function sidecarAttributionForPath(perfPath) {
+  if (!perfPath || !fs.existsSync(perfPath)) return null;
 
   let snapshot;
   try {
     snapshot = readJson(perfPath);
   } catch {
-    return new Map();
+    return null;
   }
 
-  const row = rows[0];
   const relativePath = toPortablePath(path.relative(process.cwd(), perfPath));
   const mode = snapshot.mode ?? null;
   const isAttributionMode = mode === "attribution";
-  return new Map([
-    [
-      row.name,
-      {
-        path: relativePath,
-        generated_at: fs.statSync(perfPath).mtime.toISOString(),
-        mode,
-        dominant_subsystem: isAttributionMode
-          ? inferDominantSubsystemFromPerfSnapshot(snapshot)
-          : null,
-        warning: isAttributionMode ? null : "sidecar perf snapshot mode is not attribution",
-      },
-    ],
-  ]);
+  return {
+    path: relativePath,
+    generated_at: fs.statSync(perfPath).mtime.toISOString(),
+    mode,
+    dominant_subsystem: isAttributionMode
+      ? inferDominantSubsystemFromPerfSnapshot(snapshot)
+      : null,
+    warning: isAttributionMode ? null : "sidecar perf snapshot mode is not attribution",
+  };
+}
+
+function sidecarAttribution(rows, inputPath) {
+  const attributions = new Map();
+  if (rows.length === 1) {
+    const attribution = sidecarAttributionForPath(sidecarPerfPath(inputPath));
+    if (attribution) attributions.set(rows[0].name, attribution);
+  }
+
+  for (const row of rows) {
+    if (typeof row?.name !== "string" || attributions.has(row.name)) continue;
+    const attribution = sidecarAttributionForPath(rowSidecarPerfPath(inputPath, row.name));
+    if (attribution) attributions.set(row.name, attribution);
+  }
+
+  return attributions;
 }
 
 function pickAttributionArtifact(row, fallbackArtifact = null) {
@@ -298,7 +312,7 @@ function duplicateProjectRows(rows) {
 
 export function createTsgoWinnerReport(input, inputPath) {
   const rows = Array.isArray(input.results) ? input.results : [];
-  const sidecarAttribution = singleRowSidecarAttribution(rows, inputPath);
+  const rowSidecarAttribution = sidecarAttribution(rows, inputPath);
   const duplicateRows = duplicateProjectRows(rows);
   const duplicateNames = new Set(duplicateRows.map((row) => row.name));
   const incompleteCompatExcluded = rows.filter(isIncompleteCompat).length;
@@ -323,7 +337,7 @@ export function createTsgoWinnerReport(input, inputPath) {
         exit_class: row.compatibility?.exit_class ?? null,
         semantic_owner_family: row.compatibility?.semantic_owner_family ?? null,
         loss_closure: lossClosureForRow(row),
-        attribution_status: attributionStatusForRow(row, sidecarAttribution.get(row.name)),
+        attribution_status: attributionStatusForRow(row, rowSidecarAttribution.get(row.name)),
       };
     });
   const targetGapRows = eligibleRows
@@ -349,7 +363,7 @@ export function createTsgoWinnerReport(input, inputPath) {
       exit_class: row.compatibility?.exit_class ?? null,
       semantic_owner_family: row.compatibility?.semantic_owner_family ?? null,
       loss_closure: lossClosureForRow(row),
-      attribution_status: attributionStatusForRow(row, sidecarAttribution.get(row.name)),
+      attribution_status: attributionStatusForRow(row, rowSidecarAttribution.get(row.name)),
     }))
     .sort(compareWinnersByFactorDesc);
 


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 performance measurement/tooling.

## Invariant
When a merged benchmark result contains multiple green rows and a row-specific perf snapshot exists beside it as `<bench>.<row-name>.perf.json`, the tsgo-winner report attaches that attribution to the matching row without mutating the timing JSON schema. Existing single-row `<bench>.perf.json` sidecar behavior remains unchanged.

## Scope
- `scripts/bench/tsgo-winner-report.mjs`
- `scripts/bench/test-tsgo-winner-report.mjs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: benchmark-report-only; improves canonical 2x target-gap attribution reporting and does not change compiler behavior or project fixture execution.

## Verification
- `node scripts/bench/test-tsgo-winner-report.mjs`
- `git diff --check HEAD~1..HEAD`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- No Studio-B PRs were open at intake.
- Avoids overlap with M4-D cross-file alias/export cache work; this is report tooling only.
- Disk is below the 20 GB guard on this machine, so no Rust rebuild or broad benchmark was run for this report-only change.
