### PR TITLE
fix(checker): clear canary conformance blockers

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/applicability.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/applicability.rs
@@ -2,7 +2,7 @@
 
 use super::CheckerCallAssignabilityAdapter;
 use crate::query_boundaries::checkers::call::{
-    resolve_call, resolve_call_with_arg_sources, resolve_new,
+    CallArgSourceOptions, resolve_call, resolve_call_with_arg_sources, resolve_new,
 };
 use crate::query_boundaries::common::CallResult;
 use crate::state::CheckerState;
@@ -143,6 +143,7 @@ impl<'a> CheckerState<'a> {
         contextual_type: Option<TypeId>,
         actual_this_type: Option<TypeId>,
         arg_source_is_type_annotation: &[bool],
+        arg_source_is_readonly_annotation: &[bool],
     ) -> tsz_solver::operations::CallWithCheckerResult {
         self.ensure_relation_input_ready(func_type);
         self.ensure_relation_inputs_ready(arg_types);
@@ -154,10 +155,13 @@ impl<'a> CheckerState<'a> {
             &mut checker,
             func_type,
             arg_types,
-            force_bivariant_callbacks,
-            contextual_type,
-            actual_this_type,
-            arg_source_is_type_annotation,
+            &CallArgSourceOptions {
+                force_bivariant_callbacks,
+                contextual_type,
+                actual_this_type,
+                arg_source_is_type_annotation,
+                arg_source_is_readonly_annotation,
+            },
         )
     }
 
