### PR TITLE
fix(checker): narrow target through const-alias discriminant in relative_discriminant_path

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1974,5 +1974,9 @@ path = "tests/class_interface_namespace_merge_tests.rs"
 name = "order_independent_alias_resolution_tests"
 path = "tests/order_independent_alias_resolution_tests.rs"
 
+[[test]]
+name = "const_alias_discriminant_narrowing_tests"
+path = "tests/const_alias_discriminant_narrowing_tests.rs"
+
 [lints]
 workspace = true

--- a/crates/tsz-checker/src/flow/control_flow/narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/narrowing.rs
@@ -1920,6 +1920,22 @@ impl<'a> FlowAnalyzer<'a> {
                 return Some((path, is_optional));
             }
 
+            // When `tsc` narrows `target` through `alias.prop === value` where
+            // `const alias = target`, it follows the const alias back to its
+            // initializer.  Check whether `base_expr` is a const alias whose
+            // un-annotated initializer references `target` directly.
+            //
+            // Structural rule: `const alias = target` (no type annotation, no
+            // assignment after declaration) makes `alias.prop` a valid proxy
+            // for `target.prop` in discriminant comparisons.
+            if let Some((_, init)) = self.const_condition_initializer(base_expr) {
+                let init_stripped = self.skip_parenthesized(init);
+                if self.is_matching_reference(init_stripped, target) {
+                    path.reverse();
+                    return Some((path, is_optional));
+                }
+            }
+
             current = base_expr;
         }
     }

