### PR TITLE
perf(checker): keep global lib-value receivers lazy for own-member access

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
+++ b/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
@@ -40,7 +40,8 @@
 
 use crate::state::CheckerState;
 use tsz_binder::symbol_flags;
-use tsz_solver::DefId;
+use tsz_parser::parser::NodeIndex;
+use tsz_solver::{DefId, TypeId};
 
 /// Kill-switch for the lazy single-member lib-interface property-access fast
 /// path. Set `TSZ_DISABLE_LAZY_MEMBER_ACCESS=1` to force the legacy
@@ -57,7 +58,64 @@ pub(crate) fn lazy_lib_member_access_disabled() -> bool {
     })
 }
 
+/// Kill-switch for preserving a bare-`Lazy` lib-interface receiver through the
+/// known-global value-type override in property-access resolution. Set
+/// `TSZ_DISABLE_GLOBAL_LAZY_RECV_PRESERVE=1` to force the legacy path that
+/// always re-materializes the global value type, enabling byte-identical
+/// diagnostic comparison.
+///
+/// Without this preservation, a global receiver like `document` (whose type is
+/// already `Lazy(Document)`) is eagerly materialized to its full `Object` shape
+/// — merging the entire heritage chain — even when only one own member is read,
+/// defeating [`CheckerState::try_lazy_lib_member_property_access`].
+pub(crate) fn global_lazy_receiver_preserve_disabled() -> bool {
+    use std::sync::OnceLock;
+    static DISABLED: OnceLock<bool> = OnceLock::new();
+    *DISABLED.get_or_init(|| {
+        std::env::var("TSZ_DISABLE_GLOBAL_LAZY_RECV_PRESERVE")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+    })
+}
+
 impl CheckerState<'_> {
+    /// Compute the known-global value-type override for a property-access
+    /// receiver identifier `ident_text`, given the receiver's `current_type`
+    /// and its expression node `expr`. Returns `Some(value_type)` to override,
+    /// or `None` to keep `current_type`.
+    ///
+    /// The override makes an unshadowed known-global value (e.g. `document`,
+    /// `location`) authoritative over a stale/JS-inferred receiver type. But
+    /// when `current_type` is *already* a bare `Lazy(DefId)` to an eligible
+    /// simple lib interface, it IS the authoritative global type — overriding
+    /// would only re-materialize the identical interface eagerly, defeating the
+    /// lazy single-member fast path for global receivers like `document.title`
+    /// (the receiver arrives lazy but is forced to a full `Object` shape,
+    /// merging the whole heritage chain to read one member). In that case this
+    /// returns `None` to preserve the lazy receiver; the fast path resolves the
+    /// accessed own member, and on a miss the downstream materialization
+    /// fallback produces the identical `Object` the override would have.
+    /// Preservation is gated by [`global_lazy_receiver_preserve_disabled`].
+    pub(crate) fn global_value_type_override(
+        &mut self,
+        ident_text: &str,
+        current_type: TypeId,
+        expr: NodeIndex,
+    ) -> Option<TypeId> {
+        if !self.is_known_global_value_name(ident_text)
+            || self.known_global_value_has_local_shadow(expr, ident_text)
+        {
+            return None;
+        }
+        if !global_lazy_receiver_preserve_disabled()
+            && self.lazy_lib_member_receiver_def_id(current_type).is_some()
+        {
+            return None;
+        }
+        let value_type = self.type_of_value_symbol_by_name(ident_text);
+        (value_type != TypeId::UNKNOWN && value_type != TypeId::ERROR).then_some(value_type)
+    }
+
     /// Return the `DefId` of an eligible simple lib-interface receiver when
     /// `object_type` is a bare `Lazy(DefId)` reference to one, or `None`
     /// otherwise.

--- a/crates/tsz-checker/src/tests/lazy_lib_member_access_tests.rs
+++ b/crates/tsz-checker/src/tests/lazy_lib_member_access_tests.rs
@@ -125,3 +125,75 @@ export {};
         "user-shadowed interface own member should resolve, got {codes:?}",
     );
 }
