### PR TITLE
fix(checker): reset cross-arena and alias recursion guards between batch rows

### DIFF
--- a/crates/tsz-checker/src/checkers/mod.rs
+++ b/crates/tsz-checker/src/checkers/mod.rs
@@ -73,6 +73,15 @@ pub fn reset_stack_overflow_flag() {
 /// affecting subsequent compilations. Thread-local caches use arena-local
 /// indices (`NodeIndex`) as keys, and these indices get reused across
 /// compilations, causing cross-compilation contamination.
+///
+/// This is a hand-maintained reset list: every per-compilation thread-local in
+/// the checker (memo, scratch pool, or recursion-guard depth/stack) must be
+/// reset here. Rust offers no way to enumerate `thread_local!`s, so each owning
+/// module exposes a `reset_*` function and a parent `mod.rs` aggregates them;
+/// this function calls the aggregators. When you add a new per-compilation
+/// thread-local, add its reset here too — the regression test
+/// `clear_all_thread_local_state_resets_cross_arena_and_alias_guards` guards the
+/// recursion-guard subset against drift.
 pub fn clear_all_thread_local_state() {
     // Reset stack overflow breaker
     STACK_STATE.set(0);
@@ -86,6 +95,17 @@ pub fn clear_all_thread_local_state() {
 
     // Reset resolution fuel and depth counters
     crate::state_domain::type_environment::lazy::reset_all_thread_local_state();
+
+    // Reset cross-arena/cross-file recursion-guard depth counters and stacks.
+    // These use manual (non-RAII) enter/leave or push/pop, so a project that
+    // bails out mid-delegation (stack-overflow breaker, fuel exhaustion, or a
+    // panic caught by the batch driver) can leave them dirty and suppress
+    // resolution in the next project on this worker thread.
+    crate::state_domain::state::reset_cross_arena_depth();
+    crate::state_domain::type_analysis::reset_cross_file_recursion_guards();
+
+    // Reset type-alias resolution recursion guards and scratch pools.
+    crate::types_domain::reset_type_resolution_guards();
 }
 
 /// Explicit context for synthesized JSX children, threaded from dispatch
@@ -236,6 +256,53 @@ mod tests {
             STACK_STATE.get(),
             0,
             "clear_all_thread_local_state must zero the entire STACK_STATE"
+        );
+    }
+
+    /// Regression test for issue #10880: batch mode reuses one worker process
+    /// across project rows and relies on `clear_all_thread_local_state` to
+    /// isolate them. Several cross-arena / type-alias recursion guards use
+    /// manual (non-RAII) enter/leave or push/pop, so a row that bails out
+    /// mid-delegation can leave them dirty. Before the fix these guards were
+    /// not part of the reset, leaking state into the next row. This asserts
+    /// every such guard is zero/empty after the canonical reset.
+    #[test]
+    fn clear_all_thread_local_state_resets_cross_arena_and_alias_guards() {
+        use crate::{state_domain, types_domain};
+
+        // Dirty every guard the way an aborted mid-delegation row would.
+        state_domain::state::set_cross_arena_depth_for_test(3);
+        state_domain::type_analysis::dirty_cross_file_recursion_guards_for_test();
+        types_domain::dirty_type_resolution_guards_for_test();
+
+        assert_ne!(
+            state_domain::state::cross_arena_depth_for_test(),
+            0,
+            "precondition: cross-arena depth dirtied"
+        );
+        assert!(
+            !state_domain::type_analysis::cross_file_recursion_guards_clear_for_test(),
+            "precondition: cross-file recursion guards dirtied"
+        );
+        assert!(
+            !types_domain::type_resolution_guards_clear_for_test(),
+            "precondition: type-resolution guards dirtied"
+        );
+
+        clear_all_thread_local_state();
+
+        assert_eq!(
+            state_domain::state::cross_arena_depth_for_test(),
+            0,
+            "clear_all_thread_local_state must reset the cross-arena delegation depth"
+        );
+        assert!(
+            state_domain::type_analysis::cross_file_recursion_guards_clear_for_test(),
+            "clear_all_thread_local_state must reset cross-file interface depth and alias stack"
+        );
+        assert!(
+            types_domain::type_resolution_guards_clear_for_test(),
+            "clear_all_thread_local_state must reset alias-resolution depth, stack, and scratch pool"
         );
     }
 }

