### PR TITLE
fix(solver): resolve inline `typeof f<X>` instantiation expressions in utility type args

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -207,6 +207,9 @@ mod imported_generator_iterable_tests;
 #[path = "tests/index_sig_param_intersection_validity_tests.rs"]
 mod index_sig_param_intersection_validity_tests;
 #[cfg(test)]
+#[path = "tests/instantiation_expression_inline_utility_modifier_tests.rs"]
+mod instantiation_expression_inline_utility_modifier_tests;
+#[cfg(test)]
 #[path = "tests/instantiation_expression_lib_display_tests.rs"]
 mod instantiation_expression_lib_display_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/instantiation_expression_inline_utility_modifier_tests.rs
+++ b/crates/tsz-checker/src/tests/instantiation_expression_inline_utility_modifier_tests.rs
@@ -1,0 +1,163 @@
+//! An instantiation expression `typeof f<X>` used *inline* as a type argument
+//! to a built-in utility (`ReturnType<typeof f<X>>`, `Parameters<typeof f<X>>`)
+//! must resolve to the instantiated function type, not silently degrade to
+//! `any`.
+//!
+//! The structural rule: an instantiation expression over a value generic whose
+//! type query reaches evaluation as `Application(callable, [Args])` without a
+//! type-space `DefId` is the (possibly instantiated) callable itself. When the
+//! checker has already specialized the callable so the supplied type arguments
+//! are vestigial, the application unwraps to that callable; otherwise its
+//! type-parameter-bearing signatures are instantiated. Either way the conditional
+//! `infer R` in `ReturnType`/`Parameters` sees a function shape, so the
+//! mapped-type return preserves its `readonly` / `?` modifier intent.
+//!
+//! Regression for #10847: the merged fix in #12157 handled the split-alias form
+//! (`type F = typeof f<X>; ReturnType<F>`) but the inline form
+//! (`ReturnType<typeof f<X>>`) still produced `any`, dropping modifiers.
+
+use crate::context::{CheckerOptions, ScriptTarget};
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::{check_source_with_libs, diagnostic_count, load_default_lib_files};
+
+fn strict_diags(source: &str) -> Vec<Diagnostic> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            target: ScriptTarget::ES2015,
+            strict: true,
+            strict_null_checks: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+}
+
+#[test]
+fn inline_return_type_over_instantiation_expression_preserves_readonly_and_optional() {
+    let diags = strict_diags(
+        r#"
+declare function f<T>(x: T): { [K in keyof T]: T[K] };
+type Src = { readonly a: number; b?: string };
+type RD = ReturnType<typeof f<Src>>;
+declare const rd: RD;
+rd.a = 5;                 // readonly preserved -> TS2540
+const v: string = rd.b;   // optional preserved -> TS2322 (string | undefined)
+"#,
+    );
+
+    assert_eq!(
+        diagnostic_count(&diags, 2540),
+        1,
+        "readonly modifier must survive the inline instantiation expression: {diags:?}"
+    );
+    assert_eq!(
+        diagnostic_count(&diags, 2322),
+        1,
+        "optional modifier must survive the inline instantiation expression: {diags:?}"
+    );
+}
+
+#[test]
+fn inline_return_type_does_not_degrade_to_any() {
+    // If the return degraded to `any`, assigning it to a literal type would be
+    // accepted and this assignment would NOT error. The presence of TS2322
+    // proves the return kept its concrete object shape.
+    let diags = strict_diags(
+        r#"
+declare function f<T>(x: T): { [K in keyof T]: T[K] };
+type Src = { a: number };
+type RD = ReturnType<typeof f<Src>>;
+declare const rd: RD;
+const probe: 0 = rd;   // object is not assignable to 0 -> TS2322
+"#,
+    );
+    assert_eq!(
+        diagnostic_count(&diags, 2322),
+        1,
+        "inline ReturnType<typeof f<X>> must not be `any`: {diags:?}"
+    );
+}
+
+#[test]
+fn inline_parameters_over_instantiation_expression_is_concrete() {
+    let diags = strict_diags(
+        r#"
+declare function f<T>(x: T): { [K in keyof T]: T[K] };
+type Src = { a: number };
+type P = Parameters<typeof f<Src>>;
+const bad: number = (null as unknown as P)[0];   // P[0] is Src, not number -> TS2322
+"#,
+    );
+    assert_eq!(
+        diagnostic_count(&diags, 2322),
+        1,
+        "inline Parameters<typeof f<X>> must yield the concrete tuple [Src]: {diags:?}"
+    );
+}
+
+#[test]
+fn inline_modifier_preservation_is_type_parameter_name_agnostic() {
+    // Renamed type parameters (`Item`/`P`) must behave identically: the fix is
+    // structural, not keyed on the spelling `T`/`K`.
+    let diags = strict_diags(
+        r#"
+declare function g<Item>(v: Item): { readonly [P in keyof Item]: Item[P] };
+type RG = ReturnType<typeof g<{ q: number }>>;
+declare const rg: RG;
+rg.q = 1;   // readonly preserved -> TS2540
+"#,
+    );
+    assert_eq!(
+        diagnostic_count(&diags, 2540),
+        1,
+        "renamed type parameters must preserve readonly through the inline form: {diags:?}"
+    );
+}
+
+#[test]
+fn inline_optional_removing_mapped_is_respected() {
+    // `-?` strips optionality; the concrete return must report `a` as required
+    // `number`, so assigning it to `number` is allowed (no false TS2322).
+    let diags = strict_diags(
+        r#"
+declare function h<T>(x: T): { [K in keyof T]-?: T[K] };
+type RH = ReturnType<typeof h<{ a?: number }>>;
+declare const rh: RH;
+const v: number = rh.a;   // optionality removed -> no error
+"#,
+    );
+    assert_eq!(
+        diagnostic_count(&diags, 2322),
+        0,
+        "`-?` must strip optionality through the inline form (no false TS2322): {diags:?}"
+    );
+}
+
+#[test]
+fn split_alias_form_remains_correct() {
+    // Regression guard for the form fixed by #12157 — must keep working.
+    let diags = strict_diags(
+        r#"
+declare function f<T>(x: T): { [K in keyof T]: T[K] };
+type Src = { readonly a: number; b?: string };
+type F = typeof f<Src>;
+type RD = ReturnType<F>;
+declare const rd: RD;
+rd.a = 5;                 // TS2540
+const v: string = rd.b;   // TS2322
+"#,
+    );
+    assert_eq!(
+        diagnostic_count(&diags, 2540),
+        1,
+        "split-alias readonly: {diags:?}"
+    );
+    assert_eq!(
+        diagnostic_count(&diags, 2322),
+        1,
+        "split-alias optional: {diags:?}"
+    );
+}

