### PR TITLE
fix(checker): carry module augmentations along export-star chains

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -499,6 +499,10 @@ name = "ambient_module_value_export_tests"
 path = "tests/ambient_module_value_export_tests.rs"
 
 [[test]]
+name = "export_star_module_augmentation_tests"
+path = "tests/export_star_module_augmentation_tests.rs"
+
+[[test]]
 name = "cjs_object_export_module_augmentation_merge_tests"
 path = "tests/cjs_object_export_module_augmentation_merge_tests.rs"
 

--- a/crates/tsz-checker/src/state/type_resolution/module.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module.rs
@@ -1077,9 +1077,7 @@ impl<'a> CheckerState<'a> {
         target_file_idx: usize,
         module_specifier: Option<&str>,
     ) {
-        // Programs without any module augmentation pay no cost here. This
-        // matters because the helper is now invoked once per visited file in
-        // `collect_reexported_symbols`'s wildcard chain.
+        // Skip the wildcard-chain helper cost when no augmentations exist.
         if !self.ctx.program_has_module_augmentations() {
             return;
         }

--- a/crates/tsz-checker/src/state/type_resolution/module.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module.rs
@@ -1071,12 +1071,18 @@ impl<'a> CheckerState<'a> {
         None
     }
 
-    fn merge_module_augmentation_namespace_exports(
+    pub(crate) fn merge_module_augmentation_namespace_exports(
         &self,
         exports: &mut tsz_binder::SymbolTable,
         target_file_idx: usize,
         module_specifier: Option<&str>,
     ) {
+        // Programs without any module augmentation pay no cost here. This
+        // matters because the helper is now invoked once per visited file in
+        // `collect_reexported_symbols`'s wildcard chain.
+        if !self.ctx.program_has_module_augmentations() {
+            return;
+        }
         let mut names: Vec<String> = Vec::new();
 
         if let Some(module_specifier) = module_specifier {

--- a/crates/tsz-checker/src/state/type_resolution/module/reexports.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module/reexports.rs
@@ -244,6 +244,16 @@ impl<'a> CheckerState<'a> {
                         result,
                         visited,
                     );
+                    // Fold in module augmentations targeting the re-exported source
+                    // module. `module_exports[source]` only contains the source
+                    // file's own exports; augmentations declared in other files
+                    // contribute additional names that must traverse every
+                    // `export *` edge along with the source's direct exports.
+                    self.merge_module_augmentation_namespace_exports(
+                        result,
+                        source_idx,
+                        Some(source_module),
+                    );
                 }
             }
         }

--- a/crates/tsz-checker/tests/export_star_module_augmentation_tests.rs
+++ b/crates/tsz-checker/tests/export_star_module_augmentation_tests.rs
@@ -1,0 +1,208 @@
+//! Coverage for #11353: `export *` re-export chains must surface
+//! exports added by `declare module 'M' { ... }` augmentations targeting the
+//! re-exported module.
+//!
+//! Structural rule: when module `C` does `export * from 'M'` and another file
+//! augments `M` to add a new exported binding `X`, `X` must be reachable
+//! through `C` for both named imports (`import { X } from './C'`) and
+//! namespace imports (`import * as ns from './C'; ns.X`). The augmentation's
+//! contribution to `M`'s public surface must be carried along every transitive
+//! `export *` edge.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_multi_file;
+
+fn diagnostics(files: &[(&str, &str)], entry: &str) -> Vec<(u32, String)> {
+    check_multi_file(
+        files,
+        entry,
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+    )
+    .into_iter()
+    .map(|d| (d.code, d.message_text))
+    .collect()
+}
+
+fn count_code(diags: &[(u32, String)], expected: u32) -> usize {
+    diags.iter().filter(|(code, _)| *code == expected).count()
+}
+
+/// Build the standard `a.ts` / `augment.ts` / `barrel.ts` / `use.ts` scaffold,
+/// run the checker, and assert that none of `expected_zero` codes appear.
+fn assert_export_star_augmentation(augment_body: &str, use_source: &str, expected_zero: &[u32]) {
+    let augment_source = format!(
+        r#"
+import {{}} from "./a";
+declare module "./a" {{
+{augment_body}
+}}
+"#
+    );
+    let diags = diagnostics(
+        &[
+            ("a.ts", "\nexport class Foo {}\n"),
+            ("augment.ts", augment_source.as_str()),
+            ("barrel.ts", "\nexport * from \"./a\";\n"),
+            ("use.ts", use_source),
+        ],
+        "use.ts",
+    );
+
+    for &code in expected_zero {
+        assert_eq!(
+            count_code(&diags, code),
+            0,
+            "unexpected TS{code}; got {diags:#?}"
+        );
+    }
+}
+
+/// Direct named import through `export *` should see an augmentation-added
+/// value export from a different file.
+#[test]
+fn export_star_chain_carries_augmentation_added_value_export() {
+    assert_export_star_augmentation(
+        "    export class Bar { ping(): string; }",
+        r#"
+import { Bar } from "./barrel";
+const b: Bar = new Bar();
+b.ping();
+"#,
+        &[2304, 2305],
+    );
+}
+
+/// Named import through a multi-hop `export *` chain must still see the
+/// augmentation-added export. (Custom file set: requires an extra hop.)
+#[test]
+fn export_star_multi_hop_chain_carries_augmentation_added_export() {
+    let diags = diagnostics(
+        &[
+            ("a.ts", "\nexport class Foo {}\n"),
+            (
+                "augment.ts",
+                r#"
+import {} from "./a";
+declare module "./a" {
+    export interface Bar {
+        x: number;
+    }
+}
+"#,
+            ),
+            ("mid.ts", "\nexport * from \"./a\";\n"),
+            ("barrel.ts", "\nexport * from \"./mid\";\n"),
+            (
+                "use.ts",
+                r#"
+import { Bar } from "./barrel";
+const b: Bar = { x: 1 };
+"#,
+            ),
+        ],
+        "use.ts",
+    );
+
+    for &code in &[2304, 2305] {
+        assert_eq!(
+            count_code(&diags, code),
+            0,
+            "unexpected TS{code} on multi-hop chain; got {diags:#?}"
+        );
+    }
+}
+
+/// `import * as ns` enumeration through `export *` must include
+/// augmentation-added exports as namespace members in type position.
+#[test]
+fn namespace_import_through_export_star_includes_augmentation_added_type() {
+    assert_export_star_augmentation(
+        "    export interface Bar { method(): number; }",
+        r#"
+import * as ns from "./barrel";
+const b: ns.Bar = { method() { return 1; } };
+b.method();
+"#,
+        &[2339, 2503, 2694],
+    );
+}
+
+/// Renaming the augmented export name should not change the rule.
+#[test]
+fn export_star_carries_augmentation_renamed_export() {
+    assert_export_star_augmentation(
+        "    export class Renamed { run(): void; }",
+        r#"
+import { Renamed } from "./barrel";
+const r: Renamed = new Renamed();
+r.run();
+"#,
+        &[2304, 2305],
+    );
+}
+
+/// Augmentation-added type-only export through `export *` must surface for
+/// type-position usage.
+#[test]
+fn export_star_carries_augmentation_added_type_only_export() {
+    assert_export_star_augmentation(
+        "    export type Aliased = { tag: 'aug' };",
+        r#"
+import { Aliased } from "./barrel";
+const v: Aliased = { tag: 'aug' };
+"#,
+        &[2304, 2305],
+    );
+}
+
+/// Augmenting an existing class with additional instance members via
+/// `interface Foo { ... }` inside a `declare module 'M' { ... }` block must
+/// not drop the original symbol when `M` is re-exported through `export *`.
+#[test]
+fn export_star_preserves_class_when_augmented_interface_in_other_file() {
+    let diags = diagnostics(
+        &[
+            (
+                "a.ts",
+                r"
+export class Foo {
+    base(): number { return 0; }
+}
+",
+            ),
+            (
+                "augment.ts",
+                r#"
+import {} from "./a";
+declare module "./a" {
+    interface Foo {
+        extra: string;
+    }
+}
+"#,
+            ),
+            ("barrel.ts", "\nexport * from \"./a\";\n"),
+            (
+                "use.ts",
+                r#"
+import { Foo } from "./barrel";
+const f = new Foo();
+f.base();
+const s: string = f.extra;
+"#,
+            ),
+        ],
+        "use.ts",
+    );
+
+    for &code in &[2304, 2305, 2339] {
+        assert_eq!(
+            count_code(&diags, code),
+            0,
+            "unexpected TS{code} on class augmented by another file; got {diags:#?}"
+        );
+    }
+}


### PR DESCRIPTION
## Agent
AgentName: M4-D
RefreshAgent: M5Manager-MBM4-StaleFix
RecoveryRunner: Codex-GPT5 branch recovery; M5Manager refresh/fix

## Track
Track 7 - module augmentation and cross-file export identity.

## Invariant
When module augmentations are reachable through export-star chains, tsz must carry augmentation facts through reexport resolution rather than dropping them at an intermediate module boundary. This PR keeps the behavior in checker module-resolution orchestration and does not introduce solver internals or type-shape traversal.

## Scope
- Module augmentation propagation through checker type-resolution reexports.
- Focused export-star module augmentation tests.
- M5Manager-MBM4-StaleFix refresh: rebase onto live `origin/main` and keep the touched `module.rs` comment shrink that cleared the checker boundary size ratchet.
- M5Manager-MBM4-StaleFix refreshed through current main advances, most recently from old head `995fb5e5fbe8119e7c4966a0e7a564668307e2ff` / base `8b8d9dfa2b16940e10bd78cbb82afda7472eba71` onto live `origin/main` `8220c05755aa333281c1ee2813f970c783898df5`.
- Current head is `a8be3a927d48c4a1ac4a7d2db938276dfb9f4785`.

## Project Corpus Impact
- Row: n/a
- Bug family: module augmentation export-star resolution
- Evidence: focused checker integration tests only; no project-corpus row impact identified for this recovered lane. Fresh exact-head ready-review CI is pending on `a8be3a927d48c4a1ac4a7d2db938276dfb9f4785`; `GitGuardian Security Checks` is already green.

## Verification
- Local refresh checks on `a8be3a927d48c4a1ac4a7d2db938276dfb9f4785`: `git diff --name-status origin/main...HEAD`, `git diff --check origin/main...HEAD`, `cargo fmt --check`, `python3 scripts/arch/arch_guard.py`.
- Diff shape after refresh: `crates/tsz-checker/Cargo.toml`, `crates/tsz-checker/src/state/type_resolution/module.rs`, `crates/tsz-checker/src/state/type_resolution/module/reexports.rs`, and `crates/tsz-checker/tests/export_star_module_augmentation_tests.rs`.
- Narrow touched-file line-count check on `a8be3a927d48c4a1ac4a7d2db938276dfb9f4785`: `crates/tsz-checker/src/state/type_resolution/module.rs` is 2595 lines, still below the previous failing 2596 ratchet. Other touched files checked: `module/reexports.rs` 291 lines, `export_star_module_augmentation_tests.rs` 208 lines.
- Superseded head `995fb5e5fbe8119e7c4966a0e7a564668307e2ff` had ready-review CI nearly green, but became stale when #12270 advanced main and touched overlapping `crates/tsz-checker/Cargo.toml`.
- Fresh exact-head ready-review CI for `a8be3a927d48c4a1ac4a7d2db938276dfb9f4785` is pending as of this body update; `GitGuardian Security Checks` is already green.
- No local full conformance, emit, or fourslash suites were run.

## Coordination Notes
- Recovered from orphan remote branch `claude/confident-thompson-OD0mc`.
- Current refreshed head: `a8be3a927d48c4a1ac4a7d2db938276dfb9f4785`.
- Current base: `origin/main` `8220c05755aa333281c1ee2813f970c783898df5`.
- Latest main advance was #12270 (union-source missing-property elaboration) and overlapped this PR in `crates/tsz-checker/Cargo.toml`; rebase was clean and diff shape stayed unchanged.
- This PR is currently non-draft/ready-review; keep `merge-queue` off while exact-head ready-review `CI Summary`, body gate, conformance, emit, fourslash, WASM, and project compile gates are pending or missing.
- Overlap note: #12188 also touches `crates/tsz-checker/src/state/type_resolution/module/reexports.rs` but remains stale/conflicting/dirty; #12190 is the active refreshed adjacent export-star lane and should settle before #12188 is promoted or retargeted.
- Additional overlap note: #11837 also touches `crates/tsz-checker/src/state/type_resolution/module/reexports.rs` as part of a broader wildcard-reexport data-model refactor and carries a prior ready-review `conformance-aggregate` blocker; do not promote it ahead of this focused active lane without M4-D comparison.
- Next owner/action: M4-D should inspect the fresh exact-head ready-review result. If ready-review `CI Summary`, `GitGuardian Security Checks`, body gate, and required heavy gates are all green, queue-owner can consider `merge-queue`; if any fail, leave a signed blocker with the failing job and next action.
