### PR TITLE
fix(binder): hoist var/function in namespace bodies

### DIFF
--- a/crates/tsz-binder/src/modules/binding.rs
+++ b/crates/tsz-binder/src/modules/binding.rs
@@ -294,6 +294,16 @@ impl BinderState {
                     .insert(module.body.0, self.current_scope_id);
             }
 
+            // Namespaces are function scopes (`Scope::is_function_scope` is
+            // true for `ContainerKind::Module`), so `var`/`function`
+            // declarations in the body hoist to the namespace scope, including
+            // those nested in blocks/loops/try-catch/switch.
+            if module.body.is_some() {
+                self.collect_hoisted_from_node(arena, module.body);
+                self.process_hoisted_functions(arena);
+                self.process_hoisted_vars(arena);
+            }
+
             self.bind_node(arena, module.body);
 
             // Populate exports for the module symbol

--- a/crates/tsz-binder/src/nodes/binding.rs
+++ b/crates/tsz-binder/src/nodes/binding.rs
@@ -489,6 +489,14 @@ impl BinderState {
                         !is_function_body,
                     );
                 }
+            } else if node.kind == syntax_kind_ext::MODULE_BLOCK {
+                // Namespace bodies are function scopes: top-level `function`
+                // declarations in the body are not block-scoped.
+                if let Some(block) = arena.get_module_block(node)
+                    && let Some(ref statements) = block.statements
+                {
+                    self.collect_hoisted_declarations_impl(arena, statements, false);
+                }
             } else {
                 // Handle single statement (not wrapped in a block)
                 // e.g., `if (x) var y = 1;` or `while (x) var i = 0;`

--- a/crates/tsz-binder/src/state/tests/hoisting_scopes_flow.rs
+++ b/crates/tsz-binder/src/state/tests/hoisting_scopes_flow.rs
@@ -1174,6 +1174,98 @@ function foo() {
     );
 }
 
+// 4.5 NAMESPACE-AS-FUNCTION-SCOPE HOISTING
+
+fn assert_hoisted_to_namespace(binder: &BinderState, name: &str) -> SymbolId {
+    let sym = binder
+        .symbols
+        .find_by_name(name)
+        .unwrap_or_else(|| panic!("expected symbol for {name}"));
+    let in_module = binder
+        .scopes
+        .iter()
+        .any(|scope| scope.kind == ContainerKind::Module && scope.table.get(name) == Some(sym));
+    assert!(
+        in_module,
+        "{name} should be hoisted into a namespace Module scope"
+    );
+    sym
+}
+
+#[test]
+fn nested_namespace_isolates_hoisting() {
+    // Also covers the single-namespace `var` hoist case structurally.
+    let (binder, _parser) = parse_and_bind(
+        r"
+namespace A {
+    namespace B {
+        if (true) {
+            var inner = 1;
+        }
+    }
+}
+",
+    );
+    let inner = assert_hoisted_to_namespace(&binder, "inner");
+    let owners = binder
+        .scopes
+        .iter()
+        .filter(|scope| {
+            scope.kind == ContainerKind::Module && scope.table.get("inner") == Some(inner)
+        })
+        .count();
+    assert_eq!(owners, 1, "var inner should be in exactly one Module scope");
+}
+
+#[test]
+fn var_inside_try_catch_in_namespace_hoists() {
+    let (binder, _parser) = parse_and_bind(
+        r"
+namespace N {
+    try {
+        var t = 1;
+    } catch (e) {
+        var u = 2;
+    } finally {
+        var v = 3;
+    }
+}
+",
+    );
+    for name in ["t", "u", "v"] {
+        assert_hoisted_to_namespace(&binder, name);
+    }
+}
+
+#[test]
+fn function_declaration_at_namespace_top_level_hoists() {
+    let (binder, _parser) = parse_and_bind(
+        r"
+namespace N {
+    var r = helper();
+    function helper(): number { return 1; }
+}
+",
+    );
+    let helper = assert_hoisted_to_namespace(&binder, "helper");
+    let flags = binder.symbols.get(helper).expect("symbol data").flags;
+    assert!(flags & symbol_flags::FUNCTION != 0, "FUNCTION flag missing");
+}
+
+#[test]
+fn dotted_namespace_path_hoists_at_innermost() {
+    let (binder, _parser) = parse_and_bind(
+        r"
+namespace A.B {
+    if (true) {
+        var v = 1;
+    }
+}
+",
+    );
+    assert_hoisted_to_namespace(&binder, "v");
+}
+
 // =============================================================================
 // 5. DECLARATION BINDING
 // =============================================================================


