### PR TITLE
fix(dts): gate const-call literal initializer on structural return shape

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs
@@ -286,6 +286,7 @@ mod type_inference;
 mod type_inference_accessor_property;
 mod type_inference_class_expression;
 mod type_inference_const_assertions;
+mod type_inference_declared_call;
 mod type_inference_enum_access;
 mod type_inference_expression_literals;
 mod type_inference_fallback_types;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
@@ -1636,7 +1636,7 @@ impl<'a> DeclarationEmitter<'a> {
     ///
     /// The `type_arguments.is_some_and(...)` guard rejects `T<X>` shapes: a
     /// bare type parameter cannot syntactically carry type arguments, so a
-    /// TypeReference that does is necessarily an alias or generic, not the
+    /// `TypeReference` that does is necessarily an alias or generic, not the
     /// identity reference we accept.
     pub(in crate::declaration_emitter) fn call_expression_returns_bare_type_parameter_reference(
         &self,

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
@@ -1598,98 +1598,6 @@ impl<'a> DeclarationEmitter<'a> {
         Self::simple_type_reference_name(&raw).map(|_| raw)
     }
 
-    /// Resolve a call expression to the canonical callee symbol used for
-    /// emitter-side declaration lookups, following the same portability and
-    /// import-aliasing chain as the rest of this module. Also returns the
-    /// resolved import module specifier when the callee crosses a module
-    /// boundary, since several callers need both.
-    pub(in crate::declaration_emitter) fn resolve_call_expression_callee_symbol(
-        &self,
-        callee_expr: NodeIndex,
-        raw_sym_id: SymbolId,
-        binder: &BinderState,
-    ) -> (SymbolId, Option<String>) {
-        let imported_module = self
-            .imported_value_module_specifier(raw_sym_id, binder)
-            .or_else(|| self.imported_value_module_specifier_from_syntax(callee_expr));
-        let sym_id = self
-            .resolve_portability_import_alias(raw_sym_id, binder)
-            .or_else(|| {
-                imported_module.as_deref().and_then(|module_specifier| {
-                    self.imported_value_export_symbol_from_syntax(
-                        callee_expr,
-                        module_specifier,
-                        binder,
-                    )
-                })
-            })
-            .unwrap_or_else(|| self.resolve_portability_symbol(raw_sym_id, binder));
-        (sym_id, imported_module)
-    }
-
-    /// Returns true iff the callee's declared return type is a bare reference
-    /// to one of its own type parameters (e.g. `<T>(x: T): T`). Composed
-    /// returns like `` `${T}` ``, `T | undefined`, `T[]`, `{ v: T }`, or
-    /// `Promise<T>` return false — the initializer form is only safe when the
-    /// consumer can recover the result by re-inferring T from the literal
-    /// argument.
-    ///
-    /// The `type_arguments.is_some_and(...)` guard rejects `T<X>` shapes: a
-    /// bare type parameter cannot syntactically carry type arguments, so a
-    /// `TypeReference` that does is necessarily an alias or generic, not the
-    /// identity reference we accept.
-    pub(in crate::declaration_emitter) fn call_expression_returns_bare_type_parameter_reference(
-        &self,
-        initializer: NodeIndex,
-    ) -> bool {
-        let Some(init_node) = self.arena.get(initializer) else {
-            return false;
-        };
-        if init_node.kind != syntax_kind_ext::CALL_EXPRESSION {
-            return false;
-        }
-        let Some(call) = self.arena.get_call_expr(init_node) else {
-            return false;
-        };
-        let Some(binder) = self.binder else {
-            return false;
-        };
-        let Some(raw_sym_id) = self.value_reference_symbol(call.expression) else {
-            return false;
-        };
-        let (sym_id, _imported_module) =
-            self.resolve_call_expression_callee_symbol(call.expression, raw_sym_id, binder);
-
-        self.with_symbol_declarations(sym_id, |source_arena, decl_idx| {
-            let decl_node = source_arena.get(decl_idx)?;
-            let callable = Self::callable_decl_parts_from_node(source_arena, decl_node)?;
-            let return_idx = callable.type_annotation.into_option()?;
-            let type_params = callable.type_parameters?;
-            let return_node = source_arena.get(source_arena.skip_parenthesized(return_idx))?;
-            if return_node.kind != syntax_kind_ext::TYPE_REFERENCE {
-                return Some(false);
-            }
-            let type_ref = source_arena.get_type_ref(return_node)?;
-            if type_ref
-                .type_arguments
-                .as_ref()
-                .is_some_and(|ta| !ta.nodes.is_empty())
-            {
-                return Some(false);
-            }
-            let return_name = self.identifier_text_from_arena(source_arena, type_ref.type_name)?;
-            let matched = type_params.nodes.iter().any(|&param_idx| {
-                source_arena
-                    .get(param_idx)
-                    .and_then(|n| source_arena.get_type_parameter(n))
-                    .and_then(|tp| self.identifier_text_from_arena(source_arena, tp.name))
-                    .is_some_and(|name| name == return_name)
-            });
-            Some(matched)
-        })
-        .unwrap_or(false)
-    }
-
     pub(in crate::declaration_emitter) fn call_expression_declared_return_type_text(
         &self,
         expr_idx: NodeIndex,
@@ -2445,7 +2353,7 @@ impl<'a> DeclarationEmitter<'a> {
         None
     }
 
-    fn imported_value_export_symbol_from_syntax(
+    pub(in crate::declaration_emitter) fn imported_value_export_symbol_from_syntax(
         &self,
         expr_idx: NodeIndex,
         module_specifier: &str,

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
@@ -1598,6 +1598,98 @@ impl<'a> DeclarationEmitter<'a> {
         Self::simple_type_reference_name(&raw).map(|_| raw)
     }
 
+    /// Resolve a call expression to the canonical callee symbol used for
+    /// emitter-side declaration lookups, following the same portability and
+    /// import-aliasing chain as the rest of this module. Also returns the
+    /// resolved import module specifier when the callee crosses a module
+    /// boundary, since several callers need both.
+    pub(in crate::declaration_emitter) fn resolve_call_expression_callee_symbol(
+        &self,
+        callee_expr: NodeIndex,
+        raw_sym_id: SymbolId,
+        binder: &BinderState,
+    ) -> (SymbolId, Option<String>) {
+        let imported_module = self
+            .imported_value_module_specifier(raw_sym_id, binder)
+            .or_else(|| self.imported_value_module_specifier_from_syntax(callee_expr));
+        let sym_id = self
+            .resolve_portability_import_alias(raw_sym_id, binder)
+            .or_else(|| {
+                imported_module.as_deref().and_then(|module_specifier| {
+                    self.imported_value_export_symbol_from_syntax(
+                        callee_expr,
+                        module_specifier,
+                        binder,
+                    )
+                })
+            })
+            .unwrap_or_else(|| self.resolve_portability_symbol(raw_sym_id, binder));
+        (sym_id, imported_module)
+    }
+
+    /// Returns true iff the callee's declared return type is a bare reference
+    /// to one of its own type parameters (e.g. `<T>(x: T): T`). Composed
+    /// returns like `` `${T}` ``, `T | undefined`, `T[]`, `{ v: T }`, or
+    /// `Promise<T>` return false — the initializer form is only safe when the
+    /// consumer can recover the result by re-inferring T from the literal
+    /// argument.
+    ///
+    /// The `type_arguments.is_some_and(...)` guard rejects `T<X>` shapes: a
+    /// bare type parameter cannot syntactically carry type arguments, so a
+    /// TypeReference that does is necessarily an alias or generic, not the
+    /// identity reference we accept.
+    pub(in crate::declaration_emitter) fn call_expression_returns_bare_type_parameter_reference(
+        &self,
+        initializer: NodeIndex,
+    ) -> bool {
+        let Some(init_node) = self.arena.get(initializer) else {
+            return false;
+        };
+        if init_node.kind != syntax_kind_ext::CALL_EXPRESSION {
+            return false;
+        }
+        let Some(call) = self.arena.get_call_expr(init_node) else {
+            return false;
+        };
+        let Some(binder) = self.binder else {
+            return false;
+        };
+        let Some(raw_sym_id) = self.value_reference_symbol(call.expression) else {
+            return false;
+        };
+        let (sym_id, _imported_module) =
+            self.resolve_call_expression_callee_symbol(call.expression, raw_sym_id, binder);
+
+        self.with_symbol_declarations(sym_id, |source_arena, decl_idx| {
+            let decl_node = source_arena.get(decl_idx)?;
+            let callable = Self::callable_decl_parts_from_node(source_arena, decl_node)?;
+            let return_idx = callable.type_annotation.into_option()?;
+            let type_params = callable.type_parameters?;
+            let return_node = source_arena.get(source_arena.skip_parenthesized(return_idx))?;
+            if return_node.kind != syntax_kind_ext::TYPE_REFERENCE {
+                return Some(false);
+            }
+            let type_ref = source_arena.get_type_ref(return_node)?;
+            if type_ref
+                .type_arguments
+                .as_ref()
+                .is_some_and(|ta| !ta.nodes.is_empty())
+            {
+                return Some(false);
+            }
+            let return_name = self.identifier_text_from_arena(source_arena, type_ref.type_name)?;
+            let matched = type_params.nodes.iter().any(|&param_idx| {
+                source_arena
+                    .get(param_idx)
+                    .and_then(|n| source_arena.get_type_parameter(n))
+                    .and_then(|tp| self.identifier_text_from_arena(source_arena, tp.name))
+                    .is_some_and(|name| name == return_name)
+            });
+            Some(matched)
+        })
+        .unwrap_or(false)
+    }
+
     pub(in crate::declaration_emitter) fn call_expression_declared_return_type_text(
         &self,
         expr_idx: NodeIndex,
@@ -1610,21 +1702,8 @@ impl<'a> DeclarationEmitter<'a> {
         let call = self.arena.get_call_expr(expr_node)?;
         let binder = self.binder?;
         let raw_sym_id = self.value_reference_symbol(call.expression)?;
-        let imported_module = self
-            .imported_value_module_specifier(raw_sym_id, binder)
-            .or_else(|| self.imported_value_module_specifier_from_syntax(call.expression));
-        let sym_id = self
-            .resolve_portability_import_alias(raw_sym_id, binder)
-            .or_else(|| {
-                imported_module.as_deref().and_then(|module_specifier| {
-                    self.imported_value_export_symbol_from_syntax(
-                        call.expression,
-                        module_specifier,
-                        binder,
-                    )
-                })
-            })
-            .unwrap_or_else(|| self.resolve_portability_symbol(raw_sym_id, binder));
+        let (sym_id, imported_module) =
+            self.resolve_call_expression_callee_symbol(call.expression, raw_sym_id, binder);
         let explicit_type_args = self.type_argument_list_source_text(call.type_arguments.as_ref());
         self.with_symbol_declarations(sym_id, |source_arena, decl_idx| {
             let decl_node = source_arena.get(decl_idx)?;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_declared_call.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_declared_call.rs
@@ -1,0 +1,98 @@
+use super::super::DeclarationEmitter;
+use tsz_binder::{BinderState, SymbolId};
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+
+impl<'a> DeclarationEmitter<'a> {
+    /// Resolve a call expression to the canonical callee symbol used for
+    /// emitter-side declaration lookups, following the same portability and
+    /// import-aliasing chain as the rest of this module. Also returns the
+    /// resolved import module specifier when the callee crosses a module
+    /// boundary, since several callers need both.
+    pub(in crate::declaration_emitter) fn resolve_call_expression_callee_symbol(
+        &self,
+        callee_expr: NodeIndex,
+        raw_sym_id: SymbolId,
+        binder: &BinderState,
+    ) -> (SymbolId, Option<String>) {
+        let imported_module = self
+            .imported_value_module_specifier(raw_sym_id, binder)
+            .or_else(|| self.imported_value_module_specifier_from_syntax(callee_expr));
+        let sym_id = self
+            .resolve_portability_import_alias(raw_sym_id, binder)
+            .or_else(|| {
+                imported_module.as_deref().and_then(|module_specifier| {
+                    self.imported_value_export_symbol_from_syntax(
+                        callee_expr,
+                        module_specifier,
+                        binder,
+                    )
+                })
+            })
+            .unwrap_or_else(|| self.resolve_portability_symbol(raw_sym_id, binder));
+        (sym_id, imported_module)
+    }
+
+    /// Returns true iff the callee's declared return type is a bare reference
+    /// to one of its own type parameters, for example `<T>(x: T): T`. Composed
+    /// returns like `` `${T}` ``, `T | undefined`, `T[]`, `{ v: T }`, or
+    /// `Promise<T>` return false; the initializer form is only safe when the
+    /// consumer can recover the result by re-inferring the type parameter from
+    /// the literal argument.
+    ///
+    /// The `type_arguments.is_some_and(...)` guard rejects `T<X>` shapes: a
+    /// bare type parameter cannot syntactically carry type arguments, so a
+    /// `TypeReference` that does is necessarily an alias or generic, not the
+    /// identity reference we accept.
+    pub(in crate::declaration_emitter) fn call_expression_returns_bare_type_parameter_reference(
+        &self,
+        initializer: NodeIndex,
+    ) -> bool {
+        let Some(init_node) = self.arena.get(initializer) else {
+            return false;
+        };
+        if init_node.kind != syntax_kind_ext::CALL_EXPRESSION {
+            return false;
+        }
+        let Some(call) = self.arena.get_call_expr(init_node) else {
+            return false;
+        };
+        let Some(binder) = self.binder else {
+            return false;
+        };
+        let Some(raw_sym_id) = self.value_reference_symbol(call.expression) else {
+            return false;
+        };
+        let (sym_id, _imported_module) =
+            self.resolve_call_expression_callee_symbol(call.expression, raw_sym_id, binder);
+
+        self.with_symbol_declarations(sym_id, |source_arena, decl_idx| {
+            let decl_node = source_arena.get(decl_idx)?;
+            let callable = Self::callable_decl_parts_from_node(source_arena, decl_node)?;
+            let return_idx = callable.type_annotation.into_option()?;
+            let type_params = callable.type_parameters?;
+            let return_node = source_arena.get(source_arena.skip_parenthesized(return_idx))?;
+            if return_node.kind != syntax_kind_ext::TYPE_REFERENCE {
+                return Some(false);
+            }
+            let type_ref = source_arena.get_type_ref(return_node)?;
+            if type_ref
+                .type_arguments
+                .as_ref()
+                .is_some_and(|ta| !ta.nodes.is_empty())
+            {
+                return Some(false);
+            }
+            let return_name = self.identifier_text_from_arena(source_arena, type_ref.type_name)?;
+            let matched = type_params.nodes.iter().any(|&param_idx| {
+                source_arena
+                    .get(param_idx)
+                    .and_then(|n| source_arena.get_type_parameter(n))
+                    .and_then(|tp| self.identifier_text_from_arena(source_arena, tp.name))
+                    .is_some_and(|name| name == return_name)
+            });
+            Some(matched)
+        })
+        .unwrap_or(false)
+    }
+}

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
@@ -881,6 +881,97 @@ const ts1 = ff2("foo", "bar");
 }
 
 #[test]
+fn declared_call_return_uses_annotation_for_single_placeholder_template_literal() {
+    let source = r#"
+declare function idTpl<T extends string>(x: T): `${T}`;
+const a = idTpl("foo");
+"#;
+    let output = emit_test_dts_with_binding(source);
+
+    assert!(output.contains("declare const a: \"foo\";"), "{output}");
+    assert!(!output.contains("declare const a = \"foo\";"), "{output}");
+}
+
+#[test]
+fn declared_call_return_uses_initializer_for_identity_type_parameter() {
+    let source = r#"
+declare function id<T extends string>(x: T): T;
+const b = id("foo");
+"#;
+    let output = emit_test_dts_with_binding(source);
+
+    assert!(output.contains("declare const b = \"foo\";"), "{output}");
+    assert!(!output.contains("declare const b: \"foo\";"), "{output}");
+}
+
+#[test]
+fn declared_call_return_uses_initializer_for_identity_with_renamed_type_parameter() {
+    // The structural rule must not depend on the chosen type-parameter name.
+    let source = r#"
+declare function id2<X extends string>(x: X): X;
+const c = id2("hello");
+"#;
+    let output = emit_test_dts_with_binding(source);
+
+    assert!(output.contains("declare const c = \"hello\";"), "{output}");
+    assert!(!output.contains("declare const c: \"hello\";"), "{output}");
+}
+
+#[test]
+fn declared_call_return_uses_annotation_for_union_with_undefined() {
+    // `T | undefined` is not an identity; the result is structurally composed
+    // even when one branch happens to be a literal.
+    let source = r#"
+declare function maybe<T extends string>(x: T): T | undefined;
+const u = maybe("foo");
+"#;
+    let output = emit_test_dts_with_binding(source);
+
+    assert!(!output.contains("declare const u = \"foo\";"), "{output}");
+}
+
+#[test]
+fn declared_call_return_uses_annotation_for_array_of_type_parameter() {
+    let source = r#"
+declare function wrapArr<T extends string>(x: T): T[];
+const arr = wrapArr("foo");
+"#;
+    let output = emit_test_dts_with_binding(source);
+
+    assert!(!output.contains("declare const arr = \"foo\";"), "{output}");
+}
+
+#[test]
+fn declared_call_return_uses_initializer_for_second_argument_identity() {
+    // The first arg is `any` so it can't supply T; T is bound from the
+    // second positional argument. Return type is still bare T, so the
+    // initializer form is recoverable.
+    let source = r#"
+declare function pickSecond<T extends string>(x: any, y: T): T;
+const s = pickSecond(42, "foo");
+"#;
+    let output = emit_test_dts_with_binding(source);
+
+    assert!(output.contains("declare const s = \"foo\";"), "{output}");
+    assert!(!output.contains("declare const s: \"foo\";"), "{output}");
+}
+
+#[test]
+fn declared_call_return_uses_annotation_for_object_type_return() {
+    // `{ value: T }` is a composed type, not a bare type-parameter reference.
+    let source = r#"
+declare function unwrapBox<T extends string>(x: T): { value: T };
+const wrapped = unwrapBox("foo");
+"#;
+    let output = emit_test_dts_with_binding(source);
+
+    assert!(
+        !output.contains("declare const wrapped = \"foo\";"),
+        "{output}"
+    );
+}
+
+#[test]
 fn returned_intrinsic_call_preserves_outer_type_parameter() {
     let source = r#"
 declare function foo3<T extends string>(x: Uppercase<T>): T;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -643,6 +643,7 @@ impl<'a> DeclarationEmitter<'a> {
                         initializer,
                         &type_text,
                     )
+                    && self.call_expression_returns_bare_type_parameter_reference(initializer)
                 {
                     self.write(" = ");
                     self.write(&type_text);


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Track 9 declaration emit / DTS parity: declaration-form selection for const-call literal initializers.

## Invariant
When the callee's declared return-type annotation is a bare reference to one of the function's own type parameters, `tsc` keeps the initializer form because the consumer can recover the result by re-inferring the type parameter from the literal argument. For any other return shape (template literal, union, array, object, intersection, generic application, etc.), `tsc` keeps the explicit annotation; this PR makes tsz follow that structural return-shape gate.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_declared_call.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs`

## Summary
Closes #12107.

Replace the rendered-literal-equality heuristic added by #12102 with a structural check on the callee's declared return-type annotation node. Composed-literal returns such as template literals, `T | undefined`, `T[]`, `{ value: T }`, and `Promise<T>` now keep the annotation form even when the result happens to render to the same primitive literal as one of the arguments.

## Adjacent Case Matrix
- Reported repro: single-placeholder template literal `<T>(x:T): `${T}`` keeps annotation form.
- Identity baseline: `<T>(x:T): T` keeps initializer form.
- Renamed type parameter: `<X>(x:X): X` keeps initializer form.
- Union with `undefined`: `<T>(x:T): T | undefined` keeps annotation form.
- Array-of-type-parameter: `<T>(x:T): T[]` keeps annotation form.
- Object-type return: `<T>(x:T): { value: T }` keeps annotation form.
- Second-argument identity: `<T>(x:any, y:T): T` keeps initializer form independently of argument position.

## Owner Layer
Declaration emitter type-inference/public surface selection. The structural return-shape gate lives in `type_inference_declared_call.rs`; `variable_decl.rs` consumes it when deciding whether a const call can reuse an initializer literal. It reuses a shared `resolve_call_expression_callee_symbol` helper for portability/import-alias resolution. It does not add checker diagnostics, solver relation checks, semantic validation during printing, or output surgery.

## Known Limitation / Follow-Up
The structural check is syntactic over the source declaration's AST. It does not see through type aliases such as `type Id<T> = T; function f<T>(x:T): Id<T>`. A future PR can route this through a solver/query-boundary helper that asks whether the resolved signature return `TypeId` is the identity of an inferred type parameter.

## Project Corpus Impact
- Row: n/a
- Bug family: DTS declaration-form selection for const-call literal initializers
- Evidence: issue #12107 / emit conformance-only DTS parity slice; no benchmark project row is affected.

## Verification
- Earlier on this PR: `cargo test -p tsz-emitter --lib declared_call_return` -> 20/20 pass.
- Earlier on this PR: `cargo check -p tsz-emitter` -> clean.
- After CI lint failure on head `64b4622942`: `cargo fmt --check`; `git diff --check`; `python3 scripts/arch/arch_guard.py`; `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`.
- CI lint failure root cause was the emitter boundary size ratchet: `type_inference.rs` was 2920 lines vs limit 2846. The follow-up split leaves `type_inference.rs` at 2828 lines.
- After syncing with current `origin/main` on 2026-06-01: `git diff --check origin/main...HEAD`; `cargo fmt --check`; `python3 scripts/arch/arch_guard.py`.
- Rebased/synced onto current `main`; head `6ad4df1164`.
- Exact-head CI restarted after the latest push; do not add `merge-queue` until `CI Summary` and `GitGuardian Security Checks` are green for this head.

## Coordination Notes
- AgentName: Studio-D.
- Ready PR, no stacked dependencies.
- Original issue #12107 is labeled `agent:Studio-D`; this PR should close it on merge.
- No roadmap update: focused DTS parity fix through an emitter declaration-form boundary.
