### PR TITLE
chore(readme): warn when preserving newer emit metrics

### DIFF
--- a/scripts/ci/test_refresh_readme.py
+++ b/scripts/ci/test_refresh_readme.py
@@ -1,8 +1,13 @@
 """Tests for README metric refresh helpers."""
 
+import io
 import importlib.util
+import json
 import pathlib
+import types
 import unittest
+from contextlib import redirect_stderr
+from tempfile import TemporaryDirectory
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
@@ -77,6 +82,41 @@ Declaration: [███████████████████░] 97.0
 
         self.assertEqual(selected["jsPass"], 13401)
         self.assertEqual(selected["dtsPass"], 1619)
+
+    def test_emit_fallback_warns_when_preserving_readme_summary(self):
+        with TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            detail_path = root / "scripts" / "emit" / "emit-detail.json"
+            detail_path.parent.mkdir(parents=True)
+            detail_path.write_text(json.dumps({
+                "summary": {
+                    "jsPass": 13094,
+                    "jsTotal": 13530,
+                    "dtsPass": 1606,
+                    "dtsTotal": 1669,
+                },
+            }))
+            args = types.SimpleNamespace(emit_metrics_json=None)
+            readme_text = """<!-- EMIT_START -->
+```
+JavaScript:  [████████████████████] 99.5% (13,459 / 13,530 tests)
+Declaration: [████████████████████] 98.5% (1,644 / 1,669 tests)
+```
+<!-- EMIT_END -->"""
+
+            old_root = refresh_readme.ROOT
+            stderr = io.StringIO()
+            try:
+                refresh_readme.ROOT = root
+                with redirect_stderr(stderr):
+                    selected = refresh_readme.load_emit(args, readme_text)
+            finally:
+                refresh_readme.ROOT = old_root
+
+        self.assertEqual(selected["jsPass"], 13459)
+        self.assertEqual(selected["dtsPass"], 1644)
+        self.assertIn("preserving README emit metrics", stderr.getvalue())
+        self.assertIn("scripts/emit/emit-detail.json", stderr.getvalue())
 
 
 if __name__ == "__main__":

--- a/scripts/refresh-readme.py
+++ b/scripts/refresh-readme.py
@@ -154,8 +154,14 @@ def emit_summary_from_readme(text):
 
 
 def prefer_readme_emit_summary(candidate, readme_summary):
+    if readme_emit_summary_is_ahead(candidate, readme_summary):
+        return readme_summary
+    return candidate
+
+
+def readme_emit_summary_is_ahead(candidate, readme_summary):
     if readme_summary is None:
-        return candidate
+        return False
 
     same_domain = (
         readme_summary.get("jsTotal") == candidate.get("jsTotal")
@@ -165,7 +171,7 @@ def prefer_readme_emit_summary(candidate, readme_summary):
         readme_summary.get("jsPass", 0) >= candidate.get("jsPass", 0)
         and readme_summary.get("dtsPass", 0) >= candidate.get("dtsPass", 0)
     )
-    return readme_summary if same_domain and ahead_or_equal else candidate
+    return same_domain and ahead_or_equal
 
 
 def load_emit(args, readme_text):
@@ -189,6 +195,12 @@ def load_emit(args, readme_text):
         summary = normalize_emit_summary(data)
         if summary is not None:
             if args.emit_metrics_json is None and p == ROOT / "scripts" / "emit" / "emit-detail.json":
+                if readme_emit_summary_is_ahead(summary, readme_summary):
+                    print(
+                        "warning: preserving README emit metrics because "
+                        f"{p.relative_to(ROOT)} is behind the existing README emit block",
+                        file=sys.stderr,
+                    )
                 return prefer_readme_emit_summary(summary, readme_summary)
             return summary
     return None


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Release metric truth / README metric refresh

## Invariant
When checked emit fallback data is older than the existing README emit block, README refresh preserves the newer public metrics and reports that decision instead of silently looking up to date.

## Scope
- Add a named helper for the README-ahead emit summary decision.
- Emit a stderr warning when `scripts/refresh-readme.py` preserves the existing README emit block instead of using stale `scripts/emit/emit-detail.json` fallback data.
- Cover the fallback warning path with a temp-directory unit test.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: tooling-only README metric refresh reporting; no compiler, benchmark corpus, or project row behavior changes.

## Verification
- `python3 scripts/ci/test_refresh_readme.py`
- `python3 scripts/refresh-readme.py --skip-performance` (dry-run; warning observed; no writes)
- `python3 scripts/emit/query-emit.py --freshness-json`
- `git diff --check`

## Coordination Notes
- Studio-A owned PR intake was empty before this branch.
- This avoids overlapping active emit-correctness work and only improves metric refresh reporting.
- No README or roadmap markdown changes are included.
