### PR TITLE
fix(dts): infer contextual callback length returns

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs
@@ -836,6 +836,20 @@ impl<'a> DeclarationEmitter<'a> {
                     param.type_annotation,
                     type_param_names,
                 );
+            if let Some((param_name, value_text)) = self
+                .infer_contextual_callback_return_substitution(
+                    &source_function_type,
+                    arg_idx,
+                    type_param_names,
+                    &blocked_return_type_params,
+                    &substitutions,
+                )
+                && !substitutions
+                    .iter()
+                    .any(|(name, _)| name.as_str() == param_name.as_str())
+            {
+                substitutions.push((param_name, value_text));
+            }
             Self::infer_function_type_substitutions(
                 &source_function_type,
                 &argument_function_type,

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs
@@ -286,6 +286,7 @@ mod type_inference;
 mod type_inference_accessor_property;
 mod type_inference_class_expression;
 mod type_inference_const_assertions;
+mod type_inference_contextual_callbacks;
 mod type_inference_declared_call;
 mod type_inference_enum_access;
 mod type_inference_expression_literals;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_contextual_callbacks.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_contextual_callbacks.rs
@@ -1,0 +1,116 @@
+//! Contextual callback return helpers for declaration emit.
+
+use super::super::DeclarationEmitter;
+use super::type_inference_function_text::FunctionTypeTextParts;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
+
+impl<'a> DeclarationEmitter<'a> {
+    pub(in crate::declaration_emitter::helpers) fn infer_contextual_callback_return_substitution(
+        &self,
+        source_function_type: &FunctionTypeTextParts,
+        arg_idx: NodeIndex,
+        type_param_names: &[String],
+        blocked_return_type_params: &[String],
+        substitutions: &[(String, String)],
+    ) -> Option<(String, String)> {
+        let return_param = source_function_type.return_type.trim();
+        if !type_param_names
+            .iter()
+            .any(|name| name.as_str() == return_param)
+            || blocked_return_type_params
+                .iter()
+                .any(|name| name.as_str() == return_param)
+            || substitutions
+                .iter()
+                .any(|(name, _)| name.as_str() == return_param)
+        {
+            return None;
+        }
+
+        let arg_node = self.arena.get(arg_idx)?;
+        let func = self.arena.get_function(arg_node)?;
+        let return_expr = if self
+            .arena
+            .get(func.body)
+            .is_some_and(|node| node.kind == syntax_kind_ext::BLOCK)
+        {
+            self.function_body_single_return_expression(func.body)?
+        } else {
+            func.body
+        };
+
+        let mut parameter_context = Vec::new();
+        for (source_param, &arg_param_idx) in source_function_type
+            .parameters
+            .iter()
+            .zip(&func.parameters.nodes)
+        {
+            if source_param.rest {
+                continue;
+            }
+            let Some(arg_param_node) = self.arena.get(arg_param_idx) else {
+                continue;
+            };
+            let Some(arg_param) = self.arena.get_parameter(arg_param_node) else {
+                continue;
+            };
+            let Some(arg_name) = self.get_identifier_text(arg_param.name) else {
+                continue;
+            };
+            let contextual_type =
+                Self::replace_whole_words_in_text(&source_param.type_text, substitutions);
+            if contextual_type.trim().is_empty()
+                || type_param_names
+                    .iter()
+                    .any(|name| Self::contains_whole_word_in_text(&contextual_type, name))
+            {
+                continue;
+            }
+            parameter_context.push((arg_name, contextual_type));
+        }
+
+        let value_text =
+            self.contextual_callback_return_type_text(return_expr, &parameter_context)?;
+        Some((
+            return_param.to_string(),
+            Self::parenthesize_generic_function_type_argument(&value_text),
+        ))
+    }
+
+    fn contextual_callback_return_type_text(
+        &self,
+        expr_idx: NodeIndex,
+        parameter_context: &[(String, String)],
+    ) -> Option<String> {
+        let expr_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(expr_idx);
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind == SyntaxKind::Identifier as u16 {
+            let name = self.get_identifier_text(expr_idx)?;
+            return parameter_context.iter().find_map(|(candidate, type_text)| {
+                (candidate == &name).then(|| type_text.clone())
+            });
+        }
+        if expr_node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            return None;
+        }
+        let access = self.arena.get_access_expr(expr_node)?;
+        if self.get_identifier_text(access.name_or_argument).as_deref() != Some("length") {
+            return None;
+        }
+        let receiver_name = self.get_identifier_text(access.expression)?;
+        let receiver_type = parameter_context
+            .iter()
+            .find_map(|(candidate, type_text)| (candidate == &receiver_name).then_some(type_text))?
+            .trim();
+        Self::type_text_has_length_number(receiver_type).then(|| "number".to_string())
+    }
+
+    fn type_text_has_length_number(type_text: &str) -> bool {
+        let text = type_text.trim();
+        text == "string" || text.ends_with("[]") || text.starts_with('[') && text.ends_with(']')
+    }
+}

