### PR TITLE
[WIP] fix(checker): add TypeQuery origin tracking for cross-file SymbolId collisions

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1008,6 +1008,9 @@ mod union_multi_overload_unified_sig_tests;
 #[path = "tests/unique_symbol_assignment_ts2322_tests.rs"]
 mod unique_symbol_assignment_ts2322_tests;
 #[cfg(test)]
+#[path = "../tests/use_client_probe.rs"]
+mod use_client_probe;
+#[cfg(test)]
 #[path = "../tests/variadic_tuple_elaboration_tests.rs"]
 mod variadic_tuple_elaboration_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/tests/use_client_probe.rs
+++ b/crates/tsz-checker/tests/use_client_probe.rs
@@ -3,7 +3,7 @@ use crate::test_utils::check_multi_file;
 use tsz_common::common::{ModuleKind, ScriptTarget};
 
 /// Core repro: exported function whose parameter type is Parameters<typeof LocalFn>[0]
-/// where LocalFn is NOT exported. Cross-file callers should see the concrete type.
+/// where `LocalFn` is NOT exported. Cross-file callers should see the concrete type.
 #[test]
 fn probe_use_client_parameters_typeof_local_fn() {
     let diagnostics = check_multi_file(
@@ -83,7 +83,7 @@ Widget({ name: "hello", count: 42 });
     );
 }
 
