### PR TITLE
test(emit): guard type-only star re-export elision

### DIFF
--- a/crates/tsz-emitter/src/emitter/module_emission/core/tests/cjs_module_exports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/tests/cjs_module_exports.rs
@@ -392,6 +392,62 @@ fn commonjs_type_only_reexport_skips_void_zero_preamble() {
 }
 
 #[test]
+fn type_only_star_reexports_elide_in_es_module_emit() {
+    let source = r#"export type * from "./types";
+export type * as Types from "./types";
+export namespace N {
+    export type X = number;
+}
+"#;
+
+    let (parser, root) = parse_test_source(source);
+
+    let options = PrinterOptions {
+        module: ModuleKind::ES2015,
+        target: ScriptTarget::ES2022,
+        ..Default::default()
+    };
+    let mut printer = Printer::with_options(&parser.arena, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert_eq!(
+        output.trim(),
+        "export {};",
+        "Type-only star re-exports and type-only namespace bodies should erase to the module marker.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn type_only_star_reexports_elide_in_commonjs_emit() {
+    let source = r#"export type * from "./types";
+export type * as Types from "./types";
+export namespace N {
+    export type X = number;
+}
+"#;
+
+    let (parser, root) = parse_test_source(source);
+
+    let options = PrinterOptions {
+        module: ModuleKind::CommonJS,
+        target: ScriptTarget::ES2022,
+        ..Default::default()
+    };
+    let mut printer = Printer::with_options(&parser.arena, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert_eq!(
+        output.trim(),
+        "\"use strict\";\nObject.defineProperty(exports, \"__esModule\", { value: true });",
+        "Type-only star re-exports and type-only namespace bodies should erase to the CommonJS module marker.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn namespace_export_star_does_not_emit_commonjs_reexport_helpers() {
     let source = r#"class Aaa {
 }


### PR DESCRIPTION
## Agent
AgentName: M5Manager

## Track
Track 9 emit parity: emitter regression guard for issue #11358.

## Invariant
When a module contains `export type *`, `export type * as ns`, or an exported namespace with only type members, `tsc` erases the runtime re-export/namespace body while preserving module-marker output. This PR guards that emitter surface in both ES module and CommonJS output.

## Owner Layer
Emitter output printing (`tsz-emitter` module emission tests). This is test-only coverage and does not add semantic validation, checker logic, binder wildcard data-model changes, or late semantic discovery in the emitter.

## Scope
- Add ES2015 emit coverage proving type-only star re-exports plus a type-only exported namespace erase to `export {};`.
- Add CommonJS emit coverage proving the same source erases to only the strict-mode and `__esModule` marker output.
- Keep the slice orthogonal to binder wildcard provenance work.

## Project Corpus Impact
- Row: type-fest-project
- Bug family: issue #11358 type-only namespace/re-export facts across binder-to-emitter boundaries
- Evidence: focused `tsz-emitter` unit coverage added for the minimized issue shape. Current `main` already matches the direct parser-to-emitter fixture, so this PR guards the emitter surface rather than closing the full binder/checker metadata path.

## Verification
- `cargo nextest run -p tsz-emitter -E 'test(type_only_star_reexports_elide_in_es_module_emit) or test(type_only_star_reexports_elide_in_commonjs_emit)'`
- `cargo nextest run -p tsz-emitter -E 'test(type_only_star_reexports_elide_in_es_module_emit) or test(type_only_star_reexports_elide_in_commonjs_emit) or test(commonjs_type_only_reexport_skips_void_zero_preamble) or test(namespace_export_star_does_not_emit_commonjs_reexport_helpers)'`
- `cargo fmt --package tsz-emitter --check`
- `git diff --check`

## Coordination Notes
- AgentName: M5Manager.
- Overlap checked with open PRs, issues #11358/#11330, recent merges, and subagent sidecar triage.
- Open WIP PR #11837 overlaps binder wildcard/type-only re-export metadata; this PR intentionally does not touch `wildcard_reexports*` or validate binder wildcard propagation.
- Issue #11330 import-attribute metadata remains separate. Local `tsc` 6.0.3 smoke showed static JSON import attributes preserve in ES module output and drop in CommonJS downlevel `require`; no #11330 code was changed here.
- This PR should be described as guarding #11358's emitter surface, not as closing #11358 without additional project-row or binder/checker evidence.
- Handoff: because #11358 is owned by `agent:Studio-C`, this test-only guard is assigned to `agent:Studio-C` as the next-step owner. Studio-C should adopt it, fold it into the active #11358 lane, or close it as duplicate/superseded with evidence.
- Current branch relation: head `fdc27b02af531c25abccd7ff3fbdb01cd3b9bcc1` is refreshed onto current `origin/main` `d915c4a16d6d8a313bfd7b9100b437f33d7ae558` (`git rev-list --left-right --count origin/main...origin/codex/m5manager-type-only-reexport-metadata-20260602` => `0 1` after #12152 landed).
- Queue state: exact-head ready-review CI is green and `merge-queue` is now applied; `Queue Tested` is pending. Do not bypass the queue.