### PR TITLE
chore(agents): audit LLM startup context

### DIFF
--- a/.agents/skills/tsz-architecture/SKILL.md
+++ b/.agents/skills/tsz-architecture/SKILL.md
@@ -5,56 +5,43 @@ description: Preserve TSZ architecture boundaries while changing checker, solver
 
 # TSZ Architecture
 
-Use this skill when a change touches ownership boundaries. The default direction
-is solver-first semantics, thin checker orchestration, syntax-only parser,
-symbol/flow-only binder, and output-only emitter.
+Use for ownership-boundary work. Default direction: solver-first semantics, thin
+checker, syntax parser, symbol/flow binder, output-only emitter.
 
-## Ground Rules
+## Rules
 
-- Read `AGENTS.md` and `docs/plan/ROADMAP.md` before conformance, emit,
+- Read `AGENTS.md` and `docs/plan/ROADMAP.md` for conformance, emit,
   performance, architecture, LSP/WASM, Sound Mode, or DRY cleanup work.
-- Inspect open PRs/issues before starting overlapping architecture work.
-- State the structural rule before editing:
-  `When <structural condition>, tsc does X; tsz should do X through <owner>.`
-- Do not add decisions based on fixture paths, user-chosen names, source text
-  snippets, rendered type strings, or a single test name.
-- Prefer one shared query or boundary helper over local checker branches.
+- Inspect overlapping PRs/issues.
+- State: `When <structural condition>, tsc does X; tsz does X through <owner>.`
+- No fixture paths, user names, source snippets, rendered strings, or single
+  test names as decision inputs.
+- Prefer one query/boundary helper over local checker branches.
 
-## Ownership Map
+## Owners
 
-- Scanner: tokenization and string interning.
+- Scanner: tokens and interning.
 - Parser: syntax-only AST.
-- Binder: symbols, scopes, hoisting, and flow graph; no type computation.
+- Binder: symbols, scopes, hoisting, flow graph.
 - Solver: relations, evaluation, inference, instantiation, operations,
-  narrowing, and semantic caches.
-- Checker: AST walk, contextual orchestration, diagnostics, and source spans.
-- Emitter: JS/DTS output and transform scheduling; no semantic validation.
-- LSP/WASM/CLI: consumers of checker/solver/project APIs, not owners of type
-  algorithms.
+  narrowing, semantic caches.
+- Checker: orchestration, diagnostics, source spans.
+- Emitter: JS/DTS output and transform scheduling.
+- LSP/WASM/CLI: API consumers.
 
 ## Boundary Workflow
 
-1. Classify the change as `WHAT` or `WHERE`.
-   - `WHAT`: type semantics belong in solver or a solver-backed boundary.
-   - `WHERE`: diagnostics and source locations belong in checker.
-2. Search for an existing boundary before adding one:
+1. Classify as `WHAT` (solver/query boundary) or `WHERE` (checker location/
+   diagnostic orchestration).
+2. Search existing boundaries:
+   `rg "struct .*Request|RelationRequest|query_boundaries|TypeData" crates/tsz-checker/src crates/tsz-solver/src`
+3. Put checker-facing semantic adapters under
+   `crates/tsz-checker/src/query_boundaries/`.
+4. Avoid new checker `TypeKey` matching, direct `CompatChecker`, raw interning,
+   or type-shape recursion.
+5. Add owning-crate tests and adjacent cases varying names/wrappers.
 
-   ```bash
-   rg "struct .*Request|RelationRequest|query_boundaries|TypeData" crates/tsz-checker/src crates/tsz-solver/src
-   ```
-
-3. Put new checker-facing semantic facts under a narrow
-   `crates/tsz-checker/src/query_boundaries/` module when the checker needs an
-   orchestration adapter.
-4. Keep raw solver internals crate-private where possible. Do not introduce new
-   checker `TypeKey` matching, direct `CompatChecker` construction, direct raw
-   interning, or type-shape recursion when a query can own it.
-5. Add focused unit tests in the owning crate and adjacent cases that vary names
-   and wrappers.
-
-## Guard Commands
-
-Run targeted architecture checks when the touched area can trip them:
+## Guards
 
 ```bash
 python3 scripts/arch/arch_guard.py
@@ -62,26 +49,7 @@ scripts/arch/check-checker-boundaries.sh
 python3 scripts/arch/test_arch_guard.py
 ```
 
-Use `cargo nextest run` for Rust tests; avoid `cargo test`. Wrap long,
-multi-worker, or memory-heavy commands with `scripts/safe-run.sh`.
+Use targeted `cargo nextest run`; wrap heavy runs with `scripts/safe-run.sh`.
 
-## Common Failure Classes
-
-- Checker reaches into solver internals instead of a query boundary.
-- Checker computes a semantic type fact locally.
-- Emitter patches already emitted output to encode semantic policy.
-- LSP or WASM reimplements checker/solver behavior.
-- A ratchet is updated to allow new debt without a matching owner or removal
-  condition.
-- A diagnostic fix depends on formatted type text instead of structural facts.
-
-## PR Notes
-
-Architecture-sensitive PRs should include:
-
-- structural rule,
-- owner layer and boundary chosen,
-- adjacent-case matrix,
-- guard/test commands,
-- known temporary debt and removal condition, if any,
-- `AgentName`.
+PR notes: structural rule, owner layer, adjacent matrix, guard/tests, temporary
+debt/removal condition, `AgentName`.

--- a/.agents/skills/tsz-ci-pr/SKILL.md
+++ b/.agents/skills/tsz-ci-pr/SKILL.md
@@ -5,100 +5,52 @@ description: Drive TSZ GitHub PRs through review, CI, and the merge queue. Use w
 
 # TSZ CI And PR
 
-Use this skill for TSZ PR operations. The repository uses draft PRs for
-coordination and heavy CI only after ready-for-review. TSZ's required
-`Queue Tested` status is produced by the repo-local merge queue after a ready
-PR is labeled `merge-queue`. A queued merge is not a landed merge; always
-verify the final PR state.
+Use for PR checks, CI triage, ready state, queue evidence, and landing. Use
+`tsz-pr-coordination` for PR body/label contract.
 
-## Ground Rules
+## Rules
 
-- Use `gh` for GitHub operations.
-- Include the current `AgentName` in PR bodies and substantive comments.
-- Never merge a PR that is draft, has a `WIP` label, starts with `[WIP]`, or
-  says it is WIP in the title/body/branch description.
-- Do not add `[codex]` to PR titles.
-- Draft PRs run light CI. Ready PRs run conformance, emit, fourslash, WASM, and
-  snapshot gates.
-- `Queue Tested` is queue-owned. It may be missing or pending before enqueue;
-  do not wait for it before labeling an otherwise ready PR `merge-queue`.
-- If the user asks to land a PR, do not stop at an armed queue. Verify
-  `state: MERGED` or keep working.
+- Use `gh`; sign substantive comments with `AgentName`.
+- Never merge draft/WIP PRs (`draft`, `WIP`, `[WIP]`, or body/branch says WIP).
+- Ready PRs run heavy CI. Draft PRs intentionally run light CI.
+- `Queue Tested` is queue-owned and appears after `merge-queue`.
+- If asked to land, verify `state: MERGED`; queue label alone is not enough.
 
-## Status Commands
-
-Inspect merge readiness:
+## Inspect
 
 ```bash
 gh pr view <pr> --json state,isDraft,mergeStateStatus,mergeable,autoMergeRequest,mergedAt,labels,title,url,headRefName,headRefOid
 gh pr checks <pr> --json name,state,bucket,link,completedAt
-```
-
-Watch checks only when the result is immediately needed:
-
-```bash
-gh pr checks <pr> --watch --interval 20
-```
-
-Inspect failed logs:
-
-```bash
 gh run view <run-id> --log-failed
 gh run view <run-id> --job <job-id> --log
 ```
 
-## Landing Workflow
+Use `gh pr checks <pr> --watch --interval 20` only when the result is needed
+now.
 
-1. Confirm the PR is not WIP by state, labels, title, body, and branch context.
-2. Confirm the head SHA matches the checks being inspected.
-3. If checks fail, fix the root cause, push, and comment with what changed.
-4. When implementation and verification are complete, mark ready if still draft:
+## Landing
 
-   ```bash
-   gh pr ready <pr>
-   ```
+1. Confirm not WIP and head SHA matches inspected checks.
+2. Fix failures in-PR; comment with root cause and verification.
+3. Mark ready only after implementation and verification:
+   `gh pr ready <pr>`.
+4. Add `merge-queue` only when exact-head PR-head checks such as `CI Summary`
+   and `GitGuardian Security Checks` pass and policy permits:
+   `gh pr edit <pr> --add-label merge-queue`.
+5. Inspect `Poor Man's Merge Queue` and synthetic
+   `automation/merge-queue/pr-<n>` runs if queue stalls.
+6. Verify final merge:
+   `gh pr view <pr> --json state,mergedAt,mergedBy,url`.
 
-5. Once PR-head checks such as `CI Summary` and `GitGuardian Security Checks`
-   pass for the exact head, enqueue the PR with the durable queue label:
+## Failure Hints
 
-   ```bash
-   gh pr edit <pr> --add-label merge-queue
-   ```
+- `CI Summary`: umbrella PR-head status.
+- `Queue Tested`: queue synthetic-merge status.
+- `conformance-aggregate`: accepted-regression drift can fail aggregate even
+  when shards pass.
+- `unit-cloudbuild`: often exposes memory, linking, or architecture guard
+  failures.
+- Docs-only and bench-shell-only paths short-circuit most jobs.
 
-6. Watch `Queue Tested` only as queue evidence, not as a PR-head prerequisite.
-   The `Poor Man's Merge Queue` workflow synthetic-tests one latest-`main`
-   merge branch and posts `Queue Tested` to the PR head before merging.
-7. After the queue runs, verify the merge actually happened:
-
-   ```bash
-   gh pr view <pr> --json state,mergedAt,mergedBy,url
-   ```
-
-If a `merge-queue` labeled PR remains open after green PR-head checks, inspect
-`Queue Tested`, the `Poor Man's Merge Queue` workflow, and any synthetic
-`automation/merge-queue/pr-<n>` CI run. Do not direct-merge around the queue
-unless the user explicitly asks for an emergency admin bypass.
-
-## CI Failure Triage
-
-- `CI Summary` is the required umbrella PR-head status; inspect its
-  prerequisites.
-- `Queue Tested` is the required queue status; inspect the queue workflow and
-  synthetic merge branch when it fails or stays pending.
-- `conformance-aggregate` can fail even when shards pass if accepted-regression
-  drift exists. Compare unlisted vs resolved accepted paths.
-- `unit-cloudbuild` often exposes memory, linking, or architecture-contract
-  failures that local fast tests may miss.
-- Docs-only and bench-shell-only paths intentionally short-circuit most jobs.
-- Ready-review CI failures should be fixed in the PR unless the PR is explicitly
-  abandoned or converted back to draft.
-
-## PR Comment Shape
-
-Use concise comments:
-
-- `AgentName: <name>`
-- root cause,
-- files changed,
-- verification or CI run URL,
-- remaining risk or follow-up issue.
+Comment shape: `AgentName`, root cause, files changed, verification/CI URL,
+remaining risk.

--- a/.agents/skills/tsz-conformance/SKILL.md
+++ b/.agents/skills/tsz-conformance/SKILL.md
@@ -5,22 +5,17 @@ description: Triage and maintain TSZ diagnostic conformance. Use when investigat
 
 # TSZ Conformance
 
-Use this skill to inspect conformance state without turning local work into a
-full-suite run. Conformance is a regression gate; use snapshots and targeted
-filters first, then let ready-review CI run the broad suite.
+Conformance is a regression gate. Prefer checked-in artifacts and narrow filters;
+CI owns broad runs.
 
-## Ground Rules
+## Rules
 
-- Read `AGENTS.md` and `docs/plan/ROADMAP.md` before conformance-affecting work.
-- Inspect open PRs/issues for overlapping conformance or checker/solver fixes.
-- Do not run full conformance locally. Use narrow filters only.
-- Treat the reported test as a witness for a structural rule, not as the scope.
-- Do not hide regressions in snapshot or allowlist churn. Fix them, revert them,
-  or file a tracking issue when accepting a known runway item.
+- Read `AGENTS.md` and `docs/plan/ROADMAP.md` for conformance-affecting work.
+- Do not run full conformance locally.
+- Treat a failing test as a witness for a structural rule.
+- Do not hide regressions with snapshot/allowlist churn.
 
-## Fast Orientation
-
-Prefer offline snapshot data:
+## Offline First
 
 ```bash
 python3 scripts/conformance/query-conformance.py --dashboard
@@ -30,59 +25,27 @@ python3 scripts/conformance/query-conformance.py --code TS2322
 python3 scripts/conformance/query-conformance.py --code TS2322 --paths-only
 ```
 
-Use raw artifacts when the query output is too aggregated:
+Artifacts: `conformance-detail.json`, `conformance-snapshot.json`,
+`conformance-accepted-regressions.txt`, `conformance-shard-weights.json`.
 
-- `scripts/conformance/conformance-detail.json` for per-test expected/actual
-  diagnostics and fingerprints.
-- `scripts/conformance/conformance-snapshot.json` for aggregate KPIs.
-- `scripts/conformance/conformance-accepted-regressions.txt` for the current
-  accepted regression runway.
-- `scripts/conformance/conformance-shard-weights.json` for shard balancing.
-
-## Focused Reproduction
-
-Run one test or one family only when the offline data is insufficient:
+## Focused Run
 
 ```bash
-./scripts/conformance/conformance.sh run --filter "recursiveConditionalTypes" --verbose
+./scripts/conformance/conformance.sh run --filter "<name>" --verbose
 ```
 
-Keep the filter precise. If the TypeScript submodule or dist binary is stale,
-prefer the harness rebuild path over manual broad rebuilds.
+Keep filters precise. Let harnesses rebuild stale binaries when possible.
 
-## Classification Workflow
+## Triage
 
-1. Determine whether the failure is new, accepted, resolved, fingerprint-only,
-   wrong-code, missing-code, extra-code, crash, timeout, or OOM.
-2. Identify the owning semantic operation: relation, inference, narrowing,
-   indexed access, mapped/conditional/template evaluation, symbol resolution,
-   diagnostic display, parser recovery, or emit-only behavior.
-3. State the structural rule before coding:
-   `When <structural condition>, tsc does X; tsz should do X through <owner>.`
-4. Check adjacent cases before choosing a fix: renamed binders, alias wrappers,
-   nested forms, generic and concrete forms, positive and negative cases.
-5. Add focused owning-crate tests for behavior changes.
+Classify: new/accepted/resolved/fingerprint-only/wrong-code/missing-code/
+extra-code/crash/timeout/OOM. Then identify owner: relation, inference,
+narrowing, indexed/keyof/mapped/conditional/template, symbol resolution,
+diagnostic display, parser recovery, or emit-only.
 
-## Accepted-Regression Drift
+Before coding, state the structural rule and adjacent cases. Behavior changes
+need owning-crate tests.
 
-When CI aggregate reports both unlisted regressions and accepted regressions
-that no longer fail:
-
-1. Verify shard detail artifacts for the exact commit when available.
-2. Update `scripts/conformance/conformance-accepted-regressions.txt` only to
-   make the accepted set match the observed failing set.
-3. File or link a GitHub issue for every newly accepted regression.
-4. Comment on the PR with the aggregate numbers, paths added/removed, and issue
-   link. Include the current `AgentName`.
-
-## Issue Shape
-
-For conformance issues, include:
-
-- test path and failure class,
-- expected vs actual diagnostic codes or fingerprint class,
-- minimized repro when available,
-- suspected owner layer,
-- adjacent cases that should share the rule,
-- CI run or artifact source,
-- `AgentName`.
+Accepted-regression drift: verify shard artifacts, update the accepted file
+only to match observed failing set, link/file issues for new accepts, and
+comment with numbers plus `AgentName`.

--- a/.agents/skills/tsz-disk-cache-hygiene/SKILL.md
+++ b/.agents/skills/tsz-disk-cache-hygiene/SKILL.md
@@ -5,84 +5,38 @@ description: Prevent TSZ machines and worktrees from running out of disk while p
 
 # TSZ Disk Cache Hygiene
 
-Use this skill whenever disk space or cleanup is part of the task. The priority
-order is: keep the machine usable, preserve hot build caches when possible, and
-avoid broad disk archaeology that burns time and terminal output.
+Use when disk, cleanup, or new worktrees are involved. Preserve hot caches unless
+the machine is at risk.
 
-## Default Workflow
-
-1. Start with compact signals:
-
-   ```bash
-   df -h .
-   scripts/setup/disk-worktree-guard.sh
-   scripts/agents/disk-preflight.sh <AgentName>
-   git worktree list
-   ```
-
-2. Reuse an inactive worktree before creating a new one, especially when it
-   already has `.target`, `target`, `.target-bench`, or `TypeScript` state.
-3. If disk is low, run the cache-preserving ladder in order:
-
-   ```bash
-   scripts/setup/disk-worktree-guard.sh --auto-prune
-   scripts/setup/clean.sh --quiet
-   ```
-
-4. Rerun the compact guard to see whether enough space was recovered.
-5. Escalate only when the guard still reports low space.
-
-Read `references/cleanup-ladder.md` before deleting worktrees, running
-`scripts/setup/clean.sh --full`, or removing build directories manually.
-
-## Cache Policy
-
-Preserve by default:
-
-- `.target/`
-- `.target-bench/`
-- `target/`
-- populated or symlinked `TypeScript/`
-- package-manager caches unless the task is specifically about dependency
-  corruption
-
-These are expensive to rebuild and directly affect iteration speed. Do not run
-`cargo clean`, `rm -rf target`, or `scripts/setup/clean.sh --full` as routine
-hygiene.
-
-Safe routine cleanup:
-
-- stale Cargo `incremental` subdirectories older than seven days,
-- gitignored debris outside protected build caches,
-- abandoned worktrees after confirming their branch/PR owner and preserving
-  useful findings.
-
-## New Worktree Decision
-
-Before `git worktree add`, answer:
-
-- Is there an inactive sister worktree with the right cache shape?
-- Does the disk guard show enough free space?
-- Does the task need a real TypeScript corpus, or can it run without it?
-- Can a sibling worktree link to an existing TypeScript checkout instead of
-  creating another copy?
-
-Preferred new-worktree setup:
+## Compact Checks
 
 ```bash
-git worktree add ../tsz-<short-scope> -b codex/<short-scope>-<yyyymmdd> origin/main
-cd ../tsz-<short-scope>
-scripts/setup/link-ts-submodule.sh
+df -h .
+scripts/setup/disk-worktree-guard.sh
+scripts/agents/disk-preflight.sh <AgentName>
+git worktree list
 ```
 
-## What To Report
+Reuse inactive sister worktrees before creating new ones.
 
-When cleanup or reuse affects the work, include:
+## Cleanup Ladder
 
