### PR TITLE
refactor(solver): name subtype cache policy projection

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/helpers.rs
+++ b/crates/tsz-solver/src/relations/subtype/helpers.rs
@@ -215,6 +215,16 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// vs lax, with/without weak-type suppression, etc.) cannot
     /// contaminate each other.
     pub(crate) fn make_cache_key(&self, source: TypeId, target: TypeId) -> RelationCacheKey {
+        RelationCacheKey::for_subtype(
+            source,
+            target,
+            self.cache_policy()
+                .cache_config_with_cached_any_mode(self.effective_cached_any_mode()),
+        )
+    }
+
+    /// Project this checker's behavior-affecting relation modes to a policy.
+    fn cache_policy(&self) -> RelationPolicy {
         let mut flags = RelationFlags::empty();
         if self.strict_null_checks {
             flags |= RelationFlags::STRICT_NULL_CHECKS;
@@ -256,28 +266,23 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             flags |= RelationFlags::ASSUME_RELATED_ON_CYCLE;
         }
 
-        // CRITICAL: Calculate effective `any_mode` based on depth.
+        RelationPolicy::from_relation_flags(flags)
+            .with_any_propagation_mode(self.any_propagation)
+            .with_assume_related_on_cycle(self.assume_related_on_cycle)
+    }
+
+    /// Resolve depth-sensitive `any` propagation to the cache-key mode.
+    const fn effective_cached_any_mode(&self) -> CachedAnyMode {
         // If `any_propagation` is `TopLevelOnly` but `depth > 0`, the
-        // effective mode is nested (any suppression disabled). This ensures
-        // that top-level checks don't incorrectly hit cached results from
-        // nested checks.
-        let any_mode = match self.any_propagation {
+        // effective mode is nested so top-level checks cannot hit cached
+        // nested answers.
+        match self.any_propagation {
             AnyPropagationMode::All => CachedAnyMode::All,
             AnyPropagationMode::TopLevelOnly if self.guard.depth() == 0 => {
                 CachedAnyMode::TopLevelOnlyAtTop
             }
             AnyPropagationMode::TopLevelOnly => CachedAnyMode::TopLevelOnlyNested,
-        };
-
-        let policy = RelationPolicy::from_relation_flags(flags)
-            .with_any_propagation_mode(self.any_propagation)
-            .with_assume_related_on_cycle(self.assume_related_on_cycle);
-
-        RelationCacheKey::for_subtype(
-            source,
-            target,
-            policy.cache_config_with_cached_any_mode(any_mode),
-        )
+        }
     }
 
     /// Test-only accessor that exposes the cache key this checker would use

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -21,3 +21,6 @@ mod kind_partitioning;
 
 #[path = "relation_policy_cache_agreement_tests/policy_config.rs"]
 mod policy_config;
