### PR TITLE
fix(bench): preserve Cloud Build prep target

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -245,10 +245,19 @@ jobs:
         run: |
           set -euo pipefail
 
+          target_sha="${{ env.BENCH_TARGET_SHA }}"
+          manifest_value() {
+            local key="$1"
+            awk -v key="$key" '
+              index($0, key "=") == 1 { value = substr($0, length(key) + 2) }
+              END { print value }
+            ' bench-prep.env
+          }
+
           prep_prefix="latest"
           if [[ "${{ github.event_name }}" == "workflow_dispatch" &&
                 "${{ inputs.publish_latest_pgo }}" != "true" ]]; then
-            prep_prefix="${BENCH_TARGET_SHA}"
+            prep_prefix="${target_sha}"
           fi
 
           rm -f bench-prep.env bench-prep.tar
@@ -258,16 +267,19 @@ jobs:
             gcloud storage cp \
               "gs://tsz-ci_cloudbuild/bench-prep/${prep_prefix}/bench-prep.tar" \
               bench-prep.tar >/dev/null 2>&1; then
-            # shellcheck disable=SC1091
-            source bench-prep.env
-            if [[ "${BENCH_TARGET_SHA:-}" == "${{ env.BENCH_TARGET_SHA }}" &&
-                  "${BENCH_BUILD_DATE:-}" == "$(date -u +%F)" ]] && \
+            manifest_target_sha="$(manifest_value BENCH_TARGET_SHA)"
+            manifest_build_date="$(manifest_value BENCH_BUILD_DATE)"
+            manifest_pgo_optimized="$(manifest_value BENCH_PGO_OPTIMIZED)"
+            if [[ "${manifest_target_sha}" == "${target_sha}" &&
+                  "${manifest_build_date}" == "$(date -u +%F)" &&
+                  "${manifest_pgo_optimized}" == "1" ]] && \
                 tar -tf bench-prep.tar .target-bench/dist/tsz >/dev/null && \
                 tar -tf bench-prep.tar .target-bench/dist/.bench-pgo-optimized >/dev/null; then
-              echo "Cloud Build prep artifact already exists for ${BENCH_TARGET_SHA}; skipping submit."
+              echo "Cloud Build prep artifact already exists for ${target_sha}; skipping submit."
               exit 0
             fi
             echo "Existing Cloud Build prep artifact is incomplete or stale; submitting a fresh build."
+            rm -f bench-prep.env bench-prep.tar
           fi
 
           submit_output="$(gcloud builds submit \
@@ -276,7 +288,7 @@ jobs:
             --region=us-central1 \
             --config=scripts/cloudbuild/cloudbuild-bench-prepare.yaml \
             --gcs-source-staging-dir=gs://tsz-ci_cloudbuild/cb-source-staging \
-            --substitutions=_BENCH_TARGET_SHA="${BENCH_TARGET_SHA}" \
+            --substitutions=_BENCH_TARGET_SHA="${target_sha}" \
             --format='value(id)' \
             .)"
           build_id="$(grep -Eo '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' <<<"$submit_output" | tail -n 1 || true)"

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -98,6 +98,25 @@ assert.match(
   "Cloud Build prep reuse should only skip submit after validating both the env and tar artifacts",
 );
 
