### PR TITLE
fix(emit): lower async ES5 spread before for-await

### DIFF
--- a/crates/tsz-emitter/src/transforms/async_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir.rs
@@ -2255,8 +2255,18 @@ impl<'a> AsyncES5Transformer<'a> {
         {
             let name = super::emit_utils::identifier_text_or_empty(self.arena, expression);
             if !name.is_empty() {
-                let iterator_name = format!("{name}_{env_id}");
-                return (iterator_name.clone(), format!("{iterator_name}_1"));
+                let mut ordinal = env_id;
+                loop {
+                    let iterator_name = format!("{name}_{ordinal}");
+                    let result_name = format!("{iterator_name}_1");
+                    let mut blocked = self.blocked_temp_names.borrow_mut();
+                    if !blocked.contains(&iterator_name) && !blocked.contains(&result_name) {
+                        blocked.insert(iterator_name.clone());
+                        blocked.insert(result_name.clone());
+                        return (iterator_name, result_name);
+                    }
+                    ordinal += 1;
+                }
             }
         }
         (self.generate_hoisted_temp(), self.generate_hoisted_temp())

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_calls.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_calls.rs
@@ -1187,7 +1187,7 @@ impl<'a> AsyncES5Transformer<'a> {
         }
     }
 
-    fn args_contain_spread(&self, args: &[NodeIndex]) -> bool {
+    pub(in crate::transforms) fn args_contain_spread(&self, args: &[NodeIndex]) -> bool {
         args.iter().any(|&arg| self.is_spread_arg(arg))
     }
 
@@ -1233,7 +1233,7 @@ impl<'a> AsyncES5Transformer<'a> {
         })
     }
 
-    fn is_spread_arg(&self, arg: NodeIndex) -> bool {
+    pub(in crate::transforms) fn is_spread_arg(&self, arg: NodeIndex) -> bool {
         self.arena
             .get(arg)
             .is_some_and(|node| node.kind == syntax_kind_ext::SPREAD_ELEMENT)

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_cases.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_cases.rs
@@ -16,6 +16,7 @@ impl AsyncES5Transformer<'_> {
             std::mem::take(&mut *self.planned_catch_binding_temps.borrow_mut());
         self.reset_temp_name_reservations(body_idx);
         self.plan_catch_binding_temps(body_idx);
+        self.plan_body_level_helpers(body_idx);
         let mut cases = Vec::new();
         let mut current_statements = Vec::new();
         let mut current_label = self.state.next_label();
@@ -60,6 +61,15 @@ impl AsyncES5Transformer<'_> {
             value: None,
             comment: Some("return".to_string().into()),
         })))
