### PR TITLE
chore(bench): gate CI-health benchmark freshness

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -270,10 +270,12 @@ jobs:
           check_exit=0
           node scripts/bench/check-artifact-readiness.mjs "${artifact}" \
             --expect-source-commit="${GITHUB_SHA}" \
+            --require-clean-metadata \
+            --require-source-current \
             || check_exit=$?
 
           if [[ "${check_exit}" -eq 1 ]]; then
-            echo "::warning::bench artifact is present but missing required project rows"
+            echo "::warning::bench artifact is present but not current release truth; inspect the readiness report above"
           elif [[ "${check_exit}" -eq 2 ]]; then
             echo "::warning::bench artifact absent or could not be parsed — bench did not complete for latest main"
           fi

--- a/scripts/bench/test-ci-health-benchmark-readiness.mjs
+++ b/scripts/bench/test-ci-health-benchmark-readiness.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const workflow = fs.readFileSync(".github/workflows/ci-health.yml", "utf8");
+
+const readinessStep = workflow.match(
+  /- name: Run artifact readiness check[\s\S]+?exit 0/,
+)?.[0] ?? "";
+
+assert.match(
+  readinessStep,
+  /node scripts\/bench\/check-artifact-readiness\.mjs "\$\{artifact\}"[\s\S]+--expect-source-commit="\$\{GITHUB_SHA\}"/,
+  "CI-health benchmark readiness should compare artifacts with the workflow checkout SHA",
+);
+
+assert.match(
+  readinessStep,
+  /--require-clean-metadata/,
+  "CI-health benchmark readiness should warn when artifact metadata is not clean",
+);
+
+assert.match(
+  readinessStep,
+  /--require-source-current/,
+  "CI-health benchmark readiness should warn when the artifact source commit is stale",
+);
+
+assert.match(
+  readinessStep,
+  /not current release truth; inspect the readiness report above/,
+  "CI-health warning should cover stale source and dirty metadata, not only missing rows",
+);
+
+assert.doesNotMatch(
+  readinessStep,
+  /present but missing required project rows/,
+  "CI-health warning must not misclassify metadata or source freshness failures as missing rows",
+);
+
+console.log("ci-health benchmark readiness tests passed");

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -403,6 +403,7 @@ run_lint() {
   node scripts/bench/test-reduction-backlog.mjs || return $?
   node scripts/bench/test-timeout-runner.mjs || return $?
   node scripts/bench/test-check-artifact-readiness.mjs || return $?
+  node scripts/bench/test-ci-health-benchmark-readiness.mjs || return $?
   node scripts/bench/test-benchmark-artifact-selection.mjs || return $?
   node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs || return $?
   node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs || return $?


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 10 project-corpus/release metric truth: benchmark artifact readiness reporting.

## Invariant
When CI-health checks the latest merged benchmark artifact, stale source commits or dirty artifact metadata should produce an explicit release-truth warning, not a row-missing-only warning; this PR makes the CI-health readiness caller opt into those gates and adds a workflow test for the contract.

## Scope
- Pass `--require-clean-metadata` and `--require-source-current` from `.github/workflows/ci-health.yml`.
- Replace the old row-specific exit-1 warning with a release-truth warning that covers missing rows, dirty metadata, and stale source.
- Add `scripts/bench/test-ci-health-benchmark-readiness.mjs` and include it in `scripts/ci/gcp-full-ci.sh` lint.

## Project Corpus Impact
- Row: all required project corpus rows, reporting only.
- Bug family: benchmark artifact freshness / public release metric truth.
- Evidence: the current checked-in benchmark snapshot is present but fails the stricter readiness gate because it is source-stale against `origin/main` and still has one historical runner metadata warning; no compiler, fixture, or project-check behavior changes.

## Verification
- `node scripts/bench/test-ci-health-benchmark-readiness.mjs`
- `node scripts/bench/test-check-artifact-readiness.mjs`
- `node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs`
- `node scripts/bench/check-artifact-readiness.mjs --json --expect-source-commit=$(git rev-parse origin/main) --require-clean-metadata --require-source-current crates/tsz-website/bench-snapshot.json` (expected exit 1 on current stale/dirty artifact)
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- No open Studio-A PRs existed before this branch.
- Builds on merged #12039, which added source-freshness reporting to the readiness tool.
- Addresses the CI-health warning side of #10649 without editing roadmap or markdown files.