### PR TITLE
fix(bench): wait longer for prep artifact handoff

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -701,11 +701,19 @@ jobs:
               --region=us-central1 \
               --format='value(status)' 2>/dev/null || true
           }
+          capture_cloudbuild_log() {
+            local build_id="$1"
+            [[ -n "$build_id" ]] || return 0
+            gcloud builds log "$build_id" \
+              --project=tsz-ci \
+              --region=us-central1 \
+              > bench-prep-cloudbuild.log 2>&1 || true
+          }
           cloudbuild_id="${{ needs.bench-prepare.outputs.build_id }}"
 
           deadline=$((SECONDS + 9000))
           success_seen_at=""
-          success_grace_seconds=600
+          success_grace_seconds=7200
           while true; do
             rm -f bench-prep.env bench-prep.tar
             if storage_cp \
@@ -737,12 +745,14 @@ jobs:
               fi
               if (( SECONDS - success_seen_at >= success_grace_seconds )); then
                 echo "Cloud Build benchmark prep ${cloudbuild_id} succeeded, but neither SHA-scoped, latest, nor manifest artifacts exposed valid bench-prep env/tar for ${target_sha} after ${success_grace_seconds}s."
+                capture_cloudbuild_log "$cloudbuild_id"
                 exit 1
               fi
             fi
             case "$status" in
               FAILURE|INTERNAL_ERROR|TIMEOUT|CANCELLED|EXPIRED)
                 echo "Cloud Build benchmark prep ${cloudbuild_id} ended with status ${status}; artifact is unavailable."
+                capture_cloudbuild_log "$cloudbuild_id"
                 exit 1
                 ;;
             esac
@@ -750,6 +760,7 @@ jobs:
             if (( SECONDS >= deadline )); then
               echo "No finished Cloud Build PGO prep artifact is available for ${target_sha} after 150 minutes."
               [[ -z "$status" ]] || echo "Last Cloud Build benchmark prep status: ${status} (${cloudbuild_id})."
+              capture_cloudbuild_log "$cloudbuild_id"
               exit 1
             fi
 
@@ -884,12 +895,20 @@ jobs:
               --region=us-central1 \
               --format='value(status)' 2>/dev/null || true
           }
+          capture_cloudbuild_log() {
+            local build_id="$1"
+            [[ -n "$build_id" ]] || return 0
+            gcloud builds log "$build_id" \
+              --project=tsz-ci \
+              --region=us-central1 \
+              > bench-prep-cloudbuild.log 2>&1 || true
+          }
           cloudbuild_id="${{ needs.bench-prepare-cloudbuild.outputs.build_id }}"
           target_sha="${{ env.BENCH_TARGET_SHA }}"
 
           deadline=$((SECONDS + 9000))
           success_seen_at=""
-          success_grace_seconds=600
+          success_grace_seconds=7200
           while true; do
             if storage_cp \
               "gs://tsz-ci_cloudbuild/bench-prep/${target_sha}/bench-prep.env" \
@@ -920,12 +939,14 @@ jobs:
               fi
               if (( SECONDS - success_seen_at >= success_grace_seconds )); then
                 echo "Cloud Build benchmark prep ${cloudbuild_id} succeeded, but neither SHA-scoped, latest, nor manifest artifacts exposed valid bench-prep env/tar for ${target_sha} after ${success_grace_seconds}s."
+                capture_cloudbuild_log "$cloudbuild_id"
                 exit 1
               fi
             fi
             case "$status" in
               FAILURE|INTERNAL_ERROR|TIMEOUT|CANCELLED|EXPIRED)
                 echo "Cloud Build benchmark prep ${cloudbuild_id} ended with status ${status}; artifact is unavailable."
+                capture_cloudbuild_log "$cloudbuild_id"
                 exit 1
                 ;;
             esac
@@ -933,12 +954,28 @@ jobs:
             if (( SECONDS >= deadline )); then
               echo "No finished Cloud Build benchmark prep artifact is available for ${{ env.BENCH_TARGET_SHA }} after 150 minutes."
               [[ -z "$status" ]] || echo "Last Cloud Build benchmark prep status: ${status} (${cloudbuild_id})."
+              capture_cloudbuild_log "$cloudbuild_id"
               exit 1
             fi
 
             echo "Waiting for Cloud Build benchmark prep artifact (build=${cloudbuild_id:-none}, status=${status:-unknown}, target=${target_sha}, elapsed=${SECONDS}s)..."
             sleep 30
           done
