### PR TITLE
fix(checker): omit tuple position line for single-element tuple mismatches

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -652,12 +652,14 @@ impl<'a> CheckerState<'a> {
                 source_element,
                 target_element,
                 nested_reason,
+                multi_element,
             } => self.render_tuple_element_type_mismatch(
                 &rctx,
                 *index,
                 *source_element,
                 *target_element,
                 nested_reason.as_deref(),
+                *multi_element,
             ),
 
             SubtypeFailureReason::ArrayElementMismatch {

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -506,7 +506,19 @@ impl<'a> CheckerState<'a> {
         source_element: TypeId,
         target_element: TypeId,
         nested_reason: Option<&tsz_solver::SubtypeFailureReason>,
+        multi_element: bool,
     ) -> Diagnostic {
+        // A single-element tuple has no position to disambiguate, so tsc omits
+        // the TS2626 positional line and relates the element types directly.
+        if !multi_element {
+            return self.render_single_element_tuple_mismatch(
+                ctx,
+                source_element,
+                target_element,
+                nested_reason,
+            );
+        }
+
         let source = ctx.source;
         let target = ctx.target;
         let idx = ctx.idx;
@@ -569,6 +581,192 @@ impl<'a> CheckerState<'a> {
         }
 
         diag
+    }
+
+    /// Render a single-element tuple element mismatch.
+    ///
+    /// With only one element there is no position to disambiguate, so tsc skips
+    /// the TS2626 positional line and relates the element types directly. The
+    /// element relation is rendered exactly like a top-level assignment failure
+    /// — `Type 'se' is not assignable to type 'te'.` followed by the element's
+    /// own elaboration.
+    ///
+    /// How the element relation is produced depends on whether the element's
+    /// failure reason *self-heads* with that `Type 'se' …'te'` line:
+    /// - **Self-heading** reasons (scalar leaves, unions, intersections,
+    ///   same-generic applications, …) already emit the `Type 'se' …'te'` line
+    ///   as their own top line, so the whole element relation is delegated to
+    ///   the nested reason's renderer — emitting our own header would duplicate
+    ///   it.
+    /// - **Structural-drill** reasons ([`Self::tuple_element_nested_needs_header`]
+    ///   — tuple/object/missing-property/index-signature) lead with a
+    ///   specialized line (`Types of property 'a' …`, the deeper element pair,
+    ///   …), so we emit the element-type header ourselves and then recurse.
+    fn render_single_element_tuple_mismatch(
+        &mut self,
+        ctx: &RenderContext,
+        source_element: TypeId,
+        target_element: TypeId,
+        nested_reason: Option<&tsz_solver::SubtypeFailureReason>,
+    ) -> Diagnostic {
+        let depth = ctx.depth;
+        let element_message = {
+            let source_str = self.format_type_diagnostic(source_element);
+            let target_str = self.format_type_diagnostic(target_element);
+            format_message(
+                diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+                &[&source_str, &target_str],
+            )
+        };
+        let needs_header = nested_reason.is_some_and(Self::tuple_element_nested_needs_header);
+
+        // Deeper levels (`depth > 0`) whose element self-heads: the nested
+        // reason *is* the element relation, so delegate entirely rather than
+        // wrapping it in a duplicate `Type 'se' …'te'` line.
+        if depth > 0
+            && !needs_header
+            && let Some(nested) = nested_reason
+        {
+            return self.render_failure_reason(
+                nested,
+                source_element,
+                target_element,
+                ctx.idx,
+                depth,
+            );
+        }
+
+        let mut diag = if depth == 0 {
+            let (source_str, target_str) = self
+                .format_top_level_assignability_message_types_at(ctx.source, ctx.target, ctx.idx);
+            let base = format_message(
+                diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+                &[&source_str, &target_str],
+            );
+            Diagnostic::error(
+                ctx.file_name.clone(),
+                ctx.start,
+                ctx.length,
+                base,
+                diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            )
+        } else {
+            Diagnostic::error(
+                ctx.file_name.clone(),
+                ctx.start,
+                ctx.length,
+                element_message.clone(),
+                diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            )
+        };
+
+        // Depth of the element's own elaboration (the drill beneath the
+        // element-type header). At `depth == 0` the header sits at related-depth
+        // 0, so the drill is at 1; deeper, this node's header *is* its message
+        // (placed by the parent at `depth`), so the drill is at `depth + 1`.
+        let drill_depth = if depth == 0 { 1 } else { depth + 1 };
+        if depth >= 5 {
+            return diag;
+        }
+
+        match nested_reason {
+            // Structural drill: emit the element-type header, then recurse the
+            // element's own elaboration one level deeper.
+            Some(nested) if needs_header => {
+                if depth == 0 {
+                    diag.related_information.push(DiagnosticRelatedInformation {
+                        file: diag.file.clone(),
+                        start: ctx.start,
+                        length: ctx.length,
+                        message_text: element_message,
+                        category: DiagnosticCategory::Message,
+                        code: diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+                        depth: 0,
+                    });
+                }
+                let nested_diag = self.render_failure_reason(
+                    nested,
+                    source_element,
+                    target_element,
+                    ctx.idx,
+                    drill_depth,
+                );
+                Self::push_nested_chain(&mut diag, nested_diag, drill_depth);
+            }
+            // Self-heading at `depth == 0`: the nested reason emits the
+            // `Type 'se' …'te'` element line itself. Render it at depth 1 (so
+            // the element types are formatted directly rather than recovered
+            // from the assignment anchor) and rebase its chain one level up to
+            // sit directly beneath the assignment line.
+            Some(nested) => {
+                let element_diag =
+                    self.render_failure_reason(nested, source_element, target_element, ctx.idx, 1);
+                Self::push_rebased_subdiagnostic(&mut diag, element_diag, 1, 0);
+            }
+            // No further structure: the element-type relation is terminal.
+            None => {
+                if depth == 0 {
+                    diag.related_information.push(DiagnosticRelatedInformation {
+                        file: diag.file.clone(),
+                        start: ctx.start,
+                        length: ctx.length,
+                        message_text: element_message,
+                        category: DiagnosticCategory::Message,
+                        code: diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+                        depth: 0,
+                    });
+                }
+            }
+        }
+        diag
+    }
+
+    /// Graft a sub-diagnostic (rendered at `sub_render_depth`) beneath `diag`,
+    /// placing its own message line at `base_depth` and rebasing every line of
+    /// its related chain by the same offset (`r.depth + base_depth -
+    /// sub_render_depth`). Used when a tuple element's failure is delegated to a
+    /// fresh sub-render that must be re-seated at a different chain level.
+    fn push_rebased_subdiagnostic(
+        diag: &mut Diagnostic,
+        sub: Diagnostic,
+        sub_render_depth: u32,
+        base_depth: u32,
+    ) {
+        diag.related_information.push(DiagnosticRelatedInformation {
+            file: sub.file,
+            start: sub.start,
+            length: sub.length,
+            message_text: sub.message_text,
+            category: DiagnosticCategory::Message,
+            code: sub.code,
+            depth: base_depth.min(u8::MAX as u32) as u8,
+        });
+        let delta = i64::from(base_depth) - i64::from(sub_render_depth);
+        for related in sub.related_information {
+            let rebased = (i64::from(related.depth) + delta).clamp(0, i64::from(u8::MAX)) as u8;
+            diag.related_information.push(DiagnosticRelatedInformation {
+                depth: rebased,
+                ..related
+            });
+        }
+    }
+
+    /// Whether a tuple element's nested failure reason leads with a specialized
+    /// elaboration line rather than self-heading with `Type 'se' …'te'`. Such
+    /// reasons need an explicit element-type header emitted before them;
+    /// everything else already emits that header itself.
+    const fn tuple_element_nested_needs_header(reason: &tsz_solver::SubtypeFailureReason) -> bool {
+        matches!(
+            reason,
+            tsz_solver::SubtypeFailureReason::TupleElementTypeMismatch { .. }
+                | tsz_solver::SubtypeFailureReason::PropertyTypeMismatch { .. }
+                | tsz_solver::SubtypeFailureReason::MissingProperty { .. }
+                | tsz_solver::SubtypeFailureReason::MissingProperties { .. }
+                | tsz_solver::SubtypeFailureReason::IndexSignatureMismatch { .. }
+                | tsz_solver::SubtypeFailureReason::ArrayElementMismatch { .. }
+                | tsz_solver::SubtypeFailureReason::ReturnTypeMismatch { .. }
+                | tsz_solver::SubtypeFailureReason::ParameterTypeMismatch { .. }
+        )
     }
 
     /// Render a same-generic type-argument mismatch (`C<A..>` vs `C<B..>`).
@@ -794,6 +992,36 @@ impl<'a> CheckerState<'a> {
         target_element: TypeId,
         nested_reason: Option<&tsz_solver::SubtypeFailureReason>,
     ) {
+        // When a positional (multi-element) tuple's failing element is itself a
+        // single-element tuple, tsc relates the element types directly with the
+        // element-type header `Type 'se' is not assignable to type 'te'.` before
+        // drilling — exactly like a top-level single-element tuple relation.
+        // Route through the single-element renderer so the header is preserved.
+        if let Some(
+            nested @ tsz_solver::SubtypeFailureReason::TupleElementTypeMismatch {
+                multi_element: false,
+                ..
+            },
+        ) = nested_reason
+        {
+            let element_ctx = RenderContext {
+                source: source_element,
+                target: target_element,
+                idx,
+                depth: depth + 1,
+                start: diag.start,
+                length: diag.length,
+                file_name: diag.file.clone(),
+            };
+            let element_diag = self.render_single_element_tuple_mismatch(
+                &element_ctx,
+                source_element,
+                target_element,
+                Some(nested),
+            );
+            Self::push_nested_chain(diag, element_diag, depth + 1);
+            return;
+        }
         if let Some(nested) = nested_reason {
             let (nested_source, nested_target) =
                 Self::nested_failure_display_types(nested, source_element, target_element);

--- a/crates/tsz-checker/tests/tuple_element_mismatch_tests.rs
+++ b/crates/tsz-checker/tests/tuple_element_mismatch_tests.rs
@@ -1,10 +1,16 @@
-//! Tuple element type-mismatch diagnostics must carry the element position.
+//! Tuple element type-mismatch diagnostic elaboration must match `tsc`.
 //!
-//! tsc treats a failing tuple element specially: the outer TS2322
-//! `Type 'S' is not assignable to type 'T'.` line is followed by TS2626
-//! `Type at position N in source is not compatible with type at position N in
-//! target.`, then the inner element failure. Earlier tsz dropped the position
-//! and emitted only the bare outer/inner type lines.
+//! `tsc` keys the elaboration shape on the tuple's arity:
+//! - **Multi-element tuples** disambiguate the failing slot with TS2626
+//!   `Type at position N in source is not compatible with type at position N in
+//!   target.`, nested beneath the outer `Type 'S' is not assignable to type
+//!   'T'.` line, then the inner element failure.
+//! - **Single-element tuples** have no position to disambiguate, so `tsc` omits
+//!   the positional line and relates the element types directly with the
+//!   standard `Type 'se' is not assignable to type 'te'.` message, recursing
+//!   into the element's own failure.
+//!
+//! These assertions are pinned to the exact `tsc` 5.8 output.
 
 use tsz_checker::diagnostics::Diagnostic;
 use tsz_checker::test_utils::check_source_diagnostics;
@@ -79,8 +85,17 @@ let x: [string, string] = y;
     );
 }
 
+fn has_position_line(diagnostic: &Diagnostic) -> bool {
+    related(diagnostic)
+        .iter()
+        .any(|message| message.contains("in source is not compatible with type at position"))
+}
+
 #[test]
-fn tuple_element_object_property_mismatch_chains_through_position() {
+fn single_element_tuple_object_property_mismatch_omits_position_line() {
+    // Single-element tuple: tsc relates the element types directly
+    // (`Type '{ a: string; }' is not assignable to type '{ a: number; }'.`)
+    // and never emits the TS2626 positional line.
     let diagnostic = ts2322(
         r#"
 declare let y: [{ a: string }];
@@ -89,11 +104,15 @@ let x: [{ a: number }] = y;
     );
     let messages = related(&diagnostic);
     assert!(
+        !has_position_line(&diagnostic),
+        "single-element tuple must not emit the TS2626 positional line; related = {messages:#?}"
+    );
+    assert!(
         has_related(
             &diagnostic,
-            "Type at position 0 in source is not compatible with type at position 0 in target."
+            "Type '{ a: string; }' is not assignable to type '{ a: number; }'."
         ),
-        "missing TS2626 position elaboration; related = {messages:#?}"
+        "missing element-type relation header; related = {messages:#?}"
     );
     assert!(
         has_related(&diagnostic, "Types of property 'a' are incompatible."),
@@ -109,7 +128,11 @@ let x: [{ a: number }] = y;
 }
 
 #[test]
-fn nested_tuple_element_mismatch_chains_each_position() {
+fn nested_single_element_tuple_mismatch_relates_each_level_without_position() {
+    // tsc chain (no positional lines):
+    //   Type '[[string]]' is not assignable to type '[[number]]'.
+    //     Type '[string]' is not assignable to type '[number]'.
+    //       Type 'string' is not assignable to type 'number'.
     let diagnostic = ts2322(
         r#"
 declare let y: [[string]];
@@ -117,18 +140,119 @@ let x: [[number]] = y;
 "#,
     );
     let messages = related(&diagnostic);
-    // The outer tuple has one element at position 0; the inner tuple's failing
-    // element is also at position 0, so the chain repeats the position line.
-    let position_lines = messages
+    assert!(
+        !has_position_line(&diagnostic),
+        "single-element tuples must not emit positional lines; related = {messages:#?}"
+    );
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type '[string]' is not assignable to type '[number]'."
+        ),
+        "missing inner tuple relation level; related = {messages:#?}"
+    );
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type 'string' is not assignable to type 'number'."
+        ),
+        "missing leaf element failure; related = {messages:#?}"
+    );
+}
+
+#[test]
+fn deeply_nested_single_element_tuple_relates_every_level() {
+    // `[[[string]]]` vs `[[[number]]]` must relate all three tuple levels and
+    // never emit a positional line (tsc parity).
+    let diagnostic = ts2322(
+        r#"
+declare let y: [[[string]]];
+let x: [[[number]]] = y;
+"#,
+    );
+    let messages = related(&diagnostic);
+    assert!(
+        !has_position_line(&diagnostic),
+        "single-element tuples must not emit positional lines; related = {messages:#?}"
+    );
+    for level in [
+        "Type '[[string]]' is not assignable to type '[[number]]'.",
+        "Type '[string]' is not assignable to type '[number]'.",
+        "Type 'string' is not assignable to type 'number'.",
+    ] {
+        assert!(
+            has_related(&diagnostic, level),
+            "missing tuple relation level {level:?}; related = {messages:#?}"
+        );
+    }
+}
+
+#[test]
+fn single_element_tuple_nested_in_multi_element_tuple_keeps_position_and_header() {
+    // The outer tuple is multi-element (positional line warranted); its failing
+    // element is a single-element tuple, so tsc shows the positional line, then
+    // the element-type header, then the leaf:
+    //   Type at position 0 in source is not compatible with ... position 0 ...
+    //     Type '[string]' is not assignable to type '[number]'.
+    //       Type 'string' is not assignable to type 'number'.
+    let diagnostic = ts2322(
+        r#"
+declare let y: [[string], boolean];
+let x: [[number], boolean] = y;
+"#,
+    );
+    let messages = related(&diagnostic);
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type at position 0 in source is not compatible with type at position 0 in target."
+        ),
+        "outer multi-element tuple must keep its positional line; related = {messages:#?}"
+    );
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type '[string]' is not assignable to type '[number]'."
+        ),
+        "missing single-element tuple header under the positional line; related = {messages:#?}"
+    );
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type 'string' is not assignable to type 'number'."
+        ),
+        "missing leaf element failure; related = {messages:#?}"
+    );
+}
+
+#[test]
+fn single_element_tuple_union_element_does_not_duplicate_header() {
+    // The element relation `string | boolean` -> `number` self-heads with its
+    // own `Type 'string | boolean' …'number'.` line, so the renderer must
+    // delegate to it rather than emit a second copy of that header. tsc:
+    //   Type '[string | boolean]' is not assignable to type '[number]'.
+    //     Type 'string | boolean' is not assignable to type 'number'.
+    //       Type 'string' is not assignable to type 'number'.
+    let diagnostic = ts2322(
+        r#"
+declare let y: [string | boolean];
+let x: [number] = y;
+"#,
+    );
+    let messages = related(&diagnostic);
+    assert!(
+        !has_position_line(&diagnostic),
+        "single-element tuple must not emit positional lines; related = {messages:#?}"
+    );
+    let union_header_count = messages
         .iter()
         .filter(|message| {
-            message.as_str()
-                == "Type at position 0 in source is not compatible with type at position 0 in target."
+            message.as_str() == "Type 'string | boolean' is not assignable to type 'number'."
         })
         .count();
-    assert!(
-        position_lines >= 2,
-        "expected nested position elaborations for both tuple levels; related = {messages:#?}"
+    assert_eq!(
+        union_header_count, 1,
+        "union element header must appear exactly once (no duplication); related = {messages:#?}"
     );
     assert!(
         has_related(

--- a/crates/tsz-solver/src/diagnostics/core.rs
+++ b/crates/tsz-solver/src/diagnostics/core.rs
@@ -151,16 +151,27 @@ pub enum SubtypeFailureReason {
     },
     /// Tuple element type mismatch.
     ///
-    /// tsc elaborates a failing tuple element with the outer
-    /// `Type 'S' is not assignable to type 'T'.` line, then TS2626
+    /// When the related tuple has **more than one** element (`multi_element`),
+    /// tsc disambiguates the failing slot with TS2626
     /// `Type at position <index> in source is not compatible with type at
-    /// position <index> in target.`, then the inner element failure carried in
-    /// `nested_reason`.
+    /// position <index> in target.`, nested beneath the outer
+    /// `Type 'S' is not assignable to type 'T'.` line, then the inner element
+    /// failure carried in `nested_reason`.
+    ///
+    /// When the tuple has a **single** element there is no position to
+    /// disambiguate, so tsc omits the positional line and relates the element
+    /// types directly with the standard `Type 'se' is not assignable to type
+    /// 'te'.` message, recursing through `nested_reason`. `multi_element`
+    /// records this structural distinction (`source.len() > 1`) so the renderer
+    /// can reproduce the exact chain shape.
     TupleElementTypeMismatch {
         index: usize,
         source_element: TypeId,
         target_element: TypeId,
         nested_reason: Option<Box<Self>>,
+        /// `true` when the related tuple has more than one element and the
+        /// positional disambiguation line is warranted.
+        multi_element: bool,
     },
     /// Array element type mismatch.
     ArrayElementMismatch {
@@ -848,19 +859,21 @@ impl SubtypeFailureReason {
                 source_element,
                 target_element,
                 nested_reason,
+                multi_element,
             } => {
-                // tsc elaborates a failing tuple element with TS2626
-                // "Type at position N in source is not compatible with type at
-                // position N in target." (both positions are the element index
-                // for fixed tuples), followed by the inner element failure.
+                // Multi-element tuples disambiguate the failing slot with the
+                // TS2626 positional line; single-element tuples omit it and
+                // relate the element types directly (see the variant docs).
                 let mut diag = PendingDiagnostic::error(
                     codes::TYPE_NOT_ASSIGNABLE,
                     vec![source.into(), target.into()],
-                )
-                .with_related(PendingDiagnostic::error(
-                    codes::TUPLE_ELEMENT_POSITION_MISMATCH,
-                    vec![(*index).into(), (*index).into()],
-                ));
+                );
+                if *multi_element {
+                    diag = diag.with_related(PendingDiagnostic::error(
+                        codes::TUPLE_ELEMENT_POSITION_MISMATCH,
+                        vec![(*index).into(), (*index).into()],
+                    ));
+                }
                 if let Some(nested) = nested_reason {
                     diag =
                         diag.with_related(nested.to_diagnostic(*source_element, *target_element));

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -1649,6 +1649,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         index: usize,
         source_element: TypeId,
         target_element: TypeId,
+        multi_element: bool,
     ) -> SubtypeFailureReason {
         let nested_reason = self
             .explain_failure(source_element, target_element)
@@ -1658,6 +1659,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             source_element,
             target_element,
             nested_reason,
+            multi_element,
         }
     }
 
@@ -1725,6 +1727,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                                     source_end - 1,
                                     s_elem.type_id,
                                     tail_elem.type_id,
+                                    // Rest/variadic tuples are multi-position;
+                                    // keep the positional disambiguation line.
+                                    true,
                                 ));
                             }
                             source_end -= 1;
@@ -1756,6 +1761,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                             source_end - 1,
                             s_elem.type_id,
                             tail_elem.type_id,
+                            true,
                         ));
                     }
                     source_end -= 1;
