### PR TITLE
chore(emit): mark stale family detail as triage

### DIFF
--- a/scripts/emit/query-emit.py
+++ b/scripts/emit/query-emit.py
@@ -212,7 +212,9 @@ def emit_freshness_note(detail_summary, public_summary):
         f"DTS {public_summary['dtsPass']:,}/{public_summary['dtsTotal']:,} vs "
         f"{detail_summary['dtsPass']:,}/{detail_summary['dtsTotal']:,}). "
         f"Pass delta: JS +{status['jsPassDelta']:,}, DTS +{status['dtsPassDelta']:,}. "
-        "Failure-family rows below still use checked-in per-test detail."
+        "Failure-family rows below are historical checked-detail triage only; "
+        "do not cite them as the current public remaining set until "
+        "emit-detail.json is refreshed."
     )
 
 
@@ -308,7 +310,7 @@ def failure_family_surface_heading(surface, title, detail_total, detail_summary,
         return f"{title} checked-detail: {detail_total} failures/timeouts"
 
     return (
-        f"{title} checked-detail: {detail_total} failures/timeouts "
+        f"{title} STALE checked-detail triage: {detail_total} failures/timeouts "
         f"(public aggregate remaining: {public_remaining:,}; "
         f"detail aggregate remaining: {detail_remaining:,})"
     )

--- a/scripts/emit/test_query_emit_families.py
+++ b/scripts/emit/test_query_emit_families.py
@@ -85,6 +85,8 @@ after
         self.assertIn("JS 13,459/13,530 vs 13,094/13,530", note)
         self.assertIn("DTS 1,644/1,669 vs 1,606/1,669", note)
         self.assertIn("Pass delta: JS +365, DTS +38", note)
+        self.assertIn("historical checked-detail triage only", note)
+        self.assertIn("do not cite them as the current public remaining set", note)
 
     def test_freshness_status_reports_stale_detail(self):
         status = self.mod.emit_freshness_status(
@@ -180,7 +182,7 @@ after
             "js", "JavaScript", 436, detail_summary, public_summary
         )
 
-        self.assertIn("JavaScript checked-detail: 436 failures/timeouts", heading)
+        self.assertIn("JavaScript STALE checked-detail triage: 436 failures/timeouts", heading)
         self.assertIn("public aggregate remaining: 71", heading)
         self.assertIn("detail aggregate remaining: 436", heading)
 


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Studio-A metric truth / emit reporting guardrail.

## Invariant
When README/public emit aggregate counts are ahead of checked per-test `emit-detail.json` on the same test domain, `query-emit.py --families` must identify family rows as stale checked-detail triage, not as the current public remaining set. This PR changes the emit reporting script only.

## Scope
- `scripts/emit/query-emit.py`
- `scripts/emit/test_query_emit_families.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: reporting-only change for emit metric freshness; no compiler, fixture, or project-compile behavior changes.

## Verification
- `python3 scripts/emit/test_query_emit_families.py`
- `python3 scripts/emit/query-emit.py --families --top 3`
- `python3 scripts/emit/query-emit.py --freshness`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- AgentName: Studio-A
- Start-cycle metrics showed README/public emit aggregate at JS 13,459/13,530 and DTS 1,644/1,669 while checked detail remains JS 13,094/13,530 and DTS 1,606/1,669.
- This avoids overlapping active Studio-C/Studio-D emit implementation PRs by changing only the metric reporting surface.
- Branch was rebased onto `origin/main` before commit and push.
- Ready for manager review/queue after PR-head CI passes; I did not add `merge-queue`.
