### PR TITLE
chore(agents): expose merge queue test counts

### DIFF
--- a/scripts/agents/list-owned-work.sh
+++ b/scripts/agents/list-owned-work.sh
@@ -177,6 +177,60 @@ count_ready_unqueued_pr_rows() {
   '
 }
 
+count_merge_queue_tested_pr_rows() {
+  local rows="$1"
+  if [[ -z "$rows" ]]; then
+    echo 0
+    return
+  fi
+  printf '%s\n' "$rows" | awk '
+    {
+      queued = 0
+      queue_success = 0
+      for (i = 1; i <= NF; i++) {
+        if ($i == "mergeQueue=on") {
+          queued = 1
+        } else if ($i == "queue=success") {
+          queue_success = 1
+        }
+      }
+      if (queued && queue_success) {
+        count++
+      }
+    }
+    END { print count + 0 }
+  '
+}
+
+count_merge_queue_unverified_pr_rows() {
+  local rows="$1"
+  if [[ -z "$rows" ]]; then
+    echo 0
+    return
+  fi
+  printf '%s\n' "$rows" | awk '
+    {
+      queued = 0
+      queue_seen = 0
+      queue_success = 0
+      for (i = 1; i <= NF; i++) {
+        if ($i == "mergeQueue=on") {
+          queued = 1
+        } else if ($i ~ /^queue=/) {
+          queue_seen = 1
+          if ($i == "queue=success") {
+            queue_success = 1
+          }
+        }
+      }
+      if (queued && queue_seen && !queue_success) {
+        count++
+      }
+    }
+    END { print count + 0 }
+  '
+}
+
 json_array_from_lines() {
   local rows="$1"
   ROWS="$rows" node <<'NODE'
@@ -223,8 +277,15 @@ for agent in "${SELECTED[@]}"; do
     )"
   else
     prs="$(
-      gh pr list --state open --limit 100 --label "$label" --json number,title,isDraft,url,labels,autoMergeRequest \
+      gh pr list --state open --limit 100 --label "$label" \
+        --json number,title,isDraft,url,labels,autoMergeRequest,statusCheckRollup \
         --jq '
+          def queue_state:
+            ([.statusCheckRollup[]? | select((.__typename == "StatusContext" and .context == "Queue Tested") or .name == "Queue Tested")] | first) as $queue |
+            if $queue == null then "queue=none"
+            elif $queue.__typename == "StatusContext" then "queue=\(($queue.state // "unknown") | ascii_downcase)"
+            else "queue=\((($queue.conclusion // $queue.status // "unknown")) | ascii_downcase)"
+            end;
           def merge_queue_label:
             if any(.labels[]?; .name == "merge-queue") then "mergeQueue=on" else "mergeQueue=off" end;
           .[] |
@@ -232,6 +293,7 @@ for agent in "${SELECTED[@]}"; do
             (if .isDraft then "draft" else "ready" end) +
             " autoMerge=" + (if .autoMergeRequest then "on" else "off" end) +
             " " + merge_queue_label +
+            " " + queue_state +
             " " + .title + " " + .url
         ' \
         2>/dev/null ||
@@ -248,6 +310,8 @@ for agent in "${SELECTED[@]}"; do
   draft_pr_count="$(count_pr_state_rows "$prs" draft)"
   auto_merge_pr_count="$(count_pr_token_rows "$prs" "autoMerge=on")"
   merge_queue_pr_count="$(count_pr_token_rows "$prs" "mergeQueue=on")"
+  merge_queue_tested_pr_count="$(count_merge_queue_tested_pr_rows "$prs")"
+  merge_queue_unverified_pr_count="$(count_merge_queue_unverified_pr_rows "$prs")"
   ready_unqueued_pr_count="$(count_ready_unqueued_pr_rows "$prs")"
   echo ""
   echo "Issues:"
@@ -275,6 +339,8 @@ for agent in "${SELECTED[@]}"; do
   echo "owned_draft_pr_count=$draft_pr_count"
   echo "owned_auto_merge_pr_count=$auto_merge_pr_count"
   echo "owned_merge_queue_pr_count=$merge_queue_pr_count"
+  echo "owned_merge_queue_tested_pr_count=$merge_queue_tested_pr_count"
+  echo "owned_merge_queue_unverified_pr_count=$merge_queue_unverified_pr_count"
   echo "owned_ready_unqueued_pr_count=$ready_unqueued_pr_count"
   echo "owned_issue_count=$issue_count"
   echo "owned_work_status=$owned_work_status"
@@ -291,6 +357,8 @@ for agent in "${SELECTED[@]}"; do
       ROW_DRAFT_PR_COUNT="$draft_pr_count" \
       ROW_AUTO_MERGE_PR_COUNT="$auto_merge_pr_count" \
       ROW_MERGE_QUEUE_PR_COUNT="$merge_queue_pr_count" \
