### PR TITLE
fix(solver): route recursive generic instantiation through the cross-call cache

### DIFF
--- a/crates/tsz-solver/src/caches/instantiation_cache_test.rs
+++ b/crates/tsz-solver/src/caches/instantiation_cache_test.rs
@@ -22,21 +22,25 @@
 
 use crate::caches::query_cache::QueryCache;
 use crate::instantiation::instantiate::{
-    MAX_INSTANTIATION_DEPTH, TypeSubstitution, instantiate_type_cached,
+    MAX_INSTANTIATION_DEPTH, TypeSubstitution, instantiate_generic_cached, instantiate_type_cached,
     instantiate_type_preserving_cached, substitute_this_type_at_return_position,
     substitute_this_type_cached,
 };
 use crate::intern::TypeInterner;
 use crate::types::{PropertyInfo, TypeId, TypeParamInfo, Visibility};
 
-fn type_param(interner: &TypeInterner, name: &str) -> (tsz_common::interner::Atom, TypeId) {
-    let atom = interner.intern_string(name);
-    let id = interner.type_param(TypeParamInfo {
+fn param_info(atom: tsz_common::interner::Atom) -> TypeParamInfo {
+    TypeParamInfo {
         name: atom,
         constraint: None,
         default: None,
         is_const: false,
-    });
+    }
+}
+
+fn type_param(interner: &TypeInterner, name: &str) -> (tsz_common::interner::Atom, TypeId) {
+    let atom = interner.intern_string(name);
+    let id = interner.type_param(param_info(atom));
     (atom, id)
 }
 
@@ -428,6 +432,208 @@ fn depth_exceeded_result_is_not_cached() {
         stats1.instantiation_cache_misses,
         stats0.instantiation_cache_misses + 2,
         "both depth-overflow requests should probe and miss independently"
+    );
+}
+
+#[test]
+fn instantiate_generic_cached_hits_cache_on_repeat() {
+    // Mirrors `cache_hit_after_first_instantiate_type` but exercises the
+    // substitution-building entry that recursive utility expansion uses.
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let (t_atom, t_id) = type_param(&interner, "T");
+    let body = object_with(&interner, t_id);
+    let param = param_info(t_atom);
+
+    let stats0 = db.statistics();
+
+    let r1 = instantiate_generic_cached(&interner, Some(&db), body, &[param], &[TypeId::STRING]);
+    let r2 = instantiate_generic_cached(&interner, Some(&db), body, &[param], &[TypeId::STRING]);
+
+    assert_eq!(r1, r2, "cached generic instantiation must equal recomputed");
+
+    let stats1 = db.statistics();
+    assert!(
+        stats1.instantiation_cache_misses > stats0.instantiation_cache_misses,
+        "first call must record at least one miss"
+    );
+    assert!(
+        stats1.instantiation_cache_hits > stats0.instantiation_cache_hits,
+        "second call must record a hit (got {} hits)",
+        stats1.instantiation_cache_hits
+    );
+}
+
+#[test]
+fn instantiate_generic_cached_shares_slot_with_instantiate_type_cached() {
+    // The two entry points share the canonical-substitution cache slot, so
+    // recursive utility expansion benefits from the cache regardless of which
+    // entry point the calling site uses.
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let (t_atom, t_id) = type_param(&interner, "T");
+    let body = object_with(&interner, t_id);
+    let param = param_info(t_atom);
+
+    let mut subst = TypeSubstitution::new();
+    subst.insert(t_atom, TypeId::STRING);
+
+    let stats0 = db.statistics();
+
+    let r_type = instantiate_type_cached(&interner, Some(&db), body, &subst);
+    let r_generic =
+        instantiate_generic_cached(&interner, Some(&db), body, &[param], &[TypeId::STRING]);
+
+    assert_eq!(
+        r_type, r_generic,
+        "both entry points must produce the same result"
+    );
+
+    let stats1 = db.statistics();
+    assert!(
+        stats1.instantiation_cache_hits > stats0.instantiation_cache_hits,
+        "instantiate_generic_cached must hit the slot populated by instantiate_type_cached"
+    );
+}
+
+#[test]
+fn instantiate_generic_cached_identity_short_circuits() {
+    // `is_identity_for` returns the body untouched without probing the cache.
+    // This preserves the pre-existing fast path that the uncached
+    // `instantiate_generic` had and keeps the cache cheap for no-op
+    // substitutions.
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let (t_atom, t_id) = type_param(&interner, "T");
+    let body = object_with(&interner, t_id);
+    let param = param_info(t_atom);
+
+    let stats0 = db.statistics();
+
+    // Identity substitution: T -> T.
+    let r = instantiate_generic_cached(&interner, Some(&db), body, &[param], &[t_id]);
+    assert_eq!(r, body);
+
+    let stats1 = db.statistics();
+    assert_eq!(
+        stats1.instantiation_cache_entries, stats0.instantiation_cache_entries,
+        "identity substitution must not populate the cache"
+    );
+    assert_eq!(
+        stats1.instantiation_cache_misses, stats0.instantiation_cache_misses,
+        "identity substitution must not probe the cache"
+    );
+}
+
+#[test]
+fn instantiate_generic_cached_no_query_db_disables_cache() {
+    // Backwards compat: calling with query_db=None preserves the existing
+    // semantics — the result is correct but the cache is never consulted.
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let (t_atom, t_id) = type_param(&interner, "T");
+    let body = object_with(&interner, t_id);
+    let param = param_info(t_atom);
+
+    let stats0 = db.statistics();
+
+    let r1 = instantiate_generic_cached(&interner, None, body, &[param], &[TypeId::STRING]);
+    let r2 = instantiate_generic_cached(&interner, None, body, &[param], &[TypeId::STRING]);
+    assert_eq!(r1, r2);
+
+    let stats1 = db.statistics();
+    assert_eq!(
+        stats1.instantiation_cache_entries, stats0.instantiation_cache_entries,
+        "calls with query_db=None must not populate the cache"
+    );
+    assert_eq!(
+        stats1.instantiation_cache_hits, stats0.instantiation_cache_hits,
+        "calls with query_db=None must not register hits"
+    );
+}
+
+#[test]
+fn instantiate_generic_cached_depth_overflow_not_cached() {
+    // A depth-overflow walk returns TypeId::ERROR but must not poison the
+    // cache: re-requesting the same (body, args) must miss again. Otherwise a
+    // single spurious overflow would lock the alias to ERROR for the lifetime
+    // of the QueryCache.
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let (t_atom, t_id) = type_param(&interner, "T");
+    let param = param_info(t_atom);
+
+    let depth = (MAX_INSTANTIATION_DEPTH as usize) + 2;
+    let mut body = t_id;
+    for _ in 0..depth {
+        body = interner.array(body);
+    }
+
+    let stats0 = db.statistics();
+
+    let r1 = instantiate_generic_cached(&interner, Some(&db), body, &[param], &[TypeId::STRING]);
+    let r2 = instantiate_generic_cached(&interner, Some(&db), body, &[param], &[TypeId::STRING]);
+
+    assert_eq!(r1, TypeId::ERROR);
+    assert_eq!(r2, TypeId::ERROR);
+
+    let stats1 = db.statistics();
+    assert_eq!(
+        stats1.instantiation_cache_entries, stats0.instantiation_cache_entries,
+        "depth-overflow results must not populate the cache"
+    );
+    assert_eq!(
+        stats1.instantiation_cache_hits, stats0.instantiation_cache_hits,
+        "a repeated depth-overflow request must not hit a cached ERROR"
+    );
+    assert_eq!(
+        stats1.instantiation_cache_misses,
+        stats0.instantiation_cache_misses + 2,
+        "both depth-overflow requests should probe and miss independently"
+    );
+}
+
+#[test]
+fn instantiate_generic_cached_is_invariant_to_type_param_renaming() {
+    // The cache key uses canonical (Atom, TypeId) pairs, so two callers whose
+    // `TypeParamInfo` differ only in non-name metadata (constraint, default)
+    // must hit the same cache slot.
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    // Body uses a TypeParameter atom shared with the param we'll instantiate
+    // with. (Same atom => same substitution payload.)
+    let (shared_atom, t_id) = type_param(&interner, "T");
+    let body = object_with(&interner, t_id);
+
+    // Two callers, two different `TypeParamInfo` values but the same name atom.
+    // Different constraint metadata must not perturb the cache key.
+    let param_a = param_info(shared_atom);
+    let param_b = TypeParamInfo {
+        name: shared_atom,
+        constraint: Some(TypeId::UNKNOWN),
+        default: None,
+        is_const: false,
+    };
+
+    let stats0 = db.statistics();
+    let r_a = instantiate_generic_cached(&interner, Some(&db), body, &[param_a], &[TypeId::STRING]);
+    let r_b = instantiate_generic_cached(&interner, Some(&db), body, &[param_b], &[TypeId::STRING]);
+
+    assert_eq!(
+        r_a, r_b,
+        "same substitution payload must produce the same result"
+    );
+
+    let stats1 = db.statistics();
+    assert!(
+        stats1.instantiation_cache_hits > stats0.instantiation_cache_hits,
+        "second caller must reuse the cache slot populated by the first"
     );
 }
 

