### PR TITLE
fix(checker): retry mapped constraints for property access

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/property_access.rs
+++ b/crates/tsz-checker/src/state/state_checking/property_access.rs
@@ -365,18 +365,25 @@ impl<'a> CheckerState<'a> {
             result = self.resolve_property_access_via_boundary(pruned_object_type, prop_name);
         }
 
-        // For a TypeParameter whose constraint is a cross-file `Lazy(DefId)` reference
-        // (e.g. `T extends Box` where `Box` is defined in another file), the solver's
-        // `evaluate_type_with_options` cannot resolve the constraint because it uses a
-        // noop `TypeResolver`. Evaluate through the checker's full `TypeEnvironment` and
-        // retry. Non-Lazy constraints are handled by the solver's TypeParameter branch.
+        // For a TypeParameter whose constraint still needs environment-backed
+        // evaluation (for example `T extends Box` where `Box` is cross-file
+        // `Lazy(DefId)`, or `T extends MyPartial<Foo>` where the constraint is a
+        // generic mapped alias), the solver's noop-resolver property evaluator can
+        // only see the unresolved constraint and report a missing property. Evaluate
+        // through the checker's full `TypeEnvironment` and retry the property query.
         if result.is_degenerate()
             && let Some(constraint) =
                 crate::query_boundaries::state::checking::type_parameter_constraint(
                     self.ctx.types,
                     resolved_object_type,
                 )
-            && crate::query_boundaries::common::is_lazy_type(self.ctx.types, constraint)
+            && (crate::query_boundaries::common::is_lazy_type(self.ctx.types, constraint)
+                || crate::query_boundaries::common::is_generic_application(
+                    self.ctx.types,
+                    constraint,
+                )
+                || query::is_mapped_type(self.ctx.types, constraint)
+                || query::needs_env_eval(self.ctx.types, constraint))
         {
             let evaluated = self.evaluate_type_with_env(constraint);
             if evaluated != constraint && evaluated != TypeId::ANY && evaluated != TypeId::ERROR {


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 7/9 generated app lib/module identity; checker boundary correctness prerequisite for the green-row performance lane.

## Invariant
When property access targets a type parameter whose constraint is an unresolved lazy, generic application, or mapped constraint, `tsc` resolves the constraint before deciding whether the property exists; this PR makes tsz retry through the checker `TypeEnvironment` and then re-enter the existing property-access boundary.

## Scope
- `crates/tsz-checker/src/state/state_checking/property_access.rs`
- No new DOM/lib name allowlist and no direct solver internals access.

## Project Corpus Impact
- Row: `vite-vanilla-ts-app`
- Bug family: generated app lib/module identity and generic mapped-alias property access; correctness prerequisite while the row remains a green 2x target gap.
- Evidence: pre-final-main-sync quick run stayed green: `/private/tmp/studio-b-vite-lazy-boundary-rebased-20260601.json`; winner report `/private/tmp/studio-b-vite-lazy-boundary-rebased-20260601.tsgo-winners.json` shows `eligible_green_rows=1`, `rows_below_target=1`, `tsz_ms=114.67`, `tsgo_ms=78.79`, `target_gap_factor=2.9107754791217157`. After rebasing to head `ca4ebcff7cf27ee1994ddc53422048f7906aab88`, focused local tests were rerun; CI owns final project-row confirmation.

## Verification
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib type_param_property_access_with_mapped_constraint mapped_type_name_collision_readonly_of_type_param value_merged_builtin_dom_interface_type_argument_keeps_inherited_members` (rerun after final rebase to head `ca4ebcff7cf27ee1994ddc53422048f7906aab88`)
- `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^vite-vanilla-ts-app$' --json-file /private/tmp/studio-b-vite-lazy-boundary-rebased-20260601.json`
- `node scripts/bench/tsgo-winner-report.mjs /private/tmp/studio-b-vite-lazy-boundary-rebased-20260601.json /private/tmp/studio-b-vite-lazy-boundary-rebased-20260601.tsgo-winners.json`

## Coordination Notes
- Existing Studio-B PR runway was empty before starting.
- Open overlap checked with `gh pr list --state open --limit 100 ...`; no Studio-B PRs were open. Related perf issue: #12021.
- This PR intentionally does not reintroduce the unsafe DOM value/interface or DOM type-alias direct delegation shortcuts documented on #12021.
- The Vite 2x target gap remains open; this slice protects the boundary needed before deeper alias/lazy or property-access cache work.
- Disk dropped to 143 MB after benchmark rebuild; `scripts/setup/clean.sh --quiet` restored about 21 GB but removed this worktree's local `.target` and `.target-bench` caches. Reuse sibling caches or rebuild narrowly before further local verification.
