### PR TITLE
test(solver): ratchet empty relation policy spelling

### DIFF
--- a/crates/tsz-solver/tests/relation_cache_config_tests.rs
+++ b/crates/tsz-solver/tests/relation_cache_config_tests.rs
@@ -307,14 +307,14 @@ fn any_propagation_mode_differences_produce_distinct_keys() {
             let ka = RelationCacheKey::for_subtype(
                 TypeId::STRING,
                 TypeId::NUMBER,
-                RelationPolicy::from_relation_flags(RelationFlags::empty())
+                RelationPolicy::unflagged_compatibility()
                     .cache_config()
                     .with_any_mode(a),
             );
             let kb = RelationCacheKey::for_subtype(
                 TypeId::STRING,
                 TypeId::NUMBER,
-                RelationPolicy::from_relation_flags(RelationFlags::empty())
+                RelationPolicy::unflagged_compatibility()
                     .cache_config()
                     .with_any_mode(b),
             );
@@ -902,7 +902,7 @@ fn in_callback_param_check_partitions_cache_entries() {
     assert_subtype_partitions(
         "in_callback_param_check",
         RelationPolicy::from_relation_flags(RelationFlags::IN_CALLBACK_PARAM_CHECK),
-        RelationPolicy::from_relation_flags(RelationFlags::empty()),
+        RelationPolicy::unflagged_compatibility(),
     );
 }
 
@@ -913,7 +913,7 @@ fn strict_readonly_identity_partitions_cache_entries() {
     assert_subtype_partitions(
         "strict_readonly_identity",
         RelationPolicy::from_relation_flags(RelationFlags::STRICT_READONLY_IDENTITY),
-        RelationPolicy::from_relation_flags(RelationFlags::empty()),
+        RelationPolicy::unflagged_compatibility(),
     );
 }
 
@@ -925,7 +925,7 @@ fn subtype_cache_strict_readonly_identity_policy_matches_uncached_relation_query
     let source = interner.object(vec![PropertyInfo::readonly(prop, TypeId::NUMBER)]);
     let target = interner.object(vec![PropertyInfo::new(prop, TypeId::NUMBER)]);
 
-    let ordinary = RelationPolicy::from_relation_flags(RelationFlags::empty());
+    let ordinary = RelationPolicy::unflagged_compatibility();
     let strict_readonly =
         RelationPolicy::from_relation_flags(RelationFlags::STRICT_READONLY_IDENTITY);
     let ordinary_key = RelationCacheKey::for_subtype(source, target, ordinary.cache_config());

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/default_policy_protocol.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/default_policy_protocol.rs
@@ -22,3 +22,13 @@ fn default_relation_policy_paths_do_not_spell_packed_zero_flags() {
         );
     }
 }
+
+#[test]
+fn default_relation_cache_config_tests_do_not_spell_empty_relation_flags() {
+    let source = include_str!("../relation_cache_config_tests.rs");
+
+    assert!(
+        !source.contains("RelationPolicy::from_relation_flags(RelationFlags::empty())"),
+        "relation_cache_config_tests.rs must use RelationPolicy::unflagged_compatibility() for no-flags compatibility policies",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track: solver relation policy/cache-key protocols; #8207 source/test ratchet after #12012.

## Invariant
When a no-flags relation policy appears in solver cache-policy tests, it should use `RelationPolicy::unflagged_compatibility()` rather than spelling an empty typed flag mask; this PR changes only test vocabulary and ratchets that spelling.

## Scope
- `crates/tsz-solver/tests/relation_cache_config_tests.rs`
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests/default_policy_protocol.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: solver test-only source ratchet; no compiler behavior path or project fixture behavior intentionally changed.

## Verification
- `cargo nextest run -p tsz-solver -E 'test(default_relation_cache_config_tests_do_not_spell_empty_relation_flags)'` — red first on existing `RelationPolicy::from_relation_flags(RelationFlags::empty())` spellings, then passed; rerun on rebased head `74e483b196` passed 1 / 6461 skipped
- `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests) | test(relation_cache_config_tests)'` — passed on rebased head `74e483b196`, 93 passed / 6369 skipped
- `cargo fmt --check` — passed on rebased head `74e483b196`
- `git diff --check` — passed on rebased head `74e483b196`
- file-size check: touched files are 34 and 1204 lines
- GitHub ready-review CI on exact head `74e483b196` passed: `CI Summary`, `lint`, `unit`, `unit-cloudbuild`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `wasm`, `wasm-web`, `project-corpus-pr-body`, `project-row-drift`, `conformance-snapshot-gate`, `emit`, conformance aggregate/shards, fourslash aggregate/shards, `lsp-e2e`, project compile canary/guard, and `GitGuardian Security Checks`

## Coordination Notes
- Parent #12012 landed through `merge-queue`; this branch head `74e483b196` is PR-head green. `origin/main` has advanced beyond the PR base, so `merge-queue` will own the synthetic latest-main test via `Queue Tested`.
- Supports #8207 by keeping no-flags relation policy tests on the named typed constructor instead of an empty flag-mask spelling.
- Avoids #12002/#12036 variance/session-cache production paths, #11890 checker relation-routing work, #12019 recursive instantiation/cache work, and unrelated agent tooling/bench workflow changes now on `main`.
- Ready for `merge-queue` on exact head `74e483b196`; `Queue Tested` is queue-owned and may remain pending until the queue runs.
