### PR TITLE
chore(emit-tools): print output surgery warnings

### DIFF
--- a/scripts/emit/audit-output-surgery.py
+++ b/scripts/emit/audit-output-surgery.py
@@ -385,6 +385,12 @@ def format_exhausted_category_metrics(file_summaries: list[dict[str, object]]) -
     return f"exhausted_category_count={len(names)}, exhausted_categories={formatted_names}"
 
 
+def format_warning_metrics(file_summaries: list[dict[str, object]]) -> str:
+    warning_count = len(exhausted_category_names(file_summaries))
+    warning_status = "warn" if warning_count else "clear"
+    return f"warning_count={warning_count}, warning_status={warning_status}"
+
+
 def build_json_report(
     findings: list[Finding],
     allowlist: dict[str, AllowEntry],
@@ -476,6 +482,7 @@ def format_pass_summary(
         f"{format_budget_metrics(budget)}, "
         f"{format_category_budget_metrics(file_summaries)}, "
         f"{format_exhausted_category_metrics(file_summaries)}, "
+        f"{format_warning_metrics(file_summaries)}, "
         f"unallowlisted_calls={summary.unallowlisted}, "
         f"over_allowlist_files={summary.over_allowlist_files}, "
         f"over_allowlist_excess_calls={summary.over_allowlist_excess_calls}, "
@@ -512,6 +519,7 @@ def main(argv: list[str] | None = None) -> int:
             f"{format_budget_metrics(budget)}, "
             f"{format_category_budget_metrics(file_summaries)}, "
             f"{format_exhausted_category_metrics(file_summaries)}, "
+            f"{format_warning_metrics(file_summaries)}, "
             f"unallowlisted_calls={summary.unallowlisted}, "
             f"unallowlisted_files={summary.unallowlisted_files}, "
             f"over_allowlist_files={summary.over_allowlist_files}, "

--- a/scripts/emit/test_output_surgery_audit.py
+++ b/scripts/emit/test_output_surgery_audit.py
@@ -227,6 +227,8 @@ class OutputSurgeryAuditTests(unittest.TestCase):
             "category_budgets=semantic-output-surgery=2/2:exhausted, "
             "exhausted_category_count=1, "
             "exhausted_categories=semantic-output-surgery, "
+            "warning_count=1, "
+            "warning_status=warn, "
             "unallowlisted_calls=0, "
             "over_allowlist_files=0, "
             "over_allowlist_excess_calls=0, "
@@ -302,6 +304,10 @@ class OutputSurgeryAuditTests(unittest.TestCase):
         self.assertEqual(
             self.audit.format_exhausted_category_metrics(file_summaries),
             "exhausted_category_count=1, exhausted_categories=ir-output-surgery",
+        )
+        self.assertEqual(
+            self.audit.format_warning_metrics(file_summaries),
+            "warning_count=1, warning_status=warn",
         )
 
     def test_budget_status_classifies_budget_edges(self):


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / output-surgery cheap evidence plumbing.

## Invariant
When output-surgery allowlist category budgets are exhausted, both machine-readable JSON and human-readable CLI summaries expose a warning signal while pass/fail status remains based on actual audit failures.

## Scope
- scripts/emit/audit-output-surgery.py
- scripts/emit/test_output_surgery_audit.py

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: emit-tool reporting only; no compiler, emitter, conformance, or project corpus behavior changed.

## Verification
- python3 -m unittest scripts.emit.test_output_surgery_audit
- python3 -m py_compile scripts/emit/audit-output-surgery.py scripts/emit/test_output_surgery_audit.py
- git diff --check -- scripts/emit/audit-output-surgery.py scripts/emit/test_output_surgery_audit.py
- python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery-cli-warning.json
- rg -n '"warning_|"allowlist_budget_status"|"exhausted_category' /tmp/tsz-output-surgery-cli-warning.json
- python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard-cli-warning.json

## Coordination Notes
- Owned Studio-F PR runway was clear before publishing.
- This extends #12079's JSON warning to the CLI summaries, so CI logs now print warning_count=3 and warning_status=warn when the live output-surgery budget is exhausted.
- No allowlist entries, caps, roadmap direction, or emitted output changed.
