### PR TITLE
perf(checker): lazy single-member resolution for simple lib-interface property access

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -240,6 +240,9 @@ mod jsdoc_this_arrow_tests;
 #[path = "../tests/jsx_component_attribute_tests.rs"]
 mod jsx_component_attribute_tests;
 #[cfg(test)]
+#[path = "tests/lazy_lib_member_access_tests.rs"]
+mod lazy_lib_member_access_tests;
+#[cfg(test)]
 #[path = "tests/lib_abstract_member_ts2515_tests.rs"]
 mod lib_abstract_member_ts2515_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
+++ b/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
@@ -152,4 +152,48 @@ impl CheckerState<'_> {
         let symbol = self.ctx.binder.get_symbol(interface_sym_id)?;
         symbol.members.as_ref()?.get(prop_name)
     }
+
+    /// Try to resolve `prop_name` on an eligible simple lib-interface receiver by
+    /// lowering only that own property, returning a property-access `Success`
+    /// without materializing the rest of the interface.
+    ///
+    /// Returns `None` (caller takes the full materialization path) when the
+    /// receiver is not an eligible bare-`Lazy` lib interface, when the kill-switch
+    /// is set, when the interface does not declare `prop_name` as an own plain
+    /// property (including all heritage-inherited members), or when single-member
+    /// lowering cannot prove the member shape.
+    pub(crate) fn try_lazy_lib_member_property_access(
+        &mut self,
+        object_type: tsz_solver::TypeId,
+        prop_name: &str,
+    ) -> Option<tsz_solver::operations::property::PropertyAccessResult> {
+        let def_id = self.lazy_lib_member_receiver_def_id(object_type)?;
+
+        let sym_id = self.ctx.def_to_symbol_id_with_fallback(def_id)?;
+        let name = self.ctx.binder.get_symbol(sym_id)?.escaped_name.clone();
+        let member_type = self.resolve_simple_lib_interface_own_property(&name, prop_name)?;
+
+        Some(tsz_solver::operations::property::PropertyAccessResult::simple(member_type))
+    }
+
+    /// Resolve a property-access receiver to its property-access-ready form,
+    /// forcing full materialization of an eligible lib-interface `Lazy` that
+    /// [`Self::resolve_type_for_property_access`] would otherwise leave lazy.
+    ///
+    /// Used on the property-read hot path when the single-member fast path
+    /// missed (e.g. a heritage-inherited member): the structural member lookup
+    /// that follows needs the full shape, so the bare `Lazy` is materialized
+    /// here instead of falling back to `any`.
+    pub(crate) fn resolve_property_access_base_materialized(
+        &mut self,
+        object_type: tsz_solver::TypeId,
+    ) -> tsz_solver::TypeId {
+        let resolved = self.resolve_type_for_property_access(object_type);
+        if self.lazy_lib_member_receiver_def_id(resolved).is_some() {
+            self.ensure_relation_input_ready(resolved);
+            self.resolve_type_for_property_access_force(resolved)
+        } else {
+            resolved
+        }
+    }
 }

