### PR TITLE
fix(solver,checker): preserve nested chain on deferred conditional relation failures

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -576,6 +576,20 @@ impl<'a> CheckerState<'a> {
                 *member_type,
                 nested_reason.as_ref(),
             ),
+            SubtypeFailureReason::ConditionalBranchMismatch {
+                source_type,
+                target_type,
+                branch_source,
+                branch_target,
+                nested_reason,
+            } => self.render_conditional_branch_mismatch(
+                &rctx,
+                *source_type,
+                *target_type,
+                *branch_source,
+                *branch_target,
+                nested_reason.as_ref(),
+            ),
             SubtypeFailureReason::TooManyParameters {
                 source_count,
                 target_count,

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -682,16 +682,43 @@ impl<'a> CheckerState<'a> {
         member_type: TypeId,
         nested_reason: &tsz_solver::SubtypeFailureReason,
     ) -> Diagnostic {
+        self.render_parent_with_child_relation(
+            ctx,
+            source_type,
+            target_type,
+            member_type,
+            target_type,
+            nested_reason,
+        )
+    }
+
+    /// Render an outer `Type 'S' is not assignable to type 'T'.` line and
+    /// elaborate it with the child relation `child_source <: child_target`,
+    /// preserving the nested reason chain.
+    ///
+    /// Shared by [`Self::render_union_source_mismatch`] and
+    /// [`Self::render_conditional_branch_mismatch`]: both shapes layer a
+    /// child branch relation one indent beneath the outer pair, with the
+    /// same depth handling and the same plain-leaf vs structural-recursion
+    /// split. The depth-0 outer line reuses `render_type_mismatch` so the
+    /// primary diagnostic keeps the standard source/target display
+    /// (e.g. preserving the full union surface). At deeper depths the
+    /// outer pair is formatted structurally.
+    fn render_parent_with_child_relation(
+        &mut self,
+        ctx: &RenderContext,
+        source_type: TypeId,
+        target_type: TypeId,
+        child_source: TypeId,
+        child_target: TypeId,
+        nested_reason: &tsz_solver::SubtypeFailureReason,
+    ) -> Diagnostic {
         let idx = ctx.idx;
         let depth = ctx.depth;
         let start = ctx.start;
         let length = ctx.length;
         let file_name = ctx.file_name.clone();
 
-        // The union-to-target line. At depth 0 this is the primary diagnostic, so
-        // reuse the standard type-mismatch formatting (which preserves the full
-        // union surface, e.g. `number | undefined`). When nested, the union and
-        // target types are formatted structurally one indent beneath the parent.
         let mut diag = if depth == 0 {
             self.render_type_mismatch(ctx)
         } else {
@@ -710,18 +737,19 @@ impl<'a> CheckerState<'a> {
             )
         };
 
-        // The failing member sits exactly one indent level beneath the union
-        // line. At depth 0 the union line is the (un-indented) primary, so its
-        // first child is at related-depth 0; when nested it is at related-depth
-        // `depth`, so the child is at `depth + 1`.
+        // The failing child relation sits exactly one indent level beneath
+        // the outer line. At depth 0 the outer is the (un-indented) primary,
+        // so its first child is at related-depth 0; when nested, the outer
+        // is at related-depth `depth`, so the child is at `depth + 1`.
         if depth < 5 {
             let child_depth = if depth == 0 { 0 } else { depth + 1 };
             let (nested_source, nested_target) =
-                Self::nested_failure_display_types(nested_reason, member_type, target_type);
+                Self::nested_failure_display_types(nested_reason, child_source, child_target);
             if Self::nested_reason_is_plain_type_mismatch(nested_reason) {
-                // Plain leaf relation (e.g. `undefined` vs `number`): render the
-                // member/target structurally so the displayed source is the
-                // failing member, not the enclosing assignment's RHS expression.
+                // Plain leaf relation (e.g. `undefined` vs `number`): render
+                // the child source/target structurally so the displayed
+                // source is the failing branch/member, not the enclosing
+                // assignment's RHS expression.
                 let source_str = self.format_type_diagnostic(nested_source);
                 let target_str = self.format_type_diagnostic(nested_target);
                 diag.related_information.push(DiagnosticRelatedInformation {
@@ -789,6 +817,42 @@ impl<'a> CheckerState<'a> {
                 depth: (depth + 1).min(u8::MAX as u32) as u8,
             });
         }
+    }
+
+    /// Render a `ConditionalBranchMismatch` failure: a deferred conditional
+    /// relation that failed because at least one branch fails the
+    /// corresponding branch relation.
+    ///
+    /// The shape mirrors `render_union_source_mismatch`: emit the
+    /// conditional-vs-target line as the parent, then elaborate the failing
+    /// branch relation directly beneath it. The full chain inside the branch
+    /// is preserved by recursing through `render_failure_reason`, so a
+    /// branch that itself fails because of (say) a missing property or a
+    /// deeper conditional keeps elaborating instead of stopping at the
+    /// branch line:
+    ///
+    /// ```text
+    /// Type 'S' is not assignable to type 'T extends U ? X : Y'.
+    ///   Type 'S' is not assignable to type 'X'.
+    ///     <deeper reason for 'S' vs 'X'>
+    /// ```
+    pub(super) fn render_conditional_branch_mismatch(
+        &mut self,
+        ctx: &RenderContext,
+        source_type: TypeId,
+        target_type: TypeId,
+        branch_source: TypeId,
+        branch_target: TypeId,
+        nested_reason: &tsz_solver::SubtypeFailureReason,
+    ) -> Diagnostic {
+        self.render_parent_with_child_relation(
+            ctx,
+            source_type,
+            target_type,
+            branch_source,
+            branch_target,
+            nested_reason,
+        )
     }
 
     /// Render an `IndexSignatureMismatch` failure.

--- a/crates/tsz-checker/src/query_boundaries/relation_types.rs
+++ b/crates/tsz-checker/src/query_boundaries/relation_types.rs
@@ -249,6 +249,15 @@ impl RelationFailure {
                 source_type,
                 target_type,
                 ..
+            }
+            // A deferred-conditional relation failure: the checker-facing
+            // classification keeps the outer conditional/concrete pair; the
+            // failing branch and its nested reason are rendered from the
+            // solver reason's structured chain via `render_failure_reason`.
+            | SubtypeFailureReason::ConditionalBranchMismatch {
+                source_type,
+                target_type,
+                ..
             } => Self::TypeMismatch {
                 source_type,
                 target_type,

--- a/crates/tsz-solver/src/diagnostics/core.rs
+++ b/crates/tsz-solver/src/diagnostics/core.rs
@@ -289,6 +289,48 @@ pub enum SubtypeFailureReason {
         member_type: TypeId,
         nested_reason: Box<Self>,
     },
+    /// A deferred conditional type relation failed because one of its branches
+    /// fails the corresponding branch relation.
+    ///
+    /// Without this variant, `T extends U ? X : Y` relations that cannot be
+    /// resolved at evaluation time collapse to a bare `TypeMismatch` and the
+    /// diagnostic chain stops at the outer
+    /// `Type 'S' is not assignable to type 'T extends U ? X : Y'.` line —
+    /// hiding the actual branch-level reason (for example, `"yes"` not being
+    /// assignable to `"x"` for `T extends string ? "yes" : "no" <: "x"`).
+    ///
+    /// The variant covers the three structural shapes the conditional rules
+    /// distinguish:
+    ///
+    /// 1. Concrete source vs deferred-conditional target: source must be
+    ///    `<:` both branches; `branch_source` is the original source and
+    ///    `branch_target` is the failing branch (`true_type` or `false_type`).
+    /// 2. Deferred-conditional source vs concrete target: both branches must
+    ///    be `<:` target; `branch_source` is the failing branch and
+    ///    `branch_target` is the original target.
+    /// 3. Conditional vs conditional (matching extends shape): branches are
+    ///    compared pairwise (`source.true_type <: target.true_type`, etc.);
+    ///    the variant carries the failing pair.
+    ///
+    /// `nested_reason` explains the failing branch relation and is rendered
+    /// one level deeper, preserving the full chain (a literal mismatch, a
+    /// missing property, a deeper conditional, etc.).
+    ConditionalBranchMismatch {
+        /// The original conditional-shaped source (or its concrete value when
+        /// the conditional is on the target side).
+        source_type: TypeId,
+        /// The original conditional-shaped target (or its concrete value when
+        /// the conditional is on the source side).
+        target_type: TypeId,
+        /// The source half of the failing branch relation.
+        branch_source: TypeId,
+        /// The target half of the failing branch relation. Callers needing to
+        /// distinguish the true vs false branch can compare this against the
+        /// originating conditional's `true_type` / `false_type`.
+        branch_target: TypeId,
+        /// Why the branch's relation failed.
+        nested_reason: Box<Self>,
+    },
 }
 
 /// Diagnostic severity level.
@@ -621,6 +663,7 @@ impl SubtypeFailureReason {
             | Self::IndexAccessTypeParameterMismatch { .. }
             | Self::TypeArgumentMismatch { .. }
             | Self::UnionSourceMismatch { .. }
+            | Self::ConditionalBranchMismatch { .. }
             | Self::AbstractConstructorAssignment => codes::TYPE_NOT_ASSIGNABLE,
             Self::NoCommonProperties { .. } => codes::NO_COMMON_PROPERTIES,
             Self::ExcessProperty { .. } => codes::EXCESS_PROPERTY,
@@ -1024,6 +1067,27 @@ impl SubtypeFailureReason {
                     vec![(*source_type).into(), (*target_type).into()],
                 );
                 diag = diag.with_related(nested_reason.to_diagnostic(*member_type, *target_type));
+                diag
+            }
+            Self::ConditionalBranchMismatch {
+                source_type,
+                target_type,
+                branch_source,
+                branch_target,
+                nested_reason,
+            } => {
+                // Top-level `Type 'S' is not assignable to type 'T extends U ? X : Y'.`,
+                // then the failing branch relation directly beneath it. The
+                // structural conditional-vs-conditional/source/target rule is
+                // surfaced as a relation between the branch endpoints so the
+                // chain looks the same regardless of which side held the
+                // conditional shape.
+                let mut diag = PendingDiagnostic::error(
+                    codes::TYPE_NOT_ASSIGNABLE,
+                    vec![(*source_type).into(), (*target_type).into()],
+                );
+                diag =
+                    diag.with_related(nested_reason.to_diagnostic(*branch_source, *branch_target));
                 diag
             }
         }

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -847,9 +847,129 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             }
         }
 
