### PR TITLE
fix(checker): match tsc precedence for import-attribute grammar diagnostics

### DIFF
--- a/crates/tsz-checker/src/declarations/import/declaration_attributes.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration_attributes.rs
@@ -57,8 +57,35 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    /// TS2880: Check that `assert` keyword is not used (deprecated in favor of `with`).
-    pub(crate) fn check_import_attributes_deprecated_assert(&mut self, attributes_idx: NodeIndex) {
+    /// Grammar validation for an import/export declaration's attributes clause
+    /// (`with { ... }` / `assert { ... }`).
+    ///
+    /// This mirrors `tsc`'s `checkImportAttributes` ordering exactly. The order
+    /// matters because each step *returns* (suppressing later steps), and the
+    /// diagnostic code depends on whether the deprecated `assert` keyword or the
+    /// `with` keyword was used:
+    ///
+    /// 1. A type-only declaration carrying an *effective* `resolution-mode`
+    ///    override is allowed — nothing else is reported.
+    /// 2. Module option does not support import attributes → TS2823 (`with`) /
+    ///    TS2821 (`assert`), return.
+    /// 3. `assert` under `node20`/`nodenext` → TS2880, return (the keyword is a
+    ///    hard error in these modes, so no further attribute check runs).
+    /// 4. `assert` under any other supported module → TS2880, but continue (it
+    ///    is only a deprecation warning there).
+    /// 5. Statement compiles to a CommonJS `require` → TS2856 (`with`) / TS2836
+    ///    (`assert`), return.
+    /// 6. Type-only declaration → TS2857 (`with`) / TS2822 (`assert`), return.
+    ///
+    /// Steps 5 and 6 are deliberately ordered CommonJS-before-type-only: `tsc`
+    /// reports the require-incompatibility even for `import type` statements,
+    /// because the grammar check does not depend on whether the binding is
+    /// erased.
+    pub(crate) fn check_import_attributes_grammar(
+        &mut self,
+        attributes_idx: NodeIndex,
+        declaration_is_type_only: bool,
+    ) {
         if attributes_idx.is_none() {
             return;
         }
@@ -66,106 +93,120 @@ impl<'a> CheckerState<'a> {
         let Some(attr_node) = self.ctx.arena.get(attributes_idx) else {
             return;
         };
-
         let Some(attrs_data) = self.ctx.arena.get_import_attributes_data(attr_node) else {
             return;
         };
+        let uses_with = attrs_data.token == SyntaxKind::WithKeyword as u16;
+        let node_pos = attr_node.pos;
+        let node_len = attr_node.end.saturating_sub(attr_node.pos);
 
-        // token stores the SyntaxKind of the keyword used (AssertKeyword vs WithKeyword)
-        // Route through the capability boundary to check ignore_deprecations.
-        if attrs_data.token == SyntaxKind::AssertKeyword as u16
-            && self
-                .ctx
-                .capabilities
-                .check_import_assert_deprecated()
-                .is_some()
-        {
-            // Error spans the `assert` keyword (6 characters), positioned at the node start
-            self.error_at_position(
-                attr_node.pos,
-                6, // length of "assert"
-                diagnostic_messages::IMPORT_ASSERTIONS_HAVE_BEEN_REPLACED_BY_IMPORT_ATTRIBUTES_USE_WITH_INSTEAD_OF_AS,
-                diagnostic_codes::IMPORT_ASSERTIONS_HAVE_BEEN_REPLACED_BY_IMPORT_ATTRIBUTES_USE_WITH_INSTEAD_OF_AS,
-            );
-        }
-    }
-
-    /// TS2823: Check that import attributes are only used with supported module options.
-    ///
-    /// Routes through the environment capability boundary (`check_feature_gate`)
-    /// to determine whether a diagnostic should be emitted.
-    pub(crate) fn check_import_attributes_module_option(
-        &mut self,
-        attributes_idx: NodeIndex,
-        declaration_is_type_only: bool,
-    ) {
-        if attributes_idx.is_none() {
-            return;
-        }
-
-        use crate::query_boundaries::capabilities::FeatureGate;
-        if self
-            .ctx
-            .capabilities
-            .check_feature_gate(FeatureGate::ImportAttributes)
-            .is_some()
-            && !self.resolution_mode_override_is_effective(attributes_idx, declaration_is_type_only)
-            && let Some(attr_node) = self.ctx.arena.get(attributes_idx)
-        {
-            self.error_at_position(
-                attr_node.pos,
-                attr_node.end.saturating_sub(attr_node.pos),
-                diagnostic_messages::IMPORT_ATTRIBUTES_ARE_ONLY_SUPPORTED_WHEN_THE_MODULE_OPTION_IS_SET_TO_ESNEXT_NOD,
-                diagnostic_codes::IMPORT_ATTRIBUTES_ARE_ONLY_SUPPORTED_WHEN_THE_MODULE_OPTION_IS_SET_TO_ESNEXT_NOD,
-            );
-        }
-    }
-
-    pub(crate) fn check_import_attributes_commonjs_or_type_only(
-        &mut self,
-        attributes_idx: NodeIndex,
-        declaration_is_type_only: bool,
-    ) {
-        if attributes_idx.is_none() {
-            return;
-        }
-
+        // Step 1: a valid `resolution-mode` override on a type-only declaration
+        // is accepted; nothing else is reported.
         if self.resolution_mode_override_is_effective(attributes_idx, declaration_is_type_only) {
             return;
         }
 
+        // Step 2: the module option must support import attributes at all.
         use crate::query_boundaries::capabilities::FeatureGate;
-        if self
+        if !self
             .ctx
             .capabilities
-            .check_feature_gate(FeatureGate::ImportAttributes)
-            .is_some()
+            .feature_available(FeatureGate::ImportAttributes)
         {
-            return;
-        }
-
-        let Some(attr_node) = self.ctx.arena.get(attributes_idx) else {
-            return;
-        };
-
-        if declaration_is_type_only {
-            self.error_at_position(
-                attr_node.pos,
-                attr_node.end.saturating_sub(attr_node.pos),
-                diagnostic_messages::IMPORT_ATTRIBUTES_CANNOT_BE_USED_WITH_TYPE_ONLY_IMPORTS_OR_EXPORTS,
-                diagnostic_codes::IMPORT_ATTRIBUTES_CANNOT_BE_USED_WITH_TYPE_ONLY_IMPORTS_OR_EXPORTS,
+            self.report_import_attribute_grammar_error(
+                node_pos,
+                node_len,
+                uses_with,
+                (
+                    diagnostic_messages::IMPORT_ATTRIBUTES_ARE_ONLY_SUPPORTED_WHEN_THE_MODULE_OPTION_IS_SET_TO_ESNEXT_NOD,
+                    diagnostic_codes::IMPORT_ATTRIBUTES_ARE_ONLY_SUPPORTED_WHEN_THE_MODULE_OPTION_IS_SET_TO_ESNEXT_NOD,
+                ),
+                (
+                    diagnostic_messages::IMPORT_ASSERTIONS_ARE_ONLY_SUPPORTED_WHEN_THE_MODULE_OPTION_IS_SET_TO_ESNEXT_NOD,
+                    diagnostic_codes::IMPORT_ASSERTIONS_ARE_ONLY_SUPPORTED_WHEN_THE_MODULE_OPTION_IS_SET_TO_ESNEXT_NOD,
+                ),
             );
             return;
         }
 
+        // Steps 3 & 4: the deprecated `assert` keyword. In `node20`/`nodenext`
+        // it is a hard error that emits TS2880 (unconditionally) and stops; in
+        // the other supported modes it is only a deprecation warning (gated on
+        // `ignoreDeprecations`) and grammar checking continues.
+        if !uses_with {
+            let hard_error = self.ctx.capabilities.import_assert_is_hard_error();
+            if hard_error
+                || self
+                    .ctx
+                    .capabilities
+                    .check_import_assert_deprecated()
+                    .is_some()
+            {
+                self.error_at_position(
+                    node_pos,
+                    6, // length of "assert"
+                    diagnostic_messages::IMPORT_ASSERTIONS_HAVE_BEEN_REPLACED_BY_IMPORT_ATTRIBUTES_USE_WITH_INSTEAD_OF_AS,
+                    diagnostic_codes::IMPORT_ASSERTIONS_HAVE_BEEN_REPLACED_BY_IMPORT_ATTRIBUTES_USE_WITH_INSTEAD_OF_AS,
+                );
+            }
+            if hard_error {
+                return;
+            }
+        }
+
+        // Step 5: statements that compile to a CommonJS `require` cannot carry
+        // attributes. This is checked before the type-only rule to match `tsc`.
         if self.import_declaration_emits_commonjs() {
-            self.error_at_position(
-                attr_node.pos,
-                attr_node.end.saturating_sub(attr_node.pos),
-                diagnostic_messages::IMPORT_ATTRIBUTES_ARE_NOT_ALLOWED_ON_STATEMENTS_THAT_COMPILE_TO_COMMONJS_REQUIRE,
-                diagnostic_codes::IMPORT_ATTRIBUTES_ARE_NOT_ALLOWED_ON_STATEMENTS_THAT_COMPILE_TO_COMMONJS_REQUIRE,
+            self.report_import_attribute_grammar_error(
+                node_pos,
+                node_len,
+                uses_with,
+                (
+                    diagnostic_messages::IMPORT_ATTRIBUTES_ARE_NOT_ALLOWED_ON_STATEMENTS_THAT_COMPILE_TO_COMMONJS_REQUIRE,
+                    diagnostic_codes::IMPORT_ATTRIBUTES_ARE_NOT_ALLOWED_ON_STATEMENTS_THAT_COMPILE_TO_COMMONJS_REQUIRE,
+                ),
+                (
+                    diagnostic_messages::IMPORT_ASSERTIONS_ARE_NOT_ALLOWED_ON_STATEMENTS_THAT_COMPILE_TO_COMMONJS_REQUIRE,
+                    diagnostic_codes::IMPORT_ASSERTIONS_ARE_NOT_ALLOWED_ON_STATEMENTS_THAT_COMPILE_TO_COMMONJS_REQUIRE,
+                ),
+            );
+            return;
+        }
+
+        // Step 6: type-only declarations cannot carry attributes.
+        if declaration_is_type_only {
+            self.report_import_attribute_grammar_error(
+                node_pos,
+                node_len,
+                uses_with,
+                (
+                    diagnostic_messages::IMPORT_ATTRIBUTES_CANNOT_BE_USED_WITH_TYPE_ONLY_IMPORTS_OR_EXPORTS,
+                    diagnostic_codes::IMPORT_ATTRIBUTES_CANNOT_BE_USED_WITH_TYPE_ONLY_IMPORTS_OR_EXPORTS,
+                ),
+                (
+                    diagnostic_messages::IMPORT_ASSERTIONS_CANNOT_BE_USED_WITH_TYPE_ONLY_IMPORTS_OR_EXPORTS,
+                    diagnostic_codes::IMPORT_ASSERTIONS_CANNOT_BE_USED_WITH_TYPE_ONLY_IMPORTS_OR_EXPORTS,
+                ),
             );
         }
+    }
+
+    /// Emit an import-attribute grammar error at `pos..pos+len`, selecting the
+    /// `with`-keyword diagnostic or its deprecated `assert`-keyword counterpart.
+    fn report_import_attribute_grammar_error(
+        &mut self,
+        pos: u32,
+        len: u32,
+        uses_with: bool,
+        with_diagnostic: (&'static str, u32),
+        assert_diagnostic: (&'static str, u32),
+    ) {
+        let (message, code) = if uses_with {
+            with_diagnostic
+        } else {
+            assert_diagnostic
+        };
+        self.error_at_position(pos, len, message, code);
     }
 
     pub(crate) fn import_declaration_emits_commonjs(&self) -> bool {

--- a/crates/tsz-checker/src/declarations/import/declaration_check_body.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration_check_body.rs
@@ -70,25 +70,18 @@ impl<'a> CheckerState<'a> {
                     );
         }
 
-        // TS2880: Warn about deprecated `assert` keyword
-        self.check_import_attributes_deprecated_assert(import.attributes);
-
         if !has_parse_errors {
             self.check_type_only_resolution_mode_attribute_grammar(
                 import.attributes,
                 is_type_only_import,
             );
 
-            // TS2823: Import attributes require specific module options
-            self.check_import_attributes_module_option(import.attributes, is_type_only_import);
-
             // TS2322: Check import attribute values against global ImportAttributes interface
             self.check_import_attributes_assignability(import.attributes);
 
-            self.check_import_attributes_commonjs_or_type_only(
-                import.attributes,
-                is_type_only_import,
-            );
+            // TS2821/TS2822/TS2823/TS2836/TS2856/TS2857/TS2880: attribute grammar,
+            // ordered to mirror tsc's `checkImportAttributes` precedence.
+            self.check_import_attributes_grammar(import.attributes, is_type_only_import);
         }
 
         // TS1214/TS1212: Check import binding names for strict mode reserved words.

--- a/crates/tsz-checker/src/query_boundaries/environment.rs
+++ b/crates/tsz-checker/src/query_boundaries/environment.rs
@@ -246,6 +246,17 @@ impl EnvironmentCapabilities {
         }
     }
 
+    /// Whether the deprecated `assert` import-attribute keyword is a *hard*
+    /// grammar error in the current module mode.
+    ///
+    /// In `node20`/`nodenext` `tsc` reports TS2880 and stops (suppressing the
+    /// later CommonJS / type-only attribute checks); under the other modes that
+    /// support import attributes (`node18`, `esnext`, `preserve`) it is only a
+    /// non-fatal deprecation warning and grammar checking continues.
+    pub(crate) const fn import_assert_is_hard_error(&self) -> bool {
+        self.module.is_node20_or_nodenext()
+    }
+
     /// Check config compatibility and return any diagnostics.
     ///
     /// Currently checks:

--- a/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
@@ -199,22 +199,12 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
                 }
             }
 
-            // TS2880: Warn about deprecated `assert` keyword
-            self.check_import_attributes_deprecated_assert(export_decl.attributes);
-
-            // TS2823: Import attributes require specific module options
-            self.check_import_attributes_module_option(
-                export_decl.attributes,
-                export_decl.is_type_only,
-            );
-
             // TS2322: Check export attribute values against global ImportAttributes interface
             self.check_import_attributes_assignability(export_decl.attributes);
 
-            self.check_import_attributes_commonjs_or_type_only(
-                export_decl.attributes,
-                export_decl.is_type_only,
-            );
+            // TS2821/TS2822/TS2823/TS2836/TS2856/TS2857/TS2880: attribute grammar,
+            // ordered to mirror tsc's `checkImportAttributes` precedence.
+            self.check_import_attributes_grammar(export_decl.attributes, export_decl.is_type_only);
 
             // Check module specifier for unresolved modules (TS2792)
             if export_decl.module_specifier.is_some() {

--- a/crates/tsz-checker/tests/import_attributes_resolution_mode_tests.rs
+++ b/crates/tsz-checker/tests/import_attributes_resolution_mode_tests.rs
@@ -704,7 +704,8 @@ fn import_attribute_grammar_matrix_matches_tsc() {
     const ATTR_CODES: [u32; 7] = [2821, 2822, 2823, 2836, 2856, 2857, 2880];
 
     // (module, keyword, type_only, esm, expected_codes)
-    let cases: &[(ModuleKind, &str, bool, bool, &[u32])] = &[
+    type GrammarCase = (ModuleKind, &'static str, bool, bool, &'static [u32]);
+    let cases: &[GrammarCase] = &[
         // node16: module does not support import attributes at all.
         (ModuleKind::Node16, "with", false, true, &[2823]),
         (ModuleKind::Node16, "with", true, false, &[2823]),

--- a/crates/tsz-checker/tests/import_attributes_resolution_mode_tests.rs
+++ b/crates/tsz-checker/tests/import_attributes_resolution_mode_tests.rs
@@ -655,14 +655,17 @@ fn cjs_json_default_import_does_not_emit_ts1192() {
     );
 }
 
-/// Regression for Devin 🟡 on PR #2644: type-only imports in CJS files
-/// must emit TS2857 ("Import attributes cannot be used with type-only
-/// imports or exports") rather than TS2856 ("Import attributes are not
-/// allowed on statements that compile to CommonJS 'require' calls"),
-/// because type-only imports are erased at compile time and never produce
-/// `require()` calls. The type-only check must run before the CJS check.
+/// A type-only import that *also* compiles to a CommonJS `require` reports the
+/// CommonJS-incompatibility error, not the type-only error.
+///
+/// `tsc`'s `checkImportAttributes` checks the CommonJS condition *before* the
+/// type-only condition, so for `import type value from "pkg" with { ... }` in a
+/// `.cts` file it emits TS2856 ("Import attributes are not allowed on statements
+/// that compile to CommonJS 'require' calls"), never TS2857. Verified against
+/// `tsc` 6.0.2. (A prior revision asserted the opposite ordering, which did not
+/// match `tsc`.)
 #[test]
-fn cjs_type_only_import_with_attributes_reports_ts2857_not_ts2856() {
+fn cjs_type_only_import_with_attributes_reports_ts2856_not_ts2857() {
     let diagnostics = check_resolution_mode(
         "main.cts",
         r#"import type value from "pkg" with { type: "json" };"#,
@@ -672,11 +675,88 @@ fn cjs_type_only_import_with_attributes_reports_ts2857_not_ts2856() {
     );
 
     assert!(
-        diagnostics.iter().any(|d| d.code == 2857),
-        "Expected TS2857 for type-only import attributes in a CJS file, got: {diagnostics:?}"
+        diagnostics.iter().any(|d| d.code == 2856),
+        "Expected TS2856 for type-only import attributes in a CJS file (CommonJS check runs before the type-only check), got: {diagnostics:?}"
     );
     assert!(
-        diagnostics.iter().all(|d| d.code != 2856),
-        "Did not expect TS2856 for type-only import attributes in a CJS file (type-only imports never compile to require), got: {diagnostics:?}"
+        diagnostics.iter().all(|d| d.code != 2857),
+        "Did not expect TS2857: the CommonJS-incompatibility error takes precedence, got: {diagnostics:?}"
     );
+}
+
+/// Broad parity matrix for import-attribute grammar diagnostics.
+///
+/// Each row was verified against `tsc` 6.0.2 (`--strict --module <m>
+/// --moduleResolution nodenext`). The expectation is the exact set of
+/// import-attribute grammar codes `tsc` emits for that combination of module
+/// option, attribute keyword (`with`/`assert`), type-only-ness and emit kind
+/// (`.mts` = ESM, `.cts` = CommonJS).
+///
+/// The ordering that this exercises (and that a prior implementation got
+/// wrong): module-support (TS2823/TS2821) → assert deprecation (TS2880) →
+/// CommonJS-incompatibility (TS2856/TS2836) → type-only (TS2857/TS2822), with
+/// each step suppressing later ones except the non-fatal `assert` warning under
+/// `node18`.
+#[test]
+fn import_attribute_grammar_matrix_matches_tsc() {
+    // Import-attribute grammar codes we assert on; all other diagnostics
+    // (module resolution, etc.) are ignored so the matrix stays focused.
+    const ATTR_CODES: [u32; 7] = [2821, 2822, 2823, 2836, 2856, 2857, 2880];
+
+    // (module, keyword, type_only, esm, expected_codes)
+    let cases: &[(ModuleKind, &str, bool, bool, &[u32])] = &[
+        // node16: module does not support import attributes at all.
+        (ModuleKind::Node16, "with", false, true, &[2823]),
+        (ModuleKind::Node16, "with", true, false, &[2823]),
+        (ModuleKind::Node16, "assert", false, true, &[2821]),
+        (ModuleKind::Node16, "assert", true, false, &[2821]),
+        // node18: supported; `assert` is only a (non-fatal) deprecation warning.
+        (ModuleKind::Node18, "with", false, true, &[]),
+        (ModuleKind::Node18, "with", false, false, &[2856]),
+        (ModuleKind::Node18, "with", true, true, &[2857]),
+        (ModuleKind::Node18, "with", true, false, &[2856]),
+        (ModuleKind::Node18, "assert", false, true, &[2880]),
+        (ModuleKind::Node18, "assert", false, false, &[2836, 2880]),
+        (ModuleKind::Node18, "assert", true, true, &[2822, 2880]),
+        (ModuleKind::Node18, "assert", true, false, &[2836, 2880]),
+        // node20 / nodenext: `assert` is a hard error (TS2880) that suppresses
+        // the CommonJS and type-only checks.
+        (ModuleKind::Node20, "with", false, true, &[]),
+        (ModuleKind::Node20, "with", false, false, &[2856]),
+        (ModuleKind::Node20, "with", true, true, &[2857]),
+        (ModuleKind::Node20, "with", true, false, &[2856]),
+        (ModuleKind::Node20, "assert", false, false, &[2880]),
+        (ModuleKind::Node20, "assert", true, true, &[2880]),
+        (ModuleKind::Node20, "assert", true, false, &[2880]),
+        (ModuleKind::NodeNext, "with", true, false, &[2856]),
+        (ModuleKind::NodeNext, "with", true, true, &[2857]),
+        (ModuleKind::NodeNext, "assert", true, false, &[2880]),
+        (ModuleKind::NodeNext, "assert", false, false, &[2880]),
+    ];
+
+    for &(module, keyword, type_only, esm, expected) in cases {
+        let file_name = if esm { "main.mts" } else { "main.cts" };
+        let type_prefix = if type_only { "type " } else { "" };
+        let source =
+            format!("import {type_prefix}value from \"pkg\" {keyword} {{ type: \"json\" }};");
+
+        let diagnostics = check_resolution_mode(file_name, &source, 1, module, Some(esm));
+
+        let mut got: Vec<u32> = diagnostics
+            .iter()
+            .map(|d| d.code)
+            .filter(|c| ATTR_CODES.contains(c))
+            .collect();
+        got.sort_unstable();
+        got.dedup();
+
+        let mut want: Vec<u32> = expected.to_vec();
+        want.sort_unstable();
+
+        assert_eq!(
+            got, want,
+            "module={module:?} keyword={keyword} type_only={type_only} esm={esm}: \
+             expected import-attribute codes {want:?}, got {got:?} (all: {diagnostics:?})"
+        );
+    }
 }

--- a/crates/tsz-common/src/common/mod.rs
+++ b/crates/tsz-common/src/common/mod.rs
@@ -383,6 +383,16 @@ impl ModuleKind {
         matches!(self, Self::Node16 | Self::Node18)
     }
 
+    /// Check if this is `Node20` or `NodeNext` specifically.
+    ///
+    /// These map to Node 22+, where the deprecated `assert` import-attribute
+    /// keyword is a hard grammar error (TS2880) rather than a non-fatal
+    /// deprecation warning.
+    #[must_use]
+    pub const fn is_node20_or_nodenext(self) -> bool {
+        matches!(self, Self::Node20 | Self::NodeNext)
+    }
+
     /// Check if this uses ES modules (import/export)
     ///
     /// Returns true only for pure ES module systems where `export =` is forbidden.


### PR DESCRIPTION
## Summary

Fixes #10926.

Import/export attribute (`with { ... }` / `assert { ... }`) grammar validation was split across three independently-invoked checker helpers, so the early-return precedence that `tsc`'s `checkImportAttributes` relies on was lost, and the deprecated `assert` keyword always reused the `with`-variant diagnostic codes. Consolidates them into one ordered routine that mirrors `tsc` exactly.

AgentName: claude-pensive-wright

Track: Conformance — diagnostics parity (checker import/export attribute grammar).

Invariant: For an import/export declaration carrying an attributes clause, tsz emits exactly the diagnostics `tsc` emits, with the same precedence and the same `with`/`assert` code selection.

## Scope

- `crates/tsz-checker/src/declarations/import/declaration_attributes.rs` — replace `check_import_attributes_deprecated_assert` / `check_import_attributes_module_option` / `check_import_attributes_commonjs_or_type_only` with a single `check_import_attributes_grammar` that follows `tsc`'s order: module-support → assert-deprecation → CommonJS → type-only, with `return` semantics at each step and per-step `with`/`assert` code selection via a small `report_import_attribute_grammar_error` helper.
- `crates/tsz-checker/src/query_boundaries/environment.rs` — add `EnvironmentCapabilities::import_assert_is_hard_error()` so the node20/nodenext classification is owned by the capability boundary instead of a raw module-kind match in the import module.
- `crates/tsz-common/src/common/mod.rs` — add `ModuleKind::is_node20_or_nodenext()` (sibling to the existing `is_node16_or_node18`).
- import path (`declaration_check_body.rs`) and export path (`statement_callback_bridge.rs`) now call the single shared routine.
- tests: new parity matrix + corrected a prior test that asserted the opposite (non-`tsc`) ordering.

### Structural rule

When an import/export declaration has an attributes clause, `tsc` evaluates the grammar in this order, each step suppressing the later ones:

1. type-only declaration with an effective `resolution-mode` override → accepted.
2. module does not support import attributes → **TS2823** (`with`) / **TS2821** (`assert`).
3. `assert` under `node20`/`nodenext` → **TS2880** (hard error, stops).
4. `assert` under another supported module → **TS2880** (deprecation warning, continues).
5. statement compiles to a CommonJS `require` → **TS2856** (`with`) / **TS2836** (`assert`).
6. type-only declaration → **TS2857** (`with`) / **TS2822** (`assert`).

tsz previously checked type-only before CommonJS, never emitted the `assert`-variant codes (2821/2822/2836), and emitted TS2880 alongside checks it should have suppressed.

### Divergences fixed (verified against `tsc` 6.0.2)

| case | before (tsz) | after = `tsc` |
|---|---|---|
| `assert`, unsupported module (node16) | TS2823 + TS2880 | TS2821 |
| type-only `with`, CommonJS (`.cts`) | TS2857 | TS2856 |
| `assert`, CommonJS (`.cts`) | TS2856 (+2880) | TS2836 (+2880) |
| type-only `assert`, ESM (`.mts`) | TS2857 (+2880) | TS2822 (+2880) |
| `assert`, node20/nodenext | TS2856/2857 + TS2880 | TS2880 |

## Project Corpus Impact

- Row: ts-essentials-project
- Bug family: import-attribute grammar diagnostics (TS2821/TS2822/TS2823/TS2836/TS2856/TS2857/TS2880)

No project-row regressions expected; the change only re-routes/relabels existing import-attribute grammar diagnostics to match `tsc`. The original issue is a `ts-essentials-project` benchmark-row witness in this feature area. Module-resolution behaviors (e.g. `.json` TS2732/TS2307) are untouched.

## Verification

> Note: `cargo nextest` is not installed in this execution environment, so the standard `cargo test` harness was used locally with narrow `--test` filters. The authoritative broad suites run in CI (`unit` / `unit-cloudbuild`, which use nextest), plus `conformance-snapshot-gate` and `project-row-drift`.

- New `import_attribute_grammar_matrix_matches_tsc` parity test (module × `with`/`assert` × type-only × `.mts`/`.cts`) — passes.
- Corrected `cjs_type_only_import_with_attributes_reports_ts2856_not_ts2857` (was asserting the non-`tsc` order).
- `cargo test -p tsz-checker --test import_attributes_resolution_mode_tests` → 23 passed.
- `cargo test -p tsz-checker --test type_only_import_reexport_tests` → 11 passed; `json_namespace_import_tests` → 3 passed.
- `cargo clippy -p tsz-common -p tsz-checker` → clean.
- CLI parity sweep of 56 (module × keyword × type-only × ext) cases vs `tsc` 6.0.2 → 0 diffs.

## Coordination Notes

Issue #10926 was unowned (M4-C explicitly noted "no implementation in flight"). The title pointed at the parser; the concrete, reproducible divergence in this feature area is in the checker grammar, which is what this PR fixes. The WIP label on the issue should be cleared on merge.