### PR TITLE
fix(emit): unify ES5 async for-await temp allocation order (resolves #12027 trade)

### DIFF
--- a/crates/tsz-emitter/src/transforms/async_es5_ir_for_await.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_for_await.rs
@@ -39,6 +39,24 @@ impl<'a> AsyncES5Transformer<'a> {
 
         self.helpers_needed.mark_async_values();
 
+        // tsc allocates the for-await state temps in two different orders
+        // depending on whether the loop is preceded by executable statements in
+        // the same async body. The structural condition is identical to the one
+        // that decides whether the lowered `try` must start in a fresh
+        // generator case (`try_start_label` below):
+        //
+        // * No preceding executable statements (the for-await is the first
+        //   meaningful statement, so the implicit `try` starts at the function
+        //   entry label): tsc allocates the loop guard first, then the
+        //   iterator/result temps, all in the first hoisted-var group, and
+        //   places `done`/`error`/`return`/`value` in the second group.
+        // * Preceding executable statements (the lowering opens a new `try`
+        //   case after the leading work): tsc allocates
+        //   `done`/`error`/`return`/`value`/loop-guard in that order and places
+        //   the loop guard plus iterator/result temps in the second group.
+        //
+        // Reproducing both orders keeps the plain `for await` form and the
+        // spread/sync-loop-before-`for await` form byte-for-byte with tsc.
         let has_pending_executable_statements = current_statements.iter().any(|statement| {
             !matches!(
                 statement,
@@ -48,33 +66,77 @@ impl<'a> AsyncES5Transformer<'a> {
                 } | IRNode::HoistedVarGroupBreak
             )
         });
-        let (iterator_name, result_name) = self.for_await_iterator_names(for_in_of.expression, 1);
-        let catch_value_name = self.fresh_reserved_name("e_1_1");
 
-        if let Some(loop_fn) = &captured_loop_fn {
-            current_statements.push(IRNode::var_decl(loop_fn.clone(), None));
-        }
-        if declared_name.is_some() && captured_loop_fn.is_none() {
-            current_statements.push(IRNode::var_decl(target_name.clone(), None));
-        }
-        current_statements.push(IRNode::var_decl(catch_value_name.clone(), None));
+        let done_name;
+        let error_name;
+        let return_name;
+        let value_name;
+        let loop_guard_name;
+        let iterator_name;
+        let result_name;
+        let catch_value_name;
 
-        current_statements.push(IRNode::HoistedVarGroupBreak);
-        let done_name = self.generate_hoisted_temp();
-        let error_name = self.fresh_reserved_name("e_1");
-        let return_name = self.generate_hoisted_temp();
-        let value_name = self.generate_hoisted_temp();
-        let loop_guard_name = self.generate_hoisted_temp();
-        for name in [
-            &done_name,
-            &error_name,
-            &return_name,
-            &value_name,
-            &loop_guard_name,
-            &iterator_name,
-            &result_name,
-        ] {
-            current_statements.push(IRNode::var_decl(name.clone(), None));
+        if has_pending_executable_statements {
+            // Leading-statement order: iterator/result names are reserved
+            // before the state temps, then `done`/`error`/`return`/`value`/guard
+            // are allocated and grouped after the `var`-group break together
+            // with the iterator/result temps.
+            (iterator_name, result_name) = self.for_await_iterator_names(for_in_of.expression, 1);
+            catch_value_name = self.fresh_reserved_name("e_1_1");
+
+            if let Some(loop_fn) = &captured_loop_fn {
+                current_statements.push(IRNode::var_decl(loop_fn.clone(), None));
+            }
+            if declared_name.is_some() && captured_loop_fn.is_none() {
+                current_statements.push(IRNode::var_decl(target_name.clone(), None));
+            }
+            current_statements.push(IRNode::var_decl(catch_value_name.clone(), None));
+
+            current_statements.push(IRNode::HoistedVarGroupBreak);
+            done_name = self.generate_hoisted_temp();
+            error_name = self.fresh_reserved_name("e_1");
+            return_name = self.generate_hoisted_temp();
+            value_name = self.generate_hoisted_temp();
+            loop_guard_name = self.generate_hoisted_temp();
+            for name in [
+                &done_name,
+                &error_name,
+                &return_name,
+                &value_name,
+                &loop_guard_name,
+                &iterator_name,
+                &result_name,
+            ] {
+                current_statements.push(IRNode::var_decl(name.clone(), None));
+            }
+        } else {
+            // Leading-statement-free order: the loop guard is allocated first so
+            // it claims the first generator-state temp, the iterator/result
+            // temps and guard live in the first `var`-group, and
+            // `done`/`error`/`return`/`value` follow in the second group.
+            loop_guard_name = self.generate_hoisted_temp();
+            (iterator_name, result_name) = self.for_await_iterator_names(for_in_of.expression, 1);
+            catch_value_name = self.fresh_reserved_name("e_1_1");
+
+            if let Some(loop_fn) = &captured_loop_fn {
+                current_statements.push(IRNode::var_decl(loop_fn.clone(), None));
+            }
+            for name in [&loop_guard_name, &iterator_name, &result_name] {
+                current_statements.push(IRNode::var_decl(name.clone(), None));
+            }
+            if declared_name.is_some() && captured_loop_fn.is_none() {
+                current_statements.push(IRNode::var_decl(target_name.clone(), None));
+            }
+            current_statements.push(IRNode::var_decl(catch_value_name.clone(), None));
+
+            current_statements.push(IRNode::HoistedVarGroupBreak);
+            done_name = self.generate_hoisted_temp();
+            error_name = self.fresh_reserved_name("e_1");
+            return_name = self.generate_hoisted_temp();
+            value_name = self.generate_hoisted_temp();
+            for name in [&done_name, &error_name, &return_name, &value_name] {
+                current_statements.push(IRNode::var_decl(name.clone(), None));
+            }
         }
         let captured_loop_assignment = if let Some(loop_fn) = &captured_loop_fn {
             let Some(loop_assignment) = self.captured_for_await_loop_function_assignment(

--- a/crates/tsz-emitter/tests/async_loop_emit.rs
+++ b/crates/tsz-emitter/tests/async_loop_emit.rs
@@ -366,3 +366,71 @@ fn async_es5_for_await_iterator_names_skip_sync_for_of_temps() {
         "For-await iterator setup must not reuse the sync for-of temp name.\nOutput:\n{output}"
     );
 }
+
+/// When the `for await` is the first meaningful statement in the async body
+/// (no preceding executable statements, so the lowered `try` opens at the
+/// function entry label), tsc allocates the loop guard as the first
+/// generator-state temp: `_a = true, <iter> = __asyncValues(...)`.
+#[test]
+fn async_es5_for_await_first_statement_allocates_loop_guard_first() {
+    let output = emit_es5(
+        "async function f(src: any) {
+            for await (const item of src) {
+                item;
+            }
+        }",
+    );
+
+    assert!(
+        output.contains("_a = true, src_1 = __asyncValues(src)"),
+        "A leading `for await` should claim `_a` for the loop guard and the identifier-derived `src_1` iterator.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a = false"),
+        "The loop guard reset must reuse the first state temp `_a`.\nOutput:\n{output}"
+    );
+}
+
+/// Renaming every user identifier must not change the allocation order: the
+/// rule is keyed on whether executable statements precede the loop, not on any
+/// spelling. This guards against hardcoding identifier names (§25).
+#[test]
+fn async_es5_for_await_first_statement_loop_guard_is_name_independent() {
+    let output = emit_es5(
+        "async function g(values: any) {
+            for await (const v of values) {
+                v;
+            }
+        }",
+    );
+
+    assert!(
+        output.contains("_a = true, values_1 = __asyncValues(values)"),
+        "Renamed leading `for await` should still allocate `_a` for the loop guard and `values_1` for the iterator.\nOutput:\n{output}"
+    );
+}
+
+/// When executable statements precede the `for await` (here a leading array
+/// spread, so the lowered `try` opens in a fresh generator case), tsc allocates
+/// `done`/`error`/`return`/`value`/loop-guard in that order, leaving the loop
+/// guard after `value`: `_d = true, <iter> = __asyncValues(...)`.
+#[test]
+fn async_es5_for_await_after_statements_allocates_loop_guard_after_state_temps() {
+    let output = emit_es5(
+        "async function f(c: any[]) {
+            [...c];
+            for await (const s of c) {
+                s;
+            }
+        }",
+    );
+
+    assert!(
+        output.contains("_d = true, c_1 = __asyncValues(c)"),
+        "A `for await` preceded by executable statements should allocate the loop guard after the state temps (`_d`).\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a = c_1_1.done"),
+        "The `done` temp should claim the first state name `_a` when statements precede the loop.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-C

Canonical lane claim 2026-06-01: Studio-C is claiming this PR because it supersedes Studio-C draft #12016 and directly owns the async ES5 for-await emit family. Original runner identity retained for provenance: `opus48-emit100`.

## Track
Emit -> 100% (JavaScript emit parity). Resolves the traded ES5 async for-await temp regression (issue #12027).

## Invariant
tsc's ES5 async `for await...of` state machine uses TWO temp-allocation/hoist-grouping
orders, keyed on whether executable statements precede the for-await in the same async
body (`has_pending_executable_statements`):
- **No preceding executable statements** (for-await is first; implicit `try` opens at the
  function entry label): loop guard allocated FIRST (`_a`), then iterator/result, all in the
  FIRST hoisted-var group; done/error/return/value in the SECOND group.
  (e.g. `var y, _a, y_1, y_1_1, x, e_1_1; var _b, e_1, _c, _d;`)
- **Preceding executable statements** (leading array spread or sync for-of; `try` opens a new
  case): done/error/return/value/loop-guard allocated in that order, loop-guard + iterator/result
  in the SECOND group. (e.g. `var _a, e_1, _b, _c, _d, c_2, c_2_1;`)
#12011 implemented only the second order (regressed plain for-await); #12016 only the first
(re-regressed the spread case) - they TRADED the regression. Keying the allocation on
`has_pending_executable_statements` reconciles both so all three tests pass simultaneously.

## Scope
Emitter (OUTPUT) only. Structural (keyed on the leading-work/iterator-protocol shape), no spelling/printer-output matching.
- `transforms/async_es5_ir_for_await.rs` - branch temp allocation + hoist grouping on `has_pending_executable_statements` (false -> loop-guard-first + group-before-break; true -> #12011's order).
- `tests/async_loop_emit.rs` - 3 focused tests: leading for-await (guard=`_a`), name-independence (renamed idents still `_a`/`values_1`), statements-preceding (guard=`_d`, done=`_a`).

## Project Corpus Impact
- Row: n/a - TypeScript conformance/emit fixture regression fix, not a project-corpus benchmark row.
- Bug family: ES5 async for-await temp-allocation order (unifies the #12011 <-> #12016 trade so no regression is shuffled).
- Evidence: local `scripts/emit/run.sh --js-only` Failed **39 -> 37** (-2; fixes `emitter.forAwait(es5)` + `forAwaitPerIterationBindingDownlevel(es5)` while KEEPING `operationsAvailableOnPromisedType(es5)` green; `comm`-diff zero new failures across the async/generator/iterator corpus, dist-fast cleaned before each measure); conformance pre-check clean (forAwait 8/8, asyncGenerator 21/21, operationsAvailable 1/1, asyncArrow 45/45); `cargo nextest -p tsz-emitter` +3 new tests, 15 pre-existing unrelated failures only; clippy clean.

## Verification
- Draft-light CI passed on head `3683f13d13cf0f0d2aa3980d6c39f8854f58a669` in run `26738115943`: `CI Light Summary`, `dist-binaries`, `lint`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, and GitGuardian.
- Ready-review CI passed on exact head `3683f13d13cf0f0d2aa3980d6c39f8854f58a669` in run `26738899179`: `CI Summary`, `emit`, `conformance-aggregate`, all conformance shards, `fourslash-aggregate`, all fourslash shards, `conformance-snapshot-gate`, `project-corpus-pr-body`, `project-row-drift`, `project-compile-guard`, `project-compile-canary`, `lsp-e2e`, `node-harness-prep`, `dist-binaries`, `unit`, `unit-cloudbuild`, `lint`, `cargo-deny`, `cargo-shear`, `wasm`, `wasm-web`, `gate`, `queue-one-pr`, and GitGuardian.
- All 3 ES5 tests green SIMULTANEOUSLY (the prior #12011/#12016 half-fixes each broke one of them).
- Full `--js-only` comm-diff: exactly the 2 for-await tests fixed, zero collateral. Conformance pre-checked (parser/temp changes can move diagnostics - verified none did).

## Coordination Notes
- Ready handoff 2026-06-01 (AgentName: Studio-C): exact-head ready-review CI is green on `3683f13d13cf0f0d2aa3980d6c39f8854f58a669`, including the aggregate gates that previously motivated #8432 caution. Studio-C is not adding `merge-queue`; queue handoff is left for Reviewer/EM/manager review because #8432 remains open as a shared tracker and prior Reviewer guidance requested explicit clearance before enqueueing.
- Studio-C claim update 2026-06-01: this PR supersedes #12016 and is the active Studio-C for-await temp-allocation runway.
- Restack update 2026-06-01 (AgentName: Studio-C): current head `3683f13d13cf0f0d2aa3980d6c39f8854f58a669` is based on `origin/main` `4fe6b19e883f6126a7b1cabf43fc5a4c7dfd7daa`; no restack is pending for this head.
- Resolves #12027 (the for-await temp-renumber regression introduced by #12011). Supersedes Studio-C's draft #12016 (their for-await temp-order half-fix) - credit to Studio-C for that half + the diagnosis; this unifies it with #12011's spread-order half. Studio-C closed #12016 as superseded and preserved the branch/evidence link there.
- Original AgentName: opus48-emit100. Reviews welcome.
