### PR TITLE
fix(solver): merge colliding mapped `as`-clause keys with first-key modifiers

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/state/type_environment.rs
+++ b/crates/tsz-checker/src/query_boundaries/state/type_environment.rs
@@ -152,6 +152,16 @@ pub(crate) const fn compute_mapped_modifiers(
     )
 }
 
+/// Merge mapped properties whose `as` clause remaps multiple source keys onto
+/// the same output name, mirroring tsc's `resolveMappedTypeMembers`: the value
+/// contributions union while the first source key's modifiers are kept.
+pub(crate) fn merge_colliding_mapped_properties(
+    db: &dyn TypeDatabase,
+    properties: &mut Vec<tsz_solver::PropertyInfo>,
+) {
+    tsz_solver::type_queries::merge_colliding_mapped_properties(db, properties);
+}
+
 /// Collect source property info for a homomorphic mapped type.
 pub(crate) fn collect_homomorphic_source_properties(
     db: &dyn TypeDatabase,

--- a/crates/tsz-checker/src/state/type_environment/application.rs
+++ b/crates/tsz-checker/src/state/type_environment/application.rs
@@ -1,4 +1,5 @@
 use crate::{query_boundaries::state::type_environment as query, state::CheckerState};
+use tsz_common::Atom;
 use tsz_solver::{TypeId, TypeParamInfo};
 
 pub(crate) struct ApplicationBaseBody {
@@ -159,5 +160,43 @@ impl<'a> CheckerState<'a> {
             body_type,
             type_params,
         })
+    }
+
+    pub(crate) fn instantiate_mapped_property_template_with_env(
+        &mut self,
+        mapped: &tsz_solver::MappedType,
+        key_name: Atom,
+    ) -> TypeId {
+        let key_literal = self.ctx.types.literal_string_atom(key_name);
+        let property_type =
+            crate::query_boundaries::state::checking::instantiate_mapped_template_for_property(
+                self.ctx.types,
+                mapped.template,
+                mapped.type_param.name,
+                key_literal,
+            );
+
+        // When the template produces an IndexAccess (e.g., T[K] → ObjType["key"]),
+        // resolve the object part through evaluate_type_with_resolution so that
+        // Lazy(DefId) references become concrete types.  Then attempt property
+        // access resolution with the resolved object.
+        if let Some((obj, _idx)) = query::index_access_types(self.ctx.types, property_type) {
+            let obj_type = self.evaluate_type_with_resolution(obj);
+
+            let prop_name_arc = self.ctx.types.resolve_atom_ref(key_name);
+            let prop_name: &str = &prop_name_arc;
+            match self.resolve_property_access_with_env(obj_type, prop_name) {
+                tsz_solver::operations::property::PropertyAccessResult::Success {
+                    type_id, ..
+                }
+                | tsz_solver::operations::property::PropertyAccessResult::PossiblyNullOrUndefined {
+                    property_type: Some(type_id),
+                    ..
+                } => return type_id,
+                _ => {}
+            }
+        }
+
+        self.evaluate_type_with_env(property_type)
     }
 }

--- a/crates/tsz-checker/src/state/type_environment/core.rs
+++ b/crates/tsz-checker/src/state/type_environment/core.rs
@@ -1050,6 +1050,7 @@ impl<'a> CheckerState<'a> {
             }
 
             if !properties.is_empty() {
+                query::merge_colliding_mapped_properties(self.ctx.types, &mut properties);
                 return factory.object(properties);
             }
         }