--- a/crates/tsz-checker/src/tests/instantiation_expression_inline_utility_modifier_tests.rs
+++ b/crates/tsz-checker/src/tests/instantiation_expression_inline_utility_modifier_tests.rs
@@ -161,3 +161,65 @@ const v: string = rd.b;   // TS2322
         "split-alias optional: {diags:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Invalid inline instantiation expressions must keep their tsc error parity:
+// the vestigial-argument unwrap only applies to an already-validated callable,
+// so a non-generic value or a wrong-arity generic still reports TS2635 at the
+// instantiation expression and TS2344 at the utility constraint — and must NOT
+// let `ReturnType` / `Parameters` observe a concrete return downstream.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inline_instantiation_on_non_generic_value_keeps_ts2635_ts2344() {
+    let diags = strict_diags(
+        r#"
+declare function nonGeneric(x: number): string;
+type RN = ReturnType<typeof nonGeneric<number>>;
+declare const rn: RN;
+const probe: 0 = rn;   // RN must stay error-like, NOT leak `string` (no TS2322)
+"#,
+    );
+    assert_eq!(
+        diagnostic_count(&diags, 2635),
+        1,
+        "non-generic inline instantiation must report TS2635: {diags:?}"
+    );
+    assert_eq!(
+        diagnostic_count(&diags, 2344),
+        1,
+        "ReturnType constraint must report TS2344 for the failed instantiation: {diags:?}"
+    );
+    assert_eq!(
+        diagnostic_count(&diags, 2322),
+        0,
+        "the failed instantiation must not leak a concrete return downstream: {diags:?}"
+    );
+}
+
+#[test]
+fn inline_instantiation_with_wrong_arity_keeps_ts2635_ts2344() {
+    let diags = strict_diags(
+        r#"
+declare function oneParam<T>(x: T): T;
+type RW = ReturnType<typeof oneParam<number, string>>;
+declare const rw: RW;
+const probe: 0 = rw;   // RW must stay error-like, NOT leak a concrete return
+"#,
+    );
+    assert_eq!(
+        diagnostic_count(&diags, 2635),
+        1,
+        "wrong-arity inline instantiation must report TS2635: {diags:?}"
+    );
+    assert_eq!(
+        diagnostic_count(&diags, 2344),
+        1,
+        "ReturnType constraint must report TS2344 for the wrong-arity instantiation: {diags:?}"
+    );
+    assert_eq!(
+        diagnostic_count(&diags, 2322),
+        0,
+        "the wrong-arity instantiation must not leak a concrete return downstream: {diags:?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -1302,14 +1302,24 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// function shape rather than an opaque application that silently degrades to
     /// `any`.
     ///
-    /// When no signature consumes the type arguments — the callable is already
-    /// fully concrete and the instantiation expression's arguments are vestigial
-    /// (e.g. the checker eagerly instantiated `typeof f<X>` to `(x: X) => …` but
-    /// re-wrapped it as `Application(callable, [X])`) — the application unwraps to
-    /// the callable itself, which is exactly the instantiation expression's type.
-    /// Otherwise downstream consumers would see the opaque `Application` and lose
-    /// the function shape. Any other base — or a query that does not resolve to a
-    /// callable — stays opaque for a later pass.
+    /// When no signature consumes the type arguments the two base shapes differ:
+    ///
+    /// * A `Callable` base only reaches here after the checker's
+    ///   instantiation-expression applicability gate
+    ///   (`apply_instantiation_expression_type_arguments`) accepted it and
+    ///   eagerly specialized the value to a concrete callable that was then
+    ///   re-wrapped as `Application(callable, [X])`. The leftover arguments are
+    ///   vestigial, so the application unwraps to the callable itself — exactly
+    ///   the instantiation expression's type.
+    /// * A `TypeQuery(sym)` base has **not** been re-validated for
+    ///   arity/applicability here. If no signature consumes its arguments the
+    ///   instantiation is invalid (non-generic value, or wrong arity), so the
+    ///   application is left opaque rather than unwrapped — matching tsc, which
+    ///   errors (TS2635/TS2344) and does not let `ReturnType` / `Parameters`
+    ///   observe the value's real return.
+    ///
+    /// Any other base — or a query that does not resolve to a callable — stays
+    /// opaque for a later pass.
     pub(in crate::evaluation) fn evaluate_application_no_def_id(
         &mut self,
         app_id: crate::types::TypeApplicationId,
@@ -1319,16 +1329,24 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         if app.args.is_empty() {
             return original_type_id;
         }
+        let base_is_callable = matches!(
+            self.interner().lookup(app.base),
+            Some(TypeData::Callable(_))
+        );
         let Some(callable) = self.callable_for_instantiation_base(app.base) else {
             return original_type_id;
         };
         let args = app.args.clone();
-        // A specialized callable when a generic signature consumes the args, or
-        // the already-concrete callable itself when the args are vestigial.
-        let resolved = self
-            .try_instantiate_callable_type_params(callable, &args)
-            .unwrap_or(callable);
-        self.evaluate(resolved)
+        match self.try_instantiate_callable_type_params(callable, &args) {
+            // A generic signature consumed the type arguments.
+            Some(specialized) => self.evaluate(specialized),
+            // No signature consumed them: vestigial args on an already-validated
+            // `Callable` base unwrap to the concrete callable; an unvalidated
+            // `TypeQuery` base stays opaque so invalid inline instantiations keep
+            // their tsc TS2635/TS2344 parity.
+            None if base_is_callable => self.evaluate(callable),
+            None => original_type_id,
+        }
     }
 
     /// Resolve the callable type backing an instantiation-expression base

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -1284,33 +1284,77 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
     /// Fallback for `evaluate_application` when the base has no `DefId`.
     ///
-    /// `Application(Callable, [Args])` arises when the checker wraps a
-    /// value-position generic function (`typeof f<Args>`) and the resolver
-    /// lacks a `DefId` for the bare expression type. Instantiate the callable
-    /// signatures (both call and construct) directly so downstream
-    /// `ReturnType`/`Parameters`/`infer` patterns see the substituted
-    /// function shape rather than an opaque application; other base shapes
-    /// stay opaque.
+    /// An instantiation expression `base<Args>` over a generic *value* (a
+    /// function or a `const`/`let`/`var` bound to one) reaches evaluation
+    /// without a type-space `DefId`, so [`Self::resolve_application_def_id`]
+    /// returns `None` and the application lands here. Two base shapes occur:
+    ///
+    /// * `Callable` — `typeof f<Args>` already lowered to the function's
+    ///   callable shape (value-position annotations resolve the query eagerly).
+    /// * `TypeQuery(sym)` — the lazy instantiation-expression form preserved by
+    ///   type-argument positions (`ReturnType<typeof f<Args>>`, `Parameters<…>`,
+    ///   `infer` patterns). The query base is kept intact there, so it must be
+    ///   resolved to the underlying callable before instantiation.
+    ///
+    /// Both shapes instantiate every type-parameter-bearing signature (call and
+    /// construct) via [`Self::try_instantiate_callable_type_params`] so
+    /// downstream `ReturnType`/`Parameters`/`infer` patterns see the substituted
+    /// function shape rather than an opaque application that silently degrades to
+    /// `any`.
+    ///
+    /// When no signature consumes the type arguments — the callable is already
+    /// fully concrete and the instantiation expression's arguments are vestigial
+    /// (e.g. the checker eagerly instantiated `typeof f<X>` to `(x: X) => …` but
+    /// re-wrapped it as `Application(callable, [X])`) — the application unwraps to
+    /// the callable itself, which is exactly the instantiation expression's type.
+    /// Otherwise downstream consumers would see the opaque `Application` and lose
+    /// the function shape. Any other base — or a query that does not resolve to a
+    /// callable — stays opaque for a later pass.
     pub(in crate::evaluation) fn evaluate_application_no_def_id(
         &mut self,
         app_id: crate::types::TypeApplicationId,
         original_type_id: TypeId,
     ) -> TypeId {
         let app = self.interner().type_application(app_id);
-        if app.args.is_empty()
-            || !matches!(
-                self.interner().lookup(app.base),
-                Some(TypeData::Callable(_))
-            )
-        {
+        if app.args.is_empty() {
             return original_type_id;
         }
-        let base = app.base;
-        let args = app.args.clone();
-        let Some(specialized) = self.try_instantiate_callable_type_params(base, &args) else {
+        let Some(callable) = self.callable_for_instantiation_base(app.base) else {
             return original_type_id;
         };
-        self.evaluate(specialized)
+        let args = app.args.clone();
+        // A specialized callable when a generic signature consumes the args, or
+        // the already-concrete callable itself when the args are vestigial.
+        let resolved = self
+            .try_instantiate_callable_type_params(callable, &args)
+            .unwrap_or(callable);
+        self.evaluate(resolved)
+    }
+
+    /// Resolve the callable type backing an instantiation-expression base
+    /// (`base<Args>`) that reached evaluation without a `DefId`.
+    ///
+    /// Returns a `Callable` base unchanged, or resolves a `TypeQuery(sym)` on a
+    /// generic function/`const` value to its callable shape (preferring the
+    /// value/constructor type from `resolve_type_query`, falling back to
+    /// `resolve_ref`). Any other base — or a query that does not resolve to a
+    /// callable — yields `None`, keeping the application opaque.
+    fn callable_for_instantiation_base(&self, base: TypeId) -> Option<TypeId> {
+        match self.interner().lookup(base)? {
+            TypeData::Callable(_) => Some(base),
+            TypeData::TypeQuery(sym_ref) => {
+                let resolved = self
+                    .resolver()
+                    .resolve_type_query(sym_ref, self.interner())
+                    .or_else(|| self.resolver().resolve_ref(sym_ref, self.interner()))?;
+                matches!(
+                    self.interner().lookup(resolved),
+                    Some(TypeData::Callable(_))
+                )
+                .then_some(resolved)
+            }
+            _ => None,
+        }
     }
 
     /// Check if this is a primitive type vs Function/callable target.


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Checker/solver semantic campaign - instantiation-expression evaluation (#10847 family).

## Invariant
When an instantiation expression `typeof f<X>` appears inline as a type argument to a utility type (`ReturnType<typeof f<X>>`, `Parameters<typeof f<X>>`, or a conditional `infer` pattern), tsz must evaluate valid instantiation expressions to the possibly instantiated function type so the conditional captures the real mapped/object return and preserves `readonly` / optional modifier intent instead of seeing an opaque `Application` and degrading to `any`.

## Structural Rule
When an `Application(callable, [Args])` with no `DefId` is a valid instantiation expression over a value generic, tsc evaluates it to the instantiated function type; tsz does so through the solver evaluation boundary (`evaluate_application_no_def_id`). Vestigial-argument unwrapping is limited to already-validated `Callable` bases; a `TypeQuery(sym)<Args>` base whose arguments do not match any signature remains opaque/error-like so invalid inline utility forms keep TS2635/TS2344 parity.

## Scope
- `crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs`: resolve valid instantiation-expression bases through `callable_for_instantiation_base`, instantiate type-parameter-bearing signatures, and gate vestigial-argument unwraps to already-specialized `Callable` bases.
- `crates/tsz-checker/src/tests/instantiation_expression_inline_utility_modifier_tests.rs` and `crates/tsz-checker/src/lib.rs`: add 8 regression tests for inline `ReturnType`, `Parameters`, not-`any`, renamed type parameters, `-?` optional stripping, split-alias guard coverage, and invalid non-generic / wrong-arity inline `ReturnType` forms.

## Project Corpus Impact
- Row: `vite-vanilla-ts-app` (shared with `type-fest`, `utility-types`, and `ts-toolbelt` patterns that read `ReturnType<typeof f<X>>` / `Parameters<typeof f<X>>` over mapped returns).
- Bug family: instantiation-expression evaluation; mapped/conditional return preservation; modifier propagation across generic boundaries.
- Evidence: the minimal valid repro now matches `tsc 6` diagnostic codes/positions (`rd.a = 5` -> TS2540, `const v: string = rd.b` -> TS2322), where tsz previously missed both diagnostics through an `any` fallback. Invalid inline utility forms keep TS2635 + TS2344 and do not leak a concrete return downstream.

## Verification
- `cargo build --bin tsz` - clean.
- `cargo clippy -p tsz-solver` - clean.
- `instantiation_expression_inline_utility_modifier_tests` - 8/8 pass locally per owner evidence.
- `cargo test -p tsz-solver --lib` - same 8 pre-existing failures as `main` (template-literal / `any`-widening; unrelated), zero new failures after confirming the suite on the base commit before the change.
- CLI adjacency matrix: renamed type parameters, generic object-literal methods, `Parameters<...>`, `-?` stripping, split-alias form from #12157, non-generic invalid inline `ReturnType`, and wrong-arity invalid inline `ReturnType`.
- Exact-head PR CI passed on `493eb01544348d00793ee027ee6ca10f9d6e5a57`: `CI Summary`, `lint`, `dist-binaries`, `unit`, `emit`, `project-compile-guard`, `project-compile-canary`, `conformance-aggregate`, `fourslash-aggregate`, `project-corpus-pr-body`, `queue-one-pr`, and `GitGuardian Security Checks` are green.

## Coordination Notes
- Completes #12157, which fixed the split-alias form but not the inline form that is #10847's actual repro.
- Known cosmetic follow-up, tracked separately: the reduced type may still render its display alias as `ReturnType<(x: X) => ...<X>>` in diagnostic message text; this PR is scoped to diagnostic code/position and semantic modifier preservation.
- M5Manager-Studio-Review blocker from head `919889fd341e77f1fd2f7d3df3aab4469763dba4` is addressed on `493eb01544348d00793ee027ee6ca10f9d6e5a57`; exact-head required checks are green, and final queue ownership/handoff is pending under TSZ merge-queue policy.
- Refs #10847 (lane `agent:Studio-B`). Original runner/session metadata: https://claude.ai/code/session_01SWnNpxftbLBkE6NjTmA6g3