### PR TITLE
refactor(lsp): retire signature help type-data access

### DIFF
--- a/crates/tsz-lsp/src/signature_help.rs
+++ b/crates/tsz-lsp/src/signature_help.rs
@@ -18,8 +18,7 @@ use tsz_parser::{
 };
 use tsz_scanner::SyntaxKind;
 use tsz_solver::{
-    FunctionShape, ParamInfo, TypeData, TypeId, TypePredicateTarget, apparent_intrinsic_kind,
-    visitor,
+    FunctionShape, ParamInfo, TypeId, TypePredicateTarget, apparent_intrinsic_kind, visitor,
 };
 
 use crate::intrinsic_params::{

--- a/crates/tsz-lsp/src/signature_help/shapes.rs
+++ b/crates/tsz-lsp/src/signature_help/shapes.rs
@@ -200,7 +200,7 @@ impl<'a> SignatureHelpProvider<'a> {
         has_explicit_type_args: bool,
         explicit_type_arg_texts: &[String],
     ) -> Vec<SignatureCandidate> {
-        self.expand_rest_tuple_union_variants(shape, checker)
+        self.expand_rest_tuple_union_variants(shape)
             .into_iter()
             .map(|variant| {
                 self.signature_candidate(
@@ -218,19 +218,19 @@ impl<'a> SignatureHelpProvider<'a> {
     pub(super) fn expand_rest_tuple_union_variants(
         &self,
         shape: &FunctionShape,
-        checker: &CheckerState,
     ) -> Vec<FunctionShape> {
         let Some(rest_index) = shape.params.iter().position(|param| param.rest) else {
             return vec![shape.clone()];
         };
         let rest_param = shape.params[rest_index];
-        let Some(TypeData::Union(list_id)) = checker.ctx.types.lookup(rest_param.type_id) else {
+        let Some(list_id) = visitor::union_list_id(self.interner, rest_param.type_id) else {
             return vec![shape.clone()];
         };
 
-        let mut variants = Vec::with_capacity(checker.ctx.types.type_list(list_id).len());
-        for &member in checker.ctx.types.type_list(list_id).iter() {
-            if !matches!(checker.ctx.types.lookup(member), Some(TypeData::Tuple(_))) {
+        let members = self.interner.type_list(list_id);
+        let mut variants = Vec::with_capacity(members.len());
+        for &member in members.iter() {
+            if visitor::tuple_list_id(self.interner, member).is_none() {
                 continue;
             }
             let mut variant = shape.clone();
@@ -286,9 +286,9 @@ impl<'a> SignatureHelpProvider<'a> {
             // as individual parameters. e.g. `...args: [...names: string[], allCaps: boolean]`
             // becomes `...names: string[], allCaps: boolean`.
             if param.rest
-                && let Some(TypeData::Tuple(list_id)) = checker.ctx.types.lookup(param.type_id)
+                && let Some(list_id) = visitor::tuple_list_id(self.interner, param.type_id)
             {
-                let elements = checker.ctx.types.tuple_list(list_id);
+                let elements = self.interner.tuple_list(list_id);
                 let param_base_name = param.name.map_or_else(
                     || "arg".to_string(),
                     |atom| checker.ctx.types.resolve_atom(atom),

--- a/scripts/arch/arch_guard_policy.toml
+++ b/scripts/arch/arch_guard_policy.toml
@@ -303,7 +303,6 @@ exclude_files = [
   "crates/tsz-checker/src/types/class_type/core.rs",
   "crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs",
   "crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs",
-  "crates/tsz-lsp/src/signature_help/shapes.rs",
 ]
 ignore_comment_lines = true
 
@@ -334,8 +333,6 @@ exclude_dirs = ["tests"]
 exclude_files = [
   # file_id_allocator.lookup() is not a solver interner lookup
   "crates/tsz-lsp/src/project/core.rs",
-  # Pre-existing baseline debt
-  "crates/tsz-lsp/src/signature_help/shapes.rs",
 ]
 
 [[pattern_checks]]


### PR DESCRIPTION
## Agent
AgentName: Studio-E

## Track
Track 9 / LSP compiler-service consumer boundary refactor for #10708.

## Invariant
When signature help expands rest tuple unions and formats tuple rest parameters, LSP behavior stays unchanged while the provider consumes solver visitor/accessor helpers instead of matching raw `TypeData` or calling solver interner `lookup()` directly.

## Scope
- Replace the remaining `TypeData`/direct `lookup()` sites in `crates/tsz-lsp/src/signature_help/shapes.rs` with solver visitor helpers.
- Remove `crates/tsz-lsp/src/signature_help/shapes.rs` from the TypeData and LSP lookup arch-guard exclusion lists.
- No signature display, overload selection, or active parameter behavior change intended.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: LSP boundary refactor-only; no checker/solver/project-corpus behavior intended.

## Verification
- Pre-rebase head:
  - `cargo fmt --check`
  - `python3 scripts/arch/arch_guard.py`
  - `python3 scripts/arch/test_arch_guard_policy.py`
  - `git diff --check`
  - `rg -n "TypeData|\\.lookup\\(" crates/tsz-lsp/src/signature_help.rs crates/tsz-lsp/src/signature_help/*.rs` (no matches)
  - `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo check -p tsz-lsp`
  - `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo nextest run -p tsz-lsp signature_help` (159 passed, 3837 skipped)
  - `scripts/agents/ensure-agent-labels.sh --audit`
- Rebased head `970792267e945e414c6ef84c14d66ae9807f0d48`:
  - `cargo fmt --check`
  - `python3 scripts/arch/arch_guard.py`
  - `git diff --check origin/main...HEAD`
  - `rg -n "TypeData|\\.lookup\\(" crates/tsz-lsp/src/signature_help.rs crates/tsz-lsp/src/signature_help/*.rs` (no matches)
- CI passed on earlier rebased heads `e32fea27d5a3ad7053bd76be3ea55082d42fc665`, `5e43537de160f8a991388cee507f43e05444cc73`, `852ca5512ac6dbc7b2ffc8aea8ef0f6e18a42b2d`, and `88f738bdd628bcf84f4bc3d139ac499e6c255b2a`; restarted on latest head `970792267e945e414c6ef84c14d66ae9807f0d48` after `origin/main` advanced.

## Coordination Notes
- Follows #12105, which split `signature_help.rs` and isolated this debt in `signature_help/shapes.rs`.
- Burns down the remaining #10708 arch-guard exclusion half for signature help.
- Checked current open PRs before starting; no open PR targets signature-help boundary debt.
- Ready PR; waiting for exact-head CI on `970792267e945e414c6ef84c14d66ae9807f0d48` before enqueueing.
