### PR TITLE
test(checker): guard imported ReturnType model property

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs
@@ -1,9 +1,12 @@
 use crate::context::{CheckerContext, CheckerOptions, LibContext};
 use crate::query_boundaries::common::TypeInterner;
 use crate::state::CheckerState;
-use crate::test_utils::{check_source_with_libs, load_compiled_lib_files, load_lib_files};
+use crate::test_utils::{
+    check_multi_file_with_libs, check_source_with_libs, load_compiled_lib_files, load_lib_files,
+};
 use std::sync::Arc;
 use tsz_binder::{BinderState, symbol_flags};
+use tsz_common::common::{ModuleKind, ScriptTarget};
 use tsz_common::perf_counters::CrossArenaSymbolMissSource;
 use tsz_parser::parser::ParserState;
 use tsz_parser::parser::node::NodeAccess;
@@ -534,5 +537,85 @@ if (app) {
     assert!(
         diagnostics.is_empty(),
         "expected DOM querySelector type argument to keep inherited members, got: {diagnostics:?}",
+    );
+}
+
+#[test]
+fn cross_file_return_type_property_stays_assignable_to_declared_model() {
+    let lib_files = load_compiled_lib_files(&["lib.es5.d.ts"]);
+    let diagnostics = check_multi_file_with_libs(
+        &[
+            (
+                "metrics.ts",
+                r#"
+export interface DataPoint {
+  label: string;
+  value: number;
+}
+
+export interface SeriesSummary {
+  min: number;
+  max: number;
+  mean: number;
+  p95: number;
+}
+
+export function summarizeSeries(points: readonly DataPoint[]): SeriesSummary {
+  const values = points.map((point) => point.value).sort((left, right) => left - right);
+  const total = values.reduce((sum, value) => sum + value, 0);
+  return {
+    min: values[0] || 0,
+    max: values[values.length - 1] || 0,
+    mean: values.length === 0 ? 0 : total / values.length,
+    p95: values[values.length - 1] || 0,
+  };
+}
+"#,
+            ),
+            (
+                "view.ts",
+                r#"
+import { summarizeSeries } from "./metrics";
+
+interface LocalHarnessPaddingA {}
+interface LocalHarnessPaddingB {}
+interface LocalHarnessPaddingC {}
+interface LocalHarnessPaddingD {}
+
+export interface DashboardModel {
+  title: string;
+  points: { label: string; value: number }[];
+  summary: ReturnType<typeof summarizeSeries>;
+}
+
+const points = [
+  { label: "sample-1", value: 100 },
+  { label: "sample-2", value: 200 },
+];
+const model: DashboardModel = {
+  title: "ambient module benchmark",
+  points,
+  summary: summarizeSeries(points),
+};
+model.summary.mean.toFixed(2);
+"#,
+            ),
+        ],
+        "view.ts",
+        CheckerOptions {
+            target: ScriptTarget::ES2020,
+            module: ModuleKind::ESNext,
+            module_explicitly_set: true,
+            strict: true,
+            no_implicit_any: true,
+            strict_null_checks: true,
+            ..CheckerOptions::default()
+        },
+        &lib_files,
+    );
+
+    assert!(
+        diagnostics.is_empty(),
+        "expected imported ReturnType model property to stay assignable, got: {diagnostics:?}",
     );
 }


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Performance guardrail / benchmark blocker for #12021.

## Invariant
When an imported function's `ReturnType<typeof fn>` is used as a declared model property, assigning that property from the same imported function call must remain diagnostic-free under strict ESNext-style options; this PR changes checker tests only.

## Scope
- `crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs`

## Project Corpus Impact
- Row: vite-vanilla-ts-app
- Bug family: cross-file imported `ReturnType` object-property assignability guard for unsafe DOM/alias fast paths.
- Evidence: #12021 captured failed Vite fast-path attempts that produced a `DashboardModel.summary` / `ReturnType<typeof summarizeSeries>` TS2322 regression; this PR adds the focused regression guard only and does not change compiler behavior.

## Verification
- `cargo nextest run -p tsz-checker --lib -E 'test(cross_file_return_type_property_stays_assignable_to_declared_model) | test(value_merged_builtin_dom_interface_type_argument_keeps_inherited_members) | test(direct_cross_file_interface_lowering_handles_simple_builtin_dom_interfaces)'`
- `cargo fmt --check`
- `git diff --check`

## Coordination Notes
- AgentName: Studio-B.
- Existing Studio-B PRs were merged before this branch was published; no open Studio-B PR remained at intake.
- Open overlap check found #12054 (`perf(checker): opt-in export resolution table for alias chains`) as an unassigned draft, but this PR is test-only and touches no cache or resolver implementation.
- Ready for manager review/queue; no WIP blocker and no auto-merge requested.
