### PR TITLE
refactor(cli): extract no-check diagnostics collector

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -43,13 +43,14 @@ mod check_file;
 mod check_tests;
 mod checker_diagnostics;
 mod checker_lib_diagnostics;
+mod no_check_diagnostics;
 mod source_resolution_setup;
 mod wildcard_barrel_analysis;
 
 use check_file::{
     CheckFileFlags, CheckFileForParallelContext, CheckFileResult, CheckFilesReuseCtx,
     check_file_for_parallel, check_files_in_parallel_chunks_with_reuse,
-    check_files_sequentially_with_reuse, collect_no_check_file_diagnostics,
+    check_files_sequentially_with_reuse,
 };
 use checker_diagnostics::{
     keep_checker_diagnostic_when_program_has_real_syntax_errors, post_process_checker_diagnostics,
@@ -64,6 +65,7 @@ use checker_lib_diagnostics::{
     is_datetimeformatpart_spelling_baseline_diagnostic, retain_program_induced_lib_diagnostics,
     should_preserve_datetimeformatpart_spelling_baseline,
 };
+use no_check_diagnostics::{NoCheckDiagnosticsInput, collect_no_check_diagnostics_for_files};
 use source_resolution_setup::{
     SourceResolutionSetup, SourceResolutionSetupInput, prepare_source_resolution_setup,
 };
@@ -583,35 +585,18 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
     // errors via the `if !no_check` guard around `check_source_file`); the
     // type_caches it produces feed declaration emit.
     if options.no_check && !options.emit_declarations {
-        use rayon::prelude::*;
+        let all_file_indices: Vec<usize> = (0..program.files.len()).collect();
 
-        let mut diagnostics: Vec<Diagnostic> = program
-            .files
-            .par_iter()
-            .map(|file| {
-                let mut file_diags = collect_no_check_file_diagnostics(
-                    file,
-                    options,
-                    program_has_real_syntax_errors,
-                );
-                // tsc still reports the `--isolatedDeclarations` grammar
-                // diagnostics (TS9007/TS9011/TS9012/etc.) under `--noCheck`
-                // because they gate declaration emission, not type checking
-                // (#3709). Run only the isolated-declaration grammar pass.
-                if options.checker.isolated_declarations {
-                    let mut binder = tsz_binder::state::BinderState::new();
-                    binder.bind_source_file(&file.arena, file.source_file);
-                    file_diags.extend(tsz::checker::run_isolated_declarations_pass(
-                        &file.arena,
-                        &binder,
-                        file.source_file,
-                        file.file_name.clone(),
-                        options.checker.clone(),
-                    ));
-                }
-                file_diags
+        let mut diagnostics: Vec<Diagnostic> =
+            collect_no_check_diagnostics_for_files(NoCheckDiagnosticsInput {
+                files: &program.files,
+                file_indices: &all_file_indices,
+                options,
+                program_has_real_syntax_errors,
+                include_isolated_declaration_diagnostics: true,
             })
-            .flatten()
+            .into_iter()
+            .flat_map(|file_diags| file_diags.diagnostics)
             .collect();
 
         for (file_idx, file_diags) in per_file_ts7016_diagnostics.iter().enumerate() {
@@ -668,15 +653,18 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
             .iter()
             .all(|file| is_declaration_file(&file.file_name))
     {
-        use rayon::prelude::*;
+        let all_file_indices: Vec<usize> = (0..program.files.len()).collect();
 
-        let mut diagnostics: Vec<Diagnostic> = program
-            .files
-            .par_iter()
-            .map(|file| {
-                collect_no_check_file_diagnostics(file, options, program_has_real_syntax_errors)
+        let mut diagnostics: Vec<Diagnostic> =
+            collect_no_check_diagnostics_for_files(NoCheckDiagnosticsInput {
+                files: &program.files,
+                file_indices: &all_file_indices,
+                options,
+                program_has_real_syntax_errors,
+                include_isolated_declaration_diagnostics: false,
             })
-            .flatten()
+            .into_iter()
+            .flat_map(|file_diags| file_diags.diagnostics)
             .collect();
 
         for (file_idx, file_diags) in per_file_ts7016_diagnostics.iter().enumerate() {
@@ -1165,22 +1153,29 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
         let skip_lib_check = options.skip_lib_check;
         let compiler_options = options.checker.clone();
         let mut work_items: Vec<usize> = Vec::with_capacity(work_queue.len());
-        let mut skipped_file_diagnostics: Vec<Vec<Diagnostic>> = Vec::new();
+        let mut skipped_file_indices: Vec<usize> = Vec::new();
         for file_idx in work_queue {
             let file = &program.files[file_idx];
             if should_skip_type_checking_for_file(&file.file_name, options, false) {
-                let mut file_diags = collect_no_check_file_diagnostics(
-                    file,
-                    options,
-                    program_has_real_syntax_errors,
-                );
-                file_diags.extend(per_file_ts7016_diagnostics[file_idx].iter().cloned());
-                skipped_file_diagnostics.push(file_diags);
+                skipped_file_indices.push(file_idx);
             } else {
                 work_items.push(file_idx);
             }
         }
-        diagnostics.extend(skipped_file_diagnostics.into_iter().flatten());
+        for mut file_diags in collect_no_check_diagnostics_for_files(NoCheckDiagnosticsInput {
+            files: &program.files,
+            file_indices: &skipped_file_indices,
+            options,
+            program_has_real_syntax_errors,
+            include_isolated_declaration_diagnostics: false,
+        }) {
+            file_diags.diagnostics.extend(
+                per_file_ts7016_diagnostics[file_diags.file_idx]
+                    .iter()
+                    .cloned(),
+            );
+            diagnostics.extend(file_diags.diagnostics);
+        }
 
         let build_checker_binder = |file_idx: usize| {
             let file = &program.files[file_idx];

--- a/crates/tsz-cli/src/driver/no_check_diagnostics.rs
+++ b/crates/tsz-cli/src/driver/no_check_diagnostics.rs
@@ -1,0 +1,74 @@
+//! No-check diagnostic collection for CLI check scheduling.
+
+use super::check_file::collect_no_check_file_diagnostics;
+use super::*;
+
+pub(super) struct NoCheckDiagnosticsInput<'a> {
+    pub(super) files: &'a [tsz::parallel::BoundFile],
+    pub(super) file_indices: &'a [usize],
+    pub(super) options: &'a ResolvedCompilerOptions,
+    pub(super) program_has_real_syntax_errors: bool,
+    pub(super) include_isolated_declaration_diagnostics: bool,
+}
+
+pub(super) struct NoCheckFileDiagnostics {
+    pub(super) file_idx: usize,
+    pub(super) diagnostics: Vec<Diagnostic>,
+}
+
+pub(super) fn collect_no_check_diagnostics_for_files(
+    input: NoCheckDiagnosticsInput<'_>,
+) -> Vec<NoCheckFileDiagnostics> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        use rayon::prelude::*;
+        input
+            .file_indices
+            .par_iter()
+            .map(|&file_idx| collect_no_check_diagnostics_for_file(&input, file_idx))
+            .collect()
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        input
+            .file_indices
+            .iter()
+            .map(|&file_idx| collect_no_check_diagnostics_for_file(&input, file_idx))
+            .collect()
+    }
+}
+
+fn collect_no_check_diagnostics_for_file(
+    input: &NoCheckDiagnosticsInput<'_>,
+    file_idx: usize,
+) -> NoCheckFileDiagnostics {
+    let file = &input.files[file_idx];
+    let mut diagnostics = collect_no_check_file_diagnostics(
+        file,
+        input.options,
+        input.program_has_real_syntax_errors,
+    );
+
+    // TSC still reports the `--isolatedDeclarations` grammar diagnostics
+    // (TS9007/TS9011/TS9012/etc.) under `--noCheck` because they gate
+    // declaration emission, not type checking (#3709). Run only the
+    // isolated-declaration grammar pass.
+    if input.include_isolated_declaration_diagnostics && input.options.checker.isolated_declarations
+    {
+        let mut binder = tsz_binder::state::BinderState::new();
+        binder.bind_source_file(&file.arena, file.source_file);
+        diagnostics.extend(tsz::checker::run_isolated_declarations_pass(
+            &file.arena,
+            &binder,
+            file.source_file,
+            file.file_name.clone(),
+            input.options.checker.clone(),
+        ));
+    }
+
+    NoCheckFileDiagnostics {
+        file_idx,
+        diagnostics,
+    }
+}


### PR DESCRIPTION
## Agent
AgentName: M5Manager

## Track
Track 10 / CLI tech-debt refactor for issue #9411.

## Invariant
When the CLI driver needs diagnostics for files that are intentionally not type-checked (`--noCheck`, pure declaration-file `skipLibCheck`, or skipped work-queue files), the driver should pass a prepared file set to a named no-check diagnostic collector. This PR keeps diagnostic policy, ordering, cache cleanup, emitted text, and public CLI/LSP behavior unchanged while moving no-check per-file collection out of the scheduling loops.

## Scope
- Add `crates/tsz-cli/src/driver/no_check_diagnostics.rs`.
- Route three existing no-check collection call sites in `crates/tsz-cli/src/driver/check.rs` through the helper.
- Preserve existing TS7016/cache handling in `check.rs`, including the current per-path retention behavior and skipped-file diagnostic order.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only CLI driver maintenance; no checker, solver, emitter, project corpus, module-resolution semantics, or public output behavior is intentionally changed.

## Verification
- On head `a459db2`: `git diff --check origin/main...HEAD`.
- On head `a459db2`: `cargo fmt --package tsz-cli --check`.
- On head `a459db2`: `cargo nextest run -p tsz-cli no_check --no-fail-fast` passed: 18 tests passed, 1876 skipped.
- On head `a459db2`: `cargo check -p tsz-cli`.
- On head `a459db2`: `scripts/safe-run.sh cargo clippy -p tsz-cli --lib --bins -- -D warnings`.
- On head `a459db2`: `wc -l crates/tsz-cli/src/driver/check.rs crates/tsz-cli/src/driver/no_check_diagnostics.rs` => `1835` and `74` lines.
- Draft-light CI on head `a459db2`: `CI Light Summary`, `lint`, `unit`, `dist-binaries`, and `GitGuardian Security Checks` are green.
- Ready-review CI on head `a459db2`: running after the PR was marked ready; `CI Summary` is not green yet.
- Informational only: `scripts/safe-run.sh cargo clippy -p tsz-cli --lib --tests -- -D warnings` previously failed on pre-existing unrelated test-layout lints (`clippy::duplicate_mod` for `driver/tests.rs` and `clippy::items_after_test_module` in `diagnostics_report.rs`); this PR does not touch those files.

## Coordination Notes
- AgentName: M5Manager.
- Refs #9411.
- No canonical agent lane was assigned; this is a manager/CLI-refactor PR and should stay without an `agent:*` label unless a canonical lane adopts it.
- Current remote head is `a459db2bc76f0209716dcaaf586a9884dacb4154`, one commit over current `origin/main` `8cfc6ec840a35f054f06c1972df5cb606e92363f` (`git rev-list --left-right --count origin/main...HEAD` => `0 1`).
- Protected ownership rechecked: #10683/#10677 remain `agent:M4-C`; #11358/#11330 remain `agent:Studio-C`. Open WIP #11837 still overlaps binder wildcard/type-only re-export metadata, so this PR stays away from that surface.
- This branch does not touch Kysely contextual typing, checker/solver relation work, wildcard re-export metadata, import-assertion emit metadata, DTS, or emitter code.
- M5Manager marked this PR ready on exact head `a459db2` after draft-light gates passed; signed readiness comment: https://github.com/mohsen1/tsz/pull/12156#issuecomment-4597386657.
- `merge-queue` remains off. Reassess queue eligibility only after exact-head ready-review `CI Summary` and `GitGuardian Security Checks` are green.
- Current open PR audit: canonical agent label audit passes; #12157 is draft/blocked because `lint` failed on head `4e03a3350b067cbf1feb2b4c2f93db02bc704c3d`.
