### PR TITLE
fix(solver): centralise distributive tuple-union infer merge

### DIFF
--- a/crates/tsz-checker/tests/conformance_issues/types/distributive_tuple_union.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/distributive_tuple_union.rs
@@ -1,0 +1,349 @@
+//! Regression coverage for distributive conditional evaluation over
+//! tuple-like unions.
+//!
+//! Tracks the bug family described in issue #12175 (witnesses #10799,
+//! #10815, #10823, #10831, #10848, #10856, #10864, #10872). The structural
+//! rule under test:
+//!
+//! > When conditional types distribute over tuple-like union inputs, each
+//! > union arm's tuple constraints must be preserved and its inferred
+//! > results merged independently, matching tsc behavior.
+//!
+//! Every test varies binder names so a fixture-name fast path cannot pass
+//! these checks. Patterns cover head, tail, head+rest, init+last, sandwich
+//! (init+mid+last), recursive, constrained-infer, mixed readonly/mutable,
+//! and aliased-variant shapes; both distributive (`T extends ...`) and
+//! non-distributive (`[T] extends [...]`) forms are exercised so the
+//! per-arm-merge path and the all-arms-must-match path stay distinct.
+
+use super::super::core::*;
+
+fn no_assignability_errors(source: &str) {
+    let diagnostics = compile_and_get_diagnostics_with_lib(source);
+    assert!(
+        !has_error(&diagnostics, 2322) && !has_error(&diagnostics, 2345),
+        "expected no assignability errors. diagnostics: {diagnostics:#?}\nsource:\n{source}"
+    );
+}
+
+#[test]
+fn distributive_head_over_tuple_union_keeps_per_variant_precision() {
+    no_assignability_errors(
+        r#"
+type FirstElement<Tup> = Tup extends [infer Head, ...unknown[]] ? Head : never;
+
+type TupleUnion = [string, boolean] | [number];
+type Resolved = FirstElement<TupleUnion>;
+
+declare const resolved: Resolved;
+const accepted: string | number = resolved;
+"#,
+    );
+}
+
+#[test]
+fn distributive_head_rejects_widening_to_unrelated_member() {
+    let source = r#"
+type FirstSlot<Tup> = Tup extends [infer Head, ...unknown[]] ? Head : never;
+
+type Pair = [string, number] | [boolean];
+type Pulled = FirstSlot<Pair>;
+
+declare const pulled: Pulled;
+const onlyString: string = pulled;
+"#;
+    let diagnostics = compile_and_get_diagnostics_with_lib(source);
+    assert!(
+        has_error(&diagnostics, 2322),
+        "expected TS2322 because boolean does not fit string. diagnostics: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn distributive_head_with_alias_chain_preserves_variant_precision() {
+    no_assignability_errors(
+        r#"
+type LeftPair = [string, number];
+type RightPair = [boolean];
+type Combined = LeftPair | RightPair;
+
+type Front<Tup> = Tup extends [infer Hd, ...unknown[]] ? Hd : never;
+type Picked = Front<Combined>;
+
+declare const picked: Picked;
+const allowed: string | boolean = picked;
+"#,
+    );
+}
+
+#[test]
+fn distributive_tail_rest_keeps_per_variant_tuples() {
+    no_assignability_errors(
+        r#"
+type RestSlot<Tup> = Tup extends [unknown, ...infer Tail] ? Tail : never;
+
+type Mixed = [string, number, boolean] | [string, boolean] | [string];
+type Rest = RestSlot<Mixed>;
+
+declare const rest: Rest;
+const allowed: [number, boolean] | [boolean] | [] = rest;
+"#,
+    );
+}
+
+#[test]
+fn distributive_head_and_rest_box_pattern_preserves_each_arm() {
+    // Mirrors issue #10856 / #10848 minimal-repro intent (`Box<T> = T extends
+    // [infer H, ...infer R] ? [H, ...R] : []`) with renamed binders.
+    no_assignability_errors(
+        r#"
+type Rebuild<Seq> = Seq extends [infer Front, ...infer Back] ? [Front, ...Back] : [];
+
+type Variants = [string, string] | [number, number] | [];
+type Rebuilt = Rebuild<Variants>;
+
+declare const rebuilt: Rebuilt;
+const allowed: [string, string] | [number, number] | [] = rebuilt;
+"#,
+    );
+}
+
+#[test]
+fn distributive_init_last_pattern_preserves_per_variant_arity() {
+    no_assignability_errors(
+        r#"
+type Trunk<Tup> = Tup extends [...infer Init, infer Last] ? { init: Init; last: Last } : never;
+
+type AllTuples = [1, 2, 3] | [10, 20] | [99];
+type Split = Trunk<AllTuples>;
+
+declare const split: Split;
+const allowed:
+  | { init: [1, 2]; last: 3 }
+  | { init: [10]; last: 20 }
+  | { init: []; last: 99 } = split;
+"#,
+    );
+}
+
+#[test]
+fn distributive_sandwich_pattern_extracts_mid_per_variant() {
+    no_assignability_errors(
+        r#"
+type Inner<Tup> = Tup extends [unknown, ...infer Mid, unknown] ? Mid : never;
+
+type Cases = [1, 2, 3] | [10, 11, 12, 13];
+type MidSlices = Inner<Cases>;
+
+declare const slices: MidSlices;
+const allowed: [2] | [11, 12] = slices;
+"#,
+    );
+}
+
+#[test]
+fn distributive_constrained_head_filters_per_variant() {
+    no_assignability_errors(
+        r#"
+type StrictHead<Tup extends readonly unknown[]> =
+  Tup extends readonly [infer Head extends string, ...infer Rest]
+    ? readonly [Head, ...Rest]
+    : "ERROR";
+
+type Variants = [string, number] | [number, string] | ["literal", boolean] | [];
+type Output = StrictHead<Variants>;
+
+declare const output: Output;
+const allowed:
+  | readonly [string, number]
+  | "ERROR"
+  | readonly ["literal", boolean] = output;
+"#,
+    );
+}
+
+#[test]
+fn distributive_classify_over_tuple_union_preserves_variant_value() {
+    // Original-shape repro from issues #10848/#10856 (broken in templated
+    // body; this is the well-formed form with renamed binders).
+    no_assignability_errors(
+        r#"
+type Categorise<Item> = Item extends unknown
+  ? Item extends string
+    ? { kind: 'string'; value: Item }
+    : Item extends number
+      ? { kind: 'number'; value: Item }
+      : { kind: 'other'; value: Item }
+  : never;
+
+type Shapes = [string, string] | [number, number] | [];
+type Sorted = Categorise<Shapes>;
+
+declare const sorted: Sorted;
+const allowed:
+  | { kind: 'other'; value: [string, string] }
+  | { kind: 'other'; value: [number, number] }
+  | { kind: 'other'; value: [] } = sorted;
+"#,
+    );
+}
+
+#[test]
+fn non_distributive_tuple_wrapper_unions_all_inferred_heads() {
+    no_assignability_errors(
+        r#"
+type WrappedHead<T> = [T] extends [readonly [infer H, ...unknown[]]] ? H : never;
+
+type Both = [string, number] | [boolean];
+type Combined = WrappedHead<Both>;
+
+declare const combined: Combined;
+const allowed: string | boolean = combined;
+"#,
+    );
+}
+
+#[test]
+fn non_distributive_tuple_wrapper_fails_when_any_variant_misses() {
+    no_assignability_errors(
+        r#"
+type WrappedHead<T> = [T] extends [readonly [infer H, ...unknown[]]] ? H : never;
+
+type WithEmpty = [string, number] | [];
+type Maybe = WrappedHead<WithEmpty>;
+
+declare const maybe: Maybe;
+const allowed: never = maybe;
+"#,
+    );
+}
+
+#[test]
+fn distributive_mixed_readonly_and_mutable_tuple_union() {
+    no_assignability_errors(
+        r#"
+type FrontElt<Tup> = Tup extends readonly [infer Hd, ...unknown[]] ? Hd : never;
+
+type Mixed = readonly [string, number] | [boolean, string];
+type Picked = FrontElt<Mixed>;
+
+declare const picked: Picked;
+const allowed: string | boolean = picked;
+"#,
+    );
+}
+
+#[test]
+fn distributive_recursive_reverse_over_tuple_union() {
+    no_assignability_errors(
+        r#"
+type Flip<Tup extends readonly unknown[]> =
+  Tup extends readonly [infer Hd, ...infer Tl] ? [...Flip<Tl>, Hd] : [];
+
+type Triplets = [1, 2, 3] | [10, 20] | [];
+type Flipped = Flip<Triplets>;
+
+declare const flipped: Flipped;
+const allowed: [3, 2, 1] | [20, 10] | [] = flipped;
+"#,
+    );
+}
+
+#[test]
+fn distributive_over_tuple_union_with_no_infer_wrapper_round_trips() {
+    no_assignability_errors(
+        r#"
+type Pick0<Tup> = Tup extends [infer Hd, ...unknown[]] ? Hd : never;
+
+declare function take<Args>(input: Args, fallback: NoInfer<Pick0<Args>>): Pick0<Args>;
+
+const value = take([] as [string, number] | [boolean], 'fb');
+const allowed: string | boolean = value;
+"#,
+    );
+}
+
+#[test]
+fn distributive_head_with_class_subtype_variants() {
+    no_assignability_errors(
+        r#"
+class Base { tag = 'b' as const; }
+class Derived extends Base { mark = 1; }
+
+type FirstClass<Tup> = Tup extends readonly [infer Hd, ...unknown[]] ? Hd : never;
+
+type Cases = [Base, number] | [Derived, string];
+type Heads = FirstClass<Cases>;
+
+declare const heads: Heads;
+const allowed: Base | Derived = heads;
+"#,
+    );
+}
+
+#[test]
+fn distributive_zip_pair_of_tuples_over_union() {
+    no_assignability_errors(
+        r#"
+type ZipPair<Tup> =
+  Tup extends readonly [readonly [infer Fa, infer Fb], readonly [infer Sa, infer Sb]]
+    ? [Fa, Fb, Sa, Sb]
+    : never;
+
+type Inputs = [["a", true], ["b", false]] | [[1, 2], [3, 4]];
+type Flat = ZipPair<Inputs>;
+
+declare const flat: Flat;
+const allowed: ["a", true, "b", false] | [1, 2, 3, 4] = flat;
+"#,
+    );
+}
+
+#[test]
+fn distributive_function_args_over_signature_union_preserves_param_lists() {
+    no_assignability_errors(
+        r#"
+type ParamsOf<F> = F extends (...args: infer Args) => unknown ? Args : never;
+
+type Handlers = ((path: string) => void) | ((code: number, ok: boolean) => void);
+type AllArgs = ParamsOf<Handlers>;
+
+declare const argv: AllArgs;
+const allowed: [path: string] | [code: number, ok: boolean] = argv;
+"#,
+    );
+}
+
+#[test]
+fn distributive_constrained_head_picks_only_passing_variant() {
+    no_assignability_errors(
+        r#"
+type FilterStringHead<Tup> = Tup extends [infer Hd, ...unknown[]]
+  ? Hd extends string
+    ? Hd
+    : never
+  : never;
+
+type Variants = [string, 1] | [number, 2] | ["literal"];
+type Heads = FilterStringHead<Variants>;
+
+declare const heads: Heads;
+const allowed: string = heads;
+"#,
+    );
+}
+
+#[test]
+fn distributive_tuple_length_distribute() {
+    no_assignability_errors(
+        r#"
+type LengthOf<Tup extends readonly unknown[]> = Tup['length'];
+
+type Tuples = [1] | [1, 2] | [1, 2, 3];
+type Sizes = LengthOf<Tuples>;
+
+declare const sizes: Sizes;
+const allowed: 1 | 2 | 3 = sizes;
+"#,
+    );
+}

--- a/crates/tsz-checker/tests/conformance_issues/types/mod.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/mod.rs
@@ -1,4 +1,5 @@
 mod defaults;
+mod distributive_tuple_union;
 mod r#enum;
 mod indexed_access;
 mod membership_semantics;

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/array_infer.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/array_infer.rs
@@ -542,10 +542,18 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 let members = self.interner().type_list(members);
                 let mut inferred_members: SmallVec<[TypeId; 8]> = SmallVec::new();
                 for &member in members.iter() {
-                    let member_type = match self.interner().lookup(member) {
-                        Some(TypeData::ReadonlyType(inner)) => inner,
-                        _ => member,
-                    };
+                    // Peel transparent wrappers so an aliased or
+                    // `NoInfer<readonly [...]>` arm is recognised as a tuple
+                    // and the union arm is preserved in the merged result.
+                    let mut member_type = member;
+                    for _ in 0..2 {
+                        match self.interner().lookup(member_type) {
+                            Some(TypeData::ReadonlyType(inner) | TypeData::NoInfer(inner)) => {
+                                member_type = inner
+                            }
+                            _ => break,
+                        }
+                    }
                     match self.interner().lookup(member_type) {
                         Some(TypeData::Tuple(check_elements)) => {
                             let check_elements = self.interner().tuple_list(check_elements);

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -1397,6 +1397,53 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         evaluator.evaluate(type_id)
     }
 
+    /// Match each member of a union source against `pattern`, merging the
+    /// per-member infer bindings via [`Self::merge_infer_candidates`].
+    ///
+    /// Centralises the union-distribution policy used by `match_infer_pattern`
+    /// so every entry path applies the same contravariance-aware merge: infer
+    /// names that appear in contravariant positions (function/callable
+    /// parameters) intersect their candidates, all others union them. Without
+    /// this single source of truth, inner array/tuple branches could fall back
+    /// to a naive `union2` merge, silently producing an over-constrained
+    /// binding (e.g. `string & boolean` instead of `string | boolean`) for any
+    /// pattern that reaches them.
+    ///
+    /// Returns `false` as soon as one member fails to match the pattern,
+    /// matching the all-arms-must-match semantics of non-distributive
+    /// conditionals (`[T] extends [Pattern]` with `T` a union).
+    pub(crate) fn match_infer_pattern_union_members(
+        &self,
+        members: &[TypeId],
+        pattern: TypeId,
+        bindings: &mut FxHashMap<Atom, TypeId>,
+        visited: &mut FxHashSet<(TypeId, TypeId)>,
+        checker: &mut SubtypeChecker<'_, R>,
+    ) -> bool {
+        let base = bindings.clone();
+        let mut merged = base.clone();
+
+        // Determine which infer names appear in contravariant positions
+        // (function/callable parameters) of the pattern. For those, multiple
+        // candidates from union members should be intersected (not unioned).
+        // This is essential for `UnionToIntersection<U>`:
+        //   (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
+        // where `I` is in a contravariant (parameter) position, so candidates
+        // from each union member are intersected to produce `A & B`.
+        let contravariant_infers = self.collect_contravariant_infer_names(pattern);
+
+        for &member in members.iter() {
+            let mut local = base.clone();
+            if !self.match_infer_pattern(member, pattern, &mut local, visited, checker) {
+                return false;
+            }
+            self.merge_infer_candidates(&base, &mut merged, local, &contravariant_infers);
+        }
+
+        *bindings = merged;
+        true
+    }
+
     /// Main pattern matching function for infer types.
     ///
     /// Matches a source type against a pattern containing `infer` types,
@@ -1433,28 +1480,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
         if let Some(TypeData::Union(members)) = self.interner().lookup(source) {
             let members = self.interner().type_list(members);
-            let base = bindings.clone();
-            let mut merged = base.clone();
-
-            // Determine which infer names appear in contravariant positions
-            // (function/callable parameters) of the pattern. For those, multiple
-            // candidates from union members should be intersected (not unioned).
-            // This is essential for `UnionToIntersection<U>`:
-            //   (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
-            // where `I` is in a contravariant (parameter) position, so candidates
-            // from each union member are intersected to produce `A & B`.
-            let contravariant_infers = self.collect_contravariant_infer_names(pattern);
-
-            for &member in members.iter() {
-                let mut local = base.clone();
-                if !self.match_infer_pattern(member, pattern, &mut local, visited, checker) {
-                    return false;
-                }
-                self.merge_infer_candidates(&base, &mut merged, local, &contravariant_infers);
-            }
-
-            *bindings = merged;
-            return true;
+            return self
+                .match_infer_pattern_union_members(&members, pattern, bindings, visited, checker);
         }
 
         let Some(pattern_key) = self.interner().lookup(pattern) else {
@@ -1500,36 +1527,17 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         checker,
                     )
                 }
+                // Union sources are caught by the top-level dispatch above and
+                // routed through `match_infer_pattern_union_members`, so we
+                // never reach here with `source = Union(...)`. Keep the match
+                // arm explicit so a future change that loosens the top-level
+                // catch still goes through the contravariance-aware helper
+                // rather than a naive `union2` merge.
                 Some(TypeData::Union(members)) => {
                     let members = self.interner().type_list(members);
-                    let mut combined = FxHashMap::default();
-                    for &member in members.iter() {
-                        let Some(TypeData::Array(source_elem)) = self.interner().lookup(member)
-                        else {
-                            return false;
-                        };
-                        let mut member_bindings = FxHashMap::default();
-                        let mut local_visited = FxHashSet::default();
-                        if !self.match_infer_pattern(
-                            source_elem,
-                            pattern_elem,
-                            &mut member_bindings,
-                            &mut local_visited,
-                            checker,
-                        ) {
-                            return false;
-                        }
-                        for (name, ty) in member_bindings {
-                            combined
-                                .entry(name)
-                                .and_modify(|existing| {
-                                    *existing = self.interner().union2(*existing, ty);
-                                })
-                                .or_insert(ty);
-                        }
-                    }
-                    bindings.extend(combined);
-                    true
+                    self.match_infer_pattern_union_members(
+                        &members, pattern, bindings, visited, checker,
+                    )
                 }
                 _ => false,
             },
@@ -1545,38 +1553,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         checker,
                     )
                 }
