### PR TITLE
fix(emit): restore class lowering parity for private-field init and static computed/super blocks

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -1142,6 +1142,17 @@ impl<'a> Printer<'a> {
         // Methods and accessors keep their computed names inline in ES6+.
         // After the class body, a comma expression joins all assignments and side effects.
         let needs_computed_prop_hoisting = target_needs_field_lowering;
+        // For an *erased* computed-name member (a type-only field with no runtime
+        // slot, e.g. `static [N.s]: "b";`) whose key expression has observable side
+        // effects, tsc evaluates the key inside a native `static { ... }` block when
+        // the target supports static blocks (>= ES2022). Field lowering driven by
+        // `useDefineForClassFields: false` forces `needs_computed_prop_hoisting` on
+        // even at ES2022+, but that hoisting machinery (bare after-body statements /
+        // class-expression comma evaluator) must NOT swallow these side effects for a
+        // plain class declaration — they belong in the static block. Class
+        // expressions keep using the comma/evaluator path #12126 introduced.
+        let erased_computed_side_effects_use_static_block =
+            !target_needs_static_block_lowering && !emits_as_class_expression;
         // Each entry: (Option<temp_name>, expr_idx, member_idx) — None means side-effect only
         let mut computed_prop_entries: Vec<(Option<String>, NodeIndex, NodeIndex)> = Vec::new();
         if needs_computed_prop_hoisting {
@@ -1239,7 +1250,9 @@ impl<'a> Printer<'a> {
                         self.legacy_decorator_computed_name_temp_map
                             .insert(computed.expression, temp.clone());
                         computed_prop_entries.push((Some(temp), computed.expression, member_idx));
-                    } else if !self.is_computed_name_expr_side_effect_free(computed.expression) {
+                    } else if !self.is_computed_name_expr_side_effect_free(computed.expression)
+                        && !erased_computed_side_effects_use_static_block
+                    {
                         computed_prop_entries.push((None, computed.expression, member_idx));
                     }
                 } else {
@@ -1839,6 +1852,7 @@ impl<'a> Printer<'a> {
             target_supports_native_private_names,
             has_legacy_private_name_member_decorators,
             needs_computed_prop_hoisting,
+            erased_computed_side_effects_use_static_block,
             native_computed_prop_evaluator: native_computed_prop_evaluator.as_deref(),
             private_fields: &private_fields,
             private_duplicate_conflicts: &private_duplicate_conflicts,

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6_members.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6_members.rs
@@ -22,6 +22,7 @@ pub(super) struct ClassEs6MemberEmit<'a> {
     pub(super) target_supports_native_private_names: bool,
     pub(super) has_legacy_private_name_member_decorators: bool,
     pub(super) needs_computed_prop_hoisting: bool,
+    pub(super) erased_computed_side_effects_use_static_block: bool,
     pub(super) native_computed_prop_evaluator: Option<&'a str>,
     pub(super) private_fields: &'a [PrivateFieldInfo],
     pub(super) private_duplicate_conflicts: &'a PrivateDuplicateConflictPlan,
@@ -51,6 +52,7 @@ impl<'a> Printer<'a> {
             target_supports_native_private_names,
             has_legacy_private_name_member_decorators,
             needs_computed_prop_hoisting,
+            erased_computed_side_effects_use_static_block,
             native_computed_prop_evaluator,
             private_fields,
             private_duplicate_conflicts,
@@ -425,8 +427,12 @@ impl<'a> Printer<'a> {
                     // property accesses, element accesses, calls, assignments, etc.
                     // Simple identifiers and literals are NOT emitted (no side effects).
                     // Skip this when computed property hoisting is active — the comma
-                    // expression already handles side effects.
-                    if !needs_computed_prop_hoisting
+                    // expression already handles side effects — UNLESS the target has
+                    // native static blocks, where these side effects belong in a
+                    // `static { ... }` block (and the hoisting collection deliberately
+                    // left them out of the comma expression for that reason).
+                    if (!needs_computed_prop_hoisting
+                        || erased_computed_side_effects_use_static_block)
                         && member_node.kind == syntax_kind_ext::PROPERTY_DECLARATION
                         && let Some(p) = self.arena.get_property_decl(member_node)
                         && let Some(name_node) = self.arena.get(p.name)

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_constructor.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_constructor.rs
@@ -1402,15 +1402,16 @@ impl<'a> ES5ClassTransformer<'a> {
             } else {
                 IRNode::Undefined
             };
-            body.push(IRNode::expr_stmt(IRNode::call(
-                IRNode::RuntimeHelper(std::borrow::Cow::Borrowed("__classPrivateFieldSet")),
-                vec![
-                    receiver.clone(),
-                    IRNode::id(field.weakmap_name.clone()),
-                    value,
-                    IRNode::StringLiteral("f".into()),
-                ],
-            )));
+            // The in-constructor initializer for a private instance field is the
+            // field's definition point, so tsc emits a direct `_C_field.set(this, value)`
+            // WeakMap store (see `createPrivateInstanceFieldInitializer`). The
+            // `__classPrivateFieldSet` helper is reserved for later assignment
+            // expressions (`this.#x = v`) where a brand check is required.
+            body.push(IRNode::expr_stmt(IRNode::WeakMapSet {
+                weakmap_name: field.weakmap_name.clone().into(),
+                key: Box::new(receiver.clone()),
+                value: Box::new(value),
+            }));
         }
     }
 

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
@@ -12,7 +12,7 @@ use rustc_hash::FxHashSet;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::syntax::transform_utils::{
-    contains_async_arrow_function, contains_new_target_reference, contains_this_reference,
+    contains_async_arrow_function, contains_new_target_reference, contains_this_keyword_reference,
     is_private_identifier,
 };
 use tsz_scanner::SyntaxKind;
@@ -1621,7 +1621,7 @@ impl<'a> ES5ClassTransformer<'a> {
                 }
                 // Async arrows in static initializers also need the class alias:
                 // tsc passes it to the downlevel `__generator` call as lexical `this`.
-                if contains_this_reference(self.arena, prop_data.initializer)
+                if contains_this_keyword_reference(self.arena, prop_data.initializer)
                     || contains_async_arrow_function(self.arena, prop_data.initializer)
                 {
                     return true;
@@ -1630,7 +1630,7 @@ impl<'a> ES5ClassTransformer<'a> {
                 // Check if the static block body contains `this`
                 if let Some(block_data) = self.arena.get_block(member_node) {
                     for &stmt_idx in &block_data.statements.nodes {
-                        if contains_this_reference(self.arena, stmt_idx)
+                        if contains_this_keyword_reference(self.arena, stmt_idx)
                             || contains_async_arrow_function(self.arena, stmt_idx)
                         {
                             return true;

--- a/crates/tsz-emitter/tests/class_es5.rs
+++ b/crates/tsz-emitter/tests/class_es5.rs
@@ -481,8 +481,8 @@ fn test_class_with_private_field() {
         "Should have WeakMap declaration: {output}"
     );
     assert!(
-        output.contains("__classPrivateFieldSet(this, _Container_value,"),
-        "Should have __classPrivateFieldSet call: {output}"
+        output.contains("_Container_value.set(this, 42)"),
+        "Private field initializer should store directly via WeakMap.set: {output}"
     );
 }
 

--- a/crates/tsz-emitter/tests/class_es5_ir.rs
+++ b/crates/tsz-emitter/tests/class_es5_ir.rs
@@ -140,8 +140,8 @@ fn private_members_keep_storage_inside_es5_class_iife() {
         "ES5 class declarations should not hoist private storage before the IIFE.\nOutput:\n{output}"
     );
     assert!(
-        output.contains("function A() {\n        _A_instances.add(this);\n        __classPrivateFieldSet(this, _A_field, 123, \"f\");\n    }"),
-        "Instance private methods/accessors need a WeakSet brand and private fields initialize with __classPrivateFieldSet.\nOutput:\n{output}"
+        output.contains("function A() {\n        _A_instances.add(this);\n        _A_field.set(this, 123);\n    }"),
+        "Instance private methods/accessors need a WeakSet brand and private fields initialize directly via WeakMap.set.\nOutput:\n{output}"
     );
     assert!(
         output.contains("var _A_instances, _a, _A_field, _A_method, _A_sField, _A_sMethod, _A_acc_get, _A_acc_set, _A_sAcc_get, _A_sAcc_set;"),
@@ -245,8 +245,46 @@ fn test_class_with_private_field() {
     let output = output.expect("transform should succeed in test");
 
     assert!(output.contains("var _Container_value"));
-    assert!(output.contains("__classPrivateFieldSet(this, _Container_value, 42, \"f\")"));
+    assert!(output.contains("_Container_value.set(this, 42)"));
     assert!(output.contains("_Container_value = new WeakMap()"));
+}
+
+#[test]
+fn static_field_super_access_initializer_does_not_emit_class_alias() {
+    // A static field initializer that only reads `super.f` (no `this`) lowers
+    // the static super access to `_super.f` and needs no class-value alias.
+    // Treating the `super` keyword as a `this` reference would spuriously emit
+    // `var _a; _a = D;` inside the IIFE (regression from a broadened helper).
+    let source = r#"class C { static f = 1 }
+        class D extends C {
+            static arrowFunctionBoundary = () => super.f + 1;
+            static functionExprBoundary = function () { return super.f + 2 };
+        }"#;
+
+    let mut parser =
+        tsz_parser::parser::ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let root_node = parser.arena.get(root).expect("root");
+    let source_file = parser.arena.get_source_file(root_node).expect("sf");
+    let class_idx = source_file.statements.nodes[1];
+
+    let mut transformer = ES5ClassTransformer::new(&parser.arena);
+    transformer.set_source_text(source);
+    let ir = transformer
+        .transform_class_to_ir(class_idx)
+        .expect("class should lower to ES5 IR");
+    let mut printer = IRPrinter::with_arena(&parser.arena);
+    printer.set_source_text(source);
+    let output = printer.emit(&ir).to_string();
+
+    assert!(
+        !output.contains("var _a;") && !output.contains("_a = D;"),
+        "Static `super.f` access must not force a class-value alias.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("D.arrowFunctionBoundary = function () { return _super.f + 1; };"),
+        "Static arrow `super.f` access should lower to `_super.f`.\nOutput:\n{output}"
+    );
 }
 
 #[test]

--- a/crates/tsz-emitter/tests/es5_transforms_e2e_parts/part_00.rs
+++ b/crates/tsz-emitter/tests/es5_transforms_e2e_parts/part_00.rs
@@ -365,12 +365,12 @@ fn new_target_es5_private_field_initializers_capture_default_constructor() {
             )
         });
     let direct_initializer = output
-        .find("__classPrivateFieldSet(this, _C_x, _newTarget")
+        .find("_C_x.set(this, _newTarget")
         .unwrap_or_else(|| {
             panic!("Private field initializer should read the capture.\nOutput:\n{output}")
         });
     let arrow_initializer = output
-        .find("__classPrivateFieldSet(this, _C_y, function () { return _newTarget; }")
+        .find("_C_y.set(this, function () { return _newTarget; }")
         .unwrap_or_else(|| {
             panic!(
                 "Private arrow field initializer should close over the capture.\nOutput:\n{output}"
@@ -409,12 +409,12 @@ fn new_target_es5_derived_private_field_initializers_capture_after_super() {
             )
         });
     let direct_initializer = output
-        .find("__classPrivateFieldSet(_this, _D_x, _newTarget")
+        .find("_D_x.set(_this, _newTarget")
         .unwrap_or_else(|| {
             panic!("Derived private field initializer should read the capture.\nOutput:\n{output}")
         });
     let arrow_initializer = output
-        .find("__classPrivateFieldSet(_this, _D_y, function () { return _newTarget; }")
+        .find("_D_y.set(_this, function () { return _newTarget; }")
         .unwrap_or_else(|| {
             panic!(
                 "Derived private arrow field initializer should close over the capture.\nOutput:\n{output}"

--- a/crates/tsz-parser/src/syntax/transform_utils.rs
+++ b/crates/tsz-parser/src/syntax/transform_utils.rs
@@ -34,6 +34,39 @@ pub fn contains_this_reference(arena: &NodeArena, node_idx: NodeIndex) -> bool {
     contains_target_reference(arena, node_idx, ReferenceTarget::This)
 }
 
+/// Check if an AST node contains a literal `this` keyword reference, excluding
+/// `super`.
+///
+/// [`contains_this_reference`] intentionally also matches `super` because an
+/// ES5-lowered arrow that calls `super.m(...)` threads the captured `_this`
+/// receiver. Deciding whether a *static* member initializer needs the
+/// class-value alias (`var _a; _a = Class;`) is a different question: a bare
+/// static `super.x` access lowers to `_super.x` and never references the class
+/// value, so it must not force the alias. This shares the same lexical
+/// boundaries as [`contains_this_reference`] — transparent through arrows and
+/// computed member names (so `this` inside a nested class expression's computed
+/// name is still found), opaque through ordinary functions and non-computed
+/// class member bodies — but only the `this` keyword counts.
+#[must_use]
+pub fn contains_this_keyword_reference(arena: &NodeArena, node_idx: NodeIndex) -> bool {
+    let Some(node) = arena.get(node_idx) else {
+        return false;
+    };
+    if node.kind == SyntaxKind::ThisKeyword as u16 {
+        return true;
+    }
+    if node.is_identifier()
+        && arena
+            .get_identifier(node)
+            .is_some_and(|identifier| identifier.escaped_text == "this")
+    {
+        return true;
+    }
+    target_reference_children(arena, node_idx, ReferenceTarget::This)
+        .into_iter()
+        .any(|child_idx| contains_this_keyword_reference(arena, child_idx))
+}
+
 /// Check whether an ES5-lowered arrow body must capture lexical `this`.
 ///
 /// An arrow captures `this` when it spells `this`, OR when it contains a


### PR DESCRIPTION
## Agent
AgentName: opus48-emit-fixforward

Fixes #12194.

## Track
Track — emit / ES5+ES6 class lowering (JS emit fix-forward).

## Invariant
When a class lowers to ES5/ES2015 or to ES2022+ with `useDefineForClassFields: false`, tsz must match tsc's class-feature lowering:

1. **Private instance field initializers** are the field's definition point and store directly: `_C_field.set(this, value)` (tsc `createPrivateInstanceFieldInitializer`). The `__classPrivateFieldSet` helper is reserved for later `this.#x = v` assignment expressions, which need the brand check.
2. **A static member initializer needs the class-value alias** (`var _a; _a = D;`) only when it references the class via the `this` keyword. A bare static `super.x` access lowers to `_super.x` and never references the class value, so it must not force the alias.
3. **Erased computed-name member side effects** (e.g. `static [N.s]: "b";`) evaluate inside a native `static { ... }` block on targets that support static blocks, even when `useDefineForClassFields: false` turns field-lowering hoisting on.

## Scope
Fix-forward of the JS-emit regressions from #12126 (static this capture) and #12180 (ES5 private-field lowering), verified against the pinned TypeScript 6.0.3 baselines (`050880ce`).

- `crates/tsz-emitter/src/transforms/class_es5_ir_constructor.rs` — private-field initializer emits `IRNode::WeakMapSet` (`_C_field.set(this, v)`) instead of the `__classPrivateFieldSet` helper. #12180's method-body `this.#x` access/assignment lowering is preserved.
- `crates/tsz-parser/src/syntax/transform_utils.rs` — new `contains_this_keyword_reference` (`this`-only, excludes `super`, same lexical boundaries as `contains_this_reference`).
- `crates/tsz-emitter/src/transforms/class_es5_ir_members.rs` — `static_members_need_class_alias` uses the `this`-only check.
- `crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs` + `emit_es6_members.rs` — `erased_computed_side_effects_use_static_block` routes erased computed-name side effects into a native static block instead of the hoisting/comma path on native-static-block targets.

## Project Corpus Impact
- Row: n/a (emit-suite-only regression; not a project-compile-guard row).
- Bug family: ES5/ES6 class lowering — private-field init, static-this alias, computed-name / unique-symbol static blocks.
- Evidence: per-test diff of tsz `--js-only` emit vs `tests/baselines/reference` at TS 6.0.3. Four regressed baselines now match exactly: `privateNameES5Ban(target=es5)`, `typeOfThisInStaticMembers9(target=es5)`, `uniqueSymbols`, `uniqueSymbolsDeclarations`. The #12126 win `typeOfThisInStaticMembers12(es2022/esnext)` is structurally preserved.

## Verification
- Built `tsz` and diffed emit vs the pinned TS 6.0.3 baselines for each named test — 4/4 regressed cases now match.
- Bisected against the pre-regression baseline `d394d819`: confirmed those 4 passed before #12126/#12180 and the fixes restore them.
- Two existing regression tests that already encoded the correct behavior now pass: `erased_computed_class_fields_emit_native_static_block_side_effects`, `test_static_block_super_call_does_not_emit_unused_alias` (both were failing on `main`).
- Added `static_field_super_access_initializer_does_not_emit_class_alias`; updated the private-field init assertions in `class_es5.rs`, `class_es5_ir.rs`, and `es5_transforms_e2e_parts/part_00.rs` to the correct `.set(...)` form.
- `cargo test -p tsz-emitter --lib` for the touched class/private/static/new_target groups: green. No new failures vs `main` (the unrelated `declaration_emitter` / TC39-decorator failures pre-exist on `main`, identical with and without this change).
- `cargo fmt --check` and `cargo clippy -p tsz-emitter -p tsz-parser`: clean. Rebased on current `main` (includes #12196); re-verified after rebase.

## Coordination Notes
- `classStaticBlock6(target=es5)` is **not** fully closed here: #12126's cascading temp-name shift is fixed, but two residual diffs (empty `if (true) { }` block formatting and a duplicated trailing comment in the lowered static-block IIFE) **predate** #12126 — confirmed failing at baseline `d394d819` with identical diffs. They are separate pre-existing bugs in the ES5 static-block comment/formatting path and are out of scope for this regression fix-forward; left for a focused follow-up to avoid an unverified broad change to shared comment-cursor logic.
- #12180's method-body private access lowering and #12126's nested-class computed-name `this` capture are intentionally preserved.
- Issue #12194 is owned by `agent:Studio-C`; this was unstarted (#12193 is a distinct `useDefineForClassFields`/namespace change). Marked the issue WIP when claiming.

https://claude.ai/code/session_018Jw2A9uaPbv7B9buknwZXQ

---
_Generated by [Claude Code](https://claude.ai/code/session_018Jw2A9uaPbv7B9buknwZXQ)_

---

### Base refresh (Claude-Emit-100)
Refreshed onto current `main` `2f05e5c` after #12206 (checker-only, disjoint) merged. Exact head: `411026ed3a`. Scope unchanged (8 files, +116 −24). Owner (`opus48-emit-fixforward`) content above is unchanged.

**Ordering decision (M5Manager-Studio):** this PR is the ready-lineage PR and proceeds first; draft #12209 (off-queue, shares `class_es5_ir_members.rs` at disjoint regions) refreshes later if this lands.

Narrow checks rerun on `411026ed3a` (no full conformance/fourslash/emit): named regression tests pass (incl. `test_static_block_super_call_does_not_emit_unused_alias`); `cargo nextest run -p tsz-emitter` over class/static/private/new_target groups = 444 passed, 1 failed (pre-existing `tc39_es2015_nonstatic_private_members_use_storage_and_descriptor_temps`, identical with/without this change); `cargo clippy -p tsz-emitter -p tsz-parser` and `cargo fmt --check` clean.

Force-pushed with `--force-with-lease` from `c1a1dee6f219`. Enqueue/merge-queue/merge left to M5Manager-Studio. — AgentName: Claude-Emit-100