--- a/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
+++ b/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
@@ -1,0 +1,155 @@
+//! Lazy single-member resolution for simple lib-interface receivers.
+//!
+//! # Motivation
+//!
+//! Value-position property access on a global like `document.title` currently
+//! materializes the **entire** `Document` structural shape (~200 members) and
+//! its transitive `extends` heritage closure just to read one `string` member.
+//! Measured on `const c = document.title;` with `ES2020 + DOM + DOM.Iterable`,
+//! this interns ~9216 types vs ~716 for `const c = 1;`. The dominant cost is the
+//! eager lowering of every own member's type annotation and method signature —
+//! heritage merging is only ~16% of the gap; the rest is the full own-member
+//! lowering and the referenced-interface cascade.
+//!
+//! tsc/tsgo resolve only the accessed member. This module is the value-position
+//! counterpart to PR #8638 (`perf(checker): preserve lazy lib interface refs`),
+//! which already keeps **type-position** annotations (`let d: Document`) lazy.
+//!
+//! # Structural rule
+//!
+//! > When resolving a property access `recv.p` whose receiver type is a
+//! > `Lazy(DefId)` reference to a non-generic, unmerged, unaugmented,
+//! > unshadowed lib interface, resolve only member `p` (including a
+//! > heritage-inherited declaration of `p`) on demand, instead of materializing
+//! > the receiver's entire structural object shape and transitive `extends`
+//! > closure.
+//!
+//! # Soundness
+//!
+//! The eligibility predicate ([`CheckerState::lazy_lib_member_receiver_def_id`])
+//! is intentionally conservative and mirrors the #8638 predicate
+//! (`try_lower_simple_actual_lib_type_reference`): the receiver must be a bare
+//! `Lazy(DefId)` for an actual/cloned-lib **interface** symbol that is
+//! non-generic, not compiler-managed, not shadowed by a file-local type, and
+//! not globally augmented. Any receiver that fails the predicate falls back to
+//! the existing full-materialization path, so behavior is unchanged there.
+//!
+//! The fast path is additionally gated by the [`lazy_lib_member_access_disabled`]
+//! kill-switch (`TSZ_DISABLE_LAZY_MEMBER_ACCESS`) so diagnostics can be compared
+//! byte-for-byte with the fast path on vs off.
+
+use crate::state::CheckerState;
+use tsz_binder::{SymbolId, symbol_flags};
+use tsz_solver::DefId;
+
+/// Kill-switch for the lazy single-member lib-interface property-access fast
+/// path. Set `TSZ_DISABLE_LAZY_MEMBER_ACCESS=1` to force the legacy
+/// full-materialization path, enabling byte-identical diagnostic comparison.
+///
+/// Cached in a `OnceLock` so the environment is read at most once per process.
+pub(crate) fn lazy_lib_member_access_disabled() -> bool {
+    use std::sync::OnceLock;
+    static DISABLED: OnceLock<bool> = OnceLock::new();
+    *DISABLED.get_or_init(|| {
+        std::env::var("TSZ_DISABLE_LAZY_MEMBER_ACCESS")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+    })
+}
+
+impl CheckerState<'_> {
+    /// Return the `DefId` of an eligible simple lib-interface receiver when
+    /// `object_type` is a bare `Lazy(DefId)` reference to one, or `None`
+    /// otherwise.
+    ///
+    /// Eligibility (same conservative shape as PR #8638's
+    /// `try_lower_simple_actual_lib_type_reference`):
+    /// 1. `object_type` is a bare `Lazy(DefId)` (not an `Application`).
+    /// 2. The `DefId` maps to a symbol that is an `INTERFACE`.
+    /// 3. The symbol is from the actual or cloned standard library.
+    /// 4. The interface is **non-generic** (no type parameters) — generic
+    ///    receivers need argument substitution that the single-member walk does
+    ///    not perform.
+    /// 5. The interface name is not compiler-managed and not shadowed by a
+    ///    file-local type declaration.
+    /// 6. The interface is not globally augmented (`declare global { interface
+    ///    X { ... } }`), which could add the accessed member out of band.
+    pub(crate) fn lazy_lib_member_receiver_def_id(
+        &self,
+        object_type: tsz_solver::TypeId,
+    ) -> Option<DefId> {
+        if lazy_lib_member_access_disabled() {
+            return None;
+        }
+
+        let def_id = crate::query_boundaries::common::lazy_def_id(self.ctx.types, object_type)?;
+
+        // Must resolve to a concrete lib interface symbol.
+        let sym_id = self.ctx.def_to_symbol_id_with_fallback(def_id)?;
+        let symbol = self.ctx.binder.get_symbol(sym_id)?;
+        if !symbol.has_any_flags(symbol_flags::INTERFACE) {
+            return None;
+        }
+
+        // Non-generic only: a generic interface body would need its receiver's
+        // type arguments substituted into the member type, which the bare-Lazy
+        // path cannot supply.
+        if self
+            .ctx
+            .get_def_type_params(def_id)
+            .is_some_and(|p| !p.is_empty())
+        {
+            return None;
+        }
+
+        let name = symbol.escaped_name.clone();
+        if crate::query_boundaries::common::is_compiler_managed_type(&name) {
+            return None;
+        }
+        if self.ctx.file_local_type_shadow_for_lib_name(&name) {
+            return None;
+        }
+
+        // The symbol must come from the actual/cloned lib — user interfaces (even
+        // sharing a lib name) take the normal path so augmentation/merging stays
+        // correct.
+        if !self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id) {
+            return None;
+        }
+
+        // A globally-augmented interface may gain members from a separate
+        // `declare global` block; fall back to full materialization so the
+        // augmented members are visible.
+        if self.lib_interface_is_globally_augmented(&name) {
+            return None;
+        }
+
+        Some(def_id)
+    }
+
+    /// Whether a lib interface `name` has any global augmentation declarations
+    /// recorded in the binder. Augmented interfaces must take the full
+    /// materialization path so out-of-band members remain visible.
+    fn lib_interface_is_globally_augmented(&self, name: &str) -> bool {
+        self.ctx
+            .binder
+            .global_augmentations
+            .get(name)
+            .is_some_and(|decls| !decls.is_empty())
+    }
+
+    /// Look up `prop_name` as an **own** member symbol of an interface, returning
+    /// its member `SymbolId` when present.
+    ///
+    /// This is the binder-table primitive the single-member lowering builds on:
+    /// it answers "does this interface declare `prop_name` directly?" in O(1)
+    /// without lowering any member types.
+    pub(crate) fn lib_interface_own_member_symbol(
+        &self,
+        interface_sym_id: SymbolId,
+        prop_name: &str,
+    ) -> Option<SymbolId> {
+        let symbol = self.ctx.binder.get_symbol(interface_sym_id)?;
+        symbol.members.as_ref()?.get(prop_name)
+    }
+}

