### PR TITLE
chore(agents): expose disk preflight status

### DIFF
--- a/scripts/agents/disk-preflight.sh
+++ b/scripts/agents/disk-preflight.sh
@@ -347,6 +347,7 @@ const diskOk = guard.disk_status === "ok";
 const report = {
   ok: diskOk,
   status: diskOk ? "pass" : "fail",
+  disk_preflight_status: diskOk ? "pass" : "fail",
   agent: process.env.AGENT,
   repo: process.env.ROOT,
   disk_guard: {

--- a/scripts/agents/test_disk_preflight.py
+++ b/scripts/agents/test_disk_preflight.py
@@ -113,6 +113,7 @@ class DiskPreflightTests(unittest.TestCase):
             self.assertIn("agent=Studio-F", result.stdout)
             self.assertTrue(report["ok"])
             self.assertEqual("pass", report["status"])
+            self.assertEqual("pass", report["disk_preflight_status"])
             self.assertEqual("Studio-F", report["agent"])
             self.assertEqual(str(fake_repo), report["repo"])
             self.assertEqual("populated-local-submodule", report["typescript"]["state"])
@@ -148,6 +149,7 @@ class DiskPreflightTests(unittest.TestCase):
             report = json.loads(report_path.read_text(encoding="utf-8"))
             self.assertFalse(report["ok"])
             self.assertEqual("fail", report["status"])
+            self.assertEqual("fail", report["disk_preflight_status"])
             self.assertEqual("low", report["disk_guard"]["disk_status"])
             self.assertFalse(report["disk_guard"]["ok"])
 


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / cheap evidence plumbing

## Invariant
When `scripts/agents/disk-preflight.sh --json-report` writes machine-readable evidence, the report exposes a named `disk_preflight_status` field that mirrors the generic pass/fail status so automation and agents can inspect the gate without guessing which `status` field applies.

## Scope
- Add `disk_preflight_status` to the disk preflight JSON report.
- Ratchet the focused disk preflight tests for both pass and fail reports.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: launch-tooling-only JSON report shape; no compiler, parser, checker, solver, emit, or project-corpus behavior changes.

## Verification
- `python3 -m unittest scripts.agents.test_disk_preflight`
- `scripts/agents/disk-preflight.sh Studio-F --json-report /tmp/tsz-disk-preflight-status.json`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-audit-disk-status.json`

## Coordination Notes
- No open Studio-F PRs or issues were present before this slice.
- This is a small non-overlapping follow-up to recent Studio-F status-field plumbing for launch evidence.
- GitHub Actions were reported unreliable by the user; local focused evidence is listed above and the PR can run normal checks when Actions recover.
