### PR TITLE
perf(ci): skip tsz recompilation when binary, tsconfig, and fixture ref are unchanged

### DIFF
--- a/scripts/ci/project-compile-guard.sh
+++ b/scripts/ci/project-compile-guard.sh
@@ -14,6 +14,7 @@ PROJECT_SET="${TSZ_PROJECT_COMPILE_SET:-required}"
 ALLOW_FAILURES="${TSZ_PROJECT_COMPILE_ALLOW_FAILURES:-0}"
 PROJECT_COMPATIBILITY_JSONL="${TSZ_PROJECT_COMPILE_COMPATIBILITY_JSONL:-$FIXTURE_ROOT/project-compatibility.jsonl}"
 PROJECT_COMPATIBILITY_SUMMARY="${TSZ_PROJECT_COMPILE_COMPATIBILITY_SUMMARY:-$FIXTURE_ROOT/project-compatibility-summary.json}"
+RESULT_CACHE_DIR="${TSZ_PROJECT_COMPILE_RESULT_CACHE_DIR:-$FIXTURE_ROOT/.result-cache}"
 FAILURES=0
 LAST_PEAK_RSS_BYTES=0
 TYPE_CHALLENGES_SOLUTIONS_MANIFEST_WRITTEN=0
@@ -77,7 +78,17 @@ if [[ ! -x "$TSZ_BIN" ]]; then
   exit 1
 fi
 
+# Stable sha256 hash of a file (Linux sha256sum / macOS shasum).
+sha256_of_file() {
+  sha256sum "$1" 2>/dev/null | awk '{print $1}' \
+    || shasum -a 256 "$1" 2>/dev/null | awk '{print $1}' || true
+}
+
+# Compute tsz binary hash once at startup for all per-project fingerprints.
+_TSZ_BINARY_HASH="$(sha256_of_file "$TSZ_BIN")"
+
 mkdir -p "$FIXTURE_ROOT"
+mkdir -p "$RESULT_CACHE_DIR"
 validate_project_compatibility_artifact_paths
 rm -f "$FIXTURE_ROOT/type-challenges-readiness-pairing.json"
 rm -rf "$FIXTURE_ROOT/type-challenges-assertions"
@@ -474,18 +485,106 @@ check_type_challenges_solutions_tsc_oracle() {
   return 0
 }
 
