### PR TITLE
fix(checker): make overload-impl exclusion order-independent in function-symbol resolution

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors_overload_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_overload_tests.rs
@@ -532,28 +532,19 @@ class Box {
 
 #[test]
 fn overload_impl_sig_excluded_bool_arg_errors_at_call_site() {
-    // The implementation signature (x: any) must never be included in the
-    // overload candidate set. If it were, `foo(true)` would silently succeed
-    // because `true` is assignable to `any`. The error must be TS2769 anchored
-    // at the call site (argument or callee), not inside the implementation.
-    let source = r#"
+    // If the impl `(x: any)` joined the candidate set, `foo(true)` would
+    // silently succeed because `true` is assignable to `any`. The error must
+    // be TS2769 anchored at the call site, not inside the impl.
+    assert_no_diag_in_span_emits_ts2769(
+        r#"
 function foo(x: string): string;
 function foo(x: number): number;
 function foo(x: any): any { return x; }
 foo(true);
-"#;
-    let diagnostics = check_source_with_strict_null(source);
-    let impl_start = source.find("function foo(x: any)").unwrap() as u32;
-    let impl_end = impl_start + "function foo(x: any): any { return x; }".len() as u32;
-    for diag in &diagnostics {
-        assert!(
-            diag.start < impl_start || diag.start >= impl_end,
-            "error must not be anchored inside the implementation signature, got: {diag:?}"
-        );
-    }
-    assert!(
-        diagnostics.iter().any(|d| d.code == 2769),
-        "expected TS2769 for foo(true) — impl sig must not be an overload candidate, got: {diagnostics:?}"
+"#,
+        "function foo(x: any)",
+        "function foo(x: any): any { return x; }",
+        None,
     );
 }
 
@@ -910,5 +901,169 @@ export class Foo<T> extends Base<T> {
             && d.message_text
                 .contains("not assignable to type 'Assign<T, { x: number; }>'")),
         "the initializer overload failure must not hide the real TS2322, got: {diagnostics:?}"
+    );
+}
+
+// ── Implementation-signature exclusion: structural rule ──────────────────────
+//
+// Body-less overload decls are the only externally visible call signatures.
+// The implementation signature is never a candidate.
+
+fn assert_no_diag_in_span_emits_ts2769(
+    source: &str,
+    impl_signature: &str,
+    impl_full: &str,
+    code_filter: Option<u32>,
+) {
+    let diagnostics = check_source_with_strict_null(source);
+    let impl_start = source
+        .find(impl_signature)
+        .unwrap_or_else(|| panic!("impl signature {impl_signature:?} not found in source"))
+        as u32;
+    let impl_end = impl_start + impl_full.len() as u32;
+    for diag in diagnostics
+        .iter()
+        .filter(|d| code_filter.is_none_or(|c| d.code == c))
+    {
+        assert!(
+            diag.start < impl_start || diag.start >= impl_end,
+            "error must not be anchored inside the impl, got: {diag:?}"
+        );
+    }
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2769),
+        "expected TS2769, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn overload_impl_excluded_with_renamed_parameters_p_form() {
+    assert_no_diag_in_span_emits_ts2769(
+        r#"
+function pickP(p: string): string;
+function pickP(p: number): number;
+function pickP(p: any): any { return p; }
+pickP(true);
+"#,
+        "function pickP(p: any)",
+        "function pickP(p: any): any { return p; }",
+        None,
+    );
+}
+
+#[test]
+fn overload_impl_excluded_with_renamed_parameters_q_form() {
+    assert_no_diag_in_span_emits_ts2769(
+        r#"
+function pickQ(q: string): string;
+function pickQ(q: number): number;
+function pickQ(q: any): any { return q; }
+pickQ([]);
+"#,
+        "function pickQ(q: any)",
+        "function pickQ(q: any): any { return q; }",
+        None,
+    );
+}
+
+#[test]
+fn overload_impl_excluded_with_three_overload_signatures() {
+    assert_no_diag_in_span_emits_ts2769(
+        r#"
+function makeRecord(value: string): { kind: "s" };
+function makeRecord(value: number): { kind: "n" };
+function makeRecord(value: boolean): { kind: "b" };
+function makeRecord(value: any): { kind: string } { return { kind: "x" }; }
+makeRecord({ nope: 1 });
+"#,
+        "function makeRecord(value: any)",
+        "function makeRecord(value: any): { kind: string } { return { kind: \"x\" }; }",
+        None,
+    );
+}
+
+/// `unknown` impl widening — the rule keys off body presence, not type spelling.
+#[test]
+fn overload_impl_excluded_when_impl_widens_via_unknown() {
+    assert_no_diag_in_span_emits_ts2769(
+        r#"
+function takeU(x: string): string;
+function takeU(x: number): number;
+function takeU(x: unknown): unknown { return x; }
+takeU(true);
+"#,
+        "function takeU(x: unknown)",
+        "function takeU(x: unknown): unknown { return x; }",
+        None,
+    );
+}
+
+#[test]
+fn overload_impl_excluded_for_generic_overloads_t_variant() {
+    assert_no_diag_in_span_emits_ts2769(
+        r#"
+function transformT<T>(value: string): T;
+function transformT<T>(value: number): T;
+function transformT<T>(value: any): T { return value; }
+const s: string = transformT(true);
+"#,
+        "function transformT<T>(value: any)",
+        "function transformT<T>(value: any): T { return value; }",
+        None,
+    );
+}
+
+/// Same generic rule with `K` — proves the matrix isn't pinned to `T`.
+#[test]
+fn overload_impl_excluded_for_generic_overloads_k_variant() {
+    assert_no_diag_in_span_emits_ts2769(
+        r#"
+function transformK<K>(value: string): K;
+function transformK<K>(value: number): K;
+function transformK<K>(value: any): K { return value; }
+const s: string = transformK(true);
+"#,
+        "function transformK<K>(value: any)",
+        "function transformK<K>(value: any): K { return value; }",
+        None,
+    );
+}
+
+/// Single-signature function: the lone impl signature drives diagnostics.
+/// Guards against the fix regressing the no-overloads path.
+#[test]
+fn single_signature_function_uses_impl_signature_when_no_overloads_present() {
+    let source = r#"
+function onlyImpl(x: string): string { return x; }
+const n: number = onlyImpl("hi");
+"#;
+    let diagnostics = check_source_with_strict_null(source);
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2322),
+        "expected TS2322 from single impl signature, got: {diagnostics:?}"
+    );
+    assert!(
+        !diagnostics.iter().any(|d| d.code == 2769),
+        "single-signature function must not trigger TS2769, got: {diagnostics:?}"
+    );
+}
+
+/// Class-method end-to-end witness — impl excluded across `c.method` and `c["method"]`.
+#[test]
+fn class_method_impl_excluded_across_access_paths() {
+    assert_no_diag_in_span_emits_ts2769(
+        r#"
+class Service {
+    handle(req: string): string;
+    handle(req: number): number;
+    handle(req: any): any { return req; }
+}
+const s = new Service();
+s.handle(true);
+s["handle"](true);
+"#,
+        "handle(req: any)",
+        "handle(req: any): any { return req; }",
+        Some(2769),
     );
 }

