### PR TITLE
chore(agents): expose disk reuse candidates in preflight json

### DIFF
--- a/scripts/agents/disk-preflight.sh
+++ b/scripts/agents/disk-preflight.sh
@@ -364,6 +364,39 @@ function parseWorktreeSignals(text) {
     });
 }
 
+function parseGuardReuseCandidates(text) {
+  const lines = text.split(/\n/);
+  const candidates = [];
+  let inSection = false;
+  for (const line of lines) {
+    if (line === "sister_worktree_reuse_candidates:") {
+      inSection = true;
+      continue;
+    }
+    if (!inSection) continue;
+    if (!line.startsWith("  ")) break;
+
+    const trimmed = line.trim();
+    if (!trimmed || trimmed === "none") continue;
+
+    const match = /^(.*?) branch=(.*?) inactive_hours>=(\d+)$/.exec(trimmed);
+    if (!match) {
+      candidates.push({
+        path: trimmed,
+        branch: null,
+        inactive_hours_min: null,
+      });
+      continue;
+    }
+    candidates.push({
+      path: match[1],
+      branch: match[2],
+      inactive_hours_min: Number(match[3]),
+    });
+  }
+  return candidates;
+}
+
 const guard = parseKeyValueLines(process.env.GUARD_OUTPUT ?? "");
 const bool = (value) => value === "true";
 const diskOk = guard.disk_status === "ok";
@@ -374,6 +407,9 @@ const toNumber = (value) => {
 const diskFreeMb = toNumber(guard.disk_free_mb);
 const minFreeGb = toNumber(guard.min_free_gb);
 const minFreeMb = minFreeGb * 1024;
+const sisterReuseCandidates = parseGuardReuseCandidates(
+  process.env.GUARD_OUTPUT ?? "",
+);
 const cleanupLadder = [
   "Reuse an existing worktree with TypeScript/cache state.",
   "Run scripts/setup/disk-worktree-guard.sh --auto-prune.",
@@ -403,6 +439,8 @@ const report = {
     free_mb: diskFreeMb,
     min_free_mb: minFreeMb,
     shortfall_mb: Math.max(0, minFreeMb - diskFreeMb),
+    sister_reuse_candidate_count: sisterReuseCandidates.length,
+    sister_reuse_candidates: sisterReuseCandidates,
     cleanup_ladder: diskOk ? [] : cleanupLadder,
   },
   typescript: {

--- a/scripts/agents/test_disk_preflight.py
+++ b/scripts/agents/test_disk_preflight.py
@@ -145,6 +145,8 @@ class DiskPreflightTests(unittest.TestCase):
             self.assertGreater(report["disk_pressure"]["free_mb"], 0)
             self.assertGreater(report["disk_pressure"]["min_free_mb"], 0)
             self.assertEqual(0, report["disk_pressure"]["shortfall_mb"])
+            self.assertEqual(0, report["disk_pressure"]["sister_reuse_candidate_count"])
+            self.assertEqual([], report["disk_pressure"]["sister_reuse_candidates"])
             self.assertEqual([], report["disk_pressure"]["cleanup_ladder"])
 
     def test_json_report_marks_low_disk_guard_not_ok(self):
@@ -180,6 +182,43 @@ class DiskPreflightTests(unittest.TestCase):
             self.assertIn(
                 "Use scripts/setup/clean.sh --full only as a deliberate last resort.",
                 report["disk_pressure"]["cleanup_ladder"],
+            )
+
+    def test_json_report_records_sister_reuse_candidates(self):
+        with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
+            temp_root = pathlib.Path(temp_dir).resolve()
+            fake_repo, fake_script = self.make_fake_repo(temp_root)
+            fake_guard = fake_repo / "scripts" / "setup" / "disk-worktree-guard.sh"
+            fake_guard.unlink()
+            candidate_path = temp_root / "tsz-candidate"
+            fake_guard.write_text(
+                "#!/usr/bin/env bash\n"
+                "echo 'disk_free_gb=42 path=/tmp'\n"
+                "echo 'disk_free_mb=43008'\n"
+                "echo 'disk_status=ok min_free_gb=1'\n"
+                "echo 'sister_worktree_reuse_candidates:'\n"
+                f"echo '  {candidate_path} branch=refs/heads/candidate inactive_hours>=4'\n",
+                encoding="utf-8",
+            )
+            fake_guard.chmod(0o755)
+            report_path = temp_root / "preflight.json"
+
+            self.run_preflight(
+                fake_repo,
+                fake_script,
+                "--json-report",
+                str(report_path),
+            )
+
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertEqual(1, report["disk_pressure"]["sister_reuse_candidate_count"])
+            self.assertEqual(
+                {
+                    "path": str(candidate_path),
+                    "branch": "refs/heads/candidate",
+                    "inactive_hours_min": 4,
+                },
+                report["disk_pressure"]["sister_reuse_candidates"][0],
             )
 
     def test_worktree_without_typescript_points_to_link_helper(self):


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / disk-worktree hygiene cheap evidence plumbing.

## Invariant
When disk preflight captures the guard output, the machine-readable report should expose the same sister worktree reuse candidates that the human output prints, so automation can tell whether low disk can be solved by reuse without scraping stdout.

## Scope
- `scripts/agents/disk-preflight.sh`
- `scripts/agents/test_disk_preflight.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent preflight JSON/reporting only; no compiler, checker, solver, parser, emitter, benchmark, or project-corpus behavior changed.

## Verification
- `python3 -m unittest scripts.agents.test_disk_preflight`
- `python3 -m py_compile scripts/agents/test_disk_preflight.py`
- `git diff --check -- scripts/agents/disk-preflight.sh scripts/agents/test_disk_preflight.py`
- `scripts/agents/disk-preflight.sh Studio-F --json-report /tmp/tsz-disk-preflight-reuse-json.json`

## Coordination Notes
- AgentName: Studio-F
- Studio-F owned runway was clear before opening this PR.
- This stays out of dirty emitter files currently present in the primary worktree.
- Not adding `merge-queue` until exact-head PR checks are available and green.
