### PR TITLE
fix(ci): publish try-tsz via unscoped native packages

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -179,8 +179,11 @@ jobs:
             suffix="${dir#npm/npm-native-}"
             mkdir -p "npm/@mohsen-azimi/tsz-${suffix}/bin"
             cp "$dir"/* "npm/@mohsen-azimi/tsz-${suffix}/bin/"
+            mkdir -p "npm/try-tsz-${suffix}/bin"
+            cp "$dir"/try-tsz* "npm/try-tsz-${suffix}/bin/"
           done
           find npm/@mohsen-azimi -maxdepth 3 -type f | sort
+          find npm/try-tsz-* -maxdepth 3 -type f | sort
 
       - name: Assemble package manifests
         run: scripts/build/build-npm-packages.sh --all --native-only --skip-build
@@ -189,7 +192,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          for pkg in npm/@mohsen-azimi/tsz-* npm/tsz npm/try-tsz; do
+          for pkg in npm/try-tsz-* npm/try-tsz; do
             (cd "$pkg" && npm publish --dry-run --access public)
           done
 
@@ -212,8 +215,7 @@ jobs:
             (cd "$pkg_dir" && npm publish --access public --provenance)
           }
 
-          for pkg in npm/@mohsen-azimi/tsz-*; do
+          for pkg in npm/try-tsz-*; do
             publish_if_needed "$pkg"
           done
-          publish_if_needed npm/tsz
           publish_if_needed npm/try-tsz

--- a/docs/specs/TRY_TSZ.md
+++ b/docs/specs/TRY_TSZ.md
@@ -125,8 +125,8 @@ Repository layout:
   submission.
 - Extend the npm assembly scripts so the public unscoped package `try-tsz`
   installs a launcher that selects the platform binary.
-- Reuse the existing native platform package pattern from the `tsz` npm
-  distribution where practical.
+- Publish unscoped native helper packages named `try-tsz-<platform>` so the MVP
+  does not depend on scoped npm package permissions.
 
 Compiler invocation:
 
@@ -261,7 +261,8 @@ Integration tests:
 Packaging tests:
 
 - Local npm pack installs `try-tsz` and exposes the `try-tsz` binary.
-- Platform binary selection mirrors the existing `tsz` npm package behavior.
+- Platform binary selection uses the matching `try-tsz-<platform>` helper
+  package.
 - `npx try-tsz -p tsconfig.json` works in a sample project without modifying
   source, lockfiles, or dependency folders.
 

--- a/scripts/build/build-npm-packages.sh
+++ b/scripts/build/build-npm-packages.sh
@@ -150,6 +150,7 @@ if [ "$DRY_RUN" -eq 1 ]; then
   echo "  try-tsz (main package)"
   for p in "${BUILD_PLATFORMS[@]}"; do
     echo "  @mohsen-azimi/tsz-$p"
+    echo "  try-tsz-$p"
   done
   exit 0
 fi
@@ -202,6 +203,8 @@ if [ "$WASM_ONLY" -ne 1 ] && [ "$SKIP_BUILD" -ne 1 ]; then
     # Copy binaries to the platform package
     pkg_bin="$NPM_DIR/@mohsen-azimi/tsz-$platform_suffix/bin"
     mkdir -p "$pkg_bin"
+    try_pkg_bin="$NPM_DIR/try-tsz-$platform_suffix/bin"
+    mkdir -p "$try_pkg_bin"
 
     for bin_name in "${BINARIES[@]}"; do
       ext=""
@@ -218,6 +221,10 @@ if [ "$WASM_ONLY" -ne 1 ] && [ "$SKIP_BUILD" -ne 1 ]; then
       if [ -f "$src" ]; then
         cp "$src" "$pkg_bin/$bin_name$ext"
         chmod +x "$pkg_bin/$bin_name$ext"
+        if [ "$bin_name" = "try-tsz" ]; then
+          cp "$src" "$try_pkg_bin/$bin_name$ext"
+          chmod +x "$try_pkg_bin/$bin_name$ext"
+        fi
         echo "    Copied $bin_name$ext ($(du -h "$pkg_bin/$bin_name$ext" | cut -f1))"
       else
         echo "    ERROR: binary not found: $bin_name$ext" >&2
@@ -383,20 +390,20 @@ echo ""
 echo "==> Assembling try-tsz package..."
 
 mkdir -p "$TRY_PKG/bin"
-TRY_TSZ_VERSION="$CARGO_VERSION" TRY_TSZ_PKG_FILE="$TRY_PKG/package.json" node - <<'NODE'
+TRY_TSZ_VERSION="$CARGO_VERSION" TRY_TSZ_PKG_FILE="$TRY_PKG/package.json" NPM_DIR="$NPM_DIR" node - <<'NODE'
 const fs = require("fs");
 const version = process.env.TRY_TSZ_VERSION;
 const pkgFile = process.env.TRY_TSZ_PKG_FILE;
 const platforms = [
-  "darwin-arm64",
-  "darwin-x64",
-  "linux-x64",
-  "linux-arm64",
-  "win32-x64",
-  "win32-arm64",
+  { suffix: "darwin-arm64", os: "darwin", cpu: "arm64" },
+  { suffix: "darwin-x64", os: "darwin", cpu: "x64" },
+  { suffix: "linux-x64", os: "linux", cpu: "x64" },
+  { suffix: "linux-arm64", os: "linux", cpu: "arm64" },
+  { suffix: "win32-x64", os: "win32", cpu: "x64" },
+  { suffix: "win32-arm64", os: "win32", cpu: "arm64" },
 ];
 const optionalDependencies = Object.fromEntries(
-  platforms.map((platform) => [`@mohsen-azimi/tsz-${platform}`, version]),
+  platforms.map(({ suffix }) => [`try-tsz-${suffix}`, version]),
 );
 const pkg = {
   name: "try-tsz",
@@ -416,6 +423,30 @@ const pkg = {
   files: ["bin/", "LICENSE.txt"],
 };
 fs.writeFileSync(pkgFile, JSON.stringify(pkg, null, 2) + "\n");
+
+const commonMetadata = {
+  license: "Apache-2.0",
+  author: "Mohsen Azimi <mohsen@users.noreply.github.com>",
+  repository: {
+    type: "git",
+    url: "git+https://github.com/mohsen1/tsz.git",
+  },
+};
+
+for (const { suffix, os, cpu } of platforms) {
+  const pkgDir = `${process.env.NPM_DIR}/try-tsz-${suffix}`;
+  fs.mkdirSync(`${pkgDir}/bin`, { recursive: true });
+  const nativePkg = {
+    name: `try-tsz-${suffix}`,
+    version,
+    description: `Native try-tsz binary for ${suffix}`,
+    ...commonMetadata,
+    os: [os],
+    cpu: [cpu],
+    files: ["bin/", "LICENSE.txt"],
+  };
+  fs.writeFileSync(`${pkgDir}/package.json`, JSON.stringify(nativePkg, null, 2) + "\n");
+}
 NODE
 
 cat > "$TRY_PKG/bin/try-tsz.js" <<'NODE'
@@ -443,9 +474,9 @@ if (!suffix) {
 const exe = process.platform === "win32" ? "try-tsz.exe" : "try-tsz";
 let binary;
 try {
-  binary = require.resolve(`@mohsen-azimi/tsz-${suffix}/bin/${exe}`);
+  binary = require.resolve(`try-tsz-${suffix}/bin/${exe}`);
 } catch {
-  console.error(`Missing try-tsz native package @mohsen-azimi/tsz-${suffix}`);
+  console.error(`Missing try-tsz native package try-tsz-${suffix}`);
   process.exit(1);
 }
 
@@ -469,6 +500,12 @@ NODE
 
 chmod +x "$TRY_PKG/bin/try-tsz.js"
 cp "$PROJECT_ROOT/LICENSE.txt" "$TRY_PKG/LICENSE.txt"
+for entry in "${PLATFORMS[@]}"; do
+  read -r npm_suffix _ <<< "$entry"
+  try_platform_pkg="$NPM_DIR/try-tsz-$npm_suffix"
+  mkdir -p "$try_platform_pkg"
+  cp "$PROJECT_ROOT/LICENSE.txt" "$try_platform_pkg/LICENSE.txt"
+done
 
 echo ""
 echo "==> Build complete!"
@@ -476,6 +513,7 @@ echo "    Main package: $MAIN_PKG"
 echo "    Try package:  $TRY_PKG"
 for platform_suffix in "${BUILD_PLATFORMS[@]}"; do
   echo "    Platform:     $NPM_DIR/@mohsen-azimi/tsz-$platform_suffix"
+  echo "    Try platform: $NPM_DIR/try-tsz-$platform_suffix"
 done
 echo ""
 echo "To test locally:"
@@ -483,11 +521,15 @@ echo "  cd $MAIN_PKG && npm link"
 echo "  tsz --noEmit"
 echo ""
 echo "To publish:"
-echo "  # Publish platform packages first:"
+echo "  # Publish try-tsz platform packages first:"
+for platform_suffix in "${BUILD_PLATFORMS[@]}"; do
+  echo "  cd $NPM_DIR/try-tsz-$platform_suffix && npm publish --access public"
+done
+echo "  # Then publish try-tsz package:"
+echo "  cd $TRY_PKG && npm publish --access public"
+echo "  # Publish scoped tsz platform packages separately:"
 for platform_suffix in "${BUILD_PLATFORMS[@]}"; do
   echo "  cd $NPM_DIR/@mohsen-azimi/tsz-$platform_suffix && npm publish --access public"
 done
-echo "  # Then publish main package:"
+echo "  # Then publish scoped tsz main package:"
 echo "  cd $MAIN_PKG && npm publish --access public"
-echo "  # Publish try-tsz package:"
-echo "  cd $TRY_PKG && npm publish --access public"

--- a/scripts/build/setup-npm-trusted-publishers.sh
+++ b/scripts/build/setup-npm-trusted-publishers.sh
@@ -13,13 +13,12 @@ WORKFLOW_FILE="${WORKFLOW_FILE:-npm-publish.yml}"
 REGISTRY="${REGISTRY:-https://registry.npmjs.org}"
 
 PACKAGES=(
-  "@mohsen-azimi/tsz-darwin-arm64"
-  "@mohsen-azimi/tsz-darwin-x64"
-  "@mohsen-azimi/tsz-linux-x64"
-  "@mohsen-azimi/tsz-linux-arm64"
-  "@mohsen-azimi/tsz-win32-x64"
-  "@mohsen-azimi/tsz-win32-arm64"
-  "@mohsen-azimi/tsz"
+  "try-tsz-darwin-arm64"
+  "try-tsz-darwin-x64"
+  "try-tsz-linux-x64"
+  "try-tsz-linux-arm64"
+  "try-tsz-win32-x64"
+  "try-tsz-win32-arm64"
   "try-tsz"
 )
 

--- a/scripts/build/test-npm-native-copy.sh
+++ b/scripts/build/test-npm-native-copy.sh
@@ -43,4 +43,10 @@ for bin in tsz tsz-server try-tsz; do
   fi
 done
 
+try_pkg_bin="$PROJECT_ROOT/npm/try-tsz-$suffix/bin"
+if [[ ! -x "$try_pkg_bin/try-tsz$ext" ]]; then
+  echo "missing packaged try-tsz native binary: $try_pkg_bin/try-tsz$ext" >&2
+  exit 1
+fi
+
 echo "native npm copy smoke passed for $suffix"


### PR DESCRIPTION
AgentName: Studio-F

Track: CLI/npm packaging

Invariant: `npx try-tsz` must install without requiring users or CI to publish into a scoped npm package family first.

Scope:
- Add unscoped native helper packages named `try-tsz-<platform>`.
- Make the public `try-tsz` launcher and optional dependencies use those helpers.
- Publish only the `try-tsz-*` helpers and `try-tsz` from the npm workflow for this MVP.
- Keep the scoped `@mohsen-azimi/tsz` package assembly in place for a later scope-permission setup.

Project Corpus Impact: None. This changes npm package assembly and publishing metadata only; compiler semantics and project rows are untouched.

Verification:
- `bash -n scripts/build/build-npm-packages.sh && bash -n scripts/build/setup-npm-trusted-publishers.sh && bash -n scripts/build/test-npm-native-copy.sh && git diff --check`
- `scripts/build/build-npm-packages.sh --dry-run`
- `scripts/safe-run.sh scripts/build/test-npm-native-copy.sh`

Coordination Notes:
- Fix-forward for publish run 26845655339, where all native artifacts built successfully but npm rejected the first scoped `@mohsen-azimi/tsz-*` package with E404/permission.
- The unscoped helper names `try-tsz-darwin-arm64`, `try-tsz-darwin-x64`, `try-tsz-linux-x64`, `try-tsz-linux-arm64`, `try-tsz-win32-x64`, and `try-tsz-win32-arm64` were checked as unpublished before this PR.
