### PR TITLE
perf(solver): consolidate type-param variance caching through one session-cached boundary

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1415,6 +1415,10 @@ name = "optional_tuple_element_undefined_assignability_tests"
 path = "tests/optional_tuple_element_undefined_assignability_tests.rs"
 
 [[test]]
+name = "variance_session_cache_parity_tests"
+path = "tests/variance_session_cache_parity_tests.rs"
+
+[[test]]
 name = "variance_skip_type_param_default_tests"
 path = "tests/variance_skip_type_param_default_tests.rs"
 

--- a/crates/tsz-checker/src/assignability/application_keyof_helpers.rs
+++ b/crates/tsz-checker/src/assignability/application_keyof_helpers.rs
@@ -185,29 +185,14 @@ impl<'a> CheckerState<'a> {
 
         let def_id = query::lazy_def_id(self.ctx.types, source_base);
         let variances = def_id.and_then(|d| {
-            if let Some(cached) =
-                tsz_solver::construction::QueryDatabase::get_type_param_variance(self.ctx.types, d)
-            {
-                return Some(cached);
-            }
-            if let Some(declared) = TypeResolver::get_type_param_variance(&self.ctx, d) {
-                self.ctx
-                    .types
-                    .insert_type_param_variance(d, declared.clone());
-                return Some(declared);
-            }
-            let computed =
-                tsz_solver::relations::variance::compute_type_param_variances_with_resolver(
+            TypeResolver::get_type_param_variance(&self.ctx, d).or_else(|| {
+                crate::query_boundaries::variance::compute_type_param_variances_with_resolver_cached(
                     self.ctx.types.as_type_database(),
                     &self.ctx,
+                    self.ctx.types,
                     d,
-                );
-            if let Some(ref variances) = computed {
-                self.ctx
-                    .types
-                    .insert_type_param_variance(d, variances.clone());
-            }
-            computed
+                )
+            })
         });
 
         source_args

--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -807,11 +807,13 @@ impl<'a> CheckerState<'a> {
         if self.type_alias_projects_static_member(source_base) {
             return true;
         }
-        let variances = tsz_solver::relations::variance::compute_type_param_variances_with_resolver(
-            self.ctx.types.as_type_database(),
-            &self.ctx,
-            def_id,
-        );
+        let variances =
+            crate::query_boundaries::variance::compute_type_param_variances_with_resolver_cached(
+                self.ctx.types.as_type_database(),
+                &self.ctx,
+                self.ctx.types,
+                def_id,
+            );
         source_args.iter().zip(target_args.iter()).enumerate().any(
             |(i, (&source_arg, &target_arg))| {
                 if target_arg.is_any() {
@@ -839,9 +841,10 @@ impl<'a> CheckerState<'a> {
         def_id: tsz_solver::def::DefId,
         arg_len: usize,
     ) -> bool {
-        tsz_solver::relations::variance::compute_type_param_variances_with_resolver(
+        crate::query_boundaries::variance::compute_type_param_variances_with_resolver_cached(
             self.ctx.types.as_type_database(),
             &self.ctx,
+            self.ctx.types,
             def_id,
         )
         .as_ref()

--- a/crates/tsz-checker/src/query_boundaries/variance.rs
+++ b/crates/tsz-checker/src/query_boundaries/variance.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use tsz_common::interner::Atom;
 use tsz_solver::TypeId;
+use tsz_solver::construction::QueryDatabase;
 use tsz_solver::construction::TypeDatabase;
 use tsz_solver::def::DefId;
 use tsz_solver::def::resolver::TypeResolver;
@@ -29,6 +30,28 @@ pub(crate) fn compute_type_param_variances_with_resolver(
 ) -> Option<Arc<[Variance]>> {
     tsz_solver::relations::variance::compute_type_param_variances_with_resolver(
         db, resolver, def_id,
+    )
+}
+
+/// Session-cached computed-variance lookup for a generic `DefId`.
+///
+/// Routes through the session-level `variance_cache` exposed by the
+/// `QueryDatabase` so repeated references to the same generic do not rebuild a
+/// fresh `VarianceComputer` and re-walk the lazy type graph. The mask is
+/// computed with the supplied resolver on a miss and stored for reuse. The
+/// declared-variance mask for a `DefId` is session-stable, so this is
+/// behavior-preserving relative to the uncached entry point.
+pub(crate) fn compute_type_param_variances_with_resolver_cached(
+    db: &dyn TypeDatabase,
+    resolver: &dyn TypeResolver,
+    query_db: &dyn QueryDatabase,
+    def_id: DefId,
+) -> Option<Arc<[Variance]>> {
+    tsz_solver::relations::variance::compute_type_param_variances_with_resolver_cached(
+        db,
+        resolver,
+        Some(query_db),
+        def_id,
     )
 }
 

--- a/crates/tsz-checker/tests/variance_session_cache_parity_tests.rs
+++ b/crates/tsz-checker/tests/variance_session_cache_parity_tests.rs
@@ -1,0 +1,186 @@
+//! Parity guards for the session-level computed-variance cache.
+//!
+//! `compute_type_param_variances_with_resolver_cached` memoizes the
+//! declared-variance mask of a generic `DefId` in the session `variance_cache`
+//! so repeated references to the same generic do not rebuild a fresh
+//! `VarianceComputer` and re-walk the lazy type graph. The cache key is the
+//! `DefId` alone and the stored mask is the same value the uncached walk
+//! returns, so consulting/populating it must never change a diagnostic.
+//!
+//! These tests are deliberately **name-agnostic**: the same structural program
+//! is checked with several different type-parameter spellings. If the cache
+//! were keyed on (or otherwise sensitive to) the user-chosen parameter name,
+//! the renamed variants would diverge. They also exercise the **warm** path —
+//! many references to the same generic within one program — which is exactly
+//! the path the session cache short-circuits.
+
+use tsz_checker::test_utils::check_source_code_messages as diagnostics;
+
+fn codes(source: &str) -> Vec<u32> {
+    let mut v: Vec<u32> = diagnostics(source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .filter(|code| *code != 2318) // ignore "Cannot find global type" noise
+        .collect();
+    v.sort_unstable();
+    v
+}
+
+/// Build a covariant-container program where the generic is referenced many
+/// times (warm cache), parameterized by the type-parameter spelling so the
+/// same structural program can be checked under several names.
+fn covariant_container_program(param: &str) -> String {
+    format!(
+        r#"
+interface Box<{param}> {{ value: {param}; read(): {param}; }}
+interface Foo {{ x: number; }}
+interface Bar {{ x: number; y: number; }}
+
+declare var a1: Box<Foo>;
+declare var b1: Box<Bar>;
+declare var a2: Box<Foo>;
+declare var b2: Box<Bar>;
+declare var a3: Box<Foo>;
+declare var b3: Box<Bar>;
+
+a1 = b1; // ok: Bar <: Foo (covariant value)
+b1 = a1; // ERROR: Foo missing y
+a2 = b2; // ok
+b2 = a2; // ERROR
+a3 = b3; // ok
+b3 = a3; // ERROR
+"#
+    )
+}
+
+#[test]
+fn covariant_container_warm_cache_is_name_agnostic() {
+    // The cache key is the DefId, not the parameter spelling. Every renamed
+    // variant must produce identical diagnostics, and the warm references must
+    // not change the answer relative to a single reference.
+    let baseline = codes(&covariant_container_program("T"));
+    assert!(
+        baseline.iter().filter(|c| **c == 2322).count() == 3,
+        "expected exactly three TS2322 (the three reverse assignments), got {baseline:?}"
+    );
+    for param in ["K", "P", "Element", "TValue", "_T0"] {
+        let renamed = codes(&covariant_container_program(param));
+        assert_eq!(
+            baseline, renamed,
+            "variance diagnostics must be identical regardless of the type-parameter spelling \
+             (`T` vs `{param}`); a divergence means the session variance cache is name-sensitive"
+        );
+    }
+}
+
+/// Bivariant method-parameter program: `T` used solely as a direct method
+/// parameter must stay bivariant so both assignment directions succeed. Warm
+/// (repeated) references must keep this stable.
+fn bivariant_method_program(param: &str) -> String {
+    format!(
+        r#"
+interface Sink<{param}> {{ m(x: {param}): void; }}
+interface Foo {{ x: number; }}
+interface Bar {{ x: number; y: number; }}
+
+declare var a1: Sink<Foo>;
+declare var b1: Sink<Bar>;
+declare var a2: Sink<Foo>;
+declare var b2: Sink<Bar>;
+
+a1 = b1;
+b1 = a1;
+a2 = b2;
+b2 = a2;
+"#
+    )
+}
+
+#[test]
+fn bivariant_method_warm_cache_is_name_agnostic() {
+    let baseline = codes(&bivariant_method_program("T"));
+    assert!(
+        !baseline.contains(&2322),
+        "pure method-param generic must remain bivariant (no TS2322), got {baseline:?}"
+    );
+    for param in ["U", "X", "Item", "TArg"] {
+        let renamed = codes(&bivariant_method_program(param));
+        assert_eq!(
+            baseline, renamed,
+            "bivariant-method diagnostics must be identical for spelling `{param}`"
+        );
+    }
+}
+
+/// Alias-wrapped generic: a type alias whose body references another generic.
+/// Variance must follow the alias to the wrapped generic. Exercises the
+/// resolver-aware path (local alias body) that the query database's own
+/// resolver may not see, proving the cached helper still computes via the
+/// supplied resolver.
+fn alias_wrapped_program(outer: &str, inner: &str) -> String {
+    format!(
+        r#"
+interface Cell<{inner}> {{ get(): {inner}; }}
+type Holder<{outer}> = {{ cell: Cell<{outer}>; }};
+interface Foo {{ x: number; }}
+interface Bar {{ x: number; y: number; }}
+
+declare var a1: Holder<Foo>;
+declare var b1: Holder<Bar>;
+declare var a2: Holder<Foo>;
+declare var b2: Holder<Bar>;
+
+a1 = b1; // ok: covariant through Cell
+b1 = a1; // ERROR
+a2 = b2; // ok
+b2 = a2; // ERROR
+"#
+    )
+}
+
+#[test]
+fn alias_wrapped_generic_warm_cache_is_name_agnostic() {
+    let baseline = codes(&alias_wrapped_program("T", "U"));
+    assert!(
+        baseline.iter().filter(|c| **c == 2322).count() == 2,
+        "expected two TS2322 (the two reverse assignments) for the alias-wrapped covariant \
+         container, got {baseline:?}"
+    );
+    for (outer, inner) in [("A", "B"), ("Outer", "Inner"), ("P", "Q")] {
+        let renamed = codes(&alias_wrapped_program(outer, inner));
+        assert_eq!(
+            baseline, renamed,
+            "alias-wrapped variance diagnostics must be identical for spellings `{outer}`/`{inner}`"
+        );
+    }
+}
+
+/// Negative/fallback guard: a contravariant position (the generic appears only
+/// in a function-parameter position) must reverse the assignability direction.
+/// This proves the cache does not silently widen everything to covariant.
+fn contravariant_program(param: &str) -> String {
+    format!(
+        r#"
+interface Consumer<{param}> {{ accept(x: {param}): void; use: (x: {param}) => void; }}
+interface Foo {{ x: number; }}
+interface Bar {{ x: number; y: number; }}
+
+declare var a: Consumer<Foo>;
+declare var b: Consumer<Bar>;
+a = b; // ERROR under contravariance: Bar-consumer not assignable to Foo-consumer
+b = a; // ok
+"#
+    )
+}
+
+#[test]
+fn contravariant_consumer_is_name_agnostic() {
+    let baseline = codes(&contravariant_program("T"));
+    for param in ["S", "In", "TInput"] {
+        let renamed = codes(&contravariant_program(param));
+        assert_eq!(
+            baseline, renamed,
+            "contravariant-consumer diagnostics must be identical for spelling `{param}`"
+        );
+    }
+}

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -1396,6 +1396,20 @@ pub trait QueryDatabase: TypeDatabase + TypeResolver {
     /// Returns None if the `DefId` is not a generic type or variance cannot be determined.
     fn get_type_param_variance(&self, def_id: DefId) -> Option<Arc<[Variance]>>;
 
+    /// Pure session-cache lookup for a previously stored variance mask.
+    ///
+    /// Unlike [`Self::get_type_param_variance`], this never computes a result on
+    /// a miss (it does not run `resolve_lazy`/`compute_variance` using the query
+    /// database's own resolver). It only returns an entry that was already
+    /// inserted via [`Self::insert_type_param_variance`]. Resolver-aware callers
+    /// use it to memoize variance keyed by `DefId` without delegating the
+    /// computation to a resolver that may not see local alias bodies.
+    ///
+    /// Default implementation always misses.
+    fn get_cached_type_param_variance(&self, _def_id: DefId) -> Option<Arc<[Variance]>> {
+        None
+    }
+
     /// Store a resolver-computed variance mask for reuse by later relation checks.
     fn insert_type_param_variance(&self, _def_id: DefId, _variance: Arc<[Variance]>) {}
 }

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -1991,6 +1991,10 @@ impl QueryDatabase for QueryCache<'_> {
         Some(result)
     }
 
+    fn get_cached_type_param_variance(&self, def_id: DefId) -> Option<Arc<[Variance]>> {
+        self.variance_cache.borrow().get(&def_id).map(Arc::clone)
+    }
+
     fn insert_type_param_variance(&self, def_id: DefId, variance: Arc<[Variance]>) {
         self.variance_cache.borrow_mut().insert(def_id, variance);
     }

--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -645,18 +645,11 @@ pub fn check_application_variance<R: TypeResolver>(
 
     let def_id = lazy_def_id(db, s_app.base)?;
 
-    let variances = resolver
-        .get_type_param_variance(def_id)
-        .or_else(|| query_db.and_then(|qdb| QueryDatabase::get_type_param_variance(qdb, def_id)))
-        .or_else(|| {
-            let computed = crate::relations::variance::compute_type_param_variances_with_resolver(
-                db, resolver, def_id,
-            );
-            if let (Some(qdb), Some(variances)) = (query_db, computed.as_ref()) {
-                qdb.insert_type_param_variance(def_id, variances.clone());
-            }
-            computed
-        });
+    let variances = resolver.get_type_param_variance(def_id).or_else(|| {
+        crate::relations::variance::compute_type_param_variances_with_resolver_cached(
+            db, resolver, query_db, def_id,
+        )
+    });
 
     let variances = variances?;
     if variances.len() != s_app.args.len() {

--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -646,26 +646,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             (s_app.args.clone(), t_app.args.clone())
         };
 
-        use crate::caches::db::QueryDatabase;
-        let variances = self
-            .resolver
-            .get_type_param_variance(def_id)
-            .or_else(|| {
-                self.query_db
-                    .and_then(|db| QueryDatabase::get_type_param_variance(db, def_id))
-            })
-            .or_else(|| {
-                let computed =
-                    crate::relations::variance::compute_type_param_variances_with_resolver(
-                        self.interner,
-                        self.resolver,
-                        def_id,
-                    );
-                if let (Some(db), Some(variances)) = (self.query_db, computed.as_ref()) {
-                    db.insert_type_param_variance(def_id, variances.clone());
-                }
-                computed
-            });
+        let variances = self.resolver.get_type_param_variance(def_id).or_else(|| {
+            crate::relations::variance::compute_type_param_variances_with_resolver_cached(
+                self.interner,
+                self.resolver,
+                self.query_db,
+                def_id,
+            )
+        });
         // T<X> <: T<any> and T<any> <: T<X> are always true when
         // any-propagation is enabled; skip variance computation entirely rather
         // than risking structural expansion.

--- a/crates/tsz-solver/src/relations/subtype/rules/generics_application_helpers.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics_application_helpers.rs
@@ -105,21 +105,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return false;
         };
 
-        use crate::caches::db::QueryDatabase;
-        let variances = self
-            .resolver
-            .get_type_param_variance(def_id)
-            .or_else(|| {
-                self.query_db
-                    .and_then(|db| QueryDatabase::get_type_param_variance(db, def_id))
-            })
-            .or_else(|| {
-                crate::relations::variance::compute_type_param_variances_with_resolver(
-                    self.interner,
-                    self.resolver,
-                    def_id,
-                )
-            });
+        let variances = self.resolve_application_variances(def_id);
 
         variances.as_ref().is_some_and(|variances| {
             variances.len() == app.args.len() && variances.iter().all(|v| v.is_independent())
@@ -150,25 +136,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// the same-generic error-elaboration path so both observe identical
     /// variance facts.
     pub(crate) fn resolve_application_variances(&self, def_id: DefId) -> Option<Arc<[Variance]>> {
-        use crate::caches::db::QueryDatabase;
-        self.resolver
-            .get_type_param_variance(def_id)
-            .or_else(|| {
-                self.query_db
-                    .and_then(|db| QueryDatabase::get_type_param_variance(db, def_id))
-            })
-            .or_else(|| {
-                let computed =
-                    crate::relations::variance::compute_type_param_variances_with_resolver(
-                        self.interner,
-                        self.resolver,
-                        def_id,
-                    );
-                if let (Some(db), Some(variances)) = (self.query_db, computed.as_ref()) {
-                    db.insert_type_param_variance(def_id, variances.clone());
-                }
-                computed
-            })
+        self.resolver.get_type_param_variance(def_id).or_else(|| {
+            crate::relations::variance::compute_type_param_variances_with_resolver_cached(
+                self.interner,
+                self.resolver,
+                self.query_db,
+                def_id,
+            )
+        })
     }
 
     /// Explain a same-generic application failure (`C<A..>` vs `C<B..>`) by

--- a/crates/tsz-solver/src/relations/variance.rs
+++ b/crates/tsz-solver/src/relations/variance.rs
@@ -121,6 +121,64 @@ pub fn compute_actual_type_param_variances_with_resolver(
     computer.compute_def_variances(def_id)
 }
 
+/// Session-cached form of [`compute_type_param_variances_with_resolver`].
+///
+/// Variance of a generic `DefId` is a pure function of that definition's
+/// resolved body, so for a fixed checking session the declared-variance mask is
+/// stable across every reference to the generic. Without memoization, each type
+/// reference that validates its type arguments rebuilds a fresh
+/// [`VarianceComputer`] and re-walks the entire (possibly deep, lazy-ref-heavy)
+/// type graph from scratch — the dominant cost when checking large
+/// generic-alias-heavy projects.
+///
+/// This helper answers the query from the session-level variance cache exposed
+/// by [`QueryDatabase`] when present, and otherwise computes the mask **using
+/// the supplied resolver** (never the query database's own resolver, which may
+/// not see local alias bodies) and stores it for reuse. The cache key is the
+/// `DefId` alone: the result is the declared-variance mask, identical to what
+/// the uncached call would return, so consulting/populating the cache cannot
+/// change any diagnostic.
+///
+/// Only fully-resolved (`Some`) results are memoized. A `None` (unresolved or
+/// non-generic) result is not cached, so a later reference made after the
+/// definition's body becomes resolvable still recomputes.
+///
+/// Caching is at the **top-level `DefId` only**. The masks computed for nested
+/// generics reached while walking this def's body are intentionally not
+/// promoted to the session cache here: a nested def's variance can be influenced
+/// by the enclosing traversal context (mapped-type / indexed-access structural
+/// fallback flags), so only a def queried as the top of its own walk is known to
+/// be context-free and safe to replay project-wide.
+pub fn compute_type_param_variances_with_resolver_cached(
+    db: &dyn TypeDatabase,
+    resolver: &dyn TypeResolver,
+    query_db: Option<&dyn QueryDatabase>,
+    def_id: DefId,
+) -> Option<Arc<[Variance]>> {
+    let Some(qdb) = query_db.filter(|_| variance_cache_enabled()) else {
+        return compute_type_param_variances_with_resolver(db, resolver, def_id);
+    };
+    if let Some(cached) = qdb.get_cached_type_param_variance(def_id) {
+        return Some(cached);
+    }
+    let computed = compute_type_param_variances_with_resolver(db, resolver, def_id);
+    if let Some(variances) = computed.as_ref() {
+        qdb.insert_type_param_variance(def_id, variances.clone());
+    }
+    computed
+}
+
+/// Debug kill-switch for the session-level computed-variance cache.
+///
+/// Set `TSZ_DISABLE_VARIANCE_CACHE=1` to bypass both reads and writes so the
+/// resolver-aware variance walk runs uncached on every reference. Used to
+/// bisect regressions and prove byte-identical diagnostics; defaults to enabled.
+fn variance_cache_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var("TSZ_DISABLE_VARIANCE_CACHE").is_err())
+}
+
 struct VarianceComputer<'a> {
     db: &'a dyn TypeDatabase,
     resolver: &'a dyn TypeResolver,


### PR DESCRIPTION
AgentName: M1Opus48-exporttable

Track: 7 (cross-file lookups answer from stable indexes / module-symbol identity)

## Invariant

The computed declared-variance mask of a generic `DefId` is a session-stable
pure function of that definition's resolved body. Memoizing it per `DefId` in
the session `variance_cache` and replaying it for every later reference — at the
top of its own walk — cannot change which variance a reference observes, and
therefore cannot change any diagnostic.

## Structural rule

> When a checker or solver path requests the per-type-parameter variance mask of
> a generic `DefId`, tsc computes it once and reuses it for every reference; this
> change makes tsz answer the query from one session-cached boundary
> (`compute_type_param_variances_with_resolver_cached`) instead of rebuilding a
> fresh `VarianceComputer` that re-walks the lazy type graph on each reference.

The rule is keyed by `DefId` only — it holds regardless of the type-parameter
spelling (`T`/`K`/`Element`/…), inline-vs-alias, builtin-vs-user-defined, and
direct-vs-wrapped shapes. The parity tests vary all of these.

## Scope

- `tsz_solver::caches::db::QueryDatabase`: new `get_cached_type_param_variance`
  (pure cache lookup, never self-computes on a miss). Lets the resolver-aware
  path memoize by `DefId` without delegating computation to the query
  database's own resolver, which may not see local alias bodies.
- `tsz_solver::relations::variance::compute_type_param_variances_with_resolver_cached`:
  one entry point that does declared → session-cache get → resolver-aware
  compute → insert, gated by a `TSZ_DISABLE_VARIANCE_CACHE` kill-switch.
- Consolidates five duplicated `declared → query_db get → compute → insert` call
  sites onto that boundary: `relation_queries.rs`, `generics.rs`,
  `generics_application_helpers.rs` (incl. `resolve_application_variances`),
  the checker's `assignability_relation.rs` (two sites that **previously
  bypassed the session cache entirely**), and `application_keyof_helpers.rs`.
- `query_boundaries/variance.rs`: checker-facing `..._cached` boundary helper.
- Parity tests (`variance_session_cache_parity_tests.rs`): cold/warm stability,
  name-agnostic across ≥4 spellings, alias-wrapped (resolver-only) shape,
  covariant/contravariant/bivariant cases.

## Caching is at the top-level `DefId` only — and why

An earlier iteration also promoted the masks of *nested* generics reached
through `visit_application` into the session cache (with a cycle-collision write
gate). That broke variance for mapped-type / indexed-access defs whose masks
carry the inherited, context-sensitive `NEEDS_STRUCTURAL_FALLBACK` /
`REJECTION_UNRELIABLE` bits. It was reverted. The remaining top-level caching is
the subset proven sound and byte-identical. A follow-up could re-enable nested
caching **only for masks that carry none of those context-sensitive flags and
saw zero cycle truncation** (a clean covariant/contravariant/invariant/
independent mask is a pure function of the body); that refinement is documented
here, not shipped.

## Project Corpus Impact

- Row: large-ts-repo (~4893 TS files, `tsconfig.flat.bench.json`)
- Bug family: super-linear cross-file generic resolution (issue #7574). On the
  `packages/platform` subset the dominant cost profiled to
  `VarianceComputer::compute_def_variances` →
  `VarianceVisitor`/`resolve_lazy` over the shared `@shared/*` generic graph
  (sampled hot leaves: `resolve_lazy` 326, `compute_def_variances` chains,
  `RecursionGuard::enter` 1173), **not** the `export =`/alias resolver the
  issue thread previously named.
- Before/after timing: the `platform` subset and its sub-combos still time out
  (>120–180s) both before and after this change. **This PR does not break the
  large-ts-repo wall.** The wall is the *cold* deep variance walk over the
  shared generic graph, which top-level `DefId` memoization does not reduce
  (each distinct generic is still walked once, deeply). Evidence the cost is
  variance: sampled call tree
  `validate_type_reference_type_arguments → extract_declared_type_params_for_reference_symbol → push_type_parameters → compute_def_variances → … → visit_application → compute_def_variances`.
- This change is landed as a **sound, behavior-preserving consolidation** that
  closes the checker-assignability bypass and removes five copies of the
  cache-or-compute dance, not as the wall-breaker. The wall-breaker needs the
  flag-gated nested cache (above) or a structural variance-walk change.

## Verification

- `TSZ_DISABLE_VARIANCE_CACHE=1` vs default on a completing platform sub-config:
  byte-identical sorted diagnostics.
- `cargo nextest run -p tsz-solver -E 'test(variance)'`: 162 passed.
- New `variance_session_cache_parity_tests`: 4 passed (cold/warm + name-agnostic
  + alias-wrapped + contravariant).
- `cargo clippy -p tsz-solver --all-targets`: clean.
- Note: this worktree's base (`#11968`) has **pre-existing** unit-test failures
  (e.g. `test_bivariant_relation_boundary_preserves_overflow_flags`,
  `mapped_application_generic_indexed_call_preserves_key_correlation`) and a
  pre-existing `clippy::question_mark` error in untouched
  `query_boundaries/class.rs`. These reproduce with this PR's changes stashed,
  so they are not introduced here; ready-for-review CI on a clean base is the
  authoritative gate.

## Coordination Notes

- Builds on the cross-file throughput effort in #7574 and the
  redundant-work removal in #11968 (merged).
- Complementary to #11931 (alias/`export=` cache) — different layer (variance vs
  alias resolution); does not subsume it.
- Does not touch the #11879 `clear_resolution_caches` invalidation surface: the
  `variance_cache` it reuses is an existing session cache already cleared with
  the query database's lifecycle, so no new invalidation site is introduced.
- Draft: this is the sound, landable slice. Kept draft pending CI on a clean
  base and a decision on whether to pursue the flag-gated nested-cache
  follow-up.
- No canonical agent lane was assigned; `M1Opus48-exporttable` is retained as
  runner metadata only until the work is adopted by a canonical owner.
