### PR TITLE
test(solver): ratchet default relation policy spelling

### DIFF
--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -88,9 +88,9 @@ impl Default for RelationPolicy {
 impl RelationPolicy {
     /// Construct the historical no-flags compatibility policy.
     ///
-    /// This is equivalent to `RelationPolicy::from_flags(0)`, but keeps
-    /// default relation wrappers on a typed policy constructor instead of
-    /// spelling the legacy packed flag protocol at every no-flags call site.
+    /// This keeps default relation wrappers on a typed policy constructor
+    /// instead of spelling the legacy packed flag protocol at every no-flags
+    /// call site.
     pub const fn unflagged_compatibility() -> Self {
         Self {
             flags: RelationFlags::empty(),

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -13,6 +13,9 @@ mod any_mode_partitioning;
 #[path = "relation_policy_cache_agreement_tests/class_context_partitioning.rs"]
 mod class_context_partitioning;
 
+#[path = "relation_policy_cache_agreement_tests/default_policy_protocol.rs"]
+mod default_policy_protocol;
+
 #[path = "relation_policy_cache_agreement_tests/effective_any_mode_policy_bits.rs"]
 mod effective_any_mode_policy_bits;
 

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/default_policy_protocol.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/default_policy_protocol.rs
@@ -1,0 +1,24 @@
+//! Source ratchets for keeping default relation policies on typed constructors.
+
+#[test]
+fn default_relation_policy_paths_do_not_spell_packed_zero_flags() {
+    let sources = [
+        (
+            "relation_queries.rs",
+            include_str!("../../src/relations/relation_queries.rs"),
+        ),
+        ("caches/db.rs", include_str!("../../src/caches/db.rs")),
+        (
+            "caches/query_cache.rs",
+            include_str!("../../src/caches/query_cache.rs"),
+        ),
+    ];
+
+    for (name, source) in sources {
+        assert!(
+            !source.contains("RelationPolicy::from_flags(0)")
+                && !source.contains("RelationPolicy::from_relation_flags(RelationFlags::empty())"),
+            "{name} must use RelationPolicy::unflagged_compatibility() for default relation policy paths",
+        );
+    }
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track: solver relation policy/cache-key protocols; small #8207 source ratchet.

## Invariant
When default relation policy paths need historical no-flags compatibility, they must use the typed `RelationPolicy::unflagged_compatibility()` constructor instead of spelling legacy packed-zero flags; this PR ratchets that boundary language without changing relation semantics.

## Scope
- `crates/tsz-solver/src/relations/relation_queries.rs`
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs`
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests/default_policy_protocol.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: test/docs-only relation policy protocol ratchet; no compiler behavior path or project fixture behavior intentionally changed.

## Verification
- `cargo nextest run -p tsz-solver -E 'test(default_relation_policy_paths_do_not_spell_packed_zero_flags)'` — red first on the old `RelationPolicy::from_flags(0)` documentation, then 1 passed / 6451 skipped; rerun after rebase on head `b40b0c078c` passed 1 / 6451 skipped
- `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests)'` — 37 passed / 6417 skipped on rebased head `f2460185d9` after #11993 merged
- `cargo clippy -p tsz-solver --all-targets --all-features -- -D warnings` on rebased head `f2460185d9`
- `cargo fmt --check` on rebased head `f2460185d9`
- `git diff --check` on rebased head `f2460185d9`
- Draft CI on exact head `f2460185d9`: `CI Light Summary`, `lint`, `unit`, `unit-cloudbuild`, `dist-binaries`, `cargo-shear`, `cargo-deny`, `project-row-drift`, `gate`, and `GitGuardian Security Checks` passed
- Ready CI on exact head `f2460185d9`: `CI Summary`, conformance aggregate/shards, fourslash aggregate/shards, emit, project compile guard/canary, LSP, WASM, lint, unit, `unit-cloudbuild`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `project-corpus-pr-body`, `project-row-drift`, `conformance-snapshot-gate`, and `GitGuardian Security Checks` passed
- file-size check: new shard 24 lines; touched relation query file 855 lines after #11910 base update

## Coordination Notes
- Supports #8207 by keeping default relation policy paths on named typed constructors and preventing packed-zero spelling from re-entering the relation/cache boundary.
- Avoids #12002 variance/session-cache work and M1-B checker relation-routing / RelationRequest work.
- Rebased onto `origin/main` (`3a2e1cb974`, #11993) and force-pushed head `f2460185d9`; merge queue will synthetic-test against the current latest `main` before landing.
- Marked ready after exact-head draft CI passed; exact-head ready CI is green and the `merge-queue` label is present. `Queue Tested` is queue-owned and pending until the synthetic merge run completes.