+
+      - name: Upload benchmark prep diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-prep-diagnostics
+          path: |
+            bench-prep-cloudbuild.log
+            cloudbuild-artifacts.json
+            cloudbuild-artifacts.env
+            bench-prep.env
+            latest-bench-prep.env
+          retention-days: 7
+          if-no-files-found: warn
+          compression-level: 1
 
       - name: Validate benchmark prep artifact
         shell: bash

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -18,12 +18,12 @@ const workflow = fs.readFileSync(BENCH_WORKFLOW, "utf8");
 const shardCloudbuild = fs.readFileSync(BENCH_SHARD_CLOUDBUILD, "utf8");
 
 const successGraceWindows = workflow.match(
-  /success_seen_at=""[\s\S]+?success_grace_seconds=600/g,
+  /success_seen_at=""[\s\S]+?success_grace_seconds=7200/g,
 ) ?? [];
 assert.equal(
   successGraceWindows.length,
   2,
-  "both Cloud Build prep artifact paths should use a bounded post-success artifact visibility grace window",
+  "both Cloud Build prep artifact paths should use the extended post-success artifact visibility grace window",
 );
 
 const postSuccessMessages = workflow.match(
@@ -51,6 +51,21 @@ assert.equal(
   unusableArtifactMessages.length,
   2,
   "both Cloud Build prep artifact paths should fail after the bounded post-success grace window when no usable prep artifacts appear",
+);
+
+const prepLogCaptureHelpers = workflow.match(
+  /capture_cloudbuild_log\(\) \{[\s\S]+?bench-prep-cloudbuild\.log 2>&1 \|\| true[\s\S]+?\}/g,
+) ?? [];
+assert.equal(
+  prepLogCaptureHelpers.length,
+  2,
+  "both Cloud Build prep artifact paths should capture the prep build log before terminal handoff failures",
+);
+
+assert.match(
+  workflow,
+  /- name: Upload benchmark prep diagnostics[\s\S]+if: failure\(\)[\s\S]+name: bench-prep-diagnostics[\s\S]+bench-prep-cloudbuild\.log[\s\S]+cloudbuild-artifacts\.json[\s\S]+latest-bench-prep\.env/,
+  "bench-prep-artifact should upload Cloud Build handoff diagnostics when prep artifact polling fails",
 );
 
 assert.match(


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 10 benchmark/dashboard publishing infrastructure; benchmark freshness blocker.

## Invariant
When a Cloud Build benchmark prep finishes successfully, the Bench workflow should keep polling validated SHA-scoped/latest prep artifacts until the existing prep job deadline before declaring the public benchmark pipeline stale. Main may advance while benchmarks run, but a recent active run must be allowed to finish and publish rather than leaving the dashboard two days stale.

## Scope
- `.github/workflows/bench.yml`: extend the post-success prep artifact visibility window from 600s to 7200s within the existing 9000s job deadline, and upload `bench-prep-diagnostics` when the prep handoff still fails.
- `scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`: lock the longer handoff window and diagnostic artifact behavior.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: benchmark-publishing workflow only; no compiler, fixture, corpus, conformance, emit, or benchmark-row behavior changes.

## Benchmark Evidence
- Public `https://tsz.dev/benchmark-data/latest.json` was rechecked on 2026-06-02 and still reports `generated_at=2026-05-31T09:37:56.704Z`, `source_commit=d13c6b872599f406b18b333fd569350dc724f9ea`, `workflow_run_id=26707914493`, and 74 rows.
- Public `https://tsz.dev/benchmarks/` was rechecked on 2026-06-02 and renders `Generated 2026-05-31T09:37:56Z · sha d13c6b872599`; the page shell itself has been rebuilt on newer main commits, so this is stale benchmark data rather than a static Pages cache.
- Latest complete publish: Bench run https://github.com/mohsen1/tsz/actions/runs/26707914493 completed on 2026-05-31 and uploaded `bench-results-merged`; its `bench-prep-ready` artifact is now expired.
- Failure witness: Bench run https://github.com/mohsen1/tsz/actions/runs/26798427690 for `ba47112bd9d7662271f10cab58eb034e4efc9907` failed in `bench-prep-artifact` after Cloud Build prep `747b7597-cfab-4227-846f-cd275514acb0` reached `SUCCESS`; the log says neither SHA-scoped, latest, nor manifest artifacts exposed valid `bench-prep` env/tar after 600s.
- Repeated failure witness: Bench run https://github.com/mohsen1/tsz/actions/runs/26797307010 for `54438196a5a543b8e167f1106c3c82ed3e0cb6f6` failed the same handoff after Cloud Build prep `e07e55b1-44af-4e39-b6ab-1c862d612931` reached `SUCCESS`.
- Active pre-fix witness: Bench run https://github.com/mohsen1/tsz/actions/runs/26799867493 on `d8d9e6c2e0510fce1251fd21ad8fe816c175b625` remains in `bench-prep-artifact`; it predates this PR and still uses the old 600s behavior.
- Post-merge skip witness: Bench run https://github.com/mohsen1/tsz/actions/runs/26800390087 on merge commit `23a9517de10d60ba4c9be686e1b0e22776a88aa8` skipped because active run `26799867493` was still in progress.
- Active proof run: manually dispatched Bench run https://github.com/mohsen1/tsz/actions/runs/26800589927 on merge commit `23a9517de10d60ba4c9be686e1b0e22776a88aa8` has reached `bench-prep-artifact` and includes the new `Upload benchmark prep diagnostics` step from this PR. Public freshness is not proven until this or a later run publishes `bench-results-merged` and the website/`latest.json` update.
- Website deploy witness: Deploy Website run https://github.com/mohsen1/tsz/actions/runs/26800356029 succeeded on 2026-06-02 after this PR merged, confirming the stale public data is not just a Pages/deploy cache miss.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit` (reports existing unrelated missing-label/release-issue findings; no noncanonical agent labels)
- Draft-light CI on exact head `c30c61088c87c8e511ebc73435d60d6e8b9d606b`: `CI Light Summary`, `lint`, `project-row-drift`, `cargo-deny`, `cargo-shear`, `gate`, and `GitGuardian Security Checks` passed in https://github.com/mohsen1/tsz/actions/runs/26799791672.
- Ready PR-head CI on exact head `c30c61088c87c8e511ebc73435d60d6e8b9d606b`: `CI Summary`, `lint`, `project-row-drift`, `cargo-deny`, `cargo-shear`, `gate`, `project-corpus-pr-body`, and `GitGuardian Security Checks` passed in https://github.com/mohsen1/tsz/actions/runs/26799995630.
- Queue merge evidence: Poor Man's Merge Queue run https://github.com/mohsen1/tsz/actions/runs/26800288957 merged this PR at `2026-06-02T05:27:14Z` as merge commit `23a9517de10d60ba4c9be686e1b0e22776a88aa8`.
- Not run locally: full benchmark suite, conformance, fourslash, emit, or full local project corpus suites per AGENTS.md.

## Coordination Notes
- Open PR/issue/history check found no other active PR claiming stale benchmark dashboard publishing. Open tracker issue #10649 remains the benchmark artifact truth tracker.
- Prior related merged fixes reviewed before this change include #10574, #10590, #10595, #10603, #10612, #10618, #10625, #11787, #11810, #12039, #12041, #12057, and #11915; the recurring current failure pattern is Cloud Build prep success followed by missing/late SHA-scoped/latest/manifest prep artifacts.
- Canonical lane assigned by M5Manager: `agent:Studio-A`, matching Studio-A benchmark artifact freshness / release metric truth ownership. Original contributor AgentName: `M5Bench`.
- This PR is merged. The actual freshness repair still needs proof from run https://github.com/mohsen1/tsz/actions/runs/26800589927 or a later successful Bench publish updating `bench-runs/latest.json`, `https://tsz.dev/benchmark-data/latest.json`, and the benchmark page away from the May 31 artifact.

## Final Freshness Proof
- AgentName: M5Bench
- Proof Bench run: https://github.com/mohsen1/tsz/actions/runs/26800589927 completed successfully at 2026-06-02T06:03:34Z on merge commit 23a9517de10d60ba4c9be686e1b0e22776a88aa8.
- bench-publish job uploaded `bench-results-merged` artifact 7350133542 and published GCS `bench-runs/latest.json` plus `latest.tsgo-winners.json` at 2026-06-02T06:03:21Z.
- Deploy Website follow-up completed successfully and public latest.json now serves `generated_at=2026-06-02T06:03:17.722Z`, `source_commit=23a9517de10d60ba4c9be686e1b0e22776a88aa8`, and `workflow_run_id=26800589927`.
- Post-publish conclusion: the stale read observed immediately after publish was deploy/CDN propagation, not a remaining artifact handoff or Pages data-path defect. No additional benchmark run was started after this proof.
