### PR TITLE
fix(solver): correct ${any}/${unknown} template literal test expectations (tsc parity)

### DIFF
--- a/crates/tsz-solver/src/inference/infer_resolve.rs
+++ b/crates/tsz-solver/src/inference/infer_resolve.rs
@@ -162,11 +162,22 @@ impl<'a> InferenceContext<'a> {
             return effective_types.first().copied().unwrap_or(TypeId::UNKNOWN);
         }
 
+        // tsc's `getInferredType` always uses `getIntersectionType` for
+        // contra-candidates regardless of priority. Mirror that: intersection
+        // is correct for all real inference priorities including
+        // NakedTypeVariable (which produces `string & number` = never when the
+        // constraints truly conflict). The getCommonSubtype fallback below is
+        // retained only for the degenerate same-type case which is already
+        // handled by the dedup pass above, so in practice we reach the
+        // intersection branch for any pair of distinct types.
         let best_priority = contra_types.iter().map(|c| c.priority).min();
         let priority_implies_combination = best_priority.is_some_and(|priority| {
             matches!(
                 priority,
-                InferencePriority::ReturnType
+                InferencePriority::NakedTypeVariable
+                    | InferencePriority::HomomorphicMappedType
+                    | InferencePriority::PartialHomomorphicMappedType
+                    | InferencePriority::ReturnType
                     | InferencePriority::LowPriority
                     | InferencePriority::MappedType
                     | InferencePriority::LiteralKeyof
@@ -870,13 +881,13 @@ impl<'a> InferenceContext<'a> {
         // preserved (tsc uses RequiresWidening flag for this; we approximate
         // by checking the inference priority).
         let highest_priority = filtered_no_never.first().map(|c| c.priority);
+        // Contextual inference (ReturnType, LowPriority) preserves literal types
+        // because the caller supplies the expected type. HomomorphicMappedType is
+        // NOT contextual — it comes from reverse mapped inference and its object
+        // candidates should be deep-widened like NakedTypeVariable ones.
         let is_contextual_inference = matches!(
             highest_priority,
-            Some(
-                InferencePriority::ReturnType
-                    | InferencePriority::LowPriority
-                    | InferencePriority::HomomorphicMappedType
-            )
+            Some(InferencePriority::ReturnType | InferencePriority::LowPriority)
         );
         let resolved = if !preserve_literals && !is_contextual_inference && !resolved.is_intrinsic()
         {

--- a/crates/tsz-solver/src/inference/infer_resolve.rs
+++ b/crates/tsz-solver/src/inference/infer_resolve.rs
@@ -162,22 +162,19 @@ impl<'a> InferenceContext<'a> {
             return effective_types.first().copied().unwrap_or(TypeId::UNKNOWN);
         }
 
-        // tsc's `getInferredType` always uses `getIntersectionType` for
-        // contra-candidates regardless of priority. Mirror that: intersection
-        // is correct for all real inference priorities including
-        // NakedTypeVariable (which produces `string & number` = never when the
-        // constraints truly conflict). The getCommonSubtype fallback below is
-        // retained only for the degenerate same-type case which is already
-        // handled by the dedup pass above, so in practice we reach the
-        // intersection branch for any pair of distinct types.
+        // Mirror tsc's `getCommonSubtype` for high-priority contra-candidates
+        // (NakedTypeVariable, HomomorphicMappedType, PartialHomomorphicMappedType):
+        // use common-subtype tournament rather than intersection. Switching these
+        // to intersection caused conformance regressions in coAndContraVariantInferences2,
+        // correlatedUnions, and inferentialTypingWithFunctionTypeZip because tsz's
+        // interner does not simplify `string & number` to `never` as tsc does.
+        // Only lower-priority (combination) priorities use intersection, matching
+        // tsc's PriorityImpliesCombination flag.
         let best_priority = contra_types.iter().map(|c| c.priority).min();
         let priority_implies_combination = best_priority.is_some_and(|priority| {
             matches!(
                 priority,
-                InferencePriority::NakedTypeVariable
-                    | InferencePriority::HomomorphicMappedType
-                    | InferencePriority::PartialHomomorphicMappedType
-                    | InferencePriority::ReturnType
+                InferencePriority::ReturnType
                     | InferencePriority::LowPriority
                     | InferencePriority::MappedType
                     | InferencePriority::LiteralKeyof

--- a/crates/tsz-solver/src/inference/infer_resolve.rs
+++ b/crates/tsz-solver/src/inference/infer_resolve.rs
@@ -878,13 +878,13 @@ impl<'a> InferenceContext<'a> {
         // preserved (tsc uses RequiresWidening flag for this; we approximate
         // by checking the inference priority).
         let highest_priority = filtered_no_never.first().map(|c| c.priority);
-        // Contextual inference (ReturnType, LowPriority) preserves literal types
-        // because the caller supplies the expected type. HomomorphicMappedType is
-        // NOT contextual — it comes from reverse mapped inference and its object
-        // candidates should be deep-widened like NakedTypeVariable ones.
         let is_contextual_inference = matches!(
             highest_priority,
-            Some(InferencePriority::ReturnType | InferencePriority::LowPriority)
+            Some(
+                InferencePriority::ReturnType
+                    | InferencePriority::LowPriority
+                    | InferencePriority::HomomorphicMappedType
+            )
         );
         let resolved = if !preserve_literals && !is_contextual_inference && !resolved.is_intrinsic()
         {

--- a/crates/tsz-solver/src/intern/template.rs
+++ b/crates/tsz-solver/src/intern/template.rs
@@ -433,13 +433,24 @@ impl TypeInterner {
             }
         }
 
-        // Bare `${string}` is the only intrinsic placeholder that collapses to
-        // `string`, matching tsc's `getTemplateLiteralType` single-span rule.
-        // `${any}` and `${unknown}` are intentionally kept as distinct deferred
-        // template literal types: `string` is NOT assignable to `\`${any}\`` or
-        // `\`${unknown}\`` (tsc emits TS2322 for those assignments).
+        // Unknown absorption: a template that contains `unknown` anywhere collapses
+        // to `string`. `unknown` is opaque — the template cannot describe a more
+        // precise pattern — so the whole type is just `string`. Matches tsc's
+        // `getTemplateLiteralType` behaviour (see checker.ts isUnknownLikeUnionType).
+        for span in &spans {
+            if let TemplateSpan::Type(type_id) = span
+                && *type_id == TypeId::UNKNOWN
+            {
+                return TypeId::STRING;
+            }
+        }
+
+        // Single-span collapse: `${string}` and `${any}` are mutually assignable
+        // with `string` at the top level, so collapse to `string` (tsc's
+        // `getTemplateLiteralType` rule). Multi-span `any` preserves the template
+        // structure so that fixed text ("prefix-") is not lost.
         if let [TemplateSpan::Type(type_id)] = spans.as_slice()
-            && *type_id == TypeId::STRING
+            && (*type_id == TypeId::STRING || *type_id == TypeId::ANY)
         {
             return TypeId::STRING;
         }

--- a/crates/tsz-solver/src/intern/template.rs
+++ b/crates/tsz-solver/src/intern/template.rs
@@ -445,12 +445,12 @@ impl TypeInterner {
             }
         }
 
-        // Single-span collapse: `${string}` and `${any}` are mutually assignable
-        // with `string` at the top level, so collapse to `string` (tsc's
-        // `getTemplateLiteralType` rule). Multi-span `any` preserves the template
-        // structure so that fixed text ("prefix-") is not lost.
+        // Single-span `${string}` collapses to `string` (tsc's
+        // `getTemplateLiteralType` rule). `${any}` is intentionally NOT collapsed:
+        // tsc keeps `` `${any}` `` as a distinct deferred template literal type
+        // (string is not assignable to `` `${any}` ``, TS2322).
         if let [TemplateSpan::Type(type_id)] = spans.as_slice()
-            && (*type_id == TypeId::STRING || *type_id == TypeId::ANY)
+            && *type_id == TypeId::STRING
         {
             return TypeId::STRING;
         }

--- a/crates/tsz-solver/src/intern/template.rs
+++ b/crates/tsz-solver/src/intern/template.rs
@@ -433,22 +433,11 @@ impl TypeInterner {
             }
         }
 
-        // Unknown absorption: a template that contains `unknown` anywhere collapses
-        // to `string`. `unknown` is opaque — the template cannot describe a more
-        // precise pattern — so the whole type is just `string`. Matches tsc's
-        // `getTemplateLiteralType` behaviour (see checker.ts isUnknownLikeUnionType).
-        for span in &spans {
-            if let TemplateSpan::Type(type_id) = span
-                && *type_id == TypeId::UNKNOWN
-            {
-                return TypeId::STRING;
-            }
-        }
-
-        // Single-span `${string}` collapses to `string` (tsc's
-        // `getTemplateLiteralType` rule). `${any}` is intentionally NOT collapsed:
-        // tsc keeps `` `${any}` `` as a distinct deferred template literal type
-        // (string is not assignable to `` `${any}` ``, TS2322).
+        // Bare `${string}` is the only intrinsic placeholder that collapses to
+        // `string`, matching tsc's `getTemplateLiteralType` single-span rule.
+        // `${any}` and `${unknown}` are intentionally kept as distinct deferred
+        // template literal types: `string` is NOT assignable to `` `${any}` `` or
+        // `` `${unknown}` `` (tsc emits TS2322 for those assignments).
         if let [TemplateSpan::Type(type_id)] = spans.as_slice()
             && *type_id == TypeId::STRING
         {

--- a/crates/tsz-solver/tests/evaluate_tests_parts/template_literal_infer_distribution.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/template_literal_infer_distribution.rs
@@ -1490,15 +1490,14 @@ fn test_template_literal_with_never() {
 }
 
 #[test]
-fn test_template_literal_with_any() {
-    // `${any}` template with any should produce string
-    // TypeScript: `prefix-${any}` collapses to `string` because any can be any value
+fn test_template_literal_with_any_is_distinct() {
+    // tsc keeps `${any}` as a distinct TemplateLiteral type — `string` is NOT
+    // assignable to `${any}` (TS2322). Must NOT collapse to STRING.
     let interner = TypeInterner::new();
 
     let template = interner.template_literal(vec![TemplateSpan::Type(TypeId::ANY)]);
 
-    // Template with any should widen to string - any stringifies to any possible string
-    assert_eq!(template, TypeId::STRING);
+    assert_ne!(template, TypeId::STRING);
 }
 
 #[test]

--- a/crates/tsz-solver/tests/intern_normalize_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/intern_normalize_tests_parts/part_00.rs
@@ -1524,10 +1524,12 @@ fn template_literal_with_never_is_never() {
 }
 
 #[test]
-fn template_literal_with_any_is_string() {
+fn template_literal_with_any_is_distinct_template() {
+    // tsc keeps `${any}` as a distinct TemplateLiteral — NOT equal to string (TS2322 parity).
     let i = TypeInterner::new();
     let t = i.template_literal(vec![TemplateSpan::Type(TypeId::ANY)]);
-    assert_eq!(t, TypeId::STRING);
+    assert_ne!(t, TypeId::STRING);
+    assert!(matches!(i.lookup(t), Some(TypeData::TemplateLiteral(_))));
 }
 
 #[test]

--- a/crates/tsz-solver/tests/intern_tests.rs
+++ b/crates/tsz-solver/tests/intern_tests.rs
@@ -1328,15 +1328,23 @@ fn test_template_unknown_widening() {
 }
 
 #[test]
-fn test_template_any_widening() {
+fn test_template_any_is_distinct_template_literal() {
     let interner = TypeInterner::new();
 
-    // `` `${any}` `` should widen to string (any is infectious in templates)
+    // tsc keeps `` `${any}` `` as a distinct TemplateLiteral type — `string` is NOT
+    // assignable to `` `${any}` `` (TS2322). The type must NOT be collapsed to STRING.
     let template = interner.template_literal(vec![TemplateSpan::Type(TypeId::ANY)]);
-    assert_eq!(
+    assert_ne!(
         template,
         TypeId::STRING,
-        "Template with any should widen to string"
+        "Template with bare any must NOT collapse to string (tsc parity: TS2322)"
+    );
+    assert!(
+        matches!(
+            interner.lookup(template),
+            Some(TypeData::TemplateLiteral(_))
+        ),
+        "Template with bare any should be a TemplateLiteral type"
     );
 }
 

--- a/crates/tsz-solver/tests/intern_tests.rs
+++ b/crates/tsz-solver/tests/intern_tests.rs
@@ -1315,15 +1315,23 @@ fn test_template_empty_string_removal() {
 }
 
 #[test]
-fn test_template_unknown_widening() {
+fn test_template_unknown_is_distinct_template_literal() {
     let interner = TypeInterner::new();
 
-    // `` `${unknown}` `` should widen to string
+    // tsc keeps `` `${unknown}` `` as a distinct TemplateLiteral type — `string` is NOT
+    // assignable to `` `${unknown}` `` (TS2322 parity). Must NOT collapse to STRING.
     let template = interner.template_literal(vec![TemplateSpan::Type(TypeId::UNKNOWN)]);
-    assert_eq!(
+    assert_ne!(
         template,
         TypeId::STRING,
-        "Template with unknown should widen to string"
+        "Template with bare unknown must NOT collapse to string (tsc parity: TS2322)"
+    );
+    assert!(
+        matches!(
+            interner.lookup(template),
+            Some(TypeData::TemplateLiteral(_))
+        ),
+        "Template with bare unknown should be a TemplateLiteral type"
     );
 }
 

--- a/crates/tsz-solver/tests/isomorphism_validation.rs
+++ b/crates/tsz-solver/tests/isomorphism_validation.rs
@@ -317,8 +317,9 @@ fn test_any_widening_in_template() {
 }
 
 #[test]
-fn test_unknown_widening_in_template() {
-    // unknown in template should widen to string
+fn test_unknown_in_template_is_distinct() {
+    // tsc keeps `a${unknown}b` as a distinct TemplateLiteral type — `string` is NOT
+    // assignable to it. Must NOT collapse to STRING (TS2322 parity).
     let interner = create_test_interner();
 
     let spans = vec![
@@ -328,10 +329,17 @@ fn test_unknown_widening_in_template() {
     ];
     let template = interner.template_literal(spans);
 
-    assert_eq!(
+    assert_ne!(
         template,
         TypeId::STRING,
-        "Unknown widening in template failed"
+        "Template with unknown must NOT collapse to string (tsc parity: TS2322)"
+    );
+    assert!(
+        matches!(
+            interner.lookup(template),
+            Some(TypeData::TemplateLiteral(_))
+        ),
+        "Template with unknown should be a TemplateLiteral type"
     );
 }
 


### PR DESCRIPTION
AgentName: Studio-F
Track: 10 (Architecture cleanup / solver correctness)
Invariant: Solver type construction matches tsc's `getTemplateLiteralType` structural rule without hardcoded name checks or output surgery.
Scope: `crates/tsz-solver/src/intern/template.rs`, `crates/tsz-solver/src/inference/infer_resolve.rs`, test files

## Project Corpus Impact

- Row: n/a (comment + test-expectation fixes only; no behavioral change)
- Bug family: template-literal widening

## Summary

Corrects pre-existing unit test failures where tests incorrectly asserted that `` `${any}` `` and `` `${unknown}` `` collapse to `string`. tsc keeps both as distinct deferred template literal types — `string` is NOT assignable to either (TS2322). Only `${string}` (single-span) triggers collapse.

**Structural rule**: `TypeInterner::template_literal` collapses only `${string}` to `string`. `${any}` and `${unknown}` are intentionally preserved as `TemplateLiteral` nodes. Collapsing `${unknown}` was attempted and reverted: it caused unlisted conformance regressions in `coAndContraVariantInferences2.ts` and `correlatedUnions.ts`, confirming tsc's behavior.

### Changes

**Test corrections** (5 test files): Fix 5 tests that incorrectly asserted `${any}` or `${unknown}` == `TypeId::STRING`. Updated to assert `!= STRING` and `TypeData::TemplateLiteral`, matching tsc parity.

**Comment** (`infer_resolve.rs`): Documents why `NakedTypeVariable`/`HomomorphicMappedType`/`PartialHomomorphicMappedType` are excluded from `priority_implies_combination`. Extending that set caused conformance regressions because tsz's interner does not simplify `string & number` → `never` as tsc does.

## Verification

```
cargo nextest run -p tsz-solver
# 6499/6502 passed — 3 pre-existing failures unrelated to this PR
```

Conformance: no regressions (12582/12585 expected, matching baseline).

## Coordination Notes

Three pre-existing solver failures are tracked separately:
- `test_contra_candidate_basic`: requires tsz interner to simplify `string & number` → `never` before contra-candidate intersection can safely cover `NakedTypeVariable`
- `test_deep_widen_object_candidate_homomorphic_mapped`: requires finer-grained freshness flag check before removing `HomomorphicMappedType` from contextual inference guard
- `test_infer_generic_object_with_contextual_callbacks_prefers_schema_property_type`: deeper inference session work

https://claude.ai/code/session_01RNcyWVdbt7SXZsnAMazZAL