### PR TITLE
fix(emit): skip computed-key temp for declare/abstract fields with legacy decorators and side-effect-free keys

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -1244,12 +1244,38 @@ impl<'a> Printer<'a> {
                 if property_is_erased == Some(true) {
                     // Side-effect only: expression is emitted for its effects but no temp.
                     if has_legacy_decorators {
-                        let temp = self.make_unique_name_hoisted();
-                        self.computed_prop_temp_map
-                            .insert(computed.expression, temp.clone());
-                        self.legacy_decorator_computed_name_temp_map
-                            .insert(computed.expression, temp.clone());
-                        computed_prop_entries.push((Some(temp), computed.expression, member_idx));
+                        // Only `declare`/`abstract` fields are truly erased at
+                        // runtime — for those, a side-effect-free key expression
+                        // (plain identifier, literal) can be emitted directly in
+                        // the `__decorate` call without a hoisted temp.
+                        //
+                        // Implicitly-erased fields (no initializer +
+                        // `use_define_for_class_fields: false`) are still
+                        // runtime-visible through the decorator, so `tsc` always
+                        // allocates a temp for their key to guarantee stable
+                        // evaluation order at class-definition time.
+                        let is_explicitly_erased = self
+                            .arena
+                            .has_modifier(modifiers, SyntaxKind::AbstractKeyword)
+                            || self
+                                .arena
+                                .has_modifier(modifiers, SyntaxKind::DeclareKeyword);
+                        let needs_temp = !is_explicitly_erased
+                            || !self.is_computed_name_expr_side_effect_free(computed.expression);
+                        if needs_temp {
+                            let temp = self.make_unique_name_hoisted();
+                            self.computed_prop_temp_map
+                                .insert(computed.expression, temp.clone());
+                            self.legacy_decorator_computed_name_temp_map
+                                .insert(computed.expression, temp.clone());
+                            computed_prop_entries.push((
+                                Some(temp),
+                                computed.expression,
+                                member_idx,
+                            ));
+                        }
+                        // `declare`/`abstract` + side-effect-free key: no temp;
+                        // `emit_decorator_member_name` emits the expression directly.
                     } else if !self.is_computed_name_expr_side_effect_free(computed.expression)
                         && !erased_computed_side_effects_use_static_block
                     {


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Track 9 JS emit parity | emit fix

## Invariant
When a `declare` or `abstract` computed-property field has legacy decorators and its computed key expression is side-effect-free (plain identifier or literal), `tsc` emits the key expression directly in the `__decorate(...)` call without hoisting through a temp variable. The field has no runtime slot and no evaluation-order hazard, so no temp is needed.

Implicitly-erased fields (no initializer plus `use_define_for_class_fields: false`) are still runtime-visible through the decorator and `tsc` always allocates a temp for their key. The fix preserves that boundary.

Structural rule: when `property_is_erased == Some(true)` and `has_legacy_decorators`, and the field is explicitly erased (`declare` or `abstract`), and the key expression is side-effect-free, `tsc` skips the temp and emits the expression inline in `__decorate`. `tsz` now does the same through `emit_class_es6_with_options` in the `property_is_erased == Some(true)` plus `has_legacy_decorators` branch.

## Scope
- `crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs`: add an `is_explicitly_erased` check in the `property_is_erased == Some(true)` plus `has_legacy_decorators` branch of `emit_class_es6_with_options`.
- Only fields with `AbstractKeyword` or `DeclareKeyword` are treated as explicitly erased and may skip the temp.

## Project Corpus Impact
- Row: n/a
- Bug family: emit/legacy-decorators
- Evidence: emit-only change inside the legacy-decorator computed-key hoisting path. No checker, solver, or binder changes. Effect is limited to classes that simultaneously use `experimentalDecorators: true` and have `declare` or `abstract` computed-key fields with side-effect-free key expressions.

## Verification
- `cargo nextest run -p tsz-emitter legacy_decorated_declare_computed_property_emits_decorator_target` PASS
- `cargo nextest run -p tsz-emitter legacy_decorated_computed_members_reuse_planned_key_temps` PASS; no regression in the adjacent implicitly-erased case.

## Coordination Notes
- Canonical labels: `agent:Studio-D`, `emit`.
- Does not overlap with PR #12230 (computed accessor pairs, DTS) or PR #12240 (CJS template specifier).
- No TypeScript submodule access needed; verified entirely via unit emit tests.
- Broad emit/conformance suites are deferred to CI per repo policy.
