### PR TITLE
chore(bench): surface stale readiness on website

### DIFF
--- a/crates/tsz-website/src/_data/benchmark_data.js
+++ b/crates/tsz-website/src/_data/benchmark_data.js
@@ -8,6 +8,7 @@ import {
   PROJECT_ROWS_BY_NAME,
   REQUIRED_PROJECT_ROWS,
 } from "../../../../scripts/bench/project-rows.mjs";
+import { benchReadinessMessages } from "../../../../scripts/bench/bench-readiness-banner.mjs";
 import { selectLatestBenchmarkArtifact } from "../../../../scripts/bench/benchmark-artifact-selection.mjs";
 import { subsystemForCode } from "../../../../scripts/ci/diagnostic-subsystems.mjs";
 import { fmt } from "./loc.js";
@@ -806,6 +807,12 @@ function readJsonIfExists(p) {
   } catch {
     return null;
   }
+}
+
+function benchReadinessBanner(readiness) {
+  const messages = benchReadinessMessages(readiness);
+  if (messages.length === 0) return "";
+  return `<p class="bench-readiness-warning">⚠️ ${escapeHtml(messages.join(" "))}</p>`;
 }
 
 let _benchReadinessStatus;
@@ -1855,12 +1862,7 @@ export function getProjectCompatibilityDashboard() {
   };
 
   const readiness = loadBenchReadinessStatus();
-  let artifactBanner = "";
-  if (readiness?.artifact_absent) {
-    artifactBanner = `<p class="bench-readiness-warning">⚠️ No recent benchmark artifact — compatibility data shown from repository snapshot and may be stale.</p>`;
-  } else if (readiness?.missing > 0) {
-    artifactBanner = `<p class="bench-readiness-warning">⚠️ Benchmark artifact is missing ${readiness.missing} required row(s); shown data may be incomplete.</p>`;
-  }
+  const artifactBanner = benchReadinessBanner(readiness);
 
   return `<section class="compat-dashboard">
   <h2>Compatibility</h2>

--- a/scripts/bench/bench-readiness-banner.mjs
+++ b/scripts/bench/bench-readiness-banner.mjs
@@ -1,0 +1,44 @@
+export function benchReadinessMessages(readiness) {
+  if (!readiness) return [];
+  if (readiness.artifact_absent) {
+    return [
+      "No recent benchmark artifact - compatibility data shown from repository snapshot and may be stale.",
+    ];
+  }
+
+  const messages = [];
+  const missing = Number(readiness.missing);
+  if (missing > 0) {
+    messages.push(
+      `Benchmark artifact is missing ${missing} required row(s); shown data may be incomplete.`,
+    );
+  }
+
+  const duplicateRows = Array.isArray(readiness.duplicate_rows)
+    ? readiness.duplicate_rows
+    : [];
+  if (duplicateRows.length > 0) {
+    messages.push(
+      `Benchmark artifact has ${duplicateRows.length} duplicate required row(s); shown data may be unreliable.`,
+    );
+  }
+
+  if (readiness.source_freshness?.current === false) {
+    const warning = readiness.source_freshness.warning
+      ? `: ${readiness.source_freshness.warning}`
+      : "";
+    messages.push(
+      `Benchmark artifact source is stale${warning}; shown data is not current release truth.`,
+    );
+  }
+
+  const metadataWarnings = Number(readiness.metadata_warnings_total ?? 0);
+  if (readiness.metadata_clean === false || metadataWarnings > 0) {
+    const count = metadataWarnings > 0 ? `${metadataWarnings} ` : "";
+    messages.push(
+      `Benchmark artifact metadata has ${count}warning(s); shown data may not be comparable.`,
+    );
+  }
+
+  return messages;
+}

--- a/scripts/bench/test-bench-readiness-banner.mjs
+++ b/scripts/bench/test-bench-readiness-banner.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+
+import { benchReadinessMessages } from "./bench-readiness-banner.mjs";
+
+assert.deepEqual(benchReadinessMessages(null), []);
+
+assert.match(
+  benchReadinessMessages({ artifact_absent: true }).join(" "),
+  /No recent benchmark artifact/,
+);
+
+assert.match(
+  benchReadinessMessages({ missing: 2 }).join(" "),
+  /missing 2 required row\(s\)/,
+);
+
+assert.match(
+  benchReadinessMessages({
+    duplicate_rows: [{ name: "utility-types-project", count: 2 }],
+  }).join(" "),
+  /duplicate required row\(s\)/,
+);
+
+assert.match(
+  benchReadinessMessages({
+    source_freshness: {
+      current: false,
+      warning: "source abc123 differs from expected def456",
+    },
+  }).join(" "),
+  /not current release truth/,
+);
+
+assert.match(
+  benchReadinessMessages({
+    metadata_clean: false,
+    metadata_warnings_total: 3,
+  }).join(" "),
+  /metadata has 3 warning\(s\)/,
+);
+
+assert.doesNotMatch(
+  benchReadinessMessages({
+    metadata_clean: true,
+    metadata_warnings_total: 0,
+    source_freshness: { current: true },
+  }).join(" "),
+  /warning|stale|missing|duplicate/i,
+);
+
+console.log("bench readiness banner tests passed");

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -403,6 +403,7 @@ run_lint() {
   node scripts/bench/test-reduction-backlog.mjs || return $?
   node scripts/bench/test-timeout-runner.mjs || return $?
   node scripts/bench/test-check-artifact-readiness.mjs || return $?
+  node scripts/bench/test-bench-readiness-banner.mjs || return $?
   node scripts/bench/test-ci-health-benchmark-readiness.mjs || return $?
   node scripts/bench/test-benchmark-artifact-selection.mjs || return $?
   node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs || return $?


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Release metric truth / benchmark artifact readiness

## Invariant
When benchmark readiness marks an artifact absent, incomplete, duplicate, stale against the expected source commit, or metadata-dirty, the website compatibility dashboard must surface that readiness state instead of presenting the row data as current release truth.

## Scope
- Add a dependency-free benchmark readiness message helper for absent artifacts, missing rows, duplicate rows, stale source commits, and metadata warnings.
- Reuse that helper in the website compatibility dashboard banner.
- Add a focused helper test and wire it into the existing lint script list.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: dashboard/reporting-only change; project row definitions and compiler behavior are unchanged.

## Verification
- `node scripts/bench/test-bench-readiness-banner.mjs`
- `node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs`
- `node --check scripts/bench/bench-readiness-banner.mjs && node --check scripts/bench/test-bench-readiness-banner.mjs && node --check crates/tsz-website/src/_data/benchmark_data.js`
- `git diff --check`
- PR-head CI was green on the previous head except for the repo-wide conformance aggregate drift fixed by #12065.

## Coordination Notes
- Rebased onto current `main` after #12065 fixed the conformance aggregate blocker.
- This does not modify README, roadmap, or generated benchmark markdown.
- `node crates/tsz-website/scripts/benchmark-data-smoke.mjs` was not run successfully in this reused worktree because the website dependency `marked` is not installed locally.
