### PR TITLE
fix(checker): preserve diagnostic chain order across normalization sort

### DIFF
--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -536,18 +536,23 @@ impl<'a> CheckerState<'a> {
                             diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                             &[&source_str, &target_str],
                         ),
-                        depth: 0,
+                        // Leaf sits one level beneath the `Types of property`
+                        // header. See the sort-key comment in
+                        // `normalize_related_information` for why the chain
+                        // order depends on this.
+                        depth: 1,
                     },
                 ];
                 // When the property type fails because a union member is not
                 // assignable (the common `T | undefined` vs `T` case), surface
-                // the failing member so the root mismatch stays visible, matching
-                // tsc's `... -> Type 'undefined' is not assignable to type 'T'.`
-                // leaf instead of stopping at the union line.
-                if let Some(member_line) =
-                    self.union_member_related_line(nested_reason.as_deref(), start, length)
+                // the failing member at depth 2 so the chain reads
+                //   Types of property 'p' are incompatible.
+                //     Type 'A | undefined' is not assignable to type 'A'.
+                //       Type 'undefined' is not assignable to type 'A'.
+                if let Some(line) =
+                    self.union_member_related_line(nested_reason.as_deref(), start, length, 2)
                 {
-                    items.push(member_line);
+                    items.push(line);
                 }
                 items
             }
@@ -684,7 +689,7 @@ impl<'a> CheckerState<'a> {
                             diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                             &[&source_str, &target_str],
                         ),
-                        depth: 0,
+                        depth: 1,
                     },
                 ]
             }
@@ -728,7 +733,7 @@ impl<'a> CheckerState<'a> {
                             diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                             &[&source_str, &target_str],
                         ),
-                        depth: 0,
+                        depth: 1,
                     },
                 ]
             }
@@ -766,7 +771,7 @@ impl<'a> CheckerState<'a> {
             }
             SubtypeFailureReason::UnionSourceMismatch { .. }
             | SubtypeFailureReason::ConditionalBranchMismatch { .. } => {
-                match self.union_member_related_line(Some(reason), start, length) {
+                match self.union_member_related_line(Some(reason), start, length, 0) {
                     Some(line) => vec![line],
                     None => return None,
                 }
@@ -774,18 +779,26 @@ impl<'a> CheckerState<'a> {
             _ => return None,
         };
 
-        Some(self.normalize_related_information(related, RelatedInformationPolicy::ELABORATION))
+        // The two callers (`emit_render_request`,
+        // `emit_render_request_at_anchor`) normalize again under the request's
+        // policy. Skipping the intermediate pass keeps the depth-aware sort
+        // running exactly once on the final list.
+        Some(related)
     }
 
     /// Build the child-relation elaboration line (`Type 'C' is not assignable
     /// to type 'T'.`) for a [`UnionSourceMismatch`] or
     /// [`ConditionalBranchMismatch`] reason. Used to surface the root mismatch
-    /// one level beneath a union-typed or conditional-typed failure.
+    /// `depth` levels beneath a union-typed or conditional-typed failure —
+    /// `0` for a top-level union mismatch (`Type 'A | B' is not assignable
+    /// to T.` -> `Type 'B' is not assignable to T.`) and `2` when nested
+    /// under a `Types of property` header plus its leaf.
     fn union_member_related_line(
         &mut self,
         reason: Option<&tsz_solver::SubtypeFailureReason>,
         start: u32,
         length: u32,
+        depth: u8,
     ) -> Option<DiagnosticRelatedInformation> {
         let (child_source, child_target) = match reason? {
             tsz_solver::SubtypeFailureReason::UnionSourceMismatch {
@@ -818,7 +831,7 @@ impl<'a> CheckerState<'a> {
                 diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                 &[&member_str, &target_str],
             ),
-            depth: 0,
+            depth,
         })
     }
 
@@ -875,12 +888,22 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        // Sort related information for consistent, deterministic fingerprint ordering.
-        // This ensures fingerprint-only tests match tsc's expected diagnostic output.
+        // Sort related information for consistent, deterministic fingerprint
+        // ordering. `depth` precedes the textual tiebreaker so a chain stays in
+        // outer-to-inner order: at the same anchor (file, start) a depth-0
+        // header (e.g. "Types of property 'p' are incompatible.") always
+        // precedes its depth-1+ leaves (e.g. "Type 'X' is not assignable to
+        // type 'Y'."). Without the depth key, the alphabetic compare reverses
+        // chains because "Type " (with a trailing space) sorts before "Types"
+        // — swapping the displayed type/interface output order between the
+        // main message and its note. Within the same depth the message-text
+        // tiebreaker still gives deterministic order when distinct code paths
+        // append items in different sequences.
         normalized.sort_by(|a, b| {
             a.file
                 .cmp(&b.file)
                 .then(a.start.cmp(&b.start))
+                .then(a.depth.cmp(&b.depth))
                 .then(a.message_text.cmp(&b.message_text))
         });
 

--- a/crates/tsz-checker/src/error_reporter/render_request_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/render_request_tests.rs
@@ -728,3 +728,99 @@ a.b;
         ts2339.message_text
     );
 }
