### PR TITLE
fix(cli): repair try-tsz native package copy and hoisted TypeScript preflight

### DIFF
--- a/crates/tsz-cli/src/try_tsz/mod.rs
+++ b/crates/tsz-cli/src/try_tsz/mod.rs
@@ -336,7 +336,7 @@ fn run_config(cwd: &Path, config: &Path) -> ConfigReport {
 }
 
 fn run_tsc(cwd: &Path, config: &Path) -> Result<CompilerRun> {
-    ensure_local_typescript(cwd)?;
+    ensure_local_typescript(cwd, config)?;
 
     let command = format!("node <try-tsz tsc helper> {}", config.display());
     println!("Running tsc --noEmit -p {} ...", relative_path(cwd, config));
@@ -599,19 +599,39 @@ fn should_visit_entry(entry: &DirEntry) -> bool {
     )
 }
 
-fn ensure_local_typescript(cwd: &Path) -> Result<()> {
-    let local_tsc = if cfg!(windows) {
-        cwd.join("node_modules/.bin/tsc.cmd")
-    } else {
-        cwd.join("node_modules/.bin/tsc")
-    };
-    if local_tsc.exists() {
+fn ensure_local_typescript(cwd: &Path, config: &Path) -> Result<()> {
+    if find_local_tsc(cwd, config).is_some() {
         Ok(())
     } else {
         bail!(
-            "try-tsz needs this project to have TypeScript installed locally; missing {}",
-            local_tsc.display()
+            "try-tsz needs this project to have TypeScript installed locally; searched from {} and {} for {}",
+            cwd.display(),
+            config.parent().unwrap_or(cwd).display(),
+            local_tsc_relative_path().display()
         )
+    }
+}
+
+fn find_local_tsc(cwd: &Path, config: &Path) -> Option<PathBuf> {
+    let config_root = config.parent().unwrap_or(cwd);
+    for root in [config_root, cwd] {
+        let mut dir = Some(root);
+        while let Some(current) = dir {
+            let candidate = current.join(local_tsc_relative_path());
+            if candidate.exists() {
+                return Some(candidate);
+            }
+            dir = current.parent();
+        }
+    }
+    None
+}
+
+fn local_tsc_relative_path() -> &'static Path {
+    if cfg!(windows) {
+        Path::new("node_modules/.bin/tsc.cmd")
+    } else {
+        Path::new("node_modules/.bin/tsc")
     }
 }
 
@@ -1415,6 +1435,33 @@ mod tests {
         let configs = discover_configs(&temp.path, None, true).expect("all should find configs");
 
         assert_eq!(configs, vec![temp.path.join("packages/a/tsconfig.json")]);
+    }
+
+    #[test]
+    fn local_typescript_preflight_accepts_hoisted_workspace_tsc() {
+        let temp = TempDir::new();
+        let package_dir = temp.path.join("packages/foo");
+        let config = package_dir.join("tsconfig.json");
+        write_file(&config, "{}");
+        write_file(&temp.path.join(local_tsc_relative_path()), "");
+
+        ensure_local_typescript(&package_dir, &config)
+            .expect("hoisted workspace TypeScript should satisfy preflight");
+    }
+
+    #[test]
+    fn local_typescript_preflight_rejects_missing_tsc() {
+        let temp = TempDir::new();
+        let package_dir = temp.path.join("packages/foo");
+        let config = package_dir.join("tsconfig.json");
+        write_file(&config, "{}");
+
+        let error = ensure_local_typescript(&package_dir, &config)
+            .expect_err("missing local TypeScript should be rejected")
+            .to_string();
+
+        assert!(error.contains("TypeScript installed locally"));
+        assert!(error.contains("node_modules/.bin/tsc"));
     }
 
     #[test]

--- a/scripts/build/build-npm-packages.sh
+++ b/scripts/build/build-npm-packages.sh
@@ -196,7 +196,8 @@ if [ "$WASM_ONLY" -ne 1 ] && [ "$SKIP_BUILD" -ne 1 ]; then
     rust_target=$(get_rust_target "$platform_suffix")
     echo "  Building for $platform_suffix ($rust_target)..."
 
-    cargo build --profile "$CARGO_PROFILE" -p tsz-cli --target "$rust_target"
+    CARGO_TARGET_DIR="$CARGO_TARGET_ROOT" \
+      cargo build --profile "$CARGO_PROFILE" -p tsz-cli --target "$rust_target"
 
     # Copy binaries to the platform package
     pkg_bin="$NPM_DIR/@mohsen-azimi/tsz-$platform_suffix/bin"
@@ -219,8 +220,9 @@ if [ "$WASM_ONLY" -ne 1 ] && [ "$SKIP_BUILD" -ne 1 ]; then
         chmod +x "$pkg_bin/$bin_name$ext"
         echo "    Copied $bin_name$ext ($(du -h "$pkg_bin/$bin_name$ext" | cut -f1))"
       else
-        echo "    WARNING: binary not found: $bin_name$ext"
-        echo "    Searched: $CARGO_TARGET_ROOT/$rust_target/{dist-fast,release}/$bin_name$ext"
+        echo "    ERROR: binary not found: $bin_name$ext" >&2
+        echo "    Searched: $CARGO_TARGET_ROOT/$rust_target/{dist-fast,release}/$bin_name$ext" >&2
+        exit 1
       fi
     done
   done

--- a/scripts/build/test-npm-native-copy.sh
+++ b/scripts/build/test-npm-native-copy.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Smoke-test native npm packaging copies from the same Cargo target root it
+# builds into.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir" "$PROJECT_ROOT/npm"
+}
+trap cleanup EXIT
+
+case "$(uname -s)" in
+  Darwin) os="darwin" ;;
+  Linux) os="linux" ;;
+  MINGW*|MSYS*|CYGWIN*) os="win32" ;;
+  *) echo "unsupported OS: $(uname -s)" >&2; exit 1 ;;
+esac
+
+case "$(uname -m)" in
+  x86_64|amd64) arch="x64" ;;
+  arm64|aarch64) arch="arm64" ;;
+  *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+esac
+
+suffix="$os-$arch"
+ext=""
+if [[ "$os" == "win32" ]]; then
+  ext=".exe"
+fi
+
+rm -rf "$PROJECT_ROOT/npm"
+CARGO_TARGET_DIR="$tmp_dir/target" \
+  "$PROJECT_ROOT/scripts/build/build-npm-packages.sh" --local --native-only
+
+pkg_bin="$PROJECT_ROOT/npm/@mohsen-azimi/tsz-$suffix/bin"
+for bin in tsz tsz-server try-tsz; do
+  if [[ ! -x "$pkg_bin/$bin$ext" ]]; then
+    echo "missing packaged native binary: $pkg_bin/$bin$ext" >&2
+    exit 1
+  fi
+done
+
+echo "native npm copy smoke passed for $suffix"


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Release infrastructure / try-tsz launch blocker fix.

