### PR TITLE
chore(agents): show disk preflight shortfall

### DIFF
--- a/scripts/agents/disk-preflight.sh
+++ b/scripts/agents/disk-preflight.sh
@@ -123,6 +123,21 @@ cache_size_kb() {
   fi
 }
 
+guard_value() {
+  local key="$1"
+  awk -v key="$key" '
+    {
+      for (i = 1; i <= NF; i++) {
+        split($i, parts, "=")
+        if (parts[1] == key) {
+          print parts[2]
+          exit
+        }
+      }
+    }
+  ' <<<"$GUARD_OUTPUT"
+}
+
 CARGO_CACHE_STUB_MAX_KB="${TSZ_CARGO_CACHE_STUB_MAX_KB:-1024}"
 LOCAL_CARGO_CACHE_DIR_COUNT=0
 LOCAL_CARGO_CACHE_PRESENT_COUNT=0
@@ -283,6 +298,13 @@ REUSABLE_WORKTREE_OUTPUT="$(
 echo "$REUSABLE_WORKTREE_OUTPUT"
 
 if echo "$GUARD_OUTPUT" | grep -q 'disk_status=low'; then
+  DISK_FREE_MB="$(guard_value disk_free_mb)"
+  DISK_MIN_FREE_GB="$(guard_value min_free_gb)"
+  if [[ "$DISK_FREE_MB" =~ ^[0-9]+$ && "$DISK_MIN_FREE_GB" =~ ^[0-9]+$ ]]; then
+    DISK_MIN_FREE_MB=$((DISK_MIN_FREE_GB * 1024))
+    DISK_SHORTFALL_MB=$((DISK_MIN_FREE_MB > DISK_FREE_MB ? DISK_MIN_FREE_MB - DISK_FREE_MB : 0))
+    echo "disk_shortfall_mb=$DISK_SHORTFALL_MB"
+  fi
   cat <<'LOWDISK'
 
 == low disk cleanup ladder ==

--- a/scripts/agents/test_disk_preflight.py
+++ b/scripts/agents/test_disk_preflight.py
@@ -153,7 +153,7 @@ class DiskPreflightTests(unittest.TestCase):
             fake_repo, fake_script = self.make_fake_repo(temp_root)
             report_path = temp_root / "preflight.json"
 
-            self.run_preflight(
+            result = self.run_preflight(
                 fake_repo,
                 fake_script,
                 "--json-report",
@@ -167,6 +167,7 @@ class DiskPreflightTests(unittest.TestCase):
             self.assertEqual("fail", report["disk_preflight_status"])
             self.assertEqual("low", report["disk_guard"]["disk_status"])
             self.assertFalse(report["disk_guard"]["ok"])
+            self.assertRegex(result.stdout, r"disk_shortfall_mb=\d+")
             self.assertFalse(report["disk_pressure"]["ok"])
             self.assertEqual("low", report["disk_pressure"]["status"])
             self.assertGreater(report["disk_pressure"]["shortfall_mb"], 0)


### PR DESCRIPTION
AgentName: Studio-F

Track: Studio-F disk/worktree hygiene and cheap evidence plumbing

Invariant: When disk preflight reports low free space, the human-readable output should show the numeric shortfall from the configured guard so agents can decide whether cache-preserving cleanup is enough or whether they need an ownership-aware worktree handoff.

Scope:
- Add `disk_shortfall_mb=...` to the low-disk human output in `scripts/agents/disk-preflight.sh`.
- Keep the existing JSON report shape intact; it already exposes `disk_pressure.shortfall_mb`.
- Extend the low-disk unit test to assert the human output exposes the shortfall.

Project Corpus Impact:
Row: n/a
Bug family: n/a
Evidence: agent-script-only; no compiler, checker, solver, parser, binder, emitter, LSP, WASM, conformance, or project-corpus behavior changes.

Verification:
- `python3 -m unittest scripts.agents.test_disk_preflight`
- `bash -n scripts/agents/disk-preflight.sh`
- `git diff --check origin/main..HEAD`
- `scripts/agents/disk-preflight.sh Studio-F --json-report /tmp/tsz-disk-shortfall-check.json`

Coordination Notes:
- Opened after rerunning the Studio-F start-cycle checks.
- Studio-F owned PR/issue runway was clear before starting.
- Live disk guard is low by a few hundred MB; cache-preserving cleanup was tried and no inactive sister worktree was safe to remove because the remaining sister worktrees are tied to open Studio-A/Studio-B PRs.
