### PR TITLE
fix(solver): stop false TS2589 on terminating non-tail recursive type aliases

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1734,14 +1734,6 @@ pub(crate) fn contains_type_parameter_named_shallow(
     tsz_solver::visitor::contains_type_parameter_named_shallow(db, type_id, name)
 }
 
-pub(crate) fn contains_concrete_application_with_def(
-    db: &dyn TypeDatabase,
-    type_id: TypeId,
-    def_id: tsz_solver::def::DefId,
-) -> bool {
-    tsz_solver::visitor::contains_concrete_application_with_def(db, type_id, def_id)
-}
-
 pub(crate) fn no_infer_inner_type(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeId> {
     tsz_solver::visitor::no_infer_inner_type(db, type_id)
 }

--- a/crates/tsz-checker/src/query_boundaries/state/type_environment.rs
+++ b/crates/tsz-checker/src/query_boundaries/state/type_environment.rs
@@ -12,6 +12,30 @@ pub(crate) use tsz_solver::type_queries::{
     MappedConstraintKind, PropertyAccessResolutionKind, TypeResolutionKind,
 };
 
+/// Collect every unique concrete `Application` of `def_id` reachable from
+/// `type_id` (arguments free of type parameters). Used by the TS2589
+/// convergence probe to re-examine a recursive alias's residual
+/// self-applications.
+pub(crate) fn collect_concrete_applications_with_def(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+    def_id: tsz_solver::def::DefId,
+) -> Vec<TypeId> {
+    tsz_solver::visitor::collect_concrete_applications_with_def(db, type_id, def_id)
+}
+
+/// Total structural weight of the arguments of a concrete `Application` of
+/// `def_id`, or `None` if `type_id` is not such an application. The shared
+/// recursion-growth metric used to decide whether a residual self-application
+/// is converging (shrinking) or diverging.
+pub(crate) fn self_application_arg_weight(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+    def_id: tsz_solver::def::DefId,
+) -> Option<u64> {
+    tsz_solver::visitor::self_application_arg_weight(db, type_id, def_id)
+}
+
 /// Thin wrapper around `tsz_solver::computation::TypeEvaluator`.
 ///
 /// Evaluates a complex type (conditional, mapped, index access, etc.) using

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -773,21 +773,47 @@ impl<'a> CheckerState<'a> {
             return true;
         }
 
-        // Second check: the Application may be cached from the first evaluation,
-        // causing the cycle to fire on a Conditional instead of the Application.
-        // Check if the evaluated result contains a CONCRETE Application referencing
-        // the alias (i.e., Application(Lazy(def_id), args) where args have no type
-        // params). A concrete self-reference that survives evaluation means the
-        // expansion didn't converge — infinite recursion.
+        // Second check: a concrete self-application of the alias can survive the
+        // first evaluation because the evaluator leaves a recursive reference in a
+        // non-tail position (a function return or object/mapped property, e.g. the
+        // `Curry<T, R>` inside `(h: H) => Curry<T, R>`) deferred — so a residual
+        // `Application(alias, args)` is the norm, not proof of infinite expansion.
+        // It is divergence evidence only when it makes no *progress*: at a use site
+        // (the checked type is itself a concrete application of the alias) compare
+        // the structural argument weight of the input against each residual — a
+        // residual that strictly shrinks is converging toward the base case (a
+        // variadic tuple tail) and must not raise TS2589, while one that stays the
+        // same size (`Foo<unknown>` -> `Foo<unknown>`) or grows is divergent. When
+        // there is no input application to compare against (the definition-site
+        // pass evaluates the conditional body directly), any surviving concrete
+        // self-reference stays divergent, preserving definition-site TS2589.
         let result = eval_result.result;
         if result != type_id && result != TypeId::ERROR {
             let db = self.ctx.types.as_type_database();
-            if crate::query_boundaries::common::contains_concrete_application_with_def(
+            let residuals = crate::query_boundaries::state::type_environment::collect_concrete_applications_with_def(
                 db,
                 result,
                 alias_def_id,
+            );
+            match crate::query_boundaries::state::type_environment::self_application_arg_weight(
+                db,
+                type_id,
+                alias_def_id,
             ) {
-                return true;
+                None => return !residuals.is_empty(),
+                Some(input_weight) => {
+                    let diverges = residuals.iter().any(|&residual| {
+                        crate::query_boundaries::state::type_environment::self_application_arg_weight(
+                            db,
+                            residual,
+                            alias_def_id,
+                        )
+                        .is_none_or(|residual_weight| residual_weight >= input_weight)
+                    });
+                    if diverges {
+                        return true;
+                    }
+                }
             }
         }
         false

--- a/crates/tsz-checker/tests/ts2589_tests.rs
+++ b/crates/tsz-checker/tests/ts2589_tests.rs
@@ -560,6 +560,44 @@ let s: StringOnly<"hello">;
 }
 
 #[test]
+fn terminating_nested_recursive_conditional_over_tuple_no_ts2589() {
+    // The recursive reference `Curry<Tail, Result>` sits in a *non-tail*
+    // position — the return type of a function — so the evaluator leaves the
+    // final step deferred in the result rather than expanding it inline. The
+    // driving tuple argument loses an element each step, so the recursion
+    // terminates and `tsc` emits no TS2589. Regression for the false positive
+    // where the surviving deferred self-application was mistaken for infinite
+    // instantiation.
+    let source = r#"
+type Curry<Args extends any[], Result> =
+    Args extends [infer Head, ...infer Tail] ? (head: Head) => Curry<Tail, Result> : Result;
+type Applied = Curry<[number, string, boolean], void>;
+let applied: Applied;
+"#;
+    assert!(
+        !has_error_with_code(source, 2589),
+        "terminating tuple recursion through a function-return self-reference must not emit TS2589"
+    );
+}
+
+#[test]
+fn terminating_object_nested_recursive_conditional_over_tuple_no_ts2589() {
+    // Same structural case as above but with the recursive reference nested in
+    // an object property instead of a function return. Distinct binder names
+    // confirm the fix keys on the structural recursion shape, not identifiers.
+    let source = r#"
+type Walk<Items extends readonly unknown[], Seed> =
+    Items extends [infer First, ...infer Rest] ? { value: First; next: Walk<Rest, Seed> } : Seed;
+type Path = Walk<[1, 2, 3], null>;
+let path: Path;
+"#;
+    assert!(
+        !has_error_with_code(source, 2589),
+        "terminating tuple recursion through an object-property self-reference must not emit TS2589"
+    );
+}
+
+#[test]
 fn ts2589_message_text() {
     let source = r#"
 type Foo<T extends "true", B> = { "true": Foo<T, Foo<T, B>> }[T];

--- a/crates/tsz-solver/src/evaluation/recursive_growth.rs
+++ b/crates/tsz-solver/src/evaluation/recursive_growth.rs
@@ -12,7 +12,7 @@
 use crate::def::DefId;
 use crate::instantiation::instantiate::instantiate_generic_cached;
 use crate::relations::subtype::TypeResolver;
-use crate::types::{LiteralValue, TypeData, TypeId};
+use crate::types::{TypeData, TypeId};
 
 use super::evaluate::TypeEvaluator;
 
@@ -37,28 +37,11 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
 
     /// Cheap structural-weight estimate for the divergent-growth detector.
     ///
-    /// Measures the dimensions along which recursive type arguments diverge:
-    /// concrete string-literal length and generic template-literal span count
-    /// (template-literal growth, whether the argument has collapsed to a literal
-    /// yet or is still a generic `${A}${A}` that doubles its spans each step),
-    /// tuple arity (tuple growth), and union/intersection arity (intersection
-    /// growth). Other shapes count as a single unit. Intentionally shallow — one
-    /// level for lists/spans — so the estimate stays O(arity) and never itself
-    /// walks an exploding type tree.
+    /// Thin wrapper over the shared [`crate::visitor::recursive_growth_weight`]
+    /// metric so the evaluator's tail-recursion growth detector and the checker's
+    /// TS2589 convergence check measure argument growth identically.
     fn recursive_growth_weight(&self, type_id: TypeId) -> u64 {
-        match self.interner().lookup(type_id) {
-            Some(TypeData::Literal(LiteralValue::String(atom))) => {
-                self.interner().resolve_atom_ref(atom).as_ref().len() as u64
-            }
-            Some(TypeData::TemplateLiteral(spans)) => {
-                self.interner().template_list(spans).len() as u64
-            }
-            Some(TypeData::Tuple(list)) => self.interner().tuple_list(list).len() as u64,
-            Some(TypeData::Union(list) | TypeData::Intersection(list)) => {
-                self.interner().type_list(list).len() as u64
-            }
-            _ => 1,
-        }
+        crate::visitor::recursive_growth_weight(self.interner(), type_id)
     }
 
     /// Detect divergent recursion as a recursing alias (`def_id`) is re-applied

--- a/crates/tsz-solver/src/visitors/visitor.rs
+++ b/crates/tsz-solver/src/visitors/visitor.rs
@@ -697,6 +697,93 @@ pub fn contains_concrete_application_with_def(
     found
 }
 
+/// Collect every unique concrete `Application` of `target_def_id` reachable
+/// from `root` (the application's arguments contain no free type parameters).
+///
+/// This is the collecting counterpart of [`contains_concrete_application_with_def`].
+/// It lets callers re-drive a recursive alias's residual self-applications —
+/// which the evaluator may leave deferred in non-tail positions such as a
+/// function return type or object property — to a fixpoint, so a *terminating*
+/// recursion is not mistaken for an infinite one.
+pub fn collect_concrete_applications_with_def(
+    types: &dyn TypeDatabase,
+    root: TypeId,
+    target_def_id: DefId,
+) -> Vec<TypeId> {
+    let mut out = Vec::new();
+    let mut seen = FxHashSet::default();
+    walk_referenced_types(types, root, |type_id| {
+        if let Some(TypeData::Application(app_id)) = types.lookup(type_id) {
+            let app = types.type_application(app_id);
+            if let Some(TypeData::Lazy(def_id)) = types.lookup(app.base)
+                && def_id == target_def_id
+            {
+                let args_are_concrete = !app
+                    .args
+                    .iter()
+                    .any(|&arg| super::visitor_predicates::contains_type_parameters(types, arg));
+                if args_are_concrete && seen.insert(type_id) {
+                    out.push(type_id);
+                }
+            }
+        }
+    });
+    out
+}
+
+/// Cheap structural-weight estimate of a single recursive type argument — the
+/// shared divergent-growth metric used both by the evaluator (to bound
+/// tail-recursive expansion) and by the checker's TS2589 convergence check.
+///
+/// Measures the dimensions along which recursive arguments shrink or grow
+/// between recursion steps: concrete string-literal length, generic
+/// template-literal span count, tuple arity, and union/intersection arity. Other
+/// shapes count as a single unit. Intentionally shallow — one level for
+/// lists/spans — so the estimate stays O(arity) and never walks an exploding
+/// type tree.
+pub fn recursive_growth_weight(types: &dyn TypeDatabase, type_id: TypeId) -> u64 {
+    match types.lookup(type_id) {
+        Some(TypeData::Literal(LiteralValue::String(atom))) => {
+            types.resolve_atom_ref(atom).as_ref().len() as u64
+        }
+        Some(TypeData::TemplateLiteral(spans)) => types.template_list(spans).len() as u64,
+        Some(TypeData::Tuple(list)) => types.tuple_list(list).len() as u64,
+        Some(TypeData::Union(list) | TypeData::Intersection(list)) => {
+            types.type_list(list).len() as u64
+        }
+        _ => 1,
+    }
+}
+
+/// Total structural weight of the arguments of a concrete `Application` of
+/// `target_def_id`, or `None` if `type_id` is not such an application.
+///
+/// Lets callers compare a recursive alias's input application against the
+/// residual self-applications left in its evaluated result: a residual whose
+/// argument weight is strictly smaller is making progress toward the base case
+/// (e.g. a variadic tuple tail that loses an element each step) and is not, on
+/// its own, evidence of an infinite instantiation.
+pub fn self_application_arg_weight(
+    types: &dyn TypeDatabase,
+    type_id: TypeId,
+    target_def_id: DefId,
+) -> Option<u64> {
+    if let Some(TypeData::Application(app_id)) = types.lookup(type_id) {
+        let app = types.type_application(app_id);
+        if let Some(TypeData::Lazy(def_id)) = types.lookup(app.base)
+            && def_id == target_def_id
+        {
+            return Some(
+                app.args
+                    .iter()
+                    .map(|&a| recursive_growth_weight(types, a))
+                    .sum(),
+            );
+        }
+    }
+    None
+}
+
 /// Collect all unique enum `DefIds` reachable from `root`.
 pub fn collect_enum_def_ids(types: &dyn TypeDatabase, root: TypeId) -> Vec<DefId> {
     let mut out = Vec::new();


### PR DESCRIPTION
AgentName: pensive-wright
Track: Solver — recursive type evaluation / TS2589 detection
Closes: #10802 (recursive utility expansion over-instantiates and regresses under the depth guard)

## Invariant
`tsc` parity for `TS2589: Type instantiation is excessively deep and possibly infinite`. A recursive type alias that **terminates** must not raise TS2589; a genuinely infinite one still must.

## Structural rule
When a recursive conditional type alias's self-reference sits in a **non-tail position** — a function return type or an object/mapped property, e.g.

```ts
type Curry<A extends any[], R> = A extends [infer H, ...infer T] ? (h: H) => Curry<T, R> : R;
type Expand<T> = T extends object ? { [K in keyof T]: Expand<T[K]> } : T;
```

the evaluator leaves the final recursion step **deferred** in the result (it does not expand a function return / object property inline). The TS2589 detection probe (`evaluate_type_for_ts2589_check`) treated *any* surviving concrete `Application(alias, args)` in the evaluated result as proof of infinite instantiation, so terminating recursions over a shrinking variadic tuple were wrongly reported as TS2589 while `tsc` accepts them.

The fix: a residual self-application is evidence of non-termination only when it does **not make progress**. At a use site the checked type is itself a concrete application of the alias, so we compare the structural argument weight of the input against each residual:

- residual weight **strictly shrinks** → converging toward the base case (a variadic tuple tail loses an element each step) → **no TS2589**;
- residual weight **stays equal** (`Foo<unknown>` → `Foo<unknown>`) or **grows** → genuinely divergent → TS2589.

The definition-site pass (no shrinking input application to compare against, the conditional body is evaluated directly) keeps the prior "any surviving concrete self-reference is divergent" behavior, so existing definition-site TS2589 detection is unchanged.

## Owner layer
Solver. The argument-weight metric is now a single shared function — `tsz_solver::visitor::recursive_growth_weight` — consumed by both the evaluator's tail-recursion growth detector (`recursive_growth.rs`) and the checker's TS2589 convergence probe via the `query_boundaries` gateway, so both layers measure growth identically.

## Scope
- `crates/tsz-solver/src/visitors/visitor.rs`: shared `recursive_growth_weight`; new `collect_concrete_applications_with_def` and `self_application_arg_weight`.
- `crates/tsz-solver/src/evaluation/recursive_growth.rs`: delegate the evaluator's growth metric to the shared helper (de-duplication).
- `crates/tsz-checker/src/query_boundaries/common.rs`: boundary wrappers (removed a now-dead wrapper).
- `crates/tsz-checker/src/state/type_environment/lazy.rs`: progress-aware second check in `evaluate_type_for_ts2589_check`.
- `crates/tsz-checker/tests/ts2589_tests.rs`: regression coverage.

## Adjacent-case matrix (tsz vs `tsc`, all `--strict`)
| case | shape | pre-fix tsz | post-fix tsz | tsc |
| --- | --- | --- | --- | --- |
| `Curry<[number], R>` | recursive ref in function return | **TS2589 (false)** | clean | clean |
| `Curry<[number,string,boolean], void>` + Join + Reverse | mixed tuple recursion | **TS2589 (false)** | clean | clean |
| `Walk<[1,2,3], null>` | recursive ref in object property | (class) | clean | clean |
| `Expand<{x:{y:string}}>` / `DeepObject` | recursive ref in mapped property | clean | clean | clean |
| `type Foo<T> = T extends unknown ? ... Foo<unknown> ...` | same-input def-site | TS2589 | TS2589 | TS2589 |
| `{ "true": Foo<T, Foo<T,B>> }[T]` use site | growing/equal args | TS2589 | TS2589 | TS2589 |

## Project Corpus Impact
- Row: rxjs-project
- Bug family: recursive-types
- Also benefits the `nextjs` / `ts-toolbelt-project` / `kysely-project` recursive-utility rows (#10802 and siblings).
- Removes false-positive TS2589s on terminating recursive utilities; no row should gain diagnostics.

## Verification
- `cargo test -p tsz-checker --lib ts2589` → 65 passed / 0 failed (includes 2 new regression tests with varied binder names for the function-return and object-property shapes).
- `cargo test -p tsz-solver --lib -- recursive_growth visitor` → green; `cargo test -p tsz-checker --lib -- variadic infer_ tuple_spread type_alias` → 278 passed.
- `cargo clippy -p tsz-solver -p tsz-checker --lib` → clean.
- Built the parent commit to confirm the false TS2589 pre-fix and its removal post-fix on `Curry`/`Join`/`Reverse` repros; full-output `diff` vs `tsc 5.8` matches on every case above.
- Pre-existing failures observed on the base commit (`recursive_alias_application_target_display_tests`, one relation-routing arch test, one template-literal solver test) are unrelated to this change and fail identically without it.

## Coordination Notes
Released the WIP claim on #10863 (modifier semantics verified already correct; only a separate `type-display` aliasing residue remains there). Broad suites (conformance/emit/fourslash) are owned by ready-review CI, not run locally per repo guidance.

https://claude.ai/code/session_01Pm3JyqB3HsVf8saj255bCm