-/// With exported LocalFn, there should be no issue (control case).
+/// With exported `LocalFn`, there should be no issue (control case).
 #[test]
 fn probe_parameters_typeof_exported_fn_works() {
     let diagnostics = check_multi_file(

--- a/crates/tsz-checker/tests/use_client_probe.rs
+++ b/crates/tsz-checker/tests/use_client_probe.rs
@@ -1,0 +1,122 @@
+use crate::context::CheckerOptions;
+use crate::test_utils::check_multi_file;
+use tsz_common::common::{ModuleKind, ScriptTarget};
+
+/// Core repro: exported function whose parameter type is Parameters<typeof LocalFn>[0]
+/// where LocalFn is NOT exported. Cross-file callers should see the concrete type.
+#[test]
+fn probe_use_client_parameters_typeof_local_fn() {
+    let diagnostics = check_multi_file(
+        &[
+            (
+                "client.ts",
+                r#""use client";
+
+function Inner(props: { name: string; count: number }) {
+    return null;
+}
+
+export function Widget(props: Parameters<typeof Inner>[0]) {
+    return null;
+}
+"#,
+            ),
+            (
+                "server.ts",
+                r#"import { Widget } from "./client";
+export default function Page() {
+    return Widget({ name: "hello", count: 42 });
+}
+"#,
+            ),
+        ],
+        "server.ts",
+        CheckerOptions {
+            module: ModuleKind::ESNext,
+            target: ScriptTarget::ES2022,
+            ..CheckerOptions::default()
+        },
+    );
+
+    let ts2345: Vec<_> = diagnostics.iter().filter(|d| d.code == 2345).collect();
+    assert!(
+        ts2345.is_empty(),
+        "use client + Parameters<typeof LocalFn>[0]: TS2345 should not fire, got: {ts2345:#?}\nAll: {diagnostics:#?}"
+    );
+}
+
+/// Same pattern without "use client" - the bug should exist independently.
+#[test]
+fn probe_parameters_typeof_local_fn_no_directive() {
+    let diagnostics = check_multi_file(
+        &[
+            (
+                "lib.ts",
+                r#"function Inner(props: { name: string; count: number }) {
+    return null;
+}
+
+export function Widget(props: Parameters<typeof Inner>[0]) {
+    return null;
+}
+"#,
+            ),
+            (
+                "main.ts",
+                r#"import { Widget } from "./lib";
+Widget({ name: "hello", count: 42 });
+"#,
+            ),
+        ],
+        "main.ts",
+        CheckerOptions {
+            module: ModuleKind::ESNext,
+            target: ScriptTarget::ES2022,
+            ..CheckerOptions::default()
+        },
+    );
+
+    let ts2345: Vec<_> = diagnostics.iter().filter(|d| d.code == 2345).collect();
+    assert!(
+        ts2345.is_empty(),
+        "Parameters<typeof LocalFn>[0] no directive: TS2345 should not fire, got: {ts2345:#?}\nAll: {diagnostics:#?}"
+    );
+}
+
+/// With exported LocalFn, there should be no issue (control case).
+#[test]
+fn probe_parameters_typeof_exported_fn_works() {
+    let diagnostics = check_multi_file(
+        &[
+            (
+                "lib.ts",
+                r#"export function Inner(props: { name: string; count: number }) {
+    return null;
+}
+
+export function Widget(props: Parameters<typeof Inner>[0]) {
+    return null;
+}
+"#,
+            ),
+            (
+                "main.ts",
+                r#"import { Widget } from "./lib";
+Widget({ name: "hello", count: 42 });
+"#,
+            ),
+        ],
+        "main.ts",
+        CheckerOptions {
+            module: ModuleKind::ESNext,
+            target: ScriptTarget::ES2022,
+            ..CheckerOptions::default()
+        },
+    );
+
+    let ts2345: Vec<_> = diagnostics.iter().filter(|d| d.code == 2345).collect();
+    assert!(
+        ts2345.is_empty(),
+        "Parameters<typeof ExportedFn>[0]: no TS2345, got: {ts2345:#?}"
+    );
+}

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -660,13 +660,6 @@ pub struct TypeInterner {
     /// Unique identifier scoping this interner's entries in the thread-local
     /// lookup/intern cache. See `NEXT_INTERNER_INSTANCE_ID` for context.
     pub(super) instance_id: u32,
-    /// Origin file index for `TypeQuery` `TypeId`s.
-    ///
-    /// When a `TypeData::TypeQuery(SymbolRef(X))` is created, the file index of the
-    /// source file is recorded here. Cross-file resolution uses this to resolve
-    /// `SymbolRef(X)` against the correct binder rather than the calling file's binder,
-    /// preventing `SymbolId` collisions between files from causing incorrect type lookups.
-    pub(crate) type_query_origins: DashMap<TypeId, u32, FxBuildHasher>,
 }
 
 impl std::fmt::Debug for TypeInterner {
@@ -726,7 +719,6 @@ impl TypeInterner {
             tuple_too_large: AtomicBool::new(false),
             evaluation_fuel: AtomicU32::new(0),
             instance_id: NEXT_INTERNER_INSTANCE_ID.fetch_add(1, Ordering::Relaxed),
-            type_query_origins: DashMap::with_hasher(FxBuildHasher),
         }
     }
 

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -660,6 +660,13 @@ pub struct TypeInterner {
     /// Unique identifier scoping this interner's entries in the thread-local
     /// lookup/intern cache. See `NEXT_INTERNER_INSTANCE_ID` for context.
     pub(super) instance_id: u32,
+    /// Origin file index for `TypeQuery` `TypeId`s.
+    ///
+    /// When a `TypeData::TypeQuery(SymbolRef(X))` is created, the file index of the
+    /// source file is recorded here. Cross-file resolution uses this to resolve
+    /// `SymbolRef(X)` against the correct binder rather than the calling file's binder,
+    /// preventing `SymbolId` collisions between files from causing incorrect type lookups.
+    pub(crate) type_query_origins: DashMap<TypeId, u32, FxBuildHasher>,
 }
 
 impl std::fmt::Debug for TypeInterner {
@@ -719,6 +726,7 @@ impl TypeInterner {
             tuple_too_large: AtomicBool::new(false),
             evaluation_fuel: AtomicU32::new(0),
             instance_id: NEXT_INTERNER_INSTANCE_ID.fetch_add(1, Ordering::Relaxed),
+            type_query_origins: DashMap::with_hasher(FxBuildHasher),
         }
     }
 


### PR DESCRIPTION
## Agent
AgentName: M4-D
RefreshAgent: M5Manager-MBM4-StaleFix

## Track
Track 7 - symbol/module identity and cross-file stable references.

## Invariant
When two source files allocate overlapping local `SymbolId` values, cross-file `TypeQuery` resolution must preserve file origin so tsz does not confuse distinct declarations that happen to share an arena-local id. This PR remains a preserved WIP probe for M4-D review before any semantic promotion.

