### PR TITLE
test(parser): name clean parser fixture setup

### DIFF
--- a/crates/tsz-parser/tests/parser_unit_tests.rs
+++ b/crates/tsz-parser/tests/parser_unit_tests.rs
@@ -31,6 +31,18 @@ fn assert_has_errors(parser: &ParserState, context: &str) {
     );
 }
 
+fn parse_clean_source(source: &str, context: &str) -> (ParserState, NodeIndex) {
+    let (parser, root) = parse_source(source);
+    assert_no_errors(&parser, context);
+    (parser, root)
+}
+
+fn parse_clean_var_initializer(source: &str, context: &str) -> (ParserState, NodeIndex) {
+    let (parser, root) = parse_clean_source(source, context);
+    let init = get_var_initializer(parser.get_arena(), root);
+    (parser, init)
+}
+
 fn get_first_statement(arena: &NodeArena, root: NodeIndex) -> NodeIndex {
     let sf = arena.get_source_file_at(root).expect("missing source file");
     assert!(

--- a/crates/tsz-parser/tests/parser_unit_tests_parts/part_00.rs
+++ b/crates/tsz-parser/tests/parser_unit_tests_parts/part_00.rs
@@ -1,10 +1,8 @@
 #[test]
 fn precedence_multiplication_binds_tighter_than_addition() {
     // `1 + 2 * 3` should parse as `1 + (2 * 3)`
-    let (parser, root) = parse_source("const x = 1 + 2 * 3;");
-    assert_no_errors(&parser, "1 + 2 * 3");
+    let (parser, init) = parse_clean_var_initializer("const x = 1 + 2 * 3;", "1 + 2 * 3");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let (left, op, right) = get_binary(arena, init);
     assert_eq!(op, SyntaxKind::PlusToken as u16, "top should be +");
     // left should be numeric literal 1
@@ -35,10 +33,8 @@ fn precedence_nullish_coalescing_vs_logical_or() {
 #[test]
 fn precedence_logical_and_vs_logical_or() {
     // `a || b && c` should parse as `a || (b && c)` since && binds tighter
-    let (parser, root) = parse_source("const x = a || b && c;");
-    assert_no_errors(&parser, "a || b && c");
+    let (parser, init) = parse_clean_var_initializer("const x = a || b && c;", "a || b && c");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let (_, op, right) = get_binary(arena, init);
     assert_eq!(op, SyntaxKind::BarBarToken as u16, "top should be ||");
     let right_node = arena.get(right).expect("right node");
@@ -58,10 +54,9 @@ fn precedence_logical_and_vs_logical_or() {
 #[test]
 fn precedence_ternary_nesting_right_associative() {
     // `a ? b : c ? d : e` should parse as `a ? b : (c ? d : e)`
-    let (parser, root) = parse_source("const x = a ? b : c ? d : e;");
-    assert_no_errors(&parser, "ternary nesting");
+    let (parser, init) =
+        parse_clean_var_initializer("const x = a ? b : c ? d : e;", "ternary nesting");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init node");
     assert_eq!(
         node.kind,
@@ -80,8 +75,10 @@ fn precedence_ternary_nesting_right_associative() {
 
 #[test]
 fn await_call_in_non_async_function_parses_as_identifier_call() {
-    let (parser, root) = parse_source("function f() { const x = await(Promise.resolve(1)); }");
-    assert_no_errors(&parser, "await call identifier parse");
+    let (parser, root) = parse_clean_source(
+        "function f() { const x = await(Promise.resolve(1)); }",
+        "await call identifier parse",
+    );
 
     let arena = parser.get_arena();
     let init = get_first_function_var_initializer(arena, root);
@@ -95,8 +92,10 @@ fn await_call_in_non_async_function_parses_as_identifier_call() {
 
 #[test]
 fn await_operand_in_non_async_function_stays_await_expression() {
-    let (parser, root) = parse_source("function f() { const x = await Promise.resolve(1); }");
-    assert_no_errors(&parser, "await operand expression parse");
+    let (parser, root) = parse_clean_source(
+        "function f() { const x = await Promise.resolve(1); }",
+        "await operand expression parse",
+    );
 
     let arena = parser.get_arena();
     let init = get_first_function_var_initializer(arena, root);
@@ -107,8 +106,7 @@ fn await_operand_in_non_async_function_stays_await_expression() {
 #[test]
 fn precedence_comma_operator_vs_argument_separator() {
     // In `f(a, b)`, comma separates arguments, not comma operator
-    let (parser, root) = parse_source("f(a, b);");
-    assert_no_errors(&parser, "f(a, b)");
+    let (parser, root) = parse_clean_source("f(a, b);", "f(a, b)");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt node");
@@ -122,10 +120,8 @@ fn precedence_comma_operator_vs_argument_separator() {
 #[test]
 fn precedence_comma_operator_in_expression() {
     // `const x = (1, 2, 3)` — the comma operator inside parens
-    let (parser, root) = parse_source("const x = (1, 2, 3);");
-    assert_no_errors(&parser, "comma operator");
+    let (parser, init) = parse_clean_var_initializer("const x = (1, 2, 3);", "comma operator");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     // Should be parenthesized
     let paren_node = arena.get(init).expect("node");
     assert_eq!(paren_node.kind, syntax_kind_ext::PARENTHESIZED_EXPRESSION);
@@ -175,8 +171,7 @@ fn comma_expression_with_missing_rhs_preserves_binary_shape() {
 #[test]
 fn precedence_assignment_right_associativity() {
     // `a = b = c` should parse as `a = (b = c)`
-    let (parser, root) = parse_source("a = b = c;");
-    assert_no_errors(&parser, "a = b = c");
+    let (parser, root) = parse_clean_source("a = b = c;", "a = b = c");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -202,10 +197,8 @@ fn precedence_assignment_right_associativity() {
 #[test]
 fn precedence_exponentiation_right_associative() {
     // `2 ** 3 ** 4` should parse as `2 ** (3 ** 4)`
-    let (parser, root) = parse_source("const x = 2 ** 3 ** 4;");
-    assert_no_errors(&parser, "2 ** 3 ** 4");
+    let (parser, init) = parse_clean_var_initializer("const x = 2 ** 3 ** 4;", "2 ** 3 ** 4");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let (left, op, right) = get_binary(arena, init);
     assert_eq!(
         op,
@@ -229,8 +222,7 @@ fn precedence_exponentiation_right_associative() {
 #[test]
 fn precedence_optional_chaining_with_call() {
     // `a?.b()` should parse as call on optional property access
-    let (parser, root) = parse_source("a?.b();");
-    assert_no_errors(&parser, "a?.b()");
+    let (parser, root) = parse_clean_source("a?.b();", "a?.b()");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -255,10 +247,9 @@ fn precedence_optional_chaining_with_call() {
 #[test]
 fn precedence_comparison_operators() {
     // `a < b === c > d` should parse as `(a < b) === (c > d)`
-    let (parser, root) = parse_source("const x = a < b === c > d;");
-    assert_no_errors(&parser, "comparison operators");
+    let (parser, init) =
+        parse_clean_var_initializer("const x = a < b === c > d;", "comparison operators");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let (_, op, _) = get_binary(arena, init);
     assert_eq!(
         op,
@@ -270,10 +261,8 @@ fn precedence_comparison_operators() {
 #[test]
 fn precedence_bitwise_and_vs_equality() {
     // `a === b & c`: & has lower precedence than ===, so it's `(a === b) & c`
-    let (parser, root) = parse_source("const x = a === b & c;");
-    assert_no_errors(&parser, "=== vs &");
+    let (parser, init) = parse_clean_var_initializer("const x = a === b & c;", "=== vs &");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let (_, op, _) = get_binary(arena, init);
     assert_eq!(
         op,
@@ -285,10 +274,8 @@ fn precedence_bitwise_and_vs_equality() {
 #[test]
 fn precedence_as_expression() {
     // `a as T` produces an AsExpression
-    let (parser, root) = parse_source("const x = a as number;");
-    assert_no_errors(&parser, "as expression");
+    let (parser, init) = parse_clean_var_initializer("const x = a as number;", "as expression");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(
         node.kind,
@@ -300,8 +287,8 @@ fn precedence_as_expression() {
 #[test]
 fn precedence_satisfies_expression() {
     // `a satisfies T` produces a SatisfiesExpression
-    let (parser, root) = parse_source("const x = a satisfies number;");
-    assert_no_errors(&parser, "satisfies expression");
+    let (parser, root) =
+        parse_clean_source("const x = a satisfies number;", "satisfies expression");
     let arena = parser.get_arena();
     let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
@@ -367,10 +354,8 @@ fn precedence_as_const_after_satisfies_wraps_satisfies_expression() {
 #[test]
 fn precedence_non_null_assertion() {
     // `a!` produces a NonNullExpression
-    let (parser, root) = parse_source("const x = a!;");
-    assert_no_errors(&parser, "non-null assertion");
+    let (parser, init) = parse_clean_var_initializer("const x = a!;", "non-null assertion");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(
         node.kind,
@@ -382,10 +367,8 @@ fn precedence_non_null_assertion() {
 #[test]
 fn precedence_type_assertion_angle_bracket() {
     // `<number>a` produces a TypeAssertion
-    let (parser, root) = parse_source("const x = <number>a;");
-    assert_no_errors(&parser, "type assertion");
+    let (parser, init) = parse_clean_var_initializer("const x = <number>a;", "type assertion");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(
         node.kind,
@@ -489,15 +472,16 @@ fn type_assertion_does_not_consume_yield_in_generator() {
 #[test]
 fn precedence_instanceof_and_in() {
     // `a instanceof B` and `a in b` should parse without errors
-    let (parser, _) = parse_source("const x = a instanceof B; const y = 'a' in b;");
-    assert_no_errors(&parser, "instanceof and in");
+    let (_parser, _) = parse_clean_source(
+        "const x = a instanceof B; const y = 'a' in b;",
+        "instanceof and in",
+    );
 }
 
 #[test]
 fn precedence_ternary_with_assignment() {
     // `a ? b = 1 : c = 2` should parse correctly
-    let (parser, root) = parse_source("a ? b = 1 : c = 2;");
-    assert_no_errors(&parser, "ternary with assignment");
+    let (parser, root) = parse_clean_source("a ? b = 1 : c = 2;", "ternary with assignment");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -513,10 +497,8 @@ fn precedence_ternary_with_assignment() {
 #[test]
 fn precedence_addition_left_associative() {
     // `1 + 2 + 3` should parse as `(1 + 2) + 3`
-    let (parser, root) = parse_source("const x = 1 + 2 + 3;");
-    assert_no_errors(&parser, "1 + 2 + 3");
+    let (parser, init) = parse_clean_var_initializer("const x = 1 + 2 + 3;", "1 + 2 + 3");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let (left, op, right) = get_binary(arena, init);
     assert_eq!(op, SyntaxKind::PlusToken as u16, "top should be +");
     // right should be a numeric literal (3), left should be binary
@@ -541,10 +523,8 @@ fn precedence_addition_left_associative() {
 #[test]
 fn arrow_single_param_no_parens() {
     // `x => x`
-    let (parser, root) = parse_source("const f = x => x;");
-    assert_no_errors(&parser, "x => x");
+    let (parser, init) = parse_clean_var_initializer("const f = x => x;", "x => x");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(
         node.kind,
@@ -559,10 +539,9 @@ fn arrow_single_param_no_parens() {
 #[test]
 fn arrow_multi_param() {
     // `(x, y) => x + y`
-    let (parser, root) = parse_source("const f = (x, y) => x + y;");
-    assert_no_errors(&parser, "(x, y) => x + y");
+    let (parser, init) =
+        parse_clean_var_initializer("const f = (x, y) => x + y;", "(x, y) => x + y");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(node.kind, syntax_kind_ext::ARROW_FUNCTION);
     let func = arena.get_function(node).expect("function data");
@@ -572,10 +551,8 @@ fn arrow_multi_param() {
 #[test]
 fn arrow_no_params() {
     // `() => 42`
-    let (parser, root) = parse_source("const f = () => 42;");
-    assert_no_errors(&parser, "() => 42");
+    let (parser, init) = parse_clean_var_initializer("const f = () => 42;", "() => 42");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(node.kind, syntax_kind_ext::ARROW_FUNCTION);
     let func = arena.get_function(node).expect("function data");
@@ -585,10 +562,8 @@ fn arrow_no_params() {
 #[test]
 fn arrow_object_literal_body_needs_parens() {
     // `() => ({})` — object literal body must be parenthesized
-    let (parser, root) = parse_source("const f = () => ({});");
-    assert_no_errors(&parser, "() => ({})");
+    let (parser, init) = parse_clean_var_initializer("const f = () => ({});", "() => ({})");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(node.kind, syntax_kind_ext::ARROW_FUNCTION);
     let func = arena.get_function(node).expect("function data");
@@ -604,10 +579,9 @@ fn arrow_object_literal_body_needs_parens() {
 #[test]
 fn arrow_async() {
     // `async x => await x`
-    let (parser, root) = parse_source("const f = async x => await x;");
-    assert_no_errors(&parser, "async arrow");
+    let (parser, init) =
+        parse_clean_var_initializer("const f = async x => await x;", "async arrow");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(node.kind, syntax_kind_ext::ARROW_FUNCTION);
     let func = arena.get_function(node).expect("function data");
@@ -617,10 +591,11 @@ fn arrow_async() {
 #[test]
 fn arrow_async_multi_param() {
     // `async (a, b) => a + b`
-    let (parser, root) = parse_source("const f = async (a, b) => a + b;");
-    assert_no_errors(&parser, "async multi param arrow");
+    let (parser, init) = parse_clean_var_initializer(
+        "const f = async (a, b) => a + b;",
+        "async multi param arrow",
+    );
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(node.kind, syntax_kind_ext::ARROW_FUNCTION);
     let func = arena.get_function(node).expect("function data");
@@ -631,8 +606,8 @@ fn arrow_async_multi_param() {
 #[test]
 fn arrow_with_block_body() {
     // `(x) => { return x; }`
-    let (parser, root) = parse_source("const f = (x) => { return x; };");
-    assert_no_errors(&parser, "arrow with block body");
+    let (parser, root) =
+        parse_clean_source("const f = (x) => { return x; };", "arrow with block body");
     let arena = parser.get_arena();
     let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
@@ -645,10 +620,11 @@ fn arrow_with_block_body() {
 #[test]
 fn arrow_with_type_annotation() {
     // `(x: number): string => x.toString()`
-    let (parser, root) = parse_source("const f = (x: number): string => x.toString();");
-    assert_no_errors(&parser, "arrow with type annotation");
+    let (parser, init) = parse_clean_var_initializer(
+        "const f = (x: number): string => x.toString();",
+        "arrow with type annotation",
+    );
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(node.kind, syntax_kind_ext::ARROW_FUNCTION);
     let func = arena.get_function(node).expect("function data");
@@ -658,8 +634,8 @@ fn arrow_with_type_annotation() {
 #[test]
 fn arrow_in_ternary() {
     // `cond ? x => x : y => y` — arrows in ternary branches
-    let (parser, root) = parse_source("const f = cond ? x => x : y => y;");
-    assert_no_errors(&parser, "arrow in ternary");
+    let (parser, root) =
+        parse_clean_source("const f = cond ? x => x : y => y;", "arrow in ternary");
     let arena = parser.get_arena();
     let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
@@ -686,10 +662,9 @@ fn arrow_in_ternary() {
 #[test]
 fn arrow_generic_in_ts_file() {
     // `<T>(x: T) => x` — generic arrow in .ts file (not TSX)
-    let (parser, root) = parse_source("const f = <T>(x: T) => x;");
-    assert_no_errors(&parser, "generic arrow .ts");
+    let (parser, init) =
+        parse_clean_var_initializer("const f = <T>(x: T) => x;", "generic arrow .ts");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(
         node.kind,
@@ -706,10 +681,11 @@ fn arrow_generic_in_ts_file() {
 #[test]
 fn arrow_generic_with_constraint() {
     // `<T extends string>(x: T) => x`
-    let (parser, root) = parse_source("const f = <T extends string>(x: T) => x;");
-    assert_no_errors(&parser, "generic arrow with constraint");
+    let (parser, init) = parse_clean_var_initializer(
+        "const f = <T extends string>(x: T) => x;",
+        "generic arrow with constraint",
+    );
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(node.kind, syntax_kind_ext::ARROW_FUNCTION);
 }
@@ -717,10 +693,9 @@ fn arrow_generic_with_constraint() {
 #[test]
 fn arrow_nested() {
     // `(a) => (b) => a + b` — curried arrow
-    let (parser, root) = parse_source("const f = (a) => (b) => a + b;");
-    assert_no_errors(&parser, "nested arrow");
+    let (parser, init) =
+        parse_clean_var_initializer("const f = (a) => (b) => a + b;", "nested arrow");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(node.kind, syntax_kind_ext::ARROW_FUNCTION);
     let func = arena.get_function(node).expect("function data");
@@ -758,8 +733,7 @@ fn js_optional_parameter_span_starts_at_question_token() {
 #[test]
 fn type_union() {
     // `type T = A | B | C`
-    let (parser, root) = parse_source("type T = A | B | C;");
-    assert_no_errors(&parser, "union type");
+    let (parser, root) = parse_clean_source("type T = A | B | C;", "union type");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -777,8 +751,7 @@ fn type_union() {
 #[test]
 fn type_intersection() {
     // `type T = A & B & C`
-    let (parser, root) = parse_source("type T = A & B & C;");
-    assert_no_errors(&parser, "intersection type");
+    let (parser, root) = parse_clean_source("type T = A & B & C;", "intersection type");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -796,8 +769,7 @@ fn type_intersection() {
 #[test]
 fn type_conditional() {
     // `type T = X extends Y ? A : B`
-    let (parser, root) = parse_source("type T = X extends Y ? A : B;");
-    assert_no_errors(&parser, "conditional type");
+    let (parser, root) = parse_clean_source("type T = X extends Y ? A : B;", "conditional type");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -818,8 +790,10 @@ fn type_conditional() {
 #[test]
 fn type_conditional_nested() {
     // `type T = X extends A ? B extends C ? D : E : F`
-    let (parser, root) = parse_source("type T = X extends A ? B extends C ? D : E : F;");
-    assert_no_errors(&parser, "nested conditional type");
+    let (parser, root) = parse_clean_source(
+        "type T = X extends A ? B extends C ? D : E : F;",
+        "nested conditional type",
+    );
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -839,8 +813,7 @@ fn type_conditional_nested() {
 #[test]
 fn type_mapped() {
     // `type T = { [K in keyof O]: O[K] }`
-    let (parser, root) = parse_source("type T = { [K in keyof O]: O[K] };");
-    assert_no_errors(&parser, "mapped type");
+    let (parser, root) = parse_clean_source("type T = { [K in keyof O]: O[K] };", "mapped type");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -859,8 +832,7 @@ fn type_mapped() {
 #[test]
 fn type_template_literal() {
     // type T = `${string}px`
-    let (parser, root) = parse_source("type T = `${string}px`;");
-    assert_no_errors(&parser, "template literal type");
+    let (parser, root) = parse_clean_source("type T = `${string}px`;", "template literal type");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -876,8 +848,8 @@ fn type_template_literal() {
 #[test]
 fn type_tuple_with_labels() {
     // `type T = [name: string, age: number]`
-    let (parser, root) = parse_source("type T = [name: string, age: number];");
-    assert_no_errors(&parser, "tuple with labels");
+    let (parser, root) =
+        parse_clean_source("type T = [name: string, age: number];", "tuple with labels");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -902,8 +874,8 @@ fn type_tuple_with_labels() {
 #[test]
 fn type_tuple_optional_element() {
     // `type T = [string, number?]`
-    let (parser, root) = parse_source("type T = [string, number?];");
-    assert_no_errors(&parser, "tuple optional element");
+    let (parser, root) =
+        parse_clean_source("type T = [string, number?];", "tuple optional element");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -924,8 +896,8 @@ fn type_tuple_optional_element() {
 #[test]
 fn type_tuple_rest_element() {
     // `type T = [string, ...number[]]`
-    let (parser, root) = parse_source("type T = [string, ...number[]];");
-    assert_no_errors(&parser, "tuple rest element");
+    let (parser, root) =
+        parse_clean_source("type T = [string, ...number[]];", "tuple rest element");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -946,8 +918,10 @@ fn type_tuple_rest_element() {
 #[test]
 fn type_infer_in_conditional() {
     // `type T = X extends Array<infer U> ? U : never`
-    let (parser, root) = parse_source("type T = X extends Array<infer U> ? U : never;");
-    assert_no_errors(&parser, "infer in conditional");
+    let (parser, root) = parse_clean_source(
+        "type T = X extends Array<infer U> ? U : never;",
+        "infer in conditional",
+    );
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -972,8 +946,7 @@ fn type_infer_in_conditional() {
 #[test]
 fn type_index_access() {
     // `type T = Foo["key"]`
-    let (parser, root) = parse_source("type T = Foo[\"key\"];");
-    assert_no_errors(&parser, "index access type");
+    let (parser, root) = parse_clean_source("type T = Foo[\"key\"];", "index access type");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -989,8 +962,7 @@ fn type_index_access() {
 #[test]
 fn type_index_access_allows_line_break_before_bracket() {
     let source = "type T = Foo\n[\"key\"];";
-    let (parser, root) = parse_source(source);
-    assert_no_errors(&parser, "line-broken index access type alias");
+    let (parser, root) = parse_clean_source(source, "line-broken index access type alias");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1006,8 +978,7 @@ fn type_index_access_allows_line_break_before_bracket() {
 #[test]
 fn type_annotation_index_access_allows_line_break_before_bracket() {
     let source = "let value: Foo\n[\"key\"];";
-    let (parser, root) = parse_source(source);
-    assert_no_errors(&parser, "line-broken index access type annotation");
+    let (parser, root) = parse_clean_source(source, "line-broken index access type annotation");
     let arena = parser.get_arena();
     let type_annotation = get_var_type_annotation(arena, root);
     let type_node = arena.get(type_annotation).expect("type node");
@@ -1021,8 +992,7 @@ fn type_annotation_index_access_allows_line_break_before_bracket() {
 #[test]
 fn type_index_access_number() {
     // `type T = Arr[number]`
-    let (parser, root) = parse_source("type T = Arr[number];");
-    assert_no_errors(&parser, "index access type number");
+    let (parser, root) = parse_clean_source("type T = Arr[number];", "index access type number");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1034,8 +1004,7 @@ fn type_index_access_number() {
 #[test]
 fn type_typeof() {
     // `type T = typeof x`
-    let (parser, root) = parse_source("type T = typeof x;");
-    assert_no_errors(&parser, "typeof type");
+    let (parser, root) = parse_clean_source("type T = typeof x;", "typeof type");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1051,8 +1020,7 @@ fn type_typeof() {
 #[test]
 fn type_keyof() {
     // `type T = keyof X`
-    let (parser, root) = parse_source("type T = keyof X;");
-    assert_no_errors(&parser, "keyof type");
+    let (parser, root) = parse_clean_source("type T = keyof X;", "keyof type");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1074,8 +1042,7 @@ fn type_keyof() {
 #[test]
 fn type_function_type() {
     // `type T = (x: number) => string`
-    let (parser, root) = parse_source("type T = (x: number) => string;");
-    assert_no_errors(&parser, "function type");
+    let (parser, root) = parse_clean_source("type T = (x: number) => string;", "function type");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1097,8 +1064,7 @@ fn type_function_type() {
 #[test]
 fn type_constructor_type() {
     // `type T = new (x: number) => Foo`
-    let (parser, root) = parse_source("type T = new (x: number) => Foo;");
-    assert_no_errors(&parser, "constructor type");
+    let (parser, root) = parse_clean_source("type T = new (x: number) => Foo;", "constructor type");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1114,8 +1080,7 @@ fn type_constructor_type() {
 #[test]
 fn type_array() {
     // `type T = number[]`
-    let (parser, root) = parse_source("type T = number[];");
-    assert_no_errors(&parser, "array type");
+    let (parser, root) = parse_clean_source("type T = number[];", "array type");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1131,8 +1096,7 @@ fn type_array() {
 #[test]
 fn type_parenthesized() {
     // `type T = (A | B) & C`
-    let (parser, root) = parse_source("type T = (A | B) & C;");
-    assert_no_errors(&parser, "parenthesized type");
+    let (parser, root) = parse_clean_source("type T = (A | B) & C;", "parenthesized type");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1148,8 +1112,7 @@ fn type_parenthesized() {
 #[test]
 fn type_readonly_array() {
     // `type T = readonly number[]`
-    let (parser, root) = parse_source("type T = readonly number[];");
-    assert_no_errors(&parser, "readonly array");
+    let (parser, root) = parse_clean_source("type T = readonly number[];", "readonly array");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1171,8 +1134,7 @@ fn type_readonly_array() {
 #[test]
 fn type_this() {
     // `interface I { get(): this }`
-    let (parser, root) = parse_source("interface I { get(): this; }");
-    assert_no_errors(&parser, "this type");
+    let (parser, root) = parse_clean_source("interface I { get(): this; }", "this type");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1190,8 +1152,7 @@ fn type_this() {
 #[test]
 fn type_literal_string() {
     // `type T = "hello"`
-    let (parser, root) = parse_source("type T = \"hello\";");
-    assert_no_errors(&parser, "literal type string");
+    let (parser, root) = parse_clean_source("type T = \"hello\";", "literal type string");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1211,8 +1172,10 @@ fn type_literal_string() {
 #[test]
 fn decl_export_default_function_anonymous() {
     // `export default function() {}` — wraps function in export declaration
-    let (parser, root) = parse_source("export default function() {}");
-    assert_no_errors(&parser, "export default function anonymous");
+    let (parser, root) = parse_clean_source(
+        "export default function() {}",
+        "export default function anonymous",
+    );
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1228,8 +1191,10 @@ fn decl_export_default_function_anonymous() {
 #[test]
 fn decl_export_as_default() {
     // `export { x as default }`
-    let (parser, root) = parse_source("const x = 1; export { x as default };");
-    assert_no_errors(&parser, "export { x as default }");
+    let (parser, root) = parse_clean_source(
+        "const x = 1; export { x as default };",
+        "export { x as default }",
+    );
     let arena = parser.get_arena();
     let stmts = get_statements(arena, root);
     assert_eq!(stmts.len(), 2);
@@ -1240,8 +1205,7 @@ fn decl_export_as_default() {
 #[test]
 fn decl_import_type() {
     // `import type { Foo } from 'bar'`
-    let (parser, root) = parse_source("import type { Foo } from 'bar';");
-    assert_no_errors(&parser, "import type");
+    let (parser, root) = parse_clean_source("import type { Foo } from 'bar';", "import type");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1255,8 +1219,7 @@ fn decl_import_type() {
 #[test]
 fn decl_declare_module_string_literal() {
     // `declare module 'foo' {}`
-    let (parser, root) = parse_source("declare module 'foo' {}");
-    assert_no_errors(&parser, "declare module");
+    let (parser, root) = parse_clean_source("declare module 'foo' {}", "declare module");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1270,8 +1233,7 @@ fn decl_declare_module_string_literal() {
 #[test]
 fn decl_ambient_function() {
     // `declare function f(): void`
-    let (parser, root) = parse_source("declare function f(): void;");
-    assert_no_errors(&parser, "ambient function");
+    let (parser, root) = parse_clean_source("declare function f(): void;", "ambient function");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1283,8 +1245,7 @@ fn decl_ambient_function() {
 #[test]
 fn decl_enum_basic() {
     // `enum Color { Red, Green, Blue }`
-    let (parser, root) = parse_source("enum Color { Red, Green, Blue }");
-    assert_no_errors(&parser, "enum");
+    let (parser, root) = parse_clean_source("enum Color { Red, Green, Blue }", "enum");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1296,8 +1257,8 @@ fn decl_enum_basic() {
 #[test]
 fn decl_enum_with_initializers() {
     // `enum Dir { Up = 1, Down = 2 }`
-    let (parser, root) = parse_source("enum Dir { Up = 1, Down = 2 }");
-    assert_no_errors(&parser, "enum with initializers");
+    let (parser, root) =
+        parse_clean_source("enum Dir { Up = 1, Down = 2 }", "enum with initializers");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1409,8 +1370,7 @@ fn decl_enum_reserved_name_recovery_keeps_reserved_statement() {
 #[test]
 fn decl_const_enum() {
     // `const enum Flags { A, B }`
-    let (parser, root) = parse_source("const enum Flags { A, B }");
-    assert_no_errors(&parser, "const enum");
+    let (parser, root) = parse_clean_source("const enum Flags { A, B }", "const enum");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1420,8 +1380,7 @@ fn decl_const_enum() {
 #[test]
 fn decl_namespace() {
     // `namespace Foo { export const x = 1; }`
-    let (parser, root) = parse_source("namespace Foo { export const x = 1; }");
-    assert_no_errors(&parser, "namespace");
+    let (parser, root) = parse_clean_source("namespace Foo { export const x = 1; }", "namespace");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1431,8 +1390,7 @@ fn decl_namespace() {
 #[test]
 fn decl_export_equals() {
     // `export = x`
-    let (parser, root) = parse_source("export = x;");
-    assert_no_errors(&parser, "export equals");
+    let (parser, root) = parse_clean_source("export = x;", "export equals");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1448,8 +1406,7 @@ fn decl_export_equals() {
 #[test]
 fn decl_export_default_expression() {
     // `export default 42` — parsed as EXPORT_DECLARATION with default flag
-    let (parser, root) = parse_source("export default 42;");
-    assert_no_errors(&parser, "export default expression");
+    let (parser, root) = parse_clean_source("export default 42;", "export default expression");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1465,8 +1422,10 @@ fn decl_export_default_expression() {
 #[test]
 fn decl_interface_with_extends() {
     // `interface Foo extends Bar, Baz { x: number; }`
-    let (parser, root) = parse_source("interface Foo extends Bar, Baz { x: number; }");
-    assert_no_errors(&parser, "interface extends");
+    let (parser, root) = parse_clean_source(
+        "interface Foo extends Bar, Baz { x: number; }",
+        "interface extends",
+    );
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1479,8 +1438,7 @@ fn decl_interface_with_extends() {
 #[test]
 fn decl_type_alias_generic() {
     // `type Box<T> = { value: T }`
-    let (parser, root) = parse_source("type Box<T> = { value: T };");
-    assert_no_errors(&parser, "generic type alias");
+    let (parser, root) = parse_clean_source("type Box<T> = { value: T };", "generic type alias");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1499,8 +1457,7 @@ fn decl_type_alias_generic() {
 #[test]
 fn class_basic() {
     // `class Foo { x: number; }`
-    let (parser, root) = parse_source("class Foo { x: number; }");
-    assert_no_errors(&parser, "basic class");
+    let (parser, root) = parse_clean_source("class Foo { x: number; }", "basic class");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1512,8 +1469,7 @@ fn class_basic() {
 #[test]
 fn class_private_field() {
     // `class Foo { #x: number; }`
-    let (parser, root) = parse_source("class Foo { #x: number; }");
-    assert_no_errors(&parser, "private field");
+    let (parser, root) = parse_clean_source("class Foo { #x: number; }", "private field");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1536,8 +1492,10 @@ fn class_private_field() {
 #[test]
 fn class_static_block() {
     // `class Foo { static { console.log("init"); } }`
-    let (parser, root) = parse_source("class Foo { static { console.log(\"init\"); } }");
-    assert_no_errors(&parser, "static block");
+    let (parser, root) = parse_clean_source(
+        "class Foo { static { console.log(\"init\"); } }",
+        "static block",
+    );
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1554,8 +1512,10 @@ fn class_static_block() {
 #[test]
 fn class_abstract_method() {
     // `abstract class Foo { abstract bar(): void; }`
-    let (parser, root) = parse_source("abstract class Foo { abstract bar(): void; }");
-    assert_no_errors(&parser, "abstract method");
+    let (parser, root) = parse_clean_source(
+        "abstract class Foo { abstract bar(): void; }",
+        "abstract method",
+    );
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1576,8 +1536,10 @@ fn class_abstract_method() {
 #[test]
 fn class_parameter_property() {
     // `class Foo { constructor(public x: number) {} }`
-    let (parser, root) = parse_source("class Foo { constructor(public x: number) {} }");
-    assert_no_errors(&parser, "parameter property");
+    let (parser, root) = parse_clean_source(
+        "class Foo { constructor(public x: number) {} }",
+        "parameter property",
+    );
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1684,8 +1646,8 @@ fn constructor_return_colon_recovers_following_overload_pair() {
 #[test]
 fn class_decorator() {
     // `@dec class Foo {}`
-    let (parser, root) = parse_source("declare var dec: any; @dec class Foo {}");
-    assert_no_errors(&parser, "class decorator");
+    let (parser, root) =
+        parse_clean_source("declare var dec: any; @dec class Foo {}", "class decorator");
     let arena = parser.get_arena();
     let stmts = get_statements(arena, root);
     let class_node = arena.get(stmts[1]).expect("class node");
@@ -1704,8 +1666,10 @@ fn class_decorator() {
 #[test]
 fn class_multiple_decorators() {
     // `@a @b class Foo {}`
-    let (parser, root) = parse_source("declare var a: any; declare var b: any; @a @b class Foo {}");
-    assert_no_errors(&parser, "multiple decorators");
+    let (parser, root) = parse_clean_source(
+        "declare var a: any; declare var b: any; @a @b class Foo {}",
+        "multiple decorators",
+    );
     let arena = parser.get_arena();
     let stmts = get_statements(arena, root);
     let class_node = arena.get(stmts[2]).expect("class node");
@@ -1726,8 +1690,10 @@ fn class_multiple_decorators() {
 #[test]
 fn class_index_signature() {
     // `class Foo { [key: string]: number; }`
-    let (parser, root) = parse_source("class Foo { [key: string]: number; }");
-    assert_no_errors(&parser, "class index signature");
+    let (parser, root) = parse_clean_source(
+        "class Foo { [key: string]: number; }",
+        "class index signature",
+    );
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1743,8 +1709,10 @@ fn class_index_signature() {
 #[test]
 fn class_computed_property() {
     // `class Foo { [Symbol.iterator]() {} }`
-    let (parser, root) = parse_source("class Foo { [Symbol.iterator]() {} }");
-    assert_no_errors(&parser, "computed property name");
+    let (parser, root) = parse_clean_source(
+        "class Foo { [Symbol.iterator]() {} }",
+        "computed property name",
+    );
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1787,4 +1755,3 @@ fn computed_field_typed_initializer_continuation_reports_ts1005() {
         "continuation type annotation should not cascade into TS1068, got {diagnostics:?}"
     );
 }
-

--- a/crates/tsz-parser/tests/parser_unit_tests_parts/part_01.rs
+++ b/crates/tsz-parser/tests/parser_unit_tests_parts/part_01.rs
@@ -49,8 +49,10 @@ fn computed_field_followed_by_bare_block_reports_ts1068() {
 #[test]
 fn class_getter_setter() {
     // `class Foo { get x() { return 1; } set x(v: number) {} }`
-    let (parser, root) = parse_source("class Foo { get x() { return 1; } set x(v: number) {} }");
-    assert_no_errors(&parser, "getter/setter");
+    let (parser, root) = parse_clean_source(
+        "class Foo { get x() { return 1; } set x(v: number) {} }",
+        "getter/setter",
+    );
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -73,8 +75,10 @@ fn class_getter_setter() {
 #[test]
 fn class_extends_implements() {
     // `class Foo extends Bar implements Baz {}`
-    let (parser, root) = parse_source("class Foo extends Bar implements Baz {}");
-    assert_no_errors(&parser, "extends implements");
+    let (parser, root) = parse_clean_source(
+        "class Foo extends Bar implements Baz {}",
+        "extends implements",
+    );
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -296,8 +300,7 @@ fn class_extends_object_literal_recovery_keeps_body_and_uses_ts1005() {
 #[test]
 fn class_extends_array_literal_expression_keeps_body() {
     let source = "class C extends [] { method() {} }";
-    let (parser, root) = parse_source(source);
-    assert_no_errors(&parser, "class extends array literal");
+    let (parser, root) = parse_clean_source(source, "class extends array literal");
 
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
@@ -405,8 +408,7 @@ fn interface_extends_array_literal_reports_interface_heritage_error() {
 #[test]
 fn stmt_labeled() {
     // `label: for (;;) {}`
-    let (parser, root) = parse_source("label: for (;;) {}");
-    assert_no_errors(&parser, "labeled statement");
+    let (parser, root) = parse_clean_source("label: for (;;) {}", "labeled statement");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -427,8 +429,10 @@ fn stmt_labeled() {
 #[test]
 fn stmt_for_await_of() {
     // `for await (const x of iter) {}`
-    let (parser, root) = parse_source("async function f() { for await (const x of iter) {} }");
-    assert_no_errors(&parser, "for await of");
+    let (parser, root) = parse_clean_source(
+        "async function f() { for await (const x of iter) {} }",
+        "for await of",
+    );
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let func_node = arena.get(stmt_idx).expect("func");
@@ -448,8 +452,10 @@ fn stmt_for_await_of() {
 #[test]
 fn stmt_switch_with_fallthrough() {
     // Switch with fallthrough
-    let (parser, root) = parse_source("switch (x) { case 1: case 2: break; default: break; }");
-    assert_no_errors(&parser, "switch with fallthrough");
+    let (parser, root) = parse_clean_source(
+        "switch (x) { case 1: case 2: break; default: break; }",
+        "switch with fallthrough",
+    );
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -459,8 +465,7 @@ fn stmt_switch_with_fallthrough() {
 #[test]
 fn stmt_try_catch_finally() {
     // `try {} catch (e) {} finally {}`
-    let (parser, root) = parse_source("try {} catch (e) {} finally {}");
-    assert_no_errors(&parser, "try/catch/finally");
+    let (parser, root) = parse_clean_source("try {} catch (e) {} finally {}", "try/catch/finally");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -477,8 +482,7 @@ fn stmt_try_catch_finally() {
 #[test]
 fn stmt_try_finally_no_catch() {
     // `try {} finally {}`
-    let (parser, root) = parse_source("try {} finally {}");
-    assert_no_errors(&parser, "try/finally no catch");
+    let (parser, root) = parse_clean_source("try {} finally {}", "try/finally no catch");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -490,8 +494,7 @@ fn stmt_try_finally_no_catch() {
 #[test]
 fn stmt_catch_without_binding() {
     // `try {} catch {}`  (ES2019 optional catch binding)
-    let (parser, root) = parse_source("try {} catch {}");
-    assert_no_errors(&parser, "catch without binding");
+    let (parser, root) = parse_clean_source("try {} catch {}", "catch without binding");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -507,8 +510,7 @@ fn stmt_catch_without_binding() {
 #[test]
 fn stmt_with() {
     // `with (obj) { x; }` (legacy)
-    let (parser, root) = parse_source("with (obj) { x; }");
-    assert_no_errors(&parser, "with statement");
+    let (parser, root) = parse_clean_source("with (obj) { x; }", "with statement");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -522,8 +524,7 @@ fn stmt_with() {
 #[test]
 fn stmt_empty() {
     // `;` (empty statement)
-    let (parser, root) = parse_source(";");
-    assert_no_errors(&parser, "empty statement");
+    let (parser, root) = parse_clean_source(";", "empty statement");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -537,8 +538,7 @@ fn stmt_empty() {
 #[test]
 fn stmt_debugger() {
     // `debugger;`
-    let (parser, root) = parse_source("debugger;");
-    assert_no_errors(&parser, "debugger statement");
+    let (parser, root) = parse_clean_source("debugger;", "debugger statement");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -552,8 +552,7 @@ fn stmt_debugger() {
 #[test]
 fn stmt_for_in() {
     // `for (const k in obj) {}`
-    let (parser, root) = parse_source("for (const k in obj) {}");
-    assert_no_errors(&parser, "for-in");
+    let (parser, root) = parse_clean_source("for (const k in obj) {}", "for-in");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -567,8 +566,7 @@ fn stmt_for_in() {
 #[test]
 fn stmt_for_of() {
     // `for (const x of arr) {}`
-    let (parser, root) = parse_source("for (const x of arr) {}");
-    assert_no_errors(&parser, "for-of");
+    let (parser, root) = parse_clean_source("for (const x of arr) {}", "for-of");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -582,8 +580,7 @@ fn stmt_for_of() {
 #[test]
 fn stmt_do_while() {
     // `do { x++; } while (x < 10);`
-    let (parser, root) = parse_source("do { x++; } while (x < 10);");
-    assert_no_errors(&parser, "do-while");
+    let (parser, root) = parse_clean_source("do { x++; } while (x < 10);", "do-while");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -613,8 +610,7 @@ fn stmt_break_continue_with_label() {
 #[test]
 fn error_recovery_missing_semicolon_asi() {
     // ASI should insert semicolons
-    let (parser, root) = parse_source("const x = 1\nconst y = 2");
-    assert_no_errors(&parser, "ASI");
+    let (parser, root) = parse_clean_source("const x = 1\nconst y = 2", "ASI");
     let arena = parser.get_arena();
     let stmts = get_statements(arena, root);
     assert_eq!(stmts.len(), 2, "should have 2 statements via ASI");
@@ -656,8 +652,7 @@ fn error_recovery_multiple_errors_continue_parsing() {
 #[test]
 fn error_recovery_no_panic_on_empty_input() {
     // Empty input should not panic
-    let (parser, root) = parse_source("");
-    assert_no_errors(&parser, "empty input");
+    let (parser, root) = parse_clean_source("", "empty input");
     let arena = parser.get_arena();
     let sf = arena.get_source_file_at(root).expect("source file");
     assert!(sf.statements.nodes.is_empty(), "should have no statements");
@@ -665,8 +660,7 @@ fn error_recovery_no_panic_on_empty_input() {
 
 #[test]
 fn error_recovery_no_panic_on_only_whitespace() {
-    let (parser, root) = parse_source("   \n\n  \t  ");
-    assert_no_errors(&parser, "whitespace only");
+    let (parser, root) = parse_clean_source("   \n\n  \t  ", "whitespace only");
     let arena = parser.get_arena();
     let sf = arena.get_source_file_at(root).expect("source file");
     assert!(sf.statements.nodes.is_empty());
@@ -698,10 +692,8 @@ fn error_recovery_deeply_nested_parens() {
 #[test]
 fn expr_new_expression() {
     // `new Foo(1, 2)`
-    let (parser, root) = parse_source("const x = new Foo(1, 2);");
-    assert_no_errors(&parser, "new expression");
+    let (parser, init) = parse_clean_var_initializer("const x = new Foo(1, 2);", "new expression");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(
         node.kind,
@@ -716,10 +708,8 @@ fn expr_new_expression() {
 #[test]
 fn expr_new_without_parens() {
     // `new Foo` (without arguments)
-    let (parser, root) = parse_source("const x = new Foo;");
-    assert_no_errors(&parser, "new without parens");
+    let (parser, init) = parse_clean_var_initializer("const x = new Foo;", "new without parens");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(node.kind, syntax_kind_ext::NEW_EXPRESSION);
 }
@@ -727,10 +717,9 @@ fn expr_new_without_parens() {
 #[test]
 fn expr_tagged_template() {
     // tag`hello ${x} world`
-    let (parser, root) = parse_source("const x = tag`hello ${y} world`;");
-    assert_no_errors(&parser, "tagged template");
+    let (parser, init) =
+        parse_clean_var_initializer("const x = tag`hello ${y} world`;", "tagged template");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(
         node.kind,
@@ -781,10 +770,8 @@ fn expr_tagged_template_with_type_arguments() {
 #[test]
 fn expr_spread_element() {
     // `[1, ...arr, 2]`
-    let (parser, root) = parse_source("const x = [1, ...arr, 2];");
-    assert_no_errors(&parser, "spread element");
+    let (parser, init) = parse_clean_var_initializer("const x = [1, ...arr, 2];", "spread element");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(
         node.kind,
@@ -804,8 +791,8 @@ fn expr_spread_element() {
 #[test]
 fn expr_object_literal() {
     // `{ a: 1, b, ...c, [d]: 2 }`
-    let (parser, root) = parse_source("const x = { a: 1, b, ...c, [d]: 2 };");
-    assert_no_errors(&parser, "object literal");
+    let (parser, root) =
+        parse_clean_source("const x = { a: 1, b, ...c, [d]: 2 };", "object literal");
     let arena = parser.get_arena();
     let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
@@ -941,10 +928,12 @@ fn object_literal_computed_indexer_tail_at_close_brace_reports_colon_expected() 
     // The trailing "':' expected." must land at the closing `}` position.
     let close_brace_pos = source.rfind('}').expect("closing brace") as u32;
     assert!(
-        parser.get_diagnostics().iter().any(|diag| diag.code
-            == diagnostic_codes::EXPECTED
-            && diag.start == close_brace_pos
-            && diag.message == "':' expected."),
+        parser
+            .get_diagnostics()
+            .iter()
+            .any(|diag| diag.code == diagnostic_codes::EXPECTED
+                && diag.start == close_brace_pos
+                && diag.message == "':' expected."),
         "expected TS1005 \"':' expected.\" at the closing brace, got {:?}",
         parser.get_diagnostics()
     );
@@ -1045,16 +1034,18 @@ fn object_literal_well_formed_computed_member_is_not_split() {
 #[test]
 fn expr_yield() {
     // `function* gen() { yield 1; yield* other(); }`
-    let (parser, _) = parse_source("function* gen() { yield 1; yield* other(); }");
-    assert_no_errors(&parser, "yield expression");
+    let (_parser, _) = parse_clean_source(
+        "function* gen() { yield 1; yield* other(); }",
+        "yield expression",
+    );
 }
 
 #[test]
 fn expr_void_typeof_delete() {
     // `void 0; typeof x; delete obj.x;`
     // These are parsed as PREFIX_UNARY_EXPRESSION with the keyword as operator
-    let (parser, root) = parse_source("void 0; typeof x; delete obj.x;");
-    assert_no_errors(&parser, "void/typeof/delete");
+    let (parser, root) =
+        parse_clean_source("void 0; typeof x; delete obj.x;", "void/typeof/delete");
     let arena = parser.get_arena();
     let stmts = get_statements(arena, root);
     assert_eq!(stmts.len(), 3);
@@ -1096,8 +1087,7 @@ fn expr_void_typeof_delete() {
 #[test]
 fn expr_prefix_postfix_unary() {
     // `++x; x--;`
-    let (parser, root) = parse_source("++x; x--;");
-    assert_no_errors(&parser, "prefix/postfix unary");
+    let (parser, root) = parse_clean_source("++x; x--;", "prefix/postfix unary");
     let arena = parser.get_arena();
     let stmts = get_statements(arena, root);
     let s0 = arena.get(stmts[0]).expect("s0");
@@ -1373,10 +1363,8 @@ fn expr_prefix_update_repeated_operator_after_line_break_matches_sputnik_shape()
 #[test]
 fn expr_element_access() {
     // `a[0]`
-    let (parser, root) = parse_source("const x = a[0];");
-    assert_no_errors(&parser, "element access");
+    let (parser, init) = parse_clean_var_initializer("const x = a[0];", "element access");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(
         node.kind,
@@ -1388,10 +1376,9 @@ fn expr_element_access() {
 #[test]
 fn expr_optional_element_access() {
     // `a?.[0]`
-    let (parser, root) = parse_source("const x = a?.[0];");
-    assert_no_errors(&parser, "optional element access");
+    let (parser, init) =
+        parse_clean_var_initializer("const x = a?.[0];", "optional element access");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(node.kind, syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION);
     let access = arena.get_access_expr(node).expect("access");
@@ -1401,10 +1388,8 @@ fn expr_optional_element_access() {
 #[test]
 fn expr_optional_call() {
     // `a?.(1)`
-    let (parser, root) = parse_source("const x = a?.(1);");
-    assert_no_errors(&parser, "optional call");
+    let (parser, init) = parse_clean_var_initializer("const x = a?.(1);", "optional call");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(node.kind, syntax_kind_ext::CALL_EXPRESSION);
 }
@@ -1413,11 +1398,12 @@ fn expr_optional_call() {
 fn expr_call_type_arguments_allow_trailing_comma() {
     // `id<number,>("x")` should parse as a call expression with one type
     // argument and a trailing comma marker, not as a relational expression.
-    let (parser, root) = parse_source("const x = id<number,>(\"x\");");
-    assert_no_errors(&parser, "call type arguments with trailing comma");
+    let (parser, init) = parse_clean_var_initializer(
+        "const x = id<number,>(\"x\");",
+        "call type arguments with trailing comma",
+    );
 
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(node.kind, syntax_kind_ext::CALL_EXPRESSION);
 
@@ -1451,8 +1437,10 @@ fn expr_call_type_arguments_recover_missing_leading_argument() {
 
 #[test]
 fn expr_new_type_arguments_allow_trailing_comma() {
-    let (parser, root) = parse_source("const x = new Box<string,>();");
-    assert_no_errors(&parser, "new expression type arguments with trailing comma");
+    let (parser, root) = parse_clean_source(
+        "const x = new Box<string,>();",
+        "new expression type arguments with trailing comma",
+    );
 
     let arena = parser.get_arena();
     let init = get_var_initializer(arena, root);
@@ -1492,8 +1480,8 @@ fn expr_tagged_template_type_arguments_recover_missing_leading_argument() {
 #[test]
 fn destructuring_object() {
     // `const { a, b: c, ...rest } = obj;`
-    let (parser, root) = parse_source("const { a, b: c, ...rest } = obj;");
-    assert_no_errors(&parser, "object destructuring");
+    let (parser, root) =
+        parse_clean_source("const { a, b: c, ...rest } = obj;", "object destructuring");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1515,8 +1503,8 @@ fn destructuring_object() {
 #[test]
 fn destructuring_array() {
     // `const [a, , b, ...rest] = arr;`
-    let (parser, root) = parse_source("const [a, , b, ...rest] = arr;");
-    assert_no_errors(&parser, "array destructuring");
+    let (parser, root) =
+        parse_clean_source("const [a, , b, ...rest] = arr;", "array destructuring");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1579,15 +1567,16 @@ fn array_rest_initializer_preserves_in_expression_in_for_header_recovery() {
 #[test]
 fn destructuring_nested() {
     // `const { a: { b } } = obj;`
-    let (parser, _) = parse_source("const { a: { b } } = obj;");
-    assert_no_errors(&parser, "nested destructuring");
+    let (_parser, _) = parse_clean_source("const { a: { b } } = obj;", "nested destructuring");
 }
 
 #[test]
 fn destructuring_with_defaults() {
     // `const { a = 1, b = 2 } = obj;`
-    let (parser, _) = parse_source("const { a = 1, b = 2 } = obj;");
-    assert_no_errors(&parser, "destructuring with defaults");
+    let (_parser, _) = parse_clean_source(
+        "const { a = 1, b = 2 } = obj;",
+        "destructuring with defaults",
+    );
 }
 
 // =============================================================================
@@ -1597,8 +1586,7 @@ fn destructuring_with_defaults() {
 #[test]
 fn type_import() {
     // `type T = import('module').Foo`
-    let (parser, root) = parse_source("type T = import('module').Foo;");
-    assert_no_errors(&parser, "import type");
+    let (parser, root) = parse_clean_source("type T = import('module').Foo;", "import type");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1610,8 +1598,7 @@ fn type_import() {
 #[test]
 fn type_reference_qualified_name_span_excludes_type_arguments() {
     let source = "type T = Foo.Bar<Baz>;";
-    let (parser, root) = parse_source(source);
-    assert_no_errors(&parser, "qualified type reference span");
+    let (parser, root) = parse_clean_source(source, "qualified type reference span");
 
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
@@ -1628,8 +1615,7 @@ fn type_reference_qualified_name_span_excludes_type_arguments() {
 #[test]
 fn type_query_qualified_name_span_excludes_type_arguments() {
     let source = "type T = typeof ns.Foo<Bar>;";
-    let (parser, root) = parse_source(source);
-    assert_no_errors(&parser, "type query span");
+    let (parser, root) = parse_clean_source(source, "type query span");
 
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
@@ -1649,8 +1635,7 @@ fn type_query_qualified_name_span_excludes_type_arguments() {
 #[test]
 fn import_type_qualified_name_span_excludes_type_arguments() {
     let source = "type T = import('m').Foo<Bar>;";
-    let (parser, root) = parse_source(source);
-    assert_no_errors(&parser, "import type span");
+    let (parser, root) = parse_clean_source(source, "import type span");
 
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
@@ -1695,8 +1680,7 @@ fn intrinsic_type_keyword_recovery_stops_before_qualified_name() {
 #[test]
 fn unique_symbol_keeps_symbol_as_type_reference() {
     let source = "type T = unique symbol;";
-    let (parser, root) = parse_source(source);
-    assert_no_errors(&parser, "unique symbol");
+    let (parser, root) = parse_clean_source(source, "unique symbol");
 
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
@@ -1758,8 +1742,7 @@ fn super_type_arguments_report_parser_error_and_recover_to_call() {
 #[test]
 fn accessor_children_include_body_once() {
     let source = "class C { get x() { return 1; } }";
-    let (parser, root) = parse_source(source);
-    assert_no_errors(&parser, "class accessor");
+    let (parser, root) = parse_clean_source(source, "class accessor");
 
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
@@ -1822,8 +1805,10 @@ fn class_field_type_annotation_call_reports_ts1441() {
 #[test]
 fn type_mapped_with_modifiers() {
     // `type T = { readonly [K in keyof T]-?: T[K] }`
-    let (parser, root) = parse_source("type T = { readonly [K in keyof T]-?: T[K] };");
-    assert_no_errors(&parser, "mapped type with modifiers");
+    let (parser, root) = parse_clean_source(
+        "type T = { readonly [K in keyof T]-?: T[K] };",
+        "mapped type with modifiers",
+    );
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1838,8 +1823,7 @@ fn type_mapped_with_modifiers() {
 #[test]
 fn type_type_literal() {
     // `type T = { x: string; y: number }`
-    let (parser, root) = parse_source("type T = { x: string; y: number };");
-    assert_no_errors(&parser, "type literal");
+    let (parser, root) = parse_clean_source("type T = { x: string; y: number };", "type literal");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1859,8 +1843,8 @@ fn type_type_literal() {
 #[test]
 fn type_union_intersection_precedence() {
     // `A & B | C & D` should parse as `(A & B) | (C & D)` — intersection binds tighter
-    let (parser, root) = parse_source("type T = A & B | C & D;");
-    assert_no_errors(&parser, "union/intersection precedence");
+    let (parser, root) =
+        parse_clean_source("type T = A & B | C & D;", "union/intersection precedence");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -1899,10 +1883,8 @@ fn type_union_intersection_precedence() {
 #[test]
 fn template_no_substitution() {
     // `const x = \`hello\``
-    let (parser, root) = parse_source("const x = `hello`;");
-    assert_no_errors(&parser, "no-sub template");
+    let (parser, init) = parse_clean_var_initializer("const x = `hello`;", "no-sub template");
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(
         node.kind,
@@ -1914,10 +1896,11 @@ fn template_no_substitution() {
 #[test]
 fn template_with_substitution() {
     // `const x = \`hello ${name} world\``
-    let (parser, root) = parse_source("const x = `hello ${name} world`;");
-    assert_no_errors(&parser, "template with substitution");
+    let (parser, init) = parse_clean_var_initializer(
+        "const x = `hello ${name} world`;",
+        "template with substitution",
+    );
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(
         node.kind,

--- a/crates/tsz-parser/tests/parser_unit_tests_parts/part_02.rs
+++ b/crates/tsz-parser/tests/parser_unit_tests_parts/part_02.rs
@@ -44,8 +44,7 @@ fn template_expression_parts_record_raw_token_text() {
 #[test]
 fn decl_using() {
     // `using x = getResource();`
-    let (parser, root) = parse_source("using x = getResource();");
-    assert_no_errors(&parser, "using declaration");
+    let (parser, root) = parse_clean_source("using x = getResource();", "using declaration");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -59,8 +58,10 @@ fn decl_using() {
 #[test]
 fn decl_await_using() {
     // `await using x = getResource();`
-    let (parser, _root) = parse_source("async function f() { await using x = getResource(); }");
-    assert_no_errors(&parser, "await using declaration");
+    let (_parser, _root) = parse_clean_source(
+        "async function f() { await using x = getResource(); }",
+        "await using declaration",
+    );
 }
 
 #[test]
@@ -113,11 +114,11 @@ fn decl_using_and_await_using_in_blocks_are_variable_statements() {
 #[test]
 fn class_expression() {
     // `const C = class extends Base { constructor() { super(); } };`
-    let (parser, root) =
-        parse_source("const C = class extends Base { constructor() { super(); } };");
-    assert_no_errors(&parser, "class expression");
+    let (parser, init) = parse_clean_var_initializer(
+        "const C = class extends Base { constructor() { super(); } };",
+        "class expression",
+    );
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(
         node.kind,
@@ -129,10 +130,11 @@ fn class_expression() {
 #[test]
 fn function_expression() {
     // `const f = function foo(x: number) { return x; };`
-    let (parser, root) = parse_source("const f = function foo(x: number) { return x; };");
-    assert_no_errors(&parser, "function expression");
+    let (parser, init) = parse_clean_var_initializer(
+        "const f = function foo(x: number) { return x; };",
+        "function expression",
+    );
     let arena = parser.get_arena();
-    let init = get_var_initializer(arena, root);
     let node = arena.get(init).expect("init");
     assert_eq!(
         node.kind,
@@ -146,8 +148,7 @@ fn function_expression() {
 #[test]
 fn generator_function() {
     // `function* gen() { yield 1; }`
-    let (parser, root) = parse_source("function* gen() { yield 1; }");
-    assert_no_errors(&parser, "generator function");
+    let (parser, root) = parse_clean_source("function* gen() { yield 1; }", "generator function");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -158,8 +159,8 @@ fn generator_function() {
 #[test]
 fn async_generator_function() {
     // `async function* gen() { yield 1; }`
-    let (parser, root) = parse_source("async function* gen() { yield 1; }");
-    assert_no_errors(&parser, "async generator");
+    let (parser, root) =
+        parse_clean_source("async function* gen() { yield 1; }", "async generator");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -171,8 +172,10 @@ fn async_generator_function() {
 #[test]
 fn multiple_variable_declarations() {
     // `const a = 1, b = 2, c = 3;`
-    let (parser, root) = parse_source("const a = 1, b = 2, c = 3;");
-    assert_no_errors(&parser, "multiple variable declarations");
+    let (parser, root) = parse_clean_source(
+        "const a = 1, b = 2, c = 3;",
+        "multiple variable declarations",
+    );
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -190,8 +193,10 @@ fn multiple_variable_declarations() {
 #[test]
 fn interface_call_and_construct_signatures() {
     // `interface I { (): void; new (): I; }`
-    let (parser, root) = parse_source("interface I { (): void; new (): I; }");
-    assert_no_errors(&parser, "call and construct signatures");
+    let (parser, root) = parse_clean_source(
+        "interface I { (): void; new (): I; }",
+        "call and construct signatures",
+    );
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -237,8 +242,10 @@ fn asserts_type_predicate_in_setter_parameter_type() {
     // setter parameter type produced a stray TS1005 (',' expected) instead.
     //
     // `declare class Wat { set p2(x: asserts this is string); }`
-    let (parser, root) = parse_source("declare class Wat { set p2(x: asserts this is string); }");
-    assert_no_errors(&parser, "asserts predicate in setter parameter type");
+    let (parser, root) = parse_clean_source(
+        "declare class Wat { set p2(x: asserts this is string); }",
+        "asserts predicate in setter parameter type",
+    );
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -288,8 +295,8 @@ fn asserts_identifier_with_line_break_is_type_reference() {
     // (ASI). tsc's `nextTokenIsIdentifierOrKeywordOnSameLine` enforces this; the
     // tsz lookahead used to ignore the line break, which would have parsed
     // `asserts\n  bar` as an ill-formed predicate had we entered the branch.
-    let (parser, root) = parse_source("type T = asserts\n;");
-    assert_no_errors(&parser, "asserts as plain type reference");
+    let (parser, root) =
+        parse_clean_source("type T = asserts\n;", "asserts as plain type reference");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -305,8 +312,10 @@ fn asserts_identifier_with_line_break_is_type_reference() {
 #[test]
 fn import_with_attributes() {
     // `import data from './data.json' with { type: 'json' };`
-    let (parser, root) = parse_source("import data from './data.json' with { type: 'json' };");
-    assert_no_errors(&parser, "import with attributes");
+    let (parser, root) = parse_clean_source(
+        "import data from './data.json' with { type: 'json' };",
+        "import with attributes",
+    );
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -317,8 +326,7 @@ fn import_with_attributes() {
 #[test]
 fn export_star_from() {
     // `export * from './module';`
-    let (parser, root) = parse_source("export * from './module';");
-    assert_no_errors(&parser, "export star from");
+    let (parser, root) = parse_clean_source("export * from './module';", "export star from");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");
@@ -333,8 +341,7 @@ fn export_star_from() {
 #[test]
 fn export_star_as_namespace() {
     // `export * as ns from './module';`
-    let (parser, root) = parse_source("export * as ns from './module';");
-    assert_no_errors(&parser, "export * as ns");
+    let (parser, root) = parse_clean_source("export * as ns from './module';", "export * as ns");
     let arena = parser.get_arena();
     let stmt_idx = get_first_statement(arena, root);
     let stmt_node = arena.get(stmt_idx).expect("stmt");


### PR DESCRIPTION
## Agent
AgentName: M5Manager

No canonical agent lane was assigned for this manager-side small cleanup. M5Manager is the coordination identity for this PR, so it intentionally carries no `agent:*` label unless a canonical lane takes ownership later.

## Track
Parser test-harness tech debt for #9401.

## Invariant
Parser behavior, diagnostics, spans, emitted output, and public APIs are unchanged. This PR only names repeated clean-parse fixture setup in `parser_unit_tests` so individual cases state the parser fact they assert instead of repeating raw parse/no-error boilerplate.

## Scope
- Add `parse_clean_source` for `parse_source` plus `assert_no_errors`.
- Add `parse_clean_var_initializer` for the common clean variable-initializer fixture shape.
- Replace repeated adjacent parse/no-error/setup chains in `parser_unit_tests` shards where the existing test semantics and names remain unchanged.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: test-harness-only parser unit-test refactor; no compiler behavior path changed.

## Verification
- `cargo check -p tsz-parser --tests`
- `cargo nextest run -p tsz-parser parser_unit_tests` — 187 passed, 1106 skipped
- Draft-light CI on head `60fd4fc234e0f6e8bddce8ac41b185e2d6671f3e`: `CI Light Summary`, `lint`, `unit`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `project-row-drift`, and `GitGuardian Security Checks` passed.
- Full conformance, fourslash, and emit suites were not run locally per TSZ policy; ready-review CI is responsible for those gates.

## Coordination Notes
- Refs #9401.
- Selected after the M5Manager sidecar confirmed #10683/#10677 remain M4-C Kysely contextual-callback work and #11358/#11330 remain Studio-C emit metadata work.
- This parser test cleanup does not touch Kysely checker/inference code, JavaScript/declaration emit, binder wildcard re-export metadata, or project-corpus rows.
- Marked ready on exact head `60fd4fc234e0f6e8bddce8ac41b185e2d6671f3e` after draft-light CI passed.
- `merge-queue` remains off until ready-review exact-head `CI Summary` and `GitGuardian Security Checks` are green and the PR remains ready, non-WIP, non-draft, and mergeable.
