### PR TITLE
chore(emit): expose freshness as JSON

### DIFF
--- a/scripts/emit/query-emit.py
+++ b/scripts/emit/query-emit.py
@@ -35,6 +35,7 @@ import os
 import sys
 import argparse
 import re
+import json
 from collections import Counter
 from pathlib import Path
 
@@ -243,10 +244,29 @@ def emit_freshness_status(detail_summary, public_summary):
     return {"state": "current", **status}
 
 
+def emit_freshness_report(detail_summary, public_summary):
+    status = emit_freshness_status(detail_summary, public_summary)
+    return {
+        "state": status["state"],
+        "detailSummary": detail_summary,
+        "publicSummary": public_summary,
+        "detailIsCurrent": emit_detail_is_current(status),
+        "jsPassDelta": status.get("jsPassDelta"),
+        "dtsPassDelta": status.get("dtsPassDelta"),
+        "jsTotalDelta": status.get("jsTotalDelta"),
+        "dtsTotalDelta": status.get("dtsTotalDelta"),
+        "message": emit_freshness_status_line_from_status(status),
+    }
+
+
 def emit_freshness_status_line(data):
     detail_summary = emit_summary(data)
     public_summary = emit_summary_from_readme()
     status = emit_freshness_status(detail_summary, public_summary)
+    return emit_freshness_status_line_from_status(status)
+
+
+def emit_freshness_status_line_from_status(status):
     state = status["state"]
     if state == "stale":
         return (
@@ -318,6 +338,15 @@ def failure_family_surface_heading(surface, title, detail_total, detail_summary,
 
 def print_emit_freshness_status(data):
     print(emit_freshness_status_line(data))
+
+
+def print_emit_freshness_json(data):
+    print(
+        json.dumps(
+            emit_freshness_report(emit_summary(data), emit_summary_from_readme()),
+            sort_keys=True,
+        )
+    )
 
 
 def print_emit_freshness_note(data):
@@ -579,6 +608,11 @@ def main():
     parser.add_argument("--top", type=int, default=40, help="Limit rows shown")
     parser.add_argument("--freshness", action="store_true", help="Report whether emit-detail.json is current")
     parser.add_argument(
+        "--freshness-json",
+        action="store_true",
+        help="Report emit-detail freshness as machine-readable JSON",
+    )
+    parser.add_argument(
         "--require-current-detail",
         action="store_true",
         help="Exit non-zero unless README/public aggregate matches emit-detail.json",
@@ -593,7 +627,9 @@ def main():
         print(emit_freshness_status_line(data), file=sys.stderr)
         return 1
 
-    if args.freshness:
+    if args.freshness_json:
+        print_emit_freshness_json(data)
+    elif args.freshness:
         print_emit_freshness_status(data)
     elif args.js_failures:
         show_js_failures(filtered_data, args.top, args.paths_only)

--- a/scripts/emit/test_query_emit_families.py
+++ b/scripts/emit/test_query_emit_families.py
@@ -8,6 +8,7 @@ cases confirm that unsupported shapes still fall through to "other".
 import importlib.util
 import contextlib
 import io
+import json
 import pathlib
 import sys
 import unittest
@@ -106,6 +107,59 @@ after
         self.assertEqual(status["state"], "stale")
         self.assertEqual(status["jsPassDelta"], 365)
         self.assertEqual(status["dtsPassDelta"], 38)
+
+    def test_freshness_report_preserves_stale_detail_payload(self):
+        report = self.mod.emit_freshness_report(
+            {
+                "jsPass": 13094,
+                "jsTotal": 13530,
+                "dtsPass": 1606,
+                "dtsTotal": 1669,
+            },
+            {
+                "jsPass": 13459,
+                "jsTotal": 13530,
+                "dtsPass": 1644,
+                "dtsTotal": 1669,
+            },
+        )
+
+        self.assertEqual(report["state"], "stale")
+        self.assertFalse(report["detailIsCurrent"])
+        self.assertEqual(report["jsPassDelta"], 365)
+        self.assertEqual(report["dtsPassDelta"], 38)
+        self.assertEqual(report["detailSummary"]["jsPass"], 13094)
+        self.assertEqual(report["publicSummary"]["jsPass"], 13459)
+        self.assertIn("README/public ahead", report["message"])
+
+    def test_print_freshness_json_outputs_machine_readable_status(self):
+        data = {
+            "summary": {
+                "jsPass": 13094,
+                "jsTotal": 13530,
+                "dtsPass": 1606,
+                "dtsTotal": 1669,
+            }
+        }
+        original = self.mod.emit_summary_from_readme
+        self.mod.emit_summary_from_readme = lambda: {
+            "jsPass": 13459,
+            "jsTotal": 13530,
+            "dtsPass": 1644,
+            "dtsTotal": 1669,
+        }
+        try:
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                self.mod.print_emit_freshness_json(data)
+        finally:
+            self.mod.emit_summary_from_readme = original
+
+        parsed = json.loads(out.getvalue())
+        self.assertEqual(parsed["state"], "stale")
+        self.assertFalse(parsed["detailIsCurrent"])
+        self.assertEqual(parsed["jsPassDelta"], 365)
+        self.assertEqual(parsed["dtsPassDelta"], 38)
 
     def test_freshness_note_ignores_different_emit_domains(self):
         note = self.mod.emit_freshness_note(


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 9/10 emit metric truth: emit detail freshness reporting.

## Invariant
When `scripts/emit/emit-detail.json` and the public README emit aggregate diverge, automation should be able to read the same freshness state and deltas that the human `--freshness` output reports; this PR adds a machine-readable `--freshness-json` path to `scripts/emit/query-emit.py`.

## Scope
- Add `emit_freshness_report()` with state, public/detail summaries, deltas, and `detailIsCurrent`.
- Add `--freshness-json` CLI output for dashboard/automation consumers.
- Cover the stale detail payload and JSON output in `scripts/emit/test_query_emit_families.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: reporting-only change for emit metric freshness; no compiler, fixture, project-compile, JS emit, or DTS emit behavior changes.

## Verification
- `python3 scripts/emit/test_query_emit_families.py`
- `python3 scripts/emit/query-emit.py --freshness-json`
- `python3 scripts/emit/query-emit.py --freshness`
- `python3 scripts/emit/query-emit.py --require-current-detail` (expected exit 1 on current stale detail)
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- No open Studio-A PRs existed before this branch.
- Current live evidence remains stale: README/public emit aggregate is ahead of checked `emit-detail.json` by JS +365 pass and DTS +38 pass over matching totals.
- This avoids overlapping active Studio-C emit baseline PRs and does not edit roadmap or markdown files.