### PR TITLE
fix(emit/dts): correct empty-array and undefined types in inferred object-literal DTS

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
@@ -91,7 +91,13 @@ impl<'a> DeclarationEmitter<'a> {
         let expr_node = self.arena.get(expr_idx)?;
         let array = self.arena.get_literal_expr(expr_node)?;
         if array.elements.nodes.is_empty() {
-            return Some("any".to_string());
+            // tsc: with strictNullChecks on, [] has element type never;
+            // with strictNullChecks off, [] widens to any[].
+            return if self.strict_null_checks {
+                Some("never".to_string())
+            } else {
+                Some("any".to_string())
+            };
         }
 
         let mut element_types = Vec::with_capacity(array.elements.nodes.len());

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_guards.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_guards.rs
@@ -464,7 +464,7 @@ impl<'a> DeclarationEmitter<'a> {
             .is_none_or(|_| self.value_reference_symbol(expr_idx).is_none())
     }
 
-    pub(in crate::declaration_emitter) fn undefined_identifier_type_text(
+    pub(in crate::declaration_emitter) const fn undefined_identifier_type_text(
         &self,
         _expr_idx: NodeIndex,
     ) -> Option<String> {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_guards.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_guards.rs
@@ -466,15 +466,12 @@ impl<'a> DeclarationEmitter<'a> {
 
     pub(in crate::declaration_emitter) fn undefined_identifier_type_text(
         &self,
-        expr_idx: NodeIndex,
+        _expr_idx: NodeIndex,
     ) -> Option<String> {
-        // Only the `undefined` *identifier* form falls back to `any` here;
-        // the `UndefinedKeyword` token is handled by earlier passes and
-        // must not be reclassified as `any` (its type is `undefined`).
-        let node = self.arena.get(expr_idx)?;
-        (node.kind == SyntaxKind::Identifier as u16
-            && self.is_unbound_undefined_value_reference(expr_idx))
-        .then(|| "any".to_string())
+        // Intentionally returns None so the fallback resolves via the solver:
+        // TypeId::UNDEFINED → "undefined" (strict_null_checks on) or "any" (off).
+        // Returning "any" unconditionally bypassed the strict-null-checks gate.
+        None
     }
 
     fn nullish_guarded_return_type_text(

--- a/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification.rs
@@ -1833,3 +1833,32 @@ let renamed_k = [{ p: 0 }, { p: 1, q: "x" }][0];
         "renamed variable still gets 4-space indent:\n{output}"
     );
 }
+
+#[test]
+fn fix_empty_array_literal_strict_mode_emits_never_element_type() {
+    // With strictNullChecks on, tsc infers never[] for empty array literals
+    // in object literal properties (no widening possible).
+    let output = emit_dts_strict("export const x = { foo: [] };");
+    assert!(
+        output.contains("foo: never[]"),
+        "strict mode: empty array property should be never[]: {output}"
+    );
+    assert!(
+        !output.contains("foo: any[]"),
+        "strict mode: empty array property must not be any[]: {output}"
+    );
+}
+
+#[test]
+fn fix_empty_array_literal_non_strict_mode_emits_any_element_type() {
+    // With strictNullChecks off, tsc widens empty array literals to any[].
+    let output = emit_dts("export const x = { foo: [] };");
+    assert!(
+        output.contains("foo: any[]"),
+        "non-strict mode: empty array property should be any[]: {output}"
+    );
+    assert!(
+        !output.contains("foo: never[]"),
+        "non-strict mode: empty array property must not be never[]: {output}"
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/tests/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/mod.rs
@@ -24,6 +24,14 @@ pub(super) fn emit_dts(source: &str) -> String {
     emitter.emit(root)
 }
 
+pub(super) fn emit_dts_strict(source: &str) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut emitter = DeclarationEmitter::new(&parser.arena);
+    emitter.set_strict_null_checks(true);
+    emitter.emit(root)
+}
+
 pub(super) fn emit_dts_strip_internal(source: &str) -> String {
     let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
     let root = parser.parse_source_file();


### PR DESCRIPTION
AgentName: claude/dazzling-johnson-gAH1h

Track: Emit / DTS

Invariant: Match tsc exactly. DTS output for `export default { foo: [], bar: undefined, baz: null }` must match the tsc baseline.

Scope: Two focused bug fixes in the AST-based DTS type inference path for object literal property initializers. No changes to checker, solver, binder, or parser.

## What

Fixes `declarationEmitInferredDefaultExportType`: the test case `export default { foo: [], bar: undefined, baz: null }` was emitting `foo: any[]; bar: any` instead of the correct `foo: never[]; bar: undefined`.

### Root cause 1 — `bar: undefined` emits `any`

`undefined_identifier_type_text` in `type_inference_return_guards.rs` returned `Some("any")` unconditionally for the `undefined` identifier, bypassing the `strict_null_checks` gate in the type printer.

**Structural rule:** When an object-literal property has initializer `undefined` (the identifier), tsc emits `undefined` (strict mode) or `any` (non-strict). The correct path is to return `None` and let the solver fallback resolve `TypeId::UNDEFINED` → printer prints `"undefined"` when strict, `"any"` when not.

### Root cause 2 — `foo: []` emits `any[]`

`array_literal_element_union_type_text` in `type_inference_expression_literals.rs` always returned `"any"` for empty array literals, regardless of `strict_null_checks`.

**Structural rule:** tsc infers element type `never` for `[]` when `strictNullChecks` is on (empty array has no possible element, so element type is `never`). When `strictNullChecks` is off, the array widens to `any[]`. The fix gates on `self.strict_null_checks`.

## Verification

DTS emit suite (release binary, 1669 test cases):
- Before: 1661 passed, 8 failed (99.5%)
- After: 1662 passed, 7 failed (99.6%)
- `declarationEmitInferredDefaultExportType` ✓ now passes
- `expandoFunctionNestedAssigments` ✓ still passes (`// @strict: false` → `any[]` path)
- No new regressions

## Adjacent matrix

| case | before | after | expected |
|------|--------|-------|----------|
| `{ foo: [] }` strict | `any[]` | `never[]` | `never[]` ✓ |
| `{ foo: [] }` non-strict | `any[]` | `any[]` | `any[]` ✓ |
| `{ bar: undefined }` strict | `any` | `undefined` | `undefined` ✓ |
| `{ bar: undefined }` non-strict | `any` | `any` | `any` ✓ |
| `{ baz: null }` strict | `null` | `null` | `null` ✓ (unchanged) |

## Project Corpus Impact

- Row: n/a
- Bug family: AST-based DTS type inference — empty array literals and unbound `undefined` identifiers in object literal property initializers

Two localized changes in the AST-inference fast path for object literal properties. The solver and checker are not touched. Risk of corpus impact is low.

## Coordination Notes

No lane conflicts. The failing tests remaining (7) are pre-existing and tracked separately:
- `declarationEmitUsingTypeAlias2`, `declarationMapsMultifile`, `emitClassExpressionInDeclarationFile`, `genericRestParameters1`, `jsDeclarationEmitExportedClassWithExtends`, `reactTransitiveImportHasValidDeclaration`, `typeParametersAvailableInNestedScope3`
