### PR TITLE
ci: use npm token for bootstrap publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -195,6 +195,8 @@ jobs:
 
       - name: Publish packages
         shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
           publish_if_needed() {


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Release infrastructure / npm bootstrap follow-up.

## Invariant
When the npm publish workflow runs before trusted publishing is configured for newly-created package records, npm should have access to the existing repository `NPM_TOKEN` secret for the publish step. This PR changes only workflow authentication wiring for the package publish step.

## Scope
- Adds `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` to the npm publish step in `.github/workflows/npm-publish.yml`.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: Workflow-only release authentication change; no compiler, checker, solver, emitter, CLI runtime, or project corpus behavior changes.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/npm-publish.yml"); puts "ok"'`
- `git diff -- .github/workflows/npm-publish.yml`

## Coordination Notes
- Follow-up to #12246 so the first `try-tsz` package publish can create npm package records. After package records exist, run `scripts/build/setup-npm-trusted-publishers.sh` and then remove or stop relying on token-based bootstrap publishing.
