### PR TITLE
[WIP] perf(checker): defer transitive lib-interface ref closure on the relation path

### DIFF
--- a/.target
+++ b/.target
@@ -1,1 +1,0 @@
-/Users/mohsen/.cache/tsz-target

--- a/.target
+++ b/.target
@@ -1,0 +1,1 @@
+/Users/mohsen/.cache/tsz-target

--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -24,10 +24,10 @@ use tsz_solver::narrowing::NarrowingContext;
 /// referenced def, and (legacy behaviour) pushes the resolved result back onto
 /// its worklist so the *whole transitive reference closure* is materialized
 /// before any relation runs. For a lib interface like `Node` this eagerly lowers
-/// the entire DOM reference graph (`Node -> Document/Element/... -> 66
-/// `HTML*Element``), ~8000 interned types, and burns the per-process global
-/// resolution fuel — which then suppresses later relation diagnostics in the
-/// same file (a latent parity bug vs `tsc`). See issue #12101.
+/// the entire DOM reference graph (`Node` -> `Document`/`Element`/... -> all 66
+/// HTML element interfaces), ~8000 interned types, and burns the per-process
+/// global resolution fuel — which then suppresses later relation diagnostics in
+/// the same file (a latent parity bug vs `tsc`). See issue #12101.
 ///
 /// `TSZ_TRANSITIVE_REFS_MODE` selects:
 /// - unset / `0` -> mode 0: legacy (push every resolved ref). **Default.**
@@ -1534,20 +1534,29 @@ impl<'a> CheckerState<'a> {
                 if global_resolution_fuel_exhausted() {
                     break;
                 }
-                // EXPERIMENT: decide whether to defer this referenced def's
-                // transitive closure. When the kill-switch defers (mode 2 = lib
-                // interfaces only, mode 1 = all), we still resolve+insert the def
-                // (so the top-level ref is ready) but do NOT push its resolved
-                // result onto the worklist, leaving its nested refs for on-demand
+                // Decide whether to defer this referenced def's transitive
+                // closure. When deferring (mode 2 = eligible lib interfaces only,
+                // mode 1 = all), we still resolve+insert the def (so the
+                // top-level ref is ready) but do NOT push its resolved result
+                // onto the worklist, leaving its nested refs for on-demand
                 // relation resolution. Mode 2 restricts deferral to eligible
                 // simple lib interfaces (the DOM cascade) so user/generic types
                 // keep their proven transitive pre-resolution.
+                //
+                // Deferral is ONLY safe for plain top-level relation inputs.
+                // Inside a type-evaluation frame (keyof / indexed access / mapped
+                // / conditional / contextual or generic-inference substitution)
+                // the consumer structurally decomposes the interface and needs
+                // its full member closure, so never defer there — that is the
+                // variance/contextual-typing class the conformance A/B caught.
                 let defer_mode = transitive_refs_deferral_mode();
-                let defer_this = match defer_mode {
-                    1 => true,
-                    2 => self.def_id_is_simple_lib_interface(def_id),
-                    _ => false,
-                };
+                let defer_this =
+                    !crate::state_domain::type_environment::lazy::in_type_evaluation_frame()
+                        && match defer_mode {
+                            1 => true,
+                            2 => self.def_id_is_simple_lib_interface(def_id),
+                            _ => false,
+                        };
                 if let Some(result) = self.resolve_and_insert_def_type(def_id)
                     && result != TypeId::ERROR
                     && result != TypeId::ANY

--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -17,6 +17,43 @@ use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 use tsz_solver::narrowing::NarrowingContext;
 
+/// Deferral mode for the relation-input pre-resolution walk's transitive
+/// reference-closure expansion ([`CheckerState::ensure_refs_resolved`]).
+///
+/// `ensure_refs_resolved` walks a type's `Lazy(DefId)` refs, fully resolves each
+/// referenced def, and (legacy behaviour) pushes the resolved result back onto
+/// its worklist so the *whole transitive reference closure* is materialized
+/// before any relation runs. For a lib interface like `Node` this eagerly lowers
+/// the entire DOM reference graph (`Node -> Document/Element/... -> 66
+/// `HTML*Element``), ~8000 interned types, and burns the per-process global
+/// resolution fuel — which then suppresses later relation diagnostics in the
+/// same file (a latent parity bug vs `tsc`). See issue #12101.
+///
+/// `TSZ_TRANSITIVE_REFS_MODE` selects:
+/// - unset / `0` -> mode 0: legacy (push every resolved ref). **Default.**
+/// - `2` -> mode 2: defer only eligible simple lib interfaces (the DOM cascade),
+///   keeping user/generic types on the legacy transitive path.
+/// - any other non-empty value (e.g. `1`) -> mode 1: defer all refs.
+///
+/// "Defer" means resolve+insert the top-level ref (so the relation's immediate
+/// input is ready) but do **not** push its resolved result onto the worklist,
+/// leaving its nested refs to be resolved on demand by the relation engine.
+///
+/// Kept gated (default = legacy) because the deferral changes which diagnostics
+/// are emitted across the corpus: it is byte-identical where fuel is not
+/// exhausted and strictly more `tsc`-correct where the legacy fuel-exhaustion
+/// dropped diagnostics, so flipping the default requires a full-CI conformance
+/// A/B (mode 2 vs mode 0).
+fn transitive_refs_deferral_mode() -> u8 {
+    use std::sync::OnceLock;
+    static MODE: OnceLock<u8> = OnceLock::new();
+    *MODE.get_or_init(|| match std::env::var("TSZ_TRANSITIVE_REFS_MODE") {
+        Ok(v) if v == "2" => 2,
+        Ok(v) if !v.is_empty() && v != "0" => 1,
+        _ => 0,
+    })
+}
+
 impl<'a> CheckerState<'a> {
     /// Merge overflow flags into the checker context (sticky: only ever sets to `true`).
     ///
@@ -1412,6 +1449,39 @@ impl<'a> CheckerState<'a> {
     // =========================================================================
 
     /// Ensure all Lazy/Ref types in a type are resolved into the type environment.
+    /// EXPERIMENT helper: structural eligibility check mirroring
+    /// [`Self::lazy_lib_member_receiver_def_id`] but keyed by `DefId` directly.
+    /// True when `def_id` is a non-generic, non-compiler-managed, unshadowed
+    /// interface symbol from the actual/cloned standard library — i.e. the same
+    /// "simple lib interface" the #12117 single-member path is eligible for, the
+    /// interfaces whose full materialization drives the DOM reference cascade.
+    fn def_id_is_simple_lib_interface(&self, def_id: tsz_solver::DefId) -> bool {
+        let Some(sym_id) = self.ctx.def_to_symbol_id_with_fallback(def_id) else {
+            return false;
+        };
+        let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
+            return false;
+        };
+        if !symbol.has_any_flags(tsz_binder::symbol_flags::INTERFACE) {
+            return false;
+        }
+        if self
+            .ctx
+            .get_def_type_params(def_id)
+            .is_some_and(|p| !p.is_empty())
+        {
+            return false;
+        }
+        let name = symbol.escaped_name.clone();
+        if crate::query_boundaries::common::is_compiler_managed_type(&name) {
+            return false;
+        }
+        if self.ctx.file_local_type_shadow_for_lib_name(&name) {
+            return false;
+        }
+        self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id)
+    }
+
     pub(crate) fn ensure_refs_resolved(&mut self, type_id: TypeId) {
         use crate::state_domain::type_environment::lazy::{
             enter_refs_resolution_scope, exit_refs_resolution_scope,
@@ -1464,9 +1534,24 @@ impl<'a> CheckerState<'a> {
                 if global_resolution_fuel_exhausted() {
                     break;
                 }
+                // EXPERIMENT: decide whether to defer this referenced def's
+                // transitive closure. When the kill-switch defers (mode 2 = lib
+                // interfaces only, mode 1 = all), we still resolve+insert the def
+                // (so the top-level ref is ready) but do NOT push its resolved
+                // result onto the worklist, leaving its nested refs for on-demand
+                // relation resolution. Mode 2 restricts deferral to eligible
+                // simple lib interfaces (the DOM cascade) so user/generic types
+                // keep their proven transitive pre-resolution.
+                let defer_mode = transitive_refs_deferral_mode();
+                let defer_this = match defer_mode {
+                    1 => true,
+                    2 => self.def_id_is_simple_lib_interface(def_id),
+                    _ => false,
+                };
                 if let Some(result) = self.resolve_and_insert_def_type(def_id)
                     && result != TypeId::ERROR
                     && result != TypeId::ANY
+                    && !defer_this
                 {
                     worklist.push(result);
                 }

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -95,6 +95,16 @@ pub(crate) fn reset_all_thread_local_state() {
     GLOBAL_RESOLUTION_FUEL.set(0);
 }
 
+/// Whether we are currently inside a type-evaluation frame
+/// (`evaluate_type_with_env_impl`), i.e. resolving types for keyof / indexed
+/// access / mapped / conditional / contextual or generic-inference substitution
+/// rather than preparing a plain top-level relation input. Consumers that
+/// structurally decompose a type run inside such a frame, so deferral of a lib
+/// interface's transitive reference closure is unsafe here and must be skipped.
+pub(crate) fn in_type_evaluation_frame() -> bool {
+    EVAL_ENV_DEPTH.with(|d| d.get() > 0)
+}
+
 // Maximum depth for nested `ensure_application_symbols_resolved` calls.
 // Prevents explosive recursion when resolving lazy DefIds triggers type evaluation
 // (compute_type_of_symbol → evaluate_application_type → evaluate_type_with_env)


### PR DESCRIPTION
## Agent
AgentName: M5Manager-MBM4

## Track
Track 7 — checker performance / vite-vanilla closer (Goal 4).

## Status: BLOCKED / PRESERVED — perf win and conformance regressions are structurally inseparable

This PR is preserved as research evidence, not as a ready candidate. The vite win is real and large in the enabled experiment (9068 -> 5523 interned types, ~0.19s -> ~0.085s, beating tsgo's ~0.11s), but the full-corpus A/B gate caught regressions in variance inference, generic constraint validation, contextual typing/JSX, and indexed/keyof/mapped evaluation. The root cause is that the transitive lib-interface closure being deferred is genuinely consumed by the same relation/evaluation operations that produce the speedup.

The branch is now refreshed onto live `origin/main` and the accidental tracked `.target` symlink that caused stale light-CI infra failures has been removed. It remains WIP/off-queue because the experiment is still not byte-identical and the refreshed head violates the source file-size architecture guard.

## Invariant
When a relation input references a simple lib interface via `Lazy(DefId)`, defer its transitive reference-closure materialization until a consumer needs it, without changing observable relation/inference/contextual-typing behavior.

## Scope
- `crates/tsz-checker/src/assignability/assignability_checker.rs`: gated transitive-reference deferral mode for relation-input pre-resolution and simple-lib-interface eligibility.
- `crates/tsz-checker/src/state/type_environment/lazy.rs`: exposes whether the checker is inside a type-evaluation frame so the experiment can skip deferral there.
- `.target`: removed accidental tracked symlink that made CI fail before reaching source checks.

## Root Cause Of The Regressions
The deferred closure is genuinely consumed by:
- variance inference, e.g. `readonly TypeNode[]` inferred as mutable `TypeNode[]` when `ReadonlyArray`/array closure is deferred;
- generic constraint validation / lib self-checks, e.g. dropped `TS2344 HTMLElementTagNameMap[K] does not satisfy 'Element'`;
- contextual typing of JSX attributes, with extra/missing JSX diagnostics;
- keyof / indexed-access / mapped evaluation, including correlated-union cases.

Two attempted mitigations are documented in the existing PR history:
1. Eval-frame guard (`in_type_evaluation_frame()`) fixes part of the regression family but collapses the vite win, because the useful defers are also in evaluation frames.
2. Defer-but-don't-cache keeps the win but still lets variance/inference decide incorrectly before a later walk can repair anything.

## Project Corpus Impact
- Row: vite-vanilla-ts-app
- Bug family: eager lib-interface transitive-closure materialization on the relation/call path (perf); separately, latent global-resolution-fuel diagnostic drops surfaced by the investigation.
- Evidence: historic M1Opus48 A/B on this PR found mode2 vite improvement (9068 -> 5523 types, ~0.19s -> ~0.085s) but +6 conformance regressions; eval-frame guarded mode2 reduced the win to 9068 -> 8915 / ~0.136s and still left residual regressions. The refreshed branch is not a production win because default remains legacy/off and the enabled path is not byte-identical.
- Successors/overlap: #12136 carries a narrower lazy method/heritage-member lever; #12222 closes #12144, the separable fuel-reset parity bug surfaced during this investigation.

## Verification
- Inspected PR body/comments/checks and overlap before mutation.
- `git fetch origin main` and inspected `origin/perf/lazy-refs-experiment-m1opus48`.
- Created isolated worktree `../tsz-pr12142-mbm4` from the PR branch.
- Cleanly rebased the two experiment commits from old head `8e582563221ef7d72a685c0bd157807d8c1226f3` onto live `origin/main` `bd249c5451af97a61584c2d96b8352e1f49a81aa`.
- Removed tracked `.target` symlink and committed `68497c5cb1a8563417739e9f7e0dc422a6744927` (`chore(ci): remove accidental target symlink`).
- Force-pushed with lease to head `68497c5cb1a8563417739e9f7e0dc422a6744927`.
- `git diff --name-status origin/main...HEAD`.
- `git diff --check origin/main...HEAD`.
- `cargo fmt --check`.
- `cargo check -p tsz-checker --tests`.
- `python3 scripts/arch/arch_guard.py` fails: `crates/tsz-checker/src/assignability/assignability_checker.rs` is 2039 lines (limit 2000).
- Touched-file size check confirms `assignability_checker.rs` grows from 1945 -> 2039 lines; `lazy.rs` grows from 1908 -> 1918.
- No full local conformance, emit, or fourslash suites were run by M5Manager-MBM4.

## Coordination Notes
- AgentName: M5Manager-MBM4.
- Current head: `68497c5cb1a8563417739e9f7e0dc422a6744927`.
- Current base: `origin/main` `bd249c5451af97a61584c2d96b8352e1f49a81aa`.
- Canonical ownership label remains `agent:Studio-B`; added WIP state because this is intentionally non-landable.
- Keep draft/WIP/off-queue. Do not mark ready and do not add `merge-queue`.
- Exact next owner/action: Studio-B should not promote this PR. Use #12136 for the narrower lazy member/heritage-member lever and #12222 for the #12144 fuel-reset parity fix. If a future owner wants to revive the broader vite lever, open a new lib-type snapshot/pre-materialized-closure design PR with byte-identity and residency evidence; otherwise this PR can be closed only after linking the successor issue/PR that preserves these findings.

