### PR TITLE
fix(dts): preserve generic new expression type args

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
@@ -25,6 +25,13 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         let new_expr = self.arena.get_call_expr(expr_node)?;
+        if new_expr.type_arguments.is_some()
+            && self.new_expression_constructor_is_class_like(expr_idx)
+            && let Some(type_text) = self.nameable_new_expression_type_text(expr_idx)
+        {
+            return Some(self.rewrite_exported_import_equals_type_text(type_text));
+        }
+
         let constructor_type = self
             .get_node_type_or_names(&[new_expr.expression])
             .or_else(|| self.get_type_via_symbol(new_expr.expression))?;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -1592,21 +1592,19 @@ impl<'a> DeclarationEmitter<'a> {
         let Some(expr_idx) = self.skip_parenthesized_expression(new_expr.expression) else {
             return false;
         };
-        let Some(expr_node) = self.arena.get(expr_idx) else {
-            return false;
-        };
-        if expr_node.kind != SyntaxKind::Identifier as u16 {
+        if self
+            .nameable_constructor_expression_text(expr_idx)
+            .is_none()
+        {
             return false;
         }
-        let Some(ident) = self.get_identifier_text(expr_idx) else {
-            return false;
-        };
         let Some(binder) = self.binder else {
             return false;
         };
-        let Some(sym_id) = self.resolve_identifier_symbol(expr_idx, &ident) else {
+        let Some(sym_id) = self.value_reference_symbol(expr_idx) else {
             return false;
         };
+        let sym_id = self.resolve_portability_symbol(sym_id, binder);
         let Some(symbol) = binder.symbols.get(sym_id) else {
             return false;
         };

--- a/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
@@ -109,6 +109,24 @@ let machine = new Machine({
 }
 
 #[test]
+fn test_namespace_qualified_generic_new_expression_preserves_explicit_type_arguments() {
+    let output = emit_dts_with_binding(
+        r#"
+namespace Outer {
+    export class Box<T> {}
+    export class Item {}
+}
+
+var value = new Outer.Box<Outer.Item>();
+"#,
+    );
+    assert!(
+        output.contains("declare var value: Outer.Box<Outer.Item>;"),
+        "Expected explicit type arguments on namespace-qualified new expression: {output}"
+    );
+}
+
+#[test]
 fn test_generic_call_this_type_descriptor_intersections_preserve_source_surfaces() {
     let output = emit_dts_with_binding(
         r#"


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Emit/DTS parity: declaration emit generic/type-display declarations.

## Invariant
When a variable initializer is a `new` expression whose constructor is a nameable namespace-qualified class and the source supplies explicit type arguments, `tsc` emits the instantiated class surface in the `.d.ts`; this PR lets declaration variable inference use the existing source-level constructor/type-argument surface instead of falling through to a raw inferred class name.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs`
- `crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: declaration emit generic class instance type arguments
- Evidence: targets the current `genericClassesInModule` DTS failure; no project corpus row identified for this final-mile declaration surface.

## Verification
- M5Manager ready promotion on 2026-06-02: exact-head draft-light `CI Light Summary` SUCCESS for `34b72600b2d9f4a90140b4541d0f1d04c0c3686f`.
- Before main sync: `git diff --check`
- Before main sync: `cargo fmt`
- Before main sync: `cargo nextest run -p tsz-emitter namespace_qualified_generic_new_expression_preserves_explicit_type_arguments`
- Before main sync: `scripts/emit/run.sh --filter=genericClassesInModule --dts-only --verbose --concurrency=1 --json-out=/tmp/studio-d-generic-classes-module.json`
- Earlier rebase onto `origin/main` on 2026-06-01: `git diff --check origin/main...HEAD`
- Earlier rebase onto `origin/main` on 2026-06-01: `cargo fmt --check`
- M5Manager-delegated refresh on 2026-06-02 from `526cf2a668768596de91cb03b4c0346405a2dc3d` to `34b72600b2d9f4a90140b4541d0f1d04c0c3686f`: `git fetch origin main`; `git fetch origin codex/studio-d-dts-new-expression-type-args-20260601`; `git rebase origin/main` with no conflicts; `git diff --check origin/main...HEAD`; `cargo fmt --check`; `git diff --stat origin/main...HEAD` shows only the three DTS files in this PR.

## Coordination Notes
- M5Manager delegated this one-at-a-time refresh for #12131 only; #12132, #12133, #12118, and other PRs were intentionally not touched.
- Rebased directly onto live `origin/main` `723cd1da1de852117e5ff67fad79097287bc5ff9`; current head is `34b72600b2d9f4a90140b4541d0f1d04c0c3686f`.
- Existing open emit PR overlap checked earlier: #12127 JSDoc/type-only require, #12126 static-this class expression, #12115 exact optional mapped intersections, #12092 output-surgery headroom. No overlapping PR found for namespace-qualified generic `new` expression DTS surfaces.
- This is a declaration emitter output-boundary fix. It does not add checker/solver relation checks, raw solver internals, semantic validation during printing, or output string surgery.
- Current state: ready for review after M5Manager promotion on 2026-06-02. Labels remain `emit` and `agent:Studio-D`; no `merge-queue`, merge, close, or label change was performed.
- Draft-light CI passed for refreshed head `34b72600b2d9f4a90140b4541d0f1d04c0c3686f`; M5Manager is promoting this PR first in the #12131 -> #12133 Studio-D stack. Ready-review CI should own heavy emit, conformance, fourslash, project, and WASM gates.
- Next owner/action: M5Manager should watch exact-head ready-review CI. Do not add `merge-queue` until `CI Summary`, `GitGuardian Security Checks`, and required PR-head gates pass for this head.

