### PR TITLE
fix(ci): return success for green compile-guard rows

### DIFF
--- a/scripts/ci/project-compile-guard.sh
+++ b/scripts/ci/project-compile-guard.sh
@@ -625,6 +625,7 @@ check_project() {
   fi
   [[ -n "$_cache_file" ]] && \
     write_compile_cache "$_fp" "$rc" "$file_count" "$exit_class" "$diagnostic_delta" "$_cache_file"
+  return 0
 }
 
 should_check_project() {
@@ -712,6 +713,7 @@ run_required_projects() {
       fi
     fi
   done
+  return 0
 }
 
 run_canary_projects() {
@@ -723,6 +725,7 @@ run_canary_projects() {
       fi
     fi
   done
+  return 0
 }
 
 case "$PROJECT_SET" in
@@ -748,3 +751,5 @@ if [[ "$FAILURES" -gt 0 ]]; then
     exit 1
   fi
 fi
+
+exit 0

--- a/scripts/ci/test-project-compile-guard-readiness-artifacts.mjs
+++ b/scripts/ci/test-project-compile-guard-readiness-artifacts.mjs
@@ -572,8 +572,26 @@ exit 0
     TSZ_PROJECT_COMPILE_RESULT_CACHE: "0",
   };
 
-  spawnSync("bash", [GUARD_SCRIPT], { cwd: ROOT, encoding: "utf8", env });
-  spawnSync("bash", [GUARD_SCRIPT], { cwd: ROOT, encoding: "utf8", env });
+  const r1 = spawnSync("bash", [GUARD_SCRIPT], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env,
+  });
+  assert.equal(
+    r1.status,
+    0,
+    `first cache-disabled run failed:\n${r1.stderr}\n${r1.stdout}`,
+  );
+  const r2 = spawnSync("bash", [GUARD_SCRIPT], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env,
+  });
+  assert.equal(
+    r2.status,
+    0,
+    `second cache-disabled run failed:\n${r2.stderr}\n${r2.stdout}`,
+  );
 
   assert.equal(
     fs.readFileSync(runCountFile, "utf8"),


### PR DESCRIPTION
## Agent
AgentName: MBMB4-Canary-A

## Track
Track 1 / Track 10 project-corpus harness correctness.

## Invariant
When a filtered project compile-guard row completes successfully, `project-compile-guard.sh` must exit `0` even when the result cache is disabled or the last internal conditional evaluates false. This PR changes the guard harness control-flow contract only; it does not change compiler behavior or row metadata.

## Scope
- `scripts/ci/project-compile-guard.sh`: return success explicitly from successful helper paths and top-level completion.
- `scripts/ci/test-project-compile-guard-readiness-artifacts.mjs`: assert cache-disabled successful guard runs return status `0`, not just that the fake `tsz` binary ran.

## Project Corpus Impact
- Row: n/a; harness-only reliability fix for filtered/cache-disabled green project rows.
- Bug family: successful project compile guard invocation returned non-zero despite printing `<row> compiled successfully`.
- Evidence: red/green local test reproduced the successful `utility-types-project` fake fixture returning status `1` before the shell fix and status `0` after it.

## Verification
- RED before fix: `node scripts/ci/test-project-compile-guard-readiness-artifacts.mjs` failed with `first cache-disabled run failed` while `utility-types-project compiled successfully` was printed.
- GREEN after fix: `node scripts/ci/test-project-compile-guard-readiness-artifacts.mjs`
- `git diff --check`

## Coordination Notes
- This PR was rewritten from the older duplicate compiler branch. The imported-generic-alias checker invariant for `ts-toolbelt-project` is now owned by #12242, which has the broader structural checker fix.
- No compiler source files are touched in this PR.
- Rewritten head `705dcd7` is non-draft and waiting on exact-head PR CI before queue consideration.