### PR TITLE
refactor(checker): centralize checker-side downgrade and raw-input failure detection (#10901)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1986,5 +1986,9 @@ path = "tests/const_alias_discriminant_narrowing_tests.rs"
 name = "recursive_utility_alias_fanout_tests"
 path = "tests/recursive_utility_alias_fanout_tests.rs"
 
+[[test]]
+name = "same_generic_application_assign_outcome_tests"
+path = "tests/same_generic_application_assign_outcome_tests.rs"
+
 [lints]
 workspace = true

--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -1468,16 +1468,33 @@ impl<'a> CheckerState<'a> {
 
     /// Check if source object literal has properties that don't exist in target.
     ///
-    pub(crate) fn analyze_assignability_failure(
+    /// Pre-evaluation failure detectors that work on the *raw* (unevaluated)
+    /// source/target. These cover failure shapes the structural solver pass
+    /// cannot reconstruct after `prepare_assignability_inputs` collapses the
+    /// operands to their evaluated form:
+    ///
+    /// 1. `S[T1]` vs `S[T2]` distinct type-parameter keys — both halves
+    ///    evaluate to the same shared constraint, erasing the `T1`/`T2`
+    ///    identity needed for the TS2322 + TS5075 elaboration chain.
+    /// 2. Abstract → non-abstract constructor — the abstractness flag lives
+    ///    on the symbol and the checker override consults it before any
+    ///    structural walk; the evaluated shapes are otherwise compatible.
+    /// 3. Same-generic application (`C<A..>` vs `C<B..>`) — the applications
+    ///    evaluate to object shapes losing the type-argument identity, which
+    ///    suppresses tsc's direct-argument elaboration chain.
+    ///
+    /// Returns `None` when none of the pre-evaluation detectors fires.
+    /// Cheap by design — none of these probes runs a fresh `CompatChecker`
+    /// solver pass; they only inspect type-data shape and symbol flags.
+    /// Used both as `analyze_assignability_failure`'s pre-pass and as the
+    /// cheap fallback for callers (like `assign_relation_outcome`) that
+    /// already exhausted the solver-side reason and only need to recover the
+    /// raw-input cases.
+    pub(crate) fn raw_input_failure_reason(
         &mut self,
         source: TypeId,
         target: TypeId,
-    ) -> crate::query_boundaries::assignability::AssignabilityFailureAnalysis {
-        // `S[T1]` vs `S[T2]` where T1/T2 are distinct type parameters
-        // collapses to the same evaluated shape (the constraint), so the
-        // structural pipeline loses the IndexAccess form before it can
-        // produce the TS2322 + TS5075 elaboration chain. Detect the
-        // mismatch on the unevaluated inputs and surface it directly.
+    ) -> Option<tsz_solver::SubtypeFailureReason> {
         if let Some(reason) =
             crate::query_boundaries::assignability::index_access_pair_distinct_type_param_keys_failure_reason(
                 self.ctx.types,
@@ -1486,38 +1503,28 @@ impl<'a> CheckerState<'a> {
                 target,
             )
         {
-            return crate::query_boundaries::assignability::AssignabilityFailureAnalysis {
-                weak_union_violation: false,
-                failure_reason: Some(reason),
-            };
+            return Some(reason);
         }
 
-        // The abstract→non-abstract constructor rejection lives in a checker
-        // override (it needs symbol abstractness) and is detected on the raw
-        // declared types, so the structural failure walk over the evaluated
-        // inputs produces no reason. Surface the structured reason directly so
-        // the TS2517 elaboration is rendered after the top-level TS2322/TS2345.
         if let Some(reason) = self.abstract_constructor_assignment_failure_reason(source, target) {
-            return crate::query_boundaries::assignability::AssignabilityFailureAnalysis {
-                weak_union_violation: false,
-                failure_reason: Some(reason),
-            };
+            return Some(reason);
         }
 
-        // Same-generic application (`C<A..>` vs `C<B..>`): tsc elaborates the
-        // differing type arguments directly. The structural pipeline evaluates
-        // the applications to object shapes (losing the type-argument identity)
-        // and would emit a `Types of property 'x' are incompatible.` wrapper
-        // that tsc does not produce, so detect it on the raw operands first.
-        if let Some(reason) =
-            crate::query_boundaries::assignability::same_generic_application_failure_reason(
-                self.ctx.types,
-                &self.ctx,
-                &self.ctx,
-                source,
-                target,
-            )
-        {
+        crate::query_boundaries::assignability::same_generic_application_failure_reason(
+            self.ctx.types,
+            &self.ctx,
+            &self.ctx,
+            source,
+            target,
+        )
+    }
+
+    pub(crate) fn analyze_assignability_failure(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> crate::query_boundaries::assignability::AssignabilityFailureAnalysis {
+        if let Some(reason) = self.raw_input_failure_reason(source, target) {
             return crate::query_boundaries::assignability::AssignabilityFailureAnalysis {
                 weak_union_violation: false,
                 failure_reason: Some(reason),

--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -243,27 +243,31 @@ impl<'a> CheckerState<'a> {
             };
         }
 
-        // Raw-input detectors fire on the unevaluated operands and own failure
-        // shapes the solver's evaluated pipeline cannot reconstruct (index-
-        // access type-param mismatch, abstract-constructor assignment, same-
-        // generic application with differing args). They MUST override any
-        // wrapper reason the boundary's evaluated-shape pass produced (e.g.
-        // "Types of property 'x' are incompatible"), otherwise TS2322 loses
-        // tsc's direct elaboration chain. This mirrors the early-return
-        // ordering of `analyze_assignability_failure`.
-        let raw_reason = self.raw_input_failure_reason(source, target);
-        let (prepared_source, prepared_target) = self.prepare_assignability_inputs(source, target);
-        let request = crate::query_boundaries::assignability::RelationRequest::assign(
-            prepared_source,
-            prepared_target,
-        );
+        let raw_source = source;
+        let raw_target = target;
+        let (source, target) = self.prepare_assignability_inputs(source, target);
+        let request =
+            crate::query_boundaries::assignability::RelationRequest::assign(source, target);
         let mut outcome = self.execute_relation_request(&request);
-        if let Some(reason) = raw_reason {
-            outcome.failure = Some(
-                crate::query_boundaries::relation_types::RelationFailure::from_solver_reason(
-                    reason,
-                ),
-            );
+
+        // Solver pass returned `failure=None`: `is_assignable_to` rejected via
+        // a checker-side fast-path the solver cannot reconstruct after
+        // `prepare_assignability_inputs`. The raw-input detectors recover the
+        // structured reason — see `raw_input_failure_reason` for the families.
+        //
+        // This intentionally only fires when `outcome.failure` is empty. When
+        // the boundary already produced a reason (e.g. property-incompatible
+        // for `C<A..>` vs `C<B..>`), the TS2322 emit path consumes that reason
+        // via `analyze_assignability_failure`, which runs the raw-input
+        // detectors FIRST and overrides the wrapper reason there. Overriding
+        // `outcome.failure` from here would also change what
+        // `contextual_callable_member_failure_is_generic_parameter_drift` and
+        // similar `outcome.failure`-reading predicates observe, which has
+        // unrelated semantic side-effects (see #12239 review).
+        if outcome.failure.is_none()
+            && let Some(reason) = self.raw_input_failure_reason(raw_source, raw_target)
+        {
+            Self::set_failure_from_reason_if_empty(&mut outcome, reason);
         }
 
         outcome.related = false;

--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -14,8 +14,8 @@ use crate::query_boundaries::state::type_resolution::{get_application_info, get_
 use crate::state::{CheckerOverrideProvider, CheckerState};
 use rustc_hash::FxHashSet;
 use tracing::trace;
+use tsz_solver::TypeId;
 use tsz_solver::computation::TypeResolver;
-use tsz_solver::{SubtypeFailureReason, TypeId};
 
 impl<'a> CheckerState<'a> {
     /// Shared assignability core: cache lookup → compute → cache insert → trace.
@@ -184,10 +184,15 @@ impl<'a> CheckerState<'a> {
 
     /// When the solver says the relation holds but a checker-only semantic
     /// rule (e.g., iterator-result protocol mismatch) rejects it, downgrade
-    /// `outcome.related` to false AND surface the structured reason so the
-    /// `query_boundaries/assignability` gateway returns a coherent
-    /// (related, failure) pair instead of a generic TS2322/TS2345 with no
-    /// inner chain.
+    /// `outcome.related` to false. The structured reason is recovered by the
+    /// canonical TS2322/TS2345 emit path which calls
+    /// `analyze_assignability_failure` directly (in
+    /// `error_reporter/assignability.rs:602`), so the diagnostic chain stays
+    /// elaborated without populating `outcome.failure` here. Populating
+    /// `outcome.failure` from a downgrade has unrelated semantic side-effects
+    /// on `outcome.failure`-reading predicates in `core_statement_checks.rs`
+    /// (see #12239 conformance regression on `coAndContraVariantInferences2.ts`
+    /// and `correlatedUnions.ts`).
     fn apply_checker_side_downgrade(
         &mut self,
         outcome: &mut crate::query_boundaries::assignability::RelationOutcome,
@@ -197,27 +202,11 @@ impl<'a> CheckerState<'a> {
         if !outcome.related {
             return;
         }
-        let Some(reason) = self.checker_only_assignability_failure_reason(source, target) else {
-            return;
-        };
-        outcome.related = false;
-        Self::set_failure_from_reason_if_empty(outcome, reason);
-    }
-
-    /// Populate `outcome.failure` with the structured reason iff it is
-    /// currently `None`. Centralizes the boilerplate that wraps a solver
-    /// `SubtypeFailureReason` into the checker-facing `RelationFailure` and
-    /// preserves any reason the boundary already produced.
-    fn set_failure_from_reason_if_empty(
-        outcome: &mut crate::query_boundaries::assignability::RelationOutcome,
-        reason: SubtypeFailureReason,
-    ) {
-        if outcome.failure.is_none() {
-            outcome.failure = Some(
-                crate::query_boundaries::relation_types::RelationFailure::from_solver_reason(
-                    reason,
-                ),
-            );
+        if self
+            .checker_only_assignability_failure_reason(source, target)
+            .is_some()
+        {
+            outcome.related = false;
         }
     }
 
@@ -243,33 +232,10 @@ impl<'a> CheckerState<'a> {
             };
         }
 
-        let raw_source = source;
-        let raw_target = target;
         let (source, target) = self.prepare_assignability_inputs(source, target);
         let request =
             crate::query_boundaries::assignability::RelationRequest::assign(source, target);
         let mut outcome = self.execute_relation_request(&request);
-
-        // Solver pass returned `failure=None`: `is_assignable_to` rejected via
-        // a checker-side fast-path the solver cannot reconstruct after
-        // `prepare_assignability_inputs`. The raw-input detectors recover the
-        // structured reason — see `raw_input_failure_reason` for the families.
-        //
-        // This intentionally only fires when `outcome.failure` is empty. When
-        // the boundary already produced a reason (e.g. property-incompatible
-        // for `C<A..>` vs `C<B..>`), the TS2322 emit path consumes that reason
-        // via `analyze_assignability_failure`, which runs the raw-input
-        // detectors FIRST and overrides the wrapper reason there. Overriding
-        // `outcome.failure` from here would also change what
-        // `contextual_callable_member_failure_is_generic_parameter_drift` and
-        // similar `outcome.failure`-reading predicates observe, which has
-        // unrelated semantic side-effects (see #12239 review).
-        if outcome.failure.is_none()
-            && let Some(reason) = self.raw_input_failure_reason(raw_source, raw_target)
-        {
-            Self::set_failure_from_reason_if_empty(&mut outcome, reason);
-        }
-
         outcome.related = false;
         outcome
     }

--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -14,8 +14,8 @@ use crate::query_boundaries::state::type_resolution::{get_application_info, get_
 use crate::state::{CheckerOverrideProvider, CheckerState};
 use rustc_hash::FxHashSet;
 use tracing::trace;
-use tsz_solver::TypeId;
 use tsz_solver::computation::TypeResolver;
+use tsz_solver::{SubtypeFailureReason, TypeId};
 
 impl<'a> CheckerState<'a> {
     /// Shared assignability core: cache lookup → compute → cache insert → trace.
@@ -177,19 +177,48 @@ impl<'a> CheckerState<'a> {
         );
 
         self.propagate_overflow_flags(outcome.depth_exceeded, outcome.iteration_exceeded);
-
-        // Checker-only post-check: the solver may say "related" but the checker
-        // can downgrade via deferred conditional types or other checker-specific
-        // semantic rules.
-        if outcome.related
-            && self
-                .checker_only_assignability_failure_reason(request.source, request.target)
-                .is_some()
-        {
-            outcome.related = false;
-        }
+        self.apply_checker_side_downgrade(&mut outcome, request.source, request.target);
 
         outcome
+    }
+
+    /// When the solver says the relation holds but a checker-only semantic
+    /// rule (e.g., iterator-result protocol mismatch) rejects it, downgrade
+    /// `outcome.related` to false AND surface the structured reason so the
+    /// `query_boundaries/assignability` gateway returns a coherent
+    /// (related, failure) pair instead of a generic TS2322/TS2345 with no
+    /// inner chain.
+    fn apply_checker_side_downgrade(
+        &mut self,
+        outcome: &mut crate::query_boundaries::assignability::RelationOutcome,
+        source: TypeId,
+        target: TypeId,
+    ) {
+        if !outcome.related {
+            return;
+        }
+        let Some(reason) = self.checker_only_assignability_failure_reason(source, target) else {
+            return;
+        };
+        outcome.related = false;
+        Self::set_failure_from_reason_if_empty(outcome, reason);
+    }
+
+    /// Populate `outcome.failure` with the structured reason iff it is
+    /// currently `None`. Centralizes the boilerplate that wraps a solver
+    /// `SubtypeFailureReason` into the checker-facing `RelationFailure` and
+    /// preserves any reason the boundary already produced.
+    fn set_failure_from_reason_if_empty(
+        outcome: &mut crate::query_boundaries::assignability::RelationOutcome,
+        reason: SubtypeFailureReason,
+    ) {
+        if outcome.failure.is_none() {
+            outcome.failure = Some(
+                crate::query_boundaries::relation_types::RelationFailure::from_solver_reason(
+                    reason,
+                ),
+            );
+        }
     }
 
     /// Execute a diagnostic-bearing assignment relation for raw checker types.
@@ -214,10 +243,23 @@ impl<'a> CheckerState<'a> {
             };
         }
 
+        let raw_source = source;
+        let raw_target = target;
         let (source, target) = self.prepare_assignability_inputs(source, target);
         let request =
             crate::query_boundaries::assignability::RelationRequest::assign(source, target);
         let mut outcome = self.execute_relation_request(&request);
+
+        // Solver pass returned `failure=None`: `is_assignable_to` rejected via
+        // a checker-side fast-path the solver cannot reconstruct after
+        // `prepare_assignability_inputs`. The raw-input detectors recover the
+        // structured reason — see `raw_input_failure_reason` for the families.
+        if outcome.failure.is_none()
+            && let Some(reason) = self.raw_input_failure_reason(raw_source, raw_target)
+        {
+            Self::set_failure_from_reason_if_empty(&mut outcome, reason);
+        }
+
         outcome.related = false;
         outcome
     }
@@ -294,13 +336,9 @@ impl<'a> CheckerState<'a> {
             relation_outcome.iteration_exceeded,
         );
 
-        if relation_outcome.related
-            && self
-                .checker_only_assignability_failure_reason(source, target)
-                .is_some()
-        {
-            relation_outcome.related = false;
-        }
+        // Mirror the canonical `execute_relation_request` downgrade so the
+        // env-aware path stays on the same `(related, failure)` contract.
+        self.apply_checker_side_downgrade(&mut relation_outcome, source, target);
 
         if relation_outcome.related
             && let Some(keyof_type) = get_keyof_type(self.ctx.types, target)

--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -243,21 +243,27 @@ impl<'a> CheckerState<'a> {
             };
         }
 
-        let raw_source = source;
-        let raw_target = target;
-        let (source, target) = self.prepare_assignability_inputs(source, target);
-        let request =
-            crate::query_boundaries::assignability::RelationRequest::assign(source, target);
+        // Raw-input detectors fire on the unevaluated operands and own failure
+        // shapes the solver's evaluated pipeline cannot reconstruct (index-
+        // access type-param mismatch, abstract-constructor assignment, same-
+        // generic application with differing args). They MUST override any
+        // wrapper reason the boundary's evaluated-shape pass produced (e.g.
+        // "Types of property 'x' are incompatible"), otherwise TS2322 loses
+        // tsc's direct elaboration chain. This mirrors the early-return
+        // ordering of `analyze_assignability_failure`.
+        let raw_reason = self.raw_input_failure_reason(source, target);
+        let (prepared_source, prepared_target) = self.prepare_assignability_inputs(source, target);
+        let request = crate::query_boundaries::assignability::RelationRequest::assign(
+            prepared_source,
+            prepared_target,
+        );
         let mut outcome = self.execute_relation_request(&request);
-
-        // Solver pass returned `failure=None`: `is_assignable_to` rejected via
-        // a checker-side fast-path the solver cannot reconstruct after
-        // `prepare_assignability_inputs`. The raw-input detectors recover the
-        // structured reason — see `raw_input_failure_reason` for the families.
-        if outcome.failure.is_none()
-            && let Some(reason) = self.raw_input_failure_reason(raw_source, raw_target)
-        {
-            Self::set_failure_from_reason_if_empty(&mut outcome, reason);
+        if let Some(reason) = raw_reason {
+            outcome.failure = Some(
+                crate::query_boundaries::relation_types::RelationFailure::from_solver_reason(
+                    reason,
+                ),
+            );
         }
 
         outcome.related = false;

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_02.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_02.rs
@@ -170,7 +170,7 @@ fn test_assignability_checker_has_execute_relation_request() {
 /// outcome's `weak_union_violation` hint instead of re-calling the solver.
 ///
 /// Note: per `test_assignability_diagnostics_route_through_relation_outcome_helpers`
-/// (part_03.rs), diagnostic files must NOT build `RelationRequest::*` directly;
+/// (`part_03.rs`), diagnostic files must NOT build `RelationRequest::*` directly;
 /// they must go through the named `*_relation_outcome` helpers in
 /// `assignability_relation.rs`. The named helpers internally build the
 /// `RelationRequest::assign(`/etc. and call `execute_relation_request(`, so

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_02.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_02.rs
@@ -114,16 +114,16 @@ fn test_relation_request_constructors_encode_relation_kind() {
     }
 }
 
-/// `assignability_checker.rs` must use `execute_relation_request` as the
+/// `assignability_relation.rs` must use `execute_relation_request` as the
 /// canonical checker-level entry point for structured relation queries.
 #[test]
 fn test_assignability_checker_has_execute_relation_request() {
-    let source = fs::read_to_string("src/assignability/assignability_checker.rs")
-        .expect("failed to read assignability_checker.rs");
+    let source = fs::read_to_string("src/assignability/assignability_relation.rs")
+        .expect("failed to read assignability_relation.rs");
 
     assert!(
         source.contains("fn execute_relation_request("),
-        "assignability_checker must define execute_relation_request as the canonical \
+        "assignability_relation must define execute_relation_request as the canonical \
          checker-level entry point for structured relation queries"
     );
     assert!(
@@ -131,15 +131,17 @@ fn test_assignability_checker_has_execute_relation_request() {
         "execute_relation_request must delegate to the query_boundaries::execute_relation helper"
     );
     assert!(
-        source
-            .contains("checker_only_assignability_failure_reason(request.source, request.target)"),
-        "execute_relation_request must preserve checker-only post-check downgrades \
-         after the canonical boundary returns"
+        source.contains(
+            "apply_checker_side_downgrade(&mut outcome, request.source, request.target)"
+        ),
+        "execute_relation_request must route checker-only post-check downgrades \
+         through the shared apply_checker_side_downgrade helper after the \
+         canonical boundary returns"
     );
     assert!(
         source.contains("outcome.related = false;"),
-        "execute_relation_request must be able to downgrade a solver-related result \
-         when checker-only semantics require it"
+        "the assignability path must be able to downgrade a solver-related result \
+         when checker-only semantics require it (inside apply_checker_side_downgrade)"
     );
     assert!(
         source.contains("let flags = self.ctx.pack_relation_flags();"),
@@ -158,7 +160,7 @@ fn test_assignability_checker_has_execute_relation_request() {
         "execute_relation_request must pass the checker inheritance graph into the boundary"
     );
     assert!(
-        source.contains("Some(&self.ctx),"),
+        source.contains("&self.ctx,"),
         "execute_relation_request must pass checker context into the boundary \
          for structured failure analysis"
     );
@@ -166,38 +168,54 @@ fn test_assignability_checker_has_execute_relation_request() {
 
 /// `assignability_diagnostics.rs` diagnostic paths must use the relation
 /// outcome's `weak_union_violation` hint instead of re-calling the solver.
+///
+/// Note: per `test_assignability_diagnostics_route_through_relation_outcome_helpers`
+/// (part_03.rs), diagnostic files must NOT build `RelationRequest::*` directly;
+/// they must go through the named `*_relation_outcome` helpers in
+/// `assignability_relation.rs`. The named helpers internally build the
+/// `RelationRequest::assign(`/etc. and call `execute_relation_request(`, so
+/// the assertions here verify those helper invocations rather than the raw
+/// request builder.
 #[test]
 fn test_diagnostic_paths_use_relation_outcome_hint() {
     let source = fs::read_to_string("src/assignability/assignability_diagnostics.rs")
         .expect("failed to read assignability_diagnostics.rs");
 
-    // The `check_assignable_or_report_at` method should build a RelationRequest
     assert!(
-        source.contains("RelationRequest::assign("),
-        "check_assignable_or_report_at must build a RelationRequest::assign for the canonical path"
+        source.contains("assign_relation_outcome("),
+        "check_assignable_or_report_at must obtain a RelationOutcome via the named \
+         assign_relation_outcome helper instead of re-calling the solver separately"
     );
     assert!(
-        source.contains("execute_relation_request("),
-        "check_assignable_or_report_at must call execute_relation_request"
-    );
-    assert!(
-        source.contains("should_skip_weak_union_error_with_hint("),
-        "diagnostic paths must use should_skip_weak_union_error_with_hint \
-         to avoid re-calling the solver for weak-union detection"
+        source.contains("should_skip_weak_union_error_with_hint(")
+            || source.contains("should_skip_weak_union_error_with_outcome("),
+        "diagnostic paths must use the outcome-aware weak-union skip helpers to \
+         avoid re-calling the solver for weak-union detection"
     );
 }
 
 /// `check_argument_assignable_or_report` must use the canonical
-/// `RelationRequest::call_arg` path for call-argument relation queries.
+/// call-argument relation outcome helper.
+///
+/// As with `test_diagnostic_paths_use_relation_outcome_hint`, this asserts
+/// the named-helper invocation rather than the raw `RelationRequest::call_arg(`
+/// builder, which lives behind the helper in `assignability_relation.rs`.
+/// The call lives in the `argument_reports` submodule of
+/// `assignability_diagnostics`.
 #[test]
 fn test_call_arg_diagnostic_uses_canonical_relation_path() {
-    let source = fs::read_to_string("src/assignability/assignability_diagnostics.rs")
+    let main_source = fs::read_to_string("src/assignability/assignability_diagnostics.rs")
         .expect("failed to read assignability_diagnostics.rs");
+    let arg_reports_source =
+        fs::read_to_string("src/assignability/assignability_diagnostics/argument_reports.rs")
+            .expect("failed to read assignability_diagnostics/argument_reports.rs");
 
     assert!(
-        source.contains("RelationRequest::call_arg("),
-        "check_argument_assignable_or_report must build a RelationRequest::call_arg \
-         for the canonical call-argument relation path"
+        main_source.contains("call_arg_relation_outcome(")
+            || arg_reports_source.contains("call_arg_relation_outcome("),
+        "check_argument_assignable_or_report must obtain a RelationOutcome via the \
+         named call_arg_relation_outcome helper for the canonical call-argument \
+         relation path"
     );
 }
 
@@ -323,16 +341,31 @@ fn test_execute_relation_success_path_returns_clean_outcome() {
 fn test_bivariant_relation_boundary_preserves_overflow_flags() {
     let boundary_source = fs::read_to_string("src/query_boundaries/assignability.rs")
         .expect("failed to read assignability.rs");
-    let checker_source = fs::read_to_string("src/assignability/assignability_checker.rs")
-        .expect("failed to read assignability_checker.rs");
+    let checker_source = fs::read_to_string("src/assignability/assignability_relation.rs")
+        .expect("failed to read assignability_relation.rs");
 
+    // The boundary may reference `RelationResult` via the canonical short
+    // alias (`tsz_solver::RelationResult`) or the fully-qualified path under
+    // `relations::relation_queries`. The bare `AssignableBivariantCallbacks`
+    // identifier check subsumes both qualified `RelationKind` paths.
     assert!(
-        boundary_source.contains(") -> tsz_solver::RelationResult")
-            && boundary_source.contains("tsz_solver::RelationKind::AssignableBivariantCallbacks"),
-        "bivariant relation helper must return the full solver RelationResult"
+        (boundary_source.contains("-> tsz_solver::RelationResult")
+            || boundary_source
+                .contains("-> tsz_solver::relations::relation_queries::RelationResult"))
+            && boundary_source.contains("AssignableBivariantCallbacks"),
+        "bivariant relation helper must return the full solver RelationResult \
+         for the AssignableBivariantCallbacks kind"
     );
+    // Bivariant overflow flags must reach the boundary outcome. Accept either
+    // the legacy tuple destructure (`(r.is_related(), r.depth_exceeded, r.iteration_exceeded)`)
+    // or any direct propagation via field reads.
+    let bivariant_overflow_path = boundary_source
+        .contains("(r.is_related(), r.depth_exceeded, r.iteration_exceeded)")
+        || (boundary_source.contains(".is_related()")
+            && boundary_source.contains(".depth_exceeded")
+            && boundary_source.contains(".iteration_exceeded"));
     assert!(
-        boundary_source.contains("(r.is_related(), r.depth_exceeded, r.iteration_exceeded)"),
+        bivariant_overflow_path,
         "execute_relation must forward bivariant callback depth/iteration overflow flags"
     );
     assert!(
@@ -340,9 +373,10 @@ fn test_bivariant_relation_boundary_preserves_overflow_flags() {
         "execute_relation must not erase bivariant callback overflow flags"
     );
     assert!(
-        checker_source.contains(
-            "self.propagate_overflow_flags(\n            relation_result.depth_exceeded,\n            relation_result.iteration_exceeded,\n        );"
-        ) && checker_source.contains("let result = relation_result.is_related();"),
+        checker_source.contains("self.propagate_overflow_flags(")
+            && checker_source.contains("relation_result.depth_exceeded")
+            && checker_source.contains("relation_result.iteration_exceeded")
+            && checker_source.contains("let result = relation_result.is_related();"),
         "legacy bivariant boolean wrapper must merge overflow flags before returning/caching the bool"
     );
 }

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_03.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_03.rs
@@ -262,22 +262,42 @@ fn test_checker_only_downgrade_preserves_failure_reason_through_gateway() {
          apply_checker_side_downgrade so the failure reason is preserved"
     );
 
-    // assign_relation_outcome's failed branch must recover the structured
-    // reason via the cheap raw-input pre-check (`raw_input_failure_reason`)
-    // when execute_relation_request's solver pass returned no reason. The
-    // pre-check covers the three raw-input families that `is_assignable_to`'s
-    // checker-side fast-paths reject but the solver pass considers related.
+    // assign_relation_outcome's failed branch must compute the raw-input
+    // failure reason BEFORE the boundary's evaluated-shape pass and OVERRIDE
+    // any boundary reason it produced. This matches the early-return ordering
+    // of `analyze_assignability_failure`: when a raw-input detector fires the
+    // raw reason wins, because the boundary's evaluated pipeline cannot
+    // reconstruct those shapes (e.g. same-generic `C<A..>` vs `C<B..>` evaluates
+    // to incompatible object property values, producing a wrapper reason that
+    // masks tsc's direct type-argument elaboration).
     let assign_body = extract_method_body(&source, "fn assign_relation_outcome(");
     assert!(
         assign_body.contains("raw_input_failure_reason("),
-        "assign_relation_outcome must recover the structured failure reason via \
-         raw_input_failure_reason when execute_relation_request returns no reason"
+        "assign_relation_outcome must compute the raw-input failure reason \
+         via raw_input_failure_reason"
     );
+    let raw_reason_idx = assign_body
+        .find("raw_input_failure_reason(")
+        .expect("raw_input_failure_reason call site not found");
+    let execute_idx = assign_body
+        .find("execute_relation_request(")
+        .expect("execute_relation_request call site not found");
     assert!(
-        assign_body.contains("outcome.failure.is_none()"),
-        "assign_relation_outcome must only recover the failure reason when the \
-         boundary outcome lacks one — otherwise it would override an already \
-         elaborated structured reason"
+        raw_reason_idx < execute_idx,
+        "raw_input_failure_reason must be computed BEFORE execute_relation_request \
+         so the raw reason can override any wrapper reason the boundary's \
+         evaluated-shape pass produces"
+    );
+    let override_assigns_failure_unconditionally = assign_body
+        .contains("outcome.failure = Some(")
+        && assign_body.contains("RelationFailure::from_solver_reason(");
+    let override_uses_if_let_some =
+        assign_body.contains("if let Some(reason) = raw_reason");
+    assert!(
+        override_assigns_failure_unconditionally && override_uses_if_let_some,
+        "assign_relation_outcome must overwrite outcome.failure when the raw \
+         reason fires, not gate on outcome.failure.is_none() — otherwise the \
+         boundary's wrapper reason would shadow the raw-input elaboration"
     );
 }
 

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_03.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_03.rs
@@ -203,3 +203,93 @@ fn test_assignability_diagnostics_route_through_relation_outcome_helpers() {
         violations.join("\n")
     );
 }
+
+/// Guard: when the checker downgrades a solver-related outcome via
+/// `checker_only_assignability_failure_reason` (iterator-result mismatches and
+/// peers), the structured failure reason MUST be surfaced into the
+/// `RelationOutcome.failure` slot. Otherwise TS2322/TS2345/TS2416 emit paths
+/// observe a degenerate `(related=false, failure=None)` pair and render the
+/// generic "Type 'X' is not assignable to type 'Y'." with no inner elaboration,
+/// breaking the structural rule that the `query_boundaries/assignability`
+/// gateway always returns a coherent decision-plus-reason pair.
+#[test]
+fn test_checker_only_downgrade_preserves_failure_reason_through_gateway() {
+    let source = fs::read_to_string("src/assignability/assignability_relation.rs")
+        .expect("failed to read src/assignability/assignability_relation.rs");
+
+    // The shared downgrade helper must exist so every consumer agrees on the
+    // "downgrade + reason recovery" semantics rather than open-coding the
+    // pattern at each callsite.
+    assert!(
+        source.contains("fn apply_checker_side_downgrade("),
+        "assignability_relation.rs must define a single apply_checker_side_downgrade \
+         helper so all checker-side downgrades agree on preserving the failure reason"
+    );
+
+    let downgrade_body = extract_method_body(&source, "fn apply_checker_side_downgrade(");
+    assert!(
+        downgrade_body.contains("outcome.related = false;"),
+        "apply_checker_side_downgrade must force outcome.related to false"
+    );
+    // The reason surfacing may be inlined OR delegated to the shared
+    // `set_failure_from_reason_if_empty` helper. Accept either shape.
+    let surfaces_reason_inline = downgrade_body.contains("outcome.failure = Some(")
+        && downgrade_body.contains("RelationFailure::from_solver_reason(");
+    let surfaces_reason_via_helper =
+        downgrade_body.contains("set_failure_from_reason_if_empty(");
+    assert!(
+        surfaces_reason_inline || surfaces_reason_via_helper,
+        "apply_checker_side_downgrade must surface the structured failure reason \
+         so callers don't observe (related=false, failure=None)"
+    );
+
+    // The shared helper itself must always wrap the solver reason into a
+    // `RelationFailure` and assign it iff `outcome.failure` is currently None.
+    let helper_body =
+        extract_method_body(&source, "fn set_failure_from_reason_if_empty(");
+    assert!(
+        helper_body.contains("outcome.failure.is_none()")
+            && helper_body.contains("outcome.failure = Some(")
+            && helper_body.contains("RelationFailure::from_solver_reason("),
+        "set_failure_from_reason_if_empty must guard on outcome.failure.is_none() \
+         and wrap the solver reason into a checker-facing RelationFailure"
+    );
+
+    let exec_body = extract_method_body(&source, "fn execute_relation_request(");
+    assert!(
+        exec_body.contains("apply_checker_side_downgrade("),
+        "execute_relation_request must route checker-side downgrades through \
+         apply_checker_side_downgrade so the failure reason is preserved"
+    );
+
+    // assign_relation_outcome's failed branch must recover the structured
+    // reason via the cheap raw-input pre-check (`raw_input_failure_reason`)
+    // when execute_relation_request's solver pass returned no reason. The
+    // pre-check covers the three raw-input families that `is_assignable_to`'s
+    // checker-side fast-paths reject but the solver pass considers related.
+    let assign_body = extract_method_body(&source, "fn assign_relation_outcome(");
+    assert!(
+        assign_body.contains("raw_input_failure_reason("),
+        "assign_relation_outcome must recover the structured failure reason via \
+         raw_input_failure_reason when execute_relation_request returns no reason"
+    );
+    assert!(
+        assign_body.contains("outcome.failure.is_none()"),
+        "assign_relation_outcome must only recover the failure reason when the \
+         boundary outcome lacks one — otherwise it would override an already \
+         elaborated structured reason"
+    );
+}
+
+/// Slice the body of a Rust method from `source` starting at `fn_signature`
+/// and ending at the matching `}` (assumes 4-space indented method body).
+fn extract_method_body<'a>(source: &'a str, fn_signature: &str) -> &'a str {
+    let start = source
+        .find(fn_signature)
+        .unwrap_or_else(|| panic!("{fn_signature} not found"));
+    let after = &source[start..];
+    let end = after
+        .find("\n    }\n")
+        .unwrap_or_else(|| panic!("{fn_signature} must close with a method-end '}}'"));
+    &after[..end]
+}

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_03.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_03.rs
@@ -204,91 +204,47 @@ fn test_assignability_diagnostics_route_through_relation_outcome_helpers() {
     );
 }
 
-/// Guard: when the checker downgrades a solver-related outcome via
-/// `checker_only_assignability_failure_reason` (iterator-result mismatches and
-/// peers), the structured failure reason MUST be surfaced into the
-/// `RelationOutcome.failure` slot. Otherwise TS2322/TS2345/TS2416 emit paths
-/// observe a degenerate `(related=false, failure=None)` pair and render the
-/// generic "Type 'X' is not assignable to type 'Y'." with no inner elaboration,
-/// breaking the structural rule that the `query_boundaries/assignability`
-/// gateway always returns a coherent decision-plus-reason pair.
+/// Guard: the checker-side downgrade pattern is centralized in a single
+/// `apply_checker_side_downgrade` helper so every consumer agrees on the
+/// "solver said related, checker overrides to not-related" semantics rather
+/// than open-coding the conditional at each callsite. The reason that backs
+/// the downgrade is consumed by the TS2322/TS2345 emit path through
+/// `analyze_assignability_failure` (in `error_reporter/assignability.rs:602`),
+/// which runs `raw_input_failure_reason` as a pre-pass — so the elaborated
+/// diagnostic chain stays intact without the helper itself populating
+/// `outcome.failure`. Populating `outcome.failure` from the downgrade has
+/// unrelated semantic side-effects on `outcome.failure`-reading predicates in
+/// `core_statement_checks.rs` (see #12239 conformance regression on
+/// `coAndContraVariantInferences2.ts` and `correlatedUnions.ts`).
 #[test]
 fn test_checker_only_downgrade_preserves_failure_reason_through_gateway() {
     let source = fs::read_to_string("src/assignability/assignability_relation.rs")
         .expect("failed to read src/assignability/assignability_relation.rs");
 
-    // The shared downgrade helper must exist so every consumer agrees on the
-    // "downgrade + reason recovery" semantics rather than open-coding the
-    // pattern at each callsite.
     assert!(
         source.contains("fn apply_checker_side_downgrade("),
         "assignability_relation.rs must define a single apply_checker_side_downgrade \
-         helper so all checker-side downgrades agree on preserving the failure reason"
+         helper so all checker-side downgrades agree on the downgrade semantics"
     );
 
     let downgrade_body = extract_method_body(&source, "fn apply_checker_side_downgrade(");
     assert!(
         downgrade_body.contains("outcome.related = false;"),
-        "apply_checker_side_downgrade must force outcome.related to false"
+        "apply_checker_side_downgrade must force outcome.related to false when the \
+         checker-only reason fires"
     );
-    // The reason surfacing may be inlined OR delegated to the shared
-    // `set_failure_from_reason_if_empty` helper. Accept either shape.
-    let surfaces_reason_inline = downgrade_body.contains("outcome.failure = Some(")
-        && downgrade_body.contains("RelationFailure::from_solver_reason(");
-    let surfaces_reason_via_helper =
-        downgrade_body.contains("set_failure_from_reason_if_empty(");
     assert!(
-        surfaces_reason_inline || surfaces_reason_via_helper,
-        "apply_checker_side_downgrade must surface the structured failure reason \
-         so callers don't observe (related=false, failure=None)"
-    );
-
-    // The shared helper itself must always wrap the solver reason into a
-    // `RelationFailure` and assign it iff `outcome.failure` is currently None.
-    let helper_body =
-        extract_method_body(&source, "fn set_failure_from_reason_if_empty(");
-    assert!(
-        helper_body.contains("outcome.failure.is_none()")
-            && helper_body.contains("outcome.failure = Some(")
-            && helper_body.contains("RelationFailure::from_solver_reason("),
-        "set_failure_from_reason_if_empty must guard on outcome.failure.is_none() \
-         and wrap the solver reason into a checker-facing RelationFailure"
+        downgrade_body.contains("checker_only_assignability_failure_reason("),
+        "apply_checker_side_downgrade must consult \
+         checker_only_assignability_failure_reason to decide whether to downgrade"
     );
 
     let exec_body = extract_method_body(&source, "fn execute_relation_request(");
     assert!(
         exec_body.contains("apply_checker_side_downgrade("),
         "execute_relation_request must route checker-side downgrades through \
-         apply_checker_side_downgrade so the failure reason is preserved"
-    );
-
-    // assign_relation_outcome's failed branch must recover the structured
-    // failure reason via the cheap raw-input pre-check (`raw_input_failure_reason`)
-    // when execute_relation_request's solver pass returned no reason. The
-    // pre-check covers the three raw-input families that `is_assignable_to`'s
-    // checker-side fast-paths reject but the solver pass considers related.
-    //
-    // The recovery intentionally gates on `outcome.failure.is_none()`: when
-    // the boundary already produced a reason, the TS2322 emit path consumes
-    // it through `analyze_assignability_failure` (which runs the same
-    // raw-input detectors as a pre-pass and overrides the wrapper reason
-    // there). Overriding `outcome.failure` from here would also change what
-    // `contextual_callable_member_failure_is_generic_parameter_drift` and
-    // peer `outcome.failure`-reading predicates observe, with unrelated
-    // semantic side-effects on TS2322/TS2345 conformance.
-    let assign_body = extract_method_body(&source, "fn assign_relation_outcome(");
-    assert!(
-        assign_body.contains("raw_input_failure_reason("),
-        "assign_relation_outcome must recover the structured failure reason \
-         via raw_input_failure_reason when execute_relation_request returns \
-         no reason"
-    );
-    assert!(
-        assign_body.contains("outcome.failure.is_none()"),
-        "assign_relation_outcome must only recover the failure reason when \
-         the boundary outcome lacks one — otherwise it would override an \
-         already-elaborated structured reason and silently change predicate \
-         consumers of outcome.failure"
+         apply_checker_side_downgrade so the gateway's downgrade semantics live \
+         in one place"
     );
 }
 

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_03.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_03.rs
@@ -262,42 +262,33 @@ fn test_checker_only_downgrade_preserves_failure_reason_through_gateway() {
          apply_checker_side_downgrade so the failure reason is preserved"
     );
 
-    // assign_relation_outcome's failed branch must compute the raw-input
-    // failure reason BEFORE the boundary's evaluated-shape pass and OVERRIDE
-    // any boundary reason it produced. This matches the early-return ordering
-    // of `analyze_assignability_failure`: when a raw-input detector fires the
-    // raw reason wins, because the boundary's evaluated pipeline cannot
-    // reconstruct those shapes (e.g. same-generic `C<A..>` vs `C<B..>` evaluates
-    // to incompatible object property values, producing a wrapper reason that
-    // masks tsc's direct type-argument elaboration).
+    // assign_relation_outcome's failed branch must recover the structured
+    // failure reason via the cheap raw-input pre-check (`raw_input_failure_reason`)
+    // when execute_relation_request's solver pass returned no reason. The
+    // pre-check covers the three raw-input families that `is_assignable_to`'s
+    // checker-side fast-paths reject but the solver pass considers related.
+    //
+    // The recovery intentionally gates on `outcome.failure.is_none()`: when
+    // the boundary already produced a reason, the TS2322 emit path consumes
+    // it through `analyze_assignability_failure` (which runs the same
+    // raw-input detectors as a pre-pass and overrides the wrapper reason
+    // there). Overriding `outcome.failure` from here would also change what
+    // `contextual_callable_member_failure_is_generic_parameter_drift` and
+    // peer `outcome.failure`-reading predicates observe, with unrelated
+    // semantic side-effects on TS2322/TS2345 conformance.
     let assign_body = extract_method_body(&source, "fn assign_relation_outcome(");
     assert!(
         assign_body.contains("raw_input_failure_reason("),
-        "assign_relation_outcome must compute the raw-input failure reason \
-         via raw_input_failure_reason"
+        "assign_relation_outcome must recover the structured failure reason \
+         via raw_input_failure_reason when execute_relation_request returns \
+         no reason"
     );
-    let raw_reason_idx = assign_body
-        .find("raw_input_failure_reason(")
-        .expect("raw_input_failure_reason call site not found");
-    let execute_idx = assign_body
-        .find("execute_relation_request(")
-        .expect("execute_relation_request call site not found");
     assert!(
-        raw_reason_idx < execute_idx,
-        "raw_input_failure_reason must be computed BEFORE execute_relation_request \
-         so the raw reason can override any wrapper reason the boundary's \
-         evaluated-shape pass produces"
-    );
-    let override_assigns_failure_unconditionally = assign_body
-        .contains("outcome.failure = Some(")
-        && assign_body.contains("RelationFailure::from_solver_reason(");
-    let override_uses_if_let_some =
-        assign_body.contains("if let Some(reason) = raw_reason");
-    assert!(
-        override_assigns_failure_unconditionally && override_uses_if_let_some,
-        "assign_relation_outcome must overwrite outcome.failure when the raw \
-         reason fires, not gate on outcome.failure.is_none() — otherwise the \
-         boundary's wrapper reason would shadow the raw-input elaboration"
+        assign_body.contains("outcome.failure.is_none()"),
+        "assign_relation_outcome must only recover the failure reason when \
+         the boundary outcome lacks one — otherwise it would override an \
+         already-elaborated structured reason and silently change predicate \
+         consumers of outcome.failure"
     );
 }
 

--- a/crates/tsz-checker/tests/same_generic_application_assign_outcome_tests.rs
+++ b/crates/tsz-checker/tests/same_generic_application_assign_outcome_tests.rs
@@ -1,19 +1,23 @@
-//! Regression coverage for the `assign_relation_outcome` path on
-//! same-generic `C<A..>` vs `C<B..>` mismatches.
+//! Regression coverage for the TS2322 elaboration chain on same-generic
+//! `C<A..>` vs `C<B..>` mismatches.
 //!
-//! Before #12239 the TS2322 family routed through `assign_relation_outcome`
-//! could observe a `(related=false, failure=None)` outcome OR an outcome
-//! carrying a property-wrapper reason ("Types of property 'x' are
-//! incompatible") instead of tsc's direct type-argument elaboration: the
-//! checker-side `is_assignable_to` fast-paths rejected the relation while
-//! the solver's evaluated-shape pass either yielded no reason or yielded a
-//! wrapper reason from the evaluated object shape.
+//! `analyze_assignability_failure` runs `raw_input_failure_reason` as a
+//! pre-pass and early-returns the raw same-generic-application reason. That
+//! reason is rendered as a nested elaboration entry on the top-level TS2322
+//! diagnostic (via `related_information`), not as a separate top-level
+//! diagnostic, so the TS2322 chain keeps tsc's direct type-argument
+//! elaboration ("Type 'string' is not assignable to type 'number'.") even
+//! when the boundary's evaluated-shape pass produces a wrapper reason.
 //!
-//! The fix routes the raw-input `same_generic_application_failure_reason`
-//! detector through `assign_relation_outcome` BEFORE the boundary's
-//! evaluated-shape pass, so the direct argument elaboration always wins.
-//! `analyze_assignability_failure` had this ordering already; this test
-//! exercises the parallel `assign_relation_outcome` path that emits TS2322.
+//! Note: `assign_relation_outcome` itself only recovers the raw-input reason
+//! when the boundary returned `failure=None`, to avoid changing what
+//! `outcome.failure`-reading predicates observe (see
+//! `core_statement_checks.rs:413-426` and the discussion on
+//! https://github.com/mohsen1/tsz/pull/12239#discussion_r3342820552). The
+//! TS2322 elaboration tested here does NOT consume `assign_relation_outcome
+//! .outcome.failure` — it consumes `analyze_assignability_failure` directly
+//! in `error_reporter/assignability.rs:602` — so the gating in
+//! `assign_relation_outcome` does not weaken this elaboration.
 
 use tsz_checker::diagnostics::Diagnostic;
 use tsz_checker::test_utils::check_source_diagnostics;
@@ -22,24 +26,40 @@ fn diagnostics(source: &str) -> Vec<Diagnostic> {
     check_source_diagnostics(source)
 }
 
-/// Collect the full diagnostic chain text from `message_text` plus any
-/// `related_information` sub-messages, recursively. TS2322 elaborations
-/// (e.g. "Types of property 'x' are incompatible." → "Type 'string' is
-/// not assignable to type 'number'.") live as nested related-information
-/// entries on the top-level diagnostic, not as separate top-level diags.
-fn full_chain_text(diag: &Diagnostic) -> String {
-    let mut out = diag.message_text.clone();
+/// Return true iff `diag` (TS2322) has at least one related-information
+/// entry whose message asserts the differing direct type arguments. The
+/// canonical tsc forms are:
+///
+/// - `Type 'A' is not assignable to type 'B'.`
+/// - `Types of property '<name>' are incompatible.` followed by the above
+///
+/// We check for the former exact wording, which can only be produced by the
+/// nested elaboration — the top-level message wraps the operands in
+/// `'Box<A>'`/`'Box<B>'` style and CANNOT yield the bare argument forms.
+fn has_argument_elaboration(diag: &Diagnostic, source_arg: &str, target_arg: &str) -> bool {
+    let needle = format!("Type '{source_arg}' is not assignable to type '{target_arg}'.");
+    diag.related_information
+        .iter()
+        .any(|related| related.message_text.contains(&needle))
+}
+
+/// Pretty-print a TS2322 diagnostic and its related-information chain for
+/// assertion failure output.
+fn format_chain(diag: &Diagnostic) -> String {
+    let mut out = format!("[top] {}", diag.message_text);
     for related in &diag.related_information {
-        out.push_str(" / ");
-        out.push_str(&related.message_text);
+        out.push_str(&format!(
+            "\n  [related@{}] {}",
+            related.start, related.message_text
+        ));
     }
     out
 }
 
 /// Assignment from `Box<string>` to `Box<number>` (same generic, differing
-/// args) must produce a TS2322 whose elaboration chain mentions the
-/// differing type arguments — not a bare top-level mismatch with no inner
-/// cause.
+/// args) must produce a TS2322 with a nested argument elaboration entry
+/// ("Type 'string' is not assignable to type 'number'."), not just a bare
+/// top-level "Type 'Box<string>' is not assignable to type 'Box<number>'."
 #[test]
 fn same_generic_application_assign_keeps_argument_elaboration() {
     let source = r#"
@@ -53,17 +73,26 @@ declare const b: Box<number> = a;
         !ts2322.is_empty(),
         "expected TS2322 on Box<string> -> Box<number>, got: {diags:?}"
     );
-    let chain = ts2322
+
+    // Must have the nested argument elaboration on at least one TS2322
+    // diagnostic. The top-level message embeds the operands as `'Box<string>'`
+    // / `'Box<number>'` so a substring check for `'string'`/`'number'` would
+    // be satisfied vacuously — assert the exact tsc elaboration wording
+    // instead, which can only come from the nested chain.
+    let has_elaboration = ts2322
         .iter()
-        .map(|d| full_chain_text(d))
-        .collect::<Vec<_>>()
-        .join(" || ");
-    let elaborates_arguments = chain.contains("'string'") && chain.contains("'number'");
+        .any(|d| has_argument_elaboration(d, "string", "number"));
     assert!(
-        elaborates_arguments,
-        "TS2322 must elaborate the differing type arguments (string vs number) \
-         instead of a bare top-level mismatch with no inner cause. \
-         got chain: {chain}"
+        has_elaboration,
+        "TS2322 must include a nested argument elaboration \
+         \"Type 'string' is not assignable to type 'number'.\" \
+         (mirrors tsc's direct type-argument chain). \
+         got diagnostics:\n{}",
+        ts2322
+            .iter()
+            .map(|d| format_chain(d))
+            .collect::<Vec<_>>()
+            .join("\n---\n")
     );
 }
 
@@ -82,15 +111,20 @@ declare const dst: Container<string> = src;
         !ts2322.is_empty(),
         "expected TS2322 on Container<boolean> -> Container<string>, got: {diags:?}"
     );
-    let chain = ts2322
+
+    let has_elaboration = ts2322
         .iter()
-        .map(|d| full_chain_text(d))
-        .collect::<Vec<_>>()
-        .join(" || ");
-    let elaborates_arguments = chain.contains("'boolean'") && chain.contains("'string'");
+        .any(|d| has_argument_elaboration(d, "boolean", "string"));
     assert!(
-        elaborates_arguments,
-        "TS2322 must elaborate the differing type arguments (boolean vs string) \
-         regardless of identifier names. got chain: {chain}"
+        has_elaboration,
+        "TS2322 must include a nested argument elaboration \
+         \"Type 'boolean' is not assignable to type 'string'.\" \
+         regardless of identifier names. \
+         got diagnostics:\n{}",
+        ts2322
+            .iter()
+            .map(|d| format_chain(d))
+            .collect::<Vec<_>>()
+            .join("\n---\n")
     );
 }

--- a/crates/tsz-checker/tests/same_generic_application_assign_outcome_tests.rs
+++ b/crates/tsz-checker/tests/same_generic_application_assign_outcome_tests.rs
@@ -1,0 +1,96 @@
+//! Regression coverage for the `assign_relation_outcome` path on
+//! same-generic `C<A..>` vs `C<B..>` mismatches.
+//!
+//! Before #12239 the TS2322 family routed through `assign_relation_outcome`
+//! could observe a `(related=false, failure=None)` outcome OR an outcome
+//! carrying a property-wrapper reason ("Types of property 'x' are
+//! incompatible") instead of tsc's direct type-argument elaboration: the
+//! checker-side `is_assignable_to` fast-paths rejected the relation while
+//! the solver's evaluated-shape pass either yielded no reason or yielded a
+//! wrapper reason from the evaluated object shape.
+//!
+//! The fix routes the raw-input `same_generic_application_failure_reason`
+//! detector through `assign_relation_outcome` BEFORE the boundary's
+//! evaluated-shape pass, so the direct argument elaboration always wins.
+//! `analyze_assignability_failure` had this ordering already; this test
+//! exercises the parallel `assign_relation_outcome` path that emits TS2322.
+
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn diagnostics(source: &str) -> Vec<Diagnostic> {
+    check_source_diagnostics(source)
+}
+
+/// Collect the full diagnostic chain text from `message_text` plus any
+/// `related_information` sub-messages, recursively. TS2322 elaborations
+/// (e.g. "Types of property 'x' are incompatible." → "Type 'string' is
+/// not assignable to type 'number'.") live as nested related-information
+/// entries on the top-level diagnostic, not as separate top-level diags.
+fn full_chain_text(diag: &Diagnostic) -> String {
+    let mut out = diag.message_text.clone();
+    for related in &diag.related_information {
+        out.push_str(" / ");
+        out.push_str(&related.message_text);
+    }
+    out
+}
+
+/// Assignment from `Box<string>` to `Box<number>` (same generic, differing
+/// args) must produce a TS2322 whose elaboration chain mentions the
+/// differing type arguments — not a bare top-level mismatch with no inner
+/// cause.
+#[test]
+fn same_generic_application_assign_keeps_argument_elaboration() {
+    let source = r#"
+interface Box<T> { value: T; }
+declare const a: Box<string>;
+declare const b: Box<number> = a;
+"#;
+    let diags = diagnostics(source);
+    let ts2322: Vec<&Diagnostic> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert!(
+        !ts2322.is_empty(),
+        "expected TS2322 on Box<string> -> Box<number>, got: {diags:?}"
+    );
+    let chain = ts2322
+        .iter()
+        .map(|d| full_chain_text(d))
+        .collect::<Vec<_>>()
+        .join(" || ");
+    let elaborates_arguments = chain.contains("'string'") && chain.contains("'number'");
+    assert!(
+        elaborates_arguments,
+        "TS2322 must elaborate the differing type arguments (string vs number) \
+         instead of a bare top-level mismatch with no inner cause. \
+         got chain: {chain}"
+    );
+}
+
+/// Renamed binders must not change the rule — the fix keys on the
+/// structural same-base-application shape, not on identifier spelling.
+#[test]
+fn same_generic_application_assign_keeps_argument_elaboration_renamed() {
+    let source = r#"
+interface Container<X> { contents: X; }
+declare const src: Container<boolean>;
+declare const dst: Container<string> = src;
+"#;
+    let diags = diagnostics(source);
+    let ts2322: Vec<&Diagnostic> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert!(
+        !ts2322.is_empty(),
+        "expected TS2322 on Container<boolean> -> Container<string>, got: {diags:?}"
+    );
+    let chain = ts2322
+        .iter()
+        .map(|d| full_chain_text(d))
+        .collect::<Vec<_>>()
+        .join(" || ");
+    let elaborates_arguments = chain.contains("'boolean'") && chain.contains("'string'");
+    assert!(
+        elaborates_arguments,
+        "TS2322 must elaborate the differing type arguments (boolean vs string) \
+         regardless of identifier names. got chain: {chain}"
+    );
+}

--- a/crates/tsz-checker/tests/same_generic_application_assign_outcome_tests.rs
+++ b/crates/tsz-checker/tests/same_generic_application_assign_outcome_tests.rs
@@ -13,7 +13,7 @@
 //! when the boundary returned `failure=None`, to avoid changing what
 //! `outcome.failure`-reading predicates observe (see
 //! `core_statement_checks.rs:413-426` and the discussion on
-//! https://github.com/mohsen1/tsz/pull/12239#discussion_r3342820552). The
+//! <https://github.com/mohsen1/tsz/pull/12239#discussion_r3342820552>). The
 //! TS2322 elaboration tested here does NOT consume `assign_relation_outcome
 //! .outcome.failure` — it consumes `analyze_assignability_failure` directly
 //! in `error_reporter/assignability.rs:602` — so the gating in

--- a/crates/tsz-checker/tests/same_generic_application_assign_outcome_tests.rs
+++ b/crates/tsz-checker/tests/same_generic_application_assign_outcome_tests.rs
@@ -9,15 +9,15 @@
 //! elaboration ("Type 'string' is not assignable to type 'number'.") even
 //! when the boundary's evaluated-shape pass produces a wrapper reason.
 //!
-//! Note: `assign_relation_outcome` itself only recovers the raw-input reason
-//! when the boundary returned `failure=None`, to avoid changing what
-//! `outcome.failure`-reading predicates observe (see
-//! `core_statement_checks.rs:413-426` and the discussion on
+//! Note: `assign_relation_outcome` itself does NOT populate `outcome.failure`
+//! with the raw-input reason — doing so changed what
+//! `outcome.failure`-reading predicates observe in `core_statement_checks.rs:413-426`
+//! and caused a real conformance regression on `coAndContraVariantInferences2.ts`
+//! and `correlatedUnions.ts` (see the review discussion on
 //! <https://github.com/mohsen1/tsz/pull/12239#discussion_r3342820552>). The
-//! TS2322 elaboration tested here does NOT consume `assign_relation_outcome
-//! .outcome.failure` — it consumes `analyze_assignability_failure` directly
-//! in `error_reporter/assignability.rs:602` — so the gating in
-//! `assign_relation_outcome` does not weaken this elaboration.
+//! TS2322 elaboration tested here flows through `analyze_assignability_failure`
+//! directly in `error_reporter/assignability.rs:602`, independent of the
+//! `assign_relation_outcome` outcome's `failure` field.
 
 use tsz_checker::diagnostics::Diagnostic;
 use tsz_checker::test_utils::check_source_diagnostics;


### PR DESCRIPTION
AgentName: Studio-B

Original runner: `cloud-opus47-1m-confident-thompson-ppDw9`

## Track
Checker / query-boundary architectural cleanup.

## Invariant (structural rule)
> The shared `query_boundaries/assignability` gateway has ONE place per call shape that decides "solver said related, but a checker-side semantic rule overrides to not-related". Both the canonical and env-aware paths route this through `apply_checker_side_downgrade` (in `assignability_relation.rs`), keeping the downgrade conditional out of `execute_relation_request` / `assign_relation_outcome_with_env` callsites. Separately, `analyze_assignability_failure` consolidates the three raw-input failure detectors (index-access type-param mismatch, abstract-constructor assignment, same-generic application) behind a single `raw_input_failure_reason` helper so the pre-pass and any future callers share one source of truth.

Owner layer: `crates/tsz-checker/src/assignability/`. Targets the architectural cleanup angle of #10901; the original "preserve failure reason in `RelationOutcome.failure`" framing turned out to be unnecessary — the TS2322/TS2345/TS2416 emit path re-derives the reason via `analyze_assignability_failure(source, target)` (in `error_reporter/assignability.rs:602`), not from `assign_relation_outcome.outcome.failure`. The elaborated diagnostic chain was already correct on main; this PR only consolidates the helpers and adds a regression test that pins the elaboration.

## Scope
1. **`apply_checker_side_downgrade` helper** (`assignability_relation.rs:185-210`). Centralizes the pattern
   ```
   if outcome.related && checker_only_assignability_failure_reason(...).is_some() { outcome.related = false; }
   ```
   so `execute_relation_request` and `assign_relation_outcome_with_env` no longer open-code it.
2. **`raw_input_failure_reason` helper** (`assignability_diagnostics.rs:1493`). Extracts the three raw-input pre-checks previously inlined at the top of `analyze_assignability_failure`. No behavior change — `analyze_assignability_failure` now calls `raw_input_failure_reason(...)` once instead of three inline `if let Some(reason) = ...` blocks.
3. **`same_generic_application_assign_outcome_tests`** regression test. Asserts that TS2322 for `Box<string>` → `Box<number>` (and the `Container<boolean>` / `Container<string>` renamed twin) keeps tsc's nested elaboration `Type 'string' is not assignable to type 'number'.` — checked exactly in `related_information`, NOT as a substring on the top-level message (the top-level contains `'Box<string>'` which trivially matches `'string'`).
4. **Architecture-contract test fixups in `part_02.rs`**:
   - `test_assignability_checker_has_execute_relation_request` now reads `src/assignability/assignability_relation.rs` (the actual host file) instead of the stale `assignability_checker.rs` reference.
   - `test_diagnostic_paths_use_relation_outcome_hint` and `test_call_arg_diagnostic_uses_canonical_relation_path` now assert the named-helper invocations (`assign_relation_outcome(`, `call_arg_relation_outcome(`) instead of the raw `RelationRequest::*` builders — aligning with `test_assignability_diagnostics_route_through_relation_outcome_helpers` in `part_03.rs` which explicitly forbids the builders in the diagnostic files.
   - `test_bivariant_relation_boundary_preserves_overflow_flags` corrected to read `assignability_relation.rs` and accept both short and fully-qualified `RelationKind`/`RelationResult` paths.
5. **New `test_checker_only_downgrade_preserves_failure_reason_through_gateway`** (in `part_03.rs`) pins the centralized-helper invariant: `apply_checker_side_downgrade` must exist, must downgrade via `outcome.related = false`, and must consult `checker_only_assignability_failure_reason`; `execute_relation_request` must route through the helper.

## What this PR does NOT do (and why)
- **Does not populate `outcome.failure` from the downgrade or from `assign_relation_outcome`'s failed branch.** Attempting that (commits 9edfb13 / 79754fa) caused unlisted conformance regressions on `coAndContraVariantInferences2.ts` and `correlatedUnions.ts` because `outcome.failure` is consumed by `contextual_callable_member_failure_is_generic_parameter_drift` and the `is_none()`-gated `contextual_callable_member_has_unclassified_generic_parameter_drift` fallback in `core_statement_checks.rs:413-426`. Changing the field flipped predicate decisions in generic-inference-with-constraints flows. See https://github.com/mohsen1/tsz/pull/12239#discussion_r3342820552 for the full thread.
- The TS2322 elaboration chain is unchanged from main — the diagnostic emit path was already calling `analyze_assignability_failure` (which already had the raw-input pre-pass behavior the original framing wanted) before this PR.

## Project Corpus Impact
- Row: utility-types-project (issue #10901)
- Bug family: TS2322 family path bypasses query boundaries in nested conditional calls

No semantic changes to relation decisions or diagnostic chains. Project-row diagnostic counts are unchanged from main.

## Verification
- `cargo nextest run -p tsz-checker --lib architecture_contract` — touched tests all pass.
- `cargo nextest run -p tsz-checker --test same_generic_application_assign_outcome_tests` — both regression tests pass; assertions verify the nested `Type 'string' is not assignable to type 'number'.` elaboration on `related_information`, not a vacuous substring match.
- Compile-clean: `cargo check -p tsz-checker --lib --tests`.
- Awaiting exact-head CI on head `f13e9e4` (conformance-aggregate is the gating signal — earlier conformance regressions are fixed by dropping `outcome.failure` population).

## Coordination Notes
- Auto-merge was disabled by `M5Manager-Studio-Review` (repo policy uses the local `merge-queue` label after exact-head green evidence); not re-enabling.
- `/simplify` was run 3 times during the original implementation. After this revert, the helpers/refactors that remain are the ones that passed all three rounds plus the conformance gate.
- The remaining 13 pre-existing architecture-contract failures (`test_relation_outcome_has_property_classification`, `test_simple_object_epc_uses_boundary_classification`, `test_no_inline_solver_function_calls_in_checker_modules`, etc.) are out of scope — they reference older code patterns/file paths and need separate follow-up.

https://claude.ai/code/session_019DRow1wJrdLML99du2L58q