+
+// Diagnostic chain order stability for related-information chains (issue
+// #10918). The normalization sort used to alphabetize same-anchor entries
+// by `message_text`, which placed a `Type 'X' is not assignable to type
+// 'Y'.` leaf above its `Types of property 'P' are incompatible.` header
+// because the space in `"Type "` sorts before `'s'` in `"Types"`. The fix
+// adds `depth` to the sort key before the textual tiebreaker.
+
+#[track_caller]
+fn property_chain_indices(
+    related: &[tsz_checker::diagnostics::DiagnosticRelatedInformation],
+    property_name: &str,
+) -> (usize, usize) {
+    let header = related
+        .iter()
+        .position(|info| {
+            info.message_text.contains("Types of property")
+                && info.message_text.contains(&format!("'{property_name}'"))
+        })
+        .unwrap_or_else(|| {
+            panic!("expected `Types of property '{property_name}'` header, got: {related:?}")
+        });
+    let leaf = related
+        .iter()
+        .position(|info| {
+            info.message_text.starts_with("Type ")
+                && info.message_text.contains("is not assignable to type")
+        })
+        .unwrap_or_else(|| panic!("expected leaf relation line, got: {related:?}"));
+    (header, leaf)
+}
+
+/// Header precedes leaf in `related_information`; leaf indents at least one
+/// level deeper. Varies property names so the rule is structural, not a
+/// fixture spelling. Uses `declare const arg: ...` so the call goes through
+/// `related_from_failure_reason`; an object literal would hit a different
+/// emit path with no chain.
+#[test]
+fn ts2345_property_chain_keeps_header_before_leaf_and_indents_leaf() {
+    for (prop_name, prop_ty, arg_ty) in [
+        ("p", "string", "number"),
+        ("key", "string", "boolean"),
+        ("alpha", "boolean", "string"),
+    ] {
+        let source = format!(
+            "declare const arg: {{ {prop_name}: {arg_ty} }};\n\
+             function take(o: {{ {prop_name}: {prop_ty} }}) {{}}\n\
+             take(arg);\n"
+        );
+        let diagnostics = check_source_diagnostics(&source);
+        let ts2345 = diagnostics
+            .iter()
+            .find(|d| d.code == 2345)
+            .unwrap_or_else(|| panic!("expected TS2345 for `{source}`, got: {diagnostics:?}"));
+
+        let (header_idx, leaf_idx) = property_chain_indices(&ts2345.related_information, prop_name);
+        assert!(
+            header_idx < leaf_idx,
+            "header must precede leaf in `{source}`, got header={header_idx}, leaf={leaf_idx}, related={:?}",
+            ts2345.related_information
+        );
+        assert_eq!(
+            ts2345.related_information[header_idx].depth, 0,
+            "header sits at the first elaboration level; chain: {:?}",
+            ts2345.related_information
+        );
+        assert!(
+            ts2345.related_information[leaf_idx].depth >= 1,
+            "leaf must indent at least one level beneath its header; chain: {:?}",
+            ts2345.related_information
+        );
+    }
+}
+
+/// The chain must remain stable across repeated checks of the same source —
+/// two independent compiles must produce the same ordered related-info
+/// entries.
+#[test]
+fn ts2345_property_chain_is_stable_across_repeated_checks() {
+    let source = "declare const arg: { p: number };\n\
+                  function take(o: { p: string }) {}\n\
+                  take(arg);\n";
+    let chain = |diags: &[tsz_checker::diagnostics::Diagnostic]| {
+        diags
+            .iter()
+            .find(|d| d.code == 2345)
+            .expect("expected a TS2345 chain to compare against")
+            .related_information
+            .iter()
+            .map(|r| (r.depth, r.message_text.clone()))
+            .collect::<Vec<_>>()
+    };
+    let first = chain(&check_source_diagnostics(source));
+    let second = chain(&check_source_diagnostics(source));
+    assert_eq!(first, second, "chain drifted between independent runs");
+}


