### PR TITLE
perf(checker): cache value-merged DOM direct refs

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib.rs
@@ -201,6 +201,11 @@ impl<'a> CheckerState<'a> {
                 .register_def_auto_params_in_envs(def_id, direct_type, params.clone());
         }
         let lazy_type = self.ctx.types.lazy(def_id);
+        self.ctx.symbol_types.insert(sym_id, lazy_type);
+        self.ctx
+            .lib_delegation_cache
+            .insert_symbol_type(sym_id, (lazy_type, params.clone()));
+        self.cache_shared_actual_lib_delegation(&name, lazy_type);
         Some((lazy_type, params))
     }
 }

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs
@@ -411,6 +411,16 @@ fn direct_value_merged_builtin_dom_interface_symbol_type_returns_type_position_l
         crate::query_boundaries::common::lazy_def_id(state.ctx.types, validity_state).is_some(),
         "value-merged DOM interfaces should return a type-position Lazy ref",
     );
+    let (cached_validity, cached_params) = state
+        .ctx
+        .lib_delegation_cache
+        .symbol_type(validity_sym_id)
+        .expect("admitted value-merged DOM interfaces should populate the delegation cache");
+    assert_eq!(cached_validity, validity_state);
+    assert!(
+        cached_params.is_empty(),
+        "ValidityState should cache without generic params",
+    );
 
     let document_sym_id = state
         .ctx


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 7/9 cache/residency hygiene for generated-app lib/module identity. PR type: cache/residency.

## Invariant
When a value-merged DOM interface is admitted through the direct actual-lib path, the returned type-position `Lazy(DefId)` is stable for that lib symbol within the checker context; this PR stores that result in the same symbol and lib-delegation caches used by pure built-in interface direct refs.

## Scope
- `crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib.rs`
- `crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs`

## Project Corpus Impact
- Row: `vite-vanilla-ts-app`
- Bug family: generated app lib/module identity; direct actual-lib value/interface cache residency
- Evidence: current green-row target artifact still has two 2x gaps; Vite attribution remains dominated by `checker:cross-arena-delegation`. This PR does not claim to close the Vite target gap. Post-change attribution `/private/tmp/studio-b-value-dom-cache-vite-20260601.perf.json` keeps diagnostics green and shows the remaining misses are the rejected heritage/computed DOM interfaces, not admitted value-interface repeats.

## Verification
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `cargo nextest run -p tsz-checker --lib actual_lib_tests`
- `scripts/safe-run.sh cargo build -p tsz-cli --bin tsz --features perf-tools`
- `scripts/safe-run.sh env TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 TSZ_PERF_COUNTERS=1 .target/debug/tsz --extendedDiagnostics --perf-counters-json /private/tmp/studio-b-value-dom-cache-vite-20260601.perf.json --noEmit -p .target-bench/external/vite-vanilla-ts-live/tsconfig.json`

## Coordination Notes
- Existing Studio-B PRs were merged before this branch was opened.
- Overlap checked against open PRs and agent-label audit; no active Studio-B PRs remained.
- This is intentionally a small cache-hygiene slice. It preserves the inherited-member guard for `document.querySelector<HTMLDivElement>(...)` and leaves the broader DOM heritage fast path to the next structural fix.
