### PR TITLE
chore(agents): expose disk preflight git context

### DIFF
--- a/scripts/agents/disk-preflight.sh
+++ b/scripts/agents/disk-preflight.sh
@@ -59,9 +59,28 @@ case "$AGENT" in
 esac
 
 ROOT="$(git rev-parse --show-toplevel)"
+GIT_HEAD="$(git -C "$ROOT" rev-parse HEAD)"
+GIT_HEAD_SHORT="$(git -C "$ROOT" rev-parse --short=12 HEAD)"
+GIT_BRANCH="$(git -C "$ROOT" branch --show-current)"
+GIT_DETACHED=false
+if [[ -z "$GIT_BRANCH" ]]; then
+  GIT_BRANCH="detached:$GIT_HEAD_SHORT"
+  GIT_DETACHED=true
+fi
+GIT_UPSTREAM="$(git -C "$ROOT" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
 
 echo "agent=$AGENT"
 echo "repo=$ROOT"
+echo ""
+echo "== current git state =="
+echo "git_head=$GIT_HEAD"
+echo "git_branch=$GIT_BRANCH"
+echo "git_detached=$GIT_DETACHED"
+if [[ -n "$GIT_UPSTREAM" ]]; then
+  echo "git_upstream=$GIT_UPSTREAM"
+else
+  echo "git_upstream=none"
+fi
 echo ""
 echo "== disk guard =="
 GUARD_OUTPUT="$("$ROOT/scripts/setup/disk-worktree-guard.sh")"
@@ -278,6 +297,10 @@ fi
 if [[ -n "$JSON_REPORT" ]]; then
   AGENT="$AGENT" \
   ROOT="$ROOT" \
+  GIT_HEAD="$GIT_HEAD" \
+  GIT_BRANCH="$GIT_BRANCH" \
+  GIT_DETACHED="$GIT_DETACHED" \
+  GIT_UPSTREAM="$GIT_UPSTREAM" \
   GUARD_OUTPUT="$GUARD_OUTPUT" \
   TYPESCRIPT_STATE="$TYPESCRIPT_STATE" \
   TYPESCRIPT_TARGET="$TYPESCRIPT_TARGET" \
@@ -364,6 +387,12 @@ const report = {
   disk_preflight_status: diskOk ? "pass" : "fail",
   agent: process.env.AGENT,
   repo: process.env.ROOT,
+  git_context: {
+    head: process.env.GIT_HEAD,
+    branch: process.env.GIT_BRANCH,
+    detached: bool(process.env.GIT_DETACHED),
+    upstream: process.env.GIT_UPSTREAM || null,
+  },
   disk_guard: {
     ...guard,
     ok: diskOk,

--- a/scripts/agents/test_disk_preflight.py
+++ b/scripts/agents/test_disk_preflight.py
@@ -76,6 +76,7 @@ class DiskPreflightTests(unittest.TestCase):
             result = self.run_preflight(fake_repo, fake_script)
 
             self.assertIn("agent=Studio-F", result.stdout)
+            self.assertIn("git_detached=false", result.stdout)
             self.assertIn("typescript=populated-local-submodule", result.stdout)
             self.assertIn(f"primary={fake_repo} ts-populated", result.stdout)
             self.assertRegex(result.stdout, r"target=present size_kb=\d+")
@@ -117,6 +118,13 @@ class DiskPreflightTests(unittest.TestCase):
             self.assertEqual("pass", report["disk_preflight_status"])
             self.assertEqual("Studio-F", report["agent"])
             self.assertEqual(str(fake_repo), report["repo"])
+            self.assertEqual(
+                self.run_git(["rev-parse", "HEAD"], fake_repo).stdout.strip(),
+                report["git_context"]["head"],
+            )
+            self.assertFalse(report["git_context"]["detached"])
+            self.assertTrue(report["git_context"]["branch"])
+            self.assertIsNone(report["git_context"]["upstream"])
             self.assertEqual("populated-local-submodule", report["typescript"]["state"])
             self.assertEqual(
                 {"path": str(fake_repo), "state": "ts-populated"},
@@ -187,6 +195,8 @@ class DiskPreflightTests(unittest.TestCase):
 
             result = self.run_preflight(linked_worktree, linked_script)
 
+            self.assertIn("git_detached=true", result.stdout)
+            self.assertRegex(result.stdout, r"git_branch=detached:[0-9a-f]+")
             self.assertIn("typescript=missing", result.stdout)
             self.assertIn(f"primary={fake_repo} ts-populated", result.stdout)
             self.assertIn("hint=run scripts/setup/link-ts-submodule.sh", result.stdout)


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Tooling/guardrail evidence plumbing for launch coordination.

## Invariant
When an agent runs disk preflight before selecting or creating a worktree, the report should show the current checkout's git head, branch, detached state, and upstream so a detached or borrowed checkout is not mistaken for an editable lane; this PR changes only the agent preflight script/report surface.

## Scope
- `scripts/agents/disk-preflight.sh`
- `scripts/agents/test_disk_preflight.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI script only; no compiler behavior path or project corpus fixture path is changed.

## Verification
- `python3 -m unittest scripts.agents.test_disk_preflight`
- `bash -n scripts/agents/disk-preflight.sh`
- `git diff --check`
- `scripts/agents/disk-preflight.sh Studio-F --json-report /tmp/tsz-disk-preflight-git-context.json`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Studio-F owned PR runway was clear at intake.
- Overlap scan checked open PRs and tech-debt issues before this branch.
- Branch was rebased onto current `origin/main` before commit and push.
- Ready for manager/queue-owner review once PR-head checks complete.