### PR TITLE
fix(dts): parenthesize first generic function type argument

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs
@@ -302,6 +302,7 @@ mod type_inference_package_matching;
 mod type_inference_parameter_return;
 mod type_inference_portable_mapped_objects;
 mod type_inference_public_packages;
+mod type_inference_return_async;
 mod type_inference_return_guards;
 mod type_inference_return_normalization;
 mod type_inference_return_surface;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_async.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_async.rs
@@ -1,0 +1,94 @@
+//! Async method return-type helpers for declaration inference.
+
+use super::super::DeclarationEmitter;
+use tsz_parser::parser::node::MethodDeclData;
+use tsz_scanner::SyntaxKind;
+
+impl<'a> DeclarationEmitter<'a> {
+    pub(in crate::declaration_emitter) fn inferred_method_return_type_text(
+        &self,
+        method: &MethodDeclData,
+        return_type_id: tsz_solver::types::TypeId,
+    ) -> String {
+        let return_type_id = self.widen_unique_symbol_value_type_for_dts(return_type_id, 0);
+        let text = self.print_type_id_for_inferred_declaration(return_type_id);
+        if self.async_method_return_type_is_already_global_promise(method, return_type_id) {
+            return text;
+        }
+        self.wrap_async_method_return_type_text(method, text)
+    }
+
+    pub(in crate::declaration_emitter) fn wrap_async_method_return_type_text(
+        &self,
+        method: &MethodDeclData,
+        text: String,
+    ) -> String {
+        if self.method_is_async(method) && !method.asterisk_token {
+            format!("Promise<{text}>")
+        } else {
+            text
+        }
+    }
+
+    fn async_method_return_type_is_already_global_promise(
+        &self,
+        method: &MethodDeclData,
+        return_type_id: tsz_solver::types::TypeId,
+    ) -> bool {
+        self.method_is_async(method)
+            && !method.asterisk_token
+            && self.type_id_is_global_promise_application(return_type_id)
+    }
+
+    pub(in crate::declaration_emitter) fn method_is_async(&self, method: &MethodDeclData) -> bool {
+        self.arena
+            .has_modifier(&method.modifiers, SyntaxKind::AsyncKeyword)
+    }
+
+    fn type_id_is_global_promise_application(&self, type_id: tsz_solver::types::TypeId) -> bool {
+        let Some(interner) = self.type_interner else {
+            return false;
+        };
+        let tsz_solver::type_queries::PromiseTypeKind::Application { base, .. } =
+            tsz_solver::type_queries::classify_promise_type(interner, type_id)
+        else {
+            return false;
+        };
+        self.type_id_is_global_promise_base(base)
+    }
+
+    fn type_id_is_global_promise_base(&self, type_id: tsz_solver::types::TypeId) -> bool {
+        if type_id == tsz_solver::types::TypeId::PROMISE_BASE {
+            return true;
+        }
+        let Some(interner) = self.type_interner else {
+            return false;
+        };
+        match tsz_solver::type_queries::classify_promise_type(interner, type_id) {
+            tsz_solver::type_queries::PromiseTypeKind::Lazy(def_id) => {
+                self.def_id_is_global_promise(def_id)
+            }
+            tsz_solver::type_queries::PromiseTypeKind::TypeQuery(sym_ref) => {
+                self.symbol_id_is_global_promise(tsz_binder::SymbolId(sym_ref.0))
+            }
+            tsz_solver::type_queries::PromiseTypeKind::Application { base, .. } => {
+                self.type_id_is_global_promise_base(base)
+            }
+            _ => false,
+        }
+    }
+
+    fn def_id_is_global_promise(&self, def_id: tsz_solver::DefId) -> bool {
+        self.type_cache
+            .as_ref()
+            .and_then(|cache| cache.def_to_symbol.get(&def_id).copied())
+            .is_some_and(|sym_id| self.symbol_id_is_global_promise(sym_id))
+    }
+
+    fn symbol_id_is_global_promise(&self, sym_id: tsz_binder::SymbolId) -> bool {
+        let Some(binder) = self.binder else {
+            return false;
+        };
+        binder.get_global_type("Promise") == Some(sym_id) && binder.lib_symbol_ids.contains(&sym_id)
+    }
+}

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
@@ -353,17 +353,22 @@ impl<'a> DeclarationEmitter<'a> {
     ) -> (String, bool) {
         let (text, substituted_parameter_type_query) =
             self.substitute_function_parameter_type_queries(func, source_type_text);
-        let Some(ref type_params) = func.type_parameters else {
-            return (text, substituted_parameter_type_query);
-        };
-        if type_params.nodes.is_empty() {
+        if func
+            .type_parameters
+            .as_ref()
+            .is_none_or(|type_params| type_params.nodes.is_empty())
+        {
+            let text = Self::parenthesize_first_generic_function_type_argument_text(&text);
             return (text, substituted_parameter_type_query);
         }
 
+        let type_params = func.type_parameters.as_ref().expect("checked above");
         let outer_names = self.collect_type_param_names(type_params);
         let text = Self::rename_shadowed_type_params_in_text(&text, &outer_names);
         (
-            Self::rename_shadowed_infer_type_params_in_text(&text, &outer_names),
+            Self::parenthesize_first_generic_function_type_argument_text(
+                &Self::rename_shadowed_infer_type_params_in_text(&text, &outer_names),
+            ),
             substituted_parameter_type_query,
         )
     }
@@ -393,48 +398,9 @@ impl<'a> DeclarationEmitter<'a> {
         let text = self
             .expand_mapped_alias_index_conditional_text(self.arena, &text)
             .unwrap_or(text);
+        let text = Self::parenthesize_first_generic_function_type_argument_text(&text);
         self.rewrite_current_source_named_import_type_text(&text)
             .unwrap_or(text)
-    }
-
-    pub(in crate::declaration_emitter) fn inferred_method_return_type_text(
-        &self,
-        method: &MethodDeclData,
-        return_type_id: tsz_solver::types::TypeId,
-    ) -> String {
-        let return_type_id = self.widen_unique_symbol_value_type_for_dts(return_type_id, 0);
-        let text = self.print_type_id_for_inferred_declaration(return_type_id);
-        if self.async_method_return_type_is_already_global_promise(method, return_type_id) {
-            return text;
-        }
-        self.wrap_async_method_return_type_text(method, text)
-    }
-
-    pub(in crate::declaration_emitter) fn wrap_async_method_return_type_text(
-        &self,
-        method: &MethodDeclData,
-        text: String,
-    ) -> String {
-        if self.method_is_async(method) && !method.asterisk_token {
-            format!("Promise<{text}>")
-        } else {
-            text
-        }
-    }
-
-    fn async_method_return_type_is_already_global_promise(
-        &self,
-        method: &MethodDeclData,
-        return_type_id: tsz_solver::types::TypeId,
-    ) -> bool {
-        self.method_is_async(method)
-            && !method.asterisk_token
-            && self.type_id_is_global_promise_application(return_type_id)
-    }
-
-    pub(in crate::declaration_emitter) fn method_is_async(&self, method: &MethodDeclData) -> bool {
-        self.arena
-            .has_modifier(&method.modifiers, SyntaxKind::AsyncKeyword)
     }
 
     pub(in crate::declaration_emitter) fn generator_yield_return_type_text(
@@ -526,53 +492,6 @@ impl<'a> DeclarationEmitter<'a> {
             *preferred = Some(type_text);
             true
         }
-    }
-
-    fn type_id_is_global_promise_application(&self, type_id: tsz_solver::types::TypeId) -> bool {
-        let Some(interner) = self.type_interner else {
-            return false;
-        };
-        let tsz_solver::type_queries::PromiseTypeKind::Application { base, .. } =
-            tsz_solver::type_queries::classify_promise_type(interner, type_id)
-        else {
-            return false;
-        };
-        self.type_id_is_global_promise_base(base)
-    }
-
-    fn type_id_is_global_promise_base(&self, type_id: tsz_solver::types::TypeId) -> bool {
-        if type_id == tsz_solver::types::TypeId::PROMISE_BASE {
-            return true;
-        }
-        let Some(interner) = self.type_interner else {
-            return false;
-        };
-        match tsz_solver::type_queries::classify_promise_type(interner, type_id) {
-            tsz_solver::type_queries::PromiseTypeKind::Lazy(def_id) => {
-                self.def_id_is_global_promise(def_id)
-            }
-            tsz_solver::type_queries::PromiseTypeKind::TypeQuery(sym_ref) => {
-                self.symbol_id_is_global_promise(tsz_binder::SymbolId(sym_ref.0))
-            }
-            tsz_solver::type_queries::PromiseTypeKind::Application { base, .. } => {
-                self.type_id_is_global_promise_base(base)
-            }
-            _ => false,
-        }
-    }
-
-    fn def_id_is_global_promise(&self, def_id: tsz_solver::DefId) -> bool {
-        self.type_cache
-            .as_ref()
-            .and_then(|cache| cache.def_to_symbol.get(&def_id).copied())
-            .is_some_and(|sym_id| self.symbol_id_is_global_promise(sym_id))
-    }
-
-    fn symbol_id_is_global_promise(&self, sym_id: tsz_binder::SymbolId) -> bool {
-        let Some(binder) = self.binder else {
-            return false;
-        };
-        binder.get_global_type("Promise") == Some(sym_id) && binder.lib_symbol_ids.contains(&sym_id)
     }
 
     pub(in crate::declaration_emitter) fn evaluated_literal_return_type_text_for_returned_identifier(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_text.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_text.rs
@@ -229,6 +229,169 @@ impl<'a> DeclarationEmitter<'a> {
             })
     }
 
