### PR TITLE
fix(emit): preserve JSX attribute comments

### DIFF
--- a/crates/tsz-emitter/src/emitter/jsx/emit.rs
+++ b/crates/tsz-emitter/src/emitter/jsx/emit.rs
@@ -223,7 +223,8 @@ impl<'a> Printer<'a> {
 
         self.write("<");
         self.emit(jsx.tag_name);
-        self.emit(jsx.attributes);
+        let tag_end = self.arena.get(jsx.tag_name).map_or(node.pos, |tag| tag.end);
+        self.emit_jsx_attributes_after_tag(jsx.attributes, tag_end);
         // tsc always emits writeSpace() after tagName. Our emit_jsx_attributes
         // already prepends a space before each attribute, so the space is only
         // missing when there are no attributes at all.

--- a/crates/tsz-emitter/src/emitter/jsx/mod.rs
+++ b/crates/tsz-emitter/src/emitter/jsx/mod.rs
@@ -653,6 +653,20 @@ mod tests {
     }
 
     #[test]
+    fn jsx_preserve_opening_attribute_comments_are_kept() {
+        let source = "const x = (<div\n    /* kept */\n    attr=\"x\"><span // line\n      value=\"y\" /></div>);";
+        let output = emit_jsx_preserve_es2015(source);
+        assert!(
+            output.contains("<div \n/* kept */\nattr=\"x\">"),
+            "Multiline comments before JSX attributes should stay in the opening tag.\nOutput: {output}"
+        );
+        assert!(
+            output.contains("<span // line\n value=\"y\"/>"),
+            "Line comments before JSX attributes should keep the comment and tsc continuation spacing.\nOutput: {output}"
+        );
+    }
+
+    #[test]
     fn recovered_jsx_conditional_missing_false_branch_preserves_tsc_layout() {
         let source = r#"// @target: es2015
 // @jsx: preserve

--- a/crates/tsz-emitter/src/emitter/jsx/transform.rs
+++ b/crates/tsz-emitter/src/emitter/jsx/transform.rs
@@ -309,7 +309,8 @@ impl<'a> Printer<'a> {
 
         self.write("<");
         self.emit(jsx.tag_name);
-        self.emit(jsx.attributes);
+        let tag_end = self.arena.get(jsx.tag_name).map_or(node.pos, |tag| tag.end);
+        self.emit_jsx_attributes_after_tag(jsx.attributes, tag_end);
         self.write(">");
     }
 
@@ -328,10 +329,75 @@ impl<'a> Printer<'a> {
             return;
         };
 
+        let mut gap_start = node.pos;
         for &attr in &attrs.properties.nodes {
-            self.write_space();
+            let Some(attr_node) = self.arena.get(attr) else {
+                continue;
+            };
+            if !self.emit_jsx_attribute_gap_comments(gap_start, attr_node.pos) {
+                self.write_space();
+            }
             self.emit(attr);
+            gap_start = attr_node.end;
         }
+    }
+
+    pub(in super::super) fn emit_jsx_attributes_after_tag(
+        &mut self,
+        attributes: tsz_parser::parser::NodeIndex,
+        tag_end: u32,
+    ) {
+        let Some(node) = self.arena.get(attributes) else {
+            return;
+        };
+        let Some(attrs) = self.arena.get_jsx_attributes(node) else {
+            return;
+        };
+
+        let mut gap_start = tag_end;
+        for &attr in &attrs.properties.nodes {
+            let Some(attr_node) = self.arena.get(attr) else {
+                continue;
+            };
+            if !self.emit_jsx_attribute_gap_comments(gap_start, attr_node.pos) {
+                self.write_space();
+            }
+            self.emit(attr);
+            gap_start = attr_node.end;
+        }
+    }
+
+    fn emit_jsx_attribute_gap_comments(&mut self, start_pos: u32, end_pos: u32) -> bool {
+        if self.ctx.options.remove_comments {
+            return false;
+        }
+
+        let mut has_comment = false;
+        let mut last_comment_was_single_line_with_newline = false;
+        let mut idx = self.comment_emit_idx;
+        while idx < self.all_comments.len() {
+            let comment = &self.all_comments[idx];
+            if comment.pos >= end_pos {
+                break;
+            }
+            if comment.end > start_pos {
+                has_comment = true;
+                last_comment_was_single_line_with_newline =
+                    !comment.is_multi_line && comment.has_trailing_new_line;
+            }
+            idx += 1;
+        }
+
+        if !has_comment {
+            return false;
+        }
+
+        self.write_space();
+        let (emitted, _, _) = self.emit_comments_in_range(start_pos, end_pos, false, true);
+        if emitted && last_comment_was_single_line_with_newline {
+            self.write_space();
+        }
+        emitted
     }
 
     pub(in super::super) fn emit_jsx_attribute(&mut self, node: &Node) {


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Track 9 JavaScript emit parity: JSX/react JS emit.

## Invariant
When JSX is emitted in preserve mode, comments and trivia that appear inside an opening tag before the next attribute belong to the JSX attribute-list output. The emitter consumes those source comments in attribute order so later JSX expression comments are not emitted with a stale comment cursor.

Owner layer: `tsz-emitter` JSX preserve-mode attribute/trivia emission. This PR does not add checker validation, semantic type checks, or post-emission output surgery.

## Scope
- Teaches preserve-mode JSX opening and self-closing element emit to pass the tag end into attribute emission.
- Emits comments in the source gap before each JSX attribute, preserving block-comment and line-comment attribute-list shapes that `tsc` keeps.
- Leaves the old single-space attribute path intact when the gap has no comments.
- Keeps focused emitter coverage for JSX expression/comment trivia behavior; the fixed baseline remains `jsxReactTestSuite`.

## Project Corpus Impact
- Row: n/a
- Bug family: JSX/react JS emit; preserve-mode attribute-list trivia/comment preservation.
- Evidence: `scripts/safe-run.sh scripts/emit/run.sh --filter=jsxReactTestSuite --js-only --verbose --timeout=30000 --json-out=/tmp/jsxReactTestSuite-studio-c-restack-20260601-main0ac6d.json` passes 1/1 on restacked head `882f59b3ed`. No project corpus row is known to depend on this conformance-only JSX preserve trivia baseline.

## Verification
- Restack verification 2026-06-01 (AgentName: Studio-C), head `882f59b3ed8483bd4567276644fb1dc24c9ce2a4` on `origin/main` `0ac6d659f0247401dc15bf2d67a35c8e3fca1d23`:
  - `git diff --check origin/main...HEAD`
  - `cargo nextest run -p tsz-emitter -E 'test(jsx_expression_without_expression_preserves_inner_comments)'`
  - `scripts/safe-run.sh scripts/emit/run.sh --filter=jsxReactTestSuite --js-only --verbose --timeout=30000 --json-out=/tmp/jsxReactTestSuite-studio-c-restack-20260601-main0ac6d.json`
- Note: the previous body named `jsx_preserve_opening_attribute_comments_are_kept`, but that exact test name is no longer present after current-main restack; the behavior is covered by the focused baseline filter above and existing JSX module coverage.
- Draft-light CI passed on prior head `af48f4324af5316cac42f94403239999769b5dda` in run `26738979055`: `CI Light Summary`, `dist-binaries`, `lint`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, and GitGuardian.
- Exact-head draft-light CI passed on head `882f59b3ed8483bd4567276644fb1dc24c9ce2a4` in run `26741158674`: `CI Light Summary`, `dist-binaries`, `lint`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, and GitGuardian. `Queue Tested` is queue-owned and pending before ready/queue.
- Restack-only verification 2026-06-01 (AgentName: Studio-C), head `7bff71d378ba85bfd8225f6a2c4139e964779d13` on `origin/main` `78e797339547f2898e3bd6177470bd0ece5903fb`: `git diff --check origin/main...HEAD`. No local rebuild was run for this restack-only push because disk is below the 20 GiB floor; prior focused JSX verification above still covers the unchanged patch.
- Exact-head draft-light CI passed on head `7bff71d378ba85bfd8225f6a2c4139e964779d13` in run `26742509474`: `CI Light Summary`, `dist-binaries`, `lint`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, and GitGuardian.
- Exact-head ready-review CI passed on head `7bff71d378ba85bfd8225f6a2c4139e964779d13` in run `26743111982`: `CI Summary`, `project-corpus-pr-body`, `emit`, `conformance-aggregate`, `fourslash-aggregate`, `project-compile-guard`, `project-compile-canary`, `lsp-e2e`, `wasm`, `wasm-web`, `dist-binaries`, `lint`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, and GitGuardian. `Queue Tested` is queue-owned and pending before queue.
- Earlier local verification before restack:
  - `cargo fmt --check`
  - `git diff --check`
  - `python3 scripts/arch/arch_guard.py`
  - `cargo nextest run -p tsz-emitter jsx_preserve_opening_attribute_comments_are_kept jsx_expression_without_expression_preserves_inner_comments`
  - `scripts/safe-run.sh scripts/emit/run.sh --filter=jsxReactTestSuite --js-only --verbose --timeout=30000 --json-out=/tmp/jsxReactTestSuite-studio-c-attr-comments.json` (1/1)
  - `scripts/safe-run.sh scripts/emit/run.sh --filter=jsx --js-only --verbose --timeout=30000 --json-out=/tmp/jsx-studio-c-fixed.json` (211/211)

## Coordination Notes
- Historical CI note 2026-06-01 (AgentName: Studio-C): ready-review CI on stale merge base `0ac6d659f0` failed `conformance-aggregate` in run `26741672691`: aggregate reported `12583/12587` actual vs `12585/12587` expected, with unlisted regressions `deeplyNestedMappedTypes.ts`, `intersectionsOfLargeUnions2.ts`, and `checkJsxChildrenCanBeTupleType.tsx`. The PR was converted back to draft/off-queue at that time and was later restacked onto current `origin/main` to clear the stale-base aggregate failure before another ready attempt.
- Restack update 2026-06-01 (AgentName: Studio-C): branch `codex/studio-c-jsx-react-suite-trivia-20260601` was rebased onto current `origin/main` `78e797339547f2898e3bd6177470bd0ece5903fb` and force-pushed with lease; new head is `7bff71d378ba85bfd8225f6a2c4139e964779d13`. Fresh draft-light CI passed on this head in run `26742509474`, and ready-review CI passed in run `26743111982`.
- Ready attempt 2026-06-01 (AgentName: Studio-C): exact-head draft-light CI was green for `882f59b3ed8483bd4567276644fb1dc24c9ce2a4`, so the PR was marked ready to run heavy review CI. The stale-base aggregate failure was addressed by restacking; exact-head ready-review CI is now green for `7bff71d378ba85bfd8225f6a2c4139e964779d13`, so this PR is ready for manager review and queue handoff. I did not add `merge-queue`.
- Claimed current JSX slice on #8512: https://github.com/mohsen1/tsz/issues/8512#issuecomment-4588668792
- Live orientation before this PR: `jsx` JS filter passed 210/211, with only `jsxReactTestSuite` failing.

