### PR TITLE
fix(dts): emit nonnullable never fallback returns

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_guards.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_guards.rs
@@ -197,6 +197,12 @@ impl<'a> DeclarationEmitter<'a> {
                 continue;
             }
 
+            if let Some(type_text) =
+                self.never_fallback_return_type_text(body_idx, &param_name, &param_type_text)
+            {
+                return Some(type_text);
+            }
+
             let exclusions = self
                 .nullish_exclusions_from_guarded_parameter_return(body_idx, &param_name)
                 .or_else(|| {
@@ -207,6 +213,48 @@ impl<'a> DeclarationEmitter<'a> {
             }
         }
         None
+    }
+
+    fn never_fallback_return_type_text(
+        &self,
+        body_idx: NodeIndex,
+        param_name: &str,
+        param_type_text: &str,
+    ) -> Option<String> {
+        let return_expr = self.function_body_single_return_expression(body_idx)?;
+        let expr_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(return_expr);
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind != syntax_kind_ext::BINARY_EXPRESSION {
+            return None;
+        }
+        let binary = self.arena.get_binary_expr(expr_node)?;
+        if binary.operator_token != SyntaxKind::BarBarToken as u16 {
+            return None;
+        }
+        if self.get_identifier_text(binary.left).as_deref() != Some(param_name) {
+            return None;
+        }
+        let right_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(binary.right);
+        let right_node = self.arena.get(right_idx)?;
+        if right_node.kind != syntax_kind_ext::CALL_EXPRESSION {
+            return None;
+        }
+        let call = self.arena.get_call_expr(right_node)?;
+        if call
+            .arguments
+            .as_ref()
+            .is_some_and(|args| !args.nodes.is_empty())
+        {
+            return None;
+        }
+        let callee_name = self.get_identifier_text(call.expression)?;
+        let callee_func = self.local_function_declaration_by_name(&callee_name)?;
+        let return_type_text = self.emit_type_node_text(callee_func.type_annotation)?;
+        (return_type_text.trim() == "never").then(|| format!("NonNullable<{param_type_text}>"))
     }
 
     fn nullish_exclusions_from_guarded_parameter_return(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
@@ -901,6 +901,29 @@ function foo4<U extends string>(x: Uppercase<U>) {
 }
 
 #[test]
+fn generic_return_parameter_or_never_call_uses_nonnullable_surface() {
+    let source = r#"
+function error(): never {
+    throw new Error();
+}
+
+function present<T>(value: T) {
+    return value || error();
+}
+"#;
+    let output = emit_test_dts_with_binding(source);
+
+    assert!(
+        output.contains("declare function present<T>(value: T): NonNullable<T>;"),
+        "{output}"
+    );
+    assert!(
+        !output.contains("declare function present<T>(value: T): T;"),
+        "{output}"
+    );
+}
+
+#[test]
 fn higher_order_type_parameter_parameter_blocks_direct_literal_initializer_reuse() {
     let source = r#"
 declare function direct<A>(value: A, callback: (value: A) => void): A;


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Track 9 Emit/DTS parity recovery.

## Invariant
When a generic function returns `value || localNeverCall()` and the local fallback is declared `never`, `tsc` emits `NonNullable<T>` for the returned parameter surface. Declaration emit should recognize that source-level nullish fallback shape instead of falling through to the bare parameter type.

## Owner Layer
Declaration function-return guard boundary. The change uses syntax plus the local callee declaration return annotation to select the public declaration return surface; it does not add solver semantics, relation checks, output surgery, or rendered-output decisions.

## Adjacent Case Matrix
- Reported shape: `return value || error()` where `error(): never` emits `NonNullable<T>`.
- Existing adjacent guard shapes remain covered: explicit `if (value === null) throw` / `if (value === undefined) throw` / `value == null` guard tests still pass.
- Negative/fallback shape: the new path requires a local zero-arg fallback call declared `never`; other shapes continue through the existing return inference path.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_guards.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: declaration emit non-nullish generic return surface
- Evidence: emit conformance-only DTS parity slice; `nonNullableTypes1` DTS now passes locally.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-emitter generic_return_parameter_or_never_call_uses_nonnullable_surface generic_return_parameter_after_nullish_throw_guard_keeps_flow_surface`
- `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`
- `scripts/emit/run.sh --filter=nonNullableTypes1 --dts-only --verbose --concurrency=4 --json-out=/tmp/studio-d-nonNullableTypes1-fix-final.json`

## Coordination Notes
- #12104 has merged; this branch is rebased onto current `main` at head `6e1b85a053`.
- #12111 is stacked on this PR and should land after this PR.
- No overlap found with open emit PRs #12096, #12092, or #12013 when opened.
- This changes declaration return type display only; checker diagnostics and solver relations are unaffected.
