### PR TITLE
fix(checker): reset global resolution fuel per top-level statement (#12144)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -685,9 +685,13 @@ impl<'a> CheckerState<'a> {
         if type_id.is_intrinsic() {
             return;
         }
-        if crate::state_domain::type_environment::lazy::global_resolution_fuel_exhausted() {
-            return;
-        }
+        // Do NOT gate on global_resolution_fuel_exhausted() here.  The inner
+        // guards inside ensure_refs_resolved (and ensure_application_symbols_resolved)
+        // already exit the materialization worklist when global fuel is exhausted,
+        // bounding total work per call to O(1).  Gating the entire readiness step
+        // here caused subsequent DOM/lib relation checks in the same file to skip
+        // their input step entirely, silently dropping TS2322/TS2345 diagnostics
+        // after the first large-lib type graph was materialized (issue #12144).
         self.ensure_refs_resolved(type_id);
         self.ensure_application_symbols_resolved(type_id);
     }
@@ -1461,14 +1465,25 @@ impl<'a> CheckerState<'a> {
                 }
                 increment_refs_resolution_fuel();
                 increment_global_resolution_fuel();
-                if global_resolution_fuel_exhausted() {
-                    break;
-                }
+                let at_fuel_limit = global_resolution_fuel_exhausted();
+                // Always call resolve_and_insert_def_type even when global fuel is
+                // exhausted: the call is typically a fast cache hit for lib types that
+                // were computed during type-environment building, and the resolver needs
+                // the TypeEnvironment entry to evaluate a Lazy(def_id) during
+                // assignability checks.  Without this, exhausted-fuel calls silently
+                // leave subsequent DOM/lib type refs unresolvable, causing the relation
+                // checker to treat unresolved Lazy types as compatible (issue #12144).
+                // When at the fuel limit we still resolve the direct def_id but skip
+                // adding its result to the worklist so transitive work stays bounded.
                 if let Some(result) = self.resolve_and_insert_def_type(def_id)
                     && result != TypeId::ERROR
                     && result != TypeId::ANY
+                    && !at_fuel_limit
                 {
                     worklist.push(result);
+                }
+                if at_fuel_limit {
+                    break;
                 }
             }
         }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -594,6 +594,9 @@ mod dispatch_tests;
 #[path = "tests/do_while_exit_narrowing_tests.rs"]
 mod do_while_exit_narrowing_tests;
 #[cfg(test)]
