### PR TITLE
fix(checker): preserve global window display provenance

### DIFF
--- a/crates/tsz-checker/src/error_reporter/type_value.rs
+++ b/crates/tsz-checker/src/error_reporter/type_value.rs
@@ -6,7 +6,7 @@ use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_solver::TypeId;
+use tsz_solver::{PropertyInfo, TypeId};
 
 impl<'a> CheckerState<'a> {
     // =========================================================================
@@ -45,10 +45,10 @@ impl<'a> CheckerState<'a> {
             self.ctx.types,
             current_type,
         );
-        let prev_type_str = self.format_type_diagnostic_widened(prev_display);
+        let prev_type_str = self.format_type_for_redeclaration_message(prev_display);
         let current_type_str = self
             .ts2403_typeof_fundule_initializer_display(idx)
-            .unwrap_or_else(|| self.format_type_diagnostic_widened(current_display));
+            .unwrap_or_else(|| self.format_type_for_redeclaration_message(current_display));
         // Suppress when both types format to the same name. This handles cross-binder
         // scenarios where a lib_checker resolves a type annotation (e.g., `Document`)
         // to a separate DefId from the main checker's version. Interface declaration
@@ -61,6 +61,106 @@ impl<'a> CheckerState<'a> {
             "Subsequent variable declarations must have the same type. Variable '{name}' must be of type '{prev_type_str}', but here has type '{current_type_str}'."
         );
         self.error_at_node(idx, &message, diagnostic_codes::SUBSEQUENT_VARIABLE_DECLARATIONS_MUST_HAVE_THE_SAME_TYPE_VARIABLE_MUST_BE_OF_TYP);
+    }
+
+    fn format_type_for_redeclaration_message(&self, type_id: TypeId) -> String {
+        self.format_global_window_display_object_for_redeclaration(type_id)
+            .unwrap_or_else(|| self.format_type_diagnostic_widened(type_id))
+    }
+
+    fn format_global_window_display_object_for_redeclaration(
+        &self,
+        type_id: TypeId,
+    ) -> Option<String> {
+        if let Some(members) =
+            crate::query_boundaries::diagnostics::union_members(self.ctx.types, type_id)
+        {
+            let mut member_display_order = self
+                .ctx
+                .types
+                .get_union_origin(type_id)
+                .map(|origin| origin.as_ref().clone())
+                .unwrap_or_else(|| members.to_vec());
+            member_display_order.sort_by_key(|member| member.is_nullable());
+            let mut used_global_window_display = false;
+            let rendered = member_display_order
+                .iter()
+                .map(|&member| {
+                    if let Some(display) =
+                        self.format_global_window_display_object_for_redeclaration(member)
+                    {
+                        used_global_window_display = true;
+                        display
+                    } else {
+                        self.format_type_diagnostic_widened(member)
+                    }
+                })
+                .collect::<Vec<_>>();
+            return used_global_window_display.then(|| rendered.join(" | "));
+        }
+
+        let display_props = self.ctx.types.get_display_properties(type_id)?;
+        if !display_props
+            .iter()
+            .any(|prop| self.property_uses_global_window_annotation_display(prop))
+        {
+            return None;
+        }
+
+        let props = display_props
+            .iter()
+            .map(|prop| {
+                let name = self.format_redeclaration_display_property_name(prop);
+                let optional = if prop.optional { "?" } else { "" };
+                let type_display = if self.property_uses_global_window_annotation_display(prop) {
+                    "Window & typeof globalThis".to_string()
+                } else {
+                    let widened = crate::query_boundaries::diagnostics::widen_type_deep(
+                        self.ctx.types,
+                        prop.type_id,
+                    );
+                    self.format_type_diagnostic_widened(widened)
+                };
+                format!("{name}{optional}: {type_display};")
+            })
+            .collect::<Vec<_>>();
+
+        Some(format!("{{ {} }}", props.join(" ")))
+    }
+
+    fn property_uses_global_window_annotation_display(&self, prop: &PropertyInfo) -> bool {
+        let Some(sym_id) = prop.parent_id else {
+            return false;
+        };
+        crate::types_domain::window_global_this_annotation::declared_type_annotation_for_symbol(
+            &self.ctx, sym_id,
+        )
+        .is_some_and(|idx| {
+            crate::types_domain::window_global_this_annotation::is_window_and_typeof_global_this_type_node(
+                self.ctx.arena,
+                idx,
+            )
+        }) || self.symbol_is_global_window_like_value(sym_id)
+    }
+
+    fn symbol_is_global_window_like_value(&self, sym_id: tsz_binder::SymbolId) -> bool {
+        let Some(symbol) = self.get_cross_file_symbol(sym_id) else {
+            return false;
+        };
+        matches!(symbol.escaped_name.as_str(), "self" | "window")
+            && self
+                .resolve_global_value_symbol(&symbol.escaped_name)
+                .is_some_and(|global_sym_id| global_sym_id == sym_id)
+    }
+
+    fn format_redeclaration_display_property_name(&self, prop: &PropertyInfo) -> String {
+        let name = self.ctx.types.resolve_atom_ref(prop.name);
+        if prop.is_string_named {
+            let escaped = name.replace('\\', "\\\\").replace('"', "\\\"");
+            format!("\"{escaped}\"")
+        } else {
+            name.to_string()
+        }
     }
 
     fn ts2403_typeof_fundule_initializer_display(&self, decl_idx: NodeIndex) -> Option<String> {

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -6,7 +6,7 @@ pub(crate) use super::common::{
     contains_type_parameter_named, contains_type_parameters, enum_def_id, intersection_list_id,
     intersection_members, is_symbol_or_unique_symbol, is_template_literal_type, lazy_def_id,
     literal_value, no_infer_inner_type, object_shape_for_type, union_list_id, union_members,
-    widen_literal_to_primitive,
+    widen_literal_to_primitive, widen_type_deep,
 };
 pub(crate) use tsz_solver::type_queries::AssignmentNumericDisplayChildren;
 

--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -949,19 +949,6 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        for diag in &mut self.ctx.diagnostics {
-            if diag.code == diagnostic_codes::SUBSEQUENT_VARIABLE_DECLARATIONS_MUST_HAVE_THE_SAME_TYPE_VARIABLE_MUST_BE_OF_TYP
-                && diag.message_text.contains("Variable 'a9e'")
-                && (diag.message_text.contains("z: Window; y?: undefined;")
-                    || diag.message_text.contains("z: any; y?: undefined;"))
-            {
-                diag.message_text = diag
-                    .message_text
-                    .replace("z: Window; y?: undefined;", "z: Window & typeof globalThis; y?: undefined;")
-                    .replace("z: any; y?: undefined;", "z: Window & typeof globalThis; y?: undefined;");
-            }
-        }
-
         let Some(arr_decl_start) = source_text.find("var arr: any[]") else {
             return;
         };

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -225,6 +225,8 @@ impl<'a> CheckerState<'a> {
         // Maps property name → original literal TypeId before widening.
         // Only populated when a property's type was actually widened.
         let mut display_type_overrides: FxHashMap<Atom, TypeId> = FxHashMap::default();
+        let mut display_parent_overrides: FxHashMap<Atom, tsz_binder::SymbolId> =
+            FxHashMap::default();
         let mut string_index_types: Vec<TypeId> = Vec::new();
         let mut number_index_types: Vec<TypeId> = Vec::new();
         // Wide `symbol`-typed computed keys (see `symbol_key_routing`).
@@ -760,6 +762,20 @@ impl<'a> CheckerState<'a> {
                         {
                             let name_atom = self.ctx.types.intern_string(&name);
                             display_type_overrides.insert(name_atom, lit_type);
+                        }
+                        let window_global_this_display_symbol = if prop.initializer != prop.name
+                            && (self
+                                .is_window_and_global_this_declared_expression(prop.initializer)
+                                || (!self.is_global_this_expression(prop.initializer)
+                                    && self.is_global_this_like_expression(prop.initializer)))
+                        {
+                            self.resolve_identifier_symbol(prop.initializer)
+                        } else {
+                            None
+                        };
+                        if let Some(sym_id) = window_global_this_display_symbol {
+                            let name_atom = self.ctx.types.intern_string(&name);
+                            display_parent_overrides.insert(name_atom, sym_id);
                         }
 
                         final_type
@@ -1900,6 +1916,7 @@ impl<'a> CheckerState<'a> {
             super::super::object_literal_support::ObjectLiteralFinalizeCtx {
                 properties,
                 display_type_overrides,
+                display_parent_overrides,
                 string_index_types,
                 number_index_types,
                 symbol_index_types,

--- a/crates/tsz-checker/src/types/computation/object_literal_support.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_support.rs
@@ -12,6 +12,8 @@ pub(crate) struct ObjectLiteralFinalizeCtx {
     pub(crate) properties: FxHashMap<Atom, PropertyInfo>,
     /// Per-property display-type overrides (used for freshness diagnostics).
     pub(crate) display_type_overrides: FxHashMap<Atom, TypeId>,
+    /// Per-property display parent overrides used by diagnostic-only provenance.
+    pub(crate) display_parent_overrides: FxHashMap<Atom, tsz_binder::SymbolId>,
     /// Value types for string index signatures collected from spreads.
     pub(crate) string_index_types: Vec<TypeId>,
     /// Value types for number index signatures collected from spreads.
@@ -341,6 +343,7 @@ impl<'a> CheckerState<'a> {
         let ObjectLiteralFinalizeCtx {
             properties,
             display_type_overrides,
+            display_parent_overrides,
             mut string_index_types,
             number_index_types,
             symbol_index_types,
@@ -412,19 +415,19 @@ impl<'a> CheckerState<'a> {
                     } else {
                         self.ctx.types.factory().object_fresh(properties.clone())
                     };
-                    if !display_type_overrides.is_empty() {
+                    if !display_type_overrides.is_empty() || !display_parent_overrides.is_empty() {
                         let mut display_props: Vec<PropertyInfo> = properties
                             .iter()
                             .map(|prop| {
+                                let mut display_prop = prop.clone();
                                 if let Some(&display_type) = display_type_overrides.get(&prop.name)
                                 {
-                                    PropertyInfo {
-                                        type_id: display_type,
-                                        ..prop.clone()
-                                    }
-                                } else {
-                                    prop.clone()
+                                    display_prop.type_id = display_type;
                                 }
+                                if let Some(&parent_id) = display_parent_overrides.get(&prop.name) {
+                                    display_prop.parent_id = Some(parent_id);
+                                }
+                                display_prop
                             })
                             .collect();
                         crate::query_boundaries::common::normalize_display_property_order(

--- a/crates/tsz-checker/tests/type_argument_inference_constraints_fingerprint_tests.rs
+++ b/crates/tsz-checker/tests/type_argument_inference_constraints_fingerprint_tests.rs
@@ -165,6 +165,59 @@ var arr: any[];
 }
 
 #[test]
+fn redeclaration_display_uses_window_annotation_with_renamed_members() {
+    let source = r#"
+function chooseThree<T extends any>(a: T, b: T, c: T): T {
+    return null as any;
+}
+var renamed = chooseThree(undefined, { x: 6, renamedMember: window }, { x: 6, other: '' });
+var renamed: {};
+"#;
+
+    let diagnostics = diagnostics_with_libs(source);
+    let ts2403 = diagnostics
+        .iter()
+        .find(|diagnostic| {
+            diagnostic.code == 2403 && diagnostic.message_text.contains("Variable 'renamed'")
+        })
+        .expect("expected renamed TS2403 redeclaration diagnostic");
+
+    assert!(
+        ts2403
+            .message_text
+            .contains("renamedMember: Window & typeof globalThis; other?: undefined;"),
+        "expected renamed member to use the global Window intersection, got: {ts2403:?}"
+    );
+}
+
+#[test]
+fn redeclaration_display_uses_local_window_annotation_provenance() {
+    let source = r#"
+declare var localWindow: Window & typeof globalThis;
+function chooseThree<T extends any>(a: T, b: T, c: T): T {
+    return null as any;
+}
+var localCase = chooseThree(undefined, { x: 6, localMember: localWindow }, { x: 6, other: '' });
+var localCase: {};
+"#;
+
+    let diagnostics = diagnostics_with_libs(source);
+    let ts2403 = diagnostics
+        .iter()
+        .find(|diagnostic| {
+            diagnostic.code == 2403 && diagnostic.message_text.contains("Variable 'localCase'")
+        })
+        .expect("expected localCase TS2403 redeclaration diagnostic");
+
+    assert!(
+        ts2403
+            .message_text
+            .contains("localMember: Window & typeof globalThis; other?: undefined;"),
+        "expected local annotation provenance to drive display, got: {ts2403:?}"
+    );
+}
+
+#[test]
 fn object_group_by_key_constraint_uses_property_key_in_diagnostic() {
     let source = r#"
 interface Employee {

--- a/crates/tsz-solver/src/operations/expression_ops.rs
+++ b/crates/tsz-solver/src/operations/expression_ops.rs
@@ -16,6 +16,7 @@ use crate::types::{
 };
 use rustc_hash::FxHashMap;
 use std::sync::Arc;
+use tsz_binder::SymbolId;
 use tsz_common::interner::Atom;
 
 /// Computes the result type of a conditional expression: `condition ? true_branch : false_branch`.
@@ -466,25 +467,29 @@ fn add_missing_optional_properties(existing: &[PropertyInfo], names: &[Atom]) ->
     out
 }
 
+type DisplayPropertyProvenance = (TypeId, TypeId, Option<SymbolId>);
+type DisplayPropertiesByName = FxHashMap<Atom, DisplayPropertyProvenance>;
+
 fn normalized_display_properties(
     interner: &dyn TypeDatabase,
     original_type: TypeId,
     normalized_properties: &[PropertyInfo],
 ) -> Vec<PropertyInfo> {
     let original_display = interner.get_display_properties(original_type);
-    let original_display_by_name: Option<FxHashMap<Atom, (TypeId, TypeId)>> =
+    let original_display_by_name: Option<DisplayPropertiesByName> =
         original_display.as_ref().map(|props| {
             props
                 .iter()
-                .map(|prop| (prop.name, (prop.type_id, prop.write_type)))
+                .map(|prop| (prop.name, (prop.type_id, prop.write_type, prop.parent_id)))
                 .collect()
         });
     let mut display_props: Vec<PropertyInfo> = normalized_properties
         .iter()
         .map(|prop| {
-            let Some((display_type, display_write_type)) = original_display_by_name
-                .as_ref()
-                .and_then(|props| props.get(&prop.name).copied())
+            let Some((display_type, display_write_type, display_parent_id)) =
+                original_display_by_name
+                    .as_ref()
+                    .and_then(|props| props.get(&prop.name).copied())
             else {
                 return prop.clone();
             };
@@ -492,6 +497,7 @@ fn normalized_display_properties(
             PropertyInfo {
                 type_id: display_type,
                 write_type: display_write_type,
+                parent_id: display_parent_id,
                 ..prop.clone()
             }
         })


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
Track: M1-C conformance strictness / diagnostic debt
PR type: semantic diagnostic-display cleanup

## Invariant
When best-common-type inference normalizes object-literal union members and a property value came from a value declared as `Window & typeof globalThis` (including the ambient `window`/`self` globals), `tsc` preserves that display surface in TS2403 redeclaration diagnostics; this PR makes tsz preserve it through display provenance rather than rewriting rendered diagnostic text.

Owner layer: object-literal display provenance is carried through solver fresh-object union normalization; checker TS2403 rendering consumes the recorded provenance as diagnostic display policy without widening or mutating semantic types.

## Scope
- Carries display-only property parent provenance from object literal construction into fresh-object union normalization.
- Formats TS2403 redeclaration object displays from structural display properties when that provenance identifies `Window & typeof globalThis`.
- Removes the `a9e` source-text/message rewrite from `rewrite_type_argument_inference_with_constraints_fingerprints`.
- Adds focused checker tests for original, renamed, and local-annotation witnesses.
- Keeps touched files below the 2000-line cap.

## Adjacent-Case Matrix
- Reported-style witness: ambient `window`/`self` provenance through normalized object-literal unions in `typeArgumentInferenceWithConstraints`.
- Renamed object members: the display rule follows property provenance rather than hardcoded property spelling.
- Local annotation witness: a locally declared value annotated as `Window & typeof globalThis` preserves the same diagnostic display.
- Fallback: properties without that provenance use the normal type printer; semantic types are unchanged.

## Project Corpus Impact
- Row: n/a
- Bug family: diagnostic display / conformance fingerprint debt
- Evidence: targeted checker test and focused conformance filter only; no project-row behavior expected.

## Verification
- Rebased directly on current `origin/main` `3bff65092f36afb2456d792f5c844d32f6ca72bf` before pushing latest head `1465568beeb1c44a5dc3127816758ad65242669c`.
- `git diff --check origin/main..HEAD`.
- `cargo fmt --all --check`.
- `wc -l` on touched source/test files: all below 2000 lines.
- `CARGO_BUILD_JOBS=2 cargo nextest run -p tsz-checker --test type_argument_inference_constraints_fingerprint_tests` => 7 passed.
- `CARGO_BUILD_JOBS=2 scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter typeArgumentInferenceWithConstraints --verbose` => 1/1 passed, fingerprint-only 0.
- Exact-head draft/light CI passed for `1465568beeb1c44a5dc3127816758ad65242669c`: CI Light Summary, lint, unit, dist-binaries, project-row-drift, cargo-deny, cargo-shear, gate, and GitGuardian.

## Coordination Notes
- Fresh worktree: `/Users/mohsen/code/tsz-m1c-global-window-display-20260601`, branch `codex/m1-c-global-window-display-20260601`.
- Rebased cleanly on top of current `origin/main` on 2026-06-01.
- Does not overlap #11953 or #11980; those remain separate M1-C drafts.
- Marked ready on 2026-06-01 after exact-head draft/light CI passed and #8432 had newer focused current-main evidence that the previously cited aggregate paths were clear. Do not add `merge-queue` until ready-for-review CI produces a clean exact-head CI Summary plus GitGuardian remains green.