### PR TITLE
fix(parser): recover semicolon for global class member

### DIFF
--- a/crates/tsz-parser/src/parser/state_statements_class_recovery.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_recovery.rs
@@ -17,6 +17,17 @@ impl ParserState {
             "Unexpected token. A constructor, method, accessor, or property was expected.",
             diagnostic_codes::UNEXPECTED_TOKEN_A_CONSTRUCTOR_METHOD_ACCESSOR_OR_PROPERTY_WAS_EXPECTED,
         );
+        let snapshot = self.scanner.save_state();
+        let current_token = self.current_token;
+        self.next_token();
+        if !self.scanner.has_preceding_line_break()
+            && self.is_identifier_or_keyword()
+            && self.should_report_error()
+        {
+            self.error_token_expected(";");
+        }
+        self.scanner.restore_state(snapshot);
+        self.current_token = current_token;
         self.suppress_next_missing_class_close_brace_error_once = true;
         true
     }

--- a/crates/tsz-parser/tests/parser_improvement_class_member_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_class_member_recovery_tests.rs
@@ -136,6 +136,12 @@ class C {
         }),
         "Expected TS1068 for module-like class member, got diagnostics: {diagnostics:?}"
     );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::EXPECTED && d.message == "';' expected."),
+        "Expected TS1005 semicolon recovery for module-like class member, got diagnostics: {diagnostics:?}"
+    );
 
     let arena = parser.get_arena();
     let source_file = arena.get_source_file_at(root).unwrap();


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
Track: M1-C conformance strictness / current-drift cleanup
PR type: parser recovery parity slice

## Invariant
When a class body encounters a module-like `global`/`namespace`/`module` declaration head followed by another identifier on the same line, `tsc` reports the missing semicolon at the following identifier before preserving the broader class-member recovery diagnostics. This PR makes tsz emit that TS1005 through parser recovery while keeping the existing outer-statement recovery shape.

Owner layer: parser/class-member recovery. This is syntax recovery, not checker display policy or semantic type computation.

## Scope
- Adds the missing same-line semicolon diagnostic in module-like class-member recovery without consuming the recovered token.
- Extends the existing parser class-member recovery regression test to assert the TS1005 semicolon diagnostic alongside TS1068.

## Adjacent-Case Matrix
- Reported witness: `class C { global x }` now keeps TS1068/TS1128 and also emits the missing TS1005 at `x`.
- Same recovery family: the helper is keyed by the existing structural module-like class-member predicate for `global`/`namespace`/`module` heads.
- Fallback: line-break-separated tokens are left to the existing recovery path; no extra semicolon is emitted across ASI boundaries.

## Project Corpus Impact
- Row: conformance/current drift
- Bug family: parser recovery / missing TS1005 in class-member recovery
- Evidence: focused parser test and focused conformance filter for `nestedGlobalNamespaceInClass`; no project-corpus row behavior expected.

## Verification
- Rebased directly on current `origin/main` (`291e5e18ef`) before pushing head `54731c1595a791bc9b16e60a253b7b0c1ff5ad64`.
- Current `origin/main` is an ancestor of head `54731c1595a791bc9b16e60a253b7b0c1ff5ad64` as of 2026-06-01 recheck.
- `cargo fmt --all --check`
- `git diff --check`
- `cargo nextest run -p tsz-parser parser::parser_improvement_class_member_recovery_tests::test_module_like_class_member_recovers_as_outer_statement`
- `cargo nextest run -p tsz-parser parser::parser_improvement_class_member_recovery_tests`
- `CARGO_BUILD_JOBS=2 scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter nestedGlobalNamespaceInClass --verbose`
- `CARGO_BUILD_JOBS=2 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-parser --all-targets -- -D warnings`
- Draft-light CI for head `54731c1595a791bc9b16e60a253b7b0c1ff5ad64` completed green on 2026-06-01: `CI Light Summary`, `unit`, `lint`, `dist-binaries`, `unit-cloudbuild`, `project-row-drift`, `cargo-deny`, `cargo-shear`, `gate`, `queue-one-pr`, and GitGuardian passed; heavy suites were skipped while draft.
- File-size check: touched files remain far below 2000 lines (`state_statements_class_recovery.rs` 63, `parser_improvement_class_member_recovery_tests.rs` 280).

## Coordination Notes
- Fresh worktree: `/Users/mohsen/code/tsz-m1c-nested-global-recovery-20260601`, branch `codex/m1-c-nested-global-recovery-20260601`.
- Addresses one #8432 current-drift path that #12080 head `ce8ad66326b18fd0e91c2950f4b4e425c6cb9278` still listed in its failed `12580/12585` ready-review `conformance-aggregate`: `nestedGlobalNamespaceInClass.ts`.
- #12080 remains draft after that aggregate failure. This PR is now the focused ready fallback for the parser recovery slice rather than a superseded PR.
- Does not overlap #12139/#11953/#11980; those remain draft-held behind shared conformance aggregate coordination.
- Ready handoff: mark ready to run exact-head heavy CI for this focused slice. M1-C is not adding `merge-queue` or auto-merge; manager/queue-owner should decide queue order after exact-head PR-head checks complete.