-- the guard output summary before/after,
-- whether caches were preserved,
-- any abandoned worktree removed and why it was safe,
-- any deliberate cache destruction and why no safer option was enough.
+If low disk:
 
-Do not include giant recursive size listings unless a targeted cleanup needs
-exact ownership.
+```bash
+scripts/setup/disk-worktree-guard.sh --auto-prune
+scripts/setup/clean.sh --quiet
+```
+
+Rerun the guard. Read `references/cleanup-ladder.md` before deleting worktrees,
+running `scripts/setup/clean.sh --full`, or manually removing build dirs.
+
+## Preserve
+
+Keep `.target/`, `.target-bench/`, `target/`, populated/symlinked
+`TypeScript/`, and package-manager caches unless corruption or emergency space
+pressure proves otherwise. Do not run `cargo clean`, `rm -rf target`, or full
+clean as routine hygiene.
+
+Report only before/after guard summary, caches preserved/destroyed, and why any
+worktree/cache removal was safe. Avoid giant recursive size listings.

--- a/.agents/skills/tsz-iteration-audit/SKILL.md
+++ b/.agents/skills/tsz-iteration-audit/SKILL.md
@@ -23,6 +23,7 @@ durable project direction truly changes.
 2. Inventory existing guardrails before proposing new ones:
 
    ```bash
+   scripts/agents/llm-context-audit.py
    find .agents/skills .claude/skills scripts/agents scripts/ci scripts/arch scripts/bench scripts/conformance scripts/emit -maxdepth 3 -type f | sort
    ```
 
@@ -45,6 +46,9 @@ durable project direction truly changes.
    - `duplication`: the same policy lives in multiple scripts/docs/skills.
    - `behavior debt`: compiler code violates an architecture rule and needs a
      focused owner, not process cleanup.
+   - `context debt`: startup hooks, settings, or duplicated instruction
+     surfaces make every LLM session spend tokens before it has task-specific
+     evidence.
 
 5. Choose the smallest aligned change:
 

--- a/.agents/skills/tsz-iteration-audit/SKILL.md
+++ b/.agents/skills/tsz-iteration-audit/SKILL.md
@@ -5,80 +5,47 @@ description: Audit TSZ repo iteration speed and quality. Use when asked to deep-
 
 # TSZ Iteration Audit
 
-Use this skill to turn repo-health observations into small, useful changes.
-The output should be evidence-backed and PR-sized, not a new roadmap unless the
-durable project direction truly changes.
+Use to turn recurring workflow/context/guardrail costs into small,
+evidence-backed PRs. Do not create roadmap/status docs unless durable project
+direction changes.
 
-## Audit Loop
+## Audit
 
-1. Read the current direction and coordination state:
+```bash
+sed -n '1,320p' docs/plan/ROADMAP.md
+gh pr list --state open --limit 100 --json number,title,isDraft,headRefName,baseRefName,labels,updatedAt,url
+gh pr list --state merged --limit 30 --json number,title,headRefName,mergedAt,url
+gh issue list --state open --limit 100 --json number,title,labels,updatedAt,url
+scripts/agents/llm-context-audit.py
+find .agents/skills .claude/skills scripts/agents scripts/ci scripts/arch scripts/bench scripts/conformance scripts/emit -maxdepth 3 -type f | sort
+```
 
-   ```bash
-   sed -n '1,320p' docs/plan/ROADMAP.md
-   gh pr list --state open --limit 100 --json number,title,isDraft,headRefName,baseRefName,labels,updatedAt,url
-   gh pr list --state merged --limit 30 --json number,title,headRefName,mergedAt,url
-   gh issue list --state open --limit 100 --json number,title,labels,updatedAt,url
-   ```
+Use targeted searches only when needed:
 
-2. Inventory existing guardrails before proposing new ones:
+```bash
+rg -n "source_text\\.contains|rewrite_.*fingerprints|format_type_diagnostic|TypeData|CompatChecker|is_assignable_to" crates scripts
+rg -n "WIP|stale|drift|queue|worktree|disk|allowlist|fingerprint|context" docs scripts .agents .claude .codex
+```
 
-   ```bash
-   scripts/agents/llm-context-audit.py
-   find .agents/skills .claude/skills scripts/agents scripts/ci scripts/arch scripts/bench scripts/conformance scripts/emit -maxdepth 3 -type f | sort
-   ```
+## Classify
 
-3. Look for recurring iteration costs:
+- `workflow`: stale starts, lost coordination.
+- `guardrail`: missing architecture/file-size/WIP/PR-body/CI check.
+- `visibility`: data exists but is hard to find.
+- `duplication`: policy repeated across scripts/docs/skills.
+- `behavior debt`: compiler bug; route to owner skill/issue.
+- `context debt`: startup hooks/settings/prompts waste tokens.
 
-   ```bash
-   find crates scripts .agents .claude .codex docs -type f \
-     \( -name '*.rs' -o -name '*.py' -o -name '*.mjs' -o -name '*.js' -o -name '*.sh' -o -name '*.md' \) \
-     -not -path '*/target/*' -not -path '*/.target/*' -print0 | xargs -0 wc -l | sort -nr | sed -n '1,60p'
-   rg -n "source_text\\.contains|rewrite_.*fingerprints|format_type_diagnostic|TypeData|CompatChecker|is_assignable_to" crates scripts
-   rg -n "WIP|stale|drift|queue|worktree|disk|allowlist|fingerprint" docs scripts .agents .claude .codex
-   ```
+## Choose Smallest Fix
 
-4. Classify each finding:
+- Refine a skill for repeatable procedure.
+- Add/update a script/test for deterministic enforcement.
+- Update docs only when they change future behavior.
+- File an issue if the real fix is outside the PR.
 
-   - `workflow`: agents repeatedly start from stale state or lose coordination.
-   - `guardrail`: architecture, file-size, WIP, PR-body, or CI checks miss a
-     preventable class.
-   - `visibility`: useful data exists but is hard to find at decision time.
-   - `duplication`: the same policy lives in multiple scripts/docs/skills.
-   - `behavior debt`: compiler code violates an architecture rule and needs a
-     focused owner, not process cleanup.
-   - `context debt`: startup hooks, settings, or duplicated instruction
-     surfaces make every LLM session spend tokens before it has task-specific
-     evidence.
-
-5. Choose the smallest aligned change:
-
-   - Create or refine a skill when the failure is procedural and repeatable.
-   - Add a script or test when the failure needs deterministic enforcement.
-   - Update an existing script when good tooling exists but misses one field.
-   - File an issue when the fix is real but outside the current PR scope.
-
-Use `references/2026-05-26-findings.md` as a starting evidence map. Replace it
-with fresher evidence when the repo state changes.
-
-## What Not To Do
-
-- Do not add a new plan file for routine status.
-- Do not update `docs/plan/ROADMAP.md` for ordinary cleanup or PR bookkeeping.
-- Do not broaden a process PR into compiler behavior changes.
-- Do not hide a behavior regression with snapshots, allowlists, or test skips.
-- Do not create another checker/solver workaround when the audit finds a
-  semantic bug. Route that to the owning TSZ skill and a focused issue or PR.
+For prior evidence, read `references/2026-05-26-findings.md` only when it helps.
 
 ## PR Shape
 
-For iteration-audit PRs, write:
-
-- the recurring cost found,
-- the evidence source,
-- the specific skill/script/doc change,
-- why it does not change compiler behavior,
-- the validation command,
-- the `AgentName`.
-
-The best audit PRs make the next agent faster within the first five minutes of
-their task.
+Include recurring cost, evidence source, changed skill/script/doc, why compiler
+behavior is unchanged, validation command, and `AgentName`.

--- a/.agents/skills/tsz-iteration-audit/references/2026-05-26-findings.md
+++ b/.agents/skills/tsz-iteration-audit/references/2026-05-26-findings.md
@@ -3,6 +3,16 @@
 This is a point-in-time evidence map for process/tooling improvement work. Use
 current commands before treating any count as live truth.
 
+## LLM Context Hygiene
+
+On 2026-06-02, `M5LLMAudit` found a token-heavy startup pattern: session-start
+hooks silently ran `git pull --rebase origin main` and printed the entire
+`AGENTS.md` / `.claude/CLAUDE.md` policy file even though the coding clients
+already load their project instruction surface. The fix removed those hook
+fragments, stopped forcing `CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000` at the project
+level, and added `scripts/agents/llm-context-audit.py` so future workflow
+audits can catch those regressions cheaply.
+
 ## What Could Have Been Avoided
 
 - Long-lived branches remained checked out after their PRs merged. This made new

--- a/.agents/skills/tsz-performance-engineering/SKILL.md
+++ b/.agents/skills/tsz-performance-engineering/SKILL.md
@@ -5,42 +5,25 @@ description: Use when planning, implementing, reviewing, or interpreting TSZ per
 
 # TSZ Performance Engineering
 
-## Core Rule
+Use for performance, cache/residency, OOM/timeout/stack-overflow, counters,
+benchmark regressions, and timing claims.
 
-Performance work must preserve `tsc` parity and TSZ architecture. Speed claims are useful only after the row or behavior is correct, except when the first blocker is runtime, OOM, timeout, stack overflow, or residency.
+## Rules
 
-Before starting nontrivial perf work, read:
+- Read `AGENTS.md`, `docs/plan/ROADMAP.md`, and relevant PR/issues.
+- Correctness first. Timing claims matter only for green rows or explicit
+  runtime/residency blockers.
+- Optimize the repeated operation, not a fixture spelling.
+- State invariant: cache key, invalidation/reset, request scope, fuel/cycle
+  behavior, residency bound, or complexity change.
+- No checker-local semantic algorithms, display-string heuristics, source-text
+  shortcuts, name allowlists, or cross-interner `TypeId` comparisons.
+- Read `references/perf-mistakes.md` before adding/widening caches, changing
+  residency, or claiming speedups.
 
-- `docs/plan/ROADMAP.md`
-- `docs/plan/PERFORMANCE_PLAN.md`
-- `references/perf-mistakes.md` when diagnosing a regression, designing a cache, writing PR evidence, or changing residency/session behavior
+## Evidence
 
-Also inspect open/recent PRs and issues for overlapping benchmark rows or perf tooling work.
-
-## Classify First
-
-Name the task class before coding:
-
-- `correctness blocker`: the row is red/yellow due to diagnostics, crash, missing metadata, or fixture drift. Fix correctness first; do not claim speed progress.
-- `runtime blocker`: OOM, timeout, stack overflow, excessive residency, or CI kill prevents the row from reaching a correctness result. Perf work is allowed with the runtime invariant stated.
-- `green-row speed`: row is correct and complete; before/after timing can be meaningful.
-- `cache/residency`: cache keys, invalidation, file sessions, project state, or memory growth. State the semantic identity and reset boundary.
-- `measurement/tooling`: counters, reports, dashboard interpretation, or benchmark scripts. Preserve schema stability and low overhead.
-- `micro-allocation`: clone, allocation, formatting, or buffer changes. Prove the hot path; do not overstate as project-row progress unless a row moves.
-
-## Evidence Workflow
-
-1. Record the affected project/benchmark row, bug family, and current correctness status.
-2. Pick the narrowest command that answers the question; avoid broad local suites.
-3. Separate timing mode from attribution mode. Do not compare attribution-mode TSZ to timing-mode `tsgo`.
-4. For cache or residency changes, document every behavior-affecting key field, invalidation/reset boundary, semantic mode, cycle/fuel interaction, memory-growth expectation, and cache-disabled behavior.
-5. For green-row speed claims, include before/after command, wall time, RSS/residency when relevant, cache/counter deltas, and noise sources.
-6. For runtime blockers, include the failure class before/after and the invariant that prevents recurrence.
-7. Add or update owning-crate tests for behavior changes. Let ready-for-review CI run heavy conformance, emit, fourslash, and WASM suites.
-
-## Preferred Local Commands
-
-Use filters and wrap long or memory-intensive runs with `scripts/safe-run.sh`.
+Use narrow, reproducible commands; wrap heavy runs.
 
 ```bash
 python3 scripts/perf/cache-visibility-report.py --json
@@ -48,37 +31,25 @@ python3 scripts/perf/visited-clone-report.py --json
 python3 scripts/perf/debug-print-report.py --json
 python3 scripts/perf/migration_callsite_counts.py --json
 python3 scripts/perf/query-perf-counters.py --json <artifact> --baseline <baseline>
-
 scripts/safe-run.sh ./scripts/bench/perf-hotspots.sh --quick --json-file /tmp/hotspots.json
-scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --filter '<row-or-fixture>' --json-file /tmp/bench.json
+scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --filter '<row>' --json-file /tmp/bench.json
 ```
 
-Use filtered project compile guard or focused `cargo nextest run -E 'test(...)'` when that is the shortest path to validate the change. Do not run full conformance, full emit, full fourslash, or broad project suites locally.
+Use focused compile guard or `cargo nextest run -E 'test(...)'` when shortest.
+Do not run full conformance, emit, fourslash, or broad project suites locally.
 
-## Cache And Identity Checks
+## Cache Checklist
 
-Before adding or widening a cache, answer:
-
-- What semantic question does this cache answer?
-- What stable identity is used? Avoid cross-file `NodeIndex` and do not compare `TypeId`s from different `TypeInterner`s.
-- Does the key include every mode that changes behavior: relation mode, variance, freshness/excess-property state, contextual typing, inference source, `any` propagation policy, target/module/options, request scope, cycle/fuel, and file/session generation as applicable?
-- Where is invalidation or reset performed?
-- What happens when the cache is absent, cold, disabled, or order-randomized?
+- What semantic question is cached?
+- What stable identity is the key? Avoid cross-file `NodeIndex` and
+  cross-interner `TypeId`.
+- Does the key include all behavior modes: relation, variance, freshness,
+  contextual typing, inference source, `any`, target/module/options, request
+  scope, cycle/fuel, file/session generation?
+- Where is reset/invalidation?
+- What happens cold/disabled/order-randomized?
 - Is size/residency bounded or observable?
 
-Move semantic fixes through solver/query boundaries. Do not add checker-local type algorithms, display-string heuristics, source-text shortcuts, or name-only allowlists.
-
-## PR Evidence Packet
-
-Every perf PR body or status comment should include:
-
-- `Project Corpus Impact`: row, bug family, correctness status, and evidence source
-- `Invariant`: semantic identity, cache key, invalidation/reset, request scope, or residency rule
-- `Verification`: exact local commands and any CI jobs relied on
-- before/after timing only for complete green rows
-- RSS/residency and failure-class evidence for runtime blockers
-- cache/counter deltas for cache work
-- noise sources and caveats
-- `AgentName` and coordination notes for overlapping rows/PRs
-
-Individual agents own their PR evidence and handoff notes. A manager or coordination agent should handle broad merge sequencing and cross-PR queue decisions.
+PR/comment packet: Project Corpus Impact, invariant, exact commands/CI, green
+row timing only, RSS/failure-class evidence for runtime blockers, counter
+deltas, noise/caveats, `AgentName`.

--- a/.agents/skills/tsz-pr-coordination/SKILL.md
+++ b/.agents/skills/tsz-pr-coordination/SKILL.md
@@ -5,139 +5,69 @@ description: Create, refresh, and publish TSZ pull requests with correct coordin
 
 # TSZ PR Coordination
 
-Use this skill for TSZ PR state, especially before pushing a branch or changing
-draft/WIP/ready status. It complements `tsz-ci-pr`: use this skill for the
-coordination contract and `tsz-ci-pr` for check triage. Merge and queue-label
-coordination belongs to an explicit manager or queue-owner agent, not every
-implementation agent.
+Use for PR body/state/label/review coordination. Use `tsz-ci-pr` for failing
+checks and queue status.
 
-## Required Identity
+## Rules
 
-Use a stable `AgentName`. If assigned to a canonical lane, use that lane name
-in PR bodies and substantive comments. Do not create generated runner labels
-such as `agent:claude-*` or typo labels such as `agnet:*`.
+- Stable `AgentName` in PR bodies and substantive comments.
+- Use canonical `agent:*` labels only from `docs/plan/agents/README.md`; at
+  most one per PR.
+- Implementation agents manage their own PRs. Manager/queue-owner agents handle
+  cross-PR queueing and merge order.
+- If you are not the manager/queue owner, do not merge or add `merge-queue` as
+  routine implementation work.
 
-Canonical ownership labels are documented in
-`docs/plan/agents/README.md`. Apply at most one `agent:*` label to a PR.
+## Before Publish
 
-## Role Split
+```bash
+git status --short --branch
+git diff --stat
+git diff --check
+gh pr list --state open --limit 100 --json number,title,isDraft,headRefName,baseRefName,labels,updatedAt,url
+scripts/agents/ensure-agent-labels.sh --audit
+```
 
-Individual implementation agents own only their own PRs. They should:
-
-- keep their PR body, labels, WIP/draft state, verification, and review replies
-  current,
-- mark their own PR ready only when implementation and verification are done and
-  the lane permits it,
-- leave a signed readiness or blocker note for the manager agent,
-- avoid queue sweeps, merge decisions, or queue changes on unrelated PRs.
-
-Manager or queue-owner agents handle cross-PR coordination. They may:
-
-- inspect the full PR queue and ownership state,
-- decide merge order and dependency handoffs,
-- add or remove `merge-queue` when policy and exact-head PR-head checks allow
-  it,
-- verify queued PRs landed or leave signed blocker comments.
-
-If you are not acting as the manager/queue owner, do not merge PRs or add
-`merge-queue` as part of routine implementation work.
-
-## Before Publishing
-
-1. Inspect scope:
-
-   ```bash
-   git status --short --branch
-   git diff --stat
-   git diff --check
-   ```
-
-2. Confirm the branch and overlap:
-
-   ```bash
-   gh pr list --state open --limit 100 --json number,title,isDraft,headRefName,baseRefName,labels,updatedAt,url
-   scripts/agents/ensure-agent-labels.sh --audit
-   ```
-
-3. Stage only files that belong to the requested PR. If dirty files are mixed,
-   leave unrelated files unstaged.
+Stage only files in scope.
 
 ## PR Body
 
-Use the repo template and fill every section. Never rely on `--fill` alone.
-Read `references/pr-body-checklist.md` when creating or materially editing a
-body.
-
-Minimum sections:
+Never rely on `--fill` alone. Read `references/pr-body-checklist.md` when
+creating or materially editing a body. Required sections:
 
 ```markdown
 ## Agent
 AgentName: <AgentName>
-
 ## Track
 <roadmap track and PR type>
-
 ## Invariant
 When <condition>, <expected behavior>; this PR changes <owner/surface>.
-
 ## Scope
 - <files or systems>
-
 ## Project Corpus Impact
 - Row: n/a
 - Bug family: n/a
 - Evidence: <why n/a or affected row evidence>
-
 ## Verification
 - <commands or CI gates>
-
 ## Coordination Notes
 - <overlap, dependencies, WIP state, follow-ups>
 ```
 
-After creating or editing the PR, verify the remote body:
+Verify remote body after create/edit:
 
 ```bash
 gh pr view <number> --json body
 ```
 
