### PR TITLE
fix(checker): derive assignability failure reason from the decision's own pass

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -1539,7 +1539,7 @@ impl<'a> CheckerState<'a> {
             inheritance_graph: &self.ctx.inheritance_graph,
             sound_mode: self.ctx.sound_mode(),
         };
-        let gate = check_assignable_gate_with_overrides(&inputs, &overrides, Some(&self.ctx), true);
+        let gate = check_assignable_gate_with_overrides(&inputs, &overrides, true);
         if gate.related
             && let Some(reason) =
                 self.checker_only_assignability_failure_reason(prepared_source, prepared_target)

--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -173,7 +173,6 @@ impl<'a> CheckerState<'a> {
             flags,
             &self.ctx.inheritance_graph,
             &overrides,
-            Some(&self.ctx),
             self.ctx.sound_mode(),
         );
 
@@ -286,7 +285,6 @@ impl<'a> CheckerState<'a> {
                 flags,
                 &self.ctx.inheritance_graph,
                 &overrides,
-                Some(&self.ctx),
                 self.ctx.sound_mode(),
             )
         };

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -9,9 +9,34 @@ use tsz_solver::{
 
 use crate::state::CheckerState;
 
+use tsz_solver::relations::relation_queries::{
+    RelationContext, RelationKind as SolverRelationKind, RelationPolicy, RelationQueryInputs,
+    query_assignability_with_failure_analysis,
+};
+
 use super::relation_policy;
 
 pub(crate) use super::common::{contains_type_parameters, object_shape_for_type};
+
+/// Build the `(policy, context)` pair shared by the assignability-failure query
+/// paths from packed checker relation flags. Centralizing it keeps the gate
+/// decision and the single-pass failure analysis on identical policy/context.
+fn assignability_policy_and_context<'a>(
+    db: &'a dyn QueryDatabase,
+    inheritance_graph: &'a InheritanceGraph,
+    flags: u16,
+    sound_mode: bool,
+) -> (RelationPolicy, RelationContext<'a>) {
+    let policy = relation_policy::from_checker_flags_u16(flags)
+        .with_strict_subtype_checking(sound_mode)
+        .with_strict_any_propagation(sound_mode);
+    let context = RelationContext {
+        query_db: Some(db),
+        inheritance_graph: Some(inheritance_graph),
+        class_check: None,
+    };
+    (policy, context)
+}
 
 pub(crate) fn are_types_structurally_identical<R: TypeResolver>(
     db: &dyn TypeDatabase,
@@ -950,26 +975,18 @@ pub(crate) fn is_assignable_with_overrides<R: tsz_solver::relations::subtype::Ty
         inheritance_graph,
         sound_mode,
     } = *inputs;
-    let policy = relation_policy::from_checker_flags_u16(flags)
-        .with_strict_subtype_checking(sound_mode)
-        .with_strict_any_propagation(sound_mode);
-    let context = tsz_solver::relations::relation_queries::RelationContext {
-        query_db: Some(db),
-        inheritance_graph: Some(inheritance_graph),
-        class_check: None,
-    };
-    tsz_solver::relations::relation_queries::query_relation_with_overrides(
-        tsz_solver::relations::relation_queries::RelationQueryInputs {
-            interner: db.as_type_database(),
-            resolver,
-            source,
-            target,
-            kind: tsz_solver::relations::relation_queries::RelationKind::Assignable,
-            policy,
-            context,
-            overrides,
-        },
-    )
+    let (policy, context) =
+        assignability_policy_and_context(db, inheritance_graph, flags, sound_mode);
+    tsz_solver::relations::relation_queries::query_relation_with_overrides(RelationQueryInputs {
+        interner: db.as_type_database(),
+        resolver,
+        source,
+        target,
+        kind: SolverRelationKind::Assignable,
+        policy,
+        context,
+        overrides,
+    })
 }
 
 /// Like `is_assignable_with_overrides` but skips weak type checks (TS2559).
