### PR TITLE
fix(module-resolution): align extensionless-stem candidate priority with tsc across crates

### DIFF
--- a/crates/tsz-checker/src/module_resolution.rs
+++ b/crates/tsz-checker/src/module_resolution.rs
@@ -58,20 +58,30 @@ const TS_EXTENSIONS: &[&str] = &[
 ];
 
 /// File extensions in `tsc` resolution-candidate priority order, mirroring
-/// TypeScript's `getSupportedExtensions`: an implementation (source) file wins
-/// over its declaration counterpart (`.ts` before `.d.ts`, `.mts` before
-/// `.d.mts`, `.cts` before `.d.cts`), `.ts`/`.tsx` precede `.cts`/`.mts`, and
-/// every TypeScript surface precedes its JavaScript counterpart. So `./foo`
-/// resolves to a `foo.ts` source ahead of a sibling `foo.d.ts`, exactly as
-/// `tsc` does. The same order is used by `tsz_core::module_resolver` and by the
-/// triple-slash directive resolver in `state_checking::directive`.
+/// TypeScript's `allSupportedExtensions`:
+///
+/// ```text
+///   [Ts, Tsx, Dts, Js, Jsx], [Cts, Dcts, Cjs], [Mts, Dmts, Mjs]
+/// ```
+///
+/// Grouped by module flavor, with source surfaces ahead of their declaration
+/// counterpart inside each group. So `./foo` resolves to a `foo.ts` source
+/// ahead of a sibling `foo.d.ts`; a `foo.cts` precedes a sibling `foo.mts`
+/// because the CJS-tagged group precedes the ESM-tagged group; and a `foo.cjs`
+/// precedes a sibling `foo.mjs` for the same reason (`.cjs` lives in the
+/// CJS-tagged group, `.mjs` in the ESM-tagged group).
+///
+/// This list is the dotted form of [`tsz_common::file_extensions::TSC_TS_JS_RESOLUTION_EXTENSIONS`].
+/// `tsz_core::module_resolver`'s default-mode `allow_js` path consumes the
+/// bare counterpart of the same shared constant; its Node16/Classic paths
+/// use distinct flavor-grouped lists also rooted in `tsz_common`. The
+/// triple-slash directive resolver in `state_checking::directive` follows the
+/// same shared order.
 ///
 /// This is intentionally distinct from [`TS_EXTENSIONS`], which is ordered
 /// declaration-first purely so suffix *stripping* works. There is no real
 /// `.d.tsx` file in TypeScript, so it is absent here.
-const RESOLUTION_EXTENSIONS: &[&str] = &[
-    ".ts", ".tsx", ".d.ts", ".cts", ".d.cts", ".mts", ".d.mts", ".js", ".jsx", ".cjs", ".mjs",
-];
+const RESOLUTION_EXTENSIONS: &[&str] = tsz_common::file_extensions::TSC_TS_JS_RESOLUTION_EXTENSIONS;
 
 /// `tsc` resolution priority of a concrete file path: the position of its
 /// extension in [`RESOLUTION_EXTENSIONS`], where a lower value means higher

--- a/crates/tsz-checker/src/state/state_checking/directive.rs
+++ b/crates/tsz-checker/src/state/state_checking/directive.rs
@@ -82,15 +82,11 @@ impl<'a> CheckerState<'a> {
             false
         };
 
