### PR TITLE
fix(checker): attach argument spans to overload failures for robust TS2769 anchoring

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
@@ -1508,9 +1508,10 @@ impl<'a> CheckerState<'a> {
                                 Vec::new(),
                             ));
                         }
-                        failures.push(PendingDiagnosticBuilder::argument_not_assignable(
-                            actual, expected,
-                        ));
+                        failures.push(
+                            PendingDiagnosticBuilder::argument_not_assignable(actual, expected)
+                                .with_optional_span(self.arg_source_span(args, index)),
+                        );
                         self.ctx
                             .rollback_diagnostics_filtered(&candidate_snap, |diag| {
                                 Self::should_preserve_speculative_call_diagnostic(diag)
@@ -1752,9 +1753,10 @@ impl<'a> CheckerState<'a> {
                                 ),
                             ));
                         }
-                        failures.push(PendingDiagnosticBuilder::argument_not_assignable(
-                            actual, expected,
-                        ));
+                        failures.push(
+                            PendingDiagnosticBuilder::argument_not_assignable(actual, expected)
+                                .with_optional_span(self.arg_source_span(args, index)),
+                        );
                     }
                 }
                 CallResult::ArgumentCountMismatch {
@@ -1980,5 +1982,17 @@ impl<'a> CheckerState<'a> {
             self.invalidate_expression_for_contextual_retry(arg_idx);
             let _ = self.get_type_of_node_with_request(arg_idx, &TypingRequest::NONE);
         }
+    }
+
+    /// Returns the source span for the argument at `index` in `args`, or `None`
+    /// when the index is out of range or the node has no recorded position.
+    fn arg_source_span(&self, args: &[NodeIndex], index: usize) -> Option<tsz_solver::SourceSpan> {
+        let &arg_idx = args.get(index)?;
+        let node = self.ctx.arena.get(arg_idx)?;
+        Some(tsz_solver::SourceSpan::new(
+            self.ctx.file_name.as_str(),
+            node.pos,
+            node.end.saturating_sub(node.pos),
+        ))
     }
 }

--- a/crates/tsz-checker/src/error_reporter/call_errors_overload_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_overload_tests.rs
@@ -506,6 +506,156 @@ wm.delete(s);
 }
 
 #[test]
