### PR TITLE
perf(checker): admit lib declaration provenance

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib.rs
@@ -53,6 +53,25 @@ pub(super) fn iterator_object_has_global_augmentations(
 }
 
 impl<'a> CheckerState<'a> {
+    fn symbol_has_builtin_lib_declaration_provenance(
+        &self,
+        sym_id: SymbolId,
+        symbol: &tsz_binder::Symbol,
+        delegate_arena: &NodeArena,
+    ) -> bool {
+        !symbol.declarations.is_empty()
+            && symbol.declarations.iter().all(|&decl_idx| {
+                if let Some(arenas) = self.ctx.binder.declaration_arenas.get(&(sym_id, decl_idx)) {
+                    return !arenas.is_empty()
+                        && arenas
+                            .iter()
+                            .all(|arena| is_builtin_lib_declaration_arena(arena.as_ref()));
+                }
+
+                is_builtin_lib_declaration_arena(delegate_arena)
+            })
+    }
+
     pub(super) fn direct_builtin_lib_interface_symbol_type(
         &mut self,
         sym_id: SymbolId,
@@ -60,15 +79,20 @@ impl<'a> CheckerState<'a> {
         delegate_arena: Option<&NodeArena>,
         needs_cross_file_delegation: bool,
     ) -> Option<(TypeId, Vec<TypeParamInfo>)> {
+        let delegate_arena = delegate_arena?;
         if needs_cross_file_delegation
             || delegate_arena_source != CrossArenaSymbolMissSource::SymbolArena
-            || !delegate_arena.is_some_and(is_builtin_lib_declaration_arena)
-            || !self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id)
+            || !is_builtin_lib_declaration_arena(delegate_arena)
         {
             return None;
         }
 
         let symbol = self.get_cross_file_symbol(sym_id)?.clone();
+        if !self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id)
+            && !self.symbol_has_builtin_lib_declaration_provenance(sym_id, &symbol, delegate_arena)
+        {
+            return None;
+        }
         if symbol.flags & symbol_flags::INTERFACE == 0
             || symbol.flags
                 & (symbol_flags::VALUE
@@ -107,15 +131,20 @@ impl<'a> CheckerState<'a> {
         delegate_arena: Option<&NodeArena>,
         needs_cross_file_delegation: bool,
     ) -> Option<(TypeId, Vec<TypeParamInfo>)> {
+        let delegate_arena = delegate_arena?;
         if needs_cross_file_delegation
             || delegate_arena_source != CrossArenaSymbolMissSource::SymbolArena
-            || !delegate_arena.is_some_and(is_dom_builtin_lib_declaration_arena)
-            || !self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id)
+            || !is_dom_builtin_lib_declaration_arena(delegate_arena)
         {
             return None;
         }
 
         let symbol = self.get_cross_file_symbol(sym_id)?.clone();
+        if !self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id)
+            && !self.symbol_has_builtin_lib_declaration_provenance(sym_id, &symbol, delegate_arena)
+        {
+            return None;
+        }
         let has_value_interface =
             symbol.flags & symbol_flags::INTERFACE != 0 && symbol.flags & symbol_flags::VALUE != 0;
         if !has_value_interface

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs
@@ -184,6 +184,65 @@ fn direct_cross_file_interface_lowering_handles_simple_builtin_dom_interfaces() 
 }
 
 #[test]