+                // See note above: union sources are routed via the top-level
+                // helper to keep merge semantics uniform.
                 Some(TypeData::Union(members)) => {
                     let members = self.interner().type_list(members);
-                    let mut combined = FxHashMap::default();
-                    for &member in members.iter() {
-                        let Some(TypeData::Tuple(source_elems)) = self.interner().lookup(member)
-                        else {
-                            return false;
-                        };
-                        let source_elems = self.interner().tuple_list(source_elems);
-                        let pattern_elems = self.interner().tuple_list(pattern_elems);
-                        let mut member_bindings = FxHashMap::default();
-                        let mut local_visited = FxHashSet::default();
-                        if !self.match_tuple_elements(
-                            &source_elems,
-                            &pattern_elems,
-                            &mut member_bindings,
-                            &mut local_visited,
-                            checker,
-                        ) {
-                            return false;
-                        }
-                        for (name, ty) in member_bindings {
-                            combined
-                                .entry(name)
-                                .and_modify(|existing| {
-                                    *existing = self.interner().union2(*existing, ty);
-                                })
-                                .or_insert(ty);
-                        }
-                    }
-                    bindings.extend(combined);
-                    true
+                    self.match_infer_pattern_union_members(
+                        &members, pattern, bindings, visited, checker,
+                    )
                 }
                 _ => false,
             },

