### PR TITLE
ci: use macos-14 for darwin x64 npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -60,7 +60,7 @@ jobs:
             ext: ""
           - suffix: darwin-x64
             target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-14
             cross: false
             ext: ""
           - suffix: linux-x64


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Release infrastructure / npm publish runner unblock.

## Invariant
When the npm publish workflow builds the `darwin-x64` platform package, it should use a macOS runner label that is available to the repository queue. This PR changes only the runner label for that matrix row.

## Scope
- Changes the `darwin-x64` npm publish build from `macos-13` to `macos-14`.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: Workflow-only runner label change; no compiler, CLI runtime, package manifest, or project corpus behavior changes.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/npm-publish.yml"); puts "ok"'`
- `git diff -- .github/workflows/npm-publish.yml`
- Observed publish run 26844043747 had all other matrix jobs complete while `Build darwin-x64` remained queued on `macos-13`.

## Coordination Notes
- Follow-up release unblock after #12259. The stale publish run was cancelled; rerun npm publish after this lands.
