### PR TITLE
chore(arch): include git context in guard reports

### DIFF
--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import subprocess
 import sys
 from pathlib import Path
+from typing import Optional
 
 ARCH_DIR = Path(__file__).resolve().parent
 if str(ARCH_DIR) not in sys.path:
@@ -39,13 +41,50 @@ def write_json_report(report_path: Path, payload: dict) -> None:
     temp_path.replace(report_path)
 
 
-def build_json_payload(failures: list[tuple[str, list[str]]], total_hits: int) -> dict:
+def _run_git(root: Path, args: list[str]) -> Optional[str]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), *args],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def build_git_context(root: Path = ROOT, run_git=_run_git) -> dict:
+    status = run_git(root, ["status", "--porcelain"])
+    branch = run_git(root, ["branch", "--show-current"])
+    return {
+        "repo_root": root.as_posix(),
+        "head": run_git(root, ["rev-parse", "HEAD"]),
+        "branch": branch or None,
+        "upstream": run_git(
+            root,
+            ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+        ),
+        "dirty": None if status is None else bool(status),
+        "dirty_path_count": None if status is None else len(status.splitlines()),
+    }
+
+
+def build_json_payload(
+    failures: list[tuple[str, list[str]]],
+    total_hits: int,
+    git_context: Optional[dict] = None,
+) -> dict:
     ok = not failures
     failed_hit_count = sum(len(hits) for _, hits in failures)
     return {
         "ok": ok,
         "status": "failed" if failures else "passed",
         "arch_guard_status": "failed" if failures else "passed",
+        "git_context": git_context if git_context is not None else build_git_context(),
         "total_hits": total_hits,
         "failure_count": len(failures),
         "failed_hit_count": failed_hit_count,

--- a/scripts/arch/test_arch_guard.py
+++ b/scripts/arch/test_arch_guard.py
@@ -11,12 +11,21 @@ class ArchGuardJsonReportTests(unittest.TestCase):
         self.arch_guard = load_arch_guard_module()
 
     def test_json_payload_includes_boolean_ok_status(self):
+        git_context = {
+            "repo_root": "/repo",
+            "head": "abc123",
+            "branch": "codex/example",
+            "upstream": "origin/main",
+            "dirty": False,
+            "dirty_path_count": 0,
+        }
         self.assertEqual(
-            self.arch_guard.build_json_payload([], 0),
+            self.arch_guard.build_json_payload([], 0, git_context=git_context),
             {
                 "ok": True,
                 "status": "passed",
                 "arch_guard_status": "passed",
+                "git_context": git_context,
                 "total_hits": 0,
                 "failure_count": 0,
                 "failed_hit_count": 0,
@@ -27,11 +36,13 @@ class ArchGuardJsonReportTests(unittest.TestCase):
             self.arch_guard.build_json_payload(
                 [("Rule", ["src/lib.rs:1", "src/lib.rs:2"])],
                 2,
+                git_context=git_context,
             ),
             {
                 "ok": False,
                 "status": "failed",
                 "arch_guard_status": "failed",
+                "git_context": git_context,
                 "total_hits": 2,
                 "failure_count": 1,
                 "failed_hit_count": 2,

--- a/scripts/arch/test_arch_guard_misc.py
+++ b/scripts/arch/test_arch_guard_misc.py
@@ -5,6 +5,62 @@ import unittest
 from test_arch_guard_support import ROOT, load_arch_guard_module
 
 
+class ArchGuardJsonReportTests(unittest.TestCase):
+    """Cover machine-readable report provenance for launch gate artifacts."""
+
+    def setUp(self):
+        self.arch_guard = load_arch_guard_module()
+
+    def test_json_payload_includes_git_context(self):
+        git_context = {
+            "repo_root": "/repo",
+            "head": "abc123",
+            "branch": "codex/example",
+            "upstream": "origin/main",
+            "dirty": False,
+            "dirty_path_count": 0,
+        }
+
+        payload = self.arch_guard.build_json_payload(
+            [("Example guard", ["path.rs:1"])],
+            total_hits=1,
+            git_context=git_context,
+        )
+
+        self.assertEqual(payload["status"], "failed")
+        self.assertEqual(payload["arch_guard_status"], "failed")
+        self.assertEqual(payload["git_context"], git_context)
+
+    def test_git_context_records_branch_upstream_and_dirty_count(self):
+        calls = []
+
+        def fake_run_git(root, args):
+            calls.append((root, tuple(args)))
+            responses = {
+                ("status", "--porcelain"): " M scripts/arch/arch_guard.py\n?? tmp.txt",
+                ("branch", "--show-current"): "codex/studio-f-guard",
+                ("rev-parse", "HEAD"): "abc123",
+                (
+                    "rev-parse",
+                    "--abbrev-ref",
+                    "--symbolic-full-name",
+                    "@{u}",
+                ): "origin/main",
+            }
+            return responses.get(tuple(args))
+
+        root = pathlib.Path("/repo")
+        context = self.arch_guard.build_git_context(root, run_git=fake_run_git)
+
+        self.assertEqual(context["repo_root"], "/repo")
+        self.assertEqual(context["head"], "abc123")
+        self.assertEqual(context["branch"], "codex/studio-f-guard")
+        self.assertEqual(context["upstream"], "origin/main")
+        self.assertTrue(context["dirty"])
+        self.assertEqual(context["dirty_path_count"], 2)
+        self.assertIn((root, ("status", "--porcelain")), calls)
+
+
 class ArchGuardDebugPrintMacroTests(unittest.TestCase):
     """Cover Track 10's hard debug-print macro guard."""
 


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / architecture guardrail evidence plumbing.

## Invariant
When an architecture guard JSON artifact is written from any worktree, the artifact should identify the repo root, branch, head SHA, upstream, and dirty state that produced the guard result.

## Scope
- `scripts/arch/arch_guard.py` JSON report payload
- `scripts/arch/test_arch_guard.py` aggregate JSON payload coverage
- `scripts/arch/test_arch_guard_misc.py` focused provenance coverage

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: script-only guardrail artifact metadata; no compiler behavior or project corpus row changes.

## Verification
- `python3 -m py_compile scripts/arch/*.py` plus every `scripts/arch/test_*.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard_misc`
- `python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard-studio-f-git-context-fix.json`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-audit-pr12015.json`

## Coordination Notes
- Studio-F owned PR runway was clear before opening.
- This makes start-cycle and CI architecture guard artifacts harder to misread when a sibling worktree or branch-local change produces a failure.
- No roadmap change needed; this is routine launch evidence plumbing.