--- a/crates/tsz-checker/tests/const_alias_discriminant_narrowing_tests.rs
+++ b/crates/tsz-checker/tests/const_alias_discriminant_narrowing_tests.rs
@@ -1,0 +1,153 @@
+//! Tests for discriminant narrowing through const-aliased object references.
+//!
+//! Structural rule: When `const alias = target` (no type annotation), accessing
+//! `alias.prop` in a discriminant condition `alias.prop === value` narrows
+//! `target` by the same discriminant path as `target.prop === value` would.
+//!
+//! tsc follows const aliases in `isMatchingReference` so that narrowing of
+//! `target` applies to both `target.prop === v` and `alias.prop === v` when
+//! `const alias = target`.  tsz extends `relative_discriminant_path` to
+//! resolve the const alias to its initializer before reporting failure.
+
+use tsz_checker::test_utils::check_source_strict_codes;
+
+fn assert_no_ts2339(source: &str) {
+    let codes = check_source_strict_codes(source);
+    assert!(
+        !codes.contains(&2339),
+        "expected no TS2339 via const-alias discriminant narrowing, got {codes:?}\nsource:\n{source}"
+    );
+}
+
+fn assert_has_ts2339(source: &str) {
+    let codes = check_source_strict_codes(source);
+    assert!(
+        codes.contains(&2339),
+        "expected TS2339 (alias not usable here), got {codes:?}\nsource:\n{source}"
+    );
+}
+
+/// Primary repro: `const alias = target; alias.prop === "a"` narrows `target`.
+///
+/// Adjacent case: different discriminant member and property names, confirming
+/// the rule does not rely on a specific spelling.
+#[test]
+fn const_alias_discriminant_narrows_original_target() {
+    assert_no_ts2339(
+        r#"
+type Circle = { kind: "circle"; radius: number };
+type Square = { kind: "square"; side: number };
+function f(shape: Circle | Square) {
+    const s = shape;
+    if (s.kind === "circle") {
+        const r: number = shape.radius;
+    }
+}
+"#,
+    );
+}
+
+/// Rename invariant: different identifier names for alias and target, with a
+/// different discriminant property name, confirming the rule is structural.
+#[test]
+fn const_alias_discriminant_narrows_original_rename_invariant() {
+    assert_no_ts2339(
+        r#"
+type Left = { tag: "left"; payload: number };
+type Right = { tag: "right"; payload: string };
+function g(item: Left | Right) {
+    const ref_ = item;
+    if (ref_.tag === "left") {
+        const n: number = item.payload;
+    }
+}
+"#,
+    );
+}
+
+/// Three-member union: const alias discriminant narrows to exactly the matching
+/// member, not just to a two-member remainder.
+#[test]
+fn const_alias_discriminant_three_member_union_narrows_correctly() {
+    assert_no_ts2339(
+        r#"
+type A = { kind: "a"; a: number };
+type B = { kind: "b"; b: string };
+type C = { kind: "c"; c: boolean };
+function h(x: A | B | C) {
+    const alias = x;
+    if (alias.kind === "a") {
+        const n: number = x.a;
+    }
+    if (alias.kind === "b") {
+        const s: string = x.b;
+    }
+    if (alias.kind === "c") {
+        const b: boolean = x.c;
+    }
+}
+"#,
+    );
+}
+
+/// False-branch exhaustion: in the `else` branch the matching member is
+/// excluded, so only the remaining members are valid.
+#[test]
+fn const_alias_discriminant_false_branch_excludes_member() {
+    assert_no_ts2339(
+        r#"
+type Circle = { kind: "circle"; radius: number };
+type Square = { kind: "square"; side: number };
+function f(shape: Circle | Square) {
+    const s = shape;
+    if (s.kind === "circle") {
+        const _r: number = shape.radius;
+    } else {
+        const _side: number = shape.side;
+    }
+}
+"#,
+    );
+}
+
+/// Negative: a `let` (mutable) alias should not project const-alias
+/// discriminant narrowing onto the original target.  `let alias = target` does
+/// NOT create a const-alias link because the binder treats `let` as mutable.
+#[test]
+fn let_alias_does_not_project_discriminant_narrowing() {
+    assert_has_ts2339(
+        r#"
+type Circle = { kind: "circle"; radius: number };
+type Square = { kind: "square"; side: number };
+function f(shape: Circle | Square) {
+    let s = shape;
+    if (s.kind === "circle") {
+        // shape is not narrowed through a mutable alias
+        const r: number = shape.radius;
+    }
+}
+"#,
+    );
+}
+
+/// Negative: an annotated const alias (`const alias: typeof target = target`)
+/// should not project narrowing because tsc gates alias-based narrowing on
+/// the absence of a type annotation (the annotation widens and breaks the
+/// discriminant link).
+#[test]
+fn annotated_const_alias_does_not_project_discriminant_narrowing() {
+    assert_has_ts2339(
+        r#"
+type Circle = { kind: "circle"; radius: number };
+type Square = { kind: "square"; side: number };
+type Shape = Circle | Square;
+function f(shape: Shape) {
+    const s: Shape = shape;
+    if (s.kind === "circle") {
+        // type annotation on alias breaks the link
+        const r: number = shape.radius;
+    }
+}
+"#,
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-D

## Track
Flow Narrowing (Track 6 — narrowing and flow predicate parity).

## Invariant
When `const alias = target` has no type annotation or reassignment, `alias.prop === value` is a valid proxy for `target.prop === value` in discriminant comparisons. tsc follows this rule in `isMatchingReference`; this PR makes tsz follow the same rule inside `relative_discriminant_path`.

No new user-name/file-name literals drive compiler logic; no formatted diagnostic strings are used as semantic predicates; binder names are varied in tests.

## Scope
- `crates/tsz-checker/src/flow/control_flow/narrowing.rs` — small addition inside `relative_discriminant_path` to accept const-alias bases whose initializer matches the target.
- `crates/tsz-checker/tests/const_alias_discriminant_narrowing_tests.rs` — focused regression coverage.
- `crates/tsz-checker/Cargo.toml` — new test target.

## Problem
When `const alias = target` has no type annotation, tsc narrows `target` through discriminant conditions on `alias.prop === value`. tsz returned `None` from `relative_discriminant_path` because `is_matching_reference(alias, target)` is false and the existing `aliased_discriminant` path only handled `const alias = target.prop`, not `alias.prop` as a proxy for `target.prop`.

## Fix
In the `relative_discriminant_path` loop, after `is_matching_reference(base_expr, target)` fails, call `const_condition_initializer(base_expr)`. If it returns an initializer and that initializer matches `target`, return the accumulated path. This only fires for const declarations without type annotations, preserving the tsc distinction for mutable aliases and annotated const aliases.

## Adjacent-Case Matrix
| Case | Expected | Covered |
|---|---|---|
| `const alias = target; alias.prop === "a"` narrows `target` | no TS2339 | `const_alias_discriminant_narrows_original_target` |
| Different binder names | no TS2339 | `const_alias_discriminant_narrows_original_rename_invariant` |
| Three-member union, all three `if` branches | no TS2339 | `const_alias_discriminant_three_member_union_narrows_correctly` |
| False branch excludes matched member | no TS2339 | `const_alias_discriminant_false_branch_excludes_member` |
| `let alias = target` | TS2339 | `let_alias_does_not_project_discriminant_narrowing` |
| `const alias: Shape = target` | TS2339 | `annotated_const_alias_does_not_project_discriminant_narrowing` |

## Project Corpus Impact
- Row: n/a
- Bug family: discriminant-narrowing / const-alias flow gap
- Evidence: no existing project row is claimed; this is a focused narrowing parity fix that should remove spurious TS2339 errors for code using discriminated union narrowing through const aliases.

## Verification
Author-reported local verification:
- `cargo test --package tsz-checker --test const_alias_discriminant_narrowing_tests` — 6 passed.
- `arch_guard.py` passes clean per author notes.

CI state after ready/open:
- `project-corpus-pr-body` initially failed because the body did not use the required top-level sections; AgentName M5Manager normalized the body structure without changing implementation scope.
- `GitGuardian Security Checks` is green.
- `CI Summary` is not yet green for the current head, so `merge-queue` remains off.

## Coordination Notes
- AgentName: M1-D owns this implementation in `agent:M1-D`.
- AgentName: M5Manager added the canonical owner label and normalized this body for the required PR-body gate.
- M1-C owns conformance/diagnostic display; no overlap, this is a narrowing-only fix with no diagnostic message changes.
- M1-B owns relation routing (`TS2322`/`TS2345` assignability gateway); no overlap.
- M1-A owns inference; no overlap.
- Studio-F owns architecture guardrails; no output-surgery allowlist entries are added.
- Do not add `merge-queue` until exact-head `CI Summary` and `GitGuardian Security Checks` are green.
