### PR TITLE
test(solver): guard relation cache kind partitioning

### DIFF
--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/callback_kind_partitioning.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/callback_kind_partitioning.rs
@@ -84,3 +84,64 @@ fn bivariant_callback_kind_does_not_populate_strict_assignability_slot() {
         "ordinary strict assignability should populate its own cache slot after lookup",
     );
 }
+
+#[test]
+fn bivariant_callback_kind_does_not_reuse_strict_assignability_slot() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let name = interner.intern_string("name");
+    let breed = interner.intern_string("breed");
+
+    let animal = interner.object(vec![PropertyInfo::new(name, TypeId::STRING)]);
+    let dog = interner.object(vec![
+        PropertyInfo::new(name, TypeId::STRING),
+        PropertyInfo::new(breed, TypeId::STRING),
+    ]);
+    let source = interner.function(FunctionShape::new(
+        vec![ParamInfo::unnamed(dog)],
+        TypeId::VOID,
+    ));
+    let target = interner.function(FunctionShape::new(
+        vec![ParamInfo::unnamed(animal)],
+        TypeId::VOID,
+    ));
+
+    let strict_policy = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_NULL_CHECKS | RelationFlags::STRICT_FUNCTION_TYPES,
+    );
+    let strict_assignability_key =
+        RelationCacheKey::for_assignability(source, target, strict_policy.cache_config());
+
+    let strict_cached = db.is_assignable_to_with_policy(source, target, strict_policy);
+    assert!(
+        !strict_cached,
+        "ordinary strict assignability should reject contravariant callback parameter narrowing",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(strict_assignability_key),
+        Some(strict_cached),
+        "ordinary strict assignability should populate its own cache slot first",
+    );
+
+    let bivariant_with_cache = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::AssignableBivariantCallbacks,
+        strict_policy,
+        RelationContext {
+            query_db: Some(&db),
+            ..RelationContext::default()
+        },
+    )
+    .is_related();
+    assert!(
+        bivariant_with_cache,
+        "callback-bivariant relation must not reuse the ordinary strict assignability answer",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(strict_assignability_key),
+        Some(strict_cached),
+        "callback-bivariant relation must leave the ordinary strict assignability slot intact",
+    );
+}

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/kind_partitioning.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/kind_partitioning.rs
@@ -302,3 +302,64 @@ fn redeclaration_identity_relation_does_not_populate_ordinary_relation_cache_slo
         "redeclaration identity must not populate the ordinary subtype slot",
     );
 }
+
+#[test]
+fn overlap_relation_does_not_populate_ordinary_relation_cache_slots() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let policy = RelationPolicy::default();
+    let source = TypeId::STRING;
+    let target = TypeId::NUMBER;
+    let assignability_key =
+        RelationCacheKey::for_assignability(source, target, policy.cache_config());
+    let subtype_key = RelationCacheKey::for_subtype(source, target, policy.cache_config());
+
+    assert_eq!(
+        db.lookup_assignability_cache(assignability_key),
+        None,
+        "assignability slot should start empty",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(subtype_key),
+        None,
+        "subtype slot should start empty",
+    );
+
+    let overlap_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Overlap,
+        policy,
+        RelationContext::default(),
+    )
+    .is_related();
+    let overlap_with_cache_context = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Overlap,
+        policy,
+        RelationContext {
+            query_db: Some(&db),
+            ..RelationContext::default()
+        },
+    )
+    .is_related();
+
+    assert!(!overlap_uncached, "disjoint primitives should not overlap");
+    assert_eq!(
+        overlap_with_cache_context, overlap_uncached,
+        "overlap with a query cache context must match uncached overlap semantics",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(assignability_key),
+        None,
+        "overlap must not populate the ordinary assignability slot",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(subtype_key),
+        None,
+        "overlap must not populate the ordinary subtype slot",
+    );
+}

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/kind_partitioning.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/kind_partitioning.rs
@@ -156,3 +156,71 @@ fn redeclaration_identity_relation_does_not_reuse_assignability_cache_slot() {
         "redeclaration identity must not overwrite or consume the ordinary assignability slot",
     );
 }
