### PR TITLE
chore(agents): show AgentName for unlabeled PRs

### DIFF
--- a/scripts/agents/ensure-agent-labels.sh
+++ b/scripts/agents/ensure-agent-labels.sh
@@ -267,6 +267,14 @@ const summarizeWorkItem = (item) => ({
   title: item.title,
   url: item.url ?? null,
 });
+const prAgentName = (pr) => {
+  const match = /^AgentName:[^\S\r\n]*(\S+)?/m.exec(pr.body ?? "");
+  return match?.[1]?.replace(/^`+|`+$/g, "") ?? null;
+};
+const summarizeMissingPrWorkItem = (item) => ({
+  ...summarizeWorkItem(item),
+  agent_name: prAgentName(item),
+});
 const summarizePrWorkItem = (item) => ({
   ...summarizeWorkItem(item),
   is_draft: item.isDraft === true,
@@ -291,7 +299,7 @@ if (process.env.JSON_REPORT) {
     metrics,
     missing_canonical_labels: missingCanonicalLabels,
     noncanonical_agent_labels: noncanonicalLabels,
-    open_prs_missing_agent_label: missingPrs.map(summarizeWorkItem),
+    open_prs_missing_agent_label: missingPrs.map(summarizeMissingPrWorkItem),
     open_prs_intentionally_unassigned: intentionallyUnassignedPrs.map(summarizePrWorkItem),
     open_ready_prs_intentionally_unassigned: readyIntentionallyUnassignedPrs.map(
       summarizePrWorkItem,
@@ -312,8 +320,12 @@ if (process.env.JSON_REPORT) {
 printRows("Missing Canonical Labels", missingCanonicalLabels, (label) => `- ${label}`);
 printRows("Noncanonical Agent Labels", noncanonicalLabels, (label) => `- ${label}`);
 const prRow = (pr) => `- #${pr.number} ${pr.title}${pr.url ? ` ${pr.url}` : ""}`;
+const missingPrRow = (pr) => {
+  const agentName = prAgentName(pr);
+  return `${prRow(pr)}${agentName ? ` AgentName=${agentName}` : ""}`;
+};
 
-printRows("Open PRs Missing Agent Label", missingPrs, prRow);
+printRows("Open PRs Missing Agent Label", missingPrs, missingPrRow);
 printRows(
   "Open PRs Intentionally Unassigned",
   intentionallyUnassignedPrs,

--- a/scripts/agents/test_ensure_agent_labels.py
+++ b/scripts/agents/test_ensure_agent_labels.py
@@ -140,7 +140,7 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
                     "title": "fix: missing label",
                     "isDraft": False,
                     "labels": [],
-                    "body": "AgentName: Studio-F",
+                    "body": "AgentName: `Studio-F`",
                     "url": "https://github.com/mohsen1/tsz/pull/3",
                 }
             ]
@@ -155,6 +155,7 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
             "#3 fix: missing label https://github.com/mohsen1/tsz/pull/3",
             output,
         )
+        self.assertIn("AgentName=Studio-F", output)
 
     def test_strict_audit_fails_on_actionable_findings(self):
         result = self.run_audit_result(
@@ -343,7 +344,7 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
                         "title": "fix: missing owner",
                         "isDraft": False,
                         "labels": [],
-                        "body": "AgentName: Studio-F",
+                        "body": "AgentName: `Studio-F`",
                         "url": "https://github.com/mohsen1/tsz/pull/30",
                     },
                     {
@@ -381,6 +382,7 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
                     "number": 30,
                     "title": "fix: missing owner",
                     "url": "https://github.com/mohsen1/tsz/pull/30",
+                    "agent_name": "Studio-F",
                 }
             ],
             report["open_prs_missing_agent_label"],


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Track 10 launch infrastructure / ownership hygiene.

## Invariant
When an open PR has no canonical `agent:*` label, the label audit should show the PR body `AgentName` so the next ownership repair can identify the contributor identity without opening the PR body separately; this PR changes only the agent-label audit report surface.

## Scope
- `scripts/agents/ensure-agent-labels.sh`: include `AgentName` in missing-label stdout rows and JSON entries.
- `scripts/agents/test_ensure_agent_labels.py`: cover markdown-wrapped `AgentName` extraction for missing-label findings.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent-script-only; no compiler, conformance, emit, project-row, or runtime behavior changes.

## Verification
- `python3 -m unittest scripts.agents.test_ensure_agent_labels`
- `bash -n scripts/agents/ensure-agent-labels.sh`
- `git diff --check -- scripts/agents/ensure-agent-labels.sh scripts/agents/test_ensure_agent_labels.py`
- `scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-audit-agentname.json`
- `python3 -m py_compile scripts/agents/test_ensure_agent_labels.py`
- `python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard-agentname.json`

## Coordination Notes
- Opened after the start-cycle audit found #12086 missing a canonical owner label while its body carried a generated contributor `AgentName`; Studio-F added `agent:M4-D` to #12086 with a signed comment before this PR.
- Reused the clean `/Users/mohsen/code/tsz-studio-a-bench-readiness-20260601` worktree because disk is below the 20 GiB guard and no new worktree should be created.
- Draft until PR-head CI reports back; no merge-queue label until exact-head checks are green.