--- a/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
@@ -1426,27 +1426,28 @@ impl<'a> CheckerState<'a> {
 
             use tsz_solver::CallableShape;
 
+            // Impl signature is never an externally visible call signature.
+            // Body-less decls are the overloads; JSDoc `@overload` substitutes
+            // only when zero body-less decls exist across all declarations.
             let mut overloads = Vec::new();
             let mut implementation_decl = NodeIndex::NONE;
 
             for &decl_idx in &declarations {
-                let Some(node) = self.ctx.arena.get(decl_idx) else {
+                let Some(func) = self.ctx.arena.get_function_at(decl_idx) else {
                     continue;
                 };
-                let Some(func) = self.ctx.arena.get_function(node) else {
-                    continue;
-                };
-
                 if func.body.is_none() {
                     overloads.push(self.call_signature_from_function(func, decl_idx));
                 } else {
                     implementation_decl = decl_idx;
-                    if overloads.is_empty() {
-                        overloads.extend(
-                            self.jsdoc_overload_call_signatures_for_function(func, decl_idx),
-                        );
-                    }
                 }
+            }
+
+            if overloads.is_empty()
+                && let Some(impl_func) = self.ctx.arena.get_function_at(implementation_decl)
+            {
+                overloads = self
+                    .jsdoc_overload_call_signatures_for_function(impl_func, implementation_decl);
             }
 
             let function_type = if !overloads.is_empty() {


### PR DESCRIPTION
AgentName: M1-B
Track: Conformance / Checker — TS2769 overload-impl exclusion

## Summary

The implementation signature of an overloaded function must never appear as an externally visible call signature. Fixes #10951 and the broader class of order-dependent JSDoc-overload extraction bugs in `compute_type_of_symbol`.

**Structural rule (one sentence):** when a function symbol has at least one body-less declaration, those decls alone form the callable shape's `call_signatures`; JSDoc `@overload` signatures only substitute when zero body-less decls exist across all of the symbol's declarations.

### Root cause

In `crates/tsz-checker/src/state/type_analysis/computed/mod.rs` the per-declaration loop tested `overloads.is_empty()` inline when it hit the impl decl, deciding whether to extend the candidate set with JSDoc `@overload` signatures. That made the decision order-dependent: if the impl was iterated before the body-less decls (declaration merging across files can reorder), JSDoc overloads were pushed first and then real overload signatures were stacked on top — mixing two different overload representations into the same `CallableShape`.

### Fix

Single-pass loop collects body-less decls as overload `CallSignature`s and remembers the impl `NodeIndex`. After the loop, when (and only when) `overloads.is_empty()`, take the impl's JSDoc `@overload` signatures. The decision is now an additive structural step keyed on a single invariant, not a per-iteration race.

Also reuses the existing `arena.get_function_at` helper instead of `arena.get(...).and_then(arena.get_function(...))`.

### Adjacent-case test matrix

8 new tests + 1 pre-existing test migrated to a shared helper. They vary:
- Parameter spellings — `p`/`q` forms (proves the rule isn't pinned to a name).
- Type-parameter spellings — `T`/`K` variants.
- Number of overloads — two and three.
- Impl widening type — `any` and `unknown` (proves the rule keys on body presence, not type spelling).
- Single-signature regression (impl is the only signature when no overloads exist).
- Class-method access paths — `c.method(...)` and `c["method"](...)` as an end-to-end witness.

A shared helper `assert_no_diag_in_span_emits_ts2769(source, impl_signature, impl_full, code_filter)` consolidates the span-exclusion assertion across all callers.

## Invariant

For every function symbol with declarations `D`:
- if any `d ∈ D` has `d.body.is_none()`, then `callable_shape.call_signatures == { call_sig(d) : d ∈ D, d.body.is_none() }`,
- else if the impl declaration has JSDoc `@overload` tags, `callable_shape.call_signatures == jsdoc_overloads(impl)`,
- else `callable_shape.call_signatures == { call_sig(impl) }`.

The impl declaration's own `call_sig` is never in `call_signatures` when overloads exist.

## Scope

- `crates/tsz-checker/src/state/type_analysis/computed/mod.rs` — function-symbol path of `compute_type_of_symbol` (post-loop JSDoc fallback).
- `crates/tsz-checker/src/error_reporter/call_errors_overload_tests.rs` — 8 new structural tests + helper; one pre-existing test migrated to the helper.

No other crates touched. No public-API changes.

## Project Corpus Impact

- Row: utility-types-project
- Bug family: checker / overload-impl exclusion / JSDoc-overload fallback ordering
- Evidence: focused unit tests pass locally (`cargo test -p tsz-checker --lib overload` = 173 passed, `cargo test -p tsz-checker --lib jsdoc_overload` = 4 passed). Conformance/emit/fourslash gates run on ready-for-review CI.

## Verification

Local:
- `cargo check -p tsz-checker --lib` — clean
- `cargo check -p tsz-checker --tests` — clean
- `cargo test -p tsz-checker --lib overload` — 173 passed, 0 failed
- `cargo test -p tsz-checker --lib jsdoc_overload` — 4 passed, 0 failed
- `cargo test -p tsz-checker --lib overload_impl` — 10 passed (new tests + pre-existing)
- `cargo clippy -p tsz-checker --lib --tests --all-features -- -D warnings` — clean

CI (ready-for-review):
- Conformance gate
- Emit gate
- Fourslash gate
- WASM gate
- Snapshot gates

## Coordination Notes

- Three /simplify cycles were run on the diff before opening:
  - Cycle 1: dropped a 14-line history-prose comment, removed a redundant `is_none()` guard, switched to `arena.get_function_at`, consolidated 6 near-identical tests behind a helper.
  - Cycle 2: flattened the `extend(...)` call, generalized the helper with an optional code filter so the class-method test goes through it.
  - Cycle 3: dropped a thin wrapper around the helper, inlined the JSDoc fallback assignment, migrated a pre-existing test to the helper.
- A potential cross-cutting refactor (`partition_overload_decls` shared across `class_type/core.rs`, `class_type/constructor.rs`, and this site) was identified by the altitude agent but **deferred**: those sites pre-build per-kind `CallSignature` vectors into `MethodAggregate`, whereas the function-symbol path stores the impl as a raw `NodeIndex` until the JSDoc fallback decides. Sharing would be a non-trivial refactor across four sites and outside this PR's scope.
- Issue #10951 is labeled `WIP` while this PR is in flight; it will be auto-unlabeled when this PR merges.

https://claude.ai/code/session_01Gzd8Temskoa5SixKEMoWzw

