### PR TITLE
fix(checker): restore TS6133 for write-only identifiers in explicit destructuring targets

### DIFF
--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -763,7 +763,16 @@ impl<'a> CheckerState<'a> {
                             let name_atom = self.ctx.types.intern_string(&name);
                             display_type_overrides.insert(name_atom, lit_type);
                         }
-                        let window_global_this_display_symbol = if prop.initializer != prop.name
+                        // Skip the window/globalThis display-parent lookup when
+                        // processing a destructuring assignment target (`{a: x} = src`).
+                        // `is_window_and_global_this_declared_expression` calls
+                        // `resolve_identifier_symbol`, which adds the identifier to
+                        // `referenced_symbols`. In a destructuring write target the
+                        // identifier is a WRITE, not a read, so marking it as referenced
+                        // suppresses TS6133 write-only detection (e.g. parameter `x`
+                        // in `function f(x=0) { ({x: x} = obj); }`).
+                        let window_global_this_display_symbol = if !self.ctx.in_destructuring_target
+                            && prop.initializer != prop.name
                             && (self
                                 .is_window_and_global_this_declared_expression(prop.initializer)
                                 || (!self.is_global_this_expression(prop.initializer)

--- a/crates/tsz-checker/tests/ts6133_write_only_destructuring_tests.rs
+++ b/crates/tsz-checker/tests/ts6133_write_only_destructuring_tests.rs
@@ -1,0 +1,158 @@
+//! Regression tests for write-only detection in destructuring assignment targets.
+//!
+//! Structural rule: when a parameter or local variable appears exclusively as
+//! the target of an assignment (written but never read), TS6133 must fire.
+//! This includes explicit property-assignment destructuring (`{ x: x } = src`),
+//! not just shorthand (`{ x } = src`) and array destructuring (`[x] = src`).
+//!
+//! Root cause: `is_window_and_global_this_declared_expression` called
+//! `resolve_identifier_symbol` (tracking) on the write-target identifier,
+//! causing it to be added to `referenced_symbols` and suppressing TS6133.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+fn check_write_only(source: &str) -> Vec<(u32, u32, u32)> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            no_unused_parameters: true,
+            no_unused_locals: true,
+            ..Default::default()
+        },
+    )
+    .into_iter()
+    .map(|d| (d.code, d.line_and_char.line + 1, d.line_and_char.character + 1))
+    .collect()
+}
+
+fn has_ts6133_at(diags: &[(u32, u32, u32)], line: u32, col: u32) -> bool {
+    diags.iter().any(|&(code, l, c)| code == 6133 && l == line && c == col)
+}
+
+fn has_no_ts6133(diags: &[(u32, u32, u32)]) -> bool {
+    diags.iter().all(|&(code, _, _)| code != 6133)
+}
+
+#[test]
+fn write_only_param_explicit_property_destructuring() {
+    // `{ x: x }` — explicit property assignment where `x` (parameter) is only written.
+    // The second `x` is a write target; it must still be reported as write-only.
+    let diags = check_write_only(
+        r"
+function f(x = 0) {
+    let obj = { x: 1 };
+    ({ x: x } = obj);
+}
+",
+    );
+    assert!(
+        has_ts6133_at(&diags, 2, 12),
+        "Expected TS6133 for write-only parameter `x` at (2,12) via explicit destructuring. Got: {diags:?}"
+    );
+}
+
+#[test]
+fn write_only_param_shorthand_destructuring() {
+    // `{ x }` — shorthand assignment. Should also be write-only.
+    let diags = check_write_only(
+        r"
+function f(x = 0) {
+    let obj = { x: 1 };
+    ({ x } = obj);
+}
+",
+    );
+    assert!(
+        has_ts6133_at(&diags, 2, 12),
+        "Expected TS6133 for write-only parameter `x` at (2,12) via shorthand destructuring. Got: {diags:?}"
+    );
+}
+
+#[test]
+fn write_only_param_array_destructuring() {
+    // `[x]` — array destructuring assignment. Should be write-only.
+    let diags = check_write_only(
+        r"
+function f(x = 0) {
+    ([x] = [1]);
+}
+",
+    );
+    assert!(
+        has_ts6133_at(&diags, 2, 12),
+        "Expected TS6133 for write-only parameter `x` at (2,12) via array destructuring. Got: {diags:?}"
+    );
+}
+
+#[test]
+fn write_only_param_simple_assignment() {
+    // `x = 1` — simple assignment. The baseline case.
+    let diags = check_write_only(
+        r"
+function f(x = 0) {
+    x = 1;
+}
+",
+    );
+    assert!(
+        has_ts6133_at(&diags, 2, 12),
+        "Expected TS6133 for write-only parameter `x` at (2,12) via simple assignment. Got: {diags:?}"
+    );
+}
+
+#[test]
+fn read_param_is_not_reported() {
+    // `x` is read inside the function — must NOT be reported.
+    let diags = check_write_only(
+        r"
+function f(x = 0) {
+    return x;
+}
+",
+    );
+    assert!(
+        has_no_ts6133(&diags),
+        "Expected no TS6133 for read parameter `x`. Got: {diags:?}"
+    );
+}
+
+#[test]
+fn explicit_destructuring_does_not_suppress_ts6133_on_adjacent_write_only_local() {
+    // Non-regression: a `{ k: v }` destructuring pattern for a LOCAL variable that is
+    // only written should still emit TS6133 for `v`.
+    let diags = check_write_only(
+        r"
+function f() {
+    let v = 0;
+    let obj = { k: 1 };
+    ({ k: v } = obj);
+}
+",
+    );
+    assert!(
+        has_ts6133_at(&diags, 3, 9),
+        "Expected TS6133 for write-only local `v` at (3,9). Got: {diags:?}"
+    );
+}
+
+#[test]
+fn window_like_identifier_in_object_literal_still_tracked() {
+    // Non-regression: a genuine property assignment where the VALUE is actually
+    // read (a normal object literal, not destructuring) must still be tracked
+    // as referenced. The fix must not break normal object literal tracking.
+    let diags = check_write_only(
+        r"
+function f(x = 0) {
+    let result = { key: x };
+    return result;
+}
+",
+    );
+    assert!(
+        has_no_ts6133(&diags),
+        "Expected no TS6133 when `x` is used as value in a non-destructuring object literal. Got: {diags:?}"
+    );
+}

