### PR TITLE
chore(emit-tools): expose output surgery status

### DIFF
--- a/scripts/emit/audit-output-surgery.py
+++ b/scripts/emit/audit-output-surgery.py
@@ -349,6 +349,7 @@ def build_json_report(
     return {
         "ok": not failures,
         "status": "failed" if failures else "passed",
+        "output_surgery_status": "failed" if failures else "passed",
         "total_findings": len(findings),
         "files_with_findings": len(counts),
         "allowlisted_calls": budget.allowlisted_calls,

--- a/scripts/emit/test_output_surgery_audit.py
+++ b/scripts/emit/test_output_surgery_audit.py
@@ -81,6 +81,7 @@ class OutputSurgeryAuditTests(unittest.TestCase):
 
         self.assertFalse(report["ok"])
         self.assertEqual(report["status"], "failed")
+        self.assertEqual(report["output_surgery_status"], "failed")
         self.assertEqual(report["total_findings"], 2)
         self.assertEqual(report["files_with_findings"], 2)
         self.assertEqual(report["allowlisted_calls"], 1)
@@ -148,6 +149,7 @@ class OutputSurgeryAuditTests(unittest.TestCase):
 
         self.assertTrue(report["ok"])
         self.assertEqual(report["status"], "passed")
+        self.assertEqual(report["output_surgery_status"], "passed")
         self.assertEqual(report["failures"], [])
 
     def test_pass_summary_names_clean_guardrail_counters(self):


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / cheap evidence plumbing

## Invariant
When `scripts/emit/audit-output-surgery.py --json-report` writes machine-readable evidence, the report exposes a named `output_surgery_status` field that mirrors the generic pass/fail status so automation can identify the audit gate without interpreting a bare `status` field.

## Scope
- Add `output_surgery_status` to the output-surgery JSON report.
- Ratchet focused output-surgery audit tests for both passing and failing reports.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: emit-tooling-only JSON report shape; no compiler, parser, checker, solver, emit output, or project-corpus behavior changes.

## Verification
- `python3 -m unittest scripts.emit.test_output_surgery_audit`
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery-status.json`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-audit-output-status.json`

## Coordination Notes
- Studio-F owned PR runway was clear before this PR.
- Label audit is passing; #12002 and #12007 remain explicitly intentionally unassigned generated-runner drafts.
- This complements the named-status fields already present in the Studio-F start-cycle evidence reports.