### PR TITLE
fix(emit): lower nested async arrows in ES5 async bodies

### DIFF
--- a/crates/tsz-emitter/src/transforms/async_es5_ir_convert.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_convert.rs
@@ -822,6 +822,57 @@ impl<'a> AsyncES5Transformer<'a> {
             return IRNode::Raw(generated.into());
         }
 
+        if func.is_async {
+            let uses_lexical_this = if self.is_recovered_arrow_function_expression(node) {
+                self.function_body_contains_this_reference(node)
+            } else {
+                tsz_parser::syntax::transform_utils::contains_this_reference(self.arena, idx)
+            };
+            if uses_lexical_this {
+                self.set_capture_this_references(true);
+            }
+
+            let mut transformer = AsyncES5Transformer::new(self.arena);
+            transformer.set_temp_var_counter(self.temp_var_counter());
+            transformer.downlevel_iteration = self.downlevel_iteration;
+            transformer.set_module_kind(self.module_kind);
+            transformer
+                .dynamic_import_promise_counter
+                .set(self.dynamic_import_promise_counter.get());
+            transformer.set_catch_binding_ordinals(self.catch_binding_ordinals.borrow().clone());
+            if let Some(source_text) = self.source_text {
+                transformer.set_source_text(source_text);
+            }
+
+            let has_await = transformer.body_contains_await(func.body);
+            let mut generator_body = transformer.transform_generator_body(func.body, has_await);
+            let hoisted_var_groups =
+                AsyncES5Transformer::extract_and_remove_var_decl_groups(&mut generator_body);
+            let body = transformer.build_async_arrow_awaiter_body(
+                if uses_lexical_this {
+                    IRNode::this_captured()
+                } else {
+                    IRNode::void_0()
+                },
+                generator_body,
+                hoisted_var_groups,
+            );
+            let is_expression_body = !transformer.state.captures_arguments;
+
+            self.set_temp_var_counter(transformer.temp_var_counter());
+            self.dynamic_import_promise_counter
+                .set(transformer.dynamic_import_promise_counter.get());
+            self.set_catch_binding_ordinals(transformer.take_catch_binding_ordinals());
+
+            return IRNode::FunctionExpr {
+                name: None,
+                parameters: self.convert_parameters(&func.parameters.nodes),
+                body,
+                is_expression_body,
+                body_source_range: None,
+            };
+        }
+
         // Convert parameters
         let params = self.convert_parameters(&func.parameters.nodes);
 

--- a/crates/tsz-emitter/tests/es5_transforms_e2e_parts/part_00.rs
+++ b/crates/tsz-emitter/tests/es5_transforms_e2e_parts/part_00.rs
@@ -616,6 +616,45 @@ fn async_es5_nested_regular_function_arrow_owns_this_capture() {
 }
 
 #[test]
