### PR TITLE
perf(checker): skip alias body reference lowering

### DIFF
--- a/crates/tsz-checker/src/tests/ref_type_params_cache_tests.rs
+++ b/crates/tsz-checker/src/tests/ref_type_params_cache_tests.rs
@@ -6,6 +6,17 @@ use crate::test_utils::check_source_diagnostics;
 /// that arity validation still fires when argument counts are wrong.
 
 #[test]
+fn alias_body_explicit_type_refs_use_validator_only_path() {
+    let checker_source = std::fs::read_to_string("src/types/type_checking/type_alias_checking.rs")
+        .expect("read type alias checker");
+    assert!(
+        checker_source.contains("check_explicit_type_reference_for_alias_body_validation"),
+        "alias body validation should validate explicit type reference arguments \
+         without forcing full type-reference lowering"
+    );
+}
+
+#[test]
 fn multiple_refs_to_same_two_param_utility_no_spurious_errors() {
     let diags = check_source_diagnostics(
         r#"

--- a/crates/tsz-checker/src/tests/ref_type_params_cache_tests.rs
+++ b/crates/tsz-checker/src/tests/ref_type_params_cache_tests.rs
@@ -180,6 +180,35 @@ type M2 = StringMap<string, boolean>;
 }
 
 #[test]
+fn partial_indexed_access_keeps_lib_alias_body_state() {
+    let diags = check_source_diagnostics(
+        r#"
+type Foo = {
+    x: number;
+    y: string;
+};
+
+function getValueConcrete<K extends keyof Foo>(
+    o: Partial<Foo>,
+    k: K
+): Foo[K] | undefined {
+    return o[k];
+}
+"#,
+    );
+
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| matches!(d.code, 2322 | 2536))
+        .collect();
+    assert_eq!(
+        errors.len(),
+        0,
+        "Indexed access through Partial<T> should preserve lib alias body state; got: {errors:#?}"
+    );
+}
+
+#[test]
 fn many_refs_to_same_two_param_type_all_valid() {
     let diags = check_source_diagnostics(
         r#"

--- a/crates/tsz-checker/src/types/type_checking/mod.rs
+++ b/crates/tsz-checker/src/types/type_checking/mod.rs
@@ -29,6 +29,7 @@ mod duplicate_index_signatures;
 mod global;
 mod indexed_access;
 mod property_init;
+mod type_alias_body_validation;
 mod type_alias_checking;
 mod type_alias_depth_helpers;
 mod type_alias_missing_name_coverage;

--- a/crates/tsz-checker/src/types/type_checking/type_alias_body_validation.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_body_validation.rs
@@ -1,0 +1,35 @@
+//! Helpers for type-alias body validation that stay off the hot lowering path.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+
+impl<'a> CheckerState<'a> {
+    pub(crate) fn check_explicit_type_reference_for_alias_body_validation(
+        &mut self,
+        ref_idx: NodeIndex,
+        nested_in_type_literal: bool,
+    ) -> bool {
+        if nested_in_type_literal || self.is_inside_type_parameter_declaration(ref_idx) {
+            return false;
+        }
+        let Some(node) = self.ctx.arena.get(ref_idx) else {
+            return false;
+        };
+        let Some(type_ref) = self.ctx.arena.get_type_ref(node) else {
+            return false;
+        };
+        let Some(args) = type_ref
+            .type_arguments
+            .clone()
+            .filter(|args| !args.nodes.is_empty())
+        else {
+            return false;
+        };
+        let Some(raw) = self.resolve_type_symbol_for_lowering(type_ref.type_name) else {
+            return false;
+        };
+
+        self.validate_type_reference_type_arguments(tsz_binder::SymbolId(raw), &args, ref_idx);
+        true
+    }
+}

--- a/crates/tsz-checker/src/types/type_checking/type_alias_body_validation.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_body_validation.rs
@@ -1,7 +1,9 @@
 //! Helpers for type-alias body validation that stay off the hot lowering path.
 
 use crate::state::CheckerState;
+use crate::state_type_analysis::cross_file_direct::is_builtin_lib_declaration_arena;
 use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
 
 impl<'a> CheckerState<'a> {
     pub(crate) fn check_explicit_type_reference_for_alias_body_validation(
@@ -9,7 +11,11 @@ impl<'a> CheckerState<'a> {
         ref_idx: NodeIndex,
         nested_in_type_literal: bool,
     ) -> bool {
-        if nested_in_type_literal || self.is_inside_type_parameter_declaration(ref_idx) {
+        if nested_in_type_literal
+            || self.is_inside_type_parameter_declaration(ref_idx)
+            || !self.type_reference_is_in_type_alias_body(ref_idx)
+            || is_builtin_lib_declaration_arena(self.ctx.arena)
+        {
             return false;
         }
         let Some(node) = self.ctx.arena.get(ref_idx) else {
@@ -31,5 +37,30 @@ impl<'a> CheckerState<'a> {
 
         self.validate_type_reference_type_arguments(tsz_binder::SymbolId(raw), &args, ref_idx);
         true
+    }
+
+    fn type_reference_is_in_type_alias_body(&self, ref_idx: NodeIndex) -> bool {
+        let mut current = ref_idx;
+        while current.is_some() {
+            let Some(parent_idx) = self
+                .ctx
+                .arena
+                .get_extended(current)
+                .map(|extended| extended.parent)
+            else {
+                return false;
+            };
+            if parent_idx.is_none() {
+                return false;
+            }
+            let Some(parent) = self.ctx.arena.get(parent_idx) else {
+                return false;
+            };
+            if parent.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION {
+                return true;
+            }
+            current = parent_idx;
+        }
+        false
     }
 }

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -1411,11 +1411,16 @@ impl<'a> CheckerState<'a> {
                 {
                     return;
                 }
-                let _ = if nested_in_type_literal {
-                    self.get_type_from_type_node_in_type_literal(node_idx)
-                } else {
-                    self.get_type_from_type_node(node_idx)
-                };
+                if !self.check_explicit_type_reference_for_alias_body_validation(
+                    node_idx,
+                    nested_in_type_literal,
+                ) {
+                    let _ = if nested_in_type_literal {
+                        self.get_type_from_type_node_in_type_literal(node_idx)
+                    } else {
+                        self.get_type_from_type_node(node_idx)
+                    };
+                }
                 self.check_styled_component_inner_component_constraint(node_idx);
             }
             k if k == syntax_kind_ext::TYPE_LITERAL => {

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -18,3 +18,7 @@ TypeScript/tests/cases/compiler/exportDefaultInterface.ts
 TypeScript/tests/cases/compiler/noUnusedLocals_writeOnly.ts
 TypeScript/tests/cases/conformance/externalModules/circularReference.ts
 TypeScript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts
+
+# Existing main drift exposed by PR #12237/#12242 aggregate runs; tracked in #12247.
+TypeScript/tests/cases/compiler/coAndContraVariantInferences2.ts
+TypeScript/tests/cases/compiler/correlatedUnions.ts


### PR DESCRIPTION
## Agent
AgentName: MBMB4-Canary-B

## Track
Track 10 performance; checker alias-body validation hot path for green-row canary timing, with conformance baseline metadata for existing main drift exposed by the aggregate gate.

## Invariant
When type-alias body validation visits an explicit generic `TypeReference` inside an actual type-alias body, `tsc` validates type-argument arity and constraints; tsz now does that through the existing checker generic-argument validator and falls back to full type-reference lowering outside that structural alias-body boundary or when the validator-only path cannot safely resolve the reference.

## Scope
- Add `type_alias_body_validation` helper module for explicit alias-body type reference validation.
- Route `type_alias_checking` `TypeReference` body validation through the helper before full lowering.
- Keep the shortcut out of nested type literals, type-parameter declarations, builtin lib declaration arenas, unresolved references, and non-alias-body type nodes.
- Add focused guards in `ref_type_params_cache_tests` so arity/constraint behavior and lib-alias indexed access stay explicit.
- Merge current `origin/main` (`045af3ea25a`) into the branch after implementation.
- Add accepted-regression entries for the two aggregate failures that reproduce on clean main and are tracked in #12247.

## Project Corpus Impact
- Row: `ts-essentials-project`
- Bug family: utility types plus recursive/key-space alias body validation, especially `ts-essentials/lib/xor/index.ts` from #7378.
- Evidence: final attribution `/tmp/mbmb4-ts-essentials-after-guard.perf.json` keeps diagnostics at 0 and the same optimized counter totals as the pre-guard final run (`TypeInterner` intern calls 61,967; application intern calls 10,180; mapped intern calls 581). Current guarded attribution reports XOR body validation at 1.70 ms versus the original 4.11 ms baseline.
- Evidence: clean pre-guard quick rebuilt benchmark `/tmp/mbmb4-ts-essentials-final-bench.json` reported `ts-essentials-project` at tsz 78.31 ms vs tsgo 50.66 ms, gap 1.55x, from the earlier 80.43 ms / 1.61x baseline. Post-guard quick bench reruns (`/tmp/mbmb4-ts-essentials-after-guard-bench*.json`) were noisy with outlier/cache warnings and are not used as the stable timing claim.

## Verification
- `cargo fmt --check`
- `python3 scripts/arch/arch_guard.py`
- `cargo nextest run -p tsz-checker --lib ref_type_params_cache_tests`
- `cargo nextest run -p tsz-checker --test ts2344_infer_result_application_constraint_tests --test ts2314_in_type_literal_suppresses_ts2322_tests`
- `scripts/safe-run.sh --limit 50% -- cargo build --profile dist-fast -p tsz-cli --bin tsz --features perf-tools`
- `TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh --limit 75% -- .target/dist-fast/tsz --extendedDiagnostics --perf-counters-json /tmp/mbmb4-ts-essentials-after-guard.perf.json --noEmit -p /Users/mohsen/code/tsz-mbmb4-canary-b-20260602/.target-bench/external/ts-essentials/tsconfig.flat.json`
- `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --rebuild --filter '^ts-essentials-project$' --json-file /tmp/mbmb4-ts-essentials-after-guard-bench.json` (completed, noisy/outlier run)
- `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^ts-essentials-project$' --json-file /tmp/mbmb4-ts-essentials-after-guard-bench-rerun.json` (completed, noisy/outlier run)
- `git diff --check`
- `python3 scripts/conformance/query-conformance.py --dashboard` (metadata check only; local detail snapshot is stale by +3 pinned TS tests)
- `python3 scripts/conformance/query-conformance.py --fingerprint-only`
- `scripts/agents/ensure-agent-labels.sh --audit`
- Focused conformance triage: `coAndContraVariantInferences2` and `correlatedUnions` fail locally at this head and from clean main; this PR now records them as accepted main drift and tracks them in #12247.

## Coordination Notes
- Canonical owner label should be `agent:Studio-B`; `MBMB4-Canary-B` is the stable PR-body `AgentName` for this session, not a GitHub label.
- No fixture-name or user-name semantic checks added; the fast path is structural and explicitly constrained to actual type-alias bodies.
- Head `229fe1e77b01f8aae2c1470058830f7830019b63` is pushed and expected to rerun CI with the accepted main drift recorded.
- This does not close the `ts-essentials-project` 2x gap; follow-up should target the remaining deep utility body-validation and recursive path phases.