### PR TITLE
refactor(parser): split binary rhs recovery helpers

### DIFF
--- a/crates/tsz-parser/src/parser/state_expressions.rs
+++ b/crates/tsz-parser/src/parser/state_expressions.rs
@@ -426,7 +426,7 @@ impl ParserState {
             return self.parse_conditional_expression(left, start_pos);
         }
 
-        let right = self.parse_binary_expression_rhs(left, op, precedence);
+        let right = self.parse_binary_expression_rhs(op, precedence);
         // Use token_full_start() (start of next lookahead token's trivia) rather than
         // token_end() (end of that token). After parse_binary_expression_rhs returns, the
         // scanner sits on the first token not part of this expression. token_full_start()
@@ -484,73 +484,67 @@ impl ParserState {
         )
     }
 
-    fn parse_binary_expression_rhs(
-        &mut self,
-        _left: NodeIndex,
-        op: SyntaxKind,
-        precedence: u8,
-    ) -> NodeIndex {
-        let is_assignment = matches!(
-            op,
-            SyntaxKind::EqualsToken
-                | SyntaxKind::PlusEqualsToken
-                | SyntaxKind::MinusEqualsToken
-                | SyntaxKind::AsteriskEqualsToken
-                | SyntaxKind::SlashEqualsToken
-                | SyntaxKind::PercentEqualsToken
-                | SyntaxKind::AsteriskAsteriskEqualsToken
-                | SyntaxKind::LessThanLessThanEqualsToken
-                | SyntaxKind::GreaterThanGreaterThanEqualsToken
-                | SyntaxKind::GreaterThanGreaterThanGreaterThanEqualsToken
-                | SyntaxKind::AmpersandEqualsToken
-                | SyntaxKind::CaretEqualsToken
-                | SyntaxKind::BarEqualsToken
-                | SyntaxKind::BarBarEqualsToken
-                | SyntaxKind::AmpersandAmpersandEqualsToken
-                | SyntaxKind::QuestionQuestionEqualsToken
-        );
-        let next_min = if op == SyntaxKind::AsteriskAsteriskToken {
-            precedence
-        } else {
-            precedence + 1
-        };
-        let right = if is_assignment {
-            self.parse_assignment_expression()
-        } else {
-            self.parse_binary_expression(next_min)
-        };
-
+    fn parse_binary_expression_rhs(&mut self, op: SyntaxKind, precedence: u8) -> NodeIndex {
+        let right = self.parse_binary_rhs_operand(op, precedence);
         if right.is_none() {
-            // Emit TS1109 directly, bypassing distance-based suppression.
-            // tsc only suppresses at the exact same position, so a missing RHS
-            // after a binary operator always emits TS1109 even if a prior error
-            // (e.g., TS1003 from JSX) is nearby.
-            if !(!self.is_js_file()
-                && self.is_token(SyntaxKind::GreaterThanToken)
-                && self
-                    .get_source_text()
-                    .get(self.token_pos().saturating_sub(1) as usize..self.token_pos() as usize)
-                    == Some("<"))
-            {
-                self.parse_error_at_current_token(
-                    "Expression expected.",
-                    diagnostic_codes::EXPRESSION_EXPECTED,
-                );
-            }
-            let recovered = self.try_recover_binary_rhs();
-            if recovered.is_none() {
-                // Create a missing expression placeholder instead of returning
-                // `left`. Returning `left` would duplicate the left operand in
-                // the parent binary expression (e.g., `1 > > 2` would become
-                // `1 > 1 > 2` instead of `1 >  > 2`). A missing expression
-                // keeps the AST structurally correct and the emitter will
-                // output nothing for it.
-                return self.create_missing_expression();
-            }
-            return recovered;
+            return self.recover_missing_binary_rhs();
         }
 
         right
+    }
+
+    fn parse_binary_rhs_operand(&mut self, op: SyntaxKind, precedence: u8) -> NodeIndex {
+        if self.is_assignment_operator(op) {
+            self.parse_assignment_expression()
+        } else {
+            self.parse_binary_expression(Self::binary_rhs_precedence(op, precedence))
+        }
+    }
+
+    fn recover_missing_binary_rhs(&mut self) -> NodeIndex {
+        self.report_missing_binary_rhs();
+
+        let recovered = self.try_recover_binary_rhs();
+        if !recovered.is_none() {
+            return recovered;
+        }
+
+        // Create a missing expression placeholder instead of returning the
+        // left operand. Returning the left operand would duplicate it in the
+        // parent binary expression (for example, `1 > > 2` would become
+        // `1 > 1 > 2` instead of `1 >  > 2`). A missing expression keeps the
+        // AST structurally correct and the emitter will output nothing for it.
+        self.create_missing_expression()
+    }
+
+    fn report_missing_binary_rhs(&mut self) {
+        // Emit TS1109 directly, bypassing distance-based suppression. tsc only
+        // suppresses at the exact same position, so a missing RHS after a binary
+        // operator always emits TS1109 even if a prior error (for example,
+        // TS1003 from JSX) is nearby.
+        if !self.should_suppress_missing_binary_rhs_error() {
+            self.parse_error_at_current_token(
+                "Expression expected.",
+                diagnostic_codes::EXPRESSION_EXPECTED,
+            );
+        }
+    }
+
+    fn should_suppress_missing_binary_rhs_error(&self) -> bool {
+        !self.is_js_file()
+            && self.is_token(SyntaxKind::GreaterThanToken)
+            && self
+                .get_source_text()
+                .get(self.token_pos().saturating_sub(1) as usize..self.token_pos() as usize)
+                == Some("<")
+    }
+
+    const fn binary_rhs_precedence(op: SyntaxKind, precedence: u8) -> u8 {
+        if matches!(op, SyntaxKind::AsteriskAsteriskToken) {
+            precedence
+        } else {
+            precedence + 1
+        }
     }
 
     // Parse as/satisfies expression: expr as Type, expr satisfies Type


### PR DESCRIPTION
## Agent
AgentName: M5Manager

## Track
Refactor only / parser tech-debt (#9428)

## Invariant
When binary-expression parsing consumes a right-hand operand or recovers from a missing right-hand operand, tsz preserves the same precedence, diagnostic suppression, and missing-expression AST behavior; this PR only names those parser decisions as smaller helpers.

## Scope
- Split `parse_binary_expression_rhs` in `crates/tsz-parser/src/parser/state_expressions.rs` into helper phases for operand parsing, RHS precedence, missing-RHS diagnostics, and recovery placeholder creation.
- Reuse the existing assignment-operator classifier instead of duplicating operator matching.
- No parser behavior, diagnostic wording/span, emit, checker, solver, Kysely, or Studio-C emit metadata changes intended.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: parser refactor-only; no project-corpus behavior change intended.

## Verification
- `cargo fmt --package tsz-parser --check`
- `cargo check -p tsz-parser`
- `cargo nextest run -p tsz-parser parser_unit_tests` (187 passed, 1106 skipped)
- `cargo clippy -p tsz-parser --all-targets -- -D warnings`
- `git diff --check`
- `scripts/check-crate-root-files.sh`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Refs #9428.
- Safe non-overlap candidate selected after live issue/PR triage: #10683/#10677 remain claimed by M4-C in draft #12161, and #11358/#11330 remain claimed by Studio-C in draft #12126.
- Open PR #12147 touches parser JSX/context recovery tests but not `state_expressions.rs` or binary-expression RHS parsing; this PR is parser-expression only.
- #9418 appeared nearby but is likely stale/mostly satisfied by merged #12105/#12116, so this PR does not touch signature help.
- No canonical agent lane was assigned to this M5Manager sidecar session; intentionally no `agent:*` label is applied.
- AgentName: M5Manager