### PR TITLE
fix(emit): preserve ES5 string line continuations

### DIFF
--- a/crates/tsz-emitter/src/emitter/literals/core.rs
+++ b/crates/tsz-emitter/src/emitter/literals/core.rs
@@ -713,6 +713,17 @@ impl<'a> Printer<'a> {
 
         while i < bytes.len() {
             if bytes[i] == b'\\' {
+                if i + 1 < bytes.len() && matches!(bytes[i + 1], b'\r' | b'\n') {
+                    out.push('\\');
+                    out.push('\n');
+                    i += if bytes[i + 1] == b'\r' && bytes.get(i + 2) == Some(&b'\n') {
+                        3
+                    } else {
+                        2
+                    };
+                    continue;
+                }
+
                 if i + 2 < bytes.len() && bytes[i + 1] == b'u' && bytes[i + 2] == b'{' {
                     let mut j = i + 3;
                     while j < bytes.len() && bytes[j] != b'}' {
@@ -1518,6 +1529,34 @@ const separatedHex = 0x0_ABCDEFn;
             output.contains("line 1"),
             "Output should contain the string literal.\nGot: {output}"
         );
+    }
+
+    /// ES5 string-literal downleveling still preserves source line
+    /// continuations as continuations. Normalize the source line ending to LF,
+    /// matching `tsc`, instead of escaping the CR/LF bytes into the string.
+    #[test]
+    fn es5_string_literal_line_continuations_stay_continuations() {
+        use tsz_common::ScriptTarget;
+        let cases = [
+            ("var x = \"a\\\r\nb\";", "\"a\\\nb\""),
+            ("var x = 'a\\\nb';", "'a\\\nb'"),
+            ("var x = \"a\\\rb\";", "\"a\\\nb\""),
+        ];
+        for (source, expected) in cases {
+            let (parser, root) = parse_test_source(source);
+            let opts = PrintOptions {
+                target: ScriptTarget::ES5,
+                ..Default::default()
+            };
+            let mut printer = Printer::new(&parser.arena, opts);
+            printer.set_source_text(source);
+            printer.print(root);
+            let output = printer.finish().code;
+            assert!(
+                output.contains(expected),
+                "ES5 line continuation should stay a normalized line continuation.\nSource: {source:?}\nExpected fragment: {expected:?}\nGot: {output:?}"
+            );
+        }
     }
 
     /// When a null codepoint (`\u{0}`) is downleveled to ES5, and the


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Track 9 emit parity: JS literal/template emit.

## Invariant
When ES5 string-literal downleveling sees a source backslash followed by a line terminator, `tsc` preserves it as a line continuation and normalizes the output line ending to LF; this PR makes the direct literal printer preserve that continuation instead of escaping CR/LF bytes into the string.

## Scope
- `crates/tsz-emitter/src/emitter/literals/core.rs`
- Adds a focused unit test for CRLF, LF, and CR line-continuation inputs.

## Project Corpus Impact
- Row: n/a
- Bug family: literal/template JS emit
- Evidence: baseline-style JS emit filters `literals(target=es5)` and `sourceMap-StringLiteralWithNewLine(target=es5)` pass locally with this branch's debug `tsz` binary; no project-corpus row is directly exercised.

## Verification
- `git diff --check`
- `git diff --check origin/main...HEAD` after rebasing onto current `origin/main`
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz-studio-a-current-12080/.target scripts/safe-run.sh cargo nextest run -p tsz-emitter es5_string_literal_line_continuations_stay_continuations --no-capture`
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz-studio-a-current-12080/.target scripts/safe-run.sh cargo build -p tsz-cli --bin tsz`
- `TSZ_BIN=/Users/mohsen/code/tsz-studio-a-current-12080/.target/debug/tsz /Users/mohsen/code/tsz-studio-a-conformance-current-20260601/scripts/emit/run.sh --filter='literals(target=es5)' --js-only --verbose --timeout=30000 --json-out=/tmp/emit-literals-es5-line-continuation.json --skip-build`
- `TSZ_BIN=/Users/mohsen/code/tsz-studio-a-current-12080/.target/debug/tsz /Users/mohsen/code/tsz-studio-a-conformance-current-20260601/scripts/emit/run.sh --filter='sourceMap-StringLiteralWithNewLine(target=es5)' --js-only --verbose --timeout=30000 --json-out=/tmp/emit-source-map-string-newline-es5.json --skip-build`
- No full emit, conformance, or fourslash suite run locally.

## Coordination Notes
- Branch rebased onto latest `origin/main` after #12105 landed; head reviewed after the rebase.
- Ready for PR-head CI on head `b33b212509ac3ea26b74505ac2e0d66219b177eb`; leave `merge-queue` off until exact-head PR checks complete successfully.
- Non-overlap: this is direct literal-printer layout, unrelated to active DTS/output-surgery PRs.
- Disk note: debug artifacts created for local verification were pruned after the run; release/dist caches were preserved.
