### PR TITLE
fix(dts): preserve intrinsic call type parameter returns

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs
@@ -1490,7 +1490,9 @@ impl<'a> DeclarationEmitter<'a> {
         Some((param_type.to_string(), constraint.to_string()))
     }
 
-    fn single_generic_type_argument_text(type_text: &str) -> Option<(&str, &str)> {
+    pub(in crate::declaration_emitter) fn single_generic_type_argument_text(
+        type_text: &str,
+    ) -> Option<(&str, &str)> {
         let type_text = type_text.trim();
         let open = type_text.find('<')?;
         if !type_text.ends_with('>') {
@@ -1850,7 +1852,7 @@ impl<'a> DeclarationEmitter<'a> {
             .flatten()
     }
 
-    fn referenced_parameter_declared_type_annotation_text(
+    pub(super) fn referenced_parameter_declared_type_annotation_text(
         &self,
         expr_idx: NodeIndex,
     ) -> Option<String> {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_guards.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_guards.rs
@@ -446,7 +446,7 @@ impl<'a> DeclarationEmitter<'a> {
         Some(format!("{param_type_text} & {narrowed}"))
     }
 
-    fn type_text_is_simple_reference(type_text: &str) -> bool {
+    pub(in crate::declaration_emitter) fn type_text_is_simple_reference(type_text: &str) -> bool {
         let trimmed = type_text.trim();
         !trimmed.is_empty()
             && trimmed

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_call.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_call.rs
@@ -335,6 +335,48 @@ impl<'a> DeclarationEmitter<'a> {
         None
     }
 
+    pub(in crate::declaration_emitter) fn simple_type_parameter_argument_substitution(
+        &self,
+        source_arena: &NodeArena,
+        func: &tsz_parser::parser::node::FunctionData,
+        call: &tsz_parser::parser::node::CallExprData,
+        type_param_name: &str,
+    ) -> Option<String> {
+        let args = call.arguments.as_ref()?;
+        for (&param_idx, &arg_idx) in func.parameters.nodes.iter().zip(args.nodes.iter()) {
+            let param_node = source_arena.get(param_idx)?;
+            let param = source_arena.get_parameter(param_node)?;
+            if param.dot_dot_dot_token {
+                continue;
+            }
+            let param_type_text = self
+                .emit_type_node_text_from_arena(source_arena, param.type_annotation)
+                .or_else(|| self.source_slice_from_arena(source_arena, param.type_annotation))?;
+            let Some((param_wrapper, param_inner)) =
+                Self::single_generic_type_argument_text(param_type_text.trim())
+            else {
+                continue;
+            };
+            if param_inner != type_param_name {
+                continue;
+            }
+            let arg_type_text = self
+                .lexical_parameter_declared_type_annotation_text(arg_idx)
+                .or_else(|| self.referenced_parameter_declared_type_annotation_text(arg_idx))
+                .or_else(|| self.reference_declared_source_type_annotation_text(arg_idx))
+                .or_else(|| self.reference_declared_type_annotation_text(arg_idx))?;
+            let Some((arg_wrapper, arg_inner)) =
+                Self::single_generic_type_argument_text(arg_type_text.trim())
+            else {
+                continue;
+            };
+            if param_wrapper == arg_wrapper && Self::type_text_is_simple_reference(arg_inner) {
+                return Some(arg_inner.to_string());
+            }
+        }
+        None
+    }
+
     fn replace_or_push_substitution(
         substitutions: &mut Vec<(String, String)>,
         name: &str,

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
@@ -479,6 +479,13 @@ impl<'a> DeclarationEmitter<'a> {
                                     call,
                                     type_text.trim(),
                                 );
+                            let simple_source_substitution = self
+                                .simple_type_parameter_argument_substitution(
+                                    source_arena,
+                                    func,
+                                    call,
+                                    type_text.trim(),
+                                );
                             let has_higher_order_type_param_param = self
                                 .function_has_higher_order_type_parameter_parameter(
                                     source_arena,
@@ -486,6 +493,7 @@ impl<'a> DeclarationEmitter<'a> {
                                     type_text.trim(),
                                 );
                             if (literal_direct_substitution.is_none()
+                                && simple_source_substitution.is_none()
                                 || has_higher_order_type_param_param)
                                 && let Some(canonical_text) =
                                     self.fully_resolved_call_canonical_type_text(expr_idx)

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
@@ -881,6 +881,26 @@ const ts1 = ff2("foo", "bar");
 }
 
 #[test]
+fn returned_intrinsic_call_preserves_outer_type_parameter() {
+    let source = r#"
+declare function foo3<T extends string>(x: Uppercase<T>): T;
+function foo4<U extends string>(x: Uppercase<U>) {
+    return foo3(x);
+}
+"#;
+    let output = emit_test_dts_with_binding(source);
+
+    assert!(
+        output.contains("declare function foo4<U extends string>(x: Uppercase<U>): U;"),
+        "{output}"
+    );
+    assert!(
+        !output.contains("declare function foo4<U extends string>(x: Uppercase<U>): string;"),
+        "{output}"
+    );
+}
+
+#[test]
 fn higher_order_type_parameter_parameter_blocks_direct_literal_initializer_reuse() {
     let source = r#"
 declare function direct<A>(value: A, callback: (value: A) => void): A;


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Track 9 Emit/DTS parity recovery.

## Invariant
When an unannotated function returns a call whose declared return is a bare type parameter, declaration emit should keep a safe source substitution such as `T -> U` from matching `Uppercase<T>` against `Uppercase<U>`. It should not fall back to the canonical widened solver return when the source wrapper relation carries the public return surface.

## Owner Layer
Declaration source-call return boundary. The change reuses structured source parameter/argument annotations and existing declaration-emitter helpers; it does not add solver semantics, relation checks, output surgery, or rendered-output decisions.

## Adjacent Case Matrix
- Reported shape: `foo3<T>(x: Uppercase<T>): T` returned from `foo4<U>(x: Uppercase<U>)` keeps `U`.
- Renamed type parameters: helper logic is keyed by source type-parameter positions and wrapper structure, not by names like `T` or `U`.
- Negative/fallback shape: higher-order type-parameter parameter tests continue to use the canonical fallback rather than unsafe source substitution.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_call.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_guards.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: declaration emit intrinsic/generic return surface
- Evidence: emit conformance-only DTS parity slice; `intrinsicTypes` DTS now passes locally.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-emitter returned_intrinsic_call_preserves_outer_type_parameter higher_order_type_parameter_parameter_blocks_direct_literal_initializer_reuse`
- `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`
- `scripts/emit/run.sh --filter=intrinsicTypes --dts-only --verbose --concurrency=4 --json-out=/tmp/studio-d-intrinsicTypes-fix-final.json`

## Coordination Notes
- Rebased onto `main` after #12102 landed.
- #12106 is stacked on this PR and should land after this one.
- No overlap found with open emit PRs #12096, #12092, or #12013 when opened.
- This changes declaration return type display only; checker diagnostics and solver relations are unaffected.