+# Atomically writes a compile result to the result cache (tmp-then-rename).
+# The fingerprint is stored inside the file so stale entries self-prune on the
+# next read rather than accumulating one file per fingerprint per project.
+# write_compile_cache <fp> <rc> <file_count> <exit_class> <diagnostic_delta> <cache_file>
+write_compile_cache() {
+  local _fp="$1" _rc="$2" _files="$3" _class="$4" _delta="$5" _cf="$6"
+  { printf 'FINGERPRINT=%s\nRC=%s\nFILES=%s\nCLASS=%s\nDELTA_START\n' \
+      "$_fp" "$_rc" "$_files" "$_class"
+    printf '%s' "$_delta"; } \
+    > "${_cf}.tmp" 2>/dev/null \
+    && mv "${_cf}.tmp" "$_cf" 2>/dev/null || true
+}
+
+# Fingerprint for a check_project invocation.
+# Key: tsz binary hash (computed once at startup) + tsconfig content + fixture git HEAD.
+# Returns empty on failure — callers treat empty as "caching unavailable".
+compute_compile_fingerprint() {
+  local name="$1" tsconfig="$2"
+  # The key is composed of fixed-length hashes — no need to hash it again.
+  # Return empty if critical components are missing so callers disable caching.
+  [[ -z "$_TSZ_BINARY_HASH" ]] && return
+  local tsconfig_hash=""
+  [[ -f "$tsconfig" ]] && tsconfig_hash="$(sha256_of_file "$tsconfig")"
+  [[ -f "$tsconfig" && -z "$tsconfig_hash" ]] && return
+  # git -C already performs the upward .git search, handles worktrees (.git files),
+  # and returns empty (non-zero exit suppressed) when outside any repo.
+  local git_ref=""
+  git_ref="$(git -C "$(dirname "$tsconfig")" rev-parse HEAD 2>/dev/null || true)"
+  printf '%s' "${name}|${_TSZ_BINARY_HASH}|${tsconfig_hash}|${git_ref}"
+}
+
 check_project() {
   local name="$1"
   local tsconfig="$2"
   local src_dir="${3:-$(dirname "$tsconfig")}"
   local tsc_exit_codes="${4:-}"
   local log="$FIXTURE_ROOT/${name}.log"
+
+  # Result cache: skip recompilation when tsz binary, tsconfig content, and
+  # fixture git HEAD are all unchanged from a prior run. The cache file is named
+  # per-project; the stored fingerprint is validated on read so stale entries are
+  # overwritten rather than accumulated. Disable with TSZ_PROJECT_COMPILE_RESULT_CACHE=0.
+  local _fp="" _cache_file=""
+  if [[ "${TSZ_PROJECT_COMPILE_RESULT_CACHE:-1}" == "1" ]]; then
+    _fp="$(compute_compile_fingerprint "$name" "$tsconfig" 2>/dev/null || true)"
+    [[ -n "$_fp" ]] && _cache_file="$RESULT_CACHE_DIR/${name}"
+  fi
+
+  if [[ -n "$_cache_file" && -f "$_cache_file" ]]; then
+    local _cached_fp="" _cached_rc="" _cached_files="" _cached_class="" _cached_delta="" _in_delta=0
+    local _line
+    while IFS= read -r _line; do
+      if [[ "$_in_delta" == "1" ]]; then
+        _cached_delta="${_cached_delta}${_line}"$'\n'
+      else
+        case "$_line" in
+          FINGERPRINT=*)
+            _cached_fp="${_line#FINGERPRINT=}"
+            # Bail early on mismatch — avoids reading the full delta body.
+            [[ "$_cached_fp" != "$_fp" ]] && break
+            ;;
+          RC=*)          _cached_rc="${_line#RC=}" ;;
+          FILES=*)       _cached_files="${_line#FILES=}" ;;
+          CLASS=*)       _cached_class="${_line#CLASS=}" ;;
+          DELTA_START)   _in_delta=1 ;;
+        esac
+      fi
+    done < "$_cache_file"
+    if [[ "$_cached_fp" == "$_fp" ]]; then
+      echo "::group::${name}"
+      echo "(result cache hit: ${_fp:0:12})"
+      if [[ "${_cached_rc:-1}" -ne 0 ]]; then
+        FAILURES=$((FAILURES + 1))
+        record_project_compatibility \
+          "$name" "${_cached_class:-nonzero exit}" "check" \
+          "$(project_failure_status "${_cached_class:-nonzero exit}")" \
+          "${_cached_delta:-}" "${_cached_files:-0}" "" \
+          "${_cached_rc:-1}" "$tsconfig" "$src_dir" "$tsc_exit_codes"
+        echo "error: ${name} failed (cached result)" >&2
+        echo "::endgroup::"
+        if [[ "$ALLOW_FAILURES" == "1" ]]; then
+          echo "::warning::${name} did not compile; continuing because TSZ_PROJECT_COMPILE_ALLOW_FAILURES=1"
+        fi
+      else
+        record_project_compatibility "$name" "exit success" "check" "none" "" \
+          "${_cached_files:-0}" "" "0" "$tsconfig" "$src_dir" "$tsc_exit_codes"
+        echo "${name} compiled successfully."
+        echo "::endgroup::"
+      fi
+      return 0
+    fi
+  fi
+
+  # Only reached on cache miss — avoid running find on cache hits.
   local file_count
   file_count="$(count_ts_files "$src_dir")"
 
   echo "::group::${name}"
   echo "Running: $TSZ_BIN --noEmit -p $tsconfig"
-  local rc=0
+  local rc=0 exit_class="" diagnostic_delta=""
   run_with_timeout "$PROJECT_TIMEOUT" \
     env \
       TSZ_USE_EMBEDDED_LIBS=1 \
