### PR TITLE
fix(dts): preserve exact optional mapped intersections

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
@@ -797,9 +797,10 @@ impl<'a> DeclarationEmitter<'a> {
         }
         let mapped_alias_text =
             self.source_type_alias_type_text(source_arena, mapped_alias_name)?;
+        let mapped_type_param_name = Self::first_mapped_type_parameter_name(&mapped_alias_text)?;
         if !mapped_alias_text.contains("undefined extends")
-            || !mapped_alias_text.contains("? K : never")
-            || !mapped_alias_text.contains("? never : K")
+            || !mapped_alias_text.contains(&format!("? {mapped_type_param_name} : never"))
+            || !mapped_alias_text.contains(&format!("? never : {mapped_type_param_name}"))
         {
             return None;
         }
@@ -831,6 +832,14 @@ impl<'a> DeclarationEmitter<'a> {
                 .map(|text| text.trim().trim_end_matches(';').trim().to_string());
         }
         None
+    }
+
+    fn first_mapped_type_parameter_name(type_text: &str) -> Option<&str> {
+        let bracket_start = type_text.find('[')? + 1;
+        let mapped_tail = type_text.get(bracket_start..)?;
+        let in_pos = mapped_tail.find(" in ")?;
+        let name = mapped_tail.get(..in_pos)?.trim();
+        Self::is_simple_identifier_text(name).then_some(name)
     }
 
     fn leading_balanced_brace_text(text: &str) -> Option<String> {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
@@ -543,6 +543,19 @@ impl<'a> DeclarationEmitter<'a> {
                 let source_is_foreign = !std::ptr::eq(source_arena, self.arena);
                 if self.type_interner.is_some()
                     && self.type_cache.is_some()
+                    && let Some(type_text) = self.reconstructed_source_callable_return_type_text(
+                        source_arena,
+                        decl_idx,
+                        func,
+                        call,
+                        true,
+                    )
+                {
+                    return Some(Self::strip_synthetic_anonymous_object_members(&type_text));
+                }
+
+                if self.type_interner.is_some()
+                    && self.type_cache.is_some()
                     && let Some(call_type_id) = self.get_node_type_or_names(&[expr_idx])
                     && !matches!(call_type_id, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR)
                 {
@@ -572,76 +585,12 @@ impl<'a> DeclarationEmitter<'a> {
                 }
 
                 if let Some(type_text) = {
-                    let mut scratch = if std::ptr::eq(source_arena, self.arena)
-                        && let (Some(type_cache), Some(type_interner), Some(binder)) =
-                            (&self.type_cache, self.type_interner, self.binder)
-                    {
-                        DeclarationEmitter::with_type_info(
-                            source_arena,
-                            type_cache.clone(),
-                            type_interner,
-                            binder,
-                        )
-                    } else {
-                        DeclarationEmitter::new(source_arena)
-                    };
-                    let source_file = self.arena_source_file(source_arena)?;
-                    scratch.source_is_declaration_file = source_file.is_declaration_file;
-                    scratch.source_is_js_file = scratch.source_file_is_js(source_file);
-                    scratch.current_source_file_idx = self.current_source_file_idx;
-                    scratch.source_file_text = Some(source_file.text.clone());
-                    scratch.current_file_path = self.current_file_path.clone();
-                    scratch.current_arena = self.current_arena.clone();
-                    scratch.arena_to_path = self.arena_to_path.clone();
-                    scratch.indent_level = self.indent_level;
-                    scratch.strict_null_checks = self.strict_null_checks;
-                    let generic_source_func = func
-                        .type_parameters
-                        .as_ref()
-                        .is_some_and(|params| !params.nodes.is_empty());
-                    let mut type_text =
-                        scratch.source_function_return_type_text(func).or_else(|| {
-                            scratch.source_function_cached_generic_return_type_text(decl_idx, func)
-                        })?;
-                    let source_return_text = scratch
-                        .function_body_returned_parameter_call_return_type_text(source_arena, func);
-                    if generic_source_func && let Some(source_return_text) = source_return_text {
-                        type_text = source_return_text;
-                    } else if type_text.contains("unknown")
-                        && let Some(source_return_text) = source_return_text
-                    {
-                        type_text = source_return_text;
-                    }
-                    let type_text =
-                        scratch.substitute_call_result_parameter_type_queries(func, &type_text);
-                    let (type_text, _) =
-                        scratch.function_return_type_text_for_declaration_scope(func, &type_text);
-                    let type_text = scratch.substitute_source_call_type_parameters(
+                    self.reconstructed_source_callable_return_type_text(
                         source_arena,
+                        decl_idx,
                         func,
                         call,
-                        type_text,
-                    )?;
-                    let source_matches_current_file = scratch
-                        .arena_source_file(source_arena)
-                        .and_then(|source_file| {
-                            scratch.current_file_path.as_deref().map(|current| {
-                                scratch.paths_refer_to_same_source_file(
-                                    current,
-                                    &source_file.file_name,
-                                )
-                            })
-                        })
-                        .unwrap_or(false);
-                    let type_text = if source_matches_current_file {
-                        type_text
-                    } else {
-                        scratch.qualify_foreign_imported_names_in_text(source_arena, &type_text)
-                    };
-                    Some(
-                        scratch
-                            .expand_inexact_optional_alias_reference_text(source_arena, &type_text)
-                            .unwrap_or(type_text),
+                        false,
                     )
                 } {
                     return Some(Self::strip_synthetic_anonymous_object_members(&type_text));
@@ -650,6 +599,84 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         None
+    }
+
+    fn reconstructed_source_callable_return_type_text(
+        &self,
+        source_arena: &NodeArena,
+        decl_idx: NodeIndex,
+        func: &tsz_parser::parser::node::FunctionData,
+        call: &tsz_parser::parser::node::CallExprData,
+        require_inexact_optional_expansion: bool,
+    ) -> Option<String> {
+        let mut scratch = if std::ptr::eq(source_arena, self.arena)
+            && let (Some(type_cache), Some(type_interner), Some(binder)) =
+                (&self.type_cache, self.type_interner, self.binder)
+        {
+            DeclarationEmitter::with_type_info(
+                source_arena,
+                type_cache.clone(),
+                type_interner,
+                binder,
+            )
+        } else {
+            DeclarationEmitter::new(source_arena)
+        };
+        let source_file = self.arena_source_file(source_arena)?;
+        scratch.source_is_declaration_file = source_file.is_declaration_file;
+        scratch.source_is_js_file = scratch.source_file_is_js(source_file);
+        scratch.current_source_file_idx = self.current_source_file_idx;
+        scratch.source_file_text = Some(source_file.text.clone());
+        scratch.current_file_path = self.current_file_path.clone();
+        scratch.current_arena = self.current_arena.clone();
+        scratch.arena_to_path = self.arena_to_path.clone();
+        scratch.indent_level = self.indent_level;
+        scratch.strict_null_checks = self.strict_null_checks;
+
+        let generic_source_func = func
+            .type_parameters
+            .as_ref()
+            .is_some_and(|params| !params.nodes.is_empty());
+        if require_inexact_optional_expansion && !generic_source_func {
+            return None;
+        }
+
+        let mut type_text = scratch
+            .source_function_return_type_text(func)
+            .or_else(|| scratch.source_function_cached_generic_return_type_text(decl_idx, func))?;
+        let source_return_text =
+            scratch.function_body_returned_parameter_call_return_type_text(source_arena, func);
+        if generic_source_func && let Some(source_return_text) = source_return_text {
+            type_text = source_return_text;
+        } else if type_text.contains("unknown")
+            && let Some(source_return_text) = source_return_text
+        {
+            type_text = source_return_text;
+        }
+        let type_text = scratch.substitute_call_result_parameter_type_queries(func, &type_text);
+        let (type_text, _) =
+            scratch.function_return_type_text_for_declaration_scope(func, &type_text);
+        let type_text =
+            scratch.substitute_source_call_type_parameters(source_arena, func, call, type_text)?;
+        let source_matches_current_file = scratch
+            .arena_source_file(source_arena)
+            .and_then(|source_file| {
+                scratch.current_file_path.as_deref().map(|current| {
+                    scratch.paths_refer_to_same_source_file(current, &source_file.file_name)
+                })
+            })
+            .unwrap_or(false);
+        let type_text = if source_matches_current_file {
+            type_text
+        } else {
+            scratch.qualify_foreign_imported_names_in_text(source_arena, &type_text)
+        };
+        if let Some(expanded) =
+            scratch.expand_inexact_optional_alias_reference_text(source_arena, &type_text)
+        {
+            return Some(expanded);
+        }
+        (!require_inexact_optional_expansion).then_some(type_text)
     }
 
     pub(in crate::declaration_emitter) fn source_type_annotation_text_for_declaration_reuse(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
@@ -1317,3 +1317,67 @@ let y = complete(value);
         None
     );
 }
+
+#[test]
+fn exported_call_preserves_inexact_optional_mapped_intersection_surface() {
+    let output = emit_test_dts_with_binding(
+        r#"
+type InexactOptionals<A> = {
+    [K in keyof A as undefined extends A[K] ? K : never]?: undefined extends A[K]
+    ? A[K] | undefined
+    : A[K];
+} & {
+    [K in keyof A as undefined extends A[K] ? never : K]: A[K];
+};
+
+type In = {
+    foo?: string;
+    bar: number;
+    baz: undefined;
+}
+
+type Out = InexactOptionals<In>
+
+const foo = <A = {}>() => (x: Out & A) => null
+
+export const baddts = foo()
+"#,
+    );
+
+    assert_eq!(
+        output.trim(),
+        "export declare const baddts: (x: {\n    foo?: string | undefined;\n    baz?: undefined;\n} & {\n    bar: number;\n}) => any;"
+    );
+}
+
+#[test]
+fn exported_call_preserves_renamed_inexact_optional_mapped_intersection_surface() {
+    let output = emit_test_dts_with_binding(
+        r#"
+type Loose<T> = {
+    [Key in keyof T as undefined extends T[Key] ? Key : never]?: undefined extends T[Key]
+    ? T[Key] | undefined
+    : T[Key];
+} & {
+    [Key in keyof T as undefined extends T[Key] ? never : Key]: T[Key];
+};
+
+type Input = {
+    maybe?: string;
+    count: number;
+    nil: undefined;
+}
+
+type Result = Loose<Input>
+
+const make = <Extra = {}>() => (value: Result & Extra) => null
+
+export const publicValue = make()
+"#,
+    );
+
+    assert_eq!(
+        output.trim(),
+        "export declare const publicValue: (value: {\n    maybe?: string | undefined;\n    nil?: undefined;\n} & {\n    count: number;\n}) => any;"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Track 9 declaration emit / DTS parity.

## Invariant
When an inferred exported call returns a function parameter typed as an inexact-optional mapped alias intersected with a default `{}` type parameter, `tsc` preserves the split public object intersection. This PR makes tsz prefer the source callable declaration surface only when that inexact-optional expansion is proven, before the computed reusable call surface can merge the object members.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs`

## Owner Layer
Declaration source-callable/public surface reconstruction. The change reuses the existing source-backed inexact-optional alias expansion boundary and removes the hardcoded mapped key name assumption; it does not add checker diagnostics, solver relation checks, semantic validation during printing, or output surgery.

## Adjacent Case Matrix
- Reported shape: `Out & A` with `A = {}` expands to `{ optional/undefined members } & { required members }`.
- Renamed shape: mapped key parameter, aliases, type parameter, exported variable, and object properties can all be renamed and still expand.
- Negative/fallback shape: source callable reconstruction is allowed to outrank the computed call surface only when the inexact-optional alias expansion succeeds; otherwise existing computed/source fallback ordering is preserved.

## Project Corpus Impact
- Row: n/a
- Bug family: DTS exact-optional mapped intersection public surface
- Evidence: emit conformance-only DTS parity slice; `declarationEmitExactOptionalPropertyTypesNodeNotReused` DTS passed locally before restack, and draft CI light checks were green before this refresh.

## Verification
- Before restack: `cargo fmt --check`
- Before restack: `git diff --check`
- Before restack: `cargo nextest run -p tsz-emitter exported_call_preserves_inexact_optional_mapped_intersection_surface exported_call_preserves_renamed_inexact_optional_mapped_intersection_surface`
- Before restack: `scripts/emit/run.sh --filter=declarationEmitExactOptionalPropertyTypesNodeNotReused --dts-only --verbose --concurrency=4 --json-out=/tmp/studio-d-exactOptional-node-not-reused-after-tests.json`
- Before restack: `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`
- Before restack: `scripts/agents/ensure-agent-labels.sh --audit`
- After earlier restacks onto `main`: `git diff --check origin/main...HEAD`; `cargo fmt --check`
- M5Manager-delegated refresh on 2026-06-02: `git fetch origin main`
- M5Manager-delegated refresh on 2026-06-02: `git rebase origin/main` from `dff0cecf5b2317613a18958966d77fce105c72e2` to `709bba2a9f1069fbbbefce144aa81ebba15dfb05` with no conflicts
- M5Manager-delegated refresh on 2026-06-02: `git diff --check origin/main...HEAD`
- M5Manager-delegated refresh on 2026-06-02: `cargo fmt --check`
- M5Manager-delegated refresh on 2026-06-02: `git diff --stat origin/main...HEAD` shows only the three exact-optional child files

## Coordination Notes
- M5Manager delegated this one-at-a-time refresh for #12115 only; #12131, #12132, and #12133 were intentionally not touched.
- Rebased directly onto current `origin/main` `6f51695c790f6fa13a5a8e123ce6fd782b278e8c`; current head is `709bba2a9f1069fbbbefce144aa81ebba15dfb05`.
- Current state: ready for review and off queue. Labels remain `emit` and `agent:Studio-D`; M5Manager marked the PR ready after exact-head draft-light CI passed, but did not add `merge-queue`, merge, close, or change labels.
- Draft-light CI passed for exact head `709bba2a9f1069fbbbefce144aa81ebba15dfb05`, including `CI Light Summary`, `lint`, `unit`, `dist-binaries`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, and `GitGuardian Security Checks`. Ready-review CI is now running on the same head.
- Next owner/action: keep this PR off `merge-queue` until exact-head ready-review `CI Summary` and `GitGuardian Security Checks` are green. If ready-review CI fails, inspect the failed job and leave a signed blocker note before any rerun or queue action.
- AgentName: M5Manager.
- No roadmap update: this is a focused DTS parity fix through an existing declaration source-callable boundary.