-## WIP And Draft State
+## WIP, Ready, Reviews
 
-Treat a PR as WIP if it is draft, has a `WIP` label, starts with `[WIP]`, or
-declares a blocker in the body. Do not mark ready or add `merge-queue` until
-the current head is genuinely ready.
-
-Whenever adding `WIP`, adding `[WIP]`, or converting a PR back to draft because
-it is blocked, immediately leave a signed PR comment with:
-
-- `AgentName`,
-- why the PR is WIP,
-- current blocker or active work,
-- next owner/action,
-- verification already run.
-
-## Ready Handoff
-
-Before marking your own PR ready or handing it to the manager:
-
-1. Remove WIP markers only after implementation and verification are complete.
-2. Confirm the latest pushed head SHA is the one you reviewed.
-3. Confirm the PR body has current verification and Project Corpus Impact.
-4. Comment with remaining risks, dependencies, or a clear "ready for manager
-   review/queue" note.
-
-Do not use auto-merge as a CI watcher or queue signal. Unless you are the
-manager/queue owner, leave merge-queue decisions to the manager after
-exact-head PR-head checks are complete. `Queue Tested` is produced by the merge
-queue after `merge-queue` is added; it does not need to be present before a
-ready handoff.
-
-## Review Responses
-
-When a substantive review arrives:
-
-1. Read the comment or thread.
-2. React or reply so the reviewer knows it was seen.
-3. Leave a concise signed PR comment saying whether you fixed it, will fix it,
-   or disagree and why.
-4. Update the PR body when the review changes scope, risk, or verification.
+- WIP means draft, `WIP` label, `[WIP]` title, or blocker in body. Do not mark
+  ready or queue.
+- Any WIP/draft/blocker transition needs an immediate signed comment with
+  reason, blocker/current work, next owner/action, and verification run.
+- Before ready handoff: remove WIP markers, review latest pushed head, update
+  body verification/Project Corpus Impact, and leave a signed readiness/risk
+  note for manager review.
+- For substantive reviews: read, react/reply, leave a signed fix/will-fix/
+  disagree note, and update body if scope/risk/verification changed.

--- a/.agents/skills/tsz-project-bench/SKILL.md
+++ b/.agents/skills/tsz-project-bench/SKILL.md
@@ -5,81 +5,47 @@ description: Work on TSZ benchmark and project-corpus compatibility. Use when in
 
 # TSZ Project Bench
 
-Use this skill for project-corpus and benchmark work. The benchmark dashboard is
-only meaningful when compatibility metadata is trustworthy; a red project row is
-a correctness blocker before it is a speed problem.
+Use for project-corpus rows, benchmark harness, fixture metadata, PGO bench
+setup, and website benchmark data.
 
-## Ground Rules
+## Rules
 
-- Read `AGENTS.md` and `docs/plan/ROADMAP.md` before durable benchmark,
-  performance, project-corpus, or website benchmark work.
-- Inspect open PRs/issues for overlapping benchmark blockers.
-- Do not treat timing as useful until the row is green or the failure is
-  explicitly runtime, residency, timeout, or OOM.
-- Keep fixture definitions shared between `scripts/bench/project-fixtures.sh`,
-  `scripts/bench/bench-vs-tsgo.sh`, and
-  `scripts/ci/project-compile-guard.sh`.
-- Wrap long or memory-heavy local commands with `scripts/safe-run.sh`.
+- Read `AGENTS.md` and `docs/plan/ROADMAP.md` for durable benchmark/project
+  work.
+- Inspect overlapping PRs/issues.
+- Red row = correctness blocker before speed problem unless failure is runtime,
+  residency, timeout, or OOM.
+- Keep fixture metadata shared across `project-fixtures.sh`,
+  `bench-vs-tsgo.sh`, and `project-compile-guard.sh`.
+- Wrap long/heavy local commands with `scripts/safe-run.sh`.
 
-## Source Files
+## Sources
 
-- `scripts/bench/project-fixtures.sh`: pinned repos, refs, and config writers.
-- `scripts/bench/bench-vs-tsgo.sh`: benchmark runner, PGO, metadata emission.
-- `scripts/ci/project-compile-guard.sh`: CI project compatibility smoke gate.
-- `crates/tsz-website/src/_data/benchmark_data.js`: website row ingestion.
-- `.github/workflows/bench.yml`: benchmark publication and daily latest runs.
+- `scripts/bench/project-fixtures.sh`
+- `scripts/bench/bench-vs-tsgo.sh`
+- `scripts/ci/project-compile-guard.sh`
+- `crates/tsz-website/src/_data/benchmark_data.js`
+- `.github/workflows/bench.yml`
 
-## Debug Workflow
+## Workflow
 
-1. Identify the row, phase, and first failure class: prepare, tsc validation,
-   tsz check, emit scope, crash, timeout, OOM, metadata, website ingestion, or
-   timing.
-2. Confirm whether the row is required or canary:
-   `TSZ_PROJECT_COMPILE_SET=required`, `canary`, or `all`.
-3. Reproduce with the narrowest project filter. Avoid full benchmark runs unless
-   the task is specifically about benchmark harness behavior.
-4. If the project fails to typecheck, reduce to the owning compiler operation
-   before optimizing.
-5. For speed work, identify the repeated operation and expected complexity
-   change. Do not special-case fixture names.
+1. Identify row, phase, and first failure: prepare, `tsc` validation, tsz check,
+   emit scope, crash, timeout, OOM, metadata, website ingestion, timing.
+2. Required/canary/all set: `TSZ_PROJECT_COMPILE_SET=<required|canary|all>`.
+3. Reproduce with the narrowest filter.
+4. If typecheck fails, reduce to owning compiler operation before optimizing.
+5. For speed work, name repeated operation and complexity change. No
+   fixture-name special cases.
 
-## Useful Commands
-
-Prepare benchmark dependencies without running measurements:
+## Commands
 
 ```bash
 ./scripts/bench/bench-vs-tsgo.sh --prepare-only
+./scripts/bench/bench-vs-tsgo.sh --quick --filter "<row>" --json-file /tmp/bench.json
+TSZ_PROJECT_COMPILE_FILTER="<row>" TSZ_PROJECT_COMPILE_SET=required scripts/ci/project-compile-guard.sh
+TSZ_PROJECT_COMPILE_ALLOW_FAILURES=1 TSZ_PROJECT_COMPILE_SET=all scripts/ci/project-compile-guard.sh
 ```
 
-Run a narrow benchmark smoke:
-
-```bash
-./scripts/bench/bench-vs-tsgo.sh --quick --filter "utility-types" --json-file /tmp/bench.json
-```
-
-Run a filtered project compile guard after a dist-fast binary exists:
-
-```bash
-TSZ_PROJECT_COMPILE_FILTER="utility-types-project" \
-TSZ_PROJECT_COMPILE_SET=required \
-scripts/ci/project-compile-guard.sh
-```
-
-Continue through known failures only when collecting a matrix:
-
-```bash
-TSZ_PROJECT_COMPILE_ALLOW_FAILURES=1 \
-TSZ_PROJECT_COMPILE_SET=all \
-scripts/ci/project-compile-guard.sh
-```
-
-## PR Notes
-
-Benchmark PRs should state:
-
-- project row and before/after failure class,
-- first broken phase and owner layer,
-- fixture metadata changes, if any,
-- whether timing is meaningful,
-- targeted local commands or CI run links,
-- `AgentName`.
+PR notes: row, before/after failure class, first broken phase, owner layer,
+fixture metadata changes, whether timing is meaningful, commands/CI links,
+`AgentName`.

--- a/.agents/skills/tsz-tracing/QUICKREF.md
+++ b/.agents/skills/tsz-tracing/QUICKREF.md
@@ -1,61 +1,17 @@
-# TSZ Tracing Quick Reference
-
-## Quick Commands
+# TSZ Tracing Quickref
 
 ```bash
-# Human-readable tree output (best for debugging)
-TSZ_LOG=debug TSZ_LOG_FORMAT=tree cargo run -- file.ts
-
-# Narrowing only
-TSZ_LOG="tsz::solver::narrowing=trace" TSZ_LOG_FORMAT=tree cargo run -- file.ts
-
-# Checker only  
-TSZ_LOG="tsz::checker=debug" TSZ_LOG_FORMAT=tree cargo run -- file.ts
-
-# Solver only
-TSZ_LOG="tsz::solver=debug" TSZ_LOG_FORMAT=tree cargo run -- file.ts
-
-# JSON output (for tooling)
-TSZ_LOG=debug TSZ_LOG_FORMAT=json cargo run -- file.ts
+TSZ_LOG=debug TSZ_LOG_FORMAT=tree cargo run -p tsz-cli -- file.ts
+TSZ_LOG=debug TSZ_LOG_FORMAT=json cargo run -p tsz-cli -- file.ts
+TSZ_LOG="tsz_solver=debug" TSZ_LOG_FORMAT=tree cargo run -p tsz-cli -- file.ts
+TSZ_LOG="tsz_checker=debug" TSZ_LOG_FORMAT=tree cargo run -p tsz-cli -- file.ts
+TSZ_LOG="tsz_solver::narrowing=trace" TSZ_LOG_FORMAT=tree cargo run -p tsz-cli -- file.ts
 ```
 
-## Log Levels
+Levels: `trace`, `debug`, `info`, `warn`, `error`.
+Format: `tree`, `json`, `text`.
 
-- `trace` - Most verbose, includes all details
-- `debug` - Detailed debugging info
-- `info` - General operational info
-- `warn` - Warnings only
-- `error` - Errors only
-
-## Env Variables
-
-| Variable | Description |
-|----------|-------------|
-| `TSZ_LOG` | Filter expression (same as RUST_LOG) |
-| `TSZ_LOG_FORMAT` | `tree`, `json`, or `text` |
-
-## Filter Syntax
-
-```bash
-# Single module
-TSZ_LOG="tsz::solver=debug"
-
-# Multiple modules
-TSZ_LOG="tsz::solver=trace,tsz::checker=debug"
-
-# All at level
-TSZ_LOG=debug
-```
-
-## Output Tips
-
-```bash
-# Capture to file
-TSZ_LOG=debug TSZ_LOG_FORMAT=tree cargo run -- file.ts 2> trace.log
-
-# First 100 lines
-TSZ_LOG=debug TSZ_LOG_FORMAT=tree cargo run -- file.ts 2>&1 | head -100
-
-# Search for type ID
-TSZ_LOG=debug TSZ_LOG_FORMAT=tree cargo run -- file.ts 2>&1 | grep "type_id=42"
-```
+Tips:
+- Capture: `... 2> trace.log`.
+- Trim: `... 2>&1 | head -100`.
+- Search ids: `rg "type_id=42" trace.log`.

--- a/.agents/skills/tsz-tracing/SKILL.md
+++ b/.agents/skills/tsz-tracing/SKILL.md
@@ -3,184 +3,46 @@ name: tsz-tracing
 description: Debug tsz compiler issues using the built-in tracing infrastructure. Use when investigating type inference bugs, conformance failures, or understanding runtime behavior. Provides hierarchical trace output of solver, checker, and binder operations.
 ---
 
-# TSZ Tracing Debug Skill
+# TSZ Tracing
 
-This skill helps you debug tsz compiler issues using the built-in tracing infrastructure. The tracing system provides detailed runtime information about type inference, narrowing, assignability checks, and more.
+Use tracing before adding debug prints. It is for conformance failures,
+inference/narrowing/assignability surprises, and runtime path discovery.
 
-## When to Use This Skill
-
-Use this skill when you need to:
-- Debug a failing conformance test
-- Understand why type inference produces unexpected results
-- Trace narrowing and control flow analysis
-- Investigate assignability check failures
-- Compare tsz behavior to tsc for specific inputs
-- Find where in the code path a bug occurs
-
-## Quick Start
+## Commands
 
 ```bash
-# Tree format - hierarchical, human-readable (recommended for debugging)
-TSZ_LOG=debug TSZ_LOG_FORMAT=tree cargo run -- file.ts
-
-# JSON format - machine-readable, good for tooling
-TSZ_LOG=debug TSZ_LOG_FORMAT=json cargo run -- file.ts
-
-# Plain text format (default)
-TSZ_LOG=debug cargo run -- file.ts
+TSZ_LOG=debug TSZ_LOG_FORMAT=tree cargo run -p tsz-cli -- file.ts
+TSZ_LOG=debug TSZ_LOG_FORMAT=json cargo run -p tsz-cli -- file.ts
+TSZ_LOG="tsz_solver=trace,tsz_checker=debug" TSZ_LOG_FORMAT=tree cargo run -p tsz-cli -- file.ts
+TSZ_LOG="tsz_solver::narrowing=trace" TSZ_LOG_FORMAT=tree cargo run -p tsz-cli -- file.ts
 ```
 
-## Environment Variables
+Use `RUST_LOG` only as fallback. `TSZ_LOG_FORMAT` values: `tree`, `json`,
+`text`.
 
-| Variable | Values | Description |
-|----------|--------|-------------|
-| `TSZ_LOG` | `trace`, `debug`, `info`, `warn`, `error` | Log level filter (same syntax as RUST_LOG) |
-| `TSZ_LOG_FORMAT` | `tree`, `json`, `text` | Output format |
-| `RUST_LOG` | Same as TSZ_LOG | Fallback if TSZ_LOG not set |
+## Workflow
 
-## Fine-Grained Filtering
+1. Reduce to the smallest `.ts` witness.
+2. Compare expected behavior with `npx tsc --noEmit file.ts`.
+3. Start broad (`debug`, tree), then narrow by module.
+4. Capture large traces with `2> trace.log`, `head`, `tail`, `rg`, or
+   `grep "type_id=<id>"`.
+5. Use structured trace fields and spans; never add ad-hoc stdout/stderr
+   debugging.
 
-Target specific modules for focused debugging:
+## Useful Filters
 
-```bash
-# Only solver operations
-TSZ_LOG="tsz::solver=debug" TSZ_LOG_FORMAT=tree cargo run -- file.ts
+- Narrowing: `TSZ_LOG="tsz_solver::narrowing=trace"`.
+- Relations/inference: `TSZ_LOG="tsz_solver=debug"`.
+- Checker lookup/cache: `TSZ_LOG="tsz_checker=debug"`.
+- Query events: `TSZ_LOG=tsz::query_json=trace TSZ_LOG_FORMAT=json`.
 
-# Only checker operations
-TSZ_LOG="tsz::checker=debug" TSZ_LOG_FORMAT=tree cargo run -- file.ts
+## Read Output
 
-# Multiple modules with different levels
-TSZ_LOG="tsz::solver=trace,tsz::checker=debug" TSZ_LOG_FORMAT=tree cargo run -- file.ts
+Tree output nests spans, shows elapsed ms, level, module path, event, and
+fields. Look for the first structural divergence: wrong narrowed member,
+unexpected relation result, missing lazy ref resolution, cache hit/miss, or
+diagnostic source-span decision.
 
-# Narrowing specifically (very detailed)
-TSZ_LOG="tsz::solver::narrowing=trace" TSZ_LOG_FORMAT=tree cargo run -- file.ts
-```
-
-## Instrumented Areas
-
-The following areas have tracing instrumentation:
-
-### Solver (`crates/tsz-solver/src/`)
-- `narrowing.rs` - Type narrowing operations (typeof, instanceof, discriminants)
-- `subtype.rs` - Subtype relationship checks
-- Type inference and instantiation
-
-### Checker (`crates/tsz-checker/src/`)
-- `context.rs` - Type context operations
-- `state.rs` - Node type caching (`get_type_of_node`)
-- `assignability_checker.rs` - Assignability checks
-- `class_inheritance.rs` - Class hierarchy analysis
-- `dispatch.rs` - Type dispatch operations
-
-### CLI (`crates/tsz-cli/src/`)
-- `driver.rs` - Compilation spans, file checking
-- `build.rs` - Build operations
-
-## Debugging Workflow
-
-### 1. Reproduce with Minimal Input
-
-Create a minimal `.ts` file that reproduces the issue:
-
-```typescript
-// test.ts
-function example<T>(x: T) {
-  if (typeof x === "string") {
-    return x.length; // Should narrow T to string
-  }
-}
-```
-
-### 2. Run with Tracing
-
-```bash
-TSZ_LOG=debug TSZ_LOG_FORMAT=tree cargo run -- test.ts 2>&1 | head -100
-```
-
-### 3. Compare with tsc
-
-```bash
-# Run tsc for expected behavior
-npx tsc --noEmit test.ts
-
-# Run tsz with tracing for actual behavior
-TSZ_LOG=debug TSZ_LOG_FORMAT=tree cargo run -- test.ts
-```
-
-### 4. Focus on Specific Operations
-
-If output is too verbose, narrow down:
-
-```bash
-# Just narrowing operations
-TSZ_LOG="tsz::solver::narrowing=trace" TSZ_LOG_FORMAT=tree cargo run -- test.ts
-
-# Just type lookup operations
-TSZ_LOG="tsz::checker::state=trace" TSZ_LOG_FORMAT=tree cargo run -- test.ts
-```
-
-## Reading Tree Output
-
-The tree format shows hierarchical span relationships:
-
-```
-  0ms DEBUG tsz::solver::narrowing narrow_by_typeof
-    source_type=42, typeof_result="string"
-  │ 0ms TRACE tsz::solver::narrowing Narrowing union type with 3 members
-  │ 0ms TRACE tsz::solver::narrowing Found single matching member, returning 15
-```
-
-- Indentation shows nesting (parent spans contain child spans)
-- `ms` shows elapsed time
-- Level (DEBUG, TRACE, etc.) shows severity
-- Module path shows source location
-- Key-value pairs show span fields
-
-## Common Debugging Scenarios
-
-### Incorrect Type Narrowing
-
-```bash
-TSZ_LOG="tsz::solver::narrowing=trace" TSZ_LOG_FORMAT=tree cargo run -- test.ts
-```
-
-Look for:
-- `narrow_by_typeof` spans for typeof narrowing
-- `narrow_by_truthiness` for boolean context narrowing
-- Member filtering operations
-
-### Assignability Failures
-
-```bash
-TSZ_LOG="tsz::checker::assignability=debug" TSZ_LOG_FORMAT=tree cargo run -- test.ts
-```
-
-Look for:
-- Subtype check results
-- Which types are being compared
-- Why assignability fails
-
-### Type Inference Issues
-
-```bash
-TSZ_LOG="tsz::solver=debug" TSZ_LOG_FORMAT=tree cargo run -- test.ts
-```
-
-Look for:
-- Generic instantiation
-- Constraint checking
-- Type parameter resolution
-
-## Tips
-
-1. **Pipe to file**: Traces can be large. Use `2> trace.log` to capture stderr
-2. **Use `head`/`tail`**: Filter output with `| head -200` or `| tail -100`
-3. **Use `grep`**: Search for specific type IDs: `| grep "type_id=42"`
-4. **Tree is best**: The tree format is easiest to read for debugging
-5. **Start broad, then narrow**: Begin with `debug`, then use module filters
-
-## Implementation Details
-
-Tracing is configured in `crates/tsz-cli/src/reporting/tracing_config.rs`. The subscriber is only initialized when `TSZ_LOG` or `RUST_LOG` is set, so there's zero overhead in normal usage.
-
-Output always goes to stderr to avoid interfering with compiler output (diagnostics, `--showConfig`, or LSP JSON-RPC on stdout).
+Tracing goes to stderr and is initialized only when `TSZ_LOG`/`RUST_LOG` is set.
+For trace examples and quick reminders, read `QUICKREF.md`.

