### PR TITLE
fix(solver): preserve variadic tuple arity through homomorphic mapped instantiation

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mod.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mod.rs
@@ -28,5 +28,5 @@ mod mapped_array;
 mod mapped_template_index;
 mod string_index_helpers;
 pub mod string_intrinsic;
-mod substitute;
+pub(crate) mod substitute;
 pub mod template_literal;

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/substitute.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/substitute.rs
@@ -8,11 +8,200 @@
 //! unchanged. We therefore memoize per-node substitutions and use a
 //! self-mapping placeholder to handle true cycles.
 
+use crate::caches::db::TypeDatabase;
 use crate::relations::subtype::TypeResolver;
 use crate::types::{ConditionalType, FunctionShape, TemplateSpan, TupleElement, TypeData, TypeId};
 use rustc_hash::FxHashMap;
 
 use super::super::evaluate::TypeEvaluator;
+
+/// Free-function form of [`TypeEvaluator::substitute_exact_type`] that walks
+/// the type graph using only a [`TypeDatabase`]. Crate-private so the
+/// instantiation layer can do per-element source rebinding without depending
+/// on a `TypeResolver`.
+pub(crate) fn substitute_exact_type_db(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+    from: TypeId,
+    to: TypeId,
+    memo: &mut FxHashMap<TypeId, TypeId>,
+) -> TypeId {
+    if type_id == from {
+        return to;
+    }
+    if type_id.is_intrinsic() {
+        return type_id;
+    }
+    if let Some(&cached) = memo.get(&type_id) {
+        return cached;
+    }
+    memo.insert(type_id, type_id);
+
+    let result = match db.lookup(type_id) {
+        Some(TypeData::Application(app_id)) => {
+            let app = db.type_application(app_id);
+            let base = substitute_exact_type_db(db, app.base, from, to, memo);
+            let mut changed = base != app.base;
+            let args: Vec<_> = app
+                .args
+                .iter()
+                .map(|&arg| {
+                    let substituted = substitute_exact_type_db(db, arg, from, to, memo);
+                    changed |= substituted != arg;
+                    substituted
+                })
+                .collect();
+            if changed {
+                db.application(base, args)
+            } else {
+                type_id
+            }
+        }
+        Some(TypeData::Union(list_id)) => {
+            let members = db.type_list(list_id);
+            let mut changed = false;
+            let members: Vec<_> = members
+                .iter()
+                .map(|&member| {
+                    let substituted = substitute_exact_type_db(db, member, from, to, memo);
+                    changed |= substituted != member;
+                    substituted
+                })
+                .collect();
+            if changed { db.union(members) } else { type_id }
+        }
+        Some(TypeData::Intersection(list_id)) => {
+            let members = db.type_list(list_id);
+            let mut changed = false;
+            let members: Vec<_> = members
+                .iter()
+                .map(|&member| {
+                    let substituted = substitute_exact_type_db(db, member, from, to, memo);
+                    changed |= substituted != member;
+                    substituted
+                })
+                .collect();
+            if changed {
+                db.intersection(members)
+            } else {
+                type_id
+            }
+        }
+        Some(TypeData::Array(element)) => {
+            let substituted = substitute_exact_type_db(db, element, from, to, memo);
+            if substituted != element {
+                db.array(substituted)
+            } else {
+                type_id
+            }
+        }
+        Some(TypeData::Tuple(elements_id)) => {
+            let elements = db.tuple_list(elements_id);
+            let mut changed = false;
+            let elements: Vec<_> = elements
+                .iter()
+                .map(|element| {
+                    let type_id = substitute_exact_type_db(db, element.type_id, from, to, memo);
+                    changed |= type_id != element.type_id;
+                    TupleElement {
+                        type_id,
+                        ..*element
+                    }
+                })
+                .collect();
+            if changed { db.tuple(elements) } else { type_id }
+        }
+        Some(TypeData::IndexAccess(object_type, index_type)) => {
+            let substituted_object = substitute_exact_type_db(db, object_type, from, to, memo);
+            let substituted_index = substitute_exact_type_db(db, index_type, from, to, memo);
+            if substituted_object != object_type || substituted_index != index_type {
+                db.index_access(substituted_object, substituted_index)
+            } else {
+                type_id
+            }
+        }
+        Some(TypeData::Conditional(cond_id)) => {
+            let cond = db.get_conditional(cond_id);
+            let check_type = substitute_exact_type_db(db, cond.check_type, from, to, memo);
+            let extends_type = substitute_exact_type_db(db, cond.extends_type, from, to, memo);
+            let true_type = substitute_exact_type_db(db, cond.true_type, from, to, memo);
+            let false_type = substitute_exact_type_db(db, cond.false_type, from, to, memo);
+            if check_type != cond.check_type
+                || extends_type != cond.extends_type
+                || true_type != cond.true_type
+                || false_type != cond.false_type
+            {
+                db.conditional(ConditionalType {
+                    check_type,
+                    extends_type,
+                    true_type,
+                    false_type,
+                    is_distributive: cond.is_distributive,
+                })
+            } else {
+                type_id
+            }
+        }
+        Some(TypeData::TemplateLiteral(template_id)) => {
+            let spans = db.template_list(template_id);
+            let mut changed = false;
+            let spans: Vec<_> = spans
+                .iter()
+                .map(|span| match span {
+                    TemplateSpan::Text(text) => TemplateSpan::Text(*text),
+                    TemplateSpan::Type(span_type) => {
+                        let substituted = substitute_exact_type_db(db, *span_type, from, to, memo);
+                        changed |= substituted != *span_type;
+                        TemplateSpan::Type(substituted)
+                    }
+                })
+                .collect();
+            if changed {
+                db.template_literal(spans)
+            } else {
+                type_id
+            }
+        }
+        Some(TypeData::KeyOf(inner)) => {
+            let substituted = substitute_exact_type_db(db, inner, from, to, memo);
+            if substituted != inner {
+                db.keyof(substituted)
+            } else {
+                type_id
+            }
+        }
+        Some(TypeData::ReadonlyType(inner)) => {
+            let substituted = substitute_exact_type_db(db, inner, from, to, memo);
+            if substituted != inner {
+                db.readonly_type(substituted)
+            } else {
+                type_id
+            }
+        }
+        Some(TypeData::NoInfer(inner)) => {
+            let substituted = substitute_exact_type_db(db, inner, from, to, memo);
+            if substituted != inner {
+                db.no_infer(substituted)
+            } else {
+                type_id
+            }
+        }
+        Some(TypeData::StringIntrinsic { kind, type_arg }) => {
+            let substituted = substitute_exact_type_db(db, type_arg, from, to, memo);
+            if substituted != type_arg {
+                db.string_intrinsic(kind, substituted)
+            } else {
+                type_id
+            }
+        }
+        // Object/Function/Mapped/etc. — substitution does not reach into
+        // these in the original method either; preserve behaviour.
+        _ => type_id,
+    };
+
+    memo.insert(type_id, result);
+    result
+}
 
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// Substitute every occurrence of `from` with `to` inside `type_id`.

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/substitute.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/substitute.rs
@@ -10,7 +10,9 @@
 
 use crate::caches::db::TypeDatabase;
 use crate::relations::subtype::TypeResolver;
-use crate::types::{ConditionalType, FunctionShape, TemplateSpan, TupleElement, TypeData, TypeId};
+use crate::types::{
+    ConditionalType, FunctionShape, ParamInfo, TemplateSpan, TupleElement, TypeData, TypeId,
+};
 use rustc_hash::FxHashMap;
 
 use super::super::evaluate::TypeEvaluator;
@@ -110,6 +112,47 @@ pub(crate) fn substitute_exact_type_db(
                 })
                 .collect();
             if changed { db.tuple(elements) } else { type_id }
