### PR TITLE
fix(dts): annotate composed literal call results

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
@@ -863,6 +863,24 @@ const number = valueMerge(123, (value: number | string) => {}, (value: 123) => {
 }
 
 #[test]
+fn declared_call_return_uses_annotation_for_composed_literal_result() {
+    let source = r#"
+declare function ff2<T extends string, U extends string>(x: T, y: U): `${T}-${U}`;
+const ts1 = ff2("foo", "bar");
+"#;
+    let output = emit_test_dts_with_binding(source);
+
+    assert!(
+        output.contains("declare const ts1: \"foo-bar\";"),
+        "{output}"
+    );
+    assert!(
+        !output.contains("declare const ts1 = \"foo-bar\";"),
+        "{output}"
+    );
+}
+
+#[test]
 fn higher_order_type_parameter_parameter_blocks_direct_literal_initializer_reuse() {
     let source = r#"
 declare function direct<A>(value: A, callback: (value: A) => void): A;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -639,7 +639,10 @@ impl<'a> DeclarationEmitter<'a> {
                 if keyword == "const"
                     && !self.variable_declaration_has_effective_export(decl_idx)
                     && Self::is_literal_type_text_for_const_call(&type_text)
-                    && self.call_expression_has_primitive_literal_argument(initializer)
+                    && self.call_expression_has_matching_primitive_literal_argument(
+                        initializer,
+                        &type_text,
+                    )
                 {
                     self.write(" = ");
                     self.write(&type_text);
@@ -1762,7 +1765,11 @@ impl<'a> DeclarationEmitter<'a> {
         tsz_solver::visitor::literal_value(interner, member_type)
     }
 
-    fn call_expression_has_primitive_literal_argument(&self, initializer: NodeIndex) -> bool {
+    fn call_expression_has_matching_primitive_literal_argument(
+        &self,
+        initializer: NodeIndex,
+        type_text: &str,
+    ) -> bool {
         let Some(init_node) = self.arena.get(initializer) else {
             return false;
         };
@@ -1773,10 +1780,9 @@ impl<'a> DeclarationEmitter<'a> {
             return false;
         };
         call.arguments.as_ref().is_some_and(|args| {
-            args.nodes
-                .iter()
-                .copied()
-                .any(|arg| self.primitive_literal_argument_type_text(arg).is_some())
+            args.nodes.iter().copied().any(|arg| {
+                self.primitive_literal_argument_type_text(arg).as_deref() == Some(type_text)
+            })
         })
     }
 }


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Track 9 Emit/DTS parity recovery.

## Invariant
When a `const` call expression has an inferred literal result composed by the callee return type, `tsc` emits a type annotation. Declaration emit should reserve initializer form for direct primitive literal argument reuse, such as a bare type-parameter return inferred from that argument.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: declaration emit const call literal initializer surface
- Evidence: emit conformance-only DTS parity slice; `constAssertions` DTS now passes locally.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-emitter declared_call_return_uses_annotation_for_composed_literal_result declared_call_return_preserves_bare_type_parameter_literal_argument`
- `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`
- `scripts/emit/run.sh --filter=constAssertions --dts-only --verbose --concurrency=4 --json-out=/tmp/studio-d-constAssertions-fix.json`

## Coordination Notes
- Based on current `origin/main` after #12093 merged.
- No overlap found with open emit PRs #12096, #12092, or #12013.
- This changes declaration formatting only; checker diagnostics and solver relations are unaffected.
