### PR TITLE
chore(agents): expose disk pressure in preflight json

### DIFF
--- a/scripts/agents/disk-preflight.sh
+++ b/scripts/agents/disk-preflight.sh
@@ -344,6 +344,20 @@ function parseWorktreeSignals(text) {
 const guard = parseKeyValueLines(process.env.GUARD_OUTPUT ?? "");
 const bool = (value) => value === "true";
 const diskOk = guard.disk_status === "ok";
+const toNumber = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+const diskFreeMb = toNumber(guard.disk_free_mb);
+const minFreeGb = toNumber(guard.min_free_gb);
+const minFreeMb = minFreeGb * 1024;
+const cleanupLadder = [
+  "Reuse an existing worktree with TypeScript/cache state.",
+  "Run scripts/setup/disk-worktree-guard.sh --auto-prune.",
+  "Run scripts/setup/clean.sh --quiet to preserve .target, .target-bench, and target.",
+  "Delete only abandoned worktrees whose branch/PR owner is understood.",
+  "Use scripts/setup/clean.sh --full only as a deliberate last resort.",
+];
 const report = {
   ok: diskOk,
   status: diskOk ? "pass" : "fail",
@@ -353,6 +367,14 @@ const report = {
   disk_guard: {
     ...guard,
     ok: diskOk,
+  },
+  disk_pressure: {
+    ok: diskOk,
+    status: guard.disk_status ?? "unknown",
+    free_mb: diskFreeMb,
+    min_free_mb: minFreeMb,
+    shortfall_mb: Math.max(0, minFreeMb - diskFreeMb),
+    cleanup_ladder: diskOk ? [] : cleanupLadder,
   },
   typescript: {
     state: process.env.TYPESCRIPT_STATE,

--- a/scripts/agents/test_disk_preflight.py
+++ b/scripts/agents/test_disk_preflight.py
@@ -47,6 +47,7 @@ class DiskPreflightTests(unittest.TestCase):
     def run_preflight(self, fake_repo, fake_script, *extra_args, env_overrides=None):
         env = {
             **os.environ,
+            "TSZ_DISK_MIN_FREE_GB": "1",
             "TSZ_WORKTREE_INACTIVE_HOURS": "1",
             "TSZ_CARGO_CACHE_STUB_MAX_KB": "8",
             **(env_overrides or {}),
@@ -131,6 +132,12 @@ class DiskPreflightTests(unittest.TestCase):
             self.assertTrue(report["disk_guard"]["ok"])
             self.assertNotIn("branch", report["disk_guard"])
             self.assertGreaterEqual(len(report["reusable_worktrees"]), 1)
+            self.assertTrue(report["disk_pressure"]["ok"])
+            self.assertEqual("ok", report["disk_pressure"]["status"])
+            self.assertGreater(report["disk_pressure"]["free_mb"], 0)
+            self.assertGreater(report["disk_pressure"]["min_free_mb"], 0)
+            self.assertEqual(0, report["disk_pressure"]["shortfall_mb"])
+            self.assertEqual([], report["disk_pressure"]["cleanup_ladder"])
 
     def test_json_report_marks_low_disk_guard_not_ok(self):
         with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
@@ -152,6 +159,17 @@ class DiskPreflightTests(unittest.TestCase):
             self.assertEqual("fail", report["disk_preflight_status"])
             self.assertEqual("low", report["disk_guard"]["disk_status"])
             self.assertFalse(report["disk_guard"]["ok"])
+            self.assertFalse(report["disk_pressure"]["ok"])
+            self.assertEqual("low", report["disk_pressure"]["status"])
+            self.assertGreater(report["disk_pressure"]["shortfall_mb"], 0)
+            self.assertIn(
+                "Run scripts/setup/disk-worktree-guard.sh --auto-prune.",
+                report["disk_pressure"]["cleanup_ladder"],
+            )
+            self.assertIn(
+                "Use scripts/setup/clean.sh --full only as a deliberate last resort.",
+                report["disk_pressure"]["cleanup_ladder"],
+            )
 
     def test_worktree_without_typescript_points_to_link_helper(self):
         with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / disk-worktree hygiene / cheap evidence plumbing.

## Invariant
When disk preflight writes a machine-readable report, low-disk status includes the numeric free-space shortfall and the same cache-preserving cleanup ladder shown to humans, so launch automation can distinguish actionable pressure from a generic failure.

## Scope
- `scripts/agents/disk-preflight.sh`
- `scripts/agents/test_disk_preflight.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent script/reporting only; no compiler, checker, solver, parser, binder, emitter behavior, project corpus fixture, or benchmark row behavior changes.

## Verification
- `python3 -m unittest scripts.agents.test_disk_preflight`
- `bash -n scripts/agents/disk-preflight.sh`
- `scripts/agents/disk-preflight.sh Studio-F --json-report /tmp/tsz-disk-preflight-pressure.json`
- inspected `/tmp/tsz-disk-preflight-pressure.json`: `disk_preflight_status=fail`, `shortfall_mb=2270`, `cleanup_ladder_len=5` on the current low-disk machine.
- `git diff --check`

## Coordination Notes
- Studio-F owned PR runway was clear at intake.
- Final start-cycle disk preflight showed the machine below the 20GB target after cache-preserving cleanup, with no reusable inactive worktree candidates.
- This PR does not delete caches or worktrees; it makes the low-disk artifact clearer and machine-readable for the next cleanup decision.
- Built in a fresh Studio-F sister worktree from `origin/main`; TypeScript is linked to the populated primary checkout. No roadmap update: routine launch evidence plumbing.
