### PR TITLE
fix(lsp): synthesize CANNOT_FIND_NAME for const/let/var RHS call expressions

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_nested_pkg_tests.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_nested_pkg_tests.rs
@@ -376,3 +376,76 @@ fn import_fix_with_package_json_in_nested_subpackage() {
         "expected import fix for 'useMemo' from 'preact/hooks', got: {descriptions:?}"
     );
 }
+
+/// Mirrors the exact `importFixesWithPackageJsonInSideAnotherPackage` fourslash
+/// call pattern: `verify.importFixAtPosition` calls `getCodeFixes` at each
+/// diagnostic's own span, not at the file start. `useMemo` starts at byte offset
+/// 14 (0-indexed) in `"const state = useMemo(...)"`, so the 1-indexed request is
+/// `startOffset: 15, endOffset: 22`.
+#[test]
+fn import_fix_at_diagnostic_span_not_file_start() {
+    let mut server = make_server();
+
+    let app_tsx = "/project/app.tsx";
+    let app_content = "const state = useMemo(() => 'Hello', []);";
+
+    server
+        .open_files
+        .insert(app_tsx.to_string(), app_content.to_string());
+    server.open_files.insert(
+        "/project/tsconfig.json".to_string(),
+        r#"{ "compilerOptions": { "jsx": "react", "jsxFactory": "h" } }"#.to_string(),
+    );
+    server.open_files.insert(
+        "/project/component.tsx".to_string(),
+        r#"import { useEffect } from "preact/hooks";"#.to_string(),
+    );
+    server.open_files.insert(
+        "/project/node_modules/preact/package.json".to_string(),
+        r#"{ "name": "preact", "version": "10.3.4", "types": "src/index.d.ts" }"#.to_string(),
+    );
+    server.open_files.insert(
+        "/project/node_modules/preact/hooks/package.json".to_string(),
+        r#"{ "name": "hooks", "version": "0.1.0", "types": "src/index.d.ts" }"#.to_string(),
+    );
+    server.open_files.insert(
+        "/project/node_modules/preact/hooks/src/index.d.ts".to_string(),
+        "export declare function useEffect(effect: () => void): void;\nexport declare function useMemo<T>(factory: () => T, inputs: ReadonlyArray<unknown> | undefined): T;\n".to_string(),
+    );
+
+    let req = TsServerRequest {
+        seq: 1,
+        _msg_type: "request".to_string(),
+        command: "getCodeFixes".to_string(),
+        arguments: serde_json::json!({
+            "file": app_tsx,
+            "startLine": 1,
+            "startOffset": 15,
+            "endLine": 1,
+            "endOffset": 22,
+            "errorCodes": [2304]
+        }),
+    };
+
+    let resp = server.handle_get_code_fixes(1, &req);
+    assert!(resp.success, "expected getCodeFixes to succeed");
+    let actions = resp
+        .body
+        .as_ref()
+        .and_then(serde_json::Value::as_array)
+        .expect("expected getCodeFixes actions array");
+
+    let descriptions: Vec<&str> = actions
+        .iter()
+        .filter_map(|a| a.get("description").and_then(serde_json::Value::as_str))
+        .collect();
+
+    let has_preact_import = descriptions
+        .iter()
+        .any(|d| d.contains("preact/hooks") && d.contains("useMemo"));
+
+    assert!(
+        has_preact_import,
+        "expected import fix for 'useMemo' from 'preact/hooks' at diagnostic span (1,15)-(1,22), got: {descriptions:?}"
+    );
+}

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_synthetic.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_synthetic.rs
@@ -375,6 +375,42 @@ impl Server {
                     }
                     search_from = colon_idx + 1;
                 }