+
+#[test]
+fn redeclaration_identity_relation_does_not_reuse_subtype_cache_slot() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let policy = RelationPolicy::default();
+    let name = interner.intern_string("name");
+    let breed = interner.intern_string("breed");
+    let source = interner.object(vec![
+        PropertyInfo::new(name, TypeId::STRING),
+        PropertyInfo::new(breed, TypeId::STRING),
+    ]);
+    let target = interner.object(vec![PropertyInfo::new(name, TypeId::STRING)]);
+    let subtype_key = RelationCacheKey::for_subtype(source, target, policy.cache_config());
+    let identical_key = RelationCacheKey::for_identical(source, target, policy.cache_config());
+
+    assert_ne!(
+        subtype_key, identical_key,
+        "redeclaration identity and subtype must occupy distinct relation cache keys",
+    );
+
+    let subtype_cached = db.is_subtype_of_with_policy(source, target, policy);
+    assert!(
+        subtype_cached,
+        "ordinary structural subtype should allow extra source properties",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(subtype_key),
+        Some(subtype_cached),
+        "ordinary subtype should populate the subtype cache slot",
+    );
+
+    let redeclaration_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::RedeclarationIdentical,
+        policy,
+        RelationContext::default(),
+    )
+    .is_related();
+    let redeclaration_with_cache_context = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::RedeclarationIdentical,
+        policy,
+        RelationContext {
+            query_db: Some(&db),
+            ..RelationContext::default()
+        },
+    )
+    .is_related();
+
+    assert!(
+        !redeclaration_uncached,
+        "redeclaration identity must reject structurally subtype-compatible but non-identical object types",
+    );
+    assert_eq!(
+        redeclaration_with_cache_context, redeclaration_uncached,
+        "redeclaration identity with a query cache context must match uncached identity semantics",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(subtype_key),
+        Some(subtype_cached),
+        "redeclaration identity must not overwrite or consume the ordinary subtype slot",
+    );
+}

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/kind_partitioning.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/kind_partitioning.rs
@@ -224,3 +224,81 @@ fn redeclaration_identity_relation_does_not_reuse_subtype_cache_slot() {
         "redeclaration identity must not overwrite or consume the ordinary subtype slot",
     );
 }
+
+#[test]
+fn redeclaration_identity_relation_does_not_populate_ordinary_relation_cache_slots() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let policy = RelationPolicy::default();
+    let name = interner.intern_string("name");
+    let breed = interner.intern_string("breed");
+    let source = interner.object(vec![
+        PropertyInfo::new(name, TypeId::STRING),
+        PropertyInfo::new(breed, TypeId::STRING),
+    ]);
+    let target = interner.object(vec![PropertyInfo::new(name, TypeId::STRING)]);
+    let assignability_key =
+        RelationCacheKey::for_assignability(source, target, policy.cache_config());
+    let subtype_key = RelationCacheKey::for_subtype(source, target, policy.cache_config());
+    let identical_key = RelationCacheKey::for_identical(source, target, policy.cache_config());
+
+    assert_ne!(
+        assignability_key, identical_key,
+        "redeclaration identity and assignability must occupy distinct relation cache keys",
+    );
+    assert_ne!(
+        subtype_key, identical_key,
+        "redeclaration identity and subtype must occupy distinct relation cache keys",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(assignability_key),
+        None,
+        "assignability slot should start empty",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(subtype_key),
+        None,
+        "subtype slot should start empty",
+    );
+
+    let redeclaration_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::RedeclarationIdentical,
+        policy,
+        RelationContext::default(),
+    )
+    .is_related();
+    let redeclaration_with_cache_context = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::RedeclarationIdentical,
+        policy,
+        RelationContext {
+            query_db: Some(&db),
+            ..RelationContext::default()
+        },
+    )
+    .is_related();
+
+    assert!(
+        !redeclaration_uncached,
+        "redeclaration identity must reject structurally compatible but non-identical object types",
+    );
+    assert_eq!(
+        redeclaration_with_cache_context, redeclaration_uncached,
+        "redeclaration identity with a query cache context must match uncached identity semantics",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(assignability_key),
+        None,
+        "redeclaration identity must not populate the ordinary assignability slot",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(subtype_key),
+        None,
+        "redeclaration identity must not populate the ordinary subtype slot",
+    );
+}

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/kind_partitioning.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/kind_partitioning.rs
@@ -87,3 +87,72 @@ fn relation_policy_cache_relation_kind_partitions_assignability_and_subtype() {
         "assignability slot must remain intact after the subtype lookup",
     );
 }
