### PR TITLE
checker: elaborate intersection-member requirements for multi-property mismatches

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -1528,8 +1528,13 @@ impl<'a> CheckerState<'a> {
         }
 
         // TSC emits TS2322 instead of TS2739/TS2740 when the target is an intersection type.
-        if crate::query_boundaries::common::is_intersection_type(self.ctx.types, target_type)
-            || crate::query_boundaries::common::is_intersection_type(self.ctx.types, target)
+        // Evaluated form is checked too: a mapped-type alias like `Mapped<{ a, b }> & { c }`
+        // may only resolve to an intersection after evaluation.
+        // The jsdoc anchor path also enters here (intersection_for_members = None in that case)
+        // and receives bare TS2322 without per-property elaboration, matching tsc's output.
+        let intersection_for_members =
+            self.resolve_intersection_target_for_display(target_type, target);
+        if intersection_for_members.is_some()
             || self.anchor_jsdoc_type_tag_targets_intersection_alias(idx)
         {
             let src_str = self.format_type_diagnostic(source);
@@ -1538,13 +1543,24 @@ impl<'a> CheckerState<'a> {
                 diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                 &[&src_str, &tgt_str],
             );
-            return Diagnostic::error(
+            let mut diag = Diagnostic::error(
                 file_name,
                 start,
                 length,
                 message,
                 diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
             );
+            if let Some(intersection) = intersection_for_members {
+                self.push_intersection_member_elaboration(
+                    &mut diag,
+                    intersection,
+                    property_names,
+                    &src_str,
+                    start,
+                    length,
+                );
+            }
+            return diag;
         }
 
         // TSC emits TS2322 instead of TS2739/TS2740 when both source and target have

--- a/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
@@ -219,14 +219,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // Skip single-missing-property lookup when the target is an intersection type.
-        let target_is_intersection_for_mismatch = {
-            let target_eval = self.evaluate_type_with_env(target);
-            crate::query_boundaries::common::is_intersection_type(self.ctx.types, target)
-                || crate::query_boundaries::common::is_intersection_type(
-                    self.ctx.types,
-                    target_eval,
-                )
-        };
+        let target_is_intersection_for_mismatch = self.is_intersection_target(target);
         if depth == 0
             && !target_is_intersection_for_mismatch
             && let Some(property_name) = self.missing_single_required_property(source, target)

--- a/crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs
@@ -210,30 +210,14 @@ impl<'a> CheckerState<'a> {
         }
 
         // TSC emits TS2322 instead of TS2741 when the target type is an intersection type.
-        let target_evaluated_for_intersection = self.evaluate_type_with_env(target);
-        if crate::query_boundaries::common::is_intersection_type(self.ctx.types, target_type)
-            || crate::query_boundaries::common::is_intersection_type(self.ctx.types, target)
-            || crate::query_boundaries::common::is_intersection_type(
-                self.ctx.types,
-                target_evaluated_for_intersection,
-            )
+        // tsc keeps the top-level TS2322 but elaborates which intersection member requires the
+        // missing property; returning the bare TS2322 alone hid this root reason
+        // ("intersection fallback hides root property mismatch").
+        if let Some(intersection) =
+            self.resolve_intersection_target_for_display(target_type, target)
         {
             let src_str = self.format_type_diagnostic(source_type);
-            // The intersection matched by the guard above is both the target
-            // shown in the message and the type whose members we search for the
-            // one requiring the missing property — compute it once.
-            let intersection_for_members = if crate::query_boundaries::common::is_intersection_type(
-                self.ctx.types,
-                target_evaluated_for_intersection,
-            ) {
-                target_evaluated_for_intersection
-            } else if crate::query_boundaries::common::is_intersection_type(self.ctx.types, target)
-            {
-                target
-            } else {
-                target_type
-            };
-            let tgt_str = self.format_type_diagnostic(intersection_for_members);
+            let tgt_str = self.format_type_diagnostic(intersection);
             let message = format_message(
                 diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                 &[&src_str, &tgt_str],
@@ -245,31 +229,14 @@ impl<'a> CheckerState<'a> {
                 message,
                 diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
             );
-            // tsc keeps the top-level TS2322 above, but elaborates which
-            // intersection member requires the missing property:
-            //   Property 'X' is missing in type 'S' but required in type '<member>'.
-            // Returning the bare TS2322 alone hid this root reason ("intersection
-            // fallback hides root property mismatch").
-            if let Some(member) =
-                self.intersection_member_requiring_property(intersection_for_members, property_name)
-            {
-                let prop_name_display =
-                    self.missing_property_name_for_display(property_name, member);
-                let member_str = self.format_type_diagnostic(member);
-                let elaboration = format_message(
-                    diagnostic_messages::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
-                    &[&prop_name_display, &src_str, &member_str],
-                );
-                diag.related_information.push(DiagnosticRelatedInformation {
-                    file: diag.file.clone(),
-                    start,
-                    length,
-                    message_text: elaboration,
-                    category: DiagnosticCategory::Message,
-                    code: diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
-                    depth: 0,
-                });
-            }
+            self.push_intersection_member_elaboration(
+                &mut diag,
+                intersection,
+                &[property_name],
+                &src_str,
+                start,
+                length,
+            );
             return diag;
         }
 
@@ -440,8 +407,9 @@ impl<'a> CheckerState<'a> {
         }
 
         // TSC emits TS2322 instead of TS2741 when the target is an intersection type.
-        if crate::query_boundaries::common::is_intersection_type(self.ctx.types, target_type)
-            || crate::query_boundaries::common::is_intersection_type(self.ctx.types, target)
+        if self
+            .resolve_intersection_target_for_display(target_type, target)
+            .is_some()
         {
             let src_str = self.format_type_diagnostic(source);
             let tgt_str_full = self.format_type_diagnostic(target);
@@ -687,7 +655,7 @@ impl<'a> CheckerState<'a> {
     /// expanded object). Returns `None` when no member requires the property
     /// (e.g. the requirement comes from an index signature), leaving the caller
     /// with the bare top-level message.
-    fn intersection_member_requiring_property(
+    pub(super) fn intersection_member_requiring_property(
         &mut self,
         intersection: TypeId,
         property_name: tsz_common::interner::Atom,
@@ -716,6 +684,42 @@ impl<'a> CheckerState<'a> {
             }
         }
         None
+    }
+
+    /// Append one elaboration line to `diag` for each property in
+    /// `property_names` that is required by an intersection member.
+    ///
+    /// Mirrors the elaboration tsc appends for missing-property mismatches on
+    /// intersection targets:
+    /// `Property 'X' is missing in type 'S' but required in type '<member>'`.
+    pub(super) fn push_intersection_member_elaboration(
+        &mut self,
+        diag: &mut Diagnostic,
+        intersection: TypeId,
+        property_names: &[tsz_common::interner::Atom],
+        src_str: &str,
+        start: u32,
+        length: u32,
+    ) {
+        for &prop in property_names {
+            if let Some(member) = self.intersection_member_requiring_property(intersection, prop) {
+                let prop_name_display = self.missing_property_name_for_display(prop, member);
+                let member_str = self.format_type_diagnostic(member);
+                let elaboration = format_message(
+                    diagnostic_messages::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
+                    &[&prop_name_display, src_str, &member_str],
+                );
+                diag.related_information.push(DiagnosticRelatedInformation {
+                    file: diag.file.clone(),
+                    start,
+                    length,
+                    message_text: elaboration,
+                    category: DiagnosticCategory::Message,
+                    code: diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
+                    depth: 0,
+                });
+            }
+        }
     }
 
     /// For TS2739 source display, unfold wrapper aliases like

--- a/crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs
@@ -753,4 +753,33 @@ impl<'a> CheckerState<'a> {
         let node = self.ctx.arena.get(name_idx)?;
         Some((node.pos, node.end.saturating_sub(node.pos)))
     }
+
+    /// Return the most-specific of the three target candidates that is an
+    /// intersection type, in priority order `evaluated > target > target_type`.
+    /// Returns `None` when none is an intersection.
+    ///
+    /// Shared by single-property (`render_missing_property`) and multi-property
+    /// (`render_missing_properties`) intersection fall-back paths so the candidate
+    /// priority stays consistent.
+    pub(super) fn resolve_intersection_target_for_display(
+        &mut self,
+        target_type: TypeId,
+        target: TypeId,
+    ) -> Option<TypeId> {
+        let evaluated = self.evaluate_type_with_env(target);
+        [evaluated, target, target_type]
+            .into_iter()
+            .find(|&t| crate::query_boundaries::common::is_intersection_type(self.ctx.types, t))
+    }
+
+    /// Return `true` when `target` or its evaluated form is an intersection type.
+    ///
+    /// Used as a boolean predicate when only a single candidate is available
+    /// (e.g. `render_type_mismatch` where `target_type` is not in scope).
+    pub(super) fn is_intersection_target(&mut self, target: TypeId) -> bool {
+        let evaluated = self.evaluate_type_with_env(target);
+        [evaluated, target]
+            .into_iter()
+            .any(|t| crate::query_boundaries::common::is_intersection_type(self.ctx.types, t))
+    }
 }

--- a/crates/tsz-checker/tests/intersection_target_missing_property_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/intersection_target_missing_property_elaboration_tests.rs
@@ -166,3 +166,108 @@ const v: Target = { a: 123, b: 1 };
         "expected a TS2322 for the `a` value mismatch; got {diags:?}"
     );
 }
+
+// ── Multiple-missing-property (MissingProperties) cases ──────────────────────
+
+/// When two properties are missing and both live in the same mapped intersection
+/// member, each missing property gets its own elaboration line.
+#[test]
+fn multiple_missing_in_mapped_member_elaborates_each() {
+    let diags = diagnostics(
+        r#"
+type Map1<T> = { [K in keyof T]: T[K] };
+type Target = Map1<{ a: string; b: number; c: boolean }> & { d: string };
+const v: Target = { d: "x" };
+"#,
+    );
+    assert!(
+        has_missing_member_elaboration(&diags, "a"),
+        "expected elaboration for missing `a`; got {diags:?}"
+    );
+    assert!(
+        has_missing_member_elaboration(&diags, "b"),
+        "expected elaboration for missing `b`; got {diags:?}"
+    );
+    assert!(
+        has_missing_member_elaboration(&diags, "c"),
+        "expected elaboration for missing `c`; got {diags:?}"
+    );
+}
+
+/// Properties missing from *different* intersection members each get an
+/// elaboration line pointing to their respective requiring member.
+#[test]
+fn multiple_missing_across_different_members_elaborates_each() {
+    let diags = diagnostics(
+        r#"
+type Map1<T> = { [K in keyof T]: T[K] };
+type Target = Map1<{ x: string }> & { y: number };
+const v: Target = {};
+"#,
+    );
+    assert!(
+        has_missing_member_elaboration(&diags, "x"),
+        "expected elaboration for missing `x` in mapped member; got {diags:?}"
+    );
+    assert!(
+        has_missing_member_elaboration(&diags, "y"),
+        "expected elaboration for missing `y` in plain member; got {diags:?}"
+    );
+}
+
+/// Anti-hardcoding: different iteration-variable / property / alias spellings
+/// must not affect whether elaboration fires for the multi-property case.
+#[test]
+fn multiple_missing_renamed_vars_elaborates() {
+    let diags = diagnostics(
+        r#"
+type Wrap<U> = { [Q in keyof U]: U[Q] };
+type Combined = Wrap<{ alpha: string; beta: number }> & { gamma: boolean };
+const w: Combined = { gamma: true };
+"#,
+    );
+    assert!(
+        has_missing_member_elaboration(&diags, "alpha"),
+        "expected elaboration for missing `alpha`; got {diags:?}"
+    );
+    assert!(
+        has_missing_member_elaboration(&diags, "beta"),
+        "expected elaboration for missing `beta`; got {diags:?}"
+    );
+}
+
+/// A plain (non-mapped) intersection alias is normalised to an object type by
+/// the solver before it reaches the error reporter, so multiple missing
+/// properties produce TS2739 (the standard missing-properties message) rather
+/// than the intersection-member elaboration.  This verifies we don't regress
+/// the TS2739 path while the mapped-intersection elaboration is active.
+#[test]
+fn plain_intersection_alias_multiple_missing_gives_ts2739() {
+    let diags = diagnostics(
+        r#"
+type Target = { a: string; b: number } & { c: boolean };
+const v: Target = {};
+"#,
+    );
+    assert!(
+        diags.iter().any(|d| d.code == 2739),
+        "plain intersection with multiple missing properties must emit TS2739; got {diags:?}"
+    );
+}
+
+/// Negative: a complete source must not trigger any missing-member elaboration,
+/// even for multi-property intersection targets.
+#[test]
+fn multiple_missing_complete_source_no_error() {
+    let diags = diagnostics(
+        r#"
+type Map1<T> = { [K in keyof T]: T[K] };
+type Target = Map1<{ a: string; b: number }> & { c: boolean };
+const v: Target = { a: "s", b: 1, c: true };
+"#,
+    );
+    assert!(
+        !diags.iter().any(|d| d.code == 2322 || d.code == 2741),
+        "a complete source must not produce any assignability error; got {diags:?}"
+    );
+}


### PR DESCRIPTION
AgentName: busy-lamport-3nQhf

## Track
Compiler / Diagnostic conformance

## Invariant
When a source is assigned to an intersection target, tsc emits TS2322 with per-property elaboration lines (`Property 'X' is missing in type 'S' but required in type '<member>'`). tsz must match this output for both the single-property (`MissingProperty`) and multi-property (`MissingProperties`) paths, including intersection targets that only resolve after `evaluate_type_with_env` (e.g. mapped-type aliases like `Map1<{ a, b }> & { c }`).

**Structural rule:** When `SubtypeFailureReason::MissingProperties` fires and the target (or its evaluated form) is a `TypeData::Intersection`, the error reporter must emit TS2322 with elaboration lines for each missing property, not bare TS2322 without elaboration.

## Scope
- `crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs` — two new `pub(super)` helpers
- `crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs` — DRY via helpers, `intersection_member_requiring_property` promoted to `pub(super)`
- `crates/tsz-checker/src/error_reporter/render_failure.rs` — multi-property intersection path now elaborates per missing property
- `crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs` — inline check replaced with `is_intersection_target`
- `crates/tsz-checker/tests/intersection_target_missing_property_elaboration_tests.rs` — 5 new tests

## Changes

### New helpers (render_failure_property_helpers.rs)
- `resolve_intersection_target_for_display(target_type, target) -> Option<TypeId>`: checks `evaluated > target > target_type` in priority order, returning the first that is an intersection type. Shared by both single- and multi-property paths so the candidate priority is always consistent.
- `is_intersection_target(target) -> bool`: boolean variant for call sites where `target_type` is not in scope.

### Elaboration loop (render_failure_missing_property.rs)
- `push_intersection_member_elaboration(diag, intersection, property_names, src_str, start, length)`: iterates `property_names`, finds which intersection member requires each property via `intersection_member_requiring_property`, and appends a `DiagnosticRelatedInformation` entry. `file.clone()` only happens inside the `if let Some` arm.

### Multi-property path fix (render_failure.rs)
- Replaced the bare two-candidate inline check with `resolve_intersection_target_for_display`.
- When `intersection_for_members.is_some()`, calls `push_intersection_member_elaboration` to attach per-property elaboration lines.
- JsDoc anchor path still enters the same outer `if` but with `None`, producing bare TS2322 (matching tsc).

### type_mismatch.rs
- Inline 7-line two-candidate check replaced with `self.is_intersection_target(target)`.

## Project Corpus Impact
- Row: n/a
- Bug family: diagnostic-elaboration

No regressions expected. Plain intersections normalised to Object before reaching the reporter still emit TS2739 (verified by `plain_intersection_alias_multiple_missing_gives_ts2739`). Mapped-type alias intersections that previously showed bare TS2322 now additionally show elaboration lines matching tsc output.

## Verification
```
cargo nextest run -p tsz-checker --test intersection_target_missing_property_elaboration_tests
# 11 tests: 11 passed, 0 skipped
```

Adjacent-case matrix covered:
- Single property missing in mapped intersection member (pre-existing tests)
- Multiple properties missing from same mapped member
- Multiple properties missing from different members
- Anti-hardcoding: renamed iteration var, alias, property names
- Plain intersection alias (TS2739 path, not affected)
- Complete source (no error, negative case)

## Coordination Notes
Fixes issue #10903: "utility-types-project: Mapped intersection fallback hides the actual offending property". The fix is broader than the reported case — it unifies the three-candidate intersection resolution pattern across all four call sites and extends elaboration to the multi-property (`MissingProperties`) path that was previously unhandled.

https://claude.ai/code/session_01NZ3CVakPckoqvCH4Q4w7Eo