### PR TITLE
fix(emit): hoist async for-await init temps

### DIFF
--- a/crates/tsz-emitter/src/emitter/es5/bindings_param_patterns.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings_param_patterns.rs
@@ -1273,12 +1273,19 @@ impl<'a> Printer<'a> {
         let catch_error_name = format!("e_{}_1", counter + 1);
 
         self.ctx.destructuring_state.for_of_counter += 1;
+        let hoist_loop_init_temps =
+            self.ctx.emit_await_as_yield || self.ctx.emit_await_as_yield_await;
 
         // Hoist done/error/return/value temps to the top of the source file scope.
         self.hoisted_for_of_temps.push(loop_done_name.clone());
         self.hoisted_for_of_temps.push(error_container_name.clone());
         self.hoisted_for_of_temps.push(return_temp_name.clone());
         self.hoisted_for_of_temps.push(value_temp_name.clone());
+        if hoist_loop_init_temps {
+            self.hoisted_for_of_temps.push(loop_guard_name.clone());
+            self.hoisted_for_of_temps.push(loop_iterator_name.clone());
+            self.hoisted_for_of_temps.push(loop_result_name.clone());
+        }
 
         // try block
         self.write("try {");
@@ -1299,7 +1306,12 @@ impl<'a> Printer<'a> {
         self.emit_downlevel_for_await_loop_label(for_of_idx);
 
         // for (var _d = true, iterable_1 = __asyncValues(iterable), iterable_1_1; iterable_1_1 = [await/yield/yield __await(...)] iterable_1.next(), _a = iterable_1_1.done, !_a; _d = true) {
-        self.write("for (var ");
+        // Inside generated async generator bodies, tsc hoists these loop-init temps
+        // into the generator's var group instead of redeclaring them inline.
+        self.write("for (");
+        if !hoist_loop_init_temps {
+            self.write("var ");
+        }
         self.write(&loop_guard_name);
         self.write(" = true, ");
         self.write(&loop_iterator_name);
@@ -1311,14 +1323,17 @@ impl<'a> Printer<'a> {
             self.write_helper("__asyncValues");
             self.write("(");
             self.emit_expression(for_in_of.expression);
-            self.write(")), ");
+            self.write("))");
         } else {
             self.write_helper("__asyncValues");
             self.write("(");
             self.emit_expression(for_in_of.expression);
-            self.write("), ");
+            self.write(")");
         }
-        self.write(&loop_result_name);
+        if !hoist_loop_init_temps {
+            self.write(", ");
+            self.write(&loop_result_name);
+        }
         self.write("; ");
         self.write(&loop_result_name);
         self.write(" = ");

--- a/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
@@ -132,12 +132,20 @@ fn for_await_temps_do_not_leak_to_source_scope() {
     let source_scope = &output[..function_start];
 
     assert!(
-        !source_scope.contains("var _a, e_1, _b, _c;"),
+        !source_scope.contains("var _a, e_1, _b, _c, _d, y_1, y_1_1;"),
         "for-await temps should not be hoisted outside the function.\nOutput:\n{output}"
     );
     assert!(
-        output.contains("function* () {\n        var _a, e_1, _b, _c;"),
+        output.contains("function* () {\n        var _a, e_1, _b, _c, _d, y_1, y_1_1;"),
         "for-await temps should be hoisted inside the generated async body.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("for (_d = true, y_1 = __asyncValues(y);"),
+        "for-await loop init should reuse the hoisted temps instead of redeclaring them inline.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("for (var _d = true, y_1 = __asyncValues(y);"),
+        "generated async bodies should not emit inline `var` for hoisted for-await loop temps.\nOutput:\n{output}"
     );
 }
 
@@ -163,12 +171,16 @@ fn async_arrow_for_await_temps_are_hoisted_inside_generator() {
     let source_scope = &output[..arrow_start];
 
     assert!(
-        !source_scope.contains("var _a, e_1, _b, _c;"),
+        !source_scope.contains("var _a, e_1, _b, _c, _d, _e, _f;"),
         "for-await temps from async arrows should not be hoisted outside the arrow.\nOutput:\n{output}"
     );
     assert!(
-        output.contains("function* () {\n    var _a, e_1, _b, _c;\n    try {"),
+        output.contains("function* () {\n    var _a, e_1, _b, _c, _d, _e, _f;\n    try {"),
         "for-await temps should be hoisted inside the async arrow generator body.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("for (_d = true, _e = __asyncValues(gen());"),
+        "async arrows should reuse hoisted for-await loop-init temps.\nOutput:\n{output}"
     );
 }
 
@@ -191,7 +203,7 @@ fn async_arrow_for_await_assignment_binding_temps_are_hoisted() {
     let output = printer.get_output().to_string();
 
     assert!(
-        output.contains("const arrow = () => __awaiter(void 0, void 0, void 0, function* () {\n    var _a, e_1, _b, _c;\n    try {"),
+        output.contains("const arrow = () => __awaiter(void 0, void 0, void 0, function* () {\n    var _a, e_1, _b, _c, _d, _e, _f;\n    try {"),
         "assignment-target for-await temps should be hoisted in async arrow generator bodies.\nOutput:\n{output}"
     );
     assert!(


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Emit parity / release metric truth. Code-only fix for a scoped async for-await emit gap from #11894.

## Invariant
When a downleveled `for await...of` loop is emitted inside a generated async or async-generator body, loop guard/iterator/result temps are hoisted into that generated body's `var` group and are not redeclared inline in the `for` initializer; top-level System execute lowering keeps its inline temp declarations.

## Scope
- `crates/tsz-emitter/src/emitter/es5/bindings_param_patterns.rs`
- `crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: async/await/generator emit lowering
- Evidence: targeted TypeScript emit baseline `operationsAvailableOnPromisedType` now passes for JS targets ES2015 and ES5.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-emitter for_await_temps_do_not_leak_to_source_scope async_arrow_for_await_temps_are_hoisted_inside_generator async_arrow_for_await_assignment_binding_temps_are_hoisted`
- `scripts/emit/run.sh --filter=operationsAvailableOnPromisedType --js-only --verbose --timeout=20000 --concurrency=1 --json-out=/tmp/tsz-ops-emit-after-rebase.json`

## Coordination Notes
- Code-only change; no markdown/documentation edits.
- Addresses the remaining ES2015/ES5 `operationsAvailableOnPromisedType` emit gap tracked in #11894.
- #12016 is an open Studio-C draft for ES5 for-await temp ordering. This PR is limited to generated async-body hoisting for the direct downlevel for-await printer; the targeted ES5 baseline remains green after this change.
