### PR TITLE
chore(agents): expose merge queue label counts

### DIFF
--- a/scripts/agents/list-owned-work.sh
+++ b/scripts/agents/list-owned-work.sh
@@ -138,6 +138,26 @@ count_pr_state_rows() {
   printf '%s\n' "$rows" | awk -v state="$state" '$2 == state { count++ } END { print count + 0 }'
 }
 
+count_pr_token_rows() {
+  local rows="$1"
+  local token="$2"
+  if [[ -z "$rows" ]]; then
+    echo 0
+    return
+  fi
+  printf '%s\n' "$rows" | awk -v token="$token" '
+    {
+      for (i = 1; i <= NF; i++) {
+        if ($i == token) {
+          count++
+          next
+        }
+      }
+    }
+    END { print count + 0 }
+  '
+}
+
 json_array_from_lines() {
   local rows="$1"
   ROWS="$rows" node <<'NODE'
@@ -159,7 +179,7 @@ for agent in "${SELECTED[@]}"; do
   if [[ "$WITH_PR_STATE" == true ]]; then
     prs="$(
       gh pr list --state open --limit 100 --label "$label" \
-        --json number,title,isDraft,url,mergeStateStatus,mergeable,autoMergeRequest,statusCheckRollup \
+        --json number,title,isDraft,url,mergeStateStatus,mergeable,autoMergeRequest,statusCheckRollup,labels \
         --jq '
           def queue_state:
             ([.statusCheckRollup[]? | select((.__typename == "StatusContext" and .context == "Queue Tested") or .name == "Queue Tested")] | first) as $queue |
@@ -167,12 +187,15 @@ for agent in "${SELECTED[@]}"; do
             elif $queue.__typename == "StatusContext" then "queue=\(($queue.state // "unknown") | ascii_downcase)"
             else "queue=\((($queue.conclusion // $queue.status // "unknown")) | ascii_downcase)"
             end;
+          def merge_queue_label:
+            if any(.labels[]?; .name == "merge-queue") then "mergeQueue=on" else "mergeQueue=off" end;
           .[] |
             "#\(.number) " +
             (if .isDraft then "draft" else "ready" end) +
             " merge=\(.mergeStateStatus // "UNKNOWN")" +
             " mergeable=\(.mergeable // "UNKNOWN")" +
             " autoMerge=" + (if .autoMergeRequest then "on" else "off" end) +
+            " " + merge_queue_label +
             " " + queue_state +
             " " + .title + " " + .url
         ' \
@@ -181,8 +204,12 @@ for agent in "${SELECTED[@]}"; do
     )"
   else
     prs="$(
-      gh pr list --state open --limit 100 --label "$label" --json number,title,isDraft,url \
-        --jq '.[] | "#\(.number) " + (if .isDraft then "draft" else "ready" end) + " " + .title + " " + .url' \
+      gh pr list --state open --limit 100 --label "$label" --json number,title,isDraft,url,labels \
+        --jq '
+          def merge_queue_label:
+            if any(.labels[]?; .name == "merge-queue") then "mergeQueue=on" else "mergeQueue=off" end;
+          .[] | "#\(.number) " + (if .isDraft then "draft" else "ready" end) + " " + merge_queue_label + " " + .title + " " + .url
+        ' \
         2>/dev/null ||
         list_owned_items_rest "$label" pr
     )"
@@ -195,6 +222,7 @@ for agent in "${SELECTED[@]}"; do
   pr_count="$(count_rows "$prs")"
   ready_pr_count="$(count_pr_state_rows "$prs" ready)"
   draft_pr_count="$(count_pr_state_rows "$prs" draft)"
+  merge_queue_pr_count="$(count_pr_token_rows "$prs" "mergeQueue=on")"
   echo ""
   echo "Issues:"
   issues="$(
@@ -219,6 +247,7 @@ for agent in "${SELECTED[@]}"; do
   echo "owned_pr_count=$pr_count"
   echo "owned_ready_pr_count=$ready_pr_count"
   echo "owned_draft_pr_count=$draft_pr_count"
+  echo "owned_merge_queue_pr_count=$merge_queue_pr_count"
   echo "owned_issue_count=$issue_count"
   echo "owned_work_status=$owned_work_status"
   echo ""
@@ -232,6 +261,7 @@ for agent in "${SELECTED[@]}"; do
       ROW_PR_COUNT="$pr_count" \
       ROW_READY_PR_COUNT="$ready_pr_count" \
       ROW_DRAFT_PR_COUNT="$draft_pr_count" \
+      ROW_MERGE_QUEUE_PR_COUNT="$merge_queue_pr_count" \
       ROW_ISSUE_COUNT="$issue_count" \
       ROW_STATUS="$owned_work_status" \
       ROW_PRS="$pr_json" \
