### PR TITLE
fix(checker): elaborate same-generic type-argument mismatch on TS2345 call args (#10879)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_tests.rs
@@ -1845,3 +1845,84 @@ function other<T, U>(t: T, u: U) {
         ts2345.iter().map(|d| &d.message_text).collect::<Vec<_>>()
     );
 }
+
+/// Assert that `source` produces a single TS2345 whose head message contains
+/// `expected_head` and whose related-information elaboration (each entry as
+/// `(depth, message)`) equals `expected_related`. Centralizes the shape shared
+/// by the same-generic argument-elaboration regression tests below.
+fn assert_ts2345_elaboration(source: &str, expected_head: &str, expected_related: &[(u8, &str)]) {
+    let diagnostics = check_source_with_strict_null(source);
+    let head = diagnostics
+        .iter()
+        .find(|d| d.code == 2345)
+        .unwrap_or_else(|| panic!("expected TS2345, got: {diagnostics:?}"));
+    assert!(
+        head.message_text.contains(expected_head),
+        "unexpected TS2345 head: {head:?}"
+    );
+    let related: Vec<(u8, &str)> = head
+        .related_information
+        .iter()
+        .map(|r| (r.depth, r.message_text.as_str()))
+        .collect();
+    assert_eq!(
+        related, expected_related,
+        "TS2345 must elaborate the differing type argument directly (no `Types of \
+         property` wrapper), got: {related:?}"
+    );
+}
+
+/// Same-generic call argument mismatch (`Wrap<string>` argument vs
+/// `Wrap<number>` parameter): tsc elaborates the differing type *argument*
+/// directly beneath the TS2345 head (`Type 'string' is not assignable to type
+/// 'number'.`) with no intermediate `Types of property 'held' are
+/// incompatible.` wrapper. This is the TS2345 sibling of the TS2322 assignment
+/// elaboration; before the fix the call-argument path dropped it entirely.
+/// Binder names deliberately differ from the canonical `Box`/`value` so the
+/// elaboration cannot be keyed off identifier text.
+#[test]
+fn same_generic_call_argument_elaborates_type_argument_directly() {
+    assert_ts2345_elaboration(
+        "interface Wrap<Inner> { held: Inner }\n\
+         declare function take(slot: Wrap<number>): void;\n\
+         declare let supplied: Wrap<string>;\n\
+         take(supplied);\n",
+        "Argument of type 'Wrap<string>' is not assignable to parameter of type 'Wrap<number>'.",
+        &[(0, "Type 'string' is not assignable to type 'number'.")],
+    );
+}
+
+/// Nested same-generic call argument (`Wrap<Wrap<string>>` vs
+/// `Wrap<Wrap<number>>`): the elaboration recurses, peeling one application
+/// layer per indent level just like tsc.
+#[test]
+fn nested_same_generic_call_argument_elaborates_each_layer() {
+    assert_ts2345_elaboration(
+        "interface Wrap<Inner> { held: Inner }\n\
+         declare function take(slot: Wrap<Wrap<number>>): void;\n\
+         declare let supplied: Wrap<Wrap<string>>;\n\
+         take(supplied);\n",
+        "Argument of type 'Wrap<Wrap<string>>' is not assignable to parameter of type 'Wrap<Wrap<number>>'.",
+        &[
+            (
+                0,
+                "Type 'Wrap<string>' is not assignable to type 'Wrap<number>'.",
+            ),
+            (1, "Type 'string' is not assignable to type 'number'."),
+        ],
+    );
+}
+
+/// Same-generic constructor argument routes through the identical
+/// argument-assignability path, so it carries the same elaboration.
+#[test]
+fn same_generic_constructor_argument_elaborates_type_argument_directly() {
+    assert_ts2345_elaboration(
+        "interface Wrap<Inner> { held: Inner }\n\
+         class Receiver { constructor(slot: Wrap<number>) {} }\n\
+         declare let supplied: Wrap<string>;\n\
+         new Receiver(supplied);\n",
+        "Argument of type 'Wrap<string>' is not assignable to parameter of type 'Wrap<number>'.",
+        &[(0, "Type 'string' is not assignable to type 'number'.")],
+    );
+}

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -693,27 +693,29 @@ impl<'a> CheckerState<'a> {
                     },
                 ]
             }