+
+/// Own plain property read on a **known-global lib value** receiver (e.g.
+/// `document`, `location`, `navigator` directly, not via a typed local) resolves
+/// to the correct member type with no diagnostics. This is the case the global
+/// value-type override would otherwise eagerly materialize; preserving the bare
+/// `Lazy` receiver keeps the single-member fast path engaged. Proven across three
+/// distinct globals + members so the behavior follows the shape, not a spelling.
+#[test]
+fn global_value_receiver_own_member_resolves_without_diagnostics() {
+    let codes = dom_codes(
+        r#"
+const a: string = document.title;
+const b: string = location.href;
+const c: string = navigator.userAgent;
+export {};
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "global-value own-member reads should not produce diagnostics, got {codes:?}",
+    );
+}
+
+/// A type mismatch on an own member read through a global value receiver must
+/// still report TS2322 — preserving the lazy receiver does not widen the member.
+#[test]
+fn global_value_receiver_type_mismatch_still_errors() {
+    let codes = dom_codes(
+        r#"
+const wrong: number = document.title;
+export {};
+"#,
+    );
+    assert!(
+        codes.contains(&2322),
+        "string member assigned to number via global receiver should report TS2322, got {codes:?}",
+    );
+}
+
+/// A missing member on a global value receiver must still report TS2339 — the
+/// on-demand materialization fallback runs when the fast path misses, so the
+/// diagnostic is unchanged from the eager-override path.
+#[test]
+fn global_value_receiver_missing_member_still_reports_ts2339() {
+    let codes = dom_codes(
+        r#"
+const x = document.definitelyNotARealDomMember;
+export {};
+"#,
+    );
+    assert!(
+        codes.contains(&2339),
+        "absent member on global receiver should report TS2339, got {codes:?}",
+    );
+}
+
+/// An inherited member read through a global value receiver must still resolve.
+/// The own-member fast path misses (the member lives on a base interface) and the
+/// full materialization path provides it — same result, just not eagerly forced.
+#[test]
+fn global_value_receiver_inherited_member_still_resolves() {
+    let codes = dom_codes(
+        r#"
+const n: string = document.nodeName;
+export {};
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "inherited member via global receiver should resolve cleanly, got {codes:?}",
+    );
+}

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -400,18 +400,16 @@ impl<'a> CheckerState<'a> {
             false
         };
 
-        // Override object_type with the global value type only when the identifier
-        // actually resolves to a global, not when a local variable shadows the global.
-        // E.g., `let location = shape.location; location.x` should use the local's type,
-        // not the DOM `Location` global type.
+        // Override object_type with the global value type for an unshadowed known
+        // global (e.g. `let location = shape.location; location.x` keeps the local
+        // type, but bare `location.x` uses the DOM `Location` global). Preserves an
+        // already-eligible bare `Lazy` receiver so the lazy single-member fast path
+        // stays engaged for `document.title` etc. See `global_value_type_override`.
         if let Some(ident) = self.ctx.arena.get_identifier_at(access.expression)
-            && self.is_known_global_value_name(&ident.escaped_text)
-            && !self.known_global_value_has_local_shadow(access.expression, &ident.escaped_text)
+            && let Some(value_type) =
+                self.global_value_type_override(&ident.escaped_text, object_type, access.expression)
         {
-            let value_type = self.type_of_value_symbol_by_name(&ident.escaped_text);
-            if value_type != TypeId::UNKNOWN && value_type != TypeId::ERROR {
-                object_type = value_type;
-            }
+            object_type = value_type;
         }
 
         if self.ctx.is_js_file()
@@ -805,16 +803,18 @@ impl<'a> CheckerState<'a> {
                 .unwrap_or(original_object_type)
         };
 
-        // Override display type with global value type only when the identifier
-        // actually resolves to a global, not when a local variable shadows it.
+        // Override display type with the global value type for an unshadowed known
+        // global, preserving an already-eligible bare `Lazy` display type (it
+        // renders identically by name, e.g. `Document`, without forcing a full
+        // structural materialization). See `global_value_type_override`.
         if let Some(ident) = self.ctx.arena.get_identifier_at(access.expression)
-            && self.is_known_global_value_name(&ident.escaped_text)
-            && !self.known_global_value_has_local_shadow(access.expression, &ident.escaped_text)
+            && let Some(value_type) = self.global_value_type_override(
+                &ident.escaped_text,
+                display_object_type,
+                access.expression,
+            )
         {
-            let value_type = self.type_of_value_symbol_by_name(&ident.escaped_text);
-            if value_type != TypeId::UNKNOWN && value_type != TypeId::ERROR {
-                display_object_type = value_type;
-            }
+            display_object_type = value_type;
         }
 
         if self.ctx.is_js_file()


### PR DESCRIPTION
## Agent
AgentName: M1Opus48

Manager coordination: AgentName: M5Manager refreshed this body to use the required PR coordination headings after `project-corpus-pr-body` failed on head `6d1e14dd6697c00477fa3e648d65c55181c2aba6`.

## Track
Studio-B / Track 10 green-row performance and residency, with Track 7/10 checker-performance cleanup for DOM small-row project levers.

## Invariant
When a property-access receiver is an unshadowed known-global value whose type is already a bare `Lazy(DefId)` to a non-generic, unaugmented simple lib interface, tsz should resolve only the accessed member and preserve the lazy receiver instead of overriding it with the eagerly-materialized global value type. Existing on-demand fallback must still produce the identical type for misses, inherited members, methods, augmented interfaces, and other ineligible shapes.

