### PR TITLE
fix(emit): keep trailing block comment after ASI expression statement (#11999 remnant)

### DIFF
--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -1410,7 +1410,15 @@ impl<'a> Printer<'a> {
         } else if expression_trailing_comment_range.is_none()
             && let Some(expr_node) = self.arena.get(expr_stmt.expression)
         {
-            self.emit_trailing_comments(expr_node.end);
+            // The parser extends an expression's `end` over trailing trivia up
+            // to the next token. For an ASI statement whose only trailing token
+            // is a comment (e.g. `a.public /*` at EOF), that pushes `end` past
+            // the comment's start, so the trailing-comment scanner would treat
+            // it as already-emitted leading trivia and silently drop it. Anchor
+            // the scan at the expression's real code end (before trivia) so a
+            // same-line trailing comment is recognized and kept.
+            let scan_end = self.find_last_expr_end_before_trivia(expr_node.pos, expr_node.end);
+            self.emit_trailing_comments(scan_end);
         }
         if let Some((comment_start, comment_end)) = expression_trailing_comment_range {
             self.emit_comments_after_deferred_semicolon(comment_start, comment_end);

--- a/crates/tsz-emitter/tests/comment_tests.rs
+++ b/crates/tsz-emitter/tests/comment_tests.rs
@@ -137,6 +137,52 @@ fn trailing_comment_after_arrow_block_statement_stays_after_call() {
 }
 
 #[test]
+fn trailing_block_comment_after_statement_without_semicolon_is_kept() {
+    // An unterminated block comment trailing an expression statement that has
+    // no source semicolon (ASI) must still be emitted after the inserted `;`.
+    // The statement's node `end` over-extends into the trailing trivia, so the
+    // trailing-comment scanner must not treat the comment as "before end" and
+    // silently drop it. Mirrors parserKeywordsAsIdentifierName2.
+    let source = "a.public /*";
+
+    let output = parse_and_print(source);
+
+    assert!(
+        output.contains("a.public; /*"),
+        "Trailing block comment after an ASI statement must be kept.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn trailing_block_comment_after_getter_and_setter_body_stays_after_body() {
+    // Both getter and setter accessor bodies must keep a trailing line comment
+    // after the closing brace, regardless of the accessor's iteration name.
+    let source = r#"class C {
+    get value() { return this._value; } // get-trailer
+    set thing(x: number) { this._t = x; } // set-trailer
+}"#;
+
+    let output = parse_and_print(source);
+
+    assert!(
+        output.contains("get value() { return this._value; } // get-trailer"),
+        "Getter body trailing comment must stay after the body close.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("return this._value; // get-trailer }"),
+        "Getter body must not absorb the following line comment.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("set thing(x) { this._t = x; } // set-trailer"),
+        "Setter body trailing comment must stay after the body close.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("this._t = x; // set-trailer }"),
+        "Setter body must not absorb the following line comment.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn same_line_statement_trailing_comment_still_stays_on_statement() {
     let source = r#"function f() {
     let x = 1; // inside


### PR DESCRIPTION
AgentName: opus48-emit100

## Track
Emit → 100% (JavaScript emit parity). Final remnant of the trailing-comment-placement regression cluster (issue #11999); extends #12003.

## Invariant
When an expression statement has no source semicolon (ASI) and its only trailing
token is a comment (e.g. an unterminated `a.public /*` at EOF), tsc emits the
inserted `;` followed by the trailing comment; tsz must too. The parser extends an
expression's `.end` over trailing trivia up to the next token, so for an EOF
unterminated block comment with no following newline, `.end` is pushed *past* the
comment's start — and `emit_trailing_comments(expr_node.end)` then saw the comment
as already-passed leading trivia and silently dropped it (newline-dependent: with a
trailing newline `.end` stopped before the comment, so it worked). This anchors the
trailing-comment scan at the expression's REAL code end (`find_last_expr_end_before_trivia`)
instead of the trivia-extended `.end` — the same "anchor at the real code boundary,
not the trivia-extended node.end" idea #12003 applied to brace bodies.

## Scope
Emitter (OUTPUT) only. Structural (real expression end vs trivia), no spelling/printer-output matching.
- `emitter/statements/core.rs` — `emit_expression_statement` no-source-semicolon (ASI) branch: scan from `find_last_expr_end_before_trivia(expr.pos, expr.end)`.
- `tests/comment_tests.rs` — 2 focused tests (EOF trailing block comment after an ASI statement; trailing line comment after both getter and setter bodies).

## Project Corpus Impact
- Row: n/a — TypeScript conformance/emit fixture regression fix, not a project-corpus benchmark row.
- Bug family: trailing comment placement (block comment after an ASI expression statement dropped) — the last remnant of the #11999 cluster (#12003 fixed the other 12/13, incl. accessors).
- Evidence: local `scripts/emit/run.sh --js-only` Failed **43 → 42** (−1; fixes `parserKeywordsAsIdentifierName2`; `comm`-diff zero new failures vs freshly-built origin/main baseline); conformance pre-check clean (accessors 21/21, parserKeywords 2/2, comment 99/99, ASI 6/6); `cargo nextest -p tsz-emitter` comment-tests 330 pass (+2 new); clippy clean.

## Verification
- Targeted: `parserKeywordsAsIdentifierName2` green. (The 2 accessorsOverrideProperty tests were already fixed by #12003 — same single-line brace-body emit path; an earlier re-measure showed them failing only due to a stale `dist-fast` binary.)
- Net `--js-only`: 43→42, zero collateral (the 12 #12003 fixed + all method/arrow/object-method cases stay green).
- Conformance pre-checked (comment emit is output-only but verified): no new regressions.

## Coordination Notes
- Completes the #11999 trailing-comment regression cluster: #12003 (Studio-A) fixed 12/13 (methods/object-methods/arrows/accessors), this fixes the last (ASI block-comment drop). Detected via a periodic full --js-only re-measure + set-diff (the regression was hidden behind sibling closes).
- Sibling lanes own privateName/dts/async/this-super — not touched. AgentName: opus48-emit100. Reviews welcome.