@@ -1780,6 +1786,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                                     j,
                                     s_elem.type_id,
                                     t_fixed.type_id,
+                                    true,
                                 ));
                             }
                         }
@@ -1804,6 +1811,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                                     j,
                                     s_elem.type_id,
                                     variadic_array,
+                                    true,
                                 ));
                             }
                         } else if variadic_is_type_param {
@@ -1816,6 +1824,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                                 j,
                                 s_elem.type_id,
                                 variadic,
+                                true,
                             ));
                         }
                     }
@@ -1863,6 +1872,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                         source_element: s_elem.type_id,
                         target_element: t_elem.type_id,
                         nested_reason: nested.map(Box::new),
+                        // Single-element tuples have no position to disambiguate,
+                        // so tsc omits the TS2626 positional line and relates the
+                        // element types directly.
+                        multi_element: target.len() > 1,
                     });
                 }
             } else if !t_elem.optional {


### PR DESCRIPTION
AgentName: Claude-Parity

Track: Checker / diagnostic elaboration parity — `TS2322` tuple element mismatch chain

## Invariant

The `TS2322` elaboration chain for a failing tuple element must match `tsc`'s
exact shape. `tsc` keys the shape on the tuple's arity:

- **Multi-element tuples** disambiguate the failing slot with the `TS2626`
  `Type at position N in source is not compatible with type at position N in
  target.` line.
- **Single-element tuples** have no position to disambiguate, so `tsc` omits the
  positional line and relates the element types directly with the standard
  `Type 'se' is not assignable to type 'te'.` message, recursing into the
  element's own failure.

Previously tsz emitted the positional line at *every* tuple depth regardless of
arity, so single-element tuples (and each nested single-element level) spammed a
spurious `Type at position 0 …` line.

## Structural rule

When relating tuple elements, the positional `TS2626` line is emitted iff the
related tuple has more than one element. For a single-element tuple the element
types are related directly and the chain follows the element's own failure:

- If the element's failure *self-heads* with a `Type 'se' …'te'` line (scalar
  leaves, unions, intersections, same-generic applications), the element
  relation is delegated entirely to that nested reason — emitting our own
  header would duplicate it.
