### PR TITLE
refactor(lsp): classify json-rpc dispatch lifecycle

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_lsp.rs
+++ b/crates/tsz-cli/src/bin/tsz_lsp.rs
@@ -1633,6 +1633,48 @@ mod tests {
         );
     }
 
+    #[test]
+    fn dispatch_handles_known_notifications_without_response() {
+        let mut server = LspServer::new();
+        let response = server.handle_message(JsonRpcMessage {
+            id: None,
+            method: Some("initialized".to_string()),
+            params: None,
+        });
+
+        assert!(response.is_none());
+        assert!(server.initialized);
+    }
+
+    #[test]
+    fn dispatch_reports_unknown_request_methods() {
+        let mut server = LspServer::new();
+        let response = server
+            .handle_message(JsonRpcMessage {
+                id: Some(json!(7)),
+                method: Some("workspace/notImplemented".to_string()),
+                params: None,
+            })
+            .expect("unknown requests should produce method-not-found responses");
+
+        assert_eq!(response.id, json!(7));
+        let error = response.error.expect("unknown request should be an error");
+        assert_eq!(error.code, -32601);
+        assert_eq!(error.message, "Method not found: workspace/notImplemented");
+    }
+
+    #[test]
+    fn dispatch_ignores_methodless_response_messages() {
+        let mut server = LspServer::new();
+        let response = server.handle_message(JsonRpcMessage {
+            id: Some(json!(1)),
+            method: None,
+            params: None,
+        });
+
+        assert!(response.is_none());
+    }
+
     // Issue #3545: tsz.applyCodeAction must enqueue workspace/applyEdit as a
     // server-to-client REQUEST (with `id`), not a notification. LSP spec
     // requires the client to respond with `ApplyWorkspaceEditResponse`.

--- a/crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_dispatch.rs
+++ b/crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_dispatch.rs
@@ -1,223 +1,284 @@
 use super::*;
 
