### PR TITLE
fix(emitter): emit computed accessor pairs for nameable Symbol property keys in DTS

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_members.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_members.rs
@@ -565,8 +565,10 @@ impl<'a> DeclarationEmitter<'a> {
                         && let Some(type_text) =
                             self.function_body_preferred_return_type_text(method_body)
                     {
+                        // function_body_preferred_return_type_text embeds depth=indent_level;
+                        // use write() so the pre-encoded indent is not doubled.
                         let type_text = self.wrap_async_method_return_type_text(method, type_text);
-                        self.write_type_text_with_current_indent(&type_text);
+                        self.write(&type_text);
                     } else {
                         let type_text =
                             self.inferred_method_return_type_text(method, return_type_id);
@@ -586,7 +588,7 @@ impl<'a> DeclarationEmitter<'a> {
                         self.function_body_preferred_return_type_text(method_body)
                     {
                         let type_text = self.wrap_async_method_return_type_text(method, type_text);
-                        self.write_type_text_with_current_indent(&type_text);
+                        self.write(&type_text);
                     } else if !self.source_is_declaration_file {
                         self.write("any");
                     }
@@ -603,7 +605,7 @@ impl<'a> DeclarationEmitter<'a> {
                     self.function_body_preferred_return_type_text(method_body)
                 {
                     let type_text = self.wrap_async_method_return_type_text(method, type_text);
-                    self.write_type_text_with_current_indent(&type_text);
+                    self.write(&type_text);
                 } else if !self.source_is_declaration_file {
                     self.write("any");
                 }
@@ -621,8 +623,9 @@ impl<'a> DeclarationEmitter<'a> {
             } else if let Some(type_text) =
                 self.function_body_preferred_return_type_text(method_body)
             {
+                // Pre-encoded indent_level depth; write() avoids double-counting.
                 let type_text = self.wrap_async_method_return_type_text(method, type_text);
-                self.write_type_text_with_current_indent(&type_text);
+                self.write(&type_text);
             } else if !self.source_is_declaration_file {
                 self.write("any");
             }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
@@ -673,22 +673,37 @@ impl<'a> DeclarationEmitter<'a> {
             return None;
         }
 
-        // Pre-scan: collect setter and getter names for accessor pair handling
+        // Pre-scan: collect setter and getter names for accessor pair handling.
+        // Also collect computed accessor source texts for pairs that lack type
+        // info to resolve via emittable_computed_property_name_text.
         let mut setter_names = rustc_hash::FxHashSet::<String>::default();
         let mut getter_names = rustc_hash::FxHashSet::<String>::default();
+        let mut computed_setter_source_texts = rustc_hash::FxHashSet::<String>::default();
+        let mut computed_getter_source_texts = rustc_hash::FxHashSet::<String>::default();
         for &idx in &object.elements.nodes {
             if let Some(n) = self.arena.get(idx) {
                 if n.kind == syntax_kind_ext::SET_ACCESSOR {
-                    if let Some(acc) = self.arena.get_accessor(n)
-                        && let Some(name) = self.object_literal_member_name_text(acc.name)
-                    {
-                        setter_names.insert(name);
+                    if let Some(acc) = self.arena.get_accessor(n) {
+                        if let Some(name) = self.object_literal_member_name_text(acc.name) {
+                            setter_names.insert(name);
+                        } else if let Some(name_node) = self.arena.get(acc.name)
+                            && name_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME
+                            && let Some(src) = self.get_source_slice(name_node.pos, name_node.end)
+                        {
+                            computed_setter_source_texts.insert(src.trim().to_string());
+                        }
                     }
-                } else if n.kind == syntax_kind_ext::GET_ACCESSOR
-                    && let Some(acc) = self.arena.get_accessor(n)
-                    && let Some(name) = self.object_literal_member_name_text(acc.name)
-                {
-                    getter_names.insert(name);
+                } else if n.kind == syntax_kind_ext::GET_ACCESSOR {
+                    if let Some(acc) = self.arena.get_accessor(n) {
+                        if let Some(name) = self.object_literal_member_name_text(acc.name) {
+                            getter_names.insert(name);
+                        } else if let Some(name_node) = self.arena.get(acc.name)
+                            && name_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME
+                            && let Some(src) = self.get_source_slice(name_node.pos, name_node.end)
+                        {
+                            computed_getter_source_texts.insert(src.trim().to_string());
+                        }
+                    }
                 }
             }
         }
@@ -703,13 +718,19 @@ impl<'a> DeclarationEmitter<'a> {
                 continue;
             };
 
+            // Try to resolve the member name first. If the name resolves (e.g.
+            // via infer_property_name_text for `[Symbol.isConcatSpreadable]`),
+            // use it directly. Only fall through to the non-nameable index-
+            // signature path when the name cannot be reproduced at all.
+            let name_text = self.object_literal_member_name_text(name_idx);
+
             // A computed key whose expression cannot be reproduced as a literal
             // property name (e.g. `[this.a]`) is not a named member in tsc's
             // output. tsc represents it through the object's synthesized index
             // signature, so emit that solver-derived signature instead of the
             // raw source slice. Each index signature is emitted once even when
             // several members share the same non-nameable key shape.
-            if self.is_non_nameable_computed_member_key(name_idx) {
+            if name_text.is_none() && self.is_non_nameable_computed_member_key(name_idx) {
                 if !emitted_index_signatures
                     && let Some(index_entries) =
                         self.object_literal_synthesized_index_signature_entries(object_expr_idx)
@@ -722,7 +743,7 @@ impl<'a> DeclarationEmitter<'a> {
                 continue;
             }
 
-            let Some(name) = self.object_literal_member_name_text(name_idx) else {
+            let Some(name) = name_text else {
                 continue;
             };
             if name.is_empty() || name == ":" {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs
@@ -64,19 +64,34 @@ impl<'a> DeclarationEmitter<'a> {
 
         let mut setter_names = rustc_hash::FxHashSet::<String>::default();
         let mut getter_names = rustc_hash::FxHashSet::<String>::default();
+        // Computed accessor names that lack type info to resolve via emittable_computed_property_name_text.
+        // These are collected for getter/setter pair detection by source text matching.
+        let mut computed_setter_source_texts = rustc_hash::FxHashSet::<String>::default();
+        let mut computed_getter_source_texts = rustc_hash::FxHashSet::<String>::default();
         for &idx in &object.elements.nodes {
             if let Some(n) = self.arena.get(idx) {
                 if n.kind == syntax_kind_ext::SET_ACCESSOR {
-                    if let Some(acc) = self.arena.get_accessor(n)
-                        && let Some(name) = self.object_literal_member_name_text(acc.name)
-                    {
-                        setter_names.insert(name);
+                    if let Some(acc) = self.arena.get_accessor(n) {
+                        if let Some(name) = self.object_literal_member_name_text(acc.name) {
+                            setter_names.insert(name);
+                        } else if let Some(name_node) = self.arena.get(acc.name)
+                            && name_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME
+                            && let Some(src) = self.get_source_slice(name_node.pos, name_node.end)
+                        {
+                            computed_setter_source_texts.insert(src.trim().to_string());
+                        }
                     }
-                } else if n.kind == syntax_kind_ext::GET_ACCESSOR
-                    && let Some(acc) = self.arena.get_accessor(n)
-                    && let Some(name) = self.object_literal_member_name_text(acc.name)
-                {
-                    getter_names.insert(name);
+                } else if n.kind == syntax_kind_ext::GET_ACCESSOR {
+                    if let Some(acc) = self.arena.get_accessor(n) {
+                        if let Some(name) = self.object_literal_member_name_text(acc.name) {
+                            getter_names.insert(name);
+                        } else if let Some(name_node) = self.arena.get(acc.name)
+                            && name_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME
+                            && let Some(src) = self.get_source_slice(name_node.pos, name_node.end)
+                        {
+                            computed_getter_source_texts.insert(src.trim().to_string());
+                        }
+                    }
                 }
             }
         }
@@ -127,6 +142,25 @@ impl<'a> DeclarationEmitter<'a> {
             let Some(mut name_text) = self
                 .object_literal_member_name_text(name_idx)
                 .or_else(|| self.emittable_computed_property_name_text(name_idx))
+                .or_else(|| {
+                    // Fallback: when a getter and setter share the same computed
+                    // property name source text but type info is unavailable, use
+                    // the source text directly so the pair emits as one property.
+                    if name_node.kind != syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+                        return None;
+                    }
+                    let src = self.get_source_slice(name_node.pos, name_node.end)?;
+                    let src = src.trim().to_string();
+                    let is_getter = member_node.kind == syntax_kind_ext::GET_ACCESSOR;
+                    let is_setter = member_node.kind == syntax_kind_ext::SET_ACCESSOR;
+                    if (is_getter && computed_setter_source_texts.contains(&src))
+                        || (is_setter && computed_getter_source_texts.contains(&src))
+                    {
+                        Some(src)
+                    } else {
+                        None
+                    }
+                })
             else {
                 if name_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME {
                     has_non_emittable_computed_members = true;
@@ -156,12 +190,16 @@ impl<'a> DeclarationEmitter<'a> {
                 name_text = source_name_text.trim().to_string();
             }
             concrete_member_names.push(name_text.clone());
+            let has_getter = getter_names.contains(&name_text)
+                || computed_getter_source_texts.contains(&name_text);
+            let has_setter = setter_names.contains(&name_text)
+                || computed_setter_source_texts.contains(&name_text);
             let Some(member_text) = self.infer_object_member_type_text_named_at(
                 member_idx,
                 &name_text,
                 self.indent_level + 1,
-                getter_names.contains(&name_text),
-                setter_names.contains(&name_text),
+                has_getter,
+                has_setter,
                 None,
             ) else {
                 continue;
@@ -203,8 +241,11 @@ impl<'a> DeclarationEmitter<'a> {
 
         let printed = self.print_type_id(type_id);
         let mut lines: Vec<String> = printed.lines().map(str::to_string).collect();
-        if lines.len() < 2 {
+        if lines.len() < 2 && computed_members.is_empty() && overridden_members.is_empty() {
             return Some(printed);
+        }
+        if lines.len() < 2 {
+            lines = vec!["{".to_string(), "}".to_string()];
         }
         let recovered_computed_index_signatures =
             self.rewrite_object_literal_computed_index_signatures(initializer, &mut lines);

--- a/crates/tsz-emitter/src/transforms/es_decorators_member_emit.rs
+++ b/crates/tsz-emitter/src/transforms/es_decorators_member_emit.rs
@@ -171,7 +171,14 @@ impl<'a> TC39DecoratorEmitter<'a> {
                                     ),
                                 )
                             }
-                        } else if has_instance_method {
+                        } else if has_instance_method
+                            && self.any_instance_method_precedes_field(
+                                decorated_members,
+                                fi.member_var_index,
+                            )
+                        {
+                            // A method decorator comes before this field in source order,
+                            // so its extra initializers must run inline before this field's init.
                             if is_private_weakmap {
                                 (
                                     Some(format!(
@@ -531,6 +538,33 @@ impl<'a> TC39DecoratorEmitter<'a> {
             return false;
         };
         later.pos > earlier.pos
+    }
+
+    /// Returns `true` if any non-static method/getter/setter member appears
+    /// before `field_member_var_index` in source order. Used to decide whether
+    /// `_instanceExtraInitializers` should be chained before the first field's
+    /// initializer (method-before-field ordering) or emitted as a separate
+    /// statement after the last field (field-before-method ordering).
+    fn any_instance_method_precedes_field(
+        &self,
+        decorated_members: &[DecoratedMember],
+        field_member_var_index: usize,
+    ) -> bool {
+        let Some(field_member) = decorated_members.get(field_member_var_index) else {
+            return false;
+        };
+        let Some(field_node) = self.arena.get(field_member.member_idx) else {
+            return false;
+        };
+        let field_pos = field_node.pos;
+        decorated_members.iter().any(|m| {
+            !m.is_static
+                && !matches!(m.kind, MemberKind::Field | MemberKind::Accessor)
+                && self
+                    .arena
+                    .get(m.member_idx)
+                    .is_some_and(|n| n.pos < field_pos)
+        })
     }
 
     pub(super) fn is_es2015_storage_setup_assignment(&self, assignment: &str) -> bool {


### PR DESCRIPTION
AgentName: Studio-C

## Track
Track 9 / declaration emit parity (computed property keys, legacy decorators, and computed method return formatting).

## Invariant
When TypeScript declaration emit can name a computed property key, preserve that key in DTS output instead of dropping or replacing it with a broad index-signature fallback; when legacy decorators target declare/abstract computed fields, emit the same side-effect-free key handling as tsc; when a computed method emits property syntax, do not double-indent inferred multiline return types. This PR changes emitter/DTS output logic only.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs`
- `crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs`
- `crates/tsz-emitter/src/declaration_emitter/core/emit_members.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: DTS computed property/accessor emit and legacy-decorator computed field emit
- Evidence: emitter/DTS parity fixes; no benchmark project row timing claim. Project corpus impact is expected to be output-parity only, with broad emit/CI as the gate.

## Verification
- CI on head `c1a4ab050ac981e2de8749d86b9386e1434a15de` had conformance, emit, fourslash, project-compile guard/canary, lint, unit, dist-binaries, and GitGuardian green except the PR-body gate, which failed because this body was still a placeholder.
- Manager did not run local suites. Studio-C should refresh/revalidate against current `origin/main` and rely on exact-head CI before queue.

## Coordination Notes
- Manager body repair: AgentName: M5Manager-MBM1.
- Canonical owner label: `agent:Studio-C`; scope label: `emit`.
- Revalidation status (Claude-Emit-100, head `3d47420291a7`): body-gate `project-corpus-pr-body` **green**; branch **refreshed onto current `origin/main`** (clean rebase, files disjoint from intervening commits); `GitGuardian`, `gate`, `lint`, `unit`, `unit-cloudbuild`, `wasm`/`wasm-web`, `dist-binaries`, `project-compile-guard`, `project-row-drift`, `lsp-e2e`, `conformance-snapshot-gate` **green**. Remaining gate: exact-head `CI Summary` (heavy `emit`/`conformance`/`fourslash`/`project-compile-canary` still running). **Keep off `merge-queue` until `CI Summary` + `GitGuardian` are green on `3d47420291a7`.**
- No semantic checker/solver change is claimed; this is emitter/DTS output work and must not add checker semantic validation.