+    pub(in crate::declaration_emitter) fn parenthesize_first_generic_function_type_argument_text(
+        type_text: &str,
+    ) -> String {
+        let mut output = String::with_capacity(type_text.len());
+        let mut emitted_until = 0usize;
+        let mut search_from = 0usize;
+        while let Some(rel) = type_text[search_from..].find('<') {
+            let lt = search_from + rel;
+            let Some((arg_start, arg_content_start, arg_content_end, arg_end)) =
+                Self::first_unparenthesized_generic_function_type_argument_span(type_text, lt)
+            else {
+                search_from = lt + 1;
+                continue;
+            };
+            output.push_str(&type_text[emitted_until..arg_start]);
+            output.push('(');
+            output.push_str(&type_text[arg_content_start..arg_content_end]);
+            output.push(')');
+            emitted_until = arg_end;
+            search_from = arg_end;
+        }
+        if emitted_until == 0 {
+            type_text.to_string()
+        } else {
+            output.push_str(&type_text[emitted_until..]);
+            output
+        }
+    }
+
+    fn first_unparenthesized_generic_function_type_argument_span(
+        text: &str,
+        outer_lt: usize,
+    ) -> Option<(usize, usize, usize, usize)> {
+        let bytes = text.as_bytes();
+        let arg_start = outer_lt.checked_add(1)?;
+        let arg_content_start = Self::skip_type_text_ws(bytes, arg_start);
+        if bytes.get(arg_content_start) == Some(&b'(') {
+            return None;
+        }
+        if bytes.get(arg_content_start) != Some(&b'<') {
+            return None;
+        }
+
+        let type_params_end =
+            Self::matching_type_text_delimiter(text, arg_content_start, b'<', b'>')?;
+        let params_after = Self::skip_type_text_ws(bytes, type_params_end + 1);
+        if bytes.get(params_after) != Some(&b'(') {
+            return None;
+        }
+        let params_end = Self::matching_type_text_delimiter(text, params_after, b'(', b')')?;
+        let arrow_start = Self::skip_type_text_ws(bytes, params_end + 1);
+        if bytes.get(arrow_start..arrow_start + 2) != Some(b"=>") {
+            return None;
+        }
+
+        let arg_end = Self::first_type_argument_end(text, arg_start)?;
+        let arg_content_end = Self::trim_type_text_ws_end(bytes, arg_content_start, arg_end);
+        Some((arg_start, arg_content_start, arg_content_end, arg_end))
+    }
+
+    fn first_type_argument_end(text: &str, start: usize) -> Option<usize> {
+        let bytes = text.as_bytes();
+        let mut i = start;
+        let mut angle_depth = 1i32;
+        let mut paren_depth = 0i32;
+        let mut bracket_depth = 0i32;
+        let mut brace_depth = 0i32;
+        while i < bytes.len() {
+            i = Self::skip_type_text_quoted(bytes, i);
+            let b = *bytes.get(i)?;
+            match b {
+                b'<' => angle_depth += 1,
+                b'>' if i > 0 && bytes[i - 1] == b'=' => {}
+                b'>' => {
+                    if angle_depth == 1
+                        && paren_depth == 0
+                        && bracket_depth == 0
+                        && brace_depth == 0
+                    {
+                        return Some(i);
+                    }
+                    angle_depth -= 1;
+                }
+                b',' if angle_depth == 1
+                    && paren_depth == 0
+                    && bracket_depth == 0
+                    && brace_depth == 0 =>
+                {
+                    return Some(i);
+                }
+                b'(' => paren_depth += 1,
+                b')' => paren_depth -= 1,
+                b'[' => bracket_depth += 1,
+                b']' => bracket_depth -= 1,
+                b'{' => brace_depth += 1,
+                b'}' => brace_depth -= 1,
+                _ => {}
+            }
+            i += 1;
+        }
+        None
+    }
+
+    fn matching_type_text_delimiter(
+        text: &str,
+        open_at: usize,
+        open: u8,
+        close: u8,
+    ) -> Option<usize> {
+        let bytes = text.as_bytes();
+        if bytes.get(open_at) != Some(&open) {
+            return None;
+        }
+        let mut depth = 1i32;
+        let mut i = open_at + 1;
+        while i < bytes.len() {
+            i = Self::skip_type_text_quoted(bytes, i);
+            match bytes[i] {
+                b if b == open => depth += 1,
+                b if b == close => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(i);
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        None
+    }
+
+    fn skip_type_text_ws(bytes: &[u8], mut i: usize) -> usize {
+        while bytes.get(i).is_some_and(u8::is_ascii_whitespace) {
+            i += 1;
+        }
+        i
+    }
+
+    fn trim_type_text_ws_end(bytes: &[u8], start: usize, mut end: usize) -> usize {
+        while end > start && bytes[end - 1].is_ascii_whitespace() {
+            end -= 1;
+        }
+        end
+    }
+
+    fn skip_type_text_quoted(bytes: &[u8], i: usize) -> usize {
+        let Some(&quote @ (b'"' | b'\'' | b'`')) = bytes.get(i) else {
+            return i;
+        };
+        let mut j = i + 1;
+        while j < bytes.len() {
+            if bytes[j] == b'\\' {
+                j += 2;
+            } else if bytes[j] == quote {
+                return j;
+            } else {
+                j += 1;
+            }
+        }
+        i
+    }
+
     pub(in crate::declaration_emitter) fn declaration_constructor_expression_text(
         &self,
         expr_idx: NodeIndex,

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs
@@ -873,6 +873,7 @@ impl<'a> DeclarationEmitter<'a> {
         let printed = self
             .expand_imported_indexed_access_type_text(&printed)
             .unwrap_or(printed);
+        let printed = Self::parenthesize_first_generic_function_type_argument_text(&printed);
         if Self::contains_portable_mapped_object_text(&printed)
             && let Some(expanded) =
                 self.expand_portable_intersection_type_text(self.arena, &printed)

--- a/crates/tsz-emitter/src/declaration_emitter/tests/probes_issues.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/probes_issues.rs
@@ -1168,3 +1168,19 @@ fn test_empty_namespace_inside_declare_namespace_uses_single_line_format() {
         "empty namespace (different name) inside declare namespace must use single-line format: {output}"
     );
 }
+
+#[test]
+fn type_text_parenthesizes_first_generic_function_type_argument() {
+    assert_eq!(
+        DeclarationEmitter::parenthesize_first_generic_function_type_argument_text(
+            "X< <Tany>() => Tany >"
+        ),
+        "X<(<Tany>() => Tany)>"
+    );
+    assert_eq!(
+        DeclarationEmitter::parenthesize_first_generic_function_type_argument_text(
+            "Y<string[], <Tany>() => Tany>"
+        ),
+        "Y<string[], <Tany>() => Tany>"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Track 9 — Declaration emit 100% parity

## Invariant
When declaration emit writes an inferred return type whose first type argument is a generic function type, `tsc` parenthesizes that first argument (`X<(<T>() => T)>`). This PR normalizes that grammar shape at the declaration type-text boundary without adding checker diagnostics or semantic validation during printing.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_text.rs` — add a balanced type-text scanner for the first generic function type argument shape
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs` — apply the normalization to source-backed and inferred function return type text
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs` — apply the same normalization to inferred declaration type printing
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_async.rs` — split async method return/PROMISE helpers out of the touched normalization shard so it has file-size headroom
- `crates/tsz-emitter/src/declaration_emitter/tests/probes_issues.rs` — add a focused unit probe for the type-text normalization

## Project Corpus Impact
- Row: n/a for direct project row attribution
- Bug family: DTS generic/type-display declarations
- Evidence: fixes the live CI DTS failure `declarationEmitFirstTypeArgumentGenericFunctionType`; local focused emit filter now passes on amended head `3b42aa2087`

## Verification
- `git diff --check origin/main...HEAD`
- `cargo nextest run -p tsz-emitter type_text_parenthesizes_first_generic_function_type_argument test_async_method_return_wrapper_uses_lib_promise_identity` — 2 passed / 4021 skipped
- `scripts/emit/run.sh --filter=declarationEmitFirstTypeArgumentGenericFunctionType --dts-only --verbose --json-out=/tmp/studio-d-declarationEmitFirstTypeArgumentGenericFunctionType-split.json` — Declaration Emit 1 passed / 0 failed
- Draft CI on head `3b42aa2087`: `CI Light Summary`, lint, unit, unit-cloudbuild, dist-binaries, cargo-deny, cargo-shear, and project-row-drift passed
- File-size guard: touched files remain under 2000 lines; `type_inference_return_normalization.rs` is now 1912 lines and `type_inference_return_async.rs` is 94 lines

## Coordination Notes
- AgentName: Studio-D
- Existing worktree reused: `/Users/mohsen/code/tsz-studio-a-bench-readiness-20260601`
- Rebased onto `origin/main` after #12032 merged; conflict in `probes_issues.rs` resolved by preserving both DTS probe additions
- Addressed Reviewer note about the 1999-line touched shard by splitting async method return helpers into `type_inference_return_async.rs`
- No overlap found with open DTS PRs for this exact failure; related durable architecture issues remain #9332/#8275
- Ready for review on head `3b42aa2087`; heavy CI should run after draft state is removed
