### PR TITLE
chore(conformance): warn on stale snapshot domain

### DIFF
--- a/scripts/conformance/query-conformance.py
+++ b/scripts/conformance/query-conformance.py
@@ -48,7 +48,9 @@ Usage:
 import os
 import sys
 import argparse
+import json
 from collections import Counter
+from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from lib.conformance_query import (
@@ -58,6 +60,8 @@ from lib.conformance_query import (
     is_same_code_count_drift,
     load_detail,
 )
+
+DEFAULT_TSC_CACHE_PATH = Path(__file__).with_name("tsc-cache-full.json")
 
 # =============================================================================
 # Failure-category definitions (used by --campaign / --campaigns).
@@ -364,7 +368,37 @@ def build_campaign_result(data, name):
 # =============================================================================
 
 
-def show_dashboard(data, accepted_regressions_path=DEFAULT_ACCEPTED_REGRESSIONS_PATH):
+def load_tsc_cache_test_total(path=DEFAULT_TSC_CACHE_PATH):
+    cache_path = Path(path)
+    if not cache_path.exists():
+        return None
+    with cache_path.open(encoding="utf-8") as f:
+        cache = json.load(f)
+    if not isinstance(cache, dict):
+        return None
+    return len(cache)
+
+
+def show_snapshot_freshness(data, tsc_cache_path=DEFAULT_TSC_CACHE_PATH):
+    snapshot_total = int(data["summary"].get("total", 0))
+    current_total = load_tsc_cache_test_total(tsc_cache_path)
+    if current_total is None or current_total == snapshot_total:
+        return
+
+    delta = current_total - snapshot_total
+    print(
+        "  Snapshot freshness: STALE checked detail "
+        f"covers {snapshot_total} tests, but the pinned TypeScript cache has "
+        f"{current_total} tests (delta {delta:+d})."
+    )
+    print("  Refresh conformance-detail.json before citing this dashboard as current public truth.")
+
+
+def show_dashboard(
+    data,
+    accepted_regressions_path=DEFAULT_ACCEPTED_REGRESSIONS_PATH,
+    tsc_cache_path=DEFAULT_TSC_CACHE_PATH,
+):
     """Show the KPI dashboard that replaces overall conformance % as the daily signal."""
     s = data["summary"]
     failures = data["failures"]
@@ -378,6 +412,7 @@ def show_dashboard(data, accepted_regressions_path=DEFAULT_ACCEPTED_REGRESSIONS_
     accepted_count = len(accepted["entries"])
     accepted_state = "missing" if not accepted["exists"] else f"{accepted_count} listed tests"
     print(f"  Accepted-regression gate: {accepted_state}")
+    show_snapshot_freshness(data, tsc_cache_path=tsc_cache_path)
     print()
 
     # KPI 1: Wrong-code count for big3

--- a/scripts/conformance/test_query_conformance.py
+++ b/scripts/conformance/test_query_conformance.py
@@ -1,6 +1,7 @@
 import contextlib
 import importlib.util
 import io
+import json
 import sys
 import tempfile
 import unittest
@@ -30,13 +31,20 @@ def dashboard_data(failures):
 
 
 class QueryConformanceDashboardTests(unittest.TestCase):
-    def render_dashboard(self, data, accepted_text=""):
+    def render_dashboard(self, data, accepted_text="", tsc_cache_text=None):
         with tempfile.TemporaryDirectory() as tmp:
             accepted_path = Path(tmp) / "accepted.txt"
             accepted_path.write_text(accepted_text, encoding="utf-8")
+            tsc_cache_path = Path(tmp) / "tsc-cache-full.json"
+            if tsc_cache_text is not None:
+                tsc_cache_path.write_text(tsc_cache_text, encoding="utf-8")
             output = io.StringIO()
             with contextlib.redirect_stdout(output):
-                query_conformance.show_dashboard(data, accepted_regressions_path=str(accepted_path))
+                query_conformance.show_dashboard(
+                    data,
+                    accepted_regressions_path=str(accepted_path),
+                    tsc_cache_path=tsc_cache_path,
+                )
             return output.getvalue()
 
     def test_zero_failure_dashboard_does_not_report_stale_fingerprint_share(self):
@@ -73,6 +81,25 @@ class QueryConformanceDashboardTests(unittest.TestCase):
         self.assertIn("Accepted-regression gate: 0 listed tests", output)
         self.assertIn("Fingerprint-only failures: 1/2 (50.0% of current failures).", output)
         self.assertNotIn("No conformance failures remain", output)
+
+    def test_dashboard_warns_when_snapshot_total_lags_tsc_cache(self):
+        output = self.render_dashboard(
+            dashboard_data({}),
+            tsc_cache_text=json.dumps({f"{index}.ts": {} for index in range(11)}),
+        )
+
+        self.assertIn("Overall: 10/10 (100.0%)", output)
+        self.assertIn("Snapshot freshness: STALE checked detail covers 10 tests", output)
+        self.assertIn("pinned TypeScript cache has 11 tests (delta +1)", output)
+        self.assertIn("Refresh conformance-detail.json before citing this dashboard", output)
+
+    def test_dashboard_freshness_stays_quiet_when_totals_match(self):
+        output = self.render_dashboard(
+            dashboard_data({}),
+            tsc_cache_text=json.dumps({f"{index}.ts": {} for index in range(10)}),
+        )
+
+        self.assertNotIn("Snapshot freshness", output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Release metric truth / conformance dashboard freshness

## Invariant
When the checked conformance detail total differs from the pinned TypeScript cache test domain, the dashboard must mark the snapshot as stale before anyone cites it as current public truth.

## Scope
- `scripts/conformance/query-conformance.py`
- `scripts/conformance/test_query_conformance.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: conformance reporting-only change; project row definitions, compiler behavior, and conformance snapshots are unchanged.

## Verification
- `python3 scripts/conformance/test_query_conformance.py`
- `python3 -m py_compile scripts/conformance/query-conformance.py scripts/conformance/test_query_conformance.py`
- `python3 scripts/conformance/query-conformance.py --dashboard`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- No existing Studio-A PRs were open at intake.
- No overlapping open PR found for conformance dashboard freshness.
- Code-only reporting change; no markdown, roadmap, snapshot, or allowlist files changed.
