### PR TITLE
chore(agents): expose auto-merge PR counts

### DIFF
--- a/scripts/agents/list-owned-work.sh
+++ b/scripts/agents/list-owned-work.sh
@@ -223,11 +223,16 @@ for agent in "${SELECTED[@]}"; do
     )"
   else
     prs="$(
-      gh pr list --state open --limit 100 --label "$label" --json number,title,isDraft,url,labels \
+      gh pr list --state open --limit 100 --label "$label" --json number,title,isDraft,url,labels,autoMergeRequest \
         --jq '
           def merge_queue_label:
             if any(.labels[]?; .name == "merge-queue") then "mergeQueue=on" else "mergeQueue=off" end;
-          .[] | "#\(.number) " + (if .isDraft then "draft" else "ready" end) + " " + merge_queue_label + " " + .title + " " + .url
+          .[] |
+            "#\(.number) " +
+            (if .isDraft then "draft" else "ready" end) +
+            " autoMerge=" + (if .autoMergeRequest then "on" else "off" end) +
+            " " + merge_queue_label +
+            " " + .title + " " + .url
         ' \
         2>/dev/null ||
         list_owned_items_rest "$label" pr
@@ -241,6 +246,7 @@ for agent in "${SELECTED[@]}"; do
   pr_count="$(count_rows "$prs")"
   ready_pr_count="$(count_pr_state_rows "$prs" ready)"
   draft_pr_count="$(count_pr_state_rows "$prs" draft)"
+  auto_merge_pr_count="$(count_pr_token_rows "$prs" "autoMerge=on")"
   merge_queue_pr_count="$(count_pr_token_rows "$prs" "mergeQueue=on")"
   ready_unqueued_pr_count="$(count_ready_unqueued_pr_rows "$prs")"
   echo ""
@@ -267,6 +273,7 @@ for agent in "${SELECTED[@]}"; do
   echo "owned_pr_count=$pr_count"
   echo "owned_ready_pr_count=$ready_pr_count"
   echo "owned_draft_pr_count=$draft_pr_count"
+  echo "owned_auto_merge_pr_count=$auto_merge_pr_count"
   echo "owned_merge_queue_pr_count=$merge_queue_pr_count"
   echo "owned_ready_unqueued_pr_count=$ready_unqueued_pr_count"
   echo "owned_issue_count=$issue_count"
@@ -282,6 +289,7 @@ for agent in "${SELECTED[@]}"; do
       ROW_PR_COUNT="$pr_count" \
       ROW_READY_PR_COUNT="$ready_pr_count" \
       ROW_DRAFT_PR_COUNT="$draft_pr_count" \
+      ROW_AUTO_MERGE_PR_COUNT="$auto_merge_pr_count" \
       ROW_MERGE_QUEUE_PR_COUNT="$merge_queue_pr_count" \
       ROW_READY_UNQUEUED_PR_COUNT="$ready_unqueued_pr_count" \
       ROW_ISSUE_COUNT="$issue_count" \
