### PR TITLE
fix(resolution): flatten duplicate-package redirect chains and make build order-independent

### DIFF
--- a/crates/tsz-cli/src/driver/resolution/path_resolution.rs
+++ b/crates/tsz-cli/src/driver/resolution/path_resolution.rs
@@ -647,27 +647,42 @@ pub(crate) fn is_root_alias_symlink(dir: &Path) -> bool {
 }
 
 /// Build a redirect map for duplicate packages (same name+version at different
-/// `node_modules` paths). The shallowest copy becomes canonical.
+/// `node_modules` paths). Every non-canonical copy redirects directly to the
+/// rank-winning canonical copy.
+///
+/// Rank is `(node_modules-depth, normalized-path)`: the shallowest copy wins,
+/// with lexical path used as a deterministic tie-break. The function sorts the
+/// discovered package roots by rank first, then sweeps once — within each
+/// contiguous `(name, version)` run the first entry is the canonical winner
+/// and every later entry redirects straight to it. The sort makes this a
+/// pure function of the input file set (no `FxHashSet` iteration order leaks
+/// in) and the rank-ordered sweep skips the stale-chain hazard an
+/// "encounter order" loop has to fix up after the fact.
 pub(crate) fn build_duplicate_package_redirects(
     file_names: &[String],
     options: &ResolvedCompilerOptions,
 ) -> FxHashMap<PathBuf, PathBuf> {
-    use std::collections::hash_map::Entry;
-
-    let mut canonical_packages: FxHashMap<(String, String), (PathBuf, usize)> =
-        FxHashMap::default();
+    // Map each input file to its `node_modules` package root once. The
+    // file-redirect pass below reuses these without re-walking the path.
+    let mut file_pkg_roots: Vec<Option<PathBuf>> = Vec::with_capacity(file_names.len());
     let mut package_roots: FxHashSet<PathBuf> = FxHashSet::default();
     for file_name in file_names {
-        if let Some(pkg_root) = find_node_modules_package_root(Path::new(file_name)) {
-            package_roots.insert(pkg_root);
+        let pkg_root = find_node_modules_package_root(Path::new(file_name));
+        if let Some(ref root) = pkg_root {
+            package_roots.insert(root.clone());
         }
+        file_pkg_roots.push(pkg_root);
     }
 
     for root in &package_roots {
         tracing::debug!(target: "tsz::dup_pkg", root = %root.display(), "found package root");
     }
 
-    let mut root_redirects: FxHashMap<PathBuf, PathBuf> = FxHashMap::default();
+    // Pre-resolve each package root's `(name, version)` identity. The sort
+    // key adds `(node_modules-depth, normalized-path)` as the rank tie-break,
+    // computed once per root via `sort_by_cached_key` instead of on every
+    // comparator call.
+    let mut root_identities: Vec<(PathBuf, String, String)> = Vec::new();
     for pkg_root in &package_roots {
         let pkg_json_path = pkg_root.join("package.json");
         let (name, version) = match std::fs::read_to_string(&pkg_json_path) {
@@ -688,57 +703,65 @@ pub(crate) fn build_duplicate_package_redirects(
             }
         };
         tracing::debug!(target: "tsz::dup_pkg", name = %name, version = %version, root = %pkg_root.display(), "package found");
+        root_identities.push((pkg_root.clone(), name, version));
+    }
+    root_identities.sort_by_cached_key(|(pkg_root, name, version)| {
         let depth = pkg_root
             .components()
             .filter(|c| c.as_os_str() == "node_modules")
             .count();
-        match canonical_packages.entry((name, version)) {
-            Entry::Vacant(e) => {
-                e.insert((pkg_root.clone(), depth));
+        (
+            name.clone(),
+            version.clone(),
+            depth,
+            normalize_resolved_path(pkg_root, options)
+                .to_string_lossy()
+                .into_owned(),
+        )
+    });
+
+    // Within each `(name, version)` run the first element is canonical and
+    // every later element redirects directly to it. `chunk_by` makes the run
+    // structure explicit and removes the manual `last_key`/`canonical_root`
+    // trackers a fold-style sweep would need.
+    let mut root_redirects: FxHashMap<PathBuf, PathBuf> = FxHashMap::default();
+    for run in root_identities.chunk_by(|left, right| left.1 == right.1 && left.2 == right.2) {
+        let [(canon, ..), rest @ ..] = run else {
+            continue;
+        };
+        for (pkg_root, _, _) in rest {
+            if pkg_root == canon {
+                continue;
             }
-            Entry::Occupied(mut e) => {
-                let (existing_root, existing_depth) = e.get().clone();
-                let current_rank = (
-                    depth,
-                    normalize_resolved_path(pkg_root, options)
-                        .to_string_lossy()
-                        .into_owned(),
-                );
-                let existing_rank = (
-                    existing_depth,
-                    normalize_resolved_path(&existing_root, options)
-                        .to_string_lossy()
-                        .into_owned(),
-                );
-                if current_rank < existing_rank {
-                    root_redirects.insert(existing_root, pkg_root.clone());
-                    e.insert((pkg_root.clone(), depth));
-                } else {
-                    root_redirects.insert(pkg_root.clone(), existing_root);
-                }
-            }
+            root_redirects.insert(pkg_root.clone(), canon.clone());
         }
-    }
-    if root_redirects.is_empty() {
-        return FxHashMap::default();
     }
     for (from, to) in &root_redirects {
         tracing::debug!(target: "tsz::dup_pkg", from = %from.display(), to = %to.display(), "root redirect");
     }
+    // Cache `normalize_resolved_path(canonical_root)` per redirected root.
+    // `normalize_resolved_path` calls `canonicalize` + walks every ancestor
+    // looking for symlinks, so the cache turns N files-under-one-package into
+    // one canonicalize per package instead of one per file.
+    let mut normalized_canonical: FxHashMap<&Path, PathBuf> = FxHashMap::default();
     let mut file_redirects: FxHashMap<PathBuf, PathBuf> = FxHashMap::default();
-    for file_name in file_names {
+    for (file_name, pkg_root) in file_names.iter().zip(file_pkg_roots.iter()) {
+        let Some(pkg_root) = pkg_root else { continue };
+        let Some(canonical_root) = root_redirects.get(pkg_root) else {
+            continue;
+        };
         let file_path = Path::new(file_name);
-        if let Some(pkg_root) = find_node_modules_package_root(file_path)
-            && let Some(canonical_root) = root_redirects.get(&pkg_root)
-            && let Ok(relative) = file_path.strip_prefix(&pkg_root)
-        {
-            let canonical_file = canonical_root.join(relative);
-            let from = normalize_resolved_path(file_path, options);
-            let to = normalize_resolved_path(&canonical_file, options);
-            tracing::debug!(target: "tsz::dup_pkg", from = %from.display(), to = %to.display(), "file redirect");
-            if from != to {
-                file_redirects.insert(from, to);
-            }
+        let Ok(relative) = file_path.strip_prefix(pkg_root) else {
+            continue;
+        };
+        let canonical_root_normalized = normalized_canonical
+            .entry(canonical_root.as_path())
+            .or_insert_with(|| normalize_resolved_path(canonical_root, options));
+        let to = canonical_root_normalized.join(relative);
+        let from = normalize_resolved_path(file_path, options);
+        tracing::debug!(target: "tsz::dup_pkg", from = %from.display(), to = %to.display(), "file redirect");
+        if from != to {
+            file_redirects.insert(from, to);
         }
     }
     file_redirects

--- a/crates/tsz-cli/src/driver/resolution_tests.rs
+++ b/crates/tsz-cli/src/driver/resolution_tests.rs
@@ -462,6 +462,146 @@ fn test_duplicate_package_redirects_prefer_stable_lexical_root_when_depth_ties()
     let _ = fs::remove_dir_all(&dir);
 }
 
+/// Stand up three duplicate-package copies at the given `node_modules`
+/// sub-paths, each tagged with `name`/`version` so
+/// `build_duplicate_package_redirects` groups them. Returns the per-copy
+/// `index.d.ts` paths in input order.
+fn make_duplicate_package_copies(
+    dir: &Path,
+    name: &str,
+    version: &str,
+    relative_roots: [&str; 3],
+) -> [PathBuf; 3] {
+    let pkg_json = format!(r#"{{"name":"{name}","version":"{version}"}}"#);
+    let mut indices: [PathBuf; 3] = Default::default();
+    for (i, rel) in relative_roots.iter().enumerate() {
+        let pkg_dir = dir.join(rel);
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        std::fs::write(pkg_dir.join("package.json"), &pkg_json).unwrap();
+        std::fs::write(pkg_dir.join("index.d.ts"), "export {};").unwrap();
+        indices[i] = pkg_dir.join("index.d.ts");
+    }
+    indices
+}
+
+fn dup_pkg_resolver_options() -> ResolvedCompilerOptions {
+    ResolvedCompilerOptions {
+        module_suffixes: vec![String::new()],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn test_duplicate_package_redirects_flatten_chains_to_final_canonical_root() {
+    // Three duplicate package copies at three distinct depths. Iteration over
+    // the package-roots set is hash-order, so any intermediate "winner" must
+    // not leave a stale redirect pointing at it: every non-canonical copy
+    // must rewrite directly to the depth-1 canonical, regardless of which
+    // order the build pass visited them.
+    use std::fs;
+
+    let dir = std::env::temp_dir().join("tsz_driver_resolution_duplicate_package_chain");
+    let _ = fs::remove_dir_all(&dir);
+
+    let [file1, file2, file3] = make_duplicate_package_copies(
+        &dir,
+        "pkg",
+        "2.3.4",
+        [
+            "node_modules/pkg",
+            "node_modules/host/node_modules/pkg",
+            "node_modules/host/node_modules/sub/node_modules/pkg",
+        ],
+    );
+
+    let options = dup_pkg_resolver_options();
+
+    let redirects = build_duplicate_package_redirects(
+        &[
+            file1.display().to_string(),
+            file2.display().to_string(),
+            file3.display().to_string(),
+        ],
+        &options,
+    );
+
+    let canonical1 = canonicalize_or_owned(&file1);
+    let canonical2 = canonicalize_or_owned(&file2);
+    let canonical3 = canonicalize_or_owned(&file3);
+
+    assert!(
+        !redirects.contains_key(&canonical1),
+        "the depth-1 canonical copy must never redirect away from itself, got: {redirects:?}"
+    );
+    assert_eq!(
+        redirects.get(&canonical2),
+        Some(&canonical1),
+        "depth-2 copy must redirect directly to the depth-1 canonical (no chains), got: {redirects:?}"
+    );
+    assert_eq!(
+        redirects.get(&canonical3),
+        Some(&canonical1),
+        "depth-3 copy must redirect directly to the depth-1 canonical (no chains), got: {redirects:?}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_duplicate_package_redirects_deterministic_across_input_orders() {
+    // The redirect map must be a pure function of the input file set: shuffling
+    // the input order must produce the same redirect map. This guards against
+    // hash-set iteration order leaking into the canonical-root choice.
+    use std::fs;
+
+    let dir = std::env::temp_dir().join("tsz_driver_resolution_duplicate_package_determinism");
+    let _ = fs::remove_dir_all(&dir);
+
+    let [file1_path, file2_path, file3_path] = make_duplicate_package_copies(
+        &dir,
+        "det-pkg",
+        "0.1.0",
+        [
+            "node_modules/det-pkg",
+            "node_modules/wrap/node_modules/det-pkg",
+            "node_modules/wrap/node_modules/inner/node_modules/det-pkg",
+        ],
+    );
+
+    let options = dup_pkg_resolver_options();
+
+    let file1 = file1_path.display().to_string();
+    let file2 = file2_path.display().to_string();
+    let file3 = file3_path.display().to_string();
+
+    // The pure-function property is "any reordering yields the same map".
+    // Three representative orderings cover the regression: sorted, reversed,
+    // and a rotation that visits the depth-3 (deepest) copy first — the
+    // ordering that originally exposed the stale-chain redirect bug.
+    let permutations = [
+        [file1.clone(), file2.clone(), file3.clone()],
+        [file3.clone(), file2.clone(), file1.clone()],
+        [file3, file1, file2],
+    ];
+
+    let mut maps = Vec::new();
+    for inputs in &permutations {
+        let map = build_duplicate_package_redirects(inputs, &options);
+        let mut entries: Vec<(PathBuf, PathBuf)> = map.into_iter().collect();
+        entries.sort();
+        maps.push(entries);
+    }
+    let first = &maps[0];
+    for (i, m) in maps.iter().enumerate().skip(1) {
+        assert_eq!(
+            first, m,
+            "duplicate-package redirects must not depend on input order; permutation {i} diverged"
+        );
+    }
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn test_exports_runtime_targets_substitute_matching_declaration_sidecars() {
     use std::fs;

--- a/crates/tsz-cli/src/lib.rs
+++ b/crates/tsz-cli/src/lib.rs
@@ -40,6 +40,9 @@ mod driver_tests;
 #[path = "../tests/driver_tests_ts2307.rs"]
 mod driver_tests_ts2307;
 #[cfg(test)]
+#[path = "../tests/dual_package_exports_tests.rs"]
+mod dual_package_exports_tests;
+#[cfg(test)]
 #[path = "../tests/fs_tests.rs"]
 mod fs_tests;
 #[cfg(test)]

--- a/crates/tsz-cli/tests/dual_package_exports_tests.rs
+++ b/crates/tsz-cli/tests/dual_package_exports_tests.rs
@@ -1,0 +1,535 @@
+//! Regression tests for dual-package `exports` resolution under Node16/NodeNext
+//! and `Bundler` resolution.
+//!
+//! Structural rule:
+//! When a package author writes a `package.json` with a `"types"` field, a
+//! top-level `"types"` condition, or a nested `{ "types": ... }` branch inside
+//! `"import"`/`"require"`, every successful resolution must produce a single
+//! canonical declaration file per importer mode. Repeated lookups for the same
+//! `(importer, specifier)` must converge on a stable resolved path, and ESM
+//! and CJS importers that share a single types entry must reach the same
+//! physical file rather than two declaration siblings.
+//!
+//! Owner layer: `crates/tsz-core/src/module_resolver/exports_imports.rs`
+//! (conditional-export traversal) and
+//! `crates/tsz-cli/src/driver/resolution/path_resolution.rs`
+//! (path normalization + duplicate-package redirect map).
+//!
+//! These tests drive the full CLI compile pipeline so they exercise the same
+//! resolver, source-discovery, binder, and checker paths as a real `tsz` run.
+
+use super::args::CliArgs;
+use super::driver::compile;
+use clap::Parser;
+use std::path::Path;
+use tsz_common::diagnostics::Diagnostic;
+
+fn write_file(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("failed to create parent directory");
+    }
+    std::fs::write(path, contents).expect("failed to write file");
+}
+
+fn parse_args(args: &[&str]) -> CliArgs {
+    CliArgs::try_parse_from(args).expect("test args should parse")
+}
+
+/// Diagnostic codes that surface when one logical module ends up bound under
+/// two declaration IDs. Used by every dual-package test in this file to
+/// assert the resolver kept a single canonical identity per `(importer,
+/// specifier)`.
+const DUPLICATE_DECLARATION_CODES: [u32; 4] = [2300, 2308, 2484, 2649];
+
+fn assert_no_duplicate_declaration_diags(diagnostics: &[Diagnostic], context: &str) {
+    let duplicates: Vec<_> = diagnostics
+        .iter()
+        .filter(|diag| DUPLICATE_DECLARATION_CODES.contains(&diag.code))
+        .collect();
+    assert!(
+        duplicates.is_empty(),
+        "{context}: dual-package resolution must keep one declaration identity, got: {duplicates:#?}"
+    );
+}
+
+/// Write a Node16/NodeNext-flavored `tsconfig.json` that drives the dual-package
+/// resolver paths the tests below exercise. `module_kind` is the value used for
+/// both the `module` and `moduleResolution` fields, matching how tsc treats
+/// node16 and nodenext as a paired switch.
+fn write_node16_tsconfig(base: &Path, module_kind: &str, files: &[&str]) {
+    let files_json = files
+        .iter()
+        .map(|f| format!("\"{f}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    write_file(
+        &base.join("tsconfig.json"),
+        &format!(
+            r#"{{
+          "compilerOptions": {{
+            "module": "{module_kind}",
+            "moduleResolution": "{module_kind}",
+            "target": "es2022",
+            "strict": true,
+            "noEmit": true
+          }},
+          "files": [{files_json}]
+        }}"#
+        ),
+    );
+}
+
+/// When a dual-package author lists `"types"` ahead of `"import"`/`"require"`
+/// inside a single `exports` conditional, every importer (ESM `.mts`, CJS
+/// `.cts`, neutral `.ts`) must resolve to the single shared declaration file.
+/// No duplicate-symbol diagnostic (TS2300, TS2308, TS2484, TS2649) may fire,
+/// and no TS2305 (no exported member) may surface for the named imports.
+#[test]
+fn dual_package_shared_types_condition_resolves_once_for_every_module_kind() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_node16_tsconfig(base, "node16", &["main.mts", "main.cts", "main.ts"]);
+
+    write_file(
+        &base.join("node_modules/shared-pkg/package.json"),
+        r#"{
+          "name": "shared-pkg",
+          "version": "1.0.0",
+          "type": "module",
+          "exports": {
+            ".": {
+              "types": "./shared/index.d.ts",
+              "import": "./esm/index.js",
+              "require": "./cjs/index.cjs"
+            }
+          }
+        }"#,
+    );
+    write_file(
+        &base.join("node_modules/shared-pkg/shared/index.d.ts"),
+        "export interface Greeter { greet(): string; }\nexport declare const banner: \"shared\";\n",
+    );
+    write_file(
+        &base.join("node_modules/shared-pkg/esm/index.js"),
+        "export const banner = 'shared';\nexport class Impl { greet() { return banner; } }\n",
+    );
+    write_file(
+        &base.join("node_modules/shared-pkg/cjs/index.cjs"),
+        "exports.banner = 'shared';\nexports.Impl = class { greet() { return exports.banner; } };\n",
+    );
+
+    let importer = "import { banner, Greeter } from 'shared-pkg';\nconst _b: typeof banner = 'shared';\nexport const value: Greeter = { greet: () => _b };\n";
+    write_file(&base.join("main.mts"), importer);
+    write_file(&base.join("main.cts"), importer);
+    write_file(&base.join("main.ts"), importer);
+
+    let args = parse_args(&["tsz", "--noEmit"]);
+    let result = compile(&args, base).expect("compile should succeed");
+
+    assert_no_duplicate_declaration_diags(&result.diagnostics, "shared types entry");
+
+    let missing_member: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|diag| diag.code == 2305 && diag.message_text.contains("shared-pkg"))
+        .collect();
+    assert!(
+        missing_member.is_empty(),
+        "shared types entry must expose `banner`/`Greeter` to every importer, got: {missing_member:#?}"
+    );
+}
+
+/// When a package places the `"types"` condition INSIDE each
+/// `"import"`/`"require"` branch and the two branches point at distinct
+/// declaration files, an ESM importer must select the import-branch types and
+/// a CJS importer must select the require-branch types. Each branch is its
+/// own module — neither importer may end up loading both branches' declaration
+/// files, and no spurious TS2300/TS2305 may surface from the conditional fan
+/// out.
+#[test]
+fn dual_package_nested_types_branches_route_per_importer_mode_without_dup() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_node16_tsconfig(base, "node16", &["esm-side.mts", "cjs-side.cts"]);
+
+    write_file(
+        &base.join("node_modules/split-pkg/package.json"),
+        r#"{
+          "name": "split-pkg",
+          "version": "1.0.0",
+          "type": "module",
+          "exports": {
+            ".": {
+              "import": {
+                "types": "./esm/index.d.ts",
+                "default": "./esm/index.js"
+              },
+              "require": {
+                "types": "./cjs/index.d.cts",
+                "default": "./cjs/index.cjs"
+              }
+            }
+          }
+        }"#,
+    );
+    write_file(
+        &base.join("node_modules/split-pkg/esm/index.d.ts"),
+        "export declare const flavor: 'esm';\nexport declare function describe(): 'esm';\n",
+    );
+    write_file(
+        &base.join("node_modules/split-pkg/esm/index.js"),
+        "export const flavor = 'esm';\nexport function describe() { return flavor; }\n",
+    );
+    write_file(
+        &base.join("node_modules/split-pkg/cjs/index.d.cts"),
+        "export declare const flavor: 'cjs';\nexport declare function describe(): 'cjs';\n",
+    );
+    write_file(
+        &base.join("node_modules/split-pkg/cjs/index.cjs"),
+        "exports.flavor = 'cjs';\nexports.describe = () => exports.flavor;\n",
+    );
+
+    write_file(
+        &base.join("esm-side.mts"),
+        "import { flavor, describe } from 'split-pkg';\nconst _f: 'esm' = flavor;\nexport const out = describe();\n",
+    );
+    write_file(
+        &base.join("cjs-side.cts"),
+        "import { flavor, describe } from 'split-pkg';\nconst _f: 'cjs' = flavor;\nexport const out = describe();\n",
+    );
+
+    let args = parse_args(&["tsz", "--noEmit"]);
+    let result = compile(&args, base).expect("compile should succeed");
+
+    assert_no_duplicate_declaration_diags(&result.diagnostics, "per-mode types branches");
+
+    let no_exported_member: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|diag| diag.code == 2305)
+        .collect();
+    assert!(
+        no_exported_member.is_empty(),
+        "per-mode types branches must each expose `flavor` and `describe`, got TS2305: {no_exported_member:#?}"
+    );
+
+    let flavor_conflict: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|diag| diag.code == 2322 && diag.message_text.contains("flavor"))
+        .collect();
+    assert!(
+        flavor_conflict.is_empty(),
+        "ESM and CJS branches must each return their own `flavor` literal, got: {flavor_conflict:#?}"
+    );
+}
+
+/// Repeated imports of the same dual-package specifier from a single file must
+/// converge on one resolved declaration ID. The structural guarantee here is
+/// that the resolver caches `(importer, specifier)` lookups deterministically;
+/// regressing it would re-bind the same module multiple times and surface as
+/// duplicate-identifier diagnostics or shifting `resolvedModule` paths.
+#[test]
+fn dual_package_repeated_import_is_idempotent() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_node16_tsconfig(base, "node16", &["main.mts"]);
+
+    write_file(
+        &base.join("node_modules/repeat-pkg/package.json"),
+        r#"{
+          "name": "repeat-pkg",
+          "version": "1.0.0",
+          "type": "module",
+          "main": "./esm/index.js",
+          "types": "./esm/index.d.ts",
+          "exports": {
+            ".": {
+              "types": "./esm/index.d.ts",
+              "import": "./esm/index.js"
+            }
+          }
+        }"#,
+    );
+    write_file(
+        &base.join("node_modules/repeat-pkg/esm/index.d.ts"),
+        "export declare const tag: 'repeat';\nexport interface Shape { kind: 'repeat'; }\n",
+    );
+    write_file(
+        &base.join("node_modules/repeat-pkg/esm/index.js"),
+        "export const tag = 'repeat';\n",
+    );
+
+    write_file(
+        &base.join("main.mts"),
+        r#"import { tag, Shape } from 'repeat-pkg';
+import type { Shape as Shape2 } from 'repeat-pkg';
+import { tag as tag2 } from 'repeat-pkg';
+
+const _a: Shape = { kind: tag };
+const _b: Shape2 = { kind: tag2 };
+export const out = _a.kind === _b.kind;
+"#,
+    );
+
+    let args = parse_args(&["tsz", "--noEmit"]);
+    let result = compile(&args, base).expect("compile should succeed");
+
+    assert_no_duplicate_declaration_diags(&result.diagnostics, "repeated dual-package imports");
+
+    let shape_errors: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|diag| {
+            diag.code == 2322
+                || diag.code == 2345
+                || (diag.code == 2305 && diag.message_text.contains("repeat-pkg"))
+        })
+        .collect();
+    assert!(
+        shape_errors.is_empty(),
+        "`Shape` and `Shape2` must refer to the same declaration, got: {shape_errors:#?}"
+    );
+}
+
+/// `Bundler` resolution shares the same `resolve_package_exports_with_conditions`
+/// traversal as Node16/NodeNext, so the dual-package guarantees must also hold
+/// when the importer's effective resolution kind is `bundler`. This guards
+/// against regressions where bundler mode silently drops a `types` branch and
+/// falls back to probing a sibling `.d.ts` next to the runtime entry, creating
+/// a second declaration file for a single module specifier.
+#[test]
+fn dual_package_bundler_resolution_keeps_single_declaration_identity() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "module": "preserve",
+            "moduleResolution": "bundler",
+            "target": "es2022",
+            "strict": true,
+            "noEmit": true
+          },
+          "files": ["main.ts"]
+        }"#,
+    );
+
+    write_file(
+        &base.join("node_modules/bundler-pkg/package.json"),
+        r#"{
+          "name": "bundler-pkg",
+          "version": "1.0.0",
+          "exports": {
+            ".": {
+              "types": "./types/index.d.ts",
+              "import": "./dist/index.mjs",
+              "require": "./dist/index.cjs",
+              "default": "./dist/index.js"
+            }
+          }
+        }"#,
+    );
+    write_file(
+        &base.join("node_modules/bundler-pkg/types/index.d.ts"),
+        "export declare const id: number;\nexport interface Wrapped { id: number }\n",
+    );
+    // Sibling .d.ts files next to runtime entries. The resolver must NOT pick
+    // these up — picking either would produce a second declaration identity
+    // that collides with the canonical `types/index.d.ts`.
+    write_file(
+        &base.join("node_modules/bundler-pkg/dist/index.d.ts"),
+        "export declare const id: string;\nexport interface Wrapped { id: string }\n",
+    );
+    write_file(
+        &base.join("node_modules/bundler-pkg/dist/index.d.mts"),
+        "export declare const id: string;\nexport interface Wrapped { id: string }\n",
+    );
+    write_file(
+        &base.join("node_modules/bundler-pkg/dist/index.d.cts"),
+        "export declare const id: string;\nexport interface Wrapped { id: string }\n",
+    );
+    write_file(
+        &base.join("node_modules/bundler-pkg/dist/index.mjs"),
+        "export const id = 1;\n",
+    );
+    write_file(
+        &base.join("node_modules/bundler-pkg/dist/index.cjs"),
+        "exports.id = 1;\n",
+    );
+    write_file(
+        &base.join("node_modules/bundler-pkg/dist/index.js"),
+        "export const id = 1;\n",
+    );
+
+    write_file(
+        &base.join("main.ts"),
+        r#"import { id, Wrapped } from 'bundler-pkg';
+const _n: number = id;
+export const out: Wrapped = { id };
+"#,
+    );
+
+    let args = parse_args(&["tsz", "--noEmit"]);
+    let result = compile(&args, base).expect("compile should succeed");
+
+    assert_no_duplicate_declaration_diags(&result.diagnostics, "bundler-mode dual-package");
+
+    // The `types` branch (a `number`) must win over any sibling `.d.ts` (a
+    // `string`). If the resolver drifted to a sibling, `_n: number = id` would
+    // surface TS2322.
+    let type_mismatch: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|diag| {
+            (diag.code == 2322 || diag.code == 2345)
+                && (diag.file.ends_with("main.ts") || diag.file.contains("main.ts"))
+        })
+        .collect();
+    assert!(
+        type_mismatch.is_empty(),
+        "bundler-mode dual-package must use the `types` branch (number), got: {type_mismatch:#?}"
+    );
+}
+
+/// Subpath dual-package exports (`./feature`) must also converge on a single
+/// declaration file per importer mode. This guards against the failure mode
+/// where the subpath probe falls through to a `typesVersions` fallback after
+/// already resolving an exports-map subpath, causing the same declaration to
+/// be reached via two distinct paths and bound twice.
+#[test]
+fn dual_package_subpath_resolution_keeps_single_declaration_identity() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_node16_tsconfig(base, "node16", &["main.mts", "main.cts"]);
+
+    write_file(
+        &base.join("node_modules/sub-pkg/package.json"),
+        r#"{
+          "name": "sub-pkg",
+          "version": "1.0.0",
+          "type": "module",
+          "exports": {
+            "./feature": {
+              "types": "./types/feature.d.ts",
+              "import": "./esm/feature.js",
+              "require": "./cjs/feature.cjs"
+            }
+          }
+        }"#,
+    );
+    write_file(
+        &base.join("node_modules/sub-pkg/types/feature.d.ts"),
+        "export declare function compute(value: number): number;\nexport interface Feature { compute: typeof compute }\n",
+    );
+    write_file(
+        &base.join("node_modules/sub-pkg/esm/feature.js"),
+        "export function compute(value) { return value + 1; }\n",
+    );
+    write_file(
+        &base.join("node_modules/sub-pkg/cjs/feature.cjs"),
+        "exports.compute = (value) => value + 1;\n",
+    );
+
+    let importer = "import { compute, Feature } from 'sub-pkg/feature';\nconst _x: number = compute(1);\nexport const out: Feature = { compute };\n";
+    write_file(&base.join("main.mts"), importer);
+    write_file(&base.join("main.cts"), importer);
+
+    let args = parse_args(&["tsz", "--noEmit"]);
+    let result = compile(&args, base).expect("compile should succeed");
+
+    assert_no_duplicate_declaration_diags(&result.diagnostics, "subpath dual-package exports");
+
+    let missing: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|diag| diag.code == 2305)
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "subpath dual-package exports must expose `compute`/`Feature`, got TS2305: {missing:#?}"
+    );
+}
+
+/// pnpm-style layout: a single physical declaration file under
+/// `node_modules/.pnpm/<pkg>@<ver>/node_modules/<pkg>/` is symlinked into the
+/// project's `node_modules/<pkg>/`. Both forms of the path must resolve to
+/// the same logical declaration identity. Without correct symlink handling
+/// the two paths become two file indices and the shared exports get bound
+/// twice, surfacing as duplicate-declaration diagnostics or as TS2322 when
+/// a single `Shape` value is assigned through both views.
+#[cfg(unix)]
+#[test]
+fn dual_package_pnpm_style_symlink_keeps_single_declaration_identity() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    let real_pkg = base.join("node_modules/.pnpm/sym-pkg@1.0.0/node_modules/sym-pkg");
+    std::fs::create_dir_all(&real_pkg).expect("create real pkg dir");
+    let real_pkg_esm = real_pkg.join("esm");
+    std::fs::create_dir_all(&real_pkg_esm).expect("create esm dir");
+
+    write_file(
+        &real_pkg.join("package.json"),
+        r#"{
+          "name": "sym-pkg",
+          "version": "1.0.0",
+          "type": "module",
+          "exports": {
+            ".": {
+              "types": "./esm/index.d.ts",
+              "import": "./esm/index.js"
+            }
+          }
+        }"#,
+    );
+    write_file(
+        &real_pkg_esm.join("index.d.ts"),
+        "export interface Shape { kind: 'pnpm' }\nexport declare const tag: 'pnpm';\n",
+    );
+    write_file(
+        &real_pkg_esm.join("index.js"),
+        "export const tag = 'pnpm';\n",
+    );
+
+    std::fs::create_dir_all(base.join("node_modules")).expect("create node_modules");
+    symlink(&real_pkg, base.join("node_modules/sym-pkg")).expect("create symlink");
+
+    write_node16_tsconfig(base, "node16", &["main.mts", "extra.mts"]);
+
+    // Two independent importers that resolve the same dual-package specifier.
+    // If the symlinked and real paths diverge into two file indices, the same
+    // `Shape` interface gets bound twice and the round-trip assignment in
+    // `extra.mts` surfaces TS2322 against the foreign `Shape`.
+    write_file(
+        &base.join("main.mts"),
+        "import { Shape, tag } from 'sym-pkg';\nexport const value: Shape = { kind: tag };\n",
+    );
+    write_file(
+        &base.join("extra.mts"),
+        "import { Shape, tag } from 'sym-pkg';\nimport { value } from './main.mjs';\nexport const echoed: Shape = { kind: value.kind };\nexport const _t: 'pnpm' = tag;\n",
+    );
+
+    let args = parse_args(&["tsz", "--noEmit"]);
+    let result = compile(&args, base).expect("compile should succeed");
+
+    assert_no_duplicate_declaration_diags(&result.diagnostics, "pnpm-symlinked dual-package");
+
+    let shape_mismatch: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|diag| diag.code == 2322 || diag.code == 2345)
+        .collect();
+    assert!(
+        shape_mismatch.is_empty(),
+        "pnpm-symlinked dual-package must keep one `Shape` identity, got: {shape_mismatch:#?}"
+    );
+}


