### PR TITLE
perf(checker): classify interface complex fallback reasons

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct.rs
@@ -18,9 +18,10 @@ pub(crate) use paths::{
 use tsz_binder::{BinderState, SymbolId, symbol_flags};
 use tsz_common::perf_counters::{
     CrossArenaSymbolMissSource, DirectActualLibAliasBodyOutcome,
-    DirectActualLibIntlInterfaceOutcome, DirectCrossFileInterfaceLoweringOutcome,
-    DirectSourceFileTypeAliasLoweringOutcome, record_direct_actual_lib_alias_body_outcome,
-    record_direct_actual_lib_intl_interface_outcome,
+    DirectActualLibIntlInterfaceOutcome, DirectCrossFileInterfaceComplexReason,
+    DirectCrossFileInterfaceLoweringOutcome, DirectSourceFileTypeAliasLoweringOutcome,
+    record_direct_actual_lib_alias_body_outcome, record_direct_actual_lib_intl_interface_outcome,
+    record_direct_cross_file_interface_complex_reason,
     record_direct_source_file_type_alias_lowering_outcome,
 };
 use tsz_lowering::TypeLowering;

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct/interface_methods.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct/interface_methods.rs
@@ -49,19 +49,35 @@ impl<'a> CheckerState<'a> {
         };
         let has_heritage = Self::interface_declarations_have_heritage(&declarations);
         let has_computed_names = Self::interface_declarations_have_computed_names(&declarations);
+        let record_complex_reason = |reason: DirectCrossFileInterfaceComplexReason| {
+            record_direct_cross_file_interface_complex_reason(reason);
+        };
+        let heritage_or_computed_reason = || {
+            let reason = match (has_heritage, has_computed_names) {
+                (true, true) => DirectCrossFileInterfaceComplexReason::HeritageAndComputedName,
+                (true, false) => DirectCrossFileInterfaceComplexReason::Heritage,
+                (false, true) => DirectCrossFileInterfaceComplexReason::ComputedName,
+                (false, false) => DirectCrossFileInterfaceComplexReason::SourceFileShape,
+            };
+            record_complex_reason(reason);
+        };
         if direct_source_file_arena {
-            if has_heritage
-                || has_computed_names
-                || !Self::source_file_interface_declarations_are_direct_lowerable(
-                    &declarations,
-                    delegate_binder,
-                )
-            {
+            if has_heritage || has_computed_names {
                 record(DirectCrossFileInterfaceLoweringOutcome::ComplexDeclaration);
+                heritage_or_computed_reason();
+                return None;
+            }
+            if !Self::source_file_interface_declarations_are_direct_lowerable(
+                &declarations,
+                delegate_binder,
+            ) {
+                record(DirectCrossFileInterfaceLoweringOutcome::ComplexDeclaration);
+                record_complex_reason(DirectCrossFileInterfaceComplexReason::SourceFileShape);
                 return None;
             }
         } else if !allow_complex_declarations && (has_heritage || has_computed_names) {
             record(DirectCrossFileInterfaceLoweringOutcome::ComplexDeclaration);
+            heritage_or_computed_reason();
             return None;
         }
 

--- a/crates/tsz-common/src/perf_counters/definitions.rs
+++ b/crates/tsz-common/src/perf_counters/definitions.rs
@@ -252,6 +252,21 @@ perf_counter_enum! {
     pub const DIRECT_CROSS_FILE_INTERFACE_LOWERING_OUTCOME_NAMES;
 }
 
+perf_counter_enum! {
+    /// Structural reason recorded alongside
+    /// `DirectCrossFileInterfaceLoweringOutcome::ComplexDeclaration`.
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+    pub enum DirectCrossFileInterfaceComplexReason {
+        Heritage = 0 => "heritage",
+        ComputedName = 1 => "computed_name",
+        HeritageAndComputedName = 2 => "heritage_and_computed_name",
+        SourceFileShape = 3 => "source_file_shape",
+    }
+
+    pub const DIRECT_CROSS_FILE_INTERFACE_COMPLEX_REASON_COUNT;
+    pub const DIRECT_CROSS_FILE_INTERFACE_COMPLEX_REASON_NAMES;
+}
+
 /// How `compute_type_of_symbol` found the symbol payload for a call.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(usize)]

--- a/crates/tsz-common/src/perf_counters/dump.rs
+++ b/crates/tsz-common/src/perf_counters/dump.rs
@@ -128,6 +128,7 @@ impl PerfCounters {
             + &Self::dump_cross_arena_symbol_miss_classification()
             + &Self::dump_cross_arena_alias_shortcut_outcomes()
             + &Self::dump_direct_cross_file_interface_lowering_outcomes()
+            + &Self::dump_direct_cross_file_interface_complex_reasons()
             + &Self::dump_direct_actual_lib_alias_body_outcomes()
             + &Self::dump_direct_source_file_type_alias_lowering_outcomes()
             + &Self::dump_direct_source_file_type_alias_body_rejection_kinds()
@@ -491,6 +492,31 @@ impl PerfCounters {
             .enumerate()
         {
             let count = load(&c.direct_cross_file_interface_lowering_outcome[idx]);
+            if count > 0 {
+                out.push_str(&format!("  {name:<28} {count:>12}\n"));
+            }
+        }
+        out
+    }
+
+    fn dump_direct_cross_file_interface_complex_reasons() -> String {
+        let c = counters();
+        let load = |a: &AtomicU64| a.load(Ordering::Relaxed);
+        let total: u64 = c
+            .direct_cross_file_interface_complex_reason
+            .iter()
+            .map(load)
+            .sum();
+        if total == 0 {
+            return String::new();
+        }
+
+        let mut out = String::from("\nDirect cross-file interface complex reasons:\n");
+        for (idx, name) in DIRECT_CROSS_FILE_INTERFACE_COMPLEX_REASON_NAMES
+            .iter()
+            .enumerate()
+        {
+            let count = load(&c.direct_cross_file_interface_complex_reason[idx]);
             if count > 0 {
                 out.push_str(&format!("  {name:<28} {count:>12}\n"));
             }

--- a/crates/tsz-common/src/perf_counters/runtime.rs
+++ b/crates/tsz-common/src/perf_counters/runtime.rs
@@ -30,6 +30,9 @@ pub struct PerfCounters {
     /// Outcome buckets for direct cross-file interface lowering attempts.
     pub direct_cross_file_interface_lowering_outcome:
         [AtomicU64; DIRECT_CROSS_FILE_INTERFACE_LOWERING_OUTCOME_COUNT],
+    /// Reason buckets for complex direct cross-file interface declarations.
+    pub direct_cross_file_interface_complex_reason:
+        [AtomicU64; DIRECT_CROSS_FILE_INTERFACE_COMPLEX_REASON_COUNT],
     /// Outcome buckets for direct actual-lib alias-body attempts.
     pub direct_actual_lib_alias_body_outcome:
         [AtomicU64; DIRECT_ACTUAL_LIB_ALIAS_BODY_OUTCOME_COUNT],
@@ -188,6 +191,8 @@ impl PerfCounters {
                 CROSS_ARENA_ALIAS_SHORTCUT_OUTCOME_COUNT],
             direct_cross_file_interface_lowering_outcome: [const { AtomicU64::new(0) };
                 DIRECT_CROSS_FILE_INTERFACE_LOWERING_OUTCOME_COUNT],
+            direct_cross_file_interface_complex_reason: [const { AtomicU64::new(0) };
+                DIRECT_CROSS_FILE_INTERFACE_COMPLEX_REASON_COUNT],
             direct_actual_lib_alias_body_outcome: [const { AtomicU64::new(0) };
                 DIRECT_ACTUAL_LIB_ALIAS_BODY_OUTCOME_COUNT],
             direct_source_file_type_alias_lowering_outcome: [const { AtomicU64::new(0) };
@@ -1327,6 +1332,18 @@ pub fn record_direct_cross_file_interface_lowering_outcome(
     }
     let c = counters();
     c.direct_cross_file_interface_lowering_outcome[outcome.as_index()]
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn record_direct_cross_file_interface_complex_reason(
+    reason: DirectCrossFileInterfaceComplexReason,
+) {
+    if !enabled_fast() {
+        return;
+    }
+    let c = counters();
+    c.direct_cross_file_interface_complex_reason[reason.as_index()]
         .fetch_add(1, Ordering::Relaxed);
 }
 

--- a/crates/tsz-common/src/perf_counters/snapshot.rs
+++ b/crates/tsz-common/src/perf_counters/snapshot.rs
@@ -1,6 +1,6 @@
 /// Stable schema version for `PerfCounterSnapshot`. Bump when the JSON
 /// shape changes in a way the bench harness must adapt to.
-pub const PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION: u32 = 5;
+pub const PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION: u32 = 6;
 
 /// Frozen value-object view of the counter state. Built by
 /// [`PerfCounters::snapshot`]; serializable to JSON via serde.
@@ -171,6 +171,12 @@ pub struct PerfCounterSnapshot {
     /// path from firing — the target list for "widen the direct
     /// lowering" follow-ups.
     pub direct_interface_lowering_outcomes: Vec<NamedCount>,
+    /// Structural reason buckets for
+    /// `direct_interface_lowering_outcomes.complex_declaration`.
+    ///
+    /// Always `DIRECT_CROSS_FILE_INTERFACE_COMPLEX_REASON_COUNT` long, in
+    /// `DIRECT_CROSS_FILE_INTERFACE_COMPLEX_REASON_NAMES` order.
+    pub direct_interface_complex_reasons: Vec<NamedCount>,
     /// Outcome buckets for direct actual-lib alias-body attempts.
     ///
     /// Always `DIRECT_ACTUAL_LIB_ALIAS_BODY_OUTCOME_COUNT` long, in
@@ -660,6 +666,13 @@ impl PerfCounters {
                 .map(|i| NamedCount {
                     name: DIRECT_CROSS_FILE_INTERFACE_LOWERING_OUTCOME_NAMES[i],
                     count: load(&c.direct_cross_file_interface_lowering_outcome[i]),
+                })
+                .collect(),
+            direct_interface_complex_reasons: (0
+                ..DIRECT_CROSS_FILE_INTERFACE_COMPLEX_REASON_COUNT)
+                .map(|i| NamedCount {
+                    name: DIRECT_CROSS_FILE_INTERFACE_COMPLEX_REASON_NAMES[i],
+                    count: load(&c.direct_cross_file_interface_complex_reason[i]),
                 })
                 .collect(),
             direct_actual_lib_alias_body_outcomes: (0..DIRECT_ACTUAL_LIB_ALIAS_BODY_OUTCOME_COUNT)

--- a/crates/tsz-common/src/perf_counters/tests.rs
+++ b/crates/tsz-common/src/perf_counters/tests.rs
@@ -2,10 +2,10 @@ mod json_tests {
     use super::*;
 
     #[test]
-    fn schema_version_is_five() {
+    fn schema_version_is_six() {
         // Bumping schema_version is a breaking change for the bench harness;
         // make the intent explicit.
-        assert_eq!(PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION, 5);
+        assert_eq!(PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION, 6);
     }
 
     #[test]
@@ -40,6 +40,7 @@ mod json_tests {
             "compute_type_of_symbol_interface_simple_object_actual_lib_type_reference_outcomes",
             "compute_type_of_symbol_interface_simple_object_type_reference_reject_residues",
             "direct_interface_lowering_outcomes",
+            "direct_interface_complex_reasons",
             "direct_actual_lib_alias_body_outcomes",
             "direct_source_file_type_alias_lowering_outcomes",
             "direct_source_file_type_alias_body_rejection_kinds",
@@ -55,7 +56,7 @@ mod json_tests {
         ] {
             assert!(json.get(key).is_some(), "missing top-level key: {key}");
         }
-        assert_eq!(json["schema_version"], 5);
+        assert_eq!(json["schema_version"], 6);
     }
 
     #[test]
@@ -1078,6 +1079,14 @@ mod json_tests {
                 "direct_interface_lowering_outcomes[{i}].count should be a number",
             );
         }
+        let rows = json["direct_interface_complex_reasons"]
+            .as_array()
+            .expect("direct_interface_complex_reasons is array");
+        assert_eq!(rows.len(), DIRECT_CROSS_FILE_INTERFACE_COMPLEX_REASON_COUNT);
+        for (i, row) in rows.iter().enumerate() {
+            assert_eq!(row["name"], DIRECT_CROSS_FILE_INTERFACE_COMPLEX_REASON_NAMES[i]);
+            assert!(row["count"].is_u64());
+        }
     }
 
     #[test]
@@ -1570,6 +1579,7 @@ mod json_tests {
         let aso_idx = CrossArenaAliasShortcutOutcome::Success.as_index();
         let sfsa_idx = SourceFileSymbolArenaCacheEligibilityOutcome::Cacheable.as_index();
         let dilo_idx = DirectCrossFileInterfaceLoweringOutcome::Success.as_index();
+        let dicr_idx = DirectCrossFileInterfaceComplexReason::Heritage.as_index();
         let dalabo_idx = DirectActualLibAliasBodyOutcome::Success.as_index();
         let daliio_idx = DirectActualLibIntlInterfaceOutcome::SuccessByName.as_index();
         let ctos_source_idx = ComputeTypeOfSymbolSourceOutcome::GlobalSymbol.as_index();
@@ -1602,6 +1612,8 @@ mod json_tests {
             c.source_file_symbol_arena_cache_eligibility_outcome[sfsa_idx].load(Ordering::Relaxed);
         let before_dilo =
             c.direct_cross_file_interface_lowering_outcome[dilo_idx].load(Ordering::Relaxed);
+        let before_dicr =
+            c.direct_cross_file_interface_complex_reason[dicr_idx].load(Ordering::Relaxed);
         let before_dalabo =
             c.direct_actual_lib_alias_body_outcome[dalabo_idx].load(Ordering::Relaxed);
         let before_daliio =
@@ -1654,6 +1666,7 @@ mod json_tests {
         c.source_file_symbol_arena_cache_eligibility_outcome[sfsa_idx]
             .fetch_add(1, Ordering::Relaxed);
         c.direct_cross_file_interface_lowering_outcome[dilo_idx].fetch_add(1, Ordering::Relaxed);
+        c.direct_cross_file_interface_complex_reason[dicr_idx].fetch_add(1, Ordering::Relaxed);
         c.direct_actual_lib_alias_body_outcome[dalabo_idx].fetch_add(1, Ordering::Relaxed);
         c.direct_actual_lib_intl_interface_outcome[daliio_idx].fetch_add(1, Ordering::Relaxed);
         c.compute_type_of_symbol_source_outcome[ctos_source_idx].fetch_add(1, Ordering::Relaxed);
@@ -1743,6 +1756,15 @@ mod json_tests {
         assert!(
             dilo_row["count"].as_u64().unwrap_or(0) > before_dilo,
             "direct_interface_lowering_outcomes[success] did not reflect the bump",
+        );
+        let dicr = json["direct_interface_complex_reasons"]
+            .as_array()
+            .expect("direct_interface_complex_reasons is array");
+        let dicr_row = &dicr[dicr_idx];
+        assert_eq!(dicr_row["name"], "heritage");
+        assert!(
+            dicr_row["count"].as_u64().unwrap_or(0) > before_dicr,
+            "direct_interface_complex_reasons[heritage] did not reflect the bump",
         );
 
         let dalabo = json["direct_actual_lib_alias_body_outcomes"]

--- a/scripts/perf/test_query_perf_counters.py
+++ b/scripts/perf/test_query_perf_counters.py
@@ -11,7 +11,7 @@ SCRIPT = Path(__file__).with_name("query-perf-counters.py")
 
 def sample_snapshot(*, type_environment_core: int = 7, import_type: int = 3):
     return {
-        "schema_version": 5,
+        "schema_version": 6,
         "mode": "attribution",
         "enabled": True,
         "delegate": {


### PR DESCRIPTION
AgentName: Studio-B

## Track
Track 10 performance measurement / green-row attribution

## Invariant
Measurement-only change. This PR must not change checker semantics, diagnostics, emit output, or compatibility behavior; it only adds perf-counter attribution for existing direct cross-file interface fallback decisions.

## Scope
- Add `direct_interface_complex_reasons` to the perf-counter JSON/text dump and bump the perf-counter snapshot schema to 6.
- Record whether `direct_interface_lowering_outcomes.complex_declaration` came from heritage clauses, computed names, both, or source-file direct-shape rejection.
- Keep the existing coarse `complex_declaration` outcome intact for continuity.
- Update focused perf-counter tests and the query-perf-counters fixture schema.

## Project Corpus Impact
- Row: `vite-vanilla-ts-app`
- Bug family: checker cross-arena delegation attribution
- Evidence: `/private/tmp/studio-b-vite-complex-reasons-20260601.perf.json` shows the current Vite complex interface fallback split as `heritage=227`, `computed_name=30`, `heritage_and_computed_name=6`, `source_file_shape=0`, matching the existing `complex_declaration=263` total. No behavior or timing claim is made by this PR.

## Verification
- `cargo fmt --check`
- `cargo nextest run -p tsz-common -E 'test(schema_version_is_six) | test(snapshot_serializes_with_expected_top_level_keys) | test(direct_interface_lowering_outcomes_locks_to_names_array) | test(classification_arrays_propagate_atomic_state_into_snapshot)'`
- `cargo check -p tsz-checker`
- `python3 scripts/perf/test_query_perf_counters.py`
- `git diff --check`
- `TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh cargo run -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json /private/tmp/studio-b-vite-complex-reasons-20260601.perf.json --noEmit -p .target-bench/external/vite-vanilla-ts-live/tsconfig.json > /private/tmp/studio-b-vite-complex-reasons-20260601.perf.txt`

## Coordination Notes
Studio-B first merged prior owned PR #12006 before starting this slice; there were no remaining open Studio-B PRs at branch creation. This draft claims only the perf-counter measurement surface for direct cross-file interface complex-declaration reasons. It intentionally does not widen actual-lib or source-file interface lowering, especially value-merged DOM interfaces.
