### PR TITLE
chore(emit): flag blocked output-surgery headroom

### DIFF
--- a/scripts/emit/audit-output-surgery.py
+++ b/scripts/emit/audit-output-surgery.py
@@ -324,6 +324,21 @@ def classify_budget_status(allowlisted_calls: int, allowlist_cap: int) -> str:
     return "available"
 
 
+def classify_allowlist_pressure(
+    budget: BudgetSummary,
+    exhausted_categories: list[str],
+) -> str:
+    if budget.budget_status == "over_cap":
+        return "over_cap"
+    if budget.budget_status == "no_allowlist":
+        return "no_allowlist"
+    if exhausted_categories and budget.remaining_allowlist_capacity == 0:
+        return "blocked"
+    if exhausted_categories:
+        return "category_blocked"
+    return "available"
+
+
 def _run_git(root: pathlib.Path, args: list[str]) -> Optional[str]:
     try:
         result = subprocess.run(
@@ -391,6 +406,15 @@ def format_warning_metrics(file_summaries: list[dict[str, object]]) -> str:
     return f"warning_count={warning_count}, warning_status={warning_status}"
 
 
+def format_allowlist_pressure_metrics(file_summaries: list[dict[str, object]]) -> str:
+    budget = summarize_budget(file_summaries)
+    exhausted_categories = exhausted_category_names(file_summaries)
+    return "allowlist_pressure_status=" + classify_allowlist_pressure(
+        budget,
+        exhausted_categories,
+    )
+
+
 def build_json_report(
     findings: list[Finding],
     allowlist: dict[str, AllowEntry],
@@ -408,6 +432,7 @@ def build_json_report(
         if summary["max_count"] is not None and summary["budget_status"] == "exhausted"
     ]
     warning_count = len(exhausted_categories)
+    allowlist_pressure_status = classify_allowlist_pressure(budget, exhausted_categories)
     return {
         "ok": not failures,
         "status": "failed" if failures else "passed",
@@ -421,6 +446,7 @@ def build_json_report(
         "allowlist_cap": budget.allowlist_cap,
         "remaining_allowlist_capacity": budget.remaining_allowlist_capacity,
         "allowlist_budget_status": budget.budget_status,
+        "allowlist_pressure_status": allowlist_pressure_status,
         "exhausted_category_count": warning_count,
         "exhausted_categories": exhausted_categories,
         "unallowlisted_calls": summary.unallowlisted,
@@ -482,6 +508,7 @@ def format_pass_summary(
         f"{format_budget_metrics(budget)}, "
         f"{format_category_budget_metrics(file_summaries)}, "
         f"{format_exhausted_category_metrics(file_summaries)}, "
+        f"{format_allowlist_pressure_metrics(file_summaries)}, "
         f"{format_warning_metrics(file_summaries)}, "
         f"unallowlisted_calls={summary.unallowlisted}, "
         f"over_allowlist_files={summary.over_allowlist_files}, "

--- a/scripts/emit/test_output_surgery_audit.py
+++ b/scripts/emit/test_output_surgery_audit.py
@@ -104,6 +104,7 @@ class OutputSurgeryAuditTests(unittest.TestCase):
         self.assertEqual(report["allowlist_cap"], 2)
         self.assertEqual(report["remaining_allowlist_capacity"], 1)
         self.assertEqual(report["allowlist_budget_status"], "available")
+        self.assertEqual(report["allowlist_pressure_status"], "available")
         self.assertEqual(report["exhausted_category_count"], 0)
         self.assertEqual(report["exhausted_categories"], [])
         self.assertEqual(report["unallowlisted_calls"], 1)
@@ -170,6 +171,7 @@ class OutputSurgeryAuditTests(unittest.TestCase):
         self.assertEqual(report["output_surgery_status"], "passed")
         self.assertEqual(report["warning_count"], 1)
         self.assertEqual(report["warning_status"], "warn")
+        self.assertEqual(report["allowlist_pressure_status"], "blocked")
         self.assertEqual(report["exhausted_category_count"], 1)
         self.assertEqual(report["exhausted_categories"], ["semantic-output-surgery"])
         self.assertEqual(report["failures"], [])
@@ -227,6 +229,7 @@ class OutputSurgeryAuditTests(unittest.TestCase):
             "category_budgets=semantic-output-surgery=2/2:exhausted, "
             "exhausted_category_count=1, "
             "exhausted_categories=semantic-output-surgery, "
+            "allowlist_pressure_status=blocked, "
             "warning_count=1, "
             "warning_status=warn, "
             "unallowlisted_calls=0, "
@@ -315,6 +318,31 @@ class OutputSurgeryAuditTests(unittest.TestCase):
         self.assertEqual(self.audit.classify_budget_status(1, 2), "available")
         self.assertEqual(self.audit.classify_budget_status(2, 2), "exhausted")
         self.assertEqual(self.audit.classify_budget_status(3, 2), "over_cap")
+
+    def test_allowlist_pressure_distinguishes_global_and_category_blocks(self):
+        budget = self.audit.BudgetSummary(
+            allowlisted_calls=3,
+            allowlist_cap=4,
+            remaining_allowlist_capacity=1,
+            allowlisted_files=2,
+            budget_status="available",
+        )
+        self.assertEqual(
+            self.audit.classify_allowlist_pressure(budget, ["dts-output-surgery"]),
+            "category_blocked",
+        )
+
+        budget = self.audit.BudgetSummary(
+            allowlisted_calls=4,
+            allowlist_cap=4,
+            remaining_allowlist_capacity=0,
+            allowlisted_files=2,
+            budget_status="exhausted",
+        )
+        self.assertEqual(
+            self.audit.classify_allowlist_pressure(budget, ["dts-output-surgery"]),
+            "blocked",
+        )
 
     def test_write_json_report_creates_parent_and_writes_json(self):
         with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Track 10 / launch infrastructure: output-surgery guardrail evidence clarity.

## Invariant
When the output-surgery audit passes with every allowlist slot consumed, the report must say new output-surgery headroom is blocked, not only that the guard passed with warnings.

## Scope
- `scripts/emit/audit-output-surgery.py`
- `scripts/emit/test_output_surgery_audit.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: guardrail-reporting-only change; no compiler, checker, solver, parser, binder, emitter runtime, benchmark, or project-corpus behavior changes.

## Verification
- `python3 scripts/emit/test_output_surgery_audit.py`
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery.json`
- `python3 -m py_compile scripts/emit/audit-output-surgery.py scripts/emit/test_output_surgery_audit.py`
- `git diff --check`

## Coordination Notes
- AgentName: Studio-F.
- Current audit evidence now reports `allowlist_pressure_status=blocked` when `remaining_allowlist_capacity=0` and all live categories are exhausted.
- This does not reduce the 23/23 output-surgery counter; it makes the release-gate artifact harder to misread while Studio-C/D/E burn down the underlying emit debt.
- Exact-head draft-light CI on `561988fd8025d81628107a6e13829956d571ef92` is clean: `CI Light Summary`, lint, unit, dist-binaries, cargo-deny, cargo-shear, unit-cloudbuild, project-row-drift, queue-one-pr, and GitGuardian passed. Marked ready by ReviewHelper on 2026-06-01; do not add `merge-queue` until exact-head ready-review `CI Summary` and GitGuardian pass.