--- a/.agents/skills/tsz-worktree-intake/SKILL.md
+++ b/.agents/skills/tsz-worktree-intake/SKILL.md
@@ -5,100 +5,50 @@ description: Start TSZ work safely in a crowded multi-agent checkout. Use when b
 
 # TSZ Worktree Intake
 
-Use this skill before non-trivial TSZ work. The goal is to avoid wasted cycles
-from stale branches, hidden dirty files, unowned PR overlap, missing TypeScript
-corpus state, and cache-destroying cleanup.
+Use before non-trivial TSZ work.
 
 ## Fast Path
 
-1. Pick or confirm a stable `AgentName`.
-2. Refresh the remote truth:
-
-   ```bash
-   git fetch origin main
-   ```
-
-3. Read the durable direction and lane state:
-
-   ```bash
-   sed -n '1,260p' docs/plan/ROADMAP.md
-   scripts/agents/show-goal.sh <AgentName>
-   ```
-
-4. Check local workspace health:
-
-   ```bash
-   git status --short --branch
-   scripts/agents/disk-preflight.sh <AgentName>
-   git worktree list
-   ```
-
-   If disk is low, cache state is unclear, or a new worktree might be needed,
-   use `tsz-disk-cache-hygiene` before cleaning or creating anything.
-
-5. Check coordination overlap before editing:
-
-   ```bash
-   scripts/agents/list-owned-work.sh <AgentName>
-   gh pr list --state open --limit 100 --json number,title,isDraft,headRefName,baseRefName,labels,updatedAt,url
-   gh issue list --state open --limit 100 --json number,title,labels,updatedAt,url
-   ```
-
-Read `references/common-failure-modes.md` when any command reveals a stale
-merged branch, dirty workspace, low disk, missing TypeScript corpus, or
-overlapping active PR.
-
-## Branch Choice
-
-Use the current branch only when it is the active PR branch for the requested
-work. If the current branch's PR is merged, closed, unrelated, or heavily ahead
-of `origin/main`, create a fresh branch from `origin/main`.
-
-Prefer:
-
 ```bash
-git switch -c codex/<short-scope>-<yyyymmdd> origin/main
+git fetch origin main
+sed -n '1,260p' docs/plan/ROADMAP.md
+scripts/agents/show-goal.sh <AgentName>
+git status --short --branch
+scripts/agents/disk-preflight.sh <AgentName>
+git worktree list
+scripts/agents/list-owned-work.sh <AgentName>
+gh pr list --state open --limit 100 --json number,title,isDraft,headRefName,baseRefName,labels,updatedAt,url
+gh issue list --state open --limit 100 --json number,title,labels,updatedAt,url
 ```
 
-If dirty files exist, inspect them before switching. Carry them only when they
-belong to the requested work; otherwise leave them unstaged and do not include
-them in the PR.
+If disk is low or worktree reuse is unclear, use `tsz-disk-cache-hygiene`.
+Read `references/common-failure-modes.md` only for stale merged branches, dirty
+same-path files, low disk, missing TS corpus, or overlapping active PRs.
 
-## Worktree Choice
+## Branch/Worktree Decision
 
-Reuse an existing sister worktree when disk or TypeScript corpus state makes it
-cheaper. Create new worktrees beside the checkout, not inside it:
+- Continue current branch only if it is the active PR branch for this work.
+- Otherwise create a fresh branch from `origin/main`.
+- Reuse inactive sister worktrees when useful. New worktrees go beside this
+  checkout:
 
 ```bash
-git worktree add ../tsz-<short-scope> -b codex/<short-scope>-<yyyymmdd> origin/main
-cd ../tsz-<short-scope>
+git worktree add ../tsz-<scope> -b codex/<scope>-<yyyymmdd> origin/main
+cd ../tsz-<scope>
 scripts/setup/link-ts-submodule.sh
 ```
 
-Do not run broad `du` archaeology or `cargo clean` as a reflex. If disk is low,
-follow the cleanup ladder printed by `scripts/agents/disk-preflight.sh`.
+Do not run broad `du`, `cargo clean`, or destructive cache cleanup as intake.
 
-## Intake Decisions
+## State The Decision
 
-Before coding, state the next action in one sentence:
+Before editing, say one sentence: continue existing PR, start fresh branch,
+handoff/unblock draft, or file an issue. For behavior work also state the
+structural rule and owner layer; for process/docs work state the recurring cost
+and evidence.
 
-- continue an existing PR,
-- start a fresh non-overlapping branch,
-- hand off or unblock an assigned draft,
-- file an issue instead of editing because the improvement is out of scope.
+## Stop
 
-For behavior work, also state the structural rule and owning layer before
-editing. For process or docs work, state the iteration bottleneck and the
-evidence that it is recurring.
-
-## Stop Conditions
-
-Pause and gather stronger evidence when:
-
-- more than one open PR claims the same issue or title scope,
-- the current branch is merged but still contains local-only changes,
-- local dirty files affect the same paths as the planned edit but their owner is
-  unclear,
-- the TypeScript corpus is missing and the task needs conformance, emit, or
-  fourslash source data,
-- a command would destroy caches or worktree state to solve a temporary problem.
+Pause for stronger evidence if overlap is ambiguous, branch is merged with
+local-only changes, dirty files affect your paths, TS corpus is needed but
+missing, or the next command would destroy caches/state.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,782 +1,178 @@
-# TSZ AGENT SPEC (LLM-COMPACT)
+# TSZ Agent Contract
 
-## 0) Mission
-- Absolute target: match `tsc` behavior exactly.
-- Must match diagnostics, inference, compatibility, narrowing, and edge cases.
-- `docs/plan/ROADMAP.md` is the single living roadmap. Before starting
-  conformance, emit, performance, architecture, LSP/WASM, Sound Mode, or DRY
-  cleanup work, read it and keep your work aligned with it.
-- Do **not** update `docs/plan/ROADMAP.md` for routine status, small fixes,
-  ordinary cleanup, or PR bookkeeping. That creates avoidable conflicts across
-  parallel PRs. Keep those details in draft PR bodies, PR comments, issues, or
-  review comments.
-- Update `docs/plan/ROADMAP.md` only when the work changes durable direction:
-  public metrics, release gates, track sequencing, accepted architecture,
-  active priorities, or a roadmap assumption that future agents would otherwise
-  rely on incorrectly. Do not create new roadmap files under `docs/plan/`;
-  update the living roadmap instead when a roadmap change is truly warranted.
-- To avoid duplicate work, roadmap-adjacent implementation must be visible
-  before coding starts: inspect open draft PRs, open PRs, recent merged PRs,
-  and relevant GitHub issues for overlapping work. A GitHub issue is optional;
-  a draft PR with a clear title/body is enough to claim active work.
-- Important: do not add `[codex]` to PR titles. PR titles should follow the
-  repository convention, e.g. `fix(checker): ...`, `chore(lsp-tests): ...`,
-  or `[WIP] <scope>: <intent>` while the work is still WIP.
-- While working, keep the draft PR current with new facts, root-cause
-  discoveries, scope changes, and coordination notes. Other agents use draft
-  PRs, PR comments, and review comments to decide whether their task duplicates
-  active work.
-- Do not park draft PRs and forget them. Owned open PRs are your active runway,
-  not a backlog shelf. Before opening a new branch or PR, run the live owned
-  work checks and first drive PRs you already own toward merge: land them via
-  `merge-queue`, mark them ready once verified, keep them draft/WIP only with a
-  fresh signed blocker or handoff comment, or close them only as an
-  evidence-linked duplicate/superseded PR. Opening a new PR is appropriate only
-  when your owned PRs are queued, intentionally stacked, explicitly blocked
-  with current notes, handed off, or the user explicitly redirects you.
-- Keep draft runway small. More than two unstacked draft PRs for one
-  `agent:*` owner, or a draft with no fresh commit/comment for 24 hours, is a
-  coordination smell. Update, rebase, mark ready, hand off, or add a signed
-  blocker comment before starting new work.
-- Never merge WIP branches. A branch is WIP if its PR is draft, has the `WIP`
-  label, has a `[WIP]` title prefix, or the PR/branch description says it is
-  WIP. Remove the label/prefix and mark the PR ready only after implementation,
-  verification, and any justified roadmap update are complete.
-- Do not add or re-add the `WIP` label silently. Whenever you add `WIP`, add a
-  `[WIP]` title prefix, or otherwise move a PR into WIP state, immediately post
-  a signed PR comment with your AgentName, why the PR is WIP, the current
-  blocker or active work, and the next owner/action. If a `WIP` label has no
-  signed explanatory comment within 30 minutes of the label event, another
-  agent may remove the label and add `help wanted` so the work can be picked up.
-- Do not close PRs or GitHub issues prematurely. Stale, dirty, failing,
-  conflicted, or WIP work is still repository knowledge; preserve it with a
-  signed status comment, `help wanted`, draft/WIP state, or a follow-up issue
-  instead of discarding it. Close only when the work merged, the user explicitly
-  asked for closure, it is an exact duplicate, or a newer PR/issue fully
-  supersedes it and links back to the preserved branch/commits and findings.
-  Before closing for duplicate/superseded reasons, leave a signed comment with
-  the evidence, the successor link, and what useful work was carried forward.
-- TSZ's merge gate is the repo-local merge queue. Ready PRs are enqueued with
-  the `merge-queue` label; the queue then tests a synthetic latest-`main`
-  merge, posts the required `Queue Tested` status to the PR head, and lands one
-  PR at a time. Do not bypass it with direct/admin merge unless the user
-  explicitly asks for an emergency bypass.
-- Do not add or re-add `merge-queue` unless you own the PR and the current head
-  SHA is genuinely ready to land: the PR is not draft, WIP, or blocked; PR-head
-  checks such as `CI Summary` and `GitGuardian Security Checks` have completed
-  successfully for that exact head; and you have intentionally reviewed the
-  latest pushed changes. `Queue Tested` is owned by the merge queue and may be
-  missing or pending before enqueue. Old green checks on a previous head are
-  not evidence.
-- Do not use auto-merge as a queue signal or CI watcher. If PR-head checks are
-  pending, missing, or failing, leave `merge-queue` off, keep or restore the
-  PR's draft/WIP/blocked state as appropriate, and post a signed status comment
-  naming the blocker, the affected check or rule, and the next owner/action.
-- Never re-promote a PR from draft/WIP or re-add `merge-queue` after another
-  agent removed it, converted the PR to draft, or marked it blocked unless you
-  have fixed the blocker on a new head and re-verified a clean, complete
-  PR-head check picture. Repeated queue re-arming is stop-the-line coordination
-  debt; link the blocking issue or PR comment instead of fighting the cleanup
-  agent.
-- Draft PRs intentionally run only light CI: lint, dist-fast build, and unit
-  tests. Marking a PR ready for review triggers the heavy suites: conformance,
-  emit, fourslash, and WASM. See §19.5 for the rules around local vs. CI work.
-- Keep DRY slices small and behavior-preserving unless explicitly fixing a bug.
-  Let CI perform compile, lint, unit, conformance, emit, and fourslash verification.
+Goal: match `tsc` exactly. Preserve diagnostics, inference, compatibility,
+narrowing, emit, edge cases, and project-row behavior.
 
-## 1) North Star
-- Solver-first.
-- Thin wrappers.
-- Visitor-driven type traversal.
-- Arena/interning everywhere possible.
-- One semantic `TypeId` universe (solver-canonical).
-- Public solver API uses `TypeData` naming at boundaries; raw type internals are crate-private.
+## Read First
+- Read `docs/plan/ROADMAP.md` before conformance, emit, performance,
+  architecture, LSP/WASM, Sound Mode, or DRY cleanup work.
+- Do not update the roadmap for routine status, small fixes, cleanup, or PR
+  bookkeeping. Use PR bodies, PR/review comments, or issues.
+- Inspect open PRs, recent merged PRs, and relevant issues before coding.
+- Open or update a draft PR early for roadmap-adjacent implementation.
 
-## 2) Canonical Pipeline
-- `scanner -> parser -> binder -> checker -> solver -> emitter`
-- LSP consumes project/checker/solver outputs; does not own type algorithms.
+## Architecture
+- Pipeline: `scanner -> parser -> binder -> checker -> solver -> emitter`.
+- Scanner: lexing, token stream, string/identifier interning.
+- Parser: syntax-only AST in arenas.
+- Binder: symbols, scopes, hoisting, flow graph. No type computation.
+- Checker: AST orchestration, context, diagnostics, source locations. Ask
+  solver for semantic answers.
+- Solver: relations, evaluation, inference, instantiation, operations,
+  narrowing, semantic caches, type construction, relation failure reasons.
+- Emitter: JS/DTS output and transforms. No semantic validation.
+- LSP/WASM/CLI consume project/checker/solver APIs; they do not own type
+  algorithms.
 
-## 3) Responsibility Split (WHO/WHAT/WHERE/OUTPUT)
-- Scanner: lex + token stream + string interning.
-- Parser: syntax only, builds AST in `NodeArena`.
-- Binder (`WHO`): symbols, scopes, flow graph; no type computation.
-- Checker (`WHERE`): AST walk, context, diagnostics; delegates type logic.
-- Solver (`WHAT`): all type relations/evaluation/inference/instantiation/narrowing.
-- Emitter (`OUTPUT`): JS/transform emission; no semantic type validation.
+Hard rules:
+- Type semantics belong in solver or a solver-backed query boundary.
+- Checker must not pattern-match raw solver internals, construct raw `TypeKey`,
+  directly intern solver types, or recurse type shapes when a solver visitor or
+  query can own it.
+- CLI and ancillary crates consume diagnostics through
+  `tsz_checker::diagnostics`.
+- Assignability paths for `TS2322`/`TS2345`/`TS2416` use the shared
+  `query_boundaries/assignability` gateway: relation -> reason -> diagnostic.
+- Emitter must not import checker internals or patch already emitted output to
+  encode semantic policy.
 
-## 4) Hard Architecture Rules
-- If code computes type semantics, it belongs in Solver.
-- Checker must not implement ad-hoc type algorithms.
-- Checker must not pattern-match low-level type internals when Solver query exists.
-- Checker must not import/construct raw `TypeKey` or perform direct solver interning.
-- CLI and ancillary crates must consume checker diagnostics via `tsz_checker::diagnostics`.
-- Use visitor helpers for type traversal; avoid repeated `TypeKey` matching.
-- No forbidden shortcuts:
-  - Binder importing Solver for semantic decisions.
-  - Emitter importing Checker internals for semantic checks.
-  - Any layer bypassing canonical query APIs.
-  - Checker or CLI using `tsz_checker::types` internal diagnostic paths.
+## Compatibility Model
+- Judge: strict structural/set-theoretic subtype logic.
+- Lawyer: `CompatChecker` plus `AnyPropagationRules` for TS legacy quirks:
+  `any`, variance, excess/freshness, `void` return exception, weak types.
+- Default preference: `any` must not silence structural mismatches unless
+  compatibility mode requires it.
+- Semantic refs are `TypeData::Lazy(DefId)`. Checker stabilizes `DefId`;
+  `TypeEnvironment` resolves `DefId -> TypeId`.
 
-## 5) Judge/Lawyer Model (Compatibility)
-- Judge (`SubtypeChecker`): strict structural/set-theoretic subtype logic.
-- Lawyer (`CompatChecker` + `AnyPropagationRules`): TS legacy/compat quirks.
-- Lawyer owns:
-  - `any` propagation policy,
-  - variance modes,
-  - excess property/freshness,
-  - `void` return exception,
-  - weak type detection (TS2559).
-- Preferred default: `any` must not silence structural mismatches unless compatibility mode requires it.
+## Data And Organization
+- Canonical identity handles: `TypeId(u32)`, `SymbolId(u32)`,
+  `FlowNodeId(u32)`, `Atom(u32)`.
+- One semantic type universe in the default pipeline.
+- Prefer arenas, interning, O(1) identity checks, visitor traversal, and
+  dedicated modules by concern.
+- No hand-authored source, test, script, or generated-code shard may exceed
+  2000 physical lines. Split instead of adding local allowlists or ceilings.
 
-## 6) DefId-First Semantic Type Resolution
-- Semantic refs in Solver are `TypeData::Lazy(DefId)` (with `TypeKey` sealed/private).
-- Checker creates/stabilizes `DefId` and ensures environment mapping exists.
-- `TypeEnvironment` resolves `DefId -> TypeId` during relation/evaluation.
-- Type-shape traversal and `Lazy(DefId)` discovery must use solver visitors, not checker recursion.
-- New semantic refs must not use ad-hoc symbol-backed shortcuts.
+## Testing And Commands
+- Never run full conformance, emit, or fourslash locally. Use narrow filters;
+  ready-review CI owns broad suites.
+- Use `cargo nextest run`, not `cargo test`.
+- Wrap long or memory-heavy commands with `scripts/safe-run.sh`.
+- Prefer not to checkout the full TypeScript submodule unless the specific
+  task needs it.
+- For tracing, use `TSZ_LOG`/`TSZ_LOG_FORMAT`; do not add print debugging.
+- No temporary `dbg!`; no compiler instrumentation via `println!`, `print!`,
+  or `eprintln!`. Use `tracing`.
+- In Rust doc comments, backtick CamelCase identifiers, file names, and dotted
+  paths to satisfy `clippy::doc_markdown`.
 
