### PR TITLE
fix(solver): elaborate missing-property failures for union sources

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -691,6 +691,10 @@ name = "intersection_target_missing_property_elaboration_tests"
 path = "tests/intersection_target_missing_property_elaboration_tests.rs"
 
 [[test]]
+name = "union_source_missing_property_elaboration_tests"
+path = "tests/union_source_missing_property_elaboration_tests.rs"
+
+[[test]]
 name = "ts2353_omit_pick_excess_property_tests"
 path = "tests/ts2353_omit_pick_excess_property_tests.rs"
 

--- a/crates/tsz-checker/tests/union_source_missing_property_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/union_source_missing_property_elaboration_tests.rs
@@ -1,0 +1,168 @@
+//! Union-source missing-property elaboration (TS2322 + nested reason).
+//!
+//! Structural rule: when a *union* value is assigned to an object target and the
+//! first failing union member is rejected because it is missing a required
+//! property, tsc keeps the top-level `Type 'A | B' is not assignable to type
+//! 'T'` (TS2322) and elaborates *which* member fails and *why*:
+//!
+//! ```text
+//! Type 'A | B' is not assignable to type 'A'.
+//!   Property 'a' is missing in type 'B' but required in type 'A'.
+//! ```
+//!
+//! For a member that is missing *several* required properties tsc uses the
+//! TS2739-style summary instead:
+//!
+//! ```text
+//! Type 'A | C' is not assignable to type 'A'.
+//!   Type 'C' is missing the following properties from type 'A': a, b
+//! ```
+//!
+//! tsz previously surfaced the union-source elaboration only when the failing
+//! member bottomed out in a *leaf* relation (`undefined`/literal/intrinsic
+//! mismatch); a member that failed because it was missing a property fell
+//! through to the bare top-level `TypeMismatch`, hiding the root cause. The
+//! `MissingProperty`/`MissingProperties` reasons are self-heading (their message
+//! names the member type), so routing them through `UnionSourceMismatch`
+//! reproduces tsc's chain without the spurious `Type 'M' is not assignable …`
+//! header that richer structural reasons would require.
+//!
+//! These tests vary the binder names (interface/property/alias spellings) so a
+//! fix keyed to a particular spelling would not satisfy them. They assert
+//! structurally (the elaboration line names the missing property and that it is
+//! *required in type* / *missing the following properties*) rather than
+//! depending on the exact member rendering, which is governed by the type
+//! printer.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+use tsz_common::diagnostics::Diagnostic;
+
+fn diagnostics(source: &str) -> Vec<Diagnostic> {
+    check_source_diagnostics(source)
+}
+
+/// True when some TS2322 carries a nested-elaboration line matching `predicate`.
+fn ts2322_has_nested<P: Fn(&str) -> bool>(diags: &[Diagnostic], predicate: P) -> bool {
+    diags.iter().any(|d| {
+        d.code == 2322
+            && d.related_information
+                .iter()
+                .any(|info| predicate(&info.message_text))
+    })
+}
+
+/// True when some TS2322 carries a nested "Property '<prop>' is missing ... but
+/// required in type ..." elaboration line.
+fn has_missing_property_elaboration(diags: &[Diagnostic], prop: &str) -> bool {
+    let needle = format!("Property '{prop}' is missing");
+    ts2322_has_nested(diags, |msg| {
+        msg.contains(&needle) && msg.contains("but required in type")
+    })
+}
+
+/// True when some TS2322 carries a nested "... is missing the following
+/// properties from type ...: a, b" summary line naming every property.
+fn has_missing_properties_summary(diags: &[Diagnostic], props: &[&str]) -> bool {
+    ts2322_has_nested(diags, |msg| {
+        msg.contains("missing the following properties from type")
+            && props.iter().all(|p| msg.contains(p))
+    })
+}
+
+/// Canonical repro: a two-member object union where the second member lacks a
+/// property the target requires. The top-level stays TS2322; the nested line
+/// must name `a`.
+#[test]
+fn union_member_missing_single_property_emits_elaboration() {
+    let diags = diagnostics(
+        r#"
+interface A { a: 1 }
+interface B { b: 2 }
+declare const u: A | B;
+const v: A = u;
+"#,
+    );
+    assert!(
+        has_missing_property_elaboration(&diags, "a"),
+        "expected TS2322 with a `Property 'a' is missing ... required in type` \
+         elaboration for the failing union member; got {diags:?}"
+    );
+}
+
+/// Same rule, different interface and property spellings. A name-hardcoded fix
+/// would miss this.
+#[test]
+fn union_member_missing_single_property_renamed() {
+    let diags = diagnostics(
+        r#"
+interface Alpha { first: "x" }
+interface Beta { second: "y" }
+declare const value: Alpha | Beta;
+const out: Alpha = value;
+"#,
+    );
+    assert!(
+        has_missing_property_elaboration(&diags, "first"),
+        "renamed binders should still elaborate the missing property; got {diags:?}"
+    );
+}
+
+/// A member missing *multiple* required properties uses the TS2739-style
+/// summary, still attached as a nested elaboration on the TS2322.
+#[test]
+fn union_member_missing_multiple_properties_emits_summary() {
+    let diags = diagnostics(
+        r#"
+interface Both { a: 1; b: 2 }
+interface Other { c: 3 }
+declare const u: Both | Other;
+const v: Both = u;
+"#,
+    );
+    assert!(
+        has_missing_properties_summary(&diags, &["a", "b"]),
+        "expected a `missing the following properties ...: a, b` summary for the \
+         multi-property failing union member; got {diags:?}"
+    );
+}
+
+/// The elaboration must survive when the union is produced by a distributive
+/// conditional over its members (the kysely #10831 family shape): distribution
+/// rebuilds the union, but the per-member missing-property failure must still
+/// reach the diagnostic chain.
+#[test]
+fn distributive_conditional_union_member_missing_property_emits_elaboration() {
+    let diags = diagnostics(
+        r#"
+interface S1 { kind: "a" }
+interface S2 { kind: "b"; extra: 1 }
+type Distribute<T> = T extends unknown ? T : never;
+declare const u: Distribute<S1 | S2>;
+const v: S2 = u;
+"#,
+    );
+    assert!(
+        has_missing_property_elaboration(&diags, "extra"),
+        "distributive-conditional-rebuilt unions should still elaborate the \
+         missing member property; got {diags:?}"
+    );
+}
+
+/// A leaf (primitive) member mixed with an object member keeps elaborating the
+/// first failing member — guarding that broadening to `MissingProperty` did not
+/// regress the pre-existing leaf-member elaboration.
+#[test]
+fn union_with_primitive_member_still_elaborates_leaf() {
+    let diags = diagnostics(
+        r#"
+interface Obj { a: 1 }
+declare const u: number | Obj;
+const v: Obj = u;
+"#,
+    );
+    let elaborated = ts2322_has_nested(&diags, |msg| msg.contains("is not assignable to type"));
+    assert!(
+        elaborated,
+        "primitive union member should still elaborate beneath the union line; got {diags:?}"
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -827,13 +827,19 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 if self.check_subtype(member, target).is_true() {
                     continue;
                 }
-                // Elaborate only when the first failing member fails as a simple
-                // leaf relation (e.g. `undefined` vs `number`). A member that
-                // fails structurally (object/array/etc.) needs its own
-                // `Type 'M' is not assignable to type 'T'.` header before its
-                // sub-chain; that elaboration is owned by the structural render
-                // paths, so leave those to the existing top-level handling rather
-                // than producing a headerless, mis-indented chain here.
+                // Elaborate the first failing member beneath the union-to-target
+                // line, mirroring tsc which always drills into that member. Only
+                // *self-heading* reasons are surfaced: leaf relations
+                // (`undefined`/literal/intrinsic mismatch) and the property
+                // reasons (`MissingProperty`/`MissingProperties`), whose rendered
+                // message already names the member type (`Property 'a' is missing
+                // in type '{ b: 2; }' …` / `Type '{ c: 3; }' is missing the
+                // following properties …`). They need no extra `Type 'M' is not
+                // assignable …` header, so `UnionSourceMismatch` reproduces tsc's
+                // chain exactly. Richer structural reasons (property-type/tuple
+                // element mismatches) do require that header, which the renderer
+                // does not emit on this path, so they fall through to the bare
+                // union line rather than a mis-indented chain.
                 let nested = self.explain_failure_guarded(member, target);
                 if let Some(nested) = nested
                     && matches!(
@@ -841,6 +847,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                         SubtypeFailureReason::TypeMismatch { .. }
                             | SubtypeFailureReason::IntrinsicTypeMismatch { .. }
                             | SubtypeFailureReason::LiteralTypeMismatch { .. }
+                            | SubtypeFailureReason::MissingProperty { .. }
+                            | SubtypeFailureReason::MissingProperties { .. }
                     )
                 {
                     return Some(SubtypeFailureReason::UnionSourceMismatch {


### PR DESCRIPTION
## Summary

Closes the diagnostic-redisplay gap in the distributive-conditional / union-source family tracked by #10831 (kysely-project). When a **union-typed source** is assigned to an object target and the first failing member is rejected because it is **missing a required property**, `tsc` keeps the top-level `TS2322` and drills into the failing member:

```text
Type 'A | B' is not assignable to type 'A'.
  Property 'a' is missing in type 'B' but required in type 'A'.
```

`explain_failure` only surfaced the per-member elaboration (`UnionSourceMismatch`) when the failing member bottomed out in a **leaf** relation (`TypeMismatch` / `IntrinsicTypeMismatch` / `LiteralTypeMismatch`). A member that failed because it was *missing a property* fell through to the bare top-level `TypeMismatch`, so the chain stopped at the bare union line and hid the root cause. This is the redisplay precision the issue asks for ("preserve … narrowness during simplification and redisplay").

**Structural rule:** When a union source fails, `tsc` elaborates the first failing member exactly as it would a standalone `member <: target` relation. The `MissingProperty` / `MissingProperties` reasons are *self-heading* — their rendered message already names the member type — so routing them through `UnionSourceMismatch` reproduces tsc's chain without the spurious `Type 'M' is not assignable …` header that richer structural reasons (property-type / tuple-element mismatches) require. Those richer reasons deliberately stay on the bare-union path (verified empirically: surfacing them produces a headerless, mis-indented chain the renderer does not currently emit a member header for).

This is intentionally broader than the single witness in #10831: it fixes every union-source → object-target assignment that fails on a missing member property, across single-property (`Property 'x' is missing …`) and multi-property (`… is missing the following properties …: a, b`) shapes, for named interfaces and distributive-conditional-rebuilt unions alike.

## Agent

AgentName: Studio-B

## Track
Conformance / diagnostic redisplay (solver relation-failure reasons).

## Invariant
Diagnostic semantics match `tsc` 6.0.2: a union-source assignment failure caused by a missing member property elaborates the first failing member beneath the `TS2322` line; assignability *decisions* are unchanged (the relation already failed — only the failure-reason structure is enriched). Solver owns the reason; checker owns rendering.

## Scope
- `crates/tsz-solver/src/relations/subtype/explain.rs` — extend the union-source elaboration allowlist from the three leaf reasons to also include the self-heading `MissingProperty` / `MissingProperties` reasons; rewrite the rationale comment.
- `crates/tsz-checker/tests/union_source_missing_property_elaboration_tests.rs` (new) + `crates/tsz-checker/Cargo.toml` registration.

No checker render-path changes; `UnionSourceMismatch` is already handled by `render_union_source_mismatch` / `nested_failure_display_types`.

## Project Corpus Impact
- Row: kysely-project
- Bug family: distributive-conditional / union-source missing-property redisplay (#10831)

Diagnostic-message-quality change (adds an elaboration line that `tsc` already emits; no new/removed error codes, no assignability outcome change). Targets the kysely-project row family (#10831) and any project row asserting union-source → object-target mismatches. No accepted-regression entries added or removed.

## Verification
- `cargo nextest run -p tsz-solver -E 'test(explain)'` → 28 passed, 0 failed (merged tree).
- `cargo nextest run -p tsz-checker -E 'binary(union_source_missing_property_elaboration_tests)'` → 5 passed (new regression suite).
- `cargo nextest run -p tsz-checker -E 'binary(ts2322_tests)'` → 284 passed; the 4 failures are pre-existing on the base branch (verified by stashing this change and re-running) and are unrelated (async-return / mapped-indexed-call / private-public-intersection).
- Spot-checked adjacent suites via `cargo nextest run -p tsz-checker -E 'binary(union_origin_display_tests) + binary(union_tuple_source_display_tests) + binary(object_union_assignability_fast_path_tests) + binary(ts2322_literal_source_display_tests) + binary(intersection_target_missing_property_elaboration_tests) + binary(property_chain_elaboration_collapse_tests)'` → all green.
- Differential vs `tsc` 6.0.2 on named-interface unions (single-missing, multi-missing, primitive-member, distributive-conditional-derived) → byte-exact match.
- `cargo clippy -p tsz-solver` → clean.
- Branch merged cleanly with latest `main` (no conflicts); ready-review CI owns the broad conformance/emit suites.

Tests vary binder/property/alias spellings and assert structurally on the elaboration text, so a name-keyed fix would not satisfy them (anti-hardcoding gate).

## Coordination Notes
Richer structural union-member reasons (`PropertyTypeMismatch`, tuple-element mismatches) remain on the bare-union path because the checker renderer does not emit a member header for them on this path; surfacing those would require a renderer change to emit the `Type 'M' is not assignable …` header for non-self-heading reasons — a follow-up, deliberately out of scope here to keep this change low-risk.

Refs #10831

https://claude.ai/code/session_01C3jmvtw49BLxssY4rV3WSZ