- If the element's failure leads with a specialized line (tuple position,
  `Types of property 'a' …`, return/parameter/index/missing-property), we emit
  the `Type 'se' …'te'` header ourselves and then drill.

A single-element tuple appearing as an element of a *multi*-element tuple keeps
the outer positional line and then shows the element-type header before
drilling.

Owner layers:
- Solver (`tsz-solver/relations/subtype/explain.rs`, `diagnostics/core.rs`):
  records the structural fact `multi_element` (`source.len() > 1`) on
  `SubtypeFailureReason::TupleElementTypeMismatch`.
- Checker renderer
  (`tsz-checker/error_reporter/render_failure/…`): keys the chain shape off
  `multi_element`; no relation/assignability behavior changes.

## Scope

| File | Change |
| --- | --- |
| `crates/tsz-solver/src/diagnostics/core.rs` | add `multi_element` field; honor it in the (test-only) `to_diagnostic` renderer |
| `crates/tsz-solver/src/relations/subtype/explain.rs` | set `multi_element = target.len() > 1` for closed-tuple element mismatches; keep `true` (positional) for rest/variadic paths |
| `crates/tsz-checker/src/error_reporter/render_failure.rs` | thread `multi_element` into the renderer |
| `crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs` | single-element renderer + positional-path routing for nested single-element tuples |
| `crates/tsz-checker/tests/tuple_element_mismatch_tests.rs` | replace two tests that pinned the old (wrong) positional output; add mixed/deep coverage |

