### PR TITLE
test(solver): ratchet cache agreement no-flags policy

### DIFF
--- a/crates/tsz-solver/tests/relation_cache_config_tests/cache_agreement.rs
+++ b/crates/tsz-solver/tests/relation_cache_config_tests/cache_agreement.rs
@@ -257,7 +257,7 @@ fn relation_policy_typed_accessors_preserve_packed_relation_bits() {
             | RelationFlags::ALLOW_ERASED_GENERIC_SIGNATURE_RETRY
             | RelationFlags::STRICT_READONLY_IDENTITY,
     );
-    let disabled = RelationPolicy::from_relation_flags(RelationFlags::empty());
+    let disabled = RelationPolicy::unflagged_compatibility();
 
     assert!(enabled.strict_null_checks());
     assert!(enabled.strict_function_types());

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/default_policy_protocol.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/default_policy_protocol.rs
@@ -32,3 +32,13 @@ fn default_relation_cache_config_tests_do_not_spell_empty_relation_flags() {
         "relation_cache_config_tests.rs must use RelationPolicy::unflagged_compatibility() for no-flags compatibility policies",
     );
 }
+
+#[test]
+fn cache_agreement_shard_does_not_spell_empty_relation_flags() {
+    let source = include_str!("../relation_cache_config_tests/cache_agreement.rs");
+
+    assert!(
+        !source.contains("RelationPolicy::from_relation_flags(RelationFlags::empty())"),
+        "relation_cache_config_tests/cache_agreement.rs must use RelationPolicy::unflagged_compatibility() for no-flags compatibility policies",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track: solver relation policy/cache-key protocols; #8207 source/test ratchet after #12024 landed.

## Invariant
When relation cache-agreement tests need the historical no-flags compatibility policy, they should use `RelationPolicy::unflagged_compatibility()` rather than spelling an empty typed flag mask; this PR changes only test vocabulary and ratchets that spelling for the cache-agreement shard.

## Scope
- `crates/tsz-solver/tests/relation_cache_config_tests/cache_agreement.rs`
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests/default_policy_protocol.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: solver test-only source ratchet; no compiler behavior path or project fixture behavior intentionally changed.

## Verification
- `cargo nextest run -p tsz-solver -E 'test(cache_agreement_shard_does_not_spell_empty_relation_flags)'` — passed on rebased head `42df9f11b1de`, 1 passed / 6462 skipped
- `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_agreement_tests) | test(relation_cache_config_tests)'` — passed on rebased head `42df9f11b1de`, 94 passed / 6369 skipped
- `cargo fmt --check` — passed on rebased head `42df9f11b1de`
- `git diff --check` — passed on rebased head `42df9f11b1de`
- file-size check: touched files are 44 and 1399 lines
- GitGuardian Security Checks — passed for exact head `42df9f11b1de`
- GitHub PR-head CI for exact head `42df9f11b1de` passed, including `CI Summary`, conformance, emit, fourslash, project compile, wasm, lint, unit, and GitGuardian

## Coordination Notes
- Parent #12024 landed via merge queue as `ac632a6a80`; this PR is now rebased onto `main` at `98b5da649a` and no longer stacked on the parent branch.
- Ready for merge queue on exact head `42df9f11b1de`; required exact-head PR-head checks including `CI Summary` and `GitGuardian Security Checks` are green.
- Child draft #12030 remains stacked on this branch and should be rebased/retargeted after this PR lands or if the stack is intentionally advanced.
- Supports #8207 by keeping no-flags relation policy tests on the named typed constructor instead of an empty flag-mask spelling.
- Avoids #12002/#12036 variance/session-cache production paths, #11890 checker relation-routing work, and #12019 recursive instantiation/cache work.

