### PR TITLE
fix(bench): dispatch catch-up after stale non-publish

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1545,3 +1545,56 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/gh-pages.yml/dispatches" \
             -d '{"ref":"main"}'
+
+  catch-up:
+    name: bench-catch-up
+    needs: [bench-gate, bench-prep-artifact, bench, publish]
+    if: >-
+      always() &&
+      github.event_name == 'workflow_run' &&
+      needs.bench-gate.outputs.should_run == 'true' &&
+      needs.publish.result != 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch fresh benchmark after non-publishing run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          target_sha="${{ env.BENCH_TARGET_SHA }}"
+          main_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha' 2>/dev/null || true)"
+          if [[ -z "${main_sha}" ]]; then
+            echo "Could not read current main SHA; skipping benchmark catch-up dispatch."
+            exit 0
+          fi
+          if [[ "${target_sha}" == "${main_sha}" ]]; then
+            echo "Benchmark target ${target_sha} is current main; skipping catch-up dispatch."
+            exit 0
+          fi
+
+          active_runs="$(
+            {
+              gh run list --repo "${GITHUB_REPOSITORY}" --workflow bench.yml --branch main --status in_progress --limit 20 \
+                --json databaseId,headSha,url \
+                --jq '.[] | select(.databaseId != ${{ github.run_id }}) | [.databaseId, .headSha, .url] | @tsv'
+              gh run list --repo "${GITHUB_REPOSITORY}" --workflow bench.yml --branch main --status queued --limit 20 \
+                --json databaseId,headSha,url \
+                --jq '.[] | select(.databaseId != ${{ github.run_id }}) | [.databaseId, .headSha, .url] | @tsv'
+            } | sort -u
+          )"
+          if [[ -n "${active_runs}" ]]; then
+            echo "Another Bench run is already active; skipping catch-up dispatch."
+            printf '%s\n' "${active_runs}"
+            exit 0
+          fi
+
+          echo "Bench target ${target_sha} did not publish and main is now ${main_sha}; dispatching one catch-up Bench run."
+          curl -fsSL \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/bench.yml/dispatches" \
+            -d '{"ref":"main","inputs":{"publish_latest_pgo":false}}'

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -167,10 +167,28 @@ assert.doesNotMatch(
   "bench gate must not cancel active benchmark runs just because main moved",
 );
 
-assert.doesNotMatch(
+assert.match(
   workflow,
-  /bench-prep-target-fresh:|bench-target-fresh:|catchup_main_sha|Trigger benchmark catch-up/,
-  "benchmark workflow should not kill or chase in-flight runs when main moves a few commits",
+  /catch-up:[\s\S]+needs: \[bench-gate, bench-prep-artifact, bench, publish\][\s\S]+github\.event_name == 'workflow_run'[\s\S]+needs\.bench-gate\.outputs\.should_run == 'true'[\s\S]+needs\.publish\.result != 'success'/,
+  "benchmark workflow should schedule catch-up only after a publish-capable workflow_run exits without publishing",
+);
+
+assert.match(
+  workflow,
+  /target_sha="\$\{\{ env\.BENCH_TARGET_SHA \}\}"[\s\S]+main_sha="\$\(gh api "repos\/\$\{GITHUB_REPOSITORY\}\/git\/ref\/heads\/main" --jq '\.object\.sha'[\s\S]+if \[\[ "\$\{target_sha\}" == "\$\{main_sha\}" \]\]; then[\s\S]+skipping catch-up dispatch/,
+  "benchmark catch-up should only dispatch when main moved beyond the non-publishing target",
+);
+
+assert.match(
+  workflow,
+  /gh run list --repo "\$\{GITHUB_REPOSITORY\}" --workflow bench\.yml --branch main --status in_progress[\s\S]+select\(\.databaseId != \$\{\{ github\.run_id \}\}\)[\s\S]+gh run list --repo "\$\{GITHUB_REPOSITORY\}" --workflow bench\.yml --branch main --status queued[\s\S]+Another Bench run is already active; skipping catch-up dispatch/,
+  "benchmark catch-up should avoid dispatching when another Bench run is already active",
+);
+
+assert.match(
+  workflow,
+  /Bench target \$\{target_sha\} did not publish and main is now \$\{main_sha\}; dispatching one catch-up Bench run\.[\s\S]+actions\/workflows\/bench\.yml\/dispatches[\s\S]+'{"ref":"main","inputs":\{"publish_latest_pgo":false\}}'/,
+  "benchmark catch-up should dispatch one fresh main benchmark run after a stale non-publish",
 );
 
 const benchJob = workflow.match(/  bench:[\s\S]+?  publish:/)?.[0] ?? "";


### PR DESCRIPTION
## Agent
AgentName: M5Bench-Studio

## Track
Track 1 / benchmark dashboard publishing freshness. Follow-up to #12185 after the post-merge Bench run still skipped all publish-capable jobs.

## Invariant
When one publish-capable Bench run is already active, newer main workflow_run Bench events may skip to avoid duplicate benchmark load. If that active publish-capable run exits without `bench-publish` and `main` has moved, the skipped successor events must not be lost forever; the workflow should dispatch one fresh main Bench catch-up run, unless another Bench run is already active.

## Scope
- `.github/workflows/bench.yml`: add a terminal `bench-catch-up` job that runs only for publish-capable `workflow_run` attempts whose `bench-publish` job did not succeed. It compares the target SHA to current `main`, checks for any other queued/in-progress Bench run, and dispatches one fresh `main` Bench run when needed.
- `scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`: replace the old “no catch-up” assertion with focused assertions that catch-up is terminal, publish-failure-only, main-moved-only, and active-run guarded.

## Project Corpus Impact
- Row: benchmark dashboard / public project-corpus timing artifact freshness
- Bug family: benchmark publish starvation after active-run suppression plus non-publishing terminal run
- Evidence: public `https://tsz.dev/benchmark-data/latest.json` sampled at `2026-06-02T15:53:57Z` still served `generated_at=2026-06-02T06:03:17.722Z`, `source_commit=23a9517de10d60ba4c9be686e1b0e22776a88aa8`, `workflow_run_id=26800589927`, while current main had advanced and newer Bench runs were gate-only.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/bench.yml"); puts "bench.yml YAML parsed"'`
- `git diff --check`
- Draft PR-head CI for head `47b419462cfea9cbc6e443722f414ceada595e4c`: `CI Light Summary`, `lint`, `project-row-drift`, `cargo-deny`, `cargo-shear`, and `GitGuardian Security Checks` passed on 2026-06-02.

## Coordination Notes
- #12185 merged at `2026-06-02T05:27:14Z` and addressed Cloud Build prep handoff wait/diagnostics, but it did not repair the post-publish freshness lane when a publish-capable run remains active and every newer main Bench event is suppressed.
- Live evidence: Bench run `26826183367` is still the lone active publish-capable run on `9abc85937ef0802ab7809f7b3a8c791ab6fca750`; `bench-prep-artifact` job `79094368444` was still `in_progress` when sampled at `2026-06-02T15:53:58Z`.
- Live evidence: newer Bench run `26831238972` completed in seconds with only `bench-gate` successful and `bench-prepare`, `bench-prep-artifact`, `bench-publish`, and `publish-latest-pgo` skipped; its gate log printed active blocker `26826183367`.
- This PR does not start a benchmark run and does not run local benchmark suites. It only changes future workflow recovery behavior after a non-publishing run terminates.
- Marking ready after local workflow checks plus draft PR-head light CI passed. Do not add `merge-queue` until exact-head ready PR checks complete green. AgentName: M5Bench-Studio.
