### PR TITLE
fix(checker): emit TS1343 (not TS1470) for import.meta under non-Node CommonJS/ES2015 modules

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2006,5 +2006,9 @@ path = "tests/recursive_utility_alias_fanout_tests.rs"
 name = "same_generic_application_assign_outcome_tests"
 path = "tests/same_generic_application_assign_outcome_tests.rs"
 
+[[test]]
+name = "import_meta_module_support_diagnostics_tests"
+path = "tests/import_meta_module_support_diagnostics_tests.rs"
+
 [lints]
 workspace = true

--- a/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
@@ -1099,47 +1099,62 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    /// Emit TS1470 if `import.meta` appears in a file that builds to CommonJS output.
+    /// Report the module-compatibility error for `import.meta` when the
+    /// effective module kind does not support the meta-property, matching
+    /// `tsc`'s two distinct diagnostics:
     ///
-    /// TSC logic: in Node16/NodeNext module modes, the per-file format determines
-    /// whether the file outputs CJS (TS1470). For older module modes (< ES2020,
-    /// excluding System), ALL files produce CJS output so TS1470 always fires.
-    pub(in crate::types_domain) fn check_import_meta_in_cjs(&mut self, node_idx: NodeIndex) {
+    /// * Node16/Node18/Node20/NodeNext: `import.meta` is fine in ES-module
+    ///   files but not in files that resolve to CommonJS output, so the
+    ///   per-file format decides whether to emit TS1470 ("not allowed in
+    ///   files which will build into CommonJS output").
+    /// * CommonJS, AMD, UMD, and ES2015 (every module kind below ES2020 that
+    ///   is not System and not a Node mode): the meta-property is unavailable
+    ///   regardless of the file, so `tsc` emits TS1343 ("only allowed when the
+    ///   '--module' option is 'es2020', ..."). Earlier tsz always emitted
+    ///   TS1470 here, which diverged from `tsc`.
+    /// * System and ES2020+ support `import.meta` natively, so no error.
+    ///
+    /// The default-module case (`None`) is resolved to a concrete module kind
+    /// by the driver before checking, so it never reaches this branch as
+    /// `None` for an ES2020+ target.
+    pub(in crate::types_domain) fn check_import_meta_module_support(
+        &mut self,
+        node_idx: NodeIndex,
+    ) {
         use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
         use tsz_common::common::ModuleKind;
 
         let module_kind = self.ctx.compiler_options.module;
-        let should_error = if module_kind.is_node_module() {
-            // Node16/Node18/Node20/NodeNext: per-file CJS/ESM determination
+        if module_kind.is_node_module() {
+            // Node16/Node18/Node20/NodeNext: per-file CJS/ESM determination.
+            // Only files that build into CommonJS output are rejected (TS1470).
             let current_file = &self.ctx.file_name;
             let is_commonjs_file = current_file.ends_with(".cts") || current_file.ends_with(".cjs");
             let is_esm_file = current_file.ends_with(".mts") || current_file.ends_with(".mjs");
-            if is_commonjs_file {
-                true
-            } else if is_esm_file {
-                false
-            } else if let Some(is_esm) = self.ctx.file_is_esm {
-                !is_esm
-            } else {
-                false
+            // `.cts`/`.cjs` force CJS, `.mts`/`.mjs` force ESM; otherwise an
+            // extensionless `.ts`/`.js` builds to CJS only when the resolved
+            // format is explicitly CommonJS (`file_is_esm == Some(false)`).
+            let builds_to_cjs =
+                is_commonjs_file || (!is_esm_file && self.ctx.file_is_esm == Some(false));
+            if builds_to_cjs {
+                self.error_at_node(
+                    node_idx,
+                    diagnostic_messages::THE_IMPORT_META_META_PROPERTY_IS_NOT_ALLOWED_IN_FILES_WHICH_WILL_BUILD_INTO_COMM,
+                    diagnostic_codes::THE_IMPORT_META_META_PROPERTY_IS_NOT_ALLOWED_IN_FILES_WHICH_WILL_BUILD_INTO_COMM,
+                );
             }
-        } else if module_kind == ModuleKind::System
-            || (module_kind as u32) >= (ModuleKind::ES2020 as u32)
+        } else if module_kind != ModuleKind::System
+            && (module_kind as u32) < (ModuleKind::ES2020 as u32)
         {
-            // System and ES2020+ support import.meta natively
-            false
-        } else {
-            // CommonJS, AMD, UMD, ES2015, None -> always CJS output
-            true
-        };
-
-        if should_error {
+            // CommonJS, AMD, UMD, ES2015: import.meta is unavailable for the
+            // whole module mode, not a per-file CJS-output decision (TS1343).
             self.error_at_node(
                 node_idx,
-                diagnostic_messages::THE_IMPORT_META_META_PROPERTY_IS_NOT_ALLOWED_IN_FILES_WHICH_WILL_BUILD_INTO_COMM,
-                diagnostic_codes::THE_IMPORT_META_META_PROPERTY_IS_NOT_ALLOWED_IN_FILES_WHICH_WILL_BUILD_INTO_COMM,
+                diagnostic_messages::THE_IMPORT_META_META_PROPERTY_IS_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_ES2020_E,
+                diagnostic_codes::THE_IMPORT_META_META_PROPERTY_IS_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_ES2020_E,
             );
         }
+        // System and ES2020+ support import.meta natively: no diagnostic.
     }
 
     /// Mirror the binder's `resolved_const_expando_key` logic so that the checker

--- a/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
@@ -1114,9 +1114,11 @@ impl<'a> CheckerState<'a> {
     ///   TS1470 here, which diverged from `tsc`.
     /// * System and ES2020+ support `import.meta` natively, so no error.
     ///
-    /// The default-module case (`None`) is resolved to a concrete module kind
-    /// by the driver before checking, so it never reaches this branch as
-    /// `None` for an ES2020+ target.
+    /// `ModuleKind::None` is the unspecified/unresolved sentinel: the driver
+    /// resolves it to a concrete module kind (per `--target`) before checking,
+    /// and `tsc`'s own check runs on the *resolved* kind. So a bare `None`
+    /// emits no module diagnostic here — the resolved kind (e.g. CommonJS for a
+    /// low target, ES2020 otherwise) drives the decision once it is set.
     pub(in crate::types_domain) fn check_import_meta_module_support(
         &mut self,
         node_idx: NodeIndex,
@@ -1143,11 +1145,14 @@ impl<'a> CheckerState<'a> {
                     diagnostic_codes::THE_IMPORT_META_META_PROPERTY_IS_NOT_ALLOWED_IN_FILES_WHICH_WILL_BUILD_INTO_COMM,
                 );
             }
-        } else if module_kind != ModuleKind::System
+        } else if module_kind != ModuleKind::None
+            && module_kind != ModuleKind::System
             && (module_kind as u32) < (ModuleKind::ES2020 as u32)
         {
             // CommonJS, AMD, UMD, ES2015: import.meta is unavailable for the
             // whole module mode, not a per-file CJS-output decision (TS1343).
+            // `None` is excluded — it is the unresolved default, not an
+            // explicit sub-ES2020 module choice.
             self.error_at_node(
                 node_idx,
                 diagnostic_messages::THE_IMPORT_META_META_PROPERTY_IS_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_ES2020_E,

--- a/crates/tsz-checker/src/types/property_access_type/helpers.rs
+++ b/crates/tsz-checker/src/types/property_access_type/helpers.rs
@@ -35,7 +35,7 @@ impl<'a> CheckerState<'a> {
             .is_some_and(|ident| ident.escaped_text == "meta");
 
         if is_meta {
-            self.check_import_meta_in_cjs(idx);
+            self.check_import_meta_module_support(idx);
             // import.meta resolves to the global `ImportMeta` interface
             // (declared in lib.es2020.full.d.ts). Returning that type
             // enables TS2339 on unknown properties (`import.meta.blah`)

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -31,8 +31,7 @@ impl<'a> CheckerState<'a> {
         let Some(access) = self.ctx.arena.get_access_expr(node) else {
             return TypeId::ERROR; // Missing access expression data - propagate error
         };
-        // Handle import.meta: emit the module-compatibility diagnostic
-        // (TS1343 for module < ES2020, TS1470 for Node CommonJS-output files)
+        // Handle import.meta module-compat diagnostic (TS1343 for <ES2020, TS1470 for Node CJS output)
         if let Some(result) =
             self.try_resolve_import_meta_access(idx, access.expression, access.name_or_argument)
         {

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -31,7 +31,8 @@ impl<'a> CheckerState<'a> {
         let Some(access) = self.ctx.arena.get_access_expr(node) else {
             return TypeId::ERROR; // Missing access expression data - propagate error
         };
-        // Handle import.meta: emit TS1470 in files that compile to CommonJS output
+        // Handle import.meta: emit the module-compatibility diagnostic
+        // (TS1343 for module < ES2020, TS1470 for Node CommonJS-output files)
         if let Some(result) =
             self.try_resolve_import_meta_access(idx, access.expression, access.name_or_argument)
         {

--- a/crates/tsz-checker/tests/import_meta_module_support_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/import_meta_module_support_diagnostics_tests.rs
@@ -161,6 +161,24 @@ fn node16_esm_file_supports_import_meta() {
 }
 
 #[test]
+fn default_module_none_emits_no_import_meta_diagnostic() {
+    // `ModuleKind::None` is the unresolved/default sentinel (what
+    // `CheckerOptions::default()` carries). The driver resolves it to a
+    // concrete module kind before checking, so the checker must not emit a
+    // module-kind import.meta diagnostic for a bare `None` — neither the
+    // sub-ES2020 TS1343 nor the Node-output TS1470.
+    let codes = codes(
+        "export const u = import.meta.url;",
+        "a.ts",
+        ModuleKind::None,
+    );
+    assert!(
+        !codes.contains(&TS1343) && !codes.contains(&TS1470),
+        "unresolved/default module (None) must not emit an import.meta module diagnostic; got {codes:?}"
+    );
+}
+
+#[test]
 fn nodenext_commonjs_file_emits_ts1470() {
     let codes = codes(
         "export const u = import.meta.url;",

--- a/crates/tsz-checker/tests/import_meta_module_support_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/import_meta_module_support_diagnostics_tests.rs
@@ -1,0 +1,178 @@
+//! Regression tests for the `import.meta` module-compatibility diagnostic
+//! (refs #12261).
+//!
+//! `tsc` reports two *distinct* diagnostics for an unsupported `import.meta`:
+//!
+//! * **TS1343** — "only allowed when the '--module' option is 'es2020',
+//!   'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', or
+//!   'nodenext'" — for every module kind below `ES2020` that is not `System`
+//!   and not a Node resolution mode (CommonJS, AMD, UMD, ES2015). The
+//!   meta-property is unavailable for the whole module mode, independent of
+//!   the file.
+//! * **TS1470** — "not allowed in files which will build into CommonJS
+//!   output" — only under Node16/Node18/Node20/NodeNext, and only for files
+//!   that resolve to CommonJS format (`.cts`/`.cjs` or a CJS-implied `.ts`).
+//!
+//! Earlier tsz emitted TS1470 for *all* sub-ES2020 module kinds, so plain
+//! `--module commonjs` / `es2015` produced the wrong code. The structural rule
+//! keys on the effective module kind (and, for Node modes, the file format),
+//! never on the spelling of the `import.meta` access, so the property name is
+//! varied across cases.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+use tsz_common::common::ModuleKind;
+
+const TS1343: u32 = 1343;
+const TS1470: u32 = 1470;
+
+fn codes(source: &str, file_name: &str, module: ModuleKind) -> Vec<u32> {
+    let options = CheckerOptions {
+        module,
+        ..CheckerOptions::default()
+    };
+    check_source(source, file_name, options)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+#[test]
+fn commonjs_module_emits_ts1343_not_ts1470() {
+    let codes = codes(
+        "export const u = import.meta.url;",
+        "a.ts",
+        ModuleKind::CommonJS,
+    );
+    assert!(
+        codes.contains(&TS1343),
+        "commonjs should report TS1343 for import.meta; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&TS1470),
+        "commonjs must not report the Node-only TS1470; got {codes:?}"
+    );
+}
+
+#[test]
+fn es2015_module_emits_ts1343() {
+    // Different access spelling to confirm the rule is module-kind driven.
+    let codes = codes(
+        "export const here = import.meta.dirname;",
+        "mod.ts",
+        ModuleKind::ES2015,
+    );
+    assert!(
+        codes.contains(&TS1343),
+        "es2015 should report TS1343 for import.meta; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&TS1470),
+        "es2015 must not report TS1470; got {codes:?}"
+    );
+}
+
+#[test]
+fn amd_module_emits_ts1343() {
+    let codes = codes(
+        "export const r = import.meta.resolve;",
+        "amd-file.ts",
+        ModuleKind::AMD,
+    );
+    assert!(
+        codes.contains(&TS1343),
+        "amd should report TS1343 for import.meta; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&TS1470),
+        "amd must not report TS1470; got {codes:?}"
+    );
+}
+
+#[test]
+fn es2020_module_supports_import_meta() {
+    let codes = codes(
+        "export const u = import.meta.url;",
+        "a.ts",
+        ModuleKind::ES2020,
+    );
+    assert!(
+        !codes.contains(&TS1343) && !codes.contains(&TS1470),
+        "es2020 supports import.meta natively; expected no module diagnostic, got {codes:?}"
+    );
+}
+
+#[test]
+fn esnext_module_supports_import_meta() {
+    let codes = codes(
+        "export const u = import.meta.url;",
+        "a.ts",
+        ModuleKind::ESNext,
+    );
+    assert!(
+        !codes.contains(&TS1343) && !codes.contains(&TS1470),
+        "esnext supports import.meta natively; expected no module diagnostic, got {codes:?}"
+    );
+}
+
+#[test]
+fn system_module_supports_import_meta() {
+    let codes = codes(
+        "export const u = import.meta.url;",
+        "a.ts",
+        ModuleKind::System,
+    );
+    assert!(
+        !codes.contains(&TS1343) && !codes.contains(&TS1470),
+        "system supports import.meta natively; expected no module diagnostic, got {codes:?}"
+    );
+}
+
+#[test]
+fn node16_commonjs_file_emits_ts1470_not_ts1343() {
+    // A `.cts` file under node16 builds into CommonJS output -> TS1470.
+    let codes = codes(
+        "export const u = import.meta.url;",
+        "a.cts",
+        ModuleKind::Node16,
+    );
+    assert!(
+        codes.contains(&TS1470),
+        "node16 .cts (CommonJS output) should report TS1470; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&TS1343),
+        "node16 must not fall back to the module-wide TS1343; got {codes:?}"
+    );
+}
+
+#[test]
+fn node16_esm_file_supports_import_meta() {
+    // A `.mts` file under node16 is an ES module -> import.meta is allowed.
+    let codes = codes(
+        "export const u = import.meta.url;",
+        "a.mts",
+        ModuleKind::Node16,
+    );
+    assert!(
+        !codes.contains(&TS1470) && !codes.contains(&TS1343),
+        "node16 .mts (ES module) supports import.meta; expected no module diagnostic, got {codes:?}"
+    );
+}
+
+#[test]
+fn nodenext_commonjs_file_emits_ts1470() {
+    let codes = codes(
+        "export const u = import.meta.url;",
+        "legacy.cjs",
+        ModuleKind::NodeNext,
+    );
+    assert!(
+        codes.contains(&TS1470),
+        "nodenext .cjs (CommonJS output) should report TS1470; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&TS1343),
+        "nodenext must not report TS1343; got {codes:?}"
+    );
+}

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1587,8 +1587,7 @@ pub(super) const fn is_ts1xxx_allowed_in_js(code: u32) -> bool {
         | 1274 // JSDoc '@typedef' tag should either have a type annotation or be followed by '@property' or '@member' tags
         | 1277 // 'JSDoc' types may only appear in type positions
         | 1308 // 'await' expressions are only allowed within async functions
-        | 1343 // 'import.meta' only allowed when '--module' is es2020/esnext/system/node*
-        | 1344 // Not all code paths return a value / unreachable code
+        | 1343 | 1344 // 1343 import.meta module support; 1344 unreachable code
         | 1359 // Identifier expected; 'await' is reserved in async
         | 1360 // '@satisfies' types can only be used in type positions
         | 1382 // Unexpected token

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1587,12 +1587,13 @@ pub(super) const fn is_ts1xxx_allowed_in_js(code: u32) -> bool {
         | 1274 // JSDoc '@typedef' tag should either have a type annotation or be followed by '@property' or '@member' tags
         | 1277 // 'JSDoc' types may only appear in type positions
         | 1308 // 'await' expressions are only allowed within async functions
+        | 1343 // 'import.meta' only allowed when '--module' is es2020/esnext/system/node*
         | 1344 // Not all code paths return a value / unreachable code
         | 1359 // Identifier expected; 'await' is reserved in async
         | 1360 // '@satisfies' types can only be used in type positions
         | 1382 // Unexpected token
         | 1464 // Import assertion/attribute
-        | 1470 // 'import.meta' outside module
+        | 1470 // 'import.meta' in a file building into CommonJS output
         | 1473 // Module declaration names
         | 1479 // This syntax is only allowed when 'allowImportingTsExtensions'
         | 1489 // Duplicate identifier


### PR DESCRIPTION
## Agent
AgentName: M1-C
Runner: lucid-hopper

## Track
Conformance / checker tsc-parity, refs #12261 import.meta subset.

## Invariant
When `import.meta` is referenced, `tsc` selects the diagnostic by effective module kind: Node16/Node18/Node20/NodeNext emit TS1470 only for files that resolve to CommonJS output, while CommonJS/AMD/UMD/ES2015 emit TS1343 for the whole module mode. System and ES2020+ support `import.meta` natively. This PR makes tsz select the same diagnostic through `tsz-checker` import.meta access semantics and keeps the choice independent of the spelling of the property access.

## Scope
- `crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs`: rename and expand `check_import_meta_in_cjs` into module-kind-aware `check_import_meta_module_support`.
- `crates/tsz-checker/src/types/property_access_type/helpers.rs` and `resolve.rs`: route `import.meta` through the new module support diagnostic helper.
- `crates/tsz-checker/tests/import_meta_module_support_diagnostics_tests.rs` and `crates/tsz-checker/Cargo.toml`: add adjacent module/file-format diagnostic coverage.
- `crates/tsz-cli/src/driver/check_utils.rs`: allow TS1343 in JS-file filtering alongside the already-allowed TS1470.

## Project Corpus Impact
- Row: n/a
- Bug family: conformance/import.meta diagnostics, accepted-regression follow-up for #12261.
- Evidence: no project-bench row is expected to depend on `import.meta` under CommonJS/ES2015. Existing Node-mode fixtures that expect TS1470 remain covered, and this PR adds the missing TS1343 path for non-Node sub-ES2020 module kinds.

## Verification
- New `import_meta_module_support_diagnostics_tests.rs`: 9 cases across CommonJS, ES2015, AMD, ES2020, ESNext, System, Node16 `.cts`/`.mts`, and NodeNext `.cjs`, with varied access spellings.
- Existing `ts2364_import_meta_assignment_tests`: 3/3 pass.
- Conformance harness on the #12261 fixtures plus the two Node TS1470 fixtures: 5/5 pass.
- Full tsc-vs-tsz matrix re-verified byte-for-byte with the rebuilt CLI:
  - CommonJS `.ts`: TS1343
  - ES2015 `.ts`: TS1343
  - CommonJS `.js`: TS1343
  - ES2020/ESNext `.ts`: no import.meta module diagnostic
  - System `.ts`: TS5107 only
  - default module `.ts`: no import.meta module diagnostic
  - Node16 `.cts`: TS1470
  - Node16 `.mts`: no import.meta module diagnostic
  - NodeNext `.cjs`: TS1470
- `cargo fmt --check`
- `cargo clippy -p tsz-checker --all-targets -D warnings`

## Coordination Notes
- Standalone parity fix surfaced while investigating #12261's import.meta fixture, which already passes on current `main`.
- No overlap observed with other open PRs touching `import.meta`.
- Branch is based on current `origin/main` at PR open (`ff3f6ed7b97de8886a269cf54db060555b7a4553`), but keep off `merge-queue` until labels/body gates and exact-head CI are green.

---
Generated by Claude Code session metadata was preserved as runner attribution above.
