### PR TITLE
fix(emit): order ES5 for-await temps like tsc

### DIFF
--- a/crates/tsz-emitter/src/transforms/async_es5_ir_for_await.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_for_await.rs
@@ -48,11 +48,15 @@ impl<'a> AsyncES5Transformer<'a> {
                 } | IRNode::HoistedVarGroupBreak
             )
         });
+        let loop_guard_name = self.generate_hoisted_temp();
         let (iterator_name, result_name) = self.for_await_iterator_names(for_in_of.expression, 1);
         let catch_value_name = self.fresh_reserved_name("e_1_1");
 
         if let Some(loop_fn) = &captured_loop_fn {
             current_statements.push(IRNode::var_decl(loop_fn.clone(), None));
+        }
+        for name in [&loop_guard_name, &iterator_name, &result_name] {
+            current_statements.push(IRNode::var_decl(name.clone(), None));
         }
         if declared_name.is_some() && captured_loop_fn.is_none() {
             current_statements.push(IRNode::var_decl(target_name.clone(), None));
@@ -64,16 +68,7 @@ impl<'a> AsyncES5Transformer<'a> {
         let error_name = self.fresh_reserved_name("e_1");
         let return_name = self.generate_hoisted_temp();
         let value_name = self.generate_hoisted_temp();
-        let loop_guard_name = self.generate_hoisted_temp();
-        for name in [
-            &done_name,
-            &error_name,
-            &return_name,
-            &value_name,
-            &loop_guard_name,
-            &iterator_name,
-            &result_name,
-        ] {
+        for name in [&done_name, &error_name, &return_name, &value_name] {
             current_statements.push(IRNode::var_decl(name.clone(), None));
         }
         let captured_loop_assignment = if let Some(loop_fn) = &captured_loop_fn {


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Track 9 JavaScript emit parity: async/await/generator JS lowering.

## Invariant
When `for await...of` is lowered inside an ES5 async state machine, `tsc` allocates the loop guard before iterator/result temps and declares guard/iterator/result with the loop-local binding and catch value, while done/error/return/value temps are declared in the following hoist group. This PR makes tsz use that temp-planning order in the async ES5 for-await transformer.

Owner layer: `tsz-emitter` async ES5 for-await temp planning. The change does not add checker validation, semantic type checks, or output surgery.

## Scope
- Reorders ES5 async for-await temp allocation so the loop guard receives first temp priority.
- Moves guard/iterator/result declarations into the first hoist group with the loop binding and catch temp.
- Leaves done/error/return/value temps in the second hoist group.

## Project Corpus Impact
- Row: n/a
- Bug family: async/await/generator JS lowering; ES5 `for await...of` temp-order parity.
- Evidence: emit-only baseline fixes for `emitter.forAwait(target=es5)` and `forAwaitPerIterationBindingDownlevel(target=es5)` under the focused `forAwait` JS filter. No project corpus row is known to depend on these conformance-only temp-name baselines.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- `cargo nextest run -p tsz-emitter for_await_of_in_async_function_uses_async_iterator_state_machine for_await_captured_iteration_binding_uses_plain_loop_helper`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=forAwait --js-only --verbose --timeout=30000 --json-out=/tmp/forAwait-studio-c-fixed.json` (20/20)
- Pre-restack draft-light CI passed on head `40c50e2d93` after rerunning an infra-like `dist-binaries` failure.
- Post-sync draft-light CI passed on head `a08a2c344440`: `CI Light Summary`, `lint`, `dist-binaries`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, and GitGuardian.
- The PR has now been rebased onto latest `origin/main` (`e4fab618f043`) and fresh ready-review CI is pending on head `047570df1f11`.

## Coordination Notes
- Claimed focused slice on #8510: https://github.com/mohsen1/tsz/issues/8510#issuecomment-4588618777
- Live orientation on current `origin/main` before this PR: `async` JS filter 299/299, `generator` JS filter 126/126, `forAwait` JS filter 18/20.
- Marked ready after exact-head draft-light CI passed; ready-review CI restarted after the latest rebase. Do not add `merge-queue` until required ready-review checks pass for this exact head.

Status update 2026-06-01 (AgentName: Studio-C): Parked back to draft/off-queue because sibling Studio-C PR #12013 hit the shared #8432 current-main `conformance-aggregate` blocker on exact head `d5c7b408e1bf`, and this branch is now stale behind current `origin/main` `a517d28c421e`. Restack and re-promote only after #8432 clears or explicit Reviewer/EM clearance.

Aggregate detail 2026-06-01 (AgentName: Studio-C): run 26733443769 collected 6/6 conformance shards and reported `12581/12585` actual vs `12582/12585` expected, with unlisted regressions `deeplyNestedMappedTypes.ts`, `intersectionsOfLargeUnions2.ts`, `importAttributes11.ts`, and `checkJsxChildrenCanBeTupleType.tsx`. Corroborating evidence is preserved on #8432: https://github.com/mohsen1/tsz/issues/8432#issuecomment-4589346085

Restack update 2026-06-01 (AgentName: Studio-C): draft branch rebased by cherry-pick onto current `origin/main` `a517d28c421e`; new head is `5b57c7e65d`. The PR remains draft/off-queue because #8432 is still open and blocks ready-review aggregate gates.
