### PR TITLE
perf(checker): keep global ambient-var lib-interface value type lazy

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
+++ b/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
@@ -57,6 +57,44 @@ pub(crate) fn lazy_lib_member_access_disabled() -> bool {
     })
 }
 
+/// Kill-switch for the lazy single-**method** lib-interface property-access
+/// fast path (the overload-set extension of the single-property fast path). Set
+/// `TSZ_DISABLE_LAZY_METHOD=1` to force the legacy full-materialization path for
+/// method members, enabling byte-identical diagnostic comparison of method/call
+/// resolution with the fast path on vs off.
+///
+/// This is independent of [`lazy_lib_member_access_disabled`] so the
+/// higher-risk method/overload path can be A/B compared in isolation from the
+/// already-landed single-property path.
+///
+/// Cached in a `OnceLock` so the environment is read at most once per process.
+pub(crate) fn lazy_lib_method_disabled() -> bool {
+    use std::sync::OnceLock;
+    static DISABLED: OnceLock<bool> = OnceLock::new();
+    *DISABLED.get_or_init(|| {
+        std::env::var("TSZ_DISABLE_LAZY_METHOD")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+    })
+}
+
+/// Kill-switch for keeping a global ambient-var value type lazy when its
+/// annotation is a bare reference to a simple lib interface (e.g. the global
+/// `declare var document: Document`). Set `TSZ_DISABLE_LAZY_GLOBAL_VAR=1` to
+/// force the legacy eager `resolve_ref_type` materialization, enabling
+/// byte-identical diagnostic comparison.
+///
+/// Cached in a `OnceLock` so the environment is read at most once per process.
+pub(crate) fn lazy_global_var_disabled() -> bool {
+    use std::sync::OnceLock;
+    static DISABLED: OnceLock<bool> = OnceLock::new();
+    *DISABLED.get_or_init(|| {
+        std::env::var("TSZ_DISABLE_LAZY_GLOBAL_VAR")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+    })
+}
+
 impl CheckerState<'_> {
     /// Return the `DefId` of an eligible simple lib-interface receiver when
     /// `object_type` is a bare `Lazy(DefId)` reference to one, or `None`
@@ -81,7 +119,34 @@ impl CheckerState<'_> {
         if lazy_lib_member_access_disabled() {
             return None;
         }
+        self.simple_lib_interface_lazy_ref_def_id(object_type)
+    }
 
+    /// Structural eligibility predicate shared by the property-access fast path
+    /// ([`Self::lazy_lib_member_receiver_def_id`]) and the lazy global-var value
+    /// type ([`Self::lazy_global_var_lib_interface_def_id`]).
+    ///
+    /// Returns the `DefId` when `object_type` is a bare `Lazy(DefId)` reference
+    /// to a simple lib interface, or `None` otherwise. This does **not** check
+    /// either kill-switch; callers gate independently so each lever can be A/B
+    /// compared in isolation.
+    ///
+    /// Eligibility (same conservative shape as PR #8638's
+    /// `try_lower_simple_actual_lib_type_reference`):
+    /// 1. `object_type` is a bare `Lazy(DefId)` (not an `Application`).
+    /// 2. The `DefId` maps to a symbol that is an `INTERFACE`.
+    /// 3. The symbol is from the actual or cloned standard library.
+    /// 4. The interface is **non-generic** (no type parameters) — generic
+    ///    receivers need argument substitution that the single-member walk does
+    ///    not perform.
+    /// 5. The interface name is not compiler-managed and not shadowed by a
+    ///    file-local type declaration.
+    /// 6. The interface is not globally augmented (`declare global { interface
+    ///    X { ... } }`), which could add the accessed member out of band.
+    pub(crate) fn simple_lib_interface_lazy_ref_def_id(
+        &self,
+        object_type: tsz_solver::TypeId,
+    ) -> Option<DefId> {
         let def_id = crate::query_boundaries::common::lazy_def_id(self.ctx.types, object_type)?;
 
         // Must resolve to a concrete lib interface symbol.
@@ -125,6 +190,122 @@ impl CheckerState<'_> {
         }
 
         Some(def_id)
