### PR TITLE
perf(checker): lazy method-overload + heritage member resolution for simple lib interfaces

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
+++ b/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
@@ -57,6 +57,28 @@ pub(crate) fn lazy_lib_member_access_disabled() -> bool {
     })
 }
 
+/// Kill-switch for the lazy single-**method** lib-interface property-access
+/// fast path (the overload-set + heritage-walk extension of the single-property
+/// fast path). Set `TSZ_DISABLE_LAZY_METHOD=1` to force the legacy
+/// full-materialization path for method members and inherited members, enabling
+/// byte-identical diagnostic comparison of method/call resolution with the fast
+/// path on vs off.
+///
+/// This is independent of [`lazy_lib_member_access_disabled`] so the
+/// higher-risk method/overload/heritage path can be A/B compared in isolation
+/// from the already-landed single-property path.
+///
+/// Cached in a `OnceLock` so the environment is read at most once per process.
+pub(crate) fn lazy_lib_method_disabled() -> bool {
+    use std::sync::OnceLock;
+    static DISABLED: OnceLock<bool> = OnceLock::new();
+    *DISABLED.get_or_init(|| {
+        std::env::var("TSZ_DISABLE_LAZY_METHOD")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+    })
+}
+
 /// Kill-switch for keeping a global ambient-var value type lazy when its
 /// annotation is a bare reference to a simple lib interface (e.g. the global
 /// `declare var document: Document`). Set `TSZ_DISABLE_LAZY_GLOBAL_VAR=1` to

--- a/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
+++ b/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
@@ -57,6 +57,23 @@ pub(crate) fn lazy_lib_member_access_disabled() -> bool {
     })
 }
 
+/// Kill-switch for keeping a global ambient-var value type lazy when its
+/// annotation is a bare reference to a simple lib interface (e.g. the global
+/// `declare var document: Document`). Set `TSZ_DISABLE_LAZY_GLOBAL_VAR=1` to
+/// force the legacy eager `resolve_ref_type` materialization, enabling
+/// byte-identical diagnostic comparison.
+///
+/// Cached in a `OnceLock` so the environment is read at most once per process.
+pub(crate) fn lazy_global_var_disabled() -> bool {
+    use std::sync::OnceLock;
+    static DISABLED: OnceLock<bool> = OnceLock::new();
+    *DISABLED.get_or_init(|| {
+        std::env::var("TSZ_DISABLE_LAZY_GLOBAL_VAR")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+    })
+}
+
 impl CheckerState<'_> {
     /// Return the `DefId` of an eligible simple lib-interface receiver when
     /// `object_type` is a bare `Lazy(DefId)` reference to one, or `None`
@@ -81,7 +98,34 @@ impl CheckerState<'_> {
         if lazy_lib_member_access_disabled() {
             return None;
         }
+        self.simple_lib_interface_lazy_ref_def_id(object_type)
+    }
 
+    /// Structural eligibility predicate shared by the property-access fast path
+    /// ([`Self::lazy_lib_member_receiver_def_id`]) and the lazy global-var value
+    /// type ([`Self::lazy_global_var_lib_interface_def_id`]).
+    ///
+    /// Returns the `DefId` when `object_type` is a bare `Lazy(DefId)` reference
+    /// to a simple lib interface, or `None` otherwise. This does **not** check
+    /// either kill-switch; callers gate independently so each lever can be A/B
+    /// compared in isolation.
+    ///
+    /// Eligibility (same conservative shape as PR #8638's
+    /// `try_lower_simple_actual_lib_type_reference`):
+    /// 1. `object_type` is a bare `Lazy(DefId)` (not an `Application`).
+    /// 2. The `DefId` maps to a symbol that is an `INTERFACE`.
+    /// 3. The symbol is from the actual or cloned standard library.
+    /// 4. The interface is **non-generic** (no type parameters) — generic
+    ///    receivers need argument substitution that the single-member walk does
+    ///    not perform.
+    /// 5. The interface name is not compiler-managed and not shadowed by a
+    ///    file-local type declaration.
+    /// 6. The interface is not globally augmented (`declare global { interface
+    ///    X { ... } }`), which could add the accessed member out of band.
+    pub(crate) fn simple_lib_interface_lazy_ref_def_id(
+        &self,
+        object_type: tsz_solver::TypeId,
+    ) -> Option<DefId> {
         let def_id = crate::query_boundaries::common::lazy_def_id(self.ctx.types, object_type)?;
 
         // Must resolve to a concrete lib interface symbol.
@@ -125,6 +169,56 @@ impl CheckerState<'_> {
         }
 
         Some(def_id)