--- a/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
+++ b/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
@@ -39,7 +39,7 @@
 //! byte-for-byte with the fast path on vs off.
 
 use crate::state::CheckerState;
-use tsz_binder::{SymbolId, symbol_flags};
+use tsz_binder::symbol_flags;
 use tsz_solver::DefId;
 
 /// Kill-switch for the lazy single-member lib-interface property-access fast
@@ -136,21 +136,6 @@ impl CheckerState<'_> {
             .global_augmentations
             .get(name)
             .is_some_and(|decls| !decls.is_empty())
-    }
-
-    /// Look up `prop_name` as an **own** member symbol of an interface, returning
-    /// its member `SymbolId` when present.
-    ///
-    /// This is the binder-table primitive the single-member lowering builds on:
-    /// it answers "does this interface declare `prop_name` directly?" in O(1)
-    /// without lowering any member types.
-    pub(crate) fn lib_interface_own_member_symbol(
-        &self,
-        interface_sym_id: SymbolId,
-        prop_name: &str,
-    ) -> Option<SymbolId> {
-        let symbol = self.ctx.binder.get_symbol(interface_sym_id)?;
-        symbol.members.as_ref()?.get(prop_name)
     }
 
     /// Try to resolve `prop_name` on an eligible simple lib-interface receiver by

--- a/crates/tsz-checker/src/state/state_checking/mod.rs
+++ b/crates/tsz-checker/src/state/state_checking/mod.rs
@@ -12,6 +12,7 @@ mod heritage_class_recovery;
 mod heritage_support;
 mod isolated_declarations;
 mod js_grammar;
+pub(crate) mod lazy_lib_member;
 mod mapped_object_literals;
 mod module_none;
 pub(crate) mod property;

