### PR TITLE
chore(agents): expose goal git context

### DIFF
--- a/scripts/agents/show-goal.sh
+++ b/scripts/agents/show-goal.sh
@@ -92,8 +92,24 @@ FETCH_ATTEMPTED=false
 PRINTED_SOURCE=""
 BRANCH_LOCAL_DIFFERS=false
 
+collect_git_context() {
+  GIT_HEAD="$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || echo unknown)"
+  GIT_BRANCH="$(git -C "$ROOT" symbolic-ref --short -q HEAD 2>/dev/null || true)"
+  GIT_DETACHED=false
+  if [[ -z "$GIT_BRANCH" ]]; then
+    GIT_DETACHED=true
+    if [[ "$GIT_HEAD" == "unknown" ]]; then
+      GIT_BRANCH="detached:unknown"
+    else
+      GIT_BRANCH="detached:${GIT_HEAD:0:12}"
+    fi
+  fi
+  GIT_UPSTREAM="$(git -C "$ROOT" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)"
+}
+
 write_json_report() {
   [[ -n "$JSON_REPORT" ]] || return 0
+  collect_git_context
   AGENT="$AGENT" \
   ROOT="$ROOT" \
   GOAL_PATH="$GOAL_PATH" \
@@ -102,6 +118,10 @@ write_json_report() {
   LOCAL_ONLY="$LOCAL_ONLY" \
   NO_FETCH="$NO_FETCH" \
   BRANCH_LOCAL_DIFFERS="$BRANCH_LOCAL_DIFFERS" \
+  GIT_HEAD="$GIT_HEAD" \
+  GIT_BRANCH="$GIT_BRANCH" \
+  GIT_DETACHED="$GIT_DETACHED" \
+  GIT_UPSTREAM="$GIT_UPSTREAM" \
   JSON_REPORT="$JSON_REPORT" \
   node <<'NODE'
 const fs = require("fs");
@@ -121,6 +141,12 @@ const report = {
   local_only: bool(process.env.LOCAL_ONLY),
   no_fetch: bool(process.env.NO_FETCH),
   branch_local_differs: bool(process.env.BRANCH_LOCAL_DIFFERS),
+  git_context: {
+    head: process.env.GIT_HEAD,
+    branch: process.env.GIT_BRANCH,
+    detached: bool(process.env.GIT_DETACHED),
+    upstream: process.env.GIT_UPSTREAM || null,
+  },
 };
 
 fs.mkdirSync(path.dirname(process.env.JSON_REPORT), { recursive: true });

--- a/scripts/agents/test_show_goal.py
+++ b/scripts/agents/test_show_goal.py
@@ -13,7 +13,15 @@ SCRIPT = ROOT / "scripts" / "agents" / "show-goal.sh"
 
 
 class ShowGoalTests(unittest.TestCase):
-    def run_show_goal(self, args, local_goal="# local goal\n", remote_goal="# remote goal\n"):
+    def run_show_goal(
+        self,
+        args,
+        local_goal="# local goal\n",
+        remote_goal="# remote goal\n",
+        git_head="1234567890abcdef1234567890abcdef12345678",
+        git_branch="codex/test-goal",
+        git_upstream="origin/main",
+    ):
         with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
             temp_root = pathlib.Path(temp_dir)
             fake_repo = temp_root / "repo"
@@ -44,6 +52,28 @@ class ShowGoalTests(unittest.TestCase):
                         fetch)
                           exit 0
                           ;;
+                        rev-parse)
+                          if [[ "${2:-}" == "HEAD" ]]; then
+                            printf '%s\n' "$FAKE_GIT_HEAD"
+                            exit 0
+                          fi
+                          if [[ "${2:-}" == "--abbrev-ref" && "${3:-}" == "--symbolic-full-name" && "${4:-}" == "@{upstream}" ]]; then
+                            if [[ -z "$FAKE_GIT_UPSTREAM" ]]; then
+                              exit 1
+                            fi
+                            printf '%s\n' "$FAKE_GIT_UPSTREAM"
+                            exit 0
+                          fi
+                          ;;
+                        symbolic-ref)
+                          if [[ "${2:-}" == "--short" && "${3:-}" == "-q" && "${4:-}" == "HEAD" ]]; then
+                            if [[ -z "$FAKE_GIT_BRANCH" ]]; then
+                              exit 1
+                            fi
+                            printf '%s\n' "$FAKE_GIT_BRANCH"
+                            exit 0
+                          fi
+                          ;;
                         show)
                           if [[ "${2:-}" == "origin/main:docs/plan/agents/Studio-F.md" ]]; then
                             printf '%s' "$FAKE_REMOTE_GOAL"
