### PR TITLE
test(checker): keep DOM aliases on fallback

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs
@@ -187,6 +187,69 @@ fn direct_cross_file_interface_lowering_handles_simple_builtin_dom_interfaces() 
 }
 
 #[test]
+fn direct_actual_lib_symbol_type_keeps_dom_alias_bodies_on_fallback() {
+    let lib_files = load_lib_files(&["es5.d.ts", "dom.d.ts"]);
+    let mut parser = ParserState::new("fixture.ts".to_string(), "let value;".to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file_with_libs(parser.get_arena(), root, &lib_files);
+    let arena = Arc::new(parser.get_arena().clone());
+    let binder = Arc::new(binder);
+    let types = TypeInterner::new();
+    let ctx = CheckerContext::new(
+        arena.as_ref(),
+        binder.as_ref(),
+        &types,
+        "fixture.ts".to_string(),
+        CheckerOptions::default(),
+    );
+    let mut state = CheckerState { ctx };
+    let lib_contexts: Vec<LibContext> = lib_files
+        .iter()
+        .map(|lib| LibContext {
+            arena: Arc::clone(&lib.arena),
+            binder: Arc::clone(&lib.binder),
+        })
+        .collect();
+    state.ctx.set_lib_contexts(lib_contexts);
+    state.ctx.set_actual_lib_file_count(lib_files.len());
+
+    for name in [
+        "DOMHighResTimeStamp",
+        "GLenum",
+        "Base64URLString",
+        "BigInteger",
+        "BlobPart",
+        "EventListenerOrEventListenerObject",
+    ] {
+        let sym_id = state
+            .ctx
+            .binder
+            .file_locals
+            .get(name)
+            .unwrap_or_else(|| panic!("{name} should resolve to a dom lib alias"));
+        let delegate_arena = state
+            .ctx
+            .binder
+            .symbol_arenas
+            .get(&sym_id)
+            .map(std::convert::AsRef::as_ref)
+            .unwrap_or_else(|| panic!("{name} should have a delegate arena"));
+        assert!(
+            state
+                .direct_actual_lib_symbol_type(
+                    sym_id,
+                    CrossArenaSymbolMissSource::SymbolArena,
+                    Some(delegate_arena),
+                    false,
+                )
+                .is_none(),
+            "{name} should stay on child-checker fallback until DOM alias direct answers preserve conformance fingerprints",
+        );
+    }
+}
+
+#[test]
 fn direct_builtin_dom_interface_uses_declaration_provenance_without_lib_symbol_flag() {
     let lib_files = load_lib_files(&["es5.d.ts", "dom.d.ts"]);
     let mut parser = ParserState::new("fixture.ts".to_string(), "let value;".to_string());


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 7/10 checker performance and residency safety guard.

## Invariant
DOM bundled-lib type aliases must remain on the existing child-checker fallback in the production symbol-type path. Attempts to answer those aliases directly caused conformance fingerprint drift in mapped/inference/JSX diagnostics, even when diagnostic codes still matched.

Owner layer: checker cross-file direct-query orchestration. This PR is test-only and preserves current production behavior.

## Scope
- `crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs`: add a regression guard that representative DOM aliases, including terminal primitive/literal aliases and complex aliases, do not lower through `direct_actual_lib_symbol_type`.

## Project Corpus Impact
- Row: vite-vanilla-ts-app
- Bug family: cross-arena DOM actual-lib alias delegation / child-checker residency
- Evidence: attempted direct DOM alias shortcut reduced child-checker residency directionally in local attribution, but ready-review CI showed it is not parity-safe. This PR now preserves fallback and makes no wall-time speedup claim.
- Evidence artifact from the abandoned shortcut attempt: `/private/tmp/studio-b-terminal-dom-alias-vite-20260601.tsgo-winners.json` reported `tsz_ms=115.16`, `tsgo_ms=76.91`, `rows_below_target=1`, `target_gap_factor=2.994669093745937`.

## Verification
- Local narrow conformance on a pre-fallback head reproduced fingerprint-only drift for `deeplyNestedMappedTypes.ts`, with matching TS2322 codes but alias-display differences.
- Local compile/test attempts after fallback hit local disk exhaustion while compiling `tsz-checker`; no code diagnostics were emitted before `No space left on device`.
- Local formatting/whitespace before earlier commits: pre-commit `cargo fmt`; `git diff --check`.
- Exact-head ready CI on earlier head `a7fe65883203d69f9c69cc2c8967160e0ff813b8` passed lint, unit, unit-cloudbuild, dist-binaries, emit, WASM, LSP, project compile guard/canary, fourslash shards/aggregate, and all six conformance shards; the same ready CI failed `conformance-aggregate` with shared runway unlisted regressions.
- M5Manager-delegated refresh on 2026-06-02 from `a7fe65883203d69f9c69cc2c8967160e0ff813b8` to `43b13e8be142c3d94c94a4a46f702bb3327d1366`: `git diff --check origin/main...HEAD`; `cargo nextest run -p tsz-checker --lib -E 'test(direct_actual_lib_symbol_type_keeps_dom_alias_bodies_on_fallback)'`.
- Draft-light CI passed on `43b13e8be142c3d94c94a4a46f702bb3327d1366`: `CI Light Summary`, lint, unit, unit-cloudbuild, dist-binaries, cargo-deny, cargo-shear, project-row-drift, and GitGuardian.
- M5Manager-delegated refresh on 2026-06-02 from `43b13e8be142c3d94c94a4a46f702bb3327d1366` to `9686b8cadaddb8300a90e25e7e7b54c19855b18f`: `git fetch origin main`; `git fetch origin codex/studio-b-vite-cross-arena-20260601`; `git rebase origin/main` with no conflicts; `git diff --check origin/main...HEAD`; `cargo fmt --check`; `git diff --stat origin/main...HEAD` shows only the one test file.
- M5Manager-delegated refresh on 2026-06-02 from `9686b8cadaddb8300a90e25e7e7b54c19855b18f` to `9004f68c7e627ff0064c7dbff251b94aa01a99b2`: rebased onto `origin/main` `723cd1da1de852117e5ff67fad79097287bc5ff9`; `git diff --check origin/main...HEAD`; `cargo fmt --check`; `git diff --stat origin/main...HEAD` shows only the one test file.
- Draft-light CI for refreshed head `9004f68c7e627ff0064c7dbff251b94aa01a99b2` passed in run `26795511346`: `CI Light Summary`, lint, unit, unit-cloudbuild, dist-binaries, cargo-deny, cargo-shear, project-row-drift, queue-one-pr, and GitGuardian were green. Heavy ready-review jobs were skipped while the PR was draft.

## Coordination Notes
- M5Manager delegated the one-at-a-time refresh for #12118 only; #12060, #12164, #12115, #12147, and #12161 were intentionally not touched.
- Rebased directly onto live `origin/main` `723cd1da1de852117e5ff67fad79097287bc5ff9`; current head is `9004f68c7e627ff0064c7dbff251b94aa01a99b2`.
- Labels remain `performance`, `checker`, and `agent:Studio-B`.
- M5Manager marked this PR ready after exact-head draft-light CI passed. No `merge-queue`, merge, close, or label change was performed.
- Next owner/action: let ready-review heavy CI complete. Add `merge-queue` only after exact-head PR-head checks such as `CI Summary` and GitGuardian are green and the latest pushed changes have been intentionally reviewed.