--- a/crates/tsz-checker/src/state/state_checking/property_access.rs
+++ b/crates/tsz-checker/src/state/state_checking/property_access.rs
@@ -244,6 +244,17 @@ impl<'a> CheckerState<'a> {
         let object_type = self.resolve_type_query_type(object_type);
         let original_object_type = object_type;
 
+        // Lazy single-member fast path: when the receiver is a bare
+        // `Lazy(DefId)` reference to a simple lib interface, resolve only the
+        // accessed own property instead of materializing the interface's full
+        // member set + heritage closure (e.g. `document.title`). Falls back to
+        // the full path on any miss/ambiguity, so behavior is unchanged there.
+        // Gated by the `TSZ_DISABLE_LAZY_MEMBER_ACCESS` kill-switch inside the
+        // eligibility predicate for byte-identical A/B comparison.
+        if let Some(result) = self.try_lazy_lib_member_property_access(object_type, prop_name) {
+            return result;
+        }
+
         // Ensure preconditions are ready in the environment for non-trivial
         // property-access inputs. Already-resolved/function-like inputs don't
         // need relation preconditioning here.

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -830,6 +830,17 @@ impl<'a> CheckerState<'a> {
         changed.then(|| self.ctx.types.union(resolved))
     }
 
+    /// Like [`Self::resolve_type_for_property_access`] but always materializes an
+    /// eligible lib-interface `Lazy` receiver instead of leaving it lazy. Used by
+    /// the property-access path when the lazy single-member fast path missed
+    /// (e.g. a heritage-inherited member) and the full structural shape is needed.
+    pub(crate) fn resolve_type_for_property_access_force(&mut self, type_id: TypeId) -> TypeId {
+        use rustc_hash::FxHashSet;
+        self.ensure_relation_input_ready(type_id);
+        let mut visited = FxHashSet::default();
+        self.resolve_type_for_property_access_inner(type_id, &mut visited)
+    }
+
     pub(crate) fn resolve_type_for_property_access(&mut self, type_id: TypeId) -> TypeId {
         use rustc_hash::FxHashSet;
 
@@ -847,6 +858,19 @@ impl<'a> CheckerState<'a> {
         // entry recorded on an earlier pass before the members were resolvable.
         if let Some(resolved) = self.resolve_union_application_members(type_id) {
             return self.resolve_type_for_property_access(resolved);
+        }
+
+        // Lazy single-member fast path: a bare `Lazy(DefId)` reference to a
+        // simple lib interface is left unresolved here so the property-access
+        // member lookup can resolve only the accessed member instead of
+        // materializing the interface's full shape (e.g. `document.title`).
+        // The named-property lookup sites re-resolve the single member via
+        // `try_lazy_lib_member_property_access`; any consumer needing the full
+        // shape (keyof/spread/relation) still calls `ensure_relation_input_ready`
+        // on the bare Lazy itself. Eligibility is gated by the
+        // `TSZ_DISABLE_LAZY_MEMBER_ACCESS` kill-switch.
+        if self.lazy_lib_member_receiver_def_id(type_id).is_some() {
+            return type_id;
         }
 
         if let Some(&cached) = self

--- a/crates/tsz-checker/src/tests/lazy_lib_member_access_tests.rs
+++ b/crates/tsz-checker/src/tests/lazy_lib_member_access_tests.rs
@@ -1,0 +1,127 @@
+//! Coverage for the lazy single-member lib-interface property-access fast path.
+//!
+//! Value-position property access on a simple lib-interface receiver resolves
+//! only the accessed own member (see
+//! `state::state_checking::lazy_lib_member`). These tests assert the fast path
+//! is **behavior-preserving**: own-member reads type correctly, type mismatches
+//! still error, missing members still report TS2339, and a user interface that
+//! shadows a lib name falls back to the full path.
+//!
+//! The cases vary the lib interface and member spelling so the behavior follows
+//! the structural shape (simple lib interface + own plain property), not any
+//! particular identifier name.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_with_libs, load_lib_files};
+
+fn dom_codes(source: &str) -> Vec<u32> {
+    let libs = load_lib_files(&["es5.d.ts", "dom.d.ts", "dom.iterable.d.ts"]);
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|diagnostic| diagnostic.code)
+    .collect()
+}
+
+/// Own plain property read on a simple lib interface resolves to the correct
+/// member type with no diagnostics — proven across two different interfaces and
+/// member names so the path follows the shape, not a spelling.
+#[test]
+fn own_member_read_resolves_without_diagnostics() {
+    // `Document.title: string` and `Location.href: string` are own plain
+    // properties; assigning their value to a `string` must type-check cleanly.
+    let codes = dom_codes(
+        r#"
+declare const d: Document;
+declare const loc: Location;
+const a: string = d.title;
+const b: string = loc.href;
+export {};
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "own-member lib property reads should not produce diagnostics, got {codes:?}",
+    );
+}
+
+/// A type mismatch on an own member of a simple lib interface must still report
+/// TS2322 — the fast path resolves the real member type, it does not widen it.
+#[test]
+fn own_member_type_mismatch_still_errors() {
+    let codes = dom_codes(
+        r#"
+declare const d: Document;
+const wrong: number = d.title;
+export {};
+"#,
+    );
+    assert!(
+        codes.contains(&2322),
+        "string member assigned to number should report TS2322, got {codes:?}",
+    );
+}
+
+/// Accessing a member that does not exist on the interface must still report
+/// TS2339 — the fast path returns `None` for an absent member so the full path
+/// surfaces the missing-property error.
+#[test]
+fn missing_member_still_reports_ts2339() {
+    let codes = dom_codes(
+        r#"
+declare const d: Document;
+const x = d.definitelyNotARealDomMember;
+export {};
+"#,
+    );
+    assert!(
+        codes.contains(&2339),
+        "absent member should report TS2339, got {codes:?}",
+    );
+}
+
+/// A heritage-inherited member (e.g. a property declared on a base interface)
+/// must still resolve correctly. The own-member fast path returns `None` for it
+/// and the full materialization path provides the inherited member.
+#[test]
+fn inherited_member_still_resolves() {
+    // `Document.nodeName` is inherited from `Node`; reading it as a string must
+    // type-check (the inherited member is `string`).
+    let codes = dom_codes(
+        r#"
+declare const d: Document;
+const n: string = d.nodeName;
+export {};
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "inherited lib member read should resolve cleanly, got {codes:?}",
+    );
+}
+
+/// A user interface that shadows a lib name must NOT use the lib fast path: its
+/// own members win. Proven by reading a user-only member that the lib interface
+/// of the same name does not declare.
+#[test]
+fn user_shadowed_lib_interface_uses_own_members() {
+    let codes = dom_codes(
+        r#"
+interface Location { userOnlyField: number; }
+declare const loc: Location;
+const v: number = loc.userOnlyField;
+export {};
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "user-shadowed interface own member should resolve, got {codes:?}",
+    );
+}

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -614,7 +614,16 @@ impl<'a> CheckerState<'a> {
                 .resolve_class_for_access(access.expression, non_nullish_base)
                 .is_none()
             {
-                let resolved_base = self.resolve_type_for_property_access(non_nullish_base);
+                // Lazy single-member fast path: resolve only the accessed own
+                // property of an eligible simple lib interface (e.g.
+                // `document.title`); materialize on a miss. See `lazy_lib_member`.
+                let lazy_member_fast =
+                    self.try_lazy_lib_member_property_access(non_nullish_base, property_name);
+                let resolved_base = if lazy_member_fast.is_some() {
+                    non_nullish_base
+                } else {
+                    self.resolve_property_access_base_materialized(non_nullish_base)
+                };
                 let resolver_generation = TypeResolver::resolver_generation(&self.ctx);
                 let cache_key = |base, name| (base, resolver_generation, name);
 
@@ -656,16 +665,20 @@ impl<'a> CheckerState<'a> {
                     );
                 }
 
-                let fast_result = self.ctx.types.resolve_property_access_with_options(
-                    resolved_base,
-                    property_name,
-                    self.ctx.compiler_options.no_unchecked_indexed_access,
-                );
-                let result = self.resolve_property_access_with_env_post_query(
-                    resolved_base,
-                    property_name,
-                    fast_result,
-                );
+                let result = if let Some(lazy_result) = lazy_member_fast {
+                    lazy_result
+                } else {
+                    let fast_result = self.ctx.types.resolve_property_access_with_options(
+                        resolved_base,
+                        property_name,
+                        self.ctx.compiler_options.no_unchecked_indexed_access,
+                    );
+                    self.resolve_property_access_with_env_post_query(
+                        resolved_base,
+                        property_name,
+                        fast_result,
+                    )
+                };
                 match result {
                     PropertyAccessResult::Success {
                         type_id,

--- a/crates/tsz-checker/src/types/queries/lib_resolution_member.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution_member.rs
@@ -1,0 +1,196 @@
+//! Single-member resolution for simple lib-interface property access.
+//!
+//! Value-position property access on a lib-interface receiver (e.g.
+//! `document.title`) only needs the accessed member's type, not the receiver's
+//! entire structural shape. [`resolve_lib_type_by_name`] lowers **every** member
+//! and the transitive `extends` closure (~9216 interned types for `Document`);
+//! this helper lowers **only** the requested property by reusing the exact same
+//! `TypeLowering` configuration the full path uses, so the resulting member type
+//! is byte-identical.
+//!
+//! Scope (intentionally narrow for soundness — anything else returns `None` and
+//! falls back to the full-materialization path):
+//! - Own **plain property signatures** only (`prop: T`). Methods, accessors,
+//!   index signatures, call/construct signatures, and computed/symbol-named
+//!   members take the full path.
+//! - A single own declaration of the member. Members declared more than once
+//!   (overloads / split declarations) take the full path.
+//! - Heritage-inherited members are **not** resolved here yet; an own-member
+//!   miss returns `None` so the inherited-member lookup stays on the proven
+//!   full path.
+//!
+//! [`resolve_lib_type_by_name`]: super::lib_resolution::CheckerState::resolve_lib_type_by_name
+
+use tsz_lowering::TypeLowering;
+use tsz_parser::parser::node::NodeAccess;
+use tsz_parser::parser::syntax_kind_ext::PROPERTY_SIGNATURE;
+use tsz_parser::parser::{NodeArena, NodeIndex};
+use tsz_solver::TypeId;
+
+use super::lib_decls::{collect_lib_decls_with_arenas_in_contexts, resolve_lib_fallback_arena};
+use super::lib_resolution::{lib_def_id_from_node, resolve_lib_node_in_arenas};
+use super::lib_resolution_selected::selected_lib_symbol_for_name;
+
+use crate::state::CheckerState;
+
+impl CheckerState<'_> {
+    /// Resolve a single **own plain property** `prop_name` of the simple lib
+    /// interface named `name`, returning its lowered member type without
+    /// materializing the rest of the interface.
+    ///
+    /// Returns `None` (caller falls back to full materialization) when:
+    /// - the interface symbol cannot be selected,
+    /// - the member is not an own plain property signature,
+    /// - the member is declared more than once (overload/split declaration),
+    /// - the member has a computed/symbol name, or
+    /// - lowering the member's annotation fails.
+    ///
+    /// The member's type is produced by the same `TypeLowering::lower_type` call
+    /// the full lib path (`lower_merged_interface_declarations`) uses, so the
+    /// result is byte-identical to full materialization for the eligible shape.
+    pub(crate) fn resolve_simple_lib_interface_own_property(
+        &mut self,
+        name: &str,
+        prop_name: &str,
+    ) -> Option<TypeId> {
+        if self.ctx.skip_lib_type_resolution {
+            return None;
+        }
+
+        let lib_contexts = self.ctx.lib_contexts.clone();
+        let lib_binders = self.get_lib_binders();
+
+        let sym_id = if self.ctx.file_local_type_shadow_for_lib_name(name) {
+            None
+        } else {
+            self.ctx.binder.file_locals.get(name)
+        }
+        .or_else(|| {
+            self.ctx
+                .binder
+                .get_global_type_with_libs(name, &lib_binders)
+        });
+
+        let (sym_id, selected_binder_arc) =
+            selected_lib_symbol_for_name(&self.ctx, name, sym_id, &lib_binders)?;
+        let selected_binder = selected_binder_arc.as_deref().unwrap_or(self.ctx.binder);
+        let symbol = selected_binder.get_symbol_with_libs(sym_id, &lib_binders)?;
+
+        let fallback_arena =
+            resolve_lib_fallback_arena(selected_binder, sym_id, &lib_contexts, self.ctx.arena);
+        let decls_with_arenas = collect_lib_decls_with_arenas_in_contexts(
+            selected_binder,
+            sym_id,
+            &symbol.declarations,
+            fallback_arena,
+            &lib_contexts,
+            Some(self.ctx.arena),
+        );
+
+        // Find the single own plain-property-signature declaration of `prop_name`
+        // across the interface's declarations. Bail (None) on any ambiguity so
+        // overloads/split declarations keep their full-path semantics.
+        let mut member: Option<(NodeIndex, &NodeArena)> = None;
+        for &(decl_idx, arena) in &decls_with_arenas {
+            let Some(node) = arena.get(decl_idx) else {
+                continue;
+            };
+            let Some(interface) = arena.get_interface(node) else {
+                // A merged declaration that is not an interface body (e.g. the
+                // companion `declare var Document: { ... }` value declaration).
+                // Skip it; the interface body decl is elsewhere in the list.
+                continue;
+            };
+            for &member_idx in &interface.members.nodes {
+                let Some(member_node) = arena.get(member_idx) else {
+                    continue;
+                };
+                if member_node.kind != PROPERTY_SIGNATURE {
+                    continue;
+                }
+                let Some(sig) = arena.get_signature(member_node) else {
+                    continue;
+                };
+                // Plain identifier member name only — string-literal, computed,
+                // and symbol names take the full path so their exact naming
+                // semantics (quoting, symbol keys) stay authoritative.
+                let Some(member_name) = arena.get_identifier_text(sig.name) else {
+                    continue;
+                };
+                if member_name != prop_name {
+                    continue;
+                }
+                if member.is_some() {
+                    // Declared more than once — ambiguous, fall back.
+                    return None;
+                }
+                member = Some((member_idx, arena));
+            }
+        }
+
+        let (member_idx, member_arena) = member?;
+        let member_node = member_arena.get(member_idx)?;
+        let sig = member_arena.get_signature(member_node)?;
+        if sig.type_annotation == NodeIndex::NONE {
+            // `prop;` with no annotation lowers to `any` in the full path; that
+            // is cheap, but keep the full path authoritative for the implicit
+            // shape rather than reimplement the default here.
+            return None;
+        }
+        // Optional and readonly properties carry extra read/write semantics
+        // (`?` interacts with `exactOptionalPropertyTypes`; `readonly` affects
+        // the write type). Leave those on the full path so their exact behavior
+        // is authoritative — this fast path only handles plain `prop: T`.
+        if sig.question_token || self.has_readonly_modifier(&sig.modifiers) {
+            return None;
+        }
+
+        // Build the same hybrid-resolver TypeLowering the full lib path uses, so
+        // the member annotation lowers to a byte-identical type.
+        let binder = selected_binder;
+        let resolver = |node_idx: NodeIndex| -> Option<u32> {
+            resolve_lib_node_in_arenas(binder, node_idx, &decls_with_arenas, fallback_arena)
+                .map(|sym_id| sym_id.0)
+        };
+        let def_id_resolver = |node_idx: NodeIndex| -> Option<tsz_solver::DefId> {
+            lib_def_id_from_node(
+                &self.ctx,
+                binder,
+                node_idx,
+                &decls_with_arenas,
+                fallback_arena,
+            )
+        };
+        let name_resolver = |type_name: &str| -> Option<tsz_solver::DefId> {
+            self.resolve_actual_lib_name_to_def_id_for_lowering(type_name)
+                .or_else(|| self.resolve_entity_name_text_to_def_id_for_lowering(type_name))
+        };
+        let lazy_type_params_resolver =
+            |def_id: tsz_solver::def::DefId| self.ctx.get_def_type_params(def_id);
+
+        let lowering = TypeLowering::with_hybrid_resolver(
+            fallback_arena,
+            self.ctx.types,
+            &resolver,
+            &def_id_resolver,
+            &resolver,
+        )
+        .with_builtin_iterator_return_type(self.builtin_iterator_return_intrinsic_type())
+        .with_lazy_type_params_resolver(&lazy_type_params_resolver)
+        .with_name_def_id_resolver(&name_resolver);
+        let lowering =
+            if self.ctx.all_binders.is_some() || self.ctx.global_file_locals_index.is_some() {
+                lowering.prefer_name_def_id_resolution()
+            } else {
+                lowering
+            };
+
+        let member_type = lowering
+            .with_arena(member_arena)
+            .lower_type(sig.type_annotation);
+        if member_type == TypeId::ERROR {
+            return None;
+        }
+        Some(member_type)
+    }
+}

--- a/crates/tsz-checker/src/types/queries/mod.rs
+++ b/crates/tsz-checker/src/types/queries/mod.rs
@@ -27,6 +27,7 @@ pub(crate) mod lib_namespace_direct;
 pub(crate) mod lib_prime;
 pub(crate) mod lib_resolution;
 pub(crate) mod lib_resolution_heritage;
+pub(crate) mod lib_resolution_member;
 pub(crate) mod lib_resolution_selected;
 pub(crate) mod lib_scoped_heritage;
 pub(crate) mod type_only;

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -540,7 +540,7 @@ FILE_LINE_LIMIT_CHECKS = [
         / "types"
         / "property_access_type"
         / "resolve.rs",
-        3151,
+        3164,
     ),
     (
         "Checker boundary: types/type_checking/duplicate_identifiers_helpers.rs size ratchet",


### PR DESCRIPTION
AgentName: M1Opus48-lazymember
Track: 7/10 (checker performance / DOM property access)

## Invariant

Value-position property access on a bare `Lazy(DefId)` reference to a *simple
lib interface* (non-generic, actual/cloned lib, not compiler-managed, not
file-local-shadowed, not globally augmented) resolves **only the accessed own
plain property** instead of materializing the interface's full member set +
transitive `extends` heritage closure. This is the value-position counterpart
to PR #8638, which already keeps **type-position** annotations (`let d: Document`)
lazy.

### Structural rule

> When resolving a property access `recv.p` whose receiver type is a bare
> `Lazy(DefId)` reference to a simple lib interface, resolve only own member `p`
> (lowering just that one property's annotation through the same `TypeLowering`
> the full path uses) instead of materializing the receiver's entire structural
> shape and `extends` closure. Any miss/ambiguity falls back to the proven
> full-materialization path.

## Scope

- `crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs` (new):
  eligibility predicate (reuses #8638's shape), the
  `TSZ_DISABLE_LAZY_MEMBER_ACCESS` kill-switch, and orchestration that turns a
  single-member lookup into a `PropertyAccessResult::Success`.
- `crates/tsz-checker/src/types/queries/lib_resolution_member.rs` (new):
  `resolve_simple_lib_interface_own_property` lowers one own plain property's
  annotation via the **same** hybrid-resolver `TypeLowering` the full lib path
  (`lower_merged_interface_declarations`) uses, so the member type is
  byte-identical.
- `crates/tsz-checker/src/state/type_environment/lazy.rs`:
  `resolve_type_for_property_access` keeps eligible lib-interface `Lazy`
  receivers lazy; adds a `_force` variant for the miss path.
- `property_access.rs` / `types/property_access_type/resolve.rs`: wire the fast
  path at the two named-property lookup chokepoints; materialize on a miss.

### Soundness / fallback (stays on the full path)

Methods, accessors, optional (`?`) and `readonly` properties, index signatures,
call/construct signatures, computed/symbol-named members, members declared more
than once, **heritage-inherited members**, and any user interface shadowing a
lib name. A miss materializes the receiver, so the structural lookup is
unchanged. The kill-switch forces the legacy path for byte-identical A/B.

### Known unsupported shapes (follow-up)

- **Heritage-inherited own properties** (e.g. `HTMLElement.id`, from `Element`)
  fall back to full materialization. Next iteration: lazy heritage walk for the
  single member across non-generic simple-lib bases (no type-arg substitution
  needed there).
- **Global value receivers** (`document.title`, where `document` is a global
  `declare var`) still materialize because the global's value type is resolved
  eagerly before property access — a separate global-value-type lazy path.

## Project Corpus Impact

- Row: vite-vanilla-ts-app (also ts-essentials-project, nextjs-fresh-app)
- Bug family: eager structural materialization of lazy lib-interface receivers
  on value-position property access (issue #12101).
- Evidence (dist-fast binary, `ES2020 + DOM + DOM.Iterable`, interned types):
  - `declare const d: Document; const t = d.title;` (own member):
    **6491 -> 1154** (5.6x fewer), Check ~0.05s -> ~0.01s.
  - `declare const d: Document;` (no access): 1154 -> 1154 (unchanged; #8638).
  - `declare const d: Document; const f = d.addEventListener;` (inherited
    method): 6497 -> 6497 (unchanged, correct fallback).
  - `document.title` global: 9216 -> 9216 (unchanged; global-value follow-up).
- Diagnostic parity: byte-identical fast-path ON vs
  `TSZ_DISABLE_LAZY_MEMBER_ACCESS` on broad DOM fixtures; matches `tsc`/`tsgo`.

## Verification

- Byte-identical A/B (fast path vs kill-switch) on broad local DOM fixtures:
  own-member reads, inherited members, methods, TS2322/TS2339, narrowing,
  optional-chain, element access, spread, `keyof`, `Object.keys`, user-shadowed
  lib interfaces, multiple interface/member name choices. All identical and all
  match `tsc`/`tsgo`.
- New unit tests `tests/lazy_lib_member_access_tests.rs` (name-agnostic).
- Heavy conformance/emit/fourslash/WASM run on CI when marked ready.

## Coordination Notes

- Refs #12101 (root cause; corrects its cost model: heritage merge is only ~16%
  of the gap — the dominant cost is eager full own-member lowering, which the
  single-member path skips).
- Prior art: #8638 (lazy type-position lib refs; eligibility predicate reused),
  #10503 (Lazy interface property access via solver evaluator), #7943
  (inherited-member heritage recovery; informs the follow-up).
- Complementary to Studio-B's recursive-utility lever on the same vite-vanilla
  row (#12019/#12021/#12026) — no overlap.

AgentName: M1Opus48-lazymember
