### PR TITLE
fix(bench): wait for active run before catch-up

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -48,6 +48,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.gate.outputs.should_run }}
+      active_run_id: ${{ steps.gate.outputs.active_run_id }}
+      active_run_sha: ${{ steps.gate.outputs.active_run_sha }}
+      active_run_url: ${{ steps.gate.outputs.active_run_url }}
     steps:
       - id: gate
         env:
@@ -121,6 +124,10 @@ jobs:
             if [[ -n "$active_runs" ]]; then
               echo "Another Bench run is already active; letting it finish even if main has moved, and skipping this duplicate run."
               printf '%s\n' "$active_runs"
+              IFS=$'\t' read -r active_run_id active_run_sha active_run_url <<< "$(printf '%s\n' "$active_runs" | head -n 1)"
+              echo "active_run_id=${active_run_id}" >> "$GITHUB_OUTPUT"
+              echo "active_run_sha=${active_run_sha}" >> "$GITHUB_OUTPUT"
+              echo "active_run_url=${active_run_url}" >> "$GITHUB_OUTPUT"
               should_run=false
             fi
           fi
@@ -650,6 +657,8 @@ jobs:
             "bench-prep/${_BENCH_TARGET_SHA}/bench-prep.env",
             "/bench-prep/latest/bench-prep.env",
             "bench-prep/latest/bench-prep.env",
+            "/bench-prep.env",
+            "bench-prep.env",
           ]);
           const tar = findLocation([
             `/bench-prep/${targetSha}/bench-prep.tar`,
@@ -658,6 +667,8 @@ jobs:
             "bench-prep/${_BENCH_TARGET_SHA}/bench-prep.tar",
             "/bench-prep/latest/bench-prep.tar",
             "bench-prep/latest/bench-prep.tar",
+            "/bench-prep.tar",
+            "bench-prep.tar",
           ]);
           if (!env || !tar) {
             console.error(`Cloud Build artifact manifest did not include bench prep env/tar for ${targetSha}.`);
@@ -844,6 +855,8 @@ jobs:
             "bench-prep/${_BENCH_TARGET_SHA}/bench-prep.env",
             "/bench-prep/latest/bench-prep.env",
             "bench-prep/latest/bench-prep.env",
+            "/bench-prep.env",
+            "bench-prep.env",
           ]);
           const tar = findLocation([
             `/bench-prep/${targetSha}/bench-prep.tar`,
@@ -852,6 +865,8 @@ jobs:
             "bench-prep/${_BENCH_TARGET_SHA}/bench-prep.tar",
             "/bench-prep/latest/bench-prep.tar",
             "bench-prep/latest/bench-prep.tar",
+            "/bench-prep.tar",
+            "bench-prep.tar",
           ]);
           if (!env || !tar) {
             console.error(`Cloud Build artifact manifest did not include bench prep env/tar for ${targetSha}.`);
@@ -1591,6 +1606,87 @@ jobs:
           fi
 
           echo "Bench target ${target_sha} did not publish and main is now ${main_sha}; dispatching one catch-up Bench run."
+          curl -fsSL \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/bench.yml/dispatches" \
+            -d '{"ref":"main","inputs":{"publish_latest_pgo":false}}'
+
+  catch-up-after-active:
+    name: bench-catch-up-after-active
+    needs: bench-gate
+    if: >-
+      always() &&
+      github.event_name == 'workflow_run' &&
+      needs.bench-gate.outputs.should_run != 'true' &&
+      needs.bench-gate.outputs.active_run_id != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Wait for active benchmark and dispatch if it did not publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ACTIVE_RUN_ID: ${{ needs.bench-gate.outputs.active_run_id }}
+          ACTIVE_RUN_SHA: ${{ needs.bench-gate.outputs.active_run_sha }}
+          ACTIVE_RUN_URL: ${{ needs.bench-gate.outputs.active_run_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          target_sha="${{ env.BENCH_TARGET_SHA }}"
+          max_active_minutes=180
+          max_active_seconds=$((max_active_minutes * 60))
+          echo "Waiting for active Bench run ${ACTIVE_RUN_ID} (${ACTIVE_RUN_SHA}) before deciding catch-up: ${ACTIVE_RUN_URL}"
+          while true; do
+            active_json="$(gh run view "${ACTIVE_RUN_ID}" --repo "${GITHUB_REPOSITORY}" --json status,createdAt --jq '{status,createdAt}' 2>/dev/null || true)"
+            active_status="$(jq -r '.status // empty' <<<"${active_json}" 2>/dev/null || true)"
+            active_created_at="$(jq -r '.createdAt // empty' <<<"${active_json}" 2>/dev/null || true)"
+            if [[ "${active_status}" == "completed" ]]; then
+              break
+            fi
+            active_created_epoch="$(date -u -d "${active_created_at}" +%s 2>/dev/null || true)"
+            now_epoch="$(date -u +%s)"
+            if [[ "${active_created_epoch}" =~ ^[0-9]+$ &&
+                  $((now_epoch - active_created_epoch)) -ge "${max_active_seconds}" ]]; then
+              echo "Active Bench run ${ACTIVE_RUN_ID} is still ${active_status:-unknown} after at least ${max_active_minutes} minutes; treating it as stale for catch-up."
+              break
+            fi
+            echo "Active Bench run ${ACTIVE_RUN_ID} is still ${active_status:-unknown}; waiting..."
+            sleep 60
+          done
+
+          if [[ "$(gh run view "${ACTIVE_RUN_ID}" --repo "${GITHUB_REPOSITORY}" --json jobs --jq '[.jobs[] | select(.name == "bench-publish" and .conclusion == "success")] | length')" -gt 0 ]]; then
+            echo "Active Bench run ${ACTIVE_RUN_ID} published benchmark data; skipping catch-up dispatch."
+            exit 0
+          fi
+
+          main_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha' 2>/dev/null || true)"
+          if [[ -z "${main_sha}" ]]; then
+            echo "Could not read current main SHA; skipping benchmark catch-up dispatch."
+            exit 0
+          fi
+          if [[ "${target_sha}" != "${main_sha}" ]]; then
+            echo "Skipped Bench target ${target_sha} is behind current main ${main_sha}; a newer main Bench event owns catch-up."
+            exit 0
+          fi
+
+          active_dispatches="$(
+            gh run list --repo "${GITHUB_REPOSITORY}" --workflow bench.yml --branch main --status in_progress --limit 20 \
+              --json databaseId,event,headSha,url \
+              --jq '.[] | select(.databaseId != ${{ github.run_id }} and .databaseId != '"${ACTIVE_RUN_ID}"' and .event == "workflow_dispatch") | [.databaseId, .headSha, .url] | @tsv'
+            gh run list --repo "${GITHUB_REPOSITORY}" --workflow bench.yml --branch main --status queued --limit 20 \
+              --json databaseId,event,headSha,url \
+              --jq '.[] | select(.databaseId != ${{ github.run_id }} and .databaseId != '"${ACTIVE_RUN_ID}"' and .event == "workflow_dispatch") | [.databaseId, .headSha, .url] | @tsv'
+          )"
+          if [[ -n "${active_dispatches}" ]]; then
+            echo "A dispatched Bench catch-up is already active; skipping duplicate dispatch."
+            printf '%s\n' "${active_dispatches}"
+            exit 0
+          fi
+
+          echo "Active Bench run ${ACTIVE_RUN_ID} completed without bench-publish; dispatching one fresh main Bench run for ${main_sha}."
           curl -fsSL \
             -X POST \
             -H "Accept: application/vnd.github+json" \

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -122,10 +122,10 @@ assert.doesNotMatch(
 const prepArtifactJob = workflow.match(
   /  bench-prep-artifact:[\s\S]+?  bench:/,
 )?.[0] ?? "";
-assert.doesNotMatch(
+assert.match(
   prepArtifactJob,
-  /^\s*["']\/?bench-prep\.(?:env|tar)["'],?$/m,
-  "bench-prep-artifact must not trust root-level Cloud Build artifact paths",
+  /copy_from_cloudbuild_manifest\(\) \{[\s\S]+["']\/bench-prep\.env["'][\s\S]+["']bench-prep\.env["'][\s\S]+["']\/bench-prep\.tar["'][\s\S]+["']bench-prep\.tar["'][\s\S]+if copy_from_cloudbuild_manifest[\s\S]+if validate_downloaded_prep_artifact; then[\s\S]+exit 0/,
+  "bench-prep-artifact may recover exact-build root-level Cloud Build artifacts only after validating target SHA and PGO",
 );
 
 const latestFallbacks = prepArtifactJob.match(
@@ -157,8 +157,14 @@ assert.match(
 
 assert.match(
   workflow,
-  /"\$\{\{ github\.event_name \}\}" == "workflow_run"[\s\S]+Another Bench run is already active; letting it finish even if main has moved, and skipping this duplicate run\./,
-  "bench gate should let active runs finish and skip duplicate automatic runs",
+  /active_run_id: \$\{\{ steps\.gate\.outputs\.active_run_id \}\}[\s\S]+active_run_sha: \$\{\{ steps\.gate\.outputs\.active_run_sha \}\}[\s\S]+active_run_url: \$\{\{ steps\.gate\.outputs\.active_run_url \}\}/,
+  "bench gate should expose the active benchmark run that caused duplicate automatic runs to skip",
+);
+
+assert.match(
+  workflow,
+  /"\$\{\{ github\.event_name \}\}" == "workflow_run"[\s\S]+Another Bench run is already active; letting it finish even if main has moved, and skipping this duplicate run\.[\s\S]+echo "active_run_id=\$\{active_run_id\}" >> "\$GITHUB_OUTPUT"[\s\S]+echo "active_run_sha=\$\{active_run_sha\}" >> "\$GITHUB_OUTPUT"[\s\S]+echo "active_run_url=\$\{active_run_url\}" >> "\$GITHUB_OUTPUT"/,
+  "bench gate should let active runs finish, skip duplicate automatic runs, and remember the blocker",
 );
 
 assert.doesNotMatch(
@@ -189,6 +195,42 @@ assert.match(
   workflow,
   /Bench target \$\{target_sha\} did not publish and main is now \$\{main_sha\}; dispatching one catch-up Bench run\.[\s\S]+actions\/workflows\/bench\.yml\/dispatches[\s\S]+'{"ref":"main","inputs":\{"publish_latest_pgo":false\}}'/,
   "benchmark catch-up should dispatch one fresh main benchmark run after a stale non-publish",
+);
+
+assert.match(
+  workflow,
+  /catch-up-after-active:[\s\S]+needs: bench-gate[\s\S]+needs\.bench-gate\.outputs\.should_run != 'true'[\s\S]+needs\.bench-gate\.outputs\.active_run_id != ''/,
+  "gate-only duplicate Bench runs should keep a recovery path after the active run completes",
+);
+
+assert.match(
+  workflow,
+  /max_active_minutes=180[\s\S]+Waiting for active Bench run \$\{ACTIVE_RUN_ID\}[\s\S]+gh run view "\$\{ACTIVE_RUN_ID\}"[\s\S]+--json status,createdAt --jq '\{status,createdAt\}'[\s\S]+Active Bench run \$\{ACTIVE_RUN_ID\} is still \$\{active_status:-unknown\} after at least \$\{max_active_minutes\} minutes; treating it as stale for catch-up\./,
+  "active-run catch-up should wait for the blocking Bench run to complete or age out as stale",
+);
+
+assert.match(
+  workflow,
+  /select\(\.name == "bench-publish" and \.conclusion == "success"\)[\s\S]+Active Bench run \$\{ACTIVE_RUN_ID\} published benchmark data; skipping catch-up dispatch\./,
+  "active-run catch-up should stand down when the blocking Bench run published data",
+);
+
+assert.match(
+  workflow,
+  /if \[\[ "\$\{target_sha\}" != "\$\{main_sha\}" \]\]; then[\s\S]+Skipped Bench target \$\{target_sha\} is behind current main \$\{main_sha\}; a newer main Bench event owns catch-up\./,
+  "active-run catch-up should only dispatch from the skipped duplicate that still represents current main",
+);
+
+assert.match(
+  workflow,
+  /--json databaseId,event,headSha,url[\s\S]+\.event == "workflow_dispatch"[\s\S]+A dispatched Bench catch-up is already active; skipping duplicate dispatch\./,
+  "active-run catch-up should avoid duplicate workflow_dispatch benchmark catch-ups",
+);
+
+assert.match(
+  workflow,
+  /Active Bench run \$\{ACTIVE_RUN_ID\} completed without bench-publish; dispatching one fresh main Bench run for \$\{main_sha\}\.[\s\S]+actions\/workflows\/bench\.yml\/dispatches[\s\S]+'{"ref":"main","inputs":\{"publish_latest_pgo":false\}}'/,
+  "active-run catch-up should dispatch one fresh main benchmark run when the blocker did not publish",
 );
 
 const benchJob = workflow.match(/  bench:[\s\S]+?  publish:/)?.[0] ?? "";


### PR DESCRIPTION
## Agent
AgentName: M5Bench-Studio

## Track
Track 1 / benchmark dashboard publishing freshness. Follow-up to merged #12231 after proving the remaining gate-only duplicate gap, a long-stalled active run, and exact-build Cloud Build prep artifacts that were exposed only as root-level manifest entries.

## Invariant
When a main Bench workflow_run skips because another Bench run is already active, the skipped run must retain a recovery path. If the active run publishes, it should stand down. If the active run completes without `bench-publish`, or remains active past the bounded stale-active age while the skipped run still represents current `main`, it should dispatch one fresh main Bench run. Prep artifact recovery may consume root-level env/tar entries only from the exact Cloud Build artifact manifest, and only after validating the downloaded `BENCH_TARGET_SHA` and PGO marker.

## Scope
- `.github/workflows/bench.yml`: expose the active Bench blocker from `bench-gate`, and add `bench-catch-up-after-active` for gate-only duplicate runs. The job waits for the blocker to complete or age past 180 minutes, checks whether `bench-publish` succeeded, verifies the skipped target is still current `main`, suppresses duplicate workflow_dispatch catch-ups, then dispatches one fresh Bench run only when needed.
- `.github/workflows/bench.yml`: allow `bench-prep-artifact` to recover root-level `bench-prep.env` / `bench-prep.tar` from the exact Cloud Build artifact manifest, while preserving target SHA and PGO validation before accepting them.
- `scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`: add workflow assertions for blocker outputs, active-run waiting and stale-active age-out, publish-success stand-down, latest-main ownership, duplicate dispatch suppression, final catch-up dispatch, and validated exact-build root-level prep artifact recovery.

## Project Corpus Impact
- Row: benchmark dashboard / public project-corpus timing artifact freshness
- Bug family: benchmark publish starvation after active-run suppression plus non-publishing or long-stalled active run; Cloud Build prep handoff where exact build artifacts appear only as root-level manifest entries
- Evidence: #12231 merged at `2026-06-02T16:05:24Z`, but public `https://tsz.dev/benchmark-data/latest.json` sampled at `2026-06-02T17:27:16Z` still served `generated_at=2026-06-02T06:03:17.722Z`, `source_commit=23a9517de10d60ba4c9be686e1b0e22776a88aa8`, `workflow_run_id=26800589927`. Deploy Website runs continue to succeed on current main heads, confirming deploys are moving while benchmark payload freshness is not. New Bench runs `26833104488`/`26833119233` on `1fa4a9e5afa73a9a2eab743b060e9ff74d113bd4` and `26833810497` on the post-#12234 main head `36f1a26d088582492f744e64135a7f2ed8185067` completed gate-only in seconds. Active publish-capable run `26826183367` then completed `failure` at `2026-06-02T16:54:44Z`; its `bench-prep-artifact` job failed after 7200s because neither SHA-scoped, latest, nor manifest artifacts exposed valid prep env/tar for target `9abc85937ef0802ab7809f7b3a8c791ab6fca750`. Diagnostics artifact `7364354617` showed `cloudbuild-artifacts.json` only listed root-level `gs://tsz-ci_cloudbuild/bench-prep.env` and `gs://tsz-ci_cloudbuild/bench-prep.tar`, while downloaded `bench-prep.env` from fallback/latest was stale for `23a9517de10d60ba4c9be686e1b0e22776a88aa8`.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/bench.yml"); puts "bench.yml YAML parsed"'`
- `git diff --check`
- Draft PR-head CI on `5146d18ad2a41a44f60d6e151b202099c22effc3`: `CI Light Summary`, `lint`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `queue-one-pr`, and `GitGuardian Security Checks` passed. Run: https://github.com/mohsen1/tsz/actions/runs/26833517262
- Draft PR-head CI on synced head `5ce94b43f26d86d6764fb7ff9377b8b19a8f1ed2` passed: `CI Light Summary`, `lint`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `queue-one-pr`, and `GitGuardian Security Checks`. Run: https://github.com/mohsen1/tsz/actions/runs/26833913456.
- Branch synced with current `origin/main` head `6d17e52b609b88f0159e1fe932d128410f09ae8e` from #12189. PR head `89207f5b9c3091647acdacd0de812a7fea27ee42`; focused local checks above passed after the sync. Draft PR-head CI passed: `CI Light Summary`, `lint`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `queue-one-pr`, and `GitGuardian Security Checks`. Runs: https://github.com/mohsen1/tsz/actions/runs/26835705979 and https://github.com/mohsen1/tsz/actions/runs/26835706160.
- Ready PR-head CI on `89207f5b9c3091647acdacd0de812a7fea27ee42` passed: `CI Summary`, `lint`, `cargo-deny`, `cargo-shear`, `project-corpus-pr-body`, `project-row-drift`, `queue-one-pr`, and `GitGuardian Security Checks`; broad suites were skipped by ready workflow path gating for this workflow/script-only change. Runs: https://github.com/mohsen1/tsz/actions/runs/26836245851 and https://github.com/mohsen1/tsz/actions/runs/26836245106.

## Coordination Notes
- #12231 was necessary but insufficient for already-active blockers: it catches publish-capable runs that start with the new workflow and later fail to publish, but it cannot help an older active run that began before #12231, and gate-only duplicate runs did not wait for that old blocker.
- The first #12236 draft version waited only for the active run to complete. Live run `26826183367` showed that was too passive because gate-only main runs can continue disappearing while an active prep-artifact job remains in progress. This revision bounds the active blocker by age and dispatches one workflow_dispatch catch-up when current main still needs it.
- The terminal `26826183367` diagnostics showed a second necessary fix: the next catch-up could repeat the same prep handoff failure unless exact-build root-level Cloud Build manifest entries are accepted after target/PGO validation.
- M5Manager-Studio-Review accepted the 180-minute stale-active age-out semantics on `2026-06-02T16:54:16Z`. The root-level manifest recovery is restricted to exact Cloud Build manifests and still validated by target SHA and PGO checks.
- This PR does not start a benchmark run and does not run local benchmark suites.
- Ready exact-head checks are green; `merge-queue` is being added so queue-owned `Queue Tested` can validate and land the PR. AgentName: M5Bench-Studio.