+        }
+        Some(TypeData::Function(shape_id)) => {
+            let shape = db.function_shape(shape_id);
+            let mut changed = false;
+            let params = shape
+                .params
+                .iter()
+                .map(|param| {
+                    let type_id = substitute_exact_type_db(db, param.type_id, from, to, memo);
+                    changed |= type_id != param.type_id;
+                    ParamInfo { type_id, ..*param }
+                })
+                .collect();
+            let this_type = shape.this_type.map(|this_type| {
+                let substituted = substitute_exact_type_db(db, this_type, from, to, memo);
+                changed |= substituted != this_type;
+                substituted
+            });
+            let return_type = substitute_exact_type_db(db, shape.return_type, from, to, memo);
+            changed |= return_type != shape.return_type;
+            let type_predicate = shape.type_predicate.map(|mut predicate| {
+                if let Some(predicate_type) = predicate.type_id {
+                    let substituted = substitute_exact_type_db(db, predicate_type, from, to, memo);
+                    changed |= substituted != predicate_type;
+                    predicate.type_id = Some(substituted);
+                }
+                predicate
+            });
+            if changed {
+                db.function(FunctionShape {
+                    type_params: shape.type_params.clone(),
+                    params,
+                    this_type,
+                    return_type,
+                    type_predicate,
+                    is_constructor: shape.is_constructor,
+                    is_method: shape.is_method,
+                })
+            } else {
+                type_id
+            }
         }
         Some(TypeData::IndexAccess(object_type, index_type)) => {
             let substituted_object = substitute_exact_type_db(db, object_type, from, to, memo);
@@ -220,236 +263,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         to: TypeId,
         memo: &mut FxHashMap<TypeId, TypeId>,
     ) -> TypeId {
-        if type_id == from {
-            return to;
-        }
-        if type_id.is_intrinsic() {
-            return type_id;
-        }
-        // Check the memo before installing the cycle guard. `HashMap::insert`
-        // would overwrite a completed substitution with the guard value on a
-        // repeated visit, corrupting later lookups of shared hash-consed nodes.
-        if let Some(&cached) = memo.get(&type_id) {
-            return cached;
-        }
-        memo.insert(type_id, type_id);
-
-        let result = match self.interner().lookup(type_id) {
-            Some(TypeData::Application(app_id)) => {
-                let app = self.interner().type_application(app_id);
-                let base = self.substitute_exact_type(app.base, from, to, memo);
-                let mut changed = base != app.base;
-                let args: Vec<_> = app
-                    .args
-                    .iter()
-                    .map(|&arg| {
-                        let substituted = self.substitute_exact_type(arg, from, to, memo);
-                        changed |= substituted != arg;
-                        substituted
-                    })
-                    .collect();
-                if changed {
-                    self.interner().application(base, args)
-                } else {
-                    type_id
-                }
-            }
-            Some(TypeData::Union(list_id)) => {
-                let members = self.interner().type_list(list_id);
-                let mut changed = false;
-                let members: Vec<_> = members
-                    .iter()
-                    .map(|&member| {
-                        let substituted = self.substitute_exact_type(member, from, to, memo);
-                        changed |= substituted != member;
-                        substituted
-                    })
-                    .collect();
-                if changed {
-                    self.interner().union(members)
-                } else {
-                    type_id
-                }
-            }
-            Some(TypeData::Intersection(list_id)) => {
-                let members = self.interner().type_list(list_id);
-                let mut changed = false;
-                let members: Vec<_> = members
-                    .iter()
-                    .map(|&member| {
-                        let substituted = self.substitute_exact_type(member, from, to, memo);
-                        changed |= substituted != member;
-                        substituted
-                    })
-                    .collect();
-                if changed {
-                    self.interner().intersection(members)
-                } else {
-                    type_id
-                }
-            }
-            Some(TypeData::Array(element)) => {
-                let substituted = self.substitute_exact_type(element, from, to, memo);
-                if substituted != element {
-                    self.interner().array(substituted)
-                } else {
-                    type_id
-                }
-            }
-            Some(TypeData::Tuple(elements_id)) => {
-                let elements = self.interner().tuple_list(elements_id);
-                let mut changed = false;
-                let elements: Vec<_> = elements
-                    .iter()
-                    .map(|element| {
-                        let type_id = self.substitute_exact_type(element.type_id, from, to, memo);
-                        changed |= type_id != element.type_id;
-                        TupleElement {
-                            type_id,
-                            ..*element
-                        }
-                    })
-                    .collect();
-                if changed {
-                    self.interner().tuple(elements)
-                } else {
-                    type_id
-                }
-            }
-            Some(TypeData::Function(shape_id)) => {
-                let shape = self.interner().function_shape(shape_id);
-                let mut changed = false;
-                let params = shape
-                    .params
-                    .iter()
-                    .map(|param| {
-                        let type_id = self.substitute_exact_type(param.type_id, from, to, memo);
-                        changed |= type_id != param.type_id;
-                        crate::types::ParamInfo { type_id, ..*param }
-                    })
-                    .collect();
-                let this_type = shape.this_type.map(|this_type| {
-                    let substituted = self.substitute_exact_type(this_type, from, to, memo);
-                    changed |= substituted != this_type;
-                    substituted
-                });
-                let return_type = self.substitute_exact_type(shape.return_type, from, to, memo);
-                changed |= return_type != shape.return_type;
-                let type_predicate = shape.type_predicate.map(|mut predicate| {
-                    if let Some(predicate_type) = predicate.type_id {
-                        let substituted =
-                            self.substitute_exact_type(predicate_type, from, to, memo);
-                        changed |= substituted != predicate_type;
-                        predicate.type_id = Some(substituted);
-                    }
-                    predicate
-                });
-                if changed {
-                    self.interner().function(FunctionShape {
-                        type_params: shape.type_params.clone(),
-                        params,
-                        this_type,
-                        return_type,
-                        type_predicate,
-                        is_constructor: shape.is_constructor,
-                        is_method: shape.is_method,
-                    })
-                } else {
-                    type_id
-                }
-            }
-            Some(TypeData::IndexAccess(object_type, index_type)) => {
-                let substituted_object = self.substitute_exact_type(object_type, from, to, memo);
-                let substituted_index = self.substitute_exact_type(index_type, from, to, memo);
-                if substituted_object != object_type || substituted_index != index_type {
-                    self.interner()
-                        .index_access(substituted_object, substituted_index)
-                } else {
-                    type_id
-                }
-            }
-            Some(TypeData::Conditional(cond_id)) => {
-                let cond = self.interner().get_conditional(cond_id);
-                let check_type = self.substitute_exact_type(cond.check_type, from, to, memo);
-                let extends_type = self.substitute_exact_type(cond.extends_type, from, to, memo);
-                let true_type = self.substitute_exact_type(cond.true_type, from, to, memo);
-                let false_type = self.substitute_exact_type(cond.false_type, from, to, memo);
-                if check_type != cond.check_type
-                    || extends_type != cond.extends_type
-                    || true_type != cond.true_type
-                    || false_type != cond.false_type
-                {
-                    self.interner().conditional(ConditionalType {
-                        check_type,
-                        extends_type,
-                        true_type,
-                        false_type,
-                        is_distributive: cond.is_distributive,
-                    })
-                } else {
-                    type_id
-                }
-            }
-            Some(TypeData::TemplateLiteral(template_id)) => {
-                let spans = self.interner().template_list(template_id);
-                let mut changed = false;
-                let spans: Vec<_> = spans
-                    .iter()
-                    .map(|span| match span {
-                        TemplateSpan::Text(text) => TemplateSpan::Text(*text),
-                        TemplateSpan::Type(span_type) => {
-                            let substituted =
-                                self.substitute_exact_type(*span_type, from, to, memo);
-                            changed |= substituted != *span_type;
-                            TemplateSpan::Type(substituted)
-                        }
-                    })
-                    .collect();
-                if changed {
-                    self.interner().template_literal(spans)
-                } else {
-                    type_id
-                }
-            }
-            Some(TypeData::KeyOf(inner)) => {
-                let substituted = self.substitute_exact_type(inner, from, to, memo);
-                if substituted != inner {
-                    self.interner().keyof(substituted)
-                } else {
-                    type_id
-                }
-            }
-            Some(TypeData::ReadonlyType(inner)) => {
-                let substituted = self.substitute_exact_type(inner, from, to, memo);
-                if substituted != inner {
-                    self.interner().readonly_type(substituted)
-                } else {
-                    type_id
-                }
-            }
-            Some(TypeData::NoInfer(inner)) => {
-                let substituted = self.substitute_exact_type(inner, from, to, memo);
-                if substituted != inner {
-                    self.interner().no_infer(substituted)
-                } else {
-                    type_id
-                }
-            }
-            Some(TypeData::StringIntrinsic { kind, type_arg }) => {
-                let substituted = self.substitute_exact_type(type_arg, from, to, memo);
-                if substituted != type_arg {
-                    self.interner().string_intrinsic(kind, substituted)
-                } else {
-                    type_id
-                }
-            }
-            _ => type_id,
-        };
-
-        // Overwrite the cycle-guard placeholder with the real result so later
-        // visits to this shared hash-consed node return the substituted form.
-        memo.insert(type_id, result);
-        result
+        substitute_exact_type_db(self.interner(), type_id, from, to, memo)
     }
 }
 

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -1517,12 +1517,20 @@ impl<'a> TypeInstantiator<'a> {
                         }
                     };
                     if let Some((tuple_id, source_readonly)) = tuple_source {
+                        use crate::types::MappedModifier;
                         let elements = self.interner.tuple_list(tuple_id);
                         // Instantiate template first (substitutes T, keeps K shadowed).
                         // After this `new_template` holds the *resolved* source tuple
                         // wherever T appeared.
                         let new_template = self.instantiate(mapped.template);
                         self.exit_shadowing_scope(shadowed_len, saved_visiting);
+
+                        // Pre-bind modifier flags once; both fixed and rest paths
+                        // consume them below.
+                        let add_optional =
+                            matches!(mapped.optional_modifier, Some(MappedModifier::Add));
+                        let remove_optional =
+                            matches!(mapped.optional_modifier, Some(MappedModifier::Remove));
 
                         // Per-element rebinding mirrors tsc's
                         // `instantiateMappedTupleType`. The choice of (template, key)
@@ -1586,20 +1594,27 @@ impl<'a> TypeInstantiator<'a> {
                                 )
                             };
 
