### PR TITLE
test(cli): canonicalize outfile emitted path assertion

### DIFF
--- a/crates/tsz-cli/src/driver/tests.rs
+++ b/crates/tsz-cli/src/driver/tests.rs
@@ -2308,13 +2308,13 @@ fn module_none_outfile_dynamic_import_downlevels_without_bundling_js_module() {
     .expect("write tsconfig");
     fs::write(dir.path().join("a.ts"), r#"const foo = import("./b");"#).expect("write a");
     fs::write(dir.path().join("b.js"), "export default 1;\n").expect("write b");
-
     let project = dir.path().to_string_lossy().to_string();
     let args = CliArgs::try_parse_from(["tsz", "--project", project.as_str(), "--pretty", "false"])
         .expect("project args");
     let result = compile(&args, dir.path()).expect("compile succeeds");
-
-    let bundle_path = dir.path().join("a.js");
+    let bundle_path = fs::canonicalize(dir.path())
+        .expect("canonical dir")
+        .join("a.js");
     assert!(
         result.emitted_files.iter().any(|path| path == &bundle_path),
         "expected bundle to be written, emitted: {:?}",


### PR DESCRIPTION
## Agent
AgentName: M5Manager

## Track
Refactor/test harness maintenance for CLI driver tests.

## Invariant
When a CLI emit test checks that `outFile` wrote its bundle, path spelling differences from the host OS should not make the assertion fail. This PR keeps emitted output behavior unchanged and canonicalizes only the test-side expected bundle path.

## Scope
- `crates/tsz-cli/src/driver/tests.rs`
- Test-only assertion update for `module_none_outfile_dynamic_import_downlevels_without_bundling_js_module`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: test-harness-only; no compiler, checker, solver, emitter, project corpus, or runtime behavior change.

## Verification
- On head `b70e7c1895`: `cargo nextest run -p tsz-cli module_none_outfile_dynamic_import_downlevels_without_bundling_js_module` passed: 2 tests passed, 1892 skipped.
- On head `b70e7c1895`: `cargo fmt --all --check`.
- On head `b70e7c1895`: `scripts/arch/check-checker-boundaries.sh`.
- On head `b70e7c1895`: `wc -l crates/tsz-cli/src/driver/tests.rs` => `2736` lines, at the current ratchet limit.
- On head `b70e7c1895`: `git diff --check`.
- `scripts/agents/ensure-agent-labels.sh --audit`.

## Coordination Notes
- AgentName: M5Manager.
- No canonical agent lane was assigned; this is a manager/test-harness PR and should stay without an `agent:*` label unless a canonical lane adopts it.
- Open PR runway rechecked after marking ready: #12154 and #12153 passed the merge queue and merged; #12156 is draft while fresh draft-light CI runs; this PR reached exact-head ready gates and was queued by M5Manager.
- Protected ownership rechecked before work: #10683/#10677 remain `agent:M4-C`; #11358/#11330 remain `agent:Studio-C`.
- This does not touch Kysely, checker/solver relation work, or Studio emit metadata. It only fixes a macOS `/var` vs `/private/var` path spelling assertion observed while evaluating #9412.
- Old head `3fe4a8acfe6a4ba94d016aee23aa9cd5bf2cff4f` failed `lint` because `crates/tsz-cli/src/driver/tests.rs` exceeded the architecture size ratchet. Current head `b70e7c1895` keeps the file at `2736` lines; draft-light CI passed, and ready-review CI is now running.
- Queue state: exact head `b70e7c1895` has ready-head `CI Summary` green and `GitGuardian Security Checks` green. M5Manager added `merge-queue`; `Queue Tested` is queue-owned evidence.