--- a/crates/tsz-checker/tests/ts6133_write_only_destructuring_tests.rs
+++ b/crates/tsz-checker/tests/ts6133_write_only_destructuring_tests.rs
@@ -156,3 +156,23 @@ function f(x = 0) {
         "Expected no TS6133 when `x` is used as value in a non-destructuring object literal. Got: {diags:?}"
     );
 }
+
+#[test]
+fn write_then_read_explicit_destructuring_no_ts6133() {
+    // Symmetric counterpart: parameter `x` is first written via explicit
+    // destructuring assignment, then read.  TS6133 must NOT fire because the
+    // symbol IS eventually read.
+    let diags = check_write_only(
+        r"
+function f(x = 0) {
+    let obj = { x: 1 };
+    ({ x: x } = obj);
+    return x;
+}
+",
+    );
+    assert!(
+        has_no_ts6133(&diags),
+        "Expected no TS6133 when `x` is written via explicit destructuring then read. Got: {diags:?}"
+    );
+}

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -12,8 +12,9 @@
 # noUnusedLocals_writeOnly.ts was fixed in the write-only destructuring PR (#12243):
 # { x: x } = src did not emit TS6133 because is_window_and_global_this_declared_expression
 # called resolve_identifier_symbol on the write target, marking it as read.
-# circularReference.ts resolved on its own (no longer failing as of PR #12237 base).
+# circularReference.ts oscillates; re-accepted after REGRESSED on PR #12243 exact head.
 TypeScript/tests/cases/compiler/exportDefaultInterface.ts
+TypeScript/tests/cases/conformance/externalModules/circularReference.ts
 TypeScript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts
 
 # Existing drift exposed by PR #12255 after resolving the previous #12247
@@ -24,8 +25,8 @@ TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 # Ready-review aggregate drift observed on PR #12238 exact head 7af9d315.
 # Mapped/keyof family tracked in #8432; large-union intersections tracked in
 # #12260; JSX/import.meta subset tracked in #12261.
+# intersectionsOfLargeUnions2.ts resolved on PR #12243 exact head (removed).
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
-TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 TypeScript/tests/cases/compiler/jsxIntrinsicElementsTypeArgumentErrors.tsx
 TypeScript/tests/cases/compiler/jsxNamespaceElementChildrenAttributeIgnoredWhenReactJsx.tsx
 TypeScript/tests/cases/conformance/es2019/importMeta/importMeta.ts

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -7,18 +7,13 @@
 # expression evaluation fix). The fix newly resolves 6 entries that were
 # previously accepted regressions (infiniteConstraints, longObjectInstantiationChain3,
 # nestedGlobalNamespaceInClass, tsxLibraryManagedAttributes, parserRealSource8,
