### PR TITLE
checker: honor function/block-local type aliases that shadow file-level types

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -255,6 +255,9 @@ mod lib_abstract_member_ts2515_tests;
 #[path = "../tests/literal_application_alias_display_tests.rs"]
 mod literal_application_alias_display_tests;
 #[cfg(test)]
+#[path = "tests/local_type_alias_shadowing_tests.rs"]
+mod local_type_alias_shadowing_tests;
+#[cfg(test)]
 #[path = "../tests/merged_symbol_tests.rs"]
 mod merged_symbol_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/local_type_alias_shadowing_tests.rs
+++ b/crates/tsz-checker/src/tests/local_type_alias_shadowing_tests.rs
@@ -1,0 +1,154 @@
+//! Regression coverage for lexical-scope resolution of type references.
+//!
+//! A function- or block-local `type`/`interface` declaration must shadow a
+//! same-named top-level declaration when the reference appears as the operand of
+//! a `keyof` / `readonly` type operator, inside an indexed access, or inside a
+//! mapped-type key space. The lowering previously resolved such references by
+//! bare name (file/global scope only), so the local alias was silently bound to
+//! the outer declaration — producing false `TS2322` / `TS2536` / `TS2345` /
+//! `TS7006` diagnostics for the well-typed correlated-union patterns in
+//! `correlatedUnions.ts`.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::check_source;
+
+fn strict_codes(source: &str) -> Vec<u32> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    )
+    .iter()
+    .map(|diagnostic| diagnostic.code)
+    .collect()
+}
+
+#[test]
+fn keyof_operand_resolves_local_alias_over_top_level() {
+    // `keyof T` inside `outer` must use the local `T`, whose keys are
+    // "sum" | "concat" — not the top-level `T` (keys "a").
+    let codes = strict_codes(
+        r#"
+type T = { a: number };
+function outer() {
+    type T = { sum: number; concat: string };
+    const ok: keyof T = "sum";
+    const bad: keyof T = "a";
+}
+"#,
+    );
+    // The only expected error is the deliberate `bad` assignment ("a" is not a
+    // key of the local T). No error on the `ok` line.
+    assert_eq!(
+        codes.iter().filter(|&&c| c == 2322).count(),
+        1,
+        "expected exactly one TS2322 (for `bad`), got codes: {codes:?}",
+    );
+}
+
+#[test]
+fn keyof_local_alias_without_shadow_is_unaffected() {
+    let codes = strict_codes(
+        r#"
+function outer() {
+    type T = { sum: number; concat: string };
+    const ok: keyof T = "sum";
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "expected no diagnostics, got codes: {codes:?}",
+    );
+}
+
+#[test]
+fn readonly_array_operand_resolves_local_alias() {
+    // `readonly T[]` must use the local `T` ({ sum }), so the object literal is
+    // valid and no TS2353 excess-property error is produced.
+    let codes = strict_codes(
+        r#"
+type T = { a: number };
+function outer() {
+    type T = { sum: number };
+    const v: readonly T[] = [{ sum: 1 }];
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "expected no diagnostics, got codes: {codes:?}",
+    );
+}
+
+#[test]
+fn constrained_index_access_resolves_local_alias() {
+    // `K extends Keys` where `Keys = keyof ArgMap` (local). Indexing the local
+    // `ArgMap` by `K` and passing concrete keys must type-check even though a
+    // same-named top-level `ArgMap` exists. Mirrors the `ff1` block of
+    // `correlatedUnions.ts`.
+    let codes = strict_codes(
+        r#"
+type ArgMap = { a: number; b: string };
+function f1<K extends keyof ArgMap>(key: K, arg: ArgMap[K]) {}
+
+function outer() {
+    type ArgMap = {
+        sum: [a: number, b: number];
+        concat: [a: string, b: string, c: string];
+    };
+    type Keys = keyof ArgMap;
+    function apply<K extends Keys>(funKey: K, ...args: ArgMap[K]) {}
+    apply("sum", 1, 2);
+    apply("concat", "s1", "s2", "s3");
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "expected no diagnostics, got codes: {codes:?}",
+    );
+}
+
+#[test]
+fn renamed_binders_resolve_local_alias() {
+    // Same structural rule with different binder names — guards against any
+    // accidental name-literal dependence in the fix.
+    let codes = strict_codes(
+        r#"
+type Registry = { alpha: number };
+function scope() {
+    type Registry = { beta: string; gamma: boolean };
+    const ok: keyof Registry = "beta";
+    const v: readonly Registry[] = [{ beta: "x", gamma: true }];
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "expected no diagnostics, got codes: {codes:?}",
+    );
+}
+
+#[test]
+fn block_scoped_alias_shadows_in_keyof() {
+    // A block-scoped (not just function-scoped) local alias must also win.
+    let codes = strict_codes(
+        r#"
+type T = { a: number };
+function outer() {
+    {
+        type T = { local: number };
+        const ok: keyof T = "local";
+    }
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "expected no diagnostics, got codes: {codes:?}",
+    );
+}

--- a/crates/tsz-checker/src/types/type_node_lowering.rs
+++ b/crates/tsz-checker/src/types/type_node_lowering.rs
@@ -162,6 +162,14 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             }
         };
 
+        // Honors a function- or block-local type alias that shadows a same-named
+        // file-level type. Returns `Some` strictly for genuine nested-local
+        // shadowing so the name-first ordering used for imported/lib types is
+        // otherwise preserved.
+        let local_shadow_def_id_resolver = |node_idx: NodeIndex| -> Option<tsz_solver::def::DefId> {
+            self.resolve_local_shadow_def_id(node_idx)
+        };
+
         let lazy_type_params_resolver =
             |def_id: tsz_solver::def::DefId| self.ctx.get_def_type_params(def_id);
         let computed_unique_symbol_name =
@@ -397,7 +405,8 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         .with_lazy_type_params_resolver(&lazy_type_params_resolver)
         .with_type_query_override(&type_query_override)
         .with_computed_name_resolver(&computed_name_resolver)
-        .with_computed_symbol_name_resolver(&computed_symbol_name_resolver);
+        .with_computed_symbol_name_resolver(&computed_symbol_name_resolver)
+        .with_local_shadow_def_id_resolver(&local_shadow_def_id_resolver);
         if use_qualified_names && self.type_node_is_in_lib_declaration(idx) {
             lowering = lowering.prefer_name_def_id_resolution();
         }

--- a/crates/tsz-checker/src/types/type_node_resolution.rs
+++ b/crates/tsz-checker/src/types/type_node_resolution.rs
@@ -1392,6 +1392,57 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         }
     }
 
+    /// Resolve a simple (non-qualified) type-reference identifier to its `DefId`
+    /// **only** when it lexically resolves to a function- or block-local
+    /// declaration that shadows a same-named file-level type.
+    ///
+    /// Same-arena lowering resolves identifiers name-first (see
+    /// `prefer_name_def_id_resolution`), which honors imported/lib types but
+    /// consults only file/global scope. That ordering binds a `keyof T` /
+    /// `readonly T[]` operand — or a mapped-type `K` / `T[K]` reference — to an
+    /// outer same-named declaration instead of the local one. This resolver runs
+    /// ahead of the bare-name lookup and returns `Some` strictly for genuine
+    /// nested-local shadowing: the lexically resolved symbol must differ from both
+    /// the file-level binding and the file/global name lookup for the same name,
+    /// and must not be a lib symbol. Every other reference (the common case,
+    /// including lib globals and cross-file imports) yields `None`, leaving the
+    /// existing name-first resolution untouched.
+    pub(crate) fn resolve_local_shadow_def_id(
+        &self,
+        node_idx: NodeIndex,
+    ) -> Option<tsz_solver::def::DefId> {
+        let name = self.entity_name_text(node_idx)?;
+        if name.contains('.') {
+            return None;
+        }
+        // Cheap, cached lexical resolution gates the heavier lookups below. A
+        // genuine nested-local shadow resolves to a symbol other than this name's
+        // file-level binding; the overwhelmingly common top-level reference
+        // resolves to the file-level symbol itself and exits here.
+        let lexical_sym_id = self
+            .ctx
+            .binder
+            .resolve_identifier(self.ctx.arena, node_idx)?;
+        if self.ctx.binder.file_locals.get(&name) == Some(lexical_sym_id) {
+            return None;
+        }
+        // Confirm with the type-position resolver (it applies type/value filtering
+        // and alias following) and leave lib globals and file/global name lookups
+        // to the existing name-first resolution.
+        let scoped_sym_id = tsz_binder::SymbolId(self.resolve_type_symbol(node_idx)?);
+        if self.ctx.binder.file_locals.get(&name) == Some(scoped_sym_id)
+            || self.resolve_entity_name_text_symbol(&name) == Some(scoped_sym_id)
+            || self.ctx.symbol_is_from_lib(scoped_sym_id)
+        {
+            return None;
+        }
+        let def_id = self
+            .ctx
+            .get_or_create_def_id_for_symbol_name(scoped_sym_id, name.as_str());
+        self.ensure_type_alias_resolved(scoped_sym_id, def_id);
+        Some(def_id)
+    }
+
     /// Resolve a DefId with support for qualified names (e.g., `AnimalType.cat`).
     ///
     /// Used by the `compute_type` fallback path where template literal types may

--- a/crates/tsz-lowering/src/lower/advanced.rs
+++ b/crates/tsz-lowering/src/lower/advanced.rs
@@ -780,6 +780,15 @@ impl<'a> TypeLowering<'a> {
                 return self.lower_lazy_def_reference(def_id);
             }
 
+            // A function- or block-local declaration that shadows a same-named
+            // file-level type must win over the name-first resolution below (which
+            // only consults file/global scope). This resolver returns `Some`
+            // strictly for that nested-local shadowing case, so imported/lib name
+            // resolution is otherwise unaffected.
+            if let Some(def_id) = self.resolve_local_shadow_def_id(node_idx) {
+                return self.lower_lazy_def_reference(def_id);
+            }
+
             // Must resolve to DefId.
             //
             // Same-arena lowering should prefer the NodeIndex-based path because it

--- a/crates/tsz-lowering/src/lower/core.rs
+++ b/crates/tsz-lowering/src/lower/core.rs
@@ -55,6 +55,12 @@ pub struct TypeLowering<'a> {
     /// Optional `DefId` resolver - resolves identifier nodes to `DefIds`.
     /// Resolves identifier nodes to `DefId`s for type identity.
     pub(super) def_id_resolver: Option<&'a NodeIndexResolver<'a, DefId>>,
+    /// Optional resolver that returns a `DefId` only when a simple identifier
+    /// lexically resolves to a function- or block-local declaration shadowing a
+    /// same-named file-level type. Consulted before the name-first resolution in
+    /// `prefer_name_def_id_resolution` mode so local shadows win without
+    /// disturbing imported/lib name resolution. Returns `None` otherwise.
+    pub(super) local_shadow_def_id_resolver: Option<&'a NodeIndexResolver<'a, DefId>>,
     /// Optional value resolver for typeof queries.
     pub(super) value_resolver: Option<&'a NodeIndexResolver<'a, u32>>,
     /// Optional name-based `DefId` resolver — fallback for cross-arena resolution.
@@ -390,6 +396,7 @@ impl<'a> TypeLowering<'a> {
             interner: interner.as_type_database(),
             type_resolver: resolvers.type_resolver,
             def_id_resolver: resolvers.def_id_resolver,
+            local_shadow_def_id_resolver: None,
             value_resolver: resolvers.value_resolver,
             computed_name_resolver: None,
             computed_name_resolver_with_arena: None,
@@ -506,6 +513,7 @@ impl<'a> TypeLowering<'a> {
             interner: self.interner,
             type_resolver: self.type_resolver,
             def_id_resolver: self.def_id_resolver,
+            local_shadow_def_id_resolver: self.local_shadow_def_id_resolver,
             value_resolver: self.value_resolver,
             computed_name_resolver: self.computed_name_resolver,
             computed_name_resolver_with_arena: self.computed_name_resolver_with_arena,
@@ -840,6 +848,18 @@ impl<'a> TypeLowering<'a> {
         self
     }
 
+    /// Set the local-shadow `DefId` resolver. It is consulted before the
+    /// name-first resolution (see `prefer_name_def_id_resolution`) and returns a
+    /// `DefId` only when a simple identifier resolves to a function- or
+    /// block-local declaration shadowing a same-named file-level type.
+    pub fn with_local_shadow_def_id_resolver(
+        mut self,
+        resolver: &'a dyn Fn(NodeIndex) -> Option<DefId>,
+    ) -> Self {
+        self.local_shadow_def_id_resolver = Some(resolver);
+        self
+    }
+
     /// Prefer identifier-text DefId resolution over raw NodeIndex-based resolution.
     ///
     /// This should only be enabled in cross-arena lowering contexts where `NodeIndex`
@@ -980,6 +1000,14 @@ impl<'a> TypeLowering<'a> {
     /// `DefIds` are Solver-owned identifiers that don't require Binder context.
     pub(super) fn resolve_def_id(&self, node_idx: NodeIndex) -> Option<DefId> {
         self.def_id_resolver.and_then(|resolver| resolver(node_idx))
+    }
+
+    /// Resolve a node to the `DefId` of a function- or block-local declaration
+    /// that shadows a same-named file-level type, if such a resolver is provided.
+    /// Returns `None` for every non-shadowing reference.
+    pub(super) fn resolve_local_shadow_def_id(&self, node_idx: NodeIndex) -> Option<DefId> {
+        self.local_shadow_def_id_resolver
+            .and_then(|resolver| resolver(node_idx))
     }
 
     /// Resolve a node to a value symbol ID if a resolver is provided.


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Diagnostic conformance — correlated-union / variance inference drift (#12247).

## Invariant
When a type reference's name resolves through lexical scope to a function- or block-local declaration that shadows a same-named file-level type, `tsc` binds to the local one; this PR makes tsz do the same through a checker-supplied local-shadow resolver in the type-node lowering path.

## Scope
- Fixes #12247.
- A reference to a function- or block-local `type`/`interface` that shadows a same-named top-level declaration resolved to the **outer** declaration whenever it appeared as a `keyof` / `readonly` operand, an indexed-access object, or a mapped-type key space.
- Root cause / owner layer: same-arena lowering (`TypeNodeChecker::lower_with_resolvers_impl`) consults the file/global **name** resolver before the lexically-scoped **node** resolver, so a bare identifier in a nested scope was shadowed by the outer same-named type. (Name-first ordering is required so imported/lib types resolve correctly; simply reordering/removing it reintroduced cross-arena lib regressions.)
- Fix: a dedicated `local_shadow_def_id_resolver` is consulted **first** in `lower_identifier_type`. It returns `Some` strictly for genuine nested-local shadowing (the lexically resolved symbol differs from the file-level binding and the file/global name lookup and is not a lib symbol), and `None` for every other reference, leaving name-first resolution for imported/lib types untouched. A cheap cached `binder.resolve_identifier` gate keeps the common non-shadow path off the heavier lookups.
- Adjacent-case matrix (`crates/tsz-checker/src/tests/local_type_alias_shadowing_tests.rs`): `keyof` operand (positive + negative key); `keyof` with no outer shadow (fallback unchanged); `readonly T[]` operand; constrained indexed access / mapped key (the `correlatedUnions.ts` shape); renamed binders (anti-hardcoding); block-scoped shadow.

## Project Corpus Impact
- Row: TypeScript conformance — `compiler/correlatedUnions.ts`, `compiler/coAndContraVariantInferences2.ts`
- Bug family: correlated-union / variance inference drift — lexical-scope shadowing of type references (TS2536 / TS7006 / TS2345 cascade)
- Evidence: on this branch (rebased on current `main`), both `tsc`-clean cases now report **0** diagnostics under `tsz --strict --target es2015 --skipLibCheck` (`correlatedUnions.ts` 11 → 0; `coAndContraVariantInferences2.ts` → 0), matching the empty `.errors.txt` baselines. The shadow-induced cascade (TS2536 on `ArgMap[K]`, TS7006 on the mapped-literal callbacks, TS2345 on `'sum'`/`'concat'` and `apply`) is removed by this change; the remaining residuals present before the rebase are resolved by intervening `main` progress.

## Verification
- `cargo build --profile dist-fast --bin tsz`; reduced repros (`keyof`/`readonly`/indexed-access local-alias shadowing) and both conformance cases now error-free.
- `cargo test -p tsz-checker --lib`: same pre-existing (environmental, lib-dependent) failure set as `main`, plus the 6 new regression tests passing — no new regressions.
- `cargo test -p tsz-lowering -p tsz-solver --lib`: pass.
- `cargo clippy -p tsz-checker -p tsz-lowering --lib --tests`: clean.

## Coordination Notes
- No cross-arena lib lowering behavior changed; the new resolver is wired only into the same-arena `lower_with_resolvers` path and is inert for non-shadow references.
- Altitude follow-up: a binder-owned scope-provenance query (`resolve_identifier` reporting whether the match came from a scope nested below file scope) would collapse the three-condition shadow predicate to one structural check; deferred to keep this PR within the checker/lowering boundary.

https://claude.ai/code/session_01Rh7AtB9PW4Ng4nNbUnBpyb