+        // Conditional types that survived `evaluate_type` (i.e. deferred
+        // conditionals like `T extends U ? X : Y` where `T` is a type
+        // parameter) are not handled by any structural shape arm above and
+        // would otherwise collapse to the bare `TypeMismatch` fallback,
+        // hiding the actual branch-level relation failure.
+        //
+        // The structural rule, applicable on either side: a relation
+        // involving a deferred conditional fails exactly when at least one
+        // of its branches fails the corresponding branch relation. Surface
+        // that failing branch as a `ConditionalBranchMismatch` carrying the
+        // nested branch reason so the diagnostic chain stays intact.
+        if let Some(reason) = self.explain_conditional_branch_failure(
+            source,
+            target,
+            resolved_source,
+            resolved_target,
+        ) {
+            return Some(reason);
+        }
+
         Some(SubtypeFailureReason::TypeMismatch {
             source_type: source,
             target_type: target,
+        })
+    }
+
+    /// Detect a deferred-conditional-shaped relation failure and surface the
+    /// failing branch as a `ConditionalBranchMismatch`.
+    ///
+    /// Applies to the three structural shapes:
+    ///
+    /// 1. **Concrete source vs deferred-conditional target** —
+    ///    `S <: (T extends U ? X : Y)`. Strategy 2 of
+    ///    `subtype_of_conditional_target` requires `S <: X` *and* `S <: Y`;
+    ///    when the relation has already failed, the failing branch is the
+    ///    one for which `check_subtype` returns false. Surface that branch.
+    /// 2. **Deferred-conditional source vs concrete target** —
+    ///    `(T extends U ? X : Y) <: T'`. Strategy 2 of
+    ///    `conditional_branches_subtype` requires `X <: T'` *and* `Y <: T'`;
+    ///    pick the first failing branch.
+    /// 3. **Conditional source vs conditional target** with matching extends
+    ///    shape — both `X <: X'` and `Y <: Y'` must hold; pick the first
+    ///    failing branch pair.
+    ///
+    /// True-branch failures are reported before false-branch failures so the
+    /// elaboration order is stable across runs and matches the textual
+    /// reading order of `T extends U ? X : Y`.
+    fn explain_conditional_branch_failure(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+        resolved_source: TypeId,
+        resolved_target: TypeId,
+    ) -> Option<SubtypeFailureReason> {
+        use crate::type_queries::data::get_conditional_type;
+
+        // Pick the branch pairs once based on which side is conditional. The
+        // three structural shapes all reduce to "try (true-pair, false-pair)
+        // in order", so iteration is identical regardless of side. When a
+        // side is not a conditional, the same resolved type sits in both
+        // branch slots, so the corresponding `(resolved_X, branch_Y)` pair
+        // falls out of the same construction.
+        //
+        // When neither side is a conditional there is nothing to surface and
+        // we fall back to the caller's `TypeMismatch`.
+        let source_cond = get_conditional_type(self.interner, resolved_source);
+        let target_cond = get_conditional_type(self.interner, resolved_target);
+        if source_cond.is_none() && target_cond.is_none() {
+            return None;
+        }
+
+        let (s_true, s_false) = source_cond
+            .as_deref()
+            .map_or((resolved_source, resolved_source), |s| {
+                (s.true_type, s.false_type)
+            });
+        let (t_true, t_false) = target_cond
+            .as_deref()
+            .map_or((resolved_target, resolved_target), |t| {
+                (t.true_type, t.false_type)
+            });
+        let pairs = [(s_true, t_true), (s_false, t_false)];
+
+        for (branch_source, branch_target) in pairs {
+            if let Some(reason) =
+                self.conditional_branch_reason(source, target, branch_source, branch_target)
+            {
+                return Some(reason);
+            }
+        }
+        None
+    }
+
+    /// Build a `ConditionalBranchMismatch` if the branch relation
+    /// `branch_source <: branch_target` actually fails. Returns `None` when
+    /// the branch relation succeeds (so the caller can try the other
+    /// branch) or when the branch pair would re-enter the outer relation —
+    /// a self-referential conditional whose branch reinterns to the outer
+    /// `(source, target)` pair would otherwise recurse indefinitely back
+    /// into the same explain query.
+    fn conditional_branch_reason(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+        branch_source: TypeId,
+        branch_target: TypeId,
+    ) -> Option<SubtypeFailureReason> {
+        if branch_source == branch_target {
+            return None;
+        }
+        if branch_source == source && branch_target == target {
+            return None;
+        }
+        if self.check_subtype(branch_source, branch_target).is_true() {
+            return None;
+        }
+        let nested = self.explain_failure_guarded(branch_source, branch_target)?;
+        Some(SubtypeFailureReason::ConditionalBranchMismatch {
+            source_type: source,
+            target_type: target,
+            branch_source,
+            branch_target,
+            nested_reason: Box::new(nested),
         })
     }
 

