### PR TITLE
fix(dts): reuse named constructor generic defaults

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
@@ -58,9 +58,6 @@ impl<'a> DeclarationEmitter<'a> {
             return None;
         }
         let new_expr = self.arena.get_call_expr(expr_node)?;
-        if new_expr.type_arguments.is_some() {
-            return None;
-        }
 
         if let Some(type_text) = self
             .reference_declared_source_type_annotation_text(new_expr.expression)
@@ -89,6 +86,14 @@ impl<'a> DeclarationEmitter<'a> {
             let Some(type_node) = self.arena.get(var_decl.type_annotation) else {
                 continue;
             };
+            if type_node.kind == syntax_kind_ext::TYPE_REFERENCE
+                && let Some(type_sym_id) = self
+                    .declaration_type_symbol_from_type_node(self.arena, var_decl.type_annotation)
+                && let Some(type_text) =
+                    self.source_construct_return_for_type_symbol(type_sym_id, new_expr)
+            {
+                return Some(type_text);
+            }
             if type_node.kind != syntax_kind_ext::CONSTRUCTOR_TYPE {
                 continue;
             }
@@ -251,6 +256,14 @@ impl<'a> DeclarationEmitter<'a> {
             let Some(type_node) = self.arena.get(decl.type_annotation) else {
                 continue;
             };
+            if type_node.kind == syntax_kind_ext::TYPE_REFERENCE
+                && let Some(type_sym_id) =
+                    self.declaration_type_symbol_from_type_node(self.arena, decl.type_annotation)
+                && let Some(type_text) =
+                    self.source_construct_return_for_type_symbol(type_sym_id, new_expr)
+            {
+                return Some(type_text);
+            }
             if type_node.kind != syntax_kind_ext::CONSTRUCTOR_TYPE {
                 continue;
             }
@@ -277,13 +290,112 @@ impl<'a> DeclarationEmitter<'a> {
         None
     }
 
+    fn source_construct_return_for_type_symbol(
+        &self,
+        type_sym_id: SymbolId,
+        new_expr: &tsz_parser::parser::node::CallExprData,
+    ) -> Option<String> {
+        self.with_symbol_declarations(type_sym_id, |source_arena, decl_idx| {
+            let decl_node = source_arena.get(decl_idx)?;
+            if let Some(interface) = source_arena.get_interface(decl_node) {
+                return self.source_construct_return_from_members(
+                    source_arena,
+                    &interface.members,
+                    new_expr,
+                );
+            }
+            if let Some(alias) = source_arena.get_type_alias(decl_node) {
+                let alias_node = source_arena.get(alias.type_node)?;
+                if alias_node.kind == syntax_kind_ext::TYPE_LITERAL
+                    && let Some(type_literal) = source_arena.get_type_literal(alias_node)
+                {
+                    return self.source_construct_return_from_members(
+                        source_arena,
+                        &type_literal.members,
+                        new_expr,
+                    );
+                }
+                if alias_node.kind == syntax_kind_ext::CONSTRUCTOR_TYPE {
+                    let ctor_type = source_arena.get_function_type(alias_node)?;
+                    let return_type_text = self.source_type_annotation_text_for_declaration_reuse(
+                        source_arena,
+                        ctor_type.type_annotation,
+                    )?;
+                    return self.substitute_source_construct_signature_type_parameters(
+                        source_arena,
+                        ctor_type.type_parameters.as_ref(),
+                        Some(&ctor_type.parameters),
+                        new_expr,
+                        return_type_text,
+                    );
+                }
+            }
+            None
+        })
+    }
+
+    fn source_construct_return_from_members(
+        &self,
+        source_arena: &NodeArena,
+        members: &NodeList,
+        new_expr: &tsz_parser::parser::node::CallExprData,
+    ) -> Option<String> {
+        for &member_idx in &members.nodes {
+            let Some(member_node) = source_arena.get(member_idx) else {
+                continue;
+            };
+            if member_node.kind != syntax_kind_ext::CONSTRUCT_SIGNATURE {
+                continue;
+            }
+            let Some(signature) = source_arena.get_signature(member_node) else {
+                continue;
+            };
+            let Some(return_type_text) = self.source_type_annotation_text_for_declaration_reuse(
+                source_arena,
+                signature.type_annotation,
+            ) else {
+                continue;
+            };
+            let Some(type_text) = self.substitute_source_construct_signature_type_parameters(
+                source_arena,
+                signature.type_parameters.as_ref(),
+                signature.parameters.as_ref(),
+                new_expr,
+                return_type_text,
+            ) else {
+                continue;
+            };
+            if !type_text.contains("unknown") && !type_text.contains("any") {
+                return Some(type_text);
+            }
+        }
+        None
+    }
+
     fn substitute_source_construct_type_parameters(
         &self,
         ctor_type: &tsz_parser::parser::node::FunctionTypeData,
         call: &tsz_parser::parser::node::CallExprData,
+        type_text: String,
+    ) -> Option<String> {
+        self.substitute_source_construct_signature_type_parameters(
+            self.arena,
+            ctor_type.type_parameters.as_ref(),
+            Some(&ctor_type.parameters),
+            call,
+            type_text,
+        )
+    }
+
+    fn substitute_source_construct_signature_type_parameters(
+        &self,
+        source_arena: &NodeArena,
+        type_params: Option<&NodeList>,
+        parameters: Option<&NodeList>,
+        call: &tsz_parser::parser::node::CallExprData,
         mut type_text: String,
     ) -> Option<String> {
-        let Some(type_params) = ctor_type.type_parameters.as_ref() else {
+        let Some(type_params) = type_params else {
             return Some(type_text);
         };
         if type_params.nodes.is_empty() {
@@ -294,26 +406,26 @@ impl<'a> DeclarationEmitter<'a> {
         let mut type_param_constraints = Vec::new();
         let mut type_param_defaults = Vec::new();
         for &param_idx in &type_params.nodes {
-            let Some(param_node) = self.arena.get(param_idx) else {
+            let Some(param_node) = source_arena.get(param_idx) else {
                 continue;
             };
-            let Some(param) = self.arena.get_type_parameter(param_node) else {
+            let Some(param) = source_arena.get_type_parameter(param_node) else {
                 continue;
             };
-            let Some(name_text) = self.get_identifier_text(param.name) else {
+            let Some(name_text) = self.identifier_text_from_arena(source_arena, param.name) else {
                 continue;
             };
             if param.constraint.is_some()
                 && let Some(constraint) = self
-                    .emit_type_node_text(param.constraint)
-                    .or_else(|| self.source_slice_from_arena(self.arena, param.constraint))
+                    .emit_type_node_text_from_arena(source_arena, param.constraint)
+                    .or_else(|| self.source_slice_from_arena(source_arena, param.constraint))
             {
                 type_param_constraints.push((name_text.clone(), constraint));
             }
             if param.default.is_some()
                 && let Some(default_text) = self
-                    .emit_type_node_text(param.default)
-                    .or_else(|| self.source_slice_from_arena(self.arena, param.default))
+                    .emit_type_node_text_from_arena(source_arena, param.default)
+                    .or_else(|| self.source_slice_from_arena(source_arena, param.default))
             {
                 type_param_defaults.push((name_text.clone(), default_text));
             }
@@ -327,13 +439,24 @@ impl<'a> DeclarationEmitter<'a> {
             return Some(type_text);
         }
 
-        let mut substitutions = self.infer_call_type_param_substitutions_from_arguments(
-            self.arena,
-            &ctor_type.parameters,
-            call,
-            &type_param_names,
-            &type_param_constraints,
-        );
+        let explicit_type_args = self.type_argument_list_source_text(call.type_arguments.as_ref());
+        let mut substitutions = if explicit_type_args.is_empty() {
+            parameters.map_or_else(Vec::new, |parameters| {
+                self.infer_call_type_param_substitutions_from_arguments(
+                    source_arena,
+                    parameters,
+                    call,
+                    &type_param_names,
+                    &type_param_constraints,
+                )
+            })
+        } else {
+            type_param_names
+                .iter()
+                .zip(explicit_type_args.iter())
+                .map(|(name_text, arg_text)| (name_text.clone(), arg_text.clone()))
+                .collect()
+        };
         for (name_text, default_text) in type_param_defaults {
             if substitutions
                 .iter()

--- a/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
@@ -127,6 +127,40 @@ var value = new Outer.Box<Outer.Item>();
 }
 
 #[test]
+fn test_named_constructor_interface_uses_signature_type_parameter_defaults() {
+    let output = emit_dts_with_binding(
+        r#"
+interface Holder<Value> {
+    value: Value;
+}
+
+interface HolderFactory {
+    new <Payload = number>(value?: Payload): Holder<Payload>;
+}
+
+declare const Holder: HolderFactory;
+
+let inferredDefault = new Holder();
+let inferredArgument = new Holder("text");
+let explicitArgument = new Holder<boolean>();
+"#,
+    );
+
+    assert!(
+        output.contains("declare let inferredDefault: Holder<number>;"),
+        "Expected construct signature default type argument to be reused: {output}"
+    );
+    assert!(
+        output.contains("declare let inferredArgument: Holder<string>;"),
+        "Expected construct signature argument inference to be reused: {output}"
+    );
+    assert!(
+        output.contains("declare let explicitArgument: Holder<boolean>;"),
+        "Expected construct signature explicit type argument to be reused: {output}"
+    );
+}
+
+#[test]
 fn test_generic_call_this_type_descriptor_intersections_preserve_source_surfaces() {
     let output = emit_dts_with_binding(
         r#"


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Track 9 - Declaration emit 100% through declaration/public API summary boundaries.

## Invariant
When a `new` expression targets a value whose declared type is a named constructor interface or constructor-shaped type alias with a generic construct signature, `tsc` substitutes explicit, inferred, or default construct-signature type arguments into the returned instance type; this PR makes tsz do that through the declaration emitter's source construct-return boundary.

## Scope
- Follow value annotations such as `declare const C: Ctor` from the named type reference to interface, type literal, or constructor-type declarations with construct signatures.
- Reuse construct-signature return annotations after applying explicit type arguments, argument-derived substitutions, and type parameter defaults.
- Add focused declaration emitter coverage using renamed type parameters so the rule is structural, not spelling-based.

## Project Corpus Impact
- Row: `genericDefaults` declaration emit
- Bug family: named constructor interface generic defaults in inferred `.d.ts` variable declarations
- Evidence: `scripts/emit/run.sh --filter=genericDefaults --dts-only --verbose --concurrency=1 --json-out=/tmp/studio-d-generic-defaults.json` passed `2/2` DTS cases on the original implementation head; this refresh did not run broad local suites.

## Verification
- Original implementation: `cargo nextest run -p tsz-emitter test_named_constructor_interface_uses_signature_type_parameter_defaults`
- Original implementation: `scripts/emit/run.sh --filter=genericDefaults --dts-only --verbose --concurrency=1 --json-out=/tmp/studio-d-generic-defaults.json`
- Original implementation: `git diff --check`
- Stacked refresh on 2026-06-02 from `4435cf492f7f7c6b004dcb647aa4c023888c3e90` to `fe61f3be6352bba8f92eafaa44f621cc5b6cdbb5`: `git diff --check origin/codex/studio-d-dts-new-expression-type-args-20260601...HEAD`
- Stacked refresh on 2026-06-02: `cargo fmt --check`
- Stacked refresh on 2026-06-02: `git diff --stat origin/codex/studio-d-dts-new-expression-type-args-20260601...HEAD` showed only `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs` and `crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs`.
- Main-base refresh after #12131 merged: `git diff --check origin/main...HEAD`
- Main-base refresh after #12131 merged: `cargo fmt --check`
- Main-base refresh after #12131 merged: `cargo nextest run -p tsz-emitter test_named_constructor_interface_uses_signature_type_parameter_defaults` -> 1 passed, 4062 skipped.
- Current refresh after live main advanced to `d394d819ab6b58252f125f66b2bb0af6337d3bdf`: `git merge-tree origin/main origin/codex/studio-d-dts-generic-defaults-20260601` -> clean tree preflight.
- Current refresh: `git rebase origin/main` -> clean rebase, no conflicts.
- Current refresh: `git diff --check origin/main...HEAD`
- Current refresh: `cargo fmt --check`
- Current refresh: `git diff --name-status origin/main...HEAD` -> only `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs` and `crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs`.
- Current refresh file-size check: `type_inference_source_callables.rs` is 1743 lines and `generics_and_ambient.rs` is 1501 lines.

## Coordination Notes
- AgentName: Studio-D
- Owner layer: declaration emitter source/public API summary boundary; no checker, solver, JS emit, JSDoc, or class-expression/static-this ownership changes.
- Adjacent-case test matrix: defaulted no-arg construct call (`Holder<number>`), argument-inferred construct call (`Holder<string>`), explicit construct type argument (`Holder<boolean>`), and renamed construct type parameter (`Payload`, not `T`).
- Fallback behavior: unsupported constructor shapes still fall through to the existing construct-return/nameable-new-expression paths rather than accepting an incomplete source substitution.
- Adjacent ownership: avoids Studio-E JS/JSDoc lanes and Studio-C class-expression/static-this emit lanes.
- Open/merged overlap checked before current refresh: #12132 overlaps only in `generics_and_ambient.rs`; #12126 is JS/class emit; merged #12127 and #12130 touch different declaration helper surfaces. No unsafe overlap or duplicate found.
- M5Manager delegated this refresh after live main advanced. Refreshed from old head `0c8fd7bd2cdc5bf3f39d5df6513d2686c702a173` to new head `f3a8246deab5f7fd618a08b3fea43cba100fd224` on base `d394d819ab6b58252f125f66b2bb0af6337d3bdf`.
- Exact-head ready-review CI for `f3a8246deab5f7fd618a08b3fea43cba100fd224` is green, including `CI Summary` and `GitGuardian Security Checks`.
- M5Manager added `merge-queue` after confirming the PR is ready/non-draft/non-WIP, auto-merge is off, and the head is unchanged. `Queue Tested` is queue-owned. No local full conformance/fourslash/emit run.