## Project Corpus Impact

- Row: `nextjs` (case `diagnostics-33-20`, issue #11593 — "diagnostic tuple
  mismatch output drops index and property position")
- Bug family: tuple element mismatch diagnostic-chain shape
- This is diagnostic-elaboration-only; no relation/inference/narrowing/emit
  behavior changes, so no project row flips compile status. Diagnostic
  conformance is a hard gate and is unaffected (no baseline pinned the
  single-element positional spam — tsz was at 100% *with* the bug, so no
  conformance test exercised this elaboration text; the fix moves tsz toward
  `tsc`, never away).

## Verification

Reduced repros checked against `tsc 5.8` (`tsc --noEmit --strict`) and the tsz
CLI, byte-identical elaboration for every case:

```
[string] vs [number]                   (single, primitive)        MATCH
[string, boolean] vs [number,...]      (multi, positional kept)   MATCH
[[string]] vs [[number]]               (nested single)            MATCH  <- #11593 witness
[{a:string}] vs [{a:number}]           (single, object element)   MATCH
[[[string]]] vs [[[number]]]           (deep single)              MATCH
[[string], boolean] vs [[number],..]   (single nested in multi)   MATCH
[string | boolean] vs [number]         (single, union element)    MATCH
[[string | boolean]] vs [[number]]     (nested union)             MATCH
```

Adversarial verification across adjacent element kinds (union/optional/generic/
function/intersection) confirmed no duplication or anchor-display regressions in
the single-element renderer.

Unit: `cargo test --test tuple_element_mismatch_tests -p tsz-checker` (5 tests,
all pass — two rewritten to `tsc` parity, two added for mixed/deep nesting).

## Coordination Notes

- Non-overlapping with active Codex lanes #12148, #11953, #12054 (export
  resolution / rendered-diagnostic gates / export table) — this touches only the
  tuple-element branch of the failure-reason renderer.
- Out of scope (pre-existing, orthogonal divergences, not conformance-relevant
  since no checked-in baseline exercises single-element-tuple mismatches): a
  positional tuple with an *object* element prints `Types of property 'a' are
  incompatible.` where `tsc` uses `The types of 'a' are incompatible between
  these types.`; optional tuple elements aren't widened to `X | undefined` in
  the failure reason; same-generic interface elements drill via the property
  rather than `tsc`'s type-argument collapse; and `ArrayElementMismatch` drops
  its child elaboration. These are separate reason-construction issues, left for
  follow-ups.
