### PR TITLE
refactor(checker): route class relation flags through boundary

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/class.rs
+++ b/crates/tsz-checker/src/query_boundaries/class.rs
@@ -1,3 +1,4 @@
+use super::relation_policy;
 use crate::class_checker::ClassMemberInfo;
 use crate::state::CheckerState;
 use tsz_parser::NodeIndex;
@@ -479,9 +480,7 @@ fn overload_return_base_matches_and_params_cover(
     source_type: TypeId,
     target_type: TypeId,
 ) -> bool {
-    let policy = tsz_solver::relations::relation_queries::RelationPolicy::from_flags(
-        checker.ctx.pack_relation_flags(),
-    );
+    let policy = relation_policy::from_checker_flags_u16(checker.ctx.pack_relation_flags());
     let context = tsz_solver::relations::relation_queries::RelationContext {
         query_db: Some(checker.ctx.types),
         inheritance_graph: Some(&checker.ctx.inheritance_graph),

--- a/crates/tsz-checker/src/tests/relation_flags_boundary_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/relation_flags_boundary_contract_tests.rs
@@ -30,6 +30,7 @@ fn flow_analysis_uses_boundary_relation_flags_surface() {
 fn checker_boundaries_use_explicit_legacy_relation_policy_constructor() {
     for path in [
         "src/query_boundaries/assignability.rs",
+        "src/query_boundaries/class.rs",
         "src/query_boundaries/flow_analysis.rs",
     ] {
         let source = fs::read_to_string(path).expect("failed to read checker query boundary");


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track: solver relation policy/cache-key protocols; #8207 packed relation flag boundary cleanup.

## Invariant
When checker code receives legacy packed relation flags for relation queries, the checker should decode them through the explicit `query_boundaries::relation_policy::from_checker_flags_u16` compatibility edge before constructing solver relation policy. This keeps the packed protocol quarantined at checker query boundaries while leaving solver relation behavior unchanged.

## Scope
- `crates/tsz-checker/src/query_boundaries/class.rs`
- `crates/tsz-checker/src/tests/relation_flags_boundary_contract_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: behavior-preserving checker boundary refactor and architecture contract test only; no compiler semantic behavior or project fixture behavior intentionally changed.

## Verification
- RED: `cargo nextest run -p tsz-checker -E 'test(checker_boundaries_use_explicit_legacy_relation_policy_constructor)'` failed before the production change because `src/query_boundaries/class.rs` did not name `relation_policy::from_checker_flags_u16`.
- GREEN after M5Manager rebase onto `origin/main` `aaaf39cd232c0622b23221efcfae3688ba93a03d`: `cargo nextest run -p tsz-checker --lib checker_boundaries_use_explicit_legacy_relation_policy_constructor` passed on head `2e9379e9792957022ca63115bf18ba04d676217a`, 1 passed / 5645 skipped.
- GREEN on head `2e9379e9792957022ca63115bf18ba04d676217a`: `cargo fmt --check`.
- GREEN on head `2e9379e9792957022ca63115bf18ba04d676217a`: `git diff --check origin/main...HEAD`.
- GREEN on head `2e9379e9792957022ca63115bf18ba04d676217a`: `python3 scripts/arch/arch_guard.py`.
- GREEN ready-review PR-head CI on exact head `2e9379e9792957022ca63115bf18ba04d676217a`: `CI Summary`, `GitGuardian Security Checks`, conformance aggregate, conformance snapshot gate, emit, fourslash aggregate/shards, project compile guard/canary, LSP, WASM/wasm-web, lint, unit, dist-binaries, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-corpus-pr-body`, `project-row-drift`, `gate`, and `queue-one-pr` passed.
- `Queue Tested` is queue-owned and is expected to run after the `merge-queue` label is added.

## Coordination Notes
- AgentName: M5Manager refreshed this branch on 2026-06-02 from old head `e41d1f9d3f3b7d748ddcbd3f868687708a104ef6` to head `2e9379e9792957022ca63115bf18ba04d676217a` on top of `origin/main` `aaaf39cd232c0622b23221efcfae3688ba93a03d` using `--force-with-lease`. No conflicts.
- AgentName: M5Manager marked this PR ready after draft-light checks and monitored ready-review to exact-head green.
- Supports #8207 by shrinking direct checker use of the solver packed-flag constructor; this does not change relation policy bits or cache-key semantics.
- Non-overlap: avoids #11890 checker relation-routing implementation work and does not touch #12030/#12036 merged solver relation/variance paths.
- Stacked draft child: #12060 depends on this branch and must remain draft/off queue until this PR lands or #12060 is rebased after merge.
- Queue action: exact-head ready-review gates are green and the PR is ready, mergeable, non-WIP, auto-merge off, and reviewed against head `2e9379e9792957022ca63115bf18ba04d676217a`; M5Manager is adding `merge-queue` for the repo-local queue.
- Head verified: `2e9379e9792957022ca63115bf18ba04d676217a`.
