### PR TITLE
fix(checker): substitute extends-clause type args when collecting inherited members for implements

### DIFF
--- a/crates/tsz-checker/src/classes/class_implements_helpers.rs
+++ b/crates/tsz-checker/src/classes/class_implements_helpers.rs
@@ -390,6 +390,14 @@ impl<'a> CheckerState<'a> {
     ) {
         let mut visited = rustc_hash::FxHashSet::default();
         let mut current_heritage = class_data.heritage_clauses.clone();
+        // Accumulated substitutions, in walk order (outermost step first). When
+        // collecting a member from a base, applying these in reverse order
+        // (innermost / closest to the base first, outermost last) maps the
+        // base's open type parameters through the chain to the implementing
+        // class's context. This mirrors `tsc`'s `getTypeOfPropertyOfType` on an
+        // instantiated heritage type.
+        let mut step_substitutions: Vec<crate::query_boundaries::common::TypeSubstitution> =
+            Vec::new();
 
         while let Some(ref heritage_clauses) = current_heritage {
             let mut next_heritage = None;
@@ -412,11 +420,14 @@ impl<'a> CheckerState<'a> {
                     continue;
                 };
 
-                let expr_idx =
+                let (expr_idx, heritage_type_arg_nodes) =
                     if let Some(expr_type_args) = self.ctx.arena.get_expr_type_args(type_node) {
-                        expr_type_args.expression
+                        (
+                            expr_type_args.expression,
+                            expr_type_args.type_arguments.as_ref(),
+                        )
                     } else {
-                        type_idx
+                        (type_idx, None)
                     };
 
                 let Some(expr_node) = self.ctx.arena.get(expr_idx) else {
@@ -451,12 +462,36 @@ impl<'a> CheckerState<'a> {
                     continue;
                 };
 
+                // Push the per-step substitution for this `extends BaseClass<...>`
+                // line: base's type parameters → resolved type arguments expressed
+                // in the CURRENT class's context. The arguments themselves may
+                // reference outer-class type parameters; outer steps in
+                // `step_substitutions` will substitute those when applied.
+                let base_type_params = self.get_type_params_for_symbol(sym_id);
+                if !base_type_params.is_empty() {
+                    let step_type_args: Vec<TypeId> = heritage_type_arg_nodes
+                        .map(|args| {
+                            args.nodes
+                                .iter()
+                                .map(|&arg_idx| self.get_type_from_type_node(arg_idx))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    step_substitutions.push(
+                        crate::query_boundaries::common::TypeSubstitution::from_args(
+                            self.ctx.types,
+                            &base_type_params,
+                            &step_type_args,
+                        ),
+                    );
+                }
+
                 // Collect public members from the base class
                 for &member_idx in &base_class.members.nodes {
-                    if let Some(name) = self.get_member_name(member_idx) {
-                        if direct_members.contains_key(&name) || result.contains_key(&name) {
-                            continue;
-                        }
+                    if let Some(name) = self.get_member_name(member_idx)
+                        && !direct_members.contains_key(&name)
+                        && !result.contains_key(&name)
+                    {
                         let sym_flags = self
                             .ctx
                             .binder
@@ -464,13 +499,18 @@ impl<'a> CheckerState<'a> {
                             .and_then(|sid| self.ctx.binder.get_symbol(sid))
                             .map(|s| s.flags)
                             .unwrap_or(0);
-                        if (sym_flags & tsz_binder::symbol_flags::PRIVATE) != 0
-                            || (sym_flags & tsz_binder::symbol_flags::PROTECTED) != 0
-                        {
-                            continue;
+                        let visibility_mask =
+                            tsz_binder::symbol_flags::PRIVATE | tsz_binder::symbol_flags::PROTECTED;
+                        if sym_flags & visibility_mask == 0 {
+                            let member_type = self.get_type_of_class_member(member_idx);
+                            result.insert(
+                                name,
+                                self.apply_inherited_member_substitutions(
+                                    member_type,
+                                    &step_substitutions,
+                                ),
+                            );
                         }
-                        let member_type = self.get_type_of_class_member(member_idx);
-                        result.insert(name, member_type);
                     }
 
                     // Also handle constructor parameter properties
@@ -489,7 +529,13 @@ impl<'a> CheckerState<'a> {
                                 && !result.contains_key(&name)
                             {
                                 let member_type = self.get_type_of_class_member(param_idx);
-                                result.insert(name, member_type);
+                                result.insert(
+                                    name,
+                                    self.apply_inherited_member_substitutions(
+                                        member_type,
+                                        &step_substitutions,
+                                    ),
+                                );
                             }
                         }
                     }
@@ -502,6 +548,23 @@ impl<'a> CheckerState<'a> {
 
             current_heritage = next_heritage;
         }
+    }
+
+    /// Apply per-step substitutions accumulated while walking up the extends
+    /// chain to a member type from a base class. The substitutions are applied
+    /// innermost-first (closest to the base class declaring the member) and
+    /// outermost-last, so each level's type-argument bindings resolve into the
+    /// next level's context until the implementing class's context is reached.
+    fn apply_inherited_member_substitutions(
+        &mut self,
+        mut member_type: TypeId,
+        step_substitutions: &[crate::query_boundaries::common::TypeSubstitution],
+    ) -> TypeId {
+        for sub in step_substitutions.iter().rev() {
+            member_type =
+                crate::query_boundaries::common::instantiate_type(self.ctx.types, member_type, sub);
+        }
+        member_type
     }
 
     /// Collect inherited PRIVATE/PROTECTED members from the base class chain.

--- a/crates/tsz-checker/src/classes/class_implements_helpers.rs
+++ b/crates/tsz-checker/src/classes/class_implements_helpers.rs
@@ -3,6 +3,7 @@
 //! - Private/protected member detection
 //! - Inherited public member collection
 
+use crate::query_boundaries::common::{TypeSubstitution, instantiate_type};
 use crate::state::CheckerState;
 use tsz_common::Visibility;
 use tsz_parser::parser::NodeIndex;
@@ -396,8 +397,7 @@ impl<'a> CheckerState<'a> {
         // base's open type parameters through the chain to the implementing
         // class's context. This mirrors `tsc`'s `getTypeOfPropertyOfType` on an
         // instantiated heritage type.
-        let mut step_substitutions: Vec<crate::query_boundaries::common::TypeSubstitution> =
-            Vec::new();
+        let mut step_substitutions: Vec<TypeSubstitution> = Vec::new();
 
         while let Some(ref heritage_clauses) = current_heritage {
             let mut next_heritage = None;
@@ -477,13 +477,11 @@ impl<'a> CheckerState<'a> {
                                 .collect()
                         })
                         .unwrap_or_default();
-                    step_substitutions.push(
-                        crate::query_boundaries::common::TypeSubstitution::from_args(
-                            self.ctx.types,
-                            &base_type_params,
-                            &step_type_args,
-                        ),
-                    );
+                    step_substitutions.push(TypeSubstitution::from_args(
+                        self.ctx.types,
+                        &base_type_params,
+                        &step_type_args,
+                    ));
                 }
 
                 // Collect public members from the base class
@@ -558,11 +556,10 @@ impl<'a> CheckerState<'a> {
     fn apply_inherited_member_substitutions(
         &mut self,
         mut member_type: TypeId,
-        step_substitutions: &[crate::query_boundaries::common::TypeSubstitution],
+        step_substitutions: &[TypeSubstitution],
     ) -> TypeId {
         for sub in step_substitutions.iter().rev() {
-            member_type =
-                crate::query_boundaries::common::instantiate_type(self.ctx.types, member_type, sub);
+            member_type = instantiate_type(self.ctx.types, member_type, sub);
         }
         member_type
     }

--- a/crates/tsz-checker/src/tests/generic_method_override_variance_tests.rs
+++ b/crates/tsz-checker/src/tests/generic_method_override_variance_tests.rs
@@ -157,3 +157,92 @@ fn keeps_2430_outer_param_member_overrides_bare_generic_member_renamed() {
          interface I<U> extends A { a: (x: U) => U[]; }",
     );
 }
+
+// ---------------------------------------------------------------------------
+// Mixed inheritance chain: class `extends GenericBase<Concrete>` and
+// `implements I` — the inherited method's open base type parameter must be
+// substituted with the extends-clause type argument before being compared to
+// the interface member. (Issue #10861.)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn no_false_2416_inherited_method_substitutes_extends_type_argument() {
+    assert_no_2416(
+        "interface IRepo<T> { save(item: T): T; }
+         interface IUserRepo extends IRepo<{ id: number }> {}
+         abstract class BaseRepo<T> { save(item: T): T { return item; } }
+         class UserRepo extends BaseRepo<{ id: number }> implements IUserRepo {}",
+    );
+}
+
+// Same structural rule with a renamed base type parameter — proves the fix
+// is not keyed on the identifier name (§25).
+#[test]
+fn no_false_2416_inherited_method_substitutes_extends_type_argument_renamed() {
+    assert_no_2416(
+        "interface IRepo<K> { save(item: K): K; }
+         interface IUserRepo extends IRepo<{ id: number }> {}
+         abstract class BaseRepo<K> { save(item: K): K { return item; } }
+         class UserRepo extends BaseRepo<{ id: number }> implements IUserRepo {}",
+    );
+}
+
+// Multi-level extends chain: each level contributes a substitution; an open
+// base type parameter must be threaded through every intermediate
+// substitution. `T → U[]` from Level1→Level2 then `U → string` from
+// Level2→Level3 means an inherited `method(x: T): T` from Level1 must read as
+// `(x: string[]) => string[]` when checked against `IFoo<string[]>`.
+#[test]
+fn no_false_2416_multi_level_extends_chain_substitutes_through() {
+    assert_no_2416(
+        "interface IFoo<T> { method(x: T): T; }
+         class Level1<T> { method(x: T): T { return x; } }
+         class Level2<U> extends Level1<U[]> {}
+         class Level3 extends Level2<string> implements IFoo<string[]> {}",
+    );
+}
+
+// Same multi-level shape with renamed type parameters at every level.
+#[test]
+fn no_false_2416_multi_level_extends_chain_substitutes_through_renamed() {
+    assert_no_2416(
+        "interface IFoo<A> { method(x: A): A; }
+         class Level1<X> { method(x: X): X { return x; } }
+         class Level2<Y> extends Level1<Y[]> {}
+         class Level3 extends Level2<string> implements IFoo<string[]> {}",
+    );
+}
+
+// Constructor parameter property inherited from a generic base must also
+// have its declared type substituted via the extends clause type argument.
+#[test]
+fn no_false_2416_inherited_ctor_param_property_substitutes_extends_type_argument() {
+    assert_no_2416(
+        "interface IHolder<T> { value: T; }
+         class BaseHolder<T> { constructor(public value: T) {} }
+         class StringHolder extends BaseHolder<string> implements IHolder<string> {}",
+    );
+}
+
+// Negative case: keep the diagnostic when the inherited method's signature is
+// genuinely incompatible with the interface after substitution. (Here the
+// inherited `do` returns `number`, not `T`, so even with `T = { id: number }`
+// the signatures do not match.) The fix must not silently accept this.
+#[test]
+fn keeps_diagnostic_for_genuinely_incompatible_inherited_method() {
+    let codes = crate::test_utils::check_source_codes(
+        "interface IBad<T> { do(x: T): T; }
+         interface IBadUser extends IBad<{ id: number }> {}
+         abstract class BaseBad<T> { do(x: number): number { return 0; } }
+         class BadUser extends BaseBad<{ id: number }> implements IBadUser {}",
+    );
+    // tsc emits TS2420 for inherited-member shape mismatches here, but the
+    // structural rule is that the diagnostic family must fire — either TS2416
+    // (property type mismatch) or TS2420 (class incorrectly implements). The
+    // critical regression guard is that *some* diagnostic survives, not
+    // silent acceptance from substitution-aware collection.
+    assert!(
+        codes.contains(&2416) || codes.contains(&2420),
+        "expected TS2416 or TS2420 for genuinely incompatible inherited method; got {codes:?}"
+    );
+}

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1168,7 +1168,15 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         #
         # Re-pinned after neighboring queued PRs changed the current-main
         # live direct-reference count during the merge queue.
-        3280,
+        #
+        # Bumped by 1 for the mixed-inheritance implements-clause member
+        # substitution fix (#10861): `collect_inherited_public_members` adds a
+        # single `use crate::query_boundaries::common::{TypeSubstitution,
+        # instantiate_type};` line. Both names are existing request-shaped
+        # boundary re-exports already used throughout the checker; the new
+        # call site walks the `extends` chain and substitutes inherited
+        # member types via `instantiate_type`. No new quarantine entry.
+        3281,
     ),
 ]
 


### PR DESCRIPTION
AgentName: claude-opus-47-confident-thompson

## Track
checker / class-implements

## Invariant
`tsc` parity for member-incompatibility diagnostics on classes that combine `extends GenericBase<Concrete>` with `implements I` — the inherited member's open base type parameters must be resolved through the chain before the member is compared to the implemented interface.

## Scope
- Fix `collect_inherited_public_members` to walk the `extends` chain accumulating per-step `TypeSubstitution`s and apply them (innermost first) to each inherited member type and constructor-parameter-property type.
- Add regression coverage with an adjacent-case test matrix.

## Structural rule
> When a class declared as `class C extends BaseGeneric<A> implements I` inherits member `m` from `BaseGeneric`, the type of `m` carries `BaseGeneric`'s open type parameters. Before checking `m` against `I`'s corresponding member, those parameters must be substituted using the type arguments from the `extends` clause — recursively, when `BaseGeneric` itself extends a generic base whose substitution references `BaseGeneric`'s own parameters.

This is the same rule `tsc` applies via `getTypeOfPropertyOfType` on an instantiated heritage type, just done explicitly during inherited-member collection because tsz collects inherited members syntactically rather than from an already-instantiated base type.

## Repro

Before this change:
```ts
interface IRepo<T> { save(item: T): T; }
interface IUserRepo extends IRepo<{ id: number }> {}
abstract class BaseRepo<T> { save(item: T): T { return item; } }
class UserRepo extends BaseRepo<{ id: number }> implements IUserRepo {}
```

```
error TS2416: Property 'save' in type 'UserRepo' is not assignable to the same property in base type 'IUserRepo'.
  Type '(item: T) => T' is not assignable to type '(item: { id: number; }) => { id: number; }'.
```

`tsc --strict` accepts the file; tsz now matches. The bug only triggered when an `implements` clause was present *and* the satisfying member came from a generic base — without `implements`, member access on instances correctly substituted `T`.

## Why this layer
`collect_inherited_public_members` is the only path that hands inherited public member types to the implements-clause comparator. The implements-clause comparator (`should_report_member_type_mismatch`) already routes through `query_boundaries`; the fix lives at the collection boundary because that is where the substitution context (the extends chain) is in hand. No checker-side type-shape pattern-matching is added; the substitution uses the existing `query_boundaries::common::TypeSubstitution` + `instantiate_type` boundary helpers.

## Adjacent-case test matrix
`crates/tsz-checker/src/tests/generic_method_override_variance_tests.rs`:
- Direct base substitution (`T` named `T`)
- Renamed base type parameter (`K`) — proves the fix is not keyed on identifier name (§25)
- Multi-level extends chain: `Level1<T>` ← `Level2<U> extends Level1<U[]>` ← `Level3 extends Level2<string>` against `IFoo<string[]>`
- Multi-level chain with renamed parameters at every level
- Constructor parameter property inherited from a generic base
- Negative control: genuinely incompatible inherited method still emits a diagnostic (TS2416 / TS2420)

## Project Corpus Impact
- Row: n/a
- Bug family: false-positive TS2416 on mixed generic-extends + implements
- Evidence: unit-test-only — see `generic_method_override_variance_tests.rs` (6 new tests covering the matrix above) and the minimized repro above which `tsc --strict` accepts.

## Verification
- `cargo nextest run -p tsz-checker --cargo-profile ci-unit --lib -E 'test(generic_method_override_variance) or test(class_implements) or test(implements)'` — 38 passed
- Targeted `cargo nextest run -p tsz-checker --cargo-profile ci-unit --lib -E 'test(generic_method_override_variance)'` — 15 passed (6 new + 9 existing regression guards)
- `cargo clippy -p tsz-checker --profile ci-unit --lib -- -D warnings` — clean
- Release binary verified on the minimal repro and on a broader manual matrix (multi-level chains, renamed type parameters, constructor parameter properties); negative control still rejects.

## Coordination Notes
Closes #10861 once landed. The fix is intentionally narrow to the inherited-member-collection path; the existing `should_report_member_type_mismatch` boundary already handles the relation correctly once it receives a substituted source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
