### PR TITLE
chore(agents): expose ready unqueued PR counts

### DIFF
--- a/scripts/agents/list-owned-work.sh
+++ b/scripts/agents/list-owned-work.sh
@@ -158,6 +158,25 @@ count_pr_token_rows() {
   '
 }
 
+count_ready_unqueued_pr_rows() {
+  local rows="$1"
+  if [[ -z "$rows" ]]; then
+    echo 0
+    return
+  fi
+  printf '%s\n' "$rows" | awk '
+    $2 == "ready" {
+      for (i = 1; i <= NF; i++) {
+        if ($i == "mergeQueue=off") {
+          count++
+          next
+        }
+      }
+    }
+    END { print count + 0 }
+  '
+}
+
 json_array_from_lines() {
   local rows="$1"
   ROWS="$rows" node <<'NODE'
@@ -223,6 +242,7 @@ for agent in "${SELECTED[@]}"; do
   ready_pr_count="$(count_pr_state_rows "$prs" ready)"
   draft_pr_count="$(count_pr_state_rows "$prs" draft)"
   merge_queue_pr_count="$(count_pr_token_rows "$prs" "mergeQueue=on")"
+  ready_unqueued_pr_count="$(count_ready_unqueued_pr_rows "$prs")"
   echo ""
   echo "Issues:"
   issues="$(
@@ -248,6 +268,7 @@ for agent in "${SELECTED[@]}"; do
   echo "owned_ready_pr_count=$ready_pr_count"
   echo "owned_draft_pr_count=$draft_pr_count"
   echo "owned_merge_queue_pr_count=$merge_queue_pr_count"
+  echo "owned_ready_unqueued_pr_count=$ready_unqueued_pr_count"
   echo "owned_issue_count=$issue_count"
   echo "owned_work_status=$owned_work_status"
   echo ""
@@ -262,6 +283,7 @@ for agent in "${SELECTED[@]}"; do
       ROW_READY_PR_COUNT="$ready_pr_count" \
       ROW_DRAFT_PR_COUNT="$draft_pr_count" \
       ROW_MERGE_QUEUE_PR_COUNT="$merge_queue_pr_count" \
+      ROW_READY_UNQUEUED_PR_COUNT="$ready_unqueued_pr_count" \
       ROW_ISSUE_COUNT="$issue_count" \
       ROW_STATUS="$owned_work_status" \
       ROW_PRS="$pr_json" \
@@ -276,6 +298,7 @@ const row = {
   ready_pr_count: Number(process.env.ROW_READY_PR_COUNT ?? 0),
   draft_pr_count: Number(process.env.ROW_DRAFT_PR_COUNT ?? 0),
   merge_queue_pr_count: Number(process.env.ROW_MERGE_QUEUE_PR_COUNT ?? 0),
+  ready_unqueued_pr_count: Number(process.env.ROW_READY_UNQUEUED_PR_COUNT ?? 0),
   issue_count: Number(process.env.ROW_ISSUE_COUNT ?? 0),
   owned_work_clear: process.env.ROW_STATUS === "clear",
   owned_work_status: process.env.ROW_STATUS,
@@ -313,6 +336,10 @@ const totalMergeQueuePrCount = agents.reduce(
   (sum, agent) => sum + Number(agent.merge_queue_pr_count ?? 0),
   0,
 );
+const totalReadyUnqueuedPrCount = agents.reduce(
+  (sum, agent) => sum + Number(agent.ready_unqueued_pr_count ?? 0),
+  0,
+);
 const totalIssueCount = agents.reduce(
   (sum, agent) => sum + Number(agent.issue_count ?? 0),
   0,
@@ -332,6 +359,7 @@ const report = {
   total_ready_pr_count: totalReadyPrCount,
   total_draft_pr_count: totalDraftPrCount,
   total_merge_queue_pr_count: totalMergeQueuePrCount,
+  total_ready_unqueued_pr_count: totalReadyUnqueuedPrCount,
   total_issue_count: totalIssueCount,
   total_owned_count: totalOwnedCount,
   agents,

--- a/scripts/agents/test_list_owned_work.py
+++ b/scripts/agents/test_list_owned_work.py
@@ -45,6 +45,7 @@ exec "$@"
         self.assertIn("owned_ready_pr_count=0", result.stdout)
         self.assertIn("owned_draft_pr_count=0", result.stdout)
         self.assertIn("owned_merge_queue_pr_count=0", result.stdout)
+        self.assertIn("owned_ready_unqueued_pr_count=0", result.stdout)
         self.assertIn("owned_issue_count=0", result.stdout)
         self.assertIn("owned_work_status=clear", result.stdout)
 
@@ -54,14 +55,16 @@ exec "$@"
             prs=(
                 "#1 ready mergeQueue=on first PR https://github.com/mohsen1/tsz/pull/1\n"
                 "#2 draft mergeQueue=off second PR https://github.com/mohsen1/tsz/pull/2\n"
+                "#4 ready mergeQueue=off third PR https://github.com/mohsen1/tsz/pull/4\n"
             ),
             issues="#3 issue https://github.com/mohsen1/tsz/issues/3\n",
         )
 
-        self.assertIn("owned_pr_count=2", result.stdout)
-        self.assertIn("owned_ready_pr_count=1", result.stdout)
+        self.assertIn("owned_pr_count=3", result.stdout)
+        self.assertIn("owned_ready_pr_count=2", result.stdout)
         self.assertIn("owned_draft_pr_count=1", result.stdout)
         self.assertIn("owned_merge_queue_pr_count=1", result.stdout)
+        self.assertIn("owned_ready_unqueued_pr_count=1", result.stdout)
         self.assertIn("owned_issue_count=1", result.stdout)
         self.assertIn("owned_work_status=active", result.stdout)
 
@@ -88,6 +91,7 @@ exec "$@"
             self.assertEqual(1, report["total_ready_pr_count"])
             self.assertEqual(0, report["total_draft_pr_count"])
             self.assertEqual(1, report["total_merge_queue_pr_count"])
+            self.assertEqual(0, report["total_ready_unqueued_pr_count"])
             self.assertEqual(1, report["total_issue_count"])
             self.assertEqual(2, report["total_owned_count"])
             self.assertEqual(1, len(report["agents"]))
@@ -98,6 +102,7 @@ exec "$@"
             self.assertEqual(1, row["ready_pr_count"])
             self.assertEqual(0, row["draft_pr_count"])
             self.assertEqual(1, row["merge_queue_pr_count"])
+            self.assertEqual(0, row["ready_unqueued_pr_count"])
             self.assertEqual(1, row["issue_count"])
             self.assertFalse(row["owned_work_clear"])
             self.assertEqual("active", row["owned_work_status"])
@@ -125,6 +130,7 @@ exec "$@"
             self.assertEqual(0, report["total_ready_pr_count"])
             self.assertEqual(0, report["total_draft_pr_count"])
             self.assertEqual(0, report["total_merge_queue_pr_count"])
+            self.assertEqual(0, report["total_ready_unqueued_pr_count"])
             self.assertEqual(0, report["total_issue_count"])
             self.assertEqual(0, report["total_owned_count"])
             self.assertTrue(report["agents"][0]["owned_work_clear"])


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / cheap evidence plumbing.

## Invariant
When an agent inspects owned PRs, the report should count ready PRs that are not durably labeled `merge-queue` so the actionable queue gap is visible without comparing separate counters by hand.

## Scope
- `scripts/agents/list-owned-work.sh`
- `scripts/agents/test_list_owned_work.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent-script-only; no compiler, emit, checker, solver, parser, binder, LSP, WASM, benchmark, or project-corpus behavior changes.

## Verification
- `python3 -m unittest scripts.agents.test_list_owned_work`
- `bash -n scripts/agents/list-owned-work.sh`
- `scripts/agents/list-owned-work.sh --pr-state --all --json-report /tmp/tsz-owned-work-ready-unqueued.json`
- `git diff --check origin/main...HEAD`

## Coordination Notes
- Studio-F owned PR runway was clear before starting.
- This PR only changes launch evidence output.
- Live all-agent report after the change showed `16` open owned PRs, `5` ready, `11` draft, `0` with `merge-queue`, and `5` ready-but-not-queued.