## Invariant
When try-tsz npm packaging builds native binaries, the package copy step must read from the same Cargo target root used for the build and must fail if an expected binary is missing. When try-tsz checks a nested workspace config, TypeScript preflight should accept a hoisted local `node_modules/.bin/tsc` found by walking upward from the config root or invocation cwd.

## Scope
- Exports `CARGO_TARGET_DIR="$CARGO_TARGET_ROOT"` into native npm package builds.
- Makes missing expected native binaries fatal instead of warning-only.
- Adds `scripts/build/test-npm-native-copy.sh` to smoke the local native package copy path with a temporary target dir.
- Changes try-tsz TypeScript preflight to search upward from the tsconfig directory and cwd.
- Adds focused Rust tests for hoisted local TypeScript and missing TypeScript preflight failures.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: Packaging/preflight fix for try-tsz and npm assembly; no scanner/parser/binder/checker/solver/emitter semantic behavior changes.

## Verification
- `bash -n scripts/build/build-npm-packages.sh && bash -n scripts/build/test-npm-native-copy.sh`
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-cli try_tsz`
- `cargo check -p tsz-cli --bin try-tsz`
- `cargo clippy -p tsz-cli --bin try-tsz -- -D warnings`
- `scripts/build/test-npm-native-copy.sh`
- `scripts/build/build-npm-packages.sh --dry-run`

## Coordination Notes
- Fixes #12257.
- This is a follow-up to #12246. It addresses the two queue-safety blockers recorded after the initial try-tsz launch PR merged.
- The publish workflow run started before this fix is still separate release follow-through and should be re-run after this lands if it fails or produces incomplete packages.
