### PR TITLE
fix(solver): share inner subtype/assignability cache writes cross-file (#10921)

### DIFF
--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -76,6 +76,17 @@ impl CachedPolicyRelation {
             }
         }
     }
+
+    #[inline]
+    const fn shared_slot(
+        self,
+        shared: &SharedQueryCache,
+    ) -> &DashMap<RelationCacheKey, bool, FxBuildHasher> {
+        match self {
+            Self::Subtype => &shared.subtype_cache,
+            Self::Assignability => &shared.assignability_cache,
+        }
+    }
 }
 
 /// Thread-safe shared query cache for cross-file type checking.
@@ -94,6 +105,15 @@ impl CachedPolicyRelation {
 /// - `eval_cache`: type evaluation (conditional types, mapped types, etc.)
 /// - `subtype_cache`: subtype relation results
 /// - `assignability_cache`: assignability relation results
+///
+/// For the relation caches the sharing covers *both* the top-level
+/// `is_cached_policy_relation` entry and the inner `QueryDatabase` entries
+/// driven by the `SubtypeChecker`'s recursive descent. The latter is the
+/// dominant cache traffic in deep mapped/conditional utility-type code, and
+/// without it sibling per-file checkers re-derive the same subtree relation
+/// in every file. Inner writes are gated by `cache_definitive!` in the
+/// `SubtypeChecker`, so only lazy-resolution-stable results reach the
+/// shared store (#10921).
 ///
 /// `application_eval_cache` and `instantiation_cache` are intentionally NOT
 /// shared cross-file: parallel file checking can observe incomplete lib-merge
@@ -695,6 +715,7 @@ impl<'a> QueryCache<'a> {
         None
     }
 
+    #[inline]
     const fn relation_local_cache(
         &self,
         relation: CachedPolicyRelation,
@@ -705,6 +726,7 @@ impl<'a> QueryCache<'a> {
         }
     }
 
+    #[inline]
     const fn relation_cache_hit_counter(&self, relation: CachedPolicyRelation) -> &Cell<u64> {
         match relation {
             CachedPolicyRelation::Subtype => &self.subtype_cache_hits,
@@ -712,6 +734,7 @@ impl<'a> QueryCache<'a> {
         }
     }
 
+    #[inline]
     const fn relation_cache_miss_counter(&self, relation: CachedPolicyRelation) -> &Cell<u64> {
         match relation {
             CachedPolicyRelation::Subtype => &self.subtype_cache_misses,
@@ -735,21 +758,15 @@ impl<'a> QueryCache<'a> {
             return Some(result);
         }
 
-        if let Some(shared) = self.shared {
-            let result = match relation {
-                CachedPolicyRelation::Subtype => shared.subtype_cache.get(&key).map(|r| *r),
-                CachedPolicyRelation::Assignability => {
-                    shared.assignability_cache.get(&key).map(|r| *r)
-                }
-            };
-            if let Some(result) = result {
-                self.relation_local_cache(relation)
-                    .borrow_mut()
-                    .insert(key, result);
-                let hits = self.relation_cache_hit_counter(relation);
-                hits.set(hits.get() + 1);
-                return Some(result);
-            }
+        if let Some(shared) = self.shared
+            && let Some(result) = relation.shared_slot(shared).get(&key).map(|r| *r)
+        {
+            self.relation_local_cache(relation)
+                .borrow_mut()
+                .insert(key, result);
+            let hits = self.relation_cache_hit_counter(relation);
+            hits.set(hits.get() + 1);
+            return Some(result);
         }
 
         let misses = self.relation_cache_miss_counter(relation);
@@ -767,14 +784,7 @@ impl<'a> QueryCache<'a> {
             .borrow_mut()
             .insert(key, result);
         if let Some(shared) = self.shared {
-            match relation {
-                CachedPolicyRelation::Subtype => {
-                    shared.subtype_cache.insert(key, result);
-                }
-                CachedPolicyRelation::Assignability => {
-                    shared.assignability_cache.insert(key, result);
-                }
-            }
+            relation.shared_slot(shared).insert(key, result);
         }
     }
 
@@ -1763,16 +1773,6 @@ impl QueryDatabase for QueryCache<'_> {
     fn is_assignable_to(&self, source: TypeId, target: TypeId) -> bool {
         self.is_assignable_to_with_policy(source, target, RelationPolicy::unflagged_compatibility())
     }
-
-    // The SubtypeChecker's recursive descent is the dominant cache traffic in
-    // multi-file utility-type projects: each top-level relation query expands
-    // into many inner pairs as evaluation peels back mapped/conditional bodies.
-    // Sharing those inner results across files is what keeps per-file checkers
-    // from re-deriving the same subtree relation in every sibling. These inner
-    // entry points therefore route through the same shared-aware path used by
-    // `lookup_policy_relation_cache` / `insert_policy_relation_cache`. Writes
-    // are gated by `cache_definitive!` in the SubtypeChecker, so any value
-    // observed here is already lazy-resolution stable.
 
     fn lookup_subtype_cache(&self, key: RelationCacheKey) -> Option<bool> {
         self.lookup_policy_relation_cache(CachedPolicyRelation::Subtype, key)

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -1764,36 +1764,30 @@ impl QueryDatabase for QueryCache<'_> {
         self.is_assignable_to_with_policy(source, target, RelationPolicy::unflagged_compatibility())
     }
 
+    // The SubtypeChecker's recursive descent is the dominant cache traffic in
+    // multi-file utility-type projects: each top-level relation query expands
+    // into many inner pairs as evaluation peels back mapped/conditional bodies.
+    // Sharing those inner results across files is what keeps per-file checkers
+    // from re-deriving the same subtree relation in every sibling. These inner
+    // entry points therefore route through the same shared-aware path used by
+    // `lookup_policy_relation_cache` / `insert_policy_relation_cache`. Writes
+    // are gated by `cache_definitive!` in the SubtypeChecker, so any value
+    // observed here is already lazy-resolution stable.
+
     fn lookup_subtype_cache(&self, key: RelationCacheKey) -> Option<bool> {
-        let result = self.subtype_cache.borrow().get(&key).copied();
-        if result.is_some() {
-            self.subtype_cache_hits
-                .set(self.subtype_cache_hits.get() + 1);
-        } else {
-            self.subtype_cache_misses
-                .set(self.subtype_cache_misses.get() + 1);
-        }
-        result
+        self.lookup_policy_relation_cache(CachedPolicyRelation::Subtype, key)
     }
 
     fn insert_subtype_cache(&self, key: RelationCacheKey, result: bool) {
-        self.subtype_cache.borrow_mut().insert(key, result);
+        self.insert_policy_relation_cache(CachedPolicyRelation::Subtype, key, result);
     }
 
     fn lookup_assignability_cache(&self, key: RelationCacheKey) -> Option<bool> {
-        let result = self.assignability_cache.borrow().get(&key).copied();
-        if result.is_some() {
-            self.assignability_cache_hits
-                .set(self.assignability_cache_hits.get() + 1);
-        } else {
-            self.assignability_cache_misses
-                .set(self.assignability_cache_misses.get() + 1);
-        }
-        result
+        self.lookup_policy_relation_cache(CachedPolicyRelation::Assignability, key)
     }
 
     fn insert_assignability_cache(&self, key: RelationCacheKey, result: bool) {
-        self.assignability_cache.borrow_mut().insert(key, result);
+        self.insert_policy_relation_cache(CachedPolicyRelation::Assignability, key, result);
     }
 
     fn lookup_intersection_merge(&self, intersection_id: TypeId) -> Option<Option<TypeId>> {

--- a/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
+++ b/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
@@ -161,73 +161,67 @@ fn instantiation_cache_is_per_file_isolated() {
     );
 }
 
-#[test]
-fn subtype_cache_inner_inserts_are_shared_cross_file() {
-    // Structural rule: the SubtypeChecker's recursive descent inserts results
-    // through `insert_subtype_cache`. In a multi-file project, the only way
-    // file B's checker can reuse the subtree relations file A computed for a
-    // deep mapped/conditional shape is if those inner inserts also populate
-    // the `SharedQueryCache`. Otherwise relation cache miss churn dominates
-    // utility-type project runtime (#10921).
-    let interner = TypeInterner::new();
-    let shared = SharedQueryCache::new();
-    let key = RelationCacheKey::for_subtype(
-        TypeId::STRING,
-        TypeId::OBJECT,
-        RelationCacheConfig::default(),
-    );
-
-    // File A's SubtypeChecker writes a definitive inner result via
-    // `insert_subtype_cache`. The shared cache must observe it.
-    let db_a = QueryCache::new_with_shared(&interner, &shared);
-    db_a.insert_subtype_cache(key, true);
-
-    // File B starts with an empty local cache. The lookup must traverse to
-    // the shared cache and find the previously inserted result.
-    let db_b = QueryCache::new_with_shared(&interner, &shared);
-    assert_eq!(
-        db_b.lookup_subtype_cache(key),
-        Some(true),
-        "inner subtype cache inserts must be visible cross-file"
-    );
-
-    let stats_b = db_b.statistics();
-    assert_eq!(stats_b.relation.subtype_hits, 1);
-    assert_eq!(stats_b.relation.subtype_misses, 0);
-    // The shared hit also populates B's local cache so subsequent lookups are
-    // single-pass without re-traversing the `DashMap`.
-    assert_eq!(stats_b.relation.subtype_entries, 1);
-}
+// Inner relation cache inserts driven by the `SubtypeChecker`'s recursive
+// descent must also populate `SharedQueryCache`, otherwise sibling per-file
+// checkers re-derive the same mapped/conditional subtree relations (#10921).
+// See the `SharedQueryCache` doc block for the full invariant.
 
 #[test]
-fn assignability_cache_inner_inserts_are_shared_cross_file() {
-    // Same structural rule as the subtype cache: inner assignability inserts
-    // must be visible to sibling file checkers.
-    let interner = TypeInterner::new();
-    let shared = SharedQueryCache::new();
-    let key = RelationCacheKey::for_assignability(
-        TypeId::NUMBER,
-        TypeId::UNKNOWN,
-        RelationCacheConfig::default(),
+fn relation_cache_inner_inserts_are_shared_cross_file() {
+    fn check(
+        key: RelationCacheKey,
+        result: bool,
+        insert: impl Fn(&QueryCache<'_>, RelationCacheKey, bool),
+        lookup: impl Fn(&QueryCache<'_>, RelationCacheKey) -> Option<bool>,
+        stats: impl Fn(&QueryCacheStatistics) -> (u64, u64, usize),
+    ) {
+        let interner = TypeInterner::new();
+        let shared = SharedQueryCache::new();
+
+        let db_a = QueryCache::new_with_shared(&interner, &shared);
+        insert(&db_a, key, result);
+
+        let db_b = QueryCache::new_with_shared(&interner, &shared);
+        assert_eq!(lookup(&db_b, key), Some(result));
+
+        // Shared hit also populates B's local cache so subsequent lookups
+        // skip the `DashMap` traversal.
+        assert_eq!(stats(&db_b.statistics()), (1, 0, 1));
+    }
+
+    let cfg = RelationCacheConfig::default();
+    check(
+        RelationCacheKey::for_subtype(TypeId::STRING, TypeId::OBJECT, cfg),
+        true,
+        |db, k, v| db.insert_subtype_cache(k, v),
+        |db, k| db.lookup_subtype_cache(k),
+        |s| {
+            (
+                s.relation.subtype_hits,
+                s.relation.subtype_misses,
+                s.relation.subtype_entries,
+            )
+        },
     );
-
-    let db_a = QueryCache::new_with_shared(&interner, &shared);
-    db_a.insert_assignability_cache(key, false);
-
-    let db_b = QueryCache::new_with_shared(&interner, &shared);
-    assert_eq!(db_b.lookup_assignability_cache(key), Some(false));
-
-    let stats_b = db_b.statistics();
-    assert_eq!(stats_b.relation.assignability_hits, 1);
-    assert_eq!(stats_b.relation.assignability_misses, 0);
-    assert_eq!(stats_b.relation.assignability_entries, 1);
+    check(
+        RelationCacheKey::for_assignability(TypeId::NUMBER, TypeId::UNKNOWN, cfg),
+        false,
+        |db, k, v| db.insert_assignability_cache(k, v),
+        |db, k| db.lookup_assignability_cache(k),
+        |s| {
+            (
+                s.relation.assignability_hits,
+                s.relation.assignability_misses,
+                s.relation.assignability_entries,
+            )
+        },
+    );
 }
 
 #[test]
 fn relation_cache_misses_stay_local_when_unshared() {
-    // Without a `SharedQueryCache`, the inner relation cache calls must keep
-    // their per-file behavior: a miss on file A's local cache must not leak
-    // into a different file via shared state, since there is no shared state.
+    // Without a `SharedQueryCache` there is no shared state to leak through;
+    // file B must see only its own local cache.
     let interner = TypeInterner::new();
     let key = RelationCacheKey::for_subtype(
         TypeId::STRING,
@@ -239,11 +233,7 @@ fn relation_cache_misses_stay_local_when_unshared() {
     db_a.insert_subtype_cache(key, true);
 
     let db_b = QueryCache::new(&interner);
-    assert_eq!(
-        db_b.lookup_subtype_cache(key),
-        None,
-        "without a shared cache, file B must not see file A's inner inserts"
-    );
+    assert_eq!(db_b.lookup_subtype_cache(key), None);
     let stats_b = db_b.statistics();
     assert_eq!(stats_b.relation.subtype_hits, 0);
     assert_eq!(stats_b.relation.subtype_misses, 1);
@@ -251,10 +241,9 @@ fn relation_cache_misses_stay_local_when_unshared() {
 
 #[test]
 fn shared_relation_inserts_track_subtype_and_assignability_separately() {
-    // The shared cache must preserve the subtype/assignability split: an
-    // inner `insert_subtype_cache` for `(S, T)` does not produce a hit for an
-    // `lookup_assignability_cache` of the same `(S, T)` (they live in distinct
-    // `RelationCacheKind` slots even at the shared level).
+    // Subtype and assignability live in distinct `RelationCacheKind` slots
+    // even at the shared level: a subtype insert must not satisfy an
+    // assignability lookup with the same `(source, target)` pair.
     let interner = TypeInterner::new();
     let shared = SharedQueryCache::new();
     let cfg = RelationCacheConfig::default();
@@ -267,11 +256,7 @@ fn shared_relation_inserts_track_subtype_and_assignability_separately() {
 
     let db_b = QueryCache::new_with_shared(&interner, &shared);
     assert_eq!(db_b.lookup_subtype_cache(subtype_key), Some(true));
-    assert_eq!(
-        db_b.lookup_assignability_cache(assignability_key),
-        None,
-        "subtype insert must not satisfy an assignability lookup"
-    );
+    assert_eq!(db_b.lookup_assignability_cache(assignability_key), None);
 }
 
 #[test]

--- a/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
+++ b/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
@@ -5,7 +5,7 @@ use crate::caches::instantiation_cache::{CanonicalSubst, InstantiationCacheKey};
 use crate::caches::query_cache::{QueryCache, QueryCacheStatistics, SharedQueryCache};
 use crate::def::DefId;
 use crate::intern::TypeInterner;
-use crate::types::TypeId;
+use crate::types::{RelationCacheConfig, RelationCacheKey, TypeId};
 
 #[test]
 fn intersection_merge_cache_is_visible_in_statistics_and_size_estimate() {
@@ -158,6 +158,119 @@ fn instantiation_cache_is_per_file_isolated() {
         shared.total_entries(),
         0,
         "SharedQueryCache must not store instantiation_cache entries"
+    );
+}
+
+#[test]
+fn subtype_cache_inner_inserts_are_shared_cross_file() {
+    // Structural rule: the SubtypeChecker's recursive descent inserts results
+    // through `insert_subtype_cache`. In a multi-file project, the only way
+    // file B's checker can reuse the subtree relations file A computed for a
+    // deep mapped/conditional shape is if those inner inserts also populate
+    // the `SharedQueryCache`. Otherwise relation cache miss churn dominates
+    // utility-type project runtime (#10921).
+    let interner = TypeInterner::new();
+    let shared = SharedQueryCache::new();
+    let key = RelationCacheKey::for_subtype(
+        TypeId::STRING,
+        TypeId::OBJECT,
+        RelationCacheConfig::default(),
+    );
+
+    // File A's SubtypeChecker writes a definitive inner result via
+    // `insert_subtype_cache`. The shared cache must observe it.
+    let db_a = QueryCache::new_with_shared(&interner, &shared);
+    db_a.insert_subtype_cache(key, true);
+
+    // File B starts with an empty local cache. The lookup must traverse to
+    // the shared cache and find the previously inserted result.
+    let db_b = QueryCache::new_with_shared(&interner, &shared);
+    assert_eq!(
+        db_b.lookup_subtype_cache(key),
+        Some(true),
+        "inner subtype cache inserts must be visible cross-file"
+    );
+
+    let stats_b = db_b.statistics();
+    assert_eq!(stats_b.relation.subtype_hits, 1);
+    assert_eq!(stats_b.relation.subtype_misses, 0);
+    // The shared hit also populates B's local cache so subsequent lookups are
+    // single-pass without re-traversing the `DashMap`.
+    assert_eq!(stats_b.relation.subtype_entries, 1);
+}
+
+#[test]
+fn assignability_cache_inner_inserts_are_shared_cross_file() {
+    // Same structural rule as the subtype cache: inner assignability inserts
+    // must be visible to sibling file checkers.
+    let interner = TypeInterner::new();
+    let shared = SharedQueryCache::new();
+    let key = RelationCacheKey::for_assignability(
+        TypeId::NUMBER,
+        TypeId::UNKNOWN,
+        RelationCacheConfig::default(),
+    );
+
+    let db_a = QueryCache::new_with_shared(&interner, &shared);
+    db_a.insert_assignability_cache(key, false);
+
+    let db_b = QueryCache::new_with_shared(&interner, &shared);
+    assert_eq!(db_b.lookup_assignability_cache(key), Some(false));
+
+    let stats_b = db_b.statistics();
+    assert_eq!(stats_b.relation.assignability_hits, 1);
+    assert_eq!(stats_b.relation.assignability_misses, 0);
+    assert_eq!(stats_b.relation.assignability_entries, 1);
+}
+
+#[test]
+fn relation_cache_misses_stay_local_when_unshared() {
+    // Without a `SharedQueryCache`, the inner relation cache calls must keep
+    // their per-file behavior: a miss on file A's local cache must not leak
+    // into a different file via shared state, since there is no shared state.
+    let interner = TypeInterner::new();
+    let key = RelationCacheKey::for_subtype(
+        TypeId::STRING,
+        TypeId::OBJECT,
+        RelationCacheConfig::default(),
+    );
+
+    let db_a = QueryCache::new(&interner);
+    db_a.insert_subtype_cache(key, true);
+
+    let db_b = QueryCache::new(&interner);
+    assert_eq!(
+        db_b.lookup_subtype_cache(key),
+        None,
+        "without a shared cache, file B must not see file A's inner inserts"
+    );
+    let stats_b = db_b.statistics();
+    assert_eq!(stats_b.relation.subtype_hits, 0);
+    assert_eq!(stats_b.relation.subtype_misses, 1);
+}
+
+#[test]
+fn shared_relation_inserts_track_subtype_and_assignability_separately() {
+    // The shared cache must preserve the subtype/assignability split: an
+    // inner `insert_subtype_cache` for `(S, T)` does not produce a hit for an
+    // `lookup_assignability_cache` of the same `(S, T)` (they live in distinct
+    // `RelationCacheKind` slots even at the shared level).
+    let interner = TypeInterner::new();
+    let shared = SharedQueryCache::new();
+    let cfg = RelationCacheConfig::default();
+    let subtype_key = RelationCacheKey::for_subtype(TypeId::STRING, TypeId::OBJECT, cfg);
+    let assignability_key =
+        RelationCacheKey::for_assignability(TypeId::STRING, TypeId::OBJECT, cfg);
+
+    let db_a = QueryCache::new_with_shared(&interner, &shared);
+    db_a.insert_subtype_cache(subtype_key, true);
+
+    let db_b = QueryCache::new_with_shared(&interner, &shared);
+    assert_eq!(db_b.lookup_subtype_cache(subtype_key), Some(true));
+    assert_eq!(
+        db_b.lookup_assignability_cache(assignability_key),
+        None,
+        "subtype insert must not satisfy an assignability lookup"
     );
 }
 


### PR DESCRIPTION
AgentName: claude
Track: solver / caches
Invariant: relation results computed by the `SubtypeChecker`'s recursive descent must be observable cross-file
Scope: `crates/tsz-solver/src/caches/query_cache.rs` + new tests in `crates/tsz-solver/src/caches/query_cache_statistics_test.rs`
Closes #10921

## Structural rule

When the `SubtypeChecker` writes a definitive inner relation result through
`QueryDatabase::insert_subtype_cache` or `insert_assignability_cache`, the
`SharedQueryCache` observes the write so sibling per-file checkers can reuse
the result instead of re-deriving it.

## What was wrong

The `SharedQueryCache` doc block explicitly lists `subtype_cache` and
`assignability_cache` as cross-file shared, but the implementation only
populated the shared store at the **top-level** `is_cached_policy_relation`
entry. The **inner** `QueryDatabase` entry points the `SubtypeChecker` uses on
every recursive descent —
`{lookup,insert}_{subtype,assignability}_cache` — only consulted the per-file
local `RefCell<FxHashMap>`. Every nested mapped/conditional sub-relation
computed in file A was re-derived from scratch in file B, even though file
B's top-level lookup would have hit the shared cache if the same outer key
appeared.

For deep utility-type code (utility-types, ts-toolbelt, type-fest, etc.) the
inner descent is the dominant cache traffic, so this isolation manifested as
superlinear solver time on the project-row benchmarks (#10921).

## What changed

- Route the four inner entry points through the existing shared-aware
  `lookup_policy_relation_cache` / `insert_policy_relation_cache` helpers so
  inner reads consult the shared `DashMap` on local miss and inner writes
  populate it. Definiteness is still enforced by `cache_definitive!` at the
  `SubtypeChecker` call site, so only lazy-resolution-stable results reach
  the shared store.
- Add `CachedPolicyRelation::shared_slot` as the symmetric counterpart to the
  existing `relation_local_cache` selector, removing the last hand-written
  `match relation { ... }` arms from the policy helpers.
- Promote the structural invariant into the `SharedQueryCache` rustdoc block
  alongside the existing #9507 callout for the intentionally per-file caches.

## Owner layer

`crates/tsz-solver/src/caches/query_cache.rs`. No checker, emitter, or
parser changes.

## Adjacent-case matrix (in `query_cache_statistics_test`)

| Case                                                                            | Asserts                                                                                                                  |
| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
| `relation_cache_inner_inserts_are_shared_cross_file` (parameterized over both relation kinds) | File A's `insert_*_cache` write is visible to file B's `lookup_*_cache` via the shared store, and B's local cache is populated on the read. |
| `relation_cache_misses_stay_local_when_unshared`                                | Without a `SharedQueryCache` the inner inserts must NOT leak across files.                                               |
| `shared_relation_inserts_track_subtype_and_assignability_separately`            | A subtype insert for `(S, T)` does not satisfy an assignability lookup for the same `(S, T)` at the shared level.        |

## Project Corpus Impact

- Row: utility-types-project
- Bug family: solver relation cache churn under mapped conditionals

Primary target is utility-types-project, but the fix is structural and
benefits every multi-file project row that drives the `SubtypeChecker`'s
recursive descent (ts-toolbelt, type-fest, RxJS, Zod, etc.).

## Verification

- `cargo test -p tsz-solver --lib query_cache_statistics_tests` — 8/8 pass
  (including 3 new tests).
- `cargo test -p tsz-solver --lib -- subtype_cache` — 51/51 pass.
- `cargo test -p tsz-solver --lib -- relation_cache_config` — 27/27 pass.
- Full `cargo test -p tsz-solver --lib` shows the same 8 pre-existing
  failures observed on `origin/main`; no new regressions.

## Coordination Notes

- /simplify ran three passes; cleanups are folded into the second commit on
  the branch.
- No conformance-row baseline changes were touched.
- The per-file isolation of `application_eval_cache` and `instantiation_cache`
  (#9507) is preserved — only the relation caches change.