@@ -494,8 +593,6 @@ check_project() {
 
   if [[ "$rc" -ne 0 ]]; then
     FAILURES=$((FAILURES + 1))
-    local exit_class
-    local diagnostic_delta
     exit_class="$(project_failure_class "$([[ "$rc" -eq 124 ]] && echo "timeout" || echo "nonzero exit")" "$rc")"
     diagnostic_delta="$(diagnostic_lines_from_file "tsz" "$log")"
     record_project_compatibility \
@@ -520,12 +617,14 @@ check_project() {
     if [[ "$ALLOW_FAILURES" == "1" ]]; then
       echo "::warning::${name} did not compile; continuing because TSZ_PROJECT_COMPILE_ALLOW_FAILURES=1"
     fi
-    return 0
+  else
+    record_project_compatibility "$name" "exit success" "check" "none" "" \
+      "$file_count" "$LAST_PEAK_RSS_BYTES" "0" "$tsconfig" "$src_dir" "$tsc_exit_codes"
+    echo "${name} compiled successfully."
+    echo "::endgroup::"
   fi
-
-  record_project_compatibility "$name" "exit success" "check" "none" "" "$file_count" "$LAST_PEAK_RSS_BYTES" "0" "$tsconfig" "$src_dir" "$tsc_exit_codes"
-  echo "${name} compiled successfully."
-  echo "::endgroup::"
+  [[ -n "$_cache_file" ]] && \
+    write_compile_cache "$_fp" "$rc" "$file_count" "$exit_class" "$diagnostic_delta" "$_cache_file"
 }
 
 should_check_project() {

--- a/scripts/ci/test-project-compile-guard-readiness-artifacts.mjs
+++ b/scripts/ci/test-project-compile-guard-readiness-artifacts.mjs
@@ -480,3 +480,168 @@ withTempDir((dir) => {
   assert.deepEqual(rows[0].exit_codes.tsc, [127]);
   assert.deepEqual(rows[0].exit_codes.tsz, []);
 });
+
+// Result cache: second guard run skips tsz when binary, tsconfig, and fixture ref are unchanged.
+withTempDir((dir) => {
+  const fixtureRoot = path.join(dir, "fixture-root");
+  const fakeRepo = path.join(dir, "fake-utility-types");
+  const fakeTsz = path.join(dir, "tsz");
+  const runCountFile = path.join(dir, "tsz-run-count");
+
+  const fakeRef = createGitRepo(fakeRepo, {
+    "src/index.ts": "export type Id<T> = T;\n",
+  });
+
+  writeExecutable(
+    fakeTsz,
+    `#!/usr/bin/env bash
+count=0
+[ -f ${JSON.stringify(runCountFile)} ] && count=$(cat ${JSON.stringify(runCountFile)})
+printf '%s' "$((count+1))" > ${JSON.stringify(runCountFile)}
+exit 0
+`,
+  );
+
+  const env = {
+    ...process.env,
+    TSZ_BIN: fakeTsz,
+    UTILITY_TYPES_REPO: fakeRepo,
+    UTILITY_TYPES_REF: fakeRef,
+    TSZ_PROJECT_COMPILE_FIXTURE_ROOT: fixtureRoot,
+    TSZ_PROJECT_COMPILE_SET: "required",
+    TSZ_PROJECT_COMPILE_FILTER: "^utility-types-project$",
+    TSZ_PROJECT_COMPILE_INCLUDE_GENERATED_APPS: "0",
+  };
+
+  const r1 = spawnSync("bash", [GUARD_SCRIPT], { cwd: ROOT, encoding: "utf8", env });
+  assert.equal(r1.status, 0, `first run failed:\n${r1.stderr}\n${r1.stdout}`);
+  assert.equal(
+    fs.readFileSync(runCountFile, "utf8"),
+    "1",
+    "tsz should run on first pass",
+  );
+
+  const r2 = spawnSync("bash", [GUARD_SCRIPT], { cwd: ROOT, encoding: "utf8", env });
+  assert.equal(r2.status, 0, `second run failed:\n${r2.stderr}\n${r2.stdout}`);
+  assert.equal(
+    fs.readFileSync(runCountFile, "utf8"),
+    "1",
+    "tsz must not re-run when binary, tsconfig, and fixture ref are unchanged",
+  );
+
+  const rows = readJsonl(
+    path.join(fixtureRoot, "project-compatibility.jsonl"),
+  );
+  assert.equal(rows.length, 1);
+  assertRequiredCompatibilityFields(rows[0]);
+  assert.equal(rows[0].name, "utility-types-project");
+  assert.equal(rows[0].state, "green");
+  assert.equal(rows[0].exit_class, "exit success");
+});
+
+// Result cache disabled: tsz always runs when TSZ_PROJECT_COMPILE_RESULT_CACHE=0.
+withTempDir((dir) => {
+  const fixtureRoot = path.join(dir, "fixture-root");
+  const fakeRepo = path.join(dir, "fake-utility-types");
+  const fakeTsz = path.join(dir, "tsz");
+  const runCountFile = path.join(dir, "tsz-run-count");
+
+  const fakeRef = createGitRepo(fakeRepo, {
+    "src/index.ts": "export type Id<T> = T;\n",
+  });
+
+  writeExecutable(
+    fakeTsz,
+    `#!/usr/bin/env bash
+count=0
+[ -f ${JSON.stringify(runCountFile)} ] && count=$(cat ${JSON.stringify(runCountFile)})
+printf '%s' "$((count+1))" > ${JSON.stringify(runCountFile)}
+exit 0
+`,
+  );
+
+  const env = {
+    ...process.env,
+    TSZ_BIN: fakeTsz,
+    UTILITY_TYPES_REPO: fakeRepo,
+    UTILITY_TYPES_REF: fakeRef,
+    TSZ_PROJECT_COMPILE_FIXTURE_ROOT: fixtureRoot,
+    TSZ_PROJECT_COMPILE_SET: "required",
+    TSZ_PROJECT_COMPILE_FILTER: "^utility-types-project$",
+    TSZ_PROJECT_COMPILE_INCLUDE_GENERATED_APPS: "0",
+    TSZ_PROJECT_COMPILE_RESULT_CACHE: "0",
+  };
+
+  spawnSync("bash", [GUARD_SCRIPT], { cwd: ROOT, encoding: "utf8", env });
+  spawnSync("bash", [GUARD_SCRIPT], { cwd: ROOT, encoding: "utf8", env });
+
+  assert.equal(
+    fs.readFileSync(runCountFile, "utf8"),
+    "2",
+    "tsz must re-run on every pass when cache is disabled",
+  );
+});
+
+// Result cache miss: tsz re-runs after tsz binary changes.
+withTempDir((dir) => {
+  const fixtureRoot = path.join(dir, "fixture-root");
+  const fakeRepo = path.join(dir, "fake-utility-types");
+  const tszV1 = path.join(dir, "tsz-v1");
+  const tszV2 = path.join(dir, "tsz-v2");
+  const runCountFile = path.join(dir, "tsz-run-count");
+
+  const fakeRef = createGitRepo(fakeRepo, {
+    "src/index.ts": "export type Id<T> = T;\n",
+  });
+
+  const counterScript = (tag) =>
+    `#!/usr/bin/env bash\n# ${tag}\ncount=0\n[ -f ${JSON.stringify(runCountFile)} ] && count=$(cat ${JSON.stringify(runCountFile)})\nprintf '%s' "$((count+1))" > ${JSON.stringify(runCountFile)}\nexit 0\n`;
+
+  writeExecutable(tszV1, counterScript("v1"));
+  writeExecutable(tszV2, counterScript("v2"));
+
+  const commonEnv = {
+    ...process.env,
+    UTILITY_TYPES_REPO: fakeRepo,
+    UTILITY_TYPES_REF: fakeRef,
+    TSZ_PROJECT_COMPILE_FIXTURE_ROOT: fixtureRoot,
+    TSZ_PROJECT_COMPILE_SET: "required",
+    TSZ_PROJECT_COMPILE_FILTER: "^utility-types-project$",
+    TSZ_PROJECT_COMPILE_INCLUDE_GENERATED_APPS: "0",
+  };
+
+  // First run with v1 — cache miss, tsz runs.
+  const r1 = spawnSync("bash", [GUARD_SCRIPT], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: { ...commonEnv, TSZ_BIN: tszV1 },
+  });
+  assert.equal(r1.status, 0, r1.stderr);
+  assert.equal(fs.readFileSync(runCountFile, "utf8"), "1");
+
+  // Second run with v1 — cache hit, tsz skipped.
+  const r2 = spawnSync("bash", [GUARD_SCRIPT], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: { ...commonEnv, TSZ_BIN: tszV1 },
+  });
+  assert.equal(r2.status, 0, r2.stderr);
+  assert.equal(
+    fs.readFileSync(runCountFile, "utf8"),
+    "1",
+    "same binary: cache hit",
+  );
+
+  // Third run with v2 — binary changed, cache miss, tsz re-runs.
+  const r3 = spawnSync("bash", [GUARD_SCRIPT], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: { ...commonEnv, TSZ_BIN: tszV2 },
+  });
+  assert.equal(r3.status, 0, r3.stderr);
+  assert.equal(
+    fs.readFileSync(runCountFile, "utf8"),
+    "2",
+    "new binary: cache miss",
+  );
+});


