### PR TITLE
test(solver/checker): regression coverage for identity as-clause mapped type modifier preservation

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -771,6 +771,10 @@ name = "keyof_mapped_as_clause_tests"
 path = "tests/keyof_mapped_as_clause_tests.rs"
 
 [[test]]
+name = "mapped_as_clause_identity_modifier_tests"
+path = "tests/mapped_as_clause_identity_modifier_tests.rs"
+
+[[test]]
 name = "commonjs_constructor_diagnostics_tests"
 path = "tests/commonjs_constructor_diagnostics_tests.rs"
 

--- a/crates/tsz-checker/tests/mapped_as_clause_identity_modifier_tests.rs
+++ b/crates/tsz-checker/tests/mapped_as_clause_identity_modifier_tests.rs
@@ -1,0 +1,202 @@
+//! Regression coverage for bug-family #12174.
+//!
+//! Structural rule: when a mapped type uses an identity `as K` remap clause
+//! (`{ [K in keyof T as K]: T[K] }`) with no explicit modifier directives,
+//! tsz must carry optional and readonly modifiers from the source type through
+//! to the result — matching `tsc` behavior and matching what the no-`as`-clause
+//! form (`{ [K in keyof T]: T[K] }`) already does.
+//!
+//! The absence of this equivalence produces false-positive TS2741 / TS2322
+//! diagnostics on project rows where library types use identity remapped mapped
+//! types (e.g., utility types in zod, rxjs, nextjs, kysely).
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_source;
+
+fn check(source: &str) -> Vec<Diagnostic> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict_null_checks: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn codes(diags: &[Diagnostic]) -> Vec<u32> {
+    diags.iter().map(|d| d.code).collect()
+}
+
+fn has(diags: &[Diagnostic], code: u32) -> bool {
+    diags.iter().any(|d| d.code == code)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Baseline: no-as-clause identity mapped type must preserve optionality.
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Structural rule baseline: `{ [K in keyof T]: T[K] }` (no as-clause) must
+/// preserve the source's optional modifier so that an object literal missing
+/// an optional property is accepted without a TS2741 diagnostic.
+#[test]
+fn no_as_clause_identity_mapped_optional_property_is_skippable() {
+    let diags = check(
+        r#"
+type Identity<T> = { [K in keyof T]: T[K] };
+type Source = { a?: number; b: string };
+type Wrapped = Identity<Source> & { c: boolean };
+
+const w: Wrapped = { b: "hello", c: true };
+"#,
+    );
+    assert!(
+        !has(&diags, 2741),
+        "Identity<Source> (no as-clause): optional 'a' must not require presence; got: {diags:#?}"
+    );
+    assert!(
+        !has(&diags, 2322),
+        "Identity<Source> (no as-clause): no TS2322 expected; got: {diags:#?}"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Primary: identity `as K` mapped type must behave the same as no-as-clause.
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Identity `as K` remap must treat the type as homomorphic and carry source
+/// optional modifiers forward, the same as the no-`as`-clause form.
+///
+/// tsc behavior: `{ b: "hello", c: true }` is valid for `Wrapped` because `a`
+/// is optional in `Source` and is therefore optional in `Rename<Source>` and
+/// in the intersection `Rename<Source> & { c: boolean }`.
+#[test]
+fn identity_as_clause_mapped_optional_property_is_skippable() {
+    let diags = check(
+        r#"
+type Rename<T> = { [K in keyof T as K]: T[K] };
+type Source = { a?: number; b: string };
+type Wrapped = Rename<Source> & { c: boolean };
+
+const w: Wrapped = { b: "hello", c: true };
+"#,
+    );
+    assert!(
+        !has(&diags, 2741),
+        "Rename<Source> (identity as K): optional 'a' must not require presence; got: {diags:#?}"
+    );
+    assert!(
+        !has(&diags, 2322),
+        "Rename<Source> (identity as K): no TS2322 expected; got: {diags:#?}"
+    );
+}
+
+/// Renamed iteration variable (`P` instead of `K`) must also preserve optional.
+/// The structural rule is name-agnostic.
+#[test]
+fn identity_as_clause_with_renamed_iter_var_preserves_optional() {
+    let diags = check(
+        r#"
+type Rename<T> = { [P in keyof T as P]: T[P] };
+type Source = { a?: number; b: string };
+type Wrapped = Rename<Source> & { c: boolean };
+
+const w: Wrapped = { b: "hello", c: true };
+"#,
+    );
+    assert!(
+        !has(&diags, 2741),
+        "Rename<Source> (identity as P): optional 'a' must not require presence; got: {diags:#?}"
+    );
+}
+
+/// Required properties must still require presence through identity `as K`.
+/// This validates that the fix does not accidentally make all properties optional.
+#[test]
+fn identity_as_clause_required_property_is_still_required() {
+    let diags = check(
+        r#"
+type Rename<T> = { [K in keyof T as K]: T[K] };
+type Source = { a?: number; b: string };
+type Wrapped = Rename<Source> & { c: boolean };
+
+// b is required, c is required — missing b must produce TS2741
+const bad: Wrapped = { c: true };
+"#,
+    );
+    assert!(
+        has(&diags, 2741) || has(&diags, 2322),
+        "Rename<Source> (identity as K): missing required 'b' must produce an error; got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// All three properties provided including the optional one: should accept.
+#[test]
+fn identity_as_clause_all_properties_provided_accepts() {
+    let diags = check(
+        r#"
+type Rename<T> = { [K in keyof T as K]: T[K] };
+type Source = { a?: number; b: string };
+type Wrapped = Rename<Source> & { c: boolean };
+
+const w: Wrapped = { a: 42, b: "hello", c: true };
+"#,
+    );
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.code == 2741 || d.code == 2322)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "Rename<Source> (identity as K): all properties provided should have no errors; got: {diags:#?}"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Readonly modifier preservation.
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Identity `as K` must also preserve `readonly` from the source.
+///
+/// Writing to a readonly property through an identity-remapped mapped type
+/// must be rejected with TS2540, the same as through the no-`as`-clause form.
+#[test]
+fn identity_as_clause_readonly_property_is_preserved() {
+    let diags = check(
+        r#"
+type Rename<T> = { [K in keyof T as K]: T[K] };
+type Source = { readonly x: number };
+type Wrapped = Rename<Source>;
+
+declare const w: Wrapped;
+// Assigning to a readonly property must be rejected.
+w.x = 5;
+"#,
+    );
+    assert!(
+        has(&diags, 2540),
+        "Rename<Source> (identity as K): assignment to readonly 'x' must be TS2540; got: {diags:#?}"
+    );
+}
+
+/// Baseline: the no-as-clause form must also produce TS2540.
+/// This test ensures parity between the two forms.
+#[test]
+fn no_as_clause_readonly_property_is_preserved() {
+    let diags = check(
+        r#"
+type Identity<T> = { [K in keyof T]: T[K] };
+type Source = { readonly x: number };
+type Wrapped = Identity<Source>;
+
+declare const w: Wrapped;
+w.x = 5;
+"#,
+    );
+    assert!(
+        has(&diags, 2540),
+        "Identity<Source> (no as-clause): assignment to readonly 'x' must be TS2540; got: {diags:#?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped/tests.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::construction::TypeInterner;
 use crate::recursion::RecursionResult;
-use crate::types::{TupleElement, TypeParamInfo};
+use crate::types::{PropertyInfo, TupleElement, TypeParamInfo};
 
 #[test]
 fn evaluate_keyof_or_constraint_preserves_reentrant_constraint() {
@@ -705,4 +705,204 @@ fn evaluate_keyof_or_constraint_cycle_guard_prevents_infinite_loop() {
         TypeId::ERROR,
         "self-stable union must terminate without ERROR"
     );
+}
+
+/// `{ [K in keyof T as K]: T[K] }` applied to `{ readonly a?: number; b?: string; c: boolean }`
+/// must preserve optional and readonly modifiers from the source type — matching tsc behavior.
+///
+/// Covers the structural rule: when a homomorphic mapped type has an identity `as K` remap
+/// clause (where K is the same as the iteration variable), tsz must treat the type as
+/// homomorphic and inherit source property modifiers, the same as with no `as` clause.
+///
+/// Verified for multiple iteration variable names to prove the rule is structural, not
+/// keyed on the spelling `K`.
+#[test]
+fn identity_as_clause_mapped_over_object_preserves_optional_and_readonly_modifiers() {
+    let interner = TypeInterner::new();
+
+    let a_atom = interner.intern_string("a");
+    let b_atom = interner.intern_string("b");
+    let c_atom = interner.intern_string("c");
+
+    // source: { readonly a?: number; b?: string; c: boolean }
+    let source = interner.object(vec![
+        PropertyInfo {
+            name: a_atom,
+            type_id: TypeId::NUMBER,
+            write_type: TypeId::NUMBER,
+            optional: true,
+            readonly: true,
+            ..Default::default()
+        },
+        PropertyInfo {
+            name: b_atom,
+            type_id: TypeId::STRING,
+            write_type: TypeId::STRING,
+            optional: true,
+            readonly: false,
+            ..Default::default()
+        },
+        PropertyInfo::new(c_atom, TypeId::BOOLEAN),
+    ]);
+
+    // The same structural fix must apply regardless of iteration-variable spelling.
+    for iter_name in ["K", "P", "X", "Key"] {
+        let iter_atom = interner.intern_string(iter_name);
+        let outer_t = interner.type_param(TypeParamInfo::simple(interner.intern_string("T")));
+        let original_constraint = interner.keyof(outer_t);
+        let iter_param = interner.type_param(TypeParamInfo {
+            name: iter_atom,
+            constraint: Some(original_constraint),
+            default: None,
+            is_const: false,
+        });
+        let template = interner.index_access(source, iter_param);
+        // name_type is the iteration variable itself — identity `as K` remap.
+        let name_type_param = interner.type_param(TypeParamInfo::simple(iter_atom));
+
+        let mapped = MappedType {
+            type_param: TypeParamInfo {
+                name: iter_atom,
+                constraint: Some(original_constraint),
+                default: None,
+                is_const: false,
+            },
+            constraint: interner.keyof(source),
+            name_type: Some(name_type_param),
+            template,
+            readonly_modifier: None,
+            optional_modifier: None,
+        };
+
+        let mut evaluator = TypeEvaluator::new(&interner);
+        let result = evaluator.evaluate_mapped(&mapped);
+
+        assert_ne!(
+            result,
+            TypeId::ERROR,
+            "iter `{iter_name}`: identity as-clause mapped type must not produce ERROR"
+        );
+        assert_ne!(
+            result,
+            TypeId::NEVER,
+            "iter `{iter_name}`: identity as-clause mapped type must not produce NEVER"
+        );
+
+        let shape_id = match interner.lookup(result) {
+            Some(TypeData::Object(id)) => id,
+            other => panic!(
+                "iter `{iter_name}`: expected Object result, got {other:?} (TypeId={result:?})"
+            ),
+        };
+        let shape = interner.object_shape(shape_id);
+
+        let find_prop = |atom: Atom| shape.properties.iter().find(|p| p.name == atom).cloned();
+
+        let prop_a = find_prop(a_atom)
+            .unwrap_or_else(|| panic!("iter `{iter_name}`: property 'a' must exist"));
+        assert!(
+            prop_a.optional,
+            "iter `{iter_name}`: property 'a' must be optional (source was `a?: number`)"
+        );
+        assert!(
+            prop_a.readonly,
+            "iter `{iter_name}`: property 'a' must be readonly (source was `readonly a?`)"
+        );
+
+        let prop_b = find_prop(b_atom)
+            .unwrap_or_else(|| panic!("iter `{iter_name}`: property 'b' must exist"));
+        assert!(
+            prop_b.optional,
+            "iter `{iter_name}`: property 'b' must be optional (source was `b?: string`)"
+        );
+        assert!(
+            !prop_b.readonly,
+            "iter `{iter_name}`: property 'b' must not be readonly"
+        );
+
+        let prop_c = find_prop(c_atom)
+            .unwrap_or_else(|| panic!("iter `{iter_name}`: property 'c' must exist"));
+        assert!(
+            !prop_c.optional,
+            "iter `{iter_name}`: property 'c' must not be optional (source was `c: boolean`)"
+        );
+        assert!(
+            !prop_c.readonly,
+            "iter `{iter_name}`: property 'c' must not be readonly"
+        );
+    }
+}
+
+/// When the source type has been evaluated to a concrete object through an alias,
+/// the identity `as K` mapped type must still preserve modifiers.
+///
+/// Structural rule: modifier preservation through identity `as K` must hold even
+/// when the source is accessed indirectly (e.g., through an alias-like evaluation).
+#[test]
+fn identity_as_clause_with_renamed_iter_var_is_name_agnostic() {
+    let interner = TypeInterner::new();
+    let x_atom = interner.intern_string("x");
+
+    // source: { readonly x?: boolean }
+    let source = interner.object(vec![PropertyInfo {
+        name: x_atom,
+        type_id: TypeId::BOOLEAN,
+        write_type: TypeId::BOOLEAN,
+        optional: true,
+        readonly: true,
+        ..Default::default()
+    }]);
+
+    // Build with two different variable names to confirm name-agnostic behaviour.
+    for (iter_name, outer_name) in [("K", "T"), ("Prop", "Source"), ("Item", "Obj")] {
+        let iter_atom = interner.intern_string(iter_name);
+        let outer_t =
+            interner.type_param(TypeParamInfo::simple(interner.intern_string(outer_name)));
+        let original_constraint = interner.keyof(outer_t);
+        let iter_param = interner.type_param(TypeParamInfo {
+            name: iter_atom,
+            constraint: Some(original_constraint),
+            default: None,
+            is_const: false,
+        });
+        let template = interner.index_access(source, iter_param);
+        let name_type_param = interner.type_param(TypeParamInfo::simple(iter_atom));
+
+        let mapped = MappedType {
+            type_param: TypeParamInfo {
+                name: iter_atom,
+                constraint: Some(original_constraint),
+                default: None,
+                is_const: false,
+            },
+            constraint: interner.keyof(source),
+            name_type: Some(name_type_param),
+            template,
+            readonly_modifier: None,
+            optional_modifier: None,
+        };
+
+        let mut evaluator = TypeEvaluator::new(&interner);
+        let result = evaluator.evaluate_mapped(&mapped);
+
+        let shape_id = match interner.lookup(result) {
+            Some(TypeData::Object(id)) => id,
+            other => panic!("iter `{iter_name}`: expected Object, got {other:?}"),
+        };
+        let shape = interner.object_shape(shape_id);
+        let prop = shape
+            .properties
+            .iter()
+            .find(|p| p.name == x_atom)
+            .unwrap_or_else(|| panic!("iter `{iter_name}`: property 'x' must exist"));
+
+        assert!(
+            prop.optional,
+            "iter `{iter_name}`: property 'x' must remain optional through identity as-clause"
+        );
+        assert!(
+            prop.readonly,
+            "iter `{iter_name}`: property 'x' must remain readonly through identity as-clause"
+        );
+    }
 }


### PR DESCRIPTION
AgentName: claude-sonnet-4-6 (dazzling-johnson)

## Agent
AgentName: claude-sonnet-4-6 (dazzling-johnson)

## Track
Track 1/5 - mapped/conditional/key-space type evaluation correctness.

## Invariant
When a mapped type uses an identity `as K` remap clause (`{ [K in keyof T as K]: T[K] }`), tsz must carry optional and readonly modifiers from the source type through to the result, matching `tsc` behavior and the no-`as`-clause form (`{ [K in keyof T]: T[K] }`).

Structural rule: when `name_type` is an identity mapping (the iteration variable remaps to itself), the mapped type is homomorphic and inherits source modifiers identically to the no-`as`-clause form. This rule is name-agnostic: it applies regardless of how the iteration variable is spelled (`K`, `P`, `X`, `Key`, etc.).

## Scope
Test-only PR. No behavior changes.

- Solver (`crates/tsz-solver/src/evaluation/evaluate_rules/mapped/tests.rs`): two new unit tests covering 7 distinct iteration variable name spellings prove that `evaluate_mapped` preserves `optional` + `readonly` for identity as-clauses and is name-agnostic.
- Checker (`crates/tsz-checker/tests/mapped_as_clause_identity_modifier_tests.rs`): seven new integration tests covering optional skippability, renamed iterator variables, required-property negatives, all-properties-provided acceptance, and readonly write rejection.

Adjacent-case matrix:
- Identity `as K` vs. no-`as`-clause baseline.
- Named iteration vars `K`, `P` at solver and checker level.
- Optional property skippability and required-property negative.
- Readonly property write rejection (`TS2540`).
- All-properties-provided acceptance case.

## Project Corpus Impact
- Row: n/a (test-only)
- Bug family: mapped key operations lose optional/readonly intent (refs #12174)
- Evidence: These tests guard the structural rule implemented by #12125 (`fix(solver): non-identity as-clauses in mapped types must not inherit readonly/optional modifiers`). They confirm modifier inheritance is preserved for the identity case while guarding against future regressions.

## Verification
- `cargo test -p tsz-checker --test mapped_as_clause_identity_modifier_tests` -> 7 passed
- `cargo test -p tsz-solver --lib -- identity_as_clause` -> 2 passed
- `cargo clippy -p tsz-checker --test mapped_as_clause_identity_modifier_tests -- -D warnings` -> clean

## Coordination Notes
- Canonical owner label set by M5Manager: `agent:M4-A`, because this is mapped/key-space evaluation coverage tied to #12174.
- Complements #12189 (M1-C mapped-type diagnostic-display coverage); non-overlapping because #12189 tests modifier display while this PR tests whether errors are correctly generated.
- Complements M4-A's planned fix for complex scenarios in bug-family #12174; these tests cover simple cases that already work and serve as guardrails for the general identity-mapping rule.
- No overlap with open checker/solver PRs noted by author: `mapped_as_clause_identity_modifier_tests.rs` is new; solver test additions are in `mapped/tests.rs` in a different region than any open PR touches.
- M5Manager normalized the PR body to the required `AgentName` / `## Agent` coordination shape; no code changes made by M5Manager.
- Signed: claude-sonnet-4-6 (dazzling-johnson); M5Manager coordination note added above.