### PR TITLE
chore(emit-tools): warn on exhausted output surgery budget

### DIFF
--- a/scripts/emit/audit-output-surgery.py
+++ b/scripts/emit/audit-output-surgery.py
@@ -401,10 +401,13 @@ def build_json_report(
         for summary in category_summaries
         if summary["max_count"] is not None and summary["budget_status"] == "exhausted"
     ]
+    warning_count = len(exhausted_categories)
     return {
         "ok": not failures,
         "status": "failed" if failures else "passed",
         "output_surgery_status": "failed" if failures else "passed",
+        "warning_count": warning_count,
+        "warning_status": "warn" if warning_count else "clear",
         "git_context": git_context if git_context is not None else build_git_context(),
         "total_findings": len(findings),
         "files_with_findings": len(counts),
@@ -412,7 +415,7 @@ def build_json_report(
         "allowlist_cap": budget.allowlist_cap,
         "remaining_allowlist_capacity": budget.remaining_allowlist_capacity,
         "allowlist_budget_status": budget.budget_status,
-        "exhausted_category_count": len(exhausted_categories),
+        "exhausted_category_count": warning_count,
         "exhausted_categories": exhausted_categories,
         "unallowlisted_calls": summary.unallowlisted,
         "over_allowlist_files": summary.over_allowlist_files,

--- a/scripts/emit/test_output_surgery_audit.py
+++ b/scripts/emit/test_output_surgery_audit.py
@@ -95,6 +95,8 @@ class OutputSurgeryAuditTests(unittest.TestCase):
         self.assertFalse(report["ok"])
         self.assertEqual(report["status"], "failed")
         self.assertEqual(report["output_surgery_status"], "failed")
+        self.assertEqual(report["warning_count"], 0)
+        self.assertEqual(report["warning_status"], "clear")
         self.assertEqual(report["git_context"], git_context)
         self.assertEqual(report["total_findings"], 2)
         self.assertEqual(report["files_with_findings"], 2)
@@ -166,6 +168,10 @@ class OutputSurgeryAuditTests(unittest.TestCase):
         self.assertTrue(report["ok"])
         self.assertEqual(report["status"], "passed")
         self.assertEqual(report["output_surgery_status"], "passed")
+        self.assertEqual(report["warning_count"], 1)
+        self.assertEqual(report["warning_status"], "warn")
+        self.assertEqual(report["exhausted_category_count"], 1)
+        self.assertEqual(report["exhausted_categories"], ["semantic-output-surgery"])
         self.assertEqual(report["failures"], [])
 
     def test_git_context_records_branch_upstream_and_dirty_count(self):


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / output-surgery cheap evidence plumbing.

## Invariant
When output-surgery allowlist category budgets are exhausted, the JSON report exposes a warning signal while pass/fail status remains based on actual audit failures.

## Scope
- scripts/emit/audit-output-surgery.py
- scripts/emit/test_output_surgery_audit.py

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: emit-tool reporting only; no compiler, emitter, conformance, or project corpus behavior changed.

## Verification
- python3 -m unittest scripts.emit.test_output_surgery_audit
- python3 -m py_compile scripts/emit/audit-output-surgery.py scripts/emit/test_output_surgery_audit.py
- git diff --check -- scripts/emit/audit-output-surgery.py scripts/emit/test_output_surgery_audit.py
- python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery-warning.json
- rg -n '"warning_|"exhausted_category|"allowlist_budget_status"' /tmp/tsz-output-surgery-warning.json
- python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard-studio-f.json

## Coordination Notes
- Owned Studio-F PR runway was clear before publishing.
- Live output-surgery audit remains pass/fail clean, but the JSON smoke now reports warning_status=warn and warning_count=3 because dts-output-surgery, ir-output-surgery, and resource-region-output-surgery are at budget.
- No allowlist entries, caps, roadmap direction, or emitted output changed.
