### PR TITLE
fix(checker): preserve target universal quantification in member-override variance

### DIFF
--- a/crates/tsz-checker/src/classes/interface_heritage_index_compat.rs
+++ b/crates/tsz-checker/src/classes/interface_heritage_index_compat.rs
@@ -143,17 +143,17 @@ impl<'a> CheckerState<'a> {
         derived: TypeId,
         base: TypeId,
     ) -> bool {
-        let Some(derived_generic) =
-            crate::query_boundaries::class::callable_signature_is_generic(self.ctx.types, derived)
-        else {
-            return false;
-        };
-        let Some(base_generic) =
-            crate::query_boundaries::class::callable_signature_is_generic(self.ctx.types, base)
-        else {
-            return false;
-        };
-        if !derived_generic && !base_generic {
+        // Match tsc's `compareSignaturesRelated`: target's method-local type
+        // parameters are canonicalized only when source has its own. Without
+        // method-local generics on the source (derived), target stays
+        // universally quantified and a concrete implementation cannot satisfy
+        // `<T extends C>(x: T) => T`; the genuine overloaded-builder cases
+        // that need that escape hatch are handled separately by
+        // `implementation_signature_covers_interface_overloads`.
+        use crate::query_boundaries::class::callable_signature_is_generic;
+        if !callable_signature_is_generic(self.ctx.types, derived).unwrap_or(false)
+            || callable_signature_is_generic(self.ctx.types, base).is_none()
+        {
             return false;
         }
         self.diagnostic_relation_boolean_guard(derived, base)

--- a/crates/tsz-checker/src/query_boundaries/class.rs
+++ b/crates/tsz-checker/src/query_boundaries/class.rs
@@ -58,6 +58,36 @@ fn has_own_signature_type_params(checker: &CheckerState<'_>, type_id: TypeId) ->
     false
 }
 
+/// Returns true when the standard (generic-erasing) assignability relation is
+/// safe to use as a fallback for member-override compatibility checks.
+///
+/// tsc's `compareSignaturesRelated` only canonicalizes (erases) the target's
+/// method-local type parameters when the *source* signature carries its own.
+/// Otherwise the target's type parameters stay universally quantified, so the
+/// standard tsz relation (which erases method-local generics) must not undo
+/// the strict relation's correct rejection. The fallback remains safe — and
+/// active for `any`-propagation cases like `IteratorResult<T, any>` vs
+/// `IteratorResult<T, void>` — when target has no method-local type parameters
+/// or when source has its own.
+pub(crate) fn generic_erasure_fallback_is_safe(
+    checker: &CheckerState<'_>,
+    source: TypeId,
+    target: TypeId,
+) -> bool {
+    let source = unwrap_single_property_value_type(checker, source);
+    let target = unwrap_single_property_value_type(checker, target);
+    !has_method_local_type_params(checker.ctx.types, target)
+        || has_method_local_type_params(checker.ctx.types, source)
+}
+
+/// Convenience wrapper around `callable_signature_is_generic` that treats
+/// non-callable types as "no method-local generics" — the right default for
+/// member-override gating where a non-callable member can never leak
+/// universal quantification.
+fn has_method_local_type_params(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    callable_signature_is_generic(db, type_id).unwrap_or(false)
+}
+
 fn callable_mentions_nonlocal_type_params(checker: &CheckerState<'_>, type_id: TypeId) -> bool {
     let signature_mentions_nonlocal = |type_params: &[tsz_solver::types::TypeParamInfo],
                                        params: &[tsz_solver::types::ParamInfo],
@@ -455,16 +485,17 @@ pub(crate) fn implementation_signature_covers_interface_overloads(
     let target = unwrap_single_property_value_type(checker, target);
     let source_sigs = member_call_signatures(checker.ctx.types, source);
     let target_sigs = member_call_signatures(checker.ctx.types, target);
-    if source_sigs.len() != 1 || target_sigs.is_empty() {
+    // Require a single source signature and a genuinely overloaded target
+    // (multiple call signatures). Single-target comparisons are ordinary
+    // override compatibility — the strict relation must govern there so
+    // target's universally-quantified method-local type parameters stay
+    // opaque (tsc rejects `(x: number) => Box<string>` as an override of
+    // `<T extends string>(x: number) => Box<T>`).
+    if source_sigs.len() != 1 || target_sigs.len() < 2 {
         return false;
     }
 
     let source_type = call_signature_function_type(checker, &source_sigs[0]);
-    if target_sigs.len() == 1 {
-        let target_type = call_signature_function_type(checker, &target_sigs[0]);
-        return overload_return_base_matches_and_params_cover(checker, source_type, target_type);
-    }
-
     target_sigs.iter().all(|target_sig| {
         let target_type = call_signature_function_type(checker, target_sig);
         // Do not reuse the broad overload-implementation relation here: Array's
@@ -527,13 +558,14 @@ pub(crate) fn should_report_own_member_type_mismatch(
     if checker.is_assignable_to_no_erase_generics(source, target) {
         return false;
     }
-    // Fallback: when the strict no-erase-generics relation rejects but the
-    // standard assignable-to relation accepts, the rejection is generic-arity
-    // bookkeeping rather than a real mismatch (e.g. `IteratorResult<T, any>`
-    // source vs `IteratorResult<T, void>` target — `any` is a universal sink
-    // for the standard relation but the strict path keeps the args nominally
-    // distinct). tsc does not emit TS2416 here.
-    if checker.assign_relation_outcome(source, target).related {
+    // Fallback for any-propagation cases (e.g. `IteratorResult<T, any>` vs
+    // `IteratorResult<T, void>`) where the strict path keeps args nominally
+    // distinct but tsc accepts. Gated by `generic_erasure_fallback_is_safe`
+    // so the fallback does not leak universal quantification when target has
+    // method-local type parameters and source does not.
+    if generic_erasure_fallback_is_safe(checker, source, target)
+        && checker.assign_relation_outcome(source, target).related
+    {
         return false;
     }
     if source_this_parameter_is_acceptable_for_target_without_this(checker, source, target) {

--- a/crates/tsz-checker/src/tests/generic_method_override_variance_tests.rs
+++ b/crates/tsz-checker/src/tests/generic_method_override_variance_tests.rs
@@ -40,26 +40,113 @@ fn assert_has_2430(src: &str) {
 }
 
 // ---------------------------------------------------------------------------
-// Output-only constrained type parameter — valid override.
+// Single-signature method-local generic on base, non-generic implementation:
+// tsc preserves the target's universal quantification and rejects when the
+// constrained parameter appears in a covariant (or invariant) position of
+// the return type. Earlier revisions of this file asserted the opposite,
+// matching an over-permissive `getBaseSignature`-style erasure path that
+// has since been removed; the structural rule now matches tsc.
 // ---------------------------------------------------------------------------
 
 #[test]
-fn no_false_2416_output_only_constrained_param() {
-    assert_no_2416(
+fn keeps_2416_single_sig_output_param_covariant_position() {
+    // `Box<P>` has property `tag: P | number`, so `P` appears in a covariant
+    // position of the return type. A concrete `Box<string>` is not a valid
+    // override because the caller could instantiate `P` with a narrower
+    // subtype of `string` and expect `Box<that subtype>` back.
+    assert_has_2416(
         "interface Box<P extends string> { tag: P | number }
          interface I { m<P extends string>(x: number): Box<P> }
          class C implements I { m(x: number): Box<string> { return {} as any } }",
     );
 }
 
-// Same structural rule with a different type-parameter name — proves the fix
-// is not keyed on a particular identifier (§25).
+// Same structural rule with a different type-parameter name — proves the rule
+// is not keyed on a particular identifier.
 #[test]
-fn no_false_2416_output_only_constrained_param_renamed() {
-    assert_no_2416(
+fn keeps_2416_single_sig_output_param_covariant_position_renamed() {
+    assert_has_2416(
         "interface Box<Z extends string> { tag: Z | number }
          interface I { m<Z extends string>(x: number): Box<Z> }
          class C implements I { m(x: number): Box<string> { return {} as any } }",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Contravariant return position: a constrained method-local type parameter
+// inside a function/callback return is contravariant in the outer return
+// covariance, so `FBox<string>` IS a valid implementation of `FBox<P>` for
+// any `P extends string`. tsc accepts this; tsz must too.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn no_false_2416_single_sig_constrained_param_contravariant_position() {
+    assert_no_2416(
+        "interface FBox<P extends string> { apply: (value: P) => void }
+         interface I { m<T extends string>(x: number): FBox<T> }
+         class C implements I { m(x: number): FBox<string> { return {} as any } }",
+    );
+}
+
+// Phantom type parameter (does not appear in any property): erasable, valid
+// override. tsc accepts.
+#[test]
+fn no_false_2416_single_sig_phantom_constrained_param() {
+    assert_no_2416(
+        "interface PBox<P extends string> {}
+         interface I { m<T extends string>(x: number): PBox<T> }
+         class C implements I { m(x: number): PBox<string> { return {} as any } }",
+    );
+}
+
+// Constrained method-local type parameter appears only in *input* position:
+// the implementation's wider parameter accepts any narrower instantiation,
+// so the override is valid. tsc accepts.
+#[test]
+fn no_false_2416_single_sig_constrained_param_input_only() {
+    assert_no_2416(
+        "interface I { m<T extends string>(x: T): void }
+         class C implements I { m(x: string): void {} }",
+    );
+}
+
+// Bare type parameter in return position: the implementation can never
+// satisfy the universal quantification. tsc rejects.
+#[test]
+fn keeps_2416_single_sig_bare_param_in_return() {
+    assert_has_2416(
+        "interface I { m<T extends string>(): T }
+         class C implements I { m(): string { return \"\" } }",
+    );
+}
+
+// Invariant container (read+write of same parameter): variance is invariant,
+// so the override must be rejected. tsc rejects.
+#[test]
+fn keeps_2416_single_sig_invariant_position() {
+    assert_has_2416(
+        "interface Cell<P extends string> { read: P; write: (v: P) => void }
+         interface I { m<T extends string>(x: number): Cell<T> }
+         class C implements I { m(x: number): Cell<string> { return {} as any } }",
+    );
+}
+
+// Mixed inheritance chain: `class C extends Base<concrete> implements I` where
+// `I` has a method-local generic with a covariant return. The variance
+// rejection must apply through the implements check even when the offending
+// method is inherited from the extends base (TS2420 family is also acceptable
+// — the regression guard is that *some* diagnostic surfaces, not silent
+// acceptance).
+#[test]
+fn keeps_diagnostic_for_inherited_variance_violation_in_mixed_chain() {
+    let codes = crate::test_utils::check_source_codes(
+        "interface I { m<T extends string>(x: number): { read: T } }
+         class Base { m(x: number): { read: string } { return { read: \"\" } } }
+         class C extends Base implements I {}",
+    );
+    assert!(
+        codes.contains(&2416) || codes.contains(&2420) || codes.contains(&2430),
+        "expected TS2416/TS2420/TS2430 for inherited variance violation; got {codes:?}"
     );
 }
 

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -709,87 +709,59 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // will match correctly.
                 target_instantiated.type_params.clear();
                 source_instantiated.type_params.clear();
-            } else {
-                // Non-generic source vs a genuinely generic target with no shared
-                // type-parameter identity. Follow tsc's `getBaseSignature` for the
-                // subset of the target's type parameters that are *only observed
-                // through a generic application* — i.e. they appear exclusively as a
-                // type argument such as the alias `A` in `AliasedRawBuilder<O, A>`,
-                // never as a directly-observable value type. Each such constrained
-                // parameter is instantiated to its constraint before structural
-                // comparison, so a concrete implementation whose result satisfies the
-                // constraint is accepted. This matches tsc for overloaded generic
-                // builder methods like
-                // `as<A extends string>(alias: Expression<any>): Aliased<T, A>`, where
-                // an implementation returning `Aliased<T, string>` is a valid override.
-                //
-                // Any type parameter that appears *bare* in a value position (a direct
-                // parameter/return type, including inside a nested callback signature,
-                // e.g. `T` in `() => T` or `(arg: T) => U`) stays opaque. The caller
-                // fully controls such a parameter, so a concrete implementation cannot
-                // satisfy every instantiation: `(x: string) => string` remains
-                // incompatible with `<T>(x: T) => T`, and
-                // `new () => MyClass` remains incompatible with
-                // `new <T extends {...}>() => T`. Unconstrained parameters also stay
-                // opaque (no meaningful constraint to erase to).
+            } else if self.erase_generics {
+                // Standard path: tsc's `getBaseSignature` for the subset of
+                // target's type parameters observed only through a generic
+                // application (e.g. alias `A` in `AliasedRawBuilder<O, A>`),
+                // not bare in a value position. Each erasable parameter is
+                // instantiated to its constraint so a concrete implementation
+                // whose result satisfies the constraint is accepted (matches
+                // tsc for overloaded generic builder methods). Bare or
+                // unconstrained parameters stay opaque.
                 let mut target_canonical = TypeSubstitution::new();
-                let mut has_opaque_remaining = false;
                 for tp in &target_instantiated.type_params {
                     let tp_id = self.interner.type_param(*tp);
-                    let erasable = match tp.constraint {
-                        Some(constraint) if constraint != TypeId::UNKNOWN => {
-                            let appears_bare = target_instantiated
-                                .params
-                                .iter()
-                                .any(|p| self.type_param_appears_bare(p.type_id, tp_id))
-                                || target_instantiated
-                                    .this_type
-                                    .is_some_and(|t| self.type_param_appears_bare(t, tp_id))
-                                || self.type_param_appears_bare(
-                                    target_instantiated.return_type,
-                                    tp_id,
-                                );
-                            if appears_bare {
-                                false
-                            } else {
-                                target_canonical.insert(tp.name, constraint);
-                                true
-                            }
+                    if let Some(constraint) = tp.constraint
+                        && constraint != TypeId::UNKNOWN
+                    {
+                        let appears_bare = target_instantiated
+                            .params
+                            .iter()
+                            .any(|p| self.type_param_appears_bare(p.type_id, tp_id))
+                            || target_instantiated
+                                .this_type
+                                .is_some_and(|t| self.type_param_appears_bare(t, tp_id))
+                            || self.type_param_appears_bare(target_instantiated.return_type, tp_id);
+                        if !appears_bare {
+                            target_canonical.insert(tp.name, constraint);
                         }
-                        _ => false,
-                    };
-                    if !erasable {
-                        has_opaque_remaining = true;
                     }
                 }
-
-                // A target type parameter that survives erasure stays genuinely
-                // quantified. A non-generic source that is itself pinned to an
-                // outer-scope type parameter cannot satisfy that quantification, so
-                // strict member-compatibility checks (TS2416/TS2430) must still
-                // reject it — e.g. `interface I<T> extends A { a: (x: T) => T[] }`
-                // against base `a: <T>(x: T) => T[]`. Application-only-constrained
-                // parameters were already erased above and no longer count as
-                // remaining quantification, which is what lets a concrete builder
-                // override such as `as(...): AliasedRawBuilder<O, string>` through.
-                if has_opaque_remaining && !self.erase_generics {
-                    let source_mentions_outer_type_params =
-                        source_instantiated.params.iter().any(|p| {
-                            crate::visitor::contains_type_parameters(self.interner, p.type_id)
-                        }) || source_instantiated.this_type.is_some_and(|t| {
-                            crate::visitor::contains_type_parameters(self.interner, t)
-                        }) || crate::visitor::contains_type_parameters(
-                            self.interner,
-                            source_instantiated.return_type,
-                        );
-                    if source_mentions_outer_type_params {
-                        self.type_param_equivalences.truncate(equiv_start);
-                        return SubtypeResult::False;
-                    }
-                }
-
                 target_instantiated =
                     self.instantiate_function_shape(&target_instantiated, &target_canonical);
+            } else {
+                // Strict member-compatibility (TS2416/TS2430): tsc's
+                // `compareSignaturesRelated` only canonicalizes target's
+                // method-local type parameters when source has its own.
+                // With a non-generic source, target stays universally
+                // quantified — comparing target's `T` opaquely naturally
+                // enforces variance (a covariant `Box<T>` rejects the
+                // implementation, a contravariant `FBox<T>` accepts it).
+                // Overloaded-builder overrides that need the erasure escape
+                // hatch are short-circuited upstream by
+                // `implementation_signature_covers_interface_overloads`.
+                let mentions =
+                    |ty: TypeId| crate::visitor::contains_type_parameters(self.interner, ty);
+                if source_instantiated
+                    .params
+                    .iter()
+                    .any(|p| mentions(p.type_id))
+                    || source_instantiated.this_type.is_some_and(mentions)
+                    || mentions(source_instantiated.return_type)
+                {
+                    self.type_param_equivalences.truncate(equiv_start);
+                    return SubtypeResult::False;
+                }
             }
         }
 


### PR DESCRIPTION
AgentName: Studio-B
Track: Conformance / member-override variance
Bug family: generic-method-override-variance
Row: utility-types-project

## Invariant
When source signature has no method-local type parameters and target's signature does, target's parameters stay universally quantified. The strict member-compatibility relation must not canonicalize them via `getBaseSignature`-style erasure, and the standard-relation fallback must not silently undo the strict rejection. Variance flows naturally through the structural comparison (covariant/invariant positions reject; contravariant positions accept).

## Scope
- `crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs` — strict (`erase_generics=false`) mode no longer canonicalizes target's method-local type parameters when source is non-generic with no shared identity; rejects when source mentions outer-scope type parameters and otherwise falls through to the structural comparison.
- `crates/tsz-checker/src/query_boundaries/class.rs` — new `generic_erasure_fallback_is_safe` gate around the standard-relation fallback in `should_report_own_member_type_mismatch`; `implementation_signature_covers_interface_overloads` requires multiple target signatures (single-target overload coverage was masking variance errors).
- `crates/tsz-checker/src/classes/interface_heritage_index_compat.rs` — `generic_method_override_is_valid_specialization` requires the source (derived) signature to carry its own method-local type parameters, matching tsc's `compareSignaturesRelated` direction check.
- `crates/tsz-checker/src/tests/generic_method_override_variance_tests.rs` — replaced two tests that asserted the pre-fix wrong behavior with the structural matrix: covariant/invariant rejected, contravariant/phantom/input-only/erasable accepted, bare-return rejected, plus a mixed-extends+implements regression guard.

## Project Corpus Impact
- Row: utility-types-project
- Bug family: generic-method-override-variance

Manually verified against tsc 6.0.2 on a 30-case fixture covering:
- Covariant `Box<T>` (rejected ✓)
- Contravariant `FBox<T>` via callback param (accepted ✓)
- Invariant `Cell<T>` with read+write (rejected ✓)
- Phantom `PBox<T>` (accepted ✓)
- Input-only `(x: T)` (accepted ✓)
- Bare-return `(): T` (rejected ✓)
- Multi-level extends chain with `extends Base<concrete> implements I` (variance violation rejected ✓)
- Inherited member from a base class triggering interface implements check (TS2416/TS2420 family ✓)

Kysely overloaded-builder case (multiple target overloads, single broad implementation) still accepted through `implementation_signature_covers_interface_overloads`.

## Verification
- `cargo nextest run --release -p tsz-checker --lib generic_method_override`: 21 passed, 5665 skipped.
- `cargo nextest run --release -p tsz-checker --test ts2430_tests`: 45 passed.
- `cargo nextest run --release -p tsz-checker --test class_implements_overloaded_method_ts2416_tests`: 9 passed.
- `cargo nextest run --release -p tsz-checker --test generic_method_override_constraint_ts2416_tests`: 8 passed.
- `cargo nextest run --release -p tsz-checker --test accessor_pair_override_ts2416_tests`: 12 passed.
- `cargo nextest run --release -p tsz-checker --test abstract_method_overload_ts2416_tests`: 10 passed.
- `cargo nextest run --release -p tsz-checker --test ts4112_cross_file_override_heritage_tests`: 3 passed.
- `cargo nextest run --release -p tsz-checker --lib`: 5634 passed, 55 pre-existing failures unchanged (verified against `origin/main` baseline — exact same failing test names).
- `cargo nextest run --release -p tsz-solver --lib`: same 8 pre-existing failures as `origin/main` baseline.
- Manual tsc 6.0.2 parity check: covariant/invariant cases now correctly emit TS2416; contravariant/phantom cases correctly accept.

## Coordination Notes
- Closes #10853.
- Two pre-existing tests (`no_false_2416_output_only_constrained_param` and its `_renamed` variant) asserted tsz-only behavior that tsc rejects; replaced with the structural matrix that aligns with tsc.
- Three-pass `/simplify` cleanup applied: extracted `has_method_local_type_params` helper, trimmed verbose doc comments, removed the single-target branch of `implementation_signature_covers_interface_overloads`, kept layered gates because they cover distinct call paths (solver strict mode vs checker standard-relation fallback vs checker interface-heritage gate).

https://claude.ai/code/session_01NUuZNyQWcyqrekup1Ed2ex