### PR TITLE
fix(checker): elaborate array element-type mismatches like tsc (issue #11593)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
@@ -137,6 +137,7 @@ impl<'a> CheckerState<'a> {
             Some(SubtypeFailureReason::ArrayElementMismatch {
                 source_element: _,
                 target_element,
+                ..
             }) => {
                 for &elem_idx in &arr.elements.nodes {
                     let is_spread = self

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -693,49 +693,29 @@ impl<'a> CheckerState<'a> {
                     },
                 ]
             }
-            SubtypeFailureReason::ArrayElementMismatch {
-                source_element,
-                target_element,
-            } => {
-                let source_str = self.format_type_for_diagnostic_role(
-                    *source_element,
-                    DiagnosticTypeDisplayRole::DefaultDiagnostic,
-                );
-                let target_str = self.format_type_for_diagnostic_role(
-                    *target_element,
-                    DiagnosticTypeDisplayRole::DefaultDiagnostic,
-                );
-                let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
-                    *source_element,
-                    *target_element,
-                    source_str,
-                    target_str,
-                );
-                vec![
-                    DiagnosticRelatedInformation {
-                        category: DiagnosticCategory::Error,
-                        code: reason.diagnostic_code(),
-                        file: self.ctx.file_name.clone(),
-                        start,
-                        length,
-                        message_text: format!(
-                            "Array element type '{source_str}' is not assignable to '{target_str}'."
-                        ),
-                        depth: 0,
-                    },
-                    DiagnosticRelatedInformation {
+            SubtypeFailureReason::ArrayElementMismatch { .. } => {
+                // tsc names both array types in the head message (e.g.
+                // `Argument of type 'se[]' is not assignable to parameter of
+                // type 'te[]'.`) and then relates the *element* types directly
+                // beneath it, recursing into the element's own failure — there
+                // is no separate "array element" wrapper line. Reuse the shared
+                // array renderer (single source of truth) and keep only the
+                // element elaboration beneath its array-to-array header, which
+                // the call's head message already conveys.
+                let array_diag = self.render_failure_reason(reason, source, target, anchor_idx, 0);
+                array_diag
+                    .related_information
+                    .into_iter()
+                    .map(|rel| DiagnosticRelatedInformation {
                         category: DiagnosticCategory::Message,
-                        code: diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+                        code: rel.code,
                         file: self.ctx.file_name.clone(),
                         start,
                         length,
-                        message_text: format_message(
-                            diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                            &[&source_str, &target_str],
-                        ),
-                        depth: 1,
-                    },
-                ]
+                        message_text: rel.message_text,
+                        depth: rel.depth,
+                    })
+                    .collect()
             }
             SubtypeFailureReason::MissingIndexSignature { index_kind } => {
                 vec![DiagnosticRelatedInformation {

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -752,30 +752,13 @@ impl<'a> CheckerState<'a> {
             SubtypeFailureReason::ArrayElementMismatch {
                 source_element,
                 target_element,
-            } => {
-                if depth == 0 {
-                    let (source_str, target_str) =
-                        self.format_top_level_assignability_message_types_at(source, target, idx);
-                    let base = format_message(
-                        diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                        &[&source_str, &target_str],
-                    );
-                    Diagnostic::error(
-                        file_name,
-                        start,
-                        length,
-                        base,
-                        diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                    )
-                } else {
-                    let source_str = self.format_type_diagnostic(*source_element);
-                    let target_str = self.format_type_diagnostic(*target_element);
-                    let message = format!(
-                        "Array element type '{source_str}' is not assignable to '{target_str}'."
-                    );
-                    Diagnostic::error(file_name, start, length, message, reason.diagnostic_code())
-                }
-            }
+                nested_reason,
+            } => self.render_array_element_mismatch(
+                &rctx,
+                *source_element,
+                *target_element,
+                nested_reason.as_deref(),
+            ),
 
             SubtypeFailureReason::IndexSignatureMismatch {
                 index_kind,

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -136,11 +136,17 @@ impl<'a> CheckerState<'a> {
                 source_element,
                 target_element,
                 ..
-            }
-            | tsz_solver::SubtypeFailureReason::ArrayElementMismatch {
-                source_element,
-                target_element,
             } => (*source_element, *target_element),
+            // `ArrayElementMismatch` self-heads with the *array* types (`se[]`
+            // vs `te[]`), not its element types, so the nested render must keep
+            // the parent-supplied array types rather than drilling to the
+            // element pair (which would render `Type 'number' …'string'` in
+            // place of `Type 'number[]' …'string[]'`). Keep the fallback, which
+            // carries the array types. Explicit (not an implicit `_` gap) so it
+            // is not mistakenly "fixed" to mirror the tuple arm above.
+            tsz_solver::SubtypeFailureReason::ArrayElementMismatch { .. } => {
+                (fallback_source, fallback_target)
+            }
             tsz_solver::SubtypeFailureReason::IndexSignatureMismatch {
                 source_value_type,
                 target_value_type,
@@ -763,7 +769,6 @@ impl<'a> CheckerState<'a> {
                 | tsz_solver::SubtypeFailureReason::MissingProperty { .. }
                 | tsz_solver::SubtypeFailureReason::MissingProperties { .. }
                 | tsz_solver::SubtypeFailureReason::IndexSignatureMismatch { .. }
-                | tsz_solver::SubtypeFailureReason::ArrayElementMismatch { .. }
                 | tsz_solver::SubtypeFailureReason::ReturnTypeMismatch { .. }
                 | tsz_solver::SubtypeFailureReason::ParameterTypeMismatch { .. }
         )
@@ -1142,5 +1147,139 @@ impl<'a> CheckerState<'a> {
         });
         diag.related_information
             .extend(nested_diag.related_information);
+    }
+
+    /// Render an array element-type mismatch (`se[]` vs `te[]`).
+    ///
+    /// `tsc` elaborates an array relation exactly like a single numerically
+    /// keyed element: it leads with the `Type 'se[]' is not assignable to type
+    /// 'te[]'.` line (the array types themselves — unlike a single-element
+    /// tuple, the array relation never collapses to its element line), then
+    /// relates the element types directly beneath it, recursing through the
+    /// element's own failure reason. Examples:
+    ///
+    /// ```text
+    /// Type 'number[]' is not assignable to type 'string[]'.
+    ///   Type 'number' is not assignable to type 'string'.
+    ///
+    /// Type 'number[][]' is not assignable to type 'string[][]'.
+    ///   Type 'number[]' is not assignable to type 'string[]'.
+    ///     Type 'number' is not assignable to type 'string'.
+    /// ```
+    ///
+    /// The element drill is shared with the tuple/index-signature renderers via
+    /// [`Self::push_tuple_element_inner_failure`]; only the header (always the
+    /// array types) is array-specific.
+    pub(super) fn render_array_element_mismatch(
+        &mut self,
+        ctx: &RenderContext,
+        source_element: TypeId,
+        target_element: TypeId,
+        nested_reason: Option<&tsz_solver::SubtypeFailureReason>,
+    ) -> Diagnostic {
+        let depth = ctx.depth;
+
+        // Header: the array types themselves (`se[]` vs `te[]`), at every depth.
+        // Unlike a single-element tuple, an array relation never collapses to
+        // its element line — `tsc` always shows the array-to-array line first.
+        let (source_str, target_str) = if depth == 0 {
+            self.format_top_level_assignability_message_types_at(ctx.source, ctx.target, ctx.idx)
+        } else {
+            (
+                self.format_type_diagnostic(ctx.source),
+                self.format_type_diagnostic(ctx.target),
+            )
+        };
+        let base = format_message(
+            diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            &[&source_str, &target_str],
+        );
+        let mut diag = Diagnostic::error(
+            ctx.file_name.clone(),
+            ctx.start,
+            ctx.length,
+            base,
+            diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+        );
+
+        if depth >= 5 {
+            return diag;
+        }
+
+        // The element relation `se -> te` sits directly beneath the array
+        // header (no intermediate line, exactly like a single-element tuple).
+        // It occupies related-depth `elem_depth`; its own drill goes one deeper.
+        let elem_depth = if depth == 0 { 0 } else { depth + 1 };
+
+        match nested_reason {
+            // Self-heading element (scalar leaf, union, nested array, …): the
+            // nested reason emits the `Type 'se' …'te'` element line itself.
+            // Render it one level deeper and rebase its message down to sit
+            // directly beneath the array header.
+            Some(nested) if !Self::tuple_element_nested_needs_header(nested) => {
+                let element_diag = self.render_failure_reason(
+                    nested,
+                    source_element,
+                    target_element,
+                    ctx.idx,
+                    elem_depth + 1,
+                );
+                Self::push_rebased_subdiagnostic(
+                    &mut diag,
+                    element_diag,
+                    elem_depth + 1,
+                    elem_depth,
+                );
+            }
+            // Structural element (object property, index signature, …) or a
+            // terminal scalar pair: emit the `Type 'se' …'te'` element header,
+            // then drill into the structural reason when one is present.
+            other => {
+                diag.related_information.push(DiagnosticRelatedInformation {
+                    file: diag.file.clone(),
+                    start: ctx.start,
+                    length: ctx.length,
+                    message_text: self.element_mismatch_message(source_element, target_element),
+                    category: DiagnosticCategory::Message,
+                    code: diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+                    depth: elem_depth.min(u8::MAX as u32) as u8,
+                });
+                if let Some(nested) = other {
+                    let nested_diag = self.render_failure_reason(
+                        nested,
+                        source_element,
+                        target_element,
+                        ctx.idx,
+                        elem_depth + 1,
+                    );
+                    Self::push_nested_chain(&mut diag, nested_diag, elem_depth + 1);
+                }
+            }
+        }
+
+        diag
+    }
+
+    /// Format the `Type 'se' is not assignable to type 'te'.` line for an
+    /// element-type pair, disambiguating same-named types (e.g. `N.Token` vs
+    /// `M.Token`) so the line is never the ambiguous
+    /// `Type 'Token' is not assignable to type 'Token'.`, matching `tsc`.
+    fn element_mismatch_message(
+        &mut self,
+        source_element: TypeId,
+        target_element: TypeId,
+    ) -> String {
+        let source_str = self.format_type_diagnostic(source_element);
+        let target_str = self.format_type_diagnostic(target_element);
+        let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
+            source_element,
+            target_element,
+            source_str,
+            target_str,
+        );
+        format_message(
+            diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            &[&source_str, &target_str],
+        )
     }
 }

--- a/crates/tsz-checker/src/query_boundaries/relation_types.rs
+++ b/crates/tsz-checker/src/query_boundaries/relation_types.rs
@@ -265,6 +265,7 @@ impl RelationFailure {
             SubtypeFailureReason::ArrayElementMismatch {
                 source_element,
                 target_element,
+                ..
             }
             | SubtypeFailureReason::TupleElementTypeMismatch {
                 source_element,

--- a/crates/tsz-checker/tests/ts2322_tests_parts/part_02.rs
+++ b/crates/tsz-checker/tests/ts2322_tests_parts/part_02.rs
@@ -526,12 +526,15 @@ fn test_ts2345_array_element_mismatch_includes_related_detail() {
         })
         .expect("expected TS2345 for array-element mismatch");
 
+    // tsc relates the element types directly beneath the argument message
+    // (which already names both array types) — there is no tsz-specific
+    // "Array element type ..." wrapper line.
     assert!(
-        ts2345.related_information.iter().any(|info| {
-            info.message_text
-                .contains("Array element type 'string' is not assignable to 'number'.")
-        }),
-        "Expected TS2345 to include array-element elaboration, got: {ts2345:?}"
+        !ts2345
+            .related_information
+            .iter()
+            .any(|info| info.message_text.starts_with("Array element type")),
+        "TS2345 must not emit the non-tsc 'Array element type ...' wrapper, got: {ts2345:?}"
     );
     assert!(
         ts2345.related_information.iter().any(|info| {
@@ -540,7 +543,7 @@ fn test_ts2345_array_element_mismatch_includes_related_detail() {
                     .message_text
                     .contains("Type 'string' is not assignable to type 'number'.")
         }),
-        "Expected TS2345 to include nested type mismatch under array-element elaboration, got: {ts2345:?}"
+        "Expected TS2345 to relate the element types directly, got: {ts2345:?}"
     );
 }
 
@@ -565,7 +568,7 @@ fn test_ts2345_array_element_mismatch_related_detail_qualifies_same_named_elemen
     assert!(
         ts2345.related_information.iter().any(|info| {
             info.message_text
-                .contains("Array element type 'N.Token' is not assignable to 'M.Token'.")
+                .contains("Type 'N.Token' is not assignable to type 'M.Token'.")
         }),
         "Expected TS2345 related info to qualify same-named element types, got: {ts2345:?}"
     );

--- a/crates/tsz-checker/tests/ts2322_tests_parts/part_04.rs
+++ b/crates/tsz-checker/tests/ts2322_tests_parts/part_04.rs
@@ -1684,3 +1684,123 @@ let x: "red" | "green" | "blue" = c;
         "plain string literal union target should use full literal union form, got: {msg}"
     );
 }
+
+/// Collect a TS2322 diagnostic's elaboration as `(depth, message)` pairs,
+/// outer-to-inner, for asserting the exact `tsc` chain shape.
+fn ts2322_chain(source: &str) -> (String, Vec<(u8, String)>) {
+    let diags = diagnostics_for_source(source);
+    let ts2322 = diags
+        .iter()
+        .find(|d| d.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE)
+        .unwrap_or_else(|| panic!("expected TS2322, got: {diags:?}"));
+    let chain = ts2322
+        .related_information
+        .iter()
+        .map(|r| (r.depth, r.message_text.clone()))
+        .collect();
+    (ts2322.message_text.clone(), chain)
+}
+
+#[test]
+fn test_ts2322_array_element_mismatch_emits_tsc_elaboration_chain() {
+    // `tsc` relates an array element failure exactly like a single-element
+    // tuple: the array-to-array head line, then the element types directly
+    // beneath it.
+    //   Type 'number[]' is not assignable to type 'string[]'.
+    //     Type 'number' is not assignable to type 'string'.
+    let (head, chain) = ts2322_chain("declare const s: number[]; const t: string[] = s;");
+    assert_eq!(head, "Type 'number[]' is not assignable to type 'string[]'.");
+    assert_eq!(
+        chain,
+        vec![(0u8, "Type 'number' is not assignable to type 'string'.".to_string())],
+        "array element mismatch must elaborate the element relation directly"
+    );
+    assert!(
+        !chain.iter().any(|(_, m)| m.starts_with("Array element type")),
+        "must not emit the non-tsc 'Array element type ...' wrapper"
+    );
+}
+
+#[test]
+fn test_ts2322_nested_array_element_mismatch_peels_one_level_per_line() {
+    //   Type 'number[][]' is not assignable to type 'string[][]'.
+    //     Type 'number[]' is not assignable to type 'string[]'.
+    //       Type 'number' is not assignable to type 'string'.
+    let (head, chain) = ts2322_chain("declare const s: number[][]; const t: string[][] = s;");
+    assert_eq!(head, "Type 'number[][]' is not assignable to type 'string[][]'.");
+    assert_eq!(
+        chain,
+        vec![
+            (0u8, "Type 'number[]' is not assignable to type 'string[]'.".to_string()),
+            (1u8, "Type 'number' is not assignable to type 'string'.".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn test_ts2322_array_of_object_element_drills_into_property() {
+    //   Type '{ b: number; }[]' is not assignable to type '{ b: string; }[]'.
+    //     Type '{ b: number; }' is not assignable to type '{ b: string; }'.
+    //       Types of property 'b' are incompatible.
+    //         Type 'number' is not assignable to type 'string'.
+    let (head, chain) =
+        ts2322_chain("declare const s: { b: number }[]; const t: { b: string }[] = s;");
+    assert_eq!(
+        head,
+        "Type '{ b: number; }[]' is not assignable to type '{ b: string; }[]'."
+    );
+    assert_eq!(chain.len(), 3, "got: {chain:?}");
+    assert_eq!(chain[0].0, 0);
+    assert_eq!(
+        chain[0].1,
+        "Type '{ b: number; }' is not assignable to type '{ b: string; }'."
+    );
+    assert_eq!(chain[1].0, 1);
+    assert!(chain[1].1.contains("Types of property 'b' are incompatible."));
+    assert_eq!(chain[2].0, 2);
+    assert_eq!(
+        chain[2].1,
+        "Type 'number' is not assignable to type 'string'."
+    );
+}
+
+#[test]
+fn test_ts2322_array_in_property_self_heads_with_array_relation() {
+    //   Type '{ a: number[]; }' is not assignable to type '{ a: string[]; }'.
+    //     Types of property 'a' are incompatible.
+    //       Type 'number[]' is not assignable to type 'string[]'.
+    //         Type 'number' is not assignable to type 'string'.
+    let (_head, chain) =
+        ts2322_chain("declare const s: { a: number[] }; const t: { a: string[] } = s;");
+    assert_eq!(chain.len(), 3, "got: {chain:?}");
+    assert!(chain[0].1.contains("Types of property 'a' are incompatible."));
+    assert_eq!(chain[0].0, 0);
+    assert_eq!(
+        chain[1],
+        (1u8, "Type 'number[]' is not assignable to type 'string[]'.".to_string())
+    );
+    assert_eq!(
+        chain[2],
+        (2u8, "Type 'number' is not assignable to type 'string'.".to_string())
+    );
+}
+
+#[test]
+fn test_ts2322_array_element_chain_independent_of_element_names() {
+    // Anti-hardcoding: the same elaboration shape must hold for renamed,
+    // same-shaped element interfaces — no name string drives the chain.
+    let source = "interface Alpha { tag: 1 } interface Beta { tag: 2 } \
+                  declare const s: Alpha[]; const t: Beta[] = s;";
+    let (head, chain) = ts2322_chain(source);
+    assert_eq!(head, "Type 'Alpha[]' is not assignable to type 'Beta[]'.");
+    assert_eq!(chain[0].0, 0);
+    assert_eq!(
+        chain[0].1,
+        "Type 'Alpha' is not assignable to type 'Beta'.",
+        "the array head must relate the element interfaces, not collapse them"
+    );
+    assert!(
+        chain.iter().any(|(_, m)| m.contains("Types of property 'tag' are incompatible.")),
+        "got: {chain:?}"
+    );
+}

--- a/crates/tsz-solver/src/diagnostics/core.rs
+++ b/crates/tsz-solver/src/diagnostics/core.rs
@@ -174,9 +174,19 @@ pub enum SubtypeFailureReason {
         multi_element: bool,
     },
     /// Array element type mismatch.
+    ///
+    /// Like a single-element tuple, an array relation fails through its element
+    /// type, and `tsc` elaborates the failure by relating the element types
+    /// directly beneath the `Type 'se[]' …'te[]'` line — recursing into the
+    /// element's own reason via `nested_reason` (e.g. `number[][]` →
+    /// `string[][]` walks one array level at a time, and `{ b: T }[]` drills
+    /// into the offending property). When the element relation is a terminal
+    /// scalar leaf, `nested_reason` is `None` and the renderer emits the plain
+    /// `Type 'se' …'te'` line.
     ArrayElementMismatch {
         source_element: TypeId,
         target_element: TypeId,
+        nested_reason: Option<Box<Self>>,
     },
     /// Index signature value type mismatch.
     IndexSignatureMismatch {
@@ -889,14 +899,23 @@ impl SubtypeFailureReason {
             Self::ArrayElementMismatch {
                 source_element,
                 target_element,
-            } => PendingDiagnostic::error(
-                codes::TYPE_NOT_ASSIGNABLE,
-                vec![source.into(), target.into()],
-            )
-            .with_related(PendingDiagnostic::error(
-                codes::TYPE_NOT_ASSIGNABLE,
-                vec![(*source_element).into(), (*target_element).into()],
-            )),
+                nested_reason,
+            } => {
+                let mut diag = PendingDiagnostic::error(
+                    codes::TYPE_NOT_ASSIGNABLE,
+                    vec![source.into(), target.into()],
+                );
+                if let Some(nested) = nested_reason {
+                    diag =
+                        diag.with_related(nested.to_diagnostic(*source_element, *target_element));
+                } else {
+                    diag = diag.with_related(PendingDiagnostic::error(
+                        codes::TYPE_NOT_ASSIGNABLE,
+                        vec![(*source_element).into(), (*target_element).into()],
+                    ));
+                }
+                diag
+            }
 
             Self::IndexSignatureMismatch {
                 index_kind: _,

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -656,9 +656,16 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             array_element_type(self.interner, target),
         ) {
             if !self.check_subtype(s_elem, t_elem).is_true() {
+                // Recurse into the element failure so the rendered chain carries
+                // the inner reason (matching tsc, which walks an array element
+                // exactly like a single-element tuple / numerically keyed
+                // property: `number[][]` -> `string[][]` peels one array level
+                // at a time, `{ b: T }[]` drills into the offending property).
+                let nested_reason = self.explain_failure(s_elem, t_elem).map(Box::new);
                 return Some(SubtypeFailureReason::ArrayElementMismatch {
                     source_element: s_elem,
                     target_element: t_elem,
+                    nested_reason,
                 });
             }
             return None;


### PR DESCRIPTION
AgentName: Studio-B

Track: diagnostics / type-display + error-position parity (assignability elaboration chains)

Invariant: A failing array relation `T[] -> U[]` elaborates exactly like `tsc` — lead with the `Type 'T[]' is not assignable to type 'U[]'.` line, then relate the element types directly beneath it, recursing into the element's own reason; never drop the element relation and never emit a tsz-specific `Array element type …` wrapper.

Scope: solver `SubtypeFailureReason::ArrayElementMismatch` + checker render-failure / fingerprint elaboration gateway. No relation-decision, inference, narrowing, or emit changes; diagnostic codes and primary spans are unchanged.

## Problem

For a non-literal array assignment, tsz dropped the element relation from the diagnostic:

- Variable-decl path (`render_failure_reason`): emitted only the top `Type 'number[]' is not assignable to type 'string[]'.` line — the `Type 'number' is not assignable to type 'string'.` elaboration `tsc` prints was missing entirely.
- Call-argument path (`related_from_failure_reason`): emitted a non-`tsc` `Array element type 'number' is not assignable to 'string'.` wrapper line.

This is the `diagnostics-33-20` "diagnostic output drops index and property position" family: the offending element relation/position was hidden. Tuples already elaborated correctly (`TupleElementTypeMismatch` carries a `nested_reason`); arrays did not.

## Structural rule

When an array relation fails through its element type, `tsc` walks the element exactly like a single numerically keyed element:

```
Type 'number[][]' is not assignable to type 'string[][]'.
  Type 'number[]' is not assignable to type 'string[]'.
    Type 'number' is not assignable to type 'string'.

Type '{ b: number; }[]' is not assignable to type '{ b: string; }[]'.
  Type '{ b: number; }' is not assignable to type '{ b: string; }'.
    Types of property 'b' are incompatible.
      Type 'number' is not assignable to type 'string'.
```

tsz now produces this through the solver `SubtypeFailureReason` -> checker render-failure gateway.

## Owner layer & changes

- solver (`diagnostics/core.rs`, `relations/subtype/explain.rs`): `ArrayElementMismatch` carries `nested_reason: Option<Box<Self>>` (mirroring `TupleElementTypeMismatch`), computed via the guarded `explain_failure` on the element pair; `to_diagnostic` recurses it.
- checker (`render_failure*`): shared `render_array_element_mismatch` renderer self-heads with the array types at every depth (an array relation never collapses to its element line) and reuses the existing element-drill helpers (`push_nested_chain`, `push_rebased_subdiagnostic`). `nested_failure_display_types` keeps the parent-supplied array types for array nodes (explicit arm). Same-named element types (`N.Token` vs `M.Token`) are disambiguated via `finalize_pair_display_for_diagnostic`.
- checker (`fingerprint_policy.rs`): the TS2345 call-argument path delegates to the shared renderer (single source of truth) and keeps only the element elaboration beneath the head message, replacing the bespoke two-line wrapper.

## Adjacent-case matrix (all verified to match `tsc`)

- top-level `number[] -> string[]`
- nested `number[][] -> string[][]`
- array of objects `{ b: number }[] -> { b: string }[]`
- array-valued property `{ a: number[] } -> { a: string[] }`
- union element `(number | boolean)[] -> string[]`
- TS2345 call argument `f(number[])` with param `string[]`
- renamed same-shaped element interfaces (anti-hardcoding: chain shape is name-independent)

## Project Corpus Impact

- Row: n/a (diagnostics-family elaboration; affects rows that surface array element mismatches such as nextjs / utility-types-project)
- Bug family: diagnostics chain dropping element/position info (diagnostics-33-20)
- Evidence: change is purely additive elaboration on an existing TS2322/TS2345 error path; diagnostic codes and primary spans are unchanged, so error-count parity is preserved while message text moves toward `tsc`.

## Verification

```
cargo build --workspace                                  # clean
cargo clippy -p tsz-checker -p tsz-solver                # clean
cargo test -p tsz-checker --lib ts2322_tests::           # 311 passed (3 failures pre-existing on base, unrelated)
cargo test -p tsz-checker --test tuple_element_mismatch_tests   # 7/7 pass (no tuple regression)
cargo test -p tsz-solver  --lib diagnostics              # 275/275 pass
```

New regression tests (`ts2322_tests_parts/part_04.rs`): top-level, nested, array-of-object, array-in-property, and name-independence chains. Updated the two TS2345 tests in `part_02.rs` that previously asserted the non-`tsc` `Array element type …` wrapper. The 3 pre-existing `ts2322_tests` failures fail identically on the rebased base with these changes stashed — not introduced here.

## Coordination Notes

Tracks issue #11593. Per the bug-discipline contract, this generalizes the reported "drops index and property position" symptom into the full array-element elaboration family rather than patching a single repro; the broader issue can remain open for any follow-up witnesses. Tuple/index-signature elaboration is untouched. Readonly-array element extraction (a separate `array_element_type` detection gap) is intentionally out of scope and noted for follow-up.

https://claude.ai/code/session_0165P3xTW2fTnTxt3sYqypD1