### PR TITLE
fix(emit): keep trailing comments after brace bodies

### DIFF
--- a/crates/tsz-emitter/src/emitter/comments/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/comments/helpers.rs
@@ -114,13 +114,19 @@ impl<'a> Printer<'a> {
     /// duplicate emission when the leading comment scanner has already advanced
     /// `comment_emit_idx` past a comment.
     pub(in crate::emitter) fn emit_trailing_comments(&mut self, end_pos: u32) {
-        self.emit_trailing_comments_impl(end_pos, u32::MAX);
+        self.emit_trailing_comments_impl(
+            end_pos,
+            self.trailing_comment_scan_max_pos.unwrap_or(u32::MAX),
+        );
     }
 
     /// Like `emit_trailing_comments` but only emit comments whose start position
     /// is before `max_pos`. Used to prevent a statement inside a block from
     /// consuming comments that belong on the block's closing line.
     pub(in crate::emitter) fn emit_trailing_comments_before(&mut self, end_pos: u32, max_pos: u32) {
+        let max_pos = self
+            .trailing_comment_scan_max_pos
+            .map_or(max_pos, |cap| cap.min(max_pos));
         self.emit_trailing_comments_impl(end_pos, max_pos);
     }
 

--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -619,6 +619,11 @@ pub struct Printer<'a> {
     /// to an owning semicolon when the source semicolon follows the arrow body.
     pub(crate) arrow_concise_body_trailing_comment_defer_range: Option<(u32, u32)>,
 
+    /// Upper source bound for trailing comments while emitting a nested
+    /// statement. Single-line function bodies use this to keep comments after
+    /// the closing brace from being claimed by the last body statement.
+    pub(crate) trailing_comment_scan_max_pos: Option<u32>,
+
     /// When true, suppress namespace identifier qualification (emitting a declaration name).
     pub(crate) suppress_ns_qualification: bool,
 

--- a/crates/tsz-emitter/src/emitter/core_setup.rs
+++ b/crates/tsz-emitter/src/emitter/core_setup.rs
@@ -335,6 +335,7 @@ impl<'a> Printer<'a> {
             suppress_ns_qualification: false,
             suppress_commonjs_named_import_substitution: false,
             arrow_concise_body_trailing_comment_defer_range: None,
+            trailing_comment_scan_max_pos: None,
             pending_class_field_inits: Vec::new(),
             pending_auto_accessor_inits: Vec::new(),
             next_auto_accessor_name_index: 0,

--- a/crates/tsz-emitter/src/emitter/declarations/class_members.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class_members.rs
@@ -1058,7 +1058,13 @@ impl<'a> Printer<'a> {
             self.map_opening_brace(block_node);
             self.write("{ ");
             let var_insert_pos = self.writer.len();
+            let block_close_pos = self
+                .find_block_closing_brace_end(block_node)
+                .saturating_sub(1);
+            let previous_trailing_comment_scan_max = self.trailing_comment_scan_max_pos;
+            self.trailing_comment_scan_max_pos = Some(block_close_pos);
             self.emit(block.statements.nodes[0]);
+            self.trailing_comment_scan_max_pos = previous_trailing_comment_scan_max;
             // A `??=` read-cache temp (or optional-chaining temp) can be created
             // while emitting the single statement; declare it inline so the body
             // stays runnable instead of referencing an undeclared `_a`.

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -199,6 +199,7 @@ impl<'a> Printer<'a> {
             }
             self.map_opening_brace(node);
             self.write("{ ");
+            let block_close_pos = self.find_block_closing_brace_end(node).saturating_sub(1);
             let var_insert_pos = if is_function_body_block {
                 Some(self.writer.len())
             } else {
@@ -208,7 +209,10 @@ impl<'a> Printer<'a> {
                 if si > 0 {
                     self.write(" ");
                 }
+                let previous_trailing_comment_scan_max = self.trailing_comment_scan_max_pos;
+                self.trailing_comment_scan_max_pos = Some(block_close_pos);
                 self.emit(stmt_idx);
+                self.trailing_comment_scan_max_pos = previous_trailing_comment_scan_max;
             }
             // Inject hoisted temp vars inline for single-line function bodies.
             // Temps like `_a` are created during emit (e.g. optional chaining
@@ -1826,7 +1830,10 @@ impl<'a> Printer<'a> {
         };
 
         let bytes = text.as_bytes();
-        let stmt_end = std::cmp::min(range_end as usize, bytes.len());
+        let capped_range_end = self
+            .trailing_comment_scan_max_pos
+            .map_or(range_end, |cap| cap.min(range_end));
+        let stmt_end = std::cmp::min(capped_range_end as usize, bytes.len());
         let stmt_start = range_start as usize;
 
         // Scan forwards and keep the last outermost semicolon within this node's range.
@@ -1851,6 +1858,11 @@ impl<'a> Printer<'a> {
         if let Some(pos) = semi_pos {
             let comments = get_trailing_comment_ranges(text, pos);
             for comment in comments {
+                if let Some(max_pos) = self.trailing_comment_scan_max_pos
+                    && comment.pos >= max_pos
+                {
+                    break;
+                }
                 self.write_space();
                 if let Ok(comment_text) =
                     safe_slice::slice(text, comment.pos as usize, comment.end as usize)

--- a/crates/tsz-emitter/tests/comment_tests.rs
+++ b/crates/tsz-emitter/tests/comment_tests.rs
@@ -87,6 +87,70 @@ fn object_literal_accessor_leading_comment_stays_before_accessor() {
 }
 
 #[test]
+fn trailing_comment_after_single_line_method_body_stays_after_body() {
+    let source = r#"class C {
+    set value(v: number) { this._value = v; } // error
+}
+
+const o = {
+    run() { this.count++; } // note
+};"#;
+
+    let output = parse_and_print(source);
+
+    assert!(
+        output.contains("set value(v) { this._value = v; } // error"),
+        "Class accessor body trailing comment must stay after the body close.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("this._value = v; // error }"),
+        "Class accessor body must not absorb the following line comment.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("run() { this.count++; } // note"),
+        "Object method body trailing comment must stay after the body close.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("this.count++; // note }"),
+        "Object method body must not absorb the following line comment.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn trailing_comment_after_arrow_block_statement_stays_after_call() {
+    let source = r#"class Derived extends Base {
+    constructor() {
+        super(() => { this._t; }); // keep
+    }
+}"#;
+
+    let output = parse_and_print(source);
+
+    assert!(
+        output.contains("super(() => { this._t; }); // keep"),
+        "Trailing comment after a call with an arrow block must stay on the call statement.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("this._t; // keep }"),
+        "Arrow block body must not absorb the following call-statement comment.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn same_line_statement_trailing_comment_still_stays_on_statement() {
+    let source = r#"function f() {
+    let x = 1; // inside
+}"#;
+
+    let output = parse_and_print(source);
+
+    assert!(
+        output.contains("let x = 1; // inside"),
+        "Statement-owned trailing comments must still be preserved.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn object_literal_property_comments_stay_around_function_value() {
     let source = r#"var Person = makeClass(
    {


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Emit parity bug fix for JavaScript comment placement.

## Invariant
When a trailing line comment appears after the closing brace of a single-line brace body, the inner final statement must not claim that comment; this PR changes emitter trailing-comment scan bounds for nested single-line body emission.

## Scope
- `crates/tsz-emitter/src/emitter/comments/helpers.rs`
- `crates/tsz-emitter/src/emitter/statements/core.rs`
- `crates/tsz-emitter/src/emitter/declarations/class_members.rs`
- `crates/tsz-emitter/src/emitter/core.rs`
- `crates/tsz-emitter/src/emitter/core_setup.rs`
- `crates/tsz-emitter/tests/comment_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit trailing line-comment placement after brace-delimited bodies
- Evidence: Focused emit filters for issue #11999 now pass locally: `accessorsOverrideProperty`, `constAssertions`, and `superCallBeforeThisAccessing2`.

## Verification
- `cargo fmt --check --package tsz-emitter`
- `cargo nextest run -p tsz-emitter --test comment_tests trailing_comment_after_single_line_method_body_stays_after_body trailing_comment_after_arrow_block_statement_stays_after_call same_line_statement_trailing_comment_still_stays_on_statement`
- `scripts/emit/run.sh --filter=accessorsOverrideProperty --js-only --verbose --timeout=20000 --concurrency=4 --json-out=/tmp/tsz-emit-accessors-after-rebase.json`
- `scripts/emit/run.sh --filter=constAssertions --js-only --verbose --timeout=20000 --concurrency=4 --json-out=/tmp/tsz-emit-constAssertions-after-rebase.json`
- `scripts/emit/run.sh --filter=superCallBeforeThisAccessing2 --js-only --verbose --timeout=20000 --concurrency=4 --json-out=/tmp/tsz-emit-superCall-after-rebase.json`
- `git diff --check`

## Coordination Notes
- Fixes #11999.
- No docs or roadmap files changed.
- Checked open PRs before publishing; no overlap found for this trailing-comment body ownership fix.
- `scripts/agents/ensure-agent-labels.sh --audit` currently reports unrelated PR #12002 missing an agent label; this PR uses `agent:Studio-A`.
- Baseline note: three existing property/optional-access comment unit tests fail on clean `HEAD` before this patch; they are unrelated to this scoped body trailing-comment fix.