+const cloudbuildPrepSubmit = workflow.match(
+  /  bench-prepare-cloudbuild:[\s\S]+?  publish-latest-pgo:/,
+)?.[0] ?? "";
+assert.match(
+  cloudbuildPrepSubmit,
+  /target_sha="\$\{\{ env\.BENCH_TARGET_SHA \}\}"[\s\S]+manifest_target_sha="\$\(manifest_value BENCH_TARGET_SHA\)"[\s\S]+manifest_build_date="\$\(manifest_value BENCH_BUILD_DATE\)"[\s\S]+manifest_pgo_optimized="\$\(manifest_value BENCH_PGO_OPTIMIZED\)"[\s\S]+--substitutions=_BENCH_TARGET_SHA="\$\{target_sha\}"/,
+  "Cloud Build prep submit should preserve the workflow target SHA when checking reusable artifacts",
+);
+assert.doesNotMatch(
+  cloudbuildPrepSubmit,
+  /source bench-prep\.env/,
+  "Cloud Build prep submit must not source a reusable prep env because it can clobber BENCH_TARGET_SHA before submit",
+);
+assert.match(
+  cloudbuildPrepSubmit,
+  /Existing Cloud Build prep artifact is incomplete or stale; submitting a fresh build\.[\s\S]+rm -f bench-prep\.env bench-prep\.tar[\s\S]+gcloud builds submit/,
+  "Cloud Build prep submit should remove stale reusable artifacts before uploading a fresh source archive",
+);
+
 assert.match(
   workflow,
   /target_sha="\$\{\{ env\.BENCH_TARGET_SHA \}\}"[\s\S]+gs:\/\/tsz-ci_cloudbuild\/bench-prep\/\$\{target_sha\}\/bench-prep\.env[\s\S]+gs:\/\/tsz-ci_cloudbuild\/bench-prep\/\$\{target_sha\}\/bench-prep\.tar/,


### PR DESCRIPTION
AgentName: M5Bench-Studio

## Track
Benchmark publishing freshness / dashboard data freshness

## Invariant
Benchmark prep handoff must never let a reusable or stale `bench-prep.env` mutate the workflow target SHA. A fresh Cloud Build prep submit must use the workflow's intended `BENCH_TARGET_SHA`, and stale reusable prep artifacts must not be included in the fresh source archive.

## Scope
- In `.github/workflows/bench.yml`, change `bench-prepare-cloudbuild` reuse probing to parse `bench-prep.env` keys without `source`.
- Preserve the workflow target in a local `target_sha` and pass that to `gcloud builds submit --substitutions`.
- Remove stale downloaded prep files before submitting a fresh Cloud Build source archive.
- Extend `scripts/bench/test-bench-workflow-cloudbuild-prep.mjs` so this exact target-clobber path is guarded.

## Project Corpus Impact
- Row: n/a
- Bug family: benchmark publishing freshness / CI workflow handoff
- Evidence: workflow-only fix; no compiler/project corpus behavior changes. Focused checks: `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`, `node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs`, YAML parse of `.github/workflows/bench.yml`, `git diff --check`.

## Verification
- PASS `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- PASS `node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs`
- PASS `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/bench.yml"); puts "bench.yml yaml ok"'`
- PASS `git diff --check`
- Live public data remained stale before this PR: `https://tsz.dev/benchmark-data/latest.json` reported `generated_at=2026-06-02T06:03:17.722Z`, `source_commit=23a9517de10d60ba4c9be686e1b0e22776a88aa8`, `workflow_run_id=26800589927`.
- Post-#12236 run evidence: Bench run https://github.com/mohsen1/tsz/actions/runs/26836913204 failed in `bench-prep-artifact`; diagnostics showed its intended target was `6d17e52b609b88f0159e1fe932d128410f09ae8e` but downloaded/manifest prep env advertised stale `23a9517de10d60ba4c9be686e1b0e22776a88aa8`.
- Current post-fix-chain evidence: Bench run https://github.com/mohsen1/tsz/actions/runs/26845058182 on `606ebdf8b43d654e9b7f82541739ee23279793f1` submitted Cloud Build prep `6369a46b-4536-410b-b92a-e23dda23297d`; main still contained the stale `source bench-prep.env` submit path this PR fixes.

## Coordination Notes
- #12236 merged and the active-run catch-up lane is working, but stale public data persisted because the Cloud Build submit step can reuse stale latest prep metadata and then `source` it before dispatching the fresh prep build.
- Root cause from logs: the submit step downloaded a stale reusable `bench-prep.env`; sourcing it can overwrite `BENCH_TARGET_SHA`, so a fresh Cloud Build submit may rebuild/publish the old `23a9517...` prep artifact instead of the workflow target.
- This PR does not start or require a new local benchmark suite. It relies on targeted workflow/static checks plus GitHub Actions evidence.
- `m5bench-freshness` tmux watcher is running and polling public freshness; no manual benchmark dispatch was started by M5Bench-Studio.