--- a/crates/tsz-solver/tests/evaluate_tests.rs
+++ b/crates/tsz-solver/tests/evaluate_tests.rs
@@ -68,3 +68,4 @@ include!("evaluate_tests_parts/template_literal_infer_distribution.rs");
 include!("evaluate_tests_parts/mapped_keyof_template.rs");
 include!("evaluate_tests_parts/indexed_access_template_recursive.rs");
 include!("evaluate_tests_parts/tuple_keyof_indexed_access.rs");
+include!("evaluate_tests_parts/distributive_tuple_union_regression.rs");

--- a/crates/tsz-solver/tests/evaluate_tests_parts/distributive_tuple_union_regression.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/distributive_tuple_union_regression.rs
@@ -1,0 +1,324 @@
+// Regression coverage for the distributive-conditional / tuple-union family
+// (issue #12175 and witnesses #10799, #10815, #10823, #10831, #10848, #10856,
+// #10864, #10872). The structural rule under test:
+//
+// > When conditional types distribute over tuple-like union inputs, each union
+// > arm's tuple constraints must be preserved and its inferred results merged
+// > independently, matching `tsc` behavior.
+//
+// Tests vary binder names (`T`/`U`, `H`/`F`/`Hd`, `R`/`Rest`/`Tl`) so a
+// fixture-name fast path cannot pass them, and cover both distributive
+// (`T extends ...`) and non-distributive (`[T] extends [...]`) forms so the
+// per-arm-merge path and the all-arms-must-match path stay distinct.
+
+fn make_tuple(interner: &TypeInterner, elems: Vec<TypeId>) -> TypeId {
+    interner.tuple(
+        elems
+            .into_iter()
+            .map(|t| TupleElement {
+                type_id: t,
+                name: None,
+                optional: false,
+                rest: false,
+            })
+            .collect(),
+    )
+}
+
+fn make_tuple_with_rest_tail(interner: &TypeInterner, head: Vec<TypeId>, rest: TypeId) -> TypeId {
+    let mut elems: Vec<TupleElement> = head
+        .into_iter()
+        .map(|t| TupleElement {
+            type_id: t,
+            name: None,
+            optional: false,
+            rest: false,
+        })
+        .collect();
+    elems.push(TupleElement {
+        type_id: rest,
+        name: None,
+        optional: false,
+        rest: true,
+    });
+    interner.tuple(elems)
+}
+
+#[test]
+fn distributive_tuple_union_head_only_pattern_unions_each_variant() {
+    // U extends [infer Hd, ...unknown[]] ? Hd : never
+    //   with U = [string, number] | [boolean] | [].
+    // Distribute -> { string, boolean, never } -> string | boolean.
+    let interner = TypeInterner::new();
+    let (u_name, u_param) = test_type_param(&interner, "U");
+    let (_, infer_hd) = test_infer_param(&interner, "Hd");
+
+    let unknown_arr = interner.array(TypeId::UNKNOWN);
+    let extends = make_tuple_with_rest_tail(&interner, vec![infer_hd], unknown_arr);
+    let cond = ConditionalType {
+        check_type: u_param,
+        extends_type: extends,
+        true_type: infer_hd,
+        false_type: TypeId::NEVER,
+        is_distributive: true,
+    };
+    let cond_type = interner.conditional(cond);
+
+    let arm_a = make_tuple(&interner, vec![TypeId::STRING, TypeId::NUMBER]);
+    let arm_b = make_tuple(&interner, vec![TypeId::BOOLEAN]);
+    let arm_c = make_tuple(&interner, vec![]);
+    let mut subst = TypeSubstitution::new();
+    subst.insert(u_name, interner.union(vec![arm_a, arm_b, arm_c]));
+
+    let instantiated = instantiate_type(&interner, cond_type, &subst);
+    let result = evaluate_type(&interner, instantiated);
+    let expected = interner.union(vec![TypeId::STRING, TypeId::BOOLEAN]);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn distributive_tuple_union_head_and_rest_preserves_per_variant_rest() {
+    // U extends [infer F, ...infer Tl] ? Tl : never
+    //   with U = [string, number, boolean] | [string, number] | [string].
+    // Distribute -> [number, boolean] | [number] | [].
+    let interner = TypeInterner::new();
+    let (u_name, u_param) = test_type_param(&interner, "U");
+    let (_, infer_f) = test_infer_param(&interner, "F");
+    let (_, infer_tl) = test_infer_param(&interner, "Tl");
+
+    let extends = make_tuple_with_rest_tail(&interner, vec![infer_f], infer_tl);
+    let cond = ConditionalType {
+        check_type: u_param,
+        extends_type: extends,
+        true_type: infer_tl,
+        false_type: TypeId::NEVER,
+        is_distributive: true,
+    };
+    let cond_type = interner.conditional(cond);
+
+    let arm_three = make_tuple(
+        &interner,
+        vec![TypeId::STRING, TypeId::NUMBER, TypeId::BOOLEAN],
+    );
+    let arm_two = make_tuple(&interner, vec![TypeId::STRING, TypeId::NUMBER]);
+    let arm_one = make_tuple(&interner, vec![TypeId::STRING]);
+    let mut subst = TypeSubstitution::new();
+    subst.insert(u_name, interner.union(vec![arm_three, arm_two, arm_one]));
+
+    let instantiated = instantiate_type(&interner, cond_type, &subst);
+    let result = evaluate_type(&interner, instantiated);
+
+    let expected = interner.union(vec![
+        make_tuple(&interner, vec![TypeId::NUMBER, TypeId::BOOLEAN]),
+        make_tuple(&interner, vec![TypeId::NUMBER]),
+        make_tuple(&interner, vec![]),
+    ]);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn non_distributive_tuple_wrapper_union_arms_merge_via_contravariance_helper() {
+    // [T] extends [[infer Hd, ...unknown[]]] ? Hd : never
+    //   with T = [string, number] | [boolean]. Non-distributive but the union
+    //   still flows through the contravariance-aware merge — expected
+    //   string | boolean.
+    let interner = TypeInterner::new();
+    let (t_name, t_param) = test_type_param(&interner, "T");
+    let (_, infer_hd) = test_infer_param(&interner, "Hd");
+
+    let unknown_arr = interner.array(TypeId::UNKNOWN);
+    let inner_pattern = make_tuple_with_rest_tail(&interner, vec![infer_hd], unknown_arr);
+    let outer_pattern = make_tuple(&interner, vec![inner_pattern]);
+    let outer_check = make_tuple(&interner, vec![t_param]);
+
+    let cond = ConditionalType {
+        check_type: outer_check,
+        extends_type: outer_pattern,
+        true_type: infer_hd,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+    let cond_type = interner.conditional(cond);
+
+    let arm_a = make_tuple(&interner, vec![TypeId::STRING, TypeId::NUMBER]);
+    let arm_b = make_tuple(&interner, vec![TypeId::BOOLEAN]);
+    let mut subst = TypeSubstitution::new();
+    subst.insert(t_name, interner.union(vec![arm_a, arm_b]));
+
+    let instantiated = instantiate_type(&interner, cond_type, &subst);
+    let result = evaluate_type(&interner, instantiated);
+    let expected = interner.union(vec![TypeId::STRING, TypeId::BOOLEAN]);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn non_distributive_tuple_wrapper_union_with_missing_arm_takes_false_branch() {
+    // [T] extends [[infer Hd, ...unknown[]]] ? Hd : never
+    //   with T = [string, number] | []. The empty arm doesn't fit the head
+    //   pattern, so the whole conditional fails and returns the false branch.
+    let interner = TypeInterner::new();
+    let (t_name, t_param) = test_type_param(&interner, "T");
+    let (_, infer_hd) = test_infer_param(&interner, "Hd");
+
+    let unknown_arr = interner.array(TypeId::UNKNOWN);
+    let inner_pattern = make_tuple_with_rest_tail(&interner, vec![infer_hd], unknown_arr);
+    let outer_pattern = make_tuple(&interner, vec![inner_pattern]);
+    let outer_check = make_tuple(&interner, vec![t_param]);
+
+    let cond = ConditionalType {
+        check_type: outer_check,
+        extends_type: outer_pattern,
+        true_type: infer_hd,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+    let cond_type = interner.conditional(cond);
+
+    let arm_a = make_tuple(&interner, vec![TypeId::STRING, TypeId::NUMBER]);
+    let arm_b = make_tuple(&interner, vec![]);
+    let mut subst = TypeSubstitution::new();
+    subst.insert(t_name, interner.union(vec![arm_a, arm_b]));
+
+    let instantiated = instantiate_type(&interner, cond_type, &subst);
+    let result = evaluate_type(&interner, instantiated);
+    assert_eq!(result, TypeId::NEVER);
+}
+
+#[test]
+fn distributive_tuple_union_box_pattern_rebuilds_each_arm() {
+    // Rebuild<Seq> = Seq extends [infer F, ...infer Tl] ? [F, ...Tl] : [];
+    //   with Seq = [string, string] | [number, number] | [].
+    // Distribute -> [string, string] | [number, number] | [] (the [] arm
+    //   takes the false branch).
+    let interner = TypeInterner::new();
+    let (seq_name, seq_param) = test_type_param(&interner, "Seq");
+    let (_, infer_f) = test_infer_param(&interner, "F");
+    let (_, infer_tl) = test_infer_param(&interner, "Tl");
+
+    let extends = make_tuple_with_rest_tail(&interner, vec![infer_f], infer_tl);
+    let true_branch = make_tuple_with_rest_tail(&interner, vec![infer_f], infer_tl);
+    let false_branch = make_tuple(&interner, vec![]);
+
+    let cond = ConditionalType {
+        check_type: seq_param,
+        extends_type: extends,
+        true_type: true_branch,
+        false_type: false_branch,
+        is_distributive: true,
+    };
+    let cond_type = interner.conditional(cond);
+
+    let arm_strings = make_tuple(&interner, vec![TypeId::STRING, TypeId::STRING]);
+    let arm_numbers = make_tuple(&interner, vec![TypeId::NUMBER, TypeId::NUMBER]);
+    let arm_empty = make_tuple(&interner, vec![]);
+    let mut subst = TypeSubstitution::new();
+    subst.insert(
+        seq_name,
+        interner.union(vec![arm_strings, arm_numbers, arm_empty]),
+    );
+
+    let instantiated = instantiate_type(&interner, cond_type, &subst);
+    let result = evaluate_type(&interner, instantiated);
+
+    let expected = interner.union(vec![
+        make_tuple(&interner, vec![TypeId::STRING, TypeId::STRING]),
+        make_tuple(&interner, vec![TypeId::NUMBER, TypeId::NUMBER]),
+        make_tuple(&interner, vec![]),
+    ]);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn distributive_tuple_union_readonly_arm_is_recognised_as_tuple() {
+    // U extends [infer Hd] ? Hd : never with U = readonly [string] | [number].
+    // The readonly variant must be peeled before the tuple shape is observed,
+    // otherwise its arm would be lost and the result would be number only.
+    let interner = TypeInterner::new();
+    let (u_name, u_param) = test_type_param(&interner, "U");
+    let (_, infer_hd) = test_infer_param(&interner, "Hd");
+
+    let extends = make_tuple(&interner, vec![infer_hd]);
+    let cond = ConditionalType {
+        check_type: u_param,
+        extends_type: extends,
+        true_type: infer_hd,
+        false_type: TypeId::NEVER,
+        is_distributive: false, // exercise the eval_conditional_tuple_infer Union branch
+    };
+    let cond_type = interner.conditional(cond);
+
+    let readonly_str = interner.intern(TypeData::ReadonlyType(make_tuple(
+        &interner,
+        vec![TypeId::STRING],
+    )));
+    let arm_num = make_tuple(&interner, vec![TypeId::NUMBER]);
+    let mut subst = TypeSubstitution::new();
+    subst.insert(u_name, interner.union(vec![readonly_str, arm_num]));
+
+    let instantiated = instantiate_type(&interner, cond_type, &subst);
+    let result = evaluate_type(&interner, instantiated);
+    let expected = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn distributive_tuple_union_no_infer_wrapper_arm_is_recognised_as_tuple() {
+    // Same single-element-pattern path, but one arm is `NoInfer<[number]>`.
+    // The wrapper must peel before the tuple shape is observed.
+    let interner = TypeInterner::new();
+    let (u_name, u_param) = test_type_param(&interner, "U");
+    let (_, infer_hd) = test_infer_param(&interner, "Hd");
+
+    let extends = make_tuple(&interner, vec![infer_hd]);
+    let cond = ConditionalType {
+        check_type: u_param,
+        extends_type: extends,
+        true_type: infer_hd,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+    let cond_type = interner.conditional(cond);
+
+    let arm_str = make_tuple(&interner, vec![TypeId::STRING]);
+    let noinfer_num = interner.intern(TypeData::NoInfer(make_tuple(
+        &interner,
+        vec![TypeId::NUMBER],
+    )));
+    let mut subst = TypeSubstitution::new();
+    subst.insert(u_name, interner.union(vec![arm_str, noinfer_num]));
+
+    let instantiated = instantiate_type(&interner, cond_type, &subst);
+    let result = evaluate_type(&interner, instantiated);
+    let expected = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn distributive_tuple_union_renamed_binders_match_canonical_form() {
+    // Same pattern with arbitrary binder names to confirm the result is
+    // identical (fixture-name independence).
+    let interner = TypeInterner::new();
+    let (zeta_name, zeta_param) = test_type_param(&interner, "Zeta");
+    let (_, infer_alpha) = test_infer_param(&interner, "Alpha");
+    let (_, infer_omega) = test_infer_param(&interner, "Omega");
+
+    let extends = make_tuple_with_rest_tail(&interner, vec![infer_alpha], infer_omega);
+    let cond = ConditionalType {
+        check_type: zeta_param,
+        extends_type: extends,
+        true_type: infer_alpha,
+        false_type: TypeId::NEVER,
+        is_distributive: true,
+    };
+    let cond_type = interner.conditional(cond);
+
+    let arm_a = make_tuple(&interner, vec![TypeId::STRING, TypeId::NUMBER]);
+    let arm_b = make_tuple(&interner, vec![TypeId::BOOLEAN]);
+    let mut subst = TypeSubstitution::new();
+    subst.insert(zeta_name, interner.union(vec![arm_a, arm_b]));
+
+    let instantiated = instantiate_type(&interner, cond_type, &subst);
+    let result = evaluate_type(&interner, instantiated);
+    let expected = interner.union(vec![TypeId::STRING, TypeId::BOOLEAN]);
+    assert_eq!(result, expected);
+}


### PR DESCRIPTION
AgentName: Studio-B
Track: solver / conditional types
Invariant: when conditional types distribute over tuple-like union inputs, each union arm's tuple constraints and inferred results must merge via the contravariance-aware helper, matching `tsc` behavior.
Scope: solver `match_infer_pattern` Union-source dispatch, `eval_conditional_tuple_infer` Union-arm peeling, and adjacent regression coverage.

## Summary

Refs #10856 / family #12175 (witnesses #10799 #10815 #10823 #10831 #10848 #10864 #10872).

`match_infer_pattern` had two divergent union-source merge paths:

1. Top-level `Union(source)` arm: collects `contravariant_infers` and merges per-arm bindings via `merge_infer_candidates` so infer names in function/callable parameter positions intersect and everywhere else unions.
2. Inner `Array(pattern_elem)` / `Tuple(pattern_elems)` arms each carried their own union-of-tuples fallback that merged candidates with a naive `union2` and never consulted `contravariant_infers`.

The inner fallbacks are only reachable via wrapper-driven dispatch paths that bypass the top-level Union catch (e.g. a future change that loosens what the top-level treats as "union source"). Whenever they fire today or in the future, they silently over-constrain the binding — e.g. `(U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never` would lose the intersection semantics and produce whichever arm landed last instead of `A & B`. That is the exact failure family #12175 describes: "tuple wrappers, aliases, or project-row utility layers hide the direct union shape" → per-arm precision collapses.

Centralise the union-arm merge in a single `match_infer_pattern_union_members` helper and route the top-level Union dispatch and both inner array/tuple fallbacks through it. Hot-path behavior is identical today; any future code that re-routes through the inner branches keeps the contravariance-aware merge.

Also peel `NoInfer` (in addition to the existing `ReadonlyType` peel) on each union arm inside `eval_conditional_tuple_infer`'s union branch, so a non-distributive `[T] extends [infer H]` with a `NoInfer<readonly [string]>` arm preserves the arm in the merged result instead of taking the false branch.

## Structural rule

When `match_infer_pattern` is asked to match a union-shaped source against any pattern, per-arm infer candidates must merge through `merge_infer_candidates` with the pattern's `contravariant_infers` set. The merge policy is owned by one helper; per-pattern arms route through it rather than re-implementing the merge inline.

## Owner layer

`crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs` and `crates/tsz-solver/src/evaluation/evaluate_rules/conditional/array_infer.rs`. Checker is unchanged; this is solver-internal cleanup with parity-preserving semantics on the live path.

## Adjacent matrix

19 checker integration tests in `crates/tsz-checker/tests/conformance_issues/types/distributive_tuple_union.rs` cover, with renamed binders so no fixture-name fast path can match:

- Distributive head, tail rest, head+rest (Box-style rebuild), init+last, sandwich (init+mid+last), recursive Reverse over tuple unions
- Constrained-head filter (`infer H extends string`) over heterogeneous union arms
- Mixed readonly/mutable union arms
- Aliased tuple variants (`type T1 = [string,number]; type U = T1 | ...`)
- `NoInfer<...>` round-trip via `take<T>(input, fallback: NoInfer<Head<T>>): Head<T>`
- Function signature union → `ParamsOf<F>` preserves per-arm parameter lists
- Class-subtype variants (`Base | Derived` heads)
- Zip-of-pairs nested tuple pattern
- Tuple `['length']` distribution over union of differing arity
- Non-distributive `[T] extends [readonly [infer H, ...unknown[]]]` (all arms must match; missing arm → false branch)
- Distributive `Classify_*` shape with the original-issue repro structure (well-formed, renamed binders)

8 solver-level unit tests in `crates/tsz-solver/tests/evaluate_tests_parts/distributive_tuple_union_regression.rs` exercise the underlying paths directly: head-only / head+rest distribution, Box-pattern rebuild including the `[]` arm taking the false branch, non-distributive wrapper around a union that merges via the contravariance helper, the missing-arm fall-through, readonly and `NoInfer` arm peeling in the union branch, and a renamed-binder canonical-form check.

## Project Corpus Impact

- Row: nextjs-fresh-app (primary witness), with cross-row smoke from kysely-project / type-challenges-solutions-project per #10856 notes
- Bug family: solver / distributive conditional tuple-union evaluation (#12175)

No project corpus row should regress; this PR keeps current hot-path semantics and only changes (a) the merge function used by the unreachable inner array/tuple union arms (now contravariance-aware), and (b) the wrapper-peeling depth in one union-handling branch from 1 (only `ReadonlyType`) to up to 2 (`ReadonlyType` and/or `NoInfer`). Both changes preserve or restore per-arm precision.

## Verification

Narrow `cargo nextest run` filters covering the new regression coverage and the helper hot path. (Full solver/checker suites stay on ready-review CI per the TSZ agent contract.)

```
cargo nextest run -p tsz-solver --lib 'distributive_tuple_union'
# 6 passed
cargo nextest run -p tsz-solver --lib 'non_distributive_tuple_wrapper_union'
# 2 passed
cargo nextest run -p tsz-checker --test conformance_issues_types 'distributive_tuple_union'
# 19 passed
cargo nextest run -p tsz-solver --lib
# 6483 passed; 8 failed (same 8 pre-existing failures on origin/main, unrelated:
# template-literal `unknown`/`any` widening, isomorphism validation, deep
# widening, contextual-callback schema inference). Verified by stashing this
# branch's changes and re-running on the bare main checkout — identical 8.
```

CLI smoke against the issue repros (`Head<[number] | [string, boolean]>`, `Classify_*<[string,string]|[number,number]|[]>`, `Box<[string,string]|[number,number]|[]>`, `Reverse<[1,2,3]|[10,20]>`, `Sandwich<[1,2,3]|[10,11,12,13]>`, function-signature union `ParamsOf<...>`, mixed readonly arms, `NoInfer` round-trip) all produce the same semantic answer as `tsc` 6.0.2.

## Coordination Notes

- Rebased onto live `origin/main` (post #12213) before CI re-run; new head expected to exercise the fresh base.
- Issue #10856 was templated with a syntactically-broken minimal repro (`type Box_74 = T extends [...]` missing the `<T>` parameter), so the issue body's body doesn't compile in either tsc or tsz. Reconstructed repros with the missing generic parameters all matched tsc behavior on the live path; this PR ships the structural hardening + comprehensive regression coverage that prevents the merge-policy split from re-emerging on a wrapper-driven path.
- File-size ceiling preserved: `infer_pattern.rs` 1762 → 1820 lines (under the 2000 cap), `array_infer.rs` 618 → 626.
- The 8 pre-existing solver test failures (`intern::tests::test_template_*`, `intern::intern_normalize_tests::template_literal_with_any_is_string`, `isomorphism_validation::test_unknown_widening_in_template`, `inference::infer::tests::literal_widening_and_union::test_deep_widen_object_candidate_homomorphic_mapped`, `operations::tests::test_infer_generic_object_with_contextual_callbacks_prefers_schema_property_type`) are present on the bare `origin/main` checkout and are out of scope for this PR.

https://claude.ai/code/session_01LzxaWimQ3BFZhz9K5vjvxs