### PR TITLE
fix(checker): emit TS2556 for variable-length tuple spreads into fixed parameters

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -35,6 +35,10 @@ name = "type_only_import_reexport_tests"
 path = "tests/type_only_import_reexport_tests.rs"
 
 [[test]]
+name = "variadic_tuple_spread_arity_ts2556_tests"
+path = "tests/variadic_tuple_spread_arity_ts2556_tests.rs"
+
+[[test]]
 name = "closure_boundary_property_narrowing_tests"
 path = "tests/closure_boundary_property_narrowing_tests.rs"
 

--- a/crates/tsz-checker/src/checkers/call_checker/candidate_collection.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/candidate_collection.rs
@@ -8,7 +8,7 @@ use crate::diagnostics::diagnostic_codes;
 use crate::query_boundaries::checkers::call::{
     array_element_type_for_type, contains_index_access_with_type_parameter_object,
     contains_index_access_with_variadic_tuple_object, is_type_parameter_type,
-    tuple_elements_for_type,
+    tuple_elements_for_type, tuple_slice_variable_rest_offset,
 };
 use crate::query_boundaries::common::ContextualTypeContext;
 use crate::state::CheckerState;
@@ -441,6 +441,44 @@ impl<'a> CheckerState<'a> {
 
                     // If it's a tuple type, expand its elements
                     if let Some(elems) = tuple_elements_for_type(self.ctx.types, spread_type) {
+                        // An open-ended tuple (one whose flattened rest is
+                        // array-backed, e.g. `[number, ...string[]]`) has an
+                        // indeterminate length, exactly like a bare array
+                        // spread. Its variable portion must land on a rest
+                        // parameter; when the parameter at that position is not
+                        // a rest (nor an optional trailing) position, tsc
+                        // reports TS2556 — and only TS2556. A fully fixed-length
+                        // tuple (including fully-fixed nested tuple rests) keeps
+                        // the normal positional expansion below.
+                        if let Some(variable_offset) =
+                            tuple_slice_variable_rest_offset(self.ctx.types, &elems)
+                        {
+                            let variable_index = effective_index + variable_offset;
+                            let at_rest_position = if let Some(callable_type) =
+                                callable_ctx.callable_type
+                            {
+                                let ctx = ContextualTypeContext::with_expected(
+                                    self.ctx.types,
+                                    callable_type,
+                                );
+                                ctx.allows_non_tuple_spread_position(variable_index, expanded_count)
+                            } else {
+                                // No callable type means callee is
+                                // any/error/unknown; accept the spread when a
+                                // large-index probe still resolves a param.
+                                expected_for_index(usize::MAX / 2, expanded_count).is_some()
+                            };
+                            if !at_rest_position {
+                                if !emitted_ts2556 {
+                                    self.error_spread_must_be_tuple_or_rest_at(arg_idx);
+                                    emitted_ts2556 = true;
+                                }
+                                // tsc reports only TS2556 here; do not expand the
+                                // tuple into positional args (which would cascade
+                                // into TS2345/TS2554).
+                                continue;
+                            }
+                        }
                         for elem in &elems {
                             if elem.rest {
                                 // Rest element (e.g., `...boolean[]` in `[number, string, ...boolean[]]`).

--- a/crates/tsz-checker/src/checkers/call_checker/candidate_collection.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/candidate_collection.rs
@@ -450,6 +450,16 @@ impl<'a> CheckerState<'a> {
                         // reports TS2556 — and only TS2556. A fully fixed-length
                         // tuple (including fully-fixed nested tuple rests) keeps
                         // the normal positional expansion below.
+                        //
+                        // Exception: when the callee is an inline function/arrow
+                        // expression with un-annotated parameters, tsc
+                        // contextually types those parameters from the spread
+                        // tuple's elements (the `restTuplesFromContextualTypes`
+                        // behaviour), so the call is valid by construction and no
+                        // TS2556 is reported. That suppression is specific to
+                        // tuple spreads — a bare array/iterable spread carries no
+                        // per-position element types to infer from, so its
+                        // TS2556 path (below) still fires for such callees.
                         if let Some(variable_offset) =
                             tuple_slice_variable_rest_offset(self.ctx.types, &elems)
                         {
@@ -468,7 +478,12 @@ impl<'a> CheckerState<'a> {
                                 // large-index probe still resolves a param.
                                 expected_for_index(usize::MAX / 2, expanded_count).is_some()
                             };
-                            if !at_rest_position {
+                            if !at_rest_position
+                                && !self.spread_callee_infers_params_from_arguments(
+                                    arg_idx,
+                                    variable_index,
+                                )
+                            {
                                 if !emitted_ts2556 {
                                     self.error_spread_must_be_tuple_or_rest_at(arg_idx);
                                     emitted_ts2556 = true;

--- a/crates/tsz-checker/src/checkers/call_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/mod.rs
@@ -10,6 +10,7 @@ mod applicability;
 mod candidate_collection;
 mod diagnostics;
 mod overload_resolution;
+mod spread_arity;
 
 use crate::query_boundaries::common::{AssignabilityChecker, CallResult};
 use crate::state::CheckerState;

--- a/crates/tsz-checker/src/checkers/call_checker/spread_arity.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/spread_arity.rs
@@ -1,0 +1,80 @@
+//! Spread-argument arity helpers for call checking.
+//!
+//! Split from `candidate_collection` to keep that module under the per-file
+//! line ceiling. Hosts the open-ended-tuple-spread TS2556 suppression query.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+
+impl<'a> CheckerState<'a> {
+    /// Whether the open-ended tuple spread `arg_idx`, whose variable rest lands
+    /// at positional argument index `variable_index`, targets a callee whose
+    /// parameter at that position tsc contextually types from the spread — in
+    /// which case TS2556 must be suppressed.
+    ///
+    /// tsc applies the `restTuplesFromContextualTypes` behaviour when the callee
+    /// is an inline function/arrow expression and the parameter sitting at the
+    /// variable-rest position is **un-annotated**: that parameter is then
+    /// contextually typed from the tuple's rest element and absorbs the variable
+    /// portion, so the call is valid. When that parameter is annotated it has a
+    /// fixed type the open-ended spread cannot satisfy, and when no parameter
+    /// exists at that position the rest overflows the parameter list — TS2556
+    /// still fires in both cases, exactly as for a declared function. The callee
+    /// is found by walking the parent chain from the argument to the nearest
+    /// enclosing call/new expression, so no call-node context has to be threaded
+    /// through the argument collector.
+    pub(crate) fn spread_callee_infers_params_from_arguments(
+        &self,
+        arg_idx: NodeIndex,
+        variable_index: usize,
+    ) -> bool {
+        // Walk up to the enclosing call/new expression that owns this argument.
+        let mut child = arg_idx;
+        let mut callee = NodeIndex::NONE;
+        for _ in 0..8 {
+            let Some(parent) = self.ctx.arena.parent_of(child) else {
+                return false;
+            };
+            let Some(parent_node) = self.ctx.arena.get(parent) else {
+                return false;
+            };
+            if (parent_node.kind == syntax_kind_ext::CALL_EXPRESSION
+                || parent_node.kind == syntax_kind_ext::NEW_EXPRESSION)
+                && let Some(call) = self.ctx.arena.get_call_expr(parent_node)
+            {
+                // `child` is on the argument side, never the callee side.
+                if call.expression == child {
+                    return false;
+                }
+                callee = call.expression;
+                break;
+            }
+            child = parent;
+        }
+        if callee.is_none() {
+            return false;
+        }
+
+        let callee = self.ctx.arena.skip_parenthesized(callee);
+        let Some(callee_node) = self.ctx.arena.get(callee) else {
+            return false;
+        };
+        if callee_node.kind != syntax_kind_ext::FUNCTION_EXPRESSION
+            && callee_node.kind != syntax_kind_ext::ARROW_FUNCTION
+        {
+            return false;
+        }
+        let Some(func) = self.ctx.arena.get_function(callee_node) else {
+            return false;
+        };
+        // The parameter at the variable-rest position must exist and be
+        // un-annotated for tsc to contextually type it from the rest element.
+        func.parameters
+            .nodes
+            .get(variable_index)
+            .and_then(|&param_idx| self.ctx.arena.get(param_idx))
+            .and_then(|node| self.ctx.arena.get_parameter(node))
+            .is_some_and(|param| param.type_annotation.is_none())
+    }
+}

--- a/crates/tsz-checker/src/query_boundaries/checkers/call.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/call.rs
@@ -2,13 +2,28 @@ use tsz_solver::computation::{ContextualTypeContext, TypeSubstitution};
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 use tsz_solver::operations::{AssignabilityChecker, CallResult};
 use tsz_solver::relations::subtype::{TypeEnvironment, TypeResolver};
-use tsz_solver::{FunctionShape, TypeId};
+use tsz_solver::{FunctionShape, TupleElement, TypeId};
 
 pub(crate) use super::super::common::array_element_type as array_element_type_for_type;
 pub(crate) use super::super::common::is_type_parameter_like as is_type_parameter_type;
 pub(crate) use super::super::common::lazy_def_id as lazy_def_id_for_type;
 pub(crate) use super::super::common::tuple_elements as tuple_elements_for_type;
-pub(crate) use super::super::common::tuple_slice_variable_rest_offset;
+
+/// Positional offset of the first variable-length rest element in a tuple
+/// spread, or `None` for a fully fixed-length tuple (or non-tuple). See
+/// `tsz_solver::type_queries::tuple_variable_rest_offset`.
+pub(crate) fn tuple_variable_rest_offset(db: &dyn TypeDatabase, type_id: TypeId) -> Option<usize> {
+    tsz_solver::type_queries::tuple_variable_rest_offset(db, type_id)
+}
+
+/// Slice-taking form of [`tuple_variable_rest_offset`] for callers that already
+/// hold the tuple's elements (avoids a second tuple lookup).
+pub(crate) fn tuple_slice_variable_rest_offset(
+    db: &dyn TypeDatabase,
+    elements: &[TupleElement],
+) -> Option<usize> {
+    tsz_solver::type_queries::tuple_slice_variable_rest_offset(db, elements)
+}
 
 pub(crate) fn rest_array_element_type_for_type(
     db: &dyn TypeDatabase,

--- a/crates/tsz-checker/src/query_boundaries/checkers/call.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/call.rs
@@ -8,6 +8,7 @@ pub(crate) use super::super::common::array_element_type as array_element_type_fo
 pub(crate) use super::super::common::is_type_parameter_like as is_type_parameter_type;
 pub(crate) use super::super::common::lazy_def_id as lazy_def_id_for_type;
 pub(crate) use super::super::common::tuple_elements as tuple_elements_for_type;
+pub(crate) use super::super::common::tuple_slice_variable_rest_offset;
 
 pub(crate) fn rest_array_element_type_for_type(
     db: &dyn TypeDatabase,

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -317,6 +317,22 @@ pub(crate) fn tuple_elements(db: &dyn TypeDatabase, type_id: TypeId) -> Option<V
     tsz_solver::type_queries::get_tuple_elements(db, type_id)
 }
 
+/// Positional offset of the first variable-length rest element in a tuple
+/// spread, or `None` for a fully fixed-length tuple (or non-tuple). See
+/// `tsz_solver::type_queries::tuple_variable_rest_offset`.
+pub(crate) fn tuple_variable_rest_offset(db: &dyn TypeDatabase, type_id: TypeId) -> Option<usize> {
+    tsz_solver::type_queries::tuple_variable_rest_offset(db, type_id)
+}
+
+/// Slice-taking form of [`tuple_variable_rest_offset`] for callers that already
+/// hold the tuple's elements (avoids a second tuple lookup).
+pub(crate) fn tuple_slice_variable_rest_offset(
+    db: &dyn TypeDatabase,
+    elements: &[TupleElement],
+) -> Option<usize> {
+    tsz_solver::type_queries::tuple_slice_variable_rest_offset(db, elements)
+}
+
 pub(crate) fn call_signatures_for_type(
     db: &dyn TypeDatabase,
     type_id: TypeId,

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -317,22 +317,6 @@ pub(crate) fn tuple_elements(db: &dyn TypeDatabase, type_id: TypeId) -> Option<V
     tsz_solver::type_queries::get_tuple_elements(db, type_id)
 }
 
-/// Positional offset of the first variable-length rest element in a tuple
-/// spread, or `None` for a fully fixed-length tuple (or non-tuple). See
-/// `tsz_solver::type_queries::tuple_variable_rest_offset`.
-pub(crate) fn tuple_variable_rest_offset(db: &dyn TypeDatabase, type_id: TypeId) -> Option<usize> {
-    tsz_solver::type_queries::tuple_variable_rest_offset(db, type_id)
-}
-
-/// Slice-taking form of [`tuple_variable_rest_offset`] for callers that already
-/// hold the tuple's elements (avoids a second tuple lookup).
-pub(crate) fn tuple_slice_variable_rest_offset(
-    db: &dyn TypeDatabase,
-    elements: &[TupleElement],
-) -> Option<usize> {
-    tsz_solver::type_queries::tuple_slice_variable_rest_offset(db, elements)
-}
-
 pub(crate) fn call_signatures_for_type(
     db: &dyn TypeDatabase,
     type_id: TypeId,

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -607,6 +607,45 @@ impl<'a> CheckerState<'a> {
             })
     }
 
+    /// Whether any call argument is a spread of *indeterminate* length.
+    ///
+    /// A spread provides an unknown number of positional values when it is a
+    /// non-tuple iterable/array, **or** an open-ended tuple whose flattened rest
+    /// is array-backed (e.g. `[number, ...string[]]`, `[...number[], string]`).
+    /// In both cases tsc reports TS2556 at the spread site, and the arity
+    /// diagnostics TS2554/TS2555 must not cascade afterwards.
+    ///
+    /// Array-literal spreads (`...[1, 2, 3]`) are excluded: they were already
+    /// expanded into a known number of positional arguments during call
+    /// checking, so their length is determinate and a genuine arity error should
+    /// still fire.
+    pub(crate) fn call_has_indeterminate_length_spread(&mut self, args: &[NodeIndex]) -> bool {
+        args.iter().any(|&arg_idx| {
+            if let Some(n) = self.ctx.arena.get(arg_idx)
+                && n.kind == syntax_kind_ext::SPREAD_ELEMENT
+                && let Some(spread_data) = self.ctx.arena.get_spread(n)
+            {
+                let inner_idx = self.ctx.arena.skip_parenthesized(spread_data.expression);
+                if let Some(expr_node) = self.ctx.arena.get(inner_idx)
+                    && expr_node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
+                    && self.ctx.arena.get_literal_expr(expr_node).is_some()
+                {
+                    return false;
+                }
+                let spread_type = self.get_type_of_node(spread_data.expression);
+                let spread_type = self.resolve_type_for_property_access(spread_type);
+                let spread_type = self.resolve_lazy_type(spread_type);
+                // Non-tuple spread (array/iterable) -> indeterminate length.
+                // Open-ended tuple spread (array-backed flattened rest) -> also
+                // indeterminate. A fully fixed-length tuple keeps a known count.
+                common::tuple_elements(self.ctx.types, spread_type).is_none()
+                    || common::tuple_variable_rest_offset(self.ctx.types, spread_type).is_some()
+            } else {
+                false
+            }
+        })
+    }
+
     fn callback_prefers_argument_level_return_mismatch(&self, arg_idx: NodeIndex) -> bool {
         let Some(func) = self
             .callback_function_index(arg_idx)
@@ -885,35 +924,9 @@ impl<'a> CheckerState<'a> {
                         }
                     }
 
-                    let has_non_tuple_spread = args.iter().any(|&arg_idx| {
-                        if let Some(n) = self.ctx.arena.get(arg_idx)
-                            && n.kind == syntax_kind_ext::SPREAD_ELEMENT
-                            && let Some(spread_data) = self.ctx.arena.get_spread(n)
-                        {
-                            // Array literal spreads (e.g., ...[1, 2, 3]) were already
-                            // expanded to individual arguments during call checking,
-                            // so they have a known count — treat them like tuples.
-                            let inner_idx =
-                                self.ctx.arena.skip_parenthesized(spread_data.expression);
-                            if let Some(expr_node) = self.ctx.arena.get(inner_idx)
-                                && expr_node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
-                                && self.ctx.arena.get_literal_expr(expr_node).is_some()
-                            {
-                                return false;
-                            }
-                            let spread_type = self.get_type_of_node(spread_data.expression);
-                            let spread_type = self.resolve_type_for_property_access(spread_type);
-                            let spread_type = self.resolve_lazy_type(spread_type);
-                            crate::query_boundaries::common::tuple_elements(
-                                self.ctx.types,
-                                spread_type,
-                            )
-                            .is_none()
-                        } else {
-                            false
-                        }
-                    });
+                    let has_non_tuple_spread = self.call_has_indeterminate_length_spread(args);
                     if has_non_tuple_spread {
+                        // TS2556 was already emitted; don't cascade with TS2555/TS2554.
                     } else if actual < expected_min && expected_max.is_none() {
                         self.error_expected_at_least_arguments_at(expected_min, actual, call_idx);
                     } else {

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -639,7 +639,11 @@ impl<'a> CheckerState<'a> {
                 // Open-ended tuple spread (array-backed flattened rest) -> also
                 // indeterminate. A fully fixed-length tuple keeps a known count.
                 common::tuple_elements(self.ctx.types, spread_type).is_none()
-                    || common::tuple_variable_rest_offset(self.ctx.types, spread_type).is_some()
+                    || crate::query_boundaries::checkers::call::tuple_variable_rest_offset(
+                        self.ctx.types,
+                        spread_type,
+                    )
+                    .is_some()
             } else {
                 false
             }

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -1752,34 +1752,7 @@ impl<'a> CheckerState<'a> {
                     // TSC only emits TS2556 in this case, not TS2555/TS2554.
                     // However, tuple spreads have known length, so TS2554 should
                     // still fire for those.
-                    let has_non_tuple_spread = args.iter().any(|&arg_idx| {
-                        if let Some(n) = self.ctx.arena.get(arg_idx)
-                            && n.kind == syntax_kind_ext::SPREAD_ELEMENT
-                            && let Some(spread_data) = self.ctx.arena.get_spread(n)
-                        {
-                            // Array literal spreads (e.g., ...[1, 2, 3]) were already
-                            // expanded to individual arguments during call checking,
-                            // so they have a known count — treat them like tuples.
-                            let inner_idx =
-                                self.ctx.arena.skip_parenthesized(spread_data.expression);
-                            if let Some(expr_node) = self.ctx.arena.get(inner_idx)
-                                && expr_node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
-                                && self.ctx.arena.get_literal_expr(expr_node).is_some()
-                            {
-                                return false;
-                            }
-                            let spread_type = self.get_type_of_node(spread_data.expression);
-                            let spread_type = self.resolve_type_for_property_access(spread_type);
-                            let spread_type = self.resolve_lazy_type(spread_type);
-                            crate::query_boundaries::common::tuple_elements(
-                                self.ctx.types,
-                                spread_type,
-                            )
-                            .is_none()
-                        } else {
-                            false
-                        }
-                    });
+                    let has_non_tuple_spread = self.call_has_indeterminate_length_spread(args);
                     if has_non_tuple_spread {
                         // TS2556 was already emitted; don't cascade with TS2555/TS2554.
                     } else if actual < expected_min && expected_max.is_none() {

--- a/crates/tsz-checker/tests/variadic_tuple_spread_arity_ts2556_tests.rs
+++ b/crates/tsz-checker/tests/variadic_tuple_spread_arity_ts2556_tests.rs
@@ -1,0 +1,255 @@
+//! TS2556 for open-ended (variable-length) tuple spreads in call arguments.
+//!
+//! Structural rule: a tuple whose flattened rest is array-backed (e.g.
+//! `[number, ...string[]]`, `[...number[], string]`, `[number, ...string[],
+//! boolean]`) has an *indeterminate* length, exactly like a bare array spread.
+//! When such a spread is used as a call argument, its variable portion must
+//! land on a rest parameter; otherwise `tsc` reports
+//!
+//!   TS2556: A spread argument must either have a tuple type or be passed to a
+//!           rest parameter.
+//!
+//! and only TS2556 (no cascading TS2554/TS2555 arity error). A fully
+//! fixed-length tuple (including fully-fixed nested tuple rests) keeps its known
+//! length and is spread positionally.
+//!
+//! Owner layer: the open-endedness predicate is a solver type query
+//! (`tuple_variable_rest_offset`); the checker's call-argument collection routes
+//! the spread-position decision through the shared
+//! `allows_non_tuple_spread_position` boundary, the same gateway the array and
+//! iterable spread paths use.
+
+use tsz_checker::test_utils::{check_source_diagnostics, diagnostic_codes, diagnostic_count};
+
+/// Build a tiny program that spreads `tuple_ty` into a call to a function with
+/// `params`, using `f`/`t` binder names that the caller varies (anti-hardcoding:
+/// the rule is structural, not keyed on any identifier).
+fn spread_call_src(fn_name: &str, params: &str, var: &str, tuple_ty: &str, value: &str) -> String {
+    format!(
+        "declare function {fn_name}({params}): void;\n\
+         const {var}: {tuple_ty} = {value};\n\
+         {fn_name}(...{var});\n"
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Positive: open-ended tuple spread into a fixed parameter list -> TS2556.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn trailing_rest_tuple_into_fixed_params_emits_ts2556() {
+    let src = spread_call_src(
+        "g",
+        "a: number, b: string",
+        "t",
+        "[number, ...string[]]",
+        "[1]",
+    );
+    let diags = check_source_diagnostics(&src);
+    assert_eq!(
+        diagnostic_count(&diags, 2556),
+        1,
+        "open-ended trailing-rest tuple spread into fixed params must emit TS2556: {:?}",
+        diagnostic_codes(&diags)
+    );
+    // tsc emits *only* TS2556 here — no TS2554/TS2555 arity cascade.
+    assert_eq!(
+        diagnostic_count(&diags, 2554),
+        0,
+        "no TS2554 cascade: {:?}",
+        diagnostic_codes(&diags)
+    );
+    assert_eq!(
+        diagnostic_count(&diags, 2555),
+        0,
+        "no TS2555 cascade: {:?}",
+        diagnostic_codes(&diags)
+    );
+}
+
+#[test]
+fn leading_rest_tuple_into_fixed_params_emits_ts2556() {
+    let src = spread_call_src(
+        "apply",
+        "a: number, b: string",
+        "args",
+        "[...number[], string]",
+        "[1] as any",
+    );
+    let diags = check_source_diagnostics(&src);
+    assert_eq!(
+        diagnostic_count(&diags, 2556),
+        1,
+        "open-ended leading-rest tuple spread into fixed params must emit TS2556: {:?}",
+        diagnostic_codes(&diags)
+    );
+}
+
+#[test]
+fn middle_rest_tuple_into_fixed_params_emits_ts2556() {
+    let src = spread_call_src(
+        "invoke",
+        "a: number, b: string, c: boolean",
+        "row",
+        "[number, ...string[], boolean]",
+        "[1, true] as any",
+    );
+    let diags = check_source_diagnostics(&src);
+    assert_eq!(
+        diagnostic_count(&diags, 2556),
+        1,
+        "open-ended middle-rest tuple spread into fixed params must emit TS2556: {:?}",
+        diagnostic_codes(&diags)
+    );
+    assert_eq!(
+        diagnostic_count(&diags, 2554),
+        0,
+        "no TS2554 cascade: {:?}",
+        diagnostic_codes(&diags)
+    );
+}
+
+#[test]
+fn nested_variable_tuple_rest_into_fixed_params_emits_ts2556() {
+    // The outer rest is a *fixed* tuple shell, but it nests a variable rest, so
+    // the whole tuple is still open-ended.
+    let src = spread_call_src(
+        "h",
+        "a: number, b: string",
+        "t",
+        "[number, ...[string, ...boolean[]]]",
+        "[1, \"x\"]",
+    );
+    let diags = check_source_diagnostics(&src);
+    assert_eq!(
+        diagnostic_count(&diags, 2556),
+        1,
+        "nested variable-rest tuple spread must emit TS2556: {:?}",
+        diagnostic_codes(&diags)
+    );
+    // Must be TS2556, not the pre-fix TS2554 arity miscount.
+    assert_eq!(
+        diagnostic_count(&diags, 2554),
+        0,
+        "no TS2554: {:?}",
+        diagnostic_codes(&diags)
+    );
+}
+
+#[test]
+fn readonly_open_ended_tuple_into_fixed_params_emits_ts2556() {
+    let src = spread_call_src(
+        "g",
+        "a: number, b: string",
+        "t",
+        "readonly [number, ...string[]]",
+        "[1] as any",
+    );
+    let diags = check_source_diagnostics(&src);
+    assert_eq!(
+        diagnostic_count(&diags, 2556),
+        1,
+        "readonly open-ended tuple spread must still emit TS2556: {:?}",
+        diagnostic_codes(&diags)
+    );
+}
+
+/// Anti-hardcoding: the rule must be structural, not keyed on identifiers. The
+/// same open-ended shape with different binder/function names must still fire.
+#[test]
+fn ts2556_is_not_keyed_on_identifier_names() {
+    for (fname, vname) in [("zip", "pair"), ("dispatch", "payload"), ("call", "rest")] {
+        let src = spread_call_src(
+            fname,
+            "a: number, b: string",
+            vname,
+            "[number, ...string[]]",
+            "[1]",
+        );
+        let diags = check_source_diagnostics(&src);
+        assert_eq!(
+            diagnostic_count(&diags, 2556),
+            1,
+            "TS2556 must fire regardless of names ({fname}/{vname}): {:?}",
+            diagnostic_codes(&diags)
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Negative: spreads that are valid must NOT emit TS2556.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fixed_tuple_into_fixed_params_no_ts2556() {
+    let src = spread_call_src(
+        "g",
+        "a: number, b: string",
+        "t",
+        "[number, string]",
+        "[1, \"x\"]",
+    );
+    let diags = check_source_diagnostics(&src);
+    assert_eq!(
+        diagnostic_count(&diags, 2556),
+        0,
+        "fixed-length tuple spread must not emit TS2556: {:?}",
+        diagnostic_codes(&diags)
+    );
+}
+
+#[test]
+fn nested_fixed_tuple_rest_into_fixed_params_no_ts2556() {
+    // `[number, ...[string, boolean]]` is fully fixed-length -> [number, string, boolean].
+    let src = spread_call_src(
+        "g",
+        "a: number, b: string, c: boolean",
+        "t",
+        "[number, ...[string, boolean]]",
+        "[1, \"x\", true]",
+    );
+    let diags = check_source_diagnostics(&src);
+    assert_eq!(
+        diagnostic_count(&diags, 2556),
+        0,
+        "fully-fixed nested tuple rest must not emit TS2556: {:?}",
+        diagnostic_codes(&diags)
+    );
+}
+
+#[test]
+fn open_ended_tuple_into_rest_param_no_ts2556() {
+    let src = spread_call_src(
+        "g",
+        "a: number, ...b: string[]",
+        "t",
+        "[number, ...string[]]",
+        "[1]",
+    );
+    let diags = check_source_diagnostics(&src);
+    assert_eq!(
+        diagnostic_count(&diags, 2556),
+        0,
+        "open-ended tuple landing on a rest parameter must not emit TS2556: {:?}",
+        diagnostic_codes(&diags)
+    );
+}
+
+#[test]
+fn open_ended_tuple_into_optional_trailing_no_ts2556() {
+    // The variable portion only covers an optional trailing parameter -> allowed.
+    let src = spread_call_src(
+        "g",
+        "a: number, b?: string",
+        "t",
+        "[number, ...string[]]",
+        "[1]",
+    );
+    let diags = check_source_diagnostics(&src);
+    assert_eq!(
+        diagnostic_count(&diags, 2556),
+        0,
+        "open-ended tuple covering only optional trailing params must not emit TS2556: {:?}",
+        diagnostic_codes(&diags)
+    );
+}

--- a/crates/tsz-checker/tests/variadic_tuple_spread_arity_ts2556_tests.rs
+++ b/crates/tsz-checker/tests/variadic_tuple_spread_arity_ts2556_tests.rs
@@ -253,3 +253,84 @@ fn open_ended_tuple_into_optional_trailing_no_ts2556() {
         diagnostic_codes(&diags)
     );
 }
+
+// ---------------------------------------------------------------------------
+// Contextual `restTuplesFromContextualTypes` suppression: an inline function /
+// arrow expression whose parameter at the variable-rest position is
+// un-annotated gets that parameter contextually typed from the tuple's rest
+// element, so tsc (and tsz) report no TS2556. The suppression hinges on the
+// parameter AT the rest position being un-annotated, and is specific to tuple
+// spreads (a bare array spread still errors).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn open_ended_tuple_into_iife_unannotated_param_no_ts2556() {
+    // `[number, boolean, ...string[]]` rest lands at index 2; param `c` is
+    // un-annotated, so it is contextually typed and absorbs the rest.
+    let src = "const t: [number, boolean, ...string[]] = [1, true];\n\
+               (function (a, b, c) {})(...t);\n";
+    let diags = check_source_diagnostics(src);
+    assert_eq!(
+        diagnostic_count(&diags, 2556),
+        0,
+        "inline function with un-annotated rest-position param must not emit TS2556: {:?}",
+        diagnostic_codes(&diags)
+    );
+}
+
+#[test]
+fn open_ended_tuple_into_iife_arrow_unannotated_param_no_ts2556() {
+    let src = "const t: [number, ...string[]] = [1];\n\
+               ((a, b) => {})(...t);\n";
+    let diags = check_source_diagnostics(src);
+    assert_eq!(
+        diagnostic_count(&diags, 2556),
+        0,
+        "inline arrow with un-annotated rest-position param must not emit TS2556: {:?}",
+        diagnostic_codes(&diags)
+    );
+}
+
+#[test]
+fn open_ended_tuple_into_iife_annotated_rest_position_emits_ts2556() {
+    // Param `c` at the rest position is annotated -> fixed type -> TS2556 fires,
+    // exactly as for a declared function.
+    let src = "const t: [number, boolean, ...string[]] = [1, true];\n\
+               (function (a, b, c: string) {})(...t);\n";
+    let diags = check_source_diagnostics(src);
+    assert_eq!(
+        diagnostic_count(&diags, 2556),
+        1,
+        "inline function with annotated rest-position param must emit TS2556: {:?}",
+        diagnostic_codes(&diags)
+    );
+}
+
+#[test]
+fn open_ended_tuple_into_iife_too_few_params_emits_ts2556() {
+    // Only two params; the rest at index 2 has no parameter to land on -> TS2556.
+    let src = "const t: [number, boolean, ...string[]] = [1, true];\n\
+               (function (a, b) {})(...t);\n";
+    let diags = check_source_diagnostics(src);
+    assert_eq!(
+        diagnostic_count(&diags, 2556),
+        1,
+        "inline function with no param at the rest position must emit TS2556: {:?}",
+        diagnostic_codes(&diags)
+    );
+}
+
+#[test]
+fn open_ended_tuple_into_iife_all_annotated_emits_ts2556() {
+    // Every parameter annotated -> fixed signature -> behaves like a declared
+    // function -> TS2556.
+    let src = "const t: [number, boolean, ...string[]] = [1, true];\n\
+               (function (a: number, b: boolean, c: boolean) {})(...t);\n";
+    let diags = check_source_diagnostics(src);
+    assert_eq!(
+        diagnostic_count(&diags, 2556),
+        1,
+        "inline function with all-annotated params must emit TS2556: {:?}",
+        diagnostic_codes(&diags)
+    );
+}

--- a/crates/tsz-solver/src/type_queries/core.rs
+++ b/crates/tsz-solver/src/type_queries/core.rs
@@ -229,6 +229,71 @@ pub fn get_fixed_tuple_length(db: &dyn TypeDatabase, type_id: TypeId) -> Option<
     None
 }
 
+/// Positional offset of the first *variable-length* rest element in a tuple
+/// spread, or `None` when the tuple is fully fixed-length (or not a tuple).
+///
+/// A tuple is "open-ended" when, after flattening nested fixed-length tuple
+/// rests, it still contains a rest element whose source is an array (e.g.
+/// `[number, ...string[]]`) or another open-ended tuple. Such a tuple has an
+/// indeterminate length, exactly like a bare array spread.
+///
+/// The returned offset counts the fixed positional slots that precede the first
+/// variable rest (fixed elements contribute one slot; a fully-fixed nested tuple
+/// rest contributes its flattened length). tsc treats an open-ended tuple spread
+/// like an array spread: the variable portion must land on a rest parameter, so
+/// this offset is the argument position that must be a rest-parameter position
+/// for the spread to be valid. When it is not, the call site reports TS2556.
+///
+/// Readonly wrappers, type-parameter/`infer` constraints, and alias
+/// applications are seen through via [`get_tuple_elements`].
+pub fn tuple_variable_rest_offset(db: &dyn TypeDatabase, type_id: TypeId) -> Option<usize> {
+    let elements = super::data::get_tuple_elements(db, type_id)?;
+    tuple_slice_variable_rest_offset(db, &elements)
+}
+
+/// Slice-taking form of [`tuple_variable_rest_offset`], for callers that have
+/// already fetched the tuple's elements (e.g. the call-argument spread
+/// expansion) and want to avoid a second [`get_tuple_elements`] lookup.
+pub fn tuple_slice_variable_rest_offset(
+    db: &dyn TypeDatabase,
+    elements: &[crate::types::TupleElement],
+) -> Option<usize> {
+    let mut offset = 0usize;
+    tuple_elements_variable_rest_offset(db, elements, &mut offset)
+}
+
+/// Recursive worker for [`tuple_variable_rest_offset`].
+///
+/// Advances `offset` past fixed positional slots (including fully-fixed nested
+/// tuple rests) and returns `Some(absolute_offset)` at the first variable rest.
+/// Returns `None` for a fully fixed-length element list, leaving `offset` at the
+/// total flattened fixed-slot count so an enclosing tuple can continue counting.
+fn tuple_elements_variable_rest_offset(
+    db: &dyn TypeDatabase,
+    elements: &[crate::types::TupleElement],
+    offset: &mut usize,
+) -> Option<usize> {
+    for element in elements {
+        if !element.rest {
+            *offset += 1;
+            continue;
+        }
+        match super::data::get_tuple_elements(db, element.type_id) {
+            // Nested tuple rest: a fully-fixed nested tuple just contributes its
+            // own fixed slots; a nested open-ended tuple surfaces its variable
+            // rest at the combined offset.
+            Some(inner) => {
+                if let Some(found) = tuple_elements_variable_rest_offset(db, &inner, offset) {
+                    return Some(found);
+                }
+            }
+            // Array-backed (or otherwise non-tuple) rest: variable length.
+            None => return Some(*offset),
+        }
+    }
+    None
+}
+
 /// Check if a type is invokable (has call signatures, not just construct signatures).
 ///
 /// This is more specific than `is_callable_type` - it ensures the type can be called


### PR DESCRIPTION
Fixes #10825.

AgentName: Studio-B

Track: variadic-tuples / solver + checker call-argument arity

Invariant: tsz matches `tsc` on spread-argument arity. A spread whose type is an *open-ended* tuple — one whose flattened rest is array-backed — is variable-length and must land on a rest parameter, exactly like a bare array spread; otherwise the call reports **TS2556** and only TS2556 (no TS2554/TS2555 cascade). The one exception, matched exactly, is tsc's `restTuplesFromContextualTypes` behaviour.

## Structural rule

`When a spread argument's type is an open-ended tuple (its flattened rest is array-backed, after seeing through readonly wrappers / type-parameter constraints / alias applications / fully-fixed nested tuple rests), tsc treats it like an array spread: the variable rest must land on a rest (or optional-trailing) parameter position, else TS2556. Exception: when the callee is an inline function/arrow expression whose parameter AT the variable-rest position is un-annotated, that parameter is contextually typed from the tuple's rest element and absorbs the variable portion, so no TS2556 is reported.`

Previously tsz treated **every** tuple spread as fixed-length: it expanded the tuple positionally, silently accepted `g(...t)` where `t: [number, ...string[]]` and `g(a: number, b: string)`, and (once TS2556 was wired for the prefix) cascaded a spurious TS2554. tsc emits only TS2556.

## Scope / owner layers

- **Solver** (`tsz-solver/src/type_queries/core.rs`) — new `tuple_variable_rest_offset` / `tuple_slice_variable_rest_offset`: positional offset of the first variable-length rest, flattening fully-fixed nested tuple rests and seeing through readonly / type-param / alias forms via `get_tuple_elements`.
- **Checker call-argument collection** (`candidate_collection.rs`) — gates the open-ended tuple spread on the shared `allows_non_tuple_spread_position` query at the variable rest's position; emits TS2556 (once) when it is not a rest/optional-trailing position.
- **Contextual suppression** (`checkers/call_checker/spread_arity.rs`) — `spread_callee_infers_params_from_arguments` walks the argument's parent chain to the enclosing call and suppresses TS2556 when the callee is an inline function/arrow literal whose parameter at the variable-rest index is un-annotated (the `restTuplesFromContextualTypes` case). Specific to tuple spreads; bare array/iterable spreads still error.
- **Checker arity cascade** (`call_result.rs`, `complex.rs`) — extracted `call_has_indeterminate_length_spread`, shared by both arity paths, classifying open-ended tuples alongside non-tuple spreads so TS2554/TS2555 do not cascade after TS2556.
- **Query boundary** (`query_boundaries/checkers/call.rs`) — the new query wrappers live on the call-specific boundary, not the `common.rs` quarantine.

## Adjacent-case matrix (`tsc` vs `tsz`, both verified)

| Case | Expected |
| --- | --- |
| `[number, ...string[]]` into declared `(a,b)` | TS2556 |
| `[...number[], string]` into declared `(a,b)` (leading rest) | TS2556 |
| `[number, ...string[], boolean]` into declared `(a,b,c)` (middle rest) | TS2556 |
| `[number, ...[string, ...boolean[]]]` into declared `(a,b)` (nested variable rest) | TS2556 |
| `readonly [number, ...string[]]` into declared `(a,b)` | TS2556 |
| `[number, ...string[]]` into `(a, ...rest)` / `(a, b?)` | OK |
| `[number, ...[string, boolean]]` into `(a,b,c)` (fully-fixed nested rest) | OK |
| `[number, string]` into `(a,b)` (fixed tuple) | OK |
| `[number, boolean, ...string[]]` into IIFE `(a,b,c)` (un-annotated rest-position param) | OK |
| `[number, boolean, ...string[]]` into IIFE `(a,b,c: string)` (annotated rest-position param) | TS2556 |
| `[number, boolean, ...string[]]` into IIFE `(a,b)` (no param at rest position) | TS2556 |
| `[number, boolean, ...string[]]` into IIFE all-annotated | TS2556 |
| `string[]` array spread into IIFE `(x,y,z)` | TS2556 (unchanged) |

## Project Corpus Impact

- Row: zod-project
- Bug family: variadic-tuples

Witnessed by zod-style recursive variadic utilities; the fix is general (no fixture-name or identifier fast paths). No project required-row baseline is intentionally changed; the change only adds the missing TS2556 / removes a spurious TS2554 for open-ended tuple spreads, matching `tsc`.

## Verification

- New `variadic_tuple_spread_arity_ts2556_tests` (15 tests): trailing/leading/middle/nested/readonly open-ended shapes, the contextual inline-function suppression and its boundaries (annotated rest-position param, too-few params, all-annotated), plus fixed/rest-param/optional-trailing negatives — with binder-name variation per the anti-hardcoding directive.
- Reproduces the single expected TS2345 of the `restTuplesFromContextualTypes.ts` conformance test; matches `tsc` 6.0.2 across a 20+ case IIFE/declared/arrow/array/generic matrix.
- Adjacent suites green (`spread_rest_tests`, `variadic_tuple_*`, `rest_tuple_*`, `call_resolution_regression_tests`); solver `--lib tuple` 568/568. `clippy` and `scripts/arch/arch_guard.py` clean.

The pre-existing `test_array_like_rest_rejects_aggregate_rest_arguments` failure (literal-widening display `[1]` vs `[number]`) is unrelated — it fails identically on the base commit and passes in CI's `unit` job.

## Coordination Notes

Claimed #10825 via the issue's `agent:Studio-B` ownership label; the temporary claim label has been cleared now that the fix is in review, and the issue closes automatically on merge (`Fixes #10825`). Ready (non-draft, no blocking labels). No overlap with the in-flight #11349 work (different family).

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3KYmR6XQwrCZrqso55DaC)_