### PR TITLE
fix(dts): elide type-only require destructuring

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_type_value_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_type_value_declarations.rs
@@ -617,9 +617,17 @@ impl<'a> DeclarationEmitter<'a> {
                         });
 
                         if is_destructuring {
-                            if self.js_local_bare_require_alias_without_export_surface(
-                                decl.initializer,
-                            ) {
+                            let is_exported =
+                                has_export_modifier || self.is_js_named_exported_name(decl.name);
+                            if !is_exported
+                                && (self.js_local_bare_require_alias_without_export_surface(
+                                    decl.initializer,
+                                ) || self
+                                    .js_local_bare_require_destructuring_without_value_surface(
+                                        decl.name,
+                                        decl.initializer,
+                                    ))
+                            {
                                 self.record_js_elided_bare_require_binding_names(decl.name);
                                 let skip_end = self
                                     .arena
@@ -629,8 +637,6 @@ impl<'a> DeclarationEmitter<'a> {
                                 continue;
                             }
                             // Emit destructuring as individual declarations
-                            let is_exported =
-                                has_export_modifier || self.is_js_named_exported_name(decl.name);
                             self.emit_flattened_variable_declaration(
                                 decl_idx,
                                 keyword,

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/js_exports_namespace.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/js_exports_namespace.rs
@@ -8,7 +8,7 @@ use super::super::{
 #[allow(unused_imports)]
 use rustc_hash::{FxHashMap, FxHashSet};
 #[allow(unused_imports)]
-use tsz_parser::parser::node::Node;
+use tsz_parser::parser::node::{Node, NodeAccess};
 #[allow(unused_imports)]
 use tsz_parser::parser::syntax_kind_ext;
 #[allow(unused_imports)]
@@ -449,6 +449,88 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         self.initializer_is_bare_require_call(initializer)
+    }
+
+    pub(in crate::declaration_emitter) fn js_local_bare_require_destructuring_without_value_surface(
+        &self,
+        pattern_idx: NodeIndex,
+        initializer: NodeIndex,
+    ) -> bool {
+        if !self.source_is_js_file || !self.initializer_is_bare_require_call(initializer) {
+            return false;
+        }
+
+        let mut names = FxHashSet::default();
+        for (ident_idx, _) in self.collect_flattened_binding_entries(pattern_idx, None) {
+            if let Some(name) = self.get_identifier_text(ident_idx) {
+                names.insert(name);
+            }
+        }
+        if names.is_empty() {
+            return false;
+        }
+
+        !names
+            .iter()
+            .any(|name| self.public_api_type_surface_contains_typeof_name(name))
+            && !self.js_module_exports_initializer_references_any_identifier_name(&names)
+    }
+
+    fn js_module_exports_initializer_references_any_identifier_name(
+        &self,
+        names: &FxHashSet<String>,
+    ) -> bool {
+        let Some(source_file_idx) = self.current_source_file_idx else {
+            return true;
+        };
+        let Some(source_file_node) = self.arena.get(source_file_idx) else {
+            return true;
+        };
+        let Some(source_file) = self.arena.get_source_file(source_file_node) else {
+            return true;
+        };
+
+        source_file
+            .statements
+            .nodes
+            .iter()
+            .copied()
+            .any(|stmt_idx| {
+                self.js_module_exports_assignment_initializer(stmt_idx)
+                    .is_some_and(|initializer| {
+                        self.node_references_any_identifier_name(initializer, &names)
+                    })
+            })
+    }
+
+    fn node_references_any_identifier_name(
+        &self,
+        node_idx: NodeIndex,
+        names: &FxHashSet<String>,
+    ) -> bool {
+        let mut seen = FxHashSet::default();
+        self.node_references_any_identifier_name_inner(node_idx, names, &mut seen)
+    }
+
+    fn node_references_any_identifier_name_inner(
+        &self,
+        node_idx: NodeIndex,
+        names: &FxHashSet<String>,
+        seen: &mut FxHashSet<NodeIndex>,
+    ) -> bool {
+        if node_idx.is_none() || !seen.insert(node_idx) {
+            return false;
+        }
+        if self
+            .get_identifier_text(node_idx)
+            .is_some_and(|name| names.contains(&name))
+        {
+            return true;
+        }
+        self.arena
+            .get_children(node_idx)
+            .into_iter()
+            .any(|child_idx| self.node_references_any_identifier_name_inner(child_idx, names, seen))
     }
 
     pub(in crate::declaration_emitter) fn emit_js_require_property_import_aliases(&mut self) {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
@@ -354,7 +354,10 @@ impl<'a> DeclarationEmitter<'a> {
             let Some(name_idx) = self.object_literal_member_name_idx(member_node) else {
                 continue;
             };
-            let Some(name) = self.object_literal_member_name_text(name_idx) else {
+            let Some(name) = self
+                .object_literal_member_name_text(name_idx)
+                .or_else(|| self.emittable_computed_property_name_text(name_idx))
+            else {
                 continue;
             };
             let Some(value_idx) = self.object_literal_member_value_idx(member_node) else {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_members.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_members.rs
@@ -221,6 +221,45 @@ impl<'a> DeclarationEmitter<'a> {
             .or_else(|| self.infer_property_name_text(name_idx))
     }
 
+    pub(in crate::declaration_emitter) fn emittable_computed_property_name_text(
+        &self,
+        name_idx: NodeIndex,
+    ) -> Option<String> {
+        let name_node = self.arena.get(name_idx)?;
+        if name_node.kind != syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+            return None;
+        }
+        let computed = self.arena.get_computed_property(name_node)?;
+        let expr_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(computed.expression);
+        let expr_node = self.arena.get(expr_idx)?;
+        match expr_node.kind {
+            k if k == SyntaxKind::Identifier as u16
+                || k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION =>
+            {
+                let is_unique_symbol_key = self
+                    .value_reference_symbol(expr_idx)
+                    .is_some_and(|sym_id| self.symbol_has_unique_symbol_type(sym_id));
+                let is_usable_property_name = self
+                    .type_interner
+                    .zip(self.get_node_type_or_names(&[expr_idx, name_idx]))
+                    .is_some_and(|(interner, type_id)| {
+                        tsz_solver::visitor::unique_symbol_ref(interner, type_id).is_some()
+                            || tsz_solver::type_queries::is_type_usable_as_property_name(
+                                interner, type_id,
+                            )
+                    });
+                if !is_unique_symbol_key && !is_usable_property_name {
+                    return None;
+                }
+                self.get_source_slice(name_node.pos, name_node.end)
+                    .map(|text| text.trim().to_string())
+            }
+            _ => None,
+        }
+    }
+
     pub(in crate::declaration_emitter) fn resolved_computed_property_name_text(
         &self,
         name_idx: NodeIndex,
@@ -548,6 +587,7 @@ impl<'a> DeclarationEmitter<'a> {
         // member are reproducible (`[E.A]`, `[SOME_CONST]`, unique symbols).
         if self
             .resolved_computed_property_name_text(name_idx)
+            .or_else(|| self.emittable_computed_property_name_text(name_idx))
             .is_some()
         {
             return false;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs
@@ -124,7 +124,10 @@ impl<'a> DeclarationEmitter<'a> {
                     .push((key_text.to_string(), source_name_text.trim().to_string()));
             }
 
-            let Some(mut name_text) = self.object_literal_member_name_text(name_idx) else {
+            let Some(mut name_text) = self
+                .object_literal_member_name_text(name_idx)
+                .or_else(|| self.emittable_computed_property_name_text(name_idx))
+            else {
                 if name_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME {
                     has_non_emittable_computed_members = true;
                     if synthetic_number_index_member.is_none() {
@@ -525,6 +528,7 @@ impl<'a> DeclarationEmitter<'a> {
             };
             let name_text = self
                 .object_literal_member_name_text(name_idx)
+                .or_else(|| self.emittable_computed_property_name_text(name_idx))
                 .or_else(|| self.constant_computed_property_name_text(name_idx));
             let kind = self.computed_object_index_key_kind(name_idx, name_text.as_deref());
             members.push(ComputedObjectIndexMember {

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations_parts/part_01.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations_parts/part_01.rs
@@ -1787,3 +1787,36 @@ module.exports = {
     );
 }
 
+#[test]
+fn test_commonjs_export_elides_type_only_require_destructuring() {
+    let output = emit_js_dts_with_usage_analysis(
+        r#"
+const { Thing } = require("./module.js");
+
+/** @typedef {import("./module.js").Thing} Thing */
+class Main {
+    /** @param {Thing} x */
+    constructor(x) {}
+}
+
+module.exports = Main;
+"#,
+    );
+
+    assert!(
+        !output.contains("declare const Thing:"),
+        "Expected type-only require destructuring to be elided: {output}"
+    );
+    assert!(
+        output.contains("export = Main;"),
+        "Expected CommonJS export assignment to remain: {output}"
+    );
+    assert!(
+        output.contains("constructor(x: Thing);"),
+        "Expected JSDoc import typedef to keep constructor parameter type: {output}"
+    );
+    assert!(
+        output.contains("type Thing = import(\"./module.js\").Thing;"),
+        "Expected public typedef to use import type instead of the local require binding: {output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-E

## Track
Emit/DTS parity: JSDoc/JavaScript declaration emit for CommonJS export surfaces.

## Invariant
When a JS file destructures a bare `require()` only for local JSDoc type support and the public CommonJS value surface does not reference those bindings, `tsc` elides the local require binding from `.d.ts` and keeps the public type through `import("...").Name`. When an object export uses entity-name computed keys backed by unique-symbol facts, the synthetic export root must preserve those computed members.

## Scope
- Elide local bare-require destructuring only when the destructured names are not exported as values and do not appear in the module export initializer.
- Preserve emittable computed entity names in object-literal DTS rendering when declaration/type facts make the key usable as a property name.
- Add a focused JS DTS regression test for the type-only require destructuring case.

## Project Corpus Impact
- Row: n/a
- Bug family: JavaScript declaration emit / JSDoc `@typedef` CommonJS export surface.
- Evidence: unit-level DTS regression for the minimized `require()` destructuring + `module.exports = Main` shape; nearby CommonJS object tests cover computed export root preservation.

## Verification
Refresh on 2026-06-02 for live main `b8d2dbaf62499a8f9123dce91f7ca8c38aab7007`:
- `git fetch origin main`
- `git rebase origin/main` -> clean, no conflicts
- `git diff --check origin/main...HEAD`
- `cargo fmt --check`
- `git diff --name-status origin/main...HEAD`

Prior focused implementation verification:
- `cargo fmt --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo nextest run -p tsz-emitter --lib -E 'test(test_commonjs_export_elides_type_only_require_destructuring) or test(test_js_module_exports_object)'`

## Coordination Notes
- AgentName: Studio-E.
- M5Manager delegated refresh only; #12127 was kept draft/off-queue and no ready/merge-queue/merge/close/relabel/rerun actions were taken.
- Refreshed branch `codex/studio-e-jsdoc-decl-facts-20260601` from old head `ba51fae900568cbe064a6f62900e2511b701a162` to new head `8bd212b7d4d1d522003773058462c118107d60f4`.
- Base is live `main` at `b8d2dbaf62499a8f9123dce91f7ca8c38aab7007`.
- Changed files remain limited to the existing #12127 emit/DTS implementation and focused test surface shown by `git diff --name-status origin/main...HEAD`.
- #12130/#12051/#12147/#11890 and other PRs were not touched.
- Heavy emit/conformance/fourslash suites were not run locally; draft CI owns broader coverage.
- Draft-light CI started for refreshed head `8bd212b7d4d1d522003773058462c118107d60f4`: https://github.com/mohsen1/tsz/actions/runs/26797587995