+fn direct_builtin_dom_interface_uses_declaration_provenance_without_lib_symbol_flag() {
+    let lib_files = load_lib_files(&["es5.d.ts", "dom.d.ts"]);
+    let mut parser = ParserState::new("fixture.ts".to_string(), "let value;".to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file_with_libs(parser.get_arena(), root, &lib_files);
+    Arc::make_mut(&mut binder.lib_symbol_ids).clear();
+    let arena = Arc::new(parser.get_arena().clone());
+    let binder = Arc::new(binder);
+    let types = TypeInterner::new();
+    let ctx = CheckerContext::new(
+        arena.as_ref(),
+        binder.as_ref(),
+        &types,
+        "fixture.ts".to_string(),
+        CheckerOptions::default(),
+    );
+    let mut state = CheckerState { ctx };
+    let lib_contexts: Vec<LibContext> = lib_files
+        .iter()
+        .map(|lib| LibContext {
+            arena: Arc::clone(&lib.arena),
+            binder: Arc::clone(&lib.binder),
+        })
+        .collect();
+    state.ctx.set_lib_contexts(lib_contexts);
+
+    let sym_id = state
+        .ctx
+        .binder
+        .file_locals
+        .get("PaymentCurrencyAmount")
+        .expect("PaymentCurrencyAmount should resolve to a dom lib symbol");
+    let delegate_arena = state
+        .ctx
+        .binder
+        .symbol_arenas
+        .get(&sym_id)
+        .map(std::convert::AsRef::as_ref)
+        .expect("PaymentCurrencyAmount should have a delegate arena");
+    assert!(
+        !state.ctx.symbol_is_from_actual_or_cloned_lib(sym_id),
+        "test setup should exercise declaration-provenance fallback",
+    );
+
+    let (direct_type, params) = state
+        .direct_builtin_lib_interface_symbol_type(
+            sym_id,
+            CrossArenaSymbolMissSource::SymbolArena,
+            Some(delegate_arena),
+            false,
+        )
+        .expect("builtin DOM declaration provenance should admit the direct lib path");
+    assert_ne!(direct_type, TypeId::UNKNOWN);
+    assert_ne!(direct_type, TypeId::ERROR);
+    assert!(params.is_empty());
+}
+
+#[test]
 fn direct_builtin_dom_member_batch_resolves_actual_lib_property_refs() {
     let lib_files = load_lib_files(&["es5.d.ts", "dom.d.ts"]);
     let mut parser = ParserState::new("fixture.ts".to_string(), "let value;".to_string());


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 performance/cache-residency; green-row Vite cross-arena direct actual-lib fast path.

## Invariant
When a delegated interface symbol's declaration arenas prove builtin library provenance, tsz can use the existing direct builtin-lib interface construction path even if the cloned-lib symbol marker is absent. The owning layer is checker orchestration over binder provenance facts: this does not compute new type semantics, and all unsupported shapes fall back to the normal cross-file symbol path.

## Structural Rule
A symbol-arena delegate is eligible for direct builtin-lib interface lowering only when every known declaration arena for the symbol is a builtin lib declaration arena, or the declaration-arena table is missing for that declaration and the delegate arena itself is a builtin lib declaration arena. The existing guards still require no cross-file delegation, builtin or DOM builtin arena identity, no external package/local augmentation evidence, and no value/interface shape that the direct path cannot safely lower.

## Adjacent-Case Matrix
- Builtin DOM interface symbols with a present `lib_symbol_ids` marker continue through the existing direct path.
- Builtin DOM interface symbols whose declaration arenas prove lib provenance but whose `lib_symbol_ids` marker is absent now use the same direct path.
- Non-builtin delegates, locally augmented globals, value-merged shapes outside the existing DOM value/interface path, and symbols with mixed or missing non-lib provenance still fall back to normal cross-file resolution.

## Scope
- Relax direct builtin-lib interface admission in `crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib.rs` to accept declaration-arena provenance as a fallback to `symbol_is_from_actual_or_cloned_lib`.
- Add a unit test in `crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs` that clears the lib-symbol marker and proves DOM declaration provenance still admits the direct path for a lib interface.

## Project Corpus Impact
- Row: `vite-vanilla-ts-app`
- Bug family: cross-arena delegation overhead / generated app lib identity
- Correctness status: green row in the current target-gap report; this PR is a counter-driven speed slice, not a diagnostic fix.
- Evidence: current-main report `/private/tmp/studio-b-current-main-green-gaps-with-row-attribution-20260601.tsgo-winners.json` still shows `vite-vanilla-ts-app` below the 2x target. Current-main Vite attribution `/private/tmp/studio-b-vite-current-main-after-sync-20260531.perf.txt` shows `CheckerState::new=4`, `with_parent_cache=394`, and `DelegateCrossArenaSymbol` misses dominated by declaration-file symbol arenas (`.d.ts/.d.cts/.d.mts=391`, `interface=263`, `type_alias=127`). This PR targets the interface portion by admitting proven builtin-lib declaration provenance into the existing direct actual-lib interface path.

## Verification
- Local: `cargo fmt --check`
- Local: `git diff --check`
- Local: `cargo check -p tsz-checker --tests`
- CI light at head `083e5bb3bfc0588258b65636fa430a92ccf085f7`: `lint`, `unit`, `unit-cloudbuild`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `CI Light Summary`, `GitGuardian Security Checks` all passed.
- Local targeted `cargo nextest run -p tsz-checker -E 'test(direct_builtin_dom_interface_uses_declaration_provenance_without_lib_symbol_flag) | test(direct_cross_file_interface_lowering_handles_simple_builtin_dom_interfaces) | test(direct_builtin_dom_member_batch_resolves_actual_lib_property_refs)'` was attempted before CI; it compiled but failed while linking the test binary with `No space left on device`. I removed only the freshly-created current-worktree `.target` afterward and preserved `.target-bench` plus the shared TypeScript submodule. CI `unit` now covers the linked unit-test run.

## Performance Evidence
- Measurement mode: attribution/counter-driven only for this PR; no timing-mode after artifact is claimed yet.
- Before artifact: `/private/tmp/studio-b-current-main-green-gaps-with-row-attribution-20260601.tsgo-winners.json` for target gaps and `/private/tmp/studio-b-vite-current-main-after-sync-20260531.perf.txt` for Vite counters.
- Expected complexity effect: reduce repeated cross-arena interface-symbol delegation for builtin declaration-file interfaces by admitting a structural provenance proof into the existing direct path.
- Known noise/source of missing evidence: fresh timing should be captured after ready-review CI proves the change and a release/bench binary is available.

## Coordination Notes
- Existing Studio-B PR #12000 was merged first; owned PR list showed only this PR before this body refresh.
- Open-PR overlap checked before publish. The nearby M4-D alias/export cache PR is broader and remains draft; this PR is limited to direct builtin-lib interface provenance.
- Marking ready after light CI passed for head `083e5bb3bfc0588258b65636fa430a92ccf085f7`; heavy ready-review gates are expected next.