-            SubtypeFailureReason::ArrayElementMismatch { .. } => {
-                // tsc names both array types in the head message (e.g.
-                // `Argument of type 'se[]' is not assignable to parameter of
-                // type 'te[]'.`) and then relates the *element* types directly
-                // beneath it, recursing into the element's own failure — there
-                // is no separate "array element" wrapper line. Reuse the shared
-                // array renderer (single source of truth) and keep only the
-                // element elaboration beneath its array-to-array header, which
-                // the call's head message already conveys.
-                let array_diag = self.render_failure_reason(reason, source, target, anchor_idx, 0);
-                array_diag
+            SubtypeFailureReason::ArrayElementMismatch { .. }
+            | SubtypeFailureReason::TypeArgumentMismatch { .. } => {
+                // Both reasons relate same-shaped containers whose differing
+                // *component* is the cause (array element types, or same-generic
+                // type arguments). tsc names both containers in the head — which
+                // the call's TS2345 line already does — then relates the failing
+                // component directly beneath it, with no intermediate
+                // `array element` / `Types of property 'x' are incompatible.`
+                // wrapper. Reuse the TS2322 elaboration (`render_failure_reason`)
+                // as the single source of truth: its child lines already carry
+                // the right `code`, `message_text`, `depth`, and `file`, so only
+                // the category and the call-site anchor (`start`/`length`) need
+                // rewriting for the TS2345 surface.
+                let container_diag =
+                    self.render_failure_reason(reason, source, target, anchor_idx, 0);
+                container_diag
                     .related_information
                     .into_iter()
-                    .map(|rel| DiagnosticRelatedInformation {
-                        category: DiagnosticCategory::Message,
-                        code: rel.code,
-                        file: self.ctx.file_name.clone(),
-                        start,
-                        length,
-                        message_text: rel.message_text,
-                        depth: rel.depth,
+                    .map(|mut rel| {
+                        rel.category = DiagnosticCategory::Message;
+                        rel.start = start;
+                        rel.length = length;
+                        rel
                     })
                     .collect()
             }


### PR DESCRIPTION
AgentName: Studio-B
Runner: cloud-opus48
## Summary

Closes the concrete, broad gap behind the umbrella tracker #10879 ("TS2322/TS2345 mismatch family still routes around assignability boundary in checker paths").

When two applications of the **same generic target** differ only in their type arguments (`Box<string>` vs `Box<number>`), `tsc` names both applications in the head message and relates the failing type **argument** directly beneath it:

```
Argument of type 'Box<string>' is not assignable to parameter of type 'Box<number>'.
  Type 'string' is not assignable to type 'number'.
```

The **TS2322** assignment path already produced this via the solver's `TypeArgumentMismatch` reason and `render_type_argument_mismatch`. The **TS2345** call-argument path (and constructor arguments, which share it) routed related-info through `related_from_failure_reason`, which had **no `TypeArgumentMismatch` arm** and fell into `_ => return None` — dropping the elaboration entirely. That is precisely the "TS2345 family routes around the assignability boundary" complaint: the same solver reason was rendered for assignment but discarded for call arguments.

**Before:**
```
TS2345: Argument of type 'Box<string>' is not assignable to parameter of type 'Box<number>'.
```
**After (matches tsc):**
```
TS2345: Argument of type 'Box<string>' is not assignable to parameter of type 'Box<number>'.
  Type 'string' is not assignable to type 'number'.
```

## Track
Conformance — TS2322/TS2345 assignability diagnostics (solver reason → checker render boundary).

## Invariant
`tsc` parity for the same-generic type-argument elaboration. When source and target are applications of the same generic target whose differing type arguments cause the failure, the failing argument relation is surfaced as a direct nested line under the primary diagnostic — for **every** primary code in the family (TS2322 assignment, TS2345 call/constructor arguments), not only TS2322. The solver owns the reason (`TypeArgumentMismatch`); the checker renders it through one source of truth (`render_failure_reason`).

## Scope
- `crates/tsz-checker/src/error_reporter/fingerprint_policy.rs`: add a `TypeArgumentMismatch` arm to `related_from_failure_reason`, merged with the structurally identical `ArrayElementMismatch` arm. Both delegate to `render_failure_reason` (single source of truth) and keep only the component elaboration beneath the head, which the TS2345 line already conveys. The elaboration recurses through nested same-generic layers (`Wrap<Wrap<string>>`).
- `crates/tsz-checker/src/error_reporter/call_errors_tests.rs`: regression tests.

No solver changes — the `TypeArgumentMismatch` reason and its renderer already existed; this only wires the missing checker-render arm.

## Structural rule
When `S = C<A..>` and `T = C<B..>` share the same generic target and a differing type argument is the cause, `tsc` elaborates the failing argument directly (no `Types of property 'x' are incompatible.` wrapper). tsz now does so through `related_from_failure_reason` → `render_failure_reason` for the TS2345/constructor surface, matching the existing TS2322 path.

## Adjacent-case matrix
- Covariant container call arg (`Wrap<string>` → `Wrap<number>`) — elaborates `string`→`number` directly. ✅
- Nested same-generic (`Wrap<Wrap<string>>` → `Wrap<Wrap<number>>`) — recurses one layer per indent. ✅
- Constructor argument (`new Receiver(...)`) — shares the argument path, same elaboration. ✅
- Binder names diverge from canonical `Box`/`value` (anti-hardcoding gate — elaboration is structural, not identifier-keyed). ✅
- Array element call args (`se[]` → `te[]`) preserved by the arm merge (existing tests green). ✅

## Project Corpus Impact
Diagnostic-shape parity improvement on the TS2345 family across benchmark rows that exercise generic call/constructor arguments. No new diagnostics are emitted and none are suppressed — only the related-information elaboration under an already-emitted TS2345 is added. No change to which rows pass/fail; improves message fidelity toward tsc.
- Row: n/a (cross-row TS2345 diagnostic-shape fix; not a single project row)
- Bug family: assignability-boundary-routing (#10879 — TS2322/TS2345 mismatch family)

## Verification
- New regression tests pass: `same_generic_call_argument_elaborates_type_argument_directly`, `nested_same_generic_call_argument_elaborates_each_layer`, `same_generic_constructor_argument_elaborates_type_argument_directly`.
- `cargo test -p tsz-checker --lib error_reporter::` → 169 passed, 0 failed.
- Array-element + array-literal call-arg tests → 16 passed (arm merge preserves array behavior).
- `cargo clippy -p tsz-checker --lib` → clean.
- The 7 pre-existing `ts2322`/`ts2345` local failures were confirmed failing on clean `origin/main` (baseline) and are unrelated to this change.
- Rebased onto latest `origin/main`; no conflicts (main did not touch the two changed files).

## Coordination Notes
- Used #10879 during development; this PR resolves the actionable defect identified in that tracker. Remaining row witnesses stay open per the umbrella's "treat rows as witnesses, not duplicates" guidance.
- Quality reviewed via three `/simplify` passes (arm merge, inert-guard removal, in-place mutation, table-driven tests, comment trim); the broader "generalize `_ => return None` to delegate to `render_failure_reason`" refactor was deliberately **deferred** — it would lose per-variant suppression semantics and belongs in its own PR with a full conformance run.

https://claude.ai/code/session_018yBixwB8cKDK1SVmMo1h4d