### PR DESCRIPTION
AgentName: m3-max-64g-opus47
Track: Conformance / Binder correctness
Invariant: Namespaces are function scopes for `var`/`function` hoisting (`Scope::is_function_scope` is true for `ContainerKind::Module`).

## Summary

Closes #10940.

`bind_module_declaration` in `crates/tsz-binder/src/modules/binding.rs`
entered a `Module` scope for a namespace body but never ran the
collect/process hoist sequence that source-file and function-body
binders run. `var x` (and `function f` in non-strict scripts) nested
inside `if`/`for`/`while`/`try`/`switch` blocks inside a namespace
ended up declared in the inner `Block` scope and disappeared at block
exit, producing spurious `TS2304: Cannot find name 'x'` reports.

## Structural rule

> When a namespace body contains a `var`/`function` declaration (at any
> nesting depth in blocks/loops/try-catch/switch), the declaration is
> hoisted to the namespace's `Module` scope, identical to how it would
> be hoisted inside a function body.

## Scope

- `crates/tsz-binder/src/modules/binding.rs` — run the same three-step
  hoist sequence used by source files and function bodies inside the
  namespace's `Module` scope.
- `crates/tsz-binder/src/nodes/binding.rs` — extend
  `collect_hoisted_from_node` so `MODULE_BLOCK` follows the same
  hoisting recursion as `BLOCK`, with `is_block_scope = false` because
  the body is itself the function-scope container.
- `crates/tsz-binder/src/state/tests/hoisting_scopes_flow.rs` — four
  unit tests + one helper covering: nested-namespace isolation,
  try/catch/finally hoist, top-level function hoist with forward use,
  and `namespace A.B { ... }` dotted-path hoisting at the innermost
  module-block.

## Adjacent cases covered

The test matrix exercises the rule structurally, not the specific
witness in the issue body:

1. `if (cond) { var x }` inside a namespace.
2. `try/catch/finally` with `var` in each block.
3. Inner namespace inside outer namespace — `var inner` belongs to
   exactly one (the inner) `Module` scope, never leaks into the outer.
4. `function helper(): number { … }` at the namespace top level with a
   forward reference (`var r = helper()`).
5. Dotted-path `namespace A.B { if (…) var v }` — outer body is a
   `MODULE_DECLARATION`, not a `MODULE_BLOCK`; hoisting must skip the
   outer level and apply only at the innermost block.

A negative test would assert that `let`/`const` are NOT hoisted, but
`let_not_hoisted_across_blocks` and `const_not_hoisted_across_blocks`
already cover that for function bodies, and the same `let_or_const`
guard in `collect_hoisted_var_decl` applies uniformly.

## Project Corpus Impact

- Row: utility-types-project (named in the originating issue body;
  same fix lands the structural rule, not a per-row workaround).
- Bug family: binder/symbol — namespace-as-function-scope hoisting.
- Evidence: minimal local repros (`namespace N { if (true) { var x = 1; } x; }`)
  shifted tsz output from spurious `TS2304: Cannot find name 'x'` to
  parity with `tsc --noEmit` (no diagnostic), matching tsc 5.5.4
  behavior. Full conformance/emit/fourslash runs are reserved for
  ready-for-review CI per `.claude/CLAUDE.md` §19.5.

## Verification

- `cargo test -p tsz-binder --lib` — 375 tests pass (4 new namespace
  hoist tests; one pre-existing redundant test slot consolidated).
- `cargo clippy -p tsz-binder --all-targets` — clean.
- Local CLI repros:
  - `namespace N { if (true) { var x = 1; } x; }` — was TS2304, now OK.
  - `namespace N { try { var t } catch { var u } finally { var v }; t+u+v }` —
    was three TS2304s, now matches tsc's `TS2454: Variable used before being assigned`.
  - `namespace N { var r = helper(); function helper(){…} }` — both
    cases unchanged (already worked); regression check.

## Coordination Notes

- No canonical agent lane was assigned; `m3-max-64g-opus47` is retained as runner metadata only until a canonical owner adopts the PR.
The altitude review flagged that the three-step
`collect_hoisted_from_node` + `process_hoisted_functions` +
`process_hoisted_vars` sequence now appears at 9 call sites and could
be extracted into a `hoist_body` helper. Deferred to a separate
refactor PR per the "narrow bug fix" discipline in `.claude/CLAUDE.md`
§20.2 — bundling a workspace-wide extraction would defeat
reviewability. The augmentation early-return paths
(`is_global_augmentation`, `is_augmentation`) deliberately do not
enter a `Module` scope and so are not affected by this change; the
rare `declare global { if (…) var x }` pattern remains a separately
trackable gap.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WhqJJSCPP4bkrQ8hFjMGSb)_
