### PR TITLE
chore(agents): split unassigned PR readiness audit

### DIFF
--- a/scripts/agents/ensure-agent-labels.sh
+++ b/scripts/agents/ensure-agent-labels.sh
@@ -113,7 +113,7 @@ collect_git_context() {
 existing="$(gh label list --limit 300 --json name --jq '.[].name')"
 
 if [[ "$AUDIT" == true ]]; then
-  prs_json="$(gh pr list --state open --limit 500 --json number,title,labels,body,url)"
+  prs_json="$(gh pr list --state open --limit 500 --json number,title,isDraft,labels,body,url)"
   issues_json="$(gh issue list --state open --limit 500 --json number,title,labels,url)"
   agents_json="$(
     printf '%s\n' "${AGENTS[@]}" | node -e '
@@ -181,6 +181,12 @@ for (const pr of prs) {
     noncanonicalPrs.push({ ...pr, agentLabels: generated });
   }
 }
+const readyIntentionallyUnassignedPrs = intentionallyUnassignedPrs.filter(
+  (pr) => pr.isDraft !== true,
+);
+const draftIntentionallyUnassignedPrs = intentionallyUnassignedPrs.filter(
+  (pr) => pr.isDraft === true,
+);
 
 for (const issue of issues) {
   const labels = issue.labels.map((label) => label.name);
@@ -215,6 +221,12 @@ console.log(`missing_canonical_labels=${missingCanonicalLabels.length}`);
 console.log(`noncanonical_agent_labels=${noncanonicalLabels.length}`);
 console.log(`open_prs_missing_agent_label=${missingPrs.length}`);
 console.log(`open_prs_intentionally_unassigned=${intentionallyUnassignedPrs.length}`);
+console.log(
+  `open_ready_prs_intentionally_unassigned=${readyIntentionallyUnassignedPrs.length}`,
+);
+console.log(
+  `open_draft_prs_intentionally_unassigned=${draftIntentionallyUnassignedPrs.length}`,
+);
 console.log(`open_prs_multiple_agent_labels=${multiplePrs.length}`);
 console.log(`open_prs_noncanonical_agent_label=${noncanonicalPrs.length}`);
 console.log(`open_release_issues_missing_agent_label=${missingIssues.length}`);
@@ -235,6 +247,8 @@ const metrics = {
   noncanonical_agent_labels: noncanonicalLabels.length,
   open_prs_missing_agent_label: missingPrs.length,
   open_prs_intentionally_unassigned: intentionallyUnassignedPrs.length,
+  open_ready_prs_intentionally_unassigned: readyIntentionallyUnassignedPrs.length,
+  open_draft_prs_intentionally_unassigned: draftIntentionallyUnassignedPrs.length,
   open_prs_multiple_agent_labels: multiplePrs.length,
   open_prs_noncanonical_agent_label: noncanonicalPrs.length,
   open_release_issues_missing_agent_label: missingIssues.length,
@@ -249,6 +263,10 @@ const summarizeWorkItem = (item) => ({
   number: item.number,
   title: item.title,
   url: item.url ?? null,
+});
+const summarizePrWorkItem = (item) => ({
+  ...summarizeWorkItem(item),
+  is_draft: item.isDraft === true,
 });
 const summarizeLabeledWorkItem = (item) => ({
   ...summarizeWorkItem(item),
@@ -269,7 +287,13 @@ if (process.env.JSON_REPORT) {
     missing_canonical_labels: missingCanonicalLabels,
     noncanonical_agent_labels: noncanonicalLabels,
     open_prs_missing_agent_label: missingPrs.map(summarizeWorkItem),
-    open_prs_intentionally_unassigned: intentionallyUnassignedPrs.map(summarizeWorkItem),
+    open_prs_intentionally_unassigned: intentionallyUnassignedPrs.map(summarizePrWorkItem),
+    open_ready_prs_intentionally_unassigned: readyIntentionallyUnassignedPrs.map(
+      summarizePrWorkItem,
+    ),
+    open_draft_prs_intentionally_unassigned: draftIntentionallyUnassignedPrs.map(
+      summarizePrWorkItem,
+    ),
     open_prs_multiple_agent_labels: multiplePrs.map(summarizeLabeledWorkItem),
     open_prs_noncanonical_agent_label: noncanonicalPrs.map(summarizeLabeledWorkItem),
     open_release_issues_missing_agent_label: missingIssues.map(summarizeWorkItem),
@@ -288,6 +312,16 @@ printRows("Open PRs Missing Agent Label", missingPrs, prRow);
 printRows(
   "Open PRs Intentionally Unassigned",
   intentionallyUnassignedPrs,
+  prRow,
+);
+printRows(
+  "Open Ready PRs Intentionally Unassigned",
+  readyIntentionallyUnassignedPrs,
+  prRow,
+);
+printRows(
+  "Open Draft PRs Intentionally Unassigned",
+  draftIntentionallyUnassignedPrs,
   prRow,
 );
 printRows(

--- a/scripts/agents/test_ensure_agent_labels.py
+++ b/scripts/agents/test_ensure_agent_labels.py
@@ -50,8 +50,8 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
                     fi
 
                     if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
-                      if [[ "$*" != *"--json number,title,labels,body,url"* ]]; then
-                        echo "expected PR audit to request url field: $*" >&2
+                      if [[ "$*" != *"--json number,title,isDraft,labels,body,url"* ]]; then
+                        echo "expected PR audit to request isDraft and url fields: $*" >&2
                         exit 98
                       fi
                       printf '%s\n' "${FAKE_GH_PRS}"
@@ -102,6 +102,7 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
                 {
                     "number": 1,
                     "title": "chore: intentionally unassigned",
+                    "isDraft": True,
                     "labels": [],
                     "body": "Coordination Notes\n- No canonical agent lane was assigned.",
                     "url": "https://github.com/mohsen1/tsz/pull/1",
@@ -109,6 +110,7 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
                 {
                     "number": 2,
                     "title": "fix: owned",
+                    "isDraft": False,
                     "labels": [{"name": "agent:Studio-F"}],
                     "body": "AgentName: Studio-F",
                     "url": "https://github.com/mohsen1/tsz/pull/2",
@@ -118,9 +120,12 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
 
         self.assertIn("open_prs_missing_agent_label=0", output)
         self.assertIn("open_prs_intentionally_unassigned=1", output)
+        self.assertIn("open_ready_prs_intentionally_unassigned=0", output)
+        self.assertIn("open_draft_prs_intentionally_unassigned=1", output)
         self.assertIn("agent_label_audit_findings=0", output)
         self.assertIn("agent_label_audit_status=pass", output)
         self.assertIn("Open PRs Intentionally Unassigned", output)
+        self.assertIn("Open Draft PRs Intentionally Unassigned", output)
         self.assertIn(
             "#1 chore: intentionally unassigned https://github.com/mohsen1/tsz/pull/1",
             output,
@@ -132,6 +137,7 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
                 {
                     "number": 3,
                     "title": "fix: missing label",
+                    "isDraft": False,
                     "labels": [],
                     "body": "AgentName: Studio-F",
                     "url": "https://github.com/mohsen1/tsz/pull/3",
@@ -154,6 +160,7 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
                 {
                     "number": 4,
                     "title": "fix: missing label",
+                    "isDraft": False,
                     "labels": [],
                     "body": "AgentName: Studio-F",
                     "url": "https://github.com/mohsen1/tsz/pull/4",
@@ -174,6 +181,7 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
                 {
                     "number": 5,
                     "title": "chore: intentionally unassigned",
+                    "isDraft": False,
                     "labels": [],
                     "body": "Coordination Notes\n- No canonical agent lane was assigned.",
                     "url": "https://github.com/mohsen1/tsz/pull/5",
@@ -184,8 +192,71 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
 
         self.assertEqual(0, result.returncode)
         self.assertIn("open_prs_intentionally_unassigned=1", result.stdout)
+        self.assertIn("open_ready_prs_intentionally_unassigned=1", result.stdout)
+        self.assertIn("open_draft_prs_intentionally_unassigned=0", result.stdout)
         self.assertIn("agent_label_audit_findings=0", result.stdout)
         self.assertIn("agent_label_audit_status=pass", result.stdout)
+
+    def test_json_report_splits_ready_and_draft_intentionally_unassigned_prs(self):
+        with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
+            report_path = pathlib.Path(temp_dir) / "reports" / "agent-labels.json"
+            result = self.run_audit_result(
+                [
+                    {
+                        "number": 6,
+                        "title": "fix: ready unassigned",
+                        "isDraft": False,
+                        "labels": [],
+                        "body": "Coordination Notes\n- No canonical agent lane was assigned.",
+                        "url": "https://github.com/mohsen1/tsz/pull/6",
+                    },
+                    {
+                        "number": 7,
+                        "title": "fix: draft unassigned",
+                        "isDraft": True,
+                        "labels": [],
+                        "body": "Coordination Notes\n- No canonical agent lane was assigned.",
+                        "url": "https://github.com/mohsen1/tsz/pull/7",
+                    },
+                ],
+                args=["--audit", "--json-report", str(report_path)],
+            )
+
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+
+        self.assertIn("open_prs_intentionally_unassigned=2", result.stdout)
+        self.assertIn("open_ready_prs_intentionally_unassigned=1", result.stdout)
+        self.assertIn("open_draft_prs_intentionally_unassigned=1", result.stdout)
+        self.assertEqual(
+            1,
+            report["metrics"]["open_ready_prs_intentionally_unassigned"],
+        )
+        self.assertEqual(
+            1,
+            report["metrics"]["open_draft_prs_intentionally_unassigned"],
+        )
+        self.assertEqual(
+            [
+                {
+                    "number": 6,
+                    "title": "fix: ready unassigned",
+                    "url": "https://github.com/mohsen1/tsz/pull/6",
+                    "is_draft": False,
+                }
+            ],
+            report["open_ready_prs_intentionally_unassigned"],
+        )
+        self.assertEqual(
+            [
+                {
+                    "number": 7,
+                    "title": "fix: draft unassigned",
+                    "url": "https://github.com/mohsen1/tsz/pull/7",
+                    "is_draft": True,
+                }
+            ],
+            report["open_draft_prs_intentionally_unassigned"],
+        )
 
     def test_audit_flags_release_issues_missing_agent_labels(self):
         output = self.run_audit_with_prs(
@@ -264,6 +335,7 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
                     {
                         "number": 30,
                         "title": "fix: missing owner",
+                        "isDraft": False,
                         "labels": [],
                         "body": "AgentName: Studio-F",
                         "url": "https://github.com/mohsen1/tsz/pull/30",
@@ -271,6 +343,7 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
                     {
                         "number": 31,
                         "title": "fix: generated owner",
+                        "isDraft": False,
                         "labels": [{"name": "agent:dreamy-runner"}],
                         "body": "AgentName: Studio-F",
                         "url": "https://github.com/mohsen1/tsz/pull/31",
@@ -323,6 +396,7 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
                     {
                         "number": 32,
                         "title": "fix: owned",
+                        "isDraft": False,
                         "labels": [{"name": "agent:Studio-F"}],
                         "body": "AgentName: Studio-F",
                         "url": "https://github.com/mohsen1/tsz/pull/32",


### PR DESCRIPTION
AgentName: Studio-F

Track: Studio-F launch infrastructure and cheap coordination evidence

Invariant: When an open PR explicitly says no canonical agent lane was assigned, the label audit should preserve that non-actionable status while still showing whether the PR is ready or draft so queue/coordination readers can distinguish live ready work from parked draft runway.

Scope:
- Request isDraft from gh pr list inside scripts/agents/ensure-agent-labels.sh audit mode.
- Add open_ready_prs_intentionally_unassigned and open_draft_prs_intentionally_unassigned counters.
- Add matching JSON report arrays and human-readable sections.
- Extend focused label-audit tests for ready/draft intentionally unassigned PRs.

Project Corpus Impact:
Row: n/a
Bug family: n/a
Evidence: agent-script-only; no compiler, checker, solver, parser, binder, emitter, LSP, WASM, conformance, or project-corpus behavior changes.

Verification:
- python3 -m unittest scripts.agents.test_ensure_agent_labels
- bash -n scripts/agents/ensure-agent-labels.sh
- git diff --check
- scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-audit-ready-unassigned.json

Coordination Notes:
- Owned Studio-F runway was clear before starting.
- Live audit currently reports 5 intentionally unassigned PRs, split into 1 ready (#12062) and 4 draft (#12054, #12051, #12048, #12002); this PR makes that distinction visible without turning explained unassigned work into actionable audit failures.
- Cache-preserving disk cleanup was attempted this cycle; disk remains low and no inactive sister worktree candidate was reported.