@@ -1126,29 +1143,44 @@ pub(crate) fn check_assignable_gate_with_overrides<
 >(
     inputs: &AssignabilityQueryInputs<'_, R>,
     overrides: &dyn tsz_solver::relations::compat::AssignabilityOverrideProvider,
-    ctx: Option<&crate::context::CheckerContext<'_>>,
     collect_failure_analysis: bool,
 ) -> AssignabilityGateResult {
-    let related = is_assignable_with_overrides(inputs, overrides).is_related();
-
-    if !collect_failure_analysis || related {
+    // When the caller only needs the boolean, take the cheap single-decision path.
+    if !collect_failure_analysis {
+        let related = is_assignable_with_overrides(inputs, overrides).is_related();
         return AssignabilityGateResult {
             related,
             analysis: None,
         };
     }
 
-    let analysis = ctx.map(|ctx| {
-        analyze_assignability_failure_with_context(
-            inputs.db.as_type_database(),
-            ctx,
-            inputs.resolver,
-            inputs.source,
-            inputs.target,
-        )
+    // Otherwise decide and (on failure) explain in a single configured-checker
+    // pass so the structured analysis observes exactly the same relation policy,
+    // overrides, and cached sub-results as the decision and cannot contradict it.
+    let (policy, context) = assignability_policy_and_context(
+        inputs.db,
+        inputs.inheritance_graph,
+        inputs.flags,
+        inputs.sound_mode,
+    );
+    let outcome = query_assignability_with_failure_analysis(RelationQueryInputs {
+        interner: inputs.db.as_type_database(),
+        resolver: inputs.resolver,
+        source: inputs.source,
+        target: inputs.target,
+        kind: SolverRelationKind::Assignable,
+        policy,
+        context,
+        overrides,
     });
-
-    AssignabilityGateResult { related, analysis }
+    let analysis = outcome.analysis.map(|a| AssignabilityFailureAnalysis {
+        weak_union_violation: a.weak_union_violation,
+        failure_reason: a.failure_reason,
+    });
+    AssignabilityGateResult {
+        related: outcome.result.is_related(),
+        analysis,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1205,7 +1237,6 @@ pub(crate) fn execute_relation<R: tsz_solver::relations::subtype::TypeResolver>(
     flags: u16,
     inheritance_graph: &InheritanceGraph,
     overrides: &dyn tsz_solver::relations::compat::AssignabilityOverrideProvider,
-    ctx: Option<&crate::context::CheckerContext<'_>>,
     sound_mode: bool,
 ) -> RelationOutcome {
     let _span = tracing::debug_span!(
@@ -1221,38 +1252,40 @@ pub(crate) fn execute_relation<R: tsz_solver::relations::subtype::TypeResolver>(
         relation_flags |= RelationFlags::ALLOW_ERASED_GENERIC_SIGNATURE_RETRY;
     }
 
-    // BivariantCallbacks uses a different solver entry point that treats
-    // callback parameter types bivariantly (strips strict-function-types).
-    let (related, depth_exceeded, iteration_exceeded) =
-        if request.kind == RelationKind::BivariantCallbacks {
-            let bivariant_flags = relation_flags & !RelationFlags::STRICT_FUNCTION_TYPES;
-            let r = is_assignable_bivariant_with_resolver(
-                db,
-                resolver,
-                request.source,
-                request.target,
-                bivariant_flags,
-                inheritance_graph,
-                sound_mode,
-            );
-            (r.is_related(), r.depth_exceeded, r.iteration_exceeded)
-        } else {
-            let inputs = AssignabilityQueryInputs {
-                db,
-                resolver,
-                source: request.source,
-                target: request.target,
-                flags: relation_flags,
-                inheritance_graph,
-                sound_mode,
-            };
-            let relation_result = is_assignable_with_overrides(&inputs, overrides);
-            (
-                relation_result.is_related(),
-                relation_result.depth_exceeded,
-                relation_result.iteration_exceeded,
-            )
-        };
+    // BivariantCallbacks treats callback parameter types bivariantly by stripping
+    // strict-function-types. The decision and the failure reason both run under
+    // this policy so they cannot diverge.
+    let (solver_kind, solver_flags) = if request.kind == RelationKind::BivariantCallbacks {
+        (
+            SolverRelationKind::AssignableBivariantCallbacks,
+            relation_flags & !RelationFlags::STRICT_FUNCTION_TYPES,
+        )
+    } else {
+        (SolverRelationKind::Assignable, relation_flags)
+    };
+
+    // Decide the relation and, on failure, capture the structured reason from the
+    // SAME configured checker (single pass). This is the canonical fix for the
+    // boundary's previous double evaluation, where the pass/fail decision and the
+    // failure reason were computed by two independently configured checkers and
+    // could contradict each other (or drop the reason entirely when a checker
+    // override forced the failure).
+    let (policy, context) =
+        assignability_policy_and_context(db, inheritance_graph, solver_flags, sound_mode);
+    let solver_outcome = query_assignability_with_failure_analysis(RelationQueryInputs {
+        interner: db.as_type_database(),
+        resolver,
+        source: request.source,
+        target: request.target,
+        kind: solver_kind,
+        policy,
+        context,
+        overrides,
+    });
+
+    let related = solver_outcome.result.is_related();
+    let depth_exceeded = solver_outcome.result.depth_exceeded;
+    let iteration_exceeded = solver_outcome.result.iteration_exceeded;
 
     if related {
         return RelationOutcome {
@@ -1265,18 +1298,7 @@ pub(crate) fn execute_relation<R: tsz_solver::relations::subtype::TypeResolver>(
         };
     }
 
-    // Relation failed — collect structured failure analysis.
-    let analysis = ctx.map(|ctx| {
-        analyze_assignability_failure_with_context(
-            db.as_type_database(),
-            ctx,
-            resolver,
-            request.source,
-            request.target,
-        )
-    });
-
-    let (weak_union_violation, failure) = match analysis {
+    let (weak_union_violation, failure) = match solver_outcome.analysis {
         Some(a) => (
             a.weak_union_violation,
             a.failure_reason
@@ -1770,29 +1792,6 @@ fn is_global_object_or_function_shape(
         let name = db.resolve_atom_ref(prop.name);
         OBJECT_PROTO.contains(&name.as_ref()) || FUNCTION_PROTO.contains(&name.as_ref())
     })
-}
-
-pub(crate) fn analyze_assignability_failure_with_context<
-    R: tsz_solver::relations::subtype::TypeResolver,
->(
-    db: &dyn TypeDatabase,
-    ctx: &crate::context::CheckerContext<'_>,
-    resolver: &R,
-    source: TypeId,
-    target: TypeId,
-) -> AssignabilityFailureAnalysis {
-    let analysis =
-        tsz_solver::relations::relation_queries::analyze_assignability_failure_with_resolver(
-            db,
-            resolver,
-            source,
-            target,
-            |checker| ctx.configure_compat_checker(checker),
-        );
-    AssignabilityFailureAnalysis {
-        weak_union_violation: analysis.weak_union_violation,
-        failure_reason: analysis.failure_reason,
-    }
 }
 
 /// Explain a same-generic application failure (`C<A..>` vs `C<B..>`) via the

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_00.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_00.rs
@@ -1208,8 +1208,9 @@ fn test_assignment_and_binding_default_assignability_use_central_gateway_helpers
         "query_boundaries/assignability should not construct CompatChecker directly; use solver relation-query helpers"
     );
     assert!(
-        assignability_boundary_src.contains("analyze_assignability_failure_with_resolver("),
-        "query_boundaries/assignability failure analysis should route through solver relation-query helpers"
+        assignability_boundary_src.contains("query_assignability_with_failure_analysis("),
+        "query_boundaries/assignability failure analysis should route through the solver relation-query \
+         helper that decides and explains in a single configured-checker pass"
     );
 
     let generic_checker_src = {

--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -355,6 +355,89 @@ where
     }
 }
 
+/// The relation result plus, when the relation does not hold, the structured
+/// failure analysis derived from the **same** configured-checker pass.
+#[derive(Debug, Clone)]
+pub struct AssignabilityQueryOutcome {
+    /// Pass/fail outcome of the assignability relation.
+    pub result: RelationResult,
+    /// Structured failure analysis, present iff `result.related` is `false`.
+    pub analysis: Option<AssignabilityFailureAnalysis>,
+}
+
+/// Query an assignability relation and, when it fails, derive the failure
+/// analysis from the **same** configured [`CompatChecker`] instance.
+///
+/// The query boundary previously decided pass/fail with one configured checker
+/// and then computed the failure reason with a second, independently
+/// configured checker. Those two traversals could disagree — producing a
+/// failure reason that contradicts the decision, or no reason at all when a
+/// checker override (enum / abstract-constructor / accessibility / private
+/// brand) forced the failure before the structural walk ran. Running the
+/// decision and the failure analysis on one checker shares its relation cache,
+/// so the reason is always consistent with the decision and the relation is
+/// not re-evaluated from scratch.
+///
+/// Only the assignability relation kinds (`Assignable` and
+/// `AssignableBivariantCallbacks`) carry structured failure analysis; other
+/// kinds must use [`query_relation_with_overrides`].
+pub fn query_assignability_with_failure_analysis<'a, R, P>(
+    RelationQueryInputs {
+        interner,
+        resolver,
+        source,
+        target,
+        kind,
+        policy,
+        context,
+        overrides,
+    }: RelationQueryInputs<'a, R, P>,
+) -> AssignabilityQueryOutcome
+where
+    R: TypeResolver,
+    P: AssignabilityOverrideProvider + ?Sized,
+{
+    let _span = tracing::debug_span!(
+        "query_assignability_with_failure_analysis",
+        src = source.0,
+        tgt = target.0,
+        kind = ?kind,
+    )
+    .entered();
+
+    let mut checker = configured_compat_checker(interner, resolver, policy, context);
+    let related = match kind {
+        RelationKind::Assignable => checker.is_assignable_with_overrides(source, target, overrides),
+        RelationKind::AssignableBivariantCallbacks => {
+            checker.is_assignable_to_bivariant_callback(source, target)
+        }
+        other => {
+            debug_assert!(
+                false,
+                "query_assignability_with_failure_analysis requires an assignability relation kind, got {other:?}"
+            );
+            checker.is_assignable_with_overrides(source, target, overrides)
+        }
+    };
+
+    let result = RelationResult {
+        kind,
+        related,
+        depth_exceeded: checker.depth_exceeded(),
+        iteration_exceeded: checker.iteration_exceeded(),
+    };
+
+    // The failure analysis runs on the same `checker`, so its relation cache is
+    // already warm with the decision's sub-results: the structural reason walk
+    // observes the identical outcomes the decision did and cannot contradict it.
+    let analysis = (!related).then(|| AssignabilityFailureAnalysis {
+        weak_union_violation: checker.is_weak_union_violation(source, target),
+        failure_reason: checker.explain_failure(source, target),
+    });
+
+    AssignabilityQueryOutcome { result, analysis }
+}
+
 /// Explain a same-generic application failure (`C<A..>` vs `C<B..>`) via the
 /// differing type arguments, mirroring tsc's elaboration.
 ///

--- a/crates/tsz-solver/tests/relation_queries_tests.rs
+++ b/crates/tsz-solver/tests/relation_queries_tests.rs
@@ -231,6 +231,112 @@ fn assignability_failure_analysis_helper_reports_reason() {
 }
 
 #[test]
+fn single_pass_analysis_matches_decision_and_explains_structural_failure() {
+    // `animal` (only `name`) is not assignable to `dog` (`name` + `breed`).
+    // The single-pass helper must report `related == false` AND surface a
+    // structured reason from the SAME checker pass, with a decision identical
+    // to the canonical boolean query.
+    let interner = TypeInterner::new();
+    let resolver = NoopResolver;
+    let overrides = NoopOverrideProvider;
+    let (animal, dog) = make_animal_dog(&interner);
+    let policy = RelationPolicy::from_relation_flags(RelationFlags::STRICT_NULL_CHECKS);
+
+    let inputs = || RelationQueryInputs {
+        interner: &interner,
+        resolver: &resolver,
+        source: animal,
+        target: dog,
+        kind: RelationKind::Assignable,
+        policy,
+        context: RelationContext::default(),
+        overrides: &overrides,
+    };
+
+    let outcome = query_assignability_with_failure_analysis(inputs());
+    let decision = query_relation_with_overrides(inputs());
+
+    assert_eq!(
+        outcome.result.related, decision.related,
+        "single-pass decision must match the canonical assignability query"
+    );
+    assert!(!outcome.result.related);
+
+    let analysis = outcome
+        .analysis
+        .expect("a failed relation must carry structured analysis");
+    assert!(
+        analysis.failure_reason.is_some(),
+        "missing-property failure must surface a reason from the same pass"
+    );
+}
+
+#[test]
+fn single_pass_analysis_is_absent_when_relation_holds() {
+    // `dog` (name + breed) IS assignable to `animal` (name): the helper must
+    // report `related == true` and carry no failure analysis.
+    let interner = TypeInterner::new();
+    let resolver = NoopResolver;
+    let overrides = NoopOverrideProvider;
+    let (animal, dog) = make_animal_dog(&interner);
+    let policy = RelationPolicy::from_relation_flags(RelationFlags::STRICT_NULL_CHECKS);
+
+    let outcome = query_assignability_with_failure_analysis(RelationQueryInputs {
+        interner: &interner,
+        resolver: &resolver,
+        source: dog,
+        target: animal,
+        kind: RelationKind::Assignable,
+        policy,
+        context: RelationContext::default(),
+        overrides: &overrides,
+    });
+
+    assert!(outcome.result.related);
+    assert!(
+        outcome.analysis.is_none(),
+        "a holding relation must not carry failure analysis"
+    );
+}
+
+#[test]
+fn single_pass_decision_honors_overrides_and_records_analysis() {
+    // An override that forces non-assignability for a structurally-assignable
+    // pair (`number -> number`) drives BOTH the decision and the analysis
+    // through the same configured checker. Previously the decision observed the
+    // override while a separate reason pass did not, leaving `related == false`
+    // with no analysis record. The single-pass helper keeps them coupled.
+    let interner = TypeInterner::new();
+    let resolver = NoopResolver;
+    let overrides = AlwaysRejectOverride;
+    let policy = RelationPolicy::from_relation_flags(RelationFlags::STRICT_NULL_CHECKS);
+
+    let inputs = || RelationQueryInputs {
+        interner: &interner,
+        resolver: &resolver,
+        source: TypeId::NUMBER,
+        target: TypeId::NUMBER,
+        kind: RelationKind::Assignable,
+        policy,
+        context: RelationContext::default(),
+        overrides: &overrides,
+    };
+
+    let outcome = query_assignability_with_failure_analysis(inputs());
+    let decision = query_relation_with_overrides(inputs());
+
+    assert_eq!(
+        outcome.result.related, decision.related,
+        "single-pass decision must match the canonical override-aware query"
+    );
+    assert!(!outcome.result.related, "override forces non-assignability");
+    assert!(
+        outcome.analysis.is_some(),
+        "a non-related outcome must always carry an analysis record"
+    );
+}
+
+#[test]
 fn redeclaration_identity_evaluates_keyof_to_literal_union() {
     // Regression test: `var v: "a" | "b"; var v: keyof { a: number, b: string }`
     // should NOT produce TS2403 because `keyof { a: number, b: string }` evaluates


### PR DESCRIPTION
Fixes #10906.

AgentName: M1-C

**Track:** Conformance / diagnostics — assignability query boundary (`query_boundaries/assignability`).

**Invariant:** When a relation does not hold, the failure reason rendered into a `TS2322`/`TS2345`/`TS2416` diagnostic is derived from the *same* configured `CompatChecker` pass that produced the pass/fail decision, so the reason can never contradict the decision and the relation is not re-evaluated under a second, differently configured checker.

**Structural rule:** When an assignability relation fails, `tsc` reports the reason from the same relation it just decided (a no-report pass, then a reporting pass under the *same* relation and flags). tsz did this through the `query_boundaries::assignability` gateway, but decided pass/fail with one configured checker (full policy + overrides + warm cache) and then computed the reason with a *second*, independently configured checker (`analyze_assignability_failure_with_context` → a fresh `CompatChecker` configured only by `ctx.configure_compat_checker`, with no overrides and a cold cache). The two traversals could disagree:

- A checker override (`enum` / abstract-constructor / accessibility / private-brand) forces the failure *before* the structural walk runs, so the override-blind reason pass sees the operands as structurally assignable and yields **no reason** → `related = false` with `failure = None`.
- On recursive / order-sensitive types the cold-cache reason walk can reach a **different** structural failure than the decision → contradictory message / inconsistent ordering.

That is the reported "boundary routing duplicates relation attempts and produces contradictory diagnostics".

**Scope:**
- `crates/tsz-solver/src/relations/relation_queries.rs`: new `query_assignability_with_failure_analysis` (+ `AssignabilityQueryOutcome`). Builds **one** `configured_compat_checker(policy, context)`, runs the decision (`is_assignable_with_overrides` / `is_assignable_to_bivariant_callback`) and, only on failure, `is_weak_union_violation` + `explain_failure` on that **same** checker — reusing the warm relation cache. Handles `Assignable` and `AssignableBivariantCallbacks` uniformly.
- `crates/tsz-checker/src/query_boundaries/assignability.rs`: `execute_relation` and `check_assignable_gate_with_overrides` now route through the new helper; removed the divergent `analyze_assignability_failure_with_context`; centralized policy/context construction in one `assignability_policy_and_context` helper (also reused by `is_assignable_with_overrides`). The decision is byte-identical to before; only the reason is now single-pass.
- `crates/tsz-checker/src/assignability/assignability_relation.rs`: drop the now-unused `ctx` argument at the two `execute_relation` call sites.
- `crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_00.rs`: the boundary-routing contract now asserts the canonical single-pass helper.

**Adjacent matrix:** covered by `Assignable` + `AssignableBivariantCallbacks` kinds; override-forced (abstract-constructor, enum) and structural (missing-property, tuple/element, signature) failures; positive (related ⇒ no analysis) and negative (not-related ⇒ analysis present) cases.

## Project Corpus Impact

- Row: utility-types-project
- Bug family: assignability-boundary-routing
- No required-row diagnostic changes expected — the pass/fail decision is unchanged (same `configured_compat_checker` + overrides + flags); only the failure *reason* path is unified. Net effect is fewer checker constructions on the failure path (one instead of two) plus warm-cache reuse.

**Verification:**
- `cargo check -p tsz-solver`, `cargo check -p tsz-checker` — clean (also rebased onto current `main` `a1295c0` and re-checked).
- `cargo clippy -p tsz-solver -p tsz-checker --lib` — clean.
- New solver unit tests (`single_pass_*` in `relation_queries_tests`): decision parity with `query_relation_with_overrides`, analysis present iff not-related, override-forced failure keeps decision and analysis coupled — pass.
- `abstract_constructor_elaboration_tests` (3), `abstract_constructor_argument_tests` (6), `enum_nominality_tests` (40), `signature_assignability_regression_tests` (6), `ts2322_destructuring_obj_literal_tests` (4), `tuple_element_mismatch_tests` (7) — pass.
- Note: `test_assignment_and_binding_default_assignability_use_central_gateway_helpers` is red on `main` (pre-existing, asserts on `flow/control_flow/assignment.rs`, untouched here); verified identical failure on the stashed base.

**Coordination Notes:** This PR is ready for review (not draft). Issue #10906 is claimed under lane `agent:M1-C` (the in-progress label is applied to the issue, not this PR). No overlap with the active solver bug-family efforts (variadic-tuple / recursive-utility / conditional-types). Touches the shared `query_boundaries/assignability` gateway and adds a solver relation-query helper — agents working on assignability-diagnostic display should rebase onto this.