### PR TITLE
chore(emit-tools): expose exhausted output surgery categories

### DIFF
--- a/scripts/emit/audit-output-surgery.py
+++ b/scripts/emit/audit-output-surgery.py
@@ -306,6 +306,14 @@ def summarize_budget(file_summaries: list[dict[str, object]]) -> BudgetSummary:
     )
 
 
+def exhausted_category_names(file_summaries: list[dict[str, object]]) -> list[str]:
+    return [
+        str(summary["category"])
+        for summary in build_category_summaries(file_summaries)
+        if summary["max_count"] is not None and summary["budget_status"] == "exhausted"
+    ]
+
+
 def classify_budget_status(allowlisted_calls: int, allowlist_cap: int) -> str:
     if allowlist_cap == 0:
         return "no_allowlist"
@@ -371,6 +379,12 @@ def format_category_budget_metrics(file_summaries: list[dict[str, object]]) -> s
     return "category_budgets=" + ",".join(parts)
 
 
+def format_exhausted_category_metrics(file_summaries: list[dict[str, object]]) -> str:
+    names = exhausted_category_names(file_summaries)
+    formatted_names = ";".join(names) if names else "none"
+    return f"exhausted_category_count={len(names)}, exhausted_categories={formatted_names}"
+
+
 def build_json_report(
     findings: list[Finding],
     allowlist: dict[str, AllowEntry],
@@ -381,6 +395,12 @@ def build_json_report(
     summary = summarize_failures(failures)
     file_summaries = build_file_summaries(counts, allowlist)
     budget = summarize_budget(file_summaries)
+    category_summaries = build_category_summaries(file_summaries)
+    exhausted_categories = [
+        str(summary["category"])
+        for summary in category_summaries
+        if summary["max_count"] is not None and summary["budget_status"] == "exhausted"
+    ]
     return {
         "ok": not failures,
         "status": "failed" if failures else "passed",
@@ -392,6 +412,8 @@ def build_json_report(
         "allowlist_cap": budget.allowlist_cap,
         "remaining_allowlist_capacity": budget.remaining_allowlist_capacity,
         "allowlist_budget_status": budget.budget_status,
+        "exhausted_category_count": len(exhausted_categories),
+        "exhausted_categories": exhausted_categories,
         "unallowlisted_calls": summary.unallowlisted,
         "over_allowlist_files": summary.over_allowlist_files,
         "over_allowlist_excess_calls": summary.over_allowlist_excess_calls,
@@ -399,7 +421,7 @@ def build_json_report(
         "failure_summary": dataclasses.asdict(summary),
         "budget_summary": dataclasses.asdict(budget),
         "failures": failures,
-        "categories": build_category_summaries(file_summaries),
+        "categories": category_summaries,
         "files": file_summaries,
         "findings": [
             {
@@ -450,6 +472,7 @@ def format_pass_summary(
         f"files_with_findings={len(grouped_counts(findings))}, "
         f"{format_budget_metrics(budget)}, "
         f"{format_category_budget_metrics(file_summaries)}, "
+        f"{format_exhausted_category_metrics(file_summaries)}, "
         f"unallowlisted_calls={summary.unallowlisted}, "
         f"over_allowlist_files={summary.over_allowlist_files}, "
         f"over_allowlist_excess_calls={summary.over_allowlist_excess_calls}, "
@@ -485,6 +508,7 @@ def main(argv: list[str] | None = None) -> int:
             "\nOutput-surgery audit summary: "
             f"{format_budget_metrics(budget)}, "
             f"{format_category_budget_metrics(file_summaries)}, "
+            f"{format_exhausted_category_metrics(file_summaries)}, "
             f"unallowlisted_calls={summary.unallowlisted}, "
             f"unallowlisted_files={summary.unallowlisted_files}, "
             f"over_allowlist_files={summary.over_allowlist_files}, "

--- a/scripts/emit/test_output_surgery_audit.py
+++ b/scripts/emit/test_output_surgery_audit.py
@@ -102,6 +102,8 @@ class OutputSurgeryAuditTests(unittest.TestCase):
         self.assertEqual(report["allowlist_cap"], 2)
         self.assertEqual(report["remaining_allowlist_capacity"], 1)
         self.assertEqual(report["allowlist_budget_status"], "available")
+        self.assertEqual(report["exhausted_category_count"], 0)
+        self.assertEqual(report["exhausted_categories"], [])
         self.assertEqual(report["unallowlisted_calls"], 1)
         self.assertEqual(report["over_allowlist_files"], 0)
         self.assertEqual(report["over_allowlist_excess_calls"], 0)
@@ -217,6 +219,8 @@ class OutputSurgeryAuditTests(unittest.TestCase):
             "remaining_allowlist_capacity=0, "
             "allowlist_budget_status=exhausted, "
             "category_budgets=semantic-output-surgery=2/2:exhausted, "
+            "exhausted_category_count=1, "
+            "exhausted_categories=semantic-output-surgery, "
             "unallowlisted_calls=0, "
             "over_allowlist_files=0, "
             "over_allowlist_excess_calls=0, "
@@ -258,6 +262,40 @@ class OutputSurgeryAuditTests(unittest.TestCase):
             "category_budgets=UNALLOWLISTED=unallowlisted:4,"
             "dts-output-surgery=2/3:available,"
             "ir-output-surgery=1/1:exhausted",
+        )
+
+    def test_exhausted_category_metrics_name_only_zero_capacity_categories(self):
+        file_summaries = [
+            {
+                "path": "a.rs",
+                "count": 2,
+                "category": "dts-output-surgery",
+                "max_count": 3,
+                "reason": "existing debt",
+                "status": "allowlisted",
+            },
+            {
+                "path": "b.rs",
+                "count": 1,
+                "category": "ir-output-surgery",
+                "max_count": 1,
+                "reason": "existing debt",
+                "status": "allowlisted",
+            },
+            {
+                "path": "c.rs",
+                "count": 4,
+                "category": "UNALLOWLISTED",
+                "max_count": None,
+                "reason": None,
+                "status": "unallowlisted",
+            },
+        ]
+
+        self.assertEqual(self.audit.exhausted_category_names(file_summaries), ["ir-output-surgery"])
+        self.assertEqual(
+            self.audit.format_exhausted_category_metrics(file_summaries),
+            "exhausted_category_count=1, exhausted_categories=ir-output-surgery",
         )
 
     def test_budget_status_classifies_budget_edges(self):


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Studio-F launch infrastructure and cheap coordination evidence

## Invariant
When output-surgery category budgets have no remaining capacity, the audit should expose the exhausted category count and names as first-class evidence so launch readers do not have to infer them from the category budget string.

## Scope
- Add `exhausted_category_count` and `exhausted_categories` to `scripts/emit/audit-output-surgery.py` JSON reports.
- Add exhausted category metrics to pass/failure human summaries.
- Extend focused output-surgery audit unit tests.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: emit-tooling-only; no compiler, checker, solver, parser, binder, emitter runtime, conformance, project-corpus, or emitted-output behavior changes.

## Verification
- `python3 -m unittest scripts.emit.test_output_surgery_audit`
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery-exhausted-categories.json`
- `python3 -m py_compile scripts/emit/audit-output-surgery.py scripts/emit/test_output_surgery_audit.py`
- `git diff --check`

## Coordination Notes
- Studio-F owned runway was clear before starting.
- Open output-surgery implementation PR #11916 is Studio-E draft work on retiring object-member output surgery; this PR only changes audit reporting and does not touch emitter behavior or allowlist counts.
- Live audit currently reports `allowlist_budget_status=exhausted`, `exhausted_category_count=3`, and `exhausted_categories=dts-output-surgery;ir-output-surgery;resource-region-output-surgery`.
- Disk preflight remains low by roughly 3.9GB; caches and active sibling worktrees were preserved.