+
+#[path = "relation_policy_cache_agreement_tests/subtype_policy_projection.rs"]
+mod subtype_policy_projection;

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/subtype_policy_projection.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/subtype_policy_projection.rs
@@ -1,0 +1,76 @@
+//! Subtype-checker cache policy projection tests.
+
+use crate::intern::TypeInterner;
+use crate::relations::relation_queries::RelationPolicy;
+use crate::relations::subtype::{AnyPropagationMode, SubtypeChecker};
+use crate::types::{CachedAnyMode, RelationCacheKey, RelationFlags, TypeId};
+
+#[test]
+fn subtype_cache_key_uses_named_policy_projection_helpers() {
+    let source = include_str!("../../src/relations/subtype/helpers.rs");
+    let make_cache_key = source
+        .split_once("pub(crate) fn make_cache_key")
+        .and_then(|(_, rest)| rest.split_once("/// Project this"))
+        .map(|(body, _)| body)
+        .expect("expected `SubtypeChecker::make_cache_key` before `cache_policy` helper");
+
+    assert!(
+        source.contains("fn cache_policy(") && make_cache_key.contains("self.cache_policy()"),
+        "`SubtypeChecker::make_cache_key` should delegate policy construction to a named helper",
+    );
+    assert!(
+        source.contains("fn effective_cached_any_mode(")
+            && make_cache_key.contains("self.effective_cached_any_mode()"),
+        "`SubtypeChecker::make_cache_key` should delegate depth-sensitive any-mode projection",
+    );
+}
+
+#[test]
+fn subtype_cache_key_matches_equivalent_relation_policy_projection() {
+    let interner = TypeInterner::new();
+    let source = TypeId::STRING;
+    let target = TypeId::NUMBER;
+    let mut checker = SubtypeChecker::new(&interner)
+        .with_any_propagation_mode(AnyPropagationMode::TopLevelOnly)
+        .with_assume_related_on_cycle(false);
+    checker.strict_null_checks = true;
+    checker.strict_function_types = true;
+    checker.exact_optional_property_types = true;
+    checker.strict_readonly_identity = true;
+    checker.no_unchecked_indexed_access = true;
+    checker.disable_method_bivariance = true;
+    checker.allow_void_return = true;
+    checker.allow_bivariant_rest = true;
+    checker.allow_bivariant_param_count = true;
+    checker.erase_generics = false;
+    checker.allow_erased_generic_signature_retry = true;
+    checker.in_callback_param_check = true;
+
+    let expected_flags = RelationFlags::STRICT_NULL_CHECKS
+        | RelationFlags::STRICT_FUNCTION_TYPES
+        | RelationFlags::EXACT_OPTIONAL_PROPERTY_TYPES
+        | RelationFlags::NO_UNCHECKED_INDEXED_ACCESS
+        | RelationFlags::DISABLE_METHOD_BIVARIANCE
+        | RelationFlags::ALLOW_VOID_RETURN
+        | RelationFlags::ALLOW_BIVARIANT_REST
+        | RelationFlags::ALLOW_BIVARIANT_PARAM_COUNT
+        | RelationFlags::NO_ERASE_GENERICS
+        | RelationFlags::ALLOW_ERASED_GENERIC_SIGNATURE_RETRY
+        | RelationFlags::IN_CALLBACK_PARAM_CHECK
+        | RelationFlags::STRICT_READONLY_IDENTITY;
+    let expected_policy = RelationPolicy::from_relation_flags(expected_flags)
+        .with_any_propagation_mode(AnyPropagationMode::TopLevelOnly)
+        .with_assume_related_on_cycle(false);
+
+    let key = checker.debug_cache_key_for(source, target);
+
+    assert_eq!(
+        key,
+        RelationCacheKey::for_subtype(
+            source,
+            target,
+            expected_policy.cache_config_with_cached_any_mode(CachedAnyMode::TopLevelOnlyAtTop),
+        ),
+        "equivalent `SubtypeChecker` and `RelationPolicy` configurations must share one cache key",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track: solver relation policy/cache-key protocols; small #8207 refactor and ratchet.

## Invariant
When `SubtypeChecker` derives a relation cache key, its behavior-affecting configuration must project through the same typed `RelationPolicy` model used by solver relation queries; this PR names the subtype cache policy and effective-any-mode projection without changing relation semantics.

## Scope
- `crates/tsz-solver/src/relations/subtype/helpers.rs`
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs`
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests/subtype_policy_projection.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor/test-only cache-key contract slice; no compiler behavior path or project fixture behavior intentionally changed.

## Verification
- `cargo nextest run -p tsz-solver -E 'test(subtype_cache_key)'` — 2 passed / 6451 skipped on rebased head `ca17e42839`
- `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'` — 36 passed / 6417 skipped on rebased head `ca17e42839`
- `cargo clippy -p tsz-solver --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- file-size check: new shard 76 lines; touched helper 641 lines

## Coordination Notes
- Supports #8207 by shrinking the ad-hoc subtype cache-key projection surface around typed `RelationPolicy`.
- Avoids #12002 variance/session-cache work and M1-B checker relation-routing / RelationRequest work.
- Rebased on current `origin/main` and pushed head `ca17e42839` after fixing the CI lint failure (`missing_const_for_fn`). Waiting on exact-head PR CI before any merge-queue consideration.