-## 7) Core Data/Perf Contracts
-- Identity handles:
-  - `TypeId(u32)`, `SymbolId(u32)`, `FlowNodeId(u32)`, `Atom(u32)`.
-- Single semantic type universe: no checker-local semantic `TypeId`/`TypeArena` in default pipeline.
-- O(1): type equality, symbol lookup, node access, string equality.
-- AST node header target: 16 bytes.
-- Arena allocation for AST/symbols/flow.
-- Global type interning for dedup + O(1) equality.
-
-## 8) Scanner Contracts
-- Zero-copy source handling (`Arc<str>` style).
-- Identifiers/strings interned to `Atom`.
-- Parser-driven scanning API.
-- Contextual rescans supported (`>`, `/`, template).
-
-## 9) Parser Contracts
-- Produces syntax-only AST.
-- Node header fixed/thin (`kind`, `flags`, `pos`, `end`, `data_index`).
-- Typed side pools for payloads.
-- Recursion guard limit enforced.
-
-## 10) Binder Contracts
-- Produces:
-  - symbol arena,
-  - persistent scope tree (not transient stack model),
-  - control-flow graph.
-- Handles hoisting with multi-pass strategy.
-- No type inference/subtyping logic in binder.
-
-## 11) Solver Contracts
-- Owns relation/evaluation/inference/instantiation/operations/narrowing.
-- Owns type construction via safe factories/builders (`array`, `union`, `intersection`, `lazy`, etc.).
-- Uses memoization and cycle/coinductive handling.
-- Type graph represented through interned `TypeData` variants (crate-private internals; no raw `TypeKey` leakage).
-- Owns algorithmic caches (relation/evaluation/instantiation/property/index/keyof/template).
-- Provides structured relation failure reasons for checker diagnostics.
-- Enforce recursion/fuel limits for subtype/evaluate/instantiate workloads.
-
-## 12) Checker Contracts
-- Thin orchestration only.
-- Reads AST/symbol/flow facts; asks Solver for semantic answers.
-- Tracks diagnostics and source locations.
-- Maintains node/symbol/flow/diagnostic caches and recursion guards.
-- Must not own algorithmic type caches or type-shape traversal logic.
-- Checker files follow the repository-wide hard file-size rule in §19: split
-  orchestration by concern before a file reaches 2000 lines.
-
-## 13) Emitter Contracts
-- Prints/transforms output from checked structures.
-- Supports downlevel transform pipeline (AST -> IR -> print) where applicable.
-- No on-the-fly semantic type validation.
-
-## 14) LSP Contracts
-- Consumer/orchestrator over project state.
-- Global type interning across files.
-- Incremental updates via reverse deps.
-- Should remain WASM-compatible constraints when required.
-
-## 15) Dependency Policy (Review Gate)
-For each change ask:
-1. Is this `WHAT` (type algorithm) or `WHERE` (diagnostic location/orchestration)?
-2. If `WHAT`: move to Solver/query helper.
-3. If `WHERE`: keep in Checker and call Solver.
-4. Does this introduce checker access to solver internals (`TypeKey`, raw interner)? If yes, reject.
-5. Does assignability flow through the shared compatibility gate? If no, refactor first.
-
-## 16) Type System Surface (Canonical Kinds)
-- Must support primitives, literals, arrays/tuples, objects, unions/intersections,
-  callables/functions, type params, lazy refs, applications, conditionals,
-  mapped/index/keyof/template/this/unique symbol/readonly/string intrinsics/infer/error.
-- Keep built-in TypeId reservations stable (0..99 range policy).
-
-## 17) Flow/Symbol Contracts
-- Symbols include declarations, parent linkage, member/export tables, flags/modifiers.
-- Flow graph nodes include flags + antecedents + AST link.
-- Preserve TS-relevant symbol/modifier semantics.
-
-## 18) Performance Targets (Directional)
-- Parse: high-throughput, parallel at file level.
-- Bind/check: incremental-friendly with reverse dependency tracking.
-- Hot paths avoid per-op heap allocation where practical.
-- Maintain fast identity checks before structural checks.
-
-## 19) Code Organization Guidance
-- Keep modules aligned with pipeline ownership (`scanner`, `parser`, `binder`, `solver`, `checker`, `emitter`, `transforms`).
-- Prefer dedicated files per major checker/solver concern.
-- Avoid growth of monolith modules; split before crossing maintainability threshold.
-- Hard limit: no hand-authored source, test, script, or generated-code shard may
-  exceed 2000 physical lines. There are no file-size ratchet exceptions. If a
-  generated artifact would exceed the limit, update the generator so it emits
-  smaller shards. If a checked-in asset must remain large for external
-  compatibility, treat it as data and document why it is not executable source
-  in the owning PR.
-- Do not add new local allowlists, baseline files, ignored tests, or
-  per-file ceilings for oversized code. The right fix is to split the file.
-
-## 19.5) Testing and CI
-- **Never run full conformance, fourslash, or emit suites locally.** Those are
-  CI's job. Local pre-commit stays cheap and should only run fast guardrails.
-- Prefer **not** having the full TypeScript submodule checked out locally
-  unless you actually need its sources for a specific investigation. CI has it.
-- Run local commands only when they answer a specific debugging question or
-  provide fast targeted feedback. Prefer narrow filters and stop once the
-  result informs the fix.
-- Open a draft PR early. Draft CI runs lint, dist-fast build, and unit tests.
-  When the PR is marked ready for review, CI runs conformance, emit, fourslash,
-  WASM, and snapshot gates.
-- After exact-head PR-head gates pass on a ready PR, the merge manager adds the
-  `merge-queue` label. The required `Queue Tested` status is produced by the
-  queue's synthetic latest-`main` run and is not a pre-enqueue prerequisite.
-- **Never sit waiting for CI.** Push the draft PR, note the run URL if useful,
-  then switch to non-overlapping work. Come back later to inspect status.
-- **Use `cargo nextest run` instead of `cargo test`** for unit/integration runs.
-  Better parallelism, output, and failure reporting.
-  - Filtered runs: `cargo nextest run -E 'test(pattern)'` or `cargo nextest run -- pattern`
-  - Single crate: `cargo nextest run -p tsz_checker`
-  - Wrap full-suite runs with `scripts/safe-run.sh` (see §20.75).
-
-## 19.6) Lint Hygiene For Doc Comments
-
-The workspace lints turn `clippy::doc_markdown` and `clippy::print_stderr`
-into hard errors. Both bite often enough to keep in mind upfront:
-
-- **Backtick CamelCase identifiers, file names, and dotted paths in doc
-  comments.** Bare `PerformanceDoc.md`, `MyType`, or `getrusage(RUSAGE_SELF)`
-  in `///` comments fails `clippy::doc_markdown`. Wrap the identifier in
-  backticks: `` `PerformanceDoc.md` ``. Inline code spans inside prose count
-  too — `\`docs/PERFORMANCE_PLAN.md\`` over plain `docs/PERFORMANCE_PLAN.md`.
-- **No `eprintln!` / `print!` to stderr.** `clippy::print_stderr` is denied.
-  Use `tracing::warn!` / `tracing::error!` / a structured logger. Tests can
-  use `eprintln!` only behind `#[cfg(test)]` (still preferred to avoid).
-- **No `dbg!` / `println!` to stdout** outside a deliberate user-facing CLI
-  surface — `clippy::print_stdout` is allowed today but `clippy::dbg_macro`
-  is denied; if you add a temporary `dbg!`, remove it before committing.
-- Run `cargo clippy --workspace --all-targets --all-features -- -D warnings`
-  locally before pushing when the change needs lint feedback. CI runs it too.
-
-## 19.7) Tracing And Debug Instrumentation
-
-The repo has real tracing infrastructure. Use it for internal diagnostics;
-do not add ad-hoc print debugging.
-
-- **Use `tracing`, not `printf`-style debugging.** For Rust internals, prefer
-  `tracing::trace!`, `debug!`, `info!`, `warn!`, `error!`, `trace_span!`, and
-  `debug_span!` with structured fields:
-  ```rust
-  tracing::trace!(type_id = type_id.0, symbol = symbol_id.0, "resolved type");
-  ```
-- **Keep stdout for intentional user output only.** `println!` / `print!` are
-  acceptable for tsc-compatible CLI output, help/version text, protocol output,
-  and explicit tool reports. They are not acceptable as temporary compiler
-  instrumentation. Shell scripts may still use `printf` for their own
-  user-facing output.
-- **Use the existing subscriber knobs.** `tsz`, `tsz-lsp`, and `tsz-server`
-  initialize tracing through `tsz_cli::tracing_config::init_tracing()`. Run with
-  `TSZ_LOG=debug TSZ_LOG_FORMAT=tree cargo run -p tsz-cli -- file.ts`, or narrow
-  filters such as `TSZ_LOG="tsz_checker=debug,tsz_solver::narrowing=trace"`.
-  Use `TSZ_LOG_FORMAT=json` for machine-readable traces and
-  `TSZ_LOG=tsz::query_json=trace TSZ_LOG_FORMAT=json` for solver query events.
-- **Avoid eager formatting in hot paths.** Put raw ids and small scalars in
-  tracing fields. For type display in solver traces, use lazy helpers such as
-  `TypeDisplay` and `RelationDisplay`; guard genuinely expensive trace-only
-  work with `tracing::enabled!`.
-- **If trace/debug output is missing, rebuild appropriately before adding
-  prints.** Release-like profiles may compile low-level tracing out for
-  performance; use `cargo run`, `cargo build`, or another debug/dev profile
-  when investigating `trace!` / `debug!` instrumentation.
-- **Tests that assert instrumentation should capture tracing, not stdout.** Use
-  existing test tracing helpers where available instead of printing diagnostics
-  and eyeballing `cargo nextest` output.
-
-## 20) Repo-Local Skills
-
-Repo-local TSZ skills live under `.agents/skills/`. Use them when the task
-matches their description:
-
-- `tsz-architecture`: checker/solver/binder/emitter/LSP/WASM boundary work and
-  architecture guard failures.
-- `tsz-ci-pr`: GitHub PR status, CI triage, ready/merge handling, and landing.
-- `tsz-conformance`: conformance regressions, accepted-regression drift,
-  fingerprint-only triage, and conformance issue creation.
-- `tsz-disk-cache-hygiene`: disk-space recovery, worktree reuse, and
-  cache-preserving cleanup before large builds or new worktrees.
-- `tsz-emit`: JavaScript/declaration emit and emit parity work.
-- `tsz-iteration-audit`: repo-health deep dives, iteration bottleneck triage,
-  and focused process/tooling improvement PRs.
-- `tsz-performance-engineering`: performance/cache/residency/timing work,
-  evidence packets, and past perf mistake avoidance.
-- `tsz-project-bench`: benchmark/project-corpus rows, fixture metadata, PGO, and
-  benchmark dashboard work.
-- `tsz-pr-coordination`: PR body, AgentName, WIP/draft/ready, labels, review
-  response, and merge-queue coordination.
-- `tsz-tracing`: tracing-driven debugging of checker/solver/binder behavior.
-- `tsz-worktree-intake`: safe task start, stale branch recovery, disk/cache
-  preflight, dirty workspace triage, and worktree reuse.
-
-Runtime-provided global skills may exist outside this checkout; do not document
-them as TSZ repo skills.
-
-## 20.1) Agent Identity & Collaboration
-
-- **Pick an AgentName.** If you don't have one, derive one from the machine
-  you're running on (CPU + RAM + model — e.g. `m3-max-64g-opus47`). Keep it
-  stable across the session. Claude Code and other runner-backed agents are
-  first-class contributors, but their generated runner/model names are not
-  GitHub ownership lanes. If you are launched for a planned lane, use that
-  canonical `AgentName` (`M1-*`, `M4-*`, `Studio-*`, or `Reviewer`) in PR
-  bodies, comments, and `agent:*` labels. If no canonical lane was assigned,
-  keep the runner-generated name only in signed comments or Coordination Notes
-  and do not create a new `agent:<runner-name>` label.
-- **Keep ownership labels canonical.** The only multi-agent ownership labels
-  are the labels documented in `docs/plan/agents/README.md`. Do not create or
-  apply labels such as `agent:claude-sonnet-*`, `agent:dreamy-*`, other
-  generated runner aliases, or typo labels such as `agnet:*`. If you inherit a
-  PR with a noncanonical owner label, replace it with the correct canonical
-  lane before marking the PR ready or adding `merge-queue`, and leave a
-  signed comment if the ownership handoff is not obvious from the PR body.
-- **Sign your work.** Every PR body and GitHub issue you create or comment on
-  must include your AgentName so humans (and other agents) can tell who did it.
-- **PR bodies are mandatory coordination state, not paperwork.** Never open or
-  update a PR with `--fill` alone, an empty body, a stale template, or placeholder
-  sections. Use a real body file/heredoc and fill every template section before
-  marking the PR ready. At minimum every PR body must contain:
-  `AgentName`, `Track`, `Invariant`, `Scope`, `Project Corpus Impact`,
-  `Verification`, and `Coordination Notes`.
-- **Comment when changing WIP state.** Adding or re-adding the `WIP` label,
-  adding a `[WIP]` title prefix, or converting a PR back to draft because it is
-  blocked must be paired with a signed PR comment. Include the reason for the
-  WIP state, the blocker or current investigation, the next owner/action, and
-  any verification already run. Do not rely on the label alone as a coordination
-  signal.
-- **Fill the Project Corpus Impact section on every PR.** The PR template
-  requires it. Do not delete or leave it blank. If the PR cannot affect project
-  corpus behavior, write `Row: n/a`, `Bug family: n/a`, and one concrete
-  evidence line such as `docs-only`, `agent-skill-only`, or `test-harness-only`.
-  For compiler, benchmark, emit, checker, solver, parser, binder, LSP, WASM, or
-  CI changes, name the affected project row when known, name the bug family, and
-  cite the local command, CI job, issue, or artifact used as evidence.
-- **Verify the body GitHub actually stored.** Immediately after creating or
-  materially editing a PR, run `gh pr view <number> --json body` (or equivalent)
-  and confirm the required sections are present in the remote body. If any
-  section is missing, update the PR body before pushing more work, rerunning CI,
-  or marking the PR ready. If `project-corpus-pr-body` fails, fix the PR body
-  first; do not rerun failed jobs until the remote body passes this checklist.
-- **Acknowledge code reviews.** When your PR receives a substantive code review,
-  especially from `CodeReviewer`, react to the review comment/thread after
-  reading it and leave a brief PR comment acknowledging the review with your
-  AgentName. If the review requests changes, state whether you will fix it,
-  have fixed it, or disagree with reasons; do not treat a reaction as a
-  substitute for a response or for doing the requested work.
-- **Do not close work just to tidy queues.** Closing a PR or issue is a
-  destructive coordination action because branch context, investigation notes,
-  and partial fixes can be lost. Do not close because CI is red, the branch is
-  old, the PR is draft/WIP, or the current owner is inactive. Prefer a signed
-  handoff comment plus `help wanted`. If closure is truly warranted because the
-  work is duplicate or superseded, link the successor, summarize what was
-  preserved, and include the exact branch/commit evidence in the closing
-  comment.
-- **Drain owned PRs before creating new ones.** At the start of each work
-  cycle, run `scripts/agents/list-owned-work.sh --pr-state <AgentName>` and,
-  when coordinating across lanes, `node scripts/ci/pr-ownership-report.mjs`.
-  If you own open PRs, actively move each one to `merge-queue`, ready,
-  refreshed draft/WIP with a signed blocker, signed handoff/help-wanted, or
-  evidence-linked duplicate/superseded closure before starting unrelated new
-  PR work.
-- **Queue green ready PRs instead of leaving them idle.** If an owned ready
-  `main` PR has passing PR-head `CI Summary` and `GitGuardian Security Checks`,
-  is not dirty/conflicting, and is not WIP/blocked, add `merge-queue`. If you do
-  not enqueue it, leave a signed comment naming the blocker and next action.
-- **Shared GitHub identity.** All agents push as the same GitHub user
-  (`mohsen1`). Assume sibling agents are operating concurrently under the same
-  account — check draft PRs, open PRs, recent merged PRs, and relevant issues
-  before starting work, and address other agents by their AgentName when
-  relevant.
-- **Use `gh` for GitHub operations.** The GitHub CLI is available in this
-  workspace and should be preferred over connector/integration tools for
-  inspecting PRs/issues, creating or updating PRs, and checking CI status.
-- **Stacked PRs for dependent work.** If your new PR depends on another PR
-  that should land first, open it as a stacked PR (base = the dependency
-  branch, not `main`). When the dependency merges, GitHub automatically
-  rebases the base to `main`. Do not wait for the dependency to merge before
-  starting; do not duplicate its changes into your branch.
-
-## 20.2) Opportunistic Improvements
-
-- If you spot a mistake while browsing code, fix it. If the fix is genuinely
-  unrelated to your current PR, file a GitHub issue instead (with your
-  AgentName in the body).
-- If you spot a refactor that would improve the code, apply it **only if its
-  blast radius fits inside your current PR**. Otherwise file an issue.
-- Don't bundle a sprawling refactor into a narrow bug-fix PR — that defeats
-  reviewability and breaks the stacked-PR model.
-
-## 20.21) Upstream TypeScript Bugs
-
-- If an investigation proves the observed behavior is definitely a `tsc` bug,
-  do not patch tsz away from `tsc` parity. File the bug in the tsz repository
-  as a GitHub issue documenting the minimized repro, actual `tsc` behavior,
-  expected behavior, and the evidence that this is upstream rather than a tsz
-  divergence.
-- Apply the `TypeScript bug` label to that issue and include your AgentName in
-  the body. If there is an existing upstream TypeScript issue, link it from the
-  tsz issue. Do not open issues or comments in TypeScript or any other upstream
-  repository unless the user explicitly asks you to do that.
-- If there is already a tsz issue for the same upstream bug, comment on that
-  tsz issue instead of opening a duplicate.
-
-## 20.25) Conformance Maintenance
-
-Conformance is at 100%. The daily mode is **regression prevention**, not
-recovery. There is no session picker, campaign loop, or random-pick script.
-
-- Preserve 100% when changing checker, solver, parser, binder, emitter,
-  transforms, compiler diagnostics, conformance harness code, TypeScript
-  baselines, or conformance snapshot files.
-- Every behavior-changing fix needs an owning-crate unit test.
-- **Do not run the full conformance suite locally** (see §19.5). Let
-  ready-for-review CI run it.
-- For local debugging only, use a narrow filter:
-  ```bash
-  ./scripts/conformance/conformance.sh run --filter "<name>" --verbose
-  ```
-- If you suspect a regression, the per-test detail is in
-  `scripts/conformance/conformance-detail.json` (read it offline; don't
-  re-run to inspect). Snapshot aggregates are in
-  `scripts/conformance/conformance-snapshot.json`. The
-  `python3 scripts/conformance/query-conformance.py --dashboard` command
-  surfaces the standard KPIs (big3, crashes, fingerprint-only, etc.).
-- If you do introduce a regression, fix it in the same PR or revert. Do not
-  hide regressions inside "refresh snapshots" / "integrate batch" /
-  "update baselines" commits — those must still be net-zero or net-positive.
-
-## 20.75) Memory-Guarded Execution (`scripts/safe-run.sh`)
-- **All long-running or memory-intensive commands MUST be wrapped with `scripts/safe-run.sh`.**
-- This includes: `cargo nextest run` (full suite), `cargo build --release`, and any multi-worker test runner.
-- CI-only full conformance/snapshot jobs are also memory-guarded when run by
-  maintainers, but this section does not override the local "never run full
-  conformance" rule above.
-- The wrapper monitors the process tree's total RSS and kills it if it exceeds the limit (default: 75% of system RAM).
-- Overhead is negligible — one `ps` call every 5 seconds.
-- Quick, filtered runs (`--filter`, `--max`) and `cargo check` generally don't need the wrapper.
-
-```bash
-# Wrap heavy allowed local commands
-scripts/safe-run.sh cargo nextest run
-scripts/safe-run.sh cargo build --release
-scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter mappedTypeRelationships --verbose
-
-# Custom limit (absolute MB or percentage of RAM)
-scripts/safe-run.sh --limit 8192 -- cargo nextest run --cargo-profile release
-scripts/safe-run.sh --limit 50% -- ./scripts/conformance/conformance.sh run --filter mappedTypeRelationships
-
-# Debug memory usage
-scripts/safe-run.sh --verbose -- cargo build
-```
-
-## 20.8) Disk-Space And Worktree Hygiene
-- **Do not burn tokens or terminal output on broad disk archaeology.** Avoid
-  `du -sh *`, recursive `du`, or giant sorted size dumps unless a targeted
-  cleanup needs exact ownership. Start with compact checks:
-  ```bash
-  df -h .
-  scripts/setup/disk-worktree-guard.sh
-  ```
-- Before creating a new worktree, check reusable worktrees first:
+## Worktree And Disk
+- Before new worktrees, run:
   ```bash
   scripts/setup/disk-worktree-guard.sh
   git worktree list
   ```
