### PR TITLE
fix(emit): lower private field **= and field &&=/||= in ES5 class bodies

### DIFF
--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_expressions.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_expressions.rs
@@ -620,8 +620,8 @@ impl<'a> AstToIr<'a> {
 
     /// Base operator for an ES5-lowerable private-field compound assignment
     /// (`+=` -> `+`). Returns `None` for `=`, exponent (`**=`), and logical
-    /// (`&&= ||= ??=`) assignments: those need a different lowering (`Math.pow`
-    /// / short-circuit) and stay on the existing fallthrough as follow-ups.
+    /// (`&&= ||= ??=`) assignments: `**=`/`&&=`/`||=` are handled separately by
+    /// `private_exp_or_logical_compound_ir`, and `??=` stays on the fallthrough.
     const fn es5_private_compound_base_op(token: u16) -> Option<&'static str> {
         Some(match token {
             t if t == SyntaxKind::PlusEqualsToken as u16 => "+",
@@ -637,6 +637,69 @@ impl<'a> AstToIr<'a> {
             t if t == SyntaxKind::BarEqualsToken as u16 => "|",
             _ => return None,
         })
+    }
+
+    /// Lower `this.#x **= v` / `this.#x &&= v` / `this.#x ||= v` for a known
+    /// private slot, or `None` to fall through.
+    ///
+    /// - `**=` is an *unconditional* write, so it folds to
+    ///   `__classPrivateFieldSet(this, _C_x, Math.pow(__classPrivateFieldGet(this, _C_x, "f"), v), "f")`
+    ///   for both fields and accessors. ES5/ES3 — this transform's only targets
+    ///   — have no `**` operator, so `Math.pow` is always required.
+    /// - `&&=` / `||=` are *conditional* writes. The always-write fold
+    ///   `set(this, _C_x, get() && v, "f")` is observably equivalent only when
+    ///   the slot has no write side effect, i.e. a plain field (kind `"f"`): for
+    ///   a field, `a &&= b` ≡ `a = (a && b)` because the short-circuit value is
+    ///   stored idempotently. For an accessor the setter would run when the short
+    ///   circuit says skip, so accessor short-circuit assignment falls through.
+    ///   `??=` also falls through: at ES5 the `??` itself needs nullish lowering.
+    ///
+    /// A conditional-expression rhs is parenthesized because `&&`/`||` bind
+    /// tighter than `?:`, mirroring the main emitter's private-field policy.
+    fn private_exp_or_logical_compound_ir(
+        &self,
+        operator_token: u16,
+        left_idx: NodeIndex,
+        right_idx: NodeIndex,
+    ) -> Option<IRNode> {
+        let (receiver_idx, clean) = self.private_mutation_target(left_idx)?;
+
+        if operator_token == SyntaxKind::AsteriskAsteriskEqualsToken as u16 {
+            let get_ir = self.private_field_get_ir(receiver_idx, &clean)?;
+            let rhs = self.convert_expression(right_idx);
+            let powed = IRNode::call(
+                IRNode::PropertyAccess {
+                    object: Box::new(IRNode::id("Math")),
+                    property: "pow".into(),
+                },
+                vec![get_ir, rhs],
+            );
+            return self.private_field_set_ir(receiver_idx, &clean, powed);
+        }
+
+        let short_op = if operator_token == SyntaxKind::AmpersandAmpersandEqualsToken as u16 {
+            "&&"
+        } else if operator_token == SyntaxKind::BarBarEqualsToken as u16 {
+            "||"
+        } else {
+            return None;
+        };
+        // Short-circuit assignment may only be folded into an unconditional set
+        // for a plain field; accessors keep their conditional-write semantics.
+        if self.private_write_info(&clean).map(|(_, kind)| kind) != Some("f") {
+            return None;
+        }
+        let get_ir = self.private_field_get_ir(receiver_idx, &clean)?;
+        let mut rhs = self.convert_expression(right_idx);
+        if self
+            .arena
+            .get(right_idx)
+            .is_some_and(|n| n.kind == syntax_kind_ext::CONDITIONAL_EXPRESSION)
+        {
+            rhs = IRNode::Parenthesized(Box::new(rhs));
+        }
+        let folded = IRNode::binary(get_ir, short_op, rhs);
+        self.private_field_set_ir(receiver_idx, &clean, folded)
     }
 
     /// Lower `recv.#x++` / `recv.#x--` for a known private field/accessor slot.
@@ -761,6 +824,14 @@ impl<'a> AstToIr<'a> {
                 if let Some(set_ir) = self.private_field_set_ir(receiver_idx, &clean, new_value) {
                     return set_ir;
                 }
+            }
+
+            // Private field exponent (`**=`) and short-circuit (`&&=`/`||=`)
+            // compound assignment. See `private_exp_or_logical_compound_ir`.
+            if let Some(lowered) =
+                self.private_exp_or_logical_compound_ir(bin.operator_token, bin.left, bin.right)
+            {
+                return lowered;
             }
 
             let left = self.convert_expression(bin.left);
@@ -1201,6 +1272,115 @@ mod optional_chain_in_class_member_tests {
         assert!(
             output.contains("__classPrivateFieldSet(this, _Plain_p, 9, \"f\")"),
             "Plain `this.#p = 9` must still lower to a single set.\nOutput:\n{output}"
+        );
+    }
+
+    // Structural rule: the ES5 class-IR converter must lower private-field
+    // exponent (`**=`) and short-circuit (`&&=`/`||=`) compound assignment to a
+    // get-fold-set form instead of an un-assignable `__classPrivateFieldGet(...)
+    // **= v`. `**=` is an unconditional write (fields + accessors); `&&=`/`||=`
+    // fold to an always-write set only for plain fields, where it is observably
+    // equivalent. `??=` and accessor short-circuit stay on the fallthrough. The
+    // rule keys on the member's storage slot and kind, never on its spelling.
+
+    #[test]
+    fn private_field_exponent_assign_lowers_through_math_pow() {
+        let output =
+            emit_es5("class E {\n    #x = 2;\n    m() {\n        this.#x **= 3;\n    }\n}\n");
+        assert!(
+            output.contains(
+                "__classPrivateFieldSet(this, _E_x, Math.pow(__classPrivateFieldGet(this, _E_x, \"f\"), 3), \"f\")"
+            ),
+            "Private `#x **= 3` must lower through `Math.pow`.\nOutput:\n{output}"
+        );
+        assert!(
+            !output.contains("**="),
+            "ES5 output must not retain the `**=` operator.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn private_accessor_exponent_assign_threads_get_and_set_storage() {
+        // `**=` is unconditional, so it is also correct for accessors: read from
+        // get-storage, write to set-storage, kind "a".
+        let output = emit_es5(
+            "class Box {\n    get #v() { return 2; }\n    set #v(x: number) {}\n    grow() {\n        this.#v **= 4;\n    }\n}\n",
+        );
+        assert!(
+            output.contains(
+                "__classPrivateFieldSet(this, _Box_v_set, Math.pow(__classPrivateFieldGet(this, _Box_v_get, \"a\"), 4), \"a\")"
+            ),
+            "Accessor `#v **= 4` must read get-storage and write set-storage.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn private_field_logical_and_assign_folds_to_set_get_and_rhs() {
+        let output = emit_es5(
+            "class A {\n    #flag = true;\n    m() {\n        this.#flag &&= false;\n    }\n}\n",
+        );
+        assert!(
+            output.contains(
+                "__classPrivateFieldSet(this, _A_flag, __classPrivateFieldGet(this, _A_flag, \"f\") && false, \"f\")"
+            ),
+            "Private `#flag &&= false` must fold to set(get() && rhs).\nOutput:\n{output}"
+        );
+        assert!(
+            !output.contains("&&="),
+            "Lowered output must not retain `&&=`.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn private_field_logical_or_assign_folds_to_set_get_or_rhs() {
+        let output = emit_es5(
+            "class O {\n    #cache = 0;\n    m(v: number) {\n        this.#cache ||= v;\n    }\n}\n",
+        );
+        assert!(
+            output.contains(
+                "__classPrivateFieldSet(this, _O_cache, __classPrivateFieldGet(this, _O_cache, \"f\") || v, \"f\")"
+            ),
+            "Private `#cache ||= v` must fold to set(get() || rhs).\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn private_field_logical_assign_parenthesizes_conditional_rhs() {
+        // `||` binds tighter than `?:`, so a conditional rhs must be parenthesized
+        // or the assignment silently reparses as `(get() || a) ? b : c`.
+        let output = emit_es5(
+            "declare const a: any;\nclass C {\n    #x = 0;\n    m() {\n        this.#x ||= a ? 1 : 2;\n    }\n}\n",
+        );
+        assert!(
+            output.contains(
+                "__classPrivateFieldSet(this, _C_x, __classPrivateFieldGet(this, _C_x, \"f\") || (a ? 1 : 2), \"f\")"
+            ),
+            "Conditional rhs of `||=` must be parenthesized.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn private_field_nullish_assign_stays_on_fallthrough() {
+        // Out of scope: `??=` needs ES5 nullish lowering of the folded `??`.
+        // This guards the documented scope boundary (no accidental partial fold).
+        let output =
+            emit_es5("class N {\n    #x = 0;\n    m() {\n        this.#x ??= 9;\n    }\n}\n");
+        assert!(
+            !output.contains("Math.pow") && !output.contains("\"f\") ?? "),
+            "`??=` must not be partially folded; it stays on the fallthrough.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn private_accessor_short_circuit_assign_stays_on_fallthrough() {
+        // Out of scope: an accessor `&&=` would call the setter even when the
+        // short circuit says skip, so the always-write fold is unsafe here.
+        let output = emit_es5(
+            "class Acc {\n    get #v() { return 1; }\n    set #v(x: number) {}\n    m() {\n        this.#v &&= 3;\n    }\n}\n",
+        );
+        assert!(
+            !output.contains("__classPrivateFieldSet(this, _Acc_v_set, __classPrivateFieldGet"),
+            "Accessor `&&=` must not be folded to an always-write set.\nOutput:\n{output}"
         );
     }
 }


### PR DESCRIPTION
## AgentName
Claude-Emit-100

## Track
Track 9 — Emit/DTS Parity Recovery. JS emit: ES5 class transform / private fields. Follow-up to #12196 (merged), which continues #12180.

> **Rebased onto `main`** after #12200 landed (base `e1d343833b`). Exact head: `a38f578f1ba9`. Diff is a single commit / single file. (Earlier rebase onto #12196 superseded.)

## Invariant
When the ES5 class transform lowers a class to an IIFE, a private-member exponent (`this.#x **= v`) or short-circuit (`this.#x &&= v` / `||= v`) compound assignment inside a method/accessor body must lower to a get-fold-set form, never an un-assignable `__classPrivateFieldGet(...) **= v` (also invalid ES5, since `**`/`&&=`/`||=` are post-ES5). The fold must be observably equivalent to the source operator.

## Scope

### Root cause
#12196 lowered the *simple-base-operator* compounds (`+= -= *= /= %= <<= >>= >>>= &= ^= |=`) and `++`/`--`, but explicitly left `**=` and the logical-assignments on the recursive fallthrough — where the LHS lowers to a `__classPrivateFieldGet(...)` call and the operator is applied on top, producing invalid JS. Confirmed empirically before this change:
```
__classPrivateFieldGet(this, _E_x, "f") **= 3;
__classPrivateFieldGet(this, _A_x, "f") &&= 1;
```

### Fix (`class_es5_ast_to_ir_expressions.rs`, single file)
New `private_exp_or_logical_compound_ir` helper, gated on the existing `private_mutation_target` (private member with both read+write slots and a simple receiver):

- `this.#x **= v` → `__classPrivateFieldSet(this, _C_x, Math.pow(__classPrivateFieldGet(this, _C_x, "f"), v), "f")` — **fields and accessors**. `**=` is an unconditional write, so the always-write fold is correct for both; ES5/ES3 (this transform's only targets) have no `**`, so `Math.pow` is always required.
- `this.#x &&= v` → `__classPrivateFieldSet(this, _C_x, __classPrivateFieldGet(this, _C_x, "f") && v, "f")` — **fields only**.
- `this.#x ||= v` → `set(this, _C_x, get() || v, "f")` — **fields only**.

A conditional-expression rhs is parenthesized (`&&`/`||` bind tighter than `?:`), mirroring the main emitter's private-field policy (`get() || (a ? 1 : 2)`).

### Why `&&=`/`||=` are fields-only (correctness argument)
`&&=`/`||=` are *conditional* writes; the fold `set(get() && v)` *always* writes. For a plain **field** (a `WeakMap` slot with no observable write side effect) the two are observably equivalent — `a &&= b` ≡ `a = (a && b)` because the short-circuit value is stored idempotently. For an **accessor**, the always-write form would invoke the setter when the short circuit says skip, so accessor short-circuit assignment is **not** folded and stays on the fallthrough. `**=` has no such subtlety (always writes), hence fields + accessors. This matches the main emitter's CI-green `set(get() <op> rhs)` form for private-field logical assignment.

### Owner layer
Emitter only — transform/IR lowering. No checker/solver imports, no semantic validation, no output surgery. Keys on the member's storage slot + kind (`"f"` vs `"a"`), never on its spelling (anti-hardcoding gate respected; `kind` is a structural helper marker, not rendered output).

### Adjacent matrix covered
field `**=`, accessor `**=` (distinct `_Box_v_get`/`_Box_v_set` storage, kind `"a"`), field `&&=`, field `||=`, `||=` with conditional rhs (parenthesized), plus two negative scope-boundary guards: `??=` stays on fallthrough, accessor `&&=` stays on fallthrough. Class/member/operator names varied.

### Intentionally out of scope (documented, no regression)
- `??=` (folded `??` itself needs ES5 nullish lowering),
- accessor `&&=`/`||=` (conditional-write semantics),
- non-simple receivers, private method calls `this.#m()`.

## Project Corpus Impact
- Row: n/a (no project-corpus row tracks ES5 private-member compound lowering).
- Bug family: `class/private/accessor/decorator lowering` (largest JS-emit family). Removes invalid-JS emit for ES5 private exponent/short-circuit compound assignment.
- Evidence: 7 new unit tests assert exact tsc-shaped output; invalid output empirically confirmed before the change.

## Verification
Narrow emit-unit checks only (per contract), on rebased exact head `a38f578f1ba9`:
```
cargo nextest run -p tsz-emitter private_field_exponent private_accessor_exponent private_field_logical private_field_nullish_assign_stays private_accessor_short_circuit
# 9 passed

cargo clippy -p tsz-emitter --lib -- -D warnings
# clean
```
The 2 failures under the broader `private class_es5 es5_transforms` filter (`tc39_es2015_nonstatic_private_members_use_storage_and_descriptor_temps`, `test_static_block_super_call_does_not_emit_unused_alias`) are **pre-existing** (the same known TC39-decorator / static-block set verified in #12196), unchanged by this diff.

## Coordination Notes
- Rebased onto current `main` (`e1d343833b`, #12200) after the earlier #12196 rebase; base `main`; single-commit diff. Prior pre-#12200 CI is superseded.
- No overlap with open emit PRs:
  - #12193 (Studio-C, namespace/useDefine) touches only `namespace_es5*` / `declarations/namespace` / `transform_dispatch*`.
  - #12204 (class-lowering fix-forward) touches `emit_es6*` / `class_es5_ir_constructor.rs` / `class_es5_ir_members.rs` / `transform_utils.rs`.
  - This PR's single file `class_es5_ast_to_ir_expressions.rs` is in neither set.
- Queue handoff goes to M5Manager-Studio; I do not add `merge-queue` and do not merge/close/revert others' work.

AgentName: Claude-Emit-100

