### PR TITLE
fix(emit): preserve labeled statement recovery output

### DIFF
--- a/crates/tsz-emitter/src/emitter/es5/bindings_for_of.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings_for_of.rs
@@ -275,20 +275,7 @@ impl<'a> Printer<'a> {
                     &init_vars,
                 );
                 self.write_line();
-                if let Some(capture_name) = this_capture {
-                    self.emit_loop_this_capture_decl(&capture_name);
-                }
-                if !body_info.var_decl_names.is_empty() {
-                    self.write("var ");
-                    for (i, name) in body_info.var_decl_names.iter().enumerate() {
-                        if i > 0 {
-                            self.write(", ");
-                        }
-                        self.write(name);
-                    }
-                    self.write(";");
-                    self.write_line();
-                }
+                self.emit_loop_capture_preamble(this_capture.as_deref(), &body_info);
                 Some((loop_fn_name, param_vars, body_info))
             } else {
                 None

--- a/crates/tsz-emitter/src/emitter/es5/loop_capture.rs
+++ b/crates/tsz-emitter/src/emitter/es5/loop_capture.rs
@@ -351,10 +351,7 @@ impl<'a> Printer<'a> {
             init_vars,
         );
         self.write_line();
-        if let Some(capture_name) = this_capture {
-            self.emit_loop_this_capture_decl(&capture_name);
-        }
-        self.emit_hoisted_loop_var_decls(body_info);
+        self.emit_loop_capture_preamble(this_capture.as_deref(), body_info);
 
         self.write("for (");
         self.emit_for_initializer_as_var(loop_stmt.initializer);
@@ -388,10 +385,7 @@ impl<'a> Printer<'a> {
         let this_capture =
             self.emit_loop_function(&loop_fn_name, &[], loop_stmt.statement, body_info, &[]);
         self.write_line();
-        if let Some(capture_name) = this_capture {
-            self.emit_loop_this_capture_decl(&capture_name);
-        }
-        self.emit_hoisted_loop_var_decls(body_info);
+        self.emit_loop_capture_preamble(this_capture.as_deref(), body_info);
 
         match kind {
             ConditionLoopKind::DoWhile => {
@@ -424,6 +418,30 @@ impl<'a> Printer<'a> {
             self.write(";");
             self.write_line();
         }
+    }
+
+    pub(in crate::emitter) fn emit_loop_capture_preamble(
+        &mut self,
+        this_capture: Option<&str>,
+        body_info: &LoopBodyVarInfo,
+    ) {
+        let Some(capture_name) = this_capture else {
+            self.emit_hoisted_loop_var_decls(body_info);
+            return;
+        };
+
+        if body_info.var_decl_names.is_empty() {
+            self.emit_loop_this_capture_decl(capture_name);
+            return;
+        }
+
+        self.write("var ");
+        self.write(capture_name);
+        self.write(" = this");
+        self.write(", ");
+        self.write(&body_info.var_decl_names.join(", "));
+        self.write(";");
+        self.write_line();
     }
 
     /// Emit the _`loop_N` function definition.

--- a/crates/tsz-emitter/src/emitter/es5/loop_this_capture.rs
+++ b/crates/tsz-emitter/src/emitter/es5/loop_this_capture.rs
@@ -167,6 +167,30 @@ mod tests {
         }
     }
 
+    #[test]
+    fn converted_for_of_coalesces_this_capture_and_body_var_hoists() {
+        let output = emit_es5(
+            "class C {\n\
+                run(xs: any[]) {\n\
+                    for (const item of xs) {\n\
+                        var leaked;\n\
+                        this.use(() => item);\n\
+                    }\n\
+                }\n\
+                use(f: any) {}\n\
+            }\n",
+        );
+
+        assert!(
+            output.contains("var this_1 = this, leaked;"),
+            "Converted for-of preamble should coalesce lexical `this` capture and body `var` hoists.\nOutput:\n{output}"
+        );
+        assert!(
+            !output.contains("var this_1 = this;\n        var leaked;"),
+            "Body `var` hoist should not be emitted as a separate declaration after the lexical `this` capture.\nOutput:\n{output}"
+        );
+    }
+
     // Reproduces the `nestedLoops` witness shape: the `this` site is at the
     // loop body level and the inner arrow only closes over the loop bindings.
     // The capture decl is emitted at the function scope (after the `_loop_N`

--- a/crates/tsz-emitter/src/emitter/literals/core.rs
+++ b/crates/tsz-emitter/src/emitter/literals/core.rs
@@ -429,6 +429,28 @@ impl<'a> Printer<'a> {
             return;
         }
         if let Some(lit) = self.arena.get_literal(node) {
+            if let Some(raw) = lit.raw_text.as_deref() {
+                if !self.ctx.options.target.supports_es2015()
+                    && let Some(downleveled) = self.downlevel_string_literal_for_es5(raw)
+                {
+                    self.write(&downleveled);
+                    return;
+                }
+                self.write(raw);
+                return;
+            }
+
+            if let Some(raw) = self.find_raw_string_literal_near(node, &lit.text) {
+                if !self.ctx.options.target.supports_es2015()
+                    && let Some(downleveled) = self.downlevel_string_literal_for_es5(&raw)
+                {
+                    self.write(&downleveled);
+                    return;
+                }
+                self.write(&raw);
+                return;
+            }
+
             // Preserve original quote style from source text
             let quote = self.detect_original_quote(node).unwrap_or({
                 if self.ctx.options.single_quote {
@@ -778,6 +800,18 @@ impl<'a> Printer<'a> {
                 out.push(ch);
             } else if ch == '\\' {
                 out.push_str("\\\\");
+            } else if ch == '\n' {
+                out.push_str("\\n");
+            } else if ch == '\r' {
+                out.push_str("\\r");
+            } else if ch == '\t' {
+                out.push_str("\\t");
+            } else if ch == '\u{2028}' {
+                out.push_str("\\u2028");
+            } else if ch == '\u{2029}' {
+                out.push_str("\\u2029");
+            } else if (ch as u32) < 0x20 || ch == '\x7F' {
+                let _ = write!(out, "\\u{:04X}", ch as u32);
             } else {
                 out.push(ch);
             }

--- a/crates/tsz-emitter/src/emitter/literals/template.rs
+++ b/crates/tsz-emitter/src/emitter/literals/template.rs
@@ -202,6 +202,9 @@ impl<'a> Printer<'a> {
             .and_then(|lit| lit.raw_text.as_deref())
         {
             self.write(raw);
+            if self.should_emit_recovery_newline_after_template_part(node, raw) {
+                self.write_line();
+            }
             return;
         }
 
@@ -360,10 +363,35 @@ impl<'a> Printer<'a> {
     pub(in crate::emitter) fn get_raw_template_part_text(&self, node: &Node) -> Option<String> {
         let lit = self.arena.get_literal(node)?;
         if let Some(raw) = lit.raw_text.as_deref() {
-            return Some(strip_template_delimiters(node.kind, raw).to_string());
+            let mut text = strip_template_delimiters(node.kind, raw).to_string();
+            if unterminated_template_part_ends_with_recovery_brace(node.kind, raw) {
+                text.push('\n');
+            }
+            return Some(text);
         }
         Some(lit.text.clone())
     }
+
+    fn should_emit_recovery_newline_after_template_part(&self, node: &Node, raw: &str) -> bool {
+        if !unterminated_template_part_ends_with_recovery_brace(node.kind, raw) {
+            return false;
+        }
+        if node.kind == SyntaxKind::TemplateTail as u16 {
+            return true;
+        }
+        let Some(text) = self.source_text else {
+            return false;
+        };
+        text.get(node.end as usize..)
+            .is_some_and(|tail| !tail.contains('`') && !tail.contains("${"))
+    }
+}
+
+fn unterminated_template_part_ends_with_recovery_brace(kind: u16, raw: &str) -> bool {
+    let Some((_, close)) = template_part_delimiters(kind) else {
+        return false;
+    };
+    !raw.ends_with(close) && raw.ends_with('}')
 }
 
 /// Strip the opening and (when present) closing delimiters from a template
@@ -528,6 +556,15 @@ mod tests {
         assert!(
             output.contains("`head${0"),
             "recovered template head and expression bytes should still be emitted\nGot: {output}"
+        );
+    }
+
+    #[test]
+    fn unterminated_template_tail_ending_with_brace_keeps_recovery_newline() {
+        let output = emit("`head${0}\n}");
+        assert!(
+            output.contains("}\n;"),
+            "unterminated template tail ending in `}}` should keep a line break before the synthesized semicolon\nGot: {output}"
         );
     }
 }

--- a/crates/tsz-emitter/src/output/source_writer.rs
+++ b/crates/tsz-emitter/src/output/source_writer.rs
@@ -723,6 +723,10 @@ impl SourceWriter {
     ///
     /// Optimized using memchr for SIMD newline search and ASCII fast-path
     fn raw_write(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+
         self.output.push_str(text);
 
         let bytes = text.as_bytes();
@@ -746,6 +750,7 @@ impl SourceWriter {
                     // Handle newline
                     self.line += 1;
                     self.column = 0;
+                    self.at_line_start = true;
                     i = segment_end + 1;
                 }
                 None => {
@@ -757,6 +762,7 @@ impl SourceWriter {
                     } else {
                         self.column += segment.chars().map(|c| c.len_utf16() as u32).sum::<u32>();
                     }
+                    self.at_line_start = segment.is_empty();
                     break;
                 }
             }
@@ -813,9 +819,11 @@ impl SourceWriter {
         if ch == '\n' {
             self.line += 1;
             self.column = 0;
+            self.at_line_start = true;
         } else {
             // UTF-16 code units: non-BMP characters (emojis etc.) count as 2
             self.column += ch.len_utf16() as u32;
+            self.at_line_start = false;
         }
         self.output.push(ch);
     }

--- a/crates/tsz-emitter/tests/source_writer.rs
+++ b/crates/tsz-emitter/tests/source_writer.rs
@@ -295,6 +295,19 @@ fn write_with_internal_newlines_resets_column() {
     writer.write("foo\nbar");
     assert_eq!(writer.current_line(), 1);
     assert_eq!(writer.current_column(), 3);
+    assert!(!writer.is_at_line_start());
+}
+
+#[test]
+fn write_ending_with_newline_marks_line_start_for_lazy_indent() {
+    let mut writer = SourceWriter::new();
+    writer.increase_indent();
+    writer.write("foo\n");
+    writer.write("bar");
+    assert_eq!(writer.get_output(), "    foo\n    bar");
+    assert_eq!(writer.current_line(), 1);
+    assert_eq!(writer.current_column(), 7);
+    assert!(!writer.is_at_line_start());
 }
 
 #[test]

--- a/crates/tsz-emitter/tests/tagged_template_escape_emit_tests.rs
+++ b/crates/tsz-emitter/tests/tagged_template_escape_emit_tests.rs
@@ -63,6 +63,59 @@ const y = `\u{hello} ${100} \xtraordinary ${200} wonderful ${300} \uworld`;
 }
 
 #[test]
+fn es5_template_expression_escapes_line_terminators_in_string_text() {
+    let output = parse_lower_emit(
+        "
+const y = `before
+${value}
+after`;
+",
+        ScriptTarget::ES5,
+    );
+
+    assert!(
+        output.contains(r#"var y = "before\n".concat(value, "\nafter");"#),
+        "ES5 template downlevel should keep template newlines inside string text.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn unterminated_template_at_eof_keeps_recovery_newline() {
+    let source = "// https://github.com/microsoft/TypeScript/issues/59345\n\
+export class ParseThemeData {\n\
+  parseButton(button: any) {\n\
+    const {type, size} = button;\n\
+    for (let item of type) {\n\
+      const fontType = item.type;\n\
+      const style = (state: string) => `color: var(--button-${fontType}-${state}-font-color)`;\n\
+      this.classFormat(`${style('active')});\n\
+    }\n\
+    for (let item of size) {\n\
+      const fontType = item.type;\n\
+      this.classFormat(\n\
+        [\n\
+          `font-size: var(--button-size-${fontType}-fontSize)`,\n\
+          `height: var(--button-size-${fontType}-height)`,\n\
+        ].join(';')\n\
+      );\n\
+    }\n\
+  }\n\
+}";
+
+    let es2015 = parse_lower_emit(source, ScriptTarget::ES2015);
+    assert!(
+        es2015.contains("}\n            ;"),
+        "ES2015 recovery should keep the synthesized empty statement on its own line.\nOutput:\n{es2015}"
+    );
+
+    let es5 = parse_lower_emit(source, ScriptTarget::ES5);
+    assert!(
+        es5.contains("}\\n\""),
+        "ES5 template downlevel should preserve the recovery newline inside string text.\nOutput:\n{es5}"
+    );
+}
+
+#[test]
 fn es5_tagged_template_cooked_non_bmp_codepoints_use_surrogate_escapes() {
     let output = parse_lower_emit(
         r#"


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Emit/DTS parity: JavaScript emit parser-recovery, literal/template output, and ES5 loop-capture preamble recovery.

## Invariant
Parser-recovery emit must preserve the structural output shape that `tsc` keeps for labeled-statement declaration-list recovery:

1. Unterminated template raw text ending at a recovered brace preserves the recovery newline in raw template emission and ES5 template-string data.
2. Converted ES5 loop preambles coalesce lexical `this` capture and loop-body `var` hoists into one `var` declaration when both are present.

## Scope
- `crates/tsz-emitter/src/emitter/literals/core.rs`
- `crates/tsz-emitter/src/emitter/literals/template.rs`
- `crates/tsz-emitter/src/output/source_writer.rs`
- `crates/tsz-emitter/src/emitter/es5/loop_capture.rs`
- `crates/tsz-emitter/src/emitter/es5/bindings_for_of.rs`
- `crates/tsz-emitter/src/emitter/es5/loop_this_capture.rs`
- Focused emitter/source-writer regression tests

## Project Corpus Impact
- Row: n/a
- Bug family: JavaScript emit parser-recovery / literal-template / loop-control-flow output
- Evidence: targeted emit baseline filter `labeledStatementDeclarationListInLoopNoCrash` passes `8/8` on this branch; no project-corpus row was run or claimed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- `cargo nextest run -p tsz-emitter converted_for_of_coalesces_this_capture_and_body_var_hoists converted_for_of_with_this_in_arrow_captures_this_1 write_ending_with_newline_marks_line_start_for_lazy_indent es5_template_expression unterminated_template` (`11` tests passed)
- `scripts/safe-run.sh scripts/emit/run.sh --filter=labeledStatementDeclarationListInLoopNoCrash --js-only --verbose --timeout=30000 --json-out=/tmp/labeledStatementDeclarationListInLoopNoCrash-studio-c-final.json` (`8/8`, `100.0%` JavaScript emit pass rate)

## Coordination Notes
- Existing Studio-C PRs #12013, #12016, and #12023 are queue-pending; this branch is a separate labeled-statement recovery slice.
- This PR now completes the local focused family and is ready for manager review/queue after CI light checks.
- No checker/solver semantic validation added; the change stays in emitter output/data handling.
