### PR TITLE
test(checker): cover explicit callable constraint failures

### DIFF
--- a/crates/tsz-checker/tests/ts2344_generic_ref_scoped_param_concrete_constraint.rs
+++ b/crates/tsz-checker/tests/ts2344_generic_ref_scoped_param_concrete_constraint.rs
@@ -141,6 +141,72 @@ type BadArrayQ<Q> = Box<Array<Q>>;
     );
 }
 
+#[test]
+fn explicit_type_alias_args_violating_callable_constraint_emit_ts2344() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type AppendArgument<Fn extends (...args: any[]) => any, A> =
+  Fn extends (...args: infer Args) => infer R
+    ? (...args: [...Args, A]) => R
+    : never;
+
+type BadUnknown = AppendArgument<unknown, undefined>;
+type BadString = AppendArgument<string, number>;
+type BadObject = AppendArgument<{ a: 1 }, boolean>;
+type Good = AppendArgument<(value: string) => number, boolean>;
+"#,
+    );
+
+    let ts2344: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2344)
+        .collect();
+    assert_eq!(
+        ts2344.len(),
+        3,
+        "Expected TS2344 for the three invalid AppendArgument instantiations only, got: {diagnostics:?}"
+    );
+    assert!(
+        ts2344
+            .iter()
+            .any(|(_, message)| message.contains("unknown")),
+        "Expected one TS2344 to mention unknown, got: {ts2344:?}"
+    );
+    assert!(
+        ts2344.iter().any(|(_, message)| message.contains("string")),
+        "Expected one TS2344 to mention string, got: {ts2344:?}"
+    );
+}
+
+#[test]
+fn explicit_interface_and_class_args_violating_callable_constraint_emit_ts2344() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+interface CallableBox<T extends (...args: any[]) => any> {
+  value: T;
+}
+class CallableHolder<T extends (...args: any[]) => any> {
+  value!: T;
+}
+
+type BadInterface = CallableBox<string>;
+type BadClass = CallableHolder<{ a: 1 }>;
+type GoodInterface = CallableBox<() => void>;
+type GoodClass = CallableHolder<(value: string) => number>;
+"#,
+    );
+
+    let ts2344: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2344)
+        .collect();
+    assert_eq!(
+        ts2344.len(),
+        2,
+        "Expected TS2344 for invalid interface/class callable constraints only, got: {diagnostics:?}"
+    );
+}
+
 /// Control: generic-ref type arguments whose surface IS assignable to the
 /// constraint must still be accepted.
 #[test]


### PR DESCRIPTION
## Agent
AgentName: m5-pro-48g-codex

## Track
Checker test coverage / stash salvage.

## Invariant
When an explicit generic argument violates a callable constraint on a type alias, interface, or class, tsz reports TS2344 for the invalid instantiation and accepts callable arguments. This PR adds focused regression coverage for behavior already passing on current `origin/main`.

## Scope
- `crates/tsz-checker/tests/ts2344_generic_ref_scoped_param_concrete_constraint.rs`
- Salvaged from `stash@{14}` (`preserve-pr6345-local-ts2344-tests`).

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: test-only checker coverage; no compiler behavior, project corpus, benchmark, emit, parser, binder, LSP, WASM, or CI logic changes.

## Verification
- `git diff --check`
- `cargo fmt --check`
- `cargo nextest run -p tsz-checker --test ts2344_generic_ref_scoped_param_concrete_constraint explicit_type_alias_args_violating_callable_constraint_emit_ts2344 explicit_interface_and_class_args_violating_callable_constraint_emit_ts2344` (2 passed, 9 skipped)

## Coordination Notes
- No canonical agent lane was assigned for this one-off stash salvage session, so I did not create or apply a generated `agent:*` label.
- Adjacent-case matrix: type alias helper with renamed type parameter `Fn`, explicit `unknown`/`string`/object negatives, valid callable positive, interface generic constraint, class generic constraint.
- `stash@{13}` contained an implementation change for explicit `unknown`, but the new tests pass without it on current `origin/main`; leaving that behavior change out keeps this PR test-only.