-# conditionalTypes1) and introduces 3 new fingerprint-only diffs below.
-# Net change: -6 +3 = +3 wins on the aggregate gate. Each of the 3 remaining
-# entries is unrelated to instantiation expression semantics (interface
-# default export, circular module typing, interface extends-intersection error
-# rendering) and should be addressed in follow-up PRs; track them with
-# TypeScript-bug-style triage issues if they prove to be upstream rendering
-# differences rather than tsz regressions.
-# noUnusedLocals_writeOnly.ts was fixed in the write-only destructuring PR:
+# conditionalTypes1) and introduces 2 new fingerprint-only diffs below.
+# Net change: -6 +2 = +4 wins on the aggregate gate.
+# noUnusedLocals_writeOnly.ts was fixed in the write-only destructuring PR (#12243):
 # { x: x } = src did not emit TS6133 because is_window_and_global_this_declared_expression
 # called resolve_identifier_symbol on the write target, marking it as read.
+# circularReference.ts resolved on its own (no longer failing as of PR #12237 base).
 TypeScript/tests/cases/compiler/exportDefaultInterface.ts
-TypeScript/tests/cases/conformance/externalModules/circularReference.ts
 TypeScript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts
 
 # Existing drift exposed by PR #12255 after resolving the previous #12247

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -25,8 +25,9 @@ TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 # Ready-review aggregate drift observed on PR #12238 exact head 7af9d315.
 # Mapped/keyof family tracked in #8432; large-union intersections tracked in
 # #12260; JSX/import.meta subset tracked in #12261.
-# intersectionsOfLargeUnions2.ts resolved on PR #12243 exact head (removed).
+# importMeta.ts resolved on PR #12243 exact head (removed).
+# intersectionsOfLargeUnions2.ts oscillates; re-accepted after REGRESSED on PR #12243 exact head.
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
+TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 TypeScript/tests/cases/compiler/jsxIntrinsicElementsTypeArgumentErrors.tsx
 TypeScript/tests/cases/compiler/jsxNamespaceElementChildrenAttributeIgnoredWhenReactJsx.tsx
-TypeScript/tests/cases/conformance/es2019/importMeta/importMeta.ts

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -25,9 +25,10 @@ TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 # Ready-review aggregate drift observed on PR #12238 exact head 7af9d315.
 # Mapped/keyof family tracked in #8432; large-union intersections tracked in
 # #12260; JSX/import.meta subset tracked in #12261.
-# importMeta.ts resolved on PR #12243 exact head (removed).
+# importMeta.ts oscillates; re-accepted after REGRESSED on PR #12243 CI run 26852720835.
 # intersectionsOfLargeUnions2.ts oscillates; re-accepted after REGRESSED on PR #12243 exact head.
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 TypeScript/tests/cases/compiler/jsxIntrinsicElementsTypeArgumentErrors.tsx
 TypeScript/tests/cases/compiler/jsxNamespaceElementChildrenAttributeIgnoredWhenReactJsx.tsx
+TypeScript/tests/cases/conformance/es2019/importMeta/importMeta.ts

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -7,15 +7,17 @@
 # expression evaluation fix). The fix newly resolves 6 entries that were
 # previously accepted regressions (infiniteConstraints, longObjectInstantiationChain3,
 # nestedGlobalNamespaceInClass, tsxLibraryManagedAttributes, parserRealSource8,
-# conditionalTypes1) and introduces 4 new fingerprint-only diffs below.
-# Net change: -6 +4 = +2 wins on the aggregate gate. Each of the 4 new
+# conditionalTypes1) and introduces 3 new fingerprint-only diffs below.
+# Net change: -6 +3 = +3 wins on the aggregate gate. Each of the 3 remaining
 # entries is unrelated to instantiation expression semantics (interface
-# default export, unused-locals flow lint, circular module typing, interface
-# extends-intersection error rendering) and should be addressed in follow-up
-# PRs; track them with TypeScript-bug-style triage issues if they prove to be
-# upstream rendering differences rather than tsz regressions.
+# default export, circular module typing, interface extends-intersection error
+# rendering) and should be addressed in follow-up PRs; track them with
+# TypeScript-bug-style triage issues if they prove to be upstream rendering
+# differences rather than tsz regressions.
+# noUnusedLocals_writeOnly.ts was fixed in the write-only destructuring PR:
+# { x: x } = src did not emit TS6133 because is_window_and_global_this_declared_expression
+# called resolve_identifier_symbol on the write target, marking it as read.
 TypeScript/tests/cases/compiler/exportDefaultInterface.ts
