### PR TITLE
chore(agents): expose label audit git context

### DIFF
--- a/scripts/agents/ensure-agent-labels.sh
+++ b/scripts/agents/ensure-agent-labels.sh
@@ -95,6 +95,21 @@ is_canonical_agent_label() {
   esac
 }
 
+collect_git_context() {
+  GIT_HEAD="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+  GIT_BRANCH="$(git symbolic-ref --short -q HEAD 2>/dev/null || true)"
+  GIT_DETACHED=false
+  if [[ -z "$GIT_BRANCH" ]]; then
+    GIT_DETACHED=true
+    if [[ "$GIT_HEAD" == "unknown" ]]; then
+      GIT_BRANCH="detached:unknown"
+    else
+      GIT_BRANCH="detached:${GIT_HEAD:0:12}"
+    fi
+  fi
+  GIT_UPSTREAM="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)"
+}
+
 existing="$(gh label list --limit 300 --json name --jq '.[].name')"
 
 if [[ "$AUDIT" == true ]]; then
@@ -106,7 +121,20 @@ if [[ "$AUDIT" == true ]]; then
       process.stdout.write(JSON.stringify(fs.readFileSync(0, "utf8").trim().split(/\n/).filter(Boolean)));
     '
   )"
-  AGENTS_JSON="$agents_json" LABELS_TEXT="$existing" PRS_JSON="$prs_json" ISSUES_JSON="$issues_json" STRICT_AUDIT="$STRICT_AUDIT" JSON_REPORT="$JSON_REPORT" node <<'NODE'
+  if [[ -n "$JSON_REPORT" ]]; then
+    collect_git_context
+  fi
+  AGENTS_JSON="$agents_json" \
+  LABELS_TEXT="$existing" \
+  PRS_JSON="$prs_json" \
+  ISSUES_JSON="$issues_json" \
+  STRICT_AUDIT="$STRICT_AUDIT" \
+  JSON_REPORT="$JSON_REPORT" \
+  GIT_HEAD="${GIT_HEAD:-}" \
+  GIT_BRANCH="${GIT_BRANCH:-}" \
+  GIT_DETACHED="${GIT_DETACHED:-false}" \
+  GIT_UPSTREAM="${GIT_UPSTREAM:-}" \
+  node <<'NODE'
 const fs = require("fs");
 const path = require("path");
 const canonical = new Set(JSON.parse(process.env.AGENTS_JSON).map((agent) => `agent:${agent}`));
@@ -231,6 +259,12 @@ if (process.env.JSON_REPORT) {
     ok,
     status: ok ? "pass" : "fail",
     agent_label_audit_status: ok ? "pass" : "fail",
+    git_context: {
+      head: process.env.GIT_HEAD,
+      branch: process.env.GIT_BRANCH,
+      detached: process.env.GIT_DETACHED === "true",
+      upstream: process.env.GIT_UPSTREAM || null,
+    },
     metrics,
     missing_canonical_labels: missingCanonicalLabels,
     noncanonical_agent_labels: noncanonicalLabels,

--- a/scripts/agents/test_ensure_agent_labels.py
+++ b/scripts/agents/test_ensure_agent_labels.py
@@ -285,6 +285,11 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
         self.assertEqual("fail", report["status"])
         self.assertEqual("fail", report["agent_label_audit_status"])
         self.assertFalse(report["ok"])
+        self.assertIn("git_context", report)
+        self.assertIsInstance(report["git_context"]["head"], str)
+        self.assertIsInstance(report["git_context"]["branch"], str)
+        self.assertIsInstance(report["git_context"]["detached"], bool)
+        self.assertIn("upstream", report["git_context"])
         self.assertEqual(2, report["metrics"]["agent_label_audit_findings"])
         self.assertEqual(1, report["metrics"]["open_prs_missing_agent_label"])
         self.assertEqual(1, report["metrics"]["open_prs_noncanonical_agent_label"])
@@ -332,6 +337,7 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
         self.assertTrue(report["ok"])
         self.assertEqual("pass", report["status"])
         self.assertEqual("pass", report["agent_label_audit_status"])
+        self.assertIn("git_context", report)
         self.assertEqual(0, report["metrics"]["agent_label_audit_findings"])
 
     def test_json_report_requires_audit_mode(self):


### PR DESCRIPTION
AgentName: Studio-F

Track: Studio-F launch infrastructure and cheap evidence plumbing

Invariant: Agent ownership audits must remain easy to tie back to the exact git checkout that produced the report, without changing the human-readable audit output or canonical label policy.

Scope:
- Add `git_context` to the JSON report emitted by `scripts/agents/ensure-agent-labels.sh --audit --json-report`.
- Include `head`, `branch`, `detached`, and `upstream` fields, matching the evidence shape already used by adjacent launch-infra reports.
- Cover both passing and failing JSON report paths in the existing agent-label audit unit tests.

Project Corpus Impact:
Row: n/a
Bug family: n/a
Evidence: agent-script-only; no compiler, checker, solver, parser, binder, emitter, LSP, WASM, conformance, or project-corpus behavior changes.

Verification:
- `python3 -m unittest scripts.agents.test_ensure_agent_labels`
- `bash -n scripts/agents/ensure-agent-labels.sh`
- `git diff --check origin/main..HEAD`
- `scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-git-context.json >/tmp/tsz-agent-label-git-context.out`

Coordination Notes:
- Opened after rerunning the Studio-F start-cycle checks.
- Live label audit was repaired by marking PR #12051 intentionally unassigned with the exact canonical-audit phrase; the audit now reports zero findings.
- This is a narrow evidence-only PR and does not claim any checker/solver behavior work.