-                            let (rebound_template, key_type) = if let Some(rest_arr) =
-                                rest_array_inner
-                            {
-                                (rebind_source(rest_arr), TypeId::NUMBER)
-                            } else if elem.rest {
-                                (new_template, TypeId::NUMBER)
-                            } else if is_suffix {
-                                let proxy = self.interner.tuple(vec![
-                                    crate::types::TupleElement::fixed(elem.type_id),
-                                ]);
-                                (rebind_source(proxy), self.interner.literal_string("0"))
-                            } else {
-                                (new_template, self.interner.literal_string(&i.to_string()))
-                            };
+                            let (rebound_template, key_type, wrap_in_array) =
+                                if let Some(rest_arr) = rest_array_inner {
+                                    (rebind_source(rest_arr), TypeId::NUMBER, true)
+                                } else if elem.rest {
+                                    (new_template, TypeId::NUMBER, false)
+                                } else if is_suffix {
+                                    let proxy = self.interner.tuple(vec![
+                                        crate::types::TupleElement::fixed(elem.type_id),
+                                    ]);
+                                    (
+                                        rebind_source(proxy),
+                                        self.interner.literal_string("0"),
+                                        false,
+                                    )
+                                } else {
+                                    (
+                                        new_template,
+                                        self.interner.literal_string(&i.to_string()),
+                                        false,
+                                    )
+                                };
 
                             let subst = TypeSubstitution::single(mapped.type_param.name, key_type);
                             let mapped_type = crate::evaluation::evaluate::evaluate_type(
@@ -1607,7 +1622,7 @@ impl<'a> TypeInstantiator<'a> {
                                 instantiate_type(self.interner, rebound_template, &subst),
                             );
 
-                            let wrapped = if rest_array_inner.is_some() {
+                            let wrapped = if wrap_in_array {
                                 self.interner.array(mapped_type)
                             } else {
                                 mapped_type
@@ -1616,12 +1631,7 @@ impl<'a> TypeInstantiator<'a> {
                             // Rest elements absorb `Add` as `T | undefined` (a
                             // rest cannot syntactically combine with `?`); fixed
                             // elements toggle the per-element optional flag below.
-                            let final_type = if elem.rest
-                                && matches!(
-                                    mapped.optional_modifier,
-                                    Some(crate::types::MappedModifier::Add)
-                                )
-                            {
+                            let final_type = if elem.rest && add_optional {
                                 self.interner.union2(wrapped, TypeId::UNDEFINED)
                             } else {
                                 wrapped
@@ -1629,12 +1639,12 @@ impl<'a> TypeInstantiator<'a> {
 
                             let optional = if elem.rest {
                                 elem.optional
+                            } else if add_optional {
+                                true
+                            } else if remove_optional {
+                                false
                             } else {
-                                match mapped.optional_modifier {
-                                    Some(crate::types::MappedModifier::Add) => true,
-                                    Some(crate::types::MappedModifier::Remove) => false,
-                                    None => elem.optional,
-                                }
+                                elem.optional
                             };
 
                             new_elements.push(crate::types::TupleElement {

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -1544,65 +1544,59 @@ impl<'a> TypeInstantiator<'a> {
                                 seen_rest = true;
                             }
 
-                            // For rest elements with `Array<E>` (or
-                            // `readonly E[]`), rewrite the resolved source in
-                            // the template to `Array<E>` and bind K = number
-                            // so `(E[])[number]` = E. The result is wrapped in
-                            // `Array<>` below to keep the rest array-shaped.
-                            let rest_array_inner: Option<TypeId> = if elem.rest {
-                                match self.interner.lookup(elem.type_id) {
-                                    Some(TypeData::Array(_)) => Some(elem.type_id),
-                                    Some(TypeData::ReadonlyType(roi)) => {
-                                        match self.interner.lookup(roi) {
-                                            Some(TypeData::Array(_)) => Some(roi),
-                                            _ => None,
-                                        }
-                                    }
-                                    _ => None,
+                            // Decide how to rebind the resolved source and bind
+                            // K for this element. The cases mirror tsc's
+                            // `instantiateMappedTupleType`:
+                            //   - Rest of `Array<E>` / `readonly E[]`:
+                            //     rewrite the resolved source to `Array<E>`
+                            //     and bind K = number so `(E[])[number]` = E.
+                            //     The result is re-wrapped in `Array<>` below.
+                            //   - Opaque variadic (type parameter, lazy ref):
+                            //     bind K = number on the existing template;
+                            //     the deferred `T[K]` shape is preserved.
+                            //   - Fixed element after at least one rest
+                            //     (`is_suffix`): the numeric index on the full
+                            //     source is ambiguous, so rewrite the source
+                            //     to a single-element proxy and bind K = "0".
+                            //   - Fixed prefix element: bind K = "i".
+                            let rest_array_inner: Option<TypeId> = match (
+                                elem.rest,
+                                self.interner.lookup(elem.type_id),
+                            ) {
+                                (true, Some(TypeData::Array(_))) => Some(elem.type_id),
+                                (true, Some(TypeData::ReadonlyType(roi)))
+                                    if matches!(
+                                        self.interner.lookup(roi),
+                                        Some(TypeData::Array(_))
+                                    ) =>
+                                {
+                                    Some(roi)
                                 }
-                            } else {
-                                None
+                                _ => None,
                             };
 
-                            // For a fixed element after at least one rest, the
-                            // numeric index on the *full* source is ambiguous.
-                            // Rebind the resolved source to a single-element
-                            // proxy `[elem.type_id]` and bind K = "0" so
-                            // `([elem])["0"]` = elem unambiguously.
-                            let suffix_proxy: Option<TypeId> = if is_suffix {
-                                Some(self.interner.tuple(vec![
-                                    crate::types::TupleElement::fixed(elem.type_id),
-                                ]))
-                            } else {
-                                None
+                            let rebind_source = |new_source: TypeId| {
+                                let mut memo: FxHashMap<TypeId, TypeId> = FxHashMap::default();
+                                crate::evaluation::evaluate_rules::substitute::substitute_exact_type_db(
+                                    self.interner,
+                                    new_template,
+                                    resolved,
+                                    new_source,
+                                    &mut memo,
+                                )
                             };
 
                             let (rebound_template, key_type) = if let Some(rest_arr) =
                                 rest_array_inner
                             {
-                                let mut memo: FxHashMap<TypeId, TypeId> = FxHashMap::default();
-                                let rewritten = crate::evaluation::evaluate_rules::substitute::substitute_exact_type_db(
-                                    self.interner,
-                                    new_template,
-                                    /* from = */ resolved,
-                                    /* to   = */ rest_arr,
-                                    &mut memo,
-                                );
-                                (rewritten, TypeId::NUMBER)
+                                (rebind_source(rest_arr), TypeId::NUMBER)
                             } else if elem.rest {
-                                // Opaque variadic (type parameter, lazy ref, etc.):
-                                // keep `T[K]` deferred shape by binding K = number.
                                 (new_template, TypeId::NUMBER)
-                            } else if let Some(proxy) = suffix_proxy {
-                                let mut memo: FxHashMap<TypeId, TypeId> = FxHashMap::default();
-                                let rewritten = crate::evaluation::evaluate_rules::substitute::substitute_exact_type_db(
-                                    self.interner,
-                                    new_template,
-                                    /* from = */ resolved,
-                                    /* to   = */ proxy,
-                                    &mut memo,
-                                );
-                                (rewritten, self.interner.literal_string("0"))
+                            } else if is_suffix {
+                                let proxy = self.interner.tuple(vec![
+                                    crate::types::TupleElement::fixed(elem.type_id),
+                                ]);
+                                (rebind_source(proxy), self.interner.literal_string("0"))
                             } else {
                                 (new_template, self.interner.literal_string(&i.to_string()))
                             };

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -1525,13 +1525,6 @@ impl<'a> TypeInstantiator<'a> {
                         let new_template = self.instantiate(mapped.template);
                         self.exit_shadowing_scope(shadowed_len, saved_visiting);
 
-                        // Pre-bind modifier flags once; both fixed and rest paths
-                        // consume them below.
-                        let add_optional =
-                            matches!(mapped.optional_modifier, Some(MappedModifier::Add));
-                        let remove_optional =
-                            matches!(mapped.optional_modifier, Some(MappedModifier::Remove));
-
                         // Per-element rebinding mirrors tsc's
                         // `instantiateMappedTupleType`. The choice of (template, key)
                         // determines whether `T[K]` resolves to this element's own
@@ -1544,6 +1537,39 @@ impl<'a> TypeInstantiator<'a> {
                         //     the union of all element types, because `T["i"]` is
                         //     ambiguous when the rest range could be 0 or more
                         //     elements long.
+                        //
+                        // The four cases below mirror tsc's switch on per-element kind.
+                        enum ElemBinding {
+                            /// Rest of `Array<E>` / `readonly E[]` — rewrite the
+                            /// resolved source to `Array<E>` and bind K = number;
+                            /// the result must re-wrap in `Array<>` so the rest's
+                            /// type_id stays array-shaped.
+                            RestArray(TypeId),
+                            /// Rest of an opaque type (type parameter, lazy ref,
+                            /// etc.) — bind K = number on the existing template
+                            /// so the deferred `T[K]` shape is preserved.
+                            OpaqueRest,
+                            /// Fixed element after at least one rest — the
+                            /// numeric index on the full source is ambiguous, so
+                            /// rewrite the source to a single-element proxy and
+                            /// bind K = "0".
+                            SuffixFixed,
+                            /// Fixed element before any rest — the literal index
+                            /// resolves unambiguously, no rebinding needed.
+                            PrefixFixed,
+                        }
+
+                        let rebind_source = |new_source: TypeId| {
+                            let mut memo: FxHashMap<TypeId, TypeId> = FxHashMap::default();
+                            crate::evaluation::evaluate_rules::substitute::substitute_exact_type_db(
+                                self.interner,
+                                new_template,
+                                resolved,
+                                new_source,
+                                &mut memo,
+                            )
+                        };
+
                         let mut seen_rest = false;
                         let mut new_elements = Vec::with_capacity(elements.len());
                         for (i, elem) in elements.iter().enumerate() {
@@ -1552,69 +1578,38 @@ impl<'a> TypeInstantiator<'a> {
                                 seen_rest = true;
                             }
 
-                            // Decide how to rebind the resolved source and bind
-                            // K for this element. The cases mirror tsc's
-                            // `instantiateMappedTupleType`:
-                            //   - Rest of `Array<E>` / `readonly E[]`:
-                            //     rewrite the resolved source to `Array<E>`
-                            //     and bind K = number so `(E[])[number]` = E.
-                            //     The result is re-wrapped in `Array<>` below.
-                            //   - Opaque variadic (type parameter, lazy ref):
-                            //     bind K = number on the existing template;
-                            //     the deferred `T[K]` shape is preserved.
-                            //   - Fixed element after at least one rest
-                            //     (`is_suffix`): the numeric index on the full
-                            //     source is ambiguous, so rewrite the source
-                            //     to a single-element proxy and bind K = "0".
-                            //   - Fixed prefix element: bind K = "i".
-                            let rest_array_inner: Option<TypeId> = match (
-                                elem.rest,
-                                self.interner.lookup(elem.type_id),
-                            ) {
-                                (true, Some(TypeData::Array(_))) => Some(elem.type_id),
+                            let binding = match (elem.rest, self.interner.lookup(elem.type_id)) {
+                                (true, Some(TypeData::Array(_))) => {
+                                    ElemBinding::RestArray(elem.type_id)
+                                }
                                 (true, Some(TypeData::ReadonlyType(roi)))
                                     if matches!(
                                         self.interner.lookup(roi),
                                         Some(TypeData::Array(_))
                                     ) =>
                                 {
-                                    Some(roi)
+                                    ElemBinding::RestArray(roi)
                                 }
-                                _ => None,
+                                (true, _) => ElemBinding::OpaqueRest,
+                                (false, _) if is_suffix => ElemBinding::SuffixFixed,
+                                (false, _) => ElemBinding::PrefixFixed,
                             };
 
-                            let rebind_source = |new_source: TypeId| {
-                                let mut memo: FxHashMap<TypeId, TypeId> = FxHashMap::default();
-                                crate::evaluation::evaluate_rules::substitute::substitute_exact_type_db(
-                                    self.interner,
-                                    new_template,
-                                    resolved,
-                                    new_source,
-                                    &mut memo,
-                                )
-                            };
-
-                            let (rebound_template, key_type, wrap_in_array) =
-                                if let Some(rest_arr) = rest_array_inner {
-                                    (rebind_source(rest_arr), TypeId::NUMBER, true)
-                                } else if elem.rest {
-                                    (new_template, TypeId::NUMBER, false)
-                                } else if is_suffix {
+                            let (rebound_template, key_type) = match binding {
+                                ElemBinding::RestArray(rest_arr) => {
+                                    (rebind_source(rest_arr), TypeId::NUMBER)
+                                }
+                                ElemBinding::OpaqueRest => (new_template, TypeId::NUMBER),
+                                ElemBinding::SuffixFixed => {
                                     let proxy = self.interner.tuple(vec![
                                         crate::types::TupleElement::fixed(elem.type_id),
                                     ]);
-                                    (
-                                        rebind_source(proxy),
-                                        self.interner.literal_string("0"),
-                                        false,
-                                    )
-                                } else {
-                                    (
-                                        new_template,
-                                        self.interner.literal_string(&i.to_string()),
-                                        false,
-                                    )
-                                };
+                                    (rebind_source(proxy), self.interner.literal_string("0"))
+                                }
+                                ElemBinding::PrefixFixed => {
+                                    (new_template, self.interner.literal_string(&i.to_string()))
+                                }
+                            };
 
                             let subst = TypeSubstitution::single(mapped.type_param.name, key_type);
                             let mapped_type = crate::evaluation::evaluate::evaluate_type(
@@ -1622,33 +1617,36 @@ impl<'a> TypeInstantiator<'a> {
                                 instantiate_type(self.interner, rebound_template, &subst),
                             );
 
-                            let wrapped = if wrap_in_array {
-                                self.interner.array(mapped_type)
-                            } else {
-                                mapped_type
-                            };
-
-                            // Rest elements absorb `Add` as `T | undefined` (a
-                            // rest cannot syntactically combine with `?`); fixed
-                            // elements toggle the per-element optional flag below.
-                            let final_type = if elem.rest && add_optional {
-                                self.interner.union2(wrapped, TypeId::UNDEFINED)
-                            } else {
-                                wrapped
-                            };
-
-                            let optional = if elem.rest {
-                                elem.optional
-                            } else if add_optional {
-                                true
-                            } else if remove_optional {
-                                false
-                            } else {
-                                elem.optional
+                            // Re-wrap a `...E[]` rest in `Array<>`; absorb
+                            // `Add ?` on a rest as `T | undefined` (a rest can
+                            // not syntactically combine with `?`); apply the
+                            // optional modifier to fixed slots only.
+                            let (type_id, optional) = match (binding, mapped.optional_modifier) {
+                                (ElemBinding::RestArray(_), Some(MappedModifier::Add)) => (
+                                    self.interner.union2(
+                                        self.interner.array(mapped_type),
+                                        TypeId::UNDEFINED,
+                                    ),
+                                    elem.optional,
+                                ),
+                                (ElemBinding::RestArray(_), _) => {
+                                    (self.interner.array(mapped_type), elem.optional)
+                                }
+                                (
+                                    ElemBinding::OpaqueRest,
+                                    Some(MappedModifier::Add),
+                                ) => (
+                                    self.interner.union2(mapped_type, TypeId::UNDEFINED),
+                                    elem.optional,
+                                ),
+                                (ElemBinding::OpaqueRest, _) => (mapped_type, elem.optional),
+                                (_, Some(MappedModifier::Add)) => (mapped_type, true),
+                                (_, Some(MappedModifier::Remove)) => (mapped_type, false),
+                                (_, None) => (mapped_type, elem.optional),
                             };
 
                             new_elements.push(crate::types::TupleElement {
-                                type_id: final_type,
+                                type_id,
                                 name: elem.name,
                                 optional,
                                 rest: elem.rest,

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -1543,7 +1543,7 @@ impl<'a> TypeInstantiator<'a> {
                             /// Rest of `Array<E>` / `readonly E[]` — rewrite the
                             /// resolved source to `Array<E>` and bind K = number;
                             /// the result must re-wrap in `Array<>` so the rest's
-                            /// type_id stays array-shaped.
+                            /// `type_id` stays array-shaped.
                             RestArray(TypeId),
                             /// Rest of an opaque type (type parameter, lazy ref,
                             /// etc.) — bind K = number on the existing template
@@ -1639,10 +1639,11 @@ impl<'a> TypeInstantiator<'a> {
                                     self.interner.union2(mapped_type, TypeId::UNDEFINED),
                                     elem.optional,
                                 ),
-                                (ElemBinding::OpaqueRest, _) => (mapped_type, elem.optional),
+                                (ElemBinding::OpaqueRest, _) | (_, None) => {
+                                    (mapped_type, elem.optional)
+                                }
                                 (_, Some(MappedModifier::Add)) => (mapped_type, true),
                                 (_, Some(MappedModifier::Remove)) => (mapped_type, false),
-                                (_, None) => (mapped_type, elem.optional),
                             };
 
                             new_elements.push(crate::types::TupleElement {

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -1518,32 +1518,135 @@ impl<'a> TypeInstantiator<'a> {
                     };
                     if let Some((tuple_id, source_readonly)) = tuple_source {
                         let elements = self.interner.tuple_list(tuple_id);
-                        // Instantiate template first (substitutes T, keeps K shadowed)
+                        // Instantiate template first (substitutes T, keeps K shadowed).
+                        // After this `new_template` holds the *resolved* source tuple
+                        // wherever T appeared.
                         let new_template = self.instantiate(mapped.template);
                         self.exit_shadowing_scope(shadowed_len, saved_visiting);
 
+                        // Per-element rebinding mirrors tsc's
+                        // `instantiateMappedTupleType`. The choice of (template, key)
+                        // determines whether `T[K]` resolves to this element's own
+                        // type or the union of every element type. The naive
+                        // pre-fix loop bound K = "i" for every element, which:
+                        //   - dropped the Array<> wrapper from a rest element's
+                        //     type_id (producing structurally invalid tuples like
+                        //     `[string, ...number]`); and
+                        //   - silently widened any fixed element after a rest to
+                        //     the union of all element types, because `T["i"]` is
+                        //     ambiguous when the rest range could be 0 or more
+                        //     elements long.
+                        let mut seen_rest = false;
                         let mut new_elements = Vec::with_capacity(elements.len());
                         for (i, elem) in elements.iter().enumerate() {
-                            let key_type = self.interner.literal_string(&i.to_string());
+                            let is_suffix = seen_rest && !elem.rest;
+                            if elem.rest {
+                                seen_rest = true;
+                            }
+
+                            // For rest elements with `Array<E>` (or
+                            // `readonly E[]`), rewrite the resolved source in
+                            // the template to `Array<E>` and bind K = number
+                            // so `(E[])[number]` = E. The result is wrapped in
+                            // `Array<>` below to keep the rest array-shaped.
+                            let rest_array_inner: Option<TypeId> = if elem.rest {
+                                match self.interner.lookup(elem.type_id) {
+                                    Some(TypeData::Array(_)) => Some(elem.type_id),
+                                    Some(TypeData::ReadonlyType(roi)) => {
+                                        match self.interner.lookup(roi) {
+                                            Some(TypeData::Array(_)) => Some(roi),
+                                            _ => None,
+                                        }
+                                    }
+                                    _ => None,
+                                }
+                            } else {
+                                None
+                            };
+
+                            // For a fixed element after at least one rest, the
+                            // numeric index on the *full* source is ambiguous.
+                            // Rebind the resolved source to a single-element
+                            // proxy `[elem.type_id]` and bind K = "0" so
+                            // `([elem])["0"]` = elem unambiguously.
+                            let suffix_proxy: Option<TypeId> = if is_suffix {
+                                Some(self.interner.tuple(vec![
+                                    crate::types::TupleElement::fixed(elem.type_id),
+                                ]))
+                            } else {
+                                None
+                            };
+
+                            let (rebound_template, key_type) = if let Some(rest_arr) =
+                                rest_array_inner
+                            {
+                                let mut memo: FxHashMap<TypeId, TypeId> = FxHashMap::default();
+                                let rewritten = crate::evaluation::evaluate_rules::substitute::substitute_exact_type_db(
+                                    self.interner,
+                                    new_template,
+                                    /* from = */ resolved,
+                                    /* to   = */ rest_arr,
+                                    &mut memo,
+                                );
+                                (rewritten, TypeId::NUMBER)
+                            } else if elem.rest {
+                                // Opaque variadic (type parameter, lazy ref, etc.):
+                                // keep `T[K]` deferred shape by binding K = number.
+                                (new_template, TypeId::NUMBER)
+                            } else if let Some(proxy) = suffix_proxy {
+                                let mut memo: FxHashMap<TypeId, TypeId> = FxHashMap::default();
+                                let rewritten = crate::evaluation::evaluate_rules::substitute::substitute_exact_type_db(
+                                    self.interner,
+                                    new_template,
+                                    /* from = */ resolved,
+                                    /* to   = */ proxy,
+                                    &mut memo,
+                                );
+                                (rewritten, self.interner.literal_string("0"))
+                            } else {
+                                (new_template, self.interner.literal_string(&i.to_string()))
+                            };
+
                             let subst = TypeSubstitution::single(mapped.type_param.name, key_type);
                             let mapped_type = crate::evaluation::evaluate::evaluate_type(
                                 self.interner,
-                                instantiate_type(self.interner, new_template, &subst),
+                                instantiate_type(self.interner, rebound_template, &subst),
                             );
 
-                            let final_type = if matches!(
-                                mapped.optional_modifier,
-                                Some(crate::types::MappedModifier::Add)
-                            ) {
-                                self.interner.union2(mapped_type, TypeId::UNDEFINED)
+                            let wrapped = if rest_array_inner.is_some() {
+                                self.interner.array(mapped_type)
                             } else {
                                 mapped_type
+                            };
+
+                            // Rest elements absorb `Add` as `T | undefined` (a
+                            // rest cannot syntactically combine with `?`); fixed
+                            // elements toggle the per-element optional flag below.
+                            let final_type = if elem.rest
+                                && matches!(
+                                    mapped.optional_modifier,
+                                    Some(crate::types::MappedModifier::Add)
+                                )
+                            {
+                                self.interner.union2(wrapped, TypeId::UNDEFINED)
+                            } else {
+                                wrapped
+                            };
+
+                            let optional = if elem.rest {
+                                elem.optional
+                            } else {
+                                match mapped.optional_modifier {
+                                    Some(crate::types::MappedModifier::Add) => true,
+                                    Some(crate::types::MappedModifier::Remove) => false,
+                                    None => elem.optional,
+                                }
                             };
 
                             new_elements.push(crate::types::TupleElement {
                                 type_id: final_type,
                                 name: elem.name,
-                                optional: elem.optional,
+                                optional,
                                 rest: elem.rest,
                             });
                         }

--- a/crates/tsz-solver/tests/instantiate_tests_parts/part_01.rs
+++ b/crates/tsz-solver/tests/instantiate_tests_parts/part_01.rs
@@ -460,86 +460,69 @@ fn build_identity_mapped_type(
     (mapped, t_name)
 }
 
+/// Assert that the identity homomorphic mapped
+/// `{ [<iter_name> in keyof T]: T[<iter_name>] }` round-trips the
+/// `build_elements`-built tuple `T` through the `instantiate_type` →
+/// `evaluate_type` pipeline. The closure receives the interner so the
+/// element `TypeId`s are interned in the same arena as the mapped type.
+fn assert_identity_mapped_round_trips(
+    iter_name: &str,
+    build_elements: impl FnOnce(&TypeInterner) -> Vec<crate::types::TupleElement>,
+) {
+    use crate::evaluation::evaluate::evaluate_type;
+    let interner = TypeInterner::new();
+    let (mapped, t_name) = build_identity_mapped_type(&interner, iter_name);
+    let source = interner.tuple(build_elements(&interner));
+    let mut subst = TypeSubstitution::new();
+    subst.insert(t_name, source);
+    let instantiated = instantiate_type(&interner, mapped, &subst);
+    let result = evaluate_type(&interner, instantiated);
+    assert_eq!(
+        result, source,
+        "identity homomorphic mapped over the source tuple must \
+         reproduce the same tuple via the instantiate path"
+    );
+}
+
 /// `Mp<[string, ...number[]]>` must produce the same `[string, ...number[]]`
 /// tuple. The pre-fix path bound K = "i" for every position and copied the
 /// rest's inner element type into the rest slot, producing the structurally
 /// invalid `[string, ...number]` (rest with non-array type_id).
 #[test]
 fn test_instantiate_mapped_over_trailing_rest_tuple_preserves_array_rest() {
-    use crate::evaluation::evaluate::evaluate_type;
     use crate::types::TupleElement;
-
-    let interner = TypeInterner::new();
-    let (mapped, t_name) = build_identity_mapped_type(&interner, "K");
-
-    let source = interner.tuple(vec![
-        TupleElement::fixed(TypeId::STRING),
-        TupleElement::rest(interner.array(TypeId::NUMBER)),
-    ]);
-
-    let mut subst = TypeSubstitution::new();
-    subst.insert(t_name, source);
-    let instantiated = instantiate_type(&interner, mapped, &subst);
-    let result = evaluate_type(&interner, instantiated);
-
-    assert_eq!(
-        result, source,
-        "identity homomorphic mapped over `[string, ...number[]]` must \
-         reproduce the same tuple via the instantiate path"
-    );
+    assert_identity_mapped_round_trips("K", |i| {
+        vec![
+            TupleElement::fixed(TypeId::STRING),
+            TupleElement::rest(i.array(TypeId::NUMBER)),
+        ]
+    });
 }
 
 /// Renamed iteration variable (`P` instead of `K`). The fix must be
 /// name-blind — changing the iter var must not affect rest handling.
 #[test]
 fn test_instantiate_mapped_over_trailing_rest_tuple_renamed_iter_var() {
-    use crate::evaluation::evaluate::evaluate_type;
     use crate::types::TupleElement;
-
-    let interner = TypeInterner::new();
-    let (mapped, t_name) = build_identity_mapped_type(&interner, "P");
-
-    let source = interner.tuple(vec![
-        TupleElement::fixed(TypeId::BOOLEAN),
-        TupleElement::rest(interner.array(TypeId::STRING)),
-    ]);
-
-    let mut subst = TypeSubstitution::new();
-    subst.insert(t_name, source);
-    let instantiated = instantiate_type(&interner, mapped, &subst);
-    let result = evaluate_type(&interner, instantiated);
-
-    assert_eq!(
-        result, source,
-        "rest-array shape must round-trip independent of iter var name"
-    );
+    assert_identity_mapped_round_trips("P", |i| {
+        vec![
+            TupleElement::fixed(TypeId::BOOLEAN),
+            TupleElement::rest(i.array(TypeId::STRING)),
+        ]
+    });
 }
 
 /// Leading rest: `[...string[], number]` must round-trip too. The fix
 /// must work whether the rest is at the start, middle, or end.
 #[test]
 fn test_instantiate_mapped_over_leading_rest_tuple_preserves_shape() {
-    use crate::evaluation::evaluate::evaluate_type;
     use crate::types::TupleElement;
-
-    let interner = TypeInterner::new();
-    let (mapped, t_name) = build_identity_mapped_type(&interner, "K");
-
-    let source = interner.tuple(vec![
-        TupleElement::rest(interner.array(TypeId::STRING)),
-        TupleElement::fixed(TypeId::NUMBER),
-    ]);
-
-    let mut subst = TypeSubstitution::new();
-    subst.insert(t_name, source);
-    let instantiated = instantiate_type(&interner, mapped, &subst);
-    let result = evaluate_type(&interner, instantiated);
-
-    assert_eq!(
-        result, source,
-        "identity homomorphic mapped over `[...string[], number]` must \
-         reproduce the same tuple via the instantiate path"
-    );
+    assert_identity_mapped_round_trips("K", |i| {
+        vec![
+            TupleElement::rest(i.array(TypeId::STRING)),
+            TupleElement::fixed(TypeId::NUMBER),
+        ]
+    });
 }
 
 /// Middle rest with prefix and suffix: `[string, ...number[], boolean]`.
@@ -547,28 +530,14 @@ fn test_instantiate_mapped_over_leading_rest_tuple_preserves_shape() {
 /// every element type.
 #[test]
 fn test_instantiate_mapped_over_middle_rest_tuple_preserves_shape() {
-    use crate::evaluation::evaluate::evaluate_type;
     use crate::types::TupleElement;
-
-    let interner = TypeInterner::new();
-    let (mapped, t_name) = build_identity_mapped_type(&interner, "K");
-
-    let source = interner.tuple(vec![
-        TupleElement::fixed(TypeId::STRING),
-        TupleElement::rest(interner.array(TypeId::NUMBER)),
-        TupleElement::fixed(TypeId::BOOLEAN),
-    ]);
-
-    let mut subst = TypeSubstitution::new();
-    subst.insert(t_name, source);
-    let instantiated = instantiate_type(&interner, mapped, &subst);
-    let result = evaluate_type(&interner, instantiated);
-
-    assert_eq!(
-        result, source,
-        "identity homomorphic mapped over `[string, ...number[], boolean]` \
-         must reproduce the same tuple via the instantiate path"
-    );
+    assert_identity_mapped_round_trips("K", |i| {
+        vec![
+            TupleElement::fixed(TypeId::STRING),
+            TupleElement::rest(i.array(TypeId::NUMBER)),
+            TupleElement::fixed(TypeId::BOOLEAN),
+        ]
+    });
 }
 
 /// Wrapper template `{ value: T[K] }` over a variadic tuple. Each fixed

--- a/crates/tsz-solver/tests/instantiate_tests_parts/part_01.rs
+++ b/crates/tsz-solver/tests/instantiate_tests_parts/part_01.rs
@@ -421,8 +421,8 @@ fn test_instantiate_mapped_over_tuple_with_wrapper_template() {
 // =============================================================================
 
 /// Helper: build the `{ [K in keyof T]: T[K] }` identity homomorphic mapped
-/// where the iteration variable is named `iter_name`. Returns the MappedType
-/// TypeId so the test can instantiate it with `T = ...`.
+/// where the iteration variable is named `iter_name`. Returns the `MappedType`
+/// `TypeId` so the test can instantiate it with `T = ...`.
 fn build_identity_mapped_type(
     interner: &TypeInterner,
     iter_name: &str,
@@ -487,7 +487,7 @@ fn assert_identity_mapped_round_trips(
 /// `Mp<[string, ...number[]]>` must produce the same `[string, ...number[]]`
 /// tuple. The pre-fix path bound K = "i" for every position and copied the
 /// rest's inner element type into the rest slot, producing the structurally
-/// invalid `[string, ...number]` (rest with non-array type_id).
+/// invalid `[string, ...number]` (rest with non-array `type_id`).
 #[test]
 fn test_instantiate_mapped_over_trailing_rest_tuple_preserves_array_rest() {
     use crate::types::TupleElement;

--- a/crates/tsz-solver/tests/instantiate_tests_parts/part_01.rs
+++ b/crates/tsz-solver/tests/instantiate_tests_parts/part_01.rs
@@ -404,6 +404,252 @@ fn test_instantiate_mapped_over_tuple_with_wrapper_template() {
 }
 
 // =============================================================================
+// Variadic-tuple instantiation of homomorphic mapped types.
+//
+// Structural rule: when `{ [K in keyof T]: T[K] }` is instantiated with a
+// variadic tuple source, the result must preserve each element's flags
+// (fixed / optional / rest), each rest element's type must remain array-
+// shaped (`...E[]` stays as `...E[]`, not `...E`), and each element's mapped
+// type must come from that element's own position, not from the union of
+// every element type.
+//
+// These tests cover the `instantiate_type` -> `evaluate_type` round-trip
+// (the instantiator's fast path for `keyof T` mapped types over tuples), not
+// the `evaluate_mapped` path alone. They sit alongside
+// `test_instantiate_mapped_over_tuple_preserves_tuple` and the wrapper-
+// template test above.
+// =============================================================================
+
+/// Helper: build the `{ [K in keyof T]: T[K] }` identity homomorphic mapped
+/// where the iteration variable is named `iter_name`. Returns the MappedType
+/// TypeId so the test can instantiate it with `T = ...`.
+fn build_identity_mapped_type(
+    interner: &TypeInterner,
+    iter_name: &str,
+) -> (TypeId, tsz_common::interner::Atom) {
+    use crate::types::{MappedType, TypeParamInfo};
+    let t_name = interner.intern_string("T");
+    let k_name = interner.intern_string(iter_name);
+
+    let t_param_info = TypeParamInfo {
+        name: t_name,
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let t_type = interner.intern(TypeData::TypeParameter(t_param_info));
+
+    let keyof_t = interner.keyof(t_type);
+    let k_param_info = TypeParamInfo {
+        name: k_name,
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let k_type = interner.intern(TypeData::TypeParameter(k_param_info));
+    let template = interner.index_access(t_type, k_type);
+
+    let mapped = interner.mapped(MappedType {
+        type_param: k_param_info,
+        constraint: keyof_t,
+        name_type: None,
+        template,
+        readonly_modifier: None,
+        optional_modifier: None,
+    });
+    (mapped, t_name)
+}
+
+/// `Mp<[string, ...number[]]>` must produce the same `[string, ...number[]]`
+/// tuple. The pre-fix path bound K = "i" for every position and copied the
+/// rest's inner element type into the rest slot, producing the structurally
+/// invalid `[string, ...number]` (rest with non-array type_id).
+#[test]
+fn test_instantiate_mapped_over_trailing_rest_tuple_preserves_array_rest() {
+    use crate::evaluation::evaluate::evaluate_type;
+    use crate::types::TupleElement;
+
+    let interner = TypeInterner::new();
+    let (mapped, t_name) = build_identity_mapped_type(&interner, "K");
+
+    let source = interner.tuple(vec![
+        TupleElement::fixed(TypeId::STRING),
+        TupleElement::rest(interner.array(TypeId::NUMBER)),
+    ]);
+
+    let mut subst = TypeSubstitution::new();
+    subst.insert(t_name, source);
+    let instantiated = instantiate_type(&interner, mapped, &subst);
+    let result = evaluate_type(&interner, instantiated);
+
+    assert_eq!(
+        result, source,
+        "identity homomorphic mapped over `[string, ...number[]]` must \
+         reproduce the same tuple via the instantiate path"
+    );
+}
+
+/// Renamed iteration variable (`P` instead of `K`). The fix must be
+/// name-blind — changing the iter var must not affect rest handling.
+#[test]
+fn test_instantiate_mapped_over_trailing_rest_tuple_renamed_iter_var() {
+    use crate::evaluation::evaluate::evaluate_type;
+    use crate::types::TupleElement;
+
+    let interner = TypeInterner::new();
+    let (mapped, t_name) = build_identity_mapped_type(&interner, "P");
+
+    let source = interner.tuple(vec![
+        TupleElement::fixed(TypeId::BOOLEAN),
+        TupleElement::rest(interner.array(TypeId::STRING)),
+    ]);
+
+    let mut subst = TypeSubstitution::new();
+    subst.insert(t_name, source);
+    let instantiated = instantiate_type(&interner, mapped, &subst);
+    let result = evaluate_type(&interner, instantiated);
+
+    assert_eq!(
+        result, source,
+        "rest-array shape must round-trip independent of iter var name"
+    );
+}
+
+/// Leading rest: `[...string[], number]` must round-trip too. The fix
+/// must work whether the rest is at the start, middle, or end.
+#[test]
+fn test_instantiate_mapped_over_leading_rest_tuple_preserves_shape() {
+    use crate::evaluation::evaluate::evaluate_type;
+    use crate::types::TupleElement;
+
+    let interner = TypeInterner::new();
+    let (mapped, t_name) = build_identity_mapped_type(&interner, "K");
+
+    let source = interner.tuple(vec![
+        TupleElement::rest(interner.array(TypeId::STRING)),
+        TupleElement::fixed(TypeId::NUMBER),
+    ]);
+
+    let mut subst = TypeSubstitution::new();
+    subst.insert(t_name, source);
+    let instantiated = instantiate_type(&interner, mapped, &subst);
+    let result = evaluate_type(&interner, instantiated);
+
+    assert_eq!(
+        result, source,
+        "identity homomorphic mapped over `[...string[], number]` must \
+         reproduce the same tuple via the instantiate path"
+    );
+}
+
+/// Middle rest with prefix and suffix: `[string, ...number[], boolean]`.
+/// Both fixed elements must resolve to their own types, not the union of
+/// every element type.
+#[test]
+fn test_instantiate_mapped_over_middle_rest_tuple_preserves_shape() {
+    use crate::evaluation::evaluate::evaluate_type;
+    use crate::types::TupleElement;
+
+    let interner = TypeInterner::new();
+    let (mapped, t_name) = build_identity_mapped_type(&interner, "K");
+
+    let source = interner.tuple(vec![
+        TupleElement::fixed(TypeId::STRING),
+        TupleElement::rest(interner.array(TypeId::NUMBER)),
+        TupleElement::fixed(TypeId::BOOLEAN),
+    ]);
+
+    let mut subst = TypeSubstitution::new();
+    subst.insert(t_name, source);
+    let instantiated = instantiate_type(&interner, mapped, &subst);
+    let result = evaluate_type(&interner, instantiated);
+
+    assert_eq!(
+        result, source,
+        "identity homomorphic mapped over `[string, ...number[], boolean]` \
+         must reproduce the same tuple via the instantiate path"
+    );
+}
+
+/// Wrapper template `{ value: T[K] }` over a variadic tuple. Each fixed
+/// element should map to `{ value: <element type> }` and the rest should
+/// stay array-shaped as `...{ value: number }[]`.
+#[test]
+fn test_instantiate_mapped_over_trailing_rest_tuple_with_wrapper_template() {
+    use crate::evaluation::evaluate::evaluate_type;
+    use crate::types::{MappedType, PropertyInfo, TupleElement, TypeParamInfo};
+
+    let interner = TypeInterner::new();
+    let t_name = interner.intern_string("T");
+    let k_name = interner.intern_string("K");
+
+    let t_param_info = TypeParamInfo {
+        name: t_name,
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let t_type = interner.intern(TypeData::TypeParameter(t_param_info));
+
+    let keyof_t = interner.keyof(t_type);
+    let k_param_info = TypeParamInfo {
+        name: k_name,
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let k_type = interner.intern(TypeData::TypeParameter(k_param_info));
+
+    let index_access = interner.index_access(t_type, k_type);
+    let value_atom = interner.intern_string("value");
+    let template = interner.object(vec![PropertyInfo::new(value_atom, index_access)]);
+
+    let mapped = interner.mapped(MappedType {
+        type_param: k_param_info,
+        constraint: keyof_t,
+        name_type: None,
+        template,
+        readonly_modifier: None,
+        optional_modifier: None,
+    });
+
+    let source = interner.tuple(vec![
+        TupleElement::fixed(TypeId::STRING),
+        TupleElement::rest(interner.array(TypeId::NUMBER)),
+    ]);
+
+    let mut subst = TypeSubstitution::new();
+    subst.insert(t_name, source);
+    let instantiated = instantiate_type(&interner, mapped, &subst);
+    let result = evaluate_type(&interner, instantiated);
+
+    match interner.lookup(result) {
+        Some(TypeData::Tuple(tuple_id)) => {
+            let elements = interner.tuple_list(tuple_id);
+            assert_eq!(elements.len(), 2, "Expected 2 tuple elements");
+            assert!(
+                !elements[0].rest,
+                "first element of `[string, ...number[]]` should be fixed"
+            );
+            assert!(
+                elements[1].rest,
+                "second element should preserve `rest: true`"
+            );
+            // The rest element's type_id must be Array(...) so the tuple
+            // is structurally valid.
+            assert!(
+                matches!(interner.lookup(elements[1].type_id), Some(TypeData::Array(_))),
+                "rest element type_id must remain Array<>; got {:?}",
+                interner.lookup(elements[1].type_id)
+            );
+        }
+        other => panic!(
+            "expected wrapper-mapped over variadic tuple to stay a tuple; got {other:?}"
+        ),
+    }
+}
+
+// =============================================================================
 // Tests for template_has_lazy_application_in_composite and
 // type_contains_lazy_application (new helper for Conditional check/extends)
 // =============================================================================


### PR DESCRIPTION
AgentName: Studio-B

## Summary

Fixes #10850. Instantiating a homomorphic mapped type
`{ [K in keyof T]: ... }` over a variadic tuple `T` produced structurally
invalid output:

- A rest element whose source type was `Array<E>` had its `type_id` set to the
  bare `E` (the value of `T[number]`) instead of the array form, so the
  interned tuple became the structurally invalid `[..., ...E]` instead of
  `[..., ...E[]]` (e.g. `Mp<[string, ...number[]]>` rendered as
  `[string, ...number]`).
- For rest elements, K was bound to the source position's literal string. On a
  tuple with a rest in the middle, the same position index is ambiguous (the
  rest range can be 0 or more elements long), so a fixed element after the
  rest widened to the union of every element type.

## Structural rule

When instantiating a homomorphic mapped type
`{ [K in keyof T]: ... }` over a tuple source, `T[K]` for each tuple
position must resolve to that position's *own* type, not the union of
every element type. Mirroring tsc's `instantiateMappedTupleType`:

- Rest of `Array<E>` / `readonly E[]`: rewrite the resolved source in
  the template to `Array<E>` and bind `K = number` so `(E[])[number] = E`,
  then wrap the result in `Array<>` so the rest stays array-shaped.
- Rest of an opaque type (type parameter, lazy ref): bind `K = number`;
  the deferred indexed-access shape is preserved.
- Fixed element after at least one rest: rewrite the resolved source to
  a single-element proxy `[elem]` and bind `K = "0"` so `([elem])["0"]`
  resolves unambiguously.
- Fixed prefix element: bind `K = "i"` as before.

## Adjacent-case coverage

The fix is name-blind (iter var spelling), shape-general (leading,
trailing, middle rest), and covers both identity and wrapper templates.
New unit tests in `crates/tsz-solver/tests/instantiate_tests_parts/part_01.rs`:

- `test_instantiate_mapped_over_trailing_rest_tuple_preserves_array_rest`
- `test_instantiate_mapped_over_trailing_rest_tuple_renamed_iter_var`
- `test_instantiate_mapped_over_leading_rest_tuple_preserves_shape`
- `test_instantiate_mapped_over_middle_rest_tuple_preserves_shape`
- `test_instantiate_mapped_over_trailing_rest_tuple_with_wrapper_template`

The four "preserves shape" cases use a shared `assert_identity_mapped_round_trips`
helper to keep the tests legible.

## Code organization

The instantiation-side per-element rebind needs the same exact-type
substitution as the evaluator's `substitute_exact_type`, so this PR
extracts that walk to a `TypeDatabase`-only free function
`substitute_exact_type_db` and has the existing impl method delegate to
it. Behaviour is unchanged for callers of the method, and the function
arms now live in exactly one place.

The per-element loop is driven by an `ElemBinding` enum (`RestArray`,
`OpaqueRest`, `SuffixFixed`, `PrefixFixed`) so the `(template, key)`
rebind and the `(type_id, optional)` modifier/wrap steps both come off
the same match: each per-element decision lives in one place keyed by
the variant.

## Verification

* `cargo test -p tsz-solver --lib instantiate_mapped` - all 9
  instantiate-mapped tests pass, including the 5 new variadic-tuple tests
  and the 4 pre-existing ones.
* `cargo test -p tsz-solver --lib variadic identity_homomorphic mapped tuple` -
  all green.
* `cargo test -p tsz-checker --test variadic_tuple_arity_inference_tests
  --test variadic_tuple_recursive_zip_tests` - green.
* CLI repros from issue #10850 and adjacent variadic shapes
  (`Mp<[string, ...number[]]>`, `Mp<[...number[], string]>`,
  `Mp<[string, ...number[], boolean]>`, recursive Zip) all type-check
  cleanly.
* The eight pre-existing solver lib failures
  (template-literal/widening, generic contextual callbacks) are
  unchanged on this branch - they reproduce on `main`.
* Studio-B lint-only follow-up for run `26795877710` / job `78992021340`:
  fixed `clippy::doc_markdown` and `clippy::match_same_arms` only in
  `crates/tsz-solver/src/instantiation/instantiate.rs` and
  `crates/tsz-solver/tests/instantiate_tests_parts/part_01.rs`.
  Cheap local verification: `cargo fmt --check`; `git diff --check`.
  New head: `4e942cea59b2aaa4e3728c994c562c9362732b13`.

## Project Corpus Impact

- Row: vite-vanilla-ts-app (issue #10850 row witness)
- Bug family: variadic tuple arity inference / homomorphic mapped over tuple
- Evidence: minimised `Mp<[string, ...number[]]>` repro now type-checks
  (tsc OK / tsz OK); 5 new solver-lib unit tests cover trailing/leading/middle
  rest, renamed iter var, and wrapper template.

## Deferred follow-up

A round-3 altitude review flagged that the instantiator's per-element
rebind is structurally a sibling of `evaluate_mapped_tuple_element` in
`evaluation/evaluate_rules/mapped_array.rs`. Lifting that helper plus
`evaluate_mapped_template_with_source_rebind` and `rebind_mapped_source`
to `&dyn TypeDatabase` free functions would let both call sites delegate,
closing latent gaps for variadic-tuple-spread rests, deferred opaque
`T[i]`, and `strip_removed_optional_undefined`. None of those gaps
regressed in this diff; they predate it. Tracking as follow-up work.

## Coordination Notes

- Track: bug fix / solver / variadic tuples
- Invariant: tsc parity for `instantiateMappedTupleType`
- Scope: `crates/tsz-solver/src/instantiation/instantiate.rs`,
  `crates/tsz-solver/src/evaluation/evaluate_rules/substitute.rs`,
  `crates/tsz-solver/src/evaluation/evaluate_rules/mod.rs`,
  `crates/tsz-solver/tests/instantiate_tests_parts/part_01.rs`
- Branch: `claude/confident-thompson-ie1GO`
- Studio-B pushed lint-only head `4e942cea59b2aaa4e3728c994c562c9362732b13`.
  PR-head CI will rerun automatically from the push; no jobs were manually
  rerun, and labels/ready state/merge queue were not touched.

## Test plan

- [ ] CI conformance / emit / fourslash / WASM stay green on ready PR.
- [ ] Spot-check `cargo test -p tsz-solver --lib instantiate_mapped` after merge.
- [ ] No new failures in checker variadic-tuple suites.

https://claude.ai/code/session_019PTuczQe72Tnvp3PGZSKcu