### PR DESCRIPTION
## Summary

`build_duplicate_package_redirects` walked package roots in `FxHashSet` iteration order and recorded redirects against whichever copy happened to be the current best guess. With three or more duplicate copies of one `(name, version)` package, encountering them out of rank order left behind a stale `depth-3 → depth-2` arrow when a later depth-1 copy promoted itself to canonical and only redirected `depth-2 → depth-1`. The file-redirect post-pass then rewrote `depth-3` files into `depth-2`'s root, which was no longer canonical — so the resolver produced two declaration IDs for what should have been one logical module, surfacing as duplicate-symbol diagnostics in projects with mixed transitive copies.

The rewrite sorts discovered package roots by `(name, version, node_modules-depth, normalized-path)` first, then sweeps once with `chunk_by` over each `(name, version)` run. The first entry per run is the canonical winner by construction; every later entry redirects directly to it, so no chain can form and the result no longer depends on `FxHashSet` iteration order. `normalize_resolved_path(canonical_root)` is also cached per redirected root so multiple files sharing one package don't each pay another `canonicalize` + ancestor symlink walk.

Structural rule (M4-D — Symbol, lib, module, DefId, and cross-file stable identity):
> When two `node_modules` paths host the same `(name, version)` package, the resolver picks the shallowest copy as canonical (lexical path as tie-break) and every other copy's files must redirect *directly* to the canonical root, regardless of file-set iteration order.

