### PR TITLE
fix(dts): require symbol identity for recursive alias parens

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_type_value_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_type_value_declarations.rs
@@ -54,7 +54,7 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         self.write(" = ");
-        self.emit_type_alias_rhs(alias.name, alias.type_node);
+        self.emit_type_alias_rhs(alias_idx, alias.type_node);
         self.write(";");
         self.write_line();
     }

--- a/crates/tsz-emitter/src/declaration_emitter/exports/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/exports/mod.rs
@@ -1911,7 +1911,7 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         self.write(" = ");
-        self.emit_type_alias_rhs(alias.name, alias.type_node);
+        self.emit_type_alias_rhs(alias_idx, alias.type_node);
         self.write(";");
         self.write_line();
     }

--- a/crates/tsz-emitter/src/declaration_emitter/tests/infer_paren_and_union_intersection.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/infer_paren_and_union_intersection.rs
@@ -207,6 +207,19 @@ fn parenthesized_recursive_array_alias_reference_keeps_parens_renamed() {
     );
 }
 
+#[test]
+fn parenthesized_array_element_type_parameter_same_name_as_alias_strips_parens() {
+    // The alias name and type parameter intentionally share spelling. The
+    // array element resolves to the type parameter symbol, not the alias
+    // symbol, so tsc strips the unnecessary source parens.
+    let output = emit_dts_with_binding("export type Recursive<Recursive> = (Recursive)[];");
+    assert!(
+        output.contains("type Recursive<Recursive> = Recursive[];")
+            && !output.contains("= (Recursive)[];"),
+        "same-spelled non-alias symbol must not keep recursive-alias parens: {output}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Fix C: a *bare* intersection member of a union keeps its source spelling
 // (`T | T & undefined` stays unparenthesized), while a *source-parenthesized*

--- a/crates/tsz-emitter/src/declaration_emitter/type_emission_alias_rhs.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/type_emission_alias_rhs.rs
@@ -1,25 +1,24 @@
 //! Type-alias RHS helpers for declaration type syntax emission.
 
 use super::DeclarationEmitter;
-use tsz_common::Atom;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 
 impl<'a> DeclarationEmitter<'a> {
     pub(in crate::declaration_emitter) fn emit_type_alias_rhs(
         &mut self,
-        alias_name: NodeIndex,
+        alias_idx: NodeIndex,
         type_idx: NodeIndex,
     ) {
-        if self.emit_parenthesized_recursive_array_alias_rhs(alias_name, type_idx) {
+        if self.emit_parenthesized_array_reference_alias_rhs(alias_idx, type_idx) {
             return;
         }
         self.emit_type(type_idx);
     }
 
-    fn emit_parenthesized_recursive_array_alias_rhs(
+    fn emit_parenthesized_array_reference_alias_rhs(
         &mut self,
-        alias_name: NodeIndex,
+        alias_idx: NodeIndex,
         type_idx: NodeIndex,
     ) -> bool {
         let Some(type_node) = self.arena.get(type_idx) else {
@@ -34,53 +33,38 @@ impl<'a> DeclarationEmitter<'a> {
         let Some(element_node) = self.arena.get(array_type.element_type) else {
             return false;
         };
-        let source_parenthesized_element = element_node.kind == syntax_kind_ext::PARENTHESIZED_TYPE
-            || self.array_type_source_wraps_element(type_node.pos, type_node.end);
-        if !source_parenthesized_element {
+        if element_node.kind != syntax_kind_ext::PARENTHESIZED_TYPE {
             return false;
         }
-        let inner = if element_node.kind == syntax_kind_ext::PARENTHESIZED_TYPE {
-            self.peel_paren(array_type.element_type)
-        } else {
-            array_type.element_type
-        };
+        let inner = self.peel_paren(array_type.element_type);
         let Some(inner_node) = self.arena.get(inner) else {
             return false;
         };
         let Some(type_ref) = self.arena.get_type_ref(inner_node) else {
             return false;
         };
-        if !self.type_reference_matches_alias_symbol(type_ref.type_name, alias_name) {
-            return false;
+        if self.type_reference_matches_alias_symbol(type_ref.type_name, alias_idx) {
+            self.write("(");
+            self.emit_type(inner);
+            self.write(")[]");
+        } else {
+            self.emit_type(inner);
+            self.write("[]");
         }
-
-        self.write("(");
-        self.emit_type(inner);
-        self.write(")[]");
         true
-    }
-
-    fn array_type_source_wraps_element(&self, pos: u32, end: u32) -> bool {
-        self.get_source_slice(pos, end)
-            .is_some_and(|source| source.starts_with('(') && source.ends_with(")[]"))
     }
 
     fn type_reference_matches_alias_symbol(
         &self,
         type_name: NodeIndex,
-        alias_name: NodeIndex,
+        alias_idx: NodeIndex,
     ) -> bool {
         let Some(binder) = self.binder else {
             return false;
         };
-        let alias_text = self.identifier_text_from_arena(self.arena, alias_name);
         let type_name_text = self.identifier_text_from_arena(self.arena, type_name);
 
-        let alias_symbol = binder.get_node_symbol(alias_name).or_else(|| {
-            alias_text
-                .as_deref()
-                .and_then(|name| self.resolve_identifier_symbol(alias_name, name))
-        });
+        let alias_symbol = binder.get_node_symbol(alias_idx);
         let type_symbol = binder.get_node_symbol(type_name).or_else(|| {
             type_name_text
                 .as_deref()
@@ -91,24 +75,6 @@ impl<'a> DeclarationEmitter<'a> {
             return alias_symbol == type_symbol;
         }
 
-        self.identifier_atoms_match(alias_name, type_name)
-    }
-
-    fn identifier_atoms_match(&self, left: NodeIndex, right: NodeIndex) -> bool {
-        let Some(left_ident) = self
-            .arena
-            .get(left)
-            .and_then(|node| self.arena.get_identifier(node))
-        else {
-            return false;
-        };
-        let Some(right_ident) = self
-            .arena
-            .get(right)
-            .and_then(|node| self.arena.get_identifier(node))
-        else {
-            return false;
-        };
-        left_ident.atom != Atom::NONE && left_ident.atom == right_ident.atom
+        false
     }
 }


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Track 9 declaration emit / DTS parity follow-up to merged #12111.

## Invariant
When a type-alias RHS is an array type whose element is a parsed source-parenthesized type reference to the alias declaration's own symbol, `tsc` preserves one paren layer as `(Alias)[]`; when the same spelling resolves to a different symbol, tsz must normalize to `Name[]`.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/type_emission_alias_rhs.rs`
- `crates/tsz-emitter/src/declaration_emitter/core/emit_type_value_declarations.rs`
- `crates/tsz-emitter/src/declaration_emitter/exports/mod.rs`
- `crates/tsz-emitter/src/declaration_emitter/tests/infer_paren_and_union_intersection.rs`

## Owner Layer
Direct declaration type printer syntax preservation. The helper uses parsed `PARENTHESIZED_TYPE` wrappers and binder symbol identity between the alias declaration node and RHS type-reference resolution. It does not use raw source slices, same-name/atom fallback, checker diagnostics, solver evaluation, semantic validation during printing, or output surgery.

## Project Corpus Impact
- Row: n/a
- Bug family: DTS recursive type alias formatting (`recursiveTypeReferences1`)
- Evidence: declaration-printer-only review follow-up; no project corpus row is affected.

## Verification
- On the pre-merge parent branch before cherry-picking this exact fix onto `origin/main`: `cargo fmt --check`; `git diff --check`; blocker-pattern `rg` returned no matches; focused `cargo nextest run -p tsz-emitter -E 'test(parenthesized_recursive_array_alias_reference_keeps_parens) or test(parenthesized_array_element_type_parameter_same_name_as_alias_strips_parens) or test(parenthesized_array_element_reference_strips_parens)'` passed 5/5.
- On this `origin/main` follow-up branch after cherry-pick: `git diff --check origin/main...HEAD`; blocker-pattern `rg` returned no matches.
- Did not rerun build/test on this branch because disk fell to ~267 MiB free after the previous focused build; ready CI should verify the exact head.

## Coordination Notes
- #12111 merged at old head `e11d23faa3` before the review fix could take effect. This PR carries only the Reviewer-blocker repair on top of current `origin/main`.
- Addresses Reviewer comments #issuecomment-4591824565 and #issuecomment-4591864899: removes raw source-slice paren detection and same-name/atom fallback, and adds a same-spelled alias/type-parameter negative test.
- #12115 should be restacked on this branch before it advances.
- No roadmap update: focused DTS parity follow-up within the existing declaration-printer boundary.