--- a/crates/tsz-solver/tests/conditional_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/conditional_comprehensive_tests.rs
@@ -8,6 +8,7 @@
 //! - Conditional type constraint for subtype checking
 
 use super::*;
+use crate::diagnostics::SubtypeFailureReason;
 use crate::evaluation::evaluate::evaluate_type;
 use crate::intern::TypeInterner;
 use crate::relations::subtype::SubtypeChecker;
@@ -22,3 +23,4 @@ use crate::types::{ConditionalType, TypeData, TypeParamInfo};
 include!("conditional_comprehensive_tests_parts/part_00.rs");
 include!("conditional_comprehensive_tests_parts/part_01.rs");
 include!("conditional_comprehensive_tests_parts/part_02.rs");
+include!("conditional_comprehensive_tests_parts/part_03.rs");

--- a/crates/tsz-solver/tests/conditional_comprehensive_tests_parts/part_03.rs
+++ b/crates/tsz-solver/tests/conditional_comprehensive_tests_parts/part_03.rs
@@ -1,0 +1,254 @@
+// Regression coverage for issue #10881: diagnostic chains lose nested relation
+// details in conditional failures.
+//
+// Structural rule: when a subtype/assignability check involving a deferred
+// conditional type (`T extends U ? X : Y`) fails, the failure reason should
+// preserve the branch that caused the failure and the nested reason explaining
+// why that branch failed, rather than collapsing to a generic `TypeMismatch`.
+//
+// The tests below cover the three structural shapes the explain path can see
+// — source-side conditional, target-side conditional, and conditional-vs-
+// conditional — and exercise different branch-failure reasons (literal vs.
+// intrinsic mismatch) so the assertions are about structural identity, not
+// about a particular spelling. Branch identity is derived structurally
+// (`branch_target == cond.true_type`), not from a label, per CLAUDE.md §25.
+
+/// Deferred-conditional **target**: `S <: (T extends U ? X : Y)`.
+/// Both branches must accept the source. When the true branch fails the
+/// relation, the explain path should surface that branch and the underlying
+/// literal mismatch instead of a bare `TypeMismatch`.
+#[test]
+fn test_explain_target_conditional_true_branch_mismatch_preserves_chain() {
+    let interner = TypeInterner::new();
+
+    // T extends string ? "yes" : "no"
+    let t_param = interner.type_param(TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    });
+    let yes = interner.literal_string("yes");
+    let no = interner.literal_string("no");
+    let cond = interner.conditional(ConditionalType {
+        check_type: t_param,
+        extends_type: TypeId::STRING,
+        true_type: yes,
+        false_type: no,
+        is_distributive: true,
+    });
+
+    let source = interner.literal_string("x");
+    let mut checker = SubtypeChecker::new(&interner);
+
+    // Sanity: the relation actually fails — "x" satisfies neither branch.
+    assert!(
+        !checker.is_subtype_of(source, cond),
+        "deferred conditional should reject an unrelated literal source"
+    );
+
+    let reason = checker.explain_failure(source, cond);
+    let Some(SubtypeFailureReason::ConditionalBranchMismatch {
+        source_type,
+        target_type,
+        branch_source,
+        branch_target,
+        nested_reason,
+    }) = reason
+    else {
+        panic!(
+            "deferred conditional target should produce a ConditionalBranchMismatch with the failing branch chained, got {reason:?}"
+        );
+    };
+    assert_eq!(source_type, source, "source pair preserved");
+    assert_eq!(target_type, cond, "target pair preserved");
+    assert_eq!(
+        branch_target, yes,
+        "true branch fails first ({source:?} -> {yes:?}); explain must surface the true branch as the failing branch"
+    );
+    assert_eq!(
+        branch_source, source,
+        "concrete source carried into branch relation"
+    );
+    assert!(
+        matches!(*nested_reason, SubtypeFailureReason::LiteralTypeMismatch { .. }),
+        "nested reason should preserve the underlying literal mismatch, got {nested_reason:?}"
+    );
+}
+
+/// Deferred-conditional target where the **false** branch is the one that
+/// fails. Verifies the variant carries the false branch type as `branch_target`.
+#[test]
+fn test_explain_target_conditional_false_branch_mismatch_preserves_chain() {
+    let interner = TypeInterner::new();
+
+    // T extends string ? "yes" : 42
+    // Source = "yes" satisfies the true branch but not the false branch.
+    let t_param = interner.type_param(TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    });
+    let yes = interner.literal_string("yes");
+    let forty_two = interner.literal_number(42.0);
+    let cond = interner.conditional(ConditionalType {
+        check_type: t_param,
+        extends_type: TypeId::STRING,
+        true_type: yes,
+        false_type: forty_two,
+        is_distributive: true,
+    });
+
+    let source = yes;
+    let mut checker = SubtypeChecker::new(&interner);
+
+    assert!(
+        !checker.is_subtype_of(source, cond),
+        "\"yes\" should not be assignable to deferred conditional whose false branch is 42"
+    );
+
+    let reason = checker.explain_failure(source, cond);
+    let Some(SubtypeFailureReason::ConditionalBranchMismatch {
+        branch_target,
+        nested_reason,
+        ..
+    }) = reason
+    else {
+        panic!(
+            "deferred conditional target with false-branch failure should yield ConditionalBranchMismatch, got {reason:?}"
+        );
+    };
+    assert_eq!(
+        branch_target, forty_two,
+        "true branch (\"yes\") accepts the source so explain must surface the false branch (42)"
+    );
+    assert!(
+        matches!(*nested_reason, SubtypeFailureReason::TypeMismatch { .. }
+            | SubtypeFailureReason::LiteralTypeMismatch { .. }
+            | SubtypeFailureReason::IntrinsicTypeMismatch { .. }),
+        "nested reason should preserve a structural mismatch, got {nested_reason:?}"
+    );
+}
+
+/// Deferred-conditional **source**: `(T extends U ? X : Y) <: T'`.
+/// Both branches must be `<:` the concrete target. Exercise the path with the
+/// true branch failing.
+#[test]
+fn test_explain_source_conditional_true_branch_mismatch_preserves_chain() {
+    let interner = TypeInterner::new();
+
+    // T extends string ? boolean : "no"
+    // Target = "no" — false branch matches, but true branch (boolean) fails.
+    let t_param = interner.type_param(TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    });
+    let no = interner.literal_string("no");
+    let cond = interner.conditional(ConditionalType {
+        check_type: t_param,
+        extends_type: TypeId::STRING,
+        true_type: TypeId::BOOLEAN,
+        false_type: no,
+        is_distributive: true,
+    });
+
+    let target = no;
+    let mut checker = SubtypeChecker::new(&interner);
+
+    assert!(
+        !checker.is_subtype_of(cond, target),
+        "deferred conditional with boolean true branch should not be assignable to \"no\""
+    );
+
+    let reason = checker.explain_failure(cond, target);
+    let Some(SubtypeFailureReason::ConditionalBranchMismatch {
+        source_type,
+        target_type,
+        branch_source,
+        branch_target,
+        nested_reason,
+    }) = reason
+    else {
+        panic!(
+            "deferred conditional source with branch failure should yield ConditionalBranchMismatch, got {reason:?}"
+        );
+    };
+    assert_eq!(source_type, cond);
+    assert_eq!(target_type, target);
+    assert_eq!(
+        branch_source, TypeId::BOOLEAN,
+        "true branch (boolean) is the failing branch source"
+    );
+    assert_eq!(branch_target, target, "concrete target carried into branch relation");
+    assert!(
+        matches!(*nested_reason, SubtypeFailureReason::TypeMismatch { .. }
+            | SubtypeFailureReason::IntrinsicTypeMismatch { .. }
+            | SubtypeFailureReason::LiteralTypeMismatch { .. }),
+        "nested reason should preserve the structural mismatch on the failing branch, got {nested_reason:?}"
+    );
+}
+
+/// Branch identity must be structural, not name-based: renaming the type
+/// parameter from `T` to `K` should not change the failure shape.
+/// Hardening per CLAUDE.md §25 (anti-hardcoding directive).
+#[test]
+fn test_explain_conditional_branch_identity_is_name_independent() {
+    fn build_failure(param_name: &str) -> (TypeId, SubtypeFailureReason) {
+        let interner = TypeInterner::new();
+        let t_param = interner.type_param(TypeParamInfo {
+            name: interner.intern_string(param_name),
+            constraint: None,
+            default: None,
+            is_const: false,
+        });
+        let yes = interner.literal_string("yes");
+        let cond = interner.conditional(ConditionalType {
+            check_type: t_param,
+            extends_type: TypeId::STRING,
+            true_type: yes,
+            false_type: interner.literal_string("no"),
+            is_distributive: true,
+        });
+        let source = interner.literal_string("x");
+        let mut checker = SubtypeChecker::new(&interner);
+        let reason = checker
+            .explain_failure(source, cond)
+            .expect("relation fails so explain must produce a reason");
+        (yes, reason)
+    }
+
+    fn unwrap_branch(reason: SubtypeFailureReason) -> (TypeId, Box<SubtypeFailureReason>) {
+        match reason {
+            SubtypeFailureReason::ConditionalBranchMismatch {
+                branch_target,
+                nested_reason,
+                ..
+            } => (branch_target, nested_reason),
+            other => panic!("expected ConditionalBranchMismatch, got {other:?}"),
+        }
+    }
+
+    let (t_yes, t_reason) = build_failure("T");
+    let (k_yes, k_reason) = build_failure("K");
+    let (t_branch_target, t_nested) = unwrap_branch(t_reason);
+    let (k_branch_target, k_nested) = unwrap_branch(k_reason);
+
+    // The failing branch must be the true branch in both cases — derived from
+    // structure (`branch_target == true_type`), not param name.
+    assert_eq!(
+        t_branch_target, t_yes,
+        "branch direction must be derived from structure (true branch), not param name"
+    );
+    assert_eq!(
+        k_branch_target, k_yes,
+        "renaming T -> K must not change the failing-branch identity"
+    );
+    assert!(
+        matches!(*t_nested, SubtypeFailureReason::LiteralTypeMismatch { .. })
+            && matches!(*k_nested, SubtypeFailureReason::LiteralTypeMismatch { .. }),
+        "nested reason kind must be identical for renamed type parameters"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-B

Lane: Studio-B (matching `agent:Studio-B` on the linked issue #10881). Runner identity for this session is `m3-max-64g-opus47`; the canonical lane label takes precedence per CLAUDE.md §20.1.

## Track
Diagnostics — relation-failure chain preservation. Closes #10881.

## Invariant
When a subtype/assignability check involves a deferred conditional type
(`T extends U ? X : Y`) and the relation fails because at least one
branch fails the corresponding branch relation, `tsc` keeps the
branch-level failure visible beneath the outer
`Type 'S' is not assignable to type 'T extends U ? X : Y'.` line; this
PR makes tsz do the same through the solver explain path and the
checker render path (not by pattern-matching identifier names or
printer output).

## Scope
- Solver explain path: new `SubtypeFailureReason::ConditionalBranchMismatch` variant + `explain_conditional_branch_failure` helper in `crates/tsz-solver/src/relations/subtype/explain.rs`.
- Checker render path: dispatch arm + `render_conditional_branch_mismatch` delegating to a new shared `render_parent_with_child_relation` helper extracted from `render_union_source_mismatch` in `crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs`.
- Query boundary: fold the new variant to `RelationFailure::TypeMismatch` (same precedent as `UnionSourceMismatch`) so downstream heuristics are unchanged.
- Tests: 4 new solver unit tests in `crates/tsz-solver/tests/conditional_comprehensive_tests_parts/part_03.rs` (new shard).
- No conformance baselines updated; no emit transforms touched; no binder/parser changes.

## Project Corpus Impact
- Row: n/a (diagnostic-shape preservation; no semantic accept/reject delta)
- Bug family: diagnostic chain truncation on deferred conditional failures
- Evidence: solver unit-test only (4 new tests in `crates/tsz-solver/tests/conditional_comprehensive_tests_parts/part_03.rs`); `cargo test -p tsz-solver --lib` and `cargo test -p tsz-checker` show no regressions vs `main` (same 9 unrelated preexisting failures present on both). The new variant folds to `RelationFailure::TypeMismatch` in `from_solver_reason`, so downstream heuristics (drift detection, EPC suppression) are unchanged.

## Verification
- `cargo check -p tsz-solver -p tsz-checker` clean.
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets -- -D warnings` clean.
- 4 new unit tests pass:
  - `test_explain_target_conditional_true_branch_mismatch_preserves_chain`
  - `test_explain_target_conditional_false_branch_mismatch_preserves_chain`
  - `test_explain_source_conditional_true_branch_mismatch_preserves_chain`
  - `test_explain_conditional_branch_identity_is_name_independent` (name-renaming guard per CLAUDE.md §25 — `T` vs `K` must produce identical branch-failure shape)
- Heavy CI suites (conformance / emit / fourslash / WASM) deferred to ready-for-review CI per CLAUDE.md §19.5.

## Coordination Notes
This PR was the result of three `/simplify` review rounds. Key refactors
applied along the way:

- Dropped an `in_true_branch: bool` field that was only read by tests; branch identity is now asserted structurally (`branch_target == cond.true_type`).
- Collapsed three near-duplicate branch-iteration loops into one pair-driven loop via `Option::map_or` on the conditional sides.
- Factored a shared `render_parent_with_child_relation` helper across the union-source and conditional-branch renderers.
- Switched from manual `conditional_type_id` + `get_conditional` to the one-step `get_conditional_type` query wrapper.

### Landing path

This PR is **not** using GitHub native auto-merge. The owner's
"automerge" instruction in this codebase maps to the repo-local
`merge-queue` label, which runs a synthetic latest-`main` merge and
posts the required `Queue Tested` status before landing one PR at a
time. The `merge-queue` label will be applied **only** once all
required PR-head checks are green for the current head SHA
(`CI Summary`, `GitGuardian Security Checks`, and the heavy
`conformance-*` / `fourslash-*` / `emit` / `project-compile-*` jobs).
GitHub native auto-merge is currently **disabled** and will not be
re-armed for this PR.

### Adjacent cases covered (CLAUDE.md §26 generalization gate)

| Case | Why it's covered by the structural rule |
| --- | --- |
| `"x" <: T extends string ? "yes" : "no"` (concrete source, target conditional, true branch fails) | Pair iteration over `[(S, t.true), (S, t.false)]` |
| `"yes" <: T extends string ? "yes" : 42` (concrete source, target conditional, false branch fails) | Same pair iteration; second pair fails first |
| `(T extends string ? boolean : "no") <: "no"` (source conditional, target concrete, true branch fails) | Pair iteration over `[(s.true, T), (s.false, T)]` |
| Renamed type parameter (`T` -> `K`) | Branch identity derived from `cond.true_type` TypeId equality, not the param's `name` Atom |
| `T extends X ? T : T` (degenerate self-referential conditional) | `conditional_branch_reason` guards against branch-pair equal to outer pair |
| Conditional whose branch is itself a union/object/etc. | Recursive `explain_failure_guarded` on the failing branch unwraps the inner shape |

### Deferred (out of scope)

- Collapsing `UnionSourceMismatch` / `TypeArgumentMismatch` / `ConditionalBranchMismatch` into a generic `NestedRelationMismatch` variant — `TypeArgumentMismatch` has load-bearing display policy differences (alias-skip formatting, depth offsets) that would block a clean unification.
- Tracer-based capture at the conditional rule sites instead of post-hoc reconstruction in explain — would require plumbing `&mut dyn DynSubtypeTracer` through `check_conditional_subtype` etc.; the explain-side reconstruction approach matches the existing `UnionSourceMismatch` precedent.

### Reviewer feedback addressed

- **F1 (canonical lane label):** PR body uses `AgentName: Studio-B` and the `agent:Studio-B` label is applied to the PR.
- **F2 (landing path):** GitHub native auto-merge has been **disabled**. Repo policy is `merge-queue` (with synthetic latest-`main` `Queue Tested` and one-at-a-time ordering); native auto-merge would bypass that gate. The owner's "automerge" instruction maps to applying `merge-queue` once exact-head required checks are green — not to GitHub native auto-merge. `merge-queue` will be applied only after the current head's heavy CI completes successfully.
- **F3 (PR template shape):** PR body uses the standard `## Agent` / `## Track` / `## Invariant` / `## Scope` / `## Project Corpus Impact` / `## Verification` / `## Coordination Notes` sections with bullet-form corpus fields.

https://claude.ai/code/session_01UEuYstW2teUEjfLsZYrXCZ