@@ -297,6 +305,7 @@ const row = {
   pr_count: Number(process.env.ROW_PR_COUNT ?? 0),
   ready_pr_count: Number(process.env.ROW_READY_PR_COUNT ?? 0),
   draft_pr_count: Number(process.env.ROW_DRAFT_PR_COUNT ?? 0),
+  auto_merge_pr_count: Number(process.env.ROW_AUTO_MERGE_PR_COUNT ?? 0),
   merge_queue_pr_count: Number(process.env.ROW_MERGE_QUEUE_PR_COUNT ?? 0),
   ready_unqueued_pr_count: Number(process.env.ROW_READY_UNQUEUED_PR_COUNT ?? 0),
   issue_count: Number(process.env.ROW_ISSUE_COUNT ?? 0),
@@ -336,6 +345,10 @@ const totalMergeQueuePrCount = agents.reduce(
   (sum, agent) => sum + Number(agent.merge_queue_pr_count ?? 0),
   0,
 );
+const totalAutoMergePrCount = agents.reduce(
+  (sum, agent) => sum + Number(agent.auto_merge_pr_count ?? 0),
+  0,
+);
 const totalReadyUnqueuedPrCount = agents.reduce(
   (sum, agent) => sum + Number(agent.ready_unqueued_pr_count ?? 0),
   0,
@@ -358,6 +371,7 @@ const report = {
   total_pr_count: totalPrCount,
   total_ready_pr_count: totalReadyPrCount,
   total_draft_pr_count: totalDraftPrCount,
+  total_auto_merge_pr_count: totalAutoMergePrCount,
   total_merge_queue_pr_count: totalMergeQueuePrCount,
   total_ready_unqueued_pr_count: totalReadyUnqueuedPrCount,
   total_issue_count: totalIssueCount,

--- a/scripts/agents/test_list_owned_work.py
+++ b/scripts/agents/test_list_owned_work.py
@@ -44,6 +44,7 @@ exec "$@"
         self.assertIn("owned_pr_count=0", result.stdout)
         self.assertIn("owned_ready_pr_count=0", result.stdout)
         self.assertIn("owned_draft_pr_count=0", result.stdout)
+        self.assertIn("owned_auto_merge_pr_count=0", result.stdout)
         self.assertIn("owned_merge_queue_pr_count=0", result.stdout)
         self.assertIn("owned_ready_unqueued_pr_count=0", result.stdout)
         self.assertIn("owned_issue_count=0", result.stdout)
@@ -53,9 +54,9 @@ exec "$@"
         result = self.run_list_owned_work(
             ["Studio-F"],
             prs=(
-                "#1 ready mergeQueue=on first PR https://github.com/mohsen1/tsz/pull/1\n"
-                "#2 draft mergeQueue=off second PR https://github.com/mohsen1/tsz/pull/2\n"
-                "#4 ready mergeQueue=off third PR https://github.com/mohsen1/tsz/pull/4\n"
+                "#1 ready autoMerge=off mergeQueue=on first PR https://github.com/mohsen1/tsz/pull/1\n"
+                "#2 draft autoMerge=on mergeQueue=off second PR https://github.com/mohsen1/tsz/pull/2\n"
+                "#4 ready autoMerge=off mergeQueue=off third PR https://github.com/mohsen1/tsz/pull/4\n"
             ),
             issues="#3 issue https://github.com/mohsen1/tsz/issues/3\n",
         )
@@ -63,6 +64,7 @@ exec "$@"
         self.assertIn("owned_pr_count=3", result.stdout)
         self.assertIn("owned_ready_pr_count=2", result.stdout)
         self.assertIn("owned_draft_pr_count=1", result.stdout)
+        self.assertIn("owned_auto_merge_pr_count=1", result.stdout)
         self.assertIn("owned_merge_queue_pr_count=1", result.stdout)
         self.assertIn("owned_ready_unqueued_pr_count=1", result.stdout)
         self.assertIn("owned_issue_count=1", result.stdout)
@@ -74,7 +76,7 @@ exec "$@"
 
             result = self.run_list_owned_work(
                 ["Studio-F", "--json-report", str(report_path)],
-                prs="#1 ready mergeQueue=on first PR https://github.com/mohsen1/tsz/pull/1\n",
+                prs="#1 ready autoMerge=on mergeQueue=on first PR https://github.com/mohsen1/tsz/pull/1\n",
                 issues="#2 issue https://github.com/mohsen1/tsz/issues/2\n",
             )
 
@@ -90,6 +92,7 @@ exec "$@"
             self.assertEqual(1, report["total_pr_count"])
             self.assertEqual(1, report["total_ready_pr_count"])
             self.assertEqual(0, report["total_draft_pr_count"])
+            self.assertEqual(1, report["total_auto_merge_pr_count"])
             self.assertEqual(1, report["total_merge_queue_pr_count"])
             self.assertEqual(0, report["total_ready_unqueued_pr_count"])
             self.assertEqual(1, report["total_issue_count"])
@@ -101,13 +104,14 @@ exec "$@"
             self.assertEqual(1, row["pr_count"])
             self.assertEqual(1, row["ready_pr_count"])
             self.assertEqual(0, row["draft_pr_count"])
+            self.assertEqual(1, row["auto_merge_pr_count"])
             self.assertEqual(1, row["merge_queue_pr_count"])
             self.assertEqual(0, row["ready_unqueued_pr_count"])
             self.assertEqual(1, row["issue_count"])
             self.assertFalse(row["owned_work_clear"])
             self.assertEqual("active", row["owned_work_status"])
             self.assertEqual(
-                ["#1 ready mergeQueue=on first PR https://github.com/mohsen1/tsz/pull/1"],
+                ["#1 ready autoMerge=on mergeQueue=on first PR https://github.com/mohsen1/tsz/pull/1"],
                 row["prs"],
             )
             self.assertEqual(
@@ -129,6 +133,7 @@ exec "$@"
             self.assertEqual(0, report["total_pr_count"])
             self.assertEqual(0, report["total_ready_pr_count"])
             self.assertEqual(0, report["total_draft_pr_count"])
+            self.assertEqual(0, report["total_auto_merge_pr_count"])
             self.assertEqual(0, report["total_merge_queue_pr_count"])
             self.assertEqual(0, report["total_ready_unqueued_pr_count"])
             self.assertEqual(0, report["total_issue_count"])


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / cheap evidence plumbing.

## Invariant
When an agent inspects owned PR runway, the report should count PRs with GitHub auto-merge armed so policy violations are visible without manually scanning every row.

## Scope
- `scripts/agents/list-owned-work.sh`
- `scripts/agents/test_list_owned_work.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent-script-only; no compiler, emit, checker, solver, parser, binder, LSP, WASM, benchmark, or project-corpus behavior changes.

## Verification
- `python3 -m unittest scripts.agents.test_list_owned_work`
- `bash -n scripts/agents/list-owned-work.sh`
- `git diff --check`
- `scripts/agents/list-owned-work.sh --all --pr-state --json-report /tmp/tsz-owned-work-automerge-count.json`

## Coordination Notes
- Studio-F owned PR runway was clear before starting.
- This PR follows a live coordination cleanup where an open PR had auto-merge armed while checks were pending.
- Live all-agent report after the change showed `18` open owned PRs, `6` ready, `12` draft, `0` auto-merge armed, `0` with `merge-queue`, and `6` ready-but-not-queued.