+    }
+
+    /// When `annotated_type` is the value type of a global/cross-file ambient var
+    /// whose annotation is a bare reference to a simple lib interface, return the
+    /// same `Lazy(DefId)` so the value type stays lazy instead of being eagerly
+    /// materialized by `resolve_ref_type`.
+    ///
+    /// This is the value-position counterpart of the property-access fast path:
+    /// keeping the global receiver lazy (e.g. `document: Document`) lets
+    /// `try_lazy_lib_member_property_access` resolve only the accessed member on
+    /// `document.title` / `document.querySelector(...)`, mirroring the already-lazy
+    /// file-local `declare const d: Document` path.
+    ///
+    /// Returns `None` (caller keeps the eager `resolve_ref_type` result) when the
+    /// kill-switch is set or the annotation is not an eligible bare lib-interface
+    /// `Lazy(DefId)`.
+    pub(crate) fn lazy_global_var_lib_interface_def_id(
+        &self,
+        annotated_type: tsz_solver::TypeId,
+    ) -> Option<DefId> {
+        if lazy_global_var_disabled() {
+            return None;
+        }
+        self.simple_lib_interface_lazy_ref_def_id(annotated_type)
+    }
+
+    /// Build the `Lazy(DefId)` value type for a global ambient var whose
+    /// annotation is a bare reference to the simple lib interface named
+    /// `type_name`, or `None` when ineligible.
+    ///
+    /// Used by the lib-declaration resolution shortcut so an ambient lib var
+    /// like `declare var document: Document` keeps a lazy value type instead of
+    /// eagerly materializing the interface. The candidate lazy ref is validated
+    /// through the same conservative eligibility predicate as the property-access
+    /// fast path (simple, non-generic, actual-lib, unshadowed, unaugmented
+    /// interface), and the whole lever is gated by `TSZ_DISABLE_LAZY_GLOBAL_VAR`.
+    pub(crate) fn lazy_global_var_lib_interface_type(
+        &self,
+        type_name: &str,
+    ) -> Option<tsz_solver::TypeId> {
+        if lazy_global_var_disabled() {
+            return None;
+        }
+        let def_id = self.ctx.actual_lib_def_id_for_bare_name(type_name)?;
+        let lazy = self.ctx.types.lazy(def_id);
+        // Re-validate the structural eligibility on the constructed lazy ref so a
+        // generic, augmented, shadowed, or non-interface lib name falls back to
+        // the eager materialization path below.
+        self.simple_lib_interface_lazy_ref_def_id(lazy)
+            .map(|_| lazy)
     }
 
     /// Whether a lib interface `name` has any global augmentation declarations

--- a/crates/tsz-checker/src/tests/lazy_lib_member_access_tests.rs
+++ b/crates/tsz-checker/src/tests/lazy_lib_member_access_tests.rs
@@ -125,3 +125,154 @@ export {};
         "user-shadowed interface own member should resolve, got {codes:?}",
     );
 }
+
+// --- Lazy global ambient-var value type (extends the fast path to globals) ---
+//
+// A global ambient var typed as a bare simple-lib-interface reference (e.g. the
+// lib's own `declare var document: Document`) keeps a lazy value type, so a
+// property access like `document.title` resolves only the accessed member. These
+// tests assert the global path is behavior-preserving: reads type correctly,
+// mismatches still error, missing members still report TS2339, and method /
+// inherited / shadowed / augmented shapes resolve identically to the eager path.
+// The cases vary the lib interface and the accessed member so the behavior
+// follows the structural shape, not any particular identifier name.
+
+/// Own plain property read through the lib global `document` resolves to the
+/// correct member type with no diagnostics. Proven across two globals
+/// (`document.title`, `window.name`) so the path follows the shape.
+#[test]
+fn global_own_member_read_resolves_without_diagnostics() {
+    let codes = dom_codes(
+        r#"
+const a: string = document.title;
+const b: string = window.name;
+export {};
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "global own-member reads should not produce diagnostics, got {codes:?}",
+    );
+}
+
+/// A type mismatch on an own member accessed through a lib global must still
+/// report TS2322 — keeping the global lazy does not widen the member type.
+#[test]
+fn global_own_member_type_mismatch_still_errors() {
+    let codes = dom_codes(
+        r#"
+const wrong: number = document.title;
+export {};
+"#,
+    );
+    assert!(
+        codes.contains(&2322),
+        "string member assigned to number should report TS2322, got {codes:?}",
+    );
+}
+
+/// Accessing a member that does not exist on the global's interface must still
+/// report TS2339 — the lazy global resolves the absent member through the full
+/// path, which surfaces the missing-property error.
+#[test]
+fn global_missing_member_still_reports_ts2339() {
+    let codes = dom_codes(
+        r#"
+const x = document.definitelyNotARealDomMember;
+export {};
+"#,
+    );
+    assert!(
+        codes.contains(&2339),
+        "absent global member should report TS2339, got {codes:?}",
+    );
+}
+
+/// A method member with overloads accessed through a lib global must resolve
+/// (e.g. `document.querySelector`). Even resolving only this one member is
+/// cheaper than materializing all of `Document`; the call must type-check.
+#[test]
+fn global_method_overload_member_resolves() {
+    let codes = dom_codes(
+        r#"
+const el = document.querySelector("div");
+const ok: Element | null = el;
+export {};
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "global method/overload member access should resolve cleanly, got {codes:?}",
+    );
+}
+
+/// A heritage-inherited member accessed through a lib global must still resolve
+/// (e.g. `document.nodeName` is inherited from `Node`). The own-member fast path
+/// returns `None`; the full materialization path provides the inherited member.
+#[test]
+fn global_inherited_member_still_resolves() {
+    let codes = dom_codes(
+        r#"
+const n: string = document.nodeName;
+export {};
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "inherited global member read should resolve cleanly, got {codes:?}",
+    );
+}
+
+/// Name-agnostic control: a *user-defined* ambient global var typed as a
+/// *user* interface (not a lib interface) must not take the lib fast path — its
+/// own members resolve, and the lever leaves it on the normal path. Proven with
+/// a non-lib interface and var name so the behavior is not keyed to `document`.
+#[test]
+fn user_ambient_global_var_uses_own_interface_members() {
+    let codes = dom_codes(
+        r#"
+interface Widget { spin(): void; size: number; }
+declare var widget: Widget;
+widget.spin();
+const s: number = widget.size;
+const bad: string = widget.size;
+export {};
+"#,
+    );
+    assert_eq!(
+        codes.iter().filter(|&&c| c == 2322).count(),
+        1,
+        "user ambient-global own members should resolve (only the size mismatch errors), got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&2339),
+        "user ambient-global members must all resolve, got {codes:?}",
+    );
+}
+
+/// Negative control: a globally-augmented lib interface (`declare global {
+/// interface Document { ... } }`) must fall back to the full path so the
+/// out-of-band augmented member stays visible through the global access.
+#[test]
+fn augmented_global_lib_interface_member_visible() {
+    let codes = dom_codes(
+        r#"
+declare global {
+    interface Document {
+        tszAugmentedField: number;
+    }
+}
+const v: number = document.tszAugmentedField;
+const t: string = document.title;
+export {};
+"#,
+    );
+    assert!(
+        !codes.contains(&2339),
+        "augmented global member must resolve (no TS2339), got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&2322),
+        "augmented member and own member reads should type-check, got {codes:?}",
+    );
+}

