### PR TITLE
refactor(cli): add code fix fallback builder

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_fallbacks.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_fallbacks.rs
@@ -6,6 +6,66 @@ use super::handlers_code_fixes_utils::{
 };
 use tsz::lsp::position::LineMap;
 
+struct CodeFixBuilder<'a> {
+    fix_name: &'a str,
+    description: String,
+    fix_id: Option<&'a str>,
+    fix_all_description: Option<&'a str>,
+}
+
+impl<'a> CodeFixBuilder<'a> {
+    fn new(fix_name: &'a str, description: impl Into<String>) -> Self {
+        Self {
+            fix_name,
+            description: description.into(),
+            fix_id: None,
+            fix_all_description: None,
+        }
+    }
+
+    const fn fix_id(mut self, fix_id: &'a str) -> Self {
+        self.fix_id = Some(fix_id);
+        self
+    }
+
+    const fn fix_all_description(mut self, fix_all_description: &'a str) -> Self {
+        self.fix_all_description = Some(fix_all_description);
+        self
+    }
+
+    fn single_text_change(
+        self,
+        file_name: &str,
+        line_map: &LineMap,
+        content: &str,
+        start_offset: u32,
+        end_offset: u32,
+        new_text: String,
+    ) -> serde_json::Value {
+        let start = line_map.offset_to_position(start_offset, content);
+        let end = line_map.offset_to_position(end_offset, content);
+        let mut action = serde_json::json!({
+            "fixName": self.fix_name,
+            "description": self.description,
+            "changes": [{
+                "fileName": file_name,
+                "textChanges": [{
+                    "start": { "line": start.line + 1, "offset": start.character + 1 },
+                    "end": { "line": end.line + 1, "offset": end.character + 1 },
+                    "newText": new_text
+                }]
+            }]
+        });
+        if let Some(fix_id) = self.fix_id {
+            action["fixId"] = serde_json::json!(fix_id);
+        }
+        if let Some(fix_all_description) = self.fix_all_description {
+            action["fixAllDescription"] = serde_json::json!(fix_all_description);
+        }
+        action
+    }
+}
+
 impl Server {
     pub(super) fn find_property_access_name_for_missing_member_fallback(
         content: &str,
@@ -67,40 +127,33 @@ impl Server {
         };
 
         let line_map = LineMap::build(&target_content);
-        let insert_pos = line_map.offset_to_position(insert_offset as u32, &target_content);
-        let change_for = |new_text: String| {
-            serde_json::json!([{
-                "fileName": target_file,
-                "textChanges": [{
-                    "start": { "line": insert_pos.line + 1, "offset": insert_pos.character + 1 },
-                    "end": { "line": insert_pos.line + 1, "offset": insert_pos.character + 1 },
-                    "newText": new_text
-                }]
-            }])
+        let action_for = |description: String, new_text: String| {
+            CodeFixBuilder::new("addMissingMember", description)
+                .fix_id("fixMissingMember")
+                .fix_all_description("Add all missing members")
+                .single_text_change(
+                    target_file.as_str(),
+                    &line_map,
+                    &target_content,
+                    insert_offset as u32,
+                    insert_offset as u32,
+                    new_text,
+                )
         };
 
         vec![
-            serde_json::json!({
-                "fixName": "addMissingMember",
-                "description": format!("Declare method '{prop_name}'"),
-                "changes": change_for(format!("\n    {prop_name}(): unknown;\n")),
-                "fixId": "fixMissingMember",
-                "fixAllDescription": "Add all missing members",
-            }),
-            serde_json::json!({
-                "fixName": "addMissingMember",
-                "description": format!("Declare property '{prop_name}'"),
-                "changes": change_for(format!("\n    {prop_name}: unknown;\n")),
-                "fixId": "fixMissingMember",
-                "fixAllDescription": "Add all missing members",
-            }),
-            serde_json::json!({
-                "fixName": "addMissingMember",
-                "description": format!("Add index signature for property '{prop_name}'"),
-                "changes": change_for("\n    [x: string]: unknown;\n".to_string()),
-                "fixId": "fixMissingMember",
-                "fixAllDescription": "Add all missing members",
-            }),
+            action_for(
+                format!("Declare method '{prop_name}'"),
+                format!("\n    {prop_name}(): unknown;\n"),
+            ),
+            action_for(
+                format!("Declare property '{prop_name}'"),
+                format!("\n    {prop_name}: unknown;\n"),
+            ),
+            action_for(
+                format!("Add index signature for property '{prop_name}'"),
+                "\n    [x: string]: unknown;\n".to_string(),
+            ),
         ]
     }
 


### PR DESCRIPTION
## Agent
AgentName: M5Manager

Canonical next-step owner: `agent:Studio-E`, because this is CLI/LSP code-fix fallback tech debt and Studio-E owns low-bandwidth LSP/compiler-service consumer boundary work. M5Manager authored and coordinated this manager-side slice.

## Track
CLI/LSP tech debt for #9413: code-fix fallback builder proof-of-shape.

## Invariant
When a fallback code fix returns a single-file text edit, the emitted tsserver protocol object stays byte-shape equivalent while edit construction moves behind a named helper instead of being hand-written inline.

## Scope
- Add a private `CodeFixBuilder` in `handlers_code_fixes_fallbacks.rs` for single-file text-change actions.
- Migrate the three missing-member fallback variants (`Declare method`, `Declare property`, index signature) to the builder.
- Keep all diagnostics, text edits, public tsserver responses, and fallback discovery behavior unchanged.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CLI/LSP test-harness and protocol-shape refactor only; no checker, solver, parser, binder, emitter, project-corpus, or benchmark behavior path changed.

## Verification
- Exact-head local revalidation after rebasing onto `origin/main` `6f51695c790f6fa13a5a8e123ce6fd782b278e8c` at head `3bbd04510ad2836cdd2fc29a206f90e6a413c076`: `cargo check -p tsz-cli --bin tsz-server`, `cargo clippy -p tsz-cli --bin tsz-server -- -D warnings`, and `cargo nextest run -p tsz-cli get_code_fixes_does_not_offer_spelling_for_plain_missing_property_2339` passed; `cargo fmt --package tsz-cli --check` and `git diff --check origin/main..HEAD` also passed.
- GREEN draft-light CI on exact head `3bbd04510ad2836cdd2fc29a206f90e6a413c076`: `CI Light Summary`, `lint`, `unit`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `unit-cloudbuild`, `gate`, `queue-one-pr`, and `GitGuardian Security Checks` passed.
- Informational only: `cargo nextest run -p tsz-cli code_fixes` previously reported 79 passed / 1 failed / 1814 skipped. The failure was `collect_import_candidates_respects_node_next_package_exports_root_only`, an import-candidate test outside this diff's missing-member fallback builder scope. The directly affected missing-member fallback test passed in that run and again in the focused run above.
- Ready-review CI is running on exact head `3bbd04510ad2836cdd2fc29a206f90e6a413c076`; do not add `merge-queue` until exact-head ready-review `CI Summary` and `GitGuardian Security Checks` are green.
- Full local conformance, fourslash, and emit suites were not run per TSZ policy.

## Coordination Notes
- Refs #9413.
- Selected after read-only M5Manager sidecar triage confirmed #10683/#10677 remain protected `agent:M4-C` Kysely contextual-callback work and #11358/#11330 remain protected `agent:Studio-C` emit metadata work.
- Open PR overlap check found no current #9413 / CodeFixBuilder / CLI code-fix fallback PR. The only open PR matching the word `fallback` was #12118, a Studio-B checker/DOM alias test, not this CLI/LSP code-fix surface.
- This does not touch Kysely checker/inference code, Studio-C emit metadata, binder wildcard re-export metadata, or project-corpus rows.
- M5Manager marked this PR ready after exact-head draft-light CI passed. Ready-review CI is now the next source of truth for queue eligibility.
- AgentName: M5Manager
