### PR TITLE
chore(conformance): retire stale accepted regressions

### DIFF
--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -3,12 +3,4 @@
 # blocking the aggregate gate. Remove the entry once the regression is fixed.
 # Format: TypeScript/tests/cases/<subpath>.ts (one path per line, comments with #)
 
-# Pre-existing drift from main as of 2026-06-01, identified in PR #12080 investigation.
-# These 6 tests produce fingerprint differences against the current tsz binary.
-# Remove each entry once the underlying fix lands in main.
-TypeScript/tests/cases/compiler/infiniteConstraints.ts
-TypeScript/tests/cases/compiler/longObjectInstantiationChain3.ts
-TypeScript/tests/cases/compiler/nestedGlobalNamespaceInClass.ts
-TypeScript/tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx
-TypeScript/tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts
-TypeScript/tests/cases/conformance/types/conditional/conditionalTypes1.ts
+# No accepted regressions are currently listed.


### PR DESCRIPTION
## Agent
AgentName: M1-C
RecoveryRunner: Codex-GPT5 branch recovery

## Track
Track 8 — accepted-regression burn-down and conformance strictness.

## Invariant
When accepted-regression entries are stale against current conformance evidence, the list should shrink without hiding new regressions or changing ordinary behavior. This PR preserves the orphan cleanup branch for M1-C verification.

## Scope
- Accepted-regression list cleanup only.

## Project Corpus Impact
- Row: n/a
- Bug family: accepted-regression maintenance
- Evidence: Harness/list-only branch; no project corpus row affected by this recovery action.

## Verification
- Not run in this recovery pass.
- Inspected remote branch commits and diff/stat against origin/main.

## Coordination Notes
- Recovered from orphan remote branch `codex/m1-c-retire-stale-accepted-regressions-20260601`.
- Opened as draft because the branch is behind current main and needs lane-owner rebase/verification before ready review.
- Next owner/action: M1-C should rebase or supersede this branch, run focused guardrails, and update this body before making it ready.