+#[path = "tests/dom_fuel_exhaustion_ts2322_tests.rs"]
+mod dom_fuel_exhaustion_ts2322_tests;
+#[cfg(test)]
 #[path = "tests/dynamic_import_relation_routing_arch_tests.rs"]
 mod dynamic_import_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -412,6 +412,14 @@ impl<'a> CheckerState<'a> {
             if is_dts && !suppress_grammar && !seen_dts_ambient_violation {
                 seen_dts_ambient_violation = self.check_dts_statement_in_ambient_context(stmt_idx);
             }
+            // Reset resolution fuel between top-level statements so that a
+            // large-lib type-graph materialisation in one statement (e.g. a DOM
+            // call that triggers the full HTMLElement prototype chain) does not
+            // exhaust the global budget and cause subsequent statements in the
+            // same file to receive ERROR types, silently dropping TS2322/TS2345
+            // diagnostics (issue #12144).  The inner worklist guards inside
+            // `ensure_refs_resolved` still bound the work per statement.
+            crate::state_domain::type_environment::lazy::reset_global_resolution_fuel();
             self.check_statement(stmt_idx);
             if !self.statement_falls_through(stmt_idx) {
                 self.ctx.is_unreachable = true;

--- a/crates/tsz-checker/src/tests/dom_fuel_exhaustion_ts2322_tests.rs
+++ b/crates/tsz-checker/src/tests/dom_fuel_exhaustion_ts2322_tests.rs
@@ -1,0 +1,153 @@
+//! TS2322 diagnostic coverage for DOM-call-heavy files where global resolution
+//! fuel is exhausted after the first large-lib type graph materialisation.
+//!
+//! Structural rule: when a file contains N assignments from DOM call expressions
+//! whose return types are all incompatible with the declared variable type, `tsc`
+//! reports N TS2322 diagnostics — one per assignment.  A global-fuel exhaustion
+//! guard that gated the *entire* `ensure_relation_input_ready` step caused tsz to
+//! report only the first diagnostic (issue #12144).
+//!
+//! These tests vary the DOM methods, tag string spellings, and variable names so
+//! the fix is proven structural (not name-keyed or limited to one tag).
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_with_libs, load_lib_files};
+
+fn dom_codes(source: &str) -> Vec<u32> {
+    let libs = load_lib_files(&["es5.d.ts", "dom.d.ts", "dom.iterable.d.ts"]);
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+/// Two consecutive DOM calls with incompatible targets must each produce TS2322.
+///
+/// Before the fix, only the first call fired; the second was silently dropped
+/// because the first materialization exhausted the global resolution fuel and
+/// the outer guard in `ensure_relation_input_ready` short-circuited the second
+/// check entirely.
+///
+/// Variable names are varied (`x1`/`x2`) to prove the fix is not
+/// spelling-dependent.
+#[test]
+fn two_dom_calls_both_report_ts2322() {
+    let codes = dom_codes(
+        r#"
+declare const d: Document;
+const x1: number = d.createElement("div");
+const x2: number = d.createElement("span");
+export {};
+"#,
+    );
+    let ts2322_count = codes.iter().filter(|&&c| c == 2322).count();
+    assert_eq!(
+        ts2322_count, 2,
+        "both DOM-call assignments must produce TS2322, got codes {codes:?}",
+    );
+}
+
+/// Two calls to different DOM methods — `createElement` and `querySelector` —
+/// must each produce TS2322.  Varying the method proves the fix is not specific
+/// to one overload family.
+#[test]
+fn create_element_and_query_selector_both_report_ts2322() {
+    let codes = dom_codes(
+        r#"
+declare const doc: Document;
+const a: number = doc.createElement("p");
+const b: number = doc.querySelector("x");
+export {};
+"#,
+    );
+    let ts2322_count = codes.iter().filter(|&&c| c == 2322).count();
+    assert_eq!(
+        ts2322_count, 2,
+        "createElement and querySelector must each produce TS2322, got {codes:?}",
+    );
+}
+
+/// Full seven-call repro from issue #12144.  All seven DOM-call assignments
+/// must produce TS2322, not just the first.
+///
+/// Variable names follow the issue repro exactly so this test documents the
+/// motivating case, then a renamed variant below proves the rule is structural.
+#[test]
+fn seven_dom_calls_all_report_ts2322() {
+    let codes = dom_codes(
+        r#"
+declare const d: Document;
+const a1: number = d.createElement("div");
+const a2: number = d.createElement("span");
+const a3: number = d.createElement("a");
+const a4: number = d.createElement("p");
+const a5: number = d.createElement("img");
+const a6: number = d.querySelector("x");
+const a7: number = d.getElementById("y");
+export {};
+"#,
+    );
+    let ts2322_count = codes.iter().filter(|&&c| c == 2322).count();
+    assert_eq!(
+        ts2322_count, 7,
+        "all seven DOM-call assignments must produce TS2322, got {codes:?}",
+    );
+}
+
+/// Same seven-call repro with renamed variables and a renamed document binding.
+/// Proves the fix follows the structural shape (N incompatible DOM-call results)
+/// rather than any particular identifier spelling.
+#[test]
+fn seven_dom_calls_all_report_ts2322_renamed() {
+    let codes = dom_codes(
+        r#"
+declare const myDoc: Document;
+const r1: number = myDoc.createElement("section");
+const r2: number = myDoc.createElement("article");
+const r3: number = myDoc.createElement("header");
+const r4: number = myDoc.createElement("footer");
+const r5: number = myDoc.createElement("main");
+const r6: number = myDoc.querySelector("y");
+const r7: number = myDoc.getElementById("z");
+export {};
+"#,
+    );
+    let ts2322_count = codes.iter().filter(|&&c| c == 2322).count();
+    assert_eq!(
+        ts2322_count, 7,
+        "renamed seven-call repro must also produce 7 TS2322s, got {codes:?}",
+    );
+}
+
+/// Negative/fallback case: assignments that are *correct* must not produce
+/// TS2322 even in a DOM-call-heavy file where fuel has been exhausted.
+/// The fix must not introduce spurious diagnostics on valid expressions.
+#[test]
+fn correct_assignments_after_dom_calls_produce_no_ts2322() {
+    let codes = dom_codes(
+        r#"
+declare const d: Document;
+const bad: number = d.createElement("div");
+const ok: Element | null = d.querySelector("x");
+export {};
+"#,
+    );
+    // `bad` gets TS2322; `ok` is correct.
+    assert!(
+        codes.contains(&2322),
+        "incorrect assignment should produce TS2322, got {codes:?}",
+    );
+    let ts2322_count = codes.iter().filter(|&&c| c == 2322).count();
+    assert_eq!(
+        ts2322_count, 1,
+        "correct assignment after DOM call must not gain a spurious TS2322, got {codes:?}",
+    );
+}


### PR DESCRIPTION
AgentName: dazzling-johnson-1YB9U
Track: Compiler / Diagnostic conformance
Closes #12144

## Invariant

When a file contains N top-level assignments whose initialiser types are all
incompatible with the declared variable type, `tsc` reports N TS2322
diagnostics — one per assignment. This must hold regardless of the total
type-graph materialisation work performed by earlier statements in the same
file.

**Structural rule:** `GLOBAL_RESOLUTION_FUEL` must bound the work done *within
a single statement*, not the total work across all statements in a file.  When
fuel is exhausted inside one statement the subsequent statement must start with
a fresh budget so its type-analysis calls can complete and produce correct
source types (not `TypeId::ERROR`).

## Scope

- `crates/tsz-checker/src/state/state_checking/source_file.rs` — one-line fix: `reset_global_resolution_fuel()` added before each `check_statement` call in the top-level statement loop
- `crates/tsz-checker/src/assignability/assignability_checker.rs` — secondary hardening: remove the now-redundant outer `global_resolution_fuel_exhausted()` guard from `ensure_relation_input_ready`, and make the `ensure_refs_resolved` inner loop always call `resolve_and_insert_def_type` for the direct def-id (skip transitive worklist only) even at the fuel limit, so the `TypeEnvironment` entry is populated for any `Lazy` type the solver would otherwise leave unresolvable
- `crates/tsz-checker/src/tests/dom_fuel_exhaustion_ts2322_tests.rs` — 5 new tests
- `crates/tsz-checker/src/lib.rs` — module registration for the new test file

## Root Cause

`GLOBAL_RESOLUTION_FUEL` is a thread-local counter reset once per file (before
the statement-checking loop in `prepare_source_file_for_checking`).  When
Statement 1 materialises the full HTMLElement prototype chain (~50 000 fuel
units for DOM files), the budget is spent.  Statement 2's `get_type_of_node`
for its initialiser expression then hits the `consume_fuel()` check inside
`get_type_of_symbol`/`get_type_of_node`, returns `TypeId::ERROR`, and caches
ERROR for the call expression node.  `TypeId::ERROR` is assignable to any
declared type, so the TS2322 diagnostic is silently suppressed.

## Fix

Reset `GLOBAL_RESOLUTION_FUEL` at the start of each top-level statement check.
This mirrors the per-interface reset already present in
`check_source_file_interfaces_only_with_fresh_interface_fuel`.  The inner
worklist guards inside `ensure_refs_resolved` and the per-context
`type_resolution_fuel` counter still bound the work done within a single
statement, so the OOM protection for cross-arena delegation is preserved.

## Adjacent Case Matrix

| Case | Before | After |
|---|---|---|
| 2 DOM calls, both `number` target | 1 TS2322 | 2 TS2322 |
| `createElement` + `querySelector`, both `number` | 1 TS2322 | 2 TS2322 |
| 7 DOM calls (exact issue #12144 repro) | 1 TS2322 | 7 TS2322 |
| Same 7 calls, renamed vars/doc binding | 1 TS2322 | 7 TS2322 |
| 1 bad + 1 good assignment after DOM call | 1 TS2322 | 1 TS2322 (no spurious) |

## Project Corpus Impact
- Row: n/a
- Bug family: dom-fuel-exhaustion-ts2322

No project corpus smoke-tests are expected to regress: the fix adds correctness
(produces diagnostics that were previously suppressed) and does not change
negative cases.  All pre-existing test failures verified to be pre-existing by
stash-testing on the base branch.

## Verification

```
cargo nextest run -p tsz-checker --lib -E 'test(dom_fuel_exhaustion)'
# → 5 passed
cargo nextest run -p tsz-checker --lib -E 'test(lazy_lib)'
# → 9 passed
```

## Coordination Notes

Fixes issue #12144 (labeled `agent:M1-B`). M1-B is occupied with the
routing-refactor runway so this fix is submitted from `dazzling-johnson-1YB9U`.
Reviewer may re-label as appropriate.