+enum JsonRpcMessageLifecycle {
+    Notification {
+        method: String,
+        params: Option<Value>,
+    },
+    Request {
+        id: Option<Value>,
+        method: String,
+        params: Option<Value>,
+    },
+    Response,
+}
+
+impl JsonRpcMessageLifecycle {
+    fn classify(msg: JsonRpcMessage) -> Self {
+        let Some(method) = msg.method else {
+            return Self::Response;
+        };
+
+        if LspServer::is_notification_method(&method) {
+            return Self::Notification {
+                method,
+                params: msg.params,
+            };
+        }
+
+        Self::Request {
+            id: msg.id,
+            method,
+            params: msg.params,
+        }
+    }
+}
+
 impl LspServer {
     // ─── Message dispatch ───────────────────────────────────────────────
 
     pub(super) fn handle_message(&mut self, msg: JsonRpcMessage) -> Option<JsonRpcResponse> {
-        let method = msg.method.as_deref();
-        let id = msg.id.clone();
-
-        if let Some(method) = method
-            && self.handle_notification_method(method, msg.params.clone())
-        {
-            return None;
+        match JsonRpcMessageLifecycle::classify(msg) {
+            JsonRpcMessageLifecycle::Notification { method, params } => {
+                self.handle_notification_method(&method, params);
+                None
+            }
+            JsonRpcMessageLifecycle::Request { id, method, params } => {
+                self.handle_request_message(id, &method, params)
+            }
+            JsonRpcMessageLifecycle::Response => None,
         }
+    }
 
-        // Check if this request was already cancelled
-        if self.is_cancelled(&id)
-            && let Some(id_val) = id
-        {
-            let id_str = match &id_val {
-                Value::Number(n) => n.to_string(),
-                Value::String(s) => s.clone(),
-                _ => String::new(),
-            };
-            self.cancelled_requests.remove(&id_str);
+    fn handle_request_message(
+        &mut self,
+        id: Option<Value>,
+        method: &str,
+        params: Option<Value>,
+    ) -> Option<JsonRpcResponse> {
+        if let Some(cancelled_id) = self.take_cancelled_request_id(&id) {
             return Some(self.error_response(
-                Some(id_val),
+                Some(cancelled_id),
                 -32800,
                 "Request cancelled".to_string(),
             ));
         }
 
+        self.handle_request_method(id, method, params)
+    }
+
+    fn take_cancelled_request_id(&mut self, id: &Option<Value>) -> Option<Value> {
+        if !self.is_cancelled(id) {
+            return None;
+        }
+
+        if let Some(id_val) = id {
+            let id_str = match id_val {
+                Value::Number(n) => n.to_string(),
+                Value::String(s) => s.clone(),
+                _ => String::new(),
+            };
+            self.cancelled_requests.remove(&id_str);
+            Some(id_val.clone())
+        } else {
+            None
+        }
+    }
+
+    fn handle_request_method(
+        &mut self,
+        id: Option<Value>,
+        method: &str,
+        params: Option<Value>,
+    ) -> Option<JsonRpcResponse> {
         match method {
-            Some("initialize") => {
-                let result = self.handle_initialize(msg.params.as_ref());
+            "initialize" => {
+                let result = self.handle_initialize(params.as_ref());
                 Some(self.success_response(id, result))
             }
-            Some("shutdown") => {
+            "shutdown" => {
                 self.shutdown_requested = true;
                 Some(self.success_response(id, Value::Null))
             }
 
             // ── Language features ───────────────────────────────────────
-            Some("textDocument/hover") => {
-                let r = self.handle_hover(msg.params);
+            "textDocument/hover" => {
+                let r = self.handle_hover(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/completion") => {
-                let r = self.handle_completion(msg.params);
+            "textDocument/completion" => {
+                let r = self.handle_completion(params);
                 Some(self.make_response(id, r))
             }
-            Some("completionItem/resolve") => {
-                let r = self.handle_completion_resolve(msg.params);
+            "completionItem/resolve" => {
+                let r = self.handle_completion_resolve(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/definition") | Some("textDocument/declaration") => {
-                let r = self.handle_definition(msg.params);
+            "textDocument/definition" | "textDocument/declaration" => {
+                let r = self.handle_definition(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/typeDefinition") => {
-                let r = self.handle_type_definition(msg.params);
+            "textDocument/typeDefinition" => {
+                let r = self.handle_type_definition(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/references") => {
-                let r = self.handle_references(msg.params);
+            "textDocument/references" => {
+                let r = self.handle_references(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/implementation") => {
-                let r = self.handle_implementation(msg.params);
+            "textDocument/implementation" => {
+                let r = self.handle_implementation(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/documentSymbol") => {
-                let r = self.handle_document_symbol(msg.params);
+            "textDocument/documentSymbol" => {
+                let r = self.handle_document_symbol(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/formatting") => {
-                let r = self.handle_formatting(msg.params);
+            "textDocument/formatting" => {
+                let r = self.handle_formatting(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/rename") => {
-                let r = self.handle_rename(msg.params);
+            "textDocument/rename" => {
+                let r = self.handle_rename(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/prepareRename") => {
-                let r = self.handle_prepare_rename(msg.params);
+            "textDocument/prepareRename" => {
+                let r = self.handle_prepare_rename(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/codeAction") => {
-                let r = self.handle_code_action(msg.params);
+            "textDocument/codeAction" => {
+                let r = self.handle_code_action(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/codeLens") => {
-                let r = self.handle_code_lens(msg.params);
+            "textDocument/codeLens" => {
+                let r = self.handle_code_lens(params);
                 Some(self.make_response(id, r))
             }
-            Some("codeLens/resolve") => {
-                let r = self.handle_code_lens_resolve(msg.params);
+            "codeLens/resolve" => {
+                let r = self.handle_code_lens_resolve(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/selectionRange") => {
-                let r = self.handle_selection_range(msg.params);
+            "textDocument/selectionRange" => {
+                let r = self.handle_selection_range(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/foldingRange") => {
-                let r = self.handle_folding_range(msg.params);
+            "textDocument/foldingRange" => {
+                let r = self.handle_folding_range(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/signatureHelp") => {
-                let r = self.handle_signature_help(msg.params);
+            "textDocument/signatureHelp" => {
+                let r = self.handle_signature_help(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/semanticTokens/full") => {
-                let r = self.handle_semantic_tokens_full(msg.params);
+            "textDocument/semanticTokens/full" => {
+                let r = self.handle_semantic_tokens_full(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/semanticTokens/range") => {
-                let r = self.handle_semantic_tokens_range(msg.params);
+            "textDocument/semanticTokens/range" => {
+                let r = self.handle_semantic_tokens_range(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/documentHighlight") => {
-                let r = self.handle_document_highlight(msg.params);
+            "textDocument/documentHighlight" => {
+                let r = self.handle_document_highlight(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/inlayHint") => {
-                let r = self.handle_inlay_hint(msg.params);
+            "textDocument/inlayHint" => {
+                let r = self.handle_inlay_hint(params);
                 Some(self.make_response(id, r))
             }
-            Some("inlayHint/resolve") => {
-                let r = self.handle_inlay_hint_resolve(msg.params);
+            "inlayHint/resolve" => {
+                let r = self.handle_inlay_hint_resolve(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/documentColor") => {
-                let r = self.handle_document_color(msg.params);
+            "textDocument/documentColor" => {
+                let r = self.handle_document_color(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/colorPresentation") => {
-                let r = self.handle_color_presentation(msg.params);
+            "textDocument/colorPresentation" => {
+                let r = self.handle_color_presentation(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/documentLink") => {
-                let r = self.handle_document_link(msg.params);
+            "textDocument/documentLink" => {
+                let r = self.handle_document_link(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/linkedEditingRange") => {
-                let r = self.handle_linked_editing_range(msg.params);
+            "textDocument/linkedEditingRange" => {
+                let r = self.handle_linked_editing_range(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/prepareCallHierarchy") => {
-                let r = self.handle_prepare_call_hierarchy(msg.params);
+            "textDocument/prepareCallHierarchy" => {
+                let r = self.handle_prepare_call_hierarchy(params);
                 Some(self.make_response(id, r))
             }
-            Some("callHierarchy/incomingCalls") => {
-                let r = self.handle_incoming_calls(msg.params);
+            "callHierarchy/incomingCalls" => {
+                let r = self.handle_incoming_calls(params);
                 Some(self.make_response(id, r))
             }
-            Some("callHierarchy/outgoingCalls") => {
-                let r = self.handle_outgoing_calls(msg.params);
+            "callHierarchy/outgoingCalls" => {
+                let r = self.handle_outgoing_calls(params);
                 Some(self.make_response(id, r))
             }
-            Some("textDocument/prepareTypeHierarchy") => {
-                let r = self.handle_prepare_type_hierarchy(msg.params);
+            "textDocument/prepareTypeHierarchy" => {
+                let r = self.handle_prepare_type_hierarchy(params);
                 Some(self.make_response(id, r))
             }
-            Some("typeHierarchy/supertypes") => {
-                let r = self.handle_supertypes(msg.params);
+            "typeHierarchy/supertypes" => {
+                let r = self.handle_supertypes(params);
                 Some(self.make_response(id, r))
             }
-            Some("typeHierarchy/subtypes") => {
-                let r = self.handle_subtypes(msg.params);
+            "typeHierarchy/subtypes" => {
+                let r = self.handle_subtypes(params);
                 Some(self.make_response(id, r))
             }
-            Some("workspace/symbol") => {
-                let r = self.handle_workspace_symbol(msg.params);
+            "workspace/symbol" => {
+                let r = self.handle_workspace_symbol(params);
                 Some(self.make_response(id, r))
             }
 
             // ── Range formatting ──────────────────────────────────────
-            Some("textDocument/rangeFormatting") => {
-                let r = self.handle_range_formatting(msg.params);
+            "textDocument/rangeFormatting" => {
+                let r = self.handle_range_formatting(params);
                 Some(self.make_response(id, r))
             }
 
             // ── On-type formatting ────────────────────────────────────
-            Some("textDocument/onTypeFormatting") => {
-                let r = self.handle_on_type_formatting(msg.params);
+            "textDocument/onTypeFormatting" => {
+                let r = self.handle_on_type_formatting(params);
                 Some(self.make_response(id, r))
             }
 
             // ── Execute command ────────────────────────────────────────
-            Some("workspace/executeCommand") => {
-                let r = self.handle_execute_command(msg.params);
+            "workspace/executeCommand" => {
+                let r = self.handle_execute_command(params);
                 Some(self.make_response(id, r))
             }
 
             // ── Diagnostic pull model (LSP 3.17) ─────────────────
-            Some("textDocument/diagnostic") => {
-                let r = self.handle_document_diagnostic(msg.params);
+            "textDocument/diagnostic" => {
+                let r = self.handle_document_diagnostic(params);
                 Some(self.make_response(id, r))
             }
-            Some("workspace/diagnostic") => {
-                let r = self.handle_workspace_diagnostic(msg.params);
+            "workspace/diagnostic" => {
+                let r = self.handle_workspace_diagnostic(params);
                 Some(self.make_response(id, r))
             }
 
             // ── File operations ─────────────────────────────────────
-            Some("workspace/willRenameFiles") => {
-                let r = self.handle_will_rename_files(msg.params);
+            "workspace/willRenameFiles" => {
+                let r = self.handle_will_rename_files(params);
                 Some(self.make_response(id, r))
             }
-            Some("workspace/willCreateFiles") => {
+            "workspace/willCreateFiles" => {
                 // Acknowledge but no edits needed for file creation
                 Some(self.success_response(id, Value::Null))
             }
-            Some("workspace/willDeleteFiles") => {
+            "workspace/willDeleteFiles" => {
                 // Acknowledge but no edits needed for file deletion
                 Some(self.success_response(id, Value::Null))
             }
 
             // Unknown request → method not found
-            Some(method) if id.is_some() => {
+            method if id.is_some() => {
                 Some(self.error_response(id, -32601, format!("Method not found: {method}")))
             }
             _ => None,

--- a/crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_notification_handlers.rs
+++ b/crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_notification_handlers.rs
@@ -1,6 +1,25 @@
 use super::*;
 
 impl LspServer {
+    pub(super) fn is_notification_method(method: &str) -> bool {
+        matches!(
+            method,
+            "$/cancelRequest"
+                | "initialized"
+                | "exit"
+                | "textDocument/didOpen"
+                | "textDocument/didChange"
+                | "textDocument/didClose"
+                | "textDocument/didSave"
+                | "workspace/didChangeConfiguration"
+                | "workspace/didChangeWatchedFiles"
+                | "workspace/didChangeWorkspaceFolders"
+                | "workspace/didRenameFiles"
+                | "workspace/didCreateFiles"
+                | "workspace/didDeleteFiles"
+        )
+    }
+
     pub(super) fn handle_notification_method(
         &mut self,
         method: &str,


### PR DESCRIPTION
## Agent
AgentName: M5Manager

## Track
Track LSP/WASM consumer boundary / refactor only

## Invariant
When `tsz-lsp` receives a JSON-RPC message, notification-like methods, request lifecycle cancellation, request method dispatch, and methodless response messages stay behavior-preserving binary-local orchestration. This PR makes the dispatch lifecycle explicit through named classifier/request helpers without changing LSP protocol output or compiler semantics.

## Scope
- `crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_dispatch.rs`: classify incoming JSON-RPC messages before dispatch, split request cancellation from request method routing, and keep methodless client responses ignored.
- `crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_notification_handlers.rs`: expose the shared notification-method predicate used by the classifier and notification handler.
- `crates/tsz-cli/src/bin/tsz_lsp.rs`: add focused dispatch tests for known notifications, unknown requests, and methodless response messages.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only LSP binary dispatch/test coverage; no checker, solver, emitter, Kysely project row, Studio-C emit metadata path, or project corpus behavior changed.

## Verification
```bash
cargo fmt --package tsz-cli --check
git diff --check
scripts/check-crate-root-files.sh
wc -l crates/tsz-cli/src/bin/tsz_lsp.rs crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_dispatch.rs crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_notification_handlers.rs crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_request_handlers.rs crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_response_helpers.rs
cargo check -p tsz-cli --bin tsz-lsp
cargo clippy -p tsz-cli --bin tsz-lsp -- -D warnings
cargo nextest run -p tsz-cli dispatch_
```

Line counts after this slice:
```text
1686 crates/tsz-cli/src/bin/tsz_lsp.rs
 287 crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_dispatch.rs
  84 crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_notification_handlers.rs
1124 crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_request_handlers.rs
  50 crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_response_helpers.rs
3231 total
```

## Coordination Notes
- AgentName: M5Manager
- Closes #9422. This continues the earlier #10553/#10563 lifecycle split and completes the remaining parse/classify -> notification/request -> response behavior boundary as a small non-overlapping sidecar slice.
- No canonical agent lane was assigned for this M5Manager sidecar PR, so this PR intentionally has no `agent:*` ownership label.
- Protected-lane overlap check: #10683/#10677 remain claimed by `agent:M4-C` via draft PR #12161; #11358/#11330 remain claimed by `agent:Studio-C` via draft PR #12126. This PR does not touch Kysely checker files or Studio-C emit metadata files.
- #9397 stayed unclaimed but was avoided because active WIP #11837 touches neighboring binder state/test files; #9422 had no active same-file PR for `crates/tsz-cli/src/bin/tsz_lsp.rs` or `crates/tsz-cli/src/bin/tsz_lsp/tsz_lsp_dispatch.rs`.
- Do not add `merge-queue` until exact-head PR checks are green. `Queue Tested` is expected only after queue enrollment.