-- New worktrees must be created adjacent to this checkout, as sister
-  directories under the parent of `tsz`, not nested inside the repo. Example:
-  `git worktree add ../tsz-<short-scope> <branch>`.
-- Prefer reusing an existing sister worktree that has been inactive for at
-  least 4 hours. The guard script prints compact reuse candidates and excludes
-  build/cache directories from its activity check.
-- If disk is nearly full, do not destroy useful caches first. Run the
-  cache-preserving cleanup path:
-  ```bash
-  scripts/setup/disk-worktree-guard.sh --auto-prune
-  scripts/setup/clean.sh --quiet
-  ```
-  This prunes old Cargo incremental directories and normal debris while keeping
-  `.target`, `.target-bench`, `target` artifacts, and the checked-in tsc cache
-  unless `--full` is explicitly chosen.
-- Use `scripts/setup/clean.sh --full` only as a deliberate last resort after
-  confirming the repo/worktree is not being used for an active build.
-- When a run fails immediately after a main merge or branch switch, rule out a
-  stale binary before assuming a source regression. Prefer harnesses that
-  already rebuild stale binaries, such as `scripts/emit/run.sh`; otherwise
-  rebuild the narrow binary once and rerun the focused command.
+- Reuse inactive sister worktrees when possible. New worktrees go beside this
+  checkout: `git worktree add ../tsz-<scope> ...`.
+- If disk is low, preserve caches first:
+  `scripts/setup/disk-worktree-guard.sh --auto-prune` then
+  `scripts/setup/clean.sh --quiet`.
+- Avoid broad recursive `du` output unless exact ownership is needed.
 
-## 20.9) LLM Context And Startup Hygiene
-- Keep always-loaded project instructions small enough to be useful at startup.
-  Put repeatable detailed workflows in repo-local skills, scripts, or focused
-  docs, and load them only when the task matches.
-- Do not make startup hooks print `AGENTS.md`, `.claude/CLAUDE.md`,
-  `docs/plan/ROADMAP.md`, large JSON artifacts, or broad command output. The
-  client already loads its durable instruction surface; hooks should emit short
-  reminders or machine-readable checks only.
-- Do not make startup hooks mutate git state with `pull`, `rebase`, `merge`,
-  checkout, label changes, or PR updates. Intake commands decide when to fetch
-  or rebase after the agent has inspected the current task and branch.
-- Avoid project-level output-token overrides unless a lane has measured need.
-  Forced large outputs make context management worse for ordinary coding work.
-- Run `scripts/agents/llm-context-audit.py` after editing `.codex/`,
-  `.claude/`, `AGENTS.md`, or agent startup hooks.
+## GitHub And PR Coordination
+- Use `gh`.
+- Stable `AgentName` is required in PR bodies, issues, and substantive
+  comments.
+- Canonical ownership labels are only those in `docs/plan/agents/README.md`.
+  Do not create generated runner labels or typo labels.
+- Do not add `[codex]` to PR titles.
+- PR bodies must include: `AgentName`, `Track`, `Invariant`, `Scope`,
+  `Project Corpus Impact`, `Verification`, and `Coordination Notes`.
+- Verify remote PR bodies after create/material edit:
+  `gh pr view <n> --json body`.
+- Drain owned PRs before starting unrelated work. Do not park stale draft PRs.
+- Never merge WIP: draft, `WIP` label, `[WIP]` title, or body/branch says WIP.
+- Adding WIP/draft state requires an immediate signed comment with reason,
+  blocker/current work, next owner/action, and verification already run.
+- Close PRs/issues only when merged, user-requested, exact duplicate, or fully
+  superseded with evidence and preserved findings.
+- Ready PRs land through repo-local merge queue. Add `merge-queue` only if you
+  own the PR, it is not WIP/draft/blocked, exact-head PR-head checks pass, and
+  you reviewed the latest head. Do not use auto-merge as a watcher.
+- `Queue Tested` is produced by the queue after enqueue.
 
-## 21) Non-Negotiables
+## Repo Skills
+Use repo-local skills under `.agents/skills/` when the task matches:
+- `tsz-worktree-intake`: start/resume safely, choose branch/worktree.
+- `tsz-disk-cache-hygiene`: disk cleanup/cache preservation.
+- `tsz-pr-coordination`: PR body, labels, WIP/draft/ready, reviews.
+- `tsz-ci-pr`: CI, queue, landing.
+- `tsz-architecture`: checker/solver/binder/emitter/LSP boundaries.
+- `tsz-conformance`: diagnostic conformance and accepted-regression drift.
+- `tsz-emit`: JS/DTS emit.
+- `tsz-tracing`: tracing-driven debugging.
+- `tsz-performance-engineering`: perf/cache/residency.
+- `tsz-project-bench`: project corpus and benchmark rows.
+- `tsz-iteration-audit`: workflow, guardrail, context debt.
+
+Runtime/global skills may exist outside this checkout; do not document them as
+TSZ repo skills.
+
+## Bug And Fix Discipline
 - Parity with `tsc` overrides convenience.
-- Architecture direction is one-way; no cross-layer semantic leakage.
-- Solver is the single source of truth for type computation.
+- The reported repro is one witness, not the scope.
+- Before coding, identify the wrong semantic operation: relation, inference,
+  narrowing, key/index/mapped/conditional/template/infer evaluation, property
+  lookup, symbol resolution, diagnostic display, parser recovery, or emit
+  transform.
+- State the structural rule:
+  `When <structural condition>, tsc does X; tsz does X through <owner>.`
+- Behavior fixes need adjacent cases: renamed binders, alias/wrapper/nesting,
+  generic and concrete forms, positive and negative/fallback cases.
+- Performance fixes must address the repeated operation, state complexity/cache
+  key/invalidation/fuel/residency expectations, and avoid fixture-name fast
+  paths.
+- If an observed behavior is a definite `tsc` bug, do not patch away from
+  parity. File/comment in tsz with the `TypeScript bug` label and evidence.
 
-## 22) TS2322 Priority Rules
-- `TS2322` parity is a top-level gate for checker/solver work.
-- `TS2322`/`TS2345`/`TS2416` paths must use one compatibility gateway via `query_boundaries`.
-- Gateway order is fixed: relation -> reason -> diagnostic rendering.
-- Use the assignability gate helper as a single entrypoint for relation + failure analysis; avoid split ad-hoc calls.
-- New checker code must not call `CompatChecker` directly for TS2322-family paths; route through `query_boundaries/assignability`.
-- Checker must not instantiate solver internals in feature modules when a boundary helper can exist.
-- Keep `TS2322` behavior centralized:
-  - one suppression/prioritization policy,
-  - one mismatch decision gate,
-  - one explain-to-diagnostic rendering path.
-- Prefer moving new fixes into boundary helpers and solver query logic, not ad-hoc checker branches.
+## Anti-Hardcoding Gate
+Forbidden in checker/solver/emitter decisions:
+- user-chosen identifier, alias, type parameter, property, or file-name string
+  checks;
+- regex/`contains`/`starts_with` over rendered type/printer output;
+- single-test/file/source-text scoped suppressions;
+- cosmetic widening/dropping/synthesizing types only to match a message.
 
-## 23) TS2322 Change Review Checklist
-1. Does this change alter `Assignable`/`Subtype` behavior in checker code?
-2. If yes, can it be expressed as a solver relation query or boundary helper first?
-3. Are weak-union/excess-property/any-propagation behaviors preserved and explicit?
-4. Does the path resolve `Lazy(DefId)` via `TypeEnvironment` before relation checks?
-5. Is traversal/precondition discovery delegated to solver visitors (no checker type recursion)?
-6. Is the diagnostic generated from solver failure reason instead of checker-local heuristics?
+Use binder/global builtin ids for true built-ins. Use solver or query-boundary
+structural helpers for shape decisions. The printer may read types; types must
+not read printer output.
 
-## 24) Local Setup Requirements
-- Run `./scripts/setup/setup.sh` once per workspace and keep `scripts/githooks` active.
-- This ensures `pre-commit` checks run locally before commits.
-- If hooks are not installed, local lint guardrails can be bypassed accidentally.
+Review checklist:
+1. No new user-name/file-name literals driving compiler logic.
+2. No formatted diagnostic string used as a semantic predicate.
+3. Tests vary binder names when binders are involved.
+4. PR body states structural rule, owner layer, adjacent matrix, fallback, and
+   performance numbers when performance-motivated.
 
-## 24.5) Critical: Work Philosophy
-- Prioritize **architectural integrity** over quick fixes.
-- When in doubt, choose the path that preserves the clean separation of concerns and long-term maintainability, even if it requires more upfront work.
-- Avoid patching symptoms in the checker; instead, invest in the solver and boundary helpers to keep the architecture sound.
-- Use the conformance analysis tools to guide work towards root causes, not just individual test failures.
-- See §25 for forbidden symptom-patching patterns (hardcoded identifier
-  names, regexes over printer output, single-test scoped suppressions).
+## LLM Context Hygiene
+- Keep always-loaded instructions small. Put repeatable workflows in skills,
+  scripts, or focused docs.
+- Startup hooks must not print `AGENTS.md`, `.claude/CLAUDE.md`, roadmap files,
+  large JSON, or broad command output.
+- Startup hooks must not mutate git state (`pull`, `rebase`, `merge`,
+  checkout, labels, PR updates).
+- Avoid project-level output-token overrides unless measured for a lane.
+- After editing `.codex/`, `.claude/`, `AGENTS.md`, or startup hooks, run
+  `scripts/agents/llm-context-audit.py`.
 
-## 25) ANTI-HARDCODING DIRECTIVE — never patch a single test's symptom
+## PR-Type Notes
+- Compiler PRs: structural rule, owner layer, adjacent-case matrix, cache/order
+  plan when relevant, project-corpus smoke when a required row may be affected.
+- Emit/DTS PRs: failure family, output owner, no semantic validation, no output
+  surgery, targeted baseline/unit checks.
+- Refactor PRs: behavior unchanged, future campaign enabled, focused checks.
 
-The conformance corpus is hostile to point fixes. Almost every failing
-test is one instance of a class of failures, and tsc's behaviour is
-defined by the underlying type-system rule, not by the spelling that
-happened to appear in *this* test. Fixes that only handle the spelling
-in front of you do not converge — they pass one test, miss its 30
-siblings, and add brittle code that later refactors must work around.
-
-**These patterns are forbidden in checker, solver, and emitter code.**
-If you catch yourself writing one, stop, restate the underlying rule
-in one sentence, then write a fix that expresses *that* rule.
-
-### Forbidden: hardcoded user-chosen names
-
-User-chosen identifiers (type-parameter names, mapped-type iteration
-variable names, property keys, alias names, file names) must never
-appear as string literals or `==` checks in compiler logic.
-
-```rust
-// ❌ WRONG — only matches when the user chose `P` as the iteration var.
-//    `Readonly<T> = { [K in keyof T]: T[K] }` (idiomatic) silently
-//    bypasses the suppression.
-fn looks_like_invalid_optional_mapped_display(display: &str) -> bool {
-    display.starts_with("{ [P in ")
-        && display.contains("]?: ")
-        && display.ends_with(" | undefined; }")
-}
-
-// ❌ WRONG — same anti-pattern, different surface.
-if type_param.name == "T" { /* special-case */ }
-if alias_name == "Promise" { /* special-case */ }
-if file_name.ends_with("/lib.es5.d.ts") { /* special-case */ }
-```
-
-If the rule is genuinely about a *built-in* well-known name (`Promise`,
-`Iterable`, `Symbol.iterator`), resolve it through the binder/global
-table or a builtin-id constant, not by string-matching.
-
-### Forbidden: regexes / `starts_with` / `contains` over printer output
-
-The type printer is the *output* of the type system, not its input.
-Driving compiler decisions from rendered display strings is a sign the
-fix belongs in the solver or in a boundary helper that operates on
-`TypeId` / structural shapes.
-
-```rust
-// ❌ WRONG — interrogating the printed form of a type.
-if self.format_type_diagnostic(target).contains("undefined; }") { ... }
-if display.starts_with("{ [") && display.ends_with(" | undefined; }") { ... }
-
-// ✅ RIGHT — ask the solver about the structural property.
-if self.is_optional_mapped_with_undefined_member(target) { ... }
-```
-
-Add a query helper to `query_boundaries/` (or a structural inspector in
-`tsz_solver`) and call it from the checker. The printer is allowed to
-read types; types are not allowed to read the printer.
-
-### Forbidden: single-test scoped suppressions
-
-```rust
-// ❌ WRONG — a fingerprint of one specific failing test.
-if file_name.contains("contextualTyping33") { return; }
-if source_str == "{ a: 1 }" && target_str == "{ a: true }" { ... }
-```
-
-If a diagnostic should be suppressed, the rule is "for sources/targets
-*shaped like X*", never "for the literal types in this test file".
-Express the shape via solver queries.
-
-### Forbidden: cosmetic widening to silence a fingerprint
-
-Do not widen a literal to its primitive, drop a property, or insert a
-synthesized type, **only** so the rendered message matches tsc. The
-solver's underlying types must remain accurate; the printer's display
-policy is the place to align rendering with tsc.
-
-### Required: state the rule before you write the code
-
-Every checker/solver/emitter change that affects diagnostics must be
-expressible as one sentence of the form:
-
-> "When *<structural condition over types/symbols>*, tsc <does X>; this change makes tsz <do X> too."
-
-If your one-sentence rule contains a specific identifier name, file
-path, or rendered display fragment, the fix is in the wrong place.
-Restate the rule structurally, then fix it where structures live (the
-solver, the binder, or the boundary helpers).
-
-### Review checklist (gate before merging)
-
-Before opening a PR, verify each item:
-
-1. No new string literals naming user-chosen identifiers, aliases, or
-   files in checker/solver/emitter code.
-2. No new `format_type_diagnostic` / printer-output `contains` /
-   `starts_with` / regex calls used to drive a *decision* (vs. building
-   the final user-facing message).
-3. The unit test you added covers at least two name choices for any
-   bound variable in the fix (`T`/`K`, `P`/`X`, etc.) — if changing the
-   name breaks the fix, the fix is hardcoded.
-4. The PR description states the structural rule in one sentence and
-   does not refer to a single test name as the justification.
-
-This directive supersedes any prior pattern in the codebase. Existing
-hardcoded checks discovered during review should be flagged for
-follow-up, not used as precedent for new ones.
-
-## 26) GENERALIZATION GATE - the reported repro is an example, not the scope
-
-When fixing a bug, conformance miss, or benchmark regression, treat the
-reported input as one witness for a broader rule. A PR that only matches
-the reported file, benchmark shape, library alias, or spelling is a
-stopgap, not a complete fix.
-
-Before writing code, identify the semantic operation that is wrong or too
-slow:
-
-- assignability/subtyping/compatibility decision,
-- `keyof` or indexed-access key-space check,
-- mapped/conditional/template/infer evaluation,
-- property/index lookup or object-shape projection,
-- narrowing/control-flow fact,
-- symbol resolution/binding,
-- diagnostic display policy,
-- emit transform policy.
-
-Then write the rule in structural terms:
-
-> "When *<structural condition over syntax, symbols, and/or TypeId>*, tsc
-> <does X>; this change makes tsz <do X> too."
-
-If the rule only mentions a single test name, benchmark name, alias name,
-type-parameter name, property spelling, or rendered diagnostic string, it
-is not general enough. Restate it until the owner layer and equivalent
-cases are clear.
-
-### Required before implementation
-
-1. List at least three adjacent cases that should share the same behavior.
-   Vary names and shapes: inline vs alias, generic vs concrete, builtin vs
-   user-defined, direct vs nested, union/intersection/mapped wrappers when
-   relevant.
-2. Decide the owning layer from the rule. Type semantics belong in solver
-   or query-boundary helpers; checker code should orchestrate and choose
-   diagnostic locations.
-3. Prefer one shared query/helper over two local branches that recognize
-   similar facts in different places. If checker validation and type
-   construction both need the same fact, expose that fact once.
-4. If a narrow fallback or fast path is necessary, name the semantic
-   invariant that makes it safe and document what unsupported shapes fall
-   back to the normal path.
-
-### Test matrix for non-trivial fixes
-
-Every non-trivial behavior or performance fix should include focused
-coverage for:
-
-1. The reported repro.
-2. At least two equivalent shapes that prove the rule, not the spelling.
-3. A renamed type-parameter/mapped-variable case when binders are involved.
-4. An alias/wrapper/nesting case when aliases or lazy refs are involved.
-5. A negative or fallback case proving unsupported shapes are not silently
-   accepted.
-
-If the matrix is intentionally smaller, the PR body must say why the
-change is a narrow stopgap and what follow-up would make it fundamental.
-
-### Performance fixes
-
-Performance PRs must fix the expensive operation, not only the benchmark
-fixture that exposed it.
-
-- Profile or otherwise identify the repeated operation and its expected
-  complexity.
-- State the intended complexity improvement, for example "avoid lowering
-  every union member just to answer a literal property-exists query."
-- Benchmark the reported case, but also add or run a smaller equivalent
-  fixture that would regress if the implementation only matched the
-  benchmark's exact syntax.
-- Fast paths must be keyed by structural invariants, not fixture names.
-  They must preserve correctness by falling back when the invariant cannot
-  be proven.
-- If caching is introduced, state the cache key, invalidation assumptions,
-  and cycle/fuel behavior.
-
-### PR body requirements
-
-PRs for fixes must include:
-
-- the structural rule being implemented,
-- the owner layer and why the logic belongs there,
-- the adjacent-case test matrix,
-- known unsupported shapes or fallback behavior,
-- performance numbers when the PR is performance-motivated.
-
-A PR body that says only "fixes <test>" or "makes <benchmark> pass" is not
-enough unless the PR is explicitly marked as a narrow stopgap.
+## Local Setup
+Run `./scripts/setup/setup.sh` once per workspace and keep
+`scripts/githooks` active.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -526,6 +526,22 @@ scripts/safe-run.sh --verbose -- cargo build
   already rebuild stale binaries, such as `scripts/emit/run.sh`; otherwise
   rebuild the narrow binary once and rerun the focused command.
 
