### PR TITLE
fix(binder): propagate per-specifier type modifier on re-exports

### DIFF
--- a/crates/tsz-binder/src/modules/import_export.rs
+++ b/crates/tsz-binder/src/modules/import_export.rs
@@ -626,10 +626,19 @@ impl BinderState {
                         if let Some(source_module) = module_name {
                             let current_file = self.debugger.current_file.clone();
 
-                            // Collect all the export mappings first (before mutable borrow)
-                            // Also collect node indices and names for creating symbols
-                            let mut export_mappings: Vec<(String, Option<String>, NodeIndex)> =
-                                Vec::new();
+                            // Collect per-spec re-export facts up front, then materialize
+                            // symbols and the file's `reexports` map. Carries the per-spec
+                            // type-only flag merged with the declaration-level flag so
+                            // `export { type Foo, Bar } from "./mod"` keeps `Foo` type-only
+                            // and `Bar` value-bearing (matches tsc's TS1361/TS1362).
+                            struct ReexportSpec {
+                                exported: String,
+                                original: Option<String>,
+                                spec_idx: NodeIndex,
+                                is_type_only: bool,
+                            }
+                            let mut reexport_specs: Vec<ReexportSpec> =
+                                Vec::with_capacity(named.elements.nodes.len());
                             for &spec_idx in &named.elements.nodes {
                                 if let Some(spec_node) = arena.get(spec_idx)
                                     && let Some(spec) = arena.get_specifier(spec_node)
@@ -654,11 +663,13 @@ impl BinderState {
                                     };
 
                                     if let Some(exported) = exported_name.or(original_name) {
-                                        export_mappings.push((
-                                            exported.to_string(),
-                                            original_name.map(std::string::ToString::to_string),
+                                        reexport_specs.push(ReexportSpec {
+                                            exported: exported.to_string(),
+                                            original: original_name
+                                                .map(std::string::ToString::to_string),
                                             spec_idx,
-                                        ));
+                                            is_type_only: export_type_only || spec.is_type_only,
+                                        });
                                     }
                                 }
                             }
@@ -669,41 +680,49 @@ impl BinderState {
                             // leaving the duplicate-identifier checker with two single-decl
                             // symbols and no TS2300. Append the second spec to the existing
                             // re-export alias's declarations instead so the checker sees both.
-                            for (exported, original, spec_idx) in &export_mappings {
+                            for spec in &reexport_specs {
                                 if let Some(existing_id) =
-                                    self.existing_reexport_alias_for_name(arena, exported)
+                                    self.existing_reexport_alias_for_name(arena, &spec.exported)
                                 {
-                                    let span = Self::declaration_span(arena, *spec_idx);
+                                    // First-bound spec's `is_type_only` wins; TS2300 fires on
+                                    // each conflicting declaration site.
+                                    let span = Self::declaration_span(arena, spec.spec_idx);
                                     if let Some(sym) = self.symbols.get_mut(existing_id) {
-                                        sym.add_declaration(*spec_idx, span);
+                                        sym.add_declaration(spec.spec_idx, span);
                                     }
                                     Arc::make_mut(&mut self.node_symbols)
-                                        .insert(spec_idx.0, existing_id);
+                                        .insert(spec.spec_idx.0, existing_id);
                                     continue;
                                 }
                                 let sym_id = self.declare_symbol(
                                     arena,
-                                    exported,
+                                    &spec.exported,
                                     symbol_flags::ALIAS | symbol_flags::EXPORT_VALUE,
-                                    *spec_idx,
+                                    spec.spec_idx,
                                     true,
                                 );
                                 if let Some(sym) = self.symbols.get_mut(sym_id) {
                                     sym.is_exported = true;
-                                    sym.is_type_only = export_type_only;
+                                    sym.is_type_only = spec.is_type_only;
                                     sym.import_module = Some(source_module.clone());
-                                    sym.import_name =
-                                        Some(original.clone().unwrap_or_else(|| exported.clone()));
+                                    sym.import_name = Some(
+                                        spec.original
+                                            .as_deref()
+                                            .unwrap_or(&spec.exported)
+                                            .to_string(),
+                                    );
                                 }
-                                Arc::make_mut(&mut self.node_symbols).insert(spec_idx.0, sym_id);
+                                Arc::make_mut(&mut self.node_symbols)
+                                    .insert(spec.spec_idx.0, sym_id);
                             }
 
                             // Now apply the mutable borrow to insert the mappings
                             let file_reexports = Arc::make_mut(&mut self.reexports)
                                 .entry(current_file)
                                 .or_default();
-                            for (exported, original, _) in export_mappings {
-                                file_reexports.insert(exported, (source_module.clone(), original));
+                            for spec in reexport_specs {
+                                file_reexports
+                                    .insert(spec.exported, (source_module.clone(), spec.original));
                             }
                         }
                     }

--- a/crates/tsz-binder/src/state/tests/exports_jsdoc.rs
+++ b/crates/tsz-binder/src/state/tests/exports_jsdoc.rs
@@ -182,6 +182,52 @@ export type { Foo } from './a';
     assert!(!bar_sym.is_type_only);
 }
 
+/// `export { type X, Y } from "./mod"` (per-specifier `type` modifier on a
+/// re-export) must mark only `X` as type-only — independent of whether the
+/// enclosing declaration is `export {}` or `export type {}`. Before the fix the
+/// re-export branch hard-coded `sym.is_type_only = export_type_only`, dropping
+/// the per-specifier flag and letting downstream value imports through `X`
+/// silently succeed (regression in TS1361/TS1362 attribution).
+#[test]
+fn per_specifier_type_modifier_on_reexport_marks_alias_type_only() {
+    let source = r"
+export { type Foo, Bar } from './mod';
+export { type Renamed as Aliased } from './mod';
+";
+    let (binder, _parser) = parse_and_bind(source);
+    let lookup = |name: &str| {
+        let id = binder
+            .file_locals
+            .get(name)
+            .unwrap_or_else(|| panic!("expected {name} alias in file_locals"));
+        binder
+            .symbols
+            .get(id)
+            .unwrap_or_else(|| panic!("expected symbol data for {name}"))
+    };
+
+    let foo_sym = lookup("Foo");
+    assert!(
+        foo_sym.is_type_only,
+        "per-specifier `type Foo` must mark the re-export alias type-only"
+    );
+    assert_eq!(foo_sym.import_module.as_deref(), Some("./mod"));
+    assert_eq!(foo_sym.import_name.as_deref(), Some("Foo"));
+
+    let bar_sym = lookup("Bar");
+    assert!(
+        !bar_sym.is_type_only,
+        "sibling value spec `Bar` in the same export clause must stay value-bearing"
+    );
+
+    let aliased_sym = lookup("Aliased");
+    assert!(
+        aliased_sym.is_type_only,
+        "renamed per-spec `type Renamed as Aliased` must also be type-only"
+    );
+    assert_eq!(aliased_sym.import_name.as_deref(), Some("Renamed"));
+}
+
 #[test]
 fn records_import_metadata_for_exported_reexports() {
     let source = r"

--- a/crates/tsz-checker/tests/ts1361_chain_attribution_tests.rs
+++ b/crates/tsz-checker/tests/ts1361_chain_attribution_tests.rs
@@ -191,6 +191,102 @@ const x = Animal;
     );
 }
 