+
+                // Detect `const/let/var x = identifier(...)` — the initializer is a
+                // call expression whose callee is an unbound identifier.  Scan the
+                // RHS of the first assignment operator on the declaration line and
+                // emit CANNOT_FIND_NAME if the leading identifier is not in scope.
+                //
+                // This covers `const state = useMemo(() => …)` where the real
+                // checker may not yet produce TS2304, and the bare-identifier /
+                // standalone-call-expression scanners only match lines that START
+                // with the identifier.
+                if (trimmed.starts_with("const ")
+                    || trimmed.starts_with("let ")
+                    || trimmed.starts_with("var "))
+                    && let Some(eq_pos) = trimmed.find(" = ")
+                {
+                    let rhs = trimmed[eq_pos + 3..].trim_start();
+                    let rhs_leading = trimmed[eq_pos + 3..].len() - rhs.len();
+                    if let Some((col_in_rhs, name)) = parse_identifier_call_expression(rhs)
+                        && binder.file_locals.get(name).is_none()
+                        && !jsdoc_imported_names.contains(name)
+                        && self.has_potential_auto_import_symbol(file_path, name)
+                    {
+                        let abs_col = leading_ws + eq_pos + 3 + rhs_leading + col_in_rhs;
+                        if seen_spans.insert((offset + abs_col, name.len())) {
+                            diagnostics.push(tsz::checker::diagnostics::Diagnostic {
+                                category: DiagnosticCategory::Error,
+                                code: tsz_checker::diagnostics::diagnostic_codes::CANNOT_FIND_NAME,
+                                file: file_path.to_string(),
+                                start: (offset + abs_col) as u32,
+                                length: name.len() as u32,
+                                message_text: format!("Cannot find name '{name}'."),
+                                related_information: Vec::new(),
+                            });
+                        }
+                    }
+                }
             }
 
             if trimmed.starts_with('[') && trimmed.contains('=') {

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_tests_part2.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_tests_part2.rs
@@ -1497,6 +1497,90 @@ fn fix_missing_type_annotation_jsx_element_span_fallback_different_name() {
     assert_eq!(direct_text, ": JSX.Element");
 }
 
+/// `const x = identifier(...)` — synthetic `CANNOT_FIND_NAME` for unbound call target.
+/// Structural rule: a `const/let/var` declaration whose initializer starts with a
+/// call expression `identifier(args)` should emit `CANNOT_FIND_NAME` for `identifier`
+/// when it is not locally bound, so the import-fix fallback can suggest it.
+/// This covers the `importFixesWithPackageJsonInSideAnotherPackage` scenario where
+/// the real checker may not yet produce TS2304 for this pattern.
+#[test]
+fn synthetic_missing_name_detects_rhs_call_expression_const() {
+    let mut server = make_server();
+    // Two different identifier names prove the rule is not hardcoded to `useMemo`.
+    for (callee, content, _expected_offset) in [
+        (
+            "useMemo",
+            "const state = useMemo(() => 'Hello', []);",
+            14usize,
+        ),
+        (
+            "createSignal",
+            "const [v, setV] = createSignal(0);",
+            17usize,
+        ),
+        (
+            "computedValue",
+            "let result = computedValue(x, y);",
+            13usize,
+        ),
+    ] {
+        server.open_files.insert(
+            "/lib.d.ts".to_string(),
+            format!("export declare function {callee}(): void;"),
+        );
+        let file = "/app.ts";
+        server
+            .open_files
+            .insert(file.to_string(), content.to_string());
+
+        let mut parser = ParserState::new(file.to_string(), content.to_string());
+        let root = parser.parse_source_file();
+        let arena = parser.into_arena();
+        let mut binder = tsz::binder::BinderState::new();
+        binder.bind_source_file(&arena, root);
+
+        let diagnostics =
+            server.synthetic_missing_name_expression_diagnostics(file, content, &binder);
+
+        assert!(
+            diagnostics.iter().any(|d| {
+                d.code == tsz_checker::diagnostics::diagnostic_codes::CANNOT_FIND_NAME
+                    && d.message_text.contains(callee)
+            }),
+            "expected CANNOT_FIND_NAME for '{callee}' in `{content}`, got {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn synthetic_missing_name_rhs_call_skips_locally_bound_callee() {
+    let mut server = make_server();
+    // `myFunc` is imported and bound, so no synthetic diagnostic expected.
+    let content = "import { myFunc } from './mod';\nconst result = myFunc(42);";
+    let file = "/app.ts";
+    server.open_files.insert(
+        "/mod.ts".to_string(),
+        "export function myFunc(x: number): void {}".to_string(),
+    );
+    server
+        .open_files
+        .insert(file.to_string(), content.to_string());
+
+    let mut parser = ParserState::new(file.to_string(), content.to_string());
+    let root = parser.parse_source_file();
+    let arena = parser.into_arena();
+    let mut binder = tsz::binder::BinderState::new();
+    binder.bind_source_file(&arena, root);
+
+    let diagnostics = server.synthetic_missing_name_expression_diagnostics(file, content, &binder);
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.message_text.contains("myFunc")),
+        "bound callee 'myFunc' must not produce synthetic CANNOT_FIND_NAME, got {diagnostics:?}"
+    );
+}
+
 /// Span with no `request_span` and empty diagnostics must return nothing.
 #[test]
 fn fix_missing_type_annotation_no_span_no_diag_returns_empty() {


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
LSP / import-fix parity.

## Invariant
When a `const`, `let`, or `var` declaration initializer starts with an unbound identifier call expression and that callee is exported by at least one open `.d.ts` file, tsz-server emits `CANNOT_FIND_NAME` at the callee source span so the import-fix pipeline has the same diagnostic anchor shape that tsc exposes.

## Scope
- `crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_synthetic.rs`
- `crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_tests_part2.rs`
- `crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_nested_pkg_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: fourslash import-fix diagnostics, specifically missing codefixes for `const/let/var x = fn(...)` initializer call expressions.
- Evidence: LSP/server synthetic heuristic path only; targeted import-fix tests pass locally according to the original PR verification.

## Verification
- `cargo nextest run -p tsz-cli -E 'test(import_fix) | test(synthetic_missing_name)'` recorded by the original author: 13 tests passed.
- `synthetic_missing_name_detects_rhs_call_expression_const` covers three callee names (`useMemo`, `createSignal`, `computedValue`) to avoid identifier hardcoding.
- `synthetic_missing_name_rhs_call_skips_locally_bound_callee` covers the negative case.
- `import_fix_at_diagnostic_span_not_file_start` covers the end-to-end diagnostic-span codefix anchor.
- `cargo clippy -p tsz-cli --bin tsz-server -- -D warnings` recorded clean by the original author.
- Draft checks before promotion were green except queue-owned `Queue Tested` on head `a940e7ee9af9e19d225c781e202257be667214ad`.

## Coordination Notes
- Original runner session: https://claude.ai/code/session_01DLM8CAsFdBCosptRU3AbsP.
- Separate from #12032, which is a DTS empty-namespace formatting PR; Studio-D rebased it on 2026-06-01 and cleared its merge conflict while leaving it draft for CI.
- Anti-hardcoding and generalization notes from the original body are preserved: the rule is structural over a variable-declaration RHS call expression and is not keyed on `useMemo` or any specific identifier.
- ReviewHelper normalized this body before promotion so the ready-review `project-corpus-pr-body` gate sees the required template fields.

