### PR TITLE
chore(agents): report TypeScript reuse source state

### DIFF
--- a/scripts/agents/disk-preflight.sh
+++ b/scripts/agents/disk-preflight.sh
@@ -219,7 +219,7 @@ while IFS= read -r wt; do
   [[ "$wt" != "$ROOT" ]] || continue
   if [[ -d "$wt/TypeScript/tests/cases" ]]; then
     TS_SOURCE_COUNT=$((TS_SOURCE_COUNT + 1))
-    line="source=$wt"
+    line="source=$wt ts-populated"
     TYPESCRIPT_REUSE_OUTPUT+="$line"$'\n'
     echo "$line"
   fi

--- a/scripts/agents/test_disk_preflight.py
+++ b/scripts/agents/test_disk_preflight.py
@@ -260,13 +260,29 @@ class DiskPreflightTests(unittest.TestCase):
                 fake_repo,
             )
             linked_script = linked_worktree / "scripts" / "agents" / "disk-preflight.sh"
+            report_path = temp_root / "preflight.json"
 
-            result = self.run_preflight(linked_worktree, linked_script)
+            result = self.run_preflight(
+                linked_worktree,
+                linked_script,
+                "--json-report",
+                str(report_path),
+            )
+            report = json.loads(report_path.read_text(encoding="utf-8"))
 
             self.assertIn("git_detached=true", result.stdout)
             self.assertRegex(result.stdout, r"git_branch=detached:[0-9a-f]+")
             self.assertIn("typescript=missing", result.stdout)
             self.assertIn(f"primary={fake_repo} ts-populated", result.stdout)
+            self.assertIn(f"source={fake_repo} ts-populated", result.stdout)
+            self.assertIn(
+                {
+                    "kind": "source",
+                    "path": str(fake_repo),
+                    "state": "ts-populated",
+                },
+                report["typescript"]["reuse_sources"],
+            )
             self.assertIn("hint=run scripts/setup/link-ts-submodule.sh", result.stdout)
             self.assertIn("cargo_cache_status=missing", result.stdout)
             self.assertIn("cargo_cache_reuse_sources=1", result.stdout)


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / disk-worktree cheap evidence plumbing.

## Invariant
When disk preflight reports populated TypeScript reuse sources, stdout and JSON should both name those sources as `ts-populated` so worktree reuse evidence is not ambiguous.

## Scope
- scripts/agents/disk-preflight.sh
- scripts/agents/test_disk_preflight.py

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent preflight reporting only; no compiler, emitter, conformance, or project corpus behavior changed.

## Verification
- python3 -m unittest scripts.agents.test_disk_preflight
- bash -n scripts/agents/disk-preflight.sh
- python3 -m py_compile scripts/agents/test_disk_preflight.py
- git diff --check -- scripts/agents/disk-preflight.sh scripts/agents/test_disk_preflight.py
- scripts/agents/disk-preflight.sh Studio-F --json-report /tmp/tsz-disk-preflight-ts-state.json
- rg -n '"kind": "source"|"state": null|"state": "ts-populated"' /tmp/tsz-disk-preflight-ts-state.json
- python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard-disk-ts-state.json

## Coordination Notes
- Owned Studio-F PR runway was clear before publishing.
- This fixes a misleading JSON artifact where TypeScript source entries had null state even when stdout and reusable worktree signals proved they were populated.
- No cache deletion, TypeScript checkout mutation, roadmap direction, or compiler behavior changed.