### PR DESCRIPTION
AgentName: claude/confident-thompson-KNfe5
Track: type-display / diagnostics chain
Invariant: For any assignability failure that elaborates through `related_from_failure_reason`, the related-information chain renders outer-to-inner: a depth-0 header (`Types of property 'P' are incompatible.`, `string index signature is incompatible: ...`, `Array element type '...' is not assignable to ...`) always precedes its depth-1 leaf (`Type 'X' is not assignable to type 'Y'.`), and a depth-2 union-member elaboration nests beneath the property-mismatch leaf. Same-anchor entries follow the structural chain order regardless of how their message text alphabetizes.

## Scope
Closes #10918.

Root cause: `normalize_related_information` sorted same-anchor entries by `(file, start, message_text)`. The alphabetic tiebreaker reversed chains because `"Type "` (with trailing space) sorts before `"Types"`, so a leaf relation rendered above its `Types of property` header — swapping the displayed type/interface output between the main diagnostic and its note.

Fix lives at the sort and the chain-builder layers:
- `normalize_related_information` now sorts by `(file, start, depth, message_text)`. `depth` enters the key before the textual tiebreaker so chain order survives.
- `related_from_failure_reason` assigns explicit depths to its leaf items so the depth-aware sort puts them in chain order:
  - `PropertyTypeMismatch`: header at depth 0, leaf at depth 1, union-member elaboration at depth 2.
  - `IndexSignatureMismatch` / `ArrayElementMismatch`: header at depth 0, leaf at depth 1.
- `union_member_related_line` accepts the depth as a parameter rather than being post-edited at call sites.
- The intermediate `normalize_related_information(ELABORATION)` inside `related_from_failure_reason` is dropped — both emit paths (`emit_render_request`, `emit_render_request_at_anchor`) re-normalize under the request's policy, so the depth-aware sort runs exactly once on the final list.

Structural rule covered:
- TS2345 call-argument failures whose nested reason is `PropertyTypeMismatch`, `IndexSignatureMismatch`, or `ArrayElementMismatch` now produce the tsc-shaped progressive elaboration. Property mismatches with a nested `UnionSourceMismatch` get the three-level chain (header → union leaf → member leaf).

## Project Corpus Impact
- Row: n/a (no project-row diagnostic baselines were changed; the corrected chain order applies uniformly to TS2345 call-argument elaborations across rows)
- Bug family: type-display / diagnostic-chain
- Affects the TS2345 elaboration shape that benchmark rows consume from the call-argument path. Project-row diagnostic snapshots for utility-types, ts-toolbelt, type-fest, and similar inference-heavy projects pick up the corrected outer-to-inner chain order.

## Verification
Targeted tests:
- `cargo test -p tsz-checker --lib render_request_tests::ts2345_property_chain_keeps_header_before_leaf_and_indents_leaf` — passes (3 property-name variants).
- `cargo test -p tsz-checker --lib render_request_tests::ts2345_property_chain_is_stable_across_repeated_checks` — passes.
- `cargo test -p tsz-checker --lib render_request_tests` — 30 passed; 0 failed.
- `cargo test -p tsz-checker --test property_chain_elaboration_collapse_tests --test satisfies_elaboration_chain_tests --test ts2430_tests --test tuple_element_mismatch_tests --test generic_property_mismatch_display_tests` — 70 passed; 0 failed.

Pre-existing failures confirmed unrelated by stash-and-rerun against `origin/main` (same set of 4–5 failing tests in `yield_star_return_type_tests`, `zod_type_query_regression_tests`, and `optional_property_required_elaboration_tests` fail on both the baseline and this branch).

## Coordination Notes
Touches only `crates/tsz-checker/src/error_reporter/fingerprint_policy.rs` (sort key + helper signature + depth assignments) and adds tests in `crates/tsz-checker/src/error_reporter/render_request_tests.rs`. No other reporter modules or query boundaries needed changes — the assignment-path renderer (`render_property_type_mismatch` and friends) already builds chains with proper depths through `push_nested_chain`, so the two paths are now consistent.

https://claude.ai/code/session_01HUpN4vH42RsFpBiDxR3RDL