### PR TITLE
fix(solver): correctly map homomorphic mapped types over leading-rest and middle-rest variadic tuples

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped/tests.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped/tests.rs
@@ -307,15 +307,16 @@ fn identity_homomorphic_mapped_over_trailing_rest_variadic_tuple_preserves_shape
 #[test]
 fn identity_homomorphic_mapped_over_trailing_rest_renamed_iter_var() {
     let interner = TypeInterner::new();
+    // Same element types as the canonical twin; only the iter var name changes.
     let elements = vec![
         TupleElement {
-            type_id: TypeId::BOOLEAN,
+            type_id: TypeId::NUMBER,
             name: None,
             optional: false,
             rest: false,
         },
         TupleElement {
-            type_id: interner.array(TypeId::NUMBER),
+            type_id: interner.array(TypeId::STRING),
             name: None,
             optional: false,
             rest: true,
@@ -363,6 +364,74 @@ fn identity_homomorphic_mapped_over_leading_rest_variadic_tuple_preserves_shape(
     assert_eq!(
         result, expected,
         "identity homomorphic over `[...string[], number]` must reproduce the same tuple"
+    );
+}
+
+/// Same leading-rest test with a renamed iteration variable (`P` instead of `K`).
+/// The fix must be name-blind — changing the iteration variable must not affect
+/// which branch handles suffix elements.
+#[test]
+fn identity_homomorphic_mapped_over_leading_rest_renamed_iter_var() {
+    let interner = TypeInterner::new();
+    let elements = vec![
+        TupleElement::rest(interner.array(TypeId::BOOLEAN)),
+        TupleElement::fixed(TypeId::STRING),
+    ];
+    let source = interner.tuple(elements.clone());
+    let mapped = build_identity_homomorphic_mapped(&interner, "P", source);
+    let mut evaluator = TypeEvaluator::new(&interner);
+    let result = evaluator.evaluate_mapped(&mapped);
+
+    let expected = interner.tuple(elements);
+    assert_eq!(
+        result, expected,
+        "identity homomorphic with iter `P` over `[...boolean[], string]` must preserve shape"
+    );
+}
+
+/// Middle-rest tuple `[string, ...number[], boolean]` — the suffix element
+/// follows a rest element that is itself preceded by a fixed prefix. The
+/// proxy-based suffix rebinding must handle this shape too.
+#[test]
+fn identity_homomorphic_mapped_over_middle_rest_with_prefix_and_suffix() {
+    let interner = TypeInterner::new();
+    let elements = vec![
+        TupleElement::fixed(TypeId::STRING),
+        TupleElement::rest(interner.array(TypeId::NUMBER)),
+        TupleElement::fixed(TypeId::BOOLEAN),
+    ];
+    let source = interner.tuple(elements.clone());
+    let mapped = build_identity_homomorphic_mapped(&interner, "K", source);
+    let mut evaluator = TypeEvaluator::new(&interner);
+    let result = evaluator.evaluate_mapped(&mapped);
+
+    let expected = interner.tuple(elements);
+    assert_eq!(
+        result, expected,
+        "identity homomorphic over `[string, ...number[], boolean]` must preserve shape"
+    );
+}
+
+/// Multiple suffix elements after the rest: `[...string[], number, boolean]`.
+/// Both suffix elements require the proxy rebind, and each must resolve to
+/// its own type, not the union of all element types.
+#[test]
+fn identity_homomorphic_mapped_over_leading_rest_multiple_suffixes() {
+    let interner = TypeInterner::new();
+    let elements = vec![
+        TupleElement::rest(interner.array(TypeId::STRING)),
+        TupleElement::fixed(TypeId::NUMBER),
+        TupleElement::fixed(TypeId::BOOLEAN),
+    ];
+    let source = interner.tuple(elements.clone());
+    let mapped = build_identity_homomorphic_mapped(&interner, "K", source);
+    let mut evaluator = TypeEvaluator::new(&interner);
+    let result = evaluator.evaluate_mapped(&mapped);
+
+    let expected = interner.tuple(elements);
+    assert_eq!(
+        result, expected,
+        "identity homomorphic over `[...string[], number, boolean]` must preserve all suffix types"
     );
 }
 

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped_array.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped_array.rs
@@ -127,9 +127,19 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     ) -> TypeId {
         let tuple_elements = self.interner().tuple_list(tuple_id);
         let mut mapped_elements = Vec::with_capacity(tuple_elements.len());
+        let mut seen_rest = false;
 
         for (index, elem) in tuple_elements.iter().copied().enumerate() {
-            mapped_elements.push(self.evaluate_mapped_tuple_element(mapped, source, index, elem));
+            // Fixed elements that follow any rest element have ambiguous numeric
+            // indices on the full source tuple (T[i] can land in the rest range
+            // or a suffix slot depending on the actual length). The per-element
+            // helper receives this flag so it can use a proxy source instead.
+            let is_suffix = seen_rest && !elem.rest;
+            if elem.rest {
+                seen_rest = true;
+            }
+            mapped_elements
+                .push(self.evaluate_mapped_tuple_element(mapped, source, index, elem, is_suffix));
         }
 
         self.interner().tuple(mapped_elements)
@@ -153,6 +163,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         source: TypeId,
         index: usize,
         elem: TupleElement,
+        is_suffix: bool,
     ) -> TupleElement {
         let rest_inner_kind = elem.rest.then(|| self.interner().lookup(elem.type_id));
 
@@ -196,11 +207,22 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             };
         }
 
-        // Per-element source rebinding for concrete array rests:
-        // T -> `Array<E>`, K -> number. This makes `T[K]` evaluate to E rather
-        // than the union of every tuple element type - the bug we are fixing.
+        // Per-element source rebinding so that `T[K]` evaluates to the element's
+        // own type rather than the union of every tuple element type:
+        //
+        // - Array rest `...E[]`: rebind T -> `E[]`, K -> number so `(E[])[number]` = E.
+        // - Fixed suffix element (after any rest): T[i] is ambiguous because i can
+        //   land in either the rest range or the suffix. Rebind T -> `[elem_type]` and
+        //   K -> "0" so `([elem_type])["0"]` = elem_type unambiguously.
+        // - Fixed prefix element: every preceding position is fixed, so the existing
+        //   string-literal index is unambiguous; no rebinding needed.
         let (new_source, key) = if elem.rest {
             (elem.type_id, TypeId::NUMBER)
+        } else if is_suffix {
+            let proxy = self
+                .interner()
+                .tuple(vec![TupleElement::fixed(elem.type_id)]);
+            (proxy, self.interner().literal_string("0"))
         } else {
             (source, self.interner().literal_string(&index.to_string()))
         };

--- a/crates/tsz-solver/src/types.rs
+++ b/crates/tsz-solver/src/types.rs
@@ -1336,6 +1336,27 @@ impl TupleElement {
     pub const fn is_required(&self) -> bool {
         !self.optional && !self.rest
     }
+
+    /// Create an anonymous, non-optional, non-rest element — the most common
+    /// shape when constructing proxy or synthetic tuples.
+    pub const fn fixed(type_id: TypeId) -> Self {
+        Self {
+            type_id,
+            name: None,
+            optional: false,
+            rest: false,
+        }
+    }
+
+    /// Create an anonymous rest element (`...type_id`).
+    pub const fn rest(type_id: TypeId) -> Self {
+        Self {
+            type_id,
+            name: None,
+            optional: false,
+            rest: true,
+        }
+    }
 }
 
 /// Type predicate information (x is T / asserts x is T).


### PR DESCRIPTION
## Summary

Fixes #12150 — homomorphic mapped types applied to variadic tuples with leading-rest or middle-rest elements produce wrong types for suffix elements.

**Structural rule:** When `{ [K in keyof T]: T[K] }` is applied to `[...string[], number]`, the fixed element `number` at position 1 is a *suffix* element. Evaluating `source["1"]` on the full tuple yields `string | number` (ambiguous — index 1 can land in either the rest range or the suffix slot depending on runtime tuple length). The fix creates a singleton proxy tuple `[number]` and uses key `"0"`, so `([number])["0"]` = `number` unambiguously.

**Bullet fixes:**
- `[...E[], T]` — leading-rest, single suffix
- `[A, ...E[], T]` — middle-rest, prefix + rest + suffix
- `[...E[], T, U]` — leading-rest, multiple suffixes
- Renamed iteration variable (e.g. `P` instead of `K`) — name-blind

AgentName: claude-sonnet-4-6-busy-lamport

## Track
Solver / mapped-type evaluation parity

## Invariant
When a homomorphic mapped type is applied to a variadic tuple, each element of the resulting tuple must have exactly the mapped type of the corresponding source element — not a union of all element types.

## Scope

Three files changed:

| File | Change |
|------|--------|
| `crates/tsz-solver/src/evaluation/evaluate_rules/mapped_array.rs` | `seen_rest` tracking in loop + proxy-tuple rebinding for suffix elements |
| `crates/tsz-solver/src/types.rs` | `TupleElement::fixed(type_id)` and `TupleElement::rest(type_id)` constructors |
| `crates/tsz-solver/src/evaluation/evaluate_rules/mapped/tests.rs` | 3 new tests + 1 corrected test alignment |

## Project Corpus Impact

- Row: `n/a` (no project-corpus fixture for this exact tuple shape)
- Bug family: homomorphic mapped type evaluation over variadic tuples — same family as #9694 (trailing-rest, now closed), extended to leading-rest/middle-rest shapes
- Evidence: `cargo nextest run -p tsz-solver -E 'test(identity_homomorphic_mapped_over)'` — 10 tests pass including 3 new cases

## Verification

```
cargo nextest run -p tsz-solver -E 'test(identity_homomorphic_mapped_over)'
# 10 tests run: 10 passed

cargo nextest run -p tsz-solver
# 6476 tests run: 6468 passed, 8 failed (all 8 pre-existing), 1 skipped

cargo clippy --workspace --all-targets --all-features -- -D warnings
# exit 0, no new warnings
```

## Coordination Notes

- Extends the fix from #9694 (trailing-rest, already closed/merged) to the leading-rest and middle-rest shapes that remained unfixed.
- `tuple_index_literal` (root-cause site in `index_access_keys.rs`) intentionally not changed — its behavior of returning the union for ambiguous positions is correct for non-mapped callers; the fix is correctly placed in the mapped-type evaluator.
- `TupleElement::fixed()` and `TupleElement::rest()` constructors are small additions to `types.rs` that replace repeated 5-field struct literals at construction sites.
- Three `/simplify` passes run; findings applied: `TupleElement::fixed()` adoption in test code, `TupleElement::rest()` to eliminate `..fixed(TypeId::NEVER)` dummy base, test element-type alignment for renamed-iter-var tests.


---
_Generated by [Claude Code](https://claude.ai/code/session_018uaTPebXh6wfk84wETT7AU)_