+## 20.9) LLM Context And Startup Hygiene
+- Keep always-loaded project instructions small enough to be useful at startup.
+  Put repeatable detailed workflows in repo-local skills, scripts, or focused
+  docs, and load them only when the task matches.
+- Do not make startup hooks print `AGENTS.md`, `.claude/CLAUDE.md`,
+  `docs/plan/ROADMAP.md`, large JSON artifacts, or broad command output. The
+  client already loads its durable instruction surface; hooks should emit short
+  reminders or machine-readable checks only.
+- Do not make startup hooks mutate git state with `pull`, `rebase`, `merge`,
+  checkout, label changes, or PR updates. Intake commands decide when to fetch
+  or rebase after the agent has inspected the current task and branch.
+- Avoid project-level output-token overrides unless a lane has measured need.
+  Forced large outputs make context management worse for ordinary coding work.
+- Run `scripts/agents/llm-context-audit.py` after editing `.codex/`,
+  `.claude/`, `AGENTS.md`, or agent startup hooks.
+
 ## 21) Non-Negotiables
 - Parity with `tsc` overrides convenience.
 - Architecture direction is one-way; no cross-layer semantic leakage.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,5 @@
 {
   "env": {
-    "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "64000",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
   "attribution": {
@@ -79,7 +78,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=\"${CLAUDE_PROJECT_DIR:-${CODEX_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}}\"; git -C \"$root\" pull --rebase origin main 2>/dev/null || true; cat \"$root/AGENTS.md\""
+            "command": "echo 'TSZ startup: run tsz-worktree-intake, then scripts/agents/show-goal.sh <AgentName> when a lane goal applies.'"
           }
         ]
       }

--- a/.claude/skills/tsz-emit/SKILL.md
+++ b/.claude/skills/tsz-emit/SKILL.md
@@ -3,100 +3,55 @@ name: tsz-emit
 description: Write better tsz JavaScript and declaration emit code. Use when changing crates/tsz-emitter, emit transforms, DTS output, source maps, helper scheduling, temp/hoist planning, target/module output, or emit parity tests.
 ---
 
-# TSZ Emit Engineering Skill
+# TSZ Emit
 
-Use this skill for any `tsz-emitter` or DTS change. The goal is exact `tsc`
-parity with cleaner emit architecture, not isolated baseline pokes.
+Use for JS/DTS emit, transforms, helpers, temp/hoist planning, target/module
+output, source maps, and emit parity tests.
 
-## First Checks
+## Start
 
-1. Read `AGENTS.md` and `docs/plan/ROADMAP.md` before starting durable emit,
-   DTS, target, module, or architecture work.
-2. Inspect open PRs/issues for overlapping emit work before coding.
-3. Identify the failure family: target gate, module wrapper/export schedule,
-   helper requirement, temp/hoist planning, region transform, direct printer
-   layout, DTS nameability/portability, or parser recovery.
-4. State the rule structurally: "When this syntax/output context appears,
-   `tsc` emits X; tsz should emit X through this owner."
+1. Read `AGENTS.md` and `docs/plan/ROADMAP.md` for durable emit/DTS work.
+2. Inspect overlapping emit PRs/issues.
+3. Name the failure family: target gate, module/export schedule, helper, temp/
+   hoist, region transform, printer layout, DTS nameability/portability,
+   source maps, or parser recovery.
+4. State: `When <syntax/output context>, tsc emits X; tsz emits X through
+   <owner>.`
 
-## Architecture Rules
+## Architecture
 
-- Emit is `OUTPUT`. Do not add checker/solver semantic validation to emitter
-  code.
-- Prefer planned facts over discovery while writing text: target facts, helper
-  needs, temp reservations, hoists, prologues, export bindings, and disposable
-  regions should be known before or at the owner boundary.
-- Keep direct-to-target emit. Do not introduce an `ESNext -> ... -> ES5`
-  transform pipeline.
-- Ban output surgery for semantics. Do not use `replace`, `replacen`, or
-  `replace_range` to patch already-emitted JS/DTS for exports, wrappers,
-  declarations, decorators, classes, or resource management.
-- String cleanup is fine only when the string is data: escaping, source-map
-  paths, numeric separator cleanup, and path normalization.
-- DTS has the same bar: prefer declaration summaries and structured declaration
-  emission over late string rewrites.
+- Emit is `OUTPUT`: no checker/solver semantic validation in emitter code.
+- Prefer planned facts before writing text: target/module facts, helper needs,
+  temp reservations, hoists, prologues, exports, resource/disposable regions.
+- Keep direct-to-target emit; do not introduce an `ESNext -> ... -> ES5`
+  pipeline.
+- No semantic output surgery with `replace`, `replacen`, or `replace_range`.
+  Data cleanup is fine for escaping, source-map paths, numeric separators, and
+  path normalization.
+- DTS should use declaration summaries/structured emission, not late string
+  rewrites.
 
-## Printer Hygiene
+## Hot Checks
 
-- Use structured writer helpers when available: `open_paren`, `close_paren`,
-  `open_brace`, `close_brace`, token/source-map helpers, list emitters, and
-  target/module helper APIs.
-- Add new delimiter helpers when they prevent real classes of mistakes, such as
-  unbalanced delimiters, source-map drift, or inconsistent spacing.
-- Keep handwritten `write("(")`, `write(")")`, `write("{")`, and `write("}")`
-  only when the local context needs exact custom formatting and no helper fits.
-- Do not encode target or module policy in random printer branches. Route it
-  through target/module facts or an emit-plan-like owner boundary.
+- Use writer/list/token/source-map helpers; add delimiter helpers when they
+  prevent real mistakes.
+- Target/module policy belongs in target/module facts or emit-plan-like owners,
+  not random printer branches.
+- Every function-like body needs temp scope and hoist strategy. Bypasses of
+  `emit_block` must still handle function-body flags and insertion points.
+- Check adjacent shapes: arrows, declarations, expressions, methods, accessors,
+  constructors, async/generator wrappers, static blocks, namespaces/modules,
+  parameter prologues, ES2015+ and relevant legacy targets.
 
-## Temp And Hoist Planning
+## Verification
 
-- Every function-like body needs an explicit temp scope and function-body
-  hoist insertion strategy.
-- Temps created while emitting body expressions must not leak to outer scopes or
-  disappear when the function scope is popped.
-- If a body path bypasses normal `emit_block`, it must still consume/reset the
-  function-body flag and insert hoisted temps at the correct body point.
-- Prefer preallocation/reservation when temp names affect earlier output. Late
-  insertion is acceptable only when the insertion point is explicitly recorded
-  before body emission.
-- Check adjacent bodies: arrows, function declarations, function expressions,
-  methods, accessors, constructors, async/generator wrappers, static blocks,
-  namespace/module wrappers, and parameter prologue bodies.
+No full emit/conformance/fourslash locally.
 
-## Target And Module Discipline
+```bash
+scripts/emit/run.sh --filter=<family> --js-only --verbose --json-out=/tmp/<name>.json
+scripts/emit/run.sh --filter=<family> --dts-only --verbose --json-out=/tmp/<name>.json
+cargo nextest run -p tsz-emitter <test-or-family>
+```
 
-- Treat ES2015+ as the strategic primary lane. ES3/ES5 compatibility can exist,
-  but keep legacy behavior explicit and quarantined.
-- Do not let CommonJS export scheduling affect System/ES module output.
-- Module/export folding should be structured schedule entries, not text patches.
-- Resource-management (`using`/`await using`) belongs to region planning, not
-  localized after-the-fact wrapping.
-
-## Testing
-
-- Do not run full emit, conformance, or fourslash locally. Let ready CI do that.
-- Use targeted emit filters:
-  ```bash
-  scripts/emit/run.sh --filter=<family> --js-only --verbose --json-out=/tmp/<name>.json
-  scripts/emit/run.sh --filter=<family> --dts-only --verbose --json-out=/tmp/<name>.json
-  ```
-- Use focused unit tests:
-  ```bash
-  cargo nextest run -p tsz-emitter <test-name-or-family>
-  ```
-- For every non-trivial emit fix, test the reported case plus adjacent shapes:
-  block vs concise arrow, function declaration vs expression, method/accessor
-  if relevant, ES5 vs primary ES2015+ target, and module mode if exports move.
-- Keep PRs focused. Existing ready emit PRs should land before opening new
-  overlapping emit PRs.
-
-## PR Notes
-
-Every emit PR body should include:
-
-- AgentName.
-- Failure family and structural rule.
-- Owner layer: direct printer, lowering directive, IR/plan operation,
-  declaration summary, target facts, or module/export schedule.
-- Why the change avoids semantic validation and output surgery.
-- Targeted verification commands and any known unsupported shapes.
+PR body: `AgentName`, failure family, structural rule, owner layer, why no
+semantic validation/output surgery, targeted verification, unsupported shapes.

--- a/.claude/skills/tsz-tracing/QUICKREF.md
+++ b/.claude/skills/tsz-tracing/QUICKREF.md
@@ -1,61 +1,17 @@
-# TSZ Tracing Quick Reference
-
-## Quick Commands
+# TSZ Tracing Quickref
 
 ```bash
-# Human-readable tree output (best for debugging)
-TSZ_LOG=debug TSZ_LOG_FORMAT=tree cargo run -- file.ts
-
-# Narrowing only
-TSZ_LOG="tsz::solver::narrowing=trace" TSZ_LOG_FORMAT=tree cargo run -- file.ts
-
-# Checker only  
-TSZ_LOG="tsz::checker=debug" TSZ_LOG_FORMAT=tree cargo run -- file.ts
-
-# Solver only
-TSZ_LOG="tsz::solver=debug" TSZ_LOG_FORMAT=tree cargo run -- file.ts
-
-# JSON output (for tooling)
-TSZ_LOG=debug TSZ_LOG_FORMAT=json cargo run -- file.ts
+TSZ_LOG=debug TSZ_LOG_FORMAT=tree cargo run -p tsz-cli -- file.ts
+TSZ_LOG=debug TSZ_LOG_FORMAT=json cargo run -p tsz-cli -- file.ts
+TSZ_LOG="tsz_solver=debug" TSZ_LOG_FORMAT=tree cargo run -p tsz-cli -- file.ts
+TSZ_LOG="tsz_checker=debug" TSZ_LOG_FORMAT=tree cargo run -p tsz-cli -- file.ts
+TSZ_LOG="tsz_solver::narrowing=trace" TSZ_LOG_FORMAT=tree cargo run -p tsz-cli -- file.ts
 ```
 
-## Log Levels
+Levels: `trace`, `debug`, `info`, `warn`, `error`.
+Format: `tree`, `json`, `text`.
 
-- `trace` - Most verbose, includes all details
-- `debug` - Detailed debugging info
-- `info` - General operational info
-- `warn` - Warnings only
-- `error` - Errors only
-
-## Env Variables
-
-| Variable | Description |
-|----------|-------------|
-| `TSZ_LOG` | Filter expression (same as RUST_LOG) |
-| `TSZ_LOG_FORMAT` | `tree`, `json`, or `text` |
-
-## Filter Syntax
-
-```bash
-# Single module
-TSZ_LOG="tsz::solver=debug"
-
-# Multiple modules
-TSZ_LOG="tsz::solver=trace,tsz::checker=debug"
-
-# All at level
-TSZ_LOG=debug
-```
-
-## Output Tips
-
-```bash
-# Capture to file
-TSZ_LOG=debug TSZ_LOG_FORMAT=tree cargo run -- file.ts 2> trace.log
-
-# First 100 lines
-TSZ_LOG=debug TSZ_LOG_FORMAT=tree cargo run -- file.ts 2>&1 | head -100
-
-# Search for type ID
-TSZ_LOG=debug TSZ_LOG_FORMAT=tree cargo run -- file.ts 2>&1 | grep "type_id=42"
-```
+Tips:
+- Capture: `... 2> trace.log`.
+- Trim: `... 2>&1 | head -100`.
+- Search ids: `rg "type_id=42" trace.log`.

--- a/.claude/skills/tsz-tracing/SKILL.md
+++ b/.claude/skills/tsz-tracing/SKILL.md
@@ -3,184 +3,46 @@ name: tsz-tracing
 description: Debug tsz compiler issues using the built-in tracing infrastructure. Use when investigating type inference bugs, conformance failures, or understanding runtime behavior. Provides hierarchical trace output of solver, checker, and binder operations.
 ---
 
-# TSZ Tracing Debug Skill
+# TSZ Tracing
 
-This skill helps you debug tsz compiler issues using the built-in tracing infrastructure. The tracing system provides detailed runtime information about type inference, narrowing, assignability checks, and more.
+Use tracing before adding debug prints. It is for conformance failures,
+inference/narrowing/assignability surprises, and runtime path discovery.
 
-## When to Use This Skill
-
-Use this skill when you need to:
-- Debug a failing conformance test
-- Understand why type inference produces unexpected results
-- Trace narrowing and control flow analysis
-- Investigate assignability check failures
-- Compare tsz behavior to tsc for specific inputs
-- Find where in the code path a bug occurs
-
-## Quick Start
+## Commands
 
 ```bash
-# Tree format - hierarchical, human-readable (recommended for debugging)
-TSZ_LOG=debug TSZ_LOG_FORMAT=tree cargo run -- file.ts
-
-# JSON format - machine-readable, good for tooling
-TSZ_LOG=debug TSZ_LOG_FORMAT=json cargo run -- file.ts
-
-# Plain text format (default)
-TSZ_LOG=debug cargo run -- file.ts
+TSZ_LOG=debug TSZ_LOG_FORMAT=tree cargo run -p tsz-cli -- file.ts
+TSZ_LOG=debug TSZ_LOG_FORMAT=json cargo run -p tsz-cli -- file.ts
+TSZ_LOG="tsz_solver=trace,tsz_checker=debug" TSZ_LOG_FORMAT=tree cargo run -p tsz-cli -- file.ts
+TSZ_LOG="tsz_solver::narrowing=trace" TSZ_LOG_FORMAT=tree cargo run -p tsz-cli -- file.ts
 ```
 
-## Environment Variables
+Use `RUST_LOG` only as fallback. `TSZ_LOG_FORMAT` values: `tree`, `json`,
+`text`.
 
-| Variable | Values | Description |
-|----------|--------|-------------|
-| `TSZ_LOG` | `trace`, `debug`, `info`, `warn`, `error` | Log level filter (same syntax as RUST_LOG) |
-| `TSZ_LOG_FORMAT` | `tree`, `json`, `text` | Output format |
-| `RUST_LOG` | Same as TSZ_LOG | Fallback if TSZ_LOG not set |
+## Workflow
 
-## Fine-Grained Filtering
+1. Reduce to the smallest `.ts` witness.
+2. Compare expected behavior with `npx tsc --noEmit file.ts`.
+3. Start broad (`debug`, tree), then narrow by module.
+4. Capture large traces with `2> trace.log`, `head`, `tail`, `rg`, or
+   `grep "type_id=<id>"`.
+5. Use structured trace fields and spans; never add ad-hoc stdout/stderr
+   debugging.
 
-Target specific modules for focused debugging:
+## Useful Filters
 
-```bash
-# Only solver operations
-TSZ_LOG="tsz::solver=debug" TSZ_LOG_FORMAT=tree cargo run -- file.ts
+- Narrowing: `TSZ_LOG="tsz_solver::narrowing=trace"`.
+- Relations/inference: `TSZ_LOG="tsz_solver=debug"`.
+- Checker lookup/cache: `TSZ_LOG="tsz_checker=debug"`.
+- Query events: `TSZ_LOG=tsz::query_json=trace TSZ_LOG_FORMAT=json`.
 
-# Only checker operations
-TSZ_LOG="tsz::checker=debug" TSZ_LOG_FORMAT=tree cargo run -- file.ts
+## Read Output
 
-# Multiple modules with different levels
-TSZ_LOG="tsz::solver=trace,tsz::checker=debug" TSZ_LOG_FORMAT=tree cargo run -- file.ts
+Tree output nests spans, shows elapsed ms, level, module path, event, and
+fields. Look for the first structural divergence: wrong narrowed member,
+unexpected relation result, missing lazy ref resolution, cache hit/miss, or
+diagnostic source-span decision.
 
-# Narrowing specifically (very detailed)
-TSZ_LOG="tsz::solver::narrowing=trace" TSZ_LOG_FORMAT=tree cargo run -- file.ts
-```
-
-## Instrumented Areas
-
-The following areas have tracing instrumentation:
-
-### Solver (`crates/tsz-solver/src/`)
-- `narrowing.rs` - Type narrowing operations (typeof, instanceof, discriminants)
-- `subtype.rs` - Subtype relationship checks
-- Type inference and instantiation
-
-### Checker (`crates/tsz-checker/src/`)
-- `context.rs` - Type context operations
-- `state.rs` - Node type caching (`get_type_of_node`)
-- `assignability_checker.rs` - Assignability checks
-- `class_inheritance.rs` - Class hierarchy analysis
-- `dispatch.rs` - Type dispatch operations
-
-### CLI (`crates/tsz-cli/src/`)
-- `driver.rs` - Compilation spans, file checking
-- `build.rs` - Build operations
-
-## Debugging Workflow
-
-### 1. Reproduce with Minimal Input
-
-Create a minimal `.ts` file that reproduces the issue:
-
-```typescript
-// test.ts
-function example<T>(x: T) {
-  if (typeof x === "string") {
-    return x.length; // Should narrow T to string
-  }
-}
-```
-
-### 2. Run with Tracing
-
-```bash
-TSZ_LOG=debug TSZ_LOG_FORMAT=tree cargo run -- test.ts 2>&1 | head -100
-```
-
-### 3. Compare with tsc
-
-```bash
-# Run tsc for expected behavior
-npx tsc --noEmit test.ts
-
-# Run tsz with tracing for actual behavior
-TSZ_LOG=debug TSZ_LOG_FORMAT=tree cargo run -- test.ts
-```
-
-### 4. Focus on Specific Operations
-
-If output is too verbose, narrow down:
-
-```bash
-# Just narrowing operations
-TSZ_LOG="tsz::solver::narrowing=trace" TSZ_LOG_FORMAT=tree cargo run -- test.ts
-
-# Just type lookup operations
-TSZ_LOG="tsz::checker::state=trace" TSZ_LOG_FORMAT=tree cargo run -- test.ts
-```
-
-## Reading Tree Output
-
-The tree format shows hierarchical span relationships:
-
-```
-  0ms DEBUG tsz::solver::narrowing narrow_by_typeof
-    source_type=42, typeof_result="string"
-  │ 0ms TRACE tsz::solver::narrowing Narrowing union type with 3 members
-  │ 0ms TRACE tsz::solver::narrowing Found single matching member, returning 15
-```
-
-- Indentation shows nesting (parent spans contain child spans)
-- `ms` shows elapsed time
-- Level (DEBUG, TRACE, etc.) shows severity
-- Module path shows source location
-- Key-value pairs show span fields
-
-## Common Debugging Scenarios
-
-### Incorrect Type Narrowing
-
-```bash
-TSZ_LOG="tsz::solver::narrowing=trace" TSZ_LOG_FORMAT=tree cargo run -- test.ts
-```
-
-Look for:
-- `narrow_by_typeof` spans for typeof narrowing
-- `narrow_by_truthiness` for boolean context narrowing
-- Member filtering operations
-
-### Assignability Failures
-
-```bash
-TSZ_LOG="tsz::checker::assignability=debug" TSZ_LOG_FORMAT=tree cargo run -- test.ts
-```
-
-Look for:
-- Subtype check results
-- Which types are being compared
-- Why assignability fails
-
-### Type Inference Issues
-
-```bash
-TSZ_LOG="tsz::solver=debug" TSZ_LOG_FORMAT=tree cargo run -- test.ts
-```
-
-Look for:
-- Generic instantiation
-- Constraint checking
-- Type parameter resolution
-
-## Tips
-
-1. **Pipe to file**: Traces can be large. Use `2> trace.log` to capture stderr
-2. **Use `head`/`tail`**: Filter output with `| head -200` or `| tail -100`
-3. **Use `grep`**: Search for specific type IDs: `| grep "type_id=42"`
-4. **Tree is best**: The tree format is easiest to read for debugging
-5. **Start broad, then narrow**: Begin with `debug`, then use module filters
-
-## Implementation Details
-
-Tracing is configured in `crates/tsz-cli/src/reporting/tracing_config.rs`. The subscriber is only initialized when `TSZ_LOG` or `RUST_LOG` is set, so there's zero overhead in normal usage.
-
-Output always goes to stderr to avoid interfering with compiler output (diagnostics, `--showConfig`, or LSP JSON-RPC on stdout).
+Tracing goes to stderr and is initialized only when `TSZ_LOG`/`RUST_LOG` is set.
+For trace examples and quick reminders, read `QUICKREF.md`.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -8,4 +8,3 @@ inherit = "core"
 
 [shell_environment_policy.set]
 CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1"
