### PR TITLE
perf(module-resolution): cache directory existence probes alongside files

### DIFF
--- a/crates/tsz-core/src/module_resolver/exports_imports.rs
+++ b/crates/tsz-core/src/module_resolver/exports_imports.rs
@@ -107,7 +107,7 @@ impl ModuleResolver {
         loop {
             let package_json_path = current.join("package.json");
 
-            if package_json_path.is_file()
+            if cached_is_file(&package_json_path)
                 && let Ok(package_json) = self.read_package_json(&package_json_path)
                 && let Some(imports) = &package_json.imports
             {

--- a/crates/tsz-core/src/module_resolver/file_probing.rs
+++ b/crates/tsz-core/src/module_resolver/file_probing.rs
@@ -210,12 +210,12 @@ impl ModuleResolver {
         // returned `PathBuf` is canonical (e.g. typesVersions `../` joins
         // produce `ts3.1/../ts3.1/..` otherwise).
         let path = &normalize_path_segments(path);
-        if !path.is_dir() {
+        if !cached_is_dir(path) {
             return None;
         }
 
         let package_json_path = path.join("package.json");
-        if package_json_path.exists()
+        if cached_is_file(&package_json_path)
             && let Ok(pj) = self.read_package_json(&package_json_path)
         {
             // The directory's own `package.json#type` determines the
@@ -330,7 +330,7 @@ impl ModuleResolver {
         if !skip_extension_probing && let Some(resolved) = self.try_file(path, package_type) {
             return Some(resolved);
         }
-        if path.is_dir() {
+        if cached_is_dir(path) {
             let index = path.join("index");
             return self.try_file(&index, package_type);
         }

--- a/crates/tsz-core/src/module_resolver/mod.rs
+++ b/crates/tsz-core/src/module_resolver/mod.rs
@@ -1075,7 +1075,7 @@ impl ModuleResolver {
         self.skip_fallback_cache_misses.set(0);
         self.node_modules_dir_cache_hits.set(0);
         self.node_modules_dir_cache_misses.set(0);
-        crate::resolution::helpers::clear_file_exists_cache();
+        crate::resolution::helpers::clear_path_existence_caches();
     }
 
     /// Return entry counts for module resolver-owned caches.

--- a/crates/tsz-core/src/module_resolver/node_modules_resolution.rs
+++ b/crates/tsz-core/src/module_resolver/node_modules_resolution.rs
@@ -132,7 +132,7 @@ impl ModuleResolver {
             if !package_name.starts_with("@types/") {
                 let types_package = types_package_name(&package_name);
                 let types_dir = current.join("node_modules").join(&types_package);
-                if types_dir.is_dir()
+                if cached_is_dir(&types_dir)
                     && let Ok(resolved) = self.resolve_package(
                         &types_dir,
                         subpath.as_deref(),
@@ -153,7 +153,7 @@ impl ModuleResolver {
                 } else {
                     type_root.join(&package_name)
                 };
-                if types_package.is_dir()
+                if cached_is_dir(&types_package)
                     && let Ok(resolved) = self.resolve_package(
                         &types_package,
                         subpath.as_deref(),
@@ -250,7 +250,7 @@ impl ModuleResolver {
             for node_modules in node_modules_roots {
                 let package_dir = node_modules.join(&package_name);
 
-                if package_dir.is_dir() {
+                if cached_is_dir(&package_dir) {
                     match self.resolve_package(
                         &package_dir,
                         subpath.as_deref(),
@@ -302,7 +302,7 @@ impl ModuleResolver {
                 }
                 let types_package = types_package_name(&package_name);
                 let types_dir = node_modules.join(&types_package);
-                if types_dir.is_dir()
+                if cached_is_dir(&types_dir)
                     && let Ok(resolved) = self.resolve_package(
                         &types_dir,
                         subpath.as_deref(),
@@ -326,7 +326,7 @@ impl ModuleResolver {
         // Try type roots (for @types packages)
         for type_root in &self.type_roots {
             let types_package = type_root.join(types_package_name(&package_name));
-            if types_package.is_dir()
+            if cached_is_dir(&types_package)
                 && let Ok(resolved) = self.resolve_package(
                     &types_package,
                     subpath.as_deref(),
@@ -366,7 +366,7 @@ impl ModuleResolver {
         }
 
         let package_json_path = package_dir.join("package.json");
-        if !package_json_path.is_file() {
+        if !cached_is_file(&package_json_path) {
             return false;
         }
 
@@ -460,7 +460,7 @@ impl ModuleResolver {
             };
             if nm_exists {
                 let package_dir = node_modules.join(&package_name);
-                if package_dir.is_dir()
+                if cached_is_dir(&package_dir)
                     && self.should_stop_on_exports_failure(
                         &package_dir,
                         subpath.as_deref(),
@@ -473,7 +473,7 @@ impl ModuleResolver {
 
                 if !package_name.starts_with("@types/") {
                     let types_dir = node_modules.join(types_package_name(&package_name));
-                    if types_dir.is_dir()
+                    if cached_is_dir(&types_dir)
                         && self.should_stop_on_exports_failure(
                             &types_dir,
                             subpath.as_deref(),
@@ -496,7 +496,7 @@ impl ModuleResolver {
             let types_package = types_package_name(&package_name);
             for type_root in &self.type_roots {
                 let types_dir = type_root.join(&types_package);
-                if types_dir.is_dir()
+                if cached_is_dir(&types_dir)
                     && self.should_stop_on_exports_failure(
                         &types_dir,
                         subpath.as_deref(),
@@ -527,7 +527,7 @@ impl ModuleResolver {
     ) -> Result<ResolvedModule, ResolutionFailure> {
         // Read package.json
         let package_json_path = package_dir.join("package.json");
-        let package_json = if package_json_path.exists() {
+        let package_json = if cached_is_file(&package_json_path) {
             self.read_package_json(&package_json_path).map_err(|msg| {
                 ResolutionFailure::PackageJsonError {
                     message: msg,
@@ -756,7 +756,7 @@ impl ModuleResolver {
                 });
             }
             if let Some(declaration) = declaration_substitution_for_main(&main_path)
-                && declaration.is_file()
+                && cached_is_file(&declaration)
             {
                 return Ok(ResolvedModule {
                     resolved_path: declaration.clone(),
@@ -781,7 +781,7 @@ impl ModuleResolver {
             }
             // For main field targets that are directories, only try index files.
             // Do NOT read nested package.json — main field resolution is non-recursive.
-            if main_path.is_dir() {
+            if cached_is_dir(&main_path) {
                 let index = main_path.join("index");
                 if let Some(resolved) = self.try_file(&index, target_pt) {
                     return Ok(ResolvedModule {

--- a/crates/tsz-core/src/module_resolver/package_json.rs
+++ b/crates/tsz-core/src/module_resolver/package_json.rs
@@ -7,7 +7,7 @@ use super::{ImportingModuleKind, ModuleResolver, PackageType};
 use crate::config::ModuleResolutionKind;
 use std::path::Path;
 
-use crate::module_resolver_helpers::PackageJson;
+use crate::module_resolver_helpers::{PackageJson, cached_is_file};
 
 /// Parse `package.json#type` into a [`PackageType`], or `None` when the
 /// field is missing or an unknown value. Shared by both
@@ -95,7 +95,7 @@ impl ModuleResolver {
 
             // Check for package.json
             let package_json_path = current.join("package.json");
-            if package_json_path.is_file()
+            if cached_is_file(&package_json_path)
                 && let Ok(pj) = self.read_package_json(&package_json_path)
             {
                 let package_type = parse_package_type_field(pj.package_type.as_deref());

--- a/crates/tsz-core/src/module_resolver/relative_resolution.rs
+++ b/crates/tsz-core/src/module_resolver/relative_resolution.rs
@@ -8,7 +8,9 @@ use super::{
     ResolutionFailure, ResolvedModule,
 };
 use crate::config::ModuleResolutionKind;
-use crate::module_resolver_helpers::{KNOWN_EXTENSIONS, normalize_path_segments};
+use crate::module_resolver_helpers::{
+    KNOWN_EXTENSIONS, cached_is_dir, cached_is_file, normalize_path_segments,
+};
 use crate::span::Span;
 use std::path::{Path, PathBuf};
 
@@ -80,7 +82,7 @@ impl ModuleResolver {
                 ModuleResolutionKind::Node16 | ModuleResolutionKind::NodeNext
             ) && uses_require_resolution
             {
-                let package_dir = if prefer_directory || path.is_dir() {
+                let package_dir = if prefer_directory || cached_is_dir(path) {
                     path
                 } else {
                     path.parent().unwrap_or_else(|| Path::new("."))
@@ -195,7 +197,7 @@ impl ModuleResolver {
             // (they require `resolveJsonModule`), but tsc still suggests them.
             for candidate in &candidates {
                 let json_candidate = candidate.with_extension("json");
-                if json_candidate.is_file() {
+                if cached_is_file(&json_candidate) {
                     return Err(ResolutionFailure::ImportPathNeedsExtension {
                         specifier: specifier.to_string(),
                         suggested_extension: ".json".to_string(),
@@ -248,7 +250,7 @@ impl ModuleResolver {
         if js_json_extension_suggestion {
             for candidate in &candidates {
                 let json_candidate = candidate.with_extension("json");
-                if json_candidate.is_file() {
+                if cached_is_file(&json_candidate) {
                     return Err(ResolutionFailure::ImportPathNeedsExtension {
                         specifier: specifier.to_string(),
                         suggested_extension: ".json".to_string(),

--- a/crates/tsz-core/src/module_resolver/self_reference.rs
+++ b/crates/tsz-core/src/module_resolver/self_reference.rs
@@ -5,6 +5,7 @@
 
 use super::{ModuleExtension, ModuleResolver, ResolvedModule};
 use crate::config::ModuleResolutionKind;
+use crate::module_resolver_helpers::cached_is_file;
 use crate::span::Span;
 use std::path::Path;
 
@@ -52,7 +53,7 @@ impl ModuleResolver {
         loop {
             let package_json_path = current.join("package.json");
 
-            if package_json_path.is_file()
+            if cached_is_file(&package_json_path)
                 && let Ok(package_json) = self.read_package_json(&package_json_path)
             {
                 // Check if the package name matches - this is REQUIRED for a self-reference

--- a/crates/tsz-core/src/resolution/helpers.rs
+++ b/crates/tsz-core/src/resolution/helpers.rs
@@ -9,16 +9,26 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::path::{Component, Path, PathBuf};
 
-// Per-thread file-existence cache for module-resolution hot loops.
-// `try_file_with_suffixes_and_extension` and friends probe many candidate
-// paths per import. Within a single `tsz` invocation the filesystem state is
-// stable, so caching `path.is_file()` results saves repeated `stat()`
-// syscalls. The cache is thread-local so rayon workers each have their own
-// (no locking on the hot path); unbounded growth is acceptable for a
-// one-shot CLI compile and tests reset between invocations because each
-// test runs in a fresh thread / a fresh process.
+// Per-thread path-existence caches for module-resolution hot loops.
+//
+// `try_file_with_suffixes_and_extension`, `try_directory`, and the
+// node_modules walk probe the same candidate files and directories many
+// times per build: every import in every source file re-walks overlapping
+// ancestor directories and re-tests the same extension candidates. Within a
+// single `tsz` invocation the filesystem state is stable, so caching the
+// `path.is_file()` / `path.is_dir()` results collapses those repeated
+// `stat()` syscalls to one per distinct path. This mirrors tsc's
+// `ModuleResolutionHost`, which memoizes both `fileExists` and
+// `directoryExists` for exactly the same reason.
+//
+// The caches are thread-local so rayon workers each have their own (no
+// locking on the hot path); unbounded growth is acceptable for a one-shot
+// CLI compile and tests reset between invocations because each test runs in
+// a fresh thread / a fresh process.
 thread_local! {
     static FILE_EXISTS: RefCell<FxHashMap<PathBuf, bool>> =
+        RefCell::new(FxHashMap::default());
+    static DIR_EXISTS: RefCell<FxHashMap<PathBuf, bool>> =
         RefCell::new(FxHashMap::default());
 }
 
@@ -34,13 +44,30 @@ pub(crate) fn cached_is_file(path: &Path) -> bool {
     })
 }
 
-/// Reset the caller thread's file-existence cache.
+/// Cached counterpart to `Path::is_dir`, sharing the staleness contract of
+/// [`cached_is_file`]: the filesystem is assumed stable for the lifetime of a
+/// compilation, and the result is reset together with the file cache via
+/// [`clear_path_existence_caches`].
+#[inline]
+pub(crate) fn cached_is_dir(path: &Path) -> bool {
+    DIR_EXISTS.with(|cache| {
+        if let Some(&exists) = cache.borrow().get(path) {
+            return exists;
+        }
+        let exists = path.is_dir();
+        cache.borrow_mut().insert(path.to_path_buf(), exists);
+        exists
+    })
+}
+
+/// Reset the caller thread's path-existence caches (files and directories).
 ///
 /// Long-lived hosts should use `ModuleResolver::clear_cache` between
 /// compilation cycles. That public reset path calls this helper for the
 /// current thread; rayon worker threads keep their own cache entries.
-pub(crate) fn clear_file_exists_cache() {
+pub(crate) fn clear_path_existence_caches() {
     FILE_EXISTS.with(|cache| cache.borrow_mut().clear());
+    DIR_EXISTS.with(|cache| cache.borrow_mut().clear());
 }
 
 /// Collapse `.` and `..` segments in a path without touching the filesystem.
@@ -1190,5 +1217,35 @@ mod tests {
             declaration_substitution_for_main(Path::new("pkg/index.ts")),
             None
         );
+    }
+
+    #[test]
+    fn path_existence_caches_are_stable_until_reset_for_files_and_directories() {
+        clear_path_existence_caches();
+        let root = tempdir().expect("create temp dir");
+        let file = root.path().join("index.ts");
+        let dir = root.path().join("nested");
+        std::fs::write(&file, "").expect("write probed file");
+        std::fs::create_dir(&dir).expect("create probed directory");
+
+        // First probes record the file and directory as present.
+        assert!(cached_is_file(&file));
+        assert!(cached_is_dir(&dir));
+
+        // Remove both underneath the caches. Within a single compilation the
+        // filesystem is assumed stable, so the cached answers are reused even
+        // though the paths are now gone. This is what collapses the repeated
+        // `stat()` syscalls the resolver would otherwise issue for the same
+        // files and ancestor directories across every import.
+        std::fs::remove_file(&file).expect("remove probed file");
+        std::fs::remove_dir(&dir).expect("remove probed directory");
+        assert!(cached_is_file(&file));
+        assert!(cached_is_dir(&dir));
+
+        // The unified reset clears both caches (not just the file cache), so
+        // the next compilation cycle re-reads the real filesystem state.
+        clear_path_existence_caches();
+        assert!(!cached_is_file(&file));
+        assert!(!cached_is_dir(&dir));
     }
 }


### PR DESCRIPTION
AgentName: Studio-B
Track: Studio-B (performance / project corpus)
Invariant: Module resolution remains byte-for-byte identical to `tsc`; this is a pure I/O-deduplication change with no observable resolution-result differences.
Scope: `crates/tsz-core` module resolver only (`resolution/helpers.rs` + `module_resolver/*.rs`). No checker/solver/emit/binder changes.

## Project Corpus Impact

- Row: utility-types-project
- Bug family: module-resolution / performance (avoidable filesystem I/O)

Resolution results are unchanged — only redundant `stat()` syscalls are removed — so diagnostic and emit row outcomes are unaffected. Expected effect on timed rows: fewer filesystem syscalls during the `read_source_files` BFS on multi-package fixtures (`utility-types-project`, and any row with deep/shared ancestor trees). No row should change correctness; only throughput improves.

## Structural rule

When the module resolver probes the filesystem during a single compilation, the filesystem is stable for that compilation's lifetime, so `tsc` memoizes both `fileExists` and `directoryExists` in its `ModuleResolutionHost`. tsz did this for files (`cached_is_file`) but **not** for directories: bare `path.is_dir()` and the package.json `exists()` probes re-`stat()` the same paths on every import in every file. On multi-package rows (e.g. `utility-types-project`) the BFS re-walks overlapping ancestor directories repeatedly — "file canonicalization is done repeatedly even when nothing changed" (#10920).

## Fix (owner layer: `resolution/helpers.rs`)

- Add a thread-local `cached_is_dir` mirroring the existing `cached_is_file` (same staleness contract: stable within a compile, reset between cycles).
- Rename the reset helper to `clear_path_existence_caches`, which now clears **both** the file and directory caches, wired through the existing `ModuleResolver::clear_cache`.
- Route every previously-uncached probe through the cached helpers:
  - `file_probing.rs`: `try_directory`/`try_export_target` directory probes; package.json existence.
  - `node_modules_resolution.rs`: `package_dir`/`types_dir`/`types_package`/`main_path` directory probes; package.json existence in `resolve_package`.
  - `relative_resolution.rs`, `package_json.rs`, `self_reference.rs`, `exports_imports.rs`: directory and package.json probes.
- The per-resolver `node_modules_dir_cache` (which carries its own hit/miss statistics and a dedicated test) is **left untouched** as the sole owner of `node_modules` ancestor probes, so each distinct path lives in exactly one cache (no double-caching); the new global cache owns all *other* directory probes.

## Adjacent-case matrix

Caching covers the full probe surface, not just the reported row: relative imports, `node_modules` walks, `@types` lookups, type-roots, `typesVersions`/`main`/`types` directory entries, exports/imports map walks, and self-reference resolution — positive (present) and negative (absent) probes alike, since the boolean result (including `false`) is cached.

## Cache key / invalidation

- Key: the textual, segment-normalized `PathBuf` (resolver already calls `normalize_path_segments` before probing, so alias branches that denote the same path share a key).
- Invalidation: both caches reset together via `clear_path_existence_caches` on `ModuleResolver::clear_cache` between compilation cycles (long-lived hosts / `tsz-server`); thread-local so rayon workers keep independent caches with no locking on the hot path.

## Verification

- `cargo build -p tsz-core` — clean.
- `cargo clippy -p tsz-core` — clean (no warnings).
- `cargo test -p tsz-core --lib module_resolver` — 231 passed (incl. `cache_statistics`, resolver integration).
- `cargo test -p tsz-core --lib resolution::helpers` — passed, incl. new `path_existence_caches_are_stable_until_reset_for_files_and_directories` regression test (probe → remove path → cached answer reused → reset re-reads real state).
- Rebased onto latest `main` (`36f1a26`); clean, no conflicts.

## Coordination Notes

No open PR touches `tsz-core` module resolution, so no conflict risk. The `node_modules_dir_cache` statistics API and its test are preserved unchanged. Reviewed locally with `/simplify` (reuse / simplification / efficiency / altitude) and tightened: removed an accidental double-cache of `node_modules` paths and consolidated the new helper tests.

Closes #10920

https://claude.ai/code/session_01TVydRLSjcwApWJwtFur1Ei