### PR TITLE
fix(checker): preserve generic base field this context

### DIFF
--- a/crates/tsz-checker/src/types/class_type/core.rs
+++ b/crates/tsz-checker/src/types/class_type/core.rs
@@ -140,6 +140,7 @@ impl<'a> CheckerState<'a> {
         {
             // PERF: Single pass over class members for prescan (was 3 separate loops).
             let mut prescan_props: Vec<PropertyInfo> = Vec::with_capacity(member_count);
+            let mut needs_inherited_prescan_this = false;
             for (member_pos, &member_idx) in class.members.nodes.iter().enumerate() {
                 let declaration_order = class_member_order(member_pos);
                 let Some(member_node) = self.ctx.arena.get(member_idx) else {
@@ -152,6 +153,14 @@ impl<'a> CheckerState<'a> {
                         };
                         if self.has_static_modifier(&prop.modifiers) {
                             continue;
+                        }
+                        if prop.initializer.is_some()
+                            && tsz_parser::syntax::transform_utils::contains_this_reference(
+                                self.ctx.arena,
+                                prop.initializer,
+                            )
+                        {
+                            needs_inherited_prescan_this = true;
                         }
                         let declared_type = if let Some(dt) =
                             self.effective_class_property_declared_type(member_idx, prop)
@@ -358,31 +367,35 @@ impl<'a> CheckerState<'a> {
                 }
             }
 
-            let base_prescan_type = class
-                .heritage_clauses
-                .as_ref()
-                .and_then(|heritage_clauses| {
-                    heritage_clauses.nodes.iter().find_map(|&clause_idx| {
-                        let clause_node = self.ctx.arena.get(clause_idx)?;
-                        let heritage = self.ctx.arena.get_heritage_clause(clause_node)?;
-                        if heritage.token != SyntaxKind::ExtendsKeyword as u16 {
-                            return None;
-                        }
-                        let &type_idx = heritage.types.nodes.first()?;
-                        let type_node = self.ctx.arena.get(type_idx)?;
-                        let (expr_idx, type_arguments) = if let Some(expr_type_args) =
-                            self.ctx.arena.get_expr_type_args(type_node)
-                        {
-                            (
-                                expr_type_args.expression,
-                                expr_type_args.type_arguments.as_ref(),
-                            )
-                        } else {
-                            (type_idx, None)
-                        };
-                        self.base_instance_type_from_expression(expr_idx, type_arguments)
+            let base_prescan_type = if needs_inherited_prescan_this {
+                class
+                    .heritage_clauses
+                    .as_ref()
+                    .and_then(|heritage_clauses| {
+                        heritage_clauses.nodes.iter().find_map(|&clause_idx| {
+                            let clause_node = self.ctx.arena.get(clause_idx)?;
+                            let heritage = self.ctx.arena.get_heritage_clause(clause_node)?;
+                            if heritage.token != SyntaxKind::ExtendsKeyword as u16 {
+                                return None;
+                            }
+                            let &type_idx = heritage.types.nodes.first()?;
+                            let type_node = self.ctx.arena.get(type_idx)?;
+                            let (expr_idx, type_arguments) = if let Some(expr_type_args) =
+                                self.ctx.arena.get_expr_type_args(type_node)
+                            {
+                                (
+                                    expr_type_args.expression,
+                                    expr_type_args.type_arguments.as_ref(),
+                                )
+                            } else {
+                                (type_idx, None)
+                            };
+                            self.base_instance_type_from_expression(expr_idx, type_arguments)
+                        })
                     })
-                });
+            } else {
+                None
+            };
 
             if !prescan_props.is_empty() || base_prescan_type.is_some() {
                 let own_prescan_type = if !prescan_props.is_empty() {

--- a/crates/tsz-checker/src/types/class_type/core.rs
+++ b/crates/tsz-checker/src/types/class_type/core.rs
@@ -367,35 +367,8 @@ impl<'a> CheckerState<'a> {
                 }
             }
 
-            let base_prescan_type = if needs_inherited_prescan_this {
-                class
-                    .heritage_clauses
-                    .as_ref()
-                    .and_then(|heritage_clauses| {
-                        heritage_clauses.nodes.iter().find_map(|&clause_idx| {
-                            let clause_node = self.ctx.arena.get(clause_idx)?;
-                            let heritage = self.ctx.arena.get_heritage_clause(clause_node)?;
-                            if heritage.token != SyntaxKind::ExtendsKeyword as u16 {
-                                return None;
-                            }
-                            let &type_idx = heritage.types.nodes.first()?;
-                            let type_node = self.ctx.arena.get(type_idx)?;
-                            let (expr_idx, type_arguments) = if let Some(expr_type_args) =
-                                self.ctx.arena.get_expr_type_args(type_node)
-                            {
-                                (
-                                    expr_type_args.expression,
-                                    expr_type_args.type_arguments.as_ref(),
-                                )
-                            } else {
-                                (type_idx, None)
-                            };
-                            self.base_instance_type_from_expression(expr_idx, type_arguments)
-                        })
-                    })
-            } else {
-                None
-            };
+            let base_prescan_type =
+                self.inherited_prescan_this_base_type(class, needs_inherited_prescan_this);
 
             if !prescan_props.is_empty() || base_prescan_type.is_some() {
                 let own_prescan_type = if !prescan_props.is_empty() {

--- a/crates/tsz-checker/src/types/class_type/core.rs
+++ b/crates/tsz-checker/src/types/class_type/core.rs
@@ -358,13 +358,31 @@ impl<'a> CheckerState<'a> {
                 }
             }
 
-            // Also include the base class's already-cached instance type in the prescan
-            // so that `this.inheritedProp` in a derived class initializer doesn't produce
-            // a false TS2339. For example: `class B extends A { x = this.a; }` where `a`
-            // is declared in A — without this, `this` would only have B's own properties.
-            let base_prescan_type = self
-                .get_base_class_idx(class_idx)
-                .and_then(|base_idx| self.ctx.class_instance_type_cache.get(&base_idx).copied());
+            let base_prescan_type = class
+                .heritage_clauses
+                .as_ref()
+                .and_then(|heritage_clauses| {
+                    heritage_clauses.nodes.iter().find_map(|&clause_idx| {
+                        let clause_node = self.ctx.arena.get(clause_idx)?;
+                        let heritage = self.ctx.arena.get_heritage_clause(clause_node)?;
+                        if heritage.token != SyntaxKind::ExtendsKeyword as u16 {
+                            return None;
+                        }
+                        let &type_idx = heritage.types.nodes.first()?;
+                        let type_node = self.ctx.arena.get(type_idx)?;
+                        let (expr_idx, type_arguments) = if let Some(expr_type_args) =
+                            self.ctx.arena.get_expr_type_args(type_node)
+                        {
+                            (
+                                expr_type_args.expression,
+                                expr_type_args.type_arguments.as_ref(),
+                            )
+                        } else {
+                            (type_idx, None)
+                        };
+                        self.base_instance_type_from_expression(expr_idx, type_arguments)
+                    })
+                });
 
             if !prescan_props.is_empty() || base_prescan_type.is_some() {
                 let own_prescan_type = if !prescan_props.is_empty() {

--- a/crates/tsz-checker/src/types/class_type/mod.rs
+++ b/crates/tsz-checker/src/types/class_type/mod.rs
@@ -6,5 +6,6 @@ mod entry;
 mod helpers;
 mod heritage_identity;
 mod js_class_properties;
+mod prescan;
 
 pub(super) use helpers::can_skip_base_instantiation;

--- a/crates/tsz-checker/src/types/class_type/prescan.rs
+++ b/crates/tsz-checker/src/types/class_type/prescan.rs
@@ -1,0 +1,44 @@
+//! Helpers for the class-member prescan used while constructing instance types.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::node::ClassData;
+use tsz_scanner::SyntaxKind;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    pub(super) fn inherited_prescan_this_base_type(
+        &mut self,
+        class: &ClassData,
+        needs_inherited_prescan_this: bool,
+    ) -> Option<TypeId> {
+        if !needs_inherited_prescan_this {
+            return None;
+        }
+
+        class
+            .heritage_clauses
+            .as_ref()
+            .and_then(|heritage_clauses| {
+                heritage_clauses.nodes.iter().find_map(|&clause_idx| {
+                    let clause_node = self.ctx.arena.get(clause_idx)?;
+                    let heritage = self.ctx.arena.get_heritage_clause(clause_node)?;
+                    if heritage.token != SyntaxKind::ExtendsKeyword as u16 {
+                        return None;
+                    }
+                    let &type_idx = heritage.types.nodes.first()?;
+                    let type_node = self.ctx.arena.get(type_idx)?;
+                    let (expr_idx, type_arguments) = if let Some(expr_type_args) =
+                        self.ctx.arena.get_expr_type_args(type_node)
+                    {
+                        (
+                            expr_type_args.expression,
+                            expr_type_args.type_arguments.as_ref(),
+                        )
+                    } else {
+                        (type_idx, None)
+                    };
+                    self.base_instance_type_from_expression(expr_idx, type_arguments)
+                })
+            })
+    }
+}

--- a/crates/tsz-checker/tests/this_type_tests.rs
+++ b/crates/tsz-checker/tests/this_type_tests.rs
@@ -38,6 +38,59 @@ fn messages(diagnostics: &[(u32, String)]) -> Vec<&str> {
     diagnostics.iter().map(|(_, msg)| msg.as_str()).collect()
 }
 
+#[test]
+fn field_initializer_prescan_uses_substituted_generic_base_this() {
+    let source = r#"
+class Base<T> {
+    value!: T;
+    get(): T { return this.value; }
+}
+
+class Derived extends Base<number> {
+    field = this.get();
+}
+
+const ok: number = new Derived().field;
+const bad: string = new Derived().field;
+"#;
+    let diagnostics = compile_and_get_diagnostics_with_options(
+        source,
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    );
+
+    let ts2322_errors = errors_with_code(&diagnostics, 2322);
+    assert_eq!(
+        ts2322_errors.len(),
+        1,
+        "Expected exactly one TS2322 for assigning inherited number field to string; got {diagnostics:?}"
+    );
+    assert!(
+        errors_with_code(&diagnostics, 2339).is_empty(),
+        "Inherited generic base `this` member should be visible in field initializer; got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn class_prescan_does_not_evaluate_invalid_heritage_without_this_initializer() {
+    let diagnostics = compile_and_get_diagnostics("class C extends A extends B {}");
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|(code, message)| *code == 2304 && message.contains("'A'")),
+        "Expected existing TS2304 for missing base `A`; got {diagnostics:?}"
+    );
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|(code, message)| *code == 2304 && message.contains("'B'")),
+        "Prescan must not evaluate the invalid right-hand heritage expression `B`; got {diagnostics:?}"
+    );
+}
+
 /// Fluent method chaining: `c.foo().bar().baz()` where foo/bar/baz are defined
 /// on classes A/B/C in a hierarchy and each returns `this` implicitly.
 ///


### PR DESCRIPTION
## Agent
AgentName: MBM1-Canary-A

## Track
Canary project-corpus compatibility / checker fix.

## Invariant
When a class field initializer reads `this` in `class Child extends Base<TArg>`, the prescan `this` surface must include inherited base members instantiated with the actual heritage type arguments. This PR changes the checker class-instance prescan path so initializer callback context sees `Base<TArg>`, not raw `Base<T>`, and only builds the inherited prescan base when a non-static field initializer actually contains `this`.

## Scope
- `crates/tsz-checker/src/types/class_type/core.rs`
- `crates/tsz-checker/src/types/class_type/prescan.rs`
- Prescan-only base instance surface for class field initializer `this` typing.

## Project Corpus Impact
- Row: `zod-project` canary still fails.
- Bug family: zod class field initializer / inherited generic method callback context.
- Evidence: fixes the reduced zod witness `inherited_generic_method_on_this_uses_subclass_base_arguments_for_callback_context`; uncached `zod-project` still fails on other existing families led by `parseUtil.ts(101,24)` and `parseUtil.ts(104,3)`.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib inherited_generic_method_on_this_uses_subclass_base_arguments_for_callback_context`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib zod_type_query_regression_tests` (17 passed, 2 existing failures remain: `generic_promise_then_flattens_promise_return_from_callback`, `zod_cross_file_lib_partial_omit_preserves_imported_path_property`)
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib inherited_generic_method_on_this_uses_subclass_base_arguments_for_callback_context zod_type_field_initializer_this_keeps_instance_method_alias zod_error_field_initializer_this_keeps_accessors_and_base_members inherited_generic_class_field_this_method_aliases_use_declared_base_chain base_class_field_this_does_not_recover_derived_only_members getter_returning_this_no_false_ts2339`
- `scripts/safe-run.sh cargo build --target-dir .target --profile dist-fast -p tsz-cli --bin tsz`
- `TSZ_PROJECT_COMPILE_FILTER="zod-project" TSZ_PROJECT_COMPILE_SET=canary TSZ_PROJECT_COMPILE_RESULT_CACHE=0 TSZ_PROJECT_COMPILE_ALLOW_FAILURES=1 scripts/safe-run.sh scripts/ci/project-compile-guard.sh` (still fails; first errors remain `parseUtil.ts(101,24)` and `parseUtil.ts(104,3)`)
- `scripts/safe-run.sh scripts/ci/github-suite.sh lint`
- `cargo fmt --package tsz-checker`
- `git diff --check`
- Local conformance regression checks after gating inherited prescan on `this`: `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter "jsDeclarationsDefault" --verbose` and `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter "parserClassDeclaration1" --verbose` passed.
- PR-head CI on `68c7ca7b9fd3a629f94168f0248ef85e7afdf48f`: `CI Summary`, `conformance-aggregate`, `fourslash-aggregate`, `emit`, `project-compile-guard`, `project-compile-canary`, `lsp-e2e`, `dist-binaries`, `unit`, `lint`, `unit-cloudbuild`, `wasm`, `wasm-web`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, and `GitGuardian Security Checks` passed. `Queue Tested` remains pending for merge queue.

## Coordination Notes
- Ready for focused checker review/manager queueing; not adding `merge-queue` from this implementation lane.
- `zod-project` remains red for unrelated families (`Promise.then` callback promise flattening and cross-file partial/omit path preservation) and should be continued separately.
- Earlier PR-head conformance aggregate regressions in `jsDeclarationsDefault` and `parserClassDeclaration1` were fixed by gating inherited prescan on field initializers that contain `this`; remote CI conformance aggregate is green on `68c7ca7b9fd3a629f94168f0248ef85e7afdf48f`.
- Overlap checked against active PRs: avoids Kysely-focused #12161 and Studio-B #12242/#12237; does not touch solver, project guard, or module-resolution work.
- Structural rule only; no zod/source-name/file-name decision logic.
