### PR TITLE
fix(module-resolution): order exports/imports subpath keys by PATTERN_KEY_COMPARE (#10897)

### DIFF
--- a/crates/tsz-core/src/module_resolver/tests/package_exports_imports.rs
+++ b/crates/tsz-core/src/module_resolver/tests/package_exports_imports.rs
@@ -915,3 +915,74 @@ fn test_is_valid_bare_imports_target_rejects_absolute_and_relative() {
     // Windows drive paths.
     assert!(!is_valid_bare_imports_target("C:/abs.d.ts"));
 }
+
+/// A `*` pattern key must outrank an equal-base directory key regardless of
+/// JSON declaration order. Both packages below expose the same two keys for
+/// `./foo` — a `"./*"` wildcard (→ `dist/foo`) and a `"./"` directory prefix
+/// (→ `src/foo`) — differing only in declaration order. Per Node.js
+/// `PATTERN_KEY_COMPARE`, `"./*"` (base length 3) always beats `"./"`
+/// (base length 2), so both must resolve to the same physical `dist` file.
+/// Before the fix the two keys tied on `(prefix_len, suffix_len)` and the
+/// winner flipped with key order, so the same specifier resolved to different
+/// physical files between rows.
+#[test]
+fn test_wildcard_export_beats_directory_key_independent_of_declaration_order() {
+    use std::fs;
+
+    fn resolve_foo(dir: &std::path::Path, exports_json: &str) -> std::path::PathBuf {
+        let _ = fs::remove_dir_all(dir);
+        fs::create_dir_all(dir.join("node_modules/pkg/dist")).unwrap();
+        fs::create_dir_all(dir.join("node_modules/pkg/src")).unwrap();
+        fs::create_dir_all(dir.join("app")).unwrap();
+
+        fs::write(
+            dir.join("node_modules/pkg/package.json"),
+            format!(r#"{{"name":"pkg","exports":{exports_json}}}"#),
+        )
+        .unwrap();
+        // Both candidate targets exist on disk, so selection — not mere
+        // existence — decides which physical file wins.
+        fs::write(
+            dir.join("node_modules/pkg/dist/foo.d.ts"),
+            "export declare const from_dist: number;",
+        )
+        .unwrap();
+        fs::write(
+            dir.join("node_modules/pkg/src/foo.d.ts"),
+            "export declare const from_src: number;",
+        )
+        .unwrap();
+        fs::write(dir.join("app/index.ts"), "import { x } from 'pkg/foo';").unwrap();
+
+        let options = ResolvedCompilerOptions {
+            module_resolution: Some(ModuleResolutionKind::Node16),
+            resolve_package_json_exports: true,
+            ..Default::default()
+        };
+        let mut resolver = ModuleResolver::new(&options);
+        let resolved = resolver
+            .resolve("pkg/foo", &dir.join("app/index.ts"), Span::new(15, 24))
+            .expect("pkg/foo must resolve through the `./*` wildcard export")
+            .resolved_path;
+        let _ = fs::remove_dir_all(dir);
+        resolved
+    }
+
+    // Wildcard declared AFTER the directory key (the order that regressed).
+    let dir_then_star = std::env::temp_dir().join("tsz_test_exports_dir_then_star");
+    let resolved_a = resolve_foo(&dir_then_star, r#"{"./":"./src/","./*":"./dist/*.js"}"#);
+    assert_eq!(
+        resolved_a,
+        dir_then_star.join("node_modules/pkg/dist/foo.d.ts"),
+        "`./*` must win over `./` even when declared second"
+    );
+
+    // Wildcard declared BEFORE the directory key — same winner.
+    let star_then_dir = std::env::temp_dir().join("tsz_test_exports_star_then_dir");
+    let resolved_b = resolve_foo(&star_then_dir, r#"{"./*":"./dist/*.js","./":"./src/"}"#);
+    assert_eq!(
+        resolved_b,
+        star_then_dir.join("node_modules/pkg/dist/foo.d.ts"),
+        "`./*` must win over `./` regardless of declaration order"
+    );
+}

--- a/crates/tsz-core/src/module_resolver/tests/pattern_matching.rs
+++ b/crates/tsz-core/src/module_resolver/tests/pattern_matching.rs
@@ -169,13 +169,20 @@ fn test_export_pattern_specificity_prefix_and_suffix() {
         export_pattern_specificity("./*-a"),
         export_pattern_specificity("./*-b")
     );
-    // No wildcard: treated as (pattern.len(), 0).
-    assert_eq!(export_pattern_specificity("./lib"), (5, 0));
-    assert_eq!(export_pattern_specificity("./lib/*"), (6, 0));
-    assert_eq!(export_pattern_specificity("./*-suffix"), (2, 7));
-    // Longer prefix beats longer suffix.
-    // "./abc/*" has prefix.len=6, suffix.len=0 → (6, 0)
-    // "./*-suffix" has prefix.len=2, suffix.len=7 → (2, 7)
-    // (6, 0) > (2, 7) because 6 > 2
+    // `(base_length, is_pattern, total_length)` per Node `PATTERN_KEY_COMPARE`.
+    // No wildcard: base = full length, not a pattern.
+    assert_eq!(export_pattern_specificity("./lib"), (5, 0, 5));
+    // Wildcard: base = indexOf('*') + 1, flagged as a pattern.
+    assert_eq!(export_pattern_specificity("./lib/*"), (7, 1, 7));
+    assert_eq!(export_pattern_specificity("./*-suffix"), (3, 1, 10));
+    // Longer base beats longer suffix.
+    // "./abc/*"   → base 7
+    // "./*-suffix" → base 3
     assert!(export_pattern_specificity("./abc/*") > export_pattern_specificity("./*-suffix"));
+    // At equal base length a wildcard key outranks a directory/exact key, so
+    // `"./*"` (base 3) beats `"./"` (base 2) — and even ties on base are broken
+    // toward the pattern: `"./x"` exact (base 3, not a pattern) loses to a
+    // base-3 wildcard.
+    assert!(export_pattern_specificity("./*") > export_pattern_specificity("./"));
+    assert!(export_pattern_specificity("./*") > export_pattern_specificity("./x"));
 }

--- a/crates/tsz-core/src/resolution/helpers.rs
+++ b/crates/tsz-core/src/resolution/helpers.rs
@@ -158,37 +158,49 @@ pub(crate) fn match_export_pattern(pattern: &str, subpath: &str) -> Option<Strin
     Some(subpath[start..end].to_string())
 }
 
-/// Returns the specificity of an export/import pattern for tie-breaking.
+/// Specificity ranking key for an `exports`/`imports` subpath key.
 ///
-/// Per Node.js `PACKAGE_IMPORTS_EXPORTS_RESOLVE` spec, when multiple patterns
-/// match a subpath, the most specific one wins. Specificity is defined as:
+/// `(base_length, is_pattern, total_length)`, compared lexicographically with
+/// "larger wins". This mirrors Node.js `PATTERN_KEY_COMPARE` (the comparator
+/// behind `PACKAGE_IMPORTS_EXPORTS_RESOLVE`, which tsc reimplements as
+/// `comparePatternKeys`) so the most specific key is chosen independently of
+/// JSON declaration order:
 ///
-/// 1. **Primary**: length of the prefix (characters before `*`). A longer prefix
-///    means the pattern is more anchored to the start of the subpath.
-/// 2. **Secondary**: length of the suffix (characters after `*`). A longer suffix
-///    means the pattern is more anchored to the end of the subpath.
+/// 1. **`base_length`** — the anchored prefix length. For a single-`*` key this
+///    is `indexOf('*') + 1`; for a non-wildcard key (exact or `/`-suffixed
+///    directory) it is the full key length. A longer base is more specific and
+///    wins first. This is what lets a long directory key (`"./lib/"`, base 6)
+///    correctly outrank a short wildcard (`"./*"`, base 3), and a wildcard
+///    (`"./lib/*"`, base 7) outrank that directory key.
+/// 2. **`is_pattern`** — `1` for keys containing `*`, else `0`. At equal base
+///    length a wildcard key beats a directory/exact key, matching Node rules
+///    7–8 (`if keyA does not contain "*" return 1`). Without this term `"./"`
+///    and `"./*"` tie on base length `2`, and the winner flips with JSON key
+///    order — the "different physical files between rows" divergence.
+/// 3. **`total_length`** — longer keys win last (Node rules 9–10). For two
+///    wildcards with equal base this orders by suffix length, e.g. `"./*.js"`
+///    beats `"./*"`.
 ///
-/// Exact (non-wildcard) and directory patterns use `(pattern.len(), 0)` since
-/// they always beat a wildcard match of the same or shorter length.
-///
-/// When two patterns have equal `(prefix_len, suffix_len)`, the first one in
-/// JSON source order wins — callers must iterate in insertion order (use
-/// `IndexMap`) and update `best_match` only on strict improvement (`>`).
-pub(crate) fn export_pattern_specificity(pattern: &str) -> (usize, usize) {
+/// True ties (identical ranking) resolve to the first key in iteration order, so
+/// callers must iterate an insertion-order map (`IndexMap`) and update only on
+/// strict improvement (`>`).
+pub(crate) fn export_pattern_specificity(pattern: &str) -> (usize, usize, usize) {
+    let len = pattern.len();
     if let Some(star_pos) = pattern.find('*') {
-        (star_pos, pattern.len() - star_pos - 1)
+        (star_pos + 1, 1, len)
     } else {
-        (pattern.len(), 0)
+        (len, 0, len)
     }
 }
 
 /// Find the most-specific pattern entry that matches `target`.
 ///
-/// Iterates `patterns` in order and returns the entry whose `(prefix_len, suffix_len)`
-/// specificity is largest. Equal-specificity ties resolve to the first entry in
-/// iteration order — callers must use an insertion-order map (`IndexMap`) to get
-/// deterministic JSON-source-order tie-breaking per the Node.js/TypeScript spec.
-type BestExportPatternEntry<'a> = ((usize, usize), &'a str, String, &'a PackageExports);
+/// Iterates `patterns` in order and returns the entry whose
+/// [`export_pattern_specificity`] ranking is largest. Equal-ranking ties resolve
+/// to the first entry in iteration order — callers must use an insertion-order
+/// map (`IndexMap`) to get deterministic JSON-source-order tie-breaking per the
+/// Node.js/TypeScript spec.
+type BestExportPatternEntry<'a> = ((usize, usize, usize), &'a str, String, &'a PackageExports);
 
 pub(crate) fn find_best_export_pattern<'a>(
     patterns: impl Iterator<Item = (&'a String, &'a PackageExports)>,
@@ -739,6 +751,69 @@ mod tests {
     use super::*;
     use serde_json::json;
     use tempfile::tempdir;
+
+    /// Pick the winning key from `keys` for `subpath`, returning the key text.
+    /// Mirrors how the resolver calls `find_best_export_pattern` over a subpath
+    /// `IndexMap`, but keeps the test free of filesystem probing.
+    fn best_key<'a>(keys: &'a [&'a str], subpath: &str) -> Option<&'a str> {
+        // A stable dummy value per key — only the selected *key* matters here.
+        let entries: IndexMap<String, PackageExports> = keys
+            .iter()
+            .map(|k| (k.to_string(), PackageExports::String(String::new())))
+            .collect();
+        find_best_export_pattern(entries.iter(), |p| match_export_pattern(p, subpath))
+            .map(|(pattern, _, _)| keys.iter().copied().find(|k| *k == pattern).unwrap())
+    }
+
+    #[test]
+    fn export_pattern_specificity_mirrors_pattern_key_compare() {
+        // Wildcard key: base = indexOf('*') + 1, flagged as a pattern.
+        assert_eq!(export_pattern_specificity("./*"), (3, 1, 3));
+        assert_eq!(export_pattern_specificity("./lib/*"), (7, 1, 7));
+        assert_eq!(export_pattern_specificity("./*.js"), (3, 1, 6));
+        // Directory / exact key: base = full length, not a pattern.
+        assert_eq!(export_pattern_specificity("./"), (2, 0, 2));
+        assert_eq!(export_pattern_specificity("./lib/"), (6, 0, 6));
+        assert_eq!(export_pattern_specificity("./foo"), (5, 0, 5));
+    }
+
+    #[test]
+    fn find_best_export_pattern_prefers_wildcard_over_equal_base_directory_either_order() {
+        // `"./*"` (base 3) must beat `"./"` (base 2) for `./foo`, no matter the
+        // JSON declaration order. Before the PATTERN_KEY_COMPARE fix these tied
+        // on `(prefix_len, suffix_len)` and the winner flipped with key order,
+        // resolving the same specifier to different physical files between rows.
+        assert_eq!(best_key(&["./", "./*"], "./foo"), Some("./*"));
+        assert_eq!(best_key(&["./*", "./"], "./foo"), Some("./*"));
+    }
+
+    #[test]
+    fn find_best_export_pattern_longer_directory_base_beats_short_wildcard() {
+        // A longer anchored directory prefix is more specific than a short
+        // wildcard (Node orders by base length first): `"./lib/"` (base 6) wins
+        // over `"./*"` (base 3) for `./lib/x`, independent of order.
+        assert_eq!(best_key(&["./*", "./lib/"], "./lib/x"), Some("./lib/"));
+        assert_eq!(best_key(&["./lib/", "./*"], "./lib/x"), Some("./lib/"));
+        // …but a wildcard with an even longer base reclaims the win.
+        assert_eq!(best_key(&["./lib/", "./lib/*"], "./lib/x"), Some("./lib/*"));
+        assert_eq!(best_key(&["./lib/*", "./lib/"], "./lib/x"), Some("./lib/*"));
+    }
+
+    #[test]
+    fn find_best_export_pattern_orders_wildcards_by_base_then_total_length() {
+        // Longer prefix before `*` wins.
+        assert_eq!(
+            best_key(&["./*", "./feature/*"], "./feature/btn"),
+            Some("./feature/*")
+        );
+        assert_eq!(
+            best_key(&["./feature/*", "./*"], "./feature/btn"),
+            Some("./feature/*")
+        );
+        // Equal base length → longer total (longer suffix) wins.
+        assert_eq!(best_key(&["./*", "./*.js"], "./a.js"), Some("./*.js"));
+        assert_eq!(best_key(&["./*.js", "./*"], "./a.js"), Some("./*.js"));
+    }
 
     #[test]
     fn types_versions_compiler_version_uses_trimmed_value_and_fallback() {


### PR DESCRIPTION
## Agent
AgentName: M4-D

## Track
Track 7 — module resolution / alias parity (module-resolution lane).

## Invariant
When multiple `package.json` `exports`/`imports` subpath keys match a specifier, tsz selects the most specific key by Node.js `PATTERN_KEY_COMPARE` (tsc's `comparePatternKeys`) — base length first, then wildcard-over-directory, then total key length — so selection is **independent of JSON declaration order** and matches `tsc`.

## Scope
Fixes #10897.

**Structural rule:** When several `exports`/`imports` subpath keys match, `tsc` orders them by `PATTERN_KEY_COMPARE`: base length (`indexOf('*') + 1` for a single-`*` key, full length for a non-wildcard/directory key), then a `*`-pattern key outranks an equal-base directory/exact key, then longer total key length wins. tsz must do the same through the shared `find_best_export_pattern` chokepoint.

**Wrong operation (before):** `export_pattern_specificity` ranked matched keys by `(prefix_len, suffix_len)`. For subpath `./foo`, both `"./"` and `"./*"` scored `(2, 0)`, so the tie fell back to JSON key order. A package declaring `"./"` before `"./*"` resolved `./foo` to the directory target (`./src/foo`); the reverse order resolved it to the wildcard target (`./dist/foo`). Same specifier → **different physical files depending on key order** — the "subpath pattern mapping chooses different physical files between rows" divergence.

**Fix / owner layer:** `crates/tsz-core/src/resolution/helpers.rs::export_pattern_specificity` now returns `(base_length, is_pattern, total_length)`, compared lexicographically. The `is_pattern` term breaks equal-base ties toward the wildcard (Node rules 7–8), so `"./*"` (base 3) always beats `"./"` (base 2) regardless of order. This is the single shared ranking helper used by `find_best_export_pattern`, so both `exports` (Node16/NodeNext/Bundler) and `imports` (`#`-specifiers) resolution are fixed at one chokepoint — no special cases added.

**Adjacent cases covered:**
- Equal-base directory vs wildcard → wildcard wins, both declaration orders.
- Longer directory base (`"./lib/"`) beats short wildcard (`"./*"`); a longer-base wildcard (`"./lib/*"`) reclaims the win.
- Two wildcards: longer prefix wins; equal prefix → longer suffix wins (`"./*.js"` over `"./*"`).
- `typesVersions` ranking is intentionally left untouched (it uses prefix-only ordering and has no wildcard-vs-directory rule).

## Project Corpus Impact
- Row: utility-types-project (issue target row); broadly any row using `package.json#exports`/`#imports` subpath patterns.
- Bug family: module-resolution / subpath pattern selection.
- Effect: deterministic, order-independent target selection; eliminates row-to-row physical-file drift for pattern exports.

## Verification
- `cargo test -p tsz-core --lib -- resolution::helpers::tests module_resolver::tests::pattern_matching module_resolver::tests::package_exports_imports` → 54 passed, 0 failed.
- `cargo clippy -p tsz-core --tests` → no warnings in changed files (the one pre-existing `type_complexity` lint is in unrelated `path_mapping.rs`, present on `main`, and triggered only by this container's newer clippy 1.94.0).
- New tests:
  - unit: `export_pattern_specificity_mirrors_pattern_key_compare`, `find_best_export_pattern_prefers_wildcard_over_equal_base_directory_either_order`, `find_best_export_pattern_longer_directory_base_beats_short_wildcard`, `find_best_export_pattern_orders_wildcards_by_base_then_total_length`.
  - integration: `test_wildcard_export_beats_directory_key_independent_of_declaration_order` (both key orders resolve to the same physical file).

## Coordination Notes
- Branch fast-forwarded onto current `main` before commit; no conflicts (diff is the three `tsz-core` files only).
- No anti-hardcoding concerns: no user-name/file-name literals, no diagnostic-string predicates; ranking is purely structural over key shape.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9eY4D8EYzBpUo3ksd6FQE)_