### PR TITLE
fix(checker): skip eager eval for distributive conditionals deferring into aliases

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1827,6 +1827,10 @@ name = "distributive_conditional_default_tests"
 path = "tests/distributive_conditional_default_tests.rs"
 
 [[test]]
+name = "distributive_alias_wrapped_conditional_tests"
+path = "tests/distributive_alias_wrapped_conditional_tests.rs"
+
+[[test]]
 name = "track8_debt_contract_tests"
 path = "tests/track8_debt_contract_tests.rs"
 

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1011,35 +1011,6 @@ pub(crate) fn is_evaluable_meta_type(db: &dyn TypeDatabase, type_id: TypeId) -> 
         || is_keyof_type(db, type_id)
 }
 
-/// Whether `type_id` is a distributive conditional whose check side defers
-/// into another type (`Lazy`, `Application`, `IndexAccess`, or `KeyOf`).
-///
-/// Eager evaluation of such an alias body at the declaration seam (see the
-/// non-generic conditional eager-eval gates in `state/type_analysis` and
-/// `types/type_checking`) can snapshot the true branch before the deferred
-/// union has been materialized, freezing per-member distribution into a
-/// single object that later consumers like `Extract<V, P>` then substitute
-/// against. Skipping the eager evaluation keeps the body in its raw
-/// `Conditional` form so the next consumer drives distribution through the
-/// regular evaluator path with a fully populated resolver.
-pub(crate) fn conditional_check_defers_into_alias(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
-    use tsz_solver::types::TypeData;
-    let Some(cond_id) = tsz_solver::type_queries::get_conditional_type_id(db, type_id) else {
-        return false;
-    };
-    let cond = db.get_conditional(cond_id);
-    cond.is_distributive
-        && matches!(
-            db.lookup(cond.check_type),
-            Some(
-                TypeData::Lazy(_)
-                    | TypeData::Application(_)
-                    | TypeData::IndexAccess(_, _)
-                    | TypeData::KeyOf(_)
-            )
-        )
-}
-
 // ── Type parameter constraint query ──
 
 pub(crate) fn type_parameter_constraint(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeId> {

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1011,6 +1011,35 @@ pub(crate) fn is_evaluable_meta_type(db: &dyn TypeDatabase, type_id: TypeId) -> 
         || is_keyof_type(db, type_id)
 }
 
+/// Whether `type_id` is a distributive conditional whose check side defers
+/// into another type (`Lazy`, `Application`, `IndexAccess`, or `KeyOf`).
+///
+/// Eager evaluation of such an alias body at the declaration seam (see the
+/// non-generic conditional eager-eval gates in `state/type_analysis` and
+/// `types/type_checking`) can snapshot the true branch before the deferred
+/// union has been materialized, freezing per-member distribution into a
+/// single object that later consumers like `Extract<V, P>` then substitute
+/// against. Skipping the eager evaluation keeps the body in its raw
+/// `Conditional` form so the next consumer drives distribution through the
+/// regular evaluator path with a fully populated resolver.
+pub(crate) fn conditional_check_defers_into_alias(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    use tsz_solver::types::TypeData;
+    let Some(cond_id) = tsz_solver::type_queries::get_conditional_type_id(db, type_id) else {
+        return false;
+    };
+    let cond = db.get_conditional(cond_id);
+    cond.is_distributive
+        && matches!(
+            db.lookup(cond.check_type),
+            Some(
+                TypeData::Lazy(_)
+                    | TypeData::Application(_)
+                    | TypeData::IndexAccess(_, _)
+                    | TypeData::KeyOf(_)
+            )
+        )
+}
+
 // ── Type parameter constraint query ──
 
 pub(crate) fn type_parameter_constraint(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeId> {

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -200,7 +200,7 @@ impl<'a> CheckerState<'a> {
                         && !crate::query_boundaries::common::contains_type_parameters(
                             db, alias_type,
                         )
-                        && !crate::query_boundaries::common::conditional_check_defers_into_alias(
+                        && !tsz_solver::type_queries::is_distributive_conditional_with_deferred_check(
                             db, alias_type,
                         )
                     {

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -200,6 +200,9 @@ impl<'a> CheckerState<'a> {
                         && !crate::query_boundaries::common::contains_type_parameters(
                             db, alias_type,
                         )
+                        && !crate::query_boundaries::common::conditional_check_defers_into_alias(
+                            db, alias_type,
+                        )
                     {
                         let evaluated = self.evaluate_type_with_env(alias_type);
                         if evaluated != alias_type {

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -310,6 +310,10 @@ impl<'a> CheckerState<'a> {
                 && !crate::query_boundaries::checkers::generic::contains_named_or_bound_type_parameter(
                     self.ctx.types,
                     body_type,
+                )
+                && !crate::query_boundaries::common::conditional_check_defers_into_alias(
+                    self.ctx.types,
+                    body_type,
                 );
             if !type_params.is_empty() || can_register_non_generic_conditional {
                 let alias_def_id = self.ctx.get_or_create_def_id(alias_sid);

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -311,7 +311,7 @@ impl<'a> CheckerState<'a> {
                     self.ctx.types,
                     body_type,
                 )
-                && !crate::query_boundaries::common::conditional_check_defers_into_alias(
+                && !tsz_solver::type_queries::is_distributive_conditional_with_deferred_check(
                     self.ctx.types,
                     body_type,
                 );

--- a/crates/tsz-checker/tests/distributive_alias_wrapped_conditional_tests.rs
+++ b/crates/tsz-checker/tests/distributive_alias_wrapped_conditional_tests.rs
@@ -6,9 +6,12 @@
 //! declaration seam. Snapshotting freezes distribution into a single object
 //! that later consumers (e.g. `Extract<V, P>`) then substitute against.
 //!
-//! The guard lives in
-//! `crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs`
-//! (`alias_distributive_check_is_alias_ref`).
+//! The structural classifier lives in
+//! `crates/tsz-solver/src/type_queries/classifiers.rs`
+//! (`is_distributive_conditional_with_deferred_check`) and is consulted from
+//! the two checker eager-eval gates:
+//! - `crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs`
+//! - `crates/tsz-checker/src/types/type_checking/type_alias_checking.rs`
 //!
 //! Adjacent cases (see CLAUDE.md §26) exercised here:
 //! 1. The reported repro shape (`{kind, value}` classifier over a tuple union).

--- a/crates/tsz-checker/tests/distributive_alias_wrapped_conditional_tests.rs
+++ b/crates/tsz-checker/tests/distributive_alias_wrapped_conditional_tests.rs
@@ -1,0 +1,122 @@
+//! Distributive conditionals wrapped in another alias must keep their per-
+//! member precision. When a non-generic alias' body is a distributive
+//! conditional whose check side defers into another alias (`Lazy`), a
+//! generic application (`Application`), an indexed access (`IndexAccess`),
+//! or a `KeyOf`, the checker must NOT eagerly snapshot the body at the
+//! declaration seam. Snapshotting freezes distribution into a single object
+//! that later consumers (e.g. `Extract<V, P>`) then substitute against.
+//!
+//! The guard lives in
+//! `crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs`
+//! (`alias_distributive_check_is_alias_ref`).
+//!
+//! Adjacent cases (see CLAUDE.md §26) exercised here:
+//! 1. The reported repro shape (`{kind, value}` classifier over a tuple union).
+//! 2. A different bound name (`P` instead of `T`) — proves the rule is
+//!    structural, not keyed on a specific identifier.
+//! 3. A two-member literal union — same shape with non-tuple members.
+//! 4. A negative-case probe to ensure non-distributive aliases retain their
+//!    eager-eval behavior.
+//!
+//! Each test defines `Extract<T, U>` locally so the harness does not depend on
+//! `lib.es5.d.ts`. A typo in `Extract` or `Wrap` would surface as an
+//! unfiltered TS2304 and fail the test.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+#[track_caller]
+fn assert_diagnostic_codes(source: &str, expected_codes: &[u32]) {
+    let diagnostics = check_source_diagnostics(source);
+    let actual: Vec<u32> = diagnostics.iter().map(|d| d.code).collect();
+    assert_eq!(
+        actual, expected_codes,
+        "Expected diagnostic codes {expected_codes:?}, got: {diagnostics:#?}",
+    );
+}
+
+/// Baseline: an inline-union argument to a distributive generic flows through
+/// `Extract` correctly.
+#[test]
+fn extract_on_inline_union_through_distributive_wrap() {
+    let source = r#"
+type Extract<T, U> = T extends U ? T : never;
+type Wrap<T> = T extends unknown ? { kind: 'other'; value: T } : never;
+type V = Wrap<[string, string] | [number, number] | []>;
+type E = Extract<V, { value: [string, string] }>;
+declare const e: E;
+const ok: 'other' = e.kind;
+const v0: string = e.value[0];
+"#;
+    assert_diagnostic_codes(source, &[]);
+}
+
+/// Renamed bound name (`P` instead of `T`) — proves the rule is structural.
+#[test]
+fn extract_on_inline_union_renamed_iteration_var() {
+    let source = r#"
+type Extract<T, U> = T extends U ? T : never;
+type Wrap<P> = P extends unknown ? { kind: 'other'; value: P } : never;
+type V = Wrap<[string, string] | [number, number] | []>;
+type E = Extract<V, { value: [string, string] }>;
+declare const e: E;
+const ok: 'other' = e.kind;
+const v0: string = e.value[0];
+"#;
+    assert_diagnostic_codes(source, &[]);
+}
+
+/// Two-member literal union (no tuples) — same structural rule.
+#[test]
+fn extract_on_literal_union_through_distributive_wrap() {
+    let source = r#"
+type Extract<T, U> = T extends U ? T : never;
+type Wrap<T> = T extends unknown ? { v: T } : never;
+type V = Wrap<"a" | "b">;
+type E = Extract<V, { v: "a" }>;
+declare const e: E;
+const k: 'a' = e.v;
+"#;
+    assert_diagnostic_codes(source, &[]);
+}
+
+/// Non-distributive alias body (check side is a fixed alias, not a type
+/// parameter, so the conditional is non-distributive in tsc): the eager
+/// evaluation must still happen, and `Extract` correctly yields `never`.
+/// Locks in that the new guard is narrow to *distributive* conditionals.
+#[test]
+fn non_distributive_alias_body_keeps_eager_eval() {
+    let source = r#"
+type Extract<T, U> = T extends U ? T : never;
+type U = "a" | "b";
+type V = U extends unknown ? { v: U } : never;
+type E = Extract<V, { v: "a" }>;
+declare const e: E;
+const k: 'a' = e.v;
+"#;
+    // V here is non-distributive — check side is a fixed alias `U`, not a
+    // type parameter — so V evaluates to `{ v: 'a' | 'b' }` and Extract over
+    // it yields `never`. `e.v` is therefore a missing-property access.
+    assert_diagnostic_codes(source, &[2339]);
+}
+
+/// Classify-style nested conditional — the original repro shape from #10864.
+#[test]
+fn classify_distributive_over_inline_tuple_union() {
+    let source = r#"
+type Extract<T, U> = T extends U ? T : never;
+type Classify<T> = T extends unknown
+  ? T extends string
+    ? { kind: 'string'; value: T }
+    : T extends number
+      ? { kind: 'number'; value: T }
+      : { kind: 'other'; value: T }
+  : never;
+
+type V = Classify<[string, string] | [number, number] | []>;
+type E = Extract<V, { value: [string, string] }>;
+declare const e: E;
+const ok: 'other' = e.kind;
+const v0: string = e.value[0];
+"#;
+    assert_diagnostic_codes(source, &[]);
+}

--- a/crates/tsz-solver/src/type_queries/classifiers.rs
+++ b/crates/tsz-solver/src/type_queries/classifiers.rs
@@ -245,6 +245,37 @@ pub fn get_conditional_type_id(
     }
 }
 
+/// Returns true if `type_id` is a distributive `Conditional` whose
+/// `check_type` defers into another type (`Lazy`, `Application`,
+/// `IndexAccess`, or `KeyOf`).
+///
+/// Callers (currently the checker's non-generic conditional eager-eval gates)
+/// use this to recognise alias bodies whose true-branch snapshot would freeze
+/// the deferred union before it has been materialized on the resolver,
+/// collapsing per-member distribution at the next consumer (e.g.
+/// `Extract<V, P>`). Skipping eager evaluation in that shape keeps the body in
+/// its raw `Conditional` form so the regular evaluator path with a fully
+/// populated resolver drives distribution correctly.
+pub fn is_distributive_conditional_with_deferred_check(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> bool {
+    let Some(cond_id) = get_conditional_type_id(db, type_id) else {
+        return false;
+    };
+    let cond = db.get_conditional(cond_id);
+    cond.is_distributive
+        && matches!(
+            db.lookup(cond.check_type),
+            Some(
+                TypeData::Lazy(_)
+                    | TypeData::Application(_)
+                    | TypeData::IndexAccess(_, _)
+                    | TypeData::KeyOf(_)
+            )
+        )
+}
+
 /// Returns true if `type_id` is an `IndexAccess(_, _)` type.
 pub fn is_indexed_access(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     if type_id.is_intrinsic() {

--- a/crates/tsz-solver/src/type_queries/mod.rs
+++ b/crates/tsz-solver/src/type_queries/mod.rs
@@ -58,8 +58,8 @@ pub use classifiers::{
     classify_for_constructor_access, classify_for_excess_properties, classify_for_interface_merge,
     get_application_lazy_def_id, get_conditional_type_id, get_keyof_type, get_lazy_def_id,
     get_mapped_type_id, get_type_query_symbol_ref, indexed_access_self_keyof,
-    is_deferred_lazy_or_indexed_access, is_deferred_type_operation, is_indexed_access,
-    is_only_false_or_never,
+    is_deferred_lazy_or_indexed_access, is_deferred_type_operation,
+    is_distributive_conditional_with_deferred_check, is_indexed_access, is_only_false_or_never,
 };
 // `get_def_id` is an alias for `get_lazy_def_id` (identical semantics).
 pub use classifiers::get_lazy_def_id as get_def_id;


### PR DESCRIPTION
## Agent

AgentName: M4-A (canonical lane assigned by Studio-F via the `agent:M4-A` label on this PR; runner identity `opus47-confident-thompson` (claude-opus-4-7[1m]) kept under Coordination Notes per CLAUDE.md §20.1).

## Track

Checker / distributive-conditional alias-body eager-eval correctness. Solver `type_queries` classifier owned by the M4-A conditional/mapped/indexed-access evaluation lane.

## Invariant

When a non-generic type alias body is a distributive conditional whose check side defers into another type (`Lazy`, `Application`, `IndexAccess`, or `KeyOf`), the checker must **not** eagerly evaluate the body at the declaration seam. Eager evaluation can snapshot the true branch before the deferred union has been materialized on the resolver, freezing per-member distribution into a single object that later consumers like `Extract<V, P>` then substitute against — collapsing the utility to `never` instead of the per-member result tsc produces.

## Scope

Refs #10864 (`large-ts-repo`: distributive conditional evaluation over tuple-like unions can become over-constrained).

### Root cause

Two checker sites eagerly evaluate non-generic conditional alias bodies and register the evaluated form as the alias' resolved body:

- `crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs` (compute-symbol type-alias path)
- `crates/tsz-checker/src/types/type_checking/type_alias_checking.rs` (alias-checking registration path)

Both gates were only conditioned on `(is_conditional_type || is_index_access_type) && !contains_type_parameters`. For a distributive conditional whose check side is a `Lazy(DefId)` / `Application(...)` / `IndexAccess(...)` / `KeyOf(...)`, the eager eval observes the check as a single non-union value (the unresolved alias/application form) and takes the true branch directly, producing a single object snapshot. `resolve_lazy` then returns that snapshot for the alias going forward, and downstream `Extract<V, P>`-style utilities substitute against the frozen object instead of the per-member distribution.

### Fix (owning layer = solver `type_queries`)

Adds `is_distributive_conditional_with_deferred_check(db, type_id) -> bool` to `crates/tsz-solver/src/type_queries/classifiers.rs` (re-exported from the `type_queries` module surface). The classifier returns true for a distributive `Conditional` whose `check_type` is one of `Lazy | Application | IndexAccess | KeyOf`.

The two checker eager-eval gates call the solver classifier directly. No `query_boundaries::common` wrapper is added because that file is already at the #8225 1920-line quarantine ceiling, and per CLAUDE.md §4 the classifier is a structural type-shape rule and so belongs in the solver, not in the checker boundary.

When the classifier returns true the gate skips the snapshot, keeping the alias body in its raw `Conditional` form so the next consumer drives distribution through the regular evaluator path with a fully populated resolver.

This is a class fix, not a fixture-name patch: it gates the eager-eval decision on a structural property of the alias body (distributive + deferred check), never by spelling or alias name.

## Project Corpus Impact

- Row: `large-ts-repo` (the originating issue #10864), and the same structural rule applies anywhere a non-generic alias' body is a distributive conditional with a deferred check side.
- Bug family: distributive conditional collapse through wrapping aliases.
- Evidence: new unit-level regression coverage in `crates/tsz-checker/tests/distributive_alias_wrapped_conditional_tests.rs`. CI's conformance, emit, fourslash, and WASM suites validate no other rows regress.

## Verification

- `cargo build -p tsz-checker` — clean on the latest rebase.
- `cargo clippy -p tsz-checker -p tsz-solver --tests --all-features -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — passes (`Architecture guardrails passed.`).
- `cargo test -p tsz-checker --test distributive_alias_wrapped_conditional_tests` — 5/5 pass (new regression file).
- `cargo test -p tsz-checker --test extract_alias_distributive_mapped_tests` — 6/6 pass (sibling alias-wrapped distributive coverage unchanged).
- `cargo test -p tsz-checker --test distributive_conditional_default_tests` — 17/17 pass (broader distributive-default coverage unchanged).
- `cargo fmt --check` — clean.

Pre-existing solver/lib failures (`test_template_literal_with_any`, `test_template_any_widening`, …, 9 in total, plus a pre-existing stack-overflow in `test_permutation_type_invalid_assignment_still_rejected`) reproduce identically on clean `main` and are unrelated to this change.

Exact-head ready-review CI on `2a6cc2e18fb88c65185b72573dac6785c2846254` passed: `CI Summary`, conformance aggregate, emit, fourslash aggregate, project compile guard/canary, LSP e2e, wasm/wasm-web, lint, unit, dist-binaries, project body/row gates, cargo-deny, cargo-shear, gate, queue-one-pr, and GitGuardian are green. Queued by ReviewHelper on 2026-06-01.

## Test plan

- [x] `distributive_alias_wrapped_conditional_tests::extract_on_inline_union_through_distributive_wrap` — original repro shape with tuple union.
- [x] `extract_on_inline_union_renamed_iteration_var` — renamed bound name (`P` not `T`) — proves the rule is structural.
- [x] `extract_on_literal_union_through_distributive_wrap` — two-member literal union, non-tuple element shape.
- [x] `non_distributive_alias_body_keeps_eager_eval` — negative test: non-distributive alias body (check side is a fixed alias, not a type parameter) still snapshots eagerly and tsc-correctly yields `never`. Locks the guard to *distributive* conditionals.
- [x] `classify_distributive_over_inline_tuple_union` — the original #10864 `Classify_82`/`U_82` nested-conditional repro.
- [x] Exact-head ready-review CI on `2a6cc2e18fb88c65185b72573dac6785c2846254`: CI Summary, conformance, emit, fourslash, project compile, LSP, WASM, lint, unit, dist-binaries, and GitGuardian passed.

## Coordination Notes

Runner identity: `opus47-confident-thompson` (claude-opus-4-7[1m]). Canonical lane `M4-A` was assigned by Studio-F (see PR comment thread); runner identity retained here for traceability only, not as ownership.

Reviewed via 3 `/simplify` rounds (reuse / simplification / efficiency / altitude):

- Round 1 trimmed the doc comment, narrowed the `matches!` arms from 7 to 4 variants (dropped `Conditional`/`Mapped`/`TemplateLiteral` as defensively-overlisted), collapsed the early-return chain into one short-circuit, and aligned the test file with the existing per-test `Extract` definition pattern from `extract_alias_distributive_mapped_tests.rs`.
- Round 2 promoted the helper into a query-boundary surface and applied it at both eager-eval gates (the altitude reviewer flagged the second site in `type_alias_checking.rs` as a parallel gap), and switched the `Arc<ConditionalType>` materialization to the by-value `db.get_conditional(cond_id)` accessor.
- Round 3 replaced the manual `lookup + matches!(TypeData::Conditional)` pair with the existing `tsz_solver::type_queries::get_conditional_type_id`.

Review response to architectural feedback:
- Moved the raw `TypeData` shape classifier from `query_boundaries/common.rs` into `tsz_solver::type_queries::classifiers` as `is_distributive_conditional_with_deferred_check` so the checker boundary does not match solver internals (arch_guard rule for `query_boundaries`).
- Dropped the `conditional_check_defers_into_alias` wrapper from `query_boundaries/common.rs` because the file is at its 1920-line quarantine ceiling (#8225). The two gate sites import the solver helper directly.
- Refreshed the test module `//!` comment to name the solver classifier and the two checker call sites (per Reviewer feedback on the prior head).
- Updated this PR body to put `AgentName: M4-A` (canonical lane) in the Agent section after Studio-F assigned the `agent:M4-A` label.

Skipped findings (with rationale):
- **Test helper extraction** — `assert_diagnostic_codes` is duplicated between this test file and `extract_alias_distributive_mapped_tests.rs`. Out of scope per CLAUDE.md §20.2 (refactor blast radius exceeds this PR's slice). A follow-up could hoist it into a shared test-utils module.
- **Guard conjunct reorder** — efficiency reviewer suggested putting the deferred-alias check before `contains_type_parameters`. The win is marginal (one extra arena lookup avoided in a rare case) and the gate fires at most once per non-generic conditional alias declaration, not on a hot path. Existing order preserved to keep the diff minimal.
- **Consolidator helper** at the two eager-eval call sites — altitude reviewer's recommendation was *keep inline*: only 2 callers, a consolidator buys nothing.

Out-of-scope follow-ups flagged during review (intentionally not in this PR):
- A deeper resolver-state cleanup in `crates/tsz-checker/src/context/resolver.rs::resolve_lazy` for aliases whose body is itself a generic application (e.g. `type V = Wrap<U>` — V's body is an `Application(Wrap, [U_lazy])`, not a `Conditional`, so this PR's gate does not cover that shape). That divergence has a similar surface but lives on a different code path; a separate PR can address it once the resolver's body-snapshot timing is normalized.

https://claude.ai/code/session_017R8bv4v7EgQjAJZeEqd2qt