### PR TITLE
fix(checker): preserve imported generic type-only contexts

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/core.rs
+++ b/crates/tsz-checker/src/state/type_resolution/core.rs
@@ -836,6 +836,36 @@ impl<'a> CheckerState<'a> {
                     self.error_namespace_used_as_type_at(name, type_name_idx);
                     return TypeId::ERROR;
                 }
+                if has_type_args
+                    && let Some(target_sym_id) =
+                        self.resolve_type_only_import_alias_target_symbol(name)
+                    && let Some(args) = &type_ref.type_arguments
+                {
+                    let target_name = self
+                        .get_cross_file_symbol(target_sym_id)
+                        .or_else(|| self.ctx.binder.get_symbol(target_sym_id))
+                        .map(|symbol| symbol.escaped_name.clone())
+                        .unwrap_or_else(|| name.to_string());
+                    self.ensure_def_ready_for_lowering(target_sym_id, &target_name);
+                    for &arg_idx in &args.nodes {
+                        let _ = self.get_type_from_type_node(arg_idx);
+                    }
+                    if !self.is_inside_type_parameter_declaration(idx)
+                        && self.validate_type_reference_type_arguments(target_sym_id, args, idx)
+                    {
+                        return TypeId::ERROR;
+                    }
+                    let type_args = args
+                        .nodes
+                        .iter()
+                        .map(|&arg_idx| self.get_type_from_type_node(arg_idx))
+                        .collect::<Vec<_>>();
+                    let def_id = self
+                        .ctx
+                        .get_or_create_def_id_for_symbol_name(target_sym_id, &target_name);
+                    let base = self.ctx.types.factory().lazy(def_id);
+                    return self.ctx.types.factory().application(base, type_args);
+                }
                 // TS2318: Array<T> with noLib should emit "Cannot find global type 'Array'"
                 if is_builtin_array && !has_libs && sym_id.is_none() {
                     self.error_cannot_find_global_type(name, type_name_idx);

--- a/crates/tsz-checker/src/types/computation/identifier/core.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/core.rs
@@ -259,30 +259,6 @@ impl<'a> CheckerState<'a> {
         common_query::contains_lazy_or_recursive(self.ctx.types.as_type_database(), type_id)
     }
 
-    /// Returns true when the symbol's value declaration is a variable
-    /// declaration with an explicit type annotation (e.g. `const x: AB = ...`).
-    /// Used by class-property-initializer evaluation to decide whether the
-    /// declared type should override flow narrowing.
-    fn symbol_value_decl_has_explicit_type_annotation(&self, sym_id: tsz_binder::SymbolId) -> bool {
-        let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
-            return false;
-        };
-        let decl = symbol.value_declaration;
-        if decl.is_none() {
-            return false;
-        }
-        let Some(decl_node) = self.ctx.arena.get(decl) else {
-            return false;
-        };
-        if decl_node.kind != syntax_kind_ext::VARIABLE_DECLARATION {
-            return false;
-        }
-        self.ctx
-            .arena
-            .get_variable_declaration(decl_node)
-            .is_some_and(|var| var.type_annotation.is_some())
-    }
-
     /// Get the type of an identifier expression.
     ///
     /// This function resolves the type of an identifier by:
@@ -1679,7 +1655,7 @@ impl<'a> CheckerState<'a> {
             } else {
                 self.get_type_of_symbol(sym_id)
             };
