### PR TITLE
fix(emit): gate for-await loop-init temp hoist on a preceding for-of (resolves #12084 cluster A / #12073 over-hoist)

### DIFF
--- a/crates/tsz-emitter/src/emitter/es5/bindings_param_patterns.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings_param_patterns.rs
@@ -4,7 +4,7 @@ use super::super::{ParamTransformPlan, Printer};
 use super::bindings_patterns::ES5RestProp;
 use crate::transforms::emit_utils;
 use tsz_parser::parser::NodeIndex;
-use tsz_parser::parser::node::{BindingElementData, ForInOfData, Node};
+use tsz_parser::parser::node::{BindingElementData, ForInOfData, Node, NodeAccess};
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
@@ -1192,6 +1192,80 @@ impl<'a> Printer<'a> {
     ///     finally { if (e_1) throw e_1.error; }
     /// }
     /// ```
+    /// Decide whether the downlevel for-await-of loop-init temps (loop guard,
+    /// iterator, result) should be hoisted into the enclosing async body's
+    /// `var` group rather than declared inline in `for (var ...)`.
+    ///
+    /// Structural rule (matches `tsc`): when a `for-of` / `for-await-of` loop
+    /// appears earlier in the SAME async function body than `for_await_idx`,
+    /// `tsc` hoists this loop's init temps into the body var group; otherwise it
+    /// keeps them inline in the `for (var _d = true, it = __asyncValues(x),
+    /// res; ...)` head. The earlier loop's own temps reset the per-iteration
+    /// `var` redeclaration, so a following for-await head references the hoisted
+    /// names instead of re-`var`-ing them.
+    ///
+    /// We find the nearest enclosing function-like node (the async body owner)
+    /// by walking parent links, then scan that subtree — without descending into
+    /// nested function-likes — for a `for-of`/`for-await-of` statement that
+    /// starts before `for_await_idx`. A native ES2015 sync `for-of` does not
+    /// bump the ES5 for-of emit counters, so this AST scan (not local emit
+    /// state) is required to distinguish the two cases.
+    fn body_has_for_of_before_for_await(&self, for_await_idx: NodeIndex) -> bool {
+        let Some(for_await_node) = self.arena.get(for_await_idx) else {
+            return false;
+        };
+        let for_await_pos = for_await_node.pos;
+
+        // Walk up to the nearest enclosing function-like node (the async body
+        // owner). That node's subtree is the search scope.
+        let mut owner = self.arena.parent_of(for_await_idx);
+        while let Some(idx) = owner {
+            if idx.is_none() {
+                return false;
+            }
+            let Some(node) = self.arena.get(idx) else {
+                return false;
+            };
+            if self.is_function_like_hoist_boundary(node.kind) {
+                break;
+            }
+            owner = self.arena.parent_of(idx);
+        }
+        let Some(root) = owner else {
+            return false;
+        };
+        if root.is_none() {
+            return false;
+        }
+
+        // Scan the owner subtree for a for-of/for-await-of statement that starts
+        // before this for-await. Stop at nested function-like boundaries so we
+        // do not count loops belonging to inner functions.
+        let mut stack = vec![root];
+        while let Some(idx) = stack.pop() {
+            if idx.is_none() {
+                continue;
+            }
+            let Some(node) = self.arena.get(idx) else {
+                continue;
+            };
+
+            if idx != for_await_idx
+                && node.kind == syntax_kind_ext::FOR_OF_STATEMENT
+                && node.pos < for_await_pos
+            {
+                return true;
+            }
+
+            if idx != root && self.is_function_like_hoist_boundary(node.kind) {
+                continue;
+            }
+
+            stack.extend(self.arena.get_children(idx));
+        }
+        false
+    }
+
     pub(in crate::emitter) fn emit_for_of_statement_es5_async_iterator(
         &mut self,
         for_of_idx: NodeIndex,
@@ -1273,8 +1347,12 @@ impl<'a> Printer<'a> {
         let catch_error_name = format!("e_{}_1", counter + 1);
 
         self.ctx.destructuring_state.for_of_counter += 1;
-        let hoist_loop_init_temps =
-            self.ctx.emit_await_as_yield || self.ctx.emit_await_as_yield_await;
+        // tsc hoists the for-await loop-init temps (guard/iterator/result) into
+        // the enclosing async body's `var` group IFF a preceding `for-of` /
+        // `for-await-of` loop exists earlier in the same async body; otherwise
+        // it keeps them inline in `for (var _d = true, it = __asyncValues(x),
+        // res; ...)`. See `body_has_for_of_before_for_await` for the rule.
+        let hoist_loop_init_temps = self.body_has_for_of_before_for_await(for_of_idx);
 
         // Hoist done/error/return/value temps to the top of the source file scope.
         self.hoisted_for_of_temps.push(loop_done_name.clone());

--- a/crates/tsz-emitter/src/emitter/functions_arrow.rs
+++ b/crates/tsz-emitter/src/emitter/functions_arrow.rs
@@ -1614,7 +1614,7 @@ impl<'a> Printer<'a> {
         false
     }
 
-    const fn is_function_like_hoist_boundary(&self, kind: u16) -> bool {
+    pub(in crate::emitter) const fn is_function_like_hoist_boundary(&self, kind: u16) -> bool {
         kind == syntax_kind_ext::FUNCTION_DECLARATION
             || kind == syntax_kind_ext::FUNCTION_EXPRESSION
             || kind == syntax_kind_ext::ARROW_FUNCTION

--- a/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
@@ -131,21 +131,19 @@ fn for_await_temps_do_not_leak_to_source_scope() {
     let function_start = output.find("function f()").expect("function should emit");
     let source_scope = &output[..function_start];
 
+    // No preceding for-of in this async body, so tsc keeps the loop-init temps
+    // INLINE in the `for (var ...)` head and only hoists done/error/return/value.
     assert!(
-        !source_scope.contains("var _a, e_1, _b, _c, _d, y_1, y_1_1;"),
+        !source_scope.contains("var _a, e_1, _b, _c;"),
         "for-await temps should not be hoisted outside the function.\nOutput:\n{output}"
     );
     assert!(
-        output.contains("function* () {\n        var _a, e_1, _b, _c, _d, y_1, y_1_1;"),
+        output.contains("function* () {\n        var _a, e_1, _b, _c;"),
         "for-await temps should be hoisted inside the generated async body.\nOutput:\n{output}"
     );
     assert!(
-        output.contains("for (_d = true, y_1 = __asyncValues(y);"),
-        "for-await loop init should reuse the hoisted temps instead of redeclaring them inline.\nOutput:\n{output}"
-    );
-    assert!(
-        !output.contains("for (var _d = true, y_1 = __asyncValues(y);"),
-        "generated async bodies should not emit inline `var` for hoisted for-await loop temps.\nOutput:\n{output}"
+        output.contains("for (var _d = true, y_1 = __asyncValues(y), y_1_1;"),
+        "with no preceding for-of, loop-init temps stay inline in the for-head.\nOutput:\n{output}"
     );
 }
 
@@ -170,17 +168,18 @@ fn async_arrow_for_await_temps_are_hoisted_inside_generator() {
     let arrow_start = output.find("const arrow").expect("arrow should emit");
     let source_scope = &output[..arrow_start];
 
+    // No preceding for-of in this async arrow body: loop-init temps stay inline.
     assert!(
-        !source_scope.contains("var _a, e_1, _b, _c, _d, _e, _f;"),
+        !source_scope.contains("var _a, e_1, _b, _c;"),
         "for-await temps from async arrows should not be hoisted outside the arrow.\nOutput:\n{output}"
     );
     assert!(
-        output.contains("function* () {\n    var _a, e_1, _b, _c, _d, _e, _f;\n    try {"),
+        output.contains("function* () {\n    var _a, e_1, _b, _c;\n    try {"),
         "for-await temps should be hoisted inside the async arrow generator body.\nOutput:\n{output}"
     );
     assert!(
-        output.contains("for (_d = true, _e = __asyncValues(gen());"),
-        "async arrows should reuse hoisted for-await loop-init temps.\nOutput:\n{output}"
+        output.contains("for (var _d = true, _e = __asyncValues(gen()), _f;"),
+        "with no preceding for-of, async arrows keep loop-init temps inline.\nOutput:\n{output}"
     );
 }
 
@@ -202,13 +201,86 @@ fn async_arrow_for_await_assignment_binding_temps_are_hoisted() {
     printer.emit(root);
     let output = printer.get_output().to_string();
 
+    // No preceding for-of: loop-init temps stay inline in the for-head.
     assert!(
-        output.contains("const arrow = () => __awaiter(void 0, void 0, void 0, function* () {\n    var _a, e_1, _b, _c, _d, _e, _f;\n    try {"),
+        output.contains("const arrow = () => __awaiter(void 0, void 0, void 0, function* () {\n    var _a, e_1, _b, _c;\n    try {"),
         "assignment-target for-await temps should be hoisted in async arrow generator bodies.\nOutput:\n{output}"
     );
     assert!(
         output.contains("_c = _f.value;\n            _d = false;\n            item = _c;"),
         "assignment-target for-await should still bind the yielded value through the hoisted value temp.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn for_await_loop_init_temps_hoist_after_preceding_for_of() {
+    // A preceding sync `for-of` in the same async body resets the per-iteration
+    // `var` redeclaration, so tsc hoists the following for-await's loop-init
+    // temps (guard/iterator/result) into the body var group and references them
+    // inline without `var`. Mirrors operationsAvailableOnPromisedType.
+    let source = "async function f(c: number[], y: any) {\n    for (const s of c) { s; }\n    for await (const x of y) { x; }\n}\n";
+
+    let (parser, root) = parse_test_source(source);
+    let options = PrinterOptions {
+        target: ScriptTarget::ES2015,
+        module: ModuleKind::ES2015,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    set_emitter_source(&mut printer, source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    // A preceding for-of in the same async body hoists the loop-init temps into
+    // the body var group, so the for-await head references them without `var`.
+    assert!(
+        output.contains("var _a, e_1, _b, _c, _d, y_1, y_1_1;"),
+        "preceding for-of should hoist loop-init temps (_d, y_1, y_1_1) into the body var group.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("for (_d = true, y_1 = __asyncValues(y); y_1_1 = yield y_1.next()"),
+        "with a preceding for-of, the for-await head reuses the hoisted temps without inline `var`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("for (var _d = true, y_1 = __asyncValues(y)"),
+        "with a preceding for-of, the for-await head must not redeclare loop-init temps with inline `var`.\nOutput:\n{output}"
+    );
+    // The native ES2015 sync for-of must stay un-lowered (it is what triggers
+    // the hoist via the body scan; emit counters alone cannot see it).
+    assert!(
+        output.contains("for (const s of c) {"),
+        "the preceding native sync for-of should be preserved as-is.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn for_await_alone_keeps_loop_init_temps_inline_renamed_binding() {
+    // Same shape as the leak test but with a different loop variable name, to
+    // prove the inline decision is structural (no preceding for-of), not keyed
+    // to a particular identifier spelling.
+    let source =
+        "async function g() {\n    let src: any;\n    for await (const item of src) {\n    }\n}\n";
+
+    let (parser, root) = parse_test_source(source);
+    let options = PrinterOptions {
+        target: ScriptTarget::ES2015,
+        module: ModuleKind::ES2015,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    set_emitter_source(&mut printer, source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert!(
+        output.contains("for (var _d = true, src_1 = __asyncValues(src), src_1_1;"),
+        "with no preceding for-of, loop-init temps stay inline regardless of binding name.\nOutput:\n{output}"
     );
 }
 


### PR DESCRIPTION
AgentName: opus48-emit100

## Track
Emit → 100% (JavaScript emit parity). Fixes the ES2015 for-await over-hoist regression (issue #12084 cluster A, from #12073).

## Invariant
tsc hoists the ES5/downlevel async for-await loop-init temps (`_d`/iterator/result)
into the function `var` group **iff a preceding `for-of`/`for-await-of` loop exists
earlier in the same async body**; otherwise it keeps them INLINE in
`for (var _d = true, it = __asyncValues(x), res; ...)`. #12073 over-hoisted (gated on
`emit_await_as_yield || emit_await_as_yield_await`), which over-applied to the ES2015
`for await` form and regressed it. A target gate is also wrong (would regress
`operationsAvailableOnPromisedType(es2015)`, which DOES hoist — it has a leading sync
for-of). This gates the hoist on the actual structural condition: a body pre-scan for a
preceding for-of. (Native ES2015 sync for-of doesn't bump the ES5 for-of counters, so an
AST scan is required — local emit state can't distinguish the cases.)

## Scope
Emitter (OUTPUT) only. Structural (body AST shape), no spelling/printer-output matching.
- `es5/bindings_param_patterns.rs` — new `body_has_for_of_before_for_await(for_await_idx)`
  (walks to the enclosing function-like async-body owner, scans for a preceding
  FOR_OF_STATEMENT, stops at nested function boundaries); replaces #12073's hoist gate at
  the for-await emitter with `hoist_loop_init_temps = body_has_for_of_before_for_await(...)`.
- `functions_arrow.rs` — widen `is_function_like_hoist_boundary` visibility (reused by the scan).
- `source_file/es5_emit_tests.rs` — corrected #12073's 3 unit tests (they were at ES2015 and
  asserted the over-hoisted form, i.e. encoded the regression); +2 tests: hoist-after-preceding-for-of,
  and a renamed-binding case proving the rule is structural not spelling.

## Project Corpus Impact
- Row: n/a — TypeScript conformance/emit fixture regression fix, not a project-corpus benchmark row.
- Bug family: ES5 async for-await loop-init temp hoisting (gate to preceding-for-of; fixes #12073 over-hoist).
- Evidence: 4 ES2015 tests FIXED (`emitter.forAwait`, `forAwaitPerIterationBindingDownlevel`, `usingDeclarationsInForAwaitOf`, `awaitUsingDeclarationsInForAwaitOf` @ es2015); `operationsAvailableOnPromisedType` es5+es2015 STAY green (still hoisted); es5 forAwait green (#12078 intact); ZERO collateral — async 299/299, generator 126/126, forof 114/114, forAwait 20/20, asyncGenerator 24/24, iterator 41/41, yield 49/49, await 207/207 all 100% (real before/after via origin/main rebuild + per-family comm-diff, stale dist-fast removed); conformance pre-check clean (forAwait 8/8, asyncGenerator 21/21, usingDeclarations 89/89, operationsAvailable 1/1); `cargo nextest -p tsz-emitter` 32/32 for-await unit tests + 2 new, 15 pre-existing unrelated fails only; clippy clean.

## Verification
- The 4 ES2015 over-hoist tests fixed; the hoist-case (operationsAvailable) preserved — the unifying structural rule satisfies both (a target/flag gate cannot).
- Full `--js-only` comm-diff: zero collateral across the entire async/generator/iterator corpus. Conformance pre-checked.

## Coordination Notes
- Resolves #12084 cluster A (ES2015 over-hoist introduced by #12073). Corrects #12073's 3 misencoded
  ES2015 unit tests. Complements #12078 (ES5 for-await temp ALLOCATION ORDER — intact); this is the
  hoist-WHETHER decision. Same "structural body-condition unifies the half-fixes" pattern as #12078.
- #12084 cluster B (string-literal line-break escaping es5) still open — separate, needs bisect.
- AgentName: opus48-emit100. Reviews welcome.