### PR DESCRIPTION
AgentName: claude-sonnet-4-6 (session busy-lamport-JW4x0)

## Summary

Adds a per-project result cache to `check_project` in `scripts/ci/project-compile-guard.sh` so that the guard script skips re-running `tsz --noEmit` when the tsz binary, the project tsconfig, and the fixture git HEAD are all unchanged from a prior run.

Fixes #10968.

## Track

CI / performance harness — no compiler semantics changed.

## Invariant

The guard script must produce identical `project-compatibility.jsonl` entries whether the result comes from a live tsz run or from the result cache.

## Scope

- `scripts/ci/project-compile-guard.sh` — three new helpers (`sha256_of_file`, `write_compile_cache`, `compute_compile_fingerprint`) and cache hit/miss logic in `check_project`.
- `scripts/ci/test-project-compile-guard-readiness-artifacts.mjs` — three new test cases covering cache hit, cache disabled, and cache miss on binary change.

### Design decisions (post-3× `/simplify`)

| Decision | Rationale |
|---|---|
| Fingerprint = raw key (`name\|binary_hash\|tsconfig_hash\|git_ref`) | Key is already composed of fixed-length hashes; a final sha256 over the assembled string adds 3 extra forks per project with no collision benefit |
| Cache file named per-project, fingerprint stored inside | Stale entries self-prune on the next read — no per-fingerprint filename accumulation |
| Atomic write via `tmp + mv` | Prevents partial reads if the script is interrupted mid-write |
| `mkdir -p "$RESULT_CACHE_DIR"` at startup | Called once rather than on every write |
| Early-break on fingerprint mismatch in while loop | Avoids reading the full diagnostic delta body for stale entries |
| if/else + single tail `write_compile_cache` | Unifies the two formerly separate cache-write call sites |
| `TSZ_PROJECT_COMPILE_RESULT_CACHE=0` opt-out | Allows CI matrix jobs that need deterministic re-runs to disable the cache |

