### PR TITLE
chore(emit-tools): include git context in output surgery reports

### DIFF
--- a/scripts/emit/audit-output-surgery.py
+++ b/scripts/emit/audit-output-surgery.py
@@ -14,8 +14,10 @@ import dataclasses
 import json
 import pathlib
 import re
+import subprocess
 import sys
 from collections import Counter, defaultdict
+from typing import Optional
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
@@ -314,6 +316,38 @@ def classify_budget_status(allowlisted_calls: int, allowlist_cap: int) -> str:
     return "available"
 
 
+def _run_git(root: pathlib.Path, args: list[str]) -> Optional[str]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), *args],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def build_git_context(root: pathlib.Path = ROOT, run_git=_run_git) -> dict[str, object]:
+    status = run_git(root, ["status", "--porcelain"])
+    branch = run_git(root, ["branch", "--show-current"])
+    return {
+        "repo_root": root.as_posix(),
+        "head": run_git(root, ["rev-parse", "HEAD"]),
+        "branch": branch or None,
+        "upstream": run_git(
+            root,
+            ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+        ),
+        "dirty": None if status is None else bool(status),
+        "dirty_path_count": None if status is None else len(status.splitlines()),
+    }
+
+
 def format_budget_metrics(budget: BudgetSummary) -> str:
     return (
         f"allowlisted_calls={budget.allowlisted_calls}, "
@@ -341,6 +375,7 @@ def build_json_report(
     findings: list[Finding],
     allowlist: dict[str, AllowEntry],
     failures: list[str],
+    git_context: Optional[dict[str, object]] = None,
 ) -> dict[str, object]:
     counts = grouped_counts(findings)
     summary = summarize_failures(failures)
@@ -350,6 +385,7 @@ def build_json_report(
         "ok": not failures,
         "status": "failed" if failures else "passed",
         "output_surgery_status": "failed" if failures else "passed",
+        "git_context": git_context if git_context is not None else build_git_context(),
         "total_findings": len(findings),
         "files_with_findings": len(counts),
         "allowlisted_calls": budget.allowlisted_calls,

--- a/scripts/emit/test_output_surgery_audit.py
+++ b/scripts/emit/test_output_surgery_audit.py
@@ -76,12 +76,26 @@ class OutputSurgeryAuditTests(unittest.TestCase):
             "c.rs": self.audit.AllowEntry("semantic-output-surgery", 1, "stale debt"),
         }
         failures = ["a.rs: 1 unallowlisted output-surgery call(s)"]
+        git_context = {
+            "repo_root": "/repo",
+            "head": "abc123",
+            "branch": "codex/studio-f-output-surgery",
+            "upstream": "origin/main",
+            "dirty": False,
+            "dirty_path_count": 0,
+        }
 
-        report = self.audit.build_json_report(findings, allowlist, failures)
+        report = self.audit.build_json_report(
+            findings,
+            allowlist,
+            failures,
+            git_context=git_context,
+        )
 
         self.assertFalse(report["ok"])
         self.assertEqual(report["status"], "failed")
         self.assertEqual(report["output_surgery_status"], "failed")
+        self.assertEqual(report["git_context"], git_context)
         self.assertEqual(report["total_findings"], 2)
         self.assertEqual(report["files_with_findings"], 2)
         self.assertEqual(report["allowlisted_calls"], 1)
@@ -151,6 +165,35 @@ class OutputSurgeryAuditTests(unittest.TestCase):
         self.assertEqual(report["status"], "passed")
         self.assertEqual(report["output_surgery_status"], "passed")
         self.assertEqual(report["failures"], [])
+
+    def test_git_context_records_branch_upstream_and_dirty_count(self):
+        calls = []
+
+        def fake_run_git(root, args):
+            calls.append((root, tuple(args)))
+            responses = {
+                ("status", "--porcelain"): " M scripts/emit/audit-output-surgery.py\n?? tmp.txt",
+                ("branch", "--show-current"): "codex/studio-f-output-surgery",
+                ("rev-parse", "HEAD"): "abc123",
+                (
+                    "rev-parse",
+                    "--abbrev-ref",
+                    "--symbolic-full-name",
+                    "@{u}",
+                ): "origin/main",
+            }
+            return responses.get(tuple(args))
+
+        root = pathlib.Path("/repo")
+        context = self.audit.build_git_context(root, run_git=fake_run_git)
+
+        self.assertEqual(context["repo_root"], "/repo")
+        self.assertEqual(context["head"], "abc123")
+        self.assertEqual(context["branch"], "codex/studio-f-output-surgery")
+        self.assertEqual(context["upstream"], "origin/main")
+        self.assertTrue(context["dirty"])
+        self.assertEqual(context["dirty_path_count"], 2)
+        self.assertIn((root, ("status", "--porcelain")), calls)
 
     def test_pass_summary_names_clean_guardrail_counters(self):
         findings = [


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / cheap evidence plumbing for output-surgery guardrails.

## Invariant
When the output-surgery audit writes a machine-readable report, the report identifies the exact repository root, head SHA, branch, upstream, and dirty state used to produce the release-gate artifact.

## Scope
- `scripts/emit/audit-output-surgery.py`
- `scripts/emit/test_output_surgery_audit.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: script-only launch evidence plumbing; no compiler, checker, solver, parser, binder, emitter behavior, project corpus fixture, or benchmark row behavior changes.

## Verification
- `python3 -m unittest scripts.emit.test_output_surgery_audit`
- `python3 -m py_compile scripts/emit/audit-output-surgery.py scripts/emit/test_output_surgery_audit.py`
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery-git-context.json`
- `python3 - <<'PY' ...` inspected `/tmp/tsz-output-surgery-git-context.json` and confirmed `output_surgery_status=passed`, `allowlist_budget_status=exhausted`, and populated `git_context`.
- `git diff --check`

## Coordination Notes
- No active Studio-F PRs or issues at intake.
- Overlap check found Studio-E #11916 on object-member output-surgery retirement, but no open PR changing output-surgery audit report provenance.
- Primary checkout had unrelated Studio-C dirty emitter work, so this PR was built in a fresh sister worktree from `origin/main` with the TypeScript submodule linked back to the populated primary checkout.
- No roadmap update: this is routine launch evidence plumbing, not a durable direction change.
