### PR TITLE
fix(solver): narrow `in` operator through apparent-type members

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -681,6 +681,9 @@ mod import_attributes_relation_routing_arch_tests;
 #[path = "tests/imported_predicate_false_branch_tests.rs"]
 mod imported_predicate_false_branch_tests;
 #[cfg(test)]
+#[path = "tests/in_narrow_apparent_member_tests.rs"]
+mod in_narrow_apparent_member_tests;
+#[cfg(test)]
 #[path = "tests/in_narrow_bare_type_param_chained_tests.rs"]
 mod in_narrow_bare_type_param_chained_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/in_narrow_apparent_member_tests.rs
+++ b/crates/tsz-checker/src/tests/in_narrow_apparent_member_tests.rs
@@ -1,0 +1,163 @@
+//! `in`-operator narrowing must consult the *apparent* type of a union
+//! constituent, not just its own structural object shape.
+//!
+//! Arrays, tuples, function types and primitives carry their members on their
+//! apparent type — `Array<T>`/`ReadonlyArray<T>` (`push`, `length`, ...), the
+//! global `Function` (`call`, `bind`, ...) and the boxed primitive wrappers
+//! (`String#length`, `Number#toFixed`, ...). `tsc`'s `narrowTypeByInKeyword`
+//! resolves the key against `getApparentType`, so `"push" in x` selects the
+//! array constituent and `else` selects the others.
+//!
+//! Before the fix tsz only inspected raw object shapes, so it failed to narrow
+//! these constituents in either branch and emitted spurious property/callability
+//! errors on code `tsc` accepts:
+//!   - TS2339 (property does not exist) on the un-narrowed union,
+//!   - TS2349 (expression is not callable) on un-narrowed function constituents,
+//!   - TS18046 (value is of type `unknown`) on apparent members.
+//!
+//! These tests pin the parity. They load the real libs because the apparent
+//! members of arrays/tuples live on the `Array<T>`/`ReadonlyArray<T>` interface.
+//! Binder names are varied across cases so the behavior is driven by the
+//! structural shape of the receiver, not by any identifier spelling.
+
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files, strict_checker_options};
+
+/// Codes that this fix must stop emitting on the narrowed branches. Asserting
+/// their *absence* (rather than an empty diagnostic set) keeps the tests robust
+/// to unrelated lib-surface noise while still failing on the original bug.
+const FALSE_POSITIVE_CODES: &[u32] = &[2339, 2349, 18046];
+
+fn codes(source: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    let diags: Vec<Diagnostic> =
+        check_source_with_libs(source, "test.ts", strict_checker_options(), &libs);
+    diags.iter().map(|d| d.code).collect()
+}
+
+fn assert_no_false_positives(source: &str, label: &str) {
+    let got = codes(source);
+    for code in FALSE_POSITIVE_CODES {
+        assert!(
+            !got.contains(code),
+            "{label}: expected no TS{code} after apparent-member `in` narrowing, got: {got:?}"
+        );
+    }
+}
+
+/// `"push" in x` selects the array; the `else` branch is the object.
+#[test]
+fn in_narrowing_selects_array_by_apparent_member() {
+    let source = r#"
+function pick(value: number[] | { tag: 1 }) {
+    if ("push" in value) {
+        value.push(1);
+    } else {
+        const t: 1 = value.tag;
+    }
+}
+"#;
+    assert_no_false_positives(source, "array push");
+}
+
+/// `"length" in x` is an apparent member of arrays; the `else` branch keeps the
+/// object constituent.
+#[test]
+fn in_narrowing_array_length_apparent_member() {
+    let source = r#"
+function choose(input: string[] | { only: true }) {
+    if ("length" in input) {
+        const n: number = input.length;
+    } else {
+        const o: true = input.only;
+    }
+}
+"#;
+    assert_no_false_positives(source, "array length");
+}
+
+/// `"call" in x` is an apparent member of function types; the truthy branch must
+/// narrow to the callable so the invocation is allowed, and the `else` branch to
+/// the object so its property is allowed.
+#[test]
+fn in_narrowing_selects_function_by_apparent_member() {
+    let source = r#"
+function dispatch(handler: (() => void) | { id: 7 }) {
+    if ("call" in handler) {
+        handler();
+    } else {
+        const id: 7 = handler.id;
+    }
+}
+"#;
+    assert_no_false_positives(source, "function call");
+}
+
+/// The complement: testing for the object's own property must narrow the `else`
+/// branch to the function and keep it callable.
+#[test]
+fn in_narrowing_else_branch_keeps_function_callable() {
+    let source = r#"
+function route(cb: ((n: number) => void) | { kind: "obj" }) {
+    if ("kind" in cb) {
+        const k: "obj" = cb.kind;
+    } else {
+        cb(42);
+    }
+}
+"#;
+    assert_no_false_positives(source, "else-branch function");
+}
+
+/// Tuple constituents also expose `length` through their apparent type.
+#[test]
+fn in_narrowing_selects_tuple_by_apparent_length() {
+    let source = r#"
+function take(pair: [number, string] | { single: 0 }) {
+    if ("length" in pair) {
+        const len: number = pair.length;
+    } else {
+        const s: 0 = pair.single;
+    }
+}
+"#;
+    assert_no_false_positives(source, "tuple length");
+}
+
+/// `readonly` arrays narrow identically — the wrapper around the array type must
+/// not hide the apparent members.
+#[test]
+fn in_narrowing_selects_readonly_array_by_apparent_member() {
+    let source = r#"
+function scan(data: readonly number[] | { flag: false }) {
+    if ("length" in data) {
+        const n: number = data.length;
+    } else {
+        const f: false = data.flag;
+    }
+}
+"#;
+    assert_no_false_positives(source, "readonly array length");
+}
+
+/// Regression guard for plain object unions: the apparent-type fallback must not
+/// disturb the existing own-property narrowing. Probing the *wrong* member in the
+/// `else` branch still reports TS2339, exactly as before the fix.
+#[test]
+fn in_narrowing_object_union_still_reports_wrong_property() {
+    let source = r#"
+function classify(node: { a: 1 } | { b: 2 }) {
+    if ("a" in node) {
+        const a: 1 = node.a;
+    } else {
+        // `node` is `{ b: 2 }` here; `a` is genuinely absent.
+        node.a;
+    }
+}
+"#;
+    let got = codes(source);
+    assert!(
+        got.contains(&2339),
+        "expected TS2339 for the genuinely-absent property, got: {got:?}"
+    );
+}