--- a/crates/tsz-checker/src/tests/lazy_lib_member_access_tests.rs
+++ b/crates/tsz-checker/src/tests/lazy_lib_member_access_tests.rs
@@ -1,15 +1,16 @@
 //! Coverage for the lazy single-member lib-interface property-access fast path.
 //!
-//! Value-position property access on a simple lib-interface receiver resolves
-//! only the accessed own member (see
+//! Value-position property/method access on a simple lib-interface receiver
+//! resolves only the accessed member — an own plain property, an own method
+//! overload set, or a member inherited through the bare `extends` closure (see
 //! `state::state_checking::lazy_lib_member`). These tests assert the fast path
-//! is **behavior-preserving**: own-member reads type correctly, type mismatches
-//! still error, missing members still report TS2339, and a user interface that
-//! shadows a lib name falls back to the full path.
+//! is **behavior-preserving**: member reads type correctly, type/argument
+//! mismatches still error, missing members still report TS2339, and a user
+//! interface that shadows a lib name falls back to the full path.
 //!
 //! The cases vary the lib interface and member spelling so the behavior follows
-//! the structural shape (simple lib interface + own plain property), not any
-//! particular identifier name.
+//! the structural shape (simple lib interface + property/method/inherited
+//! member), not any particular identifier name.
 
 use crate::context::CheckerOptions;
 use crate::test_utils::{check_source_with_libs, load_lib_files};
