### PR TITLE
fix(checker): prefer value exports in wildcard export-star chains

### DIFF
--- a/crates/tsz-binder/src/state/resolution.rs
+++ b/crates/tsz-binder/src/state/resolution.rs
@@ -750,6 +750,16 @@ impl BinderState {
         if let Some(source_modules) = self.wildcard_reexports.get(module_specifier) {
             let source_type_only_flags = self.wildcard_reexports_type_only.get(module_specifier);
 
+            // When the caller is in value context (`is_type_only = false`), a pure
+            // type declaration (TYPE_ALIAS/INTERFACE without value flags) found in one
+            // wildcard source must not shadow a VALUE export of the same name from a
+            // later wildcard source. TypeScript resolves each name in both type and
+            // value namespaces independently: the VALUE wins for value-position uses.
+            //
+            // Strategy: collect a type-only fallback on the first pass; only return it
+            // if no value export is found from any subsequent wildcard source.
+            let mut type_only_fallback: Option<(SymbolId, bool)> = None;
+
             for (i, source_module) in source_modules.iter().enumerate() {
                 let source_is_type_only = source_type_only_flags
                     .and_then(|flags| flags.get(i).map(|(_, is_to)| *is_to))
@@ -765,8 +775,25 @@ impl BinderState {
                     is_type_only || source_is_type_only,
                     visited,
                 ) {
+                    // When in a type-only chain any match is fine; in value
+                    // context prefer VALUE exports over pure-type declarations
+                    // so a later `export * from './values'` can win over an
+                    // earlier `export * from './types'`.
+                    if is_type_only {
+                        return Some(result);
+                    }
+                    if self.symbols.get(result.0).is_some_and(|s| s.is_pure_type())
+                        && type_only_fallback.is_none()
+                    {
+                        type_only_fallback = Some(result);
+                        continue;
+                    }
                     return Some(result);
                 }
+            }
+
+            if let Some(fallback) = type_only_fallback {
+                return Some(fallback);
             }
         }
 

--- a/crates/tsz-binder/src/state/resolution.rs
+++ b/crates/tsz-binder/src/state/resolution.rs
@@ -750,11 +750,14 @@ impl BinderState {
         if let Some(source_modules) = self.wildcard_reexports.get(module_specifier) {
             let source_type_only_flags = self.wildcard_reexports_type_only.get(module_specifier);
 
-            // When the caller is in value context (`is_type_only = false`), a pure
-            // type declaration (TYPE_ALIAS/INTERFACE without value flags) found in one
-            // wildcard source must not shadow a VALUE export of the same name from a
-            // later wildcard source. TypeScript resolves each name in both type and
-            // value namespaces independently: the VALUE wins for value-position uses.
+            // When the caller is in value context (`is_type_only = false`), a
+            // type-only path found in one wildcard source must not shadow a
+            // VALUE export of the same name from a later wildcard source.
+            // Type-only paths include pure type declarations
+            // (TYPE_ALIAS/INTERFACE without value flags) and value-bearing
+            // declarations reached through `export type *`.
+            // TypeScript resolves each name in both type and value namespaces
+            // independently: the VALUE wins for value-position uses.
             //
             // Strategy: collect a type-only fallback on the first pass; only return it
             // if no value export is found from any subsequent wildcard source.
@@ -776,13 +779,13 @@ impl BinderState {
                     visited,
                 ) {
                     // When in a type-only chain any match is fine; in value
-                    // context prefer VALUE exports over pure-type declarations
-                    // so a later `export * from './values'` can win over an
-                    // earlier `export * from './types'`.
+                    // context prefer VALUE exports over type-only paths so a
+                    // later `export * from './values'` can win over an earlier
+                    // `export * from './types'` or `export type *`.
                     if is_type_only {
                         return Some(result);
                     }
-                    if self.symbols.get(result.0).is_some_and(|s| s.is_pure_type())
+                    if (result.1 || self.symbols.get(result.0).is_some_and(|s| s.is_pure_type()))
                         && type_only_fallback.is_none()
                     {
                         type_only_fallback = Some(result);

--- a/crates/tsz-binder/src/state/tests/exports_jsdoc.rs
+++ b/crates/tsz-binder/src/state/tests/exports_jsdoc.rs
@@ -568,6 +568,86 @@ fn resolves_wildcard_type_only_reexports_with_provenance() {
     assert!(!is_type_only_value);
 }
 
+/// When two wildcard sources export the same name, one as a pure `TYPE_ALIAS`
+/// and one as a value, the value symbol must be returned.
+#[test]
+fn value_export_preferred_over_type_alias_in_wildcard_sources() {
+    let mut binder = BinderState::new();
+
+    let type_alias_sym = binder
+        .symbols
+        .alloc(symbol_flags::TYPE_ALIAS, "Config".to_string());
+    let mut types_exports = SymbolTable::new();
+    types_exports.set("Config".to_string(), type_alias_sym);
+    Arc::make_mut(&mut binder.module_exports).insert("./types".to_string(), types_exports);
+
+    let value_sym = binder
+        .symbols
+        .alloc(symbol_flags::VARIABLE, "Config".to_string());
+    let mut values_exports = SymbolTable::new();
+    values_exports.set("Config".to_string(), value_sym);
+    Arc::make_mut(&mut binder.module_exports).insert("./values".to_string(), values_exports);
+
+    Arc::make_mut(&mut binder.wildcard_reexports)
+        .entry("./barrel".to_string())
+        .or_default()
+        .push("./types".to_string());
+    Arc::make_mut(&mut binder.wildcard_reexports)
+        .entry("./barrel".to_string())
+        .or_default()
+        .push("./values".to_string());
+    Arc::make_mut(&mut binder.wildcard_reexports_type_only)
+        .entry("./barrel".to_string())
+        .or_default()
+        .push(("./types".to_string(), false));
+    Arc::make_mut(&mut binder.wildcard_reexports_type_only)
+        .entry("./barrel".to_string())
+        .or_default()
+        .push(("./values".to_string(), false));
+
+    let (resolved, is_type_only) = binder
+        .resolve_import_with_reexports_type_only("./barrel", "Config")
+        .expect("expected Config to be resolved from barrel");
+
+    assert_eq!(
+        resolved, value_sym,
+        "should resolve to value symbol, not type alias, when both are exported"
+    );
+    assert!(!is_type_only, "value export must not be marked type-only");
+}
+
+/// When only a `TYPE_ALIAS` is exported, the type-alias symbol is still the
+/// resolution result for type-position access.
+#[test]
+fn type_alias_returned_when_no_value_in_wildcard_sources() {
+    let mut binder = BinderState::new();
+
+    let type_alias_sym = binder
+        .symbols
+        .alloc(symbol_flags::TYPE_ALIAS, "Config".to_string());
+    let mut types_exports = SymbolTable::new();
+    types_exports.set("Config".to_string(), type_alias_sym);
+    Arc::make_mut(&mut binder.module_exports).insert("./types".to_string(), types_exports);
+
+    Arc::make_mut(&mut binder.wildcard_reexports)
+        .entry("./barrel".to_string())
+        .or_default()
+        .push("./types".to_string());
+    Arc::make_mut(&mut binder.wildcard_reexports_type_only)
+        .entry("./barrel".to_string())
+        .or_default()
+        .push(("./types".to_string(), false));
+
+    let (resolved, _) = binder
+        .resolve_import_with_reexports_type_only("./barrel", "Config")
+        .expect("expected Config to be resolved from barrel");
+
+    assert_eq!(
+        resolved, type_alias_sym,
+        "should resolve to type alias when no value export exists"
+    );
+}
+
 #[test]
 fn global_augmentation_namespace_appears_in_file_locals() {
     // `declare global { namespace JSX { ... } }` inside a module declaration

--- a/crates/tsz-binder/src/state/tests/exports_jsdoc.rs
+++ b/crates/tsz-binder/src/state/tests/exports_jsdoc.rs
@@ -616,6 +616,54 @@ fn value_export_preferred_over_type_alias_in_wildcard_sources() {
     assert!(!is_type_only, "value export must not be marked type-only");
 }
 
+/// A value-bearing declaration reached through `export type *` is type-only for
+/// that path, so it must not shadow a later value wildcard source.
+#[test]
+fn value_export_preferred_over_type_only_wildcard_value_source() {
+    let mut binder = BinderState::new();
+
+    let type_only_value_sym = binder
+        .symbols
+        .alloc(symbol_flags::CLASS, "Config".to_string());
+    let mut classes_exports = SymbolTable::new();
+    classes_exports.set("Config".to_string(), type_only_value_sym);
+    Arc::make_mut(&mut binder.module_exports).insert("./classes".to_string(), classes_exports);
+
+    let value_sym = binder
+        .symbols
+        .alloc(symbol_flags::VARIABLE, "Config".to_string());
+    let mut values_exports = SymbolTable::new();
+    values_exports.set("Config".to_string(), value_sym);
+    Arc::make_mut(&mut binder.module_exports).insert("./values".to_string(), values_exports);
+
+    Arc::make_mut(&mut binder.wildcard_reexports)
+        .entry("./barrel".to_string())
+        .or_default()
+        .push("./classes".to_string());
+    Arc::make_mut(&mut binder.wildcard_reexports)
+        .entry("./barrel".to_string())
+        .or_default()
+        .push("./values".to_string());
+    Arc::make_mut(&mut binder.wildcard_reexports_type_only)
+        .entry("./barrel".to_string())
+        .or_default()
+        .push(("./classes".to_string(), true));
+    Arc::make_mut(&mut binder.wildcard_reexports_type_only)
+        .entry("./barrel".to_string())
+        .or_default()
+        .push(("./values".to_string(), false));
+
+    let (resolved, is_type_only) = binder
+        .resolve_import_with_reexports_type_only("./barrel", "Config")
+        .expect("expected Config to be resolved from barrel");
+
+    assert_eq!(
+        resolved, value_sym,
+        "value context should skip the type-only wildcard path and use the later value export"
+    );
+    assert!(!is_type_only, "value export must not be marked type-only");
+}
+
 /// When only a `TYPE_ALIAS` is exported, the type-alias symbol is still the
 /// resolution result for type-position access.
 #[test]

--- a/crates/tsz-binder/src/symbols.rs
+++ b/crates/tsz-binder/src/symbols.rs
@@ -336,6 +336,21 @@ impl Symbol {
         (self.flags & flags) != 0
     }
 
+    /// Returns `true` when this symbol carries type-namespace meaning only
+    /// (a `TYPE_ALIAS` or `INTERFACE` with no value or alias flags).
+    ///
+    /// TypeScript resolves type and value namespaces independently.  When
+    /// multiple wildcard re-export sources provide the same name, a pure-type
+    /// declaration must not shadow a value export from a later source.  Call
+    /// sites use this predicate to prefer VALUE symbols over pure-type ones.
+    #[must_use]
+    pub const fn is_pure_type(&self) -> bool {
+        const TYPE_KINDS: u32 = symbol_flags::TYPE_ALIAS | symbol_flags::INTERFACE;
+        (self.flags & TYPE_KINDS) != 0
+            && (self.flags & symbol_flags::VALUE) == 0
+            && (self.flags & symbol_flags::ALIAS) == 0
+    }
+
     /// Whether a top-level declaration of this symbol is visible in the
     /// cross-file global scope.
     ///

--- a/crates/tsz-checker/src/state/type_resolution/module/reexports.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module/reexports.rs
@@ -108,6 +108,14 @@ impl<'a> CheckerState<'a> {
             })
         {
             let source_modules = source_modules.clone();
+
+            // When multiple wildcard sources provide the same name, prefer a VALUE
+            // export over a pure TYPE declaration (TYPE_ALIAS/INTERFACE with no
+            // value flags). TypeScript resolves type and value namespaces
+            // independently; a value export from one `export *` source must not be
+            // shadowed by a type-only declaration from an earlier source in the list.
+            let mut type_only_fallback: Option<(tsz_binder::SymbolId, usize)> = None;
+
             for source_module in &source_modules {
                 if let Some(source_idx) = self
                     .ctx
@@ -119,8 +127,21 @@ impl<'a> CheckerState<'a> {
                         visited,
                     )
                 {
+                    let is_pure_type = self
+                        .ctx
+                        .get_binder_for_file(source_idx)
+                        .and_then(|b| b.get_symbol(result.0))
+                        .is_some_and(|s| s.is_pure_type());
+                    if is_pure_type && type_only_fallback.is_none() {
+                        type_only_fallback = Some(result);
+                        continue;
+                    }
                     return Some(result);
                 }
+            }
+
+            if let Some(fallback) = type_only_fallback {
+                return Some(fallback);
             }
         }
 

--- a/crates/tsz-checker/src/state/type_resolution/module/reexports.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module/reexports.rs
@@ -108,15 +108,30 @@ impl<'a> CheckerState<'a> {
             })
         {
             let source_modules = source_modules.clone();
+            let type_only_flags = self
+                .ctx
+                .wildcard_reexports_type_only_for_file(target_binder, &target_file_name)
+                .or_else(|| {
+                    module_key.and_then(|key| {
+                        self.ctx
+                            .wildcard_reexports_type_only_for_file(target_binder, key)
+                    })
+                })
+                .cloned();
 
             // When multiple wildcard sources provide the same name, prefer a VALUE
-            // export over a pure TYPE declaration (TYPE_ALIAS/INTERFACE with no
-            // value flags). TypeScript resolves type and value namespaces
-            // independently; a value export from one `export *` source must not be
-            // shadowed by a type-only declaration from an earlier source in the list.
+            // export over type-only paths, including pure TYPE declarations and
+            // value-bearing declarations reached through `export type *`.
+            // TypeScript resolves type and value namespaces independently; a value
+            // export from one `export *` source must not be shadowed by an earlier
+            // type-only path in the list.
             let mut type_only_fallback: Option<(tsz_binder::SymbolId, usize)> = None;
 
-            for source_module in &source_modules {
+            for (i, source_module) in source_modules.iter().enumerate() {
+                let source_is_type_only = type_only_flags
+                    .as_ref()
+                    .and_then(|flags| flags.get(i).map(|(_, is_to)| *is_to))
+                    .unwrap_or(false);
                 if let Some(source_idx) = self
                     .ctx
                     .resolve_import_target_from_file(file_idx, source_module)
@@ -132,7 +147,7 @@ impl<'a> CheckerState<'a> {
                         .get_binder_for_file(source_idx)
                         .and_then(|b| b.get_symbol(result.0))
                         .is_some_and(|s| s.is_pure_type());
-                    if is_pure_type && type_only_fallback.is_none() {
+                    if (source_is_type_only || is_pure_type) && type_only_fallback.is_none() {
                         type_only_fallback = Some(result);
                         continue;
                     }

--- a/crates/tsz-checker/tests/ts1362_false_positive_tests.rs
+++ b/crates/tsz-checker/tests/ts1362_false_positive_tests.rs
@@ -381,3 +381,57 @@ const _n: number = Config.count;
         "Should not emit TS2339 for .count access when VALUE provides 'count' (types-first barrel). Got: {ts2339:?}. All: {diagnostics:?}"
     );
 }
+
+/// `export type *` makes even value-bearing declarations type-only along that
+/// path. A later value wildcard source with the same name must win in value
+/// context.
+#[test]
+fn no_ts1362_for_type_only_wildcard_value_source_before_value_source() {
+    let classes_file = r#"
+export class Config {}
+"#;
+    let values_file = r#"
+export const Config = { count: 42 };
+"#;
+    let barrel = r#"
+export type * from "./classes";
+export * from "./values";
+"#;
+    let usage = r#"
+import { Config } from "./barrel";
+const _n: number = Config.count;
+"#;
+    let diagnostics = compile_module_files(
+        &[
+            ("./classes.ts", classes_file),
+            ("./values.ts", values_file),
+            ("./barrel.ts", barrel),
+            ("./usage.ts", usage),
+        ],
+        3,
+    );
+    let ts1362 = diagnostics
+        .iter()
+        .filter(|(c, _)| *c == 1362)
+        .collect::<Vec<_>>();
+    assert!(
+        ts1362.is_empty(),
+        "Should not emit TS1362 when an earlier type-only wildcard path points at a value-bearing declaration. Got: {ts1362:?}. All: {diagnostics:?}"
+    );
+    let ts2308 = diagnostics
+        .iter()
+        .filter(|(c, _)| *c == 2308)
+        .collect::<Vec<_>>();
+    assert!(
+        ts2308.is_empty(),
+        "Should not emit TS2308 for type-only wildcard plus later value wildcard source. Got: {ts2308:?}. All: {diagnostics:?}"
+    );
+    let ts2339 = diagnostics
+        .iter()
+        .filter(|(c, _)| *c == 2339)
+        .collect::<Vec<_>>();
+    assert!(
+        ts2339.is_empty(),
+        "Should not emit TS2339 for .count access when the later VALUE export provides 'count'. Got: {ts2339:?}. All: {diagnostics:?}"
+    );
+}

--- a/crates/tsz-checker/tests/ts1362_false_positive_tests.rs
+++ b/crates/tsz-checker/tests/ts1362_false_positive_tests.rs
@@ -60,6 +60,62 @@ const x: Drink = Drink.TEA;
     );
 }
 
+/// Type+value merged symbol is usable through a wildcard barrel.
+///
+/// When a file has both `export * as NS from './mod'` and `export type NS = ...`,
+/// and a barrel does `export * from './that-file'`, the imported symbol must still
+/// provide both type meaning (NS<A>) and value meaning (NS.of(...)).
+#[test]
+fn no_errors_for_type_namespace_merge_through_wildcard_barrel() {
+    let something = r#"
+export type Something<A> = { value: A }
+export declare function of<A>(value: A): Something<A>
+"#;
+    let prelude = r#"
+import * as S from "./Something"
+export * as Something from "./Something"
+export type Something<A> = S.Something<A>
+"#;
+    let barrel = "export * from \"./prelude\";\n";
+    let usage = r#"
+import { Something } from "./barrel"
+const _myValue: Something<string> = Something.of("abc")
+"#;
+    let diagnostics = compile_module_files(
+        &[
+            ("./Something.ts", something),
+            ("./prelude.ts", prelude),
+            ("./barrel.ts", barrel),
+            ("./usage.ts", usage),
+        ],
+        3,
+    );
+    let ts1362 = diagnostics
+        .iter()
+        .filter(|(c, _)| *c == 1362)
+        .collect::<Vec<_>>();
+    assert!(
+        ts1362.is_empty(),
+        "Should not emit TS1362 for type+namespace merge through wildcard barrel. Got: {ts1362:?}. All: {diagnostics:?}"
+    );
+    let ts2305 = diagnostics
+        .iter()
+        .filter(|(c, _)| *c == 2305)
+        .collect::<Vec<_>>();
+    assert!(
+        ts2305.is_empty(),
+        "Should not emit TS2305 for type+namespace merge through wildcard barrel. Got: {ts2305:?}. All: {diagnostics:?}"
+    );
+    let ts2339 = diagnostics
+        .iter()
+        .filter(|(c, _)| *c == 2339)
+        .collect::<Vec<_>>();
+    assert!(
+        ts2339.is_empty(),
+        "Should not emit TS2339 for type+namespace merge through wildcard barrel. Got: {ts2339:?}. All: {diagnostics:?}"
+    );
+}
+
 /// Reproduces exportTypeMergedWithExportStarAsNamespace.ts
 #[test]
 fn no_ts1362_for_export_type_merged_with_export_star_as_namespace() {
@@ -229,5 +285,99 @@ export const IdentifierNode: IdentifierNodeFactory = {
     assert!(
         ts2339.is_empty(),
         "Imported interface+const merge should use the const value side in expression context. Got: {ts2339:?}. All: {diagnostics:?}"
+    );
+}
+
+/// Verify that a type-alias-only export (no matching value) through a wildcard
+/// barrel correctly produces TS1362 when used as a value. This is the control
+/// case that proves we *do* correctly detect type-only symbols.
+#[test]
+fn ts1362_for_type_only_through_wildcard_barrel() {
+    let types_file = r#"
+export type Config = { debug: boolean };
+"#;
+    let barrel = r#"
+export * from "./types";
+"#;
+    let usage = r#"
+import { Config } from "./barrel";
+Config.debug;
+"#;
+    let diagnostics = compile_module_files(
+        &[
+            ("./types.ts", types_file),
+            ("./barrel.ts", barrel),
+            ("./usage.ts", usage),
+        ],
+        2,
+    );
+    // Config is only a type, so using it as a value should produce TS2693 or
+    // TS1362 (or similar type-used-as-value diagnostic). It must NOT be silent.
+    let has_type_usage_error = diagnostics
+        .iter()
+        .any(|(c, _)| [1362u32, 2693, 2339, 2448].contains(c));
+    assert!(
+        has_type_usage_error,
+        "Should emit a type-used-as-value error for type-only wildcard export. Got: {diagnostics:?}"
+    );
+}
+
+/// When two `export *` sources each provide the same name — one as a type-only
+/// re-export and one as a real value — the resolved binding must be the value.
+/// tsc sees no ambiguity because one is type-only; tsz must not emit TS1362 or
+/// TS2308 (ambiguous re-export) for that case.
+#[test]
+fn no_ts1362_for_type_value_split_across_wildcard_sources() {
+    // Use different shapes so we can tell which one is actually used at the
+    // value site: value has `{ count: number }`, type has `{ debug: boolean }`.
+    let types_file = r#"
+export type Config = { debug: boolean };
+"#;
+    let values_file = r#"
+export const Config = { count: 42 };
+"#;
+    let barrel = r#"
+export * from "./types";
+export * from "./values";
+"#;
+    // Accessing .count — only valid if the VALUE (not the type alias) is used.
+    // Accessing as type Config — only valid if the TYPE alias is used in type position.
+    // tsc resolves value-position `Config` to the VALUE (from values.ts), not the TYPE.
+    let usage = r#"
+import { Config } from "./barrel";
+const _n: number = Config.count;
+"#;
+    let diagnostics = compile_module_files(
+        &[
+            ("./types.ts", types_file),
+            ("./values.ts", values_file),
+            ("./barrel.ts", barrel),
+            ("./usage.ts", usage),
+        ],
+        3,
+    );
+    let ts1362 = diagnostics
+        .iter()
+        .filter(|(c, _)| *c == 1362)
+        .collect::<Vec<_>>();
+    assert!(
+        ts1362.is_empty(),
+        "Should not emit TS1362 when type and value for same name come from separate wildcard sources. Got: {ts1362:?}. All: {diagnostics:?}"
+    );
+    let ts2308 = diagnostics
+        .iter()
+        .filter(|(c, _)| *c == 2308)
+        .collect::<Vec<_>>();
+    assert!(
+        ts2308.is_empty(),
+        "Should not emit TS2308 for type+value from separate wildcard sources. Got: {ts2308:?}. All: {diagnostics:?}"
+    );
+    let ts2339 = diagnostics
+        .iter()
+        .filter(|(c, _)| *c == 2339)
+        .collect::<Vec<_>>();
+    assert!(
+        ts2339.is_empty(),
+        "Should not emit TS2339 for .count access when VALUE provides 'count' (types-first barrel). Got: {ts2339:?}. All: {diagnostics:?}"
     );
 }


### PR DESCRIPTION
## Agent
AgentName: M4-D
RefreshAgent: M5Manager-MBM4-StaleFix

## Track
Track 7 - module symbol identity and export resolution parity.

## Invariant
When wildcard export-star chains expose both value and type-alias candidates for the same exported name, tsz must preserve the TypeScript value-space resolution choice in value contexts instead of selecting a type-only alias. This PR keeps the change in binder/checker module export-resolution plumbing and does not introduce solver internals, rendered-type predicates, fixture-name gates, or checker-local type-shape traversal.

## Scope
- `crates/tsz-binder/src/state/resolution.rs`: prefer non-type-only value exports when resolving wildcard reexport candidates.
- `crates/tsz-binder/src/symbols.rs`: expose value-bearing symbol classification used by module export resolution.
- `crates/tsz-checker/src/state/type_resolution/module/reexports.rs`: carry the binder value/type resolution result through checker reexport collection.
- `crates/tsz-binder/src/state/tests/exports_jsdoc.rs`: structural binder coverage for value-vs-type wildcard precedence and type-only fallback.
- `crates/tsz-checker/tests/ts1362_false_positive_tests.rs`: TS1362 false-positive coverage for type/value split across wildcard sources and related merged namespace cases.

## Project Corpus Impact
- Row: n/a
- Bug family: module export resolution / TS1362 false positives
- Evidence: focused binder and checker regression coverage only; no project-corpus row was run in this refresh. The change is scoped to wildcard reexport value/type selection and associated diagnostics.

## Verification
- Rebased onto current `origin/main` `bd0facd76103a5c25fa21b8fc02354ed01b5440b` after #12258 landed.
- Current refreshed head: `4d3d000131cee58d488be570b8f9dc17e3e246c6`.
- `git diff --name-status origin/main...HEAD` shows the expected five-file binder/checker diff: `resolution.rs`, `exports_jsdoc.rs`, `symbols.rs`, `module/reexports.rs`, and `ts1362_false_positive_tests.rs`.
- `git diff --check origin/main...HEAD` passed.
- `cargo fmt --check` passed.
- `cargo nextest run -p tsz-binder -E 'test(value_export_preferred_over_type_alias_in_wildcard_sources) or test(type_alias_returned_when_no_value_in_wildcard_sources)'` -> 2 passed.
- `cargo nextest run -p tsz-checker --test ts1362_false_positive_tests` -> 8 passed.
- Prior refreshed head `9068624d89554876627df2de08dd6f3d0a9c3a01` had green draft-light CI, but that run is stale after the latest rebase/push.
- New exact-head draft-light CI for `4d3d000131cee58d488be570b8f9dc17e3e246c6` is green: `CI Light Summary`, `GitGuardian Security Checks`, `lint`, `unit`, `unit-cloudbuild`, `dist-binaries`, `cargo-shear`, `cargo-deny`, and `project-row-drift` passed on 2026-06-03. Heavy ready-review gates remain skipped while draft.
- No local full conformance, emit, or fourslash suites were run.

## Coordination Notes
- Recovered from orphan remote branch `claude/busy-lamport-jfP0z`; latest refresh force-pushed with lease from `9068624d89554876627df2de08dd6f3d0a9c3a01` to `4d3d000131cee58d488be570b8f9dc17e3e246c6`.
- Prior overlap blocker resolved: #12190 landed on main as `e3f287a8ef1144897365f6b55ad7c858da26af40`; this rebase preserved #12190 module-augmentation propagation while keeping #12188 value-over-type wildcard rule.
- Keep draft/off-queue after exact-head draft-light green on `4d3d000131cee58d488be570b8f9dc17e3e246c6`; M4-D should decide whether to mark ready for heavy CI.
- Next owner/action: M4-D should review the refreshed invariant and green exact-head draft-light evidence, then decide whether to mark ready for heavy CI. If they keep it draft, leave a signed blocker/handoff naming the remaining review concern.
- Do not add `merge-queue` until the PR is non-draft/non-WIP and exact-head ready-review `CI Summary`, `GitGuardian Security Checks`, project-corpus/body gate, and required heavy gates are clean.





