### PR TITLE
fix(emit): capture static this for nested class computed names

### DIFF
--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -1015,6 +1015,9 @@ impl<'a> Printer<'a> {
         if let Some((_, alias)) = &self.scoped_class_expression_self_alias {
             es5_emitter.set_outer_reserved_for_generator_state(vec![alias.as_ref().to_string()]);
         }
+        if let Some(alias) = &self.scoped_static_this_alias {
+            es5_emitter.set_inherited_computed_name_this(alias.as_ref().to_string());
+        }
 
         let mut outer_rename_map = self.ctx.block_scope_state.visible_outer_rename_map();
         for (class_name, class_alias) in &self.scoped_class_expression_self_alias_ancestors {

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -1133,7 +1133,7 @@ impl<'a> Printer<'a> {
         let emits_as_class_expression = is_class_expression || assignment_prefix.is_some();
         let needs_private_comma_expr = is_class_expression && has_any_private_lowering;
 
-        // Computed property name hoisting for targets < ES2022.
+        // Computed property name hoisting for class fields that will be lowered.
         // tsc hoists non-constant computed property name expressions to temp variables
         // (e.g., `_a = n, _b = s + n`) so that the evaluation order is preserved and
         // the class body can reference the temp instead of the original expression.
@@ -1141,8 +1141,7 @@ impl<'a> Printer<'a> {
         // Only PROPERTY DECLARATIONS with computed names participate in hoisting.
         // Methods and accessors keep their computed names inline in ES6+.
         // After the class body, a comma expression joins all assignments and side effects.
-        let needs_computed_prop_hoisting =
-            (self.ctx.options.target as u32) < (ScriptTarget::ES2022 as u32);
+        let needs_computed_prop_hoisting = target_needs_field_lowering;
         // Each entry: (Option<temp_name>, expr_idx, member_idx) — None means side-effect only
         let mut computed_prop_entries: Vec<(Option<String>, NodeIndex, NodeIndex)> = Vec::new();
         if needs_computed_prop_hoisting {
@@ -1432,6 +1431,28 @@ impl<'a> Printer<'a> {
             computed_prop_entries_consumed_by_member_name.push(entry_idx);
         }
 
+        let native_computed_prop_evaluator = if emits_as_class_expression
+            && needs_computed_prop_hoisting
+            && !target_needs_static_block_lowering
+        {
+            computed_prop_entries
+                .iter()
+                .enumerate()
+                .any(|(entry_idx, _)| {
+                    !computed_prop_entries_consumed_by_member_name.contains(&entry_idx)
+                })
+                .then(|| self.make_unique_name_hoisted())
+        } else {
+            None
+        };
+        if native_computed_prop_evaluator.is_some() {
+            for entry_idx in 0..computed_prop_entries.len() {
+                if !computed_prop_entries_consumed_by_member_name.contains(&entry_idx) {
+                    computed_prop_entries_consumed_by_member_name.push(entry_idx);
+                }
+            }
+        }
+
         let needs_computed_prop_comma_expr = emits_as_class_expression
             && computed_prop_entries
                 .iter()
@@ -1439,8 +1460,12 @@ impl<'a> Printer<'a> {
                 .any(|(entry_idx, _)| {
                     !computed_prop_entries_consumed_by_member_name.contains(&entry_idx)
                 });
-        let needs_any_comma_expr =
+        let needs_native_computed_prop_evaluator_comma_expr =
+            native_computed_prop_evaluator.is_some();
+        let needs_class_expr_temp =
             needs_static_comma_expr || needs_private_comma_expr || needs_computed_prop_comma_expr;
+        let needs_any_comma_expr =
+            needs_class_expr_temp || needs_native_computed_prop_evaluator_comma_expr;
         let class_expr_comma_needs_parens = needs_any_comma_expr
             && !self.emitting_concise_arrow_return_argument
             && self
@@ -1451,13 +1476,42 @@ impl<'a> Printer<'a> {
                     parent.kind != syntax_kind_ext::RETURN_STATEMENT
                         && parent.kind != syntax_kind_ext::PARENTHESIZED_EXPRESSION
                 });
-        let class_expr_temp = if needs_any_comma_expr {
+        if needs_native_computed_prop_evaluator_comma_expr {
+            if class_expr_comma_needs_parens {
+                self.write("(");
+            }
+            if let Some(evaluator) = native_computed_prop_evaluator.as_ref() {
+                self.write(evaluator);
+                self.write(" = () => { ");
+                let mut emitted_entry = false;
+                for (entry_idx, (temp_name, expr_idx, _)) in
+                    computed_prop_entries.iter().enumerate()
+                {
+                    if !computed_prop_entries_consumed_by_member_name.contains(&entry_idx) {
+                        continue;
+                    }
+                    if emitted_entry {
+                        self.write(", ");
+                    }
+                    emitted_entry = true;
+                    if let Some(temp) = temp_name {
+                        self.write(temp);
+                        self.write(" = ");
+                    }
+                    self.emit_expression(*expr_idx);
+                }
+                self.write("; },");
+                self.write_line();
+                self.increase_indent();
+            }
+        }
+        let class_expr_temp = if needs_class_expr_temp {
             let temp = if let Some(ref alias) = private_class_alias {
                 alias.clone()
             } else {
                 self.make_class_static_temp_name_hoisted(_idx)
             };
-            if class_expr_comma_needs_parens {
+            if class_expr_comma_needs_parens && !needs_native_computed_prop_evaluator_comma_expr {
                 self.write("(");
             }
             self.write(&temp);
@@ -1785,6 +1839,7 @@ impl<'a> Printer<'a> {
             target_supports_native_private_names,
             has_legacy_private_name_member_decorators,
             needs_computed_prop_hoisting,
+            native_computed_prop_evaluator: native_computed_prop_evaluator.as_deref(),
             private_fields: &private_fields,
             private_duplicate_conflicts: &private_duplicate_conflicts,
             auto_accessor_member_map: &auto_accessor_member_map,
@@ -1897,6 +1952,7 @@ impl<'a> Printer<'a> {
             externalized_static_initializer_uses_undefined_receiver,
             computed_side_effects_emitted_in_static_block,
             class_expr_comma_needs_parens,
+            needs_native_computed_prop_evaluator_comma_expr,
             needs_computed_prop_comma_expr,
             needs_static_comma_expr,
             needs_private_comma_expr,

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6_after_body.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6_after_body.rs
@@ -21,6 +21,7 @@ pub(super) struct ClassEs6AfterBody<'a> {
     pub(super) externalized_static_initializer_uses_undefined_receiver: bool,
     pub(super) computed_side_effects_emitted_in_static_block: bool,
     pub(super) class_expr_comma_needs_parens: bool,
+    pub(super) needs_native_computed_prop_evaluator_comma_expr: bool,
     pub(super) needs_computed_prop_comma_expr: bool,
     pub(super) needs_static_comma_expr: bool,
     pub(super) needs_private_comma_expr: bool,
@@ -61,6 +62,7 @@ impl<'a> Printer<'a> {
             externalized_static_initializer_uses_undefined_receiver,
             computed_side_effects_emitted_in_static_block,
             class_expr_comma_needs_parens,
+            needs_native_computed_prop_evaluator_comma_expr,
             needs_computed_prop_comma_expr,
             needs_static_comma_expr,
             needs_private_comma_expr,
@@ -166,6 +168,15 @@ impl<'a> Printer<'a> {
                     self.emit_expression(*expr_idx);
                     self.write(";");
                 }
+            }
+        }
+        if needs_native_computed_prop_evaluator_comma_expr && class_expr_temp.is_none() {
+            self.decrease_indent();
+            if class_expr_comma_needs_parens {
+                self.write(")");
+            }
+            if assignment_prefix_is_some {
+                self.write(";");
             }
         }
 

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6_members.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6_members.rs
@@ -22,6 +22,7 @@ pub(super) struct ClassEs6MemberEmit<'a> {
     pub(super) target_supports_native_private_names: bool,
     pub(super) has_legacy_private_name_member_decorators: bool,
     pub(super) needs_computed_prop_hoisting: bool,
+    pub(super) native_computed_prop_evaluator: Option<&'a str>,
     pub(super) private_fields: &'a [PrivateFieldInfo],
     pub(super) private_duplicate_conflicts: &'a PrivateDuplicateConflictPlan,
     pub(super) auto_accessor_member_map: &'a FxHashMap<NodeIndex, (String, bool)>,
@@ -50,6 +51,7 @@ impl<'a> Printer<'a> {
             target_supports_native_private_names,
             has_legacy_private_name_member_decorators,
             needs_computed_prop_hoisting,
+            native_computed_prop_evaluator,
             private_fields,
             private_duplicate_conflicts,
             auto_accessor_member_map,
@@ -105,7 +107,18 @@ impl<'a> Printer<'a> {
             .unwrap_or(node.end);
 
         let mut field_init_comment_idx = 0usize;
+        let mut emitted_native_computed_prop_evaluator_call = false;
         for (member_i, &member_idx) in class.members.nodes.iter().enumerate() {
+            if let Some(evaluator) = native_computed_prop_evaluator
+                && !emitted_native_computed_prop_evaluator_call
+                && self.class_member_uses_computed_prop_temp(member_idx)
+            {
+                self.write("static { ");
+                self.write(evaluator);
+                self.write("(); }");
+                self.write_line();
+                emitted_native_computed_prop_evaluator_call = true;
+            }
             // Skip private field declarations entirely when lowering to WeakMap pattern
             if !private_fields.is_empty()
                 && let Some(member_node) = self.arena.get(member_idx)
@@ -664,5 +677,37 @@ impl<'a> Printer<'a> {
                 }
             }
         }
+    }
+
+    fn class_member_uses_computed_prop_temp(&self, member_idx: NodeIndex) -> bool {
+        let Some(member_node) = self.arena.get(member_idx) else {
+            return false;
+        };
+        let name_idx = match member_node.kind {
+            k if k == syntax_kind_ext::PROPERTY_DECLARATION => self
+                .arena
+                .get_property_decl(member_node)
+                .map(|prop| prop.name),
+            _ => None,
+        };
+        let Some(name_idx) = name_idx else {
+            return false;
+        };
+        let Some(name_node) = self.arena.get(name_idx) else {
+            return false;
+        };
+        if name_node.kind != syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+            return false;
+        }
+        let Some(computed) = self.arena.get_computed_property(name_node) else {
+            return false;
+        };
+        let expression = self
+            .arena
+            .get(computed.expression)
+            .filter(|node| node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION)
+            .and_then(|node| self.arena.get_parenthesized(node))
+            .map_or(computed.expression, |paren| paren.expression);
+        self.computed_prop_temp_map.contains_key(&expression)
     }
 }

--- a/crates/tsz-emitter/src/emitter/declarations/class_members.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class_members.rs
@@ -92,6 +92,24 @@ impl<'a> Printer<'a> {
                 .arena
                 .get(name)
                 .is_some_and(|n| n.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME);
+            if is_computed
+                && let Some(name_node) = self.arena.get(name)
+                && let Some(computed) = self.arena.get_computed_property(name_node)
+            {
+                let expression = self
+                    .arena
+                    .get(computed.expression)
+                    .filter(|node| node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION)
+                    .and_then(|node| self.arena.get_parenthesized(node))
+                    .map_or(computed.expression, |paren| paren.expression);
+                if let Some(temp_name) = self.computed_prop_temp_map.get(&expression).cloned() {
+                    self.write("[");
+                    self.write(&temp_name);
+                    self.write("]");
+                    self.scoped_class_expression_self_alias = prev_alias;
+                    return;
+                }
+            }
             // Suppress namespace/CJS-export qualification only when emitting a
             // non-computed class member name. Object-literal methods and
             // computed class names are runtime expressions and must still pick
@@ -581,9 +599,21 @@ impl<'a> Printer<'a> {
                     if let Some(computed) =
                         name_node.and_then(|n| self.arena.get_computed_property(n))
                     {
-                        self.emit_class_member_name_preserving_class_expression_name(
-                            computed.expression,
-                        );
+                        let expression = self
+                            .arena
+                            .get(computed.expression)
+                            .filter(|node| node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION)
+                            .and_then(|node| self.arena.get_parenthesized(node))
+                            .map_or(computed.expression, |paren| paren.expression);
+                        if let Some(temp_name) =
+                            self.computed_prop_temp_map.get(&expression).cloned()
+                        {
+                            self.write(&temp_name);
+                        } else {
+                            self.emit_class_member_name_preserving_class_expression_name(
+                                computed.expression,
+                            );
+                        }
                     }
                 } else {
                     self.emit_class_member_name_preserving_class_expression_name(prop.name);
@@ -595,9 +625,12 @@ impl<'a> Printer<'a> {
                 self.emit_class_member_name_preserving_class_expression_name(prop.name);
                 self.write(" = ");
             }
-            self.with_scoped_static_initializer_context_cleared(|this| {
-                this.emit(prop.initializer);
-            });
+            self.emit_expression_with_scoped_static_initializer_mode(
+                prop.initializer,
+                Some("this"),
+                None,
+                true,
+            );
             self.write("; }");
             return;
         }

--- a/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
@@ -31,7 +31,7 @@ pub(in crate::emitter) enum Es5StaticClassExpressionElement {
 }
 
 impl Es5StaticClassExpressionElement {
-    const fn member_pos(&self) -> u32 {
+    pub(in crate::emitter) const fn member_pos(&self) -> u32 {
         match self {
             Self::Field(field) => field.member_pos,
             Self::StaticBlock { member_pos, .. } => *member_pos,
@@ -158,7 +158,7 @@ impl<'a> Printer<'a> {
         })
     }
 
-    fn static_block_inner_comment_index(&self, member_node: &Node) -> usize {
+    pub(in crate::emitter) fn static_block_inner_comment_index(&self, member_node: &Node) -> usize {
         let brace_pos = if let Some(text) = self.source_text_for_map() {
             let bytes = text.as_bytes();
             let start = std::cmp::min(member_node.pos as usize, bytes.len());
@@ -318,20 +318,47 @@ impl<'a> Printer<'a> {
                     self.write(",");
                     self.write_line();
                     self.increase_indent();
-                    self.write(&temp);
-                    match &field.name_emit {
-                        PropertyNameEmit::Dot(name) => {
-                            self.write(".");
-                            self.write(name);
+                    if self.ctx.options.use_define_for_class_fields {
+                        self.write("Object.defineProperty(");
+                        self.write(&temp);
+                        self.write(", ");
+                        match &field.name_emit {
+                            PropertyNameEmit::Dot(name) => {
+                                self.write("\"");
+                                self.write(name);
+                                self.write("\"");
+                            }
+                            PropertyNameEmit::Bracket(name)
+                            | PropertyNameEmit::BracketNumeric(name) => {
+                                self.write(name);
+                            }
                         }
-                        PropertyNameEmit::Bracket(name)
-                        | PropertyNameEmit::BracketNumeric(name) => {
-                            self.write("[");
-                            self.write(name);
-                            self.write("]");
+                        self.write(", {");
+                        self.write_line();
+                        self.increase_indent();
+                        self.write("enumerable: true,");
+                        self.write_line();
+                        self.write("configurable: true,");
+                        self.write_line();
+                        self.write("writable: true,");
+                        self.write_line();
+                        self.write("value: ");
+                    } else {
+                        self.write(&temp);
+                        match &field.name_emit {
+                            PropertyNameEmit::Dot(name) => {
+                                self.write(".");
+                                self.write(name);
+                            }
+                            PropertyNameEmit::Bracket(name)
+                            | PropertyNameEmit::BracketNumeric(name) => {
+                                self.write("[");
+                                self.write(name);
+                                self.write("]");
+                            }
                         }
+                        self.write(" = ");
                     }
-                    self.write(" = ");
 
                     let prev_self_alias = self.scoped_class_expression_self_alias.clone();
                     if !class_name.is_empty() && class_name != temp {
@@ -355,6 +382,11 @@ impl<'a> Printer<'a> {
                             self.writer.truncate(before);
                             self.write(&replaced);
                         }
+                    }
+                    if self.ctx.options.use_define_for_class_fields {
+                        self.write_line();
+                        self.decrease_indent();
+                        self.write("})");
                     }
                     self.decrease_indent();
                 }
@@ -1452,7 +1484,10 @@ impl<'a> Printer<'a> {
         let use_static_comma = !static_elements.is_empty()
             && !self.ctx.options.use_define_for_class_fields
             && !defer_static_block_only_tail;
-        if use_static_comma || defer_static_block_only_tail {
+        let computed_instance_static_comma = self
+            .es5_class_expression_has_computed_instance_fields(class_data)
+            && self.es5_class_expression_has_static_runtime_elements(class_data);
+        if use_static_comma || defer_static_block_only_tail || computed_instance_static_comma {
             es5_emitter.set_skip_static_members(true);
         }
 
@@ -1489,12 +1524,19 @@ impl<'a> Printer<'a> {
                 self.make_class_static_temp_name_hoisted(class_node)
             };
 
-            let comma_static_elements = if use_static_comma {
+            let computed_static_elements = self
+                .es5_static_class_expression_elements_with_computed_temps(
+                    class_data,
+                    &computed_decls,
+                );
+            let comma_static_elements = if computed_instance_static_comma {
+                computed_static_elements.as_slice()
+            } else if use_static_comma {
                 static_elements.as_slice()
             } else {
                 &[]
             };
-            let comma_set_function_name = if use_static_comma {
+            let comma_set_function_name = if use_static_comma || computed_instance_static_comma {
                 class_expr_set_function_name.as_deref()
             } else {
                 None

--- a/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
@@ -6,38 +6,13 @@
 
 use super::super::*;
 use super::helpers::ArraySegment;
+use super::helpers_class_expression_static::Es5StaticClassExpressionElement;
 use crate::emitter::core::PropertyNameEmit;
 use crate::emitter::declarations::class::replace_identifier;
 use crate::transforms::emit_utils;
 use crate::transforms::ir::IRNode;
 use crate::transforms::ir_printer::IRPrinter;
 use std::sync::Arc;
-
-#[derive(Clone)]
-pub(in crate::emitter) struct Es5StaticClassExpressionField {
-    pub name_emit: PropertyNameEmit,
-    pub initializer: NodeIndex,
-    pub member_pos: u32,
-}
-
-#[derive(Clone)]
-pub(in crate::emitter) enum Es5StaticClassExpressionElement {
-    Field(Es5StaticClassExpressionField),
-    StaticBlock {
-        block: NodeIndex,
-        saved_comment_idx: usize,
-        member_pos: u32,
-    },
-}
-
-impl Es5StaticClassExpressionElement {
-    pub(in crate::emitter) const fn member_pos(&self) -> u32 {
-        match self {
-            Self::Field(field) => field.member_pos,
-            Self::StaticBlock { member_pos, .. } => *member_pos,
-        }
-    }
-}
 
 impl<'a> Printer<'a> {
     fn next_arguments_capture_name(&mut self) -> String {
@@ -48,134 +23,6 @@ impl<'a> Printer<'a> {
                 return candidate;
             }
         }
-    }
-
-    pub(in crate::emitter) fn es5_static_class_expression_elements(
-        &self,
-        class_data: &tsz_parser::parser::node::ClassData,
-    ) -> Vec<Es5StaticClassExpressionElement> {
-        let mut inits = Vec::new();
-
-        for &member_idx in &class_data.members.nodes {
-            let Some(member_node) = self.arena.get(member_idx) else {
-                continue;
-            };
-            if member_node.kind == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION {
-                inits.push(Es5StaticClassExpressionElement::StaticBlock {
-                    block: member_idx,
-                    saved_comment_idx: self.static_block_inner_comment_index(member_node),
-                    member_pos: member_node.pos,
-                });
-                continue;
-            }
-            if member_node.kind != syntax_kind_ext::PROPERTY_DECLARATION {
-                continue;
-            }
-            let Some(prop) = self.arena.get_property_decl(member_node) else {
-                continue;
-            };
-            if prop.initializer.is_none()
-                || !self.has_effective_static_modifier_js(&prop.modifiers)
-                || self
-                    .arena
-                    .has_modifier(&prop.modifiers, SyntaxKind::AccessorKeyword)
-                || self
-                    .arena
-                    .has_modifier(&prop.modifiers, SyntaxKind::AbstractKeyword)
-                || self
-                    .arena
-                    .has_modifier(&prop.modifiers, SyntaxKind::DeclareKeyword)
-                || self
-                    .arena
-                    .get(prop.name)
-                    .is_some_and(|n| n.kind == SyntaxKind::PrivateIdentifier as u16)
-            {
-                continue;
-            }
-
-            if let Some(name_emit) = self.get_property_name_emit(prop.name) {
-                inits.push(Es5StaticClassExpressionElement::Field(
-                    Es5StaticClassExpressionField {
-                        name_emit,
-                        initializer: prop.initializer,
-                        member_pos: member_node.pos,
-                    },
-                ));
-            }
-        }
-
-        inits.sort_by_key(Es5StaticClassExpressionElement::member_pos);
-        inits
-    }
-
-    fn es5_class_expression_has_instance_field_where(
-        &self,
-        class_data: &tsz_parser::parser::node::ClassData,
-        name_filter: impl Fn(NodeIndex) -> bool,
-    ) -> bool {
-        class_data.members.nodes.iter().copied().any(|member_idx| {
-            let Some(member_node) = self.arena.get(member_idx) else {
-                return false;
-            };
-            if member_node.kind != syntax_kind_ext::PROPERTY_DECLARATION {
-                return false;
-            }
-            let Some(prop) = self.arena.get_property_decl(member_node) else {
-                return false;
-            };
-            if self.has_effective_static_modifier_js(&prop.modifiers)
-                || self
-                    .arena
-                    .has_modifier(&prop.modifiers, SyntaxKind::AccessorKeyword)
-                || self
-                    .arena
-                    .has_modifier(&prop.modifiers, SyntaxKind::AbstractKeyword)
-                || self
-                    .arena
-                    .has_modifier(&prop.modifiers, SyntaxKind::DeclareKeyword)
-            {
-                return false;
-            }
-            name_filter(prop.name)
-        })
-    }
-
-    fn es5_class_expression_has_instance_fields(
-        &self,
-        class_data: &tsz_parser::parser::node::ClassData,
-    ) -> bool {
-        self.es5_class_expression_has_instance_field_where(class_data, |_| true)
-    }
-
-    fn es5_class_expression_has_computed_instance_fields(
-        &self,
-        class_data: &tsz_parser::parser::node::ClassData,
-    ) -> bool {
-        self.es5_class_expression_has_instance_field_where(class_data, |name_idx| {
-            self.arena
-                .get(name_idx)
-                .is_some_and(|n| n.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME)
-        })
-    }
-
-    pub(in crate::emitter) fn static_block_inner_comment_index(&self, member_node: &Node) -> usize {
-        let brace_pos = if let Some(text) = self.source_text_for_map() {
-            let bytes = text.as_bytes();
-            let start = std::cmp::min(member_node.pos as usize, bytes.len());
-            let end = std::cmp::min(member_node.end as usize, bytes.len());
-            bytes[start..end]
-                .iter()
-                .position(|&byte| byte == b'{')
-                .map(|offset| (start + offset + 1) as u32)
-                .unwrap_or(member_node.end)
-        } else {
-            member_node.end
-        };
-        let mut idx = self.comment_emit_idx;
-        while idx < self.all_comments.len() && self.all_comments[idx].end <= brace_pos {
-            idx += 1;
-        }
-        idx
     }
 
     fn es5_class_iife_expression_from_var(output: &str, class_name: &str) -> Option<String> {

--- a/crates/tsz-emitter/src/emitter/es5/helpers_class_expression_static.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_class_expression_static.rs
@@ -38,10 +38,10 @@ impl<'a> Printer<'a> {
                 && !self
                     .arena
                     .has_modifier(&prop.modifiers, SyntaxKind::DeclareKeyword)
-                && !self
+                && self
                     .arena
                     .get(prop.name)
-                    .is_some_and(|n| n.kind == SyntaxKind::PrivateIdentifier as u16)
+                    .is_none_or(|n| n.kind != SyntaxKind::PrivateIdentifier as u16)
         })
     }
 

--- a/crates/tsz-emitter/src/emitter/es5/helpers_class_expression_static.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_class_expression_static.rs
@@ -1,0 +1,134 @@
+//! ES5 class-expression static element scheduling helpers.
+
+use crate::emitter::Printer;
+use crate::emitter::core::PropertyNameEmit;
+use crate::emitter::es5::helpers_async::{
+    Es5StaticClassExpressionElement, Es5StaticClassExpressionField,
+};
+use tsz_parser::parser::node::ClassData;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
+
+impl<'a> Printer<'a> {
+    pub(in crate::emitter) fn es5_class_expression_has_static_runtime_elements(
+        &self,
+        class_data: &ClassData,
+    ) -> bool {
+        class_data.members.nodes.iter().any(|&member_idx| {
+            let Some(member_node) = self.arena.get(member_idx) else {
+                return false;
+            };
+            if member_node.kind == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION {
+                return true;
+            }
+            if member_node.kind != syntax_kind_ext::PROPERTY_DECLARATION {
+                return false;
+            }
+            let Some(prop) = self.arena.get_property_decl(member_node) else {
+                return false;
+            };
+            prop.initializer.is_some()
+                && self.has_effective_static_modifier_js(&prop.modifiers)
+                && !self
+                    .arena
+                    .has_modifier(&prop.modifiers, SyntaxKind::AccessorKeyword)
+                && !self
+                    .arena
+                    .has_modifier(&prop.modifiers, SyntaxKind::AbstractKeyword)
+                && !self
+                    .arena
+                    .has_modifier(&prop.modifiers, SyntaxKind::DeclareKeyword)
+                && !self
+                    .arena
+                    .get(prop.name)
+                    .is_some_and(|n| n.kind == SyntaxKind::PrivateIdentifier as u16)
+        })
+    }
+
+    pub(in crate::emitter) fn es5_static_class_expression_elements_with_computed_temps(
+        &self,
+        class_data: &ClassData,
+        computed_decls: &[String],
+    ) -> Vec<Es5StaticClassExpressionElement> {
+        let mut inits = Vec::new();
+        let mut computed_temps = computed_decls.iter();
+
+        for &member_idx in &class_data.members.nodes {
+            let Some(member_node) = self.arena.get(member_idx) else {
+                continue;
+            };
+            if member_node.kind == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION {
+                inits.push(Es5StaticClassExpressionElement::StaticBlock {
+                    block: member_idx,
+                    saved_comment_idx: self.static_block_inner_comment_index(member_node),
+                    member_pos: member_node.pos,
+                });
+                continue;
+            }
+            if member_node.kind != syntax_kind_ext::PROPERTY_DECLARATION {
+                continue;
+            }
+            let Some(prop) = self.arena.get_property_decl(member_node) else {
+                continue;
+            };
+            if prop.initializer.is_none()
+                || self
+                    .arena
+                    .has_modifier(&prop.modifiers, SyntaxKind::AccessorKeyword)
+                || self
+                    .arena
+                    .has_modifier(&prop.modifiers, SyntaxKind::AbstractKeyword)
+                || self
+                    .arena
+                    .has_modifier(&prop.modifiers, SyntaxKind::DeclareKeyword)
+                || self
+                    .arena
+                    .get(prop.name)
+                    .is_some_and(|n| n.kind == SyntaxKind::PrivateIdentifier as u16)
+            {
+                continue;
+            }
+
+            let computed_temp = self
+                .arena
+                .get(prop.name)
+                .and_then(|name| {
+                    (name.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME)
+                        .then(|| self.arena.get_computed_property(name))
+                        .flatten()
+                })
+                .and_then(|computed| {
+                    self.arena.get(computed.expression).and_then(|expr_node| {
+                        let is_constant = expr_node.kind == SyntaxKind::StringLiteral as u16
+                            || expr_node.kind == SyntaxKind::NumericLiteral as u16
+                            || expr_node.kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16;
+                        (!is_constant)
+                            .then(|| computed_temps.next().map(std::string::String::as_str))
+                            .flatten()
+                    })
+                });
+
+            if !self.has_effective_static_modifier_js(&prop.modifiers) {
+                continue;
+            }
+
+            let name_emit = if let Some(temp) = computed_temp {
+                Some(PropertyNameEmit::Bracket(temp.to_string()))
+            } else {
+                self.get_property_name_emit(prop.name)
+            };
+            if let Some(name_emit) = name_emit {
+                inits.push(Es5StaticClassExpressionElement::Field(
+                    Es5StaticClassExpressionField {
+                        name_emit,
+                        initializer: prop.initializer,
+                        member_pos: member_node.pos,
+                    },
+                ));
+            }
+        }
+
+        inits.sort_by_key(Es5StaticClassExpressionElement::member_pos);
+        inits
+    }
+}

--- a/crates/tsz-emitter/src/emitter/es5/helpers_class_expression_static.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_class_expression_static.rs
@@ -2,14 +2,96 @@
 
 use crate::emitter::Printer;
 use crate::emitter::core::PropertyNameEmit;
-use crate::emitter::es5::helpers_async::{
-    Es5StaticClassExpressionElement, Es5StaticClassExpressionField,
-};
-use tsz_parser::parser::node::ClassData;
+use tsz_parser::parser::base::NodeIndex;
+use tsz_parser::parser::node::{ClassData, Node};
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
+#[derive(Clone)]
+pub(in crate::emitter) struct Es5StaticClassExpressionField {
+    pub name_emit: PropertyNameEmit,
+    pub initializer: NodeIndex,
+    pub member_pos: u32,
+}
+
+#[derive(Clone)]
+pub(in crate::emitter) enum Es5StaticClassExpressionElement {
+    Field(Es5StaticClassExpressionField),
+    StaticBlock {
+        block: NodeIndex,
+        saved_comment_idx: usize,
+        member_pos: u32,
+    },
+}
+
+impl Es5StaticClassExpressionElement {
+    pub(in crate::emitter) const fn member_pos(&self) -> u32 {
+        match self {
+            Self::Field(field) => field.member_pos,
+            Self::StaticBlock { member_pos, .. } => *member_pos,
+        }
+    }
+}
+
 impl<'a> Printer<'a> {
+    pub(in crate::emitter) fn es5_static_class_expression_elements(
+        &self,
+        class_data: &ClassData,
+    ) -> Vec<Es5StaticClassExpressionElement> {
+        let mut inits = Vec::new();
+
+        for &member_idx in &class_data.members.nodes {
+            let Some(member_node) = self.arena.get(member_idx) else {
+                continue;
+            };
+            if member_node.kind == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION {
+                inits.push(Es5StaticClassExpressionElement::StaticBlock {
+                    block: member_idx,
+                    saved_comment_idx: self.static_block_inner_comment_index(member_node),
+                    member_pos: member_node.pos,
+                });
+                continue;
+            }
+            if member_node.kind != syntax_kind_ext::PROPERTY_DECLARATION {
+                continue;
+            }
+            let Some(prop) = self.arena.get_property_decl(member_node) else {
+                continue;
+            };
+            if prop.initializer.is_none()
+                || !self.has_effective_static_modifier_js(&prop.modifiers)
+                || self
+                    .arena
+                    .has_modifier(&prop.modifiers, SyntaxKind::AccessorKeyword)
+                || self
+                    .arena
+                    .has_modifier(&prop.modifiers, SyntaxKind::AbstractKeyword)
+                || self
+                    .arena
+                    .has_modifier(&prop.modifiers, SyntaxKind::DeclareKeyword)
+                || self
+                    .arena
+                    .get(prop.name)
+                    .is_some_and(|n| n.kind == SyntaxKind::PrivateIdentifier as u16)
+            {
+                continue;
+            }
+
+            if let Some(name_emit) = self.get_property_name_emit(prop.name) {
+                inits.push(Es5StaticClassExpressionElement::Field(
+                    Es5StaticClassExpressionField {
+                        name_emit,
+                        initializer: prop.initializer,
+                        member_pos: member_node.pos,
+                    },
+                ));
+            }
+        }
+
+        inits.sort_by_key(Es5StaticClassExpressionElement::member_pos);
+        inits
+    }
+
     pub(in crate::emitter) fn es5_class_expression_has_static_runtime_elements(
         &self,
         class_data: &ClassData,
@@ -42,6 +124,24 @@ impl<'a> Printer<'a> {
                     .arena
                     .get(prop.name)
                     .is_none_or(|n| n.kind != SyntaxKind::PrivateIdentifier as u16)
+        })
+    }
+
+    pub(in crate::emitter) fn es5_class_expression_has_instance_fields(
+        &self,
+        class_data: &ClassData,
+    ) -> bool {
+        self.es5_class_expression_has_instance_field_where(class_data, |_| true)
+    }
+
+    pub(in crate::emitter) fn es5_class_expression_has_computed_instance_fields(
+        &self,
+        class_data: &ClassData,
+    ) -> bool {
+        self.es5_class_expression_has_instance_field_where(class_data, |name_idx| {
+            self.arena
+                .get(name_idx)
+                .is_some_and(|n| n.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME)
         })
     }
 
@@ -130,5 +230,57 @@ impl<'a> Printer<'a> {
 
         inits.sort_by_key(Es5StaticClassExpressionElement::member_pos);
         inits
+    }
+
+    pub(in crate::emitter) fn static_block_inner_comment_index(&self, member_node: &Node) -> usize {
+        let brace_pos = if let Some(text) = self.source_text_for_map() {
+            let bytes = text.as_bytes();
+            let start = std::cmp::min(member_node.pos as usize, bytes.len());
+            let end = std::cmp::min(member_node.end as usize, bytes.len());
+            bytes[start..end]
+                .iter()
+                .position(|&byte| byte == b'{')
+                .map(|offset| (start + offset + 1) as u32)
+                .unwrap_or(member_node.end)
+        } else {
+            member_node.end
+        };
+        let mut idx = self.comment_emit_idx;
+        while idx < self.all_comments.len() && self.all_comments[idx].end <= brace_pos {
+            idx += 1;
+        }
+        idx
+    }
+
+    fn es5_class_expression_has_instance_field_where(
+        &self,
+        class_data: &ClassData,
+        name_filter: impl Fn(NodeIndex) -> bool,
+    ) -> bool {
+        class_data.members.nodes.iter().copied().any(|member_idx| {
+            let Some(member_node) = self.arena.get(member_idx) else {
+                return false;
+            };
+            if member_node.kind != syntax_kind_ext::PROPERTY_DECLARATION {
+                return false;
+            };
+            let Some(prop) = self.arena.get_property_decl(member_node) else {
+                return false;
+            };
+            if self.has_effective_static_modifier_js(&prop.modifiers)
+                || self
+                    .arena
+                    .has_modifier(&prop.modifiers, SyntaxKind::AccessorKeyword)
+                || self
+                    .arena
+                    .has_modifier(&prop.modifiers, SyntaxKind::AbstractKeyword)
+                || self
+                    .arena
+                    .has_modifier(&prop.modifiers, SyntaxKind::DeclareKeyword)
+            {
+                return false;
+            }
+            name_filter(prop.name)
+        })
     }
 }

--- a/crates/tsz-emitter/src/emitter/es5/mod.rs
+++ b/crates/tsz-emitter/src/emitter/es5/mod.rs
@@ -19,6 +19,7 @@ mod helpers_async_promise;
 mod helpers_async_shadowing;
 mod helpers_class_expression_comments;
 mod helpers_class_expression_names;
+mod helpers_class_expression_static;
 mod helpers_object_literal;
 #[allow(dead_code)]
 pub(in crate::emitter) mod loop_capture;

--- a/crates/tsz-emitter/src/emitter/source_file/class_static_alias_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/class_static_alias_tests.rs
@@ -5,11 +5,19 @@ use tsz_common::ScriptTarget;
 use tsz_parser::ParserState;
 
 fn emit(source: &str, target: ScriptTarget) -> String {
+    emit_with_define(source, target, false)
+}
+
+fn emit_with_define(
+    source: &str,
+    target: ScriptTarget,
+    use_define_for_class_fields: bool,
+) -> String {
     let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
     let root = parser.parse_source_file();
     let options = PrinterOptions {
         target,
-        use_define_for_class_fields: false,
+        use_define_for_class_fields,
         ..Default::default()
     };
     let ctx = EmitContext::with_options(options.clone());
@@ -19,6 +27,55 @@ fn emit(source: &str, target: ScriptTarget) -> String {
     printer.set_source_text(source);
     printer.emit(root);
     printer.get_output().to_string()
+}
+
+#[test]
+fn es2015_nested_class_computed_names_use_enclosing_static_this_alias() {
+    let source = "class C {\n    static c = \"foo\";\n    static bar = class Inner {\n        static [this.c] = 123;\n        [this.c] = 456;\n    };\n}\n";
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains("class Inner {\n        constructor() {\n            this[_c] = 456;"),
+        "Instance computed field should use the captured computed-name temp in the constructor.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_b = _a.c,\n    _c = _a.c,\n") && output.contains("_d[_b] = 123,"),
+        "Computed names should evaluate against the enclosing static alias before static assignment.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es5_nested_class_computed_names_use_enclosing_static_this_alias() {
+    let source = "class C {\n    static c = \"foo\";\n    static bar = class Inner {\n        static [this.c] = 123;\n        [this.c] = 456;\n    };\n}\n";
+    let output = emit(source, ScriptTarget::ES5);
+
+    assert!(
+        output.contains("_b = _a.c, _c = _a.c,\n        _d[_b] = 123,"),
+        "ES5 computed names should evaluate against the enclosing static alias before static assignment.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("Inner[_b] = 123")
+            && !output.contains("_b = this.c")
+            && !output.contains("_c = this.c"),
+        "ES5 nested class computed names must not fall back to unbound `this` or run the static assignment before key evaluation.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es5_define_nested_class_computed_names_use_enclosing_static_this_alias() {
+    let source = "class C {\n    static c = \"foo\";\n    static bar = class Inner {\n        static [this.c] = 123;\n        [this.c] = 456;\n    };\n}\n";
+    let output = emit_with_define(source, ScriptTarget::ES5, true);
+
+    assert!(
+        output.contains("_b = _a.c, _c = _a.c,\n            Object.defineProperty(_d, _b, {"),
+        "ES5 define-mode static computed field should use the enclosing static alias for key evaluation.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("Object.defineProperty(Inner, _b")
+            && !output.contains("_b = this.c")
+            && !output.contains("_c = this.c"),
+        "ES5 define-mode computed names must not use unbound `this`.\nOutput:\n{output}"
+    );
 }
 
 #[test]

--- a/crates/tsz-emitter/src/emitter/source_file/class_static_alias_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/class_static_alias_tests.rs
@@ -79,6 +79,24 @@ fn es5_define_nested_class_computed_names_use_enclosing_static_this_alias() {
 }
 
 #[test]
+fn es2022_static_block_field_initializer_captures_nested_class_computed_names() {
+    let source = "class C {\n    static c = \"foo\";\n    static bar = class Inner {\n        static [this.c] = 123;\n        [this.c] = 456;\n    };\n}\n";
+    let output = emit(source, ScriptTarget::ES2022);
+
+    assert!(
+        output.contains("static { this.bar = (_c = () => { _a = this.c, _b = this.c; },"),
+        "Native static field block should capture nested class computed names against the enclosing `this`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("constructor() {")
+            && output.contains("this[_b] = 456;")
+            && output.contains("static { _c(); }")
+            && output.contains("static { this[_a] = 123; }"),
+        "Nested class fields should consume the captured keys in instance and static initializers.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn es2015_static_async_arrow_declares_class_alias_once() {
     let source = "class Test {\n    static member = async (x: string) => { };\n}\n";
     let output = emit(source, ScriptTarget::ES2015);

--- a/crates/tsz-emitter/src/transforms/class_es5.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5.rs
@@ -220,6 +220,11 @@ impl<'a> ClassES5Emitter<'a> {
             .set_inherited_computed_name_super(super_name);
     }
 
+    pub fn set_inherited_computed_name_this(&mut self, this_alias: String) {
+        self.transformer
+            .set_inherited_computed_name_this(this_alias);
+    }
+
     pub const fn set_tc39_decorators(&mut self, enabled: bool) {
         self.tc39_decorators = enabled;
         self.transformer.set_tc39_decorators(enabled);

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
@@ -11,7 +11,8 @@ use tsz_common::common::ModuleKind;
 use tsz_parser::parser::node::{FunctionData, Node};
 use tsz_parser::parser::node_flags;
 use tsz_parser::syntax::transform_utils::{
-    contains_new_target_reference, contains_super_reference,
+    collect_class_computed_name_this_references, contains_new_target_reference,
+    contains_super_reference,
 };
 
 #[path = "class_es5_ast_to_ir_classes.rs"]
@@ -242,6 +243,17 @@ impl<'a> AstToIr<'a> {
         let has_substitution = substitution.is_some();
         self.current_this_substitution.set(substitution);
         has_substitution
+    }
+
+    fn current_this_substitution_text(&self) -> Option<String> {
+        let substitution = self.current_this_substitution.take();
+        let text = substitution
+            .as_ref()
+            .map(|substitution| match substitution {
+                ThisSubstitution::Identifier(alias) | ThisSubstitution::Raw(alias) => alias.clone(),
+            });
+        self.current_this_substitution.set(substitution);
+        text
     }
 
     fn current_this_ir(&self) -> IRNode {
@@ -491,6 +503,19 @@ impl<'a> AstToIr<'a> {
                 self.convert_object_literal(idx)
             }
             k if k == syntax_kind_ext::FUNCTION_EXPRESSION => self.convert_function_expression(idx),
+            k if k == syntax_kind_ext::CLASS_EXPRESSION
+                && self.class_expression_has_computed_name_this(idx)
+                && self.has_current_this_substitution() =>
+            {
+                if let Some(this_alias) = self.current_this_substitution_text() {
+                    IRNode::ASTRefWithInheritedComputedNameThis {
+                        node: idx,
+                        this_alias: this_alias.into(),
+                    }
+                } else {
+                    IRNode::ASTRef(idx)
+                }
+            }
             k if k == syntax_kind_ext::CLASS_EXPRESSION
                 && self.has_super
                 && !self.is_static.get()

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_classes.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_classes.rs
@@ -81,6 +81,10 @@ impl<'a> AstToIr<'a> {
         })
     }
 
+    pub(super) fn class_expression_has_computed_name_this(&self, idx: NodeIndex) -> bool {
+        !collect_class_computed_name_this_references(self.arena, idx).is_empty()
+    }
+
     fn has_tc39_decorator_directive(&self, idx: NodeIndex) -> bool {
         self.transforms
             .as_ref()

--- a/crates/tsz-emitter/src/transforms/class_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir.rs
@@ -224,6 +224,9 @@ pub struct ES5ClassTransformer<'a> {
     /// static-context `<super>.m`. `None` for a top-level/static definition
     /// site, where computed names keep static-like super access.
     inherited_computed_name_super: Option<String>,
+    /// Raw expression used for `this` in computed property names when this
+    /// class expression is evaluated inside an enclosing static initializer.
+    inherited_computed_name_this: Option<String>,
 }
 
 impl<'a> ES5ClassTransformer<'a> {
@@ -269,6 +272,7 @@ impl<'a> ES5ClassTransformer<'a> {
             emit_computed_props_outside: Cell::new(false),
             outer_rename_map: FxHashMap::default(),
             inherited_computed_name_super: None,
+            inherited_computed_name_this: None,
         }
     }
 
@@ -284,6 +288,10 @@ impl<'a> ES5ClassTransformer<'a> {
     /// computed property names.
     pub fn set_inherited_computed_name_super(&mut self, super_name: String) {
         self.inherited_computed_name_super = Some(super_name);
+    }
+
+    pub fn set_inherited_computed_name_this(&mut self, this_alias: String) {
+        self.inherited_computed_name_this = Some(this_alias);
     }
 
     pub const fn set_use_define_for_class_fields(&mut self, enable: bool) {
@@ -1146,6 +1154,10 @@ impl<'a> ES5ClassTransformer<'a> {
             return IRNode::Raw(raw.into());
         }
 
+        if let Some(alias) = self.inherited_computed_name_this.as_ref() {
+            return self.convert_expression_static_with_raw_this_substitution(idx, alias);
+        }
+
         if is_static {
             self.convert_expression_static(idx)
         } else {
@@ -1786,7 +1798,11 @@ impl<'a> ES5ClassTransformer<'a> {
                 if consumed_computed_auto_accessor_entries.contains(&entry_idx) {
                     continue;
                 }
-                let expr_ir = self.convert_expression(*expr_idx);
+                let expr_ir = if let Some(alias) = self.inherited_computed_name_this.as_ref() {
+                    self.convert_expression_static_with_raw_this_substitution(*expr_idx, alias)
+                } else {
+                    self.convert_expression(*expr_idx)
+                };
                 if let Some(temp) = temp_name {
                     comma_parts.push(IRNode::assign(IRNode::id(temp.clone()), expr_ir));
                 } else {

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
@@ -10,10 +10,10 @@ use crate::transforms::ir::{
 use crate::transforms::ir_printer::IRPrinter;
 use rustc_hash::FxHashSet;
 use tsz_parser::parser::NodeIndex;
-use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::syntax::transform_utils::{
-    contains_async_arrow_function, contains_new_target_reference, is_private_identifier,
+    contains_async_arrow_function, contains_new_target_reference, contains_this_reference,
+    is_private_identifier,
 };
 use tsz_scanner::SyntaxKind;
 
@@ -1621,7 +1621,7 @@ impl<'a> ES5ClassTransformer<'a> {
                 }
                 // Async arrows in static initializers also need the class alias:
                 // tsc passes it to the downlevel `__generator` call as lexical `this`.
-                if self.contains_static_value_this_reference(prop_data.initializer)
+                if contains_this_reference(self.arena, prop_data.initializer)
                     || contains_async_arrow_function(self.arena, prop_data.initializer)
                 {
                     return true;
@@ -1630,7 +1630,7 @@ impl<'a> ES5ClassTransformer<'a> {
                 // Check if the static block body contains `this`
                 if let Some(block_data) = self.arena.get_block(member_node) {
                     for &stmt_idx in &block_data.statements.nodes {
-                        if self.contains_static_value_this_reference(stmt_idx)
+                        if contains_this_reference(self.arena, stmt_idx)
                             || contains_async_arrow_function(self.arena, stmt_idx)
                         {
                             return true;
@@ -1640,50 +1640,6 @@ impl<'a> ES5ClassTransformer<'a> {
             }
         }
         false
-    }
-
-    fn contains_static_value_this_reference(&self, idx: NodeIndex) -> bool {
-        let Some(node) = self.arena.get(idx) else {
-            return false;
-        };
-
-        if node.kind == SyntaxKind::ThisKeyword as u16 {
-            return true;
-        }
-
-        if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-            || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-            || node.kind == syntax_kind_ext::CLASS_DECLARATION
-            || node.kind == syntax_kind_ext::CLASS_EXPRESSION
-        {
-            return false;
-        }
-
-        if node.kind == syntax_kind_ext::VARIABLE_STATEMENT
-            || node.kind == syntax_kind_ext::VARIABLE_DECLARATION_LIST
-        {
-            let Some(var_data) = self.arena.get_variable(node) else {
-                return false;
-            };
-            return var_data
-                .declarations
-                .nodes
-                .iter()
-                .any(|&decl_idx| self.contains_static_value_this_reference(decl_idx));
-        }
-
-        if node.kind == syntax_kind_ext::VARIABLE_DECLARATION {
-            let Some(decl) = self.arena.get_variable_declaration(node) else {
-                return false;
-            };
-            return decl.initializer.is_some()
-                && self.contains_static_value_this_reference(decl.initializer);
-        }
-
-        self.arena
-            .get_children(idx)
-            .into_iter()
-            .any(|child_idx| self.contains_static_value_this_reference(child_idx))
     }
 
     pub(super) fn async_method_promise_constructor(

--- a/crates/tsz-emitter/src/transforms/ir.rs
+++ b/crates/tsz-emitter/src/transforms/ir.rs
@@ -561,6 +561,14 @@ pub enum IRNode {
         super_name: Cow<'static, str>,
     },
 
+    /// Reference to an original class expression whose computed property names
+    /// should inherit an enclosing static-initializer `this` binding while the
+    /// nested printer applies normal ES5 class-expression lowering.
+    ASTRefWithInheritedComputedNameThis {
+        node: NodeIndex,
+        this_alias: Cow<'static, str>,
+    },
+
     /// Reference to an original AST node with constrained source range.
     /// Used when the parser's node.end extends into a parent block's closing brace.
     ASTRefRange(NodeIndex, u32),
@@ -1237,6 +1245,7 @@ impl IRNode {
             | Self::ASTRefWithGeneratorThis { .. }
             | Self::ASTRefWithCapturedClassHeritageThis(_)
             | Self::ASTRefWithInheritedComputedNameSuper { .. }
+            | Self::ASTRefWithInheritedComputedNameThis { .. }
             | Self::ASTRefRange(..)
             | Self::UseStrict
             | Self::EsesModuleMarker => false,

--- a/crates/tsz-emitter/src/transforms/ir_printer.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer.rs
@@ -20,6 +20,7 @@
 
 use std::borrow::Cow;
 use std::fmt::Write;
+use std::sync::Arc;
 
 #[path = "ir_printer_class_emit.rs"]
 mod ir_printer_class_emit;
@@ -1742,6 +1743,28 @@ impl<'a> IRPrinter<'a> {
                     } else {
                         es5_emitter.emit_class_as_iife_expr(*node, "class_1").0
                     };
+                    if !output.trim().is_empty() {
+                        self.write_embedded_output(output.trim());
+                        return;
+                    }
+                }
+                self.write("undefined");
+            }
+
+            IRNode::ASTRefWithInheritedComputedNameThis { node, this_alias } => {
+                if let Some(arena) = self.arena {
+                    let mut printer = self.build_nested_ast_printer(arena);
+                    printer.scoped_static_this_alias = Some(Arc::<str>::from(this_alias.as_ref()));
+                    if let Some(counter) = Self::temp_counter_after_name(this_alias.as_ref()) {
+                        printer.ctx.destructuring_state.temp_var_counter = printer
+                            .ctx
+                            .destructuring_state
+                            .temp_var_counter
+                            .max(counter);
+                    }
+                    printer.emit_expression(*node);
+                    self.merge_ast_printer_block_scope_reserved_names(&printer);
+                    let output = printer.get_output();
                     if !output.trim().is_empty() {
                         self.write_embedded_output(output.trim());
                         return;

--- a/crates/tsz-emitter/src/transforms/ir_printer_helpers.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer_helpers.rs
@@ -7,6 +7,17 @@ use super::*;
 use tsz_parser::syntax_kind_ext;
 
 impl<'a> IRPrinter<'a> {
+    pub(super) fn temp_counter_after_name(name: &str) -> Option<u32> {
+        let rest = name.strip_prefix('_')?;
+        if rest.len() == 1 {
+            let ch = rest.as_bytes()[0];
+            if ch.is_ascii_lowercase() {
+                return Some(u32::from(ch - b'a') + 1);
+            }
+        }
+        rest.parse::<u32>().ok().map(|idx| idx + 1)
+    }
+
     /// Check if a body source range represents a single-line block in the source text.
     /// Uses brace depth counting to find the matching `}` and skips leading trivia.
     /// Check if a source range is on a single line (for object literals, etc.)


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
JavaScript emit parity: class/static transform family

## Invariant
When a class expression is evaluated inside an enclosing static initializer, computed member-name expressions in the nested class inherit the enclosing static receiver. This PR evaluates those computed names through emitter output planning before the nested class static field assignment runs, including native static-block field lowering.

## Owner Layer
Emitter output planning and class transform emission. The change stays in `tsz-emitter`, carries syntax/emit context through printer and IR/output-planning paths, and does not ask checker or solver for semantic facts.

## Scope
- Propagate enclosing static `this` into ES5 nested class-expression computed-name lowering.
- Schedule ES5 class-expression static elements with computed-name temps after the nested class expression, including `useDefineForClassFields` define-mode emission.
- Extend computed property-name hoisting to class fields lowered because `useDefineForClassFields=false`, including ES2022/ESNext native static-block output.
- For native static-block class-expression output, emit an enclosing-arrow evaluator for computed-name temps and call it from a synthetic static block before lowered fields consume those temps.
- Route native `static { this[expr] = ... }` field names through the computed-property temp map.
- Add focused emitter unit coverage for ES2015, ES5 assignment semantics, ES5 define-mode, and ES2022 native static-block nested class computed names.

## Adjacent Case Matrix
- ES2015 class expression in a static field with both static and instance computed names.
- ES5 class expression in a static field with assignment-style static field lowering.
- ES5 class expression in a static field with `useDefineForClassFields` / `Object.defineProperty` lowering.
- ES2022 `useDefineForClassFields=false` static field block whose initializer is a nested class expression with static and instance computed names.
- Existing adjacent static alias coverage still passes for static async arrows, static blocks, and mixin class-expression comma wrappers.

## Project Corpus Impact
- Row: emit conformance
- Bug family: nested class expression computed names inside static initializers (`typeOfThisInStaticMembers12/13` family)
- Evidence: targeted `tsz-emitter` unit coverage for class static alias behavior; refresh on head `968dbffb2abfb7b8f1cfba257e61ef68100fa842` stayed local-cheap and did not run full emit/conformance/fourslash suites.

## Verification
- Prior implementation: `cargo fmt --package tsz-emitter --check`
- Prior implementation: `cargo fmt --all --check`
- Prior implementation: `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo clippy --profile ci-lint -p tsz-emitter --all-targets -- -D warnings`
- Prior implementation: `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo nextest run -p tsz-emitter class_static_alias_tests`
- Prior implementation: `python3 scripts/arch/arch_guard.py`
- Prior head `ac8b8bbfe7`: `env CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target scripts/safe-run.sh cargo nextest run -p tsz-emitter --lib es2022_static_block_field_initializer_captures_nested_class_computed_names`
- Prior head `ac8b8bbfe7`: `env CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target scripts/safe-run.sh cargo nextest run -p tsz-emitter --lib class_static_alias_tests`
- Refresh on 2026-06-02: `git fetch origin main`
- Refresh on 2026-06-02: `git rebase origin/main` -> clean, no conflicts
- Refresh on 2026-06-02: `git diff --check origin/main...HEAD`
- Refresh on 2026-06-02: `cargo fmt --package tsz-emitter --check`
- Refresh on 2026-06-02: `python3 scripts/arch/arch_guard.py`
- Refresh on 2026-06-02: `cargo check -p tsz-emitter`
- Refresh on 2026-06-02: `git diff --name-status origin/main...HEAD`

## Known Unsupported Shapes / Fallback
No intentional stopgap. Static receiver inheritance is applied only to computed member-name evaluation for nested class expressions; ordinary nested static initializer bodies keep their own class receiver.

## Coordination Notes
- Studio-C / M5Manager refresh rebased branch `codex/studio-c-static-this-class-expr-20260601` from old head `ac8b8bbfe7054a7d54766eb86b979b63f5ded786` onto live `origin/main` `d394d819ab6b58252f125f66b2bb0af6337d3bdf`, producing head `968dbffb2abfb7b8f1cfba257e61ef68100fa842`.
- Overlap checked: #12132/#12133 are Studio-D DTS helper/test work; #12127/#12130 are merged Studio-E DTS work. No unsafe overlap found for this class/static-this emit branch.
- Diff remains limited to `crates/tsz-emitter` class/static-this implementation and focused tests shown by `git diff --name-status origin/main...HEAD`.
- `helpers_async.rs` remains over 2000 lines but this PR reduces it from 2261 lines on `origin/main` to 2150 lines; it does not introduce that pre-existing size debt.
- Exact-head ready-review CI for `968dbffb2abfb7b8f1cfba257e61ef68100fa842` is green, including `CI Summary` and `GitGuardian Security Checks`.
- `merge-queue` is present on the ready/non-draft/non-WIP head. `Queue Tested` is queue-owned. No local full conformance/fourslash/emit run.