-CLAUDE_CODE_MAX_OUTPUT_TOKENS = "64000"

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -14,7 +14,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=\"${CLAUDE_PROJECT_DIR:-${CODEX_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}}\"; git -C \"$root\" pull --rebase origin main 2>/dev/null || true; cat \"$root/AGENTS.md\""
+            "command": "echo 'TSZ startup: run tsz-worktree-intake, then scripts/agents/show-goal.sh <AgentName> when a lane goal applies.'"
           }
         ]
       }

--- a/scripts/agents/llm-context-audit.py
+++ b/scripts/agents/llm-context-audit.py
@@ -11,6 +11,10 @@ from typing import Any
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
+MAX_INSTRUCTION_BYTES = 20_000
+MAX_INSTRUCTION_LINES = 260
+MAX_SKILL_LINES = 120
+MAX_SKILL_WORDS = 900
 FORBIDDEN_HOOK_FRAGMENTS = (
     "cat \"$root/AGENTS.md\"",
     "cat '$root/AGENTS.md'",
@@ -83,6 +87,45 @@ def audit() -> tuple[list[str], dict[str, Any]]:
     instruction_text = agents_real.read_text(encoding="utf-8")
     metrics["instruction_lines"] = len(instruction_text.splitlines())
     metrics["instruction_bytes"] = len(instruction_text.encode("utf-8"))
+    if metrics["instruction_bytes"] > MAX_INSTRUCTION_BYTES:
+        findings.append(
+            "AGENTS.md/.claude/CLAUDE.md exceeds token-efficiency budget: "
+            f"{metrics['instruction_bytes']} bytes > {MAX_INSTRUCTION_BYTES}"
+        )
+    if metrics["instruction_lines"] > MAX_INSTRUCTION_LINES:
+        findings.append(
+            "AGENTS.md/.claude/CLAUDE.md exceeds line budget: "
+            f"{metrics['instruction_lines']} lines > {MAX_INSTRUCTION_LINES}"
+        )
+
+    skill_paths = sorted(
+        {
+            *ROOT.glob(".agents/skills/*/SKILL.md"),
+            *ROOT.glob(".claude/skills/*/SKILL.md"),
+        }
+    )
+    metrics["skill_file_count"] = len(skill_paths)
+    max_skill_lines = 0
+    max_skill_words = 0
+    for skill_path in skill_paths:
+        text = skill_path.read_text(encoding="utf-8")
+        line_count = len(text.splitlines())
+        word_count = len(text.split())
+        max_skill_lines = max(max_skill_lines, line_count)
+        max_skill_words = max(max_skill_words, word_count)
+        rel_path = skill_path.relative_to(ROOT)
+        if line_count > MAX_SKILL_LINES:
+            findings.append(
+                f"{rel_path} exceeds skill line budget: "
+                f"{line_count} lines > {MAX_SKILL_LINES}"
+            )
+        if word_count > MAX_SKILL_WORDS:
+            findings.append(
+                f"{rel_path} exceeds skill word budget: "
+                f"{word_count} words > {MAX_SKILL_WORDS}"
+            )
+    metrics["max_skill_lines"] = max_skill_lines
+    metrics["max_skill_words"] = max_skill_words
 
     for rel_path in (".codex/hooks.json", ".claude/settings.json"):
         path = ROOT / rel_path

--- a/scripts/agents/llm-context-audit.py
+++ b/scripts/agents/llm-context-audit.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Audit repo-local LLM coding context for avoidable startup token waste."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+from typing import Any
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+FORBIDDEN_HOOK_FRAGMENTS = (
+    "cat \"$root/AGENTS.md\"",
+    "cat '$root/AGENTS.md'",
+    "cat $root/AGENTS.md",
+    "cat AGENTS.md",
+    "git -C \"$root\" pull --rebase",
+    "git pull --rebase",
+)
+FORBIDDEN_ENV_KEYS = {
+    "CLAUDE_CODE_MAX_OUTPUT_TOKENS": (
+        "Project defaults should not force large model outputs; Claude docs note "
+        "that increasing this reduces effective context before auto-compaction."
+    )
+}
+
+
+def load_json(path: pathlib.Path) -> Any:
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def flatten_hook_commands(value: Any) -> list[str]:
+    commands: list[str] = []
+    if isinstance(value, dict):
+        if value.get("type") == "command" and isinstance(value.get("command"), str):
+            commands.append(value["command"])
+        for child in value.values():
+            commands.extend(flatten_hook_commands(child))
+    elif isinstance(value, list):
+        for child in value:
+            commands.extend(flatten_hook_commands(child))
+    return commands
+
+
+def parse_simple_toml_set(path: pathlib.Path) -> dict[str, str]:
+    in_set = False
+    result: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            in_set = line == "[shell_environment_policy.set]"
+            continue
+        if not in_set or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        result[key.strip()] = value.strip().strip('"')
+    return result
+
+
+def audit() -> tuple[list[str], dict[str, Any]]:
+    findings: list[str] = []
+    metrics: dict[str, Any] = {}
+
+    agents_path = ROOT / "AGENTS.md"
+    claude_path = ROOT / ".claude" / "CLAUDE.md"
+    agents_real = agents_path.resolve()
+    claude_real = claude_path.resolve()
+    metrics["agents_realpath"] = str(agents_real.relative_to(ROOT))
+    metrics["claude_realpath"] = str(claude_real.relative_to(ROOT))
+    metrics["agents_is_symlink"] = agents_path.is_symlink()
+    metrics["same_instruction_target"] = agents_real == claude_real
+    if agents_real != claude_real:
+        findings.append(
+            "AGENTS.md and .claude/CLAUDE.md must resolve to one canonical "
+            "instruction file"
+        )
+
+    instruction_text = agents_real.read_text(encoding="utf-8")
+    metrics["instruction_lines"] = len(instruction_text.splitlines())
+    metrics["instruction_bytes"] = len(instruction_text.encode("utf-8"))
+
+    for rel_path in (".codex/hooks.json", ".claude/settings.json"):
+        path = ROOT / rel_path
+        data = load_json(path)
+        commands = flatten_hook_commands(data.get("hooks", {}))
+        metrics[f"{rel_path}:command_hooks"] = len(commands)
+        for command in commands:
+            for fragment in FORBIDDEN_HOOK_FRAGMENTS:
+                if fragment in command:
+                    findings.append(
+                        f"{rel_path} hook reintroduces startup context/mutation "
+                        f"fragment: {fragment}"
+                    )
+
+    claude_settings = load_json(ROOT / ".claude" / "settings.json")
+    claude_env = claude_settings.get("env", {})
+    if not isinstance(claude_env, dict):
+        findings.append(".claude/settings.json env must be an object")
+        claude_env = {}
+    codex_env = parse_simple_toml_set(ROOT / ".codex" / "config.toml")
+    for source, env in (
+        (".claude/settings.json", claude_env),
+        (".codex/config.toml", codex_env),
+    ):
+        for key, reason in FORBIDDEN_ENV_KEYS.items():
+            if key in env:
+                findings.append(f"{source} sets {key}: {reason}")
+
+    metrics["finding_count"] = len(findings)
+    return findings, metrics
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json-report", type=pathlib.Path)
+    args = parser.parse_args()
+
+    findings, metrics = audit()
+    status = "fail" if findings else "pass"
+    print(f"llm_context_audit_status={status}")
+    for key in sorted(metrics):
+        print(f"{key}={metrics[key]}")
+    for finding in findings:
+        print(f"finding={finding}")
+
+    if args.json_report:
+        args.json_report.parent.mkdir(parents=True, exist_ok=True)
+        args.json_report.write_text(
+            json.dumps(
+                {
+                    "ok": not findings,
+                    "status": status,
+                    "generated_by": "scripts/agents/llm-context-audit.py",
+                    "metrics": metrics,
+                    "findings": findings,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/agents/llm-context-audit.py
+++ b/scripts/agents/llm-context-audit.py
@@ -101,7 +101,9 @@ def audit() -> tuple[list[str], dict[str, Any]]:
     skill_paths = sorted(
         {
             *ROOT.glob(".agents/skills/*/SKILL.md"),
+            *ROOT.glob(".agents/skills/*/QUICKREF.md"),
             *ROOT.glob(".claude/skills/*/SKILL.md"),
+            *ROOT.glob(".claude/skills/*/QUICKREF.md"),
         }
     )
     metrics["skill_file_count"] = len(skill_paths)

--- a/scripts/agents/test_llm_context_audit.py
+++ b/scripts/agents/test_llm_context_audit.py
@@ -1,0 +1,106 @@
+import importlib.util
+import json
+import pathlib
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "agents" / "llm-context-audit.py"
+SPEC = importlib.util.spec_from_file_location("llm_context_audit", SCRIPT)
+llm_context_audit = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(llm_context_audit)
+
+
+class LlmContextAuditTests(unittest.TestCase):
+    def test_current_repo_passes(self):
+        findings, metrics = llm_context_audit.audit()
+
+        self.assertEqual([], findings)
+        self.assertTrue(metrics["same_instruction_target"])
+        self.assertTrue(metrics["agents_is_symlink"])
+        self.assertGreater(metrics["instruction_lines"], 0)
+
+    def test_forbidden_hook_fragments_are_reported(self):
+        with mock.patch.object(
+            llm_context_audit,
+            "load_json",
+            side_effect=lambda path: {
+                "hooks": {
+                    "SessionStart": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": 'git -C "$root" pull --rebase origin main; cat "$root/AGENTS.md"',
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "env": {},
+            },
+        ):
+            findings, _metrics = llm_context_audit.audit()
+
+        self.assertTrue(
+            any("cat \"$root/AGENTS.md\"" in finding for finding in findings),
+            findings,
+        )
+        self.assertTrue(
+            any("git -C \"$root\" pull --rebase" in finding for finding in findings),
+            findings,
+        )
+
+    def test_forced_large_output_env_is_reported(self):
+        def fake_load_json(path):
+            if path.name == "settings.json":
+                return {"hooks": {}, "env": {"CLAUDE_CODE_MAX_OUTPUT_TOKENS": "64000"}}
+            return {"hooks": {}}
+
+        with mock.patch.object(llm_context_audit, "load_json", side_effect=fake_load_json):
+            with mock.patch.object(
+                llm_context_audit,
+                "parse_simple_toml_set",
+                return_value={"CLAUDE_CODE_MAX_OUTPUT_TOKENS": "64000"},
+            ):
+                findings, _metrics = llm_context_audit.audit()
+
+        self.assertTrue(
+            any(
+                ".claude/settings.json sets CLAUDE_CODE_MAX_OUTPUT_TOKENS" in finding
+                for finding in findings
+            ),
+            findings,
+        )
+        self.assertTrue(
+            any(
+                ".codex/config.toml sets CLAUDE_CODE_MAX_OUTPUT_TOKENS" in finding
+                for finding in findings
+            ),
+            findings,
+        )
+
+    def test_json_report_shape(self):
+        with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
+            report_path = pathlib.Path(temp_dir) / "reports" / "llm-context.json"
+            with mock.patch.object(
+                llm_context_audit.sys,
+                "argv",
+                ["llm-context-audit.py", "--json-report", str(report_path)],
+            ):
+                exit_code = llm_context_audit.main()
+
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(0, exit_code)
+        self.assertTrue(report["ok"])
+        self.assertEqual("pass", report["status"])
+        self.assertEqual("scripts/agents/llm-context-audit.py", report["generated_by"])
+        self.assertEqual([], report["findings"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/agents/test_llm_context_audit.py
+++ b/scripts/agents/test_llm_context_audit.py
@@ -22,6 +22,10 @@ class LlmContextAuditTests(unittest.TestCase):
         self.assertTrue(metrics["same_instruction_target"])
         self.assertTrue(metrics["agents_is_symlink"])
         self.assertGreater(metrics["instruction_lines"], 0)
+        self.assertLessEqual(metrics["instruction_lines"], 260)
+        self.assertLessEqual(metrics["instruction_bytes"], 20_000)
+        self.assertLessEqual(metrics["max_skill_lines"], 120)
+        self.assertLessEqual(metrics["max_skill_words"], 900)
 
     def test_forbidden_hook_fragments_are_reported(self):
         with mock.patch.object(
@@ -80,6 +84,48 @@ class LlmContextAuditTests(unittest.TestCase):
                 ".codex/config.toml sets CLAUDE_CODE_MAX_OUTPUT_TOKENS" in finding
                 for finding in findings
             ),
+            findings,
+        )
+
+    def test_instruction_budget_is_reported(self):
+        original_read_text = pathlib.Path.read_text
+
+        def fake_read_text(path, *args, **kwargs):
+            if pathlib.Path(path).name == "CLAUDE.md":
+                return "\n".join(f"line {i}" for i in range(300))
+            return original_read_text(path, *args, **kwargs)
+
+        with mock.patch.object(pathlib.Path, "read_text", fake_read_text):
+            findings, _metrics = llm_context_audit.audit()
+
+        self.assertTrue(
+            any("exceeds line budget" in finding for finding in findings),
+            findings,
+        )
+
+    def test_skill_budget_is_reported(self):
+        original_glob = pathlib.Path.glob
+        original_read_text = pathlib.Path.read_text
+        fake_skill = ROOT / ".agents" / "skills" / "fake" / "SKILL.md"
+
+        def fake_glob(path, pattern):
+            if str(path) == str(ROOT) and pattern == ".agents/skills/*/SKILL.md":
+                return [fake_skill]
+            if str(path) == str(ROOT) and pattern == ".claude/skills/*/SKILL.md":
+                return []
+            return original_glob(path, pattern)
+
+        def fake_read_text(path, *args, **kwargs):
+            if pathlib.Path(path) == fake_skill:
+                return "\n".join("word" for _ in range(130))
+            return original_read_text(path, *args, **kwargs)
+
+        with mock.patch.object(pathlib.Path, "glob", fake_glob):
+            with mock.patch.object(pathlib.Path, "read_text", fake_read_text):
+                findings, _metrics = llm_context_audit.audit()
+
+        self.assertTrue(
+            any("SKILL.md exceeds skill line budget" in finding for finding in findings),
             findings,
         )
 


### PR DESCRIPTION
## Agent
AgentName: M5LLMAudit

## Track
Track 10 tooling/guardrail, LLM coding workflow audit and context-efficiency cleanup.

## Invariant
When TSZ coding agents start or load repo-local skills, startup hooks and instruction surfaces should spend tokens only on durable policy and task-matched workflow details. This PR removes startup context dumps/mutations, compacts always-loaded prompts and repo skill/reference bodies, and adds an auditable budget guard without changing compiler behavior.

## Scope
- Remove startup hook commands that silently ran `git pull --rebase origin main` and printed full instruction files.
- Replace those hooks with one-line intake reminders.
- Remove project-level `CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000` defaults from Claude/Codex settings.
- Compact `.claude/CLAUDE.md` / `AGENTS.md` from 42,552 bytes and 782 lines to 8,696 bytes and 178 lines while preserving architecture, CI, PR, testing, anti-hardcoding, and generalization rules.
- Compact all repo-local `SKILL.md` bodies under `.agents/skills/` plus mirrored `.claude/skills/tsz-emit` and `.claude/skills/tsz-tracing`; current max skill body is 73 lines / 341 words.
- Compact tracing `QUICKREF.md` files and include skill quickrefs in the same audit budget surface.
- Add `scripts/agents/llm-context-audit.py` plus tests to detect startup context/mutation fragments, forced large-output env defaults, oversized always-loaded instructions, and oversized skill/reference bodies.
- Teach `$tsz-iteration-audit` to run the new audit and classify this family as `context debt`.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent-config/script/docs/skill-only; no parser, binder, checker, solver, emitter, LSP, WASM, benchmark, conformance, or project-corpus behavior path changed.

## Verification
- `scripts/agents/llm-context-audit.py --json-report /tmp/tsz-llm-context-audit.json` -> pass; `instruction_bytes=8696`, `instruction_lines=178`, `max_skill_lines=73`, `max_skill_words=341`, `skill_file_count=15`, `finding_count=0`.
- `python3 scripts/agents/test_llm_context_audit.py` -> 6 tests passed.
- `python3 -m unittest discover scripts/agents` -> 37 tests passed.
- `python3 -m json.tool .claude/settings.json >/tmp/claude-settings.json && python3 -m json.tool .codex/hooks.json >/tmp/codex-hooks.json`.
- `git diff --check origin/main..HEAD` and `git diff --check`.

## Coordination Notes
- AgentName: M5LLMAudit.
- No canonical agent lane was assigned. I intentionally did not create or apply a generated `agent:M5LLMAudit` label because TSZ ownership labels are limited to documented M1/M4/Studio/Reviewer lanes.
- Live overlap scan found this branch/PR (#12183) as the active lane for LLM startup/context audit work, so I reused it rather than opening another branch.
- Scope remains process/config/docs/skills only; no compiler behavior files changed.
- Exact-head PR checks are green on `5bcc4fa98374a02e0dbf3f61e9282cddd2982236`, including `CI Summary` and `GitGuardian Security Checks`.
- M5Manager added `merge-queue` after confirming the PR is ready/non-draft/non-WIP, auto-merge is off, and the head is unchanged. `Queue Tested` is queue-owned. No local full conformance/fourslash/emit run.

