### PR TITLE
chore(bench): report benchmark source freshness

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -269,6 +269,7 @@ jobs:
 
           check_exit=0
           node scripts/bench/check-artifact-readiness.mjs "${artifact}" \
+            --expect-source-commit="${GITHUB_SHA}" \
             || check_exit=$?
 
           if [[ "${check_exit}" -eq 1 ]]; then

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -341,6 +341,7 @@ jobs:
           )"
 
           node scripts/bench/check-artifact-readiness.mjs "${artifact}" --json \
+            --expect-source-commit="${GITHUB_SHA}" \
             > "${readiness_out}" || true
           echo "Wrote $(wc -c < "${readiness_out}") bytes to ${readiness_out}."
         continue-on-error: true

--- a/scripts/bench/check-artifact-readiness.mjs
+++ b/scripts/bench/check-artifact-readiness.mjs
@@ -5,8 +5,9 @@
  * Exit codes:
  *   0 — artifact present, all required rows included
  *   1 — artifact present, one or more required rows are missing, the
- *       --require-green release gate found non-green required rows, or the
- *       --require-clean-metadata gate found artifact metadata warnings
+ *       --require-green release gate found non-green required rows, the
+ *       --require-clean-metadata gate found artifact metadata warnings, or the
+ *       --require-source-current gate found a stale artifact source commit
  *   2 — artifact file absent or unparseable
  *
  * Without --json: writes a markdown report to stdout (and GITHUB_STEP_SUMMARY
@@ -17,7 +18,7 @@
  * is absent (exit 2) so callers reliably get machine-readable status in all cases.
  *
  * Usage:
- *   node scripts/bench/check-artifact-readiness.mjs [--json] [--require-green] [--require-clean-metadata] <artifact.json>
+ *   node scripts/bench/check-artifact-readiness.mjs [--json] [--require-green] [--require-clean-metadata] [--expect-source-commit=<sha>] [--require-source-current] <artifact.json>
  */
 
 import fs from "node:fs";
@@ -32,10 +33,48 @@ import {
 } from "./row-utils.mjs";
 
 const args = process.argv.slice(2);
-const jsonOutput = args.includes("--json");
-const requireGreen = args.includes("--require-green");
-const requireCleanMetadata = args.includes("--require-clean-metadata");
-const filePath = args.find((a) => !a.startsWith("-")) ?? null;
+
+function parseArgs(rawArgs) {
+  const options = {
+    jsonOutput: false,
+    requireGreen: false,
+    requireCleanMetadata: false,
+    requireSourceCurrent: false,
+    expectedSourceCommit: process.env.TSZ_BENCH_EXPECT_SOURCE_COMMIT ?? null,
+    filePath: null,
+  };
+
+  for (let i = 0; i < rawArgs.length; i += 1) {
+    const arg = rawArgs[i];
+    if (arg === "--json") {
+      options.jsonOutput = true;
+    } else if (arg === "--require-green") {
+      options.requireGreen = true;
+    } else if (arg === "--require-clean-metadata") {
+      options.requireCleanMetadata = true;
+    } else if (arg === "--require-source-current") {
+      options.requireSourceCurrent = true;
+    } else if (arg === "--expect-source-commit") {
+      options.expectedSourceCommit = rawArgs[i + 1] ?? "";
+      i += 1;
+    } else if (arg.startsWith("--expect-source-commit=")) {
+      options.expectedSourceCommit = arg.slice("--expect-source-commit=".length);
+    } else if (!arg.startsWith("-") && !options.filePath) {
+      options.filePath = arg;
+    }
+  }
+
+  return options;
+}
+
+const {
+  jsonOutput,
+  requireGreen,
+  requireCleanMetadata,
+  requireSourceCurrent,
+  expectedSourceCommit,
+  filePath,
+} = parseArgs(args);
 
 function loadArtifact() {
   if (!filePath) {
@@ -149,7 +188,59 @@ function analyzeValidationWarnings(artifact) {
   };
 }
 
-function analyzeArtifact(artifact) {
+function normalizedCommit(value) {
+  const commit = String(value || "").trim().toLowerCase();
+  return /^[0-9a-f]{7,40}$/.test(commit) ? commit : null;
+}
+
+function commitsMatch(left, right) {
+  const a = normalizedCommit(left);
+  const b = normalizedCommit(right);
+  if (!a || !b) return false;
+  return a.startsWith(b) || b.startsWith(a);
+}
+
+function shortCommit(value) {
+  const commit = String(value || "").trim();
+  return commit && commit !== "local" ? commit.slice(0, 12) : commit || null;
+}
+
+function analyzeSourceFreshness(artifact, expectedCommit) {
+  const expected = normalizedCommit(expectedCommit);
+  const source = normalizedCommit(artifact?.source_commit);
+  if (!expected) {
+    return {
+      expected_source_commit: null,
+      source_commit: artifact?.source_commit ?? null,
+      current: null,
+      warning: null,
+    };
+  }
+  if (!source) {
+    return {
+      expected_source_commit: expected,
+      source_commit: artifact?.source_commit ?? null,
+      current: false,
+      warning: `source_commit missing; expected ${shortCommit(expected)}`,
+    };
+  }
+  if (commitsMatch(source, expected)) {
+    return {
+      expected_source_commit: expected,
+      source_commit: source,
+      current: true,
+      warning: null,
+    };
+  }
+  return {
+    expected_source_commit: expected,
+    source_commit: source,
+    current: false,
+    warning: `source ${shortCommit(source)} differs from expected ${shortCommit(expected)}`,
+  };
+}
+
+function analyzeArtifact(artifact, expectedCommit) {
   const byName = new Map();
   const duplicateCounts = new Map();
   for (const row of Array.isArray(artifact?.results) ? artifact.results : []) {
@@ -200,6 +291,7 @@ function analyzeArtifact(artifact) {
   return {
     measurementProfile: analyzeMeasurementProfile(artifact),
     validationWarnings: analyzeValidationWarnings(artifact),
+    sourceFreshness: analyzeSourceFreshness(artifact, expectedCommit),
     rows,
     missing: rows.filter((r) => r.state === "missing"),
     red: rows.filter((r) => r.state === "red"),
@@ -219,7 +311,7 @@ function uniqueRowsByName(rows) {
   return [...byName.values()];
 }
 
-function buildJson({ artifactAbsent, parseError, artifact, measurementProfile, validationWarnings, rows, missing, red, yellow, gray, green, duplicates }) {
+function buildJson({ artifactAbsent, parseError, artifact, measurementProfile, validationWarnings, sourceFreshness, rows, missing, red, yellow, gray, green, duplicates }) {
   const missingNames = missing?.map((r) => r.name) ?? REQUIRED_PROJECT_ROWS;
   const metadataWarningsList = metadataWarnings(measurementProfile, validationWarnings);
   const nonGreenRows = rows
@@ -238,6 +330,12 @@ function buildJson({ artifactAbsent, parseError, artifact, measurementProfile, v
     generated_at: artifact?.generated_at ?? null,
     workflow_run_url: artifact?.workflow_run_url ?? null,
     measurement_profile: measurementProfile ?? null,
+    source_freshness: sourceFreshness ?? {
+      expected_source_commit: normalizedCommit(expectedSourceCommit),
+      source_commit: artifact?.source_commit ?? null,
+      current: null,
+      warning: null,
+    },
     validation_warnings: validationWarnings ?? {
       runner_environment: [],
       measurement_profile: [],
@@ -354,7 +452,7 @@ function artifactAge(generatedAt) {
   return `${h} h ago`;
 }
 
-function buildReport({ artifact, measurementProfile, validationWarnings, rows, missing, red, yellow, gray, green, duplicates }) {
+function buildReport({ artifact, measurementProfile, validationWarnings, sourceFreshness, rows, missing, red, yellow, gray, green, duplicates }) {
   const sourceCommit = artifact?.source_commit?.slice(0, 10) ?? "unknown";
   const generatedAt = artifact?.generated_at ?? null;
   const workflowUrl = artifact?.workflow_run_url ?? null;
@@ -363,6 +461,11 @@ function buildReport({ artifact, measurementProfile, validationWarnings, rows, m
     ? `${profile.mode ?? "unknown"}${profile.warning ? ` (${profile.warning})` : ""}`
     : profile.warning;
   const measurementWarnings = measurementProfileReportWarnings(profile, validationWarnings);
+  const sourceFreshnessLabel = sourceFreshness?.expected_source_commit
+    ? sourceFreshness.current === true
+      ? `current for ${shortCommit(sourceFreshness.expected_source_commit)}`
+      : sourceFreshness.warning
+    : "not checked";
 
   const lines = [
     `## Benchmark artifact readiness — ${new Date().toUTCString()}`,
@@ -370,6 +473,7 @@ function buildReport({ artifact, measurementProfile, validationWarnings, rows, m
     "| Field | Value |",
     "|-------|-------|",
     `| Artifact SHA | \`${sourceCommit}\` |`,
+    `| Source freshness | ${sourceFreshnessLabel ?? "not checked"} |`,
     `| Generated | ${generatedAt ?? "—"} (${artifactAge(generatedAt)}) |`,
     `| Workflow run | ${workflowUrl ? `[link](${workflowUrl})` : "—"} |`,
     `| Measurement profile | ${profileLabel} |`,
@@ -470,6 +574,7 @@ if (artifactAbsent || parseError) {
         parseError,
         artifact: null,
         measurementProfile: null,
+        sourceFreshness: null,
         rows: null,
         missing: null,
         red: null,
@@ -483,8 +588,8 @@ if (artifactAbsent || parseError) {
   process.exit(2);
 }
 
-const analysis = analyzeArtifact(artifact);
-const { measurementProfile, validationWarnings, rows, missing, red, yellow, gray, green, duplicates } = analysis;
+const analysis = analyzeArtifact(artifact, expectedSourceCommit);
+const { measurementProfile, validationWarnings, sourceFreshness, rows, missing, red, yellow, gray, green, duplicates } = analysis;
 
 writeReport(buildReport({ artifact, ...analysis }));
 
@@ -496,6 +601,7 @@ if (jsonOutput) {
       artifact,
       measurementProfile,
       validationWarnings,
+      sourceFreshness,
       rows,
       missing,
       red,
@@ -541,6 +647,13 @@ if (requireCleanMetadata) {
     );
     process.exit(1);
   }
+}
+
+if (requireSourceCurrent && sourceFreshness.current !== true) {
+  process.stderr.write(
+    `bench-artifact-readiness: source freshness failed: ${sourceFreshness.warning ?? "no expected source commit provided"}\n`,
+  );
+  process.exit(1);
 }
 
 process.exit(0);

--- a/scripts/bench/test-check-artifact-readiness.mjs
+++ b/scripts/bench/test-check-artifact-readiness.mjs
@@ -173,6 +173,43 @@ withTempDir((dir) => {
 console.log("✅ complete all-green artifact exits 0");
 
 // ---------------------------------------------------------------------------
+// Test: expected source commit marks an artifact current when it matches.
+// ---------------------------------------------------------------------------
+withTempDir((dir) => {
+  const file = path.join(dir, "bench.json");
+  const rows = REQUIRED_PROJECT_ROWS.map((name) => makeRow(name, "green"));
+  writeJson(file, makeArtifact(rows, { measurement_profile: SAMPLE_MEASUREMENT_PROFILE }));
+  const result = run(file, ["--json", "--expect-source-commit=abcdef1234567890"]);
+  assert.equal(result.status, 0, `current source artifact should exit 0:\n${result.stderr}`);
+  const parsed = JSON.parse(result.stdout.trim());
+  assert.equal(parsed.source_freshness.current, true, "JSON should mark matching source current");
+  assert.equal(parsed.source_freshness.warning, null, "matching source should not warn");
+  assert.match(result.stderr, /Source freshness.*current for abcdef123456/);
+});
+console.log("✅ source freshness reports current artifact source");
+
+// ---------------------------------------------------------------------------
+// Test: --require-source-current fails when the artifact source is stale.
+// ---------------------------------------------------------------------------
+withTempDir((dir) => {
+  const file = path.join(dir, "bench.json");
+  const rows = REQUIRED_PROJECT_ROWS.map((name) => makeRow(name, "green"));
+  writeJson(file, makeArtifact(rows, { measurement_profile: SAMPLE_MEASUREMENT_PROFILE }));
+  const result = run(file, [
+    "--json",
+    "--expect-source-commit",
+    "1111111111111111111111111111111111111111",
+    "--require-source-current",
+  ]);
+  assert.equal(result.status, 1, "stale source should fail the source-current gate");
+  const parsed = JSON.parse(result.stdout.trim());
+  assert.equal(parsed.source_freshness.current, false, "JSON should mark stale source not current");
+  assert.match(parsed.source_freshness.warning, /differs from expected 111111111111/);
+  assert.match(result.stderr, /source freshness failed/);
+});
+console.log("✅ --require-source-current fails on stale artifact source");
+
+// ---------------------------------------------------------------------------
 // Test: modern artifact without measurement_profile still exits 0 but reports
 // the missing profile so dashboards can surface the metadata gap.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 10 project-corpus/release metric truth: benchmark artifact readiness reporting.

## Invariant
When a benchmark readiness check is asked to cite an expected source commit, the report should say whether the merged artifact was generated from that source; this PR adds source-freshness reporting and an opt-in source-current gate to `scripts/bench/check-artifact-readiness.mjs`.

## Scope
- Add `--expect-source-commit` and `--require-source-current` to the benchmark readiness tool.
- Emit `source_freshness` in JSON and a Source freshness row in the Markdown report.
- Pass `${GITHUB_SHA}` from the existing CI-health and gh-pages readiness callers.
- Cover current and stale artifact-source cases in the readiness script test.

## Project Corpus Impact
- Row: all required project corpus rows, reporting only.
- Bug family: benchmark artifact freshness / public release metric truth.
- Evidence: live `crates/tsz-website/bench-snapshot.json` now reports source `d13c6b872599...` as stale against current `origin/main` `125c5d7630b5...`; no compiler, fixture, or project-check behavior changes.

## Verification
- `node scripts/bench/test-check-artifact-readiness.mjs`
- `node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs`
- `node scripts/bench/check-artifact-readiness.mjs --json --expect-source-commit=$(git rev-parse origin/main) crates/tsz-website/bench-snapshot.json`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- No open Studio-A PRs existed before this branch.
- Avoided #11894 emit work because remaining live for-await slice overlaps active Studio-C PR #12016 and the nested async-expression slice was already fixed by merged #11909.
- Addresses the benchmark artifact freshness side of #10649 without editing roadmap or markdown files.