@@ -1174,6 +1175,11 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        // Collapse colliding remapped keys (e.g. `as 'x'` mapping several source
+        // keys to one name) before ordering: the value contributions union and the
+        // first source key's modifiers win, matching tsc.
+        query::merge_colliding_mapped_properties(self.ctx.types, &mut properties);
+
         if !source_decl_order.is_empty() {
             let order_map: rustc_hash::FxHashMap<tsz_common::Atom, usize> = source_decl_order
                 .iter()
@@ -1184,44 +1190,6 @@ impl<'a> CheckerState<'a> {
         }
 
         factory.object(properties)
-    }
-
-    pub(crate) fn instantiate_mapped_property_template_with_env(
-        &mut self,
-        mapped: &tsz_solver::MappedType,
-        key_name: Atom,
-    ) -> TypeId {
-        let key_literal = self.ctx.types.literal_string_atom(key_name);
-        let property_type =
-            crate::query_boundaries::state::checking::instantiate_mapped_template_for_property(
-                self.ctx.types,
-                mapped.template,
-                mapped.type_param.name,
-                key_literal,
-            );
-
-        // When the template produces an IndexAccess (e.g., T[K] → ObjType["key"]),
-        // resolve the object part through evaluate_type_with_resolution so that
-        // Lazy(DefId) references become concrete types.  Then attempt property
-        // access resolution with the resolved object.
-        if let Some((obj, _idx)) = query::index_access_types(self.ctx.types, property_type) {
-            let obj_type = self.evaluate_type_with_resolution(obj);
-
-            let prop_name_arc = self.ctx.types.resolve_atom_ref(key_name);
-            let prop_name: &str = &prop_name_arc;
-            match self.resolve_property_access_with_env(obj_type, prop_name) {
-                tsz_solver::operations::property::PropertyAccessResult::Success {
-                    type_id, ..
-                }
-                | tsz_solver::operations::property::PropertyAccessResult::PossiblyNullOrUndefined {
-                    property_type: Some(type_id),
-                    ..
-                } => return type_id,
-                _ => {}
-            }
-        }
-
-        self.evaluate_type_with_env(property_type)
     }
 
     /// Evaluate a mapped type constraint with symbol resolution.

--- a/crates/tsz-checker/tests/ts2322_tests_parts/part_00.rs
+++ b/crates/tsz-checker/tests/ts2322_tests_parts/part_00.rs
@@ -1760,3 +1760,91 @@ fnUnion(value);
     );
 }
 