Closes #10895.

AgentName: M4-D
Track: Track 7 — Symbol, lib, module, DefId, and cross-file stable identity
Invariant: `build_duplicate_package_redirects` is a pure function of the input file set (no `FxHashSet` iteration-order leakage) and every non-canonical copy redirects directly to the rank-winning canonical (no transient intermediates).
Scope: `crates/tsz-cli/src/driver/resolution/path_resolution.rs` (rewrite of `build_duplicate_package_redirects`), `crates/tsz-cli/src/driver/resolution_tests.rs` (chain + determinism unit tests), `crates/tsz-cli/tests/dual_package_exports_tests.rs` (six dual-package CLI tests).

## Project Corpus Impact

- Row: n/a
- Bug family: module-resolution / dual-package exports identity (closes #10895)
- This change tightens an existing redirect map and does not alter any project-corpus row, fixture, or compile-guard.

## Verification

- `cargo nextest run -p tsz-cli -E 'test(/duplicate_package/) | test(/dual_package/)'` — 11 passed, 0 failed.
- Full `cargo nextest run -p tsz-cli` — confirmed the 15 failures present are all pre-existing on `main` (verified by re-running them against `origin/main` with the diff stashed). No new failures introduced.
- `cargo fmt --check -p tsz-cli` clean; `cargo clippy -p tsz-cli --lib --tests` clean for the modified files (remaining warnings/errors — `items_after_test_module` in `diagnostics_report.rs`, `duplicate_mod` for `driver/tests.rs` — are pre-existing on `main`).
- `/simplify` ×3: pass 1 collapsed three loops into one and factored the duplicate-codes assertion; pass 2 dropped the `depth` tuple field, switched to `chunk_by`, cached the canonical-root normalization, added `write_node16_tsconfig`, `make_duplicate_package_copies`, and `dup_pkg_resolver_options` helpers; pass 3 — all four agents (reuse, simplification, efficiency, altitude) reported the diff was clean.

## Coordination Notes

Two altitude follow-ups identified during `/simplify` and explicitly deferred per agent recommendation: (1) returning a root-keyed map instead of pre-baking `file_redirects` (would touch two call sites in `source_resolution_setup.rs`); (2) moving the five non-symlink CLI tests down to the resolver layer once `CompilationResult` or the resolver fixture exposes `resolved_module_paths` cardinality. Both are appropriate to file as follow-up issues rather than absorb here.

## Test plan

Unit-level coverage in `crates/tsz-cli/src/driver/resolution_tests.rs`:
- `test_duplicate_package_redirects_prefer_stable_lexical_root_when_depth_ties` *(pre-existing)*
- `test_duplicate_package_redirects_flatten_chains_to_final_canonical_root` *(new — pins the depth-3 → depth-1 direct-redirect rule)*
- `test_duplicate_package_redirects_deterministic_across_input_orders` *(new — pins input-order-independence by running three rank-mixed permutations through the function)*

Integration coverage in `crates/tsz-cli/tests/dual_package_exports_tests.rs` (new file, six tests):
- `dual_package_shared_types_condition_resolves_once_for_every_module_kind` — shared `"types"` ahead of `"import"`/`"require"` resolves once for `.mts`, `.cts`, `.ts`
- `dual_package_nested_types_branches_route_per_importer_mode_without_dup` — nested `{ "import": { "types": ... } }` and `{ "require": { "types": ... } }` route per importer mode with no spurious duplication
- `dual_package_repeated_import_is_idempotent` — same specifier imported three ways from one file converges
- `dual_package_bundler_resolution_keeps_single_declaration_identity` — Bundler-mode keeps the declared `types` branch and ignores sibling `.d.ts` probes
- `dual_package_subpath_resolution_keeps_single_declaration_identity` — `./feature` subpath dual exports
- `dual_package_pnpm_style_symlink_keeps_single_declaration_identity` — pnpm `.pnpm/<pkg>@<ver>` symlinked layout

https://claude.ai/code/session_01DBw4i7rEsffHA1bTWsANjA