### PR TITLE
chore(agents): warn on ready unassigned prs

### DIFF
--- a/scripts/agents/ensure-agent-labels.sh
+++ b/scripts/agents/ensure-agent-labels.sh
@@ -242,6 +242,7 @@ const findingCount =
   multipleIssues.length +
   noncanonicalIssues.length;
 const ok = findingCount === 0;
+const warningCount = readyIntentionallyUnassignedPrs.length;
 const metrics = {
   missing_canonical_labels: missingCanonicalLabels.length,
   noncanonical_agent_labels: noncanonicalLabels.length,
@@ -255,8 +256,10 @@ const metrics = {
   open_issues_multiple_agent_labels: multipleIssues.length,
   open_issues_noncanonical_agent_label: noncanonicalIssues.length,
   agent_label_audit_findings: findingCount,
+  agent_label_audit_warnings: warningCount,
 };
 console.log(`agent_label_audit_findings=${findingCount}`);
+console.log(`agent_label_audit_warnings=${warningCount}`);
 console.log(`agent_label_audit_status=${ok ? "pass" : "fail"}`);
 
 const summarizeWorkItem = (item) => ({
@@ -277,6 +280,8 @@ if (process.env.JSON_REPORT) {
     ok,
     status: ok ? "pass" : "fail",
     agent_label_audit_status: ok ? "pass" : "fail",
+    warning_count: warningCount,
+    warning_status: warningCount > 0 ? "warn" : "clear",
     git_context: {
       head: process.env.GIT_HEAD,
       branch: process.env.GIT_BRANCH,

--- a/scripts/agents/test_ensure_agent_labels.py
+++ b/scripts/agents/test_ensure_agent_labels.py
@@ -123,6 +123,7 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
         self.assertIn("open_ready_prs_intentionally_unassigned=0", output)
         self.assertIn("open_draft_prs_intentionally_unassigned=1", output)
         self.assertIn("agent_label_audit_findings=0", output)
+        self.assertIn("agent_label_audit_warnings=0", output)
         self.assertIn("agent_label_audit_status=pass", output)
         self.assertIn("Open PRs Intentionally Unassigned", output)
         self.assertIn("Open Draft PRs Intentionally Unassigned", output)
@@ -148,6 +149,7 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
         self.assertIn("open_prs_missing_agent_label=1", output)
         self.assertIn("open_prs_intentionally_unassigned=0", output)
         self.assertIn("agent_label_audit_findings=1", output)
+        self.assertIn("agent_label_audit_warnings=0", output)
         self.assertIn("agent_label_audit_status=fail", output)
         self.assertIn(
             "#3 fix: missing label https://github.com/mohsen1/tsz/pull/3",
@@ -195,6 +197,7 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
         self.assertIn("open_ready_prs_intentionally_unassigned=1", result.stdout)
         self.assertIn("open_draft_prs_intentionally_unassigned=0", result.stdout)
         self.assertIn("agent_label_audit_findings=0", result.stdout)
+        self.assertIn("agent_label_audit_warnings=1", result.stdout)
         self.assertIn("agent_label_audit_status=pass", result.stdout)
 
     def test_json_report_splits_ready_and_draft_intentionally_unassigned_prs(self):
@@ -231,6 +234,9 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
             1,
             report["metrics"]["open_ready_prs_intentionally_unassigned"],
         )
+        self.assertEqual(1, report["metrics"]["agent_label_audit_warnings"])
+        self.assertEqual(1, report["warning_count"])
+        self.assertEqual("warn", report["warning_status"])
         self.assertEqual(
             1,
             report["metrics"]["open_draft_prs_intentionally_unassigned"],
@@ -364,6 +370,9 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
         self.assertIsInstance(report["git_context"]["detached"], bool)
         self.assertIn("upstream", report["git_context"])
         self.assertEqual(2, report["metrics"]["agent_label_audit_findings"])
+        self.assertEqual(0, report["metrics"]["agent_label_audit_warnings"])
+        self.assertEqual(0, report["warning_count"])
+        self.assertEqual("clear", report["warning_status"])
         self.assertEqual(1, report["metrics"]["open_prs_missing_agent_label"])
         self.assertEqual(1, report["metrics"]["open_prs_noncanonical_agent_label"])
         self.assertEqual(
@@ -411,8 +420,11 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
         self.assertTrue(report["ok"])
         self.assertEqual("pass", report["status"])
         self.assertEqual("pass", report["agent_label_audit_status"])
+        self.assertEqual(0, report["warning_count"])
+        self.assertEqual("clear", report["warning_status"])
         self.assertIn("git_context", report)
         self.assertEqual(0, report["metrics"]["agent_label_audit_findings"])
+        self.assertEqual(0, report["metrics"]["agent_label_audit_warnings"])
 
     def test_json_report_requires_audit_mode(self):
         result = self.run_audit_result(


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / agent-label coordination evidence

## Invariant
When the agent-label audit finds ready PRs that are intentionally unassigned, the audit should stay passable while exposing a distinct warning count/status for queue triage.

## Scope
- `scripts/agents/ensure-agent-labels.sh`
- `scripts/agents/test_ensure_agent_labels.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent-label audit reporting only; no compiler, checker, solver, parser, binder, emitter, LSP, WASM, benchmark fixture, or corpus behavior changes.

## Verification
- `python3 -m unittest scripts.agents.test_ensure_agent_labels`
- `python3 -m py_compile scripts/agents/test_ensure_agent_labels.py`
- `bash -n scripts/agents/ensure-agent-labels.sh`
- `git diff --check -- scripts/agents/ensure-agent-labels.sh scripts/agents/test_ensure_agent_labels.py`
- `scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-warning-audit.json`

## Coordination Notes
- Studio-F owned runway was clear before opening this PR.
- Live audit currently reports `agent_label_audit_findings=0` and `agent_label_audit_warnings=1` because #12048 is ready and intentionally unassigned.
- This keeps intentional unassignment non-failing while making the ready-unassigned queue signal explicit in text and JSON.