@@ -64,6 +94,9 @@ class ShowGoalTests(unittest.TestCase):
             env = {
                 **os.environ,
                 "FAKE_GIT_CALLS": str(calls_log),
+                "FAKE_GIT_BRANCH": git_branch,
+                "FAKE_GIT_HEAD": git_head,
+                "FAKE_GIT_UPSTREAM": git_upstream,
                 "FAKE_REPO": str(fake_repo),
                 "FAKE_REMOTE_GOAL": remote_goal,
                 "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
@@ -133,6 +166,15 @@ class ShowGoalTests(unittest.TestCase):
             self.assertFalse(report["local_only"])
             self.assertTrue(report["no_fetch"])
             self.assertTrue(report["branch_local_differs"])
+            self.assertEqual(
+                {
+                    "head": "1234567890abcdef1234567890abcdef12345678",
+                    "branch": "codex/test-goal",
+                    "detached": False,
+                    "upstream": "origin/main",
+                },
+                report["git_context"],
+            )
             self.assertIn("-C", calls[1])
             self.assertEqual(temp_files, [])
 
@@ -154,8 +196,38 @@ class ShowGoalTests(unittest.TestCase):
             self.assertFalse(report["fetch_attempted"])
             self.assertTrue(report["local_only"])
             self.assertFalse(report["branch_local_differs"])
-            self.assertEqual(calls, ["rev-parse --show-toplevel"])
+            self.assertEqual("rev-parse --show-toplevel", calls[0])
+            self.assertEqual(4, len(calls))
+            self.assertTrue(calls[1].endswith("/repo rev-parse HEAD"))
+            self.assertTrue(calls[2].endswith("/repo symbolic-ref --short -q HEAD"))
+            self.assertTrue(
+                calls[3].endswith(
+                    "/repo rev-parse --abbrev-ref --symbolic-full-name @{upstream}"
+                )
+            )
+            self.assertEqual("codex/test-goal", report["git_context"]["branch"])
             self.assertEqual(temp_files, [])
+
+    def test_json_report_records_detached_git_context(self):
+        with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
+            report_path = pathlib.Path(temp_dir) / "goal.json"
+
+            self.run_show_goal(
+                ["Studio-F", "--no-fetch", "--json-report", str(report_path)],
+                git_branch="",
+                git_upstream="",
+            )
+
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                {
+                    "head": "1234567890abcdef1234567890abcdef12345678",
+                    "branch": "detached:1234567890ab",
+                    "detached": True,
+                    "upstream": None,
+                },
+                report["git_context"],
+            )
 
     def test_json_report_requires_path(self):
         result = subprocess.run(


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / cheap evidence plumbing.

## Invariant
When `scripts/agents/show-goal.sh` writes a JSON report, the report should identify the git head/branch/upstream that produced the evidence while leaving the human goal-file stdout unchanged.

## Scope
- `scripts/agents/show-goal.sh`
- `scripts/agents/test_show_goal.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent-script-only; no compiler, project corpus, emit, checker, solver, parser, binder, LSP, or WASM behavior changes.

## Verification
- `python3 -m unittest scripts.agents.test_show_goal`
- `bash -n scripts/agents/show-goal.sh`
- `git diff --check origin/main..HEAD`
- `scripts/agents/show-goal.sh Studio-F --no-fetch --json-report /tmp/tsz-show-goal-git-context.json >/tmp/tsz-show-goal-git-context.out`

## Coordination Notes
- AgentName: Studio-F
- Studio-F owned runway was clear before opening this PR.
- Open PR overlap checked; this only extends the existing goal-report JSON evidence surface.
- Branch was rebased onto `origin/main` before publishing.