## Scope
- `crates/tsz-checker` property-access global-value override sites for member resolution and diagnostic display.
- A kill-switch, `TSZ_DISABLE_GLOBAL_LAZY_RECV_PRESERVE`, for A/B comparison against the legacy eager-override path.
- Unit coverage in `crates/tsz-checker/src/tests/lazy_lib_member_access_tests.rs` for global receiver cases.

## Project Corpus Impact
- Row: vite-vanilla-ts-app / nextjs-fresh-app / ts-essentials-project.
- Bug family: eager lib-interface receiver materialization on global property access (#12101), especially DOM small rows.
- Evidence: local dist-fast timing table in Details below; `document.title` improves from ~130ms to ~30ms, with byte-identical kill-switch A/B claimed for the covered local fixtures. Ready-review CI remains the repository gate before queueing.

## Verification
- Local dist-fast timing evidence is preserved in Details below.
- Local kill-switch A/B was reported byte-identical on DOM property/method/error fixtures.
- Unit matrix adds four global-receiver cases: clean own-member reads, TS2322 mismatch, TS2339 missing member, and fallback for inherited members.
- Ready-review CI on head `6d1e14dd6697c00477fa3e648d65c55181c2aba6` is running. `project-corpus-pr-body` failed before this body refresh; do not add `merge-queue` until exact-head `CI Summary` and `GitGuardian Security Checks` are green after the body check is fixed/re-run.

## Coordination Notes
- Implementation AgentName: M1Opus48.
- Manager body refresh AgentName: M5Manager.
- Canonical owner label: `agent:Studio-B`.
- Builds on the merged lazy single-member fast path (#12117).
- Complements but does not overlap Studio-B's #12136: this PR fixes the global plain-property receiver path; method shapes remain #12101/#12136's lever.
- Does not close the vite benchmark alone because vite's hotspot is `querySelector`, a generic method.
- No interaction claimed with protected M4-C Kysely issues #10683/#10677 or Studio-C emit metadata issues #11358/#11330.

## Details

### Summary

Value-position property access on a **global lib-value receiver** (for example `document.title`, `location.href`, `navigator.userAgent`) eagerly materialized the receiver interface's entire structural shape, merging its full `extends` heritage closure, even when only one own member is read. This defeated the existing lazy single-member fast path (#12117), which already keeps **typed-var** receivers (`declare const d: Document; d.title`) lazy.

Root cause: property-access resolution has two **known-global value-type override** sites that replace the receiver's already-correct bare `Lazy(DefId)` type with the eagerly-materialized global value type: one for `object_type` (member resolution) and one for `display_object_type` (diagnostic rendering). For an unshadowed global whose receiver type is already the lib interface's bare `Lazy`, that override is pure waste: it forces the whole `Document` heritage chain to materialize just to read `title: string`.

This change skips each override precisely when the receiver type is already a fast-path-eligible bare `Lazy` reference to a simple lib interface. The lazy single-member fast path then resolves the accessed own member; on a miss (inherited member, method, augmented interface) the existing on-demand materialization fallback produces the identical type the override would have.

### Structural Rule

When a property-access receiver is an unshadowed known-global value whose type is already a bare `Lazy(DefId)` to a non-generic, unaugmented simple lib interface, resolve only the accessed member, preserving the lazy receiver, instead of overriding it with the eagerly-materialized global value type.

The rule is keyed on the structural shape, not on any identifier name. It applies to `document`, `location`, `navigator`, and any other global lib-interface value equally.

### Measured Impact

`tsconfig` = `ES2020 + DOM + DOM.Iterable`, `strict`, `noEmit`:

| receiver access | before | after |
|---|---|---|
| `document.title` (own plain prop) | ~130ms | ~30ms |
| `navigator.userAgent` | ~100ms | ~80ms |
| `document.getElementById(...)` (method) | ~140ms | ~110ms |
| `document.querySelector<HTMLDivElement>(...)` (generic method) | ~160ms | ~150ms |

The win is largest for plain-property reads. Method calls still materialize because the fast path does not handle methods; that is a separate lever tracked in #12101 / #12136.

### Soundness

Gated by `TSZ_DISABLE_GLOBAL_LAZY_RECV_PRESERVE` so the fast path can be A/B compared byte-for-byte against the legacy eager-override path. Locally verified byte-identical (kill-switch ON vs OFF) across own-member reads, type mismatches (TS2322), missing members (TS2339), did-you-mean typo suggestions, method-typo errors, and assignment errors. The corpus-wide gate is ready-for-review conformance CI.

### Test Matrix

`crates/tsz-checker/src/tests/lazy_lib_member_access_tests.rs` adds four global-receiver cases varying the global and member so behavior follows the shape, not a spelling:

- `document.title`, `location.href`, and `navigator.userAgent` resolve cleanly.
- Type mismatch via global receiver still reports TS2322.
- Missing member via global receiver still reports TS2339.
- Inherited member (`document.nodeName`) still resolves via the fallback.