@@ -174,8 +178,11 @@ impl<'a> CheckerState<'a> {
         contextual_type: Option<TypeId>,
         actual_this_type: Option<TypeId>,
         arg_source_is_type_annotation: &[bool],
+        arg_source_is_readonly_annotation: &[bool],
     ) -> tsz_solver::operations::CallWithCheckerResult {
-        if arg_source_is_type_annotation.iter().any(|&m| m) {
+        if arg_source_is_type_annotation.iter().any(|&m| m)
+            || arg_source_is_readonly_annotation.iter().any(|&m| m)
+        {
             self.resolve_call_with_checker_adapter_and_arg_sources(
                 func_type,
                 arg_types,
@@ -183,6 +190,7 @@ impl<'a> CheckerState<'a> {
                 contextual_type,
                 actual_this_type,
                 arg_source_is_type_annotation,
+                arg_source_is_readonly_annotation,
             )
         } else {
             self.resolve_call_with_checker_adapter(

--- a/crates/tsz-checker/src/checkers/call_checker/candidate_collection.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/candidate_collection.rs
@@ -240,6 +240,81 @@ impl<'a> CheckerState<'a> {
             })
     }
 
+    fn declared_generic_indexed_spread_type(&mut self, expr_idx: NodeIndex) -> Option<TypeId> {
+        let idx = self.ctx.arena.skip_parenthesized(expr_idx);
+        let node = self.ctx.arena.get(idx)?;
+        if node.kind != tsz_scanner::SyntaxKind::Identifier as u16 {
+            return None;
+        }
+
+        let sym_id = self.resolve_identifier_symbol(idx)?;
+        let stable_declarations = {
+            let symbol = self
+                .get_cross_file_symbol(sym_id)
+                .or_else(|| self.ctx.binder.get_symbol(sym_id))?;
+            symbol
+                .stable_declarations
+                .iter()
+                .copied()
+                .chain(std::iter::once(symbol.stable_value_declaration))
+                .filter(|loc| loc.is_known())
+                .collect::<Vec<_>>()
+        };
+
+        for stable_location in stable_declarations {
+            let Some((decl_idx, arena)) = self.ctx.node_at_stable_location(stable_location) else {
+                continue;
+            };
+            let Some(decl_node) = arena.get(decl_idx) else {
+                continue;
+            };
+            let annotation = arena
+                .get_variable_declaration(decl_node)
+                .map(|decl| decl.type_annotation)
+                .or_else(|| {
+                    arena
+                        .get_parameter(decl_node)
+                        .map(|param| param.type_annotation)
+                })
+                .unwrap_or(NodeIndex::NONE);
+            if annotation.is_none() {
+                continue;
+            }
+
+            let declared = if std::ptr::eq(arena, self.ctx.arena) {
+                self.get_type_from_type_node(annotation)
+            } else if stable_location.has_file_idx()
+                && stable_location.file_idx != self.ctx.current_file_idx as u32
+            {
+                self.type_of_value_declaration_for_cross_file_symbol(
+                    sym_id,
+                    decl_idx,
+                    stable_location.file_idx as usize,
+                )
+            } else if !std::ptr::eq(arena, self.ctx.arena)
+                && let Some(target_file_idx) = self.ctx.get_file_idx_for_arena(arena)
+                && target_file_idx != self.ctx.current_file_idx
+            {
+                self.type_of_value_declaration_for_cross_file_symbol(
+                    sym_id,
+                    decl_idx,
+                    target_file_idx,
+                )
+            } else {
+                self.type_of_value_declaration_for_symbol(sym_id, decl_idx)
+            };
+
+            if crate::query_boundaries::common::contains_generic_indexed_access_surface(
+                self.ctx.types,
+                declared,
+            ) {
+                return Some(declared);
+            }
+        }
+
+        None
+    }
+
     /// Collect argument types with contextual typing from expected parameter types.
     ///
     /// This method handles:
@@ -560,7 +635,10 @@ impl<'a> CheckerState<'a> {
                         )
                         .is_some()
                     {
-                        arg_types.push(self.spread_argument_marker_type(spread_type));
+                        let marker_type = self
+                            .declared_generic_indexed_spread_type(spread_expression)
+                            .unwrap_or(spread_type);
+                        arg_types.push(self.spread_argument_marker_type(marker_type));
                         effective_index += 1;
                         continue;
                     }
@@ -1021,6 +1099,9 @@ impl<'a> CheckerState<'a> {
                     raw_arg_type,
                     expected_context_type.or(expected_type),
                 )
+                .unwrap_or(raw_arg_type);
+            let raw_arg_type = self
+                .readonly_array_like_annotation_for_identifier_argument(arg_idx, raw_arg_type)
                 .unwrap_or(raw_arg_type);
             let arg_type = if let Some(expected) = expected_context_type.or(expected_type) {
                 let expected_eval = self.evaluate_type_with_env(expected);
@@ -1754,210 +1835,5 @@ impl<'a> CheckerState<'a> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::context::CheckerOptions;
-    use crate::module_resolution::build_module_resolution_maps;
-    use std::sync::Arc;
-    use tsz_binder::BinderState;
-    use tsz_parser::parser::ParserState;
-    use tsz_solver::construction::TypeInterner;
-
-    fn first_argument_for_call(checker: &CheckerState<'_>, callee_name: &str) -> NodeIndex {
-        checker
-            .ctx
-            .arena
-            .nodes
-            .iter()
-            .find_map(|node| {
-                if node.kind != syntax_kind_ext::CALL_EXPRESSION {
-                    return None;
-                }
-                let call = checker.ctx.arena.get_call_expr(node)?;
-                let callee_node = checker.ctx.arena.get(call.expression)?;
-                let callee_ident = checker.ctx.arena.get_identifier(callee_node)?;
-                if callee_ident.escaped_text != callee_name {
-                    return None;
-                }
-                call.arguments.as_ref()?.nodes.first().copied()
-            })
-            .expect("expected call argument")
-    }
-
-    #[test]
-    fn generic_call_source_markers_fast_fail_parameter_identifiers() {
-        let source = r#"
-declare function fromParam<T>(value: T): T;
-declare function fromPayload<U>(value: U): U;
-declare function fromTyped<V>(value: V): V;
-declare function fromAssertion<W>(value: W): W;
-declare function fromRedeclared<X>(value: X): X;
-declare function fromDestructured<Y>(value: Y): Y;
-
-function run<T, U>(input: T, payload: U) {
-    const typed: { a: 1 } = { a: 1 };
-    fromParam(input);
-    fromPayload(payload);
-    fromTyped(typed);
-    fromAssertion(input as T);
-}
-
-function redeclared(input: unknown) {
-    var input: { a: 1 };
-    fromRedeclared(input);
-}
-
-function destructured({ item }: { item: { a: 1 } }) {
-    fromDestructured(item);
-}
-"#;
-
-        let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-        let root = parser.parse_source_file();
-        let arena = parser.get_arena().clone();
-        let mut binder = BinderState::new();
-        binder.bind_source_file(&arena, root);
-        let types = TypeInterner::new();
-        let mut checker = CheckerState::new(
-            &arena,
-            &binder,
-            &types,
-            "test.ts".to_string(),
-            CheckerOptions::default(),
-        );
-        checker.check_source_file(root);
-
-        let param_arg = first_argument_for_call(&checker, "fromParam");
-        let renamed_param_arg = first_argument_for_call(&checker, "fromPayload");
-        let typed_arg = first_argument_for_call(&checker, "fromTyped");
-        let asserted_arg = first_argument_for_call(&checker, "fromAssertion");
-        let redeclared_arg = first_argument_for_call(&checker, "fromRedeclared");
-        let destructured_arg = first_argument_for_call(&checker, "fromDestructured");
-        let param_sym = checker
-            .resolve_identifier_symbol(param_arg)
-            .expect("parameter argument should resolve");
-        let typed_sym = checker
-            .resolve_identifier_symbol(typed_arg)
-            .expect("typed local argument should resolve");
-        let redeclared_sym = checker
-            .resolve_identifier_symbol(redeclared_arg)
-            .expect("redeclared argument should resolve");
-
-        assert!(
-            checker.local_symbol_value_declaration_is_plain_parameter(param_sym),
-            "plain local parameters should take the fast-fail path"
-        );
-        assert!(
-            !checker.local_symbol_value_declaration_is_plain_parameter(typed_sym),
-            "typed locals are not parameter fast-fail candidates"
-        );
-        assert!(
-            !checker.local_symbol_value_declaration_is_plain_parameter(redeclared_sym),
-            "parameter symbols with typed variable declarations must stay on the full scan"
-        );
-
-        assert_eq!(
-            checker.call_arg_source_type_annotation_markers(&[param_arg], 1),
-            vec![false],
-            "parameter identifiers are not variable-declaration type annotation sources"
-        );
-        assert_eq!(
-            checker.call_arg_source_type_annotation_markers(&[renamed_param_arg], 1),
-            vec![false],
-            "renamed parameter identifiers should take the same fast-fail path"
-        );
-        assert_eq!(
-            checker.call_arg_source_type_annotation_markers(&[typed_arg], 1),
-            vec![true],
-            "typed local variable identifiers must still mark generic inference sources"
-        );
-        assert_eq!(
-            checker.call_arg_source_type_annotation_markers(&[asserted_arg], 1),
-            vec![true],
-            "explicit type assertions must still mark generic inference sources"
-        );
-        assert_eq!(
-            checker.call_arg_source_type_annotation_markers(&[redeclared_arg], 1),
-            vec![true],
-            "parameter symbols that also have typed variable declarations should keep old marker behavior"
-        );
-        assert_eq!(
-            checker.call_arg_source_type_annotation_markers(&[destructured_arg], 1),
-            vec![false],
-            "destructured parameter bindings are not variable-declaration type annotation sources"
-        );
-    }
-
-    #[test]
-    fn generic_call_source_markers_keep_cross_file_typed_identifier_sources() {
-        let files = [
-            (
-                "consumer.ts",
-                r#"
-declare function fromTyped<T>(value: T): T;
-
-function run(local: unknown) {
-    fromTyped(typedGlobal);
-}
-"#,
-            ),
-            (
-                "shared.ts",
-                r#"
-declare const typedGlobal: { a: 1 };
-"#,
-            ),
-        ];
-
-        let mut arenas = Vec::with_capacity(files.len());
-        let mut binders = Vec::with_capacity(files.len());
-        let mut roots = Vec::with_capacity(files.len());
-        let file_names: Vec<String> = files.iter().map(|(name, _)| (*name).to_string()).collect();
-        for (file_idx, (name, source)) in files.iter().enumerate() {
-            let mut parser = ParserState::new((*name).to_string(), (*source).to_string());
-            let root = parser.parse_source_file();
-            let mut binder = BinderState::new();
-            binder.set_file_idx(file_idx as u32);
-            binder.bind_source_file(parser.get_arena(), root);
-            arenas.push(Arc::new(parser.get_arena().clone()));
-            binders.push(Arc::new(binder));
-            roots.push(root);
-        }
-
-        let (resolved_module_paths, resolved_modules) = build_module_resolution_maps(&file_names);
-        let all_arenas = Arc::new(arenas);
-        let all_binders = Arc::new(binders);
-        let types = TypeInterner::new();
-        let mut checker = CheckerState::new(
-            all_arenas[0].as_ref(),
-            all_binders[0].as_ref(),
-            &types,
-            file_names[0].clone(),
-            CheckerOptions::default(),
-        );
-        checker.ctx.set_all_arenas(Arc::clone(&all_arenas));
-        checker.ctx.set_all_binders(Arc::clone(&all_binders));
-        checker.ctx.set_current_file_idx(0);
-        checker.ctx.set_lib_contexts(Vec::new());
-        checker
-            .ctx
-            .set_resolved_module_paths(Arc::new(resolved_module_paths));
-        checker.ctx.set_resolved_modules(resolved_modules);
-
-        checker.check_source_file(roots[0]);
-
-        let typed_arg = first_argument_for_call(&checker, "fromTyped");
-        let typed_sym = checker
-            .resolve_identifier_symbol(typed_arg)
-            .expect("cross-file typed argument should resolve");
-        assert!(
-            !checker.local_symbol_value_declaration_is_plain_parameter(typed_sym),
-            "cross-file typed variables must not collide with local parameter fast-fail"
-        );
-        assert_eq!(
-            checker.call_arg_source_type_annotation_markers(&[typed_arg], 1),
-            vec![true],
-            "cross-file typed variable identifiers must keep old marker behavior"
-        );
-    }
-}
+#[path = "candidate_collection_tests.rs"]
+mod tests;

--- a/crates/tsz-checker/src/checkers/call_checker/candidate_collection_tests.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/candidate_collection_tests.rs
@@ -1,0 +1,205 @@
+use super::*;
+use crate::context::CheckerOptions;
+use crate::module_resolution::build_module_resolution_maps;
+use std::sync::Arc;
+use tsz_binder::BinderState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::construction::TypeInterner;
+
+fn first_argument_for_call(checker: &CheckerState<'_>, callee_name: &str) -> NodeIndex {
+    checker
+        .ctx
+        .arena
+        .nodes
+        .iter()
+        .find_map(|node| {
+            if node.kind != syntax_kind_ext::CALL_EXPRESSION {
+                return None;
+            }
+            let call = checker.ctx.arena.get_call_expr(node)?;
+            let callee_node = checker.ctx.arena.get(call.expression)?;
+            let callee_ident = checker.ctx.arena.get_identifier(callee_node)?;
+            if callee_ident.escaped_text != callee_name {
+                return None;
+            }
+            call.arguments.as_ref()?.nodes.first().copied()
+        })
+        .expect("expected call argument")
+}
+
+#[test]
+fn generic_call_source_markers_fast_fail_parameter_identifiers() {
+    let source = r#"
+declare function fromParam<T>(value: T): T;
+declare function fromPayload<U>(value: U): U;
+declare function fromTyped<V>(value: V): V;
+declare function fromAssertion<W>(value: W): W;
+declare function fromRedeclared<X>(value: X): X;
+declare function fromDestructured<Y>(value: Y): Y;
+
+function run<T, U>(input: T, payload: U) {
+    const typed: { a: 1 } = { a: 1 };
+    fromParam(input);
+    fromPayload(payload);
+    fromTyped(typed);
+    fromAssertion(input as T);
+}
+
+function redeclared(input: unknown) {
+    var input: { a: 1 };
+    fromRedeclared(input);
+}
+
+function destructured({ item }: { item: { a: 1 } }) {
+    fromDestructured(item);
+}
+"#;
+
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let arena = parser.get_arena().clone();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&arena, root);
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        &arena,
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions::default(),
+    );
+    checker.check_source_file(root);
+
+    let param_arg = first_argument_for_call(&checker, "fromParam");
+    let renamed_param_arg = first_argument_for_call(&checker, "fromPayload");
+    let typed_arg = first_argument_for_call(&checker, "fromTyped");
+    let asserted_arg = first_argument_for_call(&checker, "fromAssertion");
+    let redeclared_arg = first_argument_for_call(&checker, "fromRedeclared");
+    let destructured_arg = first_argument_for_call(&checker, "fromDestructured");
+    let param_sym = checker
+        .resolve_identifier_symbol(param_arg)
+        .expect("parameter argument should resolve");
+    let typed_sym = checker
+        .resolve_identifier_symbol(typed_arg)
+        .expect("typed local argument should resolve");
+    let redeclared_sym = checker
+        .resolve_identifier_symbol(redeclared_arg)
+        .expect("redeclared argument should resolve");
+
+    assert!(
+        checker.local_symbol_value_declaration_is_plain_parameter(param_sym),
+        "plain local parameters should take the fast-fail path"
+    );
+    assert!(
+        !checker.local_symbol_value_declaration_is_plain_parameter(typed_sym),
+        "typed locals are not parameter fast-fail candidates"
+    );
+    assert!(
+        !checker.local_symbol_value_declaration_is_plain_parameter(redeclared_sym),
+        "parameter symbols with typed variable declarations must stay on the full scan"
+    );
+
+    assert_eq!(
+        checker.call_arg_source_type_annotation_markers(&[param_arg], 1),
+        vec![false],
+        "parameter identifiers are not variable-declaration type annotation sources"
+    );
+    assert_eq!(
+        checker.call_arg_source_type_annotation_markers(&[renamed_param_arg], 1),
+        vec![false],
+        "renamed parameter identifiers should take the same fast-fail path"
+    );
+    assert_eq!(
+        checker.call_arg_source_type_annotation_markers(&[typed_arg], 1),
+        vec![true],
+        "typed local variable identifiers must still mark generic inference sources"
+    );
+    assert_eq!(
+        checker.call_arg_source_type_annotation_markers(&[asserted_arg], 1),
+        vec![true],
+        "explicit type assertions must still mark generic inference sources"
+    );
+    assert_eq!(
+        checker.call_arg_source_type_annotation_markers(&[redeclared_arg], 1),
+        vec![true],
+        "parameter symbols that also have typed variable declarations should keep old marker behavior"
+    );
+    assert_eq!(
+        checker.call_arg_source_type_annotation_markers(&[destructured_arg], 1),
+        vec![false],
+        "destructured parameter bindings are not variable-declaration type annotation sources"
+    );
+}
+
+#[test]
+fn generic_call_source_markers_keep_cross_file_typed_identifier_sources() {
+    let files = [
+        (
+            "consumer.ts",
+            r#"
+declare function fromTyped<T>(value: T): T;
+
+function run(local: unknown) {
+    fromTyped(typedGlobal);
+}
+"#,
+        ),
+        (
+            "shared.ts",
+            r#"
+declare const typedGlobal: { a: 1 };
+"#,
+        ),
+    ];
+
+    let mut arenas = Vec::with_capacity(files.len());
+    let mut binders = Vec::with_capacity(files.len());
+    let mut roots = Vec::with_capacity(files.len());
+    let file_names: Vec<String> = files.iter().map(|(name, _)| (*name).to_string()).collect();
+    for (file_idx, (name, source)) in files.iter().enumerate() {
+        let mut parser = ParserState::new((*name).to_string(), (*source).to_string());
+        let root = parser.parse_source_file();
+        let mut binder = BinderState::new();
+        binder.set_file_idx(file_idx as u32);
+        binder.bind_source_file(parser.get_arena(), root);
+        arenas.push(Arc::new(parser.get_arena().clone()));
+        binders.push(Arc::new(binder));
+        roots.push(root);
+    }
+
+    let (resolved_module_paths, resolved_modules) = build_module_resolution_maps(&file_names);
+    let all_arenas = Arc::new(arenas);
+    let all_binders = Arc::new(binders);
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        all_arenas[0].as_ref(),
+        all_binders[0].as_ref(),
+        &types,
+        file_names[0].clone(),
+        CheckerOptions::default(),
+    );
+    checker.ctx.set_all_arenas(Arc::clone(&all_arenas));
+    checker.ctx.set_all_binders(Arc::clone(&all_binders));
+    checker.ctx.set_current_file_idx(0);
+    checker.ctx.set_lib_contexts(Vec::new());
+    checker
+        .ctx
+        .set_resolved_module_paths(Arc::new(resolved_module_paths));
+    checker.ctx.set_resolved_modules(resolved_modules);
+
+    checker.check_source_file(roots[0]);
+
+    let typed_arg = first_argument_for_call(&checker, "fromTyped");
+    let typed_sym = checker
+        .resolve_identifier_symbol(typed_arg)
+        .expect("cross-file typed argument should resolve");
+    assert!(
+        !checker.local_symbol_value_declaration_is_plain_parameter(typed_sym),
+        "cross-file typed variables must not collide with local parameter fast-fail"
+    );
+    assert_eq!(
+        checker.call_arg_source_type_annotation_markers(&[typed_arg], 1),
+        vec![true],
+        "cross-file typed variable identifiers must keep old marker behavior"
+    );
+}

