### PR TITLE
fix(parser): recover invalid typeof object target as declarator

### DIFF
--- a/crates/tsz-parser/src/parser/state_statements.rs
+++ b/crates/tsz-parser/src/parser/state_statements.rs
@@ -1051,6 +1051,19 @@ impl ParserState {
         )
     }
 
+    fn variable_declaration_has_missing_typeof_target(&self, decl: NodeIndex) -> bool {
+        self.arena
+            .get(decl)
+            .and_then(|node| self.arena.get_variable_declaration(node))
+            .and_then(|decl| self.arena.get(decl.type_annotation))
+            .filter(|type_node| type_node.kind == syntax_kind_ext::TYPE_QUERY)
+            .and_then(|type_node| self.arena.get_type_query(type_node))
+            .is_some_and(|type_query| {
+                self.arena
+                    .is_missing_recovery_identifier(type_query.expr_name)
+            })
+    }
+
     /// Parse variable declaration list
     pub(crate) fn parse_variable_declaration_list(&mut self) -> NodeIndex {
         use crate::parser::node_flags;
@@ -1346,6 +1359,9 @@ impl ParserState {
                 // of a new declarator so the `n` produces TS1005 "',' expected"
                 // at the right position, matching tsc.
                 if decl_had_error && !self.is_token(SyntaxKind::CloseBracketToken) {
+                    let recover_typeof_object_target_as_declarator = self
+                        .is_token(SyntaxKind::OpenBraceToken)
+                        && self.variable_declaration_has_missing_typeof_target(decl);
                     let next_starts_declarator = (self.is_identifier_or_keyword()
                         && !self.is_reserved_word())
                         || self.is_token(SyntaxKind::OpenBraceToken)
@@ -1354,7 +1370,8 @@ impl ParserState {
                         || self.current_unknown_starts_invalid_unicode_identifier_debris();
                     if !(next_starts_declarator
                         && (decl_only_literal_value_errors
-                            || self.is_token(SyntaxKind::PrivateIdentifier)))
+                            || self.is_token(SyntaxKind::PrivateIdentifier)
+                            || recover_typeof_object_target_as_declarator))
                     {
                         break;
                     }

--- a/crates/tsz-parser/tests/state_statement_tests_parts/part_00.rs
+++ b/crates/tsz-parser/tests/state_statement_tests_parts/part_00.rs
@@ -1361,6 +1361,46 @@ fn typeof_function_type_query_tail_emits_second_comma_error() {
 }
 
 #[test]
+fn typeof_object_type_query_tail_recovers_inside_variable_list() {
+    let source = "var x1: typeof {};";
+    let (parser, root) = parse_source(source);
+    let arena = parser.get_arena();
+    let sf = arena.get_source_file_at(root).expect("source file");
+
+    assert_eq!(
+        sf.statements.nodes.len(),
+        1,
+        "recovered object target should stay in the variable statement"
+    );
+
+    let stmt = arena
+        .get(sf.statements.nodes[0])
+        .and_then(|node| arena.get_variable(node))
+        .expect("variable statement");
+    let decl_list = arena
+        .get(stmt.declarations.nodes[0])
+        .and_then(|node| arena.get_variable(node))
+        .expect("declaration list");
+
+    assert_eq!(
+        decl_list.declarations.nodes.len(),
+        2,
+        "`typeof {{}}` recovery should add a second declarator"
+    );
+
+    let recovered_decl = arena
+        .get(decl_list.declarations.nodes[1])
+        .and_then(|node| arena.get_variable_declaration(node))
+        .expect("recovered declaration");
+    let recovered_name = arena.get(recovered_decl.name).expect("recovered name");
+    assert_eq!(
+        recovered_name.kind,
+        syntax_kind_ext::OBJECT_BINDING_PATTERN,
+        "recovered object target should parse as an object binding declarator"
+    );
+}
+
+#[test]
 fn class_field_initializer_does_not_asi_before_computed_member() {
     let (parser, _root) = parse_source("class C {\n    [e]: number = 0\n    [e2]: number\n}");
     let diags = parser.get_diagnostics();


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
JavaScript emit parser/recovery parity.

## Invariant
When an invalid `typeof` type-query target is followed by an object/function-like tail inside a variable declaration list, parser recovery should keep the recovered declarator shape that `tsc` emits from. This PR changes parser recovery facts; the emitter preserves the recovered AST shape and does not repair the case with output surgery or semantic validation.

## Scope
- Recover `var x: typeof {}` by continuing the variable declaration list and parsing the `{}` as a recovered object binding declarator.
- Cover the adjacent recovered function-tail shape so the rule is parser-structural rather than tied to the object literal spelling.
- Preserve `invalidTypeOfTarget` JavaScript output as `var x1, {};` instead of splitting the object target into a block-like following statement.

## Project Corpus Impact
- Row: `tests/cases/conformance/types/specifyingTypes/typeQueries/invalidTypeOfTarget.ts`
- Bug family: parser/recovery emit for invalid `typeof` type-query targets.
- Evidence: focused JS emit filter passed 1/1 on the same parser patch before the latest main restack; exact-head draft-light CI passed on restacked head `bb394cf8899e` in run `26740555427`.

## Verification
- Exact-head draft-light CI passed on head `bb394cf8899e0f80c69c7dcf947fa992ed11a913` in run `26740555427`: `CI Light Summary`, `dist-binaries`, `lint`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, and GitGuardian. Heavy ready-only jobs were skipped while the PR was draft.
- Current restack 2026-06-01 (AgentName: Studio-C), head `bb394cf8899e0f80c69c7dcf947fa992ed11a913` on `origin/main` `0ac6d659f0247401dc15bf2d67a35c8e3fca1d23`:
  - `git diff --check origin/main bb394cf8899e0f80c69c7dcf947fa992ed11a913`
- Previous focused local verification for the same patch:
  - `cargo nextest run -p tsz-parser -E 'test(typeof_object_type_query_tail_recovers_inside_variable_list) | test(typeof_function_type_query_tail_emits_second_comma_error)'`
  - `scripts/safe-run.sh scripts/emit/run.sh --filter=invalidTypeOfTarget --js-only --verbose --timeout=30000 --json-out=/tmp/invalidTypeOfTarget-studio-c-restack-20260601-main56e758.json`
- Earlier local verification before restack:
  - `cargo fmt --check`
  - `cargo nextest run -p tsz-parser typeof_object_type_query_tail_recovers_inside_variable_list`
  - `cargo nextest run -p tsz-parser typeof_function_type_query_tail_emits_second_comma_error`
  - `scripts/safe-run.sh scripts/emit/run.sh --filter=invalidTypeOfTarget --js-only --verbose --timeout=30000 --json-out=/tmp/invalidTypeOfTarget-studio-c-mainbase.json`
  - `git diff --check`
  - `python3 scripts/arch/arch_guard.py`

## Coordination Notes
- Ready handoff 2026-06-01 (AgentName: Studio-C): exact-head draft-light CI is green for `bb394cf8899e`; marking ready to trigger heavy review CI. Leave `merge-queue` off until ready-review checks complete successfully for this exact head.
- Restack update 2026-06-01 (AgentName: Studio-C): branch `codex/studio-c-invalid-typeof-target-20260601` was rebased onto current `origin/main` `0ac6d659f0247401dc15bf2d67a35c8e3fca1d23` using a temporary Git index because the main checkout then contained unrelated dirty checker edits and no clean reusable sibling worktree was available. New head is `bb394cf8899e0f80c69c7dcf947fa992ed11a913`.
- Non-overlap: no open PR matched `invalidTypeOfTarget`, invalid `typeof` object targets, or this parser recovery shape at creation time.
- File-size check: touched files remain under the 2000-line cap (`state_statements.rs` 1845 lines; `part_00.rs` 1822 lines).