+
+#[test]
+fn redeclaration_identity_relation_does_not_reuse_assignability_cache_slot() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let policy = RelationPolicy::default();
+    let name = interner.intern_string("name");
+    let breed = interner.intern_string("breed");
+    let source = interner.object(vec![
+        PropertyInfo::new(name, TypeId::STRING),
+        PropertyInfo::new(breed, TypeId::STRING),
+    ]);
+    let target = interner.object(vec![PropertyInfo::new(name, TypeId::STRING)]);
+    let assignability_key =
+        RelationCacheKey::for_assignability(source, target, policy.cache_config());
+    let identical_key = RelationCacheKey::for_identical(source, target, policy.cache_config());
+
+    assert_ne!(
+        assignability_key, identical_key,
+        "redeclaration identity and assignability must occupy distinct relation cache keys",
+    );
+
+    let assignability_cached = db.is_assignable_to_with_policy(source, target, policy);
+    assert!(
+        assignability_cached,
+        "ordinary structural assignability should allow extra source properties",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(assignability_key),
+        Some(assignability_cached),
+        "ordinary assignability should populate the assignability cache slot",
+    );
+
+    let redeclaration_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::RedeclarationIdentical,
+        policy,
+        RelationContext::default(),
+    )
+    .is_related();
+    let redeclaration_with_cache_context = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::RedeclarationIdentical,
+        policy,
+        RelationContext {
+            query_db: Some(&db),
+            ..RelationContext::default()
+        },
+    )
+    .is_related();
+
+    assert!(
+        !redeclaration_uncached,
+        "redeclaration identity must reject structurally assignable but non-identical object types",
+    );
+    assert_eq!(
+        redeclaration_with_cache_context, redeclaration_uncached,
+        "redeclaration identity with a query cache context must match uncached identity semantics",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(assignability_key),
+        Some(assignability_cached),
+        "redeclaration identity must not overwrite or consume the ordinary assignability slot",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track: solver relation policy/cache-key protocols; #8207 relation-kind cache partitioning guard.

## Invariant
When non-ordinary relation kinds (`RelationKind::RedeclarationIdentical`, `RelationKind::Overlap`, or callback-bivariant assignability) run with a `QueryCache` context, they must keep their own relation semantics and must not reuse, overwrite, or populate ordinary assignability/subtype cache slots for the same source/target/policy tuple.

## Scope
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests/kind_partitioning.rs`
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests/callback_kind_partitioning.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: test-only solver cache-kind guards; no compiler semantic behavior, emit output, or project fixture behavior intentionally changed.

## Verification
- RED: `cargo nextest run -p tsz-solver --lib redeclaration_identity_relation_does_not_reuse_assignability_cache_slot` failed before the first redeclaration test existed with `error: no tests to run`.
- RED on prior head `acbf06b4216e6b8cd13c5c9de93401fed2a92fc1`: `cargo nextest run -p tsz-solver --lib overlap_relation_does_not_populate_ordinary_relation_cache_slots` failed with `error: no tests to run`.
- RED on head `4f9aeea18ef0652aa38084766b734fc757e1e24a`: `cargo nextest run -p tsz-solver --lib bivariant_callback_kind_does_not_reuse_strict_assignability_slot` failed with `error: no tests to run` before adding the callback reuse guard.
- GREEN after M5Manager verification on head `181d83e1ecf0f3bf383526b177cdbcdbbaa137b3` rebased onto `origin/main` `aaaf39cd232c0622b23221efcfae3688ba93a03d`: `cargo nextest run -p tsz-solver -E "test(relation_policy_cache_agreement_tests::kind_partitioning) | test(relation_policy_cache_agreement_tests::callback_kind_partitioning)"` passed, 7 passed / 6475 skipped.
- GREEN on head `181d83e1ecf0f3bf383526b177cdbcdbbaa137b3`: `cargo fmt --check`.
- GREEN on head `181d83e1ecf0f3bf383526b177cdbcdbbaa137b3`: `git diff --check origin/main...HEAD` and `git diff --check`.
- GREEN prior architecture guard on this test-only slice: `python3 scripts/arch/arch_guard.py` passed on earlier head `0731e2818a6d3d40e0753c8a674033e17f04606b`; no production or boundary files changed in the current refresh.
- GREEN draft-light PR-head CI on exact head `181d83e1ecf0f3bf383526b177cdbcdbbaa137b3`: `CI Light Summary`, `GitGuardian Security Checks`, lint, unit, `unit-cloudbuild`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, and `queue-one-pr` passed. Heavy ready-review suites were skipped while the PR was draft/off queue.
- GREEN ready-review PR-head CI on exact head `181d83e1ecf0f3bf383526b177cdbcdbbaa137b3`: `CI Summary`, `GitGuardian Security Checks`, `conformance-aggregate`, `fourslash-aggregate`, `emit`, `lsp-e2e`, `project-compile-guard`, `project-compile-canary`, `wasm`, `wasm-web`, `lint`, `unit`, `unit-cloudbuild`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `project-corpus-pr-body`, `project-row-drift`, `gate`, and `queue-one-pr` passed.
- `Queue Tested` is pending as queue-owned evidence after `merge-queue` was added; it is not a pre-enqueue prerequisite.

## Coordination Notes
- AgentName: M5Manager verified this PR on 2026-06-02. The current head is `181d83e1ecf0f3bf383526b177cdbcdbbaa137b3` and the PR is ready, non-draft, mergeable, auto-merge off, and labeled `merge-queue`.
- Queue state: `merge-queue` is present after exact-head ready-review `CI Summary` and `GitGuardian Security Checks` passed. Await the repo-local merge queue to produce `Queue Tested` and verify `state: MERGED` after it runs.
- Non-overlap: independent #8207 solver test-only slice. It touches only `crates/tsz-solver/tests/relation_policy_cache_agreement_tests/*` and does not overlap #12056 checker-boundary refresh or #12060 stacked checker-boundary planning/test work.
- #8432 remains open as conformance-runway context, but its latest current-main evidence says the prior #12080 drift paths passed after #12099. This PR is test-only and exact-head ready-review CI is green.
- No local full conformance, fourslash, or emit suites were run by M5Manager.
- AgentName: M5Manager

