### PR TITLE
style(website): sharpen benchmark chart dark mode

### DIFF
--- a/crates/tsz-website/src/_data/benchmark_mean_chart.js
+++ b/crates/tsz-website/src/_data/benchmark_mean_chart.js
@@ -102,10 +102,10 @@ function formatSpeedupLabel(tszMs, tsgoMs) {
   if (!Number.isFinite(tszMs) || !Number.isFinite(tsgoMs) || tszMs <= 0) return "";
 
   if (tszMs < tsgoMs) {
-    return `tsz ${formatRatio(tsgoMs / tszMs)}x faster`;
+    return `tsz is ${formatRatio(tsgoMs / tszMs)}x faster`;
   }
   if (tsgoMs > 0) {
-    return `tsgo ${formatRatio(tszMs / tsgoMs)}x faster`;
+    return `tsgo is ${formatRatio(tszMs / tsgoMs)}x faster`;
   }
   return "";
 }

--- a/crates/tsz-website/static/style.css
+++ b/crates/tsz-website/static/style.css
@@ -967,6 +967,25 @@ tr:nth-child(even) { background: var(--table-stripe); }
 
 .benchmark-mean-card {
   margin: 1.25rem 0 2rem;
+  padding: 1rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 0;
+  background: var(--bg);
+  color: var(--text);
+  letter-spacing: 0;
+  text-rendering: geometricPrecision;
+}
+
+@media (prefers-color-scheme: dark) {
+  .benchmark-mean-card {
+    background: #0d1117;
+    border-color: #30363d;
+  }
+}
+
+.benchmark-mean-card .bench-category-desc {
+  color: var(--text);
+  font-weight: 500;
 }
 
 .benchmark-mean-card .bench-bar-row {
@@ -977,6 +996,36 @@ tr:nth-child(even) { background: var(--table-stripe); }
 .benchmark-mean-card .bench-bar {
   width: var(--bench-bar-width);
   min-width: 0;
+  border-radius: 0;
+}
+
+.benchmark-mean-card .bench-bar-label,
+.benchmark-mean-card .bench-bar-value,
+.benchmark-mean-card .bench-winner {
+  -webkit-font-smoothing: antialiased;
+  color: var(--text);
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.benchmark-mean-card .bench-bar-value {
+  color: #ffffff;
+}
+
+.benchmark-mean-card .bench-winner {
+  color: var(--success);
+  font-size: 0.88rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .benchmark-mean-card .bench-category-desc,
+  .benchmark-mean-card .bench-bar-label {
+    color: #f0f6fc;
+  }
+
+  .benchmark-mean-card .bench-winner {
+    color: #56d364;
+  }
 }
 
 .benchmark-links-block {


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Website benchmark presentation / visual polish.

## Invariant
When the home and benchmarks pages render the mean benchmark chart in dark mode, the chart background matches GitHub's default dark surface, chart corners remain square, text stays high contrast, and the aggregate speedup label reads as a sentence.

## Scope
- `crates/tsz-website/src/_data/benchmark_mean_chart.js`
- `crates/tsz-website/static/style.css`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: website-only chart presentation change; no compiler, benchmark fixture, or project-corpus behavior changed.

## Verification
- `npm --prefix crates/tsz-website run test:benchmarks`
- `npm --prefix crates/tsz-website run build`
- Browser render check against `http://localhost:4173/` in dark mode with reduced motion: mean chart background `rgb(13, 17, 23)`, card/bar radius `0px`, high-contrast labels, no mobile overflow/overlap, and `tsz is 3.05x faster` visible.

## Coordination Notes
- No overlapping open website/chart PRs found with `gh pr list` filter for benchmark, website, chart, home, dark, and style.
- No roadmap update: this is routine website presentation polish.
- Original runner signature: `m5-pro-48g-gpt5`; canonical owner label/body lane normalized to `agent:Studio-A` by M5Manager for ready/queue hygiene.
- Current head `d5556db4a499fe7a9fb37771cda257662c083bc4`; wait for exact-head `CI Summary` and `GitGuardian Security Checks` before adding `merge-queue`.
