### PR TITLE
fix(dts): preserve source setter parameter names

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs
@@ -314,6 +314,7 @@ mod type_inference_source_text;
 mod type_inference_truncation_expansion;
 mod type_inference_type_annotations;
 mod type_inference_type_nodes;
+mod type_literal_accessor_names;
 mod type_param_rewrite;
 mod type_predicate_text;
 mod type_printing;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
@@ -1026,7 +1026,20 @@ impl<'a> DeclarationEmitter<'a> {
                             type_id, 0,
                         ))
                 {
-                    let printed = self.print_type_id_for_inferred_declaration(type_id);
+                    let printed = if let Some(source_type_text) = reused_type_text.as_deref() {
+                        let setter_names =
+                            self.source_type_setter_parameter_names(self.arena, source_type_text);
+                        if setter_names.is_empty() {
+                            self.print_type_id_for_inferred_declaration(type_id)
+                        } else {
+                            self.print_type_id_for_inferred_declaration_with_setter_parameter_names(
+                                type_id,
+                                &setter_names,
+                            )
+                        }
+                    } else {
+                        self.print_type_id_for_inferred_declaration(type_id)
+                    };
                     if let Some(call) = self.arena.get_call_expr(expr_node) {
                         if let Some((alias_name, module_specifier)) =
                             self.call_receiver_default_import_alias(call.expression)

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
@@ -538,7 +538,21 @@ impl<'a> DeclarationEmitter<'a> {
                     && let Some(call_type_id) = self.get_node_type_or_names(&[expr_idx])
                     && !matches!(call_type_id, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR)
                 {
-                    let type_text = self.print_type_id_for_inferred_declaration(call_type_id);
+                    let setter_names = if std::ptr::eq(source_arena, self.arena)
+                        && let Some(source_type_text) = self.source_function_return_type_text(func)
+                    {
+                        self.source_type_setter_parameter_names(source_arena, &source_type_text)
+                    } else {
+                        FxHashMap::default()
+                    };
+                    let type_text = if setter_names.is_empty() {
+                        self.print_type_id_for_inferred_declaration(call_type_id)
+                    } else {
+                        self.print_type_id_for_inferred_declaration_with_setter_parameter_names(
+                            call_type_id,
+                            &setter_names,
+                        )
+                    };
                     if !type_text.is_empty() && !matches!(type_text.as_str(), "any" | "unknown") {
                         let type_text = if source_is_foreign {
                             self.qualify_foreign_imported_names_in_text(source_arena, &type_text)

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_literal_accessor_names.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_literal_accessor_names.rs
@@ -1,0 +1,82 @@
+//! Source-backed accessor-name recovery for structural declaration text.
+
+use super::super::DeclarationEmitter;
+use rustc_hash::FxHashMap;
+use tsz_parser::parser::NodeArena;
+use tsz_parser::parser::syntax_kind_ext;
+
+impl<'a> DeclarationEmitter<'a> {
+    pub(in crate::declaration_emitter) fn source_type_setter_parameter_names(
+        &self,
+        source_arena: &NodeArena,
+        source_type_text: &str,
+    ) -> FxHashMap<String, String> {
+        let source_names =
+            if let Some(alias_name) = Self::leading_type_reference_name(source_type_text) {
+                self.source_type_alias_setter_parameter_names(source_arena, alias_name)
+            } else {
+                Self::source_type_text_setter_parameter_names(source_type_text)
+            };
+        let mut names = FxHashMap::default();
+        for (member_name, param_name) in source_names {
+            if !Self::is_simple_identifier_text(&param_name) {
+                continue;
+            }
+            names.insert(member_name, param_name);
+        }
+        names
+    }
+
+    fn source_type_alias_setter_parameter_names(
+        &self,
+        source_arena: &NodeArena,
+        alias_name: &str,
+    ) -> Vec<(String, String)> {
+        source_arena
+            .nodes
+            .iter()
+            .filter_map(|node| source_arena.get_type_alias(node))
+            .filter(|alias| {
+                self.identifier_text_from_arena(source_arena, alias.name)
+                    .as_deref()
+                    == Some(alias_name)
+            })
+            .filter_map(|alias| source_arena.get(alias.type_node))
+            .filter_map(|node| source_arena.get_type_literal(node))
+            .flat_map(|type_literal| type_literal.members.nodes.iter().copied())
+            .filter_map(|member_idx| {
+                let member_node = source_arena.get(member_idx)?;
+                if member_node.kind != syntax_kind_ext::SET_ACCESSOR {
+                    return None;
+                }
+                let accessor = source_arena.get_accessor(member_node)?;
+                let member_name =
+                    self.property_name_text_from_arena(source_arena, accessor.name)?;
+                let param_idx = accessor.parameters.nodes.first().copied()?;
+                let param_node = source_arena.get(param_idx)?;
+                let param = source_arena.get_parameter(param_node)?;
+                let param_name = self.identifier_text_from_arena(source_arena, param.name)?;
+                Some((member_name, param_name))
+            })
+            .collect()
+    }
+
+    fn source_type_text_setter_parameter_names(source_type_text: &str) -> Vec<(String, String)> {
+        source_type_text
+            .lines()
+            .filter_map(|line| {
+                let member = line.trim().trim_end_matches(';').trim();
+                let rest = member.strip_prefix("set ")?;
+                let open_paren = rest.find('(')?;
+                let member_name = rest[..open_paren].trim();
+                if member_name.is_empty() {
+                    return None;
+                }
+                let param_text = rest[open_paren + 1..].trim_start();
+                let colon = param_text.find(':')?;
+                let param_name = param_text[..colon].trim();
+                Some((member_name.to_string(), param_name.to_string()))
+            })
+            .collect()
+    }
+}

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs
@@ -741,6 +741,23 @@ impl<'a> DeclarationEmitter<'a> {
             &tsz_solver::construction::TypeInterner,
         ) -> bool,
     ) -> String {
+        self.print_type_id_with_policy_and_setter_parameter_names(
+            type_id,
+            preserve_named_application,
+            None,
+        )
+    }
+
+    fn print_type_id_with_policy_and_setter_parameter_names(
+        &self,
+        type_id: tsz_solver::types::TypeId,
+        preserve_named_application: fn(
+            &Self,
+            tsz_solver::types::TypeId,
+            &tsz_solver::construction::TypeInterner,
+        ) -> bool,
+        setter_parameter_names: Option<&FxHashMap<String, String>>,
+    ) -> String {
         if let Some(interner) = self.type_interner {
             let type_id =
                 self.display_alias_for_policy(type_id, interner, preserve_named_application);
@@ -801,6 +818,8 @@ impl<'a> DeclarationEmitter<'a> {
                     false
                 }
             };
+            let setter_parameter_name_resolver =
+                |name: &str| setter_parameter_names.and_then(|names| names.get(name).cloned());
             let mut printer = TypePrinter::new(interner)
                 .with_indent_level(self.indent_level)
                 .with_node_arena(self.arena)
@@ -809,6 +828,7 @@ impl<'a> DeclarationEmitter<'a> {
                 .with_import_equals_alias_resolver(&import_equals_alias_resolver)
                 .with_local_import_alias_name_resolver(&local_import_alias_name_resolver)
                 .with_has_local_import_alias_resolver(&has_local_import_alias_resolver)
+                .with_setter_parameter_name_resolver(&setter_parameter_name_resolver)
                 .with_strict_null_checks(self.strict_null_checks);
 
             // Add symbol arena if available for visibility checking
@@ -845,6 +865,25 @@ impl<'a> DeclarationEmitter<'a> {
         &self,
         type_id: tsz_solver::types::TypeId,
     ) -> String {
+        self.print_type_id_for_inferred_declaration_with_optional_setter_names(type_id, None)
+    }
+
+    pub(crate) fn print_type_id_for_inferred_declaration_with_setter_parameter_names(
+        &self,
+        type_id: tsz_solver::types::TypeId,
+        setter_parameter_names: &FxHashMap<String, String>,
+    ) -> String {
+        self.print_type_id_for_inferred_declaration_with_optional_setter_names(
+            type_id,
+            Some(setter_parameter_names),
+        )
+    }
+
+    fn print_type_id_for_inferred_declaration_with_optional_setter_names(
+        &self,
+        type_id: tsz_solver::types::TypeId,
+        setter_parameter_names: Option<&FxHashMap<String, String>>,
+    ) -> String {
         let elided_alias_names = self.function_local_type_alias_application_names(type_id);
         let type_id = if let Some(interner) = self.type_interner {
             let type_id = self
@@ -859,9 +898,10 @@ impl<'a> DeclarationEmitter<'a> {
             type_id
         };
         let type_id = self.reduce_conditional_aliases_for_inferred_emit(type_id, 0);
-        let printed = self.print_type_id_with_policy(
+        let printed = self.print_type_id_with_policy_and_setter_parameter_names(
             type_id,
             Self::should_preserve_named_application_for_inferred_emit,
+            setter_parameter_names,
         );
         let printed = if elided_alias_names.is_empty() {
             printed

--- a/crates/tsz-emitter/src/declaration_emitter/tests/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/mod.rs
@@ -310,4 +310,5 @@ mod probes_tsc_comparison;
 mod simple_declarations;
 mod type_formatting;
 mod type_info;
+mod type_info_accessor_names;
 mod type_info_constructor_objects;

--- a/crates/tsz-emitter/src/declaration_emitter/tests/type_info_accessor_names.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/type_info_accessor_names.rs
@@ -1,0 +1,50 @@
+use super::type_info::parse_test_source;
+use super::*;
+use crate::emitter::type_printer::TypePrinter;
+
+#[test]
+fn source_alias_split_accessors_preserve_setter_parameter_names() {
+    let source = r#"
+function makeThing() {
+    type Box<U> = {
+        get value(): string | U;
+        set value(input: number | U);
+        get other(): U;
+        set other(next: U);
+    }
+    return null! as Box<number>;
+}
+"#;
+    let (parser, _root) = parse_test_source(source);
+    let emitter = DeclarationEmitter::new(&parser.arena);
+    let setter_names = emitter.source_type_setter_parameter_names(&parser.arena, "Box<number>");
+    let interner = TypeInterner::new();
+    let mut value = PropertyInfo::new(interner.intern_string("value"), TypeId::STRING);
+    value.write_type = TypeId::NUMBER;
+    let mut other = PropertyInfo::new(interner.intern_string("other"), TypeId::STRING);
+    other.write_type = TypeId::NUMBER;
+    let object_type = interner.object_with_index(ObjectShape {
+        flags: ObjectFlags::default(),
+        properties: vec![value, other],
+        string_index: None,
+        number_index: None,
+        symbol: None,
+    });
+    let setter_name = |name: &str| setter_names.get(name).cloned();
+    let printed = TypePrinter::new(&interner)
+        .with_setter_parameter_name_resolver(&setter_name)
+        .print_type(object_type);
+
+    assert!(
+        printed.contains("set value(input: number)"),
+        "Expected setter parameter name from source alias accessor: {printed}"
+    );
+    assert!(
+        printed.contains("set other(next: number)"),
+        "Expected renamed setter parameter from second source accessor: {printed}"
+    );
+    assert!(
+        !printed.contains("set value(arg:") && !printed.contains("set other(arg:"),
+        "Expected structural printer to use source setter names when the fact is present: {printed}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/types/printer/mod.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/mod.rs
@@ -10,6 +10,9 @@ use tsz_solver::construction::TypeInterner;
 
 use crate::type_cache_view::TypeCacheView;
 
+/// Resolves a source-authored setter parameter name from the printed property name.
+pub type SetterParameterNameResolver<'a> = dyn Fn(&str) -> Option<String> + 'a;
+
 /// Prints types as TypeScript syntax for declaration emit.
 ///
 /// # Examples
@@ -53,6 +56,9 @@ pub struct TypePrinter<'a> {
     /// Optional resolver for checking whether a foreign symbol has a local import
     /// alias that will be emitted, so the symbol can be referenced by name.
     has_local_import_alias_resolver: Option<&'a dyn Fn(SymbolId) -> bool>,
+    /// Optional source declaration fact for naming synthesized setter parameters
+    /// in structural accessor signatures.
+    setter_parameter_name_resolver: Option<&'a SetterParameterNameResolver<'a>>,
     /// When false, standalone `null` and `undefined` widen to `any` and are
     /// filtered from union members (matching tsc's DTS behaviour).
     strict_null_checks: bool,
@@ -85,6 +91,7 @@ impl<'a> TypePrinter<'a> {
             import_equals_alias_resolver: None,
             local_import_alias_name_resolver: None,
             has_local_import_alias_resolver: None,
+            setter_parameter_name_resolver: None,
             strict_null_checks: true,
             outer_type_param_names: Vec::new(),
             type_param_renames: Vec::new(),
@@ -195,6 +202,15 @@ impl<'a> TypePrinter<'a> {
         resolver: &'a dyn Fn(SymbolId) -> bool,
     ) -> Self {
         self.has_local_import_alias_resolver = Some(resolver);
+        self
+    }
+
+    /// Set a resolver for source-authored setter parameter names by property name.
+    pub fn with_setter_parameter_name_resolver(
+        mut self,
+        resolver: &'a SetterParameterNameResolver<'a>,
+    ) -> Self {
+        self.setter_parameter_name_resolver = Some(resolver);
         self
     }
 

--- a/crates/tsz-emitter/src/emitter/types/printer/type_printing.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/type_printing.rs
@@ -331,8 +331,12 @@ impl<'a> TypePrinter<'a> {
             ));
         }
         if !property.readonly && property.write_type != TypeId::UNDEFINED {
+            let param_name = self
+                .setter_parameter_name_resolver
+                .and_then(|resolve| resolve(&printed_name))
+                .unwrap_or_else(|| "arg".to_string());
             members.push(format!(
-                "set {printed_name}(arg: {})",
+                "set {printed_name}({param_name}: {})",
                 self.print_type(property.write_type)
             ));
         }


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Declaration emit / DTS parity

## Invariant
When declaration emit prints a structural object type whose accessor pair originates from source-authored type-literal accessors, `tsc` preserves the source setter parameter name in the `.d.ts`. This PR feeds that source declaration fact into `TypePrinter` so tsz prints the same setter signature without changing checker or solver semantics.

## Structural Rule
Source-authored split accessors carry public declaration syntax for setter parameter names. When alias or function-return source text is expanded structurally, the parameter name should travel as an emitter formatting fact keyed by property name. Synthetic accessor shapes without that source fact keep the generated `arg` fallback.

## Owner Layer
Declaration emit / type printer formatting. The source-name fact is collected in declaration-emitter helpers and consumed by `TypePrinter`. No relation, assignability, inference, checker diagnostic, or solver type semantics change.

## Scope
- Add a `TypePrinter` setter-parameter-name resolver.
- Collect source type-literal setter parameter names from alias/source return text.
- Use the resolver at the declaration inference paths that expand same-file function-local alias returns structurally.
- Add focused unit coverage with two different setter parameter/property names.

## Adjacent-Case Matrix
- Reported-style function-local alias application with divergent getter/setter types: covered by focused DTS filter `declarationEmitGenericTypeParamerSerialization2`.
- Renamed setter params and property names (`input`, `next`, `value`, `other`): covered by `source_alias_split_accessors_preserve_setter_parameter_names`.
- Synthetic structural accessors without a source declaration fact: fallback remains `arg` because resolver is absent or empty.
- Same-file function return source text and reused alias text paths: both pass through `source_type_setter_parameter_names` and the `TypePrinter` resolver.

## Known Unsupported/Fallback
- Foreign-source call targets currently fall back to normal structural printing unless their existing path supplies a local source fact.
- Source facts that cannot identify a simple setter parameter name fall back to normal `arg`.
- Computed/quoted member names only participate when their source/printed property text matches the property-name key.

## Project Corpus Impact
- Row: declaration emit conformance
- Bug family: DTS accessor/type-display surface for function-local alias expansion
- Evidence: focused DTS filter `declarationEmitGenericTypeParamerSerialization2` passes 1/1.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`
- `cargo nextest run -p tsz-emitter source_alias_split_accessors_preserve_setter_parameter_names`
- `scripts/emit/run.sh --filter=declarationEmitGenericTypeParamerSerialization2 --dts-only --verbose --concurrency=4 --json-out=/tmp/studio-d-declarationEmitGenericTypeParamerSerialization2-e6ba7e0.json`

## Coordination Notes
- Studio-D.
- Head SHA: `e6ba7e0b9a`.
- Rebasing/sync with `origin/main` completed before push.
- Refactored away from post-print string replacement; setter names are now a source declaration fact consumed by `TypePrinter`.
- No roadmap update: focused DTS parity fix, no durable direction change.
- No checker/solver semantic changes; checker diagnostics unaffected.
- Work performed in existing worktree `/Users/mohsen/code/tsz-studio-a-conformance-current-20260601`; TypeScript submodule and Studio-D Cargo cache preserved.
