### PR TITLE
fix(checker): elaborate function parameter relation mismatches like tsc

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -179,6 +179,94 @@ impl<'a> CheckerState<'a> {
             })
     }
 
+    /// Append tsc's signature-mismatch elaboration beneath a function-to-function
+    /// relation line: a `Types of parameters 'a' and 'b' are incompatible.` frame
+    /// followed by the contravariant leaf relation for the offending parameter.
+    ///
+    /// Only runs when both enclosing types are function/callable, so the parent
+    /// line is genuinely the signature-to-signature line rather than a parameter
+    /// leaf rendered directly. Parameters are contravariant, so the leaf is
+    /// `Type '<target param>' is not assignable to type '<source param>'.`; the
+    /// solver's `inner_reason` already carries that orientation.
+    #[allow(clippy::too_many_arguments)]
+    fn push_parameter_mismatch_elaboration(
+        &mut self,
+        diag: &mut Diagnostic,
+        source: TypeId,
+        target: TypeId,
+        param_index: usize,
+        source_param: TypeId,
+        target_param: TypeId,
+        inner_reason: Option<&tsz_solver::SubtypeFailureReason>,
+        idx: NodeIndex,
+        depth: u32,
+    ) {
+        if self
+            .callable_type_after_display_evaluation(source)
+            .is_none()
+            || self
+                .callable_type_after_display_evaluation(target)
+                .is_none()
+        {
+            return;
+        }
+        // When the offending parameter is itself a function (a callback), tsc
+        // elides intermediate signature lines between successive
+        // `Types of parameters` frames in a way that depends on the
+        // contravariance nesting depth. That elision is non-trivial to
+        // reproduce, so restrict the elaboration to the single-flip case where
+        // the parameter is a non-callable type — the contravariant leaf is then
+        // a plain relation that matches tsc directly. Callback parameters keep
+        // their previous (signature-line-only) rendering.
+        if self
+            .callable_type_after_display_evaluation(source_param)
+            .is_some()
+            || self
+                .callable_type_after_display_evaluation(target_param)
+                .is_some()
+        {
+            return;
+        }
+        let source_name = self
+            .callable_param_name_at(source, param_index)
+            .unwrap_or_else(|| format!("arg{param_index}"));
+        let target_name = self
+            .callable_param_name_at(target, param_index)
+            .unwrap_or_else(|| format!("arg{param_index}"));
+        let frame = format_message(
+            diagnostic_messages::TYPES_OF_PARAMETERS_AND_ARE_INCOMPATIBLE,
+            &[&source_name, &target_name],
+        );
+        // At depth 0 the parent line is the primary diagnostic message (indent
+        // level 0), so its first elaboration sits at field 0. At depth > 0 the
+        // parent line is itself a related entry at field `depth`, so its
+        // elaboration sits one level deeper.
+        let frame_depth = if depth == 0 { 0 } else { depth + 1 };
+        let leaf_depth = frame_depth + 1;
+        diag.related_information.push(DiagnosticRelatedInformation {
+            file: diag.file.clone(),
+            start: diag.start,
+            length: diag.length,
+            message_text: frame,
+            category: DiagnosticCategory::Message,
+            code: diagnostic_codes::TYPES_OF_PARAMETERS_AND_ARE_INCOMPATIBLE,
+            depth: frame_depth.min(u8::MAX as u32) as u8,
+        });
+        // Parameters are contravariant, so the leaf compares the target
+        // parameter against the source parameter. `push_property_chain_leaf`
+        // renders the structured `inner_reason` when present (keeping
+        // intrinsic/literal display accurate) and otherwise emits the plain
+        // `Type 'S' is not assignable to type 'T'.` line.
+        self.push_property_chain_leaf(
+            diag,
+            inner_reason,
+            target_param,
+            source_param,
+            idx,
+            leaf_depth,
+        );
+    }
+
     fn no_union_member_matches_switch_source_display(
         &mut self,
         source: TypeId,
@@ -1034,13 +1122,35 @@ impl<'a> CheckerState<'a> {
                         diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                         &[&source_str, &target_str],
                     );
-                    Diagnostic::error(
+                    let mut diag = Diagnostic::error(
                         file_name,
                         start,
                         length,
                         message,
                         diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                    )
+                    );
+                    // When the enclosing source/target are themselves
+                    // function/callable types, the line just rendered is the
+                    // signature-to-signature relation line (e.g.
+                    // `Type '(x: number) => void' is not assignable to type
+                    // '(x: string) => void'.`). tsc then explains *why* the
+                    // signatures differ with a `Types of parameters 'a' and 'b'
+                    // are incompatible.` frame followed by the contravariant
+                    // leaf relation. Descend into the structured parameter
+                    // reason so the chain matches tsc instead of stopping at the
+                    // bare function line.
+                    self.push_parameter_mismatch_elaboration(
+                        &mut diag,
+                        source,
+                        target,
+                        *param_index,
+                        *source_param,
+                        *target_param,
+                        inner_reason.as_deref(),
+                        idx,
+                        depth,
+                    );
+                    diag
                 }
             }
 

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -188,19 +188,16 @@ impl<'a> CheckerState<'a> {
     /// leaf rendered directly. Parameters are contravariant, so the leaf is
     /// `Type '<target param>' is not assignable to type '<source param>'.`; the
     /// solver's `inner_reason` already carries that orientation.
-    #[allow(clippy::too_many_arguments)]
     fn push_parameter_mismatch_elaboration(
         &mut self,
         diag: &mut Diagnostic,
-        source: TypeId,
-        target: TypeId,
+        rctx: &RenderContext,
         param_index: usize,
         source_param: TypeId,
         target_param: TypeId,
         inner_reason: Option<&tsz_solver::SubtypeFailureReason>,
-        idx: NodeIndex,
-        depth: u32,
     ) {
+        let (source, target, idx, depth) = (rctx.source, rctx.target, rctx.idx, rctx.depth);
         if self
             .callable_type_after_display_evaluation(source)
             .is_none()
@@ -1141,14 +1138,11 @@ impl<'a> CheckerState<'a> {
                     // bare function line.
                     self.push_parameter_mismatch_elaboration(
                         &mut diag,
-                        source,
-                        target,
+                        &rctx,
                         *param_index,
                         *source_param,
                         *target_param,
                         inner_reason.as_deref(),
-                        idx,
-                        depth,
                     );
                     diag
                 }

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -215,7 +215,7 @@ impl<'a> CheckerState<'a> {
     /// present so intrinsic/literal display stays accurate; otherwise renders a
     /// direct `Type 'S' is not assignable to type 'T'.` line for the deepest
     /// property's types.
-    fn push_property_chain_leaf(
+    pub(super) fn push_property_chain_leaf(
         &mut self,
         diag: &mut Diagnostic,
         leaf: Option<&tsz_solver::SubtypeFailureReason>,

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -630,6 +630,9 @@ mod for_in_narrowing_tests;
 #[path = "tests/fresh_const_array_mutable_assignment_tests.rs"]
 mod fresh_const_array_mutable_assignment_tests;
 #[cfg(test)]
+#[path = "tests/function_parameter_mismatch_elaboration_tests.rs"]
+mod function_parameter_mismatch_elaboration_tests;
+#[cfg(test)]
 #[path = "tests/generic_callback_outer_context_tests.rs"]
 mod generic_callback_outer_context_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/function_parameter_mismatch_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/function_parameter_mismatch_elaboration_tests.rs
@@ -1,0 +1,200 @@
+//! Regression tests for function/signature relation failure elaboration.
+//!
+//! Structural rule: when a function type is not assignable to another function
+//! type because a parameter is incompatible, tsc reports the signature line
+//! followed by a `Types of parameters 'a' and 'b' are incompatible.` frame and
+//! the contravariant leaf relation. tsz must produce the same chain instead of
+//! stopping at the bare signature line.
+//!
+//! Two pieces cooperate:
+//!
+//! 1. The solver compares parameters before the return type (matching tsc's
+//!    `compareSignaturesRelated`), so when both a parameter *and* the return
+//!    type mismatch, the parameter mismatch is the reported reason.
+//! 2. The checker renderer descends into the parameter reason to emit the
+//!    `Types of parameters` frame plus the contravariant leaf.
+//!
+//! The rule is structural (independent of identifier spelling and of whether
+//! the function appears directly, as an object property, or via an interface
+//! method), so the matrix below varies all three.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_with_options, strict_checker_options};
+
+/// Full elaboration text (primary message plus every related-information line)
+/// of the single error with `code` in `source`, checked under strict options.
+fn elaboration(source: &str, code: u32) -> String {
+    elaboration_with(source, code, strict_checker_options())
+}
+
+fn elaboration_with(source: &str, code: u32, options: CheckerOptions) -> String {
+    let diags = check_with_options(source, options);
+    let matching: Vec<_> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "Expected exactly one TS{code}. Got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    let mut lines = vec![matching[0].message_text.clone()];
+    lines.extend(
+        matching[0]
+            .related_information
+            .iter()
+            .map(|info| info.message_text.clone()),
+    );
+    lines.join("\n")
+}
+
+/// A direct function-to-function assignment whose only difference is a parameter
+/// type surfaces the `Types of parameters` frame and the contravariant leaf.
+#[test]
+fn direct_function_parameter_mismatch_elaborates_parameter_chain() {
+    let text = elaboration(
+        r#"
+let f: (x: string) => string;
+let g: (x: number) => number;
+f = g;
+"#,
+        2322,
+    );
+    assert!(
+        text.contains("Types of parameters 'x' and 'x' are incompatible."),
+        "Expected the parameter-incompatibility frame. Got: {text:?}"
+    );
+    // Parameters are contravariant: the leaf compares the target parameter
+    // against the source parameter, so `string` is the one not assignable.
+    assert!(
+        text.contains("Type 'string' is not assignable to type 'number'."),
+        "Expected the contravariant parameter leaf. Got: {text:?}"
+    );
+}
+
+/// When *both* a parameter and the return type mismatch, tsc reports the
+/// parameter mismatch (parameters are compared first). tsz must not report the
+/// return type instead.
+#[test]
+fn parameter_is_preferred_over_return_when_both_mismatch() {
+    let text = elaboration(
+        r#"
+type A = { m: (x: string) => string };
+type B = { m: (x: number) => number };
+declare const b: B;
+const a: A = b;
+"#,
+        2322,
+    );
+    assert!(
+        text.contains("Types of property 'm' are incompatible."),
+        "Expected the property frame. Got: {text:?}"
+    );
+    assert!(
+        text.contains("Types of parameters 'x' and 'x' are incompatible."),
+        "Expected the parameter frame to be preferred over a return-type frame. Got: {text:?}"
+    );
+    assert!(
+        text.contains("Type 'string' is not assignable to type 'number'."),
+        "Expected the contravariant parameter leaf. Got: {text:?}"
+    );
+    assert!(
+        !text.contains("returned by"),
+        "Return-type elaboration must not be reported when a parameter mismatches. Got: {text:?}"
+    );
+}
+
+/// Same rule for a function-typed object property; renamed identifiers prove the
+/// fix is structural rather than keyed on the spelling `x`.
+#[test]
+fn property_function_parameter_mismatch_renamed_identifiers() {
+    let text = elaboration(
+        r#"
+type Target = { handler: (payload: string) => void };
+type Source = { handler: (payload: number) => void };
+declare const s: Source;
+const t: Target = s;
+"#,
+        2322,
+    );
+    assert!(
+        text.contains("Types of property 'handler' are incompatible."),
+        "Expected the property frame. Got: {text:?}"
+    );
+    assert!(
+        text.contains("Types of parameters 'payload' and 'payload' are incompatible."),
+        "Expected the renamed parameter frame. Got: {text:?}"
+    );
+    assert!(
+        text.contains("Type 'string' is not assignable to type 'number'."),
+        "Expected the contravariant parameter leaf. Got: {text:?}"
+    );
+}
+
+/// The offending parameter index is reported, not always the first parameter.
+#[test]
+fn second_parameter_mismatch_names_the_correct_parameter() {
+    let text = elaboration(
+        r#"
+let f: (a: string, b: string) => void;
+let g: (a: string, b: number) => void;
+f = g;
+"#,
+        2322,
+    );
+    assert!(
+        text.contains("Types of parameters 'b' and 'b' are incompatible."),
+        "Expected the second parameter to be named. Got: {text:?}"
+    );
+}
+
+/// Method-shorthand signatures (an interface method, not a function-typed
+/// property) elaborate the same parameter chain when assigned.
+#[test]
+fn interface_method_shorthand_parameter_mismatch_elaborates_chain() {
+    let text = elaboration(
+        r#"
+interface Target { transform(value: string): void; }
+interface Source { transform(value: number): void; }
+declare const s: Source;
+const t: Target = s;
+"#,
+        2322,
+    );
+    assert!(
+        text.contains("Types of property 'transform' are incompatible."),
+        "Expected the property frame. Got: {text:?}"
+    );
+    assert!(
+        text.contains("Types of parameters 'value' and 'value' are incompatible."),
+        "Expected the parameter frame for a method-shorthand signature. Got: {text:?}"
+    );
+    assert!(
+        text.contains("Type 'string' is not assignable to type 'number'."),
+        "Expected the contravariant parameter leaf. Got: {text:?}"
+    );
+}
+
+/// A return-only mismatch (parameters identical) still reports the return type,
+/// proving the parameter-first ordering does not suppress return diagnostics.
+#[test]
+fn return_only_mismatch_still_reports_return() {
+    let text = elaboration_with(
+        r#"
+let f: () => string;
+let g: () => number;
+f = g;
+"#,
+        2322,
+        strict_checker_options(),
+    );
+    assert!(
+        text.contains("Type 'number' is not assignable to type 'string'."),
+        "Expected the return leaf for a return-only mismatch. Got: {text:?}"
+    );
+    assert!(
+        !text.contains("Types of parameters"),
+        "A return-only mismatch must not emit a parameter frame. Got: {text:?}"
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/explain_function.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain_function.rs
@@ -16,6 +16,15 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         source: &FunctionShape,
         target: &FunctionShape,
     ) -> Option<SubtypeFailureReason> {
+        // tsc's `compareSignaturesRelated` compares parameters before return
+        // types, so when both a parameter and the return type are incompatible
+        // it surfaces the parameter mismatch. Match that ordering: run the
+        // parameter (arity + per-position) checks first and only fall back to
+        // the return-type mismatch once the parameters are compatible.
+        if let Some(parameter_failure) = self.explain_function_parameter_failure(source, target) {
+            return Some(parameter_failure);
+        }
+
         // Check return type
         if !(self
             .check_subtype(source.return_type, target.return_type)
@@ -30,6 +39,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             });
         }
 
+        None
+    }
+
+    fn explain_function_parameter_failure(
+        &mut self,
+        source: &FunctionShape,
+        target: &FunctionShape,
+    ) -> Option<SubtypeFailureReason> {
         // Check parameter count
         let target_has_rest = target.params.last().is_some_and(|p| p.rest);
         let rest_elem_type = if target_has_rest {


### PR DESCRIPTION
AgentName: opus-pensive-wright

## Agent
opus-pensive-wright, operating in the `agent:M1-B` lane (relation-diagnostic rendering / failure explanation) per M5Manager intake.

## Track
Track 1 — checker/solver diagnostic parity for relation failure explanation.

## Invariant
Function/signature relation failures must elaborate the parameter mismatch chain exactly like `tsc`: parameters are compared **before** the return type (`tsc`'s `compareSignaturesRelated`), and the rendered chain is the signature line → `Types of parameters 'a' and 'b' are incompatible.` → the **contravariant** leaf relation. Assignability pass/fail is never changed — only which structured failure reason is reported, and how it is rendered.

The rule holds for any identifier spelling and whether the function appears directly, as an object property, or as a method-shorthand signature. The diagnostic is built from the solver's structured failure reason; no decision is driven from rendered strings.

## Scope
- **solver** (`relations/subtype/explain_function.rs`): `explain_function_failure` runs the parameter (arity + per-position) checks before the return-type check. `explain_*` only runs after a relation has already failed, so this changes which reason is reported, never pass/fail. Parameter logic extracted into `explain_function_parameter_failure`.
- **checker** (`error_reporter/render_failure.rs`): the `ParameterTypeMismatch` render arm descends into the parameter reason, emitting the `Types of parameters` frame and the contravariant leaf by reusing the existing `push_property_chain_leaf` helper. Restricted to non-callable parameters (callback nesting elision is a tracked follow-up).
- tests: new `function_parameter_mismatch_elaboration_tests` module.
- No public API changes.

Known unsupported shapes / follow-ups: class/interface **heritage** rendering (TS2416/TS2430) still uses a hardcoded truncated string (larger conformance-sensitive refactor); nested **callback** parameter chains keep prior rendering; pre-existing depth-0 main-line function display spacing is unrelated and untouched.

## Project Corpus Impact
- Row: project rows emitting function-typed mismatch diagnostics (diagnostics family witnesses, e.g. #12179) and generic method-override diagnostics (#12178).
- Bug family: function/signature relation failure elaboration + parameter-vs-return comparison ordering.
- Evidence: `tsc` 6.0.2 differential (direct/property/method-shorthand/return-only/multi-param), new `tsz_checker` unit tests, `cargo clippy -p tsz-solver -p tsz-checker --lib` clean.

## Verification
- `cargo build -p tsz-cli --bin tsz` ✓
- `cargo test -p tsz-checker --lib function_parameter_mismatch_elaboration` → 6 passed ✓
- `cargo clippy -p tsz-solver --lib` / `-p tsz-checker --lib` → clean ✓
- 15-case message-level differential vs `tsc` 6.0.2: all new diffs match `tsc`; remaining diffs are pre-existing and unrelated (confirmed by stashing this change on clean `main`).
- Full conformance/emit/fourslash/WASM left to CI per repo policy.

## Coordination Notes
- Owner lane: `agent:M1-B` (assigned by M5Manager). Signed runner: opus-pensive-wright.
- Refs #12178 (claimed, `WIP`) and #12179.
- Overlap reassessment vs the active diagnostics PRs:
  - #11890 (route M1-B relation diagnostics): touches `assignability/*` and `generic_checker/*`; does **not** touch `explain_function.rs` or the `ParameterTypeMismatch` render arm. Disjoint.
  - #11953 (avoid rendered diagnostic gates): edits `error_reporter/render_failure.rs` but in different match arms / formatting paths; the `ParameterTypeMismatch` arm and the new `push_parameter_mismatch_elaboration` helper are untouched there. Mechanically disjoint; trivial textual resolution if both land.
  - #12147 (preserve conditional branch mismatch details): touches `query_boundaries`/`overload_compatibility`; disjoint.
- merge-queue / auto-merge intentionally left off until a fresh exact-head ready-review check picture is green, per M5Manager.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVthee4mEJ6k32aYCB8rUt)_