+    }
+
+    fn plan_body_level_helpers(&mut self, body_idx: NodeIndex) {
+        if self.contains_for_await_recursive(body_idx) {
+            self.helpers_needed.mark_async_values();
+        }
+        if self.contains_array_spread_recursive(body_idx) {
+            self.helpers_needed.mark_spread_array();
+        }
     }
 
     fn plan_catch_binding_temps(&self, idx: NodeIndex) {

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_convert.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_convert.rs
@@ -270,6 +270,9 @@ impl<'a> AsyncES5Transformer<'a> {
 
             k if k == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION => {
                 if let Some(arr) = self.arena.get_literal_expr(node) {
+                    if self.args_contain_spread(&arr.elements.nodes) {
+                        return self.array_spread_literal_to_ir(&arr.elements.nodes);
+                    }
                     let elements: Vec<IRNode> = arr
                         .elements
                         .nodes
@@ -462,6 +465,55 @@ impl<'a> AsyncES5Transformer<'a> {
 
             _ => IRNode::ASTRef(idx),
         }
+    }
+
+    fn array_spread_literal_to_ir(&self, elements: &[NodeIndex]) -> IRNode {
+        let mut current = IRNode::ArrayLiteral(Vec::new());
+        let mut segment = Vec::new();
+
+        for &element in elements {
+            if self.is_spread_arg(element) {
+                if !segment.is_empty() {
+                    current = Self::spread_array_call_ir(
+                        current,
+                        IRNode::ArrayLiteral(std::mem::take(&mut segment)),
+                        false,
+                    );
+                }
+                current = Self::spread_array_call_ir(
+                    current,
+                    self.spread_expression_operand_to_ir(element),
+                    true,
+                );
+            } else {
+                segment.push(self.expression_to_ir(element));
+            }
+        }
+
+        if !segment.is_empty() {
+            current = Self::spread_array_call_ir(current, IRNode::ArrayLiteral(segment), false);
+        }
+
+        current
+    }
+
+    fn spread_array_call_ir(to: IRNode, from: IRNode, pack: bool) -> IRNode {
+        IRNode::CallExpr {
+            callee: Box::new(IRNode::RuntimeHelper("__spreadArray".into())),
+            arguments: vec![to, from, IRNode::BooleanLiteral(pack)],
+        }
+    }
+
+    fn spread_expression_operand_to_ir(&self, element: NodeIndex) -> IRNode {
+        if let Some(node) = self.arena.get(element) {
+            if let Some(spread) = self.arena.get_spread(node) {
+                return self.expression_to_ir(spread.expression);
+            }
+            if let Some(spread) = self.arena.get_unary_expr_ex(node) {
+                return self.expression_to_ir(spread.expression);
+            }
+        }
+        self.expression_to_ir(element)
     }
 
     fn is_type_erasure_expression(&self, idx: NodeIndex) -> bool {

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_discovery.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_discovery.rs
@@ -10,6 +10,7 @@
 
 use super::AsyncES5Transformer;
 use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::node_flags;
 use tsz_parser::parser::syntax_kind_ext;
 
@@ -39,6 +40,58 @@ impl AsyncES5Transformer<'_> {
     /// Check if a function body contains any await expressions
     pub fn body_contains_await(&self, body_idx: NodeIndex) -> bool {
         self.contains_await_recursive(body_idx)
+    }
+
+    pub(super) fn contains_for_await_recursive(&self, idx: NodeIndex) -> bool {
+        let Some(node) = self.arena.get(idx) else {
+            return false;
+        };
+
+        if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
+            || node.is_function_expression_or_arrow()
+            || node.kind == syntax_kind_ext::CLASS_DECLARATION
+            || node.kind == syntax_kind_ext::CLASS_EXPRESSION
+        {
+            return false;
+        }
+
+        if node.kind == syntax_kind_ext::FOR_OF_STATEMENT
+            && let Some(for_data) = self.arena.get_for_in_of(node)
+            && for_data.await_modifier
+        {
+            return true;
+        }
+
+        self.arena
+            .get_children(idx)
+            .into_iter()
+            .any(|child| self.contains_for_await_recursive(child))
+    }
+
+    pub(super) fn contains_array_spread_recursive(&self, idx: NodeIndex) -> bool {
+        let Some(node) = self.arena.get(idx) else {
+            return false;
+        };
+
+        if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
+            || node.is_function_expression_or_arrow()
+            || node.kind == syntax_kind_ext::CLASS_DECLARATION
+            || node.kind == syntax_kind_ext::CLASS_EXPRESSION
+        {
+            return false;
+        }
+
+        if node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
+            && let Some(array) = self.arena.get_literal_expr(node)
+            && self.args_contain_spread(&array.elements.nodes)
+        {
+            return true;
+        }
+
+        self.arena
+            .get_children(idx)
+            .into_iter()
+            .any(|child| self.contains_array_spread_recursive(child))
     }
 
     /// Walk the sub-tree at `idx` looking for any node the current

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_for_await.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_for_await.rs
@@ -39,19 +39,20 @@ impl<'a> AsyncES5Transformer<'a> {
 
         self.helpers_needed.mark_async_values();
 
-        let loop_guard_name = self.generate_hoisted_temp();
+        let has_pending_executable_statements = current_statements.iter().any(|statement| {
+            !matches!(
+                statement,
+                IRNode::VarDecl {
+                    initializer: None,
+                    ..
+                } | IRNode::HoistedVarGroupBreak
+            )
+        });
         let (iterator_name, result_name) = self.for_await_iterator_names(for_in_of.expression, 1);
         let catch_value_name = self.fresh_reserved_name("e_1_1");
 
         if let Some(loop_fn) = &captured_loop_fn {
             current_statements.push(IRNode::var_decl(loop_fn.clone(), None));
-        }
-        for name in [
-            loop_guard_name.as_str(),
-            iterator_name.as_str(),
-            result_name.as_str(),
-        ] {
-            current_statements.push(IRNode::var_decl(name.to_string(), None));
         }
         if declared_name.is_some() && captured_loop_fn.is_none() {
             current_statements.push(IRNode::var_decl(target_name.clone(), None));
@@ -63,7 +64,16 @@ impl<'a> AsyncES5Transformer<'a> {
         let error_name = self.fresh_reserved_name("e_1");
         let return_name = self.generate_hoisted_temp();
         let value_name = self.generate_hoisted_temp();
-        for name in [&done_name, &error_name, &return_name, &value_name] {
+        let loop_guard_name = self.generate_hoisted_temp();
+        for name in [
+            &done_name,
+            &error_name,
+            &return_name,
+            &value_name,
+            &loop_guard_name,
+            &iterator_name,
+            &result_name,
+        ] {
             current_statements.push(IRNode::var_decl(name.clone(), None));
         }
         let captured_loop_assignment = if let Some(loop_fn) = &captured_loop_fn {
@@ -82,6 +92,11 @@ impl<'a> AsyncES5Transformer<'a> {
             None
         };
 
+        let try_start_label = if has_pending_executable_statements {
+            Some(self.state.next_label())
+        } else {
+            None
+        };
         let loop_yield_label = self.state.next_label();
         let after_next_label = self.state.next_label();
         let iteration_label = self.state.next_label();
@@ -98,6 +113,15 @@ impl<'a> AsyncES5Transformer<'a> {
             for_in_of.expression,
             current_statements,
         );
+
+        if let Some(label) = try_start_label {
+            current_statements.push(Self::generator_label_assignment(label));
+            cases.push(IRGeneratorCase {
+                label: *current_label,
+                statements: std::mem::take(current_statements),
+            });
+            *current_label = label;
+        }
 
         current_statements.push(IRNode::GeneratorTryPush {
             start_label: *current_label,

--- a/crates/tsz-emitter/src/transforms/helpers.rs
+++ b/crates/tsz-emitter/src/transforms/helpers.rs
@@ -490,7 +490,22 @@ impl HelpersNeeded {
 
     pub fn mark_async_values(&mut self) {
         self.async_values = true;
-        self.remember_unprioritized(HelperEmitOrder::AsyncValues);
+        if self
+            .unprioritized_order
+            .contains(&HelperEmitOrder::AsyncValues)
+        {
+            return;
+        }
+        if let Some(spread_pos) = self
+            .unprioritized_order
+            .iter()
+            .position(|helper| *helper == HelperEmitOrder::SpreadArray)
+        {
+            self.unprioritized_order
+                .insert(spread_pos, HelperEmitOrder::AsyncValues);
+        } else {
+            self.unprioritized_order.push(HelperEmitOrder::AsyncValues);
+        }
     }
 
     pub fn mark_class_private_field_get(&mut self) {
@@ -1427,6 +1442,22 @@ mod tests {
         let i_spread = find_helper(&output, "__spreadArray");
         assert!(i_read < i_spread);
         assert_eq!(helpers.needed_names(), vec!["__read", "__spreadArray"]);
+    }
+
+    #[test]
+    fn emit_helpers_async_values_precedes_spread_array_when_requested_after_spread() {
+        let mut helpers = HelpersNeeded::default();
+        helpers.mark_spread_array();
+        helpers.mark_async_values();
+
+        let output = emit_helpers(&helpers);
+        let i_async_values = find_helper(&output, "__asyncValues");
+        let i_spread = find_helper(&output, "__spreadArray");
+        assert!(i_async_values < i_spread);
+        assert_eq!(
+            helpers.needed_names(),
+            vec!["__asyncValues", "__spreadArray"]
+        );
     }
 
     #[test]

--- a/crates/tsz-emitter/tests/async_loop_emit.rs
+++ b/crates/tsz-emitter/tests/async_loop_emit.rs
@@ -312,3 +312,57 @@ fn for_await_captured_iteration_binding_uses_plain_loop_helper() {
         "The async iterator state machine should call the helper for each awaited result.\nOutput:\n{output}"
     );
 }
+
+#[test]
+fn async_es5_array_spread_before_for_await_uses_spread_array_helper() {
+    let output = emit_es5(
+        "async function f(c: any[]) {
+            [...c];
+            for await (const s of c) {
+                s;
+            }
+        }",
+    );
+
+    let async_values = output.find("var __asyncValues").unwrap_or(usize::MAX);
+    let spread_array = output.find("var __spreadArray").unwrap_or(usize::MAX);
+    assert!(
+        async_values < spread_array,
+        "`__asyncValues` should be declared before `__spreadArray` when both helpers are planned for one async ES5 body.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("__spreadArray([], c, true);"),
+        "Array spread inside an async ES5 state machine should lower through `__spreadArray`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("[...c]"),
+        "Raw array spread syntax must not survive async ES5 lowering.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_es5_for_await_iterator_names_skip_sync_for_of_temps() {
+    let output = emit_es5(
+        "async function f(c: any[]) {
+            for (const s of c) {
+                s;
+            }
+            for await (const t of c) {
+                t;
+            }
+        }",
+    );
+
+    assert!(
+        output.contains("for (_i = 0, c_1 = c;"),
+        "The preceding sync for-of should reserve the identifier-derived `c_1` temp.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("c_2 = __asyncValues(c)") && output.contains("c_2_1"),
+        "The following for-await loop should skip to `c_2`/`c_2_1` instead of colliding with `c_1`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("c_1 = __asyncValues(c)"),
+        "For-await iterator setup must not reuse the sync for-of temp name.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
AgentName: Studio-A

## Track
Emit parity bug fix

## Invariant
When an ES5 async state-machine body contains array spread and `for await`, emitter lowering owns the helper and temp planning: array spreads lower through `__spreadArray`, `for await` lowers through `__asyncValues`, and identifier-derived iterator/result temps are reserved against sibling downlevel loop temps.

## Owner Layer
Emitter/output transform. This is JavaScript lowering policy inside async ES5 IR; it does not change checker, solver, or semantic validation.

## Scope
- Lower array spread literals in async ES5 IR conversion instead of leaving raw spread syntax inside generator cases.
- Plan body-level `__asyncValues`/`__spreadArray` helpers before statement conversion so helper declaration order matches tsc when both appear in one async body.
- Reserve `for await` iterator/result names against blocked temp names and split the try-start case when a for-await loop follows existing executable statements.
- Add focused emitter tests for async ES5 array spread plus for-await temp collision.

## Adjacent-Case Test Matrix
- Array spread before `for await` over a renamed source identifier verifies helper order and `__spreadArray` lowering without raw spread syntax.
- Sync `for..of` followed by `for await` over the same renamed source verifies iterator/result names skip already-reserved sibling loop temps.
- Helper-order unit covers the shared helper registry when `__asyncValues` is requested after `__spreadArray`.
- Focused emit baseline covers `operationsAvailableOnPromisedType(target=es5)` as the reported witness.

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit async ES5 spread/for-await helper and temp planning
- Evidence: `operationsAvailableOnPromisedType(target=es5)` now passes in the focused emit runner; `operationsAvailableOnPromisedType(target=es2015)` remains the pre-existing generator for-await var-hoisting mismatch noted outside this ES5 fix.

## Verification
- `cargo fmt --check`
- `cargo nextest run -p tsz-emitter --test async_loop_emit -E 'test(async_es5_array_spread_before_for_await_uses_spread_array_helper) | test(async_es5_for_await_iterator_names_skip_sync_for_of_temps)'`
- `cargo nextest run -p tsz-emitter transforms::helpers::tests::emit_helpers_async_values_precedes_spread_array_when_requested_after_spread`
- `scripts/emit/run.sh --filter=operationsAvailableOnPromisedType --js-only --verbose --timeout=20000 --concurrency=4 --json-out=/tmp/tsz-emit-operations-promised-rebased.json` (ES5 pass; ES2015 still fails on existing var-hoisting shape)

## Known Unsupported Shapes Or Follow-Up
- This PR intentionally does not change the ES2015 generator for-await var-hoisting shape shown by the same filter.

## Coordination Notes
- Refs #11894.
- This addresses the ES5 async spread/for-await part of the issue without changing the ES2015 generator for-await lowering.
- No repo markdown or roadmap files changed.