-            let declared_type = if self.ctx.is_js_file()
+            let mut declared_type = if self.ctx.is_js_file()
                 && self.ctx.should_resolve_jsdoc()
                 && (flags
                     & (symbol_flags::FUNCTION_SCOPED_VARIABLE
@@ -1692,6 +1668,17 @@ impl<'a> CheckerState<'a> {
             } else {
                 declared_type
             };
+            if matches!(declared_type, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR)
+                && value_decl.is_some()
+                && let Some(annotated) = self.explicit_value_declared_type_for_symbol(
+                    sym_id,
+                    value_decl,
+                    &symbol_declarations,
+                )
+            {
+                self.ctx.symbol_types.insert(sym_id, annotated);
+                declared_type = annotated;
+            }
             // In JS files, prefer non-JS cross-file global value types for
             // variables that don't have an explicit JSDoc @type annotation.
             // When a JSDoc @type annotation is present, it takes precedence

--- a/crates/tsz-checker/src/types/computation/identifier/explicit_annotation.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/explicit_annotation.rs
@@ -1,0 +1,86 @@
+//! Explicit value annotation recovery for identifier type computation.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// Returns true when the symbol's value declaration is a variable
+    /// declaration with an explicit type annotation (e.g. `const x: AB = ...`).
+    /// Used by class-property-initializer evaluation to decide whether the
+    /// declared type should override flow narrowing.
+    pub(super) fn symbol_value_decl_has_explicit_type_annotation(
+        &self,
+        sym_id: tsz_binder::SymbolId,
+    ) -> bool {
+        let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
+            return false;
+        };
+        let decl = symbol.value_declaration;
+        if decl.is_none() {
+            return false;
+        }
+        let Some(decl_node) = self.ctx.arena.get(decl) else {
+            return false;
+        };
+        if decl_node.kind != syntax_kind_ext::VARIABLE_DECLARATION {
+            return false;
+        }
+        self.ctx
+            .arena
+            .get_variable_declaration(decl_node)
+            .is_some_and(|var| var.type_annotation.is_some())
+    }
+
+    pub(super) fn explicit_value_declared_type_for_symbol(
+        &mut self,
+        sym_id: tsz_binder::SymbolId,
+        fallback_decl: NodeIndex,
+        declarations: &[NodeIndex],
+    ) -> Option<TypeId> {
+        let value_decl = self
+            .preferred_value_declaration(sym_id, fallback_decl, declarations)
+            .unwrap_or(fallback_decl);
+        if value_decl.is_none() {
+            return None;
+        }
+        let node = self.ctx.arena.get(value_decl)?;
+        let var_decl = self.ctx.arena.get_variable_declaration(node)?;
+        if var_decl.type_annotation.is_none() {
+            return None;
+        }
+        if !self.type_annotation_targets_generic_type_only_import(var_decl.type_annotation) {
+            return None;
+        }
+        self.ctx.node_types.remove(&var_decl.type_annotation.0);
+        let annotated = self.get_type_from_type_node(var_decl.type_annotation);
+        (!matches!(annotated, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR)).then_some(annotated)
+    }
+
+    fn type_annotation_targets_generic_type_only_import(&mut self, annotation: NodeIndex) -> bool {
+        let Some(node) = self.ctx.arena.get(annotation) else {
+            return false;
+        };
+        if node.kind != syntax_kind_ext::TYPE_REFERENCE {
+            return false;
+        }
+        let Some(type_ref) = self.ctx.arena.get_type_ref(node) else {
+            return false;
+        };
+        if type_ref
+            .type_arguments
+            .as_ref()
+            .is_none_or(|args| args.nodes.is_empty())
+        {
+            return false;
+        }
+        let Some(name_node) = self.ctx.arena.get(type_ref.type_name) else {
+            return false;
+        };
+        let Some(ident) = self.ctx.arena.get_identifier(name_node) else {
+            return false;
+        };
+        self.resolve_type_only_import_alias_target_symbol(&ident.escaped_text)
+            .is_some()
+    }
+}

--- a/crates/tsz-checker/src/types/computation/identifier/mod.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/mod.rs
@@ -6,6 +6,7 @@
 
 mod constraint_position;
 mod core;
+mod explicit_annotation;
 mod resolution;
 
 #[cfg(test)]

--- a/crates/tsz-checker/tests/kysely_callback_context_tests.rs
+++ b/crates/tsz-checker/tests/kysely_callback_context_tests.rs
@@ -43,6 +43,75 @@ fn format_diagnostics(source: &str, diagnostics: &[Diagnostic]) -> Vec<String> {
 }
 
 #[test]