+
+#[test]
+fn mapped_as_clause_key_collision_keeps_first_source_modifiers() {
+    // Structural rule: when an `as` clause remaps several source keys onto the
+    // same output name, tsc unions the value contributions but keeps the
+    // optional/readonly modifiers of the FIRST source key in declaration order
+    // (see `resolveMappedTypeMembers`). The first key `a` here is
+    // `readonly a?`, so the merged `x` is readonly+optional and assigning to it
+    // is rejected with TS2540.
+    let source = r#"
+type Source = { readonly a?: number; b: string; c: boolean };
+type Merged = { [K in keyof Source as "x"]: Source[K] };
+declare const merged: Merged;
+merged.x = 1;
+"#;
+
+    let diagnostics = compile_with_options(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    );
+
+    assert!(
+        has_diagnostic_code(&diagnostics, 2540),
+        "merged collision key inherits readonly from the first source key, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn mapped_as_clause_key_collision_merges_value_union() {
+    // The merged collision key accepts any contribution of the unioned value
+    // type. `{ x: 1 }` satisfies `Merged` because `x` is
+    // `number | string | boolean | undefined` (optional, from first key `a`).
+    let source = r#"
+type Source = { readonly a?: number; b: string; c: boolean };
+type Merged = { [K in keyof Source as "x"]: Source[K] };
+const ok: Merged = { x: 1 };
+const ok2: Merged = { x: "s" };
+const ok3: Merged = {};
+"#;
+
+    let diagnostics = compile_with_options(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    );
+
+    assert!(
+        !has_diagnostic_code(&diagnostics, 2322),
+        "merged collision key value union should accept each contribution, got: {diagnostics:?}"
+    );
+    assert!(
+        !has_diagnostic_code(&diagnostics, 2741),
+        "merged collision key is optional, so empty object is allowed, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn mapped_as_clause_key_collision_first_key_not_readonly_allows_write() {
+    // When the first source key is neither readonly nor optional, the merged key
+    // is writable: renaming `Renamed` to guard against spelling-based fixes.
+    let source = r#"
+type Bag = { first: number; readonly second?: string };
+type Renamed = { [Slot in keyof Bag as "merged"]: Bag[Slot] };
+declare const bag: Renamed;
+bag.merged = 1;
+"#;
+
+    let diagnostics = compile_with_options(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    );
+
+    assert!(
+        !has_diagnostic_code(&diagnostics, 2540),
+        "merged key inherits writability from the first source key, got: {diagnostics:?}"
+    );
+}

--- a/crates/tsz-solver/src/objects/collect.rs
+++ b/crates/tsz-solver/src/objects/collect.rs
@@ -379,7 +379,15 @@ impl<'a, R: TypeResolver> PropertyCollector<'a, R> {
         mapped: &crate::types::MappedType,
         property_name: Atom,
     ) -> (bool, bool) {
-        let source_modifiers = self.finite_mapped_source_property_modifiers(mapped, property_name);
+        // Honor `as`-clause key remapping: the inherited modifiers come from the
+        // source key whose remap produced `property_name` (first contributor wins
+        // on a collision), not from looking the output name up directly in the
+        // source.
+        let source_modifiers = crate::type_queries::finite_mapped_output_property_modifiers(
+            self.interner,
+            mapped,
+            property_name,
+        );
         let (source_optional, source_readonly) = source_modifiers.unwrap_or((false, false));
         let is_homomorphic = source_modifiers.is_some();
         crate::type_queries::compute_mapped_modifiers(
@@ -388,33 +396,6 @@ impl<'a, R: TypeResolver> PropertyCollector<'a, R> {
             source_optional,
             source_readonly,
         )
-    }
-
-    fn finite_mapped_source_property_modifiers(
-        &self,
-        mapped: &crate::types::MappedType,
-        property_name: Atom,
-    ) -> Option<(bool, bool)> {
-        let (source_type, key_type) =
-            crate::type_queries::get_index_access_types(self.interner, mapped.template)?;
-        let key_param = crate::type_param_info(self.interner, key_type)?;
-        if key_param.name != mapped.type_param.name {
-            return None;
-        }
-
-        let resolved_source = resolve_type(source_type, self.interner, self.resolver);
-        match collect_properties_cached(
-            resolved_source,
-            self.interner,
-            self.resolver,
-            self.query_db,
-        ) {
-            PropertyCollectionResult::Properties { properties, .. } => {
-                PropertyInfo::find_in_slice(&properties, property_name)
-                    .map(|prop| (prop.optional, prop.readonly))
-            }
-            _ => None,
-        }
     }
 
     /// Collect common properties from all union members.

--- a/crates/tsz-solver/src/relations/subtype/rules/mapped_expansion.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/mapped_expansion.rs
@@ -210,6 +210,15 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             }
         }
 
+        // An `as` clause can remap several source keys onto the same output
+        // name (e.g. `{ [K in keyof S as 'x']: S[K] }`). tsc collapses those into
+        // one property: the value type is the union of the contributions and the
+        // optional/readonly modifiers come from the first source key. Without
+        // this, the expanded object carried duplicate properties, which lost the
+        // merged modifiers (so `readonly`/optional intent vanished) and produced
+        // incorrect assignability and type display.
+        crate::type_queries::merge_colliding_mapped_properties(self.interner, &mut properties);
+
         Some(self.interner.object(properties))
     }
 

--- a/crates/tsz-solver/src/type_queries/mapped.rs
+++ b/crates/tsz-solver/src/type_queries/mapped.rs
@@ -785,6 +785,53 @@ pub fn get_finite_mapped_property_display_type(
     }
 }
 