## Scope
- Focused checker coverage for `Parameters<typeof LocalFn>[0]` across imported files, including a `"use client"` case and exported-function control.
- Remote WIP head `3ae7ba317df261f6ec1b2eb1f6007aae073a46a3` rebased earlier onto `045af3ea25a53ba374d6882a0ccc1dd8d0ae0926` and cleaned up stale lint/doc-comment issues.
- Local-only M5Manager-MBM4-StaleFix probe head `eef5e69a0fa1393e8b522615fc9b956f06cb8b70` rebased the probe commits onto then-live `origin/main` `8220c05755aa333281c1ee2813f970c783898df5`; it is not pushed because the focused probe still fails, and it is now stale relative to live `origin/main` `bd0facd76103a5c25fa21b8fc02354ed01b5440b`.
- No ready semantic plumbing is claimed: `TypeData::TypeQuery(SymbolRef)` still carries only the symbol ref, and no checker/solver query boundary has been added for file-origin lookup.

## Project Corpus Impact
- Row: n/a
- Bug family: cross-file symbol identity / `TypeQuery` origin tracking
- Evidence: focused checker probe coverage only; no project-corpus row was run or changed during this stale-runway refresh. Current-main local probe evidence is failing, so no corpus/readiness claim is made.

## Verification
- Historical remote-head evidence on `3ae7ba317df261f6ec1b2eb1f6007aae073a46a3`: `git diff --name-status origin/main...HEAD`, `git diff --check origin/main...HEAD`, `cargo fmt --check`, `python3 scripts/arch/arch_guard.py`, and `cargo clippy -p tsz-checker --lib --tests -- -D warnings` passed.
- Exact-head draft-light CI passed on 2026-06-02 for `3ae7ba317df261f6ec1b2eb1f6007aae073a46a3`: `CI Light Summary`, `lint`, `unit`, `unit-cloudbuild`, `dist-binaries`, and `GitGuardian Security Checks` are green. `project-corpus-pr-body` was skipped for this draft-light run.
- Prior local refresh attempt onto `origin/main` `6985ca5e676d320b721acd0c12f116181ca14972` produced local head `3ccc44c1d7a14a5f522418a32344bf6ab6d9b453`; `git diff --name-status origin/main...HEAD`, `git diff --check origin/main...HEAD`, `cargo fmt --check`, and `python3 scripts/arch/arch_guard.py` passed.
- Fresh M5Manager-MBM4-StaleFix local-only refresh onto then-live `origin/main` `8220c05755aa333281c1ee2813f970c783898df5` produced local head `eef5e69a0fa1393e8b522615fc9b956f06cb8b70` with diff limited to `crates/tsz-checker/src/lib.rs` and `crates/tsz-checker/tests/use_client_probe.rs`. That local-only probe was not rebased again onto live `origin/main` `bd0facd76103a5c25fa21b8fc02354ed01b5440b` in this metadata pass.
- Focused probe verification on the local-only head `eef5e69a0fa1393e8b522615fc9b956f06cb8b70` failed: `cargo nextest run -p tsz-checker --lib probe_` ran 13 filtered tests; 10 passed, 3 failed: `use_client_probe::probe_use_client_parameters_typeof_local_fn`, `use_client_probe::probe_parameters_typeof_local_fn_no_directive`, and `use_client_probe::probe_parameters_typeof_exported_fn_works`, all still reporting TS2345 for `Parameters<typeof Widget>[0]`.
- No branch push, full conformance, emit, fourslash, ready-review CI, or project-corpus suite was run for #12187 in this pass.

## Coordination Notes
- Keep draft/WIP/off-queue. The WIP label and `[WIP]` title are intentional.
- Current remote head: `3ae7ba317df261f6ec1b2eb1f6007aae073a46a3`.
- Current remote base: `045af3ea25a53ba374d6882a0ccc1dd8d0ae0926`; live `origin/main` is now `bd0facd76103a5c25fa21b8fc02354ed01b5440b`.
- Do not force-push the local-only probe head `eef5e69a0fa1393e8b522615fc9b956f06cb8b70`: replacing a green draft-light remote head with a known failing probe head, now also stale relative to live main, would not advance readiness.
- The remaining blocker is semantic scope ownership: this branch preserves failing/probe coverage but does not implement a ready origin-preserving checker/solver `TypeQuery` boundary.
- Structural next owner/action: M4-D should either keep this PR probe-only/superseded, or implement the real origin-preserving `TypeQuery` query boundary so the three focused `use_client_probe` tests pass on a current-main head before any refresh is pushed.
- Do not mark ready or add `merge-queue` until the PR is non-draft/non-WIP and exact-head ready-review `CI Summary`, `GitGuardian Security Checks`, body gate, and required heavy gates are clean.