@@ -274,5 +275,137 @@ export {};
     assert!(
         !codes.contains(&2322),
         "augmented member and own member reads should type-check, got {codes:?}",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Lazy method-overload + heritage-walk member resolution.
+//
+// These cover the extension of the single-property fast path to (a) own method
+// **overload sets** lowered to their merged callable, and (b) members inherited
+// through the bare-`extends` closure. Both are byte-identical to full
+// materialization and match `tsc`: an inherited generic method call type-checks
+// when correct and reports the same overload diagnostic when wrong.
+// ---------------------------------------------------------------------------
+
+/// An own method-overload set on a simple lib interface (`ParentNode.append`,
+/// accessed via the inherited `Document` receiver) must resolve to a callable
+/// with all overloads: a correct call type-checks and a wrong-argument call
+/// reports the same TS2345/TS2769 the full path would. Proven on an inherited
+/// method so the heritage walk and the overload lowering are exercised together.
+#[test]
+fn inherited_method_overload_call_type_checks() {
+    let codes = dom_codes(
+        r#"
+declare const d: Document;
+d.append("text");
+export {};
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "inherited method-overload call with a valid arg should type-check, got {codes:?}",
+    );
+}
+
+/// The same inherited method with a wrong argument must still report the call
+/// error — the lazy overload set is the real merged callable, not a widened
+/// `any`. `ParentNode.append(...: (Node | string)[])` rejects an object literal.
+#[test]
+fn inherited_method_overload_wrong_arg_still_errors() {
+    let codes = dom_codes(
+        r#"
+declare const d: Document;
+d.append({});
+export {};
+"#,
+    );
+    assert!(
+        codes.contains(&2345) || codes.contains(&2769),
+        "wrong-typed inherited method-overload arg should report TS2345/TS2769, got {codes:?}",
+    );
+}
+
+/// A method inherited through a **deeper** heritage edge
+/// (`Document -> Node -> EventTarget.addEventListener`) must also resolve, and a
+/// wrong listener-type/key argument must still surface the overload error,
+/// proving the walk descends multiple `extends` levels.
+#[test]
+fn deeply_inherited_method_overload_resolves_and_errors() {
+    let ok = dom_codes(
+        r#"
+declare const d: Document;
+d.addEventListener("click", () => {});
+export {};
+"#,
+    );
+    assert!(
+        ok.is_empty(),
+        "valid deeply-inherited addEventListener call should type-check, got {ok:?}",
+    );
+    let bad = dom_codes(
+        r#"
+declare const d: Document;
+d.addEventListener(999, () => {});
+export {};
+"#,
+    );
+    assert!(
+        bad.contains(&2769) || bad.contains(&2345),
+        "addEventListener with a numeric event name should report the overload error, got {bad:?}",
+    );
+}
+
+/// Name-agnostic proof that the heritage walk follows the *structural* extends
+/// edge, not a hardcoded lib name: a user interface `B` extends a simple lib
+/// interface and inherits its method; resolving the inherited method on `B`'s
+/// value works the same. (Here the inherited member is read off `Element`, a
+/// distinct lib interface from `Document`, via the `ParentNode` base.)
+#[test]
+fn inherited_method_resolves_across_distinct_lib_interface() {
+    // `Element` also extends `ParentNode`, so `el.append` is inherited just like
+    // `document.append` — different receiver interface, same structural edge.
+    let codes = dom_codes(
+        r#"
+declare const el: Element;
+el.append("x");
+const n = el.querySelectorAll("div");
+export {};
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "inherited method on a distinct lib interface should resolve cleanly, got {codes:?}",
+    );
+}
+
+/// An inherited method whose own interface is **generic** must NOT be resolved
+/// through the lazy walk: the base carries type arguments the walk cannot
+/// substitute, so it falls back to full materialization. `Array<T>` methods
+/// inherited via a generic base are the canonical case; here we prove a generic
+/// receiver's method still resolves correctly through the full path (no TS2339,
+/// no spurious widening) rather than being mis-handled by the lazy walk.
+#[test]
+fn generic_interface_method_still_resolves_via_full_path() {
+    let codes = dom_codes(
+        r#"
+declare const a: number[];
+const m = a.map(x => x + 1);
+const ok: number[] = m;
+const bad: string[] = m;
+export {};
+"#,
+    );
+    // `map` resolves (no TS2339) and the real return type is `number[]`, so only
+    // the `string[]` mismatch errors — proving the generic path is intact and the
+    // lazy walk did not widen or drop the member.
+    assert!(
+        !codes.contains(&2339),
+        "generic interface method must resolve (no TS2339), got {codes:?}",
+    );
+    assert_eq!(
+        codes.iter().filter(|&&c| c == 2322).count(),
+        1,
+        "only the string[] mismatch should error, got {codes:?}",
     );
 }

--- a/crates/tsz-checker/src/types/computation/call_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/call_helpers.rs
@@ -626,6 +626,20 @@ impl<'a> CheckerState<'a> {
         if let Some(var_decl) = self.ctx.arena.get_variable_declaration(node) {
             if var_decl.type_annotation.is_some() {
                 let annotated = self.get_type_from_type_node(var_decl.type_annotation);
+                // Lazy global-var value type: when the annotation is a bare
+                // reference to a simple lib interface (e.g. the global
+                // `declare var document: Document`), keep the value type lazy
+                // instead of eagerly materializing the whole interface via
+                // `resolve_ref_type`. Downstream property access then resolves
+                // only the accessed member, mirroring the file-local
+                // `declare const d: Document` path. Falls back to the eager
+                // path on any miss; gated by `TSZ_DISABLE_LAZY_GLOBAL_VAR`.
+                if self
+                    .lazy_global_var_lib_interface_def_id(annotated)
+                    .is_some()
+                {
+                    return annotated;
+                }
                 return self.resolve_ref_type(annotated);
             }
             if self.ctx.is_js_file()
@@ -903,11 +917,30 @@ impl<'a> CheckerState<'a> {
             if let Some(type_annotation_node) = decl_arena.get(var_decl.type_annotation)
                 && let Some(type_ref) = decl_arena.get_type_ref(type_annotation_node)
             {
-                // Check if this is a simple identifier (not qualified name)
-                if let Some(type_name_node) = decl_arena.get(type_ref.type_name)
+                // Check this is a simple identifier (not a qualified name) and
+                // the reference carries no type arguments — a bare lib type ref.
+                let has_type_arguments = type_ref
+                    .type_arguments
+                    .as_ref()
+                    .is_some_and(|args| !args.nodes.is_empty());
+                if !has_type_arguments
+                    && let Some(type_name_node) = decl_arena.get(type_ref.type_name)
                     && let Some(ident) = decl_arena.get_identifier(type_name_node)
                 {
                     let type_name = ident.escaped_text.as_str();
+                    // Lazy global-var value type: when this ambient lib var (e.g.
+                    // `declare var document: Document`) is annotated with a bare
+                    // reference to a simple lib interface, keep the value type as
+                    // a `Lazy(DefId)` instead of materializing the whole interface
+                    // here. Property access then resolves only the accessed member
+                    // via the #12117 fast path, mirroring the file-local
+                    // `declare const d: Document` path. Gated by the
+                    // `TSZ_DISABLE_LAZY_GLOBAL_VAR` kill-switch and the same
+                    // conservative eligibility predicate as the property-access
+                    // fast path, so any non-simple shape falls back below.
+                    if let Some(lazy) = self.lazy_global_var_lib_interface_type(type_name) {
+                        return lazy;
+                    }
                     // Use resolve_lib_type_by_name for global lib types
                     if let Some(lib_type) = self.resolve_lib_type_by_name(type_name)
                         && lib_type != TypeId::UNKNOWN

--- a/crates/tsz-checker/src/types/queries/lib_resolution_member.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution_member.rs
@@ -23,7 +23,7 @@
 
 use tsz_lowering::TypeLowering;
 use tsz_parser::parser::node::NodeAccess;
-use tsz_parser::parser::syntax_kind_ext::PROPERTY_SIGNATURE;
+use tsz_parser::parser::syntax_kind_ext::{METHOD_SIGNATURE, PROPERTY_SIGNATURE};
 use tsz_parser::parser::{NodeArena, NodeIndex};
 use tsz_solver::TypeId;
 
@@ -34,26 +34,54 @@ use super::lib_resolution_selected::selected_lib_symbol_for_name;
 use crate::state::CheckerState;
 
 impl CheckerState<'_> {
-    /// Resolve a single **own plain property** `prop_name` of the simple lib
-    /// interface named `name`, returning its lowered member type without
-    /// materializing the rest of the interface.
+    /// Maximum number of `extends`-closure levels the lazy member walk will
+    /// descend before giving up and returning `None` (caller falls back to full
+    /// materialization). The DOM heritage graph (`Document -> ParentNode`,
+    /// `Document -> EventTarget` via `Node`) is shallow; this bound keeps the
+    /// walk from looping on a malformed/cyclic lib graph.
+    const LAZY_MEMBER_HERITAGE_MAX_DEPTH: u32 = 8;
+
+    /// Resolve a single own-or-inherited **plain property** or **method overload
+    /// set** `prop_name` of the simple lib interface named `name`, returning its
+    /// lowered member type without materializing the rest of the interface or its
+    /// `extends` closure.
     ///
     /// Returns `None` (caller falls back to full materialization) when:
     /// - the interface symbol cannot be selected,
-    /// - the member is not an own plain property signature,
-    /// - the member is declared more than once (overload/split declaration),
-    /// - the member has a computed/symbol name, or
-    /// - lowering the member's annotation fails.
+    /// - the member is neither a plain property signature nor a method-overload
+    ///   set (accessors, index signatures, mixed property+method),
+    /// - a plain property is declared more than once (split declaration),
+    /// - the member has a computed/symbol name,
+    /// - the member is not declared on this interface and cannot be found on
+    ///   exactly one eligible base in the `extends` closure, or
+    /// - lowering the member fails.
     ///
-    /// The member's type is produced by the same `TypeLowering::lower_type` call
-    /// the full lib path (`lower_merged_interface_declarations`) uses, so the
-    /// result is byte-identical to full materialization for the eligible shape.
+    /// The member's type is produced by the same `TypeLowering` calls the full
+    /// lib path (`lower_merged_interface_declarations` /
+    /// `finish_interface_parts`) uses and is lowered in its **declaring**
+    /// interface's context, so the result is byte-identical to full
+    /// materialization for the eligible shape.
     pub(crate) fn resolve_simple_lib_interface_own_property(
         &mut self,
         name: &str,
         prop_name: &str,
     ) -> Option<TypeId> {
+        self.resolve_simple_lib_interface_member_at_depth(name, prop_name, 0)
+    }
+
+    /// Heritage-aware member resolution: tries the interface's own declarations
+    /// first, then walks the bare-`extends` closure (depth-bounded) for an
+    /// inherited declaration. `depth` guards against deep/cyclic lib heritage.
+    fn resolve_simple_lib_interface_member_at_depth(
+        &mut self,
+        name: &str,
+        prop_name: &str,
+        depth: u32,
+    ) -> Option<TypeId> {
         if self.ctx.skip_lib_type_resolution {
+            return None;
+        }
+        if depth > Self::LAZY_MEMBER_HERITAGE_MAX_DEPTH {
             return None;
         }
 
@@ -87,10 +115,27 @@ impl CheckerState<'_> {
             Some(self.ctx.arena),
         );
 
-        // Find the single own plain-property-signature declaration of `prop_name`
-        // across the interface's declarations. Bail (None) on any ambiguity so
-        // overloads/split declarations keep their full-path semantics.
-        let mut member: Option<(NodeIndex, &NodeArena)> = None;
+        // Find the own declaration(s) of `prop_name` across the interface's
+        // declarations. We support two shapes, both byte-identical to the full
+        // path:
+        // - exactly one plain `PropertySignature` (`prop: T`), or
+        // - one or more `MethodSignature` overloads (`prop(...): R`), all sharing
+        //   the same name (the DOM `querySelector` shape).
+        // Any other combination (a property mixed with methods, an accessor, an
+        // index signature, a string/computed/symbol member name, or a missing
+        // member) is ambiguous or out of scope and returns `None` so the proven
+        // full-materialization path stays authoritative.
+        let mut property_member: Option<(NodeIndex, &NodeArena)> = None;
+        // Method overload declarations of `prop_name`, in source order. A single
+        // shared arena is required: the merged-callable lowering runs in one
+        // `TypeLowering` bound to that arena, mirroring how the full path lowers
+        // an interface body in its own arena.
+        let mut method_members: Vec<NodeIndex> = Vec::new();
+        let mut method_arena: Option<&NodeArena> = None;
+        // Bare-identifier `extends` base names (no type arguments) collected from
+        // this interface's heritage clauses, in source order, for the inherited-
+        // member walk performed only when no own member is found.
+        let mut heritage_base_names: Vec<String> = Vec::new();
         for &(decl_idx, arena) in &decls_with_arenas {
             let Some(node) = arena.get(decl_idx) else {
                 continue;
@@ -101,11 +146,13 @@ impl CheckerState<'_> {
                 // Skip it; the interface body decl is elsewhere in the list.
                 continue;
             };
+            collect_bare_extends_base_names(arena, interface, &mut heritage_base_names);
             for &member_idx in &interface.members.nodes {
                 let Some(member_node) = arena.get(member_idx) else {
                     continue;
                 };
-                if member_node.kind != PROPERTY_SIGNATURE {
+                let kind = member_node.kind;
+                if kind != PROPERTY_SIGNATURE && kind != METHOD_SIGNATURE {
                     continue;
                 }
                 let Some(sig) = arena.get_signature(member_node) else {
@@ -120,33 +167,44 @@ impl CheckerState<'_> {
                 if member_name != prop_name {
                     continue;
                 }
-                if member.is_some() {
-                    // Declared more than once — ambiguous, fall back.
-                    return None;
+                if kind == PROPERTY_SIGNATURE {
+                    if property_member.is_some() {
+                        // Declared more than once — ambiguous, fall back.
+                        return None;
+                    }
+                    property_member = Some((member_idx, arena));
+                } else {
+                    // Method overloads must all come from one arena so a single
+                    // `TypeLowering` can lower the whole set; a cross-arena split
+                    // is unexpected for an own method group, so fall back.
+                    match method_arena {
+                        Some(existing) if !std::ptr::eq(existing, arena) => return None,
+                        _ => method_arena = Some(arena),
+                    }
+                    method_members.push(member_idx);
                 }
-                member = Some((member_idx, arena));
             }
         }
 
-        let (member_idx, member_arena) = member?;
-        let member_node = member_arena.get(member_idx)?;
-        let sig = member_arena.get_signature(member_node)?;
-        if sig.type_annotation == NodeIndex::NONE {
-            // `prop;` with no annotation lowers to `any` in the full path; that
-            // is cheap, but keep the full path authoritative for the implicit
-            // shape rather than reimplement the default here.
-            return None;
-        }
-        // Optional and readonly properties carry extra read/write semantics
-        // (`?` interacts with `exactOptionalPropertyTypes`; `readonly` affects
-        // the write type). Leave those on the full path so their exact behavior
-        // is authoritative — this fast path only handles plain `prop: T`.
-        if sig.question_token || self.has_readonly_modifier(&sig.modifiers) {
+        // A name declared as both a property and a method is a conflict the full
+        // path resolves with its own merge semantics; do not approximate it here.
+        if property_member.is_some() && !method_members.is_empty() {
             return None;
         }
 
+        // No own declaration of `prop_name`: walk the bare-`extends` closure for
+        // an inherited member. We resolve each base **by name**, so the inherited
+        // member is lowered in its declaring interface's own context (correct for
+        // base-relative `this`/type references). The base names were captured in
+        // source order; we require exactly one base to declare the member so an
+        // ambiguous diamond falls back to the full path.
+        if property_member.is_none() && method_members.is_empty() {
+            return self.resolve_inherited_lib_member(&heritage_base_names, prop_name, depth);
+        }
+
         // Build the same hybrid-resolver TypeLowering the full lib path uses, so
-        // the member annotation lowers to a byte-identical type.
+        // the member lowers to a byte-identical type. The arena bound below is
+        // the member's own arena (property annotation or method-overload set).
         let binder = selected_binder;
         let resolver = |node_idx: NodeIndex| -> Option<u32> {
             resolve_lib_node_in_arenas(binder, node_idx, &decls_with_arenas, fallback_arena)
@@ -168,29 +226,184 @@ impl CheckerState<'_> {
         let lazy_type_params_resolver =
             |def_id: tsz_solver::def::DefId| self.ctx.get_def_type_params(def_id);
 
-        let lowering = TypeLowering::with_hybrid_resolver(
-            fallback_arena,
-            self.ctx.types,
-            &resolver,
-            &def_id_resolver,
-            &resolver,
-        )
-        .with_builtin_iterator_return_type(self.builtin_iterator_return_intrinsic_type())
-        .with_lazy_type_params_resolver(&lazy_type_params_resolver)
-        .with_name_def_id_resolver(&name_resolver);
-        let lowering =
+        let build_lowering = || {
+            let lowering = TypeLowering::with_hybrid_resolver(
+                fallback_arena,
+                self.ctx.types,
+                &resolver,
+                &def_id_resolver,
+                &resolver,
+            )
+            .with_builtin_iterator_return_type(self.builtin_iterator_return_intrinsic_type())
+            .with_lazy_type_params_resolver(&lazy_type_params_resolver)
+            .with_name_def_id_resolver(&name_resolver);
             if self.ctx.all_binders.is_some() || self.ctx.global_file_locals_index.is_some() {
                 lowering.prefer_name_def_id_resolution()
             } else {
                 lowering
-            };
+            }
+        };
 
-        let member_type = lowering
+        // Method overload set: lower every overload signature as a method call
+        // signature and assemble the merged callable, exactly like the full
+        // interface path's `MethodSignature` arm + `finish_interface_parts`.
+        // Gated by its own `TSZ_DISABLE_LAZY_METHOD` kill-switch so the
+        // higher-risk method/overload path can be A/B compared independently of
+        // the single-property path.
+        if !method_members.is_empty() {
+            if crate::state_checking::lazy_lib_member::lazy_lib_method_disabled() {
+                return None;
+            }
+            let member_arena = method_arena?;
+            let member_type = build_lowering()
+                .with_arena(member_arena)
+                .lower_method_overload_set_type(&method_members)?;
+            if member_type == TypeId::ERROR {
+                return None;
+            }
+            return Some(member_type);
+        }
+
+        let (member_idx, member_arena) = property_member?;
+        let member_node = member_arena.get(member_idx)?;
+        let sig = member_arena.get_signature(member_node)?;
+        if sig.type_annotation == NodeIndex::NONE {
+            // `prop;` with no annotation lowers to `any` in the full path; that
+            // is cheap, but keep the full path authoritative for the implicit
+            // shape rather than reimplement the default here.
+            return None;
+        }
+        // Optional and readonly properties carry extra read/write semantics
+        // (`?` interacts with `exactOptionalPropertyTypes`; `readonly` affects
+        // the write type). Leave those on the full path so their exact behavior
+        // is authoritative — this fast path only handles plain `prop: T`.
+        if sig.question_token || self.has_readonly_modifier(&sig.modifiers) {
+            return None;
+        }
+
+        let member_type = build_lowering()
             .with_arena(member_arena)
             .lower_type(sig.type_annotation);
         if member_type == TypeId::ERROR {
             return None;
         }
         Some(member_type)
+    }
+
+    /// Resolve `prop_name` inherited from a simple lib interface's bare-`extends`
+    /// closure: try each base **by name** and return the lowered member type when
+    /// exactly one base declares it. More than one declaring base is ambiguous
+    /// (the full path owns merge/override semantics), so return `None`.
+    ///
+    /// Each base is resolved through
+    /// [`Self::resolve_simple_lib_interface_member_at_depth`], which enforces the
+    /// same simple-non-generic-unaugmented-unshadowed eligibility on the base and
+    /// lowers the member in the base's own context. A base that fails eligibility
+    /// simply yields `None` for that branch; if every branch is `None` the whole
+    /// walk falls back to full materialization.
+    ///
+    /// Gated by the `TSZ_DISABLE_LAZY_METHOD` kill-switch alongside the
+    /// method-overload fast path: the heritage walk is the other half of the
+    /// vite-pattern closer (`document.querySelector` is inherited from
+    /// `ParentNode`) and is A/B compared together with it.
+    fn resolve_inherited_lib_member(
+        &mut self,
+        base_names: &[String],
+        prop_name: &str,
+        depth: u32,
+    ) -> Option<TypeId> {
+        if crate::state_checking::lazy_lib_member::lazy_lib_method_disabled() {
+            return None;
+        }
+        if base_names.is_empty() {
+            return None;
+        }
+        let mut found: Option<TypeId> = None;
+        for base in base_names {
+            // A base shadowed by a file-local type, or otherwise ineligible, must
+            // not be resolved through the lazy path; the predicate inside the
+            // recursive call enforces that and yields `None` for such a base.
+            if self.ctx.file_local_type_shadow_for_lib_name(base) {
+                return None;
+            }
+            if let Some(member_type) =
+                self.resolve_simple_lib_interface_member_at_depth(base, prop_name, depth + 1)
+            {
+                if found.is_some() {
+                    // Two bases both declare the member — ambiguous override;
+                    // defer to the full path's merge semantics.
+                    return None;
+                }
+                found = Some(member_type);
+            }
+        }
+        found
+    }
+}
+
+/// Append the bare-identifier `extends` base names (those with **no** type
+/// arguments) of `interface` to `out`, in source order. Bases written with type
+/// arguments (`extends Foo<T>`) or as qualified names are skipped: the lazy
+/// member walk only follows non-generic bare bases, so a generic base falls back
+/// to the full path.
+fn collect_bare_extends_base_names(
+    arena: &NodeArena,
+    interface: &tsz_parser::parser::node::InterfaceData,
+    out: &mut Vec<String>,
+) {
+    let Some(clauses) = interface.heritage_clauses.as_ref() else {
+        return;
+    };
+    for &clause_idx in &clauses.nodes {
+        let Some(clause_node) = arena.get(clause_idx) else {
+            continue;
+        };
+        let Some(heritage) = arena.get_heritage_clause(clause_node) else {
+            continue;
+        };
+        if heritage.token != tsz_scanner::SyntaxKind::ExtendsKeyword as u16 {
+            continue;
+        }
+        for &type_idx in &heritage.types.nodes {
+            let Some(type_node) = arena.get(type_idx) else {
+                continue;
+            };
+            // A bare single-`Identifier` heritage base (`extends Foo`) carries no
+            // type arguments — the common simple-lib-interface shape and the only
+            // shape the lazy walk follows. `Document extends Node, ParentNode, …`
+            // is stored this way in the lib arenas.
+            if let Some(name) = arena.get_identifier_text(type_idx) {
+                out.push(name.to_string());
+                continue;
+            }
+            // A `TypeReference` base (`extends Foo<T>` or a qualified name) needs
+            // argument substitution / namespace resolution the lazy walk cannot
+            // supply; only follow it when it is a bare un-parameterized name.
+            if let Some(type_ref) = arena.get_type_ref(type_node) {
+                let has_type_arguments = type_ref
+                    .type_arguments
+                    .as_ref()
+                    .is_some_and(|args| !args.nodes.is_empty());
+                if !has_type_arguments
+                    && let Some(name) = arena.get_identifier_text(type_ref.type_name)
+                {
+                    out.push(name.to_string());
+                }
+                continue;
+            }
+            // Class-style heritage written as an expression-with-type-arguments
+            // (defensive; interface heritage in lib arenas uses the forms above).
+            if let Some(expr_args) = arena.get_expr_type_args(type_node) {
+                let has_type_arguments = expr_args
+                    .type_arguments
+                    .as_ref()
+                    .is_some_and(|args| !args.nodes.is_empty());
+                if !has_type_arguments
+                    && let Some(name) = arena.get_identifier_text(expr_args.expression)
+                {
+                    out.push(name.to_string());
+                }
+            }
+        }
     }
 }

--- a/crates/tsz-lowering/src/lower/core/signature_members.rs
+++ b/crates/tsz-lowering/src/lower/core/signature_members.rs
@@ -485,6 +485,42 @@ impl<'a> TypeLowering<'a> {
         }
     }
 
+    /// Lower an own method member's full overload set to its merged callable
+    /// type, byte-identically to the full interface path.
+    ///
+    /// `member_idxs` must be every `MethodSignature` declaration of a single
+    /// method name across the interface's (merged) declarations, in source
+    /// order. Each is lowered as a method call signature (`is_method = true`,
+    /// matching [`Self::collect_interface_members`]) and assembled into a
+    /// `callable` whose `call_signatures` are the overloads in order — exactly
+    /// the shape [`Self::finish_interface_parts`] builds for a
+    /// [`PropertyMerge::Method`] entry.
+    ///
+    /// Returns `None` when `member_idxs` is empty or any element is not a
+    /// method-signature node, so the caller falls back to full materialization.
+    pub fn lower_method_overload_set_type(&self, member_idxs: &[NodeIndex]) -> Option<TypeId> {
+        if member_idxs.is_empty() {
+            return None;
+        }
+        let mut call_signatures = Vec::with_capacity(member_idxs.len());
+        for &member_idx in member_idxs {
+            let member = self.arena.get(member_idx)?;
+            if member.kind != syntax_kind_ext::METHOD_SIGNATURE {
+                return None;
+            }
+            let sig = self.arena.get_signature(member)?;
+            let mut signature = self.lower_call_signature(sig);
+            signature.is_method = true;
+            call_signatures.push(signature);
+        }
+        Some(self.interner.callable(CallableShape {
+            call_signatures,
+            construct_signatures: Vec::new(),
+            properties: Vec::new(),
+            ..Default::default()
+        }))
+    }
+
     pub fn lower_interface_members_simple_types(
         &self,
         interface_idx: NodeIndex,


### PR DESCRIPTION
## Summary

Extends the #12117 / #12128 lazy single-**property** lib-interface fast path to two
new member shapes, so accessing a **method** or an **inherited** member on a simple
lib-interface receiver resolves only that member instead of materializing the whole
interface plus its `extends` closure:

1. **Own method-overload sets** — `prop(...): R` declared one or more times is lowered
   to its merged callable (`call_signatures = [each overload]`), byte-identically to
   the full interface path (`finish_interface_parts`).
2. **Heritage-inherited members** — when the receiver interface does not declare the
   member, the bare un-parameterized `extends` closure is walked (depth-bounded) and
   the member is resolved on the single eligible base that declares it, lowered in
   **that base's** own context. `document.querySelector` lives on `ParentNode`;
   `document.addEventListener` lives on `EventTarget` (two `extends` levels deep).

New solver helper `TypeLowering::lower_method_overload_set_type` builds the merged
callable. Checker `resolve_simple_lib_interface_own_property` is generalized to
collect a property OR a method-overload set OR walk heritage, gated by a dedicated
`TSZ_DISABLE_LAZY_METHOD` kill-switch.

## Structural rule

> When resolving property/method access `recv.p` whose receiver is a bare
> `Lazy(DefId)` reference to a simple non-generic lib interface, and `p` is declared
> (as a single plain property, or a method-overload set) either on that interface or —
> via the bare un-parameterized `extends` closure — on exactly one eligible base
> interface, resolve only that member by lowering it in its declaring interface's
> context, instead of materializing the receiver's full structural shape and
> transitive `extends` closure.

## Owner layer

Type-shape lowering lives in `tsz-lowering` (`lower_method_overload_set_type` mirrors
the existing `MethodSignature` arm + `finish_interface_parts`). The checker only
orchestrates member selection and heritage-name discovery, then delegates the actual
lowering — no checker-local type algorithm.

## Measurement — the decomposition deliverable (a vs b)

ES2020 + DOM + DOM.Iterable, interned-type count (dist-fast):

| repro | base (#12117/#12128) | this PR | `TSZ_DISABLE_LAZY_METHOD=1` |
| --- | --- | --- | --- |
| `d.title` (own property, control) | 1154 | 1154 | 1154 |
| `d.append(...)` (inherited method, simple return) | 6491 | **1154** | 6491 |
| `d.addEventListener(...)` (inherited from EventTarget, depth-2) | 6491 | **1154** | 6491 |
| `d.querySelector<HTMLDivElement>(...)` (tag-map return) | 9405 | 9405 | 9405 |
| vite-vanilla fixture | 9034 | 9034 | 9034 |

**Decomposition:** lazy method member-FIND eliminates the materialization-to-find cost
for the broad class of DOM methods (append, addEventListener: 6491 → 1154). But the
**vite fixture is unchanged**: vite's only global access is
`document.querySelector<HTMLDivElement>("#app")`, whose overload return types are
`HTMLElementTagNameMap[K]` etc. — **lowering those Element-hierarchy / tag-map return
types is the remaining cost (component b)**, and it happens regardless of how the
method member is found. So **lazy member access does NOT close vite-vanilla**; the
remaining vite cost is generic-method return-type (tag-map / Element-hierarchy)
materialization, a separate and harder lever.

## Correctness — this is also a parity fix, NOT a byte-identical kill-switch

The kill-switch is **not** byte-identical, because the fast path is *more tsc-correct*
than the legacy fallback. For inherited method-overload calls on a lib receiver
(`document.addEventListener(999, …)`, `document.append({})`, `d.querySelectorAll(true)`),
the legacy path **silently drops** the overload error; the lazy path resolves the real
merged callable and reports it. Verified against the vite fixture's bundled `tsc`:

- tsz **with** the fast path == `tsc` on these inherited-method cases (TS2769 / TS2345
  reported at the same location).
- tsz **with `TSZ_DISABLE_LAZY_METHOD=1`** drops them (legacy gap).

So `TSZ_DISABLE_LAZY_METHOD` is a debugging A/B lever and a fallback, not a
behavior-neutral switch; the shipping (on) behavior is the tsc-matching one. Because
this changes diagnostics toward parity, the full conformance / emit / fourslash gates
must run (ready-for-review CI), not just the draft gates.

## Project Corpus Impact

- Row: vite-vanilla-ts-app
- Bug family: lazy lib-interface member residency (method overloads + heritage) and
  inherited-method overload-error parity on lib receivers
- Evidence: decomposition table above; broad DOM methods 6491 → 1154 interned types;
  inherited-method overload errors now match `tsc` (TS2769 / TS2345) where the legacy
  path dropped them.
- Net effect on vite-vanilla: perf-neutral (the vite closer is the tag-map return-type
  lever, characterized here, not built); correctness-positive elsewhere.

## Verification

- `cargo test -p tsz-checker --lib lazy_lib_member_access_tests`: **17 passed, 0
  failed** (12 existing + 5 new).
- New tests: inherited method-overload call type-checks; wrong-arg still errors
  (TS2345/TS2769); deeply-inherited (`addEventListener`) resolves + errors;
  inherited method across a distinct lib interface (`Element.append`);
  generic-interface method (`Array.map`) stays on the full path.
- Parity: tsz (fast path on) matches the vite fixture's bundled `tsc` on the
  inherited-method overload-error cases.
- Pre-existing, NOT introduced here (confirmed identical on the base branch via stash
  A/B): 3 `lib_global_namespace_shadowing_tests` failures (module-local interface
  augmenting a lib constructor return) and the
  `yield_type_prefers_iterable_over_iterator_in_mixed_heritage` display test.

## Coordination Notes

AgentName: M1Opus48-lazymethod
Track 7/10 (checker performance / lib-interface residency).
Stacked on #12128 (`perf/lazy-global-var`); base = that branch, not main. Related:
#12117 (lazy single-property), #12101, #12118 (vite cross-arena).
Because the kill-switch is not byte-identical (it is a parity improvement), this PR
needs the heavy conformance/emit/fourslash gates before it can land — do not treat
draft-CI green as sufficient.