+/// Resolve the `(optional, readonly)` modifiers for an output property of a
+/// finite mapped type, honoring `as`-clause key remapping.
+///
+/// When the `as` clause renames keys, the output property name is not itself a
+/// source key, so looking the output name up directly in the source loses the
+/// inherited modifiers. tsc derives the modifiers from the source key whose
+/// remap produced the output name; when several keys collide on one name, the
+/// first in declaration order wins (see `resolveMappedTypeMembers`). Returns
+/// `None` when the mapped type is not homomorphic over a concrete object source
+/// or no source key maps to `property_name`.
+pub fn finite_mapped_output_property_modifiers(
+    db: &dyn TypeDatabase,
+    mapped: &crate::types::MappedType,
+    property_name: Atom,
+) -> Option<(bool, bool)> {
+    let (source_type, key_type) = crate::type_queries::get_index_access_types(db, mapped.template)?;
+    let key_param = crate::type_param_info(db, key_type)?;
+    if key_param.name != mapped.type_param.name {
+        return None;
+    }
+
+    // Source properties in declaration order so the first colliding contributor
+    // wins, matching tsc.
+    let source_props =
+        super::mapped_display_order::collect_homomorphic_source_property_infos(db, source_type);
+    for prop in &source_props {
+        let key_literal = property_key_to_type(
+            db,
+            ExactLiteralPropertyKey {
+                name: prop.name,
+                is_symbol_named: prop.is_symbol_named,
+            },
+        );
+        let remapped = remap_mapped_property_key(db, mapped, key_literal);
+        if remapped == TypeId::NEVER {
+            continue;
+        }
+        let produces_target =
+            super::data::collect_exact_literal_property_keys_with_symbol_info(db, remapped)
+                .is_some_and(|keys| keys.iter().any(|key| key.name == property_name));
+        if produces_target {
+            return Some((prop.optional, prop.readonly));
+        }
+    }
+    None
+}
+
 fn property_key_to_type(db: &dyn TypeDatabase, key: ExactLiteralPropertyKey) -> TypeId {
     let key_str = db.resolve_atom(key.name);
     if key.is_symbol_named
@@ -1325,15 +1372,17 @@ pub fn merge_colliding_mapped_properties(
     for property in properties.drain(..) {
         if let Some(&existing_index) = by_name.get(&property.name) {
             let existing: &mut PropertyInfo = &mut merged[existing_index];
+            // tsc's `resolveMappedTypeMembers` widens a colliding output key by
+            // unioning the value contributions of every source key that maps to
+            // it, but it keeps the optional/readonly modifiers (and naming
+            // metadata) of the FIRST source key in declaration order. The
+            // colliding branch there only updates `keyType`/`nameType`; it never
+            // recomputes the property symbol's modifier flags. AND-combining the
+            // modifiers (the previous behavior) dropped `readonly`/`optional`
+            // intent whenever the source keys disagreed.
             existing.type_id = db.union_preserve_members(vec![existing.type_id, property.type_id]);
             existing.write_type =
                 db.union_preserve_members(vec![existing.write_type, property.write_type]);
-            existing.optional &= property.optional;
-            existing.readonly &= property.readonly;
-            existing.is_method &= property.is_method;
-            existing.is_string_named &= property.is_string_named;
-            existing.is_symbol_named &= property.is_symbol_named;
-            existing.single_quoted_name &= property.single_quoted_name;
             existing.declaration_order = existing.declaration_order.min(property.declaration_order);
         } else {
             by_name.insert(property.name, merged.len());


### PR DESCRIPTION
AgentName: Studio-B
Track: Solver — conditional/mapped type evaluation and relation simplification

## Summary

Fixes #10830 (and the broader `bug-family(solver)` "mapped key operations can lose optional/readonly modifier intent after merges").

When a mapped type's `as` clause remaps several source keys onto the **same** output name (e.g. `{ [K in keyof S as 'x']: S[K] }`), `tsc` collapses them into a single property: the value contributions **union**, and the optional/readonly modifiers come from the **first** source key in declaration order. (`resolveMappedTypeMembers`'s colliding branch only widens `keyType`/`nameType`; it never recomputes the modifier flags.)

tsz diverged on **every** mapped→object expansion path:

- `merge_colliding_mapped_properties` AND-combined the modifiers, dropping `readonly`/optional intent whenever the colliding source keys disagreed.
- The relations path `try_expand_mapped` and the checker's `evaluate_mapped_type_with_resolution_inner` (two build sites) never merged colliding keys at all — they emitted duplicate same-named properties, producing wrong assignability **and** duplicated type display.
- Finite mapped property collection looked modifiers up by the *output* name in the source, losing inherited modifiers under any key remapping.

### Before / after (verified against `tsc` 6.0.2)

```ts
type S = { readonly a?: number; b: string; c: boolean };
type M = { [K in keyof S as "x"]: S[K] };
declare const m: M;
m.x = 1;                 // tsc: TS2540 (readonly). tsz before: no error. after: TS2540 ✓
const ok: M = { x: 1 };  // tsc: ok.          tsz before: TS2322.   after: ok ✓
type VX = M["x"];        // tsc: number|string|...|undefined. tsz before: "string". after: matches ✓
```

## Invariant

When an `as` clause maps multiple source keys to one output name, `tsc` unions the value contributions and keeps the optional/readonly modifiers of the first source key (declaration order); tsz now does the same through the shared `merge_colliding_mapped_properties` helper (owned by the solver), plus a new `finite_mapped_output_property_modifiers` query that resolves a finite-mapped output property's modifiers via the *remapped* source key. Non-colliding/identity mapped types are unchanged (each output name is distinct, so the merge is a no-op).

## Scope

- `crates/tsz-solver/src/type_queries/mapped.rs` — `merge_colliding_mapped_properties` now keeps first-key modifiers (was AND); new `finite_mapped_output_property_modifiers`.
- `crates/tsz-solver/src/relations/subtype/rules/mapped_expansion.rs` — merge colliding keys in `try_expand_mapped`.
- `crates/tsz-solver/src/objects/collect.rs` — finite-mapped modifier lookup now honors remapping.
- `crates/tsz-checker/src/state/type_environment/core.rs` (+ query boundary wrapper) — merge colliding keys at both checker expansion build sites.
- `crates/tsz-checker/tests/ts2322_tests_parts/part_00.rs` — 3 regression tests (readonly preservation, value-union acceptance, writable-when-first-key-writable), with renamed binders.

## Project Corpus Impact

- Row: kysely-project (also zod-project, nextjs, ts-toolbelt-project, type-challenges-solutions-project mapped-modifier rows)
- Bug family: bug-family(solver) mapped key operations lose optional/readonly modifier intent after merges (#10830)
- Common homomorphic renaming (`Capitalize`, `_${K}`, filtering `as ... ? K : never`) already matched `tsc` and is unchanged; only the collision/merge behavior is corrected.

## Verification

- New tests: `cargo test -p tsz-checker --lib mapped_as_clause_key_collision` → 3 passed.
- `cargo build -p tsz-solver -p tsz-checker` clean; `cargo clippy` clean.
- Solver lib mapped tests: 378 passed, 1 failed (pre-existing on clean `main`: `test_deep_widen_object_candidate_homomorphic_mapped`). Checker lib mapped failures verified pre-existing on clean `main` (generic key-correlation tests). No new failures.
- Manual `tsz` vs `tsc` parity battery across collision and non-collision cases (readonly/optional/value-union, intersection merges, `+readonly`, template-literal renames).

## Coordination Notes

One known residual is **out of scope** (not modifier intent): a non-first *optional* colliding key's index-access `| undefined` is not yet folded into the merged value union (`S["b"]` for optional `b`). This is a separate index-access-of-optional value-type nuance and does not affect modifier preservation.

https://claude.ai/code/session_01ULY6bgWVaafnkn2MEoGpde