+fn imported_select_callback_alias_contextually_types_array_expression_factory() {
+    let lib_files = load_default_lib_files();
+    let options = CheckerOptions {
+        strict: true,
+        no_implicit_any: true,
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    };
+    let files = [
+        (
+            "expression-builder.ts",
+            r#"
+export interface ExpressionBuilder<T> {
+  ref<K extends keyof T & string>(key: K): T[K];
+}
+"#,
+        ),
+        (
+            "select-parser.ts",
+            r#"
+import type { ExpressionBuilder } from "./expression-builder.js";
+
+export type SelectExpression<T> =
+  | keyof T & string
+  | ((eb: ExpressionBuilder<T>) => unknown);
+
+export type SelectCallback<T> = (
+  eb: ExpressionBuilder<T>,
+) => ReadonlyArray<SelectExpression<T>>;
+"#,
+        ),
+        (
+            "query-builder.ts",
+            r#"
+import type { SelectCallback, SelectExpression } from "./select-parser.js";
+
+export interface Builder<T> {
+  select<SE extends SelectExpression<T>>(selections: ReadonlyArray<SE>): void;
+  select<CB extends SelectCallback<T>>(callback: CB): void;
+}
+"#,
+        ),
+        (
+            "main.ts",
+            r#"
+import type { Builder } from "./query-builder.js";
+
+declare const builder: Builder<{ kind: "table" }>;
+
+builder.select([
+  "kind",
+  (eb) => eb.ref("kind"),
+]);
+"#,
+        ),
+    ];
+
+    let diagnostics = check_multi_file_with_libs(&files, "main.ts", options, &lib_files)
+        .into_iter()
+        .filter(|diagnostic| diagnostic.code != 2318)
+        .collect::<Vec<_>>();
+
+    assert!(
+        lacks_any_diagnostic_code(&diagnostics, &[7006, 2347, 2693]),
+        "imported callback aliases should contextually type selection factories. Got: {diagnostics:#?}"
+    );
+}
+
+#[test]
 fn kysely_join_if_chain_preserves_select_callback_context() {
     let source = r#"
 type SelectType<T> = T;


### PR DESCRIPTION
## Agent
AgentName: M4-C

## Track
M4-C Kysely contextual generic inference / benchmark blocker reduction

## Invariant
When a type-only import names a generic interface used in an explicit value annotation, `tsc` instantiates the imported target interface and preserves that declared value type; this PR makes tsz do that through checker type-reference resolution and the existing value-declaration annotation path.

## Scope
- Resolve generic type-only import aliases with type arguments through their cross-file target `DefId`.
- Re-read explicit value annotations when a prior symbol cache entry collapsed to `any`, `unknown`, or `error`.
- Add a multi-file Kysely-style callback-array reduction covering false TS7006/TS2347/TS2693.

## Project Corpus Impact
- Row: `kysely-project`
- Bug family: false TS7006/TS2347/TS2693 from imported builder callback contexts.
- Evidence: local reduction fixed; focused `kysely-project` canary still fails with broader existing blockers, including remaining `selectFrom`/callback implicit-any errors outside this slice.

## Verification
- `cargo fmt --check`
- `cargo nextest run -p tsz-checker --test kysely_callback_context_tests imported_select_callback_alias_contextually_types_array_expression_factory`
- `cargo nextest run -p tsz-checker --test kysely_callback_context_tests`
- `scripts/safe-run.sh --limit 50% -- cargo build --profile dist-fast -p tsz-cli --bin tsz`
- `scripts/safe-run.sh --limit 50% -- env TSZ_BIN=/Users/mohsen/code/tsz-m4c-kysely-callback-context2-20260601/.target/dist-fast/tsz TSZ_PROJECT_COMPILE_FIXTURE_ROOT=/Users/mohsen/code/tsz-m4c-kysely-callback-rest-20260601/.target/project-compile-guard TSZ_PROJECT_COMPILE_FILTER='^kysely-project$' TSZ_PROJECT_COMPILE_SET=canary TSZ_PROJECT_COMPILE_ALLOW_FAILURES=1 scripts/ci/project-compile-guard.sh`

- `scripts/safe-run.sh --limit 50% -- env TSZ_CI_CACHE_RESTORE=0 TSZ_CI_CACHE_SAVE=0 scripts/ci/github-suite.sh lint`

## Coordination Notes
- Fixes a bounded imported-generic callback-context reduction for issues #10683 and #10677.
- Does not claim the full Kysely canary row is green; remaining project diagnostics need follow-up slices.
- No overlap found with Studio-A Kysely async iterability work.