+      ROW_MERGE_QUEUE_TESTED_PR_COUNT="$merge_queue_tested_pr_count" \
+      ROW_MERGE_QUEUE_UNVERIFIED_PR_COUNT="$merge_queue_unverified_pr_count" \
       ROW_READY_UNQUEUED_PR_COUNT="$ready_unqueued_pr_count" \
       ROW_ISSUE_COUNT="$issue_count" \
       ROW_STATUS="$owned_work_status" \
@@ -307,6 +375,8 @@ const row = {
   draft_pr_count: Number(process.env.ROW_DRAFT_PR_COUNT ?? 0),
   auto_merge_pr_count: Number(process.env.ROW_AUTO_MERGE_PR_COUNT ?? 0),
   merge_queue_pr_count: Number(process.env.ROW_MERGE_QUEUE_PR_COUNT ?? 0),
+  merge_queue_tested_pr_count: Number(process.env.ROW_MERGE_QUEUE_TESTED_PR_COUNT ?? 0),
+  merge_queue_unverified_pr_count: Number(process.env.ROW_MERGE_QUEUE_UNVERIFIED_PR_COUNT ?? 0),
   ready_unqueued_pr_count: Number(process.env.ROW_READY_UNQUEUED_PR_COUNT ?? 0),
   issue_count: Number(process.env.ROW_ISSUE_COUNT ?? 0),
   owned_work_clear: process.env.ROW_STATUS === "clear",
@@ -349,6 +419,14 @@ const totalAutoMergePrCount = agents.reduce(
   (sum, agent) => sum + Number(agent.auto_merge_pr_count ?? 0),
   0,
 );
+const totalMergeQueueTestedPrCount = agents.reduce(
+  (sum, agent) => sum + Number(agent.merge_queue_tested_pr_count ?? 0),
+  0,
+);
+const totalMergeQueueUnverifiedPrCount = agents.reduce(
+  (sum, agent) => sum + Number(agent.merge_queue_unverified_pr_count ?? 0),
+  0,
+);
 const totalReadyUnqueuedPrCount = agents.reduce(
   (sum, agent) => sum + Number(agent.ready_unqueued_pr_count ?? 0),
   0,
@@ -373,6 +451,8 @@ const report = {
   total_draft_pr_count: totalDraftPrCount,
   total_auto_merge_pr_count: totalAutoMergePrCount,
   total_merge_queue_pr_count: totalMergeQueuePrCount,
+  total_merge_queue_tested_pr_count: totalMergeQueueTestedPrCount,
+  total_merge_queue_unverified_pr_count: totalMergeQueueUnverifiedPrCount,
   total_ready_unqueued_pr_count: totalReadyUnqueuedPrCount,
   total_issue_count: totalIssueCount,
   total_owned_count: totalOwnedCount,

--- a/scripts/agents/test_list_owned_work.py
+++ b/scripts/agents/test_list_owned_work.py
@@ -46,6 +46,8 @@ exec "$@"
         self.assertIn("owned_draft_pr_count=0", result.stdout)
         self.assertIn("owned_auto_merge_pr_count=0", result.stdout)
         self.assertIn("owned_merge_queue_pr_count=0", result.stdout)
+        self.assertIn("owned_merge_queue_tested_pr_count=0", result.stdout)
+        self.assertIn("owned_merge_queue_unverified_pr_count=0", result.stdout)
         self.assertIn("owned_ready_unqueued_pr_count=0", result.stdout)
         self.assertIn("owned_issue_count=0", result.stdout)
         self.assertIn("owned_work_status=clear", result.stdout)
@@ -54,18 +56,21 @@ exec "$@"
         result = self.run_list_owned_work(
             ["Studio-F"],
             prs=(
-                "#1 ready autoMerge=off mergeQueue=on first PR https://github.com/mohsen1/tsz/pull/1\n"
-                "#2 draft autoMerge=on mergeQueue=off second PR https://github.com/mohsen1/tsz/pull/2\n"
-                "#4 ready autoMerge=off mergeQueue=off third PR https://github.com/mohsen1/tsz/pull/4\n"
+                "#1 ready autoMerge=off mergeQueue=on queue=success first PR https://github.com/mohsen1/tsz/pull/1\n"
+                "#2 draft autoMerge=on mergeQueue=off queue=none second PR https://github.com/mohsen1/tsz/pull/2\n"
+                "#4 ready autoMerge=off mergeQueue=off queue=none third PR https://github.com/mohsen1/tsz/pull/4\n"
+                "#5 ready autoMerge=off mergeQueue=on queue=pending fourth PR https://github.com/mohsen1/tsz/pull/5\n"
             ),
             issues="#3 issue https://github.com/mohsen1/tsz/issues/3\n",
         )
 
-        self.assertIn("owned_pr_count=3", result.stdout)
-        self.assertIn("owned_ready_pr_count=2", result.stdout)
+        self.assertIn("owned_pr_count=4", result.stdout)
+        self.assertIn("owned_ready_pr_count=3", result.stdout)
         self.assertIn("owned_draft_pr_count=1", result.stdout)
         self.assertIn("owned_auto_merge_pr_count=1", result.stdout)
-        self.assertIn("owned_merge_queue_pr_count=1", result.stdout)
+        self.assertIn("owned_merge_queue_pr_count=2", result.stdout)
+        self.assertIn("owned_merge_queue_tested_pr_count=1", result.stdout)
+        self.assertIn("owned_merge_queue_unverified_pr_count=1", result.stdout)
         self.assertIn("owned_ready_unqueued_pr_count=1", result.stdout)
         self.assertIn("owned_issue_count=1", result.stdout)
         self.assertIn("owned_work_status=active", result.stdout)
@@ -76,7 +81,7 @@ exec "$@"
 
             result = self.run_list_owned_work(
                 ["Studio-F", "--json-report", str(report_path)],
-                prs="#1 ready autoMerge=on mergeQueue=on first PR https://github.com/mohsen1/tsz/pull/1\n",
+                prs="#1 ready autoMerge=on mergeQueue=on queue=pending first PR https://github.com/mohsen1/tsz/pull/1\n",
                 issues="#2 issue https://github.com/mohsen1/tsz/issues/2\n",
             )
 
@@ -94,6 +99,8 @@ exec "$@"
             self.assertEqual(0, report["total_draft_pr_count"])
             self.assertEqual(1, report["total_auto_merge_pr_count"])
             self.assertEqual(1, report["total_merge_queue_pr_count"])
+            self.assertEqual(0, report["total_merge_queue_tested_pr_count"])
+            self.assertEqual(1, report["total_merge_queue_unverified_pr_count"])
             self.assertEqual(0, report["total_ready_unqueued_pr_count"])
             self.assertEqual(1, report["total_issue_count"])
             self.assertEqual(2, report["total_owned_count"])
@@ -106,12 +113,14 @@ exec "$@"
             self.assertEqual(0, row["draft_pr_count"])
             self.assertEqual(1, row["auto_merge_pr_count"])
             self.assertEqual(1, row["merge_queue_pr_count"])
+            self.assertEqual(0, row["merge_queue_tested_pr_count"])
+            self.assertEqual(1, row["merge_queue_unverified_pr_count"])
             self.assertEqual(0, row["ready_unqueued_pr_count"])
             self.assertEqual(1, row["issue_count"])
             self.assertFalse(row["owned_work_clear"])
             self.assertEqual("active", row["owned_work_status"])
             self.assertEqual(
-                ["#1 ready autoMerge=on mergeQueue=on first PR https://github.com/mohsen1/tsz/pull/1"],
+                ["#1 ready autoMerge=on mergeQueue=on queue=pending first PR https://github.com/mohsen1/tsz/pull/1"],
                 row["prs"],
             )
             self.assertEqual(
@@ -135,6 +144,8 @@ exec "$@"
             self.assertEqual(0, report["total_draft_pr_count"])
             self.assertEqual(0, report["total_auto_merge_pr_count"])
             self.assertEqual(0, report["total_merge_queue_pr_count"])
+            self.assertEqual(0, report["total_merge_queue_tested_pr_count"])
+            self.assertEqual(0, report["total_merge_queue_unverified_pr_count"])
             self.assertEqual(0, report["total_ready_unqueued_pr_count"])
             self.assertEqual(0, report["total_issue_count"])
             self.assertEqual(0, report["total_owned_count"])


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Tooling/guardrail evidence plumbing for launch coordination.

## Invariant
When an owned PR has the `merge-queue` label, the owned-work report should distinguish queue-tested PRs from queued PRs whose `Queue Tested` signal is still absent, pending, or failing; this PR changes only the agent coordination script/report surface.

## Scope
- `scripts/agents/list-owned-work.sh`
- `scripts/agents/test_list_owned_work.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI script only; no compiler behavior path or project corpus fixture path is changed.

## Verification
- `python3 -m unittest scripts.agents.test_list_owned_work`
- `bash -n scripts/agents/list-owned-work.sh`
- `git diff --check`
- `scripts/agents/list-owned-work.sh --all --pr-state --json-report /tmp/tsz-owned-work-queue-evidence.json`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- No existing Studio-F PRs were open at intake.
- Overlap scan checked open PRs and tech-debt issues before this branch.
- Branch was rebased onto current `origin/main` after #12039 landed.
- Ready for manager/queue-owner review once PR-head checks complete.