--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
@@ -227,6 +227,8 @@ impl<'a> CheckerState<'a> {
         // because the call happened to be overloaded.
         let arg_source_markers =
             self.call_arg_source_type_annotation_markers(args, arg_types.len());
+        let arg_readonly_markers =
+            self.call_arg_source_readonly_annotation_markers(args, arg_types.len());
         for (idx, original_sig) in signatures.iter().enumerate() {
             let sig = self.overload_signature_for_inference(
                 original_sig,
@@ -278,6 +280,7 @@ impl<'a> CheckerState<'a> {
                     sig_contextual_type,
                     None,
                     &arg_source_markers,
+                    &arg_readonly_markers,
                 )
             };
             if let CallResult::ArgumentTypeMismatch {
@@ -1050,6 +1053,7 @@ impl<'a> CheckerState<'a> {
                         sig_contextual_type,
                         actual_this_type,
                         &arg_source_markers,
+                        &arg_readonly_markers,
                     )
                     .2;
                 let return_sub_for_preinfer = if sig_contextual_type.is_some() {
@@ -1308,6 +1312,7 @@ impl<'a> CheckerState<'a> {
                     sig_contextual_type,
                     actual_this_type,
                     &arg_source_markers,
+                    &arg_readonly_markers,
                 );
             if let CallResult::ArgumentTypeMismatch {
                 expected,
@@ -1446,6 +1451,7 @@ impl<'a> CheckerState<'a> {
                         sig_contextual_type,
                         actual_this_type,
                         &arg_source_markers,
+                        &arg_readonly_markers,
                     );
                 if retry_predicate.is_some() {
                     selected_type_predicate = retry_predicate;

--- a/crates/tsz-checker/src/checkers/generic_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mod.rs
@@ -770,8 +770,15 @@ impl<'a> CheckerState<'a> {
             .get(type_ref_idx)
             .and_then(|node| self.ctx.arena.get_type_ref(node))
             .and_then(|type_ref| self.entity_name_text(type_ref.type_name));
+        let mut local_base_name = None;
         let mut import_base_name = None;
         if let Some(base_name) = syntax_base_name.as_deref()
+            && let Some(local_sym_id) =
+                self.current_non_import_reference_symbol_id(sym_id, base_name)
+        {
+            sym_id = local_sym_id;
+            local_base_name = Some(base_name.to_owned());
+        } else if let Some(base_name) = syntax_base_name.as_deref()
             && let Some(alias_sym_id) = self.ctx.binder.file_locals.get(base_name)
             && let Some(alias_symbol) = self.ctx.binder.get_symbol(alias_sym_id)
             && self.reference_symbol_is_import_alias(alias_symbol)
@@ -824,7 +831,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let lib_binders = self.get_lib_binders();
-        let base_name = import_base_name.unwrap_or_else(|| {
+        let base_name = import_base_name.or(local_base_name).unwrap_or_else(|| {
             self.get_symbol_from_registered_file_target(sym_id)
                 .or_else(|| self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders))
                 .map_or_else(|| "<unknown>".to_string(), |s| s.escaped_name.clone())

--- a/crates/tsz-checker/src/query_boundaries/checkers/call.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/call.rs
@@ -237,15 +237,20 @@ pub(crate) fn resolve_call<C: AssignabilityChecker>(
     )
 }
 
+pub(crate) struct CallArgSourceOptions<'a> {
+    pub(crate) force_bivariant_callbacks: bool,
+    pub(crate) contextual_type: Option<TypeId>,
+    pub(crate) actual_this_type: Option<TypeId>,
+    pub(crate) arg_source_is_type_annotation: &'a [bool],
+    pub(crate) arg_source_is_readonly_annotation: &'a [bool],
+}
+
 pub(crate) fn resolve_call_with_arg_sources<C: AssignabilityChecker>(
     db: &dyn QueryDatabase,
     checker: &mut C,
     func_type: TypeId,
     arg_types: &[TypeId],
-    force_bivariant_callbacks: bool,
-    contextual_type: Option<TypeId>,
-    actual_this_type: Option<TypeId>,
-    arg_source_is_type_annotation: &[bool],
+    opts: &CallArgSourceOptions<'_>,
 ) -> tsz_solver::operations::CallWithCheckerResult {
     tsz_solver::operations::resolve_call_with_checker_and_arg_sources(
         db,
@@ -253,10 +258,11 @@ pub(crate) fn resolve_call_with_arg_sources<C: AssignabilityChecker>(
         func_type,
         arg_types,
         &tsz_solver::operations::ResolveCallOptions {
-            force_bivariant_callbacks,
-            contextual_type,
-            actual_this_type,
-            arg_source_is_type_annotation,
+            force_bivariant_callbacks: opts.force_bivariant_callbacks,
+            contextual_type: opts.contextual_type,
+            actual_this_type: opts.actual_this_type,
+            arg_source_is_type_annotation: opts.arg_source_is_type_annotation,
+            arg_source_is_readonly_annotation: opts.arg_source_is_readonly_annotation,
         },
     )
 }

--- a/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
+++ b/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
@@ -102,10 +102,41 @@ impl<'a> CheckerState<'a> {
         sym_id: SymbolId,
         expected_name: &str,
     ) -> (SymbolId, Option<usize>, String) {
+        if let Some(local_sym_id) =
+            self.current_non_import_reference_symbol_id(sym_id, expected_name)
+        {
+            return (local_sym_id, None, expected_name.to_owned());
+        }
         let (sym_id, file_idx) = self
             .reference_type_params_import_target(sym_id, expected_name)
             .unwrap_or_else(|| (sym_id, self.ctx.resolve_symbol_file_index(sym_id)));
         (sym_id, file_idx, expected_name.to_owned())
+    }
+
+    pub(crate) fn current_non_import_reference_symbol_id(
+        &self,
+        sym_id: SymbolId,
+        expected_name: &str,
+    ) -> Option<SymbolId> {
+        if self.reference_symbol_is_current_non_import(sym_id, expected_name) {
+            return Some(sym_id);
+        }
+        if let Some(local_sym_id) = self.ctx.binder.file_locals.get(expected_name)
+            && self.reference_symbol_is_current_non_import(local_sym_id, expected_name)
+        {
+            return Some(local_sym_id);
+        }
+        None
+    }
+
+    fn reference_symbol_is_current_non_import(
+        &self,
+        sym_id: SymbolId,
+        expected_name: &str,
+    ) -> bool {
+        self.ctx.binder.get_symbol(sym_id).is_some_and(|symbol| {
+            symbol.escaped_name == expected_name && !self.reference_symbol_is_import_alias(symbol)
+        })
     }
 
     fn reference_type_params_import_target(
@@ -591,6 +622,9 @@ impl<'a> CheckerState<'a> {
         expected_name: &str,
     ) -> Vec<tsz_solver::TypeParamInfo> {
         let mut effective_sym_id = sym_id;
+        let mut effective_file_idx = None;
+        let local_reference_sym_id =
+            self.current_non_import_reference_symbol_id(sym_id, expected_name);
         let import_target = self
             .ctx
             .binder
@@ -608,12 +642,18 @@ impl<'a> CheckerState<'a> {
                     .register_symbol_file_target(target_sym_id, target_idx);
             }
             effective_sym_id = target_sym_id;
+            effective_file_idx = target_idx;
+        } else if let Some(local_sym_id) = local_reference_sym_id {
+            effective_sym_id = local_sym_id;
         }
 
-        let Some(symbol) = self
-            .get_symbol_from_registered_file_target(effective_sym_id)
-            .or_else(|| self.get_cross_file_symbol(effective_sym_id))
-        else {
+        let current_non_import = local_reference_sym_id == Some(effective_sym_id);
+        let Some(symbol) = (if current_non_import {
+            self.ctx.binder.get_symbol(effective_sym_id)
+        } else {
+            self.get_symbol_from_registered_file_target(effective_sym_id)
+                .or_else(|| self.get_cross_file_symbol(effective_sym_id))
+        }) else {
             return Vec::new();
         };
         let declarations = symbol.declarations.clone();
@@ -630,7 +670,8 @@ impl<'a> CheckerState<'a> {
             && symbol.has_any_flags(symbol_flags::INTERFACE);
 
         if symbol.has_any_flags(symbol_flags::CLASS)
-            && let Some(file_idx) = self.ctx.resolve_symbol_file_index(effective_sym_id)
+            && let Some(file_idx) =
+                effective_file_idx.or_else(|| self.ctx.resolve_symbol_file_index(effective_sym_id))
             && !std::ptr::eq(self.ctx.get_arena_for_file(file_idx as u32), self.ctx.arena)
         {
             let decl_arena = self.ctx.get_arena_for_file(file_idx as u32);
@@ -658,13 +699,17 @@ impl<'a> CheckerState<'a> {
         let mut merged: Vec<tsz_solver::TypeParamInfo> = Vec::new();
         let mut jsdoc_fallback: Option<Vec<tsz_solver::TypeParamInfo>> = None;
         for &decl_idx in &declarations {
-            let cross_file_arena = if let Some(file_idx) =
-                self.ctx.resolve_symbol_file_index(effective_sym_id)
-                && let Some(arena) = self
-                    .ctx
-                    .all_arenas
-                    .as_ref()
-                    .and_then(|arenas| arenas.get(file_idx).cloned())
+            let cross_file_arena = if let Some(file_idx) = effective_file_idx.or_else(|| {
+                if current_non_import {
+                    None
+                } else {
+                    self.ctx.resolve_symbol_file_index(effective_sym_id)
+                }
+            }) && let Some(arena) = self
+                .ctx
+                .all_arenas
+                .as_ref()
+                .and_then(|arenas| arenas.get(file_idx).cloned())
                 && !std::ptr::eq(arena.as_ref(), self.ctx.arena)
             {
                 Some(arena)

--- a/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
+++ b/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
@@ -31,7 +31,13 @@ impl<'a> CheckerState<'a> {
                     .filter(|symbol| symbol.has_any_flags(symbol_flags::ALIAS))
             })
             .flatten();
+        let current_non_import_symbol = self
+            .ctx
+            .binder
+            .get_symbol(sym_id)
+            .filter(|symbol| !self.reference_symbol_is_import_alias(symbol));
         let symbol_meta = local_alias_symbol
+            .or(current_non_import_symbol)
             .or_else(|| self.get_cross_file_symbol(sym_id))
             .map(|symbol| {
                 (

--- a/crates/tsz-checker/src/tests/ref_type_params_cache_tests.rs
+++ b/crates/tsz-checker/src/tests/ref_type_params_cache_tests.rs
@@ -361,3 +361,36 @@ type B = StarBoxed<number, boolean>;
         "Imported generic aliases should follow barrel re-exports to the declaration file; got: {diags:#?}"
     );
 }
+
+#[test]
+fn local_ref_type_params_ignore_cross_file_raw_symbol_owner_collision() {
+    let diags = check_multi_file_with_global_index(
+        &[
+            (
+                "sources/remote.ts",
+                r#"
+export type Remote<A, B> = { first: A; second: B };
+"#,
+            ),
+            (
+                "sources/main.ts",
+                r#"
+type Local<T> = { value: T };
+type UseLocal = Local<string>;
+"#,
+            ),
+        ],
+        "sources/main.ts",
+        CheckerOptions::default(),
+    );
+
+    let type_arg_errors: Vec<_> = diags
+        .iter()
+        .filter(|d| matches!(d.code, 2314 | 2315 | 2558))
+        .collect();
+    assert_eq!(
+        type_arg_errors.len(),
+        0,
+        "Current-file generic aliases must not read type parameters from a colliding cross-file raw SymbolId; got: {diags:#?}"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/call/inner.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner.rs
@@ -827,6 +827,14 @@ impl<'a> CheckerState<'a> {
         } else {
             Vec::new()
         };
+        let generic_inference_arg_readonly_markers = if is_generic_call {
+            self.call_arg_source_readonly_annotation_markers(
+                args,
+                generic_inference_arg_types.len(),
+            )
+        } else {
+            Vec::new()
+        };
         let call_resolution_contextual_type = if is_generic_call {
             // Generic calls in contextual positions need the outer request at the
             // solver boundary, even when they have arguments. The checker-side
@@ -852,7 +860,9 @@ impl<'a> CheckerState<'a> {
                     None,
                     None,
                 )
-            } else if generic_inference_arg_source_markers.iter().any(|&m| m) {
+            } else if generic_inference_arg_source_markers.iter().any(|&m| m)
+                || generic_inference_arg_readonly_markers.iter().any(|&m| m)
+            {
                 self.resolve_call_with_checker_adapter_and_arg_sources(
                     callee_type_for_call,
                     &generic_inference_arg_types,
@@ -860,6 +870,7 @@ impl<'a> CheckerState<'a> {
                     call_resolution_contextual_type,
                     actual_this_type,
                     &generic_inference_arg_source_markers,
+                    &generic_inference_arg_readonly_markers,
                 )
             } else {
                 self.resolve_call_with_checker_adapter(
@@ -1067,6 +1078,8 @@ impl<'a> CheckerState<'a> {
                 .sanitize_generic_inference_arg_types(call.expression, args, &refreshed_arg_types);
             let retry_arg_source_markers =
                 self.call_arg_source_type_annotation_markers(args, retry_generic_arg_types.len());
+            let retry_arg_readonly_markers = self
+                .call_arg_source_readonly_annotation_markers(args, retry_generic_arg_types.len());
             let mut retry = if is_super_call {
                 (
                     self.resolve_new_with_checker_adapter(
@@ -1078,7 +1091,9 @@ impl<'a> CheckerState<'a> {
                     None,
                     None,
                 )
-            } else if retry_arg_source_markers.iter().any(|&m| m) {
+            } else if retry_arg_source_markers.iter().any(|&m| m)
+                || retry_arg_readonly_markers.iter().any(|&m| m)
+            {
                 self.resolve_call_with_checker_adapter_and_arg_sources(
                     callee_type_for_call,
                     &retry_generic_arg_types,
@@ -1086,6 +1101,7 @@ impl<'a> CheckerState<'a> {
                     contextual_type,
                     actual_this_type,
                     &retry_arg_source_markers,
+                    &retry_arg_readonly_markers,
                 )
             } else {
                 self.resolve_call_with_checker_adapter(

--- a/crates/tsz-checker/src/types/computation/call/mod.rs
+++ b/crates/tsz-checker/src/types/computation/call/mod.rs
@@ -914,6 +914,14 @@ impl<'a> CheckerState<'a> {
         } else {
             Vec::new()
         };
+        let generic_inference_arg_readonly_markers = if is_generic_call {
+            self.call_arg_source_readonly_annotation_markers(
+                args,
+                generic_inference_arg_types.len(),
+            )
+        } else {
+            Vec::new()
+        };
         let call_resolution_contextual_type = contextual_type;
 
         let (mut result, mut instantiated_predicate, mut generic_instantiated_params) =
@@ -928,7 +936,9 @@ impl<'a> CheckerState<'a> {
                     None,
                     None,
                 )
-            } else if generic_inference_arg_source_markers.iter().any(|&m| m) {
+            } else if generic_inference_arg_source_markers.iter().any(|&m| m)
+                || generic_inference_arg_readonly_markers.iter().any(|&m| m)
+            {
                 self.resolve_call_with_checker_adapter_and_arg_sources(
                     callee_type_for_call,
                     &generic_inference_arg_types,
@@ -936,6 +946,7 @@ impl<'a> CheckerState<'a> {
                     call_resolution_contextual_type,
                     actual_this_type,
                     &generic_inference_arg_source_markers,
+                    &generic_inference_arg_readonly_markers,
                 )
             } else {
                 self.resolve_call_with_checker_adapter(
@@ -1080,6 +1091,8 @@ impl<'a> CheckerState<'a> {
                 self.sanitize_generic_inference_arg_types(callee_expr, args, &arg_types);
             let retry_arg_source_markers =
                 self.call_arg_source_type_annotation_markers(args, retry_generic_arg_types.len());
+            let retry_arg_readonly_markers = self
+                .call_arg_source_readonly_annotation_markers(args, retry_generic_arg_types.len());
             let retry = if is_super_call {
                 (
                     self.resolve_new_with_checker_adapter(
@@ -1091,7 +1104,9 @@ impl<'a> CheckerState<'a> {
                     None,
                     None,
                 )
-            } else if retry_arg_source_markers.iter().any(|&m| m) {
+            } else if retry_arg_source_markers.iter().any(|&m| m)
+                || retry_arg_readonly_markers.iter().any(|&m| m)
+            {
                 self.resolve_call_with_checker_adapter_and_arg_sources(
                     callee_type_for_call,
                     &retry_generic_arg_types,
@@ -1099,6 +1114,7 @@ impl<'a> CheckerState<'a> {
                     contextual_type,
                     actual_this_type,
                     &retry_arg_source_markers,
+                    &retry_arg_readonly_markers,
                 )
             } else {
                 self.resolve_call_with_checker_adapter(

--- a/crates/tsz-checker/src/types/computation/call_inference.rs
+++ b/crates/tsz-checker/src/types/computation/call_inference.rs
@@ -20,8 +20,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use std::borrow::Cow;
 use tsz_common::Atom;
 use tsz_common::diagnostics::diagnostic_codes;
-use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
+use tsz_parser::parser::{NodeArena, NodeIndex};
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 use tsz_solver::{FunctionShape, TypeId};
 
@@ -1008,6 +1008,210 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    pub(crate) fn readonly_array_like_annotation_for_identifier_argument(
+        &mut self,
+        arg_idx: NodeIndex,
+        arg_type: TypeId,
+    ) -> Option<TypeId> {
+        let idx = self.ctx.arena.skip_parenthesized(arg_idx);
+        let node = self.ctx.arena.get(idx)?;
+        if node.kind != tsz_scanner::SyntaxKind::Identifier as u16 {
+            return None;
+        }
+
+        let sym_id = self.resolve_identifier_symbol(idx)?;
+        let stable_declarations = {
+            let symbol = self
+                .get_cross_file_symbol(sym_id)
+                .or_else(|| self.ctx.binder.get_symbol(sym_id))?;
+            symbol
+                .stable_declarations
+                .iter()
+                .copied()
+                .chain(std::iter::once(symbol.stable_value_declaration))
+                .filter(|loc| loc.is_known())
+                .collect::<Vec<_>>()
+        };
+
+        for stable_location in stable_declarations {
+            let Some((decl_idx, arena)) = self.ctx.node_at_stable_location(stable_location) else {
+                continue;
+            };
+            let Some(decl_node) = arena.get(decl_idx) else {
+                continue;
+            };
+            let annotation = arena
+                .get_variable_declaration(decl_node)
+                .map(|decl| decl.type_annotation)
+                .or_else(|| {
+                    arena
+                        .get_parameter(decl_node)
+                        .map(|param| param.type_annotation)
+                })
+                .unwrap_or(NodeIndex::NONE);
+            if annotation.is_none() {
+                continue;
+            }
+
+            let declared = if std::ptr::eq(arena, self.ctx.arena) {
+                self.get_type_from_type_node(annotation)
+            } else if stable_location.has_file_idx()
+                && stable_location.file_idx != self.ctx.current_file_idx as u32
+            {
+                self.type_of_value_declaration_for_cross_file_symbol(
+                    sym_id,
+                    decl_idx,
+                    stable_location.file_idx as usize,
+                )
+            } else if !std::ptr::eq(arena, self.ctx.arena)
+                && let Some(target_file_idx) = self.ctx.get_file_idx_for_arena(arena)
+                && target_file_idx != self.ctx.current_file_idx
+            {
+                self.type_of_value_declaration_for_cross_file_symbol(
+                    sym_id,
+                    decl_idx,
+                    target_file_idx,
+                )
+            } else {
+                self.type_of_value_declaration_for_symbol(sym_id, decl_idx)
+            };
+
+            if self.is_matching_readonly_array_like_annotation(declared, arg_type) {
+                return Some(declared);
+            }
+        }
+
+        None
+    }
+
+    pub(crate) fn call_arg_source_readonly_annotation_markers(
+        &self,
+        args: &[NodeIndex],
+        arg_type_count: usize,
+    ) -> Vec<bool> {
+        if args.len() == arg_type_count {
+            return args
+                .iter()
+                .map(|&arg_idx| self.call_arg_source_is_readonly_typed_identifier(arg_idx))
+                .collect();
+        }
+
+        let mut markers = Vec::with_capacity(arg_type_count);
+        for &arg_idx in args {
+            markers.push(self.call_arg_source_is_readonly_typed_identifier(arg_idx));
+        }
+        markers.resize(arg_type_count, false);
+        markers
+    }
+
+    fn call_arg_source_is_readonly_typed_identifier(&self, arg_idx: NodeIndex) -> bool {
+        let idx = self.ctx.arena.skip_parenthesized(arg_idx);
+        let Some(node) = self.ctx.arena.get(idx) else {
+            return false;
+        };
+        if node.kind != tsz_scanner::SyntaxKind::Identifier as u16 {
+            return false;
+        }
+
+        let Some(sym_id) = self.resolve_identifier_symbol(idx) else {
+            return false;
+        };
+        let Some(symbol) = self
+            .get_cross_file_symbol(sym_id)
+            .or_else(|| self.ctx.binder.get_symbol(sym_id))
+        else {
+            return false;
+        };
+
+        symbol
+            .stable_declarations
+            .iter()
+            .copied()
+            .chain(std::iter::once(symbol.stable_value_declaration))
+            .filter(|loc| loc.is_known())
+            .any(|loc| {
+                self.ctx
+                    .node_at_stable_location(loc)
+                    .is_some_and(|(decl_idx, arena)| {
+                        let Some(decl_node) = arena.get(decl_idx) else {
+                            return false;
+                        };
+                        let annotation = arena
+                            .get_variable_declaration(decl_node)
+                            .map(|decl| decl.type_annotation)
+                            .or_else(|| {
+                                arena
+                                    .get_parameter(decl_node)
+                                    .map(|param| param.type_annotation)
+                            })
+                            .unwrap_or(NodeIndex::NONE);
+                        annotation.is_some()
+                            && self.annotation_is_readonly_array_like(arena, annotation)
+                    })
+            })
+    }
+
+    fn annotation_is_readonly_array_like(&self, arena: &NodeArena, annotation: NodeIndex) -> bool {
+        let annotation = arena.skip_parenthesized(annotation);
+        let Some(annotation_node) = arena.get(annotation) else {
+            return false;
+        };
+        if annotation_node.kind != syntax_kind_ext::TYPE_OPERATOR {
+            return false;
+        }
+        let Some(operator) = arena.get_type_operator(annotation_node) else {
+            return false;
+        };
+        if operator.operator != tsz_scanner::SyntaxKind::ReadonlyKeyword as u16 {
+            return false;
+        }
+
+        let type_node = arena.skip_parenthesized(operator.type_node);
+        arena.get(type_node).is_some_and(|node| {
+            node.kind == syntax_kind_ext::ARRAY_TYPE || node.kind == syntax_kind_ext::TUPLE_TYPE
+        })
+    }
+
+    fn is_matching_readonly_array_like_annotation(
+        &self,
+        declared: TypeId,
+        arg_type: TypeId,
+    ) -> bool {
+        if !self.is_readonly_array_like_wrapper(declared) {
+            return false;
+        }
+        if common::unwrap_readonly(self.ctx.types, declared) == arg_type {
+            return true;
+        }
+
+        if let (Some(declared_elem), Some(arg_elem)) = (
+            common::array_element_type(self.ctx.types, declared),
+            common::array_element_type(self.ctx.types, arg_type),
+        ) {
+            return declared_elem == arg_elem;
+        }
+
+        if let (Some(declared_elems), Some(arg_elems)) = (
+            common::tuple_elements(self.ctx.types, declared),
+            common::tuple_elements(self.ctx.types, arg_type),
+        ) {
+            return declared_elems.len() == arg_elems.len()
+                && declared_elems.iter().zip(arg_elems.iter()).all(|(l, r)| {
+                    l.type_id == r.type_id && l.optional == r.optional && l.rest == r.rest
+                });
+        }
+
+        false
+    }
+
+    fn is_readonly_array_like_wrapper(&self, type_id: TypeId) -> bool {
+        let Some(inner) = common::get_readonly_inner(self.ctx.types, type_id) else {
+            return false;
+        };
+        common::array_element_type(self.ctx.types, inner).is_some()
+            || common::tuple_elements(self.ctx.types, inner).is_some()
+    }
+
     pub(crate) fn inference_type_is_anyish(&self, ty: TypeId) -> bool {
         common::is_type_deeply_any(self.ctx.types, ty)
     }
@@ -1064,6 +1268,13 @@ impl<'a> CheckerState<'a> {
             {
                 changed = true;
                 arg_type = self.ctx.types.this_type();
+            }
+
+            if let Some(declared) =
+                self.readonly_array_like_annotation_for_identifier_argument(arg_idx, arg_type)
+            {
+                changed = true;
+                arg_type = declared;
             }
 
             let sanitized_arg = self.sanitize_generic_inference_arg_type(arg_idx, arg_type);

--- a/crates/tsz-checker/src/types/type_node_lowering.rs
+++ b/crates/tsz-checker/src/types/type_node_lowering.rs
@@ -398,7 +398,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         .with_type_query_override(&type_query_override)
         .with_computed_name_resolver(&computed_name_resolver)
         .with_computed_symbol_name_resolver(&computed_symbol_name_resolver);
-        if use_qualified_names {
+        if use_qualified_names && self.type_node_is_in_lib_declaration(idx) {
             lowering = lowering.prefer_name_def_id_resolution();
         }
         if !type_param_bindings.is_empty() {
@@ -415,5 +415,28 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             lowering = lowering.with_import_type_resolver(resolver);
         }
         lowering.lower_type(idx)
+    }
+
+    fn type_node_is_in_lib_declaration(&self, idx: NodeIndex) -> bool {
+        let mut current = idx;
+        while let Some(ext) = self.ctx.arena.get_extended(current) {
+            if ext.parent.is_none() {
+                break;
+            }
+            current = ext.parent;
+        }
+        self.ctx
+            .arena
+            .get(current)
+            .and_then(|node| self.ctx.arena.get_source_file(node))
+            .is_some_and(|source| {
+                let file_name = std::path::Path::new(&source.file_name)
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or(source.file_name.as_str());
+                source.is_declaration_file
+                    && file_name.starts_with("lib.")
+                    && file_name.ends_with(".d.ts")
+            })
     }
 }

--- a/crates/tsz-checker/src/types/type_node_resolution.rs
+++ b/crates/tsz-checker/src/types/type_node_resolution.rs
@@ -1410,6 +1410,23 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         }
 
         if let Some(name) = self.entity_name_text(node_idx)
+            && !name.contains('.')
+            && let Some(sym_id) = self.resolve_type_symbol(node_idx)
+        {
+            let sym_id = tsz_binder::SymbolId(sym_id);
+            let def_id = if self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id)
+                || self.ctx.symbol_is_from_lib(sym_id)
+            {
+                self.ctx.get_canonical_lib_def_id(name.as_str(), sym_id)
+            } else {
+                self.ctx
+                    .get_or_create_def_id_for_symbol_name(sym_id, name.as_str())
+            };
+            self.ensure_type_alias_resolved(sym_id, def_id);
+            return Some(def_id);
+        }
+
+        if let Some(name) = self.entity_name_text(node_idx)
             && let Some(sym_id) = self.resolve_entity_name_text_symbol(&name)
         {
             let expected_name = name.rsplit('.').next().unwrap_or(name.as_str());

--- a/crates/tsz-checker/tests/generic_call_inference_tests_parts/part_02.rs
+++ b/crates/tsz-checker/tests/generic_call_inference_tests_parts/part_02.rs
@@ -89,6 +89,31 @@ function flatMapChildren2<T>(node: Node, cb: (child: Node) => readonly T[] | T |
 }
 
 #[test]
+fn readonly_array_predicate_call_keeps_direct_argument_inference() {
+    let source = r#"
+interface Node { kind: number; }
+interface TypeNode extends Node { typeInfo: string; }
+interface NodeArray<T extends Node> extends Array<T> {
+    someProp: string;
+}
+
+declare function tryCast<TOut extends TIn, TIn = any>(
+    value: TIn | undefined,
+    test: (value: TIn) => value is TOut
+): TOut;
+declare function isNodeArray<T extends Node>(array: readonly T[]): array is NodeArray<T>;
+declare const types: readonly TypeNode[];
+
+const x = tryCast(types, isNodeArray);
+"#;
+    let diags = relevant_strict_default_lib_diagnostics(source);
+    assert!(
+        lacks_diagnostic_code(&diags, 2345),
+        "readonly direct argument inference should not be replaced by mutable predicate candidate. Got: {diags:#?}"
+    );
+}
+
+#[test]
 fn conformance_probe_infer_from_generic_function_return_types_2() {
     let source = r#"
 type Mapper<T, U> = (x: T) => U;

--- a/crates/tsz-checker/tests/mapped_keyof_index_access_tests.rs
+++ b/crates/tsz-checker/tests/mapped_keyof_index_access_tests.rs
@@ -60,7 +60,24 @@ declare const key: keyof {foo(): void};
 spyObj[key].and.returnValue(1);
 "#;
 
-    let diags = check_strict(source);
+    let diags = tsz_checker::test_utils::check_multi_file_with_global_index(
+        &[
+            (
+                "remote.ts",
+                r#"
+export type Remote<A, B> = { first: A; second: B };
+export type OtherKey = "remote";
+"#,
+            ),
+            ("test.ts", source),
+        ],
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            strict_null_checks: true,
+            ..CheckerOptions::default()
+        },
+    );
     assert!(
         has_code(&diags, 2339),
         "expected TS2339 for returnValue on Function, got: {diags:#?}"
@@ -121,6 +138,8 @@ fn mapped_keyof_index_access_assigns_to_value_type() {
 function f<T>(obj: { [k in keyof T]: number }, key: keyof T): void {
     const x: number = obj[key];
 }
+
+type ArgMap = { a: number, b: string };
 "#;
 
     let diags = check_strict(source);
@@ -188,6 +207,111 @@ processRecord(r);
     assert!(
         no_errors(&diags),
         "UnionRecord should remain a per-key correlated union, got: {diags:#?}"
+    );
+}
+
+#[test]
+fn mapped_keyof_tuple_rest_context_preserves_local_alias_scope() {
+    let source = r#"
+type TypeMap = {
+    foo: string,
+    bar: number
+};
+type Keys = keyof TypeMap;
+type HandlerMap = { [P in Keys]: (x: TypeMap[P]) => void };
+const handlers: HandlerMap = {
+    foo: s => s.length,
+    bar: n => n.toFixed(2)
+};
+type DataEntry<K extends Keys = Keys> = { [P in K]: {
+    type: P,
+    data: TypeMap[P]
+}}[K];
+const data: DataEntry[] = [
+    { type: 'foo', data: 'abc' },
+    { type: 'bar', data: 42 },
+];
+function process<K extends Keys>(data: DataEntry<K>[]) {
+    data.forEach(block => {
+        if (block.type in handlers) {
+            handlers[block.type](block.data)
+        }
+    });
+}
+process(data);
+
+interface DocumentEventMap {
+    click: { x: number };
+    scroll: { y: number };
+}
+type Ev<K extends keyof DocumentEventMap> = { [P in K]: {
+    readonly name: P;
+    readonly once?: boolean;
+    readonly callback: (ev: DocumentEventMap[P]) => void;
+}}[K];
+function processEvents<K extends keyof DocumentEventMap>(events: Ev<K>[]) {
+    for (const event of events) {
+        event.callback({} as DocumentEventMap[K]);
+    }
+}
+function createEventListener<K extends keyof DocumentEventMap>({ name, once = false, callback }: Ev<K>): Ev<K> {
+    return { name, once, callback };
+}
+const clickEvent = createEventListener({
+    name: "click",
+    callback: ev => ev.x,
+});
+const scrollEvent = createEventListener({
+    name: "scroll",
+    callback: ev => ev.y,
+});
+processEvents([clickEvent, scrollEvent]);
+
+function ff1() {
+    type ArgMap = {
+        sum: [a: number, b: number],
+        concat: [a: string, b: string, c: string]
+    }
+    type Keys = keyof ArgMap;
+    const funs: { [P in Keys]: (...args: ArgMap[P]) => void } = {
+        sum: (a, b) => a + b,
+        concat: (a, b, c) => a + b + c
+    }
+    function apply<K extends Keys>(funKey: K, ...args: ArgMap[K]) {
+        const fn = funs[funKey];
+        fn(...args);
+    }
+    const x1 = apply('sum', 1, 2)
+    const x2 = apply('concat', 'str1', 'str2', 'str3')
+}
+type ArgMap = { a: number, b: string };
+"#;
+
+    let diags = check_strict(source);
+    assert!(
+        no_errors(&diags),
+        "function-local ArgMap/Keys should contextually type rest handlers and calls, got: {diags:#?}"
+    );
+}
+
+#[test]
+fn required_mapped_index_read_removes_optional_undefined() {
+    let source = r#"
+interface Foo {
+    bar?: string
+}
+
+declare function takeString(value: string): void;
+
+function readRequired<T extends keyof Foo>(prop: T, value: Required<Foo>) {
+    takeString(value[prop]);
+}
+"#;
+
+    let diags = check_strict(source);
+    assert!(
+        no_errors(&diags),
+        "Required<Foo>[T] should read as string, not string | undefined: {diags:#?}"
     );
 }
 

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -1232,6 +1232,31 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         value_type
     }
 
+    fn homomorphic_mapped_source_for_index_read(&mut self, mapped: &MappedType) -> Option<TypeId> {
+        let Some(TypeData::IndexAccess(source, idx)) = self.interner().lookup(mapped.template)
+        else {
+            return None;
+        };
+        let Some(TypeData::TypeParameter(param)) = self.interner().lookup(idx) else {
+            return None;
+        };
+        if param.name != mapped.type_param.name {
+            return None;
+        }
+
+        if let Some(keyof_source) = keyof_inner_type(self.interner(), mapped.constraint) {
+            return (source == keyof_source).then_some(source);
+        }
+
+        if matches!(
+            self.interner().lookup(source),
+            Some(TypeData::TypeParameter(_))
+        ) {
+            return None;
+        }
+        (self.evaluate(self.interner().keyof(source)) == mapped.constraint).then_some(source)
+    }
+
     fn constrained_index_type(&mut self, index_type: TypeId) -> Option<TypeId> {
         if index_type.is_intrinsic() {
             return None;
@@ -1369,6 +1394,15 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let subst = TypeSubstitution::single(mapped.type_param.name, substitution_index);
 
         let value_type = self.evaluate(instantiate_type(self.interner(), mapped.template, &subst));
+        let value_type = if matches!(mapped.optional_modifier, Some(MappedModifier::Remove))
+            && !self.interner().exact_optional_property_types()
+            && let Some(source) = self.homomorphic_mapped_source_for_index_read(&mapped)
+            && self.index_type_can_hit_optional_property(source, substitution_index)
+        {
+            crate::narrowing::utils::remove_undefined(self.interner(), value_type)
+        } else {
+            value_type
+        };
 
         Some(self.apply_mapped_optional_read_semantics(
             mapped_object_type,

--- a/crates/tsz-solver/src/inference/infer.rs
+++ b/crates/tsz-solver/src/inference/infer.rs
@@ -69,6 +69,10 @@ pub(crate) struct InferenceCandidate {
     /// Candidate came from array element inference (`T[]` vs a literal array).
     /// tsc's BCT widening applies to these in `NoInfer<T>` positions.
     pub(crate) from_array_element: bool,
+    /// Candidate came from a readonly array-like source. Used when mixed
+    /// co/contra inference would otherwise replace a direct readonly argument
+    /// with a mutable callback parameter candidate.
+    pub(crate) from_readonly_source: bool,
 }
 
 #[derive(Copy, Clone, Debug, Default)]
@@ -129,7 +133,7 @@ impl UnifyValue for InferenceInfo {
         // Deduplicate upper bounds using helper
         extend_dedup(&mut merged.upper_bounds, &b.upper_bounds);
 
-        if merged.resolved.is_none() {
+        if b.resolved.is_some() {
             merged.resolved = b.resolved;
         }
         Ok(merged)
@@ -664,6 +668,7 @@ impl<'a> InferenceContext<'a> {
                 object_property_name: candidate.object_property_name,
                 source_is_type_annotation: candidate.source_is_type_annotation,
                 from_array_element: candidate.from_array_element,
+                from_readonly_source: candidate.from_readonly_source,
             });
         }
 
@@ -1195,6 +1200,7 @@ impl<'a> InferenceContext<'a> {
             object_property_name: None,
             source_is_type_annotation: self.source_is_type_annotation,
             from_array_element: self.in_array_element_context,
+            from_readonly_source: self.candidate_is_from_readonly_source(ty),
         };
         self.table.union_value(
             root,
@@ -1286,6 +1292,7 @@ impl<'a> InferenceContext<'a> {
             object_property_name: context.object_property_name,
             source_is_type_annotation: self.source_is_type_annotation,
             from_array_element: self.in_array_element_context,
+            from_readonly_source: self.candidate_is_from_readonly_source(ty),
         };
         if self.in_contra_mode {
             // In contravariant context (e.g., callback parameter structural
@@ -1306,6 +1313,30 @@ impl<'a> InferenceContext<'a> {
                     ..InferenceInfo::default()
                 },
             );
+        }
+    }
+
+    fn candidate_is_from_readonly_source(&self, ty: TypeId) -> bool {
+        self.in_readonly_source_context || self.type_is_readonly_array_like(ty)
+    }
+
+    fn type_is_readonly_array_like(&self, ty: TypeId) -> bool {
+        if ty.is_intrinsic() {
+            return false;
+        }
+        match self.interner.lookup(ty) {
+            Some(TypeData::ReadonlyType(inner)) => {
+                matches!(
+                    self.interner.lookup(inner),
+                    Some(TypeData::Array(_) | TypeData::Tuple(_))
+                ) || self.type_is_readonly_array_like(inner)
+            }
+            Some(TypeData::Union(members) | TypeData::Intersection(members)) => self
+                .interner
+                .type_list(members)
+                .iter()
+                .any(|&member| self.type_is_readonly_array_like(member)),
+            _ => false,
         }
     }
 
@@ -1518,6 +1549,23 @@ impl<'a> InferenceContext<'a> {
         let root = self.table.find(var);
         let info = self.table.probe_value(root);
         info.candidates.iter().any(|c| c.source_is_type_annotation)
+    }
+
+    /// Returns true when the winning covariant candidate type was produced
+    /// while descending through a readonly array/tuple source.
+    pub fn has_readonly_source_candidate_for(&mut self, var: InferenceVar, ty: TypeId) -> bool {
+        let root = self.table.find(var);
+        let info = self.table.probe_value(root);
+        info.candidates
+            .iter()
+            .any(|candidate| candidate.type_id == ty && candidate.from_readonly_source)
+    }
+
+    pub fn set_resolved_type(&mut self, var: InferenceVar, ty: TypeId) {
+        let root = self.table.find(var);
+        let mut info = self.table.probe_value(root);
+        info.resolved = Some(ty);
+        self.table.union_value(root, info);
     }
 }
 

--- a/crates/tsz-solver/src/inference/infer_resolve.rs
+++ b/crates/tsz-solver/src/inference/infer_resolve.rs
@@ -37,6 +37,7 @@ impl<'a> InferenceContext<'a> {
     fn resolve_covariant_against_contra(
         &self,
         covariant_result: TypeId,
+        covariant_has_readonly_source: bool,
         concrete_contra_candidates: &[InferenceCandidate],
         from_array_element: bool,
         mut external_is_subtype: Option<&mut dyn FnMut(TypeId, TypeId) -> bool>,
@@ -62,6 +63,17 @@ impl<'a> InferenceContext<'a> {
             let contra_result = self.resolve_from_contra_candidates(concrete_contra_candidates);
             if contra_result == TypeId::NEVER {
                 return covariant_result;
+            }
+            if covariant_has_readonly_source {
+                let contra_assignable_to_covariant = if let Some(ref mut ext) = external_is_subtype
+                {
+                    ext(contra_result, covariant_widened)
+                } else {
+                    self.is_subtype(contra_result, covariant_widened)
+                };
+                if contra_assignable_to_covariant {
+                    return covariant_widened;
+                }
             }
         }
         self.choose_covariant_or_contra(
@@ -553,6 +565,7 @@ impl<'a> InferenceContext<'a> {
                 // object literal type is not assignable to Props.
                 self.resolve_covariant_against_contra(
                     covariant_result,
+                    candidates.iter().any(|c| c.from_readonly_source),
                     &concrete_contra_candidates,
                     candidates.iter().any(|c| c.from_array_element),
                     external_is_subtype
@@ -1769,6 +1782,7 @@ impl<'a> InferenceContext<'a> {
                 if !concrete_contra_candidates.is_empty() {
                     self.resolve_covariant_against_contra(
                         covariant_result,
+                        candidates.iter().any(|c| c.from_readonly_source),
                         &concrete_contra_candidates,
                         candidates.iter().any(|c| c.from_array_element),
                         external_is_subtype

--- a/crates/tsz-solver/src/operations/core/call_evaluator.rs
+++ b/crates/tsz-solver/src/operations/core/call_evaluator.rs
@@ -202,6 +202,10 @@ pub struct CallEvaluator<'a, C: AssignabilityChecker> {
     /// Per-argument marker for sources whose type came from an explicit type
     /// annotation/assertion rather than a fresh expression.
     pub(crate) arg_source_is_type_annotation: Vec<bool>,
+    /// Per-argument marker for typed identifiers declared with a readonly
+    /// array/tuple annotation whose computed argument type was normalized to the
+    /// mutable inner container before generic inference.
+    pub(crate) arg_source_is_readonly_annotation: Vec<bool>,
     /// The `this` type provided by the caller (e.g. `obj` in `obj.method()`)
     pub(crate) actual_this_type: Option<TypeId>,
     /// Current recursion depth for `constrain_types` to prevent infinite loops
@@ -308,6 +312,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             force_bivariant_callbacks: false,
             contextual_type: None,
             arg_source_is_type_annotation: Vec::new(),
+            arg_source_is_readonly_annotation: Vec::new(),
             actual_this_type: None,
             constraint_recursion_depth: Cell::new(0),
             constraint_step_count: Cell::new(0),
@@ -353,6 +358,12 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             .extend_from_slice(markers);
     }
 
+    pub fn set_arg_source_is_readonly_annotation(&mut self, markers: &[bool]) {
+        self.arg_source_is_readonly_annotation.clear();
+        self.arg_source_is_readonly_annotation
+            .extend_from_slice(markers);
+    }
+
     /// Returns true if the first argument came from a type assertion (e.g. `1 as 1`).
     /// Non-fresh literals from assertions are preserved rather than widened.
     pub(crate) fn is_first_arg_type_annotated(&self) -> bool {
@@ -386,6 +397,10 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
     ) -> bool {
         let non_fresh = crate::relations::freshness::widen_freshness(self.interner, arg_type);
         if self.checker.is_assignable_to(non_fresh, constraint) {
+            return true;
+        }
+        let evaluated = self.checker.evaluate_type(non_fresh);
+        if evaluated != non_fresh && self.checker.is_assignable_to(evaluated, constraint) {
             return true;
         }
         self.arg_satisfies_constraint_via_readonly_widening(non_fresh, constraint)

--- a/crates/tsz-solver/src/operations/core/call_resolution.rs
+++ b/crates/tsz-solver/src/operations/core/call_resolution.rs
@@ -17,7 +17,6 @@ use crate::types::{
     TypeId, TypeListId,
 };
 use rustc_hash::FxHashSet;
-
 /// Returns the declared `this` type only when it constrains the receiver. Per
 /// tsc's `checkApplicableSignature` gate (`thisType !== voidType`, source of
 /// TS2684), a callable declared `this: void` opts out of the receiver check
@@ -1812,7 +1811,6 @@ pub fn infer_call_signature<C: AssignabilityChecker>(
     let mut evaluator = CallEvaluator::new(interner, checker);
     evaluator.infer_call_signature(sig, arg_types)
 }
-
 pub fn infer_generic_function<C: AssignabilityChecker>(
     interner: &dyn QueryDatabase,
     checker: &mut C,
@@ -1829,6 +1827,7 @@ pub struct ResolveCallOptions<'a> {
     pub contextual_type: Option<TypeId>,
     pub actual_this_type: Option<TypeId>,
     pub arg_source_is_type_annotation: &'a [bool],
+    pub arg_source_is_readonly_annotation: &'a [bool],
 }
 
 pub fn resolve_call_with_checker<C: AssignabilityChecker>(
@@ -1850,10 +1849,10 @@ pub fn resolve_call_with_checker<C: AssignabilityChecker>(
             contextual_type,
             actual_this_type,
             arg_source_is_type_annotation: &[],
+            arg_source_is_readonly_annotation: &[],
         },
     )
 }
-
 pub fn resolve_call_with_checker_and_arg_sources<C: AssignabilityChecker>(
     interner: &dyn QueryDatabase,
     checker: &mut C,
@@ -1866,6 +1865,7 @@ pub fn resolve_call_with_checker_and_arg_sources<C: AssignabilityChecker>(
     evaluator.set_contextual_type(opts.contextual_type);
     evaluator.set_actual_this_type(opts.actual_this_type);
     evaluator.set_arg_source_is_type_annotation(opts.arg_source_is_type_annotation);
+    evaluator.set_arg_source_is_readonly_annotation(opts.arg_source_is_readonly_annotation);
     let result = evaluator.resolve_call(func_type, arg_types);
     let predicate = evaluator.last_instantiated_predicate.take();
     let instantiated_params = evaluator.last_instantiated_params.take();

--- a/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
+++ b/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
@@ -6,6 +6,35 @@ use crate::operations::{AssignabilityChecker, CallEvaluator};
 use crate::types::{FunctionShape, ObjectFlags, ParamInfo, TypeData, TypeId, TypePredicate};
 use rustc_hash::{FxHashMap, FxHashSet};
 
+pub(super) fn is_bare_foreign_type_param(
+    interner: &dyn crate::construction::TypeDatabase,
+    ty: TypeId,
+    local_type_params: &FxHashSet<tsz_common::Atom>,
+    local_placeholders: &[tsz_common::Atom],
+) -> bool {
+    if ty.is_intrinsic() {
+        return false;
+    }
+    match interner.lookup(ty) {
+        Some(TypeData::TypeParameter(info) | TypeData::Infer(info)) => {
+            !local_type_params.contains(&info.name) && !local_placeholders.contains(&info.name)
+        }
+        _ => false,
+    }
+}
+
+pub(super) fn is_substantive_inference_candidate(
+    interner: &dyn crate::construction::TypeDatabase,
+    ty: TypeId,
+    local_type_params: &FxHashSet<tsz_common::Atom>,
+    local_placeholders: &[tsz_common::Atom],
+) -> bool {
+    !ty.is_any_unknown_or_error()
+        && !is_bare_foreign_type_param(interner, ty, local_type_params, local_placeholders)
+        && !crate::visitor::contains_type_parameters(interner, ty)
+        && !crate::type_queries::contains_infer_types_db(interner, ty)
+}
+
 impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
     pub(super) fn eval_type_param_default(
         &mut self,

--- a/crates/tsz-solver/src/operations/generic_call/mod.rs
+++ b/crates/tsz-solver/src/operations/generic_call/mod.rs
@@ -542,6 +542,7 @@ fn instantiate_call_type(
 mod contextual_signature_instantiation;
 mod inference_helpers;
 mod normalization;
+mod readonly_direct_inference;
 pub mod request;
 mod resolve;
 pub mod result;

--- a/crates/tsz-solver/src/operations/generic_call/readonly_direct_inference.rs
+++ b/crates/tsz-solver/src/operations/generic_call/readonly_direct_inference.rs
@@ -1,0 +1,38 @@
+use crate::construction::TypeDatabase;
+use crate::inference::infer::{InferenceContext, InferenceVar};
+use crate::types::{TypeData, TypeId};
+
+fn source_needs_readonly_annotation_wrapper(db: &dyn TypeDatabase, source: TypeId) -> bool {
+    !matches!(db.lookup(source), Some(TypeData::ReadonlyType(_)))
+        && (crate::type_queries::get_array_element_type(db, source).is_some()
+            || crate::type_queries::get_tuple_elements(db, source).is_some())
+}
+
+pub(super) fn wrap_readonly_annotation_source(
+    db: &dyn TypeDatabase,
+    source: TypeId,
+    is_readonly_annotation: bool,
+) -> TypeId {
+    if is_readonly_annotation && source_needs_readonly_annotation_wrapper(db, source) {
+        db.readonly_type(source)
+    } else {
+        source
+    }
+}
+
+pub(super) fn restore_direct_inference(
+    db: &dyn TypeDatabase,
+    infer_ctx: &mut InferenceContext,
+    var: InferenceVar,
+    ty: TypeId,
+) -> TypeId {
+    if infer_ctx.has_readonly_source_candidate_for(var, ty)
+        && source_needs_readonly_annotation_wrapper(db, ty)
+    {
+        let readonly_ty = db.readonly_type(ty);
+        infer_ctx.set_resolved_type(var, readonly_ty);
+        readonly_ty
+    } else {
+        ty
+    }
+}

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -12,35 +12,8 @@ use crate::types::{
 use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::{debug, trace};
 
-fn is_bare_foreign_type_param(
-    interner: &dyn crate::construction::TypeDatabase,
-    ty: TypeId,
-    local_type_params: &FxHashSet<tsz_common::Atom>,
-    local_placeholders: &[tsz_common::Atom],
-) -> bool {
-    if ty.is_intrinsic() {
-        return false;
-    }
-    match interner.lookup(ty) {
-        Some(TypeData::TypeParameter(info) | TypeData::Infer(info)) => {
-            !local_type_params.contains(&info.name) && !local_placeholders.contains(&info.name)
-        }
-        _ => false,
-    }
-}
-
-fn is_substantive_inference_candidate(
-    interner: &dyn crate::construction::TypeDatabase,
-    ty: TypeId,
-    local_type_params: &FxHashSet<tsz_common::Atom>,
-    local_placeholders: &[tsz_common::Atom],
-) -> bool {
-    !ty.is_any_unknown_or_error()
-        && !is_bare_foreign_type_param(interner, ty, local_type_params, local_placeholders)
-        && !crate::visitor::contains_type_parameters(interner, ty)
-        && !crate::type_queries::contains_infer_types_db(interner, ty)
-}
-
+use super::inference_helpers::{is_bare_foreign_type_param, is_substantive_inference_candidate};
+use super::readonly_direct_inference;
 use super::{
     constraint_contains_primitive_constrained_type_param,
     constraint_is_primitive_type_with_resolver, instantiate_call_type, type_implies_literals_deep,
@@ -226,6 +199,15 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         target: TypeId,
         priority: crate::types::InferencePriority,
     ) {
+        let source = readonly_direct_inference::wrap_readonly_annotation_source(
+            self.interner.as_type_database(),
+            source,
+            self.arg_source_is_readonly_annotation
+                .get(arg_index)
+                .copied()
+                .unwrap_or(false),
+        );
+
         if !self
             .arg_source_is_type_annotation
             .get(arg_index)
@@ -2341,6 +2323,16 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     [single] => *single,
                     bounds => infer_ctx.best_common_type(bounds),
                 }
+            } else {
+                ty
+            };
+            let ty = if direct_param_vars.contains(&var) {
+                readonly_direct_inference::restore_direct_inference(
+                    self.interner.as_type_database(),
+                    &mut infer_ctx,
+                    var,
+                    ty,
+                )
             } else {
                 ty
             };

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
@@ -344,7 +344,18 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                                 // representations before comparison.
                                 let se = self.evaluate_type(source_type);
                                 let te = self.evaluate_type(target_type);
-                                se == te || self.check_subtype(se, te).is_true()
+                                if se == te || self.check_subtype(se, te).is_true() {
+                                    return true;
+                                }
+                                if let Some(target_elem) = self
+                                    .readonly_array_syntax_element(target_type)
+                                    .or_else(|| self.readonly_array_syntax_element(te))
+                                    && let Some(source_elem) =
+                                        self.predicate_array_like_element_type(source_type, se)
+                                {
+                                    return self.check_subtype(source_elem, target_elem).is_true();
+                                }
+                                false
                             }
                             (None, Some(_)) => false,
                             (Some(_), None) | (None, None) => true,
@@ -353,6 +364,24 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 }
             }
         }
+    }
+
+    fn predicate_array_like_element_type(&self, raw: TypeId, evaluated: TypeId) -> Option<TypeId> {
+        crate::type_queries::get_array_element_type(self.interner, raw)
+            .or_else(|| crate::type_queries::get_array_element_type(self.interner, evaluated))
+            .or_else(|| {
+                crate::objects::IndexSignatureResolver::with_resolver(self.interner, self.resolver)
+                    .resolve_number_index(raw)
+            })
+            .or_else(|| {
+                (evaluated != raw).then(|| {
+                    crate::objects::IndexSignatureResolver::with_resolver(
+                        self.interner,
+                        self.resolver,
+                    )
+                    .resolve_number_index(evaluated)
+                })?
+            })
     }
 
     /// Check parameter compatibility with method bivariance support.

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -19,6 +19,7 @@ TypeScript/tests/cases/compiler/noUnusedLocals_writeOnly.ts
 TypeScript/tests/cases/conformance/externalModules/circularReference.ts
 TypeScript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts
 
-# Existing main drift exposed by PR #12237/#12242 aggregate runs; tracked in #12247.
-TypeScript/tests/cases/compiler/coAndContraVariantInferences2.ts
-TypeScript/tests/cases/compiler/correlatedUnions.ts
+# Existing drift exposed by PR #12255 after resolving the previous #12247
+# accepted rows for coAndContraVariantInferences2/correlatedUnions; tracked in
+# #12260.
+TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts


### PR DESCRIPTION
## Agent
AgentName: Studio-Canary-A

## Track
Checker/solver semantic parity follow-up for imported generic canary and focused conformance blockers.

## Invariant
When a type reference, generic call inference, or indexed access crosses import aliases, local alias scopes, readonly direct arguments, or homomorphic `-?` mapped reads, tsz preserves tsc's symbol/owner/DefId structural identity and modifier semantics through checker/solver boundaries instead of relying on file-local text or raw-symbol collisions.

## Scope
- Preserve imported generic ref type parameters through target-file structural cache keys and barrel re-exports.
- Preserve local alias scope for unqualified type references in user source while keeping qualified-name/name-first lookup for lib declaration files.
- Keep readonly direct-argument inference when type-predicate callbacks contribute mutable/contravariant candidates.
- Strip synthetic optional `undefined` from indexed access through homomorphic `-?` mapped types such as `Required<T>[K]`.
- Split call-candidate tests out of `candidate_collection.rs` and move solver helper predicates out of `generic_call/resolve.rs` so touched shards stay under the source-size guards.
- Refresh accepted conformance drift: remove the resolved `coAndContraVariantInferences2`/`correlatedUnions` rows and track the remaining `intersectionsOfLargeUnions` witness in #12260.

## Project Corpus Impact
- Row: imported-generic alias/cache canary originally covered by #12242.
- Bug family: imported generic TS2315 cache collisions plus focused `correlatedUnions` and `coAndContraVariantInferences2` conformance blockers found during the same canary ownership pass.
- This follow-up is rebased onto current `origin/main` after #12242 merged and removes focused canary/conformance blockers found during the same ownership pass.
- CI conformance aggregate on the prior head reported 12580/12585 actual vs 12582/12585 expected, with `intersectionsOfLargeUnions.ts` as the only unlisted remaining row and the two rows above resolved; #12260 tracks that witness.
- No broad project-corpus or full conformance run was performed locally; ready-review CI should own broad coverage.

## Verification
- `git diff --check origin/main...HEAD`
- `cargo fmt --all --check`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh -- cargo clippy --profile ci-lint -p tsz-common -p tsz-scanner -p tsz-parser -p tsz-binder -p tsz-solver -p tsz-checker -p tsz-emitter -p tsz-lowering -p tsz-lsp --all-targets -- -D warnings`
- `scripts/safe-run.sh -- cargo nextest run --target-dir .target -p tsz-checker --test mapped_keyof_index_access_tests`
- `scripts/safe-run.sh -- cargo nextest run --target-dir .target -p tsz-checker --lib ref_type_params`
- `scripts/safe-run.sh -- cargo nextest run --target-dir .target -p tsz-checker --test generic_call_inference_tests readonly_array_predicate_call_keeps_direct_argument_inference`
- `scripts/safe-run.sh -- cargo nextest run --target-dir .target -p tsz-checker --lib generic_call_source_markers`
- `python3 scripts/conformance/test_query_conformance.py`
- `scripts/safe-run.sh -- ./scripts/conformance/conformance.sh run --filter "correlatedUnions" --verbose`
- `scripts/safe-run.sh -- ./scripts/conformance/conformance.sh run --filter "coAndContraVariantInferences2" --verbose`
- `scripts/safe-run.sh -- ./scripts/conformance/conformance.sh run --filter "intersectionsOfLargeUnions" --verbose` (expected accepted witness: extra TS2345/missing TS2536; tracked in #12260)

## Coordination Notes
- #12242 merged while this follow-up verification was in progress, so this PR carries the remaining one-commit follow-up on top of current `origin/main`.
- AgentName remains Studio-Canary-A for this canary lane; the canonical repo ownership label uses `agent:Studio-A` because `Studio-Canary-A` is not a canonical label in `docs/plan/agents/README.md`.
- Studio-Canary-B and MBMB4-Canary-A should not duplicate this imported-generic/ref-type-params cache follow-up.
- The lint architecture guard caught the readonly helper placement and source-size ratchets; the current head moves the direct type-shape check behind a query-boundary helper and keeps `generic_call/resolve.rs` below the guard limit.