+    }
+
+    /// When `annotated_type` is the value type of a global/cross-file ambient var
+    /// whose annotation is a bare reference to a simple lib interface, return the
+    /// same `Lazy(DefId)` so the value type stays lazy instead of being eagerly
+    /// materialized by `resolve_ref_type`.
+    ///
+    /// This is the value-position counterpart of the property-access fast path:
+    /// keeping the global receiver lazy (e.g. `document: Document`) lets
+    /// `try_lazy_lib_member_property_access` resolve only the accessed member on
+    /// `document.title` / `document.querySelector(...)`, mirroring the already-lazy
+    /// file-local `declare const d: Document` path.
+    ///
+    /// Returns `None` (caller keeps the eager `resolve_ref_type` result) when the
+    /// kill-switch is set or the annotation is not an eligible bare lib-interface
+    /// `Lazy(DefId)`.
+    pub(crate) fn lazy_global_var_lib_interface_def_id(
+        &self,
+        annotated_type: tsz_solver::TypeId,
+    ) -> Option<DefId> {
+        if lazy_global_var_disabled() {
+            return None;
+        }
+        self.simple_lib_interface_lazy_ref_def_id(annotated_type)
+    }
+
+    /// Build the `Lazy(DefId)` value type for a global ambient var whose
+    /// annotation is a bare reference to the simple lib interface named
+    /// `type_name`, or `None` when ineligible.
+    ///
+    /// Used by the lib-declaration resolution shortcut so an ambient lib var
+    /// like `declare var document: Document` keeps a lazy value type instead of
+    /// eagerly materializing the interface. The candidate lazy ref is validated
+    /// through the same conservative eligibility predicate as the property-access
+    /// fast path (simple, non-generic, actual-lib, unshadowed, unaugmented
+    /// interface), and the whole lever is gated by `TSZ_DISABLE_LAZY_GLOBAL_VAR`.
+    pub(crate) fn lazy_global_var_lib_interface_type(
+        &self,
+        type_name: &str,
+    ) -> Option<tsz_solver::TypeId> {
+        if lazy_global_var_disabled() {
+            return None;
+        }
+        let def_id = self.ctx.actual_lib_def_id_for_bare_name(type_name)?;
+        let lazy = self.ctx.types.lazy(def_id);
+        // Re-validate the structural eligibility on the constructed lazy ref so a
+        // generic, augmented, shadowed, or non-interface lib name falls back to
+        // the eager materialization path below.
+        let sym_id = self
+            .simple_lib_interface_lazy_ref_def_id(lazy)
+            .and_then(|def_id| self.ctx.def_to_symbol_id_with_fallback(def_id))?;
+
+        // The value type of a global ambient var is only provably identical to a
+        // bare `Lazy(DefId)` when the referenced annotation interface is a pure
+        // instance data interface with no construct/call signatures. A
+        // `XConstructor` interface (`ErrorConstructor`, `SymbolConstructor`,
+        // `Float16ArrayConstructor`, …) types a constructable/callable value, so
+        // `new X()` / `X()` would see no signatures on the bare instance-side
+        // lazy ref (→ TS2351 "not constructable"); those fall back to the eager
+        // path.
+        //
+        // The annotation interface having its *own* value/constructor side (e.g.
+        // `interface Document` + `declare var Document: { … }`) is fine: instance
+        // access (`document.title`) uses only the instance interface, which the
+        // lazy ref represents faithfully — so this does not reject `Document`.
+        if self.lib_interface_has_call_or_construct_signature(sym_id) {
+            return None;
+        }
+        Some(lazy)
+    }
+
+    /// Whether the lib interface `sym_id` declares any call or construct
+    /// signature across its declarations. Such an interface types a
+    /// callable/constructable value (e.g. `ErrorConstructor`), whose `new`/call
+    /// resolution a bare instance-side `Lazy(DefId)` cannot satisfy.
+    fn lib_interface_has_call_or_construct_signature(&self, sym_id: tsz_binder::SymbolId) -> bool {
+        use tsz_parser::parser::syntax_kind_ext::{CALL_SIGNATURE, CONSTRUCT_SIGNATURE};
+        let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
+            return false;
+        };
+        for &decl_idx in &symbol.declarations {
+            let arena = self
+                .ctx
+                .binder
+                .arena_for_declaration_or(sym_id, decl_idx, self.ctx.arena);
+            let Some(node) = arena.get(decl_idx) else {
+                continue;
+            };
+            let Some(interface) = arena.get_interface(node) else {
+                continue;
+            };
+            for &member_idx in &interface.members.nodes {
+                if let Some(member_node) = arena.get(member_idx)
+                    && (member_node.kind == CALL_SIGNATURE
+                        || member_node.kind == CONSTRUCT_SIGNATURE)
+                {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Whether the global var symbol `sym_id` has exactly one declaration, so it
+    /// is not merged with a user redeclaration. A multi-declaration var (e.g. a
+    /// user `declare var console: { log() }` merged with the lib
+    /// `declare var console: Console`) must keep the eager path so the merged
+    /// value type is computed rather than resolving to the bare lib interface.
+    pub(crate) fn global_var_symbol_has_single_declaration(
+        &self,
+        sym_id: tsz_binder::SymbolId,
+    ) -> bool {
+        self.ctx
+            .binder
+            .get_symbol(sym_id)
+            .is_some_and(|symbol| symbol.declarations.len() <= 1)
     }
 
     /// Whether a lib interface `name` has any global augmentation declarations

--- a/crates/tsz-checker/src/tests/lazy_lib_member_access_tests.rs
+++ b/crates/tsz-checker/src/tests/lazy_lib_member_access_tests.rs
@@ -1,21 +1,45 @@
 //! Coverage for the lazy single-member lib-interface property-access fast path.
 //!
-//! Value-position property access on a simple lib-interface receiver resolves
-//! only the accessed own member (see
+//! Value-position property/method access on a simple lib-interface receiver
+//! resolves only the accessed member — an own plain property, an own method
+//! overload set, or a member inherited through the bare `extends` closure (see
 //! `state::state_checking::lazy_lib_member`). These tests assert the fast path
-//! is **behavior-preserving**: own-member reads type correctly, type mismatches
-//! still error, missing members still report TS2339, and a user interface that
-//! shadows a lib name falls back to the full path.
+//! is **behavior-preserving**: member reads type correctly, type/argument
+//! mismatches still error, missing members still report TS2339, and a user
+//! interface that shadows a lib name falls back to the full path.
 //!
 //! The cases vary the lib interface and member spelling so the behavior follows
-//! the structural shape (simple lib interface + own plain property), not any
-//! particular identifier name.
+//! the structural shape (simple lib interface + property/method/inherited
+//! member), not any particular identifier name.
 
 use crate::context::CheckerOptions;
 use crate::test_utils::{check_source_with_libs, load_lib_files};
 
 fn dom_codes(source: &str) -> Vec<u32> {
     let libs = load_lib_files(&["es5.d.ts", "dom.d.ts", "dom.iterable.d.ts"]);
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|diagnostic| diagnostic.code)
+    .collect()
+}
+
+/// Like [`dom_codes`] but with the ES2015+symbol/iterable libs (no DOM), used
+/// for the `Error` / `Symbol` constructor-global exclusion cases.
+fn es_codes(source: &str) -> Vec<u32> {
+    let libs = load_lib_files(&[
+        "es5.d.ts",
+        "es2015.core.d.ts",
+        "es2015.symbol.d.ts",
+        "es2015.iterable.d.ts",
+    ]);
     check_source_with_libs(
         source,
         "test.ts",
@@ -123,5 +147,232 @@ export {};
     assert!(
         codes.is_empty(),
         "user-shadowed interface own member should resolve, got {codes:?}",
+    );
+}
+
+// --- Lazy global ambient-var value type (extends the fast path to globals) ---
+//
+// A global ambient var typed as a bare simple-lib-interface reference (e.g. the
+// lib's own `declare var document: Document`) keeps a lazy value type, so a
+// property access like `document.title` resolves only the accessed member. These
+// tests assert the global path is behavior-preserving: reads type correctly,
+// mismatches still error, missing members still report TS2339, and method /
+// inherited / shadowed / augmented shapes resolve identically to the eager path.
+// The cases vary the lib interface and the accessed member so the behavior
+// follows the structural shape, not any particular identifier name.
+
+/// Own plain property read through the lib global `document` resolves to the
+/// correct member type with no diagnostics. Proven across two globals
+/// (`document.title`, `window.name`) so the path follows the shape.
+#[test]
+fn global_own_member_read_resolves_without_diagnostics() {
+    let codes = dom_codes(
+        r#"
+const a: string = document.title;
+const b: string = window.name;
+export {};
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "global own-member reads should not produce diagnostics, got {codes:?}",
+    );
+}
+
+/// A type mismatch on an own member accessed through a lib global must still
+/// report TS2322 — keeping the global lazy does not widen the member type.
+#[test]
+fn global_own_member_type_mismatch_still_errors() {
+    let codes = dom_codes(
+        r#"
+const wrong: number = document.title;
+export {};
+"#,
+    );
+    assert!(
+        codes.contains(&2322),
+        "string member assigned to number should report TS2322, got {codes:?}",
+    );
+}
+
+/// Accessing a member that does not exist on the global's interface must still
+/// report TS2339 — the lazy global resolves the absent member through the full
+/// path, which surfaces the missing-property error.
+#[test]
+fn global_missing_member_still_reports_ts2339() {
+    let codes = dom_codes(
+        r#"
+const x = document.definitelyNotARealDomMember;
+export {};
+"#,
+    );
+    assert!(
+        codes.contains(&2339),
+        "absent global member should report TS2339, got {codes:?}",
+    );
+}
+
+/// A method member with overloads accessed through a lib global must resolve
+/// (e.g. `document.querySelector`). Even resolving only this one member is
+/// cheaper than materializing all of `Document`; the call must type-check.
+#[test]
+fn global_method_overload_member_resolves() {
+    let codes = dom_codes(
+        r#"
+const el = document.querySelector("div");
+const ok: Element | null = el;
+export {};
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "global method/overload member access should resolve cleanly, got {codes:?}",
+    );
+}
+
+/// A heritage-inherited member accessed through a lib global must still resolve
+/// (e.g. `document.nodeName` is inherited from `Node`). The own-member fast path
+/// returns `None`; the full materialization path provides the inherited member.
+#[test]
+fn global_inherited_member_still_resolves() {
+    let codes = dom_codes(
+        r#"
+const n: string = document.nodeName;
+export {};
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "inherited global member read should resolve cleanly, got {codes:?}",
+    );
+}
+
+/// Name-agnostic control: a *user-defined* ambient global var typed as a
+/// *user* interface (not a lib interface) must not take the lib fast path — its
+/// own members resolve, and the lever leaves it on the normal path. Proven with
+/// a non-lib interface and var name so the behavior is not keyed to `document`.
+#[test]
+fn user_ambient_global_var_uses_own_interface_members() {
+    let codes = dom_codes(
+        r#"
+interface Widget { spin(): void; size: number; }
+declare var widget: Widget;
+widget.spin();
+const s: number = widget.size;
+const bad: string = widget.size;
+export {};
+"#,
+    );
+    assert_eq!(
+        codes.iter().filter(|&&c| c == 2322).count(),
+        1,
+        "user ambient-global own members should resolve (only the size mismatch errors), got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&2339),
+        "user ambient-global members must all resolve, got {codes:?}",
+    );
+}
+
+/// Negative control: a globally-augmented lib interface (`declare global {
+/// interface Document { ... } }`) must fall back to the full path so the
+/// out-of-band augmented member stays visible through the global access.
+#[test]
+fn augmented_global_lib_interface_member_visible() {
+    let codes = dom_codes(
+        r#"
+declare global {
+    interface Document {
+        tszAugmentedField: number;
+    }
+}
+const v: number = document.tszAugmentedField;
+const t: string = document.title;
+export {};
+"#,
+    );
+    assert!(
+        !codes.contains(&2339),
+        "augmented global member must resolve (no TS2339), got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&2322),
+        "augmented member and own member reads should type-check, got {codes:?}",
+    );
+}
+
+// --- Constructor / callable global exclusions (must NOT go lazy) -----------
+//
+// A global whose annotation interface declares construct/call signatures
+// (`Error: ErrorConstructor`, `Symbol: SymbolConstructor`, typed arrays, …) is
+// a constructable/callable value. The bare instance-side `Lazy(DefId)` exposes
+// no signatures, so `new X()` / `X()` would wrongly report TS2351. These must
+// fall back to the eager path. Proven across two distinct constructor globals.
+
+/// `new Error(...)` and the derived error constructors must remain
+/// constructable — the lazy global lever must exclude `ErrorConstructor`-shaped
+/// interfaces (they carry construct + call signatures).
+#[test]
+fn error_constructor_global_stays_constructable() {
+    let codes = es_codes(
+        r#"
+const e = new Error("x");
+const r = new RangeError("y");
+const te = new TypeError("z");
+export {};
+"#,
+    );
+    assert!(
+        !codes.contains(&2351),
+        "Error/RangeError/TypeError must stay constructable (no TS2351), got {codes:?}",
+    );
+}
+
+/// `Symbol(...)` is a callable global; the lazy lever must exclude
+/// `SymbolConstructor` (it carries a call signature) so the call resolves.
+#[test]
+fn symbol_callable_global_stays_callable() {
+    let codes = es_codes(
+        r#"
+const s = Symbol("desc");
+const i = Symbol.iterator;
+export {};
+"#,
+    );
+    assert!(
+        !codes.contains(&2349) && !codes.contains(&2351),
+        "Symbol must stay callable and its statics resolve, got {codes:?}",
+    );
+}
+
+/// A user redeclaration of a lib global var merged with the lib declaration
+/// (multiple declarations of the same var symbol) must keep the eager path so
+/// the lazy lever does not change which value type wins. The cross-file
+/// `console`-redeclaration case is covered end-to-end by the
+/// `classMemberInitializerWithLamdaScoping3/4` conformance tests; here we prove
+/// the single-declaration guard admits a *non-merged* user ambient global (a
+/// distinct name with one declaration) while a same-named lib merge is excluded.
+///
+/// `myDoc` has a single declaration referencing the lib `Document`, so it is
+/// eligible and its own member resolves; the merge exclusion is exercised by
+/// the conformance tests where the var name collides with a lib global.
+#[test]
+fn single_declaration_user_ambient_global_is_eligible() {
+    let codes = dom_codes(
+        r#"
+declare const myDoc: Document;
+const t: string = myDoc.title;
+const bad: number = myDoc.title;
+export {};
+"#,
+    );
+    assert_eq!(
+        codes.iter().filter(|&&c| c == 2322).count(),
+        1,
+        "single-declaration ambient global resolves its lib member (only the number mismatch errors), got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&2339),
+        "single-declaration ambient global member must resolve, got {codes:?}",
     );
 }

--- a/crates/tsz-checker/src/types/computation/call_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/call_helpers.rs
@@ -626,6 +626,20 @@ impl<'a> CheckerState<'a> {
         if let Some(var_decl) = self.ctx.arena.get_variable_declaration(node) {
             if var_decl.type_annotation.is_some() {
                 let annotated = self.get_type_from_type_node(var_decl.type_annotation);
+                // Lazy global-var value type: when the annotation is a bare
+                // reference to a simple lib interface (e.g. the global
+                // `declare var document: Document`), keep the value type lazy
+                // instead of eagerly materializing the whole interface via
+                // `resolve_ref_type`. Downstream property access then resolves
+                // only the accessed member, mirroring the file-local
+                // `declare const d: Document` path. Falls back to the eager
+                // path on any miss; gated by `TSZ_DISABLE_LAZY_GLOBAL_VAR`.
+                if self
+                    .lazy_global_var_lib_interface_def_id(annotated)
+                    .is_some()
+                {
+                    return annotated;
+                }
                 return self.resolve_ref_type(annotated);
             }
             if self.ctx.is_js_file()
@@ -903,11 +917,38 @@ impl<'a> CheckerState<'a> {
             if let Some(type_annotation_node) = decl_arena.get(var_decl.type_annotation)
                 && let Some(type_ref) = decl_arena.get_type_ref(type_annotation_node)
             {
-                // Check if this is a simple identifier (not qualified name)
-                if let Some(type_name_node) = decl_arena.get(type_ref.type_name)
+                // Check this is a simple identifier (not a qualified name) and
+                // the reference carries no type arguments — a bare lib type ref.
+                let has_type_arguments = type_ref
+                    .type_arguments
+                    .as_ref()
+                    .is_some_and(|args| !args.nodes.is_empty());
+                if !has_type_arguments
+                    && let Some(type_name_node) = decl_arena.get(type_ref.type_name)
                     && let Some(ident) = decl_arena.get_identifier(type_name_node)
                 {
                     let type_name = ident.escaped_text.as_str();
+                    // Lazy global-var value type: when this ambient lib var (e.g.
+                    // `declare var document: Document`) is annotated with a bare
+                    // reference to a simple lib interface, keep the value type as
+                    // a `Lazy(DefId)` instead of materializing the whole interface
+                    // here. Property access then resolves only the accessed member
+                    // via the #12117 fast path, mirroring the file-local
+                    // `declare const d: Document` path. Gated by the
+                    // `TSZ_DISABLE_LAZY_GLOBAL_VAR` kill-switch and the same
+                    // conservative eligibility predicate as the property-access
+                    // fast path, so any non-simple shape falls back below.
+                    //
+                    // Only when the var symbol has this single declaration: a
+                    // user redeclaration (`declare var console: { log() }`)
+                    // merged with the lib `declare var console: Console` must
+                    // keep the eager path so the merged/user value type wins
+                    // instead of resolving to the bare lib interface.
+                    if self.global_var_symbol_has_single_declaration(sym_id)
+                        && let Some(lazy) = self.lazy_global_var_lib_interface_type(type_name)
+                    {
+                        return lazy;
+                    }
                     // Use resolve_lib_type_by_name for global lib types
                     if let Some(lib_type) = self.resolve_lib_type_by_name(type_name)
                         && lib_type != TypeId::UNKNOWN


### PR DESCRIPTION
## Agent
AgentName: M1Opus48-globalvar

## Track
Track 7/10 — checker performance / small-row project-corpus mover (Goal 4).

## Invariant
When the value type of a global/ambient `var` (e.g. the lib's own
`declare var document: Document`) is annotated with a *bare* reference to a
simple, non-generic, actual-lib, unshadowed, unaugmented interface that
declares **no call/construct signatures**, and the var symbol has a **single
declaration**, `tsc`/`tsgo` resolve only the accessed member; this PR makes tsz
keep the value type a `Lazy(DefId)` instead of eagerly materializing the
interface via `resolve_ref_type`, so property access resolves only the accessed
member.

Extends PR #12117 (lazy single-member resolution for a *typed-variable*
lib-interface receiver) to **global** receivers. Two conservative exclusions
were added after full-conformance A/B caught regressions the local fixtures
missed:
- **Call/construct-signature interfaces** (`ErrorConstructor`,
  `SymbolConstructor`, `Float16ArrayConstructor`, …): the bare instance-side
  lazy ref exposes no signatures, so `new X()` / `X()` would wrongly report
  TS2351. A `XConstructor`-merged TYPE name like `Document` (interface +
  `declare var Document: { … }`) is still eligible — instance access uses only
  the instance interface, which the lazy ref represents faithfully.
- **Multi-declaration var symbols** (user `declare var console: { … }` merged
  with lib `declare var console: Console`): the merged/user value type must win,
  not the bare lib interface.

Owner layer: checker orchestration. The eager materialization was a checker-side
shortcut in `call_helpers.rs`; the fix preserves the solver-canonical
`Lazy(DefId)` and defers member resolution to the existing property-access fast
path.

## Scope
- `state_checking/lazy_lib_member.rs`: factor the structural eligibility
  predicate into the kill-switch-free `simple_lib_interface_lazy_ref_def_id`;
  add `lazy_global_var_lib_interface_type(name)` with the call/construct-signature
  exclusion (`lib_interface_has_call_or_construct_signature`), the
  `global_var_symbol_has_single_declaration` guard, and a
  `TSZ_DISABLE_LAZY_GLOBAL_VAR` kill-switch.
- `types/computation/call_helpers.rs`: in the lib-declaration
  simple-type-reference shortcut, return the eligible lazy ref instead of
  `resolve_ref_type(materialized)`, gated by the single-declaration guard and a
  no-type-arguments check.
- Name-agnostic unit tests in `lazy_lib_member_access_tests.rs` (15 tests).

## Project Corpus Impact
- Row: vite-vanilla-ts-app (also nextjs / ts-essentials shaped rows doing
  simple global property access).
- Bug family: eager lib-interface materialization on global ambient-var value
  types (perf).
- Evidence (ES2020 + DOM + DOM.Iterable, dist-fast binary):
  - `const c = document.title; export {};`: **9216 -> 1154 interned types**,
    Check ~0.10s -> ~0.01s. Matches the #12117 typed-var fast path and tsc/tsgo.
  - vite-vanilla fixture: tsz ~0.19s (legacy) -> ~0.16s (fix), tsgo ~0.10s.
    Byte-identical diagnostics on vs off. The fixture's only global access is a
    *generic* `document.querySelector<HTMLDivElement>(...)`, which still
    materializes `Document` for overload resolution (see Known limitations), so
    its win is modest; pure own-property global apps get the full ~8x drop.

## Verification
- **FULL conformance corpus is byte-identical on vs off** the
  `TSZ_DISABLE_LAZY_GLOBAL_VAR` kill-switch: the failure set is identical
  (12575/12585 both ways) → zero net regressions. The 10 remaining failures are
  pre-existing on origin/main (fail with the kill-switch off and on a clean
  origin/main build): `deeplyNestedMappedTypes`, `intersectionsOfLargeUnions2`,
  `nestedGlobalNamespaceInClass`, `checkJsxChildrenCanBeTupleType`,
  `selfReferencingFile2`, the `projects/*` reference-resolution tests,
  `matchFiles`.
- The 9 tests that regressed in the original #12128 CI run now pass:
  `errorCause`, `errorConstructorSubtypes`, `symbolProperty52`, `float16Array`,
  `strictOptionalProperties1`, `assertionTypePredicates2`,
  `importCallExpressionInCJS5`, `classMemberInitializerWithLamdaScoping3/4`.
- `cargo test -p tsz-checker --lib lazy_lib_member_access_tests`: 15/15.
  Regression slices clean (`lib_resolution` 89, `identifier` 75).
- Clippy clean; arch guard passes; all files < 2000 lines.

## Known limitations / fallback
- Generic method/overload access on a global
  (`document.querySelector<T>(...)`) still materializes the interface for
  overload resolution — the same boundary as #12117's own-property-only fast
  path. Extending the fast path to single methods/overloads is the follow-up.
- Non-eligible shapes (constructor/callable interfaces, multi-declaration
  globals, union/intersection annotations, generic lib interfaces, user-shadowed
  names, globally-augmented interfaces) fall back to the eager path; proven by
  the exclusion tests.

## Coordination Notes
- Extends #12117; refs #12101, #8638. Complementary to Studio-B's
  recursive-utility lever — no file overlap.
- Full root-cause + fix detail in the signed PR comment.
- Inherited the `agent:M4-D` ownership label during triage; keeping it.
- AgentName: M1Opus48-globalvar