--- a/crates/tsz-solver/src/caches/instantiation_cache_test.rs
+++ b/crates/tsz-solver/src/caches/instantiation_cache_test.rs
@@ -638,6 +638,47 @@ fn instantiate_generic_cached_is_invariant_to_type_param_renaming() {
 }
 
 #[test]
+fn evaluator_recursive_utility_application_populates_cache() {
+    // End-to-end wiring evidence for issue #10851: route an alias body that
+    // contains the type parameter twice through the actual `TypeEvaluator`
+    // with a `QueryCache` attached. The known-params instantiation path goes
+    // through `instantiate_generic_cached`, which must populate the cross-
+    // call `InstantiationCache`. Guards the wiring at the callsite, not just
+    // the helper in isolation.
+    use crate::def::{DefId, DefKind};
+    use crate::evaluation::evaluate::TypeEvaluator;
+    use crate::relations::subtype::TypeEnvironment;
+
+    let interner = TypeInterner::new();
+    let (t_atom, t_id) = type_param(&interner, "T");
+    let body = object_with_pair(&interner, t_id, t_id);
+
+    let mut env = TypeEnvironment::new();
+    let def_id = DefId(908_510);
+    env.insert_def_with_params(def_id, body, vec![param_info(t_atom)]);
+    env.insert_def_kind(def_id, DefKind::TypeAlias);
+
+    let app = interner.application(interner.lazy(def_id), vec![TypeId::STRING]);
+    let qc = QueryCache::new(&interner);
+
+    let stats0 = qc.statistics();
+    let mut evaluator = TypeEvaluator::with_resolver(&interner, &env).with_query_db(&qc);
+    let _ = evaluator.evaluate(app);
+    let stats1 = qc.statistics();
+
+    assert!(
+        stats1.instantiation_cache_entries > stats0.instantiation_cache_entries
+            || stats1.instantiation_cache_misses > stats0.instantiation_cache_misses,
+        "evaluator must reach instantiation cache through instantiate_generic_cached \
+         (entries: {} -> {}, misses: {} -> {})",
+        stats0.instantiation_cache_entries,
+        stats1.instantiation_cache_entries,
+        stats0.instantiation_cache_misses,
+        stats1.instantiation_cache_misses,
+    );
+}
+
+#[test]
 fn cache_clear_drops_all_instantiation_entries() {
     // QueryCache::clear() must drop the instantiation cache too.
     let interner = TypeInterner::new();

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -23,9 +23,6 @@ use crate::diagnostics::display_provenance::{
 };
 use crate::evaluation::request::EvaluationRequest;
 use crate::evaluation::result::EvaluationResult;
-use crate::instantiation::instantiate::instantiate_generic_cached;
-// Re-imported so `tests/evaluate_tests_parts/*` (mounted via `#[path]` below)
-// resolve it through `use super::*;`.
 #[cfg(test)]
 #[allow(unused_imports)]
 use crate::instantiation::instantiate::instantiate_generic;
@@ -1455,9 +1452,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 {
                     return None;
                 }
-                Some(instantiate_generic_cached(
-                    self.interner,
-                    self.query_db,
+                Some(self.cached_generic_instantiation(
                     shape.return_type,
                     &shape.type_params,
                     type_args,
@@ -1468,9 +1463,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 let signature = shape.call_signatures.iter().find(|sig| {
                     !sig.type_params.is_empty() && sig.type_params.len() == type_args.len()
                 })?;
-                Some(instantiate_generic_cached(
-                    self.interner,
-                    self.query_db,
+                Some(self.cached_generic_instantiation(
                     signature.return_type,
                     &signature.type_params,
                     type_args,
@@ -1511,13 +1504,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             }
             let mut member_args = expanded_args.to_vec();
             member_args[idx] = member;
-            let instantiated = instantiate_generic_cached(
-                self.interner,
-                self.query_db,
-                effective_body,
-                type_params,
-                &member_args,
-            );
+            let instantiated =
+                self.cached_generic_instantiation(effective_body, type_params, &member_args);
             distributed.push(self.evaluate(instantiated));
         }
         let evaluated = self.interner.union(distributed);
@@ -1556,13 +1544,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         record_structural_back_reference: bool,
         no_unchecked_indexed_access: bool,
     ) -> TypeId {
-        let mut instantiated = instantiate_generic_cached(
-            self.interner,
-            self.query_db,
-            body,
-            type_params,
-            expanded_args,
-        );
+        let mut instantiated = self.cached_generic_instantiation(body, type_params, expanded_args);
         // Rebind polymorphic `this` to the concrete application so
         // interface bodies like `constraint: Constraint<this>` preserve
         // their receiver-specific invariance.

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -23,6 +23,11 @@ use crate::diagnostics::display_provenance::{
 };
 use crate::evaluation::request::EvaluationRequest;
 use crate::evaluation::result::EvaluationResult;
+use crate::instantiation::instantiate::instantiate_generic_cached;
+// Re-imported so `tests/evaluate_tests_parts/*` (mounted via `#[path]` below)
+// resolve it through `use super::*;`.
+#[cfg(test)]
+#[allow(unused_imports)]
 use crate::instantiation::instantiate::instantiate_generic;
 use crate::relations::subtype::{NoopResolver, TypeResolver};
 #[cfg(test)]
@@ -1450,8 +1455,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 {
                     return None;
                 }
-                Some(instantiate_generic(
+                Some(instantiate_generic_cached(
                     self.interner,
+                    self.query_db,
                     shape.return_type,
                     &shape.type_params,
                     type_args,
@@ -1462,8 +1468,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 let signature = shape.call_signatures.iter().find(|sig| {
                     !sig.type_params.is_empty() && sig.type_params.len() == type_args.len()
                 })?;
-                Some(instantiate_generic(
+                Some(instantiate_generic_cached(
                     self.interner,
+                    self.query_db,
                     signature.return_type,
                     &signature.type_params,
                     type_args,
@@ -1504,8 +1511,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             }
             let mut member_args = expanded_args.to_vec();
             member_args[idx] = member;
-            let instantiated =
-                instantiate_generic(self.interner, effective_body, type_params, &member_args);
+            let instantiated = instantiate_generic_cached(
+                self.interner,
+                self.query_db,
+                effective_body,
+                type_params,
+                &member_args,
+            );
             distributed.push(self.evaluate(instantiated));
         }
         let evaluated = self.interner.union(distributed);
@@ -1544,7 +1556,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         record_structural_back_reference: bool,
         no_unchecked_indexed_access: bool,
     ) -> TypeId {
-        let mut instantiated = instantiate_generic(self.interner, body, type_params, expanded_args);
+        let mut instantiated = instantiate_generic_cached(
+            self.interner,
+            self.query_db,
+            body,
+            type_params,
+            expanded_args,
+        );
         // Rebind polymorphic `this` to the concrete application so
         // interface bodies like `constraint: Constraint<this>` preserve
         // their receiver-specific invariance.

--- a/crates/tsz-solver/src/evaluation/evaluate/support.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/support.rs
@@ -1,9 +1,21 @@
 //! Support methods for `TypeEvaluator` argument expansion, simplification,
 //! and visitor dispatch.
 
+use crate::instantiation::instantiate::instantiate_generic_cached;
+
 use super::*;
 
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
+    #[inline]
+    pub(super) fn cached_generic_instantiation(
+        &self,
+        body: TypeId,
+        type_params: &[TypeParamInfo],
+        args: &[TypeId],
+    ) -> TypeId {
+        instantiate_generic_cached(self.interner, self.query_db, body, type_params, args)
+    }
+
     /// Check if a type is a Conditional whose `extends_type` is an Application containing infer.
     /// This detects patterns like `T extends Promise<infer U> ? U : T`.
     pub(crate) fn is_conditional_with_application_infer(&self, type_id: TypeId) -> bool {

--- a/crates/tsz-solver/src/evaluation/evaluate/support.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/support.rs
@@ -1167,7 +1167,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         .iter()
                         .map(|p| p.default.unwrap_or(TypeId::ERROR))
                         .collect();
-                    instantiate_generic(self.interner, resolved, &type_params, &default_args)
+                    instantiate_generic_cached(
+                        self.interner,
+                        self.query_db,
+                        resolved,
+                        &type_params,
+                        &default_args,
+                    )
                 } else {
                     resolved
                 }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -9,7 +9,7 @@ mod object_infer;
 mod phases;
 
 use crate::instantiation::instantiate::{
-    TypeSubstitution, instantiate_generic, instantiate_type, instantiate_type_with_infer,
+    TypeSubstitution, instantiate_generic_cached, instantiate_type, instantiate_type_with_infer,
 };
 use crate::operations::property::PropertyAccessResult;
 use crate::relations::subtype::{SubtypeChecker, TypeResolver};
@@ -1143,7 +1143,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         if type_params.len() != app.args.len() {
             return None;
         }
-        let instantiated = instantiate_generic(self.interner(), resolved, &type_params, &app.args);
+        let instantiated = instantiate_generic_cached(
+            self.interner(),
+            self.query_db(),
+            resolved,
+            &type_params,
+            &app.args,
+        );
         if let Some(TypeData::IndexAccess(obj, idx)) = self.interner().lookup(instantiated) {
             let evaluated_obj = self.evaluate(obj);
             let evaluated_idx = self.evaluate(idx);

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
@@ -1,6 +1,6 @@
 //! Named phases for conditional type evaluation.
 
-use crate::instantiation::instantiate::instantiate_generic;
+use crate::instantiation::instantiate::instantiate_generic_cached;
 use crate::relations::subtype::TypeResolver;
 use crate::types::{ConditionalType, TypeData, TypeId};
 use tracing::trace;
@@ -66,8 +66,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             {
                 let args = app.args.clone();
                 let expanded_args = self.expand_type_args(&args);
-                let instantiated = instantiate_generic(
+                let instantiated = instantiate_generic_cached(
                     self.interner(),
+                    self.query_db(),
                     resolved_base,
                     &type_params,
                     &expanded_args,

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -1296,8 +1296,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             return None;
         }
         let body = self.resolver().resolve_lazy(def_id, self.interner())?;
-        let substituted = crate::instantiation::instantiate::instantiate_generic(
+        let substituted = crate::instantiation::instantiate::instantiate_generic_cached(
             self.interner(),
+            self.query_db(),
             body,
             &type_params,
             &app.args,

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
@@ -3,7 +3,7 @@
 //! Handles TypeScript's keyof operator: `keyof T`
 
 use crate::construction::TypeDatabase;
-use crate::instantiation::instantiate::instantiate_generic;
+use crate::instantiation::instantiate::instantiate_generic_cached;
 use crate::objects::PropertyCollectionResult;
 use crate::objects::apparent::literal_value_intrinsic_kind;
 use crate::relations::subtype::TypeResolver;
@@ -742,8 +742,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 if mapped.name_type.is_some() {
                     return None;
                 }
-                let instantiated = instantiate_generic(
+                let instantiated = instantiate_generic_cached(
                     self.interner(),
+                    self.query_db(),
                     mapped.constraint,
                     &type_params,
                     &app.args,
@@ -810,11 +811,23 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let matches_by_arg = |ty: TypeId| {
             ty == source_arg || source_arg_name.is_some_and(|n| self.is_type_param_named(ty, n))
         };
-        let inst_true = instantiate_generic(self.interner(), cond.true_type, type_params, args);
+        let inst_true = instantiate_generic_cached(
+            self.interner(),
+            self.query_db(),
+            cond.true_type,
+            type_params,
+            args,
+        );
         if !self.branch_matches_keyof_source(inst_true, &matches_by_arg) {
             return None;
         }
-        let inst_false = instantiate_generic(self.interner(), cond.false_type, type_params, args);
+        let inst_false = instantiate_generic_cached(
+            self.interner(),
+            self.query_db(),
+            cond.false_type,
+            type_params,
+            args,
+        );
         if !self.branch_matches_keyof_source(inst_false, &matches_by_arg) {
             return None;
         }

--- a/crates/tsz-solver/src/evaluation/recursive_growth.rs
+++ b/crates/tsz-solver/src/evaluation/recursive_growth.rs
@@ -10,7 +10,7 @@
 //! infinite") for such aliases; these helpers let the evaluator do the same.
 
 use crate::def::DefId;
-use crate::instantiation::instantiate::instantiate_generic;
+use crate::instantiation::instantiate::instantiate_generic_cached;
 use crate::relations::subtype::TypeResolver;
 use crate::types::{LiteralValue, TypeData, TypeId};
 
@@ -158,8 +158,13 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
         }
 
         // Instantiate the body with the type arguments — but do NOT evaluate.
-        let instantiated =
-            instantiate_generic(self.interner(), resolved, &type_params, &expanded_args);
+        let instantiated = instantiate_generic_cached(
+            self.interner(),
+            self.query_db(),
+            resolved,
+            &type_params,
+            &expanded_args,
+        );
         Some(instantiated)
     }
 }

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -487,10 +487,19 @@ pub fn instantiate_generic(
     instantiate_generic_cached(interner, None, type_id, type_params, type_args)
 }
 
-/// Cache-aware variant of [`instantiate_generic`]. Shares cache slots with
-/// [`instantiate_type_cached`] via the same `(body, canonical_subst)` key, so
+/// Cache-aware variant of [`instantiate_generic`]. Shares the canonical
+/// `(body, canonical_subst, mode_bits=0, this_type=None)` cache slot so
 /// recursive utility expansion that re-applies the same body/substitution
 /// pair reuses memoized walks instead of re-traversing the body each step.
+///
+/// Routes through the staged [`instantiate_with_request_cached`] engine
+/// rather than [`instantiate_type_cached`] so the full `TypeInstantiator`
+/// walk runs on every cache miss. The leaf fast path on `instantiate_type_cached`
+/// for top-level `IndexAccess` returns the raw `IndexAccess(obj, idx)`
+/// without the eager `evaluate_index_access` step that
+/// `TypeInstantiator::instantiate` performs for fully-concrete index-access
+/// types; delegating to it would regress mapped/keyof conformance for
+/// bodies whose top-level shape is `T[K]`.
 pub fn instantiate_generic_cached(
     interner: &dyn TypeDatabase,
     query_db: Option<&dyn QueryDatabase>,
@@ -504,10 +513,15 @@ pub fn instantiate_generic_cached(
         return type_id;
     }
     let substitution = TypeSubstitution::from_args(interner, type_params, type_args);
-    if substitution.is_identity_for(interner, type_params) {
+    if substitution.is_empty() || substitution.is_identity_for(interner, type_params) {
         return type_id;
     }
-    instantiate_type_cached(interner, query_db, type_id, &substitution)
+    instantiate_with_request_cached(
+        interner,
+        query_db,
+        InstantiationRequest::new(type_id, &substitution),
+    )
+    .into_type_id()
 }
 
 /// Substitute `ThisType` with a concrete type throughout a type.

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -484,20 +484,30 @@ pub fn instantiate_generic(
     type_params: &[TypeParamInfo],
     type_args: &[TypeId],
 ) -> TypeId {
-    if type_params.is_empty() || type_args.is_empty() {
+    instantiate_generic_cached(interner, None, type_id, type_params, type_args)
+}
+
+/// Cache-aware variant of [`instantiate_generic`]. Shares cache slots with
+/// [`instantiate_type_cached`] via the same `(body, canonical_subst)` key, so
+/// recursive utility expansion that re-applies the same body/substitution
+/// pair reuses memoized walks instead of re-traversing the body each step.
+pub fn instantiate_generic_cached(
+    interner: &dyn TypeDatabase,
+    query_db: Option<&dyn QueryDatabase>,
+    type_id: TypeId,
+    type_params: &[TypeParamInfo],
+    type_args: &[TypeId],
+) -> TypeId {
+    // Hoisted before substitution-building so intrinsic bodies skip the
+    // FxHashMap allocation and default-resolution passes in `from_args`.
+    if type_id.is_intrinsic() || type_params.is_empty() || type_args.is_empty() {
         return type_id;
     }
     let substitution = TypeSubstitution::from_args(interner, type_params, type_args);
-    if substitution.is_empty() || substitution.is_identity_for(interner, type_params) {
+    if substitution.is_identity_for(interner, type_params) {
         return type_id;
     }
-    let mut instantiator = TypeInstantiator::new(interner, &substitution);
-    let result = instantiator.instantiate(type_id);
-    if instantiator.depth_exceeded {
-        TypeId::ERROR
-    } else {
-        result
-    }
+    instantiate_type_cached(interner, query_db, type_id, &substitution)
 }
 
 /// Substitute `ThisType` with a concrete type throughout a type.

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -164,8 +164,8 @@ pub mod computation {
     pub use crate::instantiation::application::ApplicationEvaluator;
     pub use crate::instantiation::instantiate::{
         MAX_INSTANTIATION_DEPTH, TypeInstantiator, TypeSubstitution, fill_application_defaults,
-        instantiate_function_with_type_args, instantiate_generic, instantiate_type,
-        instantiate_type_cached, instantiate_type_params_to_constraints,
+        instantiate_function_with_type_args, instantiate_generic, instantiate_generic_cached,
+        instantiate_type, instantiate_type_cached, instantiate_type_params_to_constraints,
         instantiate_type_preserving, instantiate_type_preserving_cached,
         instantiate_type_preserving_meta, instantiate_type_preserving_meta_cached,
         instantiate_type_with_depth_status, instantiate_type_with_infer,

--- a/crates/tsz-solver/src/narrowing/core.rs
+++ b/crates/tsz-solver/src/narrowing/core.rs
@@ -721,12 +721,14 @@ impl<'a> NarrowingContext<'a> {
                                 // structural forms (e.g. Union) for distribution.
                                 let resolved_args: Vec<TypeId> =
                                     app.args.iter().map(|&arg| self.resolve_type(arg)).collect();
-                                type_id = crate::instantiation::instantiate::instantiate_generic(
-                                    self.db.as_type_database(),
-                                    body,
-                                    &params,
-                                    &resolved_args,
-                                );
+                                type_id =
+                                    crate::instantiation::instantiate::instantiate_generic_cached(
+                                        self.db.as_type_database(),
+                                        Some(self.db),
+                                        body,
+                                        &params,
+                                        &resolved_args,
+                                    );
                                 continue;
                             }
                         }

--- a/crates/tsz-solver/src/narrowing/utils.rs
+++ b/crates/tsz-solver/src/narrowing/utils.rs
@@ -502,8 +502,9 @@ fn remove_nullish_inner(
             && let Some(type_params) = db.get_lazy_type_params(def_id)
             && let Some(resolved) = db.resolve_lazy(def_id, types)
         {
-            let instantiated = crate::instantiation::instantiate::instantiate_generic(
+            let instantiated = crate::instantiation::instantiate::instantiate_generic_cached(
                 types,
+                query_db,
                 resolved,
                 &type_params,
                 &app.args,

--- a/crates/tsz-solver/src/operations/generic_call/mod.rs
+++ b/crates/tsz-solver/src/operations/generic_call/mod.rs
@@ -7,7 +7,9 @@
 //! - Placeholder normalization
 
 use crate::construction::TypeDatabase;
-use crate::instantiation::instantiate::{TypeInstantiator, TypeSubstitution, instantiate_generic};
+use crate::instantiation::instantiate::{
+    TypeInstantiator, TypeSubstitution, instantiate_generic_cached,
+};
 use crate::relations::subtype::TypeResolver;
 use crate::types::{TypeData, TypeId};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -59,8 +61,13 @@ fn literal_preservation_constraint_target(
             };
             let type_params = resolver.get_lazy_type_params(def_id)?;
             let body = resolver.resolve_lazy(def_id, interner.as_type_database())?;
-            let instantiated =
-                instantiate_generic(interner.as_type_database(), body, &type_params, &app.args);
+            let instantiated = instantiate_generic_cached(
+                interner.as_type_database(),
+                Some(interner),
+                body,
+                &type_params,
+                &app.args,
+            );
             Some(interner.evaluate_type(instantiated))
         }
         Some(


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Conformance / performance — recursive utility expansion enabling slice for
issue #10851. This PR wires the cross-call `InstantiationCache` into the hot
recursive solver paths; the row-level/timed proof of the
`vite-vanilla-ts-app` fan-out improvement is tracked as a follow-up in
#12021.

## Invariant
When `(body, canonical_subst, mode_bits, this_type)` is requested twice
within a `QueryCache` lifetime, return the memoized instantiation. The cache
key uses canonical `(Atom, TypeId)` pairs, so two callers whose
`TypeParamInfo` differ only in non-name metadata (constraint, default) hit
the same slot, and the cache is not fooled by type-parameter spelling.

## Scope
Solver-only. No changes to checker, emitter, LSP, or downstream crates. No
new dependencies. No public-API breakage — `instantiate_generic` is
preserved as a wrapper that forwards `query_db = None`.

## Project Corpus Impact
- Row: vite-vanilla-ts-app (recursive utility expansion fan-out — issue #10851; row-level measurement deferred to follow-up issue #12021)
- Bug family: recursive-types / instantiation cache underutilization
- Evidence: 7 new solver unit tests (cache hit / shared slot / identity short-circuit / no-DB fallback / depth-overflow non-poisoning / renaming invariance / end-to-end evaluator wiring). The unit tests prove the *cache wiring*, not the *row delta*; the row delta is follow-up work, captured in #12021.

## Verification (current head `cc5ed65`)
- 18 cache-wiring unit tests pass (`cargo test -p tsz-solver --lib instantiation_cache_wiring_tests`): 12 pre-existing + 6 new `instantiate_generic_cached_*` + 1 new end-to-end `evaluator_recursive_utility_application_populates_cache`.
- All previously-passing solver lib tests still pass; the 9 failing tests on this branch are identical to the 9 failing on `main` (pre-existing, not introduced by this PR).
- `cargo check -p tsz-solver` clean on `cc5ed65`.
- `crates/tsz-solver/src/evaluation/evaluate.rs` is at exactly 2065 lines (== the §19 ratchet ceiling); the per-evaluator helper now lives in the sibling `evaluation/evaluate/support.rs` module.
- Conformance regressions seen on the previous head (`bc508e1`) — `deeplyNestedMappedTypes.ts`, `intersectionsOfLargeUnions2.ts`, `importAttributes11.ts` — are addressed by the `8c751ac` routing fix; full conformance re-validation is owned by exact-head CI on `cc5ed65`.
- Auto-merge stays off. Exact-head PR-head checks on `cc5ed65` passed in run `26729658346`; `merge-queue` is present and `Queue Tested` is the remaining queue-owned status.

## Coordination Notes (current head `cc5ed65`)
- Lane: `agent:Studio-B`. Owner: AgentName `Studio-B`.
- Enabling slice for #10851. The row-level/timed measurement on
  `vite-vanilla-ts-app` is **deferred to follow-up issue #12021**, not
  proven by this PR. Cache mechanics ≠ row improvement; the PR body
  reflects that explicitly.
- Head history (newest first):
  - `cc5ed65` `test(solver): restore evaluator-level wiring test for instantiate_generic_cached` — re-adds the end-to-end `TypeEvaluator` + `QueryCache` test that proves the cache is populated through the actual evaluator path (catches regressions where the helper is reachable in isolation but the evaluator is rewired to bypass it).
  - `8c751ac` `fix(solver): route instantiate_generic_cached through the staged engine` — conformance-regression fix. `instantiate_generic_cached` was delegating to `instantiate_type_cached`, whose top-level `IndexAccess` leaf fast path returns the raw `IndexAccess(obj, idx)` without the eager `evaluate_index_access` step that `TypeInstantiator::instantiate` performs for fully-concrete bodies. Routed through the staged `instantiate_with_request_cached` engine instead so the full `TypeInstantiator` walk runs on every cache miss; the canonical cache slot is still shared with the other cached entry points.
  - `8196c20` `chore(solver): keep evaluate cache plumbing under ratchet` — moved the per-evaluator cache helper out of `evaluation/evaluate.rs` (which had ratcheted to 2083 lines) and into the sibling `evaluation/evaluate/support.rs` so `evaluate.rs` is back under the 2065-line §19 ceiling.
  - `c700446` `fix(solver): route recursive generic instantiation through the cross-call cache` — original cache wiring across the recursive solver hot paths.
- Auto-merge is **off permanently** for this PR. Exact-head CI on `cc5ed65` passed in run `26729658346`; the repo-local `merge-queue` label is present and `Queue Tested` is now the remaining queue-owned status.
- Stacking opportunity (deliberately deferred): callers in `SubtypeChecker`
  (`relations/judge.rs`), `ContextualTypeContext`, `InferenceContext`, and
  the diagnostics formatter still use the uncached `instantiate_generic`.
  Plumbing `QueryDatabase` into those types is a follow-up refactor
  intentionally not bundled into this PR to keep blast radius small.

---

## Summary

`instantiate_generic(...)` — the substitution entry used by every recursive
alias/conditional/keyof expansion in the solver — bypassed the cross-call
`InstantiationCache`. Every recursive utility expansion, mapped-union
distribution, conditional expansion, keyof distribution, and conditional
tail-call rebuilt a fresh `TypeInstantiator` and re-walked the body from
scratch on every step, even when the same `(body, canonical_subst)` pair
was already memoized.

This PR adds `instantiate_generic_cached(interner, query_db, ...)` next to
the existing `instantiate_generic` and routes the recursion-heavy solver
call sites through it. The fix sits at the architecture-correct layer:
Solver owns substitution; `QueryCache` owns the cache.
`instantiate_generic_cached` builds the substitution, runs `is_identity_for`,
then delegates to the staged `instantiate_with_request_cached` engine so the
full `TypeInstantiator` walk runs on every miss while the canonical cache
slot is shared across cached entries.

## Hot paths routed through the cache

- `evaluation::recursive_growth::try_instantiate_application_for_tail_call`
- `evaluation::evaluate` (application expansion, mapped-union distribution,
  finalize)
- `evaluation::evaluate_rules::conditional` and `conditional/phases`
- `evaluation::evaluate_rules::keyof` (mapped + conditional branches)
- `evaluation::evaluate_rules::infer_pattern::alias_application_substituted_body`
- `evaluation::evaluate::support` (default-args expansion)
- `narrowing::core` (Application narrowing loop)
- `narrowing::utils::remove_nullish_inner` (recursive)
- `operations::generic_call::literal_preservation_constraint_target`

## Repro (issue #10851)

```ts
type BuildTuple<A extends unknown[], N extends number> =
  A['length'] extends N ? A : BuildTuple<[unknown, ...A], N>;

type DeepObject<T, D extends number> =
  BuildTuple<[], D> extends []
    ? T
    : { [K in keyof T]: DeepObject<T[K], D> };

type Anchor = { value: string; nested?: Anchor };
type Fixed = DeepObject<Anchor, 4>;
```

## Test plan
- [x] 7 new unit tests in `crates/tsz-solver/src/caches/instantiation_cache_test.rs`
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo test -p tsz-solver --lib` — 6445 pass; the 9 failures are pre-existing on `main`
- [x] `evaluate.rs` is at exactly 2065 lines (== §19 ratchet ceiling)
- [x] Exact-head CI on `cc5ed65`: lint, conformance, emit, fourslash, WASM passed in run `26729658346`
- [ ] Follow-up: row-level measurement on `vite-vanilla-ts-app` (issue #12021)

Enabling slice for #10851; row-level proof tracked in #12021.