+/// `export { type X, Y } from "./mod"` carries a *per-specifier* `type`
+/// modifier — only `X` is type-only, `Y` is value-bearing. Before the fix the
+/// re-export branch dropped the per-spec flag, so a downstream `import { X }
+/// from "./barrel"; new X();` silently succeeded instead of reporting
+/// `TS1362`.
+///
+/// Structural rule: a re-export specifier marked `type` must mark the
+/// synthesized alias type-only, independent of whether the enclosing
+/// declaration is `export {}` or `export type {}`.
+#[test]
+fn reexport_per_specifier_type_modifier_emits_ts1362() {
+    let source = r#"
+export class Foo { x = 1 }
+export class Bar { y = 1 }
+"#;
+    let barrel = r#"
+export { type Foo, Bar } from "./source";
+"#;
+    let user = r#"
+import { Foo, Bar } from "./barrel";
+new Foo();
+new Bar();
+"#;
+
+    let diagnostics = compile_module_files(
+        &[
+            ("./source.ts", source),
+            ("./barrel.ts", barrel),
+            ("./user.ts", user),
+        ],
+        2,
+    );
+
+    let ts1362: Vec<_> = diagnostics.iter().filter(|(c, _)| *c == 1362).collect();
+    assert_eq!(
+        ts1362.len(),
+        1,
+        "Expected exactly one TS1362 for value use of per-spec type re-export. \
+         Got TS1362={ts1362:?}, all={diagnostics:?}",
+    );
+    assert!(
+        ts1362[0].1.contains("Foo"),
+        "TS1362 should attribute to the type-only spec `Foo`, not its value-spec sibling `Bar`. \
+         Got message={:?}",
+        ts1362[0].1,
+    );
+}
+
+/// Two barrels re-exporting the same source module — one with per-spec
+/// `type`, one without — must produce different value-meaning answers.
+/// Before the fix the per-spec type-only flag was dropped, so both barrels
+/// resolved `Foo` as a value (TS1362 missed) and the modules "diverged in
+/// identity" — same name, same source, but type-only-ness inconsistent.
+#[test]
+fn type_only_and_value_barrels_for_same_source_disagree_on_value_meaning() {
+    let source = r#"
+export class Foo { x = 1 }
+"#;
+    let barrel_type = r#"
+export { type Foo } from "./source";
+"#;
+    let barrel_value = r#"
+export { Foo } from "./source";
+"#;
+    let user = r#"
+import { Foo as FooT } from "./barrel_type";
+import { Foo as FooV } from "./barrel_value";
+new FooT(); // TS1362 — type-only barrel
+new FooV(); // OK
+"#;
+
+    let diagnostics = compile_module_files(
+        &[
+            ("./source.ts", source),
+            ("./barrel_type.ts", barrel_type),
+            ("./barrel_value.ts", barrel_value),
+            ("./user.ts", user),
+        ],
+        3,
+    );
+
+    let ts1362: Vec<_> = diagnostics.iter().filter(|(c, _)| *c == 1362).collect();
+    assert_eq!(
+        ts1362.len(),
+        1,
+        "Expected exactly one TS1362 — only the type-only barrel side should reject `new FooT()`. \
+         Got TS1362={ts1362:?}, all={diagnostics:?}",
+    );
+    assert!(
+        ts1362[0].1.contains("FooT"),
+        "TS1362 must point at `FooT` (the type-only-barrel alias), not at `FooV`. \
+         Got message={:?}",
+        ts1362[0].1,
+    );
+}
+
 #[test]
 fn import_type_equals_require_value_use_reports_ts1361() {
     let foo = r#"


### PR DESCRIPTION
AgentName: M4-D

## Track

Conformance / TS1361-TS1362 attribution

## Invariant

> A re-export specifier with the `type` modifier (`export { type X } from "./mod"`) must mark the synthesized alias `is_type_only`, independent of whether the enclosing declaration is `export {}` or `export type {}`.

The checker already consults `sym.is_type_only` correctly on the alias-chain walk; the binder was dropping the per-specifier flag at the symbol-creation site, causing the value-use check to silently follow the alias chain to the concrete source class and clear the diagnostic.

## Scope

`crates/tsz-binder/src/modules/import_export.rs` — single function `bind_export_declaration`, the `else` branch handling `export { ... } from "./mod"` re-exports. The local-binding branch (line 462, `export { type X }` without `from`) already used the correct `export_type_only || spec.is_type_only` merge; the re-export branch was the asymmetric outlier and now matches.

Threads the merged flag via a small local `struct ReexportSpec { exported, original, spec_idx, is_type_only }` instead of widening the previous 3-tuple — keeps the three iteration sites (collect from AST, materialize symbols, populate `file_reexports`) self-documenting.

## Repro (closes #10899)

Before this PR, `tsz` silently accepted value imports through a type-only barrel that used the per-spec form:

```ts
// source.ts
export class Foo { x = 1 }
export class Bar { y = 1 }

// barrel.ts
export { type Foo, Bar } from "./source";

// user.ts
import { Foo } from "./barrel";
new Foo();   // tsc: TS1362  |  tsz before: no error  |  tsz after: TS1362
```

"Module identity diverges" example — same `Foo`, same source, two barrels (one type-only, one value):

```ts
// barrel-t.ts: export { type Foo } from "./source";
// barrel-v.ts: export { Foo } from "./source";
// user.ts:
import { Foo as FooT } from "./barrel-t";
import { Foo as FooV } from "./barrel-v";
new FooT();  // tsc: TS1362  |  tsz before: silent  |  tsz after: TS1362
new FooV();  // OK
```

## Project Corpus Impact

- Row: utility-types-project (the issue was filed against this row, but the root cause is general — see test matrix).
- Bug family: module-resolution / type-only barrel value imports.
- Evidence: per-spec `type` modifier was hard-coded out at one site (`sym.is_type_only = export_type_only`); the fix uses the existing local-binding merge idiom. Verified with hand-crafted multi-file repros that reproduce the divergence before the patch and disappear after.

## Verification

Adjacent test matrix (per CLAUDE.md §26):

1. Reported repro — `export { type Foo, Bar } from "./mod"`, value use of `Foo` → TS1362, `Bar` OK.
2. Renamed per-spec — `export { type Renamed as Aliased } from "./mod"` → alias type-only.
3. Two-barrel identity divergence — type-only barrel rejects value use, value barrel accepts.
4. `export type * from` wildcard chain (already worked) — regression coverage held.
5. Mixed value + type-only re-export from same source (local binding branch) — unchanged.
6. Duplicate `export { X }; export { type X }` — `is_type_only` NOT escalated, preserves existing `duplicate_reexport_specifiers_share_one_symbol_with_multiple_declarations` invariant.

Local checks:
- `cargo test -p tsz-binder --lib` → 376 passed, 0 failed.
- `cargo test -p tsz-checker --test ts1361_chain_attribution_tests` → 7 passed (2 new + 5 pre-existing).
- `cargo test -p tsz-checker --test type_only_import_reexport_tests` → 11 passed.
- `cargo test -p tsz-checker --test heritage_type_only_tests` → 11 passed.
- `cargo test -p tsz-checker --test ts1362_false_positive_tests` → 5 passed.
- `cargo test -p tsz-checker --test ts2451_type_only_namespace_merge_tests` → 4 passed.
- `cargo test -p tsz-checker --test ts2304_tests` → 41 passed.
- Multi-file hand repros — tsc and tsz now match diagnostics 1:1.

Heavy suites (conformance, fourslash, emit, WASM) run in CI on ready PRs.

## Coordination Notes

- Runner: opus47-claude-web (Claude Code on the web) operating under canonical lane `M4-D`.
- Issue: closes #10899.
- Cleanup: ran /simplify 3 times; converted a 4-tuple to a named `ReexportSpec`, simplified an `unwrap_or_else` clone, deduped repeated test lookups with a local closure, trimmed a redundant comment.
- No name-fingerprinting, no display-output regex, no test-name suppressions (CLAUDE.md §25).
- The fix is binder-layer (CLAUDE.md §3 "WHO" — symbol flags). The checker is unchanged.
- Auto-merge has been disabled per repo policy (merge gate is the `merge-queue` label after exact-head PR-head checks are green).
