### PR TITLE
chore(agents): expose dirty preflight git state

### DIFF
--- a/scripts/agents/disk-preflight.sh
+++ b/scripts/agents/disk-preflight.sh
@@ -68,6 +68,15 @@ if [[ -z "$GIT_BRANCH" ]]; then
   GIT_DETACHED=true
 fi
 GIT_UPSTREAM="$(git -C "$ROOT" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+GIT_STATUS_OUTPUT="$(git -C "$ROOT" status --porcelain --untracked-files=normal)"
+GIT_DIRTY=false
+GIT_DIRTY_FILES=0
+GIT_UNTRACKED_FILES=0
+if [[ -n "$GIT_STATUS_OUTPUT" ]]; then
+  GIT_DIRTY=true
+  GIT_DIRTY_FILES="$(printf '%s\n' "$GIT_STATUS_OUTPUT" | wc -l | awk '{ print $1 }')"
+  GIT_UNTRACKED_FILES="$(printf '%s\n' "$GIT_STATUS_OUTPUT" | awk 'substr($0, 1, 2) == "??" { count++ } END { print count + 0 }')"
+fi
 
 echo "agent=$AGENT"
 echo "repo=$ROOT"
@@ -81,6 +90,9 @@ if [[ -n "$GIT_UPSTREAM" ]]; then
 else
   echo "git_upstream=none"
 fi
+echo "git_dirty=$GIT_DIRTY"
+echo "git_dirty_files=$GIT_DIRTY_FILES"
+echo "git_untracked_files=$GIT_UNTRACKED_FILES"
 echo ""
 echo "== disk guard =="
 GUARD_OUTPUT="$("$ROOT/scripts/setup/disk-worktree-guard.sh")"
@@ -301,6 +313,9 @@ if [[ -n "$JSON_REPORT" ]]; then
   GIT_BRANCH="$GIT_BRANCH" \
   GIT_DETACHED="$GIT_DETACHED" \
   GIT_UPSTREAM="$GIT_UPSTREAM" \
+  GIT_DIRTY="$GIT_DIRTY" \
+  GIT_DIRTY_FILES="$GIT_DIRTY_FILES" \
+  GIT_UNTRACKED_FILES="$GIT_UNTRACKED_FILES" \
   GUARD_OUTPUT="$GUARD_OUTPUT" \
   TYPESCRIPT_STATE="$TYPESCRIPT_STATE" \
   TYPESCRIPT_TARGET="$TYPESCRIPT_TARGET" \
@@ -428,6 +443,9 @@ const report = {
     branch: process.env.GIT_BRANCH,
     detached: bool(process.env.GIT_DETACHED),
     upstream: process.env.GIT_UPSTREAM || null,
+    dirty: bool(process.env.GIT_DIRTY),
+    dirty_files: Number(process.env.GIT_DIRTY_FILES ?? 0),
+    untracked_files: Number(process.env.GIT_UNTRACKED_FILES ?? 0),
   },
   disk_guard: {
     ...guard,

--- a/scripts/agents/test_disk_preflight.py
+++ b/scripts/agents/test_disk_preflight.py
@@ -167,6 +167,9 @@ class DiskPreflightTests(unittest.TestCase):
             self.assertFalse(report["ok"])
             self.assertEqual("fail", report["status"])
             self.assertEqual("fail", report["disk_preflight_status"])
+            self.assertFalse(report["git_context"]["dirty"])
+            self.assertEqual(0, report["git_context"]["dirty_files"])
+            self.assertEqual(0, report["git_context"]["untracked_files"])
             self.assertEqual("low", report["disk_guard"]["disk_status"])
             self.assertIn("disk_shortfall_mb", report["disk_guard"])
             self.assertFalse(report["disk_guard"]["ok"])
@@ -183,6 +186,29 @@ class DiskPreflightTests(unittest.TestCase):
                 "Use scripts/setup/clean.sh --full only as a deliberate last resort.",
                 report["disk_pressure"]["cleanup_ladder"],
             )
+
+    def test_json_report_records_dirty_git_state(self):
+        with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
+            temp_root = pathlib.Path(temp_dir).resolve()
+            fake_repo, fake_script = self.make_fake_repo(temp_root)
+            report_path = temp_root / "preflight.json"
+            (fake_repo / "README.md").write_text("# fake repo\n\nchanged\n", encoding="utf-8")
+            (fake_repo / "scratch.txt").write_text("scratch\n", encoding="utf-8")
+
+            result = self.run_preflight(
+                fake_repo,
+                fake_script,
+                "--json-report",
+                str(report_path),
+            )
+
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertIn("git_dirty=true", result.stdout)
+            self.assertIn("git_dirty_files=2", result.stdout)
+            self.assertIn("git_untracked_files=1", result.stdout)
+            self.assertTrue(report["git_context"]["dirty"])
+            self.assertEqual(2, report["git_context"]["dirty_files"])
+            self.assertEqual(1, report["git_context"]["untracked_files"])
 
     def test_json_report_records_sister_reuse_candidates(self):
         with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / disk-worktree hygiene cheap evidence plumbing.

## Invariant
When an agent runs disk preflight from a dirty checkout, the preflight should expose dirty/tracked-untracked git state in the human output and JSON report so PR publishing and worktree reuse decisions do not rely on a separate status scrape.

## Scope
- `scripts/agents/disk-preflight.sh`
- `scripts/agents/test_disk_preflight.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent preflight reporting only; no compiler, checker, solver, parser, emitter, benchmark, or project-corpus behavior changed.

## Verification
- `python3 -m unittest scripts.agents.test_disk_preflight`
- `python3 -m py_compile scripts/agents/test_disk_preflight.py`
- `git diff --check -- scripts/agents/disk-preflight.sh scripts/agents/test_disk_preflight.py`
- `scripts/agents/disk-preflight.sh Studio-F --json-report /tmp/tsz-disk-preflight-dirty-state-post-verify.json`

## Coordination Notes
- AgentName: Studio-F
- Studio-F owned runway was clear before opening this PR.
- The primary checkout has unrelated dirty emitter files; this PR intentionally stages only `scripts/agents` changes.
- Not adding `merge-queue` until exact-head PR checks are available and green.
