### PR TITLE
fix(checker): report intersection-target missing properties member-by-member

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
@@ -521,6 +521,178 @@ impl<'a> CheckerState<'a> {
         Some(false)
     }
 
+    /// Whether the assignment target's *written* type annotation denotes an
+    /// intersection — directly (`A & B`), through parentheses, or through a
+    /// type-alias reference whose body resolves (recursively) to an
+    /// intersection (`type W = A & B; const x: W = ...`).
+    ///
+    /// This is a purely syntactic check over annotation NODES. tsz eagerly
+    /// merges concrete object-intersections into a single object that interns
+    /// identically to a plain object literal of the same shape, so the merged
+    /// type cannot be distinguished from a plain object by its `TypeId` (or its
+    /// display alias) alone. The annotation's syntactic provenance is the only
+    /// reliable signal that tsc would report the mismatch member-by-member.
+    pub(super) fn target_annotation_denotes_intersection(&self, anchor_idx: NodeIndex) -> bool {
+        self.target_annotation_node(anchor_idx)
+            .is_some_and(|node| self.type_node_denotes_intersection(node, 0))
+    }
+
+    /// Whether the target annotation is *written* as an intersection literal
+    /// (`A & B`, possibly parenthesized) rather than a type-alias reference that
+    /// resolves to one. tsc echoes the inline `&` form for the former
+    /// (`{ g: number; } & { h: string; }`) but the alias name for the latter
+    /// (`PlainWrap`), so the recovered-intersection display chooses accordingly.
+    pub(super) fn target_annotation_is_intersection_literal(&self, anchor_idx: NodeIndex) -> bool {
+        self.target_annotation_node(anchor_idx)
+            .is_some_and(|node| self.type_node_is_intersection_literal(node, 0))
+    }
+
+    fn type_node_is_intersection_literal(&self, type_node_idx: NodeIndex, depth: u32) -> bool {
+        use tsz_parser::parser::syntax_kind_ext;
+        if depth > 16 {
+            return false;
+        }
+        let Some(node) = self.ctx.arena.get(type_node_idx) else {
+            return false;
+        };
+        if node.kind == syntax_kind_ext::INTERSECTION_TYPE {
+            return true;
+        }
+        if let Some(inner) = self.parenthesized_inner_type_node(node) {
+            return self.type_node_is_intersection_literal(inner, depth + 1);
+        }
+        false
+    }
+
+    /// Inner type node of a `PARENTHESIZED_TYPE`, if `node` is one.
+    fn parenthesized_inner_type_node(
+        &self,
+        node: &tsz_parser::parser::node::Node,
+    ) -> Option<NodeIndex> {
+        use tsz_parser::parser::syntax_kind_ext;
+        if node.kind == syntax_kind_ext::PARENTHESIZED_TYPE {
+            self.ctx.arena.get_wrapped_type(node).map(|w| w.type_node)
+        } else {
+            None
+        }
+    }
+
+    /// Type-annotation node of a binding declaration (variable / parameter /
+    /// property), if it carries one.
+    fn declaration_type_annotation_node(
+        &self,
+        decl: &tsz_parser::parser::node::Node,
+    ) -> Option<NodeIndex> {
+        let annotation = if let Some(var_decl) = self.ctx.arena.get_variable_declaration(decl) {
+            var_decl.type_annotation
+        } else if let Some(param) = self.ctx.arena.get_parameter(decl) {
+            param.type_annotation
+        } else if let Some(prop) = self.ctx.arena.get_property_decl(decl) {
+            prop.type_annotation
+        } else {
+            return None;
+        };
+        annotation.is_some().then_some(annotation)
+    }
+
+    /// Resolve the assignment target's type-annotation node from an anchor.
+    fn target_annotation_node(&self, anchor_idx: NodeIndex) -> Option<NodeIndex> {
+        use tsz_parser::parser::syntax_kind_ext;
+        // The anchor may be the annotated declaration itself or, more commonly, a
+        // descendant such as the initializer expression. Walk up the ancestor
+        // chain (bounded) until an annotated binding or assignment is found,
+        // stopping at function/statement boundaries so an unrelated outer
+        // annotation is never attributed to this assignment.
+        let mut current = anchor_idx;
+        let mut guard = 0u32;
+        while current.is_some() {
+            guard += 1;
+            if guard > 32 {
+                break;
+            }
+            let node = self.ctx.arena.get(current)?;
+            if node.kind == syntax_kind_ext::VARIABLE_DECLARATION
+                || node.kind == syntax_kind_ext::PARAMETER
+                || node.kind == syntax_kind_ext::PROPERTY_DECLARATION
+            {
+                return self.declaration_type_annotation_node(node);
+            }
+            if node.kind == syntax_kind_ext::BINARY_EXPRESSION {
+                let binary = self.ctx.arena.get_binary_expr(node)?;
+                return self.declared_assignment_type_annotation_node(binary.left);
+            }
+            if node.kind == syntax_kind_ext::EXPRESSION_STATEMENT {
+                let expr_stmt = self.ctx.arena.get_expression_statement(node)?;
+                let expr_node = self.ctx.arena.get(expr_stmt.expression)?;
+                if expr_node.kind == syntax_kind_ext::BINARY_EXPRESSION {
+                    let binary = self.ctx.arena.get_binary_expr(expr_node)?;
+                    return self.declared_assignment_type_annotation_node(binary.left);
+                }
+                return None;
+            }
+            if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
+                || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
+                || node.kind == syntax_kind_ext::ARROW_FUNCTION
+                || node.kind == syntax_kind_ext::METHOD_DECLARATION
+                || node.kind == syntax_kind_ext::BLOCK
+                || node.kind == syntax_kind_ext::SOURCE_FILE
+            {
+                return None;
+            }
+            current = self.ctx.arena.get_extended(current).map(|ext| ext.parent)?;
+        }
+        None
+    }
+
+    /// Recursively decide whether a type-annotation node denotes an
+    /// intersection, unwrapping parentheses and following type-alias references.
+    fn type_node_denotes_intersection(&self, type_node_idx: NodeIndex, depth: u32) -> bool {
+        use crate::symbol_resolver::TypeSymbolResolution;
+        use tsz_parser::parser::syntax_kind_ext;
+        if depth > 16 {
+            return false;
+        }
+        let Some(node) = self.ctx.arena.get(type_node_idx) else {
+            return false;
+        };
+        if node.kind == syntax_kind_ext::INTERSECTION_TYPE {
+            return true;
+        }
+        if let Some(inner) = self.parenthesized_inner_type_node(node) {
+            return self.type_node_denotes_intersection(inner, depth + 1);
+        }
+        if node.kind == syntax_kind_ext::TYPE_REFERENCE {
+            let Some(type_ref) = self.ctx.arena.get_type_ref(node) else {
+                return false;
+            };
+            let type_name = type_ref.type_name;
+            let sym_id = match self.resolve_qualified_symbol_in_type_position(type_name) {
+                TypeSymbolResolution::Type(sym_id) | TypeSymbolResolution::ValueOnly(sym_id) => {
+                    sym_id
+                }
+                TypeSymbolResolution::NotFound => return false,
+            };
+            let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
+                return false;
+            };
+            let mut declarations = Vec::new();
+            if symbol.value_declaration.is_some() {
+                declarations.push(symbol.value_declaration);
+            }
+            declarations.extend(symbol.declarations.iter().copied());
+            return declarations.into_iter().any(|decl_idx| {
+                self.ctx
+                    .arena
+                    .get(decl_idx)
+                    .and_then(|decl| self.ctx.arena.get_type_alias(decl))
+                    .is_some_and(|alias| {
+                        self.type_node_denotes_intersection(alias.type_node, depth + 1)
+                    })
+            });
+        }
+        false
+    }
+
     pub(super) fn missing_required_properties_from_index_signature_source(
         &mut self,
         source: TypeId,

--- a/crates/tsz-checker/src/error_reporter/assignability_keyof_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_keyof_alias_display.rs
@@ -118,7 +118,10 @@ impl<'a> CheckerState<'a> {
         self.keyof_type_alias_annotation_display(&annotation)
     }
 
-    fn declared_assignment_type_annotation_node(&self, expr_idx: NodeIndex) -> Option<NodeIndex> {
+    pub(in crate::error_reporter) fn declared_assignment_type_annotation_node(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<NodeIndex> {
         let expr_idx = self.ctx.arena.skip_parenthesized_and_assertions(expr_idx);
         let node = self.ctx.arena.get(expr_idx)?;
         if node.kind != tsz_scanner::SyntaxKind::Identifier as u16 {

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -1517,12 +1517,39 @@ impl<'a> CheckerState<'a> {
         // The jsdoc anchor path also enters here (intersection_for_members = None in that case)
         // and receives bare TS2322 without per-property elaboration, matching tsc's output.
         let intersection_for_members =
-            self.resolve_intersection_target_for_display(target_type, target);
+            self.resolve_intersection_target_for_display_kind(target_type, target, idx);
         if intersection_for_members.is_some()
             || self.anchor_jsdoc_type_tag_targets_intersection_alias(idx)
         {
-            let src_str = self.format_type_diagnostic(source);
-            let tgt_str = self.format_type_diagnostic(target);
+            // Source display must replicate the path that previously handled
+            // each case so no conformance baseline shifts:
+            // - recovered (merged) intersections were the flat TS2739 path, which
+            //   widens the top-level assigned literal at the anchor
+            //   (`{ b: "s" }` -> `{ b: string }`);
+            // - genuine intersections were the old intersection path, which keeps
+            //   the source as-is so a contextually-literal nested value stays
+            //   intact (`{ a: 0 }` -> `{ a: 0 }`, not `{ a: number }`).
+            let recovered = matches!(intersection_for_members, Some((_, true)));
+            let src_str = if recovered && depth == 0 {
+                self.format_type_for_diagnostic_role(
+                    source,
+                    DiagnosticTypeDisplayRole::AssignmentSource {
+                        target,
+                        anchor_idx: idx,
+                    },
+                )
+            } else {
+                self.format_type_diagnostic(source)
+            };
+            // A recovered (merged) intersection renders its top-level target from
+            // the written annotation (see helper); genuine intersections keep the
+            // structural display.
+            let tgt_str = match intersection_for_members {
+                Some((intersection, true)) => {
+                    self.recovered_intersection_top_level_display(intersection, target, source, idx)
+                }
+                _ => self.format_type_diagnostic(target),
+            };
             let message = format_message(
                 diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                 &[&src_str, &tgt_str],
@@ -1534,7 +1561,7 @@ impl<'a> CheckerState<'a> {
                 message,
                 diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
             );
-            if let Some(intersection) = intersection_for_members {
+            if let Some((intersection, _recovered)) = intersection_for_members {
                 self.push_intersection_member_elaboration(
                     &mut diag,
                     intersection,
@@ -1936,19 +1963,9 @@ impl<'a> CheckerState<'a> {
         };
         let ordered_names =
             self.sort_missing_property_names_for_display(target_type, &filtered_names);
-        // tsc lists up to 5 properties inline (TS2739), and uses "and N more"
-        // truncation (TS2740) when there are 6+. For TS2740, tsc lists the
-        // first 4 properties then "and N more" (where N = total - 4).
-        let is_truncated = ordered_names.len() > 5;
-        let display_count = if is_truncated { 4 } else { 5 };
-        let prop_list: Vec<String> = ordered_names
-            .iter()
-            .take(display_count)
-            .map(|name| self.missing_property_list_name_for_display(*name))
-            .collect();
-        let props_joined = prop_list.join(", ");
-        if is_truncated {
-            let more_count = (ordered_names.len() - display_count).to_string();
+        let (props_joined, more) = self.truncated_missing_property_list(&ordered_names);
+        if let Some(more_count) = more {
+            let more_count = more_count.to_string();
             let message = format_message(
                 diagnostic_messages::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE_AND_MORE,
                 &[&src_str, &tgt_str, &props_joined, &more_count],

--- a/crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs
@@ -213,11 +213,36 @@ impl<'a> CheckerState<'a> {
         // tsc keeps the top-level TS2322 but elaborates which intersection member requires the
         // missing property; returning the bare TS2322 alone hid this root reason
         // ("intersection fallback hides root property mismatch").
-        if let Some(intersection) =
-            self.resolve_intersection_target_for_display(target_type, target)
+        if let Some((intersection, recovered)) =
+            self.resolve_intersection_target_for_display_kind(target_type, target, idx)
         {
-            let src_str = self.format_type_diagnostic(source_type);
-            let tgt_str = self.format_type_diagnostic(intersection);
+            // Source display must replicate the path that previously handled
+            // each case so no conformance baseline shifts:
+            // - recovered (merged) intersections were the flat TS2741 path, which
+            //   widens the top-level assigned literal at the anchor
+            //   (`{ b: "s" }` -> `{ b: string }`);
+            // - genuine intersections were the old intersection path, which keeps
+            //   the source as-is so a contextually-literal nested value stays
+            //   intact (`{ a: 0 }` -> `{ a: 0 }`, not `{ a: number }`).
+            let src_str = if recovered && depth == 0 {
+                self.format_type_for_diagnostic_role(
+                    source,
+                    DiagnosticTypeDisplayRole::AssignmentSource {
+                        target,
+                        anchor_idx: idx,
+                    },
+                )
+            } else {
+                self.format_type_diagnostic(source_type)
+            };
+            // A recovered (merged) intersection renders its top-level target from
+            // the written annotation (see helper); genuine intersections keep the
+            // structural display.
+            let tgt_str = if recovered {
+                self.recovered_intersection_top_level_display(intersection, target, source, idx)
+            } else {
+                self.format_type_diagnostic(intersection)
+            };
             let message = format_message(
                 diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                 &[&src_str, &tgt_str],
@@ -408,7 +433,7 @@ impl<'a> CheckerState<'a> {
 
         // TSC emits TS2322 instead of TS2741 when the target is an intersection type.
         if self
-            .resolve_intersection_target_for_display(target_type, target)
+            .resolve_intersection_target_for_display(target_type, target, idx)
             .is_some()
         {
             let src_str = self.format_type_diagnostic(source);
@@ -657,43 +682,43 @@ impl<'a> CheckerState<'a> {
     /// expanded object). Returns `None` when no member requires the property
     /// (e.g. the requirement comes from an index signature), leaving the caller
     /// with the bare top-level message.
-    pub(super) fn intersection_member_requiring_property(
+    /// Whether intersection `member` declares `property_name` as a required
+    /// (non-optional) named property. Members are evaluated when a direct lookup
+    /// misses so mapped/applied members such as `Map1<{...}>` are inspected too.
+    pub(super) fn intersection_member_requires_property(
         &mut self,
-        intersection: TypeId,
+        member: TypeId,
         property_name: tsz_common::interner::Atom,
-    ) -> Option<TypeId> {
-        let members =
-            crate::query_boundaries::common::intersection_members(self.ctx.types, intersection)?;
+    ) -> bool {
         let prop_str = self.ctx.types.resolve_atom_ref(property_name);
-        for member in members {
-            let found = crate::query_boundaries::common::find_property_by_str(
+        let found = crate::query_boundaries::common::find_property_by_str(
+            self.ctx.types,
+            member,
+            &prop_str,
+        )
+        .or_else(|| {
+            let evaluated = self.evaluate_type_with_env(member);
+            crate::query_boundaries::common::find_property_by_str(
                 self.ctx.types,
-                member,
+                evaluated,
                 &prop_str,
             )
-            .or_else(|| {
-                let evaluated = self.evaluate_type_with_env(member);
-                crate::query_boundaries::common::find_property_by_str(
-                    self.ctx.types,
-                    evaluated,
-                    &prop_str,
-                )
-            });
-            if let Some(prop) = found
-                && !prop.optional
-            {
-                return Some(member);
-            }
-        }
-        None
+        });
+        found.is_some_and(|prop| !prop.optional)
     }
 
-    /// Append one elaboration line to `diag` for each property in
-    /// `property_names` that is required by an intersection member.
+    /// Append the elaboration tsc emits for a missing-property mismatch against
+    /// an intersection target.
     ///
-    /// Mirrors the elaboration tsc appends for missing-property mismatches on
-    /// intersection targets:
-    /// `Property 'X' is missing in type 'S' but required in type '<member>'`.
+    /// tsc checks intersection members left-to-right and elaborates only the
+    /// FIRST member the source fails against, grouping that member's missing
+    /// required properties into a single line:
+    /// - one miss   -> `Property 'X' is missing in type 'S' but required in type '<member>'`
+    /// - several    -> `Type 'S' is missing the following properties from type '<member>': a, b`
+    ///
+    /// Reproduce that here instead of emitting one line per property, which
+    /// diverged from tsc whenever several missing properties belonged to the
+    /// same member.
     pub(super) fn push_intersection_member_elaboration(
         &mut self,
         diag: &mut Diagnostic,
@@ -703,25 +728,68 @@ impl<'a> CheckerState<'a> {
         start: u32,
         length: u32,
     ) {
-        for &prop in property_names {
-            if let Some(member) = self.intersection_member_requiring_property(intersection, prop) {
-                let prop_name_display = self.missing_property_name_for_display(prop, member);
-                let member_str = self.format_type_diagnostic(member);
-                let elaboration = format_message(
-                    diagnostic_messages::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
-                    &[&prop_name_display, src_str, &member_str],
-                );
-                diag.related_information.push(DiagnosticRelatedInformation {
-                    file: diag.file.clone(),
-                    start,
-                    length,
-                    message_text: elaboration,
-                    category: DiagnosticCategory::Message,
-                    code: diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
-                    depth: 0,
-                });
+        let Some(members) =
+            crate::query_boundaries::common::intersection_members(self.ctx.types, intersection)
+        else {
+            return;
+        };
+        let mut failing: Option<(TypeId, Vec<tsz_common::interner::Atom>)> = None;
+        for member in members {
+            let member_missing: Vec<tsz_common::interner::Atom> = property_names
+                .iter()
+                .copied()
+                .filter(|&prop| self.intersection_member_requires_property(member, prop))
+                .collect();
+            if !member_missing.is_empty() {
+                failing = Some((member, member_missing));
+                break;
             }
         }
+        let Some((member, member_missing)) = failing else {
+            return;
+        };
+
+        let member_str = self.format_type_diagnostic(member);
+        let ordered = self.sort_missing_property_names_for_display(member, &member_missing);
+        let (message, code) = if ordered.len() == 1 {
+            let prop_name_display = self.missing_property_name_for_display(ordered[0], member);
+            (
+                format_message(
+                    diagnostic_messages::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
+                    &[&prop_name_display, src_str, &member_str],
+                ),
+                diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
+            )
+        } else {
+            let (props_joined, more) = self.truncated_missing_property_list(&ordered);
+            if let Some(more_count) = more {
+                let more_count = more_count.to_string();
+                (
+                    format_message(
+                        diagnostic_messages::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE_AND_MORE,
+                        &[src_str, &member_str, &props_joined, &more_count],
+                    ),
+                    diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE_AND_MORE,
+                )
+            } else {
+                (
+                    format_message(
+                        diagnostic_messages::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE,
+                        &[src_str, &member_str, &props_joined],
+                    ),
+                    diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE,
+                )
+            }
+        };
+        diag.related_information.push(DiagnosticRelatedInformation {
+            file: diag.file.clone(),
+            start,
+            length,
+            message_text: message,
+            category: DiagnosticCategory::Message,
+            code,
+            depth: 0,
+        });
     }
 
     /// For TS2739 source display, unfold wrapper aliases like

--- a/crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs
@@ -34,6 +34,26 @@ impl<'a> CheckerState<'a> {
         self.ctx.types.resolve_atom_ref(property_name).to_string()
     }
 
+    /// Format a missing-property name list for the TS2739/TS2740 "missing the
+    /// following properties" message. tsc lists up to 5 names inline; for 6+ it
+    /// lists the first 4 then "and N more". Returns the joined list and the
+    /// "and N more" count (present only when truncated).
+    pub(super) fn truncated_missing_property_list(
+        &mut self,
+        ordered: &[tsz_common::interner::Atom],
+    ) -> (String, Option<usize>) {
+        let is_truncated = ordered.len() > 5;
+        let display_count = if is_truncated { 4 } else { 5 };
+        let joined = ordered
+            .iter()
+            .take(display_count)
+            .map(|name| self.missing_property_list_name_for_display(*name))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let more = is_truncated.then(|| ordered.len() - display_count);
+        (joined, more)
+    }
+
     pub(super) fn enum_mapped_property_name_for_display(
         &mut self,
         property_name: tsz_common::interner::Atom,
@@ -765,11 +785,73 @@ impl<'a> CheckerState<'a> {
         &mut self,
         target_type: TypeId,
         target: TypeId,
+        anchor_idx: NodeIndex,
     ) -> Option<TypeId> {
+        self.resolve_intersection_target_for_display_kind(target_type, target, anchor_idx)
+            .map(|(intersection, _recovered)| intersection)
+    }
+
+    /// Like [`Self::resolve_intersection_target_for_display`] but also reports
+    /// whether the intersection was a genuine `Intersection` type (`false`) or
+    /// was recovered from a merged object's display alias (`true`). The
+    /// recovered case must render its top-level target from the written
+    /// annotation, since the merged object's display alias does not preserve the
+    /// user's alias name (`PlainWrap`) or the inline-vs-named form tsc echoes.
+    pub(super) fn resolve_intersection_target_for_display_kind(
+        &mut self,
+        target_type: TypeId,
+        target: TypeId,
+        anchor_idx: NodeIndex,
+    ) -> Option<(TypeId, bool)> {
         let evaluated = self.evaluate_type_with_env(target);
-        [evaluated, target, target_type]
+        if let Some(direct) = [evaluated, target, target_type]
             .into_iter()
             .find(|&t| crate::query_boundaries::common::is_intersection_type(self.ctx.types, t))
+        {
+            return Some((direct, false));
+        }
+        // tsz eagerly merges concrete object-intersections (`{ a } & { b }`) into
+        // a single object (`{ a; b }`) and records a display alias back to the
+        // original `{ a } & { b }` intersection so the formatter can still print
+        // the `&` form. Recover that intersection here so a missing-property
+        // mismatch reports member-by-member like tsc ("required in type 'B'")
+        // instead of collapsing to the merged object and reporting a flat
+        // TS2741/TS2739 against `{ a; b }`.
+        //
+        // The merged object interns identically to a plain object literal of the
+        // same shape, so its `TypeId` (and display alias) alone cannot tell the
+        // two apart. Gate the recovery on the target *annotation* actually being
+        // written as an intersection, which is the only reliable signal.
+        if !self.target_annotation_denotes_intersection(anchor_idx) {
+            return None;
+        }
+        [evaluated, target, target_type].into_iter().find_map(|t| {
+            let alias = self.ctx.types.get_display_alias(t)?;
+            crate::query_boundaries::common::is_intersection_type(self.ctx.types, alias)
+                .then_some((alias, true))
+        })
+    }
+
+    /// Top-level target string for a *recovered* (merged-object) intersection
+    /// target, shared by the single- and multi-missing render paths.
+    ///
+    /// The merged object's display alias does not preserve the user's alias name
+    /// or the inline-vs-named form tsc echoes, so render from the written
+    /// annotation: an inline `A & B` literal keeps the structural `&` form (the
+    /// recovered intersection), while a type-alias reference keeps the alias
+    /// name. (Genuine, non-recovered intersections are rendered by the caller.)
+    pub(super) fn recovered_intersection_top_level_display(
+        &mut self,
+        intersection: TypeId,
+        target: TypeId,
+        source: TypeId,
+        anchor_idx: NodeIndex,
+    ) -> String {
+        if self.target_annotation_is_intersection_literal(anchor_idx) {
+            self.format_type_diagnostic(intersection)
+        } else {
+            self.format_assignability_type_for_message(target, source)
+        }
     }
 
     /// Return `true` when `target` or its evaluated form is an intersection type.

--- a/crates/tsz-checker/tests/intersection_target_missing_property_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/intersection_target_missing_property_elaboration_tests.rs
@@ -41,6 +41,21 @@ fn has_missing_member_elaboration(diags: &[Diagnostic], prop: &str) -> bool {
     })
 }
 
+/// True when some TS2322 carries a nested grouped "Type 'S' is missing the
+/// following properties from type '<member>': ..." elaboration listing every
+/// property in `props` (the form tsc uses when one intersection member is
+/// missing several required properties).
+fn has_grouped_member_elaboration(diags: &[Diagnostic], props: &[&str]) -> bool {
+    diags.iter().any(|d| {
+        d.code == 2322
+            && d.related_information.iter().any(|info| {
+                info.message_text
+                    .contains("is missing the following properties from type")
+                    && props.iter().all(|p| info.message_text.contains(p))
+            })
+    })
+}
+
 /// Reported repro: a mapped member of the intersection requires the missing
 /// property. The top-level stays TS2322; the nested line must name `b`.
 #[test]
@@ -169,10 +184,12 @@ const v: Target = { a: 123, b: 1 };
 
 // ── Multiple-missing-property (MissingProperties) cases ──────────────────────
 
-/// When two properties are missing and both live in the same mapped intersection
-/// member, each missing property gets its own elaboration line.
+/// When several properties are missing and all live in the *same* intersection
+/// member, tsc groups them into one `... is missing the following properties
+/// from type '<member>': a, b, c` line under the top-level TS2322 (rather than
+/// one line per property).
 #[test]
-fn multiple_missing_in_mapped_member_elaborates_each() {
+fn multiple_missing_in_mapped_member_groups_properties() {
     let diags = diagnostics(
         r#"
 type Map1<T> = { [K in keyof T]: T[K] };
@@ -181,23 +198,18 @@ const v: Target = { d: "x" };
 "#,
     );
     assert!(
-        has_missing_member_elaboration(&diags, "a"),
-        "expected elaboration for missing `a`; got {diags:?}"
-    );
-    assert!(
-        has_missing_member_elaboration(&diags, "b"),
-        "expected elaboration for missing `b`; got {diags:?}"
-    );
-    assert!(
-        has_missing_member_elaboration(&diags, "c"),
-        "expected elaboration for missing `c`; got {diags:?}"
+        has_grouped_member_elaboration(&diags, &["a", "b", "c"]),
+        "expected a single grouped `... missing the following properties ... a, b, c` \
+         elaboration on the mapped member; got {diags:?}"
     );
 }
 
-/// Properties missing from *different* intersection members each get an
-/// elaboration line pointing to their respective requiring member.
+/// tsc checks intersection members left-to-right and elaborates only the FIRST
+/// member the source fails against. With `x` missing from the mapped member and
+/// `y` missing from a later member, only the `x`/mapped-member elaboration is
+/// reported.
 #[test]
-fn multiple_missing_across_different_members_elaborates_each() {
+fn multiple_missing_across_members_reports_first_member_only() {
     let diags = diagnostics(
         r#"
 type Map1<T> = { [K in keyof T]: T[K] };
@@ -207,18 +219,20 @@ const v: Target = {};
     );
     assert!(
         has_missing_member_elaboration(&diags, "x"),
-        "expected elaboration for missing `x` in mapped member; got {diags:?}"
+        "expected elaboration for missing `x` in the first (mapped) member; got {diags:?}"
     );
     assert!(
-        has_missing_member_elaboration(&diags, "y"),
-        "expected elaboration for missing `y` in plain member; got {diags:?}"
+        !has_missing_member_elaboration(&diags, "y")
+            && !has_grouped_member_elaboration(&diags, &["y"]),
+        "only the first failing member should be elaborated; `y` (from a later member) \
+         must not appear; got {diags:?}"
     );
 }
 
 /// Anti-hardcoding: different iteration-variable / property / alias spellings
-/// must not affect whether elaboration fires for the multi-property case.
+/// must not affect the grouped multi-property elaboration.
 #[test]
-fn multiple_missing_renamed_vars_elaborates() {
+fn multiple_missing_renamed_vars_groups_properties() {
     let diags = diagnostics(
         r#"
 type Wrap<U> = { [Q in keyof U]: U[Q] };
@@ -227,22 +241,18 @@ const w: Combined = { gamma: true };
 "#,
     );
     assert!(
-        has_missing_member_elaboration(&diags, "alpha"),
-        "expected elaboration for missing `alpha`; got {diags:?}"
-    );
-    assert!(
-        has_missing_member_elaboration(&diags, "beta"),
-        "expected elaboration for missing `beta`; got {diags:?}"
+        has_grouped_member_elaboration(&diags, &["alpha", "beta"]),
+        "expected the grouped elaboration regardless of mapped-variable / property / \
+         alias spelling; got {diags:?}"
     );
 }
 
 /// A plain (non-mapped) intersection alias is normalised to an object type by
-/// the solver before it reaches the error reporter, so multiple missing
-/// properties produce TS2739 (the standard missing-properties message) rather
-/// than the intersection-member elaboration.  This verifies we don't regress
-/// the TS2739 path while the mapped-intersection elaboration is active.
+/// the solver, but the written annotation is still an intersection, so tsc keeps
+/// the top-level TS2322 and elaborates the first member member-by-member — not a
+/// flat top-level TS2739 against the merged object.
 #[test]
-fn plain_intersection_alias_multiple_missing_gives_ts2739() {
+fn plain_intersection_alias_multiple_missing_elaborates_member() {
     let diags = diagnostics(
         r#"
 type Target = { a: string; b: number } & { c: boolean };
@@ -250,8 +260,14 @@ const v: Target = {};
 "#,
     );
     assert!(
-        diags.iter().any(|d| d.code == 2739),
-        "plain intersection with multiple missing properties must emit TS2739; got {diags:?}"
+        diags.iter().any(|d| d.code == 2322) && !diags.iter().any(|d| d.code == 2739),
+        "a plain intersection annotation must report TS2322 with a member elaboration, \
+         not a flat top-level TS2739; got {diags:?}"
+    );
+    assert!(
+        has_grouped_member_elaboration(&diags, &["a", "b"]),
+        "expected the first member `{{ a: string; b: number; }}` to be elaborated with \
+         its missing properties `a, b`; got {diags:?}"
     );
 }
 
@@ -269,5 +285,101 @@ const v: Target = { a: "s", b: 1, c: true };
     assert!(
         !diags.iter().any(|d| d.code == 2322 || d.code == 2741),
         "a complete source must not produce any assignability error; got {diags:?}"
+    );
+}
+
+// ── Assignment-expression target & plain-object anti-leak negative ────────────
+
+/// The member elaboration also fires for an assignment *expression*
+/// (`target = { ... }`) whose left-hand side was declared with an intersection
+/// annotation — not only declaration initializers. This exercises the
+/// `BINARY_EXPRESSION` branch of the annotation walk in `target_annotation_node`.
+/// Renamed alias/property spellings guard against a name-keyed fix.
+#[test]
+fn assignment_expression_to_intersection_target_elaborates_member() {
+    let diags = diagnostics(
+        r#"
+type Lhs1 = { alpha: number };
+type Lhs2 = { beta: string };
+let target: Lhs1 & Lhs2;
+target = { alpha: 1 };
+"#,
+    );
+    let matched = diags.iter().any(|d| {
+        d.code == 2322
+            && d.related_information.iter().any(|info| {
+                info.message_text.contains("Property 'beta' is missing")
+                    && info.message_text.contains("required in type 'Lhs2'")
+            })
+    });
+    assert!(
+        matched,
+        "expected TS2322 + `... required in type 'Lhs2'` for an assignment-expression \
+         target declared as an intersection; got {diags:?}"
+    );
+}
+
+/// Anti-leak negative: a PLAIN object-literal target that is structurally
+/// identical to a named intersection elsewhere in the program must still report
+/// a flat TS2741 with no member elaboration. The merged intersection and the
+/// plain object intern to the same `TypeId` (sharing the display alias), so the
+/// member-elaboration recovery — which is gated on the *written annotation*
+/// being an intersection — must NOT fire here. Renamed spellings guard against a
+/// fix keyed to particular names.
+#[test]
+fn plain_object_target_does_not_leak_intersection_elaboration() {
+    let diags = diagnostics(
+        r#"
+type Leaf1 = { qq: number };
+type Leaf2 = { rr: string };
+type Merged = Leaf1 & Leaf2;
+declare const forcesMerged: Merged;
+const plain: { qq: number; rr: string } = { qq: 1 };
+"#,
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.code == 2741 && d.message_text.contains("Property 'rr' is missing")),
+        "expected a flat TS2741 for the missing `rr` on the plain object target; got {diags:?}"
+    );
+    assert!(
+        !diags.iter().any(|d| d.code == 2322),
+        "a plain object-literal target must not receive the intersection-member \
+         elaboration (TS2322) even when an identically-shaped named intersection \
+         exists in the program; got {diags:?}"
+    );
+    assert!(
+        !has_missing_member_elaboration(&diags, "rr"),
+        "no `required in type '<member>'` elaboration may leak onto a plain object \
+         target; got {diags:?}"
+    );
+}
+
+/// Regression for `excessPropertyCheckIntersectionWithIndexSignature`: when the
+/// intersection target is an index-signature *value* type and the failing
+/// source is a nested, contextually-literal object (`{ a: 0 }` checked against
+/// `{ a: 0 } & { b: 0 }`), the source must render with its literal preserved
+/// (`{ a: 0; }`), not widened to `{ a: number; }`. The genuine-intersection path
+/// must not apply the assignment-anchor literal widening that the merged
+/// (recovered) path uses for top-level assigned literals.
+#[test]
+fn nested_index_signature_intersection_keeps_literal_source() {
+    let diags = diagnostics(
+        r#"
+let x: { [k: string]: { a: 0 } } & { [k: string]: { b: 0 } };
+x = { y: { a: 0 } };
+"#,
+    );
+    let matched = diags.iter().any(|d| {
+        d.code == 2322
+            && d.message_text
+                .contains("Type '{ a: 0; }' is not assignable")
+            && d.message_text.contains("'{ a: 0; } & { b: 0; }'")
+    });
+    assert!(
+        matched,
+        "the nested index-signature intersection source must keep its literal type \
+         (`{{ a: 0; }}`, not the widened `{{ a: number; }}`); got {diags:?}"
     );
 }


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Conformance / diagnostics.

## Invariant
When a value is assigned to an intersection target and a required property of one intersection member is missing, `tsc` keeps the top-level TS2322 and elaborates the first failing member. This PR changes diagnostic rendering only, through `tsz_checker::error_reporter`, with no solver/type-semantics change.

## Scope
- `crates/tsz-checker/src/error_reporter/`
- `crates/tsz-checker/tests/intersection_target_missing_property_elaboration_tests.rs`

## Summary

Closes the diagnostic half of the mapped/intersection bug family tracked in #12174 (witnesses all use a `Rename<Source> & { d: Date }` intersection wrapper).

When a value is assigned to an **intersection target** and a required property of one intersection member is missing, `tsc` keeps the top-level `TS2322` and elaborates the **first failing member**, grouping that member's missing properties:

```
Type 'S' is not assignable to type 'A & B'.
  Property 'p' is missing in type 'S' but required in type 'B'.
  // or, when one member misses several:
  Type 'S' is missing the following properties from type 'B': p, q
```

tsz eagerly merges concrete object-intersections (`{ a } & { b }` -> `{ a; b }`) in `normalize_intersection`, so these targets reached the checker as a plain object and produced a **flat `TS2741`/`TS2739`** against the merged shape, losing per-member identity and the root reason. Unmerged (mapped/generic) members already worked, proving the chain path existed but was bypassed.

## Structural rule

When the source is assigned to an intersection target and the failure is a missing required property, `tsc` reports `TS2322` against the written intersection plus a single elaboration for the first member the source fails against (one `Property 'X' ...` line for a single miss, one grouped `... missing the following properties ...` line for several). tsz now does the same through the `error_reporter` assignability render path.

## Owner layer

`tsz_checker::error_reporter` (diagnostic rendering only). The intersection is recovered from the merged object's existing display alias, gated on the written annotation syntactically denoting an intersection — the merged object interns identically to a plain object literal of the same shape, so its `TypeId`/alias alone is not a reliable signal. The deeper root cause (eager intersection merging in the solver) is intentionally not touched: it is high-blast-radius and the contained diagnostic-layer recovery matches `tsc` for the cases that matter. The source-display path widens only for recovered (merged) intersections and preserves contextually-literal nested sources for genuine intersections, matching `tsc` (e.g. `excessPropertyCheckIntersectionWithIndexSignature` keeps `{ a: 0; }`).

## Adjacent-case matrix (verified identical to `tsc` 6.x)

- named-alias intersection, single missing -> `... required in type 'M2'`
- multi-member intersection -> first failing member only (`tsc` short-circuits)
- one member missing several props -> grouped `missing the following properties: a, b`
- genuine (mapped) intersection `Id<M1> & M2` -> grouped on `Id<M1>`
- inline `{ a } & { b }` literal -> structural `&` form
- type-alias-to-intersection (`type W = A & B; const x: W`) -> alias name `W`
- assignment-expression form (`a8 = {...}`)
- nested index-signature intersection value keeps literal source (`{ a: 0; }`, not `{ a: number; }`)
- plain object target (`{ a; b }`) -> still `TS2741` (no intersection leak; renamed/distinct shapes confirm the annotation gate prevents false positives)

## Project Corpus Impact

Diagnostic-only change to intersection-target missing-property reporting (`TS2322`/`TS2741`/`TS2739`). Affects message code/shape for object-literal assignments to intersection annotations; converges toward `tsc`. No type-relation, inference, or emit behavior changes.

- Row: n/a (diagnostic-only; the bug family spans nextjs / large-ts-repo / kysely / zod / ts-toolbelt / rxjs / type-fest / vite rows, no single row gate)
- Bug family: mapped/intersection missing-property elaboration (#12174)

## Verification

- `cargo build --bin tsz` clean; `cargo clippy -p tsz-checker --lib` clean.
- `crates/tsz-checker/tests/intersection_target_missing_property_elaboration_tests.rs`: 14/14, including `assignment_expression_to_intersection_target_elaborates_member`, `plain_object_target_does_not_leak_intersection_elaboration`, and `nested_index_signature_intersection_keeps_literal_source`.
- Regression batch green: `mapped_type_errors_conformance_tests`, `intersection_index_signature_fingerprint_tests`, `intersection_mapped_alias_indexed_access_tests`, `intersection_primitive_member_assignability_tests`, `jsx_spread_assignability_suppresses_ts2741`, `recursive_intersection_assignability_tests`, `generic_property_mismatch_display_tests`, `object_literal_property_target_display_tests`, `homomorphic_mapped_keyof_modifier_tests`, `mapped_as_clause_identity_modifier_tests`, `union_protected_intersection_property_tests`.
- A full 37/37 exact-head CI sweep passed green on an identical-code prior head; re-verified locally after rebasing onto live main including the `solver/relations/subtype/explain.rs` reason-generation delta.
- `/simplify` run 3x to convergence (shared helpers extracted: `declaration_type_annotation_node`, `parenthesized_inner_type_node`, `recovered_intersection_top_level_display`, `truncated_missing_property_list`; reused existing `declared_assignment_type_annotation_node`).

## Coordination Notes

- This PR is render-path only; no merge-queue/project-row gate is expected to be affected beyond diagnostic message shape.
- Tracking issue #12174 was labeled in-progress during implementation; row witnesses (#10871, #10814, #10798, #10822, #10830, #10847, #10855, #10863) remain open as witnesses.
- Not a draft; no work-in-progress markers — ready for queue once exact-head gates are green on the current base.

https://claude.ai/code/session_01McPzYFmCQrFRwfRVNi8Hif