-        let unresolved_extensions: Vec<&'static str> =
-            if self.ctx.compiler_options.allow_js || self.ctx.is_js_file() {
-                vec![
-                    ".ts", ".tsx", ".d.ts", ".js", ".jsx", ".cts", ".d.cts", ".cjs", ".mts",
-                    ".d.mts", ".mjs",
-                ]
-            } else {
-                vec![".ts", ".tsx", ".d.ts", ".cts", ".d.cts", ".mts", ".d.mts"]
-            };
+        let unresolved_extensions = if self.ctx.compiler_options.allow_js || self.ctx.is_js_file() {
+            tsz_common::file_extensions::TSC_TS_JS_RESOLUTION_EXTENSIONS
+        } else {
+            tsz_common::file_extensions::TSC_TS_RESOLUTION_EXTENSIONS
+        };
 
         for (reference_path, line_num, quote_offset) in references {
             if !has_virtual_reference(&reference_path) {

--- a/crates/tsz-checker/tests/module_resolution.rs
+++ b/crates/tsz-checker/tests/module_resolution.rs
@@ -1504,7 +1504,7 @@ fn test_resolution_priority_ranks_source_before_declaration() {
     assert!(resolution_priority("foo.tsx") < resolution_priority("foo.d.ts"));
     assert!(resolution_priority("foo.mts") < resolution_priority("foo.d.mts"));
     assert!(resolution_priority("foo.cts") < resolution_priority("foo.d.cts"));
-    // TypeScript surfaces outrank JavaScript ones.
+    // TypeScript surfaces outrank JavaScript ones in their own group.
     assert!(resolution_priority("foo.ts") < resolution_priority("foo.js"));
     assert!(resolution_priority("foo.d.ts") < resolution_priority("foo.js"));
     // Unknown extensions sort last.
@@ -1512,6 +1512,84 @@ fn test_resolution_priority_ranks_source_before_declaration() {
         resolution_priority("foo.unknown"),
         RESOLUTION_EXTENSIONS.len()
     );
+}
+
+#[test]
+fn test_resolution_priority_matches_tsc_group_order() {
+    // Mirrors tsc's `allSupportedExtensions`:
+    //   [Ts, Tsx, Dts, Js, Jsx], [Cts, Dcts, Cjs], [Mts, Dmts, Mjs]
+    //
+    // The CJS-tagged group precedes the ESM-tagged group, so `.cts`/`.cjs`
+    // outrank `.mts`/`.mjs`. The universal first group puts `.js`/`.jsx`
+    // alongside `.ts`/`.tsx`/`.d.ts`, ahead of either module-tagged group.
+    //
+    // Pre-fix, `tsz-core::TS_EXTENSION_CANDIDATES` ranked `.mts` ahead of
+    // `.cts`, diverging from tsc on every extensionless path-mapping stem
+    // collision in default / Classic / Bundler modes.
+
+    // CJS-tagged group precedes ESM-tagged group across all surfaces.
+    assert!(resolution_priority("foo.cts") < resolution_priority("foo.mts"));
+    assert!(resolution_priority("foo.d.cts") < resolution_priority("foo.d.mts"));
+    assert!(resolution_priority("foo.cts") < resolution_priority("foo.d.mts"));
+    assert!(resolution_priority("foo.cjs") < resolution_priority("foo.mjs"));
+
+    // Universal first group `[Ts, Tsx, Dts, Js, Jsx]` precedes both module groups.
+    assert!(resolution_priority("foo.js") < resolution_priority("foo.cts"));
+    assert!(resolution_priority("foo.jsx") < resolution_priority("foo.cts"));
+    assert!(resolution_priority("foo.jsx") < resolution_priority("foo.mts"));
+    assert!(resolution_priority("foo.cjs") < resolution_priority("foo.mts"));
+}
+
+#[test]
+fn test_fan_out_picks_cjs_tagged_sibling_over_esm_tagged_sibling() {
+    // Structural rule: `tsc`'s `allSupportedExtensions` keeps the CJS-tagged
+    // group ahead of the ESM-tagged group, so an extensionless stem with
+    // siblings in both groups must pick the CJS-tagged one. Covers the
+    // `.cts`/`.mts` (TS source), `.d.cts`/`.d.mts` (TS declaration), and
+    // `.cjs`/`.mjs` (JS) variants. Each row is tested under both file
+    // orderings to prove the fan-out is order-independent.
+    let rows: &[(&str, &str, &str)] = &[
+        ("dual", "cts", "mts"),
+        ("dual", "d.cts", "d.mts"),
+        ("legacy", "cjs", "mjs"),
+    ];
+    for (stem, cjs_ext, esm_ext) in rows {
+        let cjs_file = format!("/proj/{stem}.{cjs_ext}");
+        let esm_file = format!("/proj/{stem}.{esm_ext}");
+        for files in [
+            ["/proj/main.ts", cjs_file.as_str(), esm_file.as_str()],
+            ["/proj/main.ts", esm_file.as_str(), cjs_file.as_str()],
+        ] {
+            let idx = file_index_from(&files);
+            let resolved =
+                resolve_specifier_via_file_index("/proj/main.ts", &format!("./{stem}"), &idx);
+            assert_eq!(
+                resolved.map(|i| files[i]),
+                Some(cjs_file.as_str()),
+                "files={files:?}: ./{stem} must resolve to the .{cjs_ext} sibling \
+                 — CJS-tagged group precedes ESM-tagged group",
+            );
+        }
+    }
+}
+
+#[test]
+fn test_fan_out_prefers_universal_group_over_module_tagged_group() {
+    // `allSupportedExtensions` puts the universal `[Ts, Tsx, Dts, Js, Jsx]`
+    // group ahead of either module-tagged group, so a stem with a `.js`
+    // sibling and a `.cts` sibling resolves to the `.js` file.
+    for files in [
+        vec!["/proj/main.ts", "/proj/dual.cts", "/proj/dual.js"],
+        vec!["/proj/main.ts", "/proj/dual.js", "/proj/dual.cts"],
+    ] {
+        let idx = file_index_from(&files);
+        let resolved = resolve_specifier_via_file_index("/proj/main.ts", "./dual", &idx);
+        assert_eq!(
+            resolved.map(|i| files[i]),
+            Some("/proj/dual.js"),
+            "files={files:?}: ./dual must resolve to dual.js — universal group precedes CJS-tagged group",
+        );
+    }
 }
 
 #[test]

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_utils.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_utils.rs
@@ -357,10 +357,10 @@ pub(super) fn relative_module_path_candidates(
     }
 
     let mut candidates = Vec::new();
-    for ext in ["ts", "tsx", "d.ts", "mts", "cts", "d.mts", "d.cts"] {
+    for ext in tsz_common::file_extensions::TSC_TS_RESOLUTION_EXTENSIONS_BARE {
         candidates.push(format!("{joined_str}.{ext}"));
     }
-    for ext in ["ts", "tsx", "d.ts", "mts", "cts", "d.mts", "d.cts"] {
+    for ext in tsz_common::file_extensions::TSC_TS_RESOLUTION_EXTENSIONS_BARE {
         candidates.push(format!("{joined_str}/index.{ext}"));
     }
     candidates

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_completions.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_completions.rs
@@ -1134,7 +1134,7 @@ impl Server {
         }
 
         let mut candidates = Vec::new();
-        let exts = ["ts", "tsx", "d.ts", "js", "jsx", "mts", "cts", "mjs", "cjs"];
+        let exts = tsz_common::file_extensions::TSC_TS_JS_RESOLUTION_EXTENSIONS_BARE;
 
         let push_path = |out: &mut Vec<String>, path: std::path::PathBuf| {
             let normalized = Self::normalize_virtual_path(&path.to_string_lossy());

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_structure.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_structure.rs
@@ -2279,7 +2279,7 @@ impl Server {
         specifier: &str,
     ) -> Option<std::path::PathBuf> {
         let base = Self::normalize_path(&importer_dir.join(specifier));
-        const EXTS: &[&str] = &["ts", "tsx", "d.ts", "js", "jsx", "mts", "cts", "mjs", "cjs"];
+        const EXTS: &[&str] = tsz_common::file_extensions::TSC_TS_JS_RESOLUTION_EXTENSIONS_BARE;
         let exists_anywhere = |p: &std::path::Path| -> bool {
             if p.exists() {
                 return true;

--- a/crates/tsz-cli/src/driver/resolution/path_resolution.rs
+++ b/crates/tsz-cli/src/driver/resolution/path_resolution.rs
@@ -525,9 +525,9 @@ pub(crate) const fn extension_candidates_for_resolution(
         ModuleResolutionKind::Node16 | ModuleResolutionKind::NodeNext => match package_type {
             Some(PackageType::Module) => &NODE16_MODULE_EXTENSION_CANDIDATES,
             Some(PackageType::CommonJs) => &NODE16_COMMONJS_EXTENSION_CANDIDATES,
-            None => &TS_EXTENSION_CANDIDATES,
+            None => TS_EXTENSION_CANDIDATES,
         },
-        _ => &TS_EXTENSION_CANDIDATES,
+        _ => TS_EXTENSION_CANDIDATES,
     }
 }
 
@@ -748,8 +748,11 @@ pub(crate) const KNOWN_EXTENSIONS: [&str; 12] = [
     ".d.mts", ".d.cts", ".d.ts", ".mts", ".cts", ".tsx", ".ts", ".mjs", ".cjs", ".jsx", ".js",
     ".json",
 ];
-pub(crate) const TS_EXTENSION_CANDIDATES: [&str; 7] =
-    ["ts", "tsx", "d.ts", "mts", "cts", "d.mts", "d.cts"];
+/// TS-only candidate priority for non-Node16 fan-outs (path mapping, baseUrl,
+/// classic, bundler). Mirrors tsc's `supportedTSExtensions` via the shared
+/// constant in `tsz-common::file_extensions` so all crates use the same order.
+pub(crate) const TS_EXTENSION_CANDIDATES: &[&str] =
+    tsz_common::file_extensions::TSC_TS_RESOLUTION_EXTENSIONS_BARE;
 pub(crate) const PACKAGE_INDEX_FALLBACK_EXTENSIONS: [&str; 3] = ["ts", "tsx", "d.ts"];
 pub(crate) const PACKAGE_INDEX_FALLBACK_ALLOW_JS_EXTENSIONS: [&str; 5] =
     ["ts", "tsx", "d.ts", "js", "jsx"];

--- a/crates/tsz-common/src/file_extensions.rs
+++ b/crates/tsz-common/src/file_extensions.rs
@@ -46,6 +46,59 @@ pub const KNOWN_MODULE_EXTENSIONS: &[&str] = &[
     ".json",
 ];
 
+// ---------------------------------------------------------------------------
+// Resolution-candidate priority lists (tsc parity)
+//
+// These mirror tsc's `supportedTSExtensions` and `allSupportedExtensions`
+// from `src/compiler/utilities.ts` (TypeScript 5.5+). They are the single
+// source of truth for extensionless-stem fan-out order across the crates:
+//
+//   tsz-common      — defines the order (this file)
+//   tsz-core        — uses `BARE_*` lists (no leading dot) for filesystem probes
+//   tsz-cli         — uses `BARE_*` lists for the CLI driver probes
+//   tsz-lsp         — uses `BARE_*` lists for module-specifier inference
+//   tsz-checker     — uses `DOTTED_*` lists for filename-index lookups
+//
+// Structural rule from tsc (`supportedTSExtensions`):
+//
+//   [[Ts, Tsx, Dts], [Cts, Dcts], [Mts, Dmts]]
+//
+// Grouped by module flavor: the universal TS group first, then the CJS-tagged
+// pair, then the ESM-tagged pair. Source surfaces precede their declaration
+// counterpart inside each group. `supportedJSExtensions` follows the same
+// shape: `[[Js, Jsx], [Mjs], [Cjs]]` — note that for JS, `mjs` precedes `cjs`,
+// the opposite of the TS grouping. `allSupportedExtensions` interleaves them
+// by module flavor: `[[Ts, Tsx, Dts, Js, Jsx], [Cts, Dcts, Cjs], [Mts, Dmts, Mjs]]`.
+// ---------------------------------------------------------------------------
+
+/// TS-only resolution candidate priority, with leading dot. Mirrors tsc's
+/// `supportedTSExtensions` flattened. Used by `tsz-checker` for
+/// filename-index probing where each entry already carries the dot.
+pub const TSC_TS_RESOLUTION_EXTENSIONS: &[&str] =
+    &[".ts", ".tsx", ".d.ts", ".cts", ".d.cts", ".mts", ".d.mts"];
+
+/// TS+JS resolution candidate priority, with leading dot. Mirrors tsc's
+/// `allSupportedExtensions` flattened: TS+JS are interleaved by module
+/// flavor (`[Ts, Tsx, Dts, Js, Jsx], [Cts, Dcts, Cjs], [Mts, Dmts, Mjs]`).
+/// Used by `tsz-checker` for stem fan-out on projects that may contain
+/// either TS or JS files.
+pub const TSC_TS_JS_RESOLUTION_EXTENSIONS: &[&str] = &[
+    ".ts", ".tsx", ".d.ts", ".js", ".jsx", ".cts", ".d.cts", ".cjs", ".mts", ".d.mts", ".mjs",
+];
+
+/// TS-only resolution candidate priority, without leading dot. Mirrors
+/// `TSC_TS_RESOLUTION_EXTENSIONS`. Used by `tsz-core` / `tsz-cli` / `tsz-lsp`
+/// where the probe API takes the bare extension stem (it appends the dot
+/// internally via `Path::with_extension`).
+pub const TSC_TS_RESOLUTION_EXTENSIONS_BARE: &[&str] =
+    &["ts", "tsx", "d.ts", "cts", "d.cts", "mts", "d.mts"];
+
+/// TS+JS resolution candidate priority, without leading dot. Mirrors
+/// `TSC_TS_JS_RESOLUTION_EXTENSIONS`.
+pub const TSC_TS_JS_RESOLUTION_EXTENSIONS_BARE: &[&str] = &[
+    "ts", "tsx", "d.ts", "js", "jsx", "cts", "d.cts", "cjs", "mts", "d.mts", "mjs",
+];
+
 /// Strip a TS-family extension from a module-specifier display string.
 /// Matches tsc's `typeof import("X")` behaviour: TS extensions are dropped,
 /// JS extensions (and unknown suffixes) are preserved.
@@ -289,6 +342,48 @@ mod tests {
         assert!(include_pattern_has_supported_extension("src/index.mjs"));
         assert!(!include_pattern_has_supported_extension("src/*.json"));
         assert!(!include_pattern_has_supported_extension("src"));
+    }
+
+    #[test]
+    fn resolution_priority_lists_match_tsc_supported_extensions() {
+        // `supportedTSExtensions = [[Ts, Tsx, Dts], [Cts, Dcts], [Mts, Dmts]]`
+        // — universal TS group, then CJS-tagged group, then ESM-tagged group.
+        assert_eq!(
+            TSC_TS_RESOLUTION_EXTENSIONS,
+            &[".ts", ".tsx", ".d.ts", ".cts", ".d.cts", ".mts", ".d.mts"],
+        );
+        // `allSupportedExtensions = [[Ts, Tsx, Dts, Js, Jsx], [Cts, Dcts, Cjs], [Mts, Dmts, Mjs]]`
+        // — JS surfaces sit in the universal first group; `.cjs` ships with
+        // the CJS-tagged group; `.mjs` ships with the ESM-tagged group.
+        assert_eq!(
+            TSC_TS_JS_RESOLUTION_EXTENSIONS,
+            &[
+                ".ts", ".tsx", ".d.ts", ".js", ".jsx", ".cts", ".d.cts", ".cjs", ".mts", ".d.mts",
+                ".mjs",
+            ],
+        );
+    }
+
+    #[test]
+    fn bare_resolution_lists_mirror_dotted_lists_without_leading_dot() {
+        // The bare lists are the same priority order, with the leading dot
+        // stripped. `tsz-core` / `tsz-cli` / `tsz-lsp` append the dot via
+        // `Path::with_extension`, so they consume the bare form.
+        for (dotted, bare) in [
+            (
+                TSC_TS_RESOLUTION_EXTENSIONS,
+                TSC_TS_RESOLUTION_EXTENSIONS_BARE,
+            ),
+            (
+                TSC_TS_JS_RESOLUTION_EXTENSIONS,
+                TSC_TS_JS_RESOLUTION_EXTENSIONS_BARE,
+            ),
+        ] {
+            assert_eq!(dotted.len(), bare.len());
+            for (d, b) in dotted.iter().zip(bare) {
+                assert_eq!(d.strip_prefix('.'), Some(*b), "{d} → {b}");
+            }
+        }
     }
 
     #[test]

--- a/crates/tsz-core/src/module_resolver/file_probing.rs
+++ b/crates/tsz-core/src/module_resolver/file_probing.rs
@@ -194,24 +194,24 @@ impl ModuleResolver {
                 }
                 None => {
                     if self.allow_js {
-                        &TS_JS_EXTENSION_CANDIDATES
+                        TS_JS_EXTENSION_CANDIDATES
                     } else {
-                        &TS_EXTENSION_CANDIDATES
+                        TS_EXTENSION_CANDIDATES
                     }
                 }
             },
             ModuleResolutionKind::Classic => {
                 if self.allow_js {
-                    &TS_JS_EXTENSION_CANDIDATES
+                    TS_JS_EXTENSION_CANDIDATES
                 } else {
-                    &CLASSIC_EXTENSION_CANDIDATES
+                    CLASSIC_EXTENSION_CANDIDATES
                 }
             }
             _ => {
                 if self.allow_js {
-                    &TS_JS_EXTENSION_CANDIDATES
+                    TS_JS_EXTENSION_CANDIDATES
                 } else {
-                    &TS_EXTENSION_CANDIDATES
+                    TS_EXTENSION_CANDIDATES
                 }
             }
         }

--- a/crates/tsz-core/src/module_resolver/tests/path_mapping.rs
+++ b/crates/tsz-core/src/module_resolver/tests/path_mapping.rs
@@ -334,3 +334,51 @@ fn test_path_mapping_nextjs_guard_config_pattern() {
         .expect("\"*\" catch-all must resolve react to external.d.ts");
     assert_eq!(react.resolved_path, fx.join("external.d.ts"));
 }
+
+// ── tsc-canonical extension priority for extensionless aliases ───────────────
+//
+// Regression for issue #10944. Structural rule: for an extensionless alias /
+// path-mapping target (i.e. no package context — `package_type = None`), tsc's
+// `supportedTSExtensions` orders the candidates as
+// `[Ts, Tsx, Dts], [Cts, Dcts], [Mts, Dmts]`. The CJS-tagged group precedes
+// the ESM-tagged group, so a `.cts` sibling outranks a `.mts` sibling. Pre-fix,
+// `tsz-core::TS_EXTENSION_CANDIDATES` had `mts` ahead of `cts` and the
+// extensionless fan-out picked the wrong sibling on every stem collision in
+// Bundler / Classic / path-mapping resolution.
+
+#[test]
+fn test_path_mapping_extensionless_alias_follows_tsc_group_order() {
+    // Three rows exercising the same structural rule on different surfaces:
+    // (sibling extensions to drop into `src/dual.*`, expected winner). The
+    // first two rows test the CJS-vs-ESM grouping; the third confirms the
+    // universal `[Ts, Tsx, Dts]` group still outranks both module-tagged
+    // groups. Per row, `make_options` builds a fresh resolver against the
+    // same `@app/*` → `src/*` alias.
+    let rows: &[(&[&str], &str)] = &[
+        (&["src/dual.cts", "src/dual.mts"], "src/dual.cts"),
+        (&["src/dual.d.cts", "src/dual.d.mts"], "src/dual.d.cts"),
+        (
+            &["src/dual.ts", "src/dual.cts", "src/dual.mts"],
+            "src/dual.ts",
+        ),
+    ];
+    for (siblings, expected) in rows {
+        let fx = TempFixture::new();
+        for sibling in *siblings {
+            fx.write(sibling, "export const v: number;");
+        }
+        fx.write("index.ts", "import '@app/dual';");
+
+        let options = make_options(fx.path(), vec![pm("@app/*", "@app/", &["src/*"])]);
+        let mut resolver = ModuleResolver::new(&options);
+        let resolved = resolver
+            .resolve("@app/dual", &fx.join("index.ts"), Span::new(0, 9))
+            .expect("@app/dual must resolve");
+        assert_eq!(
+            resolved.resolved_path,
+            fx.join(expected),
+            "siblings={siblings:?}: extensionless @app/dual must pick {expected} \
+             per tsc's supportedTSExtensions grouping",
+        );
+    }
+}

--- a/crates/tsz-core/src/resolution/helpers.rs
+++ b/crates/tsz-core/src/resolution/helpers.rs
@@ -506,8 +506,11 @@ pub(crate) const KNOWN_EXTENSIONS: [&str; 12] = [
     ".d.mts", ".d.cts", ".d.ts", ".mts", ".cts", ".tsx", ".ts", ".mjs", ".cjs", ".jsx", ".js",
     ".json",
 ];
-pub(crate) const TS_EXTENSION_CANDIDATES: [&str; 7] =
-    ["ts", "tsx", "d.ts", "mts", "cts", "d.mts", "d.cts"];
+/// TS-only candidate priority for path-mapping, baseUrl, classic, and bundler
+/// probes (mirrors tsc's `supportedTSExtensions` — `[Ts, Tsx, Dts]` then
+/// `[Cts, Dcts]` then `[Mts, Dmts]`).
+pub(crate) const TS_EXTENSION_CANDIDATES: &[&str] =
+    tsz_common::file_extensions::TSC_TS_RESOLUTION_EXTENSIONS_BARE;
 pub(crate) const NODE16_MODULE_EXTENSION_CANDIDATES: [&str; 7] =
     ["mts", "d.mts", "ts", "tsx", "d.ts", "cts", "d.cts"];
 pub(crate) const NODE16_MODULE_ALLOWJS_EXTENSION_CANDIDATES: [&str; 11] = [
@@ -518,12 +521,13 @@ pub(crate) const NODE16_COMMONJS_EXTENSION_CANDIDATES: [&str; 7] =
 pub(crate) const NODE16_COMMONJS_ALLOWJS_EXTENSION_CANDIDATES: [&str; 11] = [
     "cts", "d.cts", "ts", "tsx", "d.ts", "mts", "d.mts", "cjs", "js", "jsx", "mjs",
 ];
-pub(crate) const CLASSIC_EXTENSION_CANDIDATES: [&str; 7] = TS_EXTENSION_CANDIDATES;
+pub(crate) const CLASSIC_EXTENSION_CANDIDATES: &[&str] = TS_EXTENSION_CANDIDATES;
 
-/// Extension candidates when allowJs is enabled (TypeScript + JavaScript)
-pub(crate) const TS_JS_EXTENSION_CANDIDATES: [&str; 11] = [
-    "ts", "tsx", "d.ts", "mts", "cts", "d.mts", "d.cts", "js", "jsx", "mjs", "cjs",
-];
+/// TS+JS candidate priority for path-mapping, baseUrl, classic, and bundler
+/// probes when `allowJs` is enabled (mirrors tsc's `allSupportedExtensions` —
+/// `[Ts, Tsx, Dts, Js, Jsx]` then `[Cts, Dcts, Cjs]` then `[Mts, Dmts, Mjs]`).
+pub(crate) const TS_JS_EXTENSION_CANDIDATES: &[&str] =
+    tsz_common::file_extensions::TSC_TS_JS_RESOLUTION_EXTENSIONS_BARE;
 
 pub(crate) fn node16_extension_substitution(path: &Path, extension: &str) -> Option<Vec<PathBuf>> {
     let replacements: &[&str] = match extension {

--- a/crates/tsz-lsp/src/project/module_specifiers.rs
+++ b/crates/tsz-lsp/src/project/module_specifiers.rs
@@ -14,16 +14,8 @@ use tsz_parser::parser::node::NodeAccess;
 
 use super::{ImportSpecifierPreference, Project};
 
-/// Mirrors tsc's `supportedTSExtensions` (shared with `tsz-core` and `tsz-cli`
-/// via `tsz-common::file_extensions`). Source-before-decl per group, with
-/// `[Cts, Dcts]` ordered before `[Mts, Dmts]`.
-const TS_EXTENSION_CANDIDATES: &[&str] =
-    tsz_common::file_extensions::TSC_TS_RESOLUTION_EXTENSIONS_BARE;
-
-/// Declaration-first stripping order for `strip_ts_extension` below. Sharing
-/// `tsz_common::file_extensions::TS_FAMILY_EXTENSIONS` keeps every "strip a
-/// TS-family suffix" loop in lock-step.
-const TS_EXTENSION_SUFFIXES: &[&str] = tsz_common::file_extensions::TS_FAMILY_EXTENSIONS;
+use tsz_common::file_extensions::TS_FAMILY_EXTENSIONS as TS_EXTENSION_SUFFIXES;
+use tsz_common::file_extensions::TSC_TS_RESOLUTION_EXTENSIONS_BARE as TS_EXTENSION_CANDIDATES;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum RelativeImportStyle {

--- a/crates/tsz-lsp/src/project/module_specifiers.rs
+++ b/crates/tsz-lsp/src/project/module_specifiers.rs
@@ -14,9 +14,16 @@ use tsz_parser::parser::node::NodeAccess;
 
 use super::{ImportSpecifierPreference, Project};
 
-const TS_EXTENSION_CANDIDATES: [&str; 7] = ["ts", "tsx", "d.ts", "mts", "cts", "d.mts", "d.cts"];
-const TS_EXTENSION_SUFFIXES: [&str; 7] =
-    [".d.ts", ".d.mts", ".d.cts", ".ts", ".tsx", ".mts", ".cts"];
+/// Mirrors tsc's `supportedTSExtensions` (shared with `tsz-core` and `tsz-cli`
+/// via `tsz-common::file_extensions`). Source-before-decl per group, with
+/// `[Cts, Dcts]` ordered before `[Mts, Dmts]`.
+const TS_EXTENSION_CANDIDATES: &[&str] =
+    tsz_common::file_extensions::TSC_TS_RESOLUTION_EXTENSIONS_BARE;
+
+/// Declaration-first stripping order for `strip_ts_extension` below. Sharing
+/// `tsz_common::file_extensions::TS_FAMILY_EXTENSIONS` keeps every "strip a
+/// TS-family suffix" loop in lock-step.
+const TS_EXTENSION_SUFFIXES: &[&str] = tsz_common::file_extensions::TS_FAMILY_EXTENSIONS;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum RelativeImportStyle {


### PR DESCRIPTION
## Agent

AgentName: M4-D

Canonical owner assigned by ReviewHelper for module-resolution/symbol-lane merge hygiene. Runner identity `opus47-confident-thompson` (model: claude-opus-4-7) is retained under Coordination Notes.

## Track

Module resolution / `tsc` parity — extensionless-alias extension priority.

## Invariant

When several files share an extensionless stem (e.g. `foo.cts` and `foo.mts` under one path-mapping target), `tsc`'s `supportedTSExtensions` / `allSupportedExtensions` (TypeScript 5.5+, `src/compiler/utilities.ts`) groups candidates by module flavor:

```
supportedTSExtensions     = [Ts, Tsx, Dts], [Cts, Dcts], [Mts, Dmts]
allSupportedExtensions    = [Ts, Tsx, Dts, Js, Jsx], [Cts, Dcts, Cjs], [Mts, Dmts, Mjs]
```

The CJS-tagged group precedes the ESM-tagged group, with source surfaces ahead of declaration counterparts inside each group. So `./foo` resolves to `foo.cts` ahead of a sibling `foo.mts`. This PR makes tsz apply that exact order through every layer that probes extensionless stems.

## Scope

Fixes #10944 (`utility-types-project` row: module-resolution extension priority diverges for extensionless aliases) and the same root cause behind the rest of the family.

### Root cause

Each crate carried its own hand-rolled `TS_EXTENSION_CANDIDATES` list with `.mts` ranked ahead of `.cts`, plus `tsz-checker::RESOLUTION_EXTENSIONS` disagreed with `tsz-core` on cjs/mjs ordering. Three of the five crates (`tsz-cli`, `tsz-lsp`, the `tsz-server` code-fix surface) drifted from the others on the same constant.

### Fix (owning layer = `tsz-common::file_extensions`)

Hoist the canonical priority lists into `tsz-common::file_extensions` as the single source of truth:

- `TSC_TS_RESOLUTION_EXTENSIONS` (dotted) / `_BARE` (no leading dot)
- `TSC_TS_JS_RESOLUTION_EXTENSIONS` (dotted) / `_BARE` (no leading dot)

Both forms are needed because `Path::with_extension(".ts")` produces `foo..ts` — the bare form is required for `with_extension` callers, the dotted form for direct filename-index lookups (a runtime test in `tsz-common` asserts the bare lists mirror the dotted lists).

Reroute every existing site through them:

- `tsz-checker::module_resolution::RESOLUTION_EXTENSIONS` (project-relative filename-index fan-out + stem tie-breaking)
- `tsz-checker::state_checking::directive` (triple-slash unresolved-path diagnostic — also drops a per-call `Vec<&'static str>` allocation)
- `tsz-core::resolution::helpers::{TS_EXTENSION_CANDIDATES, TS_JS_EXTENSION_CANDIDATES, CLASSIC_EXTENSION_CANDIDATES}` (filesystem-probe fan-out for path-mapping, baseUrl, classic, bundler)
- `tsz-cli::driver::resolution::TS_EXTENSION_CANDIDATES` (CLI driver probe)
- `tsz-cli::bin::tsz_server::handlers_code_fixes_utils` (code-fix candidate generation — same wrong cts/mts order pre-fix)
- `tsz-lsp::project::module_specifiers::{TS_EXTENSION_CANDIDATES, TS_EXTENSION_SUFFIXES}` — `TS_EXTENSION_SUFFIXES` (declaration-first stripping order) now reuses the pre-existing `tsz_common::TS_FAMILY_EXTENSIONS`

This is a class fix, not a fixture-name patch: it reorders candidates by structural extension priority, never by a specific spelling, and falls back to the same fan-out when only one sibling exists (so a declaration-only stem still resolves).

`NODE16_*_EXTENSION_CANDIDATES` (which use a different per-module-flavor order) are intentionally kept local — they remain Node16-mode-specific and out of scope for this PR.

## Project Corpus Impact

- Row: `utility-types-project` (the originating issue), plus the same structural rule applies across the rest of the bench corpus where extensionless aliases collide on a `.cts/.mts` or `.cjs/.mjs` stem.
- Bug family: module-resolution, extensionless-stem extension priority.
- Evidence: new tests in `tsz-checker`, `tsz-core`, and `tsz-common` cover the cjs-tagged-precedes-esm-tagged rule and the universal-first-group rule under both file orderings, plus the bare-vs-dotted invariant.

## Verification

- `cargo check --workspace` — clean.
- `cargo clippy -p tsz-common -p tsz-core -p tsz-cli -p tsz-lsp -p tsz-checker --tests --all-features -- -D warnings` — clean.
- `cargo test -p tsz-common --lib file_extensions` — 8 passed (incl. 2 new).
- `cargo test -p tsz-core --lib module_resolver --no-fail-fast` — 220 passed, 0 failed (incl. 1 new table-driven test covering 3 rows).
- `cargo test -p tsz-checker --lib module_resolution --no-fail-fast` — 108 passed, 0 failed (incl. 3 new tests, one of them table-driven across 3 surfaces).
- `cargo test -p tsz-cli --lib` and `cargo test -p tsz-lsp --lib` — pre-existing-only failures (the 120 `tsc_compat_tests` failures need an external `tsc` binary not present in the local sandbox; baseline-equal).
- Pre-existing source_map and architecture-contract failures on the full `tsz-checker --lib` and `tsz-core --lib` runs reproduce identically on clean `main` and are unrelated to this change.

Exact-head PR-head CI on `f62a2b9ad91cbbb3b7223294297c9ed9fe98367b` passed the draft/ready gate through dist-fast, lint, unit, unit-cloudbuild, wasm, wasm-web, cargo-deny, cargo-shear, project-corpus-pr-body, project-row-drift, conformance-snapshot-gate, gate, queue-one-pr, and GitGuardian. Marked ready by ReviewHelper on 2026-06-01 to trigger ready-review heavy CI; do not add `merge-queue` until exact-head ready-review `CI Summary` and GitGuardian pass.

## Test plan

- [x] `tsz-common::file_extensions` constants assert the literal tsc orderings and the bare↔dotted invariant.
- [x] `tsz-checker::module_resolution` adds:
  - `test_resolution_priority_matches_tsc_group_order` — `.cts < .mts`, `.d.cts < .d.mts`, `.cjs < .mjs`, universal-group-first.
  - `test_fan_out_picks_cjs_tagged_sibling_over_esm_tagged_sibling` — table-driven across `.cts/.mts`, `.d.cts/.d.mts`, `.cjs/.mjs`, both file orderings.
  - `test_fan_out_prefers_universal_group_over_module_tagged_group` — `.js` outranks `.cts`.
- [x] `tsz-core::module_resolver::tests::path_mapping::test_path_mapping_extensionless_alias_follows_tsc_group_order` — table-driven across `.cts/.mts`, `.d.cts/.d.mts`, and the `.ts`-outranks-both case using `@app/*` → `src/*` path-mapping.
- [x] Workspace `cargo check` clean. Workspace `cargo clippy -D warnings` clean.
- [ ] CI: lint, dist-fast build, conformance, emit, fourslash, WASM.

## Coordination Notes

AgentName: M4-D. Runner identity: `opus47-confident-thompson` (claude-opus-4-7).

Reviewed via 3 `/simplify` rounds (reuse / simplification / efficiency / altitude):
- Round 1 dropped redundant `Vec` allocation and a redundant type annotation.
- Round 2 collapsed 3+3 new tests into 1+1 table-driven tests (~65 LOC saved); tightened cross-crate doc comment about which `tsz-core` paths consume the shared constant.
- Round 3 collapsed `iter::once + chain + collect` into a literal 3-element array (no `Vec` allocation).

Out-of-scope follow-up flagged by the altitude reviewer:
- `NODE16_*_EXTENSION_CANDIDATES` are still duplicated between `tsz-core` and `tsz-cli`. They use a different per-module-flavor ordering, so they aren't covered by the new constants. A separate PR can hoist them once their tsc-parity ordering is validated.
- `KNOWN_EXTENSIONS` is duplicated between `tsz-core` and `tsz-cli`. Pre-existing, declaration-first stripping order; out of scope.

https://claude.ai/code/session_01NPW23gcEQ2SSmRkZTSdydJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPW23gcEQ2SSmRkZTSdydJ)_


AgentName: ReviewHelper coordination note: assigned canonical `agent:M4-D` because this PR owns module-resolution extension-priority behavior, which maps to the M4-D symbol/lib/module lane. No generated runner label was applied.