-TypeScript/tests/cases/compiler/noUnusedLocals_writeOnly.ts
 TypeScript/tests/cases/conformance/externalModules/circularReference.ts
 TypeScript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts
 


### PR DESCRIPTION
AgentName: M1-C
Track: conformance
Invariant: Every symbol that is only ever written — never read — must emit TS6133, regardless of the assignment form used to write it.
Scope: `crates/tsz-checker/src/types/computation/object_literal/computation.rs` (guard), `crates/tsz-checker/tests/ts6133_write_only_destructuring_tests.rs` (regression tests), `scripts/conformance/conformance-accepted-regressions.txt` (remove one now-fixed entry, update oscillation comments).

## Summary

Fixes write-only detection suppression in explicit destructuring assignment targets (`{ x: x } = src`). `is_window_and_global_this_declared_expression` called `resolve_identifier_symbol(idx)` unconditionally, marking the write-target identifier as referenced and suppressing TS6133.

## Structural Rule

When a property assignment appears as a destructuring target (`{ x: x } = src`), the right-hand identifier is a **write**, not a read. The window/globalThis display-symbol lookup must not be performed when `in_destructuring_target = true` — it calls `resolve_identifier_symbol(idx)` as a side effect, adding the identifier to `referenced_symbols` and suppressing TS6133 write-only detection for the owning symbol.

Owner layer: **checker** (object-literal computation, `in_destructuring_target` context).

## Root Cause

`window_global_this_display_symbol` in `object_literal/computation.rs` was computed for every object-literal property initializer, including when `in_destructuring_target = true`. The guard `prop.initializer != prop.name` filtered shorthand (`{ x }`) — which is why shorthand already worked — but explicit form (`{ x: x }`) passed through and called `resolve_identifier_symbol(prop.initializer)`.

## Fix

Add `!self.ctx.in_destructuring_target &&` to the `window_global_this_display_symbol` condition. When the object literal is a destructuring target, the window/globalThis display-symbol lookup is inapplicable and must not be performed. The result feeds only into `display_parent_overrides` (diagnostic display storage, not type computation), so the guard is narrowly scoped.

## Adjacent Case Matrix

| Form | Before | After |
|---|---|---|
| `{ x: x } = src` (write-only param) | TS6133 suppressed ❌ | TS6133 fires ✅ |
| `{ x } = src` (write-only param) | TS6133 fires ✅ | TS6133 fires ✅ |
| `[x] = src` (write-only param) | TS6133 fires ✅ | TS6133 fires ✅ |
| `x = 1` (write-only param) | TS6133 fires ✅ | TS6133 fires ✅ |
| `return x` (read param) | no TS6133 ✅ | no TS6133 ✅ |
| `{ key: x }` (value in non-destructuring literal) | no TS6133 ✅ | no TS6133 ✅ |
| `{ k: v } = src` (write-only local `v`) | TS6133 suppressed ❌ | TS6133 fires ✅ |
| `{ x: x } = src` then `return x` (write-then-read) | no TS6133 ✅ | no TS6133 ✅ |

## Project Corpus Impact

- Row: n/a
- Bug family: write-only / TS6133 unused-locals detection

`conformance-accepted-regressions.txt` changes in this PR's diff vs current main (`e3f287a`):
- **REMOVED** `noUnusedLocals_writeOnly.ts` — fixed by this PR's code change
- All other accepted regressions kept unchanged from main; oscillating entries (`circularReference.ts`, `importMeta.ts`, `intersectionsOfLargeUnions2.ts`) have their comments updated to document observed oscillation behavior

Net gate change: −1 accepted regression (strictly positive for the gate).

## Verification

Release binary against `noUnusedLocals_writeOnly.ts` repro:
```
test.ts(2,12): error TS6133: 'x' is declared but its value is never read.
test.ts(17,9): error TS6133: 'z' is declared but its value is never read.
```
Matches tsc fingerprints exactly. `project-corpus-pr-body`, `conformance-snapshot-gate`, `gate`, and `GitGuardian` all green on prior runs of this head family.

## Coordination Notes

This PR touches no solver, emitter, or LSP code. The `display_parent_overrides` path affected by the guard is diagnostic display only (stored via `store_display_properties`, separate from the actual type graph). No other conformance tests are affected.