### PR TITLE
perf(checker): cache boundary generic instantiation

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -642,6 +642,9 @@ mod generic_class_self_ref_method_param_tests;
 #[path = "../tests/generic_inference_manual.rs"]
 mod generic_inference_manual;
 #[cfg(test)]
+#[path = "tests/generic_instantiation_boundary_cache_tests.rs"]
+mod generic_instantiation_boundary_cache_tests;
+#[cfg(test)]
 #[path = "tests/generic_rest_satisfies_anchor_tests.rs"]
 mod generic_rest_satisfies_anchor_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -20,19 +20,12 @@ pub(crate) use tsz_solver::type_queries::{
 pub(crate) use tsz_solver::{
     FunctionShape, IntrinsicKind, MappedType, ObjectFlags, ParamInfo, PendingDiagnostic,
     PendingDiagnosticBuilder, SourceLocation, SubtypeFailureReason, TypeFormatter,
-    computation::{ContextualTypeContext, TypeSubstitution, instantiate_generic},
+    computation::{ContextualTypeContext, TypeSubstitution},
 };
 
 pub(crate) use super::construct_signatures::construct_signatures_for_type;
+pub(crate) use super::generic_instantiation::{instantiate_generic, instantiate_type};
 pub(crate) use super::type_rewrite::replace_type_queries_and_lazies_with;
-
-pub(crate) fn instantiate_type(
-    db: &dyn QueryDatabase,
-    type_id: TypeId,
-    substitution: &TypeSubstitution,
-) -> TypeId {
-    c::instantiate_type_cached(db.as_type_database(), Some(db), type_id, substitution)
-}
 
 pub(crate) fn is_compiler_managed_type(name: &str) -> bool {
     tsz_solver::is_compiler_managed_type(name)

--- a/crates/tsz-checker/src/query_boundaries/generic_instantiation.rs
+++ b/crates/tsz-checker/src/query_boundaries/generic_instantiation.rs
@@ -1,0 +1,25 @@
+use tsz_solver::construction::QueryDatabase;
+use tsz_solver::{TypeId, TypeParamInfo, computation as c};
+
+pub(crate) fn instantiate_type(
+    db: &dyn QueryDatabase,
+    type_id: TypeId,
+    substitution: &c::TypeSubstitution,
+) -> TypeId {
+    c::instantiate_type_cached(db.as_type_database(), Some(db), type_id, substitution)
+}
+
+pub(crate) fn instantiate_generic(
+    db: &dyn QueryDatabase,
+    type_id: TypeId,
+    type_params: &[TypeParamInfo],
+    type_args: &[TypeId],
+) -> TypeId {
+    c::instantiate_generic_cached(
+        db.as_type_database(),
+        Some(db),
+        type_id,
+        type_params,
+        type_args,
+    )
+}

--- a/crates/tsz-checker/src/query_boundaries/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/mod.rs
@@ -30,6 +30,7 @@ pub(crate) mod environment;
 pub(crate) mod flow;
 pub(crate) mod flow_analysis;
 pub(crate) mod function_returns;
+pub(crate) mod generic_instantiation;
 pub(crate) mod index_signature;
 pub(crate) mod inference;
 pub(crate) mod intersection_display;

--- a/crates/tsz-checker/src/tests/generic_instantiation_boundary_cache_tests.rs
+++ b/crates/tsz-checker/src/tests/generic_instantiation_boundary_cache_tests.rs
@@ -1,0 +1,50 @@
+use crate::query_boundaries::common::instantiate_generic;
+use tsz_solver::construction::{QueryCache, TypeInterner};
+use tsz_solver::{PropertyInfo, TypeId, TypeParamInfo, Visibility};
+
+fn param_info(name: tsz_common::interner::Atom) -> TypeParamInfo {
+    TypeParamInfo {
+        name,
+        constraint: None,
+        default: None,
+        is_const: false,
+    }
+}
+
+fn object_with(interner: &TypeInterner, type_id: TypeId) -> TypeId {
+    let name = interner.intern_string("value");
+    interner.object(vec![PropertyInfo {
+        name,
+        type_id,
+        write_type: type_id,
+        optional: false,
+        readonly: false,
+        is_method: false,
+        is_class_prototype: false,
+        visibility: Visibility::Public,
+        parent_id: None,
+        declaration_order: 0,
+        is_string_named: true,
+        is_symbol_named: false,
+        single_quoted_name: false,
+    }])
+}
+
+#[test]
+fn instantiate_generic_boundary_uses_query_cache() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let param_name = interner.intern_string("T");
+    let param_type = interner.type_param(param_info(param_name));
+    let body = object_with(&interner, param_type);
+    let param = param_info(param_name);
+
+    let before = db.statistics();
+    let first = instantiate_generic(&db, body, &[param], &[TypeId::STRING]);
+    let second = instantiate_generic(&db, body, &[param], &[TypeId::STRING]);
+    let after = db.statistics();
+
+    assert_eq!(first, second);
+    assert!(after.instantiation_cache_misses > before.instantiation_cache_misses);
+    assert!(after.instantiation_cache_hits > before.instantiation_cache_hits);
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 1/2/5 cache/residency slice: recursive utility and checker query-boundary generic instantiation.

## Invariant
When checker query-boundary code instantiates a generic body while holding a resolver-equipped `QueryDatabase`, the result must stay identical to the uncached solver instantiation; this PR routes that boundary helper through the existing solver instantiation cache keyed by the generic body and canonical substitution so repeated boundary instantiations can reuse the per-file query cache.

## Scope
- `crates/tsz-checker/src/query_boundaries/generic_instantiation.rs`
- `crates/tsz-checker/src/query_boundaries/common.rs`
- `crates/tsz-checker/src/query_boundaries/mod.rs`
- `crates/tsz-checker/src/tests/generic_instantiation_boundary_cache_tests.rs`
- `crates/tsz-checker/src/lib.rs`
- Moves cache-aware generic/type instantiation wrappers into a focused query-boundary module.
- Keeps existing `common::{instantiate_generic, instantiate_type}` caller paths as re-exports while reducing `common.rs` to 1913 lines, below the 1920 quarantine guard.
- Adds focused unit coverage that repeats the same non-leaf generic body instantiation and observes the `QueryCache` miss-then-hit path.

## Project Corpus Impact
- Row: `ts-essentials-project` / `vite-vanilla-ts-app` target-gap follow-up context from #12021.
- Bug family: recursive utility expansion fan-out and checker-boundary generic instantiation cache reuse.
- Evidence: existing #12021 artifacts show green rows still below the 2x target; this PR makes the next enabling cache path observable and active at checker query boundaries, but does not claim a timing win until fresh row benchmarks compare before/after.

## Verification
- `cargo fmt --check`
- `git diff --check -- crates/tsz-checker/src/query_boundaries/common.rs crates/tsz-checker/src/query_boundaries/generic_instantiation.rs crates/tsz-checker/src/query_boundaries/mod.rs crates/tsz-checker/src/lib.rs crates/tsz-checker/src/tests/generic_instantiation_boundary_cache_tests.rs`
- `cargo nextest run -p tsz-checker --lib instantiate_generic_boundary_uses_query_cache`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`

## Coordination Notes
- Open PR overlap checked on 2026-06-01; #12054 is a separate export-resolution table draft and does not touch generic instantiation.
- Follow-up to #12019 and #12021. The unsafe DOM/actual-lib cache experiment documented on #12021 is intentionally not included here.
- Draft CI previously failed because the initial test placement grew `common.rs` past the 1920 query-boundary quarantine guard; head `661b28bbc8` fixes that by splitting the helper/test out of `common.rs`.
- Ready for manager review after draft/light CI confirms the exact pushed head.