@@ -245,6 +275,7 @@ const row = {
   pr_count: Number(process.env.ROW_PR_COUNT ?? 0),
   ready_pr_count: Number(process.env.ROW_READY_PR_COUNT ?? 0),
   draft_pr_count: Number(process.env.ROW_DRAFT_PR_COUNT ?? 0),
+  merge_queue_pr_count: Number(process.env.ROW_MERGE_QUEUE_PR_COUNT ?? 0),
   issue_count: Number(process.env.ROW_ISSUE_COUNT ?? 0),
   owned_work_clear: process.env.ROW_STATUS === "clear",
   owned_work_status: process.env.ROW_STATUS,
@@ -278,6 +309,10 @@ const totalDraftPrCount = agents.reduce(
   (sum, agent) => sum + Number(agent.draft_pr_count ?? 0),
   0,
 );
+const totalMergeQueuePrCount = agents.reduce(
+  (sum, agent) => sum + Number(agent.merge_queue_pr_count ?? 0),
+  0,
+);
 const totalIssueCount = agents.reduce(
   (sum, agent) => sum + Number(agent.issue_count ?? 0),
   0,
@@ -296,6 +331,7 @@ const report = {
   total_pr_count: totalPrCount,
   total_ready_pr_count: totalReadyPrCount,
   total_draft_pr_count: totalDraftPrCount,
+  total_merge_queue_pr_count: totalMergeQueuePrCount,
   total_issue_count: totalIssueCount,
   total_owned_count: totalOwnedCount,
   agents,

--- a/scripts/agents/test_list_owned_work.py
+++ b/scripts/agents/test_list_owned_work.py
@@ -44,6 +44,7 @@ exec "$@"
         self.assertIn("owned_pr_count=0", result.stdout)
         self.assertIn("owned_ready_pr_count=0", result.stdout)
         self.assertIn("owned_draft_pr_count=0", result.stdout)
+        self.assertIn("owned_merge_queue_pr_count=0", result.stdout)
         self.assertIn("owned_issue_count=0", result.stdout)
         self.assertIn("owned_work_status=clear", result.stdout)
 
@@ -51,8 +52,8 @@ exec "$@"
         result = self.run_list_owned_work(
             ["Studio-F"],
             prs=(
-                "#1 ready first PR https://github.com/mohsen1/tsz/pull/1\n"
-                "#2 draft second PR https://github.com/mohsen1/tsz/pull/2\n"
+                "#1 ready mergeQueue=on first PR https://github.com/mohsen1/tsz/pull/1\n"
+                "#2 draft mergeQueue=off second PR https://github.com/mohsen1/tsz/pull/2\n"
             ),
             issues="#3 issue https://github.com/mohsen1/tsz/issues/3\n",
         )
@@ -60,6 +61,7 @@ exec "$@"
         self.assertIn("owned_pr_count=2", result.stdout)
         self.assertIn("owned_ready_pr_count=1", result.stdout)
         self.assertIn("owned_draft_pr_count=1", result.stdout)
+        self.assertIn("owned_merge_queue_pr_count=1", result.stdout)
         self.assertIn("owned_issue_count=1", result.stdout)
         self.assertIn("owned_work_status=active", result.stdout)
 
@@ -69,7 +71,7 @@ exec "$@"
 
             result = self.run_list_owned_work(
                 ["Studio-F", "--json-report", str(report_path)],
-                prs="#1 ready first PR https://github.com/mohsen1/tsz/pull/1\n",
+                prs="#1 ready mergeQueue=on first PR https://github.com/mohsen1/tsz/pull/1\n",
                 issues="#2 issue https://github.com/mohsen1/tsz/issues/2\n",
             )
 
@@ -85,6 +87,7 @@ exec "$@"
             self.assertEqual(1, report["total_pr_count"])
             self.assertEqual(1, report["total_ready_pr_count"])
             self.assertEqual(0, report["total_draft_pr_count"])
+            self.assertEqual(1, report["total_merge_queue_pr_count"])
             self.assertEqual(1, report["total_issue_count"])
             self.assertEqual(2, report["total_owned_count"])
             self.assertEqual(1, len(report["agents"]))
@@ -94,11 +97,12 @@ exec "$@"
             self.assertEqual(1, row["pr_count"])
             self.assertEqual(1, row["ready_pr_count"])
             self.assertEqual(0, row["draft_pr_count"])
+            self.assertEqual(1, row["merge_queue_pr_count"])
             self.assertEqual(1, row["issue_count"])
             self.assertFalse(row["owned_work_clear"])
             self.assertEqual("active", row["owned_work_status"])
             self.assertEqual(
-                ["#1 ready first PR https://github.com/mohsen1/tsz/pull/1"],
+                ["#1 ready mergeQueue=on first PR https://github.com/mohsen1/tsz/pull/1"],
                 row["prs"],
             )
             self.assertEqual(
@@ -120,6 +124,7 @@ exec "$@"
             self.assertEqual(0, report["total_pr_count"])
             self.assertEqual(0, report["total_ready_pr_count"])
             self.assertEqual(0, report["total_draft_pr_count"])
+            self.assertEqual(0, report["total_merge_queue_pr_count"])
             self.assertEqual(0, report["total_issue_count"])
             self.assertEqual(0, report["total_owned_count"])
             self.assertTrue(report["agents"][0]["owned_work_clear"])


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / cheap evidence plumbing.

## Invariant
When an agent inspects owned PRs, the report should distinguish the durable `merge-queue` label from the transient `Queue Tested` status so queued work is not inferred from a pending check context.

## Scope
- `scripts/agents/list-owned-work.sh`
- `scripts/agents/test_list_owned_work.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent-script-only; no compiler, emit, checker, solver, parser, binder, LSP, WASM, benchmark, or project-corpus behavior changes.

## Verification
- `python3 -m unittest scripts.agents.test_list_owned_work`
- `bash -n scripts/agents/list-owned-work.sh`
- `scripts/agents/list-owned-work.sh Studio-F --json-report /tmp/tsz-owned-work-studio-f-queue-label.json`
- `scripts/agents/list-owned-work.sh --pr-state --all --json-report /tmp/tsz-owned-work-merge-queue-label.json`
- `git diff --check`

## Coordination Notes
- Studio-F owned PR runway was clear before starting.
- This PR only changes launch evidence output. It adds `mergeQueue=on/off` row tokens and `owned_merge_queue_pr_count` / `total_merge_queue_pr_count` counters.
- Live all-agent report after the change showed `17` open owned PRs, `7` ready, `10` draft, and `0` with the durable `merge-queue` label, despite several `queue=pending` statuses.
