### PR TITLE
perf(bench): aggregate project-row diagnostics in a single linear pass

### DIFF
--- a/scripts/bench/bench-vs-tsgo.sh
+++ b/scripts/bench/bench-vs-tsgo.sh
@@ -1987,6 +1987,7 @@ export_results_json() {
     BENCHMARK_SOURCES_JSONL_VALUE="${BENCHMARK_SOURCES_JSONL:-}" \
     PROJECT_OWNER_FAMILIES_JSON_VALUE="$project_owner_families_json" \
     PROJECT_README_CANDIDATES_JSON_VALUE="$project_readme_candidates_json" \
+    DIAGNOSTIC_SUBSYSTEMS_JSON_PATH="$PROJECT_ROOT/scripts/ci/diagnostic-subsystems.json" \
     node - "$out_file" <<'NODE'
 const fs = require("node:fs");
 const os = require("node:os");
@@ -2146,28 +2147,7 @@ function normalizedDiagnosticDeltas(recorded) {
     .slice(0, 20);
 }
 
-function diagnosticCodesFrom(deltas) {
-  const codes = [];
-  const seen = new Set();
-  for (const line of deltas) {
-    for (const match of line.matchAll(/\bTS\d{4,5}\b/g)) {
-      const code = match[0];
-      if (seen.has(code)) continue;
-      seen.add(code);
-      codes.push(code);
-      if (codes.length >= 8) return codes;
-    }
-  }
-  return codes;
-}
-
-function reductionCandidatesFrom(deltas) {
-  const coded = deltas.filter((line) => /\bTS\d{4,5}\b/.test(line));
-  const source = coded.length ? coded : deltas;
-  return source.slice(0, 5);
-}
-
-function knownBlockersFrom(recorded, diagnosticSubsystems, diagnosticDeltas) {
+function knownBlockersFrom(recorded, diagnosticSubsystems, diagnosticCodes) {
   const existing = Array.isArray(recorded.known_blockers) ? recorded.known_blockers : [];
   if (existing.length) {
     return existing.map(String).filter(Boolean).slice(0, 8);
@@ -2193,43 +2173,62 @@ function knownBlockersFrom(recorded, diagnosticSubsystems, diagnosticDeltas) {
     add(String(group?.subsystem || ""));
   }
 
-  if (!blockers.length && diagnosticCodesFrom(diagnosticDeltas).length) {
+  if (!blockers.length && diagnosticCodes.length) {
     add("unclassified diagnostic mismatch");
   }
 
   return blockers;
 }
 
-const DIAGNOSTIC_SUBSYSTEM_RULES = [
-  ["project-config", new Set(["TS18003", "TS5052", "TS5069", "TS5070", "TS5083", "TS5110", "TS6053", "TS2688"])],
-  ["syntax-parser-jsdoc", new Set(["TS1005", "TS1109", "TS1128", "TS17004", "TS8010", "TS8023", "TS8032"])],
-  ["module-symbol-resolution", new Set(["TS2304", "TS2305", "TS2306", "TS2307", "TS2451", "TS2503", "TS2580", "TS2583", "TS2664", "TS2665", "TS2666", "TS2694"])],
-  ["relations-assignability", new Set(["TS2322", "TS2345", "TS2352", "TS2394", "TS2416", "TS2420", "TS2430", "TS2559", "TS2740", "TS2741", "TS2769"])],
-  ["evaluation-inference-instantiation", new Set(["TS2313", "TS2314", "TS2315", "TS2344", "TS2558", "TS2589", "TS2590", "TS2615", "TS7022"])],
-  ["keyspace-property-indexed", new Set(["TS2339", "TS2353", "TS2536", "TS2537", "TS2538", "TS2540", "TS4111", "TS7053"])],
-  ["flow-narrowing", new Set(["TS2367", "TS2677", "TS2774", "TS18047", "TS18048"])],
-  ["class-this-accessor", new Set(["TS2415", "TS2511", "TS2515", "TS2526", "TS2683", "TS4113", "TS4114"])],
-  ["emit-dts-nameability", new Set(["TS4023", "TS4058", "TS4082", "TS4094", "TS9005", "TS9039"])],
-];
-
-function subsystemForCode(code) {
-  for (const [subsystem, codes] of DIAGNOSTIC_SUBSYSTEM_RULES) {
-    if (codes.has(code)) return subsystem;
-  }
-  return "unclassified diagnostic";
+// The subsystem rules table is shared with `scripts/ci/diagnostic-subsystems.mjs`
+// via `scripts/ci/diagnostic-subsystems.json`. Loading from JSON eliminates
+// the drift between this heredoc and the canonical .mjs module (e.g. the
+// previously missing `contextual-inference` row). The flatten into a single
+// Map gives O(1) `subsystemForCode` lookups vs the old linear scan.
+const DIAGNOSTIC_SUBSYSTEMS_TABLE = JSON.parse(
+  fs.readFileSync(process.env.DIAGNOSTIC_SUBSYSTEMS_JSON_PATH, "utf8"),
+);
+const CODE_TO_SUBSYSTEM = new Map();
+for (const rule of DIAGNOSTIC_SUBSYSTEMS_TABLE.rules) {
+  for (const code of rule.codes) CODE_TO_SUBSYSTEM.set(code, rule.subsystem);
 }
 
-function diagnosticSubsystemsFrom(deltas) {
-  const groups = new Map();
+function subsystemForCode(code) {
+  return CODE_TO_SUBSYSTEM.get(code) || "unclassified diagnostic";
+}
+
+// Single-pass aggregation over a row's diagnostic delta list. The previous
+// `compatibilityFor()` path walked the same list five separate times
+// (subsystems, codes, blocker fallback, output codes, reduction candidates);
+// every bucket downstream now reads from the result of this one walk.
+function aggregateDeltas(deltas) {
+  const subsystemGroups = new Map();
+  const codes = [];
+  const codeSeen = new Set();
+  const coded = [];
+  const uncoded = [];
   for (const line of deltas) {
-    const codes = [...line.matchAll(/\bTS\d{4,5}\b/g)].map((match) => match[0]);
-    const lineCodes = codes.length ? codes : ["uncoded"];
-    for (const code of lineCodes) {
-      const subsystem = code === "uncoded" ? "uncoded diagnostic" : subsystemForCode(code);
-      if (!groups.has(subsystem)) {
-        groups.set(subsystem, { subsystem, codes: [], count: 0, examples: [] });
+    const lineCodes = [];
+    for (const match of line.matchAll(/\bTS\d{4,5}\b/g)) lineCodes.push(match[0]);
+    if (lineCodes.length) {
+      coded.push(line);
+      for (const code of lineCodes) {
+        if (!codeSeen.has(code) && codes.length < 8) {
+          codeSeen.add(code);
+          codes.push(code);
+        }
       }
-      const group = groups.get(subsystem);
+    } else {
+      uncoded.push(line);
+    }
+    const groupKeys = lineCodes.length ? lineCodes : ["uncoded"];
+    for (const code of groupKeys) {
+      const subsystem = code === "uncoded" ? "uncoded diagnostic" : subsystemForCode(code);
+      let group = subsystemGroups.get(subsystem);
+      if (!group) {
+        group = { subsystem, codes: [], count: 0, examples: [] };
+        subsystemGroups.set(subsystem, group);
+      }
       group.count += 1;
       if (code !== "uncoded" && !group.codes.includes(code) && group.codes.length < 8) {
         group.codes.push(code);
@@ -2239,10 +2238,14 @@ function diagnosticSubsystemsFrom(deltas) {
       }
     }
   }
-  return [...groups.values()];
+  return {
+    subsystems: [...subsystemGroups.values()],
+    codes,
+    reductionCandidates: (coded.length ? coded : uncoded).slice(0, 5),
+  };
 }
 
-function normalizedDiagnosticSubsystems(recorded, deltas) {
+function normalizedDiagnosticSubsystems(recorded, aggregate) {
   const existing = Array.isArray(recorded.diagnostic_subsystems) ? recorded.diagnostic_subsystems : [];
   if (existing.length) {
     return existing
@@ -2255,7 +2258,7 @@ function normalizedDiagnosticSubsystems(recorded, deltas) {
       .filter((group) => group.count > 0 || group.codes.length || group.examples.length)
       .slice(0, 8);
   }
-  return diagnosticSubsystemsFrom(deltas).slice(0, 8);
+  return aggregate.subsystems.slice(0, 8);
 }
 
 function lastSuccessfulPhaseFrom(recorded) {
@@ -2307,8 +2310,12 @@ function compatibilityFor(row, compatibilityRows) {
   const recorded = compatibilityRows.get(row.name) || fallbackCompatibility(row);
   if (!recorded) return {};
   const diagnosticDeltas = normalizedDiagnosticDeltas(recorded);
-  const diagnosticSubsystems = normalizedDiagnosticSubsystems(recorded, diagnosticDeltas);
-  const knownBlockers = knownBlockersFrom(recorded, diagnosticSubsystems, diagnosticDeltas);
+  // One walk over diagnosticDeltas populates subsystems, codes, and
+  // reduction candidates. Issue #11598 traced repeated per-row scans of
+  // this list to quadratic-feeling cost when row counts grew.
+  const aggregate = aggregateDeltas(diagnosticDeltas);
+  const diagnosticSubsystems = normalizedDiagnosticSubsystems(recorded, aggregate);
+  const knownBlockers = knownBlockersFrom(recorded, diagnosticSubsystems, aggregate.codes);
   const state = rowStateFrom(recorded);
   return {
     compatibility: {
@@ -2321,10 +2328,10 @@ function compatibilityFor(row, compatibilityRows) {
       last_successful_phase: lastSuccessfulPhaseFrom(recorded),
       diagnostic_status: recorded.diagnostic_status || "unknown",
       diagnostic_deltas: diagnosticDeltas,
-      diagnostic_codes: diagnosticCodesFrom(diagnosticDeltas),
+      diagnostic_codes: aggregate.codes,
       diagnostic_subsystems: diagnosticSubsystems,
       primary_subsystem: recorded.primary_subsystem || diagnosticSubsystems[0]?.subsystem || null,
-      reduction_candidates: reductionCandidatesFrom(diagnosticDeltas),
+      reduction_candidates: aggregate.reductionCandidates,
       emit_status: recorded.emit_status || "not in scope (noEmit project check)",
       dts_status: recorded.dts_status || "not in scope (noEmit project check)",
       known_blockers: knownBlockers,

--- a/scripts/ci/diagnostic-aggregator.mjs
+++ b/scripts/ci/diagnostic-aggregator.mjs
@@ -80,6 +80,16 @@ export function aggregateRowDeltas(deltas, { subsystemFor } = {}) {
   };
   const bodiesBySource = { tsc: [], tsz: [], tsgo: [], unattributed: [] };
   const subsystemGroups = new Map();
+  // Global `codes` list and seen-set track input-order encounter across the
+  // unified delta walk. Recording first-seen codes inline (rather than
+  // re-deriving from `codesBySource` per source) preserves the historical
+  // encounter order when source labels interleave — e.g. a `tsz: TS2322`
+  // line before a `tsc: TS2304` line must report `[TS2322, TS2304]`,
+  // not the source-bucket order `[TS2304, TS2322]`. This invariant feeds
+  // `known_blockers` and summary routing, so reshuffling would change the
+  // recorded row fingerprint without any underlying diagnostic change.
+  const codes = [];
+  const codesSeen = new Set();
   const coded = [];
   const uncoded = [];
   let firstLocation = null;
@@ -110,6 +120,10 @@ export function aggregateRowDeltas(deltas, { subsystemFor } = {}) {
       const sourceCodeList = codesBySource[sourceKey];
       const sourceCodeSeen = codesSeenBySource[sourceKey];
       for (const code of lineCodes) {
+        if (!codesSeen.has(code) && codes.length < CODE_LIMIT) {
+          codesSeen.add(code);
+          codes.push(code);
+        }
         if (!sourceCodeSeen.has(code) && sourceCodeList.length < CODE_LIMIT) {
           sourceCodeSeen.add(code);
           sourceCodeList.push(code);
@@ -143,20 +157,6 @@ export function aggregateRowDeltas(deltas, { subsystemFor } = {}) {
         for (const code of lineCodes) pushUnique(group.codes, code, CODE_LIMIT);
       }
       if (group.examples.length < SUBSYSTEM_EXAMPLE_LIMIT) group.examples.push(line);
-    }
-  }
-
-  // `codes` is the deduped union of the four per-source lists in
-  // encounter order. Maintaining it inline during the walk would duplicate
-  // the per-source dedup state; deriving it once at the end is cleaner.
-  const codes = [];
-  const codesSeen = new Set();
-  for (const sourceKey of ["tsc", "tsz", "tsgo", "unattributed"]) {
-    for (const code of codesBySource[sourceKey]) {
-      if (codes.length >= CODE_LIMIT) break;
-      if (codesSeen.has(code)) continue;
-      codesSeen.add(code);
-      codes.push(code);
     }
   }
 

--- a/scripts/ci/diagnostic-aggregator.mjs
+++ b/scripts/ci/diagnostic-aggregator.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+// Single-pass aggregators for project-row diagnostic data.
+//
+// The structural rule these helpers enforce: every diagnostic-delta list is
+// walked exactly once, and every row list is walked exactly once, with all
+// needed summary buckets (codes, per-source split, subsystem groups, first
+// failure location, reduction candidates, state/oracle counts, top deltas,
+// residency table) populated incrementally on that single pass. Repeated
+// scans of the same diagnostic list per code/family/section are forbidden:
+// they were the source of issue #11598's quadratic blow-up.
+
+import { subsystemForCode } from "./diagnostic-subsystems.mjs";
+
+const DELTA_SOURCE_SET = new Set(["tsc", "tsz", "tsgo"]);
+const SOURCE_LABEL_PATTERN = /^([a-z][\w-]*):\s+(.*)$/;
+const DIAGNOSTIC_CODE_PATTERN = /\bTS\d{4,5}\b/g;
+const PAREN_LOCATION_PATTERN = /^(.+?)\((\d+),(\d+)\):\s+(?:error\s+)?(TS\d{4,5})/;
+const COLON_LOCATION_PATTERN = /^(.+?):(\d+):(\d+)(?:\s+-)?\s+(?:error\s+)?(TS\d{4,5})/;
+
+const CODE_LIMIT = 8;
+const SUBSYSTEM_EXAMPLE_LIMIT = 3;
+const REDUCTION_LIMIT = 5;
+
+// Parses a single diagnostic delta line into the structured location it
+// describes, after stripping any `source: ` label prefix. Returns null when
+// the line is not a parsable `path(line,col): error TSnnnn` or
+// `path:line:col: error TSnnnn` shape. Exported so callers that need to
+// classify an individual line (e.g. summary subsystem lookup) reuse this
+// canonical parser rather than re-implementing the same two regexes.
+export function parseDiagnosticLine(rawLine) {
+  const text = String(rawLine || "").trim();
+  const labelMatch = text.match(SOURCE_LABEL_PATTERN);
+  const body = labelMatch && DELTA_SOURCE_SET.has(labelMatch[1].toLowerCase())
+    ? labelMatch[2].trim()
+    : text;
+  const paren = body.match(PAREN_LOCATION_PATTERN);
+  if (paren) {
+    return { path: paren[1], line: Number(paren[2]), column: Number(paren[3]), code: paren[4] };
+  }
+  const colon = body.match(COLON_LOCATION_PATTERN);
+  if (colon) {
+    return { path: colon[1], line: Number(colon[2]), column: Number(colon[3]), code: colon[4] };
+  }
+  return null;
+}
+
+function pushUnique(target, value, limit) {
+  if (target.length >= limit) return;
+  if (target.includes(value)) return;
+  target.push(value);
+}
+
+// Single-pass aggregation over a row's diagnostic delta list.
+//
+// `deltas` is the canonical (already-trimmed, already-line-capped) list. The
+// returned shape is intentionally a superset so callers can pick the buckets
+// they care about without re-walking the list:
+//
+//   {
+//     codes:                deduped TS codes in encounter order (capped),
+//     codesBySource:        { tsc, tsz, tsgo, unattributed } — deduped codes,
+//     bodiesBySource:       { tsc, tsz, tsgo, unattributed } — body lines,
+//     subsystems:           [{ subsystem, codes, count, examples }],
+//     firstLocation:        first parsable {path,line,column,code} or null,
+//     reductionCandidates:  up to N coded lines, with uncoded fallback,
+//   }
+//
+// `subsystemFor(line, parsedLocation) -> string[] | null` lets callers
+// (e.g. type-challenges row classification) plug a different subsystem
+// classifier into the same single-pass walk instead of re-iterating the
+// delta list. Returning `null` means "use the default code -> subsystem
+// table"; returning `[]` means "skip this line for subsystem grouping".
+//
+// All bucket caps mirror the previous individual helpers exactly, so the
+// fingerprint of the recorded row is unchanged.
+export function aggregateRowDeltas(deltas, { subsystemFor } = {}) {
+  const codesBySource = { tsc: [], tsz: [], tsgo: [], unattributed: [] };
+  const codesSeenBySource = {
+    tsc: new Set(), tsz: new Set(), tsgo: new Set(), unattributed: new Set(),
+  };
+  const bodiesBySource = { tsc: [], tsz: [], tsgo: [], unattributed: [] };
+  const subsystemGroups = new Map();
+  const coded = [];
+  const uncoded = [];
+  let firstLocation = null;
+
+  for (const rawLine of deltas) {
+    const line = String(rawLine || "").trim();
+    const labelMatch = line.match(SOURCE_LABEL_PATTERN);
+    const labeledSource = labelMatch && DELTA_SOURCE_SET.has(labelMatch[1].toLowerCase())
+      ? labelMatch[1].toLowerCase()
+      : null;
+    const body = labeledSource ? labelMatch[2].trim() : line;
+    const sourceKey = labeledSource ?? "unattributed";
+    bodiesBySource[sourceKey].push(body);
+
+    const lineCodes = [];
+    for (const m of body.matchAll(DIAGNOSTIC_CODE_PATTERN)) lineCodes.push(m[0]);
+    const hasCodes = lineCodes.length > 0;
+
+    if (hasCodes) coded.push(line);
+    else uncoded.push(line);
+
+    // Each line is parsed exactly once; the result feeds both
+    // first-location capture and any custom subsystem hook.
+    const parsedLocation = parseDiagnosticLine(line);
+    if (firstLocation === null && parsedLocation) firstLocation = parsedLocation;
+
+    if (hasCodes) {
+      const sourceCodeList = codesBySource[sourceKey];
+      const sourceCodeSeen = codesSeenBySource[sourceKey];
+      for (const code of lineCodes) {
+        if (!sourceCodeSeen.has(code) && sourceCodeList.length < CODE_LIMIT) {
+          sourceCodeSeen.add(code);
+          sourceCodeList.push(code);
+        }
+      }
+    }
+
+    const customSubsystems = subsystemFor ? subsystemFor(line, parsedLocation) : null;
+    let subsystems;
+    if (customSubsystems !== null && customSubsystems !== undefined) {
+      if (customSubsystems.length === 0) continue;
+      subsystems = customSubsystems;
+    } else if (hasCodes) {
+      subsystems = lineCodes.map(subsystemForCode);
+    } else {
+      subsystems = ["uncoded diagnostic"];
+    }
+
+    for (const subsystem of subsystems) {
+      let group = subsystemGroups.get(subsystem);
+      if (!group) {
+        group = { subsystem, codes: [], count: 0, examples: [] };
+        subsystemGroups.set(subsystem, group);
+      }
+      group.count += 1;
+      // Each code on the line still flows into the matching group's code
+      // list when the custom hook returned codes-per-line (default case);
+      // for hooks that return categorical labels we still record codes
+      // because that's what the existing recorded shape expects.
+      if (hasCodes) {
+        for (const code of lineCodes) pushUnique(group.codes, code, CODE_LIMIT);
+      }
+      if (group.examples.length < SUBSYSTEM_EXAMPLE_LIMIT) group.examples.push(line);
+    }
+  }
+
+  // `codes` is the deduped union of the four per-source lists in
+  // encounter order. Maintaining it inline during the walk would duplicate
+  // the per-source dedup state; deriving it once at the end is cleaner.
+  const codes = [];
+  const codesSeen = new Set();
+  for (const sourceKey of ["tsc", "tsz", "tsgo", "unattributed"]) {
+    for (const code of codesBySource[sourceKey]) {
+      if (codes.length >= CODE_LIMIT) break;
+      if (codesSeen.has(code)) continue;
+      codesSeen.add(code);
+      codes.push(code);
+    }
+  }
+
+  const reductionSource = coded.length ? coded : uncoded;
+  const reductionCandidates = reductionSource.slice(0, REDUCTION_LIMIT);
+
+  return {
+    codes,
+    codesBySource,
+    bodiesBySource,
+    subsystems: [...subsystemGroups.values()],
+    firstLocation,
+    reductionCandidates,
+  };
+}
+
+// Single-pass aggregation over a row list for summary generation.
+//
+// Returns:
+//   {
+//     byState:                  { green, yellow, red, gray, ... },
+//     byOracleClassification:   { both-pass, tsz-fails-only, ... },
+//     topDiagnosticDeltas:      up to N items, ordered by row state priority,
+//     residencyByRow:           red+yellow rows, ordered by state priority,
+//   }
+//
+// The function avoids the previous "4 passes over rows + extra sort of all
+// rows" pattern: each row contributes to every bucket as we visit it.
+// State-priority order is preserved by bucketing rows-with-deltas / red /
+// yellow into per-state lists and then stitching them together at the end,
+// which is O(rowsWithDeltas) for stitching versus O(R log R) for sorting.
+export function aggregateRowsForSummary(rows, options = {}) {
+  const {
+    topDeltasLimit = 3,
+    oracleClassifications,
+    stateOrder = ["red", "yellow", "gray", "green"],
+  } = options;
+
+  const byState = {};
+  const byOracleClassification = {};
+  const rowsByStateWithDeltas = { red: [], yellow: [], gray: [], green: [] };
+  const residencyByState = { red: [], yellow: [] };
+
+  for (const row of rows) {
+    const stateKey = row?.state || "unknown";
+    byState[stateKey] = (byState[stateKey] || 0) + 1;
+
+    const rawOracle = row?.oracle_classification;
+    const oracleKey = oracleClassifications && !oracleClassifications.has(rawOracle)
+      ? "unknown"
+      : (rawOracle || "unknown");
+    byOracleClassification[oracleKey] = (byOracleClassification[oracleKey] || 0) + 1;
+
+    if (stateKey === "red" || stateKey === "yellow") {
+      residencyByState[stateKey].push(row);
+    }
+    if (Array.isArray(row?.diagnostic_deltas) && row.diagnostic_deltas.length > 0) {
+      const bucket = rowsByStateWithDeltas[stateKey] || (rowsByStateWithDeltas[stateKey] = []);
+      bucket.push(row);
+    }
+  }
+
+  const topDiagnosticDeltas = [];
+  outer: for (const state of stateOrder) {
+    const bucket = rowsByStateWithDeltas[state];
+    if (!bucket) continue;
+    for (const row of bucket) {
+      const subsystemByLine = new Map();
+      const subsystems = Array.isArray(row.diagnostic_subsystems) ? row.diagnostic_subsystems : [];
+      for (const group of subsystems) {
+        if (!group?.subsystem) continue;
+        for (const example of group.examples || []) {
+          if (!subsystemByLine.has(example)) subsystemByLine.set(example, group.subsystem);
+        }
+      }
+      for (const delta of row.diagnostic_deltas) {
+        const parsed = parseDiagnosticLine(delta) || { path: null, code: null };
+        const subsystem = subsystemByLine.get(delta)
+          || (parsed.code ? subsystemForCode(parsed.code) : "unattributed");
+        topDiagnosticDeltas.push({
+          project: row.name || null,
+          oracle_classification: row.oracle_classification || "unknown",
+          state: row.state || null,
+          code: parsed.code || null,
+          path: parsed.path || null,
+          subsystem,
+          delta,
+        });
+        if (topDiagnosticDeltas.length >= topDeltasLimit) break outer;
+      }
+    }
+  }
+
+  const residencyByRow = [];
+  for (const state of stateOrder) {
+    if (state !== "red" && state !== "yellow") continue;
+    for (const row of residencyByState[state] || []) {
+      residencyByRow.push({
+        project: row?.name || null,
+        state: row?.state || null,
+        files_reached: row?.files_reached ?? null,
+        files_reached_reason: row?.files_reached_reason ?? null,
+        peak_memory_bytes: row?.peak_memory_bytes ?? null,
+        peak_memory_bytes_reason: row?.peak_memory_bytes_reason ?? null,
+      });
+    }
+  }
+
+  return {
+    byState,
+    byOracleClassification,
+    topDiagnosticDeltas,
+    residencyByRow,
+  };
+}
+

--- a/scripts/ci/diagnostic-subsystems.json
+++ b/scripts/ci/diagnostic-subsystems.json
@@ -1,0 +1,80 @@
+{
+  "rules": [
+    {
+      "subsystem": "project-config",
+      "codes": ["TS18003", "TS5052", "TS5069", "TS5070", "TS5083", "TS5110", "TS6053", "TS2688"],
+      "owner_track": "Track 1 project-corpus harness/config",
+      "crate": "bench",
+      "labels": ["bench"]
+    },
+    {
+      "subsystem": "syntax-parser-jsdoc",
+      "codes": ["TS1005", "TS1109", "TS1128", "TS17004", "TS8010", "TS8023", "TS8032"],
+      "owner_track": "Track 8 syntax/parser/jsdoc parity",
+      "crate": "parser",
+      "labels": ["bench", "parser"]
+    },
+    {
+      "subsystem": "module-symbol-resolution",
+      "codes": ["TS2304", "TS2305", "TS2306", "TS2307", "TS2451", "TS2503", "TS2580", "TS2583", "TS2664", "TS2665", "TS2666", "TS2694"],
+      "owner_track": "Track 7 lib/module identity",
+      "crate": "checker",
+      "labels": ["checker"]
+    },
+    {
+      "subsystem": "relations-assignability",
+      "codes": ["TS2322", "TS2345", "TS2352", "TS2394", "TS2416", "TS2420", "TS2430", "TS2559", "TS2740", "TS2741", "TS2769"],
+      "owner_track": "Track 4 relation diagnostics/compatibility",
+      "crate": "solver",
+      "labels": ["solver", "checker"]
+    },
+    {
+      "subsystem": "contextual-inference",
+      "codes": ["TS2347", "TS7006", "TS7031"],
+      "owner_track": "Track 3 inference/session/contextual typing",
+      "crate": "checker",
+      "labels": ["checker", "type-inference"]
+    },
+    {
+      "subsystem": "evaluation-inference-instantiation",
+      "codes": ["TS2313", "TS2314", "TS2315", "TS2344", "TS2558", "TS2589", "TS2590", "TS2615", "TS7022"],
+      "owner_track": "Track 2/3 conditional, mapped, inference, instantiation",
+      "crate": "solver",
+      "labels": ["solver"]
+    },
+    {
+      "subsystem": "keyspace-property-indexed",
+      "codes": ["TS2339", "TS2353", "TS2536", "TS2537", "TS2538", "TS2540", "TS4111", "TS7053"],
+      "owner_track": "Track 5 keyspace/property/indexed access",
+      "crate": "solver",
+      "labels": ["solver"]
+    },
+    {
+      "subsystem": "flow-narrowing",
+      "codes": ["TS2367", "TS2677", "TS2774", "TS18047", "TS18048"],
+      "owner_track": "Track 6 flow/narrowing",
+      "crate": "solver",
+      "labels": ["solver"]
+    },
+    {
+      "subsystem": "class-this-accessor",
+      "codes": ["TS2415", "TS2511", "TS2515", "TS2526", "TS2683", "TS4113", "TS4114"],
+      "owner_track": "Track 4 class/this/accessor compatibility",
+      "crate": "solver",
+      "labels": ["solver", "checker"]
+    },
+    {
+      "subsystem": "emit-dts-nameability",
+      "codes": ["TS4023", "TS4058", "TS4082", "TS4094", "TS9005", "TS9039"],
+      "owner_track": "emit/dts nameability",
+      "crate": "emitter",
+      "labels": ["emitter"]
+    }
+  ],
+  "exit_class_crates": {
+    "runtime-timeout": "bench",
+    "runtime-oom": "bench",
+    "runtime-crash": "bench",
+    "runner-error": "bench"
+  }
+}

--- a/scripts/ci/diagnostic-subsystems.mjs
+++ b/scripts/ci/diagnostic-subsystems.mjs
@@ -1,65 +1,40 @@
 #!/usr/bin/env node
+// Diagnostic-subsystem classification table.
+//
+// The rules table is the single source of truth for mapping TypeScript
+// diagnostic codes to owning subsystems, owner tracks, owning crates, and
+// labels. It lives in `diagnostic-subsystems.json` so JS modules (this file
+// + the `node <<'NODE'` heredoc in `scripts/bench/bench-vs-tsgo.sh`) read
+// the same table and cannot drift.
 
-export const DIAGNOSTIC_SUBSYSTEM_RULES = [
-  ["project-config", new Set(["TS18003", "TS5052", "TS5069", "TS5070", "TS5083", "TS5110", "TS6053", "TS2688"])],
-  ["syntax-parser-jsdoc", new Set(["TS1005", "TS1109", "TS1128", "TS17004", "TS8010", "TS8023", "TS8032"])],
-  ["module-symbol-resolution", new Set(["TS2304", "TS2305", "TS2306", "TS2307", "TS2451", "TS2503", "TS2580", "TS2583", "TS2664", "TS2665", "TS2666", "TS2694"])],
-  ["relations-assignability", new Set(["TS2322", "TS2345", "TS2352", "TS2394", "TS2416", "TS2420", "TS2430", "TS2559", "TS2740", "TS2741", "TS2769"])],
-  ["contextual-inference", new Set(["TS2347", "TS7006", "TS7031"])],
-  ["evaluation-inference-instantiation", new Set(["TS2313", "TS2314", "TS2315", "TS2344", "TS2558", "TS2589", "TS2590", "TS2615", "TS7022"])],
-  ["keyspace-property-indexed", new Set(["TS2339", "TS2353", "TS2536", "TS2537", "TS2538", "TS2540", "TS4111", "TS7053"])],
-  ["flow-narrowing", new Set(["TS2367", "TS2677", "TS2774", "TS18047", "TS18048"])],
-  ["class-this-accessor", new Set(["TS2415", "TS2511", "TS2515", "TS2526", "TS2683", "TS4113", "TS4114"])],
-  ["emit-dts-nameability", new Set(["TS4023", "TS4058", "TS4082", "TS4094", "TS9005", "TS9039"])],
-];
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const TABLE = JSON.parse(fs.readFileSync(path.join(HERE, "diagnostic-subsystems.json"), "utf8"));
+
+export const DIAGNOSTIC_SUBSYSTEM_RULES = TABLE.rules.map(
+  (rule) => [rule.subsystem, new Set(rule.codes)],
+);
 
 const CODE_TO_SUBSYSTEM = new Map();
-for (const [subsystem, codes] of DIAGNOSTIC_SUBSYSTEM_RULES) {
-  for (const code of codes) CODE_TO_SUBSYSTEM.set(code, subsystem);
+for (const rule of TABLE.rules) {
+  for (const code of rule.codes) CODE_TO_SUBSYSTEM.set(code, rule.subsystem);
 }
 
-export const OWNER_TRACK_BY_SUBSYSTEM = new Map([
-  ["project-config", "Track 1 project-corpus harness/config"],
-  ["syntax-parser-jsdoc", "Track 8 syntax/parser/jsdoc parity"],
-  ["module-symbol-resolution", "Track 7 lib/module identity"],
-  ["relations-assignability", "Track 4 relation diagnostics/compatibility"],
-  ["contextual-inference", "Track 3 inference/session/contextual typing"],
-  ["evaluation-inference-instantiation", "Track 2/3 conditional, mapped, inference, instantiation"],
-  ["keyspace-property-indexed", "Track 5 keyspace/property/indexed access"],
-  ["flow-narrowing", "Track 6 flow/narrowing"],
-  ["class-this-accessor", "Track 4 class/this/accessor compatibility"],
-  ["emit-dts-nameability", "emit/dts nameability"],
-]);
+export const OWNER_TRACK_BY_SUBSYSTEM = new Map(
+  TABLE.rules.map((rule) => [rule.subsystem, rule.owner_track]),
+);
 
 export const CRATE_BY_SUBSYSTEM = new Map([
-  ["project-config", "bench"],
-  ["syntax-parser-jsdoc", "parser"],
-  ["module-symbol-resolution", "checker"],
-  ["relations-assignability", "solver"],
-  ["contextual-inference", "checker"],
-  ["evaluation-inference-instantiation", "solver"],
-  ["keyspace-property-indexed", "solver"],
-  ["flow-narrowing", "solver"],
-  ["class-this-accessor", "solver"],
-  ["emit-dts-nameability", "emitter"],
-  ["runtime-timeout", "bench"],
-  ["runtime-oom", "bench"],
-  ["runtime-crash", "bench"],
-  ["runner-error", "bench"],
+  ...TABLE.rules.map((rule) => [rule.subsystem, rule.crate]),
+  ...Object.entries(TABLE.exit_class_crates ?? {}),
 ]);
 
-export const LABELS_BY_SUBSYSTEM = new Map([
-  ["project-config", ["bench"]],
-  ["syntax-parser-jsdoc", ["bench", "parser"]],
-  ["module-symbol-resolution", ["checker"]],
-  ["relations-assignability", ["solver", "checker"]],
-  ["contextual-inference", ["checker", "type-inference"]],
-  ["evaluation-inference-instantiation", ["solver"]],
-  ["keyspace-property-indexed", ["solver"]],
-  ["flow-narrowing", ["solver"]],
-  ["class-this-accessor", ["solver", "checker"]],
-  ["emit-dts-nameability", ["emitter"]],
-]);
+export const LABELS_BY_SUBSYSTEM = new Map(
+  TABLE.rules.map((rule) => [rule.subsystem, rule.labels]),
+);
 
 export function subsystemForCode(code) {
   return CODE_TO_SUBSYSTEM.get(code) ?? "unclassified diagnostic";

--- a/scripts/ci/project-compatibility.mjs
+++ b/scripts/ci/project-compatibility.mjs
@@ -5,18 +5,16 @@ import {
   normalizePath,
   semanticFamiliesForFile,
 } from "./type-challenges-semantic-families.mjs";
+import { ownerTrackForSubsystem } from "./diagnostic-subsystems.mjs";
 import {
-  ownerTrackForSubsystem,
-  subsystemForCode,
-} from "./diagnostic-subsystems.mjs";
+  aggregateRowDeltas,
+  aggregateRowsForSummary,
+  parseDiagnosticLine,
+} from "./diagnostic-aggregator.mjs";
 
 const TYPE_CHALLENGES_PROJECT_ROWS = new Set([
   "type-challenges-solutions-project",
 ]);
-
-const DELTA_SOURCES = ["tsc", "tsz", "tsgo"];
-const DELTA_SOURCE_SET = new Set(DELTA_SOURCES);
-const SOURCE_LABEL_PATTERN = /^([a-z][\w-]*):\s+(.*)$/;
 
 const ORACLE_CLASSIFICATION_ORDER = [
   "both-pass",
@@ -29,7 +27,6 @@ const ORACLE_CLASSIFICATION_ORDER = [
 const ORACLE_CLASSIFICATIONS = new Set(ORACLE_CLASSIFICATION_ORDER);
 
 const ROW_STATE_DISPLAY_ORDER = ["green", "yellow", "red", "gray"];
-const ROW_STATE_PRIORITY = { red: 0, yellow: 1, gray: 2, green: 3 };
 
 // Closed vocabulary for the structured reason a residency field is absent.
 // Null is reserved for "measurement present"; every other value must come
@@ -92,43 +89,20 @@ function splitDeltaLines(value) {
     .filter(Boolean);
 }
 
-function stripSourceLabel(line) {
-  const text = String(line || "").trim();
-  const match = text.match(SOURCE_LABEL_PATTERN);
-  if (!match) return { source: null, body: text };
-  const source = match[1].toLowerCase();
-  if (!DELTA_SOURCE_SET.has(source)) return { source: null, body: text };
-  return { source, body: match[2].trim() };
-}
-
-// Unattributed lines are folded into the tsz bucket downstream because tsz
-// is the active failing side in the common project-row failure path.
-function partitionDeltaBySource(lines) {
-  const buckets = { unattributed: [] };
-  for (const source of DELTA_SOURCES) buckets[source] = [];
-  for (const line of lines) {
-    const { source, body } = stripSourceLabel(line);
-    (source ? buckets[source] : buckets.unattributed).push(body);
-  }
-  return buckets;
-}
-
-function perSourceDeltasFrom(env, unifiedLines) {
-  const explicit = {
-    tsc: env.COMPAT_TSC_DIAGNOSTIC_DELTA,
-    tsz: env.COMPAT_TSZ_DIAGNOSTIC_DELTA,
-    tsgo: env.COMPAT_TSGO_DIAGNOSTIC_DELTA,
-  };
-  const needsPartition = DELTA_SOURCES.some((source) => explicit[source] === undefined);
-  const partitioned = needsPartition
-    ? partitionDeltaBySource(unifiedLines)
-    : { tsc: [], tsz: [], tsgo: [], unattributed: [] };
+// When per-source COMPAT_*_DIAGNOSTIC_DELTA env overrides are set they win
+// over the unified-delta partition; otherwise the per-source bodies come
+// directly from the unified-delta aggregator so the unified list is walked
+// exactly once for both subsystem grouping AND per-source code extraction.
+// `explicit` is taken from the caller so the env triplet is read in exactly
+// one place per row.
+function perSourceDeltasFrom(explicit, aggregate) {
+  const bodiesBySource = aggregate.bodiesBySource;
   return {
-    tsc: explicit.tsc !== undefined ? splitDeltaLines(explicit.tsc) : partitioned.tsc,
+    tsc: explicit.tsc !== undefined ? splitDeltaLines(explicit.tsc) : bodiesBySource.tsc,
     tsz: explicit.tsz !== undefined
       ? splitDeltaLines(explicit.tsz)
-      : [...partitioned.tsz, ...partitioned.unattributed],
-    tsgo: explicit.tsgo !== undefined ? splitDeltaLines(explicit.tsgo) : partitioned.tsgo,
+      : [...bodiesBySource.tsz, ...bodiesBySource.unattributed],
+    tsgo: explicit.tsgo !== undefined ? splitDeltaLines(explicit.tsgo) : bodiesBySource.tsgo,
   };
 }
 
@@ -242,56 +216,6 @@ function fixtureSourcesFrom(value) {
   return sources;
 }
 
-function diagnosticSubsystemsFrom(deltas) {
-  const groups = new Map();
-  for (const line of deltas) {
-    const codes = [...line.matchAll(/\bTS\d{4,5}\b/g)].map((match) => match[0]);
-    const lineCodes = codes.length ? codes : ["uncoded"];
-    for (const code of lineCodes) {
-      const subsystem = code === "uncoded" ? "uncoded diagnostic" : subsystemForCode(code);
-      if (!groups.has(subsystem)) {
-        groups.set(subsystem, { subsystem, codes: [], count: 0, examples: [] });
-      }
-      const group = groups.get(subsystem);
-      group.count += 1;
-      if (code !== "uncoded" && !group.codes.includes(code) && group.codes.length < 8) {
-        group.codes.push(code);
-      }
-      if (group.examples.length < 3) {
-        group.examples.push(line);
-      }
-    }
-  }
-  return [...groups.values()];
-}
-
-function parseDiagnosticDelta(line) {
-  const withoutLabel = String(line || "").replace(/^[a-z][\w-]*:\s+/, "");
-  const parenMatch = withoutLabel.match(
-    /^(.+?)\((\d+),(\d+)\):\s+(?:error\s+)?(TS\d{4,5})/,
-  );
-  if (parenMatch) {
-    return {
-      path: parenMatch[1],
-      code: parenMatch[4],
-    };
-  }
-
-  const colonMatch = withoutLabel.match(
-    /^(.+?):(\d+):(\d+)(?:\s+-)?\s+(?:error\s+)?(TS\d{4,5})/,
-  );
-  if (colonMatch) {
-    return {
-      path: colonMatch[1],
-      code: colonMatch[4],
-    };
-  }
-  return {
-    path: null,
-    code: null,
-  };
-}
-
 function sourceRootsForTypeChallenges() {
   const roots = [];
   const add = (value) => {
@@ -327,52 +251,20 @@ function typeChallengesFamiliesForFile(file, sourceRoots, sourceCache) {
   return ["unknown"];
 }
 
-function typeChallengesDiagnosticSubsystemsFrom(projectName, deltas) {
-  if (!TYPE_CHALLENGES_PROJECT_ROWS.has(projectName)) {
-    return [];
-  }
-
-  const groups = new Map();
+// Plug-in subsystem classifier for the type-challenges project row. Returns
+// the family labels for the line if any match, or null to fall back to the
+// default code -> subsystem table. Returning `[]` would suppress the line
+// for grouping; we instead fall back so the unified aggregator's
+// subsystem-or-uncoded bucket is still populated for non-classifiable lines.
+function typeChallengesSubsystemHook() {
   const sourceRoots = sourceRootsForTypeChallenges();
   const sourceCache = new Map();
-  for (const line of deltas) {
-    const diagnostic = parseDiagnosticDelta(line);
-    const codes = diagnostic.code
-      ? [diagnostic.code]
-      : [...line.matchAll(/\bTS\d{4,5}\b/g)].map((match) => match[0]);
-    const lineCodes = codes.length ? codes : ["uncoded"];
-    const families = typeChallengesFamiliesForFile(diagnostic.path, sourceRoots, sourceCache);
-    if (families.length === 1 && families[0] === "unknown") {
-      continue;
-    }
-
-    for (const family of families) {
-      const subsystem = `type-challenges ${family}`;
-      if (!groups.has(subsystem)) {
-        groups.set(subsystem, { subsystem, codes: [], count: 0, examples: [] });
-      }
-      const group = groups.get(subsystem);
-      group.count += 1;
-      for (const code of lineCodes) {
-        if (code !== "uncoded" && !group.codes.includes(code) && group.codes.length < 8) {
-          group.codes.push(code);
-        }
-      }
-      if (group.examples.length < 3) {
-        group.examples.push(line);
-      }
-    }
-  }
-  return [...groups.values()];
-}
-
-function diagnosticSubsystemsForProject(projectName, deltas) {
-  const typeChallengesSubsystems = typeChallengesDiagnosticSubsystemsFrom(projectName, deltas);
-  return typeChallengesSubsystems.length ? typeChallengesSubsystems : diagnosticSubsystemsFrom(deltas);
-}
-
-function diagnosticCodesFrom(deltas) {
-  return codesFromLines(deltas, 8);
+  return (_line, parsedLocation) => {
+    const filePath = parsedLocation?.path ?? null;
+    const families = typeChallengesFamiliesForFile(filePath, sourceRoots, sourceCache);
+    if (families.length === 1 && families[0] === "unknown") return null;
+    return families.map((family) => `type-challenges ${family}`);
+  };
 }
 
 function knownBlockersFrom({ exitClass, phase, diagnosticSubsystems, diagnosticCodes }) {
@@ -453,47 +345,25 @@ function relativeToFixture(value) {
   return value;
 }
 
-function firstDiagnosticLocation(diagnosticDeltas) {
-  for (const line of diagnosticDeltas) {
-    const withoutLabel = String(line || "").replace(/^[a-z][\w-]*:\s+/, "");
-    const parenMatch = withoutLabel.match(/^(.+?)\((\d+),(\d+)\):\s+(?:error\s+)?(TS\d{4,5})/);
-    if (parenMatch) {
-      return {
-        path: relativeToFixture(parenMatch[1]),
-        line: Number(parenMatch[2]),
-        column: Number(parenMatch[3]),
-        code: parenMatch[4],
-      };
-    }
-
-    const colonMatch = withoutLabel.match(/^(.+?):(\d+):(\d+)(?:\s+-)?\s+(?:error\s+)?(TS\d{4,5})/);
-    if (colonMatch) {
-      return {
-        path: relativeToFixture(colonMatch[1]),
-        line: Number(colonMatch[2]),
-        column: Number(colonMatch[3]),
-        code: colonMatch[4],
-      };
-    }
-  }
-  return null;
-}
-
-function reproFrom(diagnosticDeltas) {
-  const location = firstDiagnosticLocation(diagnosticDeltas);
+// Builds the repro payload from the aggregator's first-failure location.
+// The aggregator captures the location during its single walk over the delta
+// list, so the delta list is not re-scanned here. `relativeToFixture` is
+// applied to the path at the boundary (raw paths flow into the aggregator).
+function reproFrom(rawLocation) {
+  const relativePath = rawLocation ? relativeToFixture(rawLocation.path) : null;
   const tsconfigPath = relativeToFixture(process.env.COMPAT_TSCONFIG_PATH || "");
   const sourceRoot = relativeToFixture(process.env.COMPAT_SOURCE_ROOT || "");
-  const reducedReproPath = location?.path || sourceRoot || tsconfigPath || null;
+  const reducedReproPath = relativePath || sourceRoot || tsconfigPath || null;
   const tszCommandEnvPrefix = String(process.env.COMPAT_TSZ_COMMAND_ENV_PREFIX || "").trim();
   const commandPrefix = tszCommandEnvPrefix ? `${tszCommandEnvPrefix} ` : "";
 
   return {
     tsconfig_path: tsconfigPath,
     source_root: sourceRoot,
-    first_failure_path: location?.path || null,
-    first_failure_line: location?.line ?? null,
-    first_failure_column: location?.column ?? null,
-    first_failure_code: location?.code || null,
+    first_failure_path: relativePath || null,
+    first_failure_line: rawLocation?.line ?? null,
+    first_failure_column: rawLocation?.column ?? null,
+    first_failure_code: rawLocation?.code || null,
     reduced_repro_path: reducedReproPath,
     command: tsconfigPath ? `${commandPrefix}$TSZ_BIN --noEmit -p ${tsconfigPath}` : null,
   };
@@ -578,17 +448,45 @@ function record() {
     process.exit(1);
   }
 
-  const diagnosticSubsystems = diagnosticSubsystemsForProject(projectName, diagnosticDeltas);
-  const diagnosticCodes = diagnosticCodesFrom(diagnosticDeltas);
+  // One linear walk over the canonical (capped) delta list populates every
+  // bucket downstream: subsystem groups, deduped codes, per-source bodies,
+  // and the first-failure location. Type-challenges family classification
+  // piggybacks on the same walk via the subsystem hook so the delta list
+  // is never re-iterated for that project family either.
+  const aggregate = aggregateRowDeltas(diagnosticDeltas, {
+    subsystemFor: TYPE_CHALLENGES_PROJECT_ROWS.has(projectName)
+      ? typeChallengesSubsystemHook()
+      : undefined,
+  });
+  const diagnosticSubsystems = aggregate.subsystems;
+  const diagnosticCodes = aggregate.codes;
 
   const tscExitCodes = toExitCodes(process.env.COMPAT_TSC_EXIT_CODES);
   const tszExitCodes = toExitCodes(process.env.COMPAT_TSZ_EXIT_CODES);
   const tsgoExitCodes = toExitCodes(process.env.COMPAT_TSGO_EXIT_CODES);
 
-  const perSourceDeltas = perSourceDeltasFrom(process.env, diagnosticDeltas);
-  const tscDiagnosticCodes = codesFromLines(perSourceDeltas.tsc, 8);
-  const tszDiagnosticCodes = codesFromLines(perSourceDeltas.tsz, 8);
-  const tsgoDiagnosticCodes = codesFromLines(perSourceDeltas.tsgo, 8);
+  // env reads, per-source body partition, and per-source code lists are all
+  // derived from a single shared `explicit` object so each env var is read
+  // exactly once even though it gates multiple downstream decisions.
+  const explicit = {
+    tsc: process.env.COMPAT_TSC_DIAGNOSTIC_DELTA,
+    tsz: process.env.COMPAT_TSZ_DIAGNOSTIC_DELTA,
+    tsgo: process.env.COMPAT_TSGO_DIAGNOSTIC_DELTA,
+  };
+  const perSourceDeltas = perSourceDeltasFrom(explicit, aggregate);
+  const tscDiagnosticCodes = explicit.tsc !== undefined
+    ? codesFromLines(perSourceDeltas.tsc, 8)
+    : aggregate.codesBySource.tsc;
+  // Unattributed bodies fold into the tsz bucket (the active failing side
+  // in the common project-row failure path). Both source lists are already
+  // deduped and capped at CODE_LIMIT by the aggregator, so the merge is
+  // bounded and small enough to express inline.
+  const tszDiagnosticCodes = explicit.tsz !== undefined
+    ? codesFromLines(perSourceDeltas.tsz, 8)
+    : [...new Set([...aggregate.codesBySource.tsz, ...aggregate.codesBySource.unattributed])].slice(0, 8);
+  const tsgoDiagnosticCodes = explicit.tsgo !== undefined
+    ? codesFromLines(perSourceDeltas.tsgo, 8)
+    : aggregate.codesBySource.tsgo;
 
   const oracleClassification = oracleClassificationFrom({
     tscExitCodes,
@@ -604,7 +502,7 @@ function record() {
   const exitClass = process.env.COMPAT_EXIT_CLASS || "unknown";
   const diagnosticStatus = process.env.COMPAT_DIAGNOSTIC_STATUS || "unknown";
   const state = rowStateFrom({ exitClass, diagnosticStatus });
-  const repro = reproFrom(diagnosticDeltas);
+  const repro = reproFrom(aggregate.firstLocation);
   const knownBlockers = knownBlockersFrom({
     exitClass,
     phase: process.env.COMPAT_PHASE || "unknown",
@@ -684,66 +582,6 @@ function record() {
   fs.appendFileSync(outputFile, `${JSON.stringify(row)}\n`, "utf8");
 }
 
-function topDiagnosticDeltasFrom(rows, limit) {
-  const priority = (state) => ROW_STATE_PRIORITY[state] ?? 4;
-  const sorted = rows
-    .filter((row) => Array.isArray(row?.diagnostic_deltas) && row.diagnostic_deltas.length > 0)
-    .sort((a, b) => priority(a.state) - priority(b.state));
-
-  const items = [];
-  for (const row of sorted) {
-    const deltas = row.diagnostic_deltas;
-
-    const subsystemByLine = new Map();
-    const subsystems = Array.isArray(row.diagnostic_subsystems) ? row.diagnostic_subsystems : [];
-    for (const group of subsystems) {
-      if (!group?.subsystem) continue;
-      for (const example of group.examples || []) {
-        if (!subsystemByLine.has(example)) {
-          subsystemByLine.set(example, group.subsystem);
-        }
-      }
-    }
-
-    for (const delta of deltas) {
-      const parsed = parseDiagnosticDelta(delta);
-      const subsystem = subsystemByLine.get(delta)
-        || (parsed.code ? subsystemForCode(parsed.code) : "unattributed");
-      items.push({
-        project: row.name || null,
-        oracle_classification: row.oracle_classification || "unknown",
-        state: row.state || null,
-        code: parsed.code || null,
-        path: parsed.path || null,
-        subsystem,
-        delta,
-      });
-      if (items.length >= limit) return items;
-    }
-  }
-  return items;
-}
-
-// Residency facts (files_reached, peak_memory_bytes) are surfaced for every
-// red/yellow row so a reader can distinguish semantic failure from runner /
-// timeout / OOM / scale failure without scrolling through full row JSON.
-// Rows with neither a measurement nor a reason are still listed; the table
-// would otherwise hide schema gaps.
-function residencyByRowFrom(rows) {
-  const priority = (state) => ROW_STATE_PRIORITY[state] ?? 4;
-  return rows
-    .filter((row) => row?.state === "red" || row?.state === "yellow")
-    .sort((a, b) => priority(a.state) - priority(b.state))
-    .map((row) => ({
-      project: row.name || null,
-      state: row.state || null,
-      files_reached: row.files_reached ?? null,
-      files_reached_reason: row.files_reached_reason ?? null,
-      peak_memory_bytes: row.peak_memory_bytes ?? null,
-      peak_memory_bytes_reason: row.peak_memory_bytes_reason ?? null,
-    }));
-}
-
 function summarize() {
   const generatedAt = new Date().toISOString();
   const { rows, malformedLineCount, malformedExamples } = readRows(process.env.SUMMARY_JSONL_FILE || "");
@@ -759,25 +597,35 @@ function summarize() {
     console.error(`error: ${error.message}`);
     process.exit(1);
   }
-  const byState = rows.reduce((counts, row) => {
-    const key = row.state || rowStateFrom({
-      exitClass: row.exit_class,
-      diagnosticStatus: row.diagnostic_status,
-    });
-    counts[key] = (counts[key] || 0) + 1;
-    return counts;
-  }, {});
 
-  const byOracleClassification = rows.reduce((counts, row) => {
-    const key = ORACLE_CLASSIFICATIONS.has(row.oracle_classification)
-      ? row.oracle_classification
-      : "unknown";
-    counts[key] = (counts[key] || 0) + 1;
-    return counts;
-  }, {});
+  // Ensure every row has a `state` populated before the single-pass
+  // aggregator runs. Recorded rows already carry `state`; the few that
+  // don't (legacy fixtures, malformed manual inputs) get derived once
+  // here so the aggregator stays a pure data-flow function.
+  for (const row of rows) {
+    if (!row?.state) {
+      row.state = rowStateFrom({
+        exitClass: row?.exit_class,
+        diagnosticStatus: row?.diagnostic_status,
+      });
+    }
+  }
 
-  const firstDiagnosticDeltas = topDiagnosticDeltasFrom(rows, 3);
-  const residencyByRow = residencyByRowFrom(rows);
+  // Single-pass row aggregation: by_state, by_oracle_classification, top
+  // diagnostic deltas, and the residency table are all built in one walk
+  // over `rows`. The old code path had four separate scans (two reduces,
+  // a filter+sort+iter+map for top deltas, and another filter+sort+map for
+  // residency) which scaled superlinearly when every row carried up to 20
+  // diagnostic delta lines.
+  const {
+    byState,
+    byOracleClassification,
+    topDiagnosticDeltas: firstDiagnosticDeltas,
+    residencyByRow,
+  } = aggregateRowsForSummary(rows, {
+    topDeltasLimit: 3,
+    oracleClassifications: ORACLE_CLASSIFICATIONS,
+  });
 
   const summary = {
     ...artifactMetadata(process.env, "SUMMARY", generatedAt),

--- a/scripts/ci/test-diagnostic-aggregator.mjs
+++ b/scripts/ci/test-diagnostic-aggregator.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import {
+  aggregateRowDeltas,
+  aggregateRowsForSummary,
+  parseDiagnosticLine,
+} from "./diagnostic-aggregator.mjs";
+
+// Basic shape: codes are deduped in encounter order; subsystems group by
+// owning track; firstLocation captures the first parsable line; per-source
+// buckets are populated from the source label.
+{
+  const deltas = [
+    "tsc: src/a.ts(1,1): error TS2304: Cannot find name 'foo'.",
+    "tsz: src/b.ts(2,2): error TS2322: assignability failed.",
+    "tsz: src/b.ts(3,3): error TS2322: assignability failed again.",
+    "src/c.ts(4,4): error TS2345: argument mismatch.",
+  ];
+  const agg = aggregateRowDeltas(deltas);
+  assert.deepEqual(agg.codes, ["TS2304", "TS2322", "TS2345"]);
+  assert.deepEqual(agg.codesBySource.tsc, ["TS2304"]);
+  assert.deepEqual(agg.codesBySource.tsz, ["TS2322"]);
+  assert.deepEqual(agg.codesBySource.tsgo, []);
+  assert.deepEqual(agg.codesBySource.unattributed, ["TS2345"]);
+  assert.equal(agg.bodiesBySource.tsc.length, 1);
+  assert.equal(agg.bodiesBySource.tsz.length, 2);
+  assert.equal(agg.bodiesBySource.unattributed.length, 1);
+  assert.equal(agg.firstLocation.code, "TS2304");
+  assert.equal(agg.firstLocation.path, "src/a.ts");
+  assert.equal(agg.firstLocation.line, 1);
+
+  const subsystems = Object.fromEntries(agg.subsystems.map((g) => [g.subsystem, g]));
+  assert.equal(subsystems["module-symbol-resolution"].count, 1);
+  assert.equal(subsystems["relations-assignability"].count, 3);
+}
+
+// Single-pass property: aggregateRowDeltas must populate every output bucket
+// using a single linear walk. Drive that with a counted accessor and assert
+// each delta line is read at most once for bucket population.
+{
+  const lines = Array.from({ length: 64 }, (_, i) => `tsz: src/x${i}.ts(${i + 1},1): error TS2322: m${i}`);
+  let reads = 0;
+  const probe = new Proxy(lines, {
+    get(target, key) {
+      if (typeof key === "string" && /^\d+$/.test(key)) reads++;
+      return Reflect.get(target, key);
+    },
+  });
+  aggregateRowDeltas(probe);
+  // We expect one read per element (the for..of iteration). Subsystem rules
+  // are looked up O(1) via the Map, so no per-line constant blow-up.
+  assert.ok(reads <= lines.length + 2, `expected ~${lines.length} reads, got ${reads}`);
+}
+
+// Uncoded lines fall into the "uncoded diagnostic" subsystem and are kept
+// out of the codes list. They still seed reductionCandidates as a fallback.
+{
+  const agg = aggregateRowDeltas([
+    "tsz: runner note without a diagnostic code",
+    "tsz: another note",
+  ]);
+  assert.deepEqual(agg.codes, []);
+  assert.equal(agg.subsystems.length, 1);
+  assert.equal(agg.subsystems[0].subsystem, "uncoded diagnostic");
+  assert.equal(agg.subsystems[0].count, 2);
+  assert.equal(agg.reductionCandidates.length, 2);
+  assert.equal(agg.firstLocation, null);
+}
+
+// Reduction candidates prefer coded lines when any exist.
+{
+  const agg = aggregateRowDeltas([
+    "src/a.ts(1,1): error TS2322: coded",
+    "tsz: note without code",
+    "src/b.ts(2,2): error TS2345: coded too",
+  ]);
+  assert.equal(agg.reductionCandidates.length, 2);
+  assert.ok(agg.reductionCandidates[0].includes("TS2322"));
+  assert.ok(agg.reductionCandidates[1].includes("TS2345"));
+}
+
+// Caps mirror the previous individual helpers exactly (deduped to 8 codes,
+// 8 subsystem codes, 3 examples per group, 5 reduction candidates).
+{
+  const lines = Array.from({ length: 30 }, (_, i) => `tsz: src/x.ts(1,1): error TS23${String(i).padStart(2, "0")}: m`);
+  const agg = aggregateRowDeltas(lines);
+  assert.equal(agg.codes.length, 8);
+  // First 8 unique codes win.
+  assert.equal(agg.codes[0], "TS2300");
+  assert.equal(agg.codes[7], "TS2307");
+  assert.equal(agg.reductionCandidates.length, 5);
+  for (const group of agg.subsystems) {
+    assert.ok(group.codes.length <= 8);
+    assert.ok(group.examples.length <= 3);
+  }
+}
+
+// summary aggregator: state counts + oracle counts + top deltas +
+// residency table built in one row pass with state-priority ordering.
+{
+  const rows = [
+    { name: "alpha", state: "green", oracle_classification: "both-pass", diagnostic_deltas: [], diagnostic_subsystems: [] },
+    {
+      name: "beta",
+      state: "yellow",
+      oracle_classification: "tsz-fails-only",
+      diagnostic_deltas: [
+        "src/index.ts(1,1): error TS2322: mismatch one",
+        "src/index.ts(2,2): error TS2322: mismatch two",
+      ],
+      diagnostic_subsystems: [
+        {
+          subsystem: "relations-assignability",
+          codes: ["TS2322"],
+          count: 2,
+          examples: [
+            "src/index.ts(1,1): error TS2322: mismatch one",
+            "src/index.ts(2,2): error TS2322: mismatch two",
+          ],
+        },
+      ],
+      files_reached: 200,
+      files_reached_reason: null,
+      peak_memory_bytes: null,
+      peak_memory_bytes_reason: "not measured on platform",
+    },
+    {
+      name: "gamma",
+      state: "red",
+      oracle_classification: "tsc-fails-only",
+      diagnostic_deltas: ["tsc: src/a.ts(1,1): error TS2304: Cannot find name 'foo'."],
+      diagnostic_subsystems: [
+        {
+          subsystem: "module-symbol-resolution",
+          codes: ["TS2304"],
+          count: 1,
+          examples: ["tsc: src/a.ts(1,1): error TS2304: Cannot find name 'foo'."],
+        },
+      ],
+      files_reached: null,
+      files_reached_reason: "runner did not count",
+      peak_memory_bytes: null,
+      peak_memory_bytes_reason: "process exited before sampling",
+    },
+  ];
+
+  const result = aggregateRowsForSummary(rows, {
+    topDeltasLimit: 3,
+  });
+
+  assert.deepEqual(result.byState, { green: 1, yellow: 1, red: 1 });
+  assert.deepEqual(result.byOracleClassification, {
+    "both-pass": 1,
+    "tsc-fails-only": 1,
+    "tsz-fails-only": 1,
+  });
+  assert.equal(result.topDiagnosticDeltas.length, 3);
+  // Red rows come first by priority ordering.
+  assert.equal(result.topDiagnosticDeltas[0].project, "gamma");
+  assert.equal(result.topDiagnosticDeltas[0].subsystem, "module-symbol-resolution");
+  assert.equal(result.topDiagnosticDeltas[1].project, "beta");
+  assert.equal(result.topDiagnosticDeltas[2].project, "beta");
+  // Residency includes only red + yellow rows, in priority order.
+  assert.equal(result.residencyByRow.length, 2);
+  assert.equal(result.residencyByRow[0].project, "gamma");
+  assert.equal(result.residencyByRow[0].peak_memory_bytes_reason, "process exited before sampling");
+  assert.equal(result.residencyByRow[1].project, "beta");
+}
+
+// The subsystemFor hook lets callers (e.g. type-challenges) classify lines
+// without re-iterating the delta list outside the single pass.
+{
+  const deltas = [
+    "src/a.ts(1,1): error TS2322: assignability failed.",
+    "src/b.ts(2,2): error TS2345: argument mismatch.",
+  ];
+  let calls = 0;
+  const agg = aggregateRowDeltas(deltas, {
+    subsystemFor: (_line, parsed) => {
+      calls++;
+      return parsed?.path?.startsWith("src/a.") ? ["type-challenges utility"] : null;
+    },
+  });
+  // Hook fires once per line (single pass).
+  assert.equal(calls, deltas.length);
+  const labels = agg.subsystems.map((g) => g.subsystem).sort();
+  assert.deepEqual(labels, ["relations-assignability", "type-challenges utility"]);
+  const tcGroup = agg.subsystems.find((g) => g.subsystem === "type-challenges utility");
+  assert.equal(tcGroup.count, 1);
+  assert.deepEqual(tcGroup.codes, ["TS2322"]);
+}
+
+// The exported parseDiagnosticLine handles colon-style locations the
+// aggregator's other tests don't otherwise drive; this guards both shapes
+// of the canonical parser since callers (type-challenges hook etc.)
+// depend on a single source of truth.
+{
+  assert.deepEqual(
+    parseDiagnosticLine("src/a.ts:5:6 - error TS2322: bad."),
+    { path: "src/a.ts", line: 5, column: 6, code: "TS2322" },
+  );
+  assert.equal(parseDiagnosticLine("noise without a location"), null);
+}
+
+// Linear scaling property: doubling the row count + diagnostic count must
+// roughly double the work, not quadruple it. Concretely: the number of
+// per-line callback invocations the aggregator makes scales as O(R * D)
+// not O((R * D)^2). We exercise this by counting how many times we touch
+// each delta string via Proxy reads.
+{
+  function makeRows(rowCount, deltasPerRow) {
+    return Array.from({ length: rowCount }, (_, r) => ({
+      name: `row-${r}`,
+      state: r % 3 === 0 ? "red" : r % 3 === 1 ? "yellow" : "green",
+      oracle_classification: "tsz-fails-only",
+      diagnostic_deltas: Array.from(
+        { length: deltasPerRow },
+        (_, d) => `src/r${r}d${d}.ts(${d + 1},1): error TS2322: m${d}`,
+      ),
+      diagnostic_subsystems: [],
+    }));
+  }
+
+  function countDeltaReads(rows) {
+    let reads = 0;
+    const wrapped = rows.map((row) => ({
+      ...row,
+      diagnostic_deltas: new Proxy(row.diagnostic_deltas, {
+        get(target, key) {
+          if (typeof key === "string" && /^\d+$/.test(key)) reads++;
+          return Reflect.get(target, key);
+        },
+      }),
+    }));
+    aggregateRowsForSummary(wrapped, { topDeltasLimit: 3 });
+    return reads;
+  }
+
+  // Top deltas is capped at 3, so once we've found 3 we stop walking. The
+  // important invariant is: number of delta reads <= 3 (it never iterates
+  // beyond the limit, regardless of total row/delta counts).
+  const small = countDeltaReads(makeRows(5, 4));
+  const big = countDeltaReads(makeRows(50, 40));
+  assert.ok(small <= 3, `small reads should be <= 3, got ${small}`);
+  assert.ok(big <= 3, `big reads should be <= 3, got ${big}`);
+}
+
+console.log("test-diagnostic-aggregator: all tests passed");

--- a/scripts/ci/test-diagnostic-aggregator.mjs
+++ b/scripts/ci/test-diagnostic-aggregator.mjs
@@ -34,6 +34,24 @@ import {
   assert.equal(subsystems["relations-assignability"].count, 3);
 }
 
+// Encounter-order regression: when source labels interleave, the global
+// `codes` list must reflect input order, NOT the source-bucket order. A
+// previous refactor derived `codes` post-walk by iterating buckets in the
+// fixed sequence (tsc, tsz, tsgo, unattributed); that reshuffled the order
+// recorded into row.diagnostic_codes when a `tsz:` line preceded a `tsc:`
+// line, which downstream feeds known_blockers/summary routing.
+{
+  const agg = aggregateRowDeltas([
+    "tsz: src/a.ts(1,1): error TS2322: assignability failed.",
+    "tsc: src/b.ts(2,2): error TS2304: Cannot find name 'foo'.",
+    "tsz: src/c.ts(3,3): error TS2345: argument mismatch.",
+  ]);
+  assert.deepEqual(agg.codes, ["TS2322", "TS2304", "TS2345"]);
+  // Per-source codes still group by source.
+  assert.deepEqual(agg.codesBySource.tsz, ["TS2322", "TS2345"]);
+  assert.deepEqual(agg.codesBySource.tsc, ["TS2304"]);
+}
+
 // Single-pass property: aggregateRowDeltas must populate every output bucket
 // using a single linear walk. Drive that with a counted accessor and assert
 // each delta line is read at most once for bucket population.


### PR DESCRIPTION
AgentName: m3-max-64g-opus47
Track: Bench / project-row tooling (Studio-B lane handoff for issue #11598)
Invariant: project-row summary build walks every diagnostic-delta list and every row list exactly once; quadratic re-scans per code/family/section are forbidden by structure, not by convention.

## Scope

Closes #11598. Implements the structural rule the issue calls out:

> "Project row summary generation should aggregate diagnostics in a single
> linear pass, preserving stable ordering and counts without repeatedly
> scanning the full diagnostic list for every row, code, family, or
> summary section."

### Before

- `scripts/ci/project-compatibility.mjs` `record()`: 4-7 separate scans of the same delta list per row (subsystems, codes, per-source split, per-source codes, first-failure location, reduction candidates).
- `scripts/ci/project-compatibility.mjs` `summarize()`: 4 separate scans over rows (`by_state` reduce, `by_oracle_classification` reduce, `topDiagnosticDeltasFrom` filter+sort+iter+map, `residencyByRowFrom` filter+sort+map).
- `scripts/bench/bench-vs-tsgo.sh` `compatibilityFor()` (embedded JS): 5 separate scans of each row's deltas. Also: linear-scan `subsystemForCode` (no `Map` lookup).
- Pre-existing bench/CI rules-table drift: the bench heredoc was missing the `contextual-inference` subsystem row.

### After

- New `scripts/ci/diagnostic-aggregator.mjs` with two single-pass aggregators:
  - `aggregateRowDeltas(deltas, { subsystemFor })` — codes, codes-by-source, bodies-by-source, subsystem groups, first-failure location, reduction candidates, all from one walk. Optional `subsystemFor(line, parsedLocation)` hook lets type-challenges family classification piggyback on the same walk instead of re-iterating.
  - `aggregateRowsForSummary(rows, { topDeltasLimit, oracleClassifications })` — `by_state`, `by_oracle_classification`, top diagnostic deltas, residency table, all from one walk.
- `record()` and `summarize()` route through these. Removed `diagnosticSubsystemsFrom`, `diagnosticSubsystemsForProject`, `diagnosticCodesFrom`, `firstDiagnosticLocation`, `topDiagnosticDeltasFrom`, `residencyByRowFrom`, `partitionDeltaBySource`, `stripSourceLabel`, `parseDiagnosticDelta`, and the standalone `typeChallengesDiagnosticSubsystemsFrom` (folded into the `subsystemFor` hook).
- `compatibilityFor()` in `bench-vs-tsgo.sh` uses one walk via an inlined `aggregateDeltas`. Replaced linear `subsystemForCode` with a `CODE_TO_SUBSYSTEM` `Map` (O(1) lookup).
- Eliminated the bench/CI rules-table drift: `DIAGNOSTIC_SUBSYSTEM_RULES` plus owner-track / crate / labels metadata moved to `scripts/ci/diagnostic-subsystems.json`, loaded by both `scripts/ci/diagnostic-subsystems.mjs` and the bench heredoc (via a `DIAGNOSTIC_SUBSYSTEMS_JSON_PATH` env var). The previously missing `contextual-inference` row is now consistent across both consumers.

## Tests

- New `scripts/ci/test-diagnostic-aggregator.mjs` — covers shape, caps, `subsystemFor` hook, and the canonical parser. The **structural regression for #11598** is a Proxy-counted delta-read test: regardless of row count (5/4 deltas vs 50/40 deltas vs anything), the number of indexed reads into any row's `diagnostic_deltas` is bounded by `topDeltasLimit`. A quadratic regression would push it past the cap and fail.
- Existing `scripts/ci/test-project-compatibility.mjs`, `scripts/bench/test-project-row-summary.mjs`, `scripts/bench/test-reduction-backlog.mjs` all pass unchanged (the public schema of the recorded row and the summary artifact is unchanged).

## Project Corpus Impact

- Row: nextjs (the witness in #11598), applies uniformly to every project row's summary build.
- Bug family: bench/project-corpus tooling complexity (quadratic aggregation on diagnostic lists).
- Evidence: structural Proxy-counted-reads test in `scripts/ci/test-diagnostic-aggregator.mjs` proves the per-row delta list is read at most `topDeltasLimit` (3) times regardless of fixture size. Local commands: `node scripts/ci/test-project-compatibility.mjs`, `node scripts/ci/test-diagnostic-aggregator.mjs`, `node scripts/bench/test-project-row-summary.mjs`, `node scripts/bench/test-reduction-backlog.mjs` — all pass.

## Verification

- `node scripts/ci/test-project-compatibility.mjs` — pass.
- `node scripts/ci/test-diagnostic-aggregator.mjs` — pass.
- `node scripts/bench/test-project-row-summary.mjs` — pass.
- `node scripts/bench/test-reduction-backlog.mjs` — pass.
- `bash -n scripts/bench/bench-vs-tsgo.sh` — pass.
- Embedded node heredoc syntax-checked with `node --check`.

## Coordination Notes

- Ran `/simplify` three rounds before opening. Round 1: dropped duplicate parser, folded type-challenges into the `subsystemFor` hook, removed dead helpers. Round 2: dropped redundant `classifyState` callback, inlined `splitSourceLabel`, extracted the rules table to shared JSON. Round 3: dropped `parsedFor` closure (parse unconditionally once per line) and inlined `mergeCodesCapped`.
- Out-of-scope follow-up: rewrite the `node <<'NODE'` heredoc in `bench-vs-tsgo.sh` as a standalone `.mjs` script so it can `import` the aggregator module directly. The shared JSON rules table eliminated the actual drift surface (different code sets) without that bigger refactor; the algorithm copy is small (≈40 LoC) and now provably backed by the same per-line CPU profile because the rules input is identical.
- Not roadmap-affecting: this is bench tooling complexity work, not a track-sequencing or release-gate change. No `docs/plan/ROADMAP.md` update.

---
_Generated by [Claude Code](https://claude.ai/code/session_017wL3cUGkf7SXGDS5iRKnns)_