+fn ts2769_pipe_like_single_arity_overload_emits_ts2345_at_argument() {
+    // When only ONE overload is arity-compatible and it fails by type, tsc emits
+    // TS2345 directly at the failing argument (not TS2769). Verify tsz does the same.
+    let source = r#"
+interface PipeOp<A, B> {
+    tag: [A, B];
+}
+interface Obs<T> {
+    pipe<A>(op1: PipeOp<T, A>): A;
+    pipe<A, B>(op1: PipeOp<T, A>, op2: PipeOp<A, B>): B;
+    pipe<A, B, C>(op1: PipeOp<T, A>, op2: PipeOp<A, B>, op3: PipeOp<B, C>): C;
+}
+declare function mapOp(fn: (x: number) => string): PipeOp<number, string>;
+declare function wrongOp(): PipeOp<number, number>;
+declare var obs: Obs<number>;
+obs.pipe(mapOp(x => x.toString()), wrongOp());
+"#;
+
+    let diagnostics = check_source_with_strict_null(source);
+    // Only one arity-compatible overload → TS2345, not TS2769
+    let ts2345: Vec<_> = diagnostics.iter().filter(|d| d.code == 2345).collect();
+    assert_eq!(
+        ts2345.len(),
+        1,
+        "expected exactly one TS2345 (single arity-compatible overload path), got: {diagnostics:?}"
+    );
+    let diag = &ts2345[0];
+    let failing_arg_start = source.rfind("wrongOp()").expect("wrongOp() not found") as u32;
+    assert_eq!(
+        diag.start, failing_arg_start,
+        "TS2345 should anchor at wrongOp(), got start={}, length={}",
+        diag.start, diag.length
+    );
+}
+
+#[test]
+fn ts2769_pipe_like_multi_arity_overload_anchors_failing_argument() {
+    // When MULTIPLE overloads are arity-compatible and ALL fail on the SAME
+    // argument, tsc emits TS2769 anchored at the failing argument — not the callee.
+    // This models the rxjs `pipe(map(...), wrongOp())` pattern.
+    //
+    // Structural rule: when all overload failures share the same argument as
+    // the mismatching node (same `actual_type`), anchor TS2769 at that argument.
+    let source = r#"
+interface PipeOp<A, B> {
+    tag: [A, B];
+}
+interface Obs<T> {
+    pipe<A>(op1: PipeOp<T, A>, op2: PipeOp<A, A>): A;
+    pipe<A, B>(op1: PipeOp<T, A>, op2: PipeOp<A, B>): B;
+}
+declare function mapOp(fn: (x: number) => string): PipeOp<number, string>;
+declare function wrongOp(): PipeOp<number, number>;
+declare var obs: Obs<number>;
+obs.pipe(mapOp(x => x.toString()), wrongOp());
+"#;
+
+    let diagnostics = check_source_with_strict_null(source);
+    // Multiple arity-compatible overloads → TS2769
+    let ts2769: Vec<_> = diagnostics.iter().filter(|d| d.code == 2769).collect();
+    assert_eq!(
+        ts2769.len(),
+        1,
+        "expected exactly one TS2769 (multiple arity-compatible overloads fail), got: {diagnostics:?}"
+    );
+    let diag = &ts2769[0];
+    let failing_arg_start = source.rfind("wrongOp()").expect("wrongOp() not found") as u32;
+    assert_eq!(
+        diag.start, failing_arg_start,
+        "TS2769 should anchor at wrongOp() (the shared failing argument), not at the callee. got start={}, length={}",
+        diag.start, diag.length
+    );
+
+    // Name-variation witness: the same structural rule holds regardless of
+    // what the interface, method, and function names are.
+    let source2 = r#"
+interface Op<X, Y> { tag: [X, Y]; }
+interface Stream<T> {
+    transform<X>(t1: Op<T, X>, t2: Op<X, X>): X;
+    transform<X, Y>(t1: Op<T, X>, t2: Op<X, Y>): Y;
+}
+declare function buildOp(fn: (n: number) => string): Op<number, string>;
+declare function badOp(): Op<number, number>;
+declare var s: Stream<number>;
+s.transform(buildOp(n => n.toString()), badOp());
+"#;
+    let diagnostics2 = check_source_with_strict_null(source2);
+    let ts2769_2: Vec<_> = diagnostics2.iter().filter(|d| d.code == 2769).collect();
+    assert_eq!(
+        ts2769_2.len(),
+        1,
+        "name-variation: expected TS2769 anchored at badOp(), got: {diagnostics2:?}"
+    );
+    let failing2 = source2.rfind("badOp()").expect("badOp() not found") as u32;
+    assert_eq!(
+        ts2769_2[0].start, failing2,
+        "name-variation: TS2769 should anchor at badOp(), got start={}",
+        ts2769_2[0].start
+    );
+}
+
+#[test]
+fn ts2769_property_call_anchors_callee_when_different_args_fail_different_overloads() {
+    // When each overload fails because a DISTINCT argument doesn't match that
+    // overload's parameter — overload 1 rejects arg 0, overload 2 rejects arg 1
+    // — there is no shared failing argument, so tsc anchors TS2769 at the
+    // property callee rather than at any argument.
+    //
+    // Structural rule: `shared_overload_argument_anchor` returns `None` when
+    // the set of type-mismatching arguments differs across overloads, causing
+    // the anchor to fall back to the callee.
+    let source = r#"
+interface Obs {
+    pipe(op1: string, op2: number): void;
+    pipe(op1: number, op2: string): void;
+}
+declare var obs: Obs;
+obs.pipe(42, 42);
+"#;
+
+    let diagnostics = check_source_with_strict_null(source);
+    let ts2769: Vec<_> = diagnostics.iter().filter(|d| d.code == 2769).collect();
+    assert_eq!(
+        ts2769.len(),
+        1,
+        "expected exactly one TS2769 for cross-overload argument failure, got: {diagnostics:?}"
+    );
+    let diag = &ts2769[0];
+    // The callee in `obs.pipe(42, 42)` is `pipe` (a property access).
+    let pipe_token_start = source.rfind("pipe(42").expect("pipe(42") as u32;
+    let first_arg_start = source.rfind("42, 42)").expect("42, 42)") as u32;
+    let second_arg_start = first_arg_start + "42, ".len() as u32;
+    // TS2769 must NOT anchor at either argument.
+    assert_ne!(
+        diag.start, first_arg_start,
+        "should not anchor at first arg when overloads fail on different arguments, got: {diag:?}"
+    );
+    assert_ne!(
+        diag.start, second_arg_start,
+        "should not anchor at second arg when overloads fail on different arguments, got: {diag:?}"
+    );
+    // TS2769 should anchor at or before the end of the `pipe` token.
+    assert!(
+        diag.start <= pipe_token_start + "pipe".len() as u32,
+        "TS2769 should anchor at callee when failures diverge across args, got start={}",
+        diag.start
+    );
+}
+
+#[test]
 fn ts2769_array_best_common_type_keeps_nullable_member() {
     let source = r#"
 class Box {

--- a/crates/tsz-solver/src/diagnostics/core.rs
+++ b/crates/tsz-solver/src/diagnostics/core.rs
@@ -390,6 +390,15 @@ impl PendingDiagnostic {
         self.related.push(related);
         self
     }
+
+    /// Attach `span` when present; no-op when `None`.
+    pub fn with_optional_span(self, span: Option<SourceSpan>) -> Self {
+        if let Some(s) = span {
+            self.with_span(s)
+        } else {
+            self
+        }
+    }
 }
 
 /// A source location span.


### PR DESCRIPTION
## Agent
AgentName: M1-B
Runner: claude-sonnet-4-6 / busy-lamport

## Track
Checker — TS2769 diagnostic anchor correctness

## Invariant
When all overload failures share the same failing argument (identified by source position), TS2769 must anchor at that argument, not at the callee. When failures diverge across arguments, TS2769 must anchor at the callee.

## Scope

Fixes issue #11326: "rxjs-project: checker loses error span for pipe operator callback mismatch."

### Root Cause

`PendingDiagnosticBuilder::argument_not_assignable` creates `PendingDiagnostic` entries with `span: None`. The primary anchor function `shared_overload_argument_anchor_from_spans` (in `call_errors_anchors.rs`) requires every failure to carry a span — it short-circuits to `None` on the first span-less failure. The fallback TypeId-based path (`shared_overload_argument_anchor`) can also miss when `original_node_types` is restored between overload candidates and node-type cache entries become stale.

This caused TS2769 on complex generic `pipe`-like calls (where the failing arg's TypeId doesn't survive `original_node_types` restoration) to anchor at the callee instead of the failing argument.

### Structural Rule

> When `resolve_overloaded_call_with_signatures` pushes an `ArgumentTypeMismatch` failure for the `NoOverloadMatch` path, the `PendingDiagnostic` carries the source span of the failing argument. `shared_overload_argument_anchor_from_spans` is tried first; it succeeds when all failures share the same argument span and is TypeId-independent.

### Changes

**`crates/tsz-solver/src/diagnostics/core.rs`**
- `PendingDiagnostic::with_optional_span(span: Option<SourceSpan>) -> Self` — attaches a span when present, no-op when `None`.

**`crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs`**
- `CheckerState::arg_source_span(args, index) -> Option<SourceSpan>` — extracts the source span for argument at `index`.
- Two `argument_not_assignable` push sites (first-pass callback-return mismatch and second-pass `ArgumentTypeMismatch`) now call `.with_optional_span(self.arg_source_span(args, index))`.

**`crates/tsz-checker/src/error_reporter/call_errors_overload_tests.rs`**
- `ts2769_pipe_like_single_arity_overload_emits_ts2345_at_argument` — single arity-compatible overload → TS2345 at arg (best_type_mismatch path, unchanged by this PR).
- `ts2769_pipe_like_multi_arity_overload_anchors_failing_argument` — multiple arity-compatible overloads all failing on arg 1 → TS2769 anchored at that argument. Includes a name-variation witness (`Op`/`Stream`/`buildOp`/`badOp`) proving the fix is structural.
- `ts2769_property_call_anchors_callee_when_different_args_fail_different_overloads` — cross-overload argument divergence → TS2769 at callee.

## Project Corpus Impact

- Row: rxjs-project (pipe operator patterns with multiple arity-compatible overloads)
- Bug family: TS2769 anchor lost when overload resolution restores `original_node_types` and TypeId matching fails for stale generic call node types
- Evidence: 3 new unit tests covering single-overload, multi-overload shared-failure, and divergent-failure cases. Name-variation witness (`buildOp`/`badOp` vs `mapOp`/`wrongOp`) confirms the fix uses span position, not identifier matching.

## Verification

```
cargo nextest run -p tsz-checker -- error_reporter::call_errors::overload_tests
# 19 passed; 0 failed

cargo nextest run -p tsz-checker -- error_reporter::call_errors
# 92 passed; 0 failed

cargo check -p tsz-checker -p tsz-solver
# Finished (clean)
```

## Coordination Notes

- Picked issue #11326 via random seed 42 from open non-WIP issues. Issue was labeled `agent:M1-B`; M4-B applied `agent:M1-B` to this PR for ownership alignment — acknowledged.
- No canonical lane was pre-assigned to this session; AgentName uses runner identity per §20.1.
- No overlap with other open PRs on the overload resolution path found at branch creation time.
- `/simplify` run 3× before PR; each pass reviewed for reuse, simplification, efficiency, altitude.
  - Pass 1: renamed `apply_arg_span` → `with_optional_span` (too argument-specific).
  - Pass 2: switched `file_name.clone()` → `.as_str()` (avoids double allocation).
  - Pass 3: added name-variation witness in test 2 to satisfy §25 structural-rule test matrix.


