### PR TITLE
test(checker): guard direct actual-lib shared cache provenance

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_tests.rs
@@ -1174,8 +1174,8 @@ fn resolves_intl_namespace_exported_lib_interface_directly() {
 }
 
 #[test]
-fn direct_actual_lib_delegation_cache_preserves_type_params() {
-    let lib_files = load_lib_files(&["es2015.iterable.d.ts"]);
+fn direct_actual_lib_delegation_cache_stays_file_local() {
+    let lib_files = load_lib_files(&["es5.d.ts", "es2015.iterable.d.ts"]);
     let mut parser = ParserState::new("fixture.ts".to_string(), "let value;".to_string());
     let root = parser.parse_source_file();
     let mut binder = BinderState::new();
@@ -1191,6 +1191,7 @@ fn direct_actual_lib_delegation_cache_preserves_type_params() {
         CheckerOptions::default(),
     );
     let mut state = CheckerState { ctx };
+    state.ctx.shared_lib_type_cache = Some(Arc::new(dashmap::DashMap::new()));
     let lib_contexts: Vec<LibContext> = lib_files
         .iter()
         .map(|lib| LibContext {
@@ -1237,6 +1238,44 @@ fn direct_actual_lib_delegation_cache_preserves_type_params() {
         cached_params.len(),
         params.len(),
         "cache hits must preserve generic application metadata",
+    );
+    assert!(
+        state
+            .cached_shared_actual_lib_delegation(sym_id, "ArrayIterator")
+            .is_none(),
+        "generic direct actual-lib results need provenance beyond a bare shared TypeId",
+    );
+
+    let date_sym_id = state
+        .ctx
+        .binder
+        .file_locals
+        .get("Date")
+        .expect("Date should resolve to a lib symbol");
+    let date_arena = state
+        .ctx
+        .binder
+        .symbol_arenas
+        .get(&date_sym_id)
+        .map(std::convert::AsRef::as_ref);
+    let (date_ty, date_params) = state
+        .direct_actual_lib_symbol_type(
+            date_sym_id,
+            CrossArenaSymbolMissSource::SymbolArena,
+            date_arena,
+            false,
+        )
+        .expect("Date should lower through the direct lib path");
+    assert_ne!(date_ty, TypeId::UNKNOWN);
+    assert_ne!(date_ty, TypeId::ERROR);
+    assert!(date_params.is_empty());
+    state.ctx.lib_delegation_cache.clear_file_local();
+    state.ctx.symbol_types.remove(&date_sym_id);
+    assert!(
+        state
+            .cached_shared_actual_lib_delegation(date_sym_id, "Date")
+            .is_none(),
+        "direct actual-lib results stay file-local until child delegation proves shared-cache provenance",
     );
 }
 


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 7/9 cache/residency hygiene. PR type: test guard / cache provenance.

## Invariant
Direct actual-lib symbol lowering may warm the file-local delegation cache, but it must not populate `shared_lib_type_cache` with a bare `TypeId` unless the mature child-delegation path proves shared-cache provenance. Generic and non-generic direct actual-lib results both stay file-local here; callers can still replay entries that were written by the existing shared-cache owner.

## Scope
- `crates/tsz-checker/src/state/type_analysis/cross_file_direct_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: test-harness-only guard after ready-review CI proved the attempted performance write-through was unsafe. The current head has no compiler code changes against `origin/main`; it preserves the existing shared-cache behavior and prevents reintroducing the failed direct-write-through assumption.

## Verification
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `cargo nextest run -p tsz-checker --lib direct_actual_lib_delegation_cache_stays_file_local`
- Focused investigation command used on the unsafe head: `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter deeplyNestedMappedTypes --verbose`

## Coordination Notes
- Existing Studio-B PRs were merged first; #12049 landed before this branch started from current `origin/main`.
- The previous ready head `2489e9c60f0f2074d9e708c28456359d1a69786f` failed `conformance-aggregate` with fingerprint-only regressions in `deeplyNestedMappedTypes.ts`, `intersectionsOfLargeUnions2.ts`, `importAttributes11.ts`, and `checkJsxChildrenCanBeTupleType.tsx`.
- This head removes the unsafe compiler write-through and leaves a focused guard proving direct actual-lib generic `ArrayIterator` and non-generic `Date` results are not replayed from the shared actual-lib delegation cache.
- The original cache-residency optimization is abandoned for now; a future performance slice needs a stronger provenance key than bare shared name plus `TypeId`.
