### PR TITLE
fix(checker): preserve imported arrayToEnum value members

### DIFF
--- a/crates/tsz-checker/src/tests/zod_type_query_regression_tests.rs
+++ b/crates/tsz-checker/src/tests/zod_type_query_regression_tests.rs
@@ -421,6 +421,87 @@ const msg = issueData.message || "";
 }
 
 #[test]
+fn cross_file_array_to_enum_value_import_preserves_literal_members() {
+    let diags = check_multi_file(
+        &[
+            (
+                "helpers/util.ts",
+                r#"
+export namespace util {
+    export const arrayToEnum = <T extends string, U extends [T, ...T[]]>(
+        items: U
+    ): { [k in U[number]]: k } => {
+        const obj: any = {};
+        for (const item of items) obj[item] = item;
+        return obj as any;
+    };
+}
+"#,
+            ),
+            (
+                "helpers/parseUtil.ts",
+                r#"
+import { ZodIssueCode } from "../ZodError";
+import { util } from "./util";
+
+export const ZodParsedType = util.arrayToEnum([
+    "string",
+    "undefined",
+]);
+export type ZodParsedType = keyof typeof ZodParsedType;
+
+export const makeIssueCode = () => ZodIssueCode.invalid_type;
+"#,
+            ),
+            (
+                "ZodError.ts",
+                r#"
+import { ZodParsedType } from "./helpers/parseUtil";
+import { util } from "./helpers/util";
+
+export const ZodIssueCode = util.arrayToEnum([
+    "invalid_type",
+    "custom",
+]);
+export type ZodIssueCode = keyof typeof ZodIssueCode;
+"#,
+            ),
+            (
+                "types.ts",
+                r#"
+import { ZodIssueCode } from "./ZodError";
+import { makeIssueCode, ZodParsedType } from "./helpers/parseUtil";
+
+const code: "invalid_type" = ZodIssueCode.invalid_type;
+const viaCycle: "invalid_type" = makeIssueCode();
+const parsed: "string" = ZodParsedType.string;
+"#,
+            ),
+        ],
+        "types.ts",
+        CheckerOptions {
+            module: ModuleKind::CommonJS,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    );
+
+    let relevant: Vec<_> = diags
+        .iter()
+        .filter(|d| matches!(d.code, 2322 | 2339 | 2345 | 2353))
+        .collect();
+    assert_eq!(
+        relevant.len(),
+        0,
+        "Expected imported arrayToEnum members to keep literal value members, got: {:?}",
+        relevant
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn zod_issue_5030_defaults_path_with_logical_or_array_literal() {
     let diags = check_source_diagnostics(
         r#"

--- a/crates/tsz-checker/src/types/computation/identifier/core.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/core.rs
@@ -198,7 +198,7 @@ impl<'a> CheckerState<'a> {
         None
     }
 
-    fn same_file_value_symbol_for_type_symbol(
+    pub(crate) fn same_file_value_symbol_for_type_symbol(
         &self,
         type_sym_id: tsz_binder::SymbolId,
     ) -> Option<(tsz_binder::SymbolId, NodeIndex, usize)> {

--- a/crates/tsz-checker/src/types/property_access_type/imported_array_to_enum.rs
+++ b/crates/tsz-checker/src/types/property_access_type/imported_array_to_enum.rs
@@ -3,6 +3,7 @@
 use crate::state::CheckerState;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
@@ -33,20 +34,50 @@ impl<'a> CheckerState<'a> {
         if base_node.kind != SyntaxKind::Identifier as u16 {
             return None;
         }
+        let base_name = self
+            .ctx
+            .arena
+            .get_identifier(base_node)?
+            .escaped_text
+            .clone();
         let base_sym_id = self
             .ctx
             .binder
             .resolve_identifier(self.ctx.arena, base_expr)?;
-        let target_sym_id = self
-            .ctx
-            .resolve_import_alias_and_register(base_sym_id)
-            .unwrap_or(base_sym_id);
-        let target_symbol = self.get_cross_file_symbol(target_sym_id)?;
+        let (mut target_sym_id, mut target_file_idx) = if let Some((sym_id, file_idx)) = self
+            .value_import_target_symbol_named(base_expr, &base_name)
+            .or_else(|| self.imported_value_target_symbol(base_sym_id))
+        {
+            (sym_id, Some(file_idx))
+        } else if let Some(sym_id) = self.ctx.resolve_import_alias_and_register(base_sym_id) {
+            (sym_id, self.ctx.resolve_symbol_file_index(sym_id))
+        } else {
+            (base_sym_id, self.ctx.resolve_symbol_file_index(base_sym_id))
+        };
+        let mut target_symbol = if let Some(file_idx) = target_file_idx {
+            self.ctx
+                .get_binder_for_file(file_idx)?
+                .get_symbol(target_sym_id)?
+        } else {
+            self.get_cross_file_symbol(target_sym_id)?
+        };
+        if target_symbol.flags & symbol_flags::BLOCK_SCOPED_VARIABLE == 0
+            && let Some((value_sym_id, _, file_idx)) =
+                self.same_file_value_symbol_for_type_symbol(target_sym_id)
+        {
+            target_sym_id = value_sym_id;
+            target_file_idx = Some(file_idx);
+            target_symbol = self
+                .ctx
+                .get_binder_for_file(file_idx)?
+                .get_symbol(target_sym_id)?;
+        }
         if target_symbol.flags & symbol_flags::BLOCK_SCOPED_VARIABLE == 0 {
             return None;
         }
 
-        let file_idx = self.ctx.resolve_symbol_file_index(target_sym_id)?;
+        let file_idx =
+            target_file_idx.or_else(|| self.ctx.resolve_symbol_file_index(target_sym_id))?;
         let arena = self.ctx.get_arena_for_file(file_idx as u32);
         let mut value_decl = if target_symbol.value_declaration.is_some() {
             target_symbol.value_declaration
@@ -99,5 +130,151 @@ impl<'a> CheckerState<'a> {
         }
 
         None
+    }
+
+    fn value_import_target_symbol_named(
+        &self,
+        idx: NodeIndex,
+        name: &str,
+    ) -> Option<(tsz_binder::SymbolId, usize)> {
+        let mut current = idx;
+        let mut guard = 0u32;
+        while let Some(ext) = self.ctx.arena.get_extended(current) {
+            guard += 1;
+            if guard > 4096 {
+                return None;
+            }
+            if ext.parent.is_none() {
+                break;
+            }
+            current = ext.parent;
+            if let Some(node) = self.ctx.arena.get(current)
+                && (node.kind == syntax_kind_ext::SOURCE_FILE
+                    || node.kind == syntax_kind_ext::MODULE_BLOCK)
+            {
+                break;
+            }
+        }
+
+        let root = self.ctx.arena.get(current)?;
+        if root.kind != syntax_kind_ext::SOURCE_FILE && root.kind != syntax_kind_ext::MODULE_BLOCK {
+            return None;
+        }
+
+        for stmt_idx in self.ctx.arena.get_children(current) {
+            let Some(stmt_node) = self.ctx.arena.get(stmt_idx) else {
+                continue;
+            };
+            if stmt_node.kind != syntax_kind_ext::IMPORT_DECLARATION {
+                continue;
+            }
+            let Some(import_decl) = self.ctx.arena.get_import_decl(stmt_node) else {
+                continue;
+            };
+            let Some(clause_node) = self.ctx.arena.get(import_decl.import_clause) else {
+                continue;
+            };
+            let Some(clause) = self.ctx.arena.get_import_clause(clause_node) else {
+                continue;
+            };
+            if clause.is_type_only || clause.named_bindings.is_none() {
+                continue;
+            }
+            let Some(named_bindings_node) = self.ctx.arena.get(clause.named_bindings) else {
+                continue;
+            };
+            if named_bindings_node.kind != syntax_kind_ext::NAMED_IMPORTS {
+                continue;
+            }
+            let Some(named_imports) = self.ctx.arena.get_named_imports(named_bindings_node) else {
+                continue;
+            };
+            for &specifier_idx in &named_imports.elements.nodes {
+                let Some(specifier_node) = self.ctx.arena.get(specifier_idx) else {
+                    continue;
+                };
+                let Some(specifier) = self.ctx.arena.get_specifier(specifier_node) else {
+                    continue;
+                };
+                if specifier.is_type_only
+                    || specifier.name.is_none()
+                    || self.ctx.arena.get_identifier_text(specifier.name) != Some(name)
+                {
+                    continue;
+                }
+                let export_name = if specifier.property_name.is_some() {
+                    self.ctx
+                        .arena
+                        .get_identifier_text(specifier.property_name)?
+                        .to_string()
+                } else {
+                    name.to_string()
+                };
+                let module_specifier = self.import_module_specifier_text(import_decl)?;
+                if self.is_export_type_only_across_binders(&module_specifier, &export_name) {
+                    continue;
+                }
+                if let Some(target) =
+                    self.exported_block_scoped_value_symbol(&module_specifier, &export_name)
+                {
+                    return Some(target);
+                }
+            }
+        }
+
+        None
+    }
+
+    fn imported_value_target_symbol(
+        &self,
+        alias_sym_id: tsz_binder::SymbolId,
+    ) -> Option<(tsz_binder::SymbolId, usize)> {
+        let alias = self.ctx.binder.get_symbol(alias_sym_id)?;
+        if alias.flags & symbol_flags::ALIAS == 0 {
+            return None;
+        }
+
+        let module_specifier = alias.import_module.as_ref()?;
+        let import_name = alias.import_name.as_deref().unwrap_or(&alias.escaped_name);
+        self.exported_block_scoped_value_symbol(module_specifier, import_name)
+    }
+
+    fn exported_block_scoped_value_symbol(
+        &self,
+        module_specifier: &str,
+        export_name: &str,
+    ) -> Option<(tsz_binder::SymbolId, usize)> {
+        let target_idx = self
+            .ctx
+            .resolve_import_target_from_file(self.ctx.current_file_idx, module_specifier)?;
+        let target_binder = self.ctx.get_binder_for_file(target_idx)?;
+
+        for &candidate_id in target_binder.get_symbols().find_all_by_name(export_name) {
+            let Some(candidate) = target_binder.get_symbol(candidate_id) else {
+                continue;
+            };
+            if candidate.escaped_name == export_name
+                && candidate.flags & symbol_flags::BLOCK_SCOPED_VARIABLE != 0
+                && candidate.flags & symbol_flags::ALIAS == 0
+                && candidate.import_module.is_none()
+                && candidate.value_declaration.is_some()
+                && candidate.is_exported
+            {
+                self.ctx
+                    .register_symbol_file_target(candidate_id, target_idx);
+                return Some((candidate_id, target_idx));
+            }
+        }
+
+        None
+    }
+
+    fn import_module_specifier_text(
+        &self,
+        import_decl: &tsz_parser::parser::node::ImportDeclData,
+    ) -> Option<String> {
+        let spec_node = self.ctx.arena.get(import_decl.module_specifier)?;
+        let literal = self.ctx.arena.get_literal(spec_node)?;
+        Some(literal.text.clone())
     }
 }


### PR DESCRIPTION
## Agent
AgentName: m5-pro-48g-codex

## Track
Checker/property-access stash salvage; Zod project-corpus adjacent value import behavior.

## Invariant
When a named import is used in value position and the target module exports a `const` plus a same-name type alias, property access should resolve through the exported value declaration. This PR changes checker property-access `arrayToEnum` literal recovery to keep the explicit cross-file value symbol and file index instead of falling back through a colliding local alias/type symbol.

## Scope
- `crates/tsz-checker/src/types/property_access_type/imported_array_to_enum.rs`
- `crates/tsz-checker/src/types/computation/identifier/core.rs`
- `crates/tsz-checker/src/tests/zod_type_query_regression_tests.rs`

## Project Corpus Impact
- Row: zod-adjacent
- Bug family: cross-file enum-like value import with same-name type alias
- Evidence: focused multi-file Zod-style regression covers `ZodIssueCode.invalid_type`, `ZodParsedType.string`, and a cross-file import cycle without TS2339/TS2322.

## Verification
- `git diff --check`
- `cargo fmt --check`
- `cargo nextest run -p tsz-checker --lib cross_file_array_to_enum_value_import_preserves_literal_members zod_issue_data_preserves_union_properties_through_omit_and_spread`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`

## Coordination Notes
- Salvaged from `stash@{8}` after confirming the stash's old static-property recursion cap did not fix the broader IssueData case on current `main`.
- This PR intentionally narrows to the landable value-member behavior; the broader IssueData/contextual-union path still needs a separate investigation.