## Project Corpus Impact

- Row: all `guard_set=required` and `guard_set=canary` rows (utility-types, ts-essentials, RxJS, type-fest, ts-toolbelt, Zod, Kysely, type-challenges-solutions, vite-vanilla-ts-app, nextjs-fresh-app)
- Bug family: CI performance — guard re-ran `tsz --noEmit` unconditionally on every invocation even when nothing changed
- Evidence: CI script only; no compiler behavior path changed. Three new integration tests in `test-project-compile-guard-readiness-artifacts.mjs` exercise the cache hit path, the opt-out path (`TSZ_PROJECT_COMPILE_RESULT_CACHE=0`), and the cache miss path (binary hash change). All pass locally: `GIT_CONFIG_GLOBAL=/dev/null node scripts/ci/test-project-compile-guard-readiness-artifacts.mjs` → EXIT: 0

## Verification

- [x] `GIT_CONFIG_GLOBAL=/dev/null node scripts/ci/test-project-compile-guard-readiness-artifacts.mjs` — all tests pass (including 3 new cache tests)
- [x] `/simplify` run ×3 before this PR; each pass improved a distinct axis (reuse, efficiency, altitude)
- [x] No compiler semantics changed — pure CI harness change

## Coordination Notes

- Claimed issue #10968 at the start of the session; WIP label added before work started.
- No overlap with open PRs inspected before starting.
- Cache directory defaults to `$FIXTURE_ROOT/.result-cache`; override via `TSZ_PROJECT_COMPILE_RESULT_CACHE_DIR`.
- The `check_type_challenges_solutions_tsc_oracle` tsc invocation is intentionally not cached in this PR (it's a separate tsc run, not tsz); caching it is a follow-up.

https://claude.ai/code/session_018z6VaEkfdgQ5iSynXoeoDu