### PR TITLE
fix(ci): scope try-tsz native helper packages

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -179,11 +179,10 @@ jobs:
             suffix="${dir#npm/npm-native-}"
             mkdir -p "npm/@mohsen-azimi/tsz-${suffix}/bin"
             cp "$dir"/* "npm/@mohsen-azimi/tsz-${suffix}/bin/"
-            mkdir -p "npm/try-tsz-${suffix}/bin"
-            cp "$dir"/try-tsz* "npm/try-tsz-${suffix}/bin/"
+            mkdir -p "npm/@mohsen-azimi/try-tsz-${suffix}/bin"
+            cp "$dir"/try-tsz* "npm/@mohsen-azimi/try-tsz-${suffix}/bin/"
           done
           find npm/@mohsen-azimi -maxdepth 3 -type f | sort
-          find npm/try-tsz-* -maxdepth 3 -type f | sort
 
       - name: Assemble package manifests
         run: scripts/build/build-npm-packages.sh --all --native-only --skip-build
@@ -192,7 +191,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          for pkg in npm/try-tsz-* npm/try-tsz; do
+          for pkg in npm/@mohsen-azimi/try-tsz-* npm/try-tsz; do
             (cd "$pkg" && npm publish --dry-run --access public)
           done
 
@@ -215,7 +214,7 @@ jobs:
             (cd "$pkg_dir" && npm publish --access public --provenance)
           }
 
-          for pkg in npm/try-tsz-*; do
+          for pkg in npm/@mohsen-azimi/try-tsz-*; do
             publish_if_needed "$pkg"
           done
           publish_if_needed npm/try-tsz

--- a/docs/specs/TRY_TSZ.md
+++ b/docs/specs/TRY_TSZ.md
@@ -125,8 +125,9 @@ Repository layout:
   submission.
 - Extend the npm assembly scripts so the public unscoped package `try-tsz`
   installs a launcher that selects the platform binary.
-- Publish unscoped native helper packages named `try-tsz-<platform>` so the MVP
-  does not depend on scoped npm package permissions.
+- Publish scoped native helper packages named
+  `@mohsen-azimi/try-tsz-<platform>` so the public package can stay
+  `try-tsz` while helper package names avoid npm's unscoped-name spam gate.
 
 Compiler invocation:
 
@@ -261,8 +262,8 @@ Integration tests:
 Packaging tests:
 
 - Local npm pack installs `try-tsz` and exposes the `try-tsz` binary.
-- Platform binary selection uses the matching `try-tsz-<platform>` helper
-  package.
+- Platform binary selection uses the matching
+  `@mohsen-azimi/try-tsz-<platform>` helper package.
 - `npx try-tsz -p tsconfig.json` works in a sample project without modifying
   source, lockfiles, or dependency folders.
 

--- a/scripts/build/build-npm-packages.sh
+++ b/scripts/build/build-npm-packages.sh
@@ -150,7 +150,7 @@ if [ "$DRY_RUN" -eq 1 ]; then
   echo "  try-tsz (main package)"
   for p in "${BUILD_PLATFORMS[@]}"; do
     echo "  @mohsen-azimi/tsz-$p"
-    echo "  try-tsz-$p"
+    echo "  @mohsen-azimi/try-tsz-$p"
   done
   exit 0
 fi
@@ -203,7 +203,7 @@ if [ "$WASM_ONLY" -ne 1 ] && [ "$SKIP_BUILD" -ne 1 ]; then
     # Copy binaries to the platform package
     pkg_bin="$NPM_DIR/@mohsen-azimi/tsz-$platform_suffix/bin"
     mkdir -p "$pkg_bin"
-    try_pkg_bin="$NPM_DIR/try-tsz-$platform_suffix/bin"
+    try_pkg_bin="$NPM_DIR/@mohsen-azimi/try-tsz-$platform_suffix/bin"
     mkdir -p "$try_pkg_bin"
 
     for bin_name in "${BINARIES[@]}"; do
@@ -278,8 +278,8 @@ const mainPackage = {
   ...commonMetadata,
   keywords: ["typescript", "compiler", "tsz", "tsc"],
   bin: {
-    tsz: "./bin/tsz.js",
-    "tsz-server": "./bin/tsz-server.js",
+    tsz: "bin/tsz.js",
+    "tsz-server": "bin/tsz-server.js",
   },
   optionalDependencies,
   files: ["bin/", "wasm/", "lib-assets/", "LICENSE.txt"],
@@ -403,7 +403,7 @@ const platforms = [
   { suffix: "win32-arm64", os: "win32", cpu: "arm64" },
 ];
 const optionalDependencies = Object.fromEntries(
-  platforms.map(({ suffix }) => [`try-tsz-${suffix}`, version]),
+  platforms.map(({ suffix }) => [`@mohsen-azimi/try-tsz-${suffix}`, version]),
 );
 const pkg = {
   name: "try-tsz",
@@ -417,7 +417,7 @@ const pkg = {
   },
   keywords: ["typescript", "compiler", "tsz", "tsc"],
   bin: {
-    "try-tsz": "./bin/try-tsz.js",
+    "try-tsz": "bin/try-tsz.js",
   },
   optionalDependencies,
   files: ["bin/", "LICENSE.txt"],
@@ -434,10 +434,10 @@ const commonMetadata = {
 };
 
 for (const { suffix, os, cpu } of platforms) {
-  const pkgDir = `${process.env.NPM_DIR}/try-tsz-${suffix}`;
+  const pkgDir = `${process.env.NPM_DIR}/@mohsen-azimi/try-tsz-${suffix}`;
   fs.mkdirSync(`${pkgDir}/bin`, { recursive: true });
   const nativePkg = {
-    name: `try-tsz-${suffix}`,
+    name: `@mohsen-azimi/try-tsz-${suffix}`,
     version,
     description: `Native try-tsz binary for ${suffix}`,
     ...commonMetadata,
@@ -474,9 +474,9 @@ if (!suffix) {
 const exe = process.platform === "win32" ? "try-tsz.exe" : "try-tsz";
 let binary;
 try {
-  binary = require.resolve(`try-tsz-${suffix}/bin/${exe}`);
+  binary = require.resolve(`@mohsen-azimi/try-tsz-${suffix}/bin/${exe}`);
 } catch {
-  console.error(`Missing try-tsz native package try-tsz-${suffix}`);
+  console.error(`Missing try-tsz native package @mohsen-azimi/try-tsz-${suffix}`);
   process.exit(1);
 }
 
@@ -502,7 +502,7 @@ chmod +x "$TRY_PKG/bin/try-tsz.js"
 cp "$PROJECT_ROOT/LICENSE.txt" "$TRY_PKG/LICENSE.txt"
 for entry in "${PLATFORMS[@]}"; do
   read -r npm_suffix _ <<< "$entry"
-  try_platform_pkg="$NPM_DIR/try-tsz-$npm_suffix"
+  try_platform_pkg="$NPM_DIR/@mohsen-azimi/try-tsz-$npm_suffix"
   mkdir -p "$try_platform_pkg"
   cp "$PROJECT_ROOT/LICENSE.txt" "$try_platform_pkg/LICENSE.txt"
 done
@@ -513,7 +513,7 @@ echo "    Main package: $MAIN_PKG"
 echo "    Try package:  $TRY_PKG"
 for platform_suffix in "${BUILD_PLATFORMS[@]}"; do
   echo "    Platform:     $NPM_DIR/@mohsen-azimi/tsz-$platform_suffix"
-  echo "    Try platform: $NPM_DIR/try-tsz-$platform_suffix"
+  echo "    Try platform: $NPM_DIR/@mohsen-azimi/try-tsz-$platform_suffix"
 done
 echo ""
 echo "To test locally:"
@@ -523,7 +523,7 @@ echo ""
 echo "To publish:"
 echo "  # Publish try-tsz platform packages first:"
 for platform_suffix in "${BUILD_PLATFORMS[@]}"; do
-  echo "  cd $NPM_DIR/try-tsz-$platform_suffix && npm publish --access public"
+  echo "  cd $NPM_DIR/@mohsen-azimi/try-tsz-$platform_suffix && npm publish --access public"
 done
 echo "  # Then publish try-tsz package:"
 echo "  cd $TRY_PKG && npm publish --access public"

--- a/scripts/build/setup-npm-trusted-publishers.sh
+++ b/scripts/build/setup-npm-trusted-publishers.sh
@@ -13,12 +13,12 @@ WORKFLOW_FILE="${WORKFLOW_FILE:-npm-publish.yml}"
 REGISTRY="${REGISTRY:-https://registry.npmjs.org}"
 
 PACKAGES=(
-  "try-tsz-darwin-arm64"
-  "try-tsz-darwin-x64"
-  "try-tsz-linux-x64"
-  "try-tsz-linux-arm64"
-  "try-tsz-win32-x64"
-  "try-tsz-win32-arm64"
+  "@mohsen-azimi/try-tsz-darwin-arm64"
+  "@mohsen-azimi/try-tsz-darwin-x64"
+  "@mohsen-azimi/try-tsz-linux-x64"
+  "@mohsen-azimi/try-tsz-linux-arm64"
+  "@mohsen-azimi/try-tsz-win32-x64"
+  "@mohsen-azimi/try-tsz-win32-arm64"
   "try-tsz"
 )
 

--- a/scripts/build/test-npm-native-copy.sh
+++ b/scripts/build/test-npm-native-copy.sh
@@ -43,7 +43,7 @@ for bin in tsz tsz-server try-tsz; do
   fi
 done
 
-try_pkg_bin="$PROJECT_ROOT/npm/try-tsz-$suffix/bin"
+try_pkg_bin="$PROJECT_ROOT/npm/@mohsen-azimi/try-tsz-$suffix/bin"
 if [[ ! -x "$try_pkg_bin/try-tsz$ext" ]]; then
   echo "missing packaged try-tsz native binary: $try_pkg_bin/try-tsz$ext" >&2
   exit 1


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
CLI/npm packaging

## Invariant
When `try-tsz` is published for npm, the public `try-tsz` package resolves native helper packages that npm will allow us to create and publish. This PR changes npm package assembly and publish workflow metadata only.

## Scope
- Rename native `try-tsz` helper packages from unscoped `try-tsz-<platform>` to scoped `@mohsen-azimi/try-tsz-<platform>`.
- Update launcher optional dependencies and `require.resolve` paths.
- Update npm publish workflow loops and trusted-publisher setup helper.
- Remove npm bin normalization warnings by generating bin paths without `./`.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: packaging-only change; compiler behavior, diagnostics, and project rows are untouched.

## Verification
- `bash -n scripts/build/build-npm-packages.sh && bash -n scripts/build/setup-npm-trusted-publishers.sh && bash -n scripts/build/test-npm-native-copy.sh && git diff --check`
- `scripts/safe-run.sh scripts/build/test-npm-native-copy.sh`
- Reassembled all six native packages from publish-run artifacts and ran `npm publish --dry-run --access public` for `npm/@mohsen-azimi/try-tsz-*` and `npm/try-tsz`.

## Coordination Notes
- Fix-forward after unscoped `try-tsz-win32-*` helper names triggered npm spam detection during local bootstrap publish.
- Scoped helper names were checked as unpublished before this PR.
- Publishing still requires a fresh npm OTP or an updated CI token/trusted-publisher bootstrap after this lands.
