### PR TITLE
test(solver): cover assume-cycle policy projection

### DIFF
--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/policy_config.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/policy_config.rs
@@ -30,11 +30,23 @@ fn relation_policy_cache_config_unifies_equivalent_flag_and_builder_bits() {
             RelationPolicy::unflagged_compatibility().with_skip_weak_type_checks(true),
         ),
         (
+            "assume related on cycle",
+            RelationPolicy::from_relation_flags(RelationFlags::ASSUME_RELATED_ON_CYCLE),
+            RelationPolicy::unflagged_compatibility().with_assume_related_on_cycle(true),
+        ),
+        (
             "disable generic erasure",
             RelationPolicy::from_relation_flags(RelationFlags::NO_ERASE_GENERICS),
             RelationPolicy::unflagged_compatibility().with_erase_generics(false),
         ),
     ];
+
+    assert!(
+        cases
+            .iter()
+            .any(|(name, _, _)| *name == "assume related on cycle"),
+        "flag-vs-builder cache config matrix must cover ASSUME_RELATED_ON_CYCLE",
+    );
 
     for (name, flagged, builder) in cases {
         assert_eq!(


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track: solver relation policy/cache-key protocols; #8207 relation-policy coverage ratchet.

## Invariant
When a behavior-affecting relation policy can be constructed either from a typed flag or a builder override, both construction paths must project to the same `RelationCacheConfig`; this PR adds the missing `ASSUME_RELATED_ON_CYCLE` row to that flag-vs-builder matrix.

## Scope
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests/policy_config.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: solver test-only relation-policy cache projection coverage; no compiler behavior path or project fixture behavior intentionally changed.

## Verification
- `cargo nextest run -p tsz-solver -E 'test(relation_policy_cache_config_unifies_equivalent_flag_and_builder_bits)'` — passed on rebased head `c53c080c`, 1 passed / 6462 skipped
- `cargo nextest run -p tsz-solver -E 'test(policy_config) | test(relation_policy_cache_agreement_tests)'` — passed on rebased head `c53c080c`, 39 passed / 6424 skipped
- `cargo fmt --check` — passed on rebased head `c53c080c`
- `git diff --check origin/main...HEAD` — passed on rebased head `c53c080c`
- file-size check: touched file is 267 lines
- GitHub ready-review CI pending for exact head `c53c080c` after retargeting to `main`

## Coordination Notes
- Parent #12029 merged into `main` as `6eb21384017`; this branch was rebased with only this PR's own test commit on top of current `origin/main` and the PR base was retargeted to `main`.
- Ready for review/heavy CI on exact head `c53c080c`; leave `merge-queue` off until PR-head `CI Summary` and `GitGuardian Security Checks` are green for this head.
- Supports #8207 by keeping relation-policy cache projection coverage explicit for behavior-affecting policy fields.
- Avoids #12002/#12036 variance/session-cache production paths, #11890 checker relation-routing work, and #12019 recursive instantiation/cache work.