+fn async_es5_nested_async_function_likes_lower_inside_outer_async_body() {
+    let output = emit_es5(
+        "async function outer() {\n\
+             await first();\n\
+             const named = async function inner(value: number) {\n\
+                 await second(value);\n\
+                 return value;\n\
+             };\n\
+             const arrow = async (value: number) => {\n\
+                 await third(value);\n\
+                 return value;\n\
+             };\n\
+             return [named, arrow];\n\
+         }\n",
+    );
+
+    let awaiter_calls = output.matches("return __awaiter(").count();
+    assert!(
+        awaiter_calls >= 3,
+        "Outer async function, nested async function expression, and nested async arrow should each lower through __awaiter.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("function inner(value) {\n")
+            && output.contains("arrow = function (value) {"),
+        "Nested async function-like expressions should become ordinary ES5 functions.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("return [4 /*yield*/, second(value)];")
+            && output.contains("return [4 /*yield*/, third(value)];"),
+        "Nested async bodies should lower their own await expressions to generator yields.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("async function inner") && !output.contains("await second(value)")
+            && !output.contains("await third(value)"),
+        "Raw async/await syntax must not leak from nested async function-like expressions.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn async_es5_user_this_alias_identifier_does_not_trigger_capture() {
     let output = emit_es5(
         "async function f() {\n\

--- a/crates/tsz-emitter/tests/es5_transforms_e2e_parts/part_01.rs
+++ b/crates/tsz-emitter/tests/es5_transforms_e2e_parts/part_01.rs
@@ -41,6 +41,46 @@ fn async_namespace_import_return_type_does_not_become_promise_constructor() {
 }
 
 #[test]
+fn async_es5_nested_function_expression_gets_own_state_machine() {
+    let output = emit_es5_with_module(
+        "import * as Bluebird from \"bluebird\";\n\
+         async function a(): Bluebird<void> {\n\
+             try {\n\
+                 const b = async function b(): Bluebird<void> {\n\
+                     try {\n\
+                         await Bluebird.resolve();\n\
+                     } catch (error) {\n\
+                     }\n\
+                 };\n\
+                 await b();\n\
+             } catch (error) {\n\
+             }\n\
+         }\n",
+        ModuleKind::CommonJS,
+    );
+
+    assert!(
+        output.contains("b = function b()"),
+        "Nested async function expressions should remain named function expressions.\nOutput:\n{output}"
+    );
+    assert!(
+        output
+            .matches("return __awaiter(this, void 0, void 0, function ()")
+            .count()
+            >= 2,
+        "The outer function and nested function expression should each lower to an awaiter.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("await "),
+        "ES5 output must not leak raw await from the nested async function expression.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("var b, error_1;") && output.contains("var error_2;"),
+        "Nested catch bindings should stay in the nested async state machine.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn system_import_meta_file_is_wrapped_as_module() {
     let output = emit_es5_with_module(
         "(async () => {\n\


### PR DESCRIPTION
## Agent
AgentName: M5Manager

## Track
Track 9 emit parity: ES5 async lowering / issue #11894 gap #2.

## Invariant
When an async function body targeting ES5 contains a nested async function-like expression, `tsc` lowers that nested async body through its own `__awaiter`/`__generator` state machine; this PR makes tsz route nested async arrows through the emitter async-arrow IR lowering path instead of ordinary function-body conversion.

## Owner Layer
Emitter output lowering (`tsz-emitter` ES5 async IR conversion). The change stays in emit planning/conversion, uses syntax/emit context already available to the emitter, and does not add checker or solver semantic validation.

## Scope
- Route async arrow expressions seen by `AsyncES5Transformer::convert_arrow_function` through a nested `AsyncES5Transformer`.
- Preserve module kind, downlevel-iteration mode, temp counters, dynamic-import counters, and catch-binding ordinals across the nested async-arrow transform.
- Keep lexical `this` capture structural: async arrows that reference `this` pass the captured `_this`; arrows that do not use `this` keep `void 0` as the awaiter receiver.
- Add focused ES5 emitter coverage for nested async arrows and adjacent named async function expressions inside outer async bodies.

## Adjacent Case Matrix
- Named async function expression assigned inside an outer async body keeps its own state machine and catch binding scope.
- Async arrow assigned inside an outer async body gets its own state machine and no raw `await` leakage.
- Existing nested regular-function arrow `this` ownership still passes.
- Existing async arrow lexical `this` and top-level `void 0` receiver behavior still passes.
- Existing for-await helper nested async arrow coverage still passes.

## Project Corpus Impact
- Row: emit conformance
- Bug family: ES5 async lowering for `transformNestedGeneratorsWithTry` / issue #11894 gap #2
- Evidence: targeted emit filter `transformNestedGeneratorsWithTry` passed JS-only `2/2` locally after linking the existing TypeScript corpus; focused `tsz-emitter` unit coverage added.

## Verification
- `cargo nextest run -p tsz-emitter async_es5_nested_async_function_likes_lower_inside_outer_async_body`
- `cargo nextest run -p tsz-emitter -E 'test(async_es5_nested_async_function_likes_lower_inside_outer_async_body) or test(async_es5_nested_function_expression_gets_own_state_machine)'`
- `cargo nextest run -p tsz-emitter -E 'test(async_es5_nested_regular_function_arrow_owns_this_capture) or test(test_async_arrow_in_function_passes_lexical_this_to_awaiter) or test(test_top_level_async_arrow_still_passes_void_0_to_awaiter) or test(for_await_captured_iteration_binding_uses_plain_loop_helper)'`
- `cargo fmt --package tsz-emitter --check`
- `git diff --check`
- `scripts/emit/run.sh --filter=transformNestedGeneratorsWithTry --js-only --verbose --json-out=/tmp/emit-nested-async.json` -> JS emit `2/2` passed

## Known Unsupported Shapes / Fallback
No intentional stopgap. This applies to async arrow expressions converted by the ES5 async IR path; other nested non-async function boundaries continue to use ordinary function conversion.

## Coordination Notes
- AgentName: M5Manager.
- Overlap checked against open PRs/issues/recent merges. Active emit PR #12126 is in the static class computed-name lane and does not touch this nested async-arrow conversion path.
- Related issue: #11894. This PR fixes gap #2 only; it does not address the separate `operationsAvailableOnPromisedType` ES5 array-spread/for-await temp subcluster or the likely-WONTFIX ES2015 hoisting idiosyncrasy noted in that issue.
- Handoff: because #11894 is owned by `agent:Studio-A`, this async ES5 emit slice remains labeled `agent:Studio-A`. M5Manager marked it ready after exact-head draft-light CI passed, then queued it after ready-head `CI Summary` and GitGuardian were green.
- Queue state: exact head `b6495027fe504dc60ca699f5f45502e9396498ca` has ready-head `CI Summary` green and `GitGuardian Security Checks` green. M5Manager added `merge-queue`; `Queue Tested` is queue-owned evidence.