--- a/crates/tsz-checker/src/state/state.rs
+++ b/crates/tsz-checker/src/state/state.rs
@@ -39,6 +39,29 @@ thread_local! {
     static CROSS_ARENA_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
 }
 
+/// Reset the cross-arena delegation depth counter to zero.
+///
+/// `enter_cross_arena_delegation` / `leave_cross_arena_delegation` are a manual
+/// (non-RAII) enter/leave pair, so a compilation that bails out between them
+/// without unwinding — e.g. the stack-overflow breaker tripping or resolution
+/// fuel running out — can leave the counter non-zero. A leftover depth would
+/// then make `enter_cross_arena_delegation` refuse delegation in an unrelated
+/// later compilation. Reset between independent compilations (batch mode) so a
+/// pathological project cannot poison the next one.
+pub(crate) fn reset_cross_arena_depth() {
+    CROSS_ARENA_DEPTH.with(|c| c.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn set_cross_arena_depth_for_test(value: u32) {
+    CROSS_ARENA_DEPTH.with(|c| c.set(value));
+}
+
+#[cfg(test)]
+pub(crate) fn cross_arena_depth_for_test() -> u32 {
+    CROSS_ARENA_DEPTH.with(std::cell::Cell::get)
+}
+
 // =============================================================================
 // CheckerState
 // =============================================================================

--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -14,44 +14,7 @@ use tsz_solver::TypeId;
 
 pub(crate) use super::cross_file_query_types::CrossFileQueryKind;
 
-thread_local! {
-    static CROSS_ARENA_INTERFACE_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
-}
-
-/// Reset the cross-arena interface-delegation depth counter to zero.
-///
-/// `enter_cross_arena_interface_delegation` / `leave_...` form a manual
-/// (non-RAII) pair, so an early bail-out between them (stack-overflow breaker,
-/// resolution fuel exhaustion) can leave the counter non-zero and suppress
-/// interface delegation in a later, unrelated compilation. Reset between
-/// independent compilations in batch mode.
-pub(crate) fn reset_cross_arena_interface_depth() {
-    CROSS_ARENA_INTERFACE_DEPTH.with(|c| c.set(0));
-}
-
-#[cfg(test)]
-pub(crate) fn set_cross_arena_interface_depth_for_test(value: u32) {
-    CROSS_ARENA_INTERFACE_DEPTH.with(|c| c.set(value));
-}
-
-#[cfg(test)]
-pub(crate) fn cross_arena_interface_depth_for_test() -> u32 {
-    CROSS_ARENA_INTERFACE_DEPTH.with(std::cell::Cell::get)
-}
-
 impl<'a> CheckerState<'a> {
-    pub(crate) fn enter_cross_arena_interface_delegation() {
-        CROSS_ARENA_INTERFACE_DEPTH.with(|c| c.set(c.get() + 1));
-    }
-
-    pub(crate) fn leave_cross_arena_interface_delegation() {
-        CROSS_ARENA_INTERFACE_DEPTH.with(|c| c.set(c.get().saturating_sub(1)));
-    }
-
-    pub(crate) fn in_cross_arena_interface_delegation() -> bool {
-        CROSS_ARENA_INTERFACE_DEPTH.with(|c| c.get() > 0)
-    }
-
     fn resolve_cross_file_heritage_type_arg(
         &mut self,
         arena: &tsz_parser::NodeArena,

--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -18,6 +18,27 @@ thread_local! {
     static CROSS_ARENA_INTERFACE_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
 }
 
+/// Reset the cross-arena interface-delegation depth counter to zero.
+///
+/// `enter_cross_arena_interface_delegation` / `leave_...` form a manual
+/// (non-RAII) pair, so an early bail-out between them (stack-overflow breaker,
+/// resolution fuel exhaustion) can leave the counter non-zero and suppress
+/// interface delegation in a later, unrelated compilation. Reset between
+/// independent compilations in batch mode.
+pub(crate) fn reset_cross_arena_interface_depth() {
+    CROSS_ARENA_INTERFACE_DEPTH.with(|c| c.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn set_cross_arena_interface_depth_for_test(value: u32) {
+    CROSS_ARENA_INTERFACE_DEPTH.with(|c| c.set(value));
+}
+
+#[cfg(test)]
+pub(crate) fn cross_arena_interface_depth_for_test() -> u32 {
+    CROSS_ARENA_INTERFACE_DEPTH.with(std::cell::Cell::get)
+}
+
 impl<'a> CheckerState<'a> {
     pub(crate) fn enter_cross_arena_interface_delegation() {
         CROSS_ARENA_INTERFACE_DEPTH.with(|c| c.set(c.get() + 1));

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_alias_cycle.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_alias_cycle.rs
@@ -24,6 +24,27 @@ thread_local! {
         const { std::cell::RefCell::new(Vec::new()) };
 }
 
+/// Clear the cross-arena alias-resolution stack.
+///
+/// `CrossArenaAliasGuard` already pops on scope exit (including panic unwind),
+/// so this stack is normally empty between compilations. It is reset anyway at
+/// batch row boundaries to make row isolation total: any leftover entries pin
+/// arena-scoped `DefId`s, so dropping them releases per-row memory and
+/// guarantees a clean DFS even if a future non-unwinding bail-out path is added.
+pub(crate) fn reset_cross_arena_alias_stack() {
+    CROSS_ARENA_ALIAS_STACK.with(|stack| stack.borrow_mut().clear());
+}
+
+#[cfg(test)]
+pub(crate) fn push_cross_arena_alias_for_test(def_id: DefId) {
+    CROSS_ARENA_ALIAS_STACK.with(|stack| stack.borrow_mut().push(def_id));
+}
+
+#[cfg(test)]
+pub(crate) fn cross_arena_alias_stack_len_for_test() -> usize {
+    CROSS_ARENA_ALIAS_STACK.with(|stack| stack.borrow().len())
+}
+
 /// RAII guard returned by [`CheckerState::enter_cross_arena_alias`]. Pops the
 /// pushed alias `DefId` on drop — including on panic unwind — so a stale entry
 /// cannot poison later resolutions on a reused worker thread.

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_interface_depth.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_interface_depth.rs
@@ -1,0 +1,47 @@
+//! Cross-arena interface-delegation depth guard.
+//!
+//! Extracted from `cross_file.rs` to keep that module under the 2000-line
+//! maintainability limit. Tracks the recursion depth of cross-arena interface
+//! delegation so deeply nested child-checker creation cannot overflow the
+//! stack, and exposes a reset hook for independent-compilation boundaries.
+
+use crate::state::CheckerState;
+
+thread_local! {
+    static CROSS_ARENA_INTERFACE_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
+/// Reset the cross-arena interface-delegation depth counter to zero.
+///
+/// `enter_cross_arena_interface_delegation` / `leave_...` form a manual
+/// (non-RAII) pair, so an early bail-out between them (stack-overflow breaker,
+/// resolution fuel exhaustion) can leave the counter non-zero and suppress
+/// interface delegation in a later, unrelated compilation. Reset between
+/// independent compilations in batch mode.
+pub(crate) fn reset_cross_arena_interface_depth() {
+    CROSS_ARENA_INTERFACE_DEPTH.with(|c| c.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn set_cross_arena_interface_depth_for_test(value: u32) {
+    CROSS_ARENA_INTERFACE_DEPTH.with(|c| c.set(value));
+}
+
+#[cfg(test)]
+pub(crate) fn cross_arena_interface_depth_for_test() -> u32 {
+    CROSS_ARENA_INTERFACE_DEPTH.with(std::cell::Cell::get)
+}
+
+impl<'a> CheckerState<'a> {
+    pub(crate) fn enter_cross_arena_interface_delegation() {
+        CROSS_ARENA_INTERFACE_DEPTH.with(|c| c.set(c.get() + 1));
+    }
+
+    pub(crate) fn leave_cross_arena_interface_delegation() {
+        CROSS_ARENA_INTERFACE_DEPTH.with(|c| c.set(c.get().saturating_sub(1)));
+    }
+
+    pub(crate) fn in_cross_arena_interface_delegation() -> bool {
+        CROSS_ARENA_INTERFACE_DEPTH.with(|c| c.get() > 0)
+    }
+}

--- a/crates/tsz-checker/src/state/type_analysis/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/mod.rs
@@ -26,6 +26,7 @@ mod cross_file_direct_functions;
 mod cross_file_env_merge;
 mod cross_file_globals;
 mod cross_file_import_alias_pin;
+mod cross_file_interface_depth;
 mod cross_file_overlay_gate;
 pub(crate) mod cross_file_query_types;
 mod cross_file_residue;
@@ -42,18 +43,18 @@ mod type_param_defaults;
 /// leave a non-zero depth counter or a non-empty resolution stack that would
 /// suppress cross-file resolution in the next project on the same worker.
 pub(crate) fn reset_cross_file_recursion_guards() {
-    cross_file::reset_cross_arena_interface_depth();
+    cross_file_interface_depth::reset_cross_arena_interface_depth();
     cross_file_alias_cycle::reset_cross_arena_alias_stack();
 }
 
 #[cfg(test)]
 pub(crate) fn dirty_cross_file_recursion_guards_for_test() {
-    cross_file::set_cross_arena_interface_depth_for_test(2);
+    cross_file_interface_depth::set_cross_arena_interface_depth_for_test(2);
     cross_file_alias_cycle::push_cross_arena_alias_for_test(tsz_solver::def::DefId::INVALID);
 }
 
 #[cfg(test)]
 pub(crate) fn cross_file_recursion_guards_clear_for_test() -> bool {
-    cross_file::cross_arena_interface_depth_for_test() == 0
+    cross_file_interface_depth::cross_arena_interface_depth_for_test() == 0
         && cross_file_alias_cycle::cross_arena_alias_stack_len_for_test() == 0
 }

--- a/crates/tsz-checker/src/state/type_analysis/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/mod.rs
@@ -33,3 +33,27 @@ mod cross_file_shared_cache;
 mod source_alias_attribution;
 mod symbol_type_helpers;
 mod type_param_defaults;
+
+/// Reset every cross-file/cross-arena recursion-guard thread-local owned by
+/// this module tree to its empty state.
+///
+/// Called from `clear_all_thread_local_state` at independent-compilation
+/// boundaries (batch mode) so a project that bails out mid-delegation cannot
+/// leave a non-zero depth counter or a non-empty resolution stack that would
+/// suppress cross-file resolution in the next project on the same worker.
+pub(crate) fn reset_cross_file_recursion_guards() {
+    cross_file::reset_cross_arena_interface_depth();
+    cross_file_alias_cycle::reset_cross_arena_alias_stack();
+}
+
+#[cfg(test)]
+pub(crate) fn dirty_cross_file_recursion_guards_for_test() {
+    cross_file::set_cross_arena_interface_depth_for_test(2);
+    cross_file_alias_cycle::push_cross_arena_alias_for_test(tsz_solver::def::DefId::INVALID);
+}
+
+#[cfg(test)]
+pub(crate) fn cross_file_recursion_guards_clear_for_test() -> bool {
+    cross_file::cross_arena_interface_depth_for_test() == 0
+        && cross_file_alias_cycle::cross_arena_alias_stack_len_for_test() == 0
+}

--- a/crates/tsz-checker/src/types/mod.rs
+++ b/crates/tsz-checker/src/types/mod.rs
@@ -27,3 +27,27 @@ mod type_node_resolution;
 pub(crate) mod unique_symbol_arena;
 pub(crate) mod utilities;
 pub(crate) mod window_global_this_annotation;
+
+/// Reset every type-resolution recursion-guard and scratch-pool thread-local
+/// owned by this module tree to its empty state.
+///
+/// Called from `clear_all_thread_local_state` at independent-compilation
+/// boundaries (batch mode) so a project that bails out mid alias-resolution
+/// cannot leave a non-zero depth counter, a stale active-set entry, or a
+/// retained scratch pool that would affect the next project on the same worker.
+pub(crate) fn reset_type_resolution_guards() {
+    type_node_resolution::reset_alias_resolve_state();
+    type_checking::reset_alias_resolution_pools();
+}
+
+#[cfg(test)]
+pub(crate) fn dirty_type_resolution_guards_for_test() {
+    type_node_resolution::dirty_alias_resolve_state_for_test();
+    type_checking::dirty_alias_resolution_pools_for_test();
+}
+
+#[cfg(test)]
+pub(crate) fn type_resolution_guards_clear_for_test() -> bool {
+    type_node_resolution::alias_resolve_state_is_clear_for_test()
+        && type_checking::alias_resolution_pools_clear_for_test()
+}

--- a/crates/tsz-checker/src/types/type_checking/alias_defid_visited_pool.rs
+++ b/crates/tsz-checker/src/types/type_checking/alias_defid_visited_pool.rs
@@ -1,0 +1,66 @@
+//! Reusable scratch `FxHashSet<DefId>` pool for the type-alias resolution DFS.
+//!
+//! Extracted from `type_alias_checking.rs` to keep that module under the
+//! 2000-line maintainability limit. The pool lets the alias-resolution DFS
+//! reuse one allocation across calls; `reset_alias_defid_visited_pool` releases
+//! it at independent-compilation boundaries (batch mode).
+
+use std::cell::RefCell;
+use tsz_solver::def::DefId;
+
+// Reusable scratch `FxHashSet<DefId>` for the alias-resolution DFS.
+// Mirrors the pool pattern from #4722 / #4790 and follow-up PRs.
+thread_local! {
+    static ALIAS_DEFID_VISITED_POOL: RefCell<Option<rustc_hash::FxHashSet<DefId>>> =
+        const { RefCell::new(None) };
+}
+
+/// Run `f` with a cleared scratch `FxHashSet<DefId>` borrowed from the
+/// thread-local pool, returning the set to the pool afterwards (keeping the
+/// larger of the two capacities so repeated calls stop reallocating).
+#[inline]
+pub(crate) fn with_alias_defid_visited<R>(
+    f: impl FnOnce(&mut rustc_hash::FxHashSet<DefId>) -> R,
+) -> R {
+    let mut visited = ALIAS_DEFID_VISITED_POOL
+        .with(|p| p.borrow_mut().take())
+        .unwrap_or_default();
+    visited.clear();
+    let r = f(&mut visited);
+    ALIAS_DEFID_VISITED_POOL.with(|p| {
+        let mut slot = p.borrow_mut();
+        let keep = match &*slot {
+            None => true,
+            Some(existing) => visited.capacity() >= existing.capacity(),
+        };
+        if keep {
+            *slot = Some(visited);
+        }
+    });
+    r
+}
+
+/// Drop the pooled alias-resolution scratch set.
+///
+/// `with_alias_defid_visited` clears the set before each use, so a retained
+/// pool is never a correctness hazard mid-run, but it holds arena-scoped
+/// `DefId`s and their backing capacity across compilations. Releasing it at
+/// batch row boundaries keeps per-row memory from accumulating across the
+/// worker's lifetime.
+pub(crate) fn reset_alias_defid_visited_pool() {
+    ALIAS_DEFID_VISITED_POOL.with(|p| *p.borrow_mut() = None);
+}
+
+#[cfg(test)]
+pub(crate) fn set_alias_defid_visited_pool_dirty_for_test() {
+    ALIAS_DEFID_VISITED_POOL.with(|p| {
+        let mut set = rustc_hash::FxHashSet::default();
+        set.insert(DefId::INVALID);
+        *p.borrow_mut() = Some(set);
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn alias_defid_visited_pool_is_released_for_test() -> bool {
+    ALIAS_DEFID_VISITED_POOL.with(|p| p.borrow().is_none())
+}

--- a/crates/tsz-checker/src/types/type_checking/mod.rs
+++ b/crates/tsz-checker/src/types/type_checking/mod.rs
@@ -33,3 +33,19 @@ mod type_alias_depth_helpers;
 mod type_alias_missing_name_coverage;
 mod type_alias_recursion_patterns;
 mod unused;
+
+/// Release the type-alias resolution scratch pool owned by this module tree.
+/// Called at independent-compilation boundaries (batch mode).
+pub(crate) fn reset_alias_resolution_pools() {
+    type_alias_checking::reset_alias_defid_visited_pool();
+}
+
+#[cfg(test)]
+pub(crate) fn dirty_alias_resolution_pools_for_test() {
+    type_alias_checking::set_alias_defid_visited_pool_dirty_for_test();
+}
+
+#[cfg(test)]
+pub(crate) fn alias_resolution_pools_clear_for_test() -> bool {
+    type_alias_checking::alias_defid_visited_pool_is_released_for_test()
+}

--- a/crates/tsz-checker/src/types/type_checking/mod.rs
+++ b/crates/tsz-checker/src/types/type_checking/mod.rs
@@ -10,6 +10,7 @@
 //! - `type_alias_checking` — type alias declaration checking, type node validation
 //! - `unused` — unused variable/parameter detection
 
+mod alias_defid_visited_pool;
 mod commonjs_object_exports;
 mod core;
 mod core_statement_checks;
@@ -37,15 +38,15 @@ mod unused;
 /// Release the type-alias resolution scratch pool owned by this module tree.
 /// Called at independent-compilation boundaries (batch mode).
 pub(crate) fn reset_alias_resolution_pools() {
-    type_alias_checking::reset_alias_defid_visited_pool();
+    alias_defid_visited_pool::reset_alias_defid_visited_pool();
 }
 
 #[cfg(test)]
 pub(crate) fn dirty_alias_resolution_pools_for_test() {
-    type_alias_checking::set_alias_defid_visited_pool_dirty_for_test();
+    alias_defid_visited_pool::set_alias_defid_visited_pool_dirty_for_test();
 }
 
 #[cfg(test)]
 pub(crate) fn alias_resolution_pools_clear_for_test() -> bool {
-    type_alias_checking::alias_defid_visited_pool_is_released_for_test()
+    alias_defid_visited_pool::alias_defid_visited_pool_is_released_for_test()
 }

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -26,6 +26,31 @@ thread_local! {
         const { RefCell::new(None) };
 }
 
+/// Drop the pooled alias-resolution scratch set.
+///
+/// `with_alias_defid_visited` clears the set before each use, so a retained
+/// pool is never a correctness hazard mid-run, but it holds arena-scoped
+/// `DefId`s and their backing capacity across compilations. Releasing it at
+/// batch row boundaries keeps per-row memory from accumulating across the
+/// worker's lifetime.
+pub(crate) fn reset_alias_defid_visited_pool() {
+    ALIAS_DEFID_VISITED_POOL.with(|p| *p.borrow_mut() = None);
+}
+
+#[cfg(test)]
+pub(crate) fn set_alias_defid_visited_pool_dirty_for_test() {
+    ALIAS_DEFID_VISITED_POOL.with(|p| {
+        let mut set = rustc_hash::FxHashSet::default();
+        set.insert(DefId::INVALID);
+        *p.borrow_mut() = Some(set);
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn alias_defid_visited_pool_is_released_for_test() -> bool {
+    ALIAS_DEFID_VISITED_POOL.with(|p| p.borrow().is_none())
+}
+
 #[inline]
 fn with_alias_defid_visited<R>(f: impl FnOnce(&mut rustc_hash::FxHashSet<DefId>) -> R) -> R {
     let mut visited = ALIAS_DEFID_VISITED_POOL

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -10,66 +10,13 @@
 //! - `check_type_node` — recursive type node validation (mapped types, conditionals, etc.)
 //! - `precompute_type_query_flow_types` — pre-computes `typeof` flow-narrowed types
 
+use super::alias_defid_visited_pool::with_alias_defid_visited;
 use crate::state::CheckerState;
-use std::cell::RefCell;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::parser::{NodeIndex, NodeList};
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
-use tsz_solver::def::DefId;
-
-// Reusable scratch `FxHashSet<DefId>` for the alias-resolution DFS in this
-// module. Mirrors the pool pattern from #4722 / #4790 and follow-up PRs.
-thread_local! {
-    static ALIAS_DEFID_VISITED_POOL: RefCell<Option<rustc_hash::FxHashSet<DefId>>> =
-        const { RefCell::new(None) };
-}
-
-/// Drop the pooled alias-resolution scratch set.
-///
-/// `with_alias_defid_visited` clears the set before each use, so a retained
-/// pool is never a correctness hazard mid-run, but it holds arena-scoped
-/// `DefId`s and their backing capacity across compilations. Releasing it at
-/// batch row boundaries keeps per-row memory from accumulating across the
-/// worker's lifetime.
-pub(crate) fn reset_alias_defid_visited_pool() {
-    ALIAS_DEFID_VISITED_POOL.with(|p| *p.borrow_mut() = None);
-}
-
-#[cfg(test)]
-pub(crate) fn set_alias_defid_visited_pool_dirty_for_test() {
-    ALIAS_DEFID_VISITED_POOL.with(|p| {
-        let mut set = rustc_hash::FxHashSet::default();
-        set.insert(DefId::INVALID);
-        *p.borrow_mut() = Some(set);
-    });
-}
-
-#[cfg(test)]
-pub(crate) fn alias_defid_visited_pool_is_released_for_test() -> bool {
-    ALIAS_DEFID_VISITED_POOL.with(|p| p.borrow().is_none())
-}
-
-#[inline]
-fn with_alias_defid_visited<R>(f: impl FnOnce(&mut rustc_hash::FxHashSet<DefId>) -> R) -> R {
-    let mut visited = ALIAS_DEFID_VISITED_POOL
-        .with(|p| p.borrow_mut().take())
-        .unwrap_or_default();
-    visited.clear();
-    let r = f(&mut visited);
-    ALIAS_DEFID_VISITED_POOL.with(|p| {
-        let mut slot = p.borrow_mut();
-        let keep = match &*slot {
-            None => true,
-            Some(existing) => visited.capacity() >= existing.capacity(),
-        };
-        if keep {
-            *slot = Some(visited);
-        }
-    });
-    r
-}
 
 #[inline]
 fn record_type_alias_phase_timing(

--- a/crates/tsz-checker/src/types/type_node_resolution.rs
+++ b/crates/tsz-checker/src/types/type_node_resolution.rs
@@ -15,6 +15,38 @@ use tsz_solver::is_compiler_managed_type;
 
 use super::type_node::TypeNodeChecker;
 
+thread_local! {
+    /// Depth and active-set guards for recursive type-alias resolution chains
+    /// (see `ensure_type_alias_resolved`). Module-scoped rather than
+    /// function-scoped so they can be reset at independent-compilation
+    /// boundaries: the push/pop around `ensure_type_alias_resolved_inner` is
+    /// manual (non-RAII), so a panic unwinding through that call — caught
+    /// upstream by the batch driver — would otherwise leave a stale `DefId` in
+    /// the active set, wrongly short-circuiting that alias in the next project.
+    static ALIAS_RESOLVE_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+    static ALIAS_RESOLVE_STACK: std::cell::RefCell<Vec<tsz_solver::def::DefId>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// Reset the type-alias resolution depth counter and active-set stack.
+/// Called from `clear_all_thread_local_state` at batch row boundaries.
+pub(crate) fn reset_alias_resolve_state() {
+    ALIAS_RESOLVE_DEPTH.with(|c| c.set(0));
+    ALIAS_RESOLVE_STACK.with(|stack| stack.borrow_mut().clear());
+}
+
+#[cfg(test)]
+pub(crate) fn dirty_alias_resolve_state_for_test() {
+    ALIAS_RESOLVE_DEPTH.with(|c| c.set(7));
+    ALIAS_RESOLVE_STACK.with(|stack| stack.borrow_mut().push(tsz_solver::def::DefId::INVALID));
+}
+
+#[cfg(test)]
+pub(crate) fn alias_resolve_state_is_clear_for_test() -> bool {
+    ALIAS_RESOLVE_DEPTH.with(std::cell::Cell::get) == 0
+        && ALIAS_RESOLVE_STACK.with(|stack| stack.borrow().is_empty())
+}
+
 impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
     pub(super) fn resolve_import_alias_type_target_symbol(
         &self,
@@ -814,12 +846,9 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         // Depth guard for recursive type alias resolution chains.
         // ts-toolbelt has type aliases like `type Merge<...> = ...Patch<...Diff<...>>`
         // where each referenced alias recursively triggers lowering of its body,
-        // creating unbounded stack growth. Cap at 100 levels.
-        thread_local! {
-            static ALIAS_RESOLVE_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
-            static ALIAS_RESOLVE_STACK: std::cell::RefCell<Vec<tsz_solver::def::DefId>> =
-                const { std::cell::RefCell::new(Vec::new()) };
-        }
+        // creating unbounded stack growth. Cap at 100 levels. The depth/active-set
+        // guards are module-scoped (defined at the top of this file) so they can
+        // be cleared between independent compilations via `reset_alias_resolve_state`.
         let depth = ALIAS_RESOLVE_DEPTH.get();
         if depth >= 100 {
             return;


### PR DESCRIPTION
## Agent
AgentName: Studio-B
Contributor identity: claude-opus48-pensive-wright (Claude Code runner; not an ownership lane).

Fixes #10880.

## Track
Architecture / batch-driver row isolation (benchmark + project-corpus harness determinism).

## Invariant
When a project row aborts mid-delegation in batch mode — the stack-overflow breaker tripping, resolution fuel running out, or a panic caught by the batch driver — a manual (non-RAII) recursion guard can be left non-zero/non-empty; `tsc` is one process per project so it never carries such state across projects. This PR makes tsz match that isolation by resetting **every** per-compilation recursion guard at the batch row boundary, in `tsz_checker::clear_all_thread_local_state` (the checker layer that owns those thread-locals).

## Scope
`crates/tsz-checker` only. Batch mode (`tsz --batch`, used by the project-corpus / benchmark harness and the conformance runner) checks many projects in one long-lived worker process and relies on `clear_all_thread_local_state()` to isolate each row. That reset list was incomplete — these per-compilation thread-locals were never cleared:

- `CROSS_ARENA_DEPTH` — cross-arena delegation depth (`state/state.rs`)
- `CROSS_ARENA_INTERFACE_DEPTH` — cross-arena interface delegation depth (`state/type_analysis/cross_file.rs`)
- `CROSS_ARENA_ALIAS_STACK` — cross-arena alias DFS stack (`state/type_analysis/cross_file_alias_cycle.rs`)
- `ALIAS_RESOLVE_DEPTH` / `ALIAS_RESOLVE_STACK` — type-alias resolution chain guard (`types/type_node_resolution.rs`), hoisted from function scope to module scope so it is resettable
- `ALIAS_DEFID_VISITED_POOL` — alias-resolution scratch pool (`types/type_checking/type_alias_checking.rs`), released to free per-row memory

Each owning module now exposes a `reset_*` function; parent `mod.rs` files aggregate them; `clear_all_thread_local_state()` calls the aggregators. Resetting at the row boundary is unconditionally safe because no resolution is in progress between rows. The reset list is documented as hand-maintained (Rust cannot enumerate `thread_local!`s) so future guards get added here too.

Why this is the root-cause fix, not a point patch: the leak class is "a per-compilation recursion guard that uses manual enter/leave or push/pop and is not in the canonical reset." The fix generalizes over all five such guards (varying owning module, counter vs. stack vs. pool), not the one repro shape, and centralizes them through the single existing isolation barrier rather than adding per-call-site cleanup.

## Project Corpus Impact
- Row: all rows (batch-mode row isolation; the harness compiles every project row through one worker).
- Bug family: benchmark-harness cross-row state leak / order-dependent row output (#10880).
- Evidence: new unit test `clear_all_thread_local_state_resets_cross_arena_and_alias_guards` dirties every guard the way an aborted row would and asserts the canonical reset clears them all. Behavior within a single row is unchanged (each row already begins with the reset), so single-file conformance/emit output is unaffected — the change only strengthens isolation between rows.

## Verification
- `cargo test -p tsz-checker --lib clear_all` → 2 passed (existing `clear_all_thread_local_state_zeros_stack_state` + new guard-reset regression test).
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` → clean.
- `cargo check -p tsz-checker` → clean.
- Full conformance/emit/fourslash/wasm: ready-for-review CI (in progress on this head).

## Coordination Notes
- Owner lane: `agent:Studio-B` (matches issue #10880). Contributor identity `claude-opus48-pensive-wright` kept in comments only.
- Landing path: repo-local `merge-queue` only — GitHub auto-merge intentionally left OFF until exact-head PR checks complete clean, then the owner/queue manager enqueues. (Auto-merge was briefly enabled then disabled; not used as a CI watcher.)
- Concrete leak locations surfaced by a thread-local audit of the batch driver reset path; `CROSS_ARENA_ALIAS_STACK` already self-pops via RAII so it is reset defensively (memory release + future-proofing), while the depth counters and pool are the genuine non-unwinding leak vectors.