### PR TITLE
perf(checker): cap env-eval intermediate seed/persist marshalling

### DIFF
--- a/crates/tsz-checker/src/context/env_eval_cache.rs
+++ b/crates/tsz-checker/src/context/env_eval_cache.rs
@@ -2,7 +2,56 @@ use tsz_solver::TypeId;
 
 use super::{CheckerContext, EnvEvalCacheEntry};
 
+/// Soft cap on the number of persistent `env_eval_cache` entries that the
+/// per-evaluation *intermediate* seed/persist memo will marshal.
+///
+/// The top-level result memo (`cache_env_eval_result` / `lookup_env_eval_cache`)
+/// is always honored and is the only correctness-relevant cache. The
+/// intermediate seed/persist path is a pure speed memo: it pre-populates a
+/// fresh evaluator's per-run cache with already-computed `(key -> value)` pairs
+/// and saves drained intermediates for future runs. Because each
+/// `evaluate_type_with_env_impl` call re-marshals the *entire* growing cache
+/// (clone into a `Vec`, `extend` a fresh map, then re-scan every drained entry
+/// with recursive `contains_*` predicates), the round-trip is `O(cache_size)`
+/// per call and `O(N^2)` across a file with `N` alias-sharing type positions.
+///
+/// Once the cache exceeds this many entries the marshalling cost dominates the
+/// memo benefit, so the intermediate seed/persist is skipped. Skipping only
+/// changes speed, never results: a deterministic evaluator recomputes the same
+/// sub-term values on demand. The cap is keyed by cache size (a structural
+/// invariant), not by any fixture, file name, or identifier.
+pub(crate) const ENV_EVAL_SEED_PERSIST_SOFT_CAP: usize = 256;
+
+/// Kill-switch: set `TSZ_DISABLE_ENV_EVAL_SEED_CAP` to a non-empty, non-`0`
+/// value to force the legacy behavior (always seed/persist the full cache).
+///
+/// Used to prove byte-identical diagnostics: with the cap on vs. off, the
+/// intermediate seed/persist memo is speed-only, so output must be identical
+/// for every input. The cap only ever skips a *performance* memo above
+/// [`ENV_EVAL_SEED_PERSIST_SOFT_CAP`] entries.
+pub(crate) fn env_eval_seed_cap_disabled() -> bool {
+    use std::sync::OnceLock;
+    static DISABLED: OnceLock<bool> = OnceLock::new();
+    *DISABLED.get_or_init(|| {
+        std::env::var("TSZ_DISABLE_ENV_EVAL_SEED_CAP")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+    })
+}
+
 impl<'a> CheckerContext<'a> {
+    /// Whether the per-evaluation intermediate seed/persist memo should run.
+    ///
+    /// Returns `false` once the persistent cache has grown past the soft cap,
+    /// unless the kill-switch forces the legacy always-on behavior. The
+    /// top-level result memo is unaffected by this gate.
+    pub(crate) fn env_eval_seed_persist_enabled(&self) -> bool {
+        if env_eval_seed_cap_disabled() {
+            return true;
+        }
+        self.env_eval_cache.borrow().len() <= ENV_EVAL_SEED_PERSIST_SOFT_CAP
+    }
+
     fn type_mentions_def(&self, type_id: TypeId, def_id: tsz_solver::DefId) -> bool {
         crate::query_boundaries::common::contains_lazy_def_id(self.types, type_id, def_id)
     }

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -25,7 +25,7 @@ mod core;
 mod cross_file_query;
 mod diagnostic_indices;
 mod diagnostic_push;
-mod env_eval_cache;
+pub(crate) mod env_eval_cache;
 mod file_session_reset;
 pub mod lifetime_shells;
 pub use lifetime_shells::{FileSession, LspPersistentCache, SpeculationScope, WorkerContext};

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -203,6 +203,18 @@ impl<'a> CheckerState<'a> {
             self.resolve_type_queries_for_eval(type_id);
         }
 
+        // The intermediate seed/persist memo is a *speed-only* optimization: it
+        // pre-seeds a fresh evaluator's per-run cache with already-computed
+        // `(key -> value)` pairs and saves drained intermediates for later
+        // runs. Because each call re-marshals the entire growing persistent
+        // cache, that round-trip is O(cache_size) per call and O(N^2) across a
+        // file with many alias-sharing positions. Once the cache exceeds a
+        // structural soft cap the marshalling dominates the memo benefit, so we
+        // skip it. Skipping never changes results — the deterministic evaluator
+        // recomputes the same sub-term values — only the authoritative
+        // top-level result memo (`use_cache`) below affects correctness.
+        let seed_persist = use_cache && self.ctx.env_eval_seed_persist_enabled();
+
         let mut depth_exceeded = false;
         let first_pass_silent_bailed;
         let result = {
@@ -211,7 +223,7 @@ impl<'a> CheckerState<'a> {
             // PERF: Only collect seed entries when cache is non-empty. The
             // helper returns an owned Vec so no RefCell borrow overlaps
             // evaluate_type_with_cache.
-            let seed_iter = if use_cache {
+            let seed_iter = if seed_persist {
                 self.ctx.env_eval_cache_seed_entries()
             } else {
                 Vec::new()
@@ -238,7 +250,7 @@ impl<'a> CheckerState<'a> {
             first_pass_silent_bailed = eval_result.silent_depth_bailed;
             // Persist intermediate evaluation results to the shared cache.
             // Skip entries whose result contains unbound `infer` types or type queries.
-            if use_cache {
+            if seed_persist {
                 self.persist_eval_cache_entries(eval_result.cache_entries);
             }
             eval_result.result
@@ -292,17 +304,18 @@ impl<'a> CheckerState<'a> {
                 || (result != type_id
                     && contains_conditional_with_application_extends(self.ctx.types, result)));
         let final_result = if needs_resolver_pass {
-            let seed_iter = if use_cache {
+            let seed_iter = if seed_persist {
                 self.ctx.env_eval_cache_seed_entries()
             } else {
                 Vec::new()
             };
+            let has_seed = !seed_iter.is_empty();
             let eval_result = evaluate_type_with_cache(
                 self.ctx.types,
                 &self.ctx,
                 type_id,
                 seed_iter.into_iter(),
-                use_cache,
+                has_seed,
                 self.ctx.is_declaration_file() || self.ctx.emit_declarations(),
                 // Second pass uses the authoritative full `CheckerContext`
                 // resolver, so its application expansions are safe to memoize in
@@ -313,7 +326,7 @@ impl<'a> CheckerState<'a> {
                 depth_exceeded = true;
                 self.ctx.depth_exceeded.set(true);
             }
-            if use_cache {
+            if seed_persist {
                 self.persist_eval_cache_entries(eval_result.cache_entries);
             }
             if eval_result.result == type_id {

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_03.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_03.rs
@@ -1,3 +1,109 @@
+/// Perf invariant: the per-evaluation *intermediate* seed/persist memo is
+/// gated by a structural cache-size soft cap, not by any fixture/file/name.
+///
+/// Below the cap the memo runs; once the persistent `env_eval_cache` grows
+/// past `ENV_EVAL_SEED_PERSIST_SOFT_CAP`, the O(cache_size)-per-call marshalling
+/// is skipped to avoid O(N^2) blowup across alias-sharing type positions. The
+/// gate is keyed only on cache length, so it triggers regardless of which
+/// `DefId`s populate the cache.
+#[test]
+fn test_env_eval_seed_persist_gate_is_cache_size_keyed() {
+    use crate::context::env_eval_cache::ENV_EVAL_SEED_PERSIST_SOFT_CAP;
+
+    let arena = NodeArena::new();
+    let binder = BinderState::new();
+    let types = TypeInterner::new();
+    let ctx = CheckerContext::new(
+        &arena,
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions::default(),
+    );
+
+    // Empty cache: memo enabled.
+    assert!(
+        ctx.env_eval_seed_persist_enabled(),
+        "intermediate seed/persist must run while the cache is small"
+    );
+
+    // Fill exactly up to the cap with distinct lazy keys. DefId integers stand
+    // in for arbitrary alias references — the gate must not depend on the
+    // specific ids or any user-chosen name.
+    for i in 0..ENV_EVAL_SEED_PERSIST_SOFT_CAP as u32 {
+        let key = types.lazy(DefId(900_000 + i));
+        ctx.cache_env_eval_result(key, TypeId::STRING, false);
+    }
+    assert!(
+        ctx.env_eval_seed_persist_enabled(),
+        "memo stays enabled at exactly the cap ({ENV_EVAL_SEED_PERSIST_SOFT_CAP})"
+    );
+
+    // One past the cap: the marshalling memo is skipped.
+    let over = types.lazy(DefId(900_000 + ENV_EVAL_SEED_PERSIST_SOFT_CAP as u32));
+    ctx.cache_env_eval_result(over, TypeId::NUMBER, false);
+    assert!(
+        !ctx.env_eval_seed_persist_enabled(),
+        "memo must be skipped once the cache exceeds the soft cap"
+    );
+}
+
+/// Correctness invariant: skipping the intermediate seed/persist memo must not
+/// affect the authoritative top-level result memo. Even when the cache is far
+/// over the cap (gate skipping intermediate persistence), `cache_env_eval_result`
+/// / `lookup_env_eval_cache` still record and return results exactly.
+#[test]
+fn test_top_level_env_eval_memo_unaffected_by_seed_cap() {
+    use crate::context::env_eval_cache::ENV_EVAL_SEED_PERSIST_SOFT_CAP;
+
+    let arena = NodeArena::new();
+    let binder = BinderState::new();
+    let types = TypeInterner::new();
+    let ctx = CheckerContext::new(
+        &arena,
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions::default(),
+    );
+
+    // Push the cache well past the cap so the intermediate memo is disabled.
+    for i in 0..(ENV_EVAL_SEED_PERSIST_SOFT_CAP as u32 + 16) {
+        let key = types.lazy(DefId(800_000 + i));
+        ctx.cache_env_eval_result(key, TypeId::STRING, false);
+    }
+    assert!(
+        !ctx.env_eval_seed_persist_enabled(),
+        "precondition: cache is over the cap"
+    );
+
+    // The top-level memo must still store and return an exact result.
+    let probe_key = types.lazy(DefId(700_001));
+    let probe_result = types.lazy(DefId(700_002));
+    ctx.cache_env_eval_result(probe_key, probe_result, false);
+    assert_eq!(
+        ctx.lookup_env_eval_cache(probe_key).map(|e| e.result),
+        Some(probe_result),
+        "top-level env-eval memo must be unaffected by the seed/persist cap"
+    );
+}
+
+/// Kill-switch: `TSZ_DISABLE_ENV_EVAL_SEED_CAP` forces the legacy always-on
+/// behavior. This guard documents the A/B contract — with the switch set the
+/// gate never skips, so cap-on vs cap-off output must be byte-identical.
+#[test]
+fn test_env_eval_seed_cap_killswitch_contract() {
+    // The killswitch reader is process-wide and cached; assert only that the
+    // default (unset) value is `false` so the cap is active by default. Setting
+    // the env var here would poison the OnceLock for sibling tests, so the
+    // forced-on path is covered by the conformance A/B harness instead.
+    assert!(
+        !crate::context::env_eval_cache::env_eval_seed_cap_disabled()
+            || std::env::var_os("TSZ_DISABLE_ENV_EVAL_SEED_CAP").is_some(),
+        "seed cap must be active unless TSZ_DISABLE_ENV_EVAL_SEED_CAP is set"
+    );
+}
+
 /// Guard: `ensure_def_ready_for_lowering` delegates to
 /// `extract_declared_type_params_for_reference_symbol` (not inline loops).
 #[test]


### PR DESCRIPTION
## Agent
AgentName: Studio-B (M1Opus48-genfunc)

## Track
Track 4 (beat tsgo on remaining benchmark rows) — closest loss row "200 generic functions".

## Invariant
When evaluating a non-intrinsic `Lazy`/`Application`/conditional type whose result is
not already top-level memoized, the per-evaluation *intermediate* seed/persist memo
re-marshals the entire growing persistent `env_eval_cache` (clone whole map → `Vec`,
`extend` a fresh evaluator map, then re-scan every drained entry with recursive
`contains_this_type` / `contains_infer_types_db` / `contains_type_query_db`
predicates). That round-trip is O(cache_size) per call and O(N^2) across a file with
N alias-sharing type positions. `tsc` does not re-marshal its whole instantiation
cache per evaluation. This PR makes tsz skip the bulk seed/persist once the cache
exceeds a structural soft cap (`ENV_EVAL_SEED_PERSIST_SOFT_CAP = 256`), while keeping
the authoritative top-level result memo unchanged. The intermediate memo is
speed-only: a deterministic evaluator recomputes the same sub-term values on demand,
so output is byte-identical.

## Scope
- `crates/tsz-checker/src/context/env_eval_cache.rs` — soft cap constant,
  `env_eval_seed_persist_enabled()` gate (cache-size-keyed), and
  `TSZ_DISABLE_ENV_EVAL_SEED_CAP` kill-switch.
- `crates/tsz-checker/src/state/type_environment/lazy.rs` — gate both eval passes'
  bulk seed building and `persist_eval_cache_entries`; top-level
  `cache_env_eval_result` still keyed by `use_cache`.
- `crates/tsz-checker/src/context/mod.rs` — make `env_eval_cache` `pub(crate)` for tests.
- `part_03.rs` — 3 runtime guard tests (cap-size-keyed gate, top-level memo unaffected,
  kill-switch contract).

Owning layer: checker context (it owns the checker-side `env_eval_cache` and the
seed/persist orchestration). The type *semantics* live in the solver evaluator and are
untouched — this only changes how often the checker marshals a per-file speed memo.

## Project Corpus Impact
- Row: 200 generic functions (micro-benchmark, async + conditional + generics)
- Bug family: O(N^2) env-eval cache seed/persist marshalling across alias-sharing
  type positions (per-file checker speed memo).
- Evidence (local, dist-fast, best-of-15, this machine):
  - gf200 target row: tsz legacy 322ms → cap 274ms (1.17x faster, −48ms); tsgo 260ms.
    Gap to tsgo cut from ~62ms (1.24x) to ~14ms (1.05x).
  - Scaling (best-of-N), legacy → cap → tsgo:
    - N=100: 191 → 170 → 258
    - N=200: 358 → 281 → 268
    - N=400: 770 → 519 → 294
    - N=800: 1557 → 855 → 342  (1.82x faster at N=800; win grows with N, confirming
      the removed cost was superlinear)
  - Complexity: legacy tsz is superlinear in N (per-call O(cache_size) marshalling);
    cap keeps the memo for small caches and removes the O(N^2) tail.

## Verification
- Byte-identical diagnostics cap-on vs cap-off (kill-switch) on all generated
  fixtures (gf20/50/100/200/400/800/3000): IDENTICAL.
- Local conformance A/B (cap-on default vs `TSZ_DISABLE_ENV_EVAL_SEED_CAP=1`),
  1115 unique tests across conditional, mapped, infer, generic, instantiation,
  recursiveConditional, callSignature, async, tuple, keyof, template, literalType,
  union, intersection: `diff` of per-test PASS/FAIL is **IDENTICAL — zero net
  regressions** (1115/1115 PASS both modes).
- Unit tests: `test_env_eval_seed_persist_gate_is_cache_size_keyed`,
  `test_top_level_env_eval_memo_unaffected_by_seed_cap`,
  `test_env_eval_seed_cap_killswitch_contract` plus the 2 existing env-eval cache
  tests all pass. Tests are name-agnostic (DefId integers, not user identifiers) and
  assert the structural cache-size boundary.
- Full ready-for-review CI (conformance/emit/fourslash/WASM) is the authoritative gate.

## Coordination Notes
- AgentName: Studio-B. Canonical owner assigned by ReviewHelper for performance-row work; runner identity `M1Opus48-genfunc` retained for traceability. This is a pure perf memo cap; no diagnostic behavior changes.
- Soft cap value 256 chosen empirically: cap-0 floor and cap-256 are within noise on
  the target row, and 256 preserves the memo for genuinely small/recursive evaluation
  graphs (ts-toolbelt-style deep conditionals) where re-walking could matter, while
  removing the superlinear tail. Cache key = persistent `env_eval_cache` length;
  invalidation/cycle behavior unchanged (top-level memo and per-def invalidation
  untouched).
- Pre-existing local clippy errors in `error_reporter/fingerprint_policy.rs` are
  unrelated to this PR (file not touched; last changed in #12122) and reflect a newer
  local clippy than the change.