### PR TITLE
fix(dts): multiline format for empty namespaces inside declare module

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/exports/imports_and_modules.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/exports/imports_and_modules.rs
@@ -509,9 +509,19 @@ impl<'a> DeclarationEmitter<'a> {
                 });
 
             if is_empty_body {
-                // tsc uses single-line `{ }` for empty namespaces nested inside
-                // another declare namespace, but multi-line `{\n}` for top-level.
-                if self.inside_declare_namespace && !use_module_keyword {
+                // tsc uses single-line `{ }` for empty identifier-namespaces that are
+                // directly nested inside a `declare namespace X` body.
+                // In all other positions — top-level, inside `declare module "..."`, and
+                // non-ambient source namespaces — tsc uses the multi-line `{\n}` form.
+                //
+                // `current_ambient_module_specifier` being `Some(_)` indicates we are
+                // inside a string-literal ambient module; that context requires multiline.
+                // `inside_declare_namespace && !use_module_keyword` identifies the
+                // ambient-identifier-namespace nesting case that requires single-line.
+                let in_ambient_identifier_namespace = self.inside_declare_namespace
+                    && !use_module_keyword
+                    && self.current_ambient_module_specifier.is_none();
+                if in_ambient_identifier_namespace {
                     self.write(" { }");
                     self.write_line();
                 } else {

--- a/crates/tsz-emitter/src/declaration_emitter/exports/imports_and_modules.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/exports/imports_and_modules.rs
@@ -509,19 +509,25 @@ impl<'a> DeclarationEmitter<'a> {
                 });
 
             if is_empty_body {
-                // tsc uses single-line `{ }` for empty identifier-namespaces that are
-                // directly nested inside a `declare namespace X` body.
-                // In all other positions — top-level, inside `declare module "..."`, and
-                // non-ambient source namespaces — tsc uses the multi-line `{\n}` form.
+                // tsc uses single-line `{ }` for empty namespaces that are nested inside
+                // another namespace body — whether that outer namespace is ambient
+                // (`declare namespace X`) or non-ambient (`namespace X`).
+                // The emitter sets `inside_declare_namespace = true` on entry to any
+                // namespace body, so the flag covers both ambient and non-ambient nesting.
                 //
-                // `current_ambient_module_specifier` being `Some(_)` indicates we are
-                // inside a string-literal ambient module; that context requires multiline.
-                // `inside_declare_namespace && !use_module_keyword` identifies the
-                // ambient-identifier-namespace nesting case that requires single-line.
-                let in_ambient_identifier_namespace = self.inside_declare_namespace
+                // Exceptions that require multiline `{\n}`:
+                //   - Top-level namespace (`inside_declare_namespace` is false).
+                //   - Inside a string-literal ambient module (`declare module "..."`);
+                //     `current_ambient_module_specifier` is `Some(_)` in that context.
+                //
+                // See also `test_non_ambient_exported_empty_inner_namespace_is_preserved`
+                // (non-ambient nested → single-line) and
+                // `test_empty_namespace_inside_declare_module_uses_multiline_format`
+                // (string-literal ambient module → multiline).
+                let in_identifier_namespace_context = self.inside_declare_namespace
                     && !use_module_keyword
                     && self.current_ambient_module_specifier.is_none();
-                if in_ambient_identifier_namespace {
+                if in_identifier_namespace_context {
                     self.write(" { }");
                     self.write_line();
                 } else {

--- a/crates/tsz-emitter/src/declaration_emitter/tests/probes_issues.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/probes_issues.rs
@@ -1120,8 +1120,8 @@ fn test_conditional_type_in_indexed_access() {
 
 // =============================================================================
 // Empty namespace formatting: tsc emits `namespace X { }` (single-line) only
-// when inside a `declare namespace` body; inside a `declare module "..."` body
-// or at the top level, empty namespaces use the multi-line `{\n}` form.
+// when inside an identifier namespace body; inside a `declare module "..."`
+// body or at the top level, empty namespaces use the multi-line `{\n}` form.
 // =============================================================================
 
 #[test]
@@ -1151,8 +1151,8 @@ fn test_empty_namespace_inside_declare_module_uses_multiline_format() {
 #[test]
 fn test_empty_namespace_inside_declare_namespace_uses_single_line_format() {
     // tsc uses `namespace X { }` (single line) for empty identifier-namespaces
-    // nested inside a `declare namespace` body.  Renaming the iteration
-    // variable must not change this behavior.
+    // nested inside a `declare namespace` body. Renaming the nested namespaces
+    // must not change this behavior.
     let output = emit_dts(
         r#"declare namespace outer {
     namespace innerEmpty {}

--- a/crates/tsz-emitter/src/declaration_emitter/tests/probes_issues.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/probes_issues.rs
@@ -1117,3 +1117,54 @@ fn test_conditional_type_in_indexed_access() {
         "conditional in indexed access needs parens: {output}"
     );
 }
+
+// =============================================================================
+// Empty namespace formatting: tsc emits `namespace X { }` (single-line) only
+// when inside a `declare namespace` body; inside a `declare module "..."` body
+// or at the top level, empty namespaces use the multi-line `{\n}` form.
+// =============================================================================
+
+#[test]
+fn test_empty_namespace_inside_declare_module_uses_multiline_format() {
+    // Empty namespaces directly inside a `declare module "..."` block must use
+    // the multi-line format to match tsc output.  In particular, multiple empty
+    // namespaces with the same name (parse-error recovery) must each be on their
+    // own line rather than collapsed to `{ }`.
+    let output = emit_dts(
+        r#"declare module "anotherParseError" {
+    namespace m2 {
+    }
+    namespace m2 {
+    }
+}"#,
+    );
+    assert!(
+        output.contains("namespace m2 {\n    }") || output.contains("namespace m2 {\n}"),
+        "empty namespace inside declare module must use multi-line format: {output}"
+    );
+    assert!(
+        !output.contains("namespace m2 { }"),
+        "empty namespace inside declare module must not use single-line format: {output}"
+    );
+}
+
+#[test]
+fn test_empty_namespace_inside_declare_namespace_uses_single_line_format() {
+    // tsc uses `namespace X { }` (single line) for empty identifier-namespaces
+    // nested inside a `declare namespace` body.  Renaming the iteration
+    // variable must not change this behavior.
+    let output = emit_dts(
+        r#"declare namespace outer {
+    namespace innerEmpty {}
+    namespace anotherName {}
+}"#,
+    );
+    assert!(
+        output.contains("namespace innerEmpty { }"),
+        "empty namespace inside declare namespace must use single-line format: {output}"
+    );
+    assert!(
+        output.contains("namespace anotherName { }"),
+        "empty namespace (different name) inside declare namespace must use single-line format: {output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Track 9 — Declaration emit 100% parity

## Invariant
When `tsc` emits an empty namespace body, it uses:
- Single-line `{ }` when the namespace is **nested inside any namespace body** (ambient `declare namespace X` OR non-ambient `namespace X`), as long as there is no active string-literal ambient module context
- Multi-line `{\n}` in all other positions: top-level (not nested), or inside a string-literal `declare module "..."` ambient module

The emitter sets `inside_declare_namespace = true` on entry to any namespace body, so the flag covers both ambient and non-ambient nesting. The `current_ambient_module_specifier` field distinguishes the string-literal-module context that requires multiline.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/exports/imports_and_modules.rs` — fix the empty-body dispatch condition to distinguish `declare namespace` from `declare module "..."`, and correct the inline comment to match the actual structural rule
- `crates/tsz-emitter/src/declaration_emitter/tests/probes_issues.rs` — two new unit tests covering both paths

## Root Cause
The original condition used `inside_declare_namespace && !use_module_keyword` to select single-line `{ }` for empty namespaces in any ambient context. This incorrectly applied single-line formatting to empty namespaces inside `declare module "..."` bodies (where `inside_declare_namespace = true` but the enclosing context is a string-literal module, not an identifier namespace).

## Fix
Added `&& self.current_ambient_module_specifier.is_none()` to the single-line condition. `current_ambient_module_specifier` is `Some(_)` only when we are inside a `declare module "..."` body, so the revised condition correctly restricts single-line to the nested-identifier-namespace case. Also updated the inline comment to accurately state that `inside_declare_namespace` covers both ambient and non-ambient nesting.

## Structural Rule
When an empty namespace body is emitted, single-line `{ }` applies when the emitter is currently inside any namespace body (the `inside_declare_namespace` flag) and there is no active string-literal ambient module specifier. Multiline `{\n}` applies when at the top level or inside a string-literal `declare module "..."`.

## Adjacent Cases Covered
1. Empty namespace inside `declare namespace X { namespace A {} }` → single-line `{ }` ✓
2. Empty namespace inside `declare module "mod" { namespace A {} }` → multiline `{\n}` ✓
3. Non-ambient source `namespace X { export namespace A {} }` → single-line `{ }` ✓ (existing `test_non_ambient_exported_empty_inner_namespace_is_preserved` unaffected)
4. Top-level `declare namespace X {}` → multiline `{\n}` ✓ (top-level, `inside_declare_namespace = false`)

## Project Corpus Impact
- Row: n/a for direct row attribution
- Bug family: DTS emit formatting — empty block body format mismatch between `declare namespace` and `declare module "..."` contexts
- Evidence: `privacyGloImport` DTS emit test now passes when compared against TypeScript baselines; `cargo nextest run -p tsz-emitter -E 'test(test_empty_namespace)'` — 4 passed / 4015 skipped

## Verification
- `cargo nextest run -p tsz-emitter -E 'test(declaration_emitter)'` — 1406 passed / 8 pre-existing failures (unchanged) / 2602 skipped
- `cargo nextest run -p tsz-emitter -E 'test(test_empty_namespace)'` — 4 passed (includes 2 new tests)
- `cargo nextest run -p tsz-emitter -E 'test(non_ambient_exported_empty)'` — 1 passed (existing test still green)
- `cargo clippy -p tsz-emitter --all-targets -- -D warnings` — no new warnings
- Manual CLI test: `privacyGloImport` DTS output matches TypeScript baseline exactly

## Coordination Notes
- AgentName: Studio-D (session claude-sonnet-4-6, session 17b0494c)
- Studio-D had no open PRs before this; this is the first DTS emit fix for the lane
- No overlap with Studio-E #11916 (that PR is about output surgery, not empty namespace formatting)
- Stale `emit-detail.json` (from 2026-05-19) lists `privacyGloImport` as +2/-4 failure; that snapshot reflects pre-fix state
- The 8 pre-existing `declaration_emitter` test failures are unrelated to this change and were already failing on `main`
- v2 (185d77b): corrected inline comment and PR body Invariant — previous text incorrectly stated non-ambient source namespaces use multiline; `inside_declare_namespace` covers both ambient and non-ambient nesting, so single-line applies in both contexts

https://claude.ai/code/session_01DLM8CAsFdBCosptRU3AbsP

- v3 (9eb02ab): rebased onto current `origin/main` (`4a194acc0f`), resolved merge conflicts, and kept the PR scoped to the two DTS empty-namespace files. Local verification for this rebase: `git diff --check origin/main...HEAD`; broader reruns deferred to draft/ready CI because disk is below the 20 GB local floor.