--- a/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
@@ -1168,6 +1168,42 @@ let result = dispatchMethod<StringMethodDescriptor>("stringMethod", ["hello", 35
 }
 
 #[test]
+fn test_generic_pipe_callback_contextual_length_return_is_number() {
+    let output = emit_dts_with_binding(
+        r#"
+declare function compose<Args extends any[], Value, Result>(
+    first: (...args: Args) => Value,
+    second: (value: Value) => Result
+): (...args: Args) => Result;
+
+let made = compose(input => "hello", value => value.length);
+"#,
+    );
+    assert!(
+        output.contains("declare let made: (input: any) => number;"),
+        "Expected contextual callback length return to infer number: {output}"
+    );
+}
+
+#[test]
+fn test_renamed_generic_pipe_callback_contextual_length_return_is_number() {
+    let output = emit_dts_with_binding(
+        r#"
+declare function flow<Items extends any[], Item, Output>(
+    left: (...parts: Items) => Item,
+    right: (source: Item) => Output
+): (...parts: Items) => Output;
+
+let result = flow(token => "x", renamed => renamed.length);
+"#,
+    );
+    assert!(
+        output.contains("declare let result: (token: any) => number;"),
+        "Expected renamed contextual callback length return to infer number: {output}"
+    );
+}
+
+#[test]
 fn test_unannotated_method_returning_indexed_helper_call_preserves_this_surface() {
     let output = emit_dts_with_method_node_return_type(
         r#"


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Emit/DTS parity: declaration emit generic/type-display declarations.

## Invariant
When declaration emit reconstructs a generic call result from function-typed arguments and an earlier argument fixes a callback context type, an unannotated later callback body should use that contextual parameter type to infer a type-parameter return instead of substituting `any`.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_contextual_callbacks.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs`
- `crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs`

## Owner Layer
Declaration source-callable/public surface reconstruction. The new helper consumes source function-type text and already-inferred call-site substitutions; it does not add checker diagnostics, solver relation checks, raw solver internals, semantic validation during printing, or output surgery.

## Adjacent Case Matrix
- Reported shape: `pipe(x => "hello", s => s.length)` now emits `(x: any) => number`.
- Renamed shape: helper, type parameters, callback parameters, and bindings are renamed in unit coverage and still infer `number`.
- Equivalent structural shape: the helper is keyed on function-typed parameters plus contextual callback parameter substitutions, not on the `pipe` name or fixture path.
- Fallback shape: unsupported callback bodies still fall through to the existing source/canonical type paths; only identifier returns and well-known `.length` access on context types with numeric length are reconstructed.

## Project Corpus Impact
- Row: n/a
- Bug family: declaration emit generic callback contextual return inference
- Evidence: targeted DTS conformance slice `restTuplesFromContextualTypes` passed during original focused verification; no project corpus row identified for this final-mile declaration surface.

## Verification
- Original focused verification:
- `git diff --check`
- `cargo fmt --check`
- `cargo nextest run -p tsz-emitter generic_pipe_callback_contextual_length_return_is_number renamed_generic_pipe_callback_contextual_length_return_is_number`
- `scripts/emit/run.sh --filter=restTuplesFromContextualTypes --dts-only --verbose --concurrency=1 --json-out=/tmp/studio-d-rest-tuples-context.json`
- File-size check: `correlated_union.rs` is 1981 lines after splitting the new helper shard.
- Refresh on live `origin/main` `b8d2dbaf62499a8f9123dce91f7ca8c38aab7007`:
- `git merge-tree origin/main origin/codex/studio-d-dts-rest-tuple-context-20260601` -> clean tree preflight.
- `git rebase origin/main` -> clean rebase, no conflicts.
- `git diff --check origin/main...HEAD`
- `cargo fmt --check`
- `git diff --name-status origin/main...HEAD` -> only the four scoped emit/DTS files.
- `wc -l crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_contextual_callbacks.rs` -> 1981 and 116 lines.
- Previous rebased head `6601227af86fd0b62881d7fe149c21937a802244` passed draft-light CI: https://github.com/mohsen1/tsz/actions/runs/26798357540.
- Current refresh after live main advanced to `d394d819ab6b58252f125f66b2bb0af6337d3bdf`:
- `git fetch origin main`
- `git fetch origin codex/studio-d-dts-rest-tuple-context-20260601`
- `git merge-tree origin/main origin/codex/studio-d-dts-rest-tuple-context-20260601` -> clean tree preflight.
- `git rebase origin/main` -> clean rebase, no conflicts.
- `git diff --check origin/main...HEAD`
- `cargo fmt --check`
- `git diff --name-status origin/main...HEAD` -> only the four scoped emit/DTS files.

## Coordination Notes
- AgentName: Studio-D
- Refreshed by Studio-D under M5Manager direction from old head `6601227af86fd0b62881d7fe149c21937a802244` to new head `8c37467bcb2a589b7a0baa5b07947e3054bd02b7` on base `d394d819ab6b58252f125f66b2bb0af6337d3bdf`.
- Open emit overlap checked before current refresh: #12133 overlaps only in `generics_and_ambient.rs`; #12126 is JS/class emit. #12127 and #12130 are merged and touch different helper surfaces. No unsafe overlap or semantic conflict found for contextual generic callback return inference.
- Previous current-state note: old ready-review run 26757691128 / conformance-aggregate job 78864296956 produced the stale `CI Summary` failure; later draft-light CI on old heads `f2c04078c2b36d67a146009ba902e071435e2ffa` and `6601227af86fd0b62881d7fe149c21937a802244` was green.
- Current head `8c37467bcb2a589b7a0baa5b07947e3054bd02b7` is ready/non-draft. Exact-head ready-review CI is green, including `CI Summary` and `GitGuardian Security Checks`.
- `merge-queue` is present for current head `8c37467bcb2a589b7a0baa5b07947e3054bd02b7`. `Queue Tested` is queue-owned and may remain pending until the repo-local merge queue runs the synthetic latest-`main` merge. M5Manager did not run local full conformance/fourslash/emit and did not rerun CI.