--- a/crates/tsz-solver/src/narrowing/property.rs
+++ b/crates/tsz-solver/src/narrowing/property.rs
@@ -6,7 +6,10 @@
 //! - Object-like type detection for instanceof support
 
 use super::{CachedPropertyType, NarrowingContext};
-use crate::types::{ObjectFlags, ObjectShapeId, PropertyInfo, TypeData, TypeId, Visibility};
+use crate::operations::property::PropertyAccessResult;
+use crate::types::{
+    IntrinsicKind, ObjectFlags, ObjectShapeId, PropertyInfo, TypeData, TypeId, Visibility,
+};
 use crate::visitor::{
     intersection_list_id, object_shape_id, object_with_index_shape_id, type_param_info,
     union_list_id,
@@ -225,6 +228,20 @@ impl<'a> NarrowingContext<'a> {
 
         if present {
             // Positive: "prop" in x
+            //
+            // `has_property` is apparent-type aware (so arrays/functions/
+            // primitives are recognised), but the structural property the
+            // promotion logic below needs only exists for object shapes. When
+            // the member is contributed purely by the apparent type (e.g.
+            // `push` on `T[]`, `call` on a function type) there is no own slot
+            // to promote, and tsc leaves the receiver unchanged — so return it
+            // as-is rather than synthesising a bogus `{ prop: unknown }` slot.
+            let has_own_property = self
+                .get_property_type(resolved_type, property_name)
+                .is_some();
+            if has_property && !has_own_property {
+                return source_type;
+            }
             if has_property {
                 // Property exists: promote to required. For exact-optional
                 // slots the write type excludes the synthetic missing-property
@@ -334,7 +351,17 @@ impl<'a> NarrowingContext<'a> {
     /// Returns true if the type has the property (required or optional),
     /// or has an index signature that would match the property.
     pub(crate) fn type_has_property(&self, type_id: TypeId, property_name: Atom) -> bool {
-        self.get_property_type(type_id, property_name).is_some()
+        if self.get_property_type(type_id, property_name).is_some() {
+            return true;
+        }
+        // The structural lookup above only models object/intersection shapes.
+        // Array, tuple, function and primitive receivers carry their members on
+        // their *apparent* type (`Array<T>`/`ReadonlyArray<T>`, the global
+        // `Function`, the boxed primitive interfaces), so `tsc`'s `in`-operator
+        // narrowing resolves the key against the apparent type. Mirror that for
+        // parity (e.g. `"push" in arr`, `"call" in fn`).
+        self.apparent_member_presence(type_id, property_name)
+            .is_some()
     }
 
     /// Check if a property exists and is required on a type.
@@ -397,7 +424,68 @@ impl<'a> NarrowingContext<'a> {
                 .any(|&m| self.is_property_required(m, property_name));
         }
 
+        // Apparent-type members of arrays/tuples/functions/primitives (e.g.
+        // `push`, `call`, `length`) are non-optional declarations on the boxed
+        // interface, so they are *required*: `!("push" in x)` excludes a `T[]`
+        // constituent. Members reached only through an index signature are not
+        // guaranteed to be present, so they stay (mirroring the object-shape
+        // index-signature handling, which never marks index members required).
+        if let Some(from_index_signature) =
+            self.apparent_member_presence(resolved_type, property_name)
+        {
+            return !from_index_signature;
+        }
+
         false
+    }
+
+    /// Resolve `property_name` against the *apparent* type of receivers that the
+    /// structural lookup above does not model: arrays, tuples, function types
+    /// and primitives expose their members through their apparent type
+    /// (`Array<T>`/`ReadonlyArray<T>`, the global `Function`, the boxed
+    /// primitive interfaces) rather than through an object shape.
+    ///
+    /// Returns `Some(from_index_signature)` when the apparent type has the
+    /// member, where `from_index_signature` reports whether it was matched via
+    /// an index signature rather than a named declaration. Object, class and
+    /// interface shapes are intentionally excluded because the structural
+    /// lookup already covers them, and routing them through the heavier
+    /// property resolver would be redundant.
+    fn apparent_member_presence(&self, type_id: TypeId, property_name: Atom) -> Option<bool> {
+        let resolved_type = self.resolve_type(type_id);
+        let bears_apparent_members = match self.db.lookup(resolved_type) {
+            Some(
+                TypeData::Array(_)
+                | TypeData::Tuple(_)
+                | TypeData::Function(_)
+                | TypeData::Callable(_)
+                | TypeData::ReadonlyType(_),
+            ) => true,
+            Some(TypeData::Intrinsic(kind)) => matches!(
+                kind,
+                IntrinsicKind::String
+                    | IntrinsicKind::Number
+                    | IntrinsicKind::Boolean
+                    | IntrinsicKind::Bigint
+                    | IntrinsicKind::Symbol
+            ),
+            _ => false,
+        };
+        if !bears_apparent_members {
+            return None;
+        }
+
+        let name = self.db.resolve_atom_ref(property_name);
+        match self
+            .db
+            .resolve_property_access(resolved_type, name.as_ref())
+        {
+            PropertyAccessResult::Success {
+                from_index_signature,
+                ..
+            } => Some(from_index_signature),
+            _ => None,
+        }
     }
 
     /// Get the type of a property if it exists.


### PR DESCRIPTION
## Agent
AgentName: Claude-Narrowing

## Track
fix(solver) — control-flow narrowing parity for the `in` operator. Closes #12233.

## Invariant
When `"k" in x` is evaluated, `tsc`'s `narrowTypeByInKeyword` tests the key
against each union constituent's **apparent type** (`getApparentType`). A
constituent stays in the true branch when its apparent type has `k`, and is
removed from the false branch when `k` is a required (non-index) apparent
member. tsz must apply the same rule structurally — independent of the
receiver's declared form or any identifier spelling.

## Scope
- `crates/tsz-solver/src/narrowing/property.rs`:
  - The bespoke property lookup (`get_property_type` →
    `get_property_type_uncached`) only models `Object`/`ObjectWithIndex`
    shapes, so arrays (`push`/`length` from `Array<T>`/`ReadonlyArray<T>`),
    function types (`call`/`bind` from the global `Function`), tuples and
    primitives (boxed wrapper interfaces) were invisible to `in`-narrowing.
  - New `apparent_member_presence(type)`: when the cheap structural lookup
    misses **and** the receiver is `Array`/`Tuple`/`Function`/`Callable`/
    `ReadonlyType`/primitive intrinsic, route through the canonical
    apparent-aware `QueryDatabase::resolve_property_access` query and report
    whether the member exists + whether it came from an index signature.
  - `type_has_property` (true-branch filter) consults the fallback after the
    structural check.
  - `is_property_required_uncached` (false-branch filter) treats apparent
    members as required unless reached via an index signature, so
    `!("push" in x)` removes a `T[]` constituent while index-signature-only
    matches stay.
  - Positive non-union branch: when the member is contributed purely by the
    apparent type there is no own slot to promote, so the receiver is returned
    unchanged (matching `tsc`) instead of synthesising a bogus
    `{ prop: unknown }` slot.
- `crates/tsz-checker/src/tests/in_narrow_apparent_member_tests.rs` (new) +
  registration in `crates/tsz-checker/src/lib.rs`.

The object-shape fast path is preserved; the heavier resolver only runs on a
structural miss for the receiver kinds it actually models. No relation,
inference or evaluation semantics change — only which `in`-narrowed branch a
constituent lands in.

## Structural rule
When a union constituent's apparent type (`Array<T>`, the global `Function`,
the boxed primitive wrappers, tuple `length`) has the probed key, `tsc` keeps
it in the `in` true branch and drops it from the false branch (for required,
non-index members); tsz previously only saw own object-shape members and so
dropped/kept the wrong constituents — owner: solver narrowing
(`narrow_by_property_presence`).

## Project Corpus Impact
- Row: cross-row control-flow-narrowing parity (`narrowing`, `false-positive`).
- Bug family: `in`-operator narrowing ignored apparent-type members.
- Evidence — these `tsc 6.0.x` repros are now exact-matched (previously tsz
  emitted the noted false positives):
  - `number[] | { tag: 1 }` + `"push" in x` → was TS18046 + TS2339.
  - `(() => void) | { id: 7 }` + `"call" in x` → was TS2349 + TS2339.
  - `[number, string] | { single: 0 }` + `"length" in x` → was TS2339.
  - `readonly number[] | { flag: false }` + `"length" in x` → was TS2339.

## Verification
Oracle: bundled `tsc 6.0.2` (`./.target/dist-fast/tsz` vs `tsc`),
`--noEmit --strict`.
- Apparent-member repros (array/tuple/readonly-array/function/primitive),
  both branches: tsz now EXACT-MATCHES `tsc` (no TS2339/TS2349/TS18046).
- Regression battery vs `tsc` (object/class/interface/index-signature/optional
  unions, shared-key discriminants, `!("push" in x)` → `never`): all match.
- New focused suite (libs loaded so `Array<T>` apparent members resolve):
  `cargo test -p tsz-checker --lib in_narrow_apparent` → **7 passed, 0 failed**.
- No regressions: `cargo test -p tsz-solver --lib narrow` → **316 passed**;
  `cargo test -p tsz-solver --lib property` → only a **pre-existing** failure
  (`test_infer_generic_object_with_contextual_callbacks_prefers_schema_property_type`,
  fails identically with the change stashed — unrelated contextual-callback
  inference); `cargo test -p tsz-checker --lib -- narrow guard flow_guard for_in
  in_operator` → **337 passed**.
- `cargo fmt -p tsz-solver -p tsz-checker -- --check` and
  `cargo clippy -p tsz-solver`: clean.
- Rebased onto latest `main`; clean rebase, tests re-run green.

No full conformance/emit/fourslash run locally per repo guidance; ready-review
CI owns the broad suites.

## Coordination Notes
- AgentName: Claude-Narrowing.
- Independent of in-flight work: #12147 (M5Fixer — JSX/arrayToEnum recovery)
  and #12201 (Claude-Project-Corpus — tuple-arity display) touch neither
  `narrow_by_property_presence` nor the `in`-operator true/false-branch filters.
- Discovered while triaging the RNG-selected `bug` backlog: #11345 is already
  covered by #12147; the distributive-conditional family (#10831/#10815/#12175)
  reproduces only as a type-display nuance (acceptance matches `tsc`). This
  unowned narrowing parity gap was filed as #12233 and fixed here instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_018VVyZfj6WChfhFiLE3swtb)_