### PR TITLE
fix(checker): preserve imported generic alias params

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mod.rs
@@ -764,6 +764,22 @@ impl<'a> CheckerState<'a> {
     ) -> bool {
         use tsz_binder::symbol_flags;
         let mut sym_id = sym_id;
+        let syntax_base_name = self
+            .ctx
+            .arena
+            .get(type_ref_idx)
+            .and_then(|node| self.ctx.arena.get_type_ref(node))
+            .and_then(|type_ref| self.entity_name_text(type_ref.type_name));
+        let mut import_base_name = None;
+        if let Some(base_name) = syntax_base_name.as_deref()
+            && let Some(alias_sym_id) = self.ctx.binder.file_locals.get(base_name)
+            && let Some(alias_symbol) = self.ctx.binder.get_symbol(alias_sym_id)
+            && self.reference_symbol_is_import_alias(alias_symbol)
+            && let Some(target) = self.resolve_import_alias_cross_file(alias_sym_id)
+        {
+            sym_id = target;
+            import_base_name = Some(base_name.to_owned());
+        }
         if let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
             && symbol.has_any_flags(symbol_flags::ALIAS)
         {
@@ -808,10 +824,13 @@ impl<'a> CheckerState<'a> {
         }
 
         let lib_binders = self.get_lib_binders();
-        let base_name = self
-            .get_symbol_from_registered_file_target(sym_id)
-            .or_else(|| self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders))
-            .map_or_else(|| "<unknown>".to_string(), |s| s.escaped_name.clone());
+        let base_name = import_base_name.unwrap_or_else(|| {
+            self.get_symbol_from_registered_file_target(sym_id)
+                .or_else(|| self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders))
+                .map_or_else(|| "<unknown>".to_string(), |s| s.escaped_name.clone())
+        });
+
+        let type_params = self.get_reference_type_params_for_symbol(sym_id, &base_name);
 
         // A type alias that circularly references itself collapses to a
         // non-generic error type. Applying type arguments to it is therefore
@@ -819,7 +838,9 @@ impl<'a> CheckerState<'a> {
         // behavior; a bare reference yields no diagnostic. This must override
         // the normal arity checks below, which would otherwise read the stale
         // generic parameter list off the AST and emit TS2314.
-        if self.type_reference_alias_collapsed_to_error(sym_id) {
+        if self.type_reference_alias_collapsed_to_error(sym_id)
+            && (type_params.is_empty() || self.type_alias_is_generic_self_circular(sym_id))
+        {
             if !type_args_list.nodes.is_empty() {
                 let error_anchor = self
                     .ctx
@@ -840,7 +861,6 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        let type_params = self.get_reference_type_params_for_symbol(sym_id, &base_name);
         if type_params.is_empty() {
             // Before emitting TS2315, check if this symbol's declaration actually has
             // type parameters. Cross-arena symbols (e.g., lib types like Awaited<T>)

--- a/crates/tsz-checker/src/context/caches.rs
+++ b/crates/tsz-checker/src/context/caches.rs
@@ -12,12 +12,11 @@ pub struct TypeReferenceValidationCaches {
     /// Syntax-guided type-reference argument instantiations in the current
     /// lexical type-parameter scope, including misses.
     pub syntax_instantiation: FxHashMap<(usize, u32, TypeId, u64), Option<TypeId>>,
-    /// Declared type-parameter lists keyed by `SymbolId`, valid for the
-    /// lifetime of the current source file.  Multiple type-reference nodes
-    /// that point to the same generic utility type would otherwise each
-    /// trigger a full `extract_declared_type_params_for_reference_symbol`
-    /// walk including O(N²) `push_type_parameters` refinement passes.
-    pub ref_type_params: FxHashMap<SymbolId, Vec<TypeParamInfo>>,
+    /// Declared type-parameter lists keyed by reference symbol identity, valid
+    /// for the lifetime of the current source file. `SymbolId` values are
+    /// arena-local in project checks, so imported aliases from different files
+    /// can share the same raw id while declaring different arities.
+    pub ref_type_params: FxHashMap<(SymbolId, Option<usize>, String), Vec<TypeParamInfo>>,
 }
 
 /// Sparse cache for node-index-keyed `TypeId` lookups.

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_circular.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_circular.rs
@@ -90,6 +90,15 @@ impl<'a> CheckerState<'a> {
     /// non-generic error type: either it was already recorded as circular, or
     /// it is a generic self-application cycle.
     pub(crate) fn type_reference_alias_collapsed_to_error(&self, sym_id: SymbolId) -> bool {
+        if let Some(file_idx) = self.ctx.resolve_symbol_file_index(sym_id)
+            && file_idx != self.ctx.current_file_idx
+            && !std::ptr::eq(self.ctx.get_arena_for_file(file_idx as u32), self.ctx.arena)
+        {
+            return self
+                .ctx
+                .get_existing_def_id(sym_id)
+                .is_some_and(|def_id| self.ctx.definition_store.is_circular_def(def_id));
+        }
         self.ctx.circular_type_aliases.contains(&sym_id)
             || self.type_alias_is_generic_self_circular(sym_id)
     }

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_alias_cycle.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_alias_cycle.rs
@@ -13,6 +13,7 @@
 
 use crate::state::CheckerState;
 use tsz_binder::{Symbol, SymbolId, symbol_flags};
+use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::def::DefId;
 
@@ -115,6 +116,28 @@ impl<'a> CheckerState<'a> {
         symbol: &Symbol,
         sym_id: SymbolId,
     ) -> bool {
+        if let Some(owner_file_idx) = self.ctx.resolve_symbol_file_index(sym_id)
+            && owner_file_idx != self.ctx.current_file_idx
+            && let Some(owner_arena) = self
+                .ctx
+                .all_arenas
+                .as_ref()
+                .and_then(|arenas| arenas.get(owner_file_idx))
+            && symbol.declarations.iter().any(|&decl| {
+                owner_arena
+                    .get(decl)
+                    .and_then(|node| {
+                        (node.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION)
+                            .then(|| owner_arena.get_type_alias(node))
+                            .flatten()
+                    })
+                    .and_then(|type_alias| owner_arena.get_identifier_text(type_alias.name))
+                    .is_some_and(|name| name == symbol.escaped_name)
+            })
+        {
+            return false;
+        }
+
         symbol.declarations.iter().any(|&decl| {
             if self.ctx.binder.get_node_symbol(decl) != Some(sym_id) {
                 return false;

--- a/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
+++ b/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
@@ -44,25 +44,26 @@ impl<'a> CheckerState<'a> {
         sym_id: SymbolId,
         expected_name: &str,
     ) -> Vec<tsz_solver::TypeParamInfo> {
+        let cache_key = self.reference_type_params_cache_key(sym_id, expected_name);
         if let Some(cached) = self
             .ctx
             .type_reference_validation_caches
             .ref_type_params
-            .get(&sym_id)
+            .get(&cache_key)
         {
             return cached.clone();
         }
         let declared =
-            self.extract_declared_type_params_for_reference_symbol(sym_id, expected_name);
+            self.extract_declared_type_params_for_reference_symbol(cache_key.0, expected_name);
         let result = if !declared.is_empty() {
             declared
         } else {
-            self.get_display_type_params_for_symbol(sym_id)
+            self.get_display_type_params_for_symbol(cache_key.0)
         };
         self.ctx
             .type_reference_validation_caches
             .ref_type_params
-            .insert(sym_id, result.clone());
+            .insert(cache_key, result.clone());
         result
     }
 
@@ -71,16 +72,17 @@ impl<'a> CheckerState<'a> {
         sym_id: SymbolId,
         expected_name: &str,
     ) -> usize {
+        let cache_key = self.reference_type_params_cache_key(sym_id, expected_name);
         if let Some(cached) = self
             .ctx
             .type_reference_validation_caches
             .ref_type_params
-            .get(&sym_id)
+            .get(&cache_key)
         {
             return cached.iter().filter(|p| p.default.is_none()).count();
         }
         let declared =
-            self.extract_declared_type_params_for_reference_symbol(sym_id, expected_name);
+            self.extract_declared_type_params_for_reference_symbol(cache_key.0, expected_name);
         if !declared.is_empty() {
             let count = declared
                 .iter()
@@ -89,10 +91,129 @@ impl<'a> CheckerState<'a> {
             self.ctx
                 .type_reference_validation_caches
                 .ref_type_params
-                .insert(sym_id, declared);
+                .insert(cache_key, declared);
             return count;
         }
-        self.count_required_type_params(sym_id)
+        self.count_required_type_params(cache_key.0)
+    }
+
+    fn reference_type_params_cache_key(
+        &self,
+        sym_id: SymbolId,
+        expected_name: &str,
+    ) -> (SymbolId, Option<usize>, String) {
+        let (sym_id, file_idx) = self
+            .reference_type_params_import_target(sym_id, expected_name)
+            .unwrap_or_else(|| (sym_id, self.ctx.resolve_symbol_file_index(sym_id)));
+        (sym_id, file_idx, expected_name.to_owned())
+    }
+
+    fn reference_type_params_import_target(
+        &self,
+        sym_id: SymbolId,
+        expected_name: &str,
+    ) -> Option<(SymbolId, Option<usize>)> {
+        let alias_symbol = self
+            .ctx
+            .binder
+            .file_locals
+            .get(expected_name)
+            .and_then(|alias_sym_id| self.ctx.binder.get_symbol(alias_sym_id))
+            .or_else(|| self.ctx.binder.get_symbol(sym_id))?;
+        if !self.reference_symbol_is_import_alias(alias_symbol) {
+            return None;
+        }
+        self.reference_import_alias_export_target(alias_symbol, expected_name)
+    }
+
+    fn reference_import_alias_export_target(
+        &self,
+        alias_symbol: &tsz_binder::Symbol,
+        expected_name: &str,
+    ) -> Option<(SymbolId, Option<usize>)> {
+        let module_specifier = alias_symbol.import_module.as_ref()?;
+        let import_name = alias_symbol.import_name.as_deref().unwrap_or(expected_name);
+        let source_file_idx = if alias_symbol.decl_file_idx == u32::MAX {
+            self.ctx.current_file_idx
+        } else {
+            alias_symbol.decl_file_idx as usize
+        };
+        if let Some(target_file_idx) = self
+            .ctx
+            .resolve_import_target_from_file(source_file_idx, module_specifier)
+        {
+            let mut visited = rustc_hash::FxHashSet::default();
+            if let Some((target_sym_id, actual_file_idx)) =
+                self.resolve_export_in_file(target_file_idx, import_name, &mut visited)
+                && self
+                    .ctx
+                    .get_binder_for_file(actual_file_idx)
+                    .and_then(|binder| binder.get_symbol(target_sym_id))
+                    .is_none_or(|symbol| symbol.import_module.is_none())
+            {
+                self.ctx
+                    .register_symbol_file_target(target_sym_id, actual_file_idx);
+                return Some((target_sym_id, Some(actual_file_idx)));
+            }
+        }
+
+        let target_sym_id = self.resolve_cross_file_export_from_file(
+            module_specifier,
+            import_name,
+            Some(source_file_idx),
+        )?;
+        let target_file_idx = self
+            .ctx
+            .resolve_symbol_file_index_stable(target_sym_id)
+            .or_else(|| self.ctx.resolve_symbol_file_index(target_sym_id));
+        if let Some(file_idx) = target_file_idx {
+            self.ctx
+                .register_symbol_file_target(target_sym_id, file_idx);
+        }
+        Some((target_sym_id, target_file_idx))
+    }
+
+    pub(crate) fn reference_symbol_is_import_alias(&self, symbol: &tsz_binder::Symbol) -> bool {
+        let arena = if symbol.decl_file_idx == u32::MAX {
+            self.ctx.arena
+        } else {
+            self.ctx.get_arena_for_file(symbol.decl_file_idx)
+        };
+        symbol.has_any_flags(symbol_flags::ALIAS)
+            && symbol.import_module.is_some()
+            && symbol
+                .declarations
+                .iter()
+                .copied()
+                .any(|decl_idx| self.reference_decl_is_import_alias_syntax(arena, decl_idx))
+    }
+
+    fn reference_decl_is_import_alias_syntax(
+        &self,
+        arena: &NodeArena,
+        mut decl_idx: NodeIndex,
+    ) -> bool {
+        for _ in 0..4 {
+            let Some(node) = arena.get(decl_idx) else {
+                return false;
+            };
+            if node.kind == syntax_kind_ext::IMPORT_SPECIFIER
+                || node.kind == syntax_kind_ext::IMPORT_CLAUSE
+                || node.kind == syntax_kind_ext::NAMESPACE_IMPORT
+                || node.kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION
+            {
+                return true;
+            }
+            let Some(extended) = arena.get_extended(decl_idx) else {
+                return false;
+            };
+            let parent_idx = extended.parent;
+            if parent_idx == NodeIndex::NONE {
+                return false;
+            }
+            decl_idx = parent_idx;
+        }
+        false
     }
 
     pub(crate) fn symbol_has_declared_type_meaning(&self, sym_id: SymbolId) -> bool {
@@ -469,19 +590,48 @@ impl<'a> CheckerState<'a> {
         sym_id: SymbolId,
         expected_name: &str,
     ) -> Vec<tsz_solver::TypeParamInfo> {
+        let mut effective_sym_id = sym_id;
+        let import_target = self
+            .ctx
+            .binder
+            .file_locals
+            .get(expected_name)
+            .and_then(|alias_sym_id| self.ctx.binder.get_symbol(alias_sym_id))
+            .or_else(|| self.ctx.binder.get_symbol(sym_id))
+            .filter(|alias_symbol| self.reference_symbol_is_import_alias(alias_symbol))
+            .and_then(|alias_symbol| {
+                self.reference_import_alias_export_target(alias_symbol, expected_name)
+            });
+        if let Some((target_sym_id, target_idx)) = import_target {
+            if let Some(target_idx) = target_idx {
+                self.ctx
+                    .register_symbol_file_target(target_sym_id, target_idx);
+            }
+            effective_sym_id = target_sym_id;
+        }
+
         let Some(symbol) = self
-            .get_symbol_from_registered_file_target(sym_id)
-            .or_else(|| self.get_cross_file_symbol(sym_id))
+            .get_symbol_from_registered_file_target(effective_sym_id)
+            .or_else(|| self.get_cross_file_symbol(effective_sym_id))
         else {
             return Vec::new();
         };
         let declarations = symbol.declarations.clone();
+        let imported_decl_name = self
+            .ctx
+            .binder
+            .file_locals
+            .get(expected_name)
+            .and_then(|alias_sym_id| self.ctx.binder.get_symbol(alias_sym_id))
+            .or_else(|| self.ctx.binder.get_symbol(sym_id))
+            .filter(|alias_symbol| self.reference_symbol_is_import_alias(alias_symbol))
+            .and_then(|alias_symbol| alias_symbol.import_name.clone());
         let mixed_class_interface = symbol.has_any_flags(symbol_flags::CLASS)
             && symbol.has_any_flags(symbol_flags::INTERFACE);
 
         if symbol.has_any_flags(symbol_flags::CLASS)
-            && let Some(file_idx) = self.ctx.resolve_symbol_file_index(sym_id)
-            && file_idx != self.ctx.current_file_idx
+            && let Some(file_idx) = self.ctx.resolve_symbol_file_index(effective_sym_id)
+            && !std::ptr::eq(self.ctx.get_arena_for_file(file_idx as u32), self.ctx.arena)
         {
             let decl_arena = self.ctx.get_arena_for_file(file_idx as u32);
             for &decl_idx in &declarations {
@@ -508,22 +658,49 @@ impl<'a> CheckerState<'a> {
         let mut merged: Vec<tsz_solver::TypeParamInfo> = Vec::new();
         let mut jsdoc_fallback: Option<Vec<tsz_solver::TypeParamInfo>> = None;
         for &decl_idx in &declarations {
-            let decl_arenas: Vec<&NodeArena> = self
-                .ctx
-                .binder
-                .declaration_arenas
-                .get(&(sym_id, decl_idx))
-                .map(|arenas| arenas.iter().map(std::convert::AsRef::as_ref).collect())
-                .or_else(|| {
-                    self.ctx
-                        .binder
-                        .symbol_arenas
-                        .get(&sym_id)
-                        .map(|arena| vec![arena.as_ref()])
-                })
-                .unwrap_or_else(|| vec![self.ctx.arena]);
+            let cross_file_arena = if let Some(file_idx) =
+                self.ctx.resolve_symbol_file_index(effective_sym_id)
+                && let Some(arena) = self
+                    .ctx
+                    .all_arenas
+                    .as_ref()
+                    .and_then(|arenas| arenas.get(file_idx).cloned())
+                && !std::ptr::eq(arena.as_ref(), self.ctx.arena)
+            {
+                Some(arena)
+            } else {
+                None
+            };
+            let decl_arenas: Vec<(&NodeArena, bool)> = if let Some(arena) =
+                cross_file_arena.as_deref()
+            {
+                vec![(arena, false)]
+            } else {
+                self.ctx
+                    .binder
+                    .declaration_arenas
+                    .get(&(effective_sym_id, decl_idx))
+                    .map(|arenas| {
+                        arenas
+                            .iter()
+                            .map(|arena| {
+                                (arena.as_ref(), std::ptr::eq(arena.as_ref(), self.ctx.arena))
+                            })
+                            .collect()
+                    })
+                    .or_else(|| {
+                        self.ctx
+                            .binder
+                            .symbol_arenas
+                            .get(&effective_sym_id)
+                            .map(|arena| {
+                                vec![(arena.as_ref(), std::ptr::eq(arena.as_ref(), self.ctx.arena))]
+                            })
+                    })
+                    .unwrap_or_else(|| vec![(self.ctx.arena, true)])
+            };
 
-            for decl_arena in decl_arenas {
+            for (decl_arena, is_current_arena) in decl_arenas {
                 let Some(node) = decl_arena.get(decl_idx) else {
                     continue;
                 };
@@ -534,10 +711,11 @@ impl<'a> CheckerState<'a> {
                     if let Some(name_node) = decl_arena.get(type_alias.name)
                         && let Some(ident) = decl_arena.get_identifier(name_node)
                         && ident.escaped_text != expected_name
+                        && imported_decl_name.as_deref() != Some(ident.escaped_text.as_str())
                     {
                         continue;
                     }
-                    let params = if std::ptr::eq(decl_arena, self.ctx.arena) {
+                    let params = if is_current_arena {
                         let (params, updates) =
                             self.push_type_parameters(&type_alias.type_parameters);
                         self.pop_type_parameters(updates);
@@ -599,10 +777,11 @@ impl<'a> CheckerState<'a> {
                     if let Some(name_node) = decl_arena.get(iface.name)
                         && let Some(ident) = decl_arena.get_identifier(name_node)
                         && ident.escaped_text != expected_name
+                        && imported_decl_name.as_deref() != Some(ident.escaped_text.as_str())
                     {
                         continue;
                     }
-                    let params = if std::ptr::eq(decl_arena, self.ctx.arena) {
+                    let params = if is_current_arena {
                         let (params, updates) = self.push_type_parameters(&iface.type_parameters);
                         self.pop_type_parameters(updates);
                         params
@@ -663,10 +842,11 @@ impl<'a> CheckerState<'a> {
                     if let Some(name_node) = decl_arena.get(class.name)
                         && let Some(ident) = decl_arena.get_identifier(name_node)
                         && ident.escaped_text != expected_name
+                        && imported_decl_name.as_deref() != Some(ident.escaped_text.as_str())
                     {
                         continue;
                     }
-                    if std::ptr::eq(decl_arena, self.ctx.arena) {
+                    if is_current_arena {
                         let (params, updates) = self.push_type_parameters(&class.type_parameters);
                         self.pop_type_parameters(updates);
                         if !params.is_empty() {

--- a/crates/tsz-checker/src/tests/ref_type_params_cache_tests.rs
+++ b/crates/tsz-checker/src/tests/ref_type_params_cache_tests.rs
@@ -1,4 +1,5 @@
-use crate::test_utils::check_source_diagnostics;
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_multi_file_with_global_index, check_source_diagnostics};
 
 /// When multiple type references in the same alias body refer to the same
 /// generic utility type, tsz must resolve that type's parameter list once per
@@ -235,5 +236,128 @@ type E10 = Either<E03, E04>;
         errors.len(),
         0,
         "Ten valid instantiations of Either should produce no errors; got: {errors:#?}"
+    );
+}
+
+#[test]
+fn imported_ref_type_params_cache_is_keyed_by_target_file() {
+    let diags = check_multi_file_with_global_index(
+        &[
+            (
+                "sources/List/one.ts",
+                r#"
+export type Key = string | number | symbol;
+export type List<A = any> = readonly A[];
+export type One<T, Path extends List<Key>, M extends any = any> = {
+    readonly one: T;
+    readonly path: Path;
+    readonly match: M;
+};
+"#,
+            ),
+            (
+                "sources/Object/two.ts",
+                r#"
+export type Key = string | number | symbol;
+export type Two<K extends Key, V extends any = unknown> = {
+    readonly key: K;
+    readonly value: V;
+};
+"#,
+            ),
+            (
+                "sources/List/main.ts",
+                r#"
+import { Key, List, One as Pathish } from "./one";
+import { Two as Pairish } from "../Object/two";
+
+type A = Pathish<object, List<Key>, string>;
+type B = Pairish<string, number>;
+"#,
+            ),
+            (
+                "sources/Object/HasPath.ts",
+                r#"
+export type HasPath<O extends object, Path, M extends any = any, match extends string = 'default'> = {
+    readonly object: O;
+    readonly path: Path;
+    readonly match: M;
+    readonly mode: match;
+};
+"#,
+            ),
+            (
+                "sources/Any/Compute.ts",
+                r#"
+export type ComputeRaw<A extends any> = A;
+"#,
+            ),
+            (
+                "sources/List/toolbelt.ts",
+                r#"
+import { HasPath as OHasPath } from "../Object/HasPath";
+import { ComputeRaw } from "../Any/Compute";
+
+type C = OHasPath<object, readonly ['a'], string, 'default'>;
+type D = ComputeRaw<{ readonly a: string }>;
+"#,
+            ),
+        ],
+        "sources/List/toolbelt.ts",
+        CheckerOptions::default(),
+    );
+
+    let arity_errors: Vec<_> = diags
+        .iter()
+        .filter(|d| matches!(d.code, 2314 | 2315 | 2558))
+        .collect();
+    assert_eq!(
+        arity_errors.len(),
+        0,
+        "Imported generic aliases with colliding raw ids should keep distinct arities; got: {diags:#?}"
+    );
+}
+
+#[test]
+fn imported_ref_type_params_follow_barrel_reexports_to_decl_file() {
+    let diags = check_multi_file_with_global_index(
+        &[
+            (
+                "src/generic.ts",
+                r#"
+export type Boxed<T, U = unknown> = {
+    readonly value: T;
+    readonly extra: U;
+};
+"#,
+            ),
+            (
+                "src/namedBarrel.ts",
+                r#"export { Boxed } from "./generic";"#,
+            ),
+            ("src/starBarrel.ts", r#"export * from "./generic";"#),
+            (
+                "src/main.ts",
+                r#"
+import { Boxed as NamedBoxed } from "./namedBarrel";
+import { Boxed as StarBoxed } from "./starBarrel";
+
+type A = NamedBoxed<string>;
+type B = StarBoxed<number, boolean>;
+"#,
+            ),
+        ],
+        "src/main.ts",
+        CheckerOptions::default(),
+    );
+
+    let arity_errors: Vec<_> = diags
+        .iter()
+        .filter(|d| matches!(d.code, 2314 | 2315 | 2558))
+        .collect();
+    assert_eq!(
+        arity_errors.len(),
+        0,
+        "Imported generic aliases should follow barrel re-exports to the declaration file; got: {diags:#?}"
     );
 }


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Benchmark blocker / checker semantic parity for canary project rows.

## Invariant
When a type reference is a local import alias for a generic type alias declared in another file, TSZ must validate and instantiate type arguments against the resolved target declaration's type-parameter list, not a colliding arena-local `SymbolId`, export-surface alias, or stale circular-alias marker. This PR changes checker reference type-parameter lookup and generic type-argument validation.

## Scope
- Key type-reference validation cache entries by resolved reference identity: symbol, owner file, and local syntax name.
- Resolve import aliases through their declaring file and target declaration arena before extracting generic parameters.
- Follow named-barrel and export-star re-export paths to the exported declaration before caching imported generic parameter lists.
- Keep TS2315 circular-alias collapse limited to non-generic/error aliases or structurally self-circular generic aliases.
- Add multi-file coverage for renamed imports, barrel re-exports, export-star re-exports, and ts-toolbelt-shaped `OHasPath`/`ComputeRaw` generic aliases.

## Project Corpus Impact
- Row: `ts-toolbelt-project`
- Bug family: false TS2315 on imported generic type aliases with cross-file/raw-symbol alias collisions.
- Evidence: `ts-toolbelt-project` moved from red (`OHasPath`/`ComputeRaw` “is not generic”) to green locally, including an uncached guard run against the rebuilt dist-fast compiler; quick benchmark artifact remains a tsgo winner, so this PR claims correctness movement rather than speed improvement.

## Verification
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib ref_type_params_cache`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib circular`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `scripts/safe-run.sh cargo build --target-dir .target --profile dist-fast -p tsz-cli --bin tsz`
- `TSZ_PROJECT_COMPILE_FILTER="ts-toolbelt-project" TSZ_PROJECT_COMPILE_SET=canary TSZ_PROJECT_COMPILE_RESULT_CACHE=0 scripts/safe-run.sh scripts/ci/project-compile-guard.sh`
- `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter "ts-toolbelt-project" --json-file /tmp/studio-canary-b-ts-toolbelt-after.json`
- Baseline drift check: clean `origin/main` worktree reproduced `coAndContraVariantInferences2` and `correlatedUnions` focused conformance failures with `--test-dir /Users/mohsen/code/tsz/TypeScript/tests/cases`; accepted-regression entries added and tracked in #12247.

## Coordination Notes
- Overlap checked against open PRs. Related Studio-B perf PRs #12237/#12238 are active but target different checker hot paths; this PR is a correctness unblock for a red canary row.
- Repo-wide `scripts/agents/ensure-agent-labels.sh --audit` passed after manager metadata repairs; this branch uses canonical `agent:Studio-B` ownership.
- Synced to current `origin/main` and pushed head `c82b1a4462`; the named-barrel/export-star review blocker is addressed, exact-head PR CI run `26839835802` passed, and this PR is queued via `merge-queue`.
- `conformance-aggregate` on the first head exposed existing main drift (`coAndContraVariantInferences2`, `correlatedUnions`); tracked in #12247 and added to accepted regressions after baseline verification.