### PR TITLE
test(parser): cover nested generic angle-bracket chains in type positions

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -102,6 +102,9 @@ mod parser_improvement_merging_no_duplicate_tests;
 #[path = "../../tests/parser_improvement_misc_statement_recovery_tests.rs"]
 mod parser_improvement_misc_statement_recovery_tests;
 #[cfg(test)]
+#[path = "../../tests/parser_improvement_nested_generic_chain_tests.rs"]
+mod parser_improvement_nested_generic_chain_tests;
+#[cfg(test)]
 #[path = "../../tests/parser_improvement_nullable_type_recovery_tests.rs"]
 mod parser_improvement_nullable_type_recovery_tests;
 #[cfg(test)]

--- a/crates/tsz-parser/tests/parser_improvement_nested_generic_chain_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_nested_generic_chain_tests.rs
@@ -1,0 +1,157 @@
+//! Regression coverage for deeply nested generic angle-bracket chains in
+//! *type positions* (issue #11322).
+//!
+//! `parser_improvement_jsx_recovery_tests.rs` already covers the
+//! `look_ahead_is_generic_arrow_function` depth tracker (`<T extends …>(…) =>`
+//! shapes in `.tsx`) and the ambient-context JSX suppression added in PR #12112.
+//! This file covers the *type positions* — type alias RHS, parameter and return
+//! annotations, variable annotations, class heritage, mapped types, conditional
+//! types with `infer`, type-arguments to call/`new`, and `as`/`satisfies` — that
+//! flow through `parse_type_arguments` / `parse_expected_greater_than` and were
+//! not exercised by the original PR.
+
+use crate::parser::test_fixture::assert_no_errors;
+
+// ---------------------------------------------------------------------------
+// Type alias RHS — the position named in issue #11322.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn type_alias_nested_awaited_chain() {
+    assert_no_errors("type F<T> = Awaited<Promise<Promise<Promise<Promise<T>>>>>;");
+}
+
+#[test]
+fn type_alias_with_multi_arg_inner_generic() {
+    // The inner `Map<string, …>` ends with `>>` — the inner type must absorb
+    // one `>` so the outer alias's `>` remains for its own close.
+    assert_no_errors("type G<U> = Awaited<Promise<Map<string, Promise<U>>>>;");
+}
+
+#[test]
+fn type_alias_array_of_array_chain() {
+    // Same closing-token shape (`>>>>`) with a non-Promise leaf identifier so
+    // the rule isn't anchored to the Awaited/Promise family.
+    assert_no_errors("type F<T> = Array<Array<Array<Array<T>>>>;");
+}
+
+#[test]
+fn type_alias_mixed_utility_chain() {
+    assert_no_errors("type F<T> = Partial<Required<Readonly<Pick<T, keyof T>>>>;");
+}
+
+// ---------------------------------------------------------------------------
+// Function signatures — parameter and return annotations.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn function_parameter_nested_generic_chain() {
+    assert_no_errors("function f<T>(x: Awaited<Promise<Promise<T>>>): void {}");
+}
+
+#[test]
+fn function_return_type_nested_generic_chain() {
+    assert_no_errors("declare function f<T>(x: T): Awaited<Promise<Promise<T>>>;");
+}
+
+#[test]
+fn function_multiple_nested_parameter_annotations() {
+    assert_no_errors("function f<A, B>(x: Map<A, Array<B>>, y: Array<Map<A, B>>): void {}");
+}
+
+#[test]
+fn arrow_function_with_nested_generic_parameter() {
+    assert_no_errors("const f = <T,>(x: Awaited<Promise<Promise<T>>>): T => x as T;");
+}
+
+// ---------------------------------------------------------------------------
+// Class declarations — heritage clauses and field/method annotations.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn class_extends_nested_generic_heritage() {
+    assert_no_errors(
+        "class Base<T> {} class A extends Base<Map<string, Map<string, Map<string, number>>>> {}",
+    );
+}
+
+#[test]
+fn class_method_nested_generic_signature() {
+    assert_no_errors(
+        "class A<T> { m(x: Map<string, Array<T>>): Map<string, Array<T>> { return x; } }",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Type assertions, casts, and `satisfies` at depth-4 close (`>>>>`).
+//
+// `parser_improvement_satisfies_generic_chain_tests.rs` already covers depth-3
+// closes; this file pushes one position deeper.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn as_expression_with_deep_nested_chain() {
+    assert_no_errors("const x = value as Array<Array<Array<Array<string>>>>;");
+}
+
+#[test]
+fn old_style_type_assertion_with_nested_generic() {
+    // `<T>expr` form (non-JSX file): the assertion's own `>` must remain after
+    // the inner generics' compound `>` closes are absorbed.
+    assert_no_errors("const x = <Array<Array<Array<string>>>>value;");
+}
+
+#[test]
+fn satisfies_with_deep_nested_chain() {
+    assert_no_errors("const x = value satisfies Map<string, Map<string, Map<string, number>>>;");
+}
+
+// ---------------------------------------------------------------------------
+// Conditional types with `infer` and nested utility chains.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn conditional_type_with_deep_nested_infer() {
+    assert_no_errors("type Unwrap<T> = T extends Promise<Promise<Promise<infer U>>> ? U : never;");
+}
+
+#[test]
+fn nested_conditional_with_nested_utility_chain() {
+    // Three-arm nested conditional with the same nested-utility shape inside
+    // each branch — exercises the conditional-arm type-position parser path
+    // crossing nested `>>>` closes in each arm.
+    assert_no_errors(
+        "type C<T> = T extends string ? Awaited<Promise<T>> \
+         : T extends number ? Awaited<Promise<T>> \
+         : Awaited<Promise<T>>;",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Mapped types with nested utility on the value side. Iteration variable is
+// renamed `P` (not `K`) once to prove the rule isn't anchored to a name a
+// future printer-driven decision might pattern-match on (CLAUDE.md §25).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mapped_type_with_nested_utility_value() {
+    assert_no_errors("type Wrap<T> = { [P in keyof T]: Awaited<Promise<Promise<T[P]>>> };");
+}
+
+// ---------------------------------------------------------------------------
+// Type-argument lists on call and `new` expressions.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn call_expression_with_nested_generic_type_arguments() {
+    assert_no_errors(
+        "declare function f<T>(): T; const x = f<Awaited<Promise<Promise<string>>>>();",
+    );
+}
+
+#[test]
+fn new_expression_with_nested_generic_type_arguments() {
+    assert_no_errors(
+        "declare class C<T> {} const x = new C<Map<string, Array<Promise<number>>>>();",
+    );
+}


### PR DESCRIPTION
## Agent

m3-max-64g-opus47 (agent:M4-D lane — issue's existing owner label)

## Track

parser — regression coverage for `parse_type_arguments` / `parse_expected_greater_than` in type positions

## Invariant

A type position containing a chain of generic utility types nested deeply enough that closing `>` characters collapse into compound shift-like tokens (`>>`, `>>>`, `>>>>`) must parse without diagnostics in every position where a type is accepted.

## Scope

`crates/tsz-parser/tests/parser_improvement_nested_generic_chain_tests.rs` (new) and `crates/tsz-parser/src/parser/mod.rs` (3-line registration). No parser, scanner, checker, solver, or emitter source changes.

## Summary

Closes #11322.

PR #12112 added compound-`>` depth tracking to `look_ahead_is_generic_arrow_function` (and ambient-context JSX suppression) and locked the behavior in `parser_improvement_jsx_recovery_tests.rs:1183-1349` — but only for the `.tsx` generic-arrow lookahead path.

The orthogonal `parse_type_arguments` / `parse_expected_greater_than` path that handles type-position parsing (where the inner type absorbs one `>` from a compound and re-buckets the remainder) had no explicit regression coverage. Issue #11322's title ("utility-types-project: parser nested Awaited angle-bracket chain recovery") points at exactly this gap.

The reported reproducer parses cleanly on `main`; this PR locks that behavior so future scanner/parser refactors cannot silently regress it.

## Structural rule

> When a type position contains a chain of generic utility types nested deeply enough that the closing `>` characters collapse into compound shift-like tokens (`>>`, `>>>`, `>>>>`), the parser must successfully parse the entire chain without diagnostics in every position where a type is accepted (type alias RHS, parameter and return annotations, class heritage, mapped types, conditional types with `infer`, type-arguments to call/`new`, and `as`/`satisfies`).

## Adjacent-case test matrix (per §26)

18 tests covering positions PR #12112 left untouched:

| Section | Tests | Notes |
| --- | ---: | --- |
| Type alias RHS | 4 | Includes the position named in #11322, plus multi-arg-inner, non-Promise-leaf, and mixed-utility variants |
| Function signatures | 4 | param + return + multi-param + arrow |
| Class declarations | 2 | `extends` heritage + method signature |
| `as` / `<T>expr` / `satisfies` at depth-4 close (`>>>>`) | 3 | One position deeper than `parser_improvement_satisfies_generic_chain_tests.rs` |
| Conditional types | 2 | Deep nested `infer` + three-arm nested conditional with utility chain |
| Mapped type | 1 | Iteration variable renamed `P` (not `K`) per §25 |
| Call / `new` type-argument lists | 2 | distinct parser entry points |

## Owner layer

Lives entirely in `crates/tsz-parser/tests/`. Per the existing crate convention every regression area gets its own `parser_improvement_*` file (compare neighbors like `parser_improvement_satisfies_generic_chain_tests.rs` and `parser_improvement_jsx_recovery_tests.rs`).

## Project Corpus Impact

- Row: n/a (no benchmark-row failures referenced by the issue, and the reported repro already parses cleanly on `main`)
- Bug family: parser angle-bracket close in nested-generic type positions
- Evidence: `cargo test -p tsz-parser --lib` → 1235/1235 pass (18 new + 1217 pre-existing); `cargo clippy -p tsz-parser --tests --all-features -- -D warnings` → clean.

## Verification

- [x] `cargo test -p tsz-parser --lib parser_improvement_nested_generic_chain_tests` — 18/18 pass
- [x] `cargo test -p tsz-parser --lib` — 1235/1235 pass
- [x] `cargo clippy -p tsz-parser --tests --all-features -- -D warnings` — clean
- [x] `/simplify` driven 3 times before opening (47 → 22 → 20 → 18 tests after pass-1/2/3 deduping against sibling test files and dropping shallow rename pairs)
- [x] Rebased onto current `main`; head 008c004

## Coordination Notes

AgentName: m3-max-64g-opus47. WIP label removed from issue #11322 before merge. No stacked dependencies. Auto-merge SQUASH will be requested. Issue's existing `agent:M4-D` ownership label applied to this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRWFZ3FkF2RZkMnZB2gkvJ)_