### PR TITLE
fix(checker): elaborate union-source tuple/property mismatches with member header

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -699,6 +699,10 @@ name = "union_source_missing_property_elaboration_tests"
 path = "tests/union_source_missing_property_elaboration_tests.rs"
 
 [[test]]
+name = "union_source_structural_elaboration_tests"
+path = "tests/union_source_structural_elaboration_tests.rs"
+
+[[test]]
 name = "ts2353_omit_pick_excess_property_tests"
 path = "tests/ts2353_omit_pick_excess_property_tests.rs"
 

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -864,6 +864,21 @@ impl<'a> CheckerState<'a> {
         diag
     }
 
+    /// Whether a failing union member's nested reason leads its elaboration
+    /// with a specialized line (`Type at position 0 …`, `Types of property
+    /// 'p' …`) instead of self-heading with `Type 'M' is not assignable to
+    /// type 'T'.`. Such reasons need an explicit member-type header emitted
+    /// before the structural drill; self-heading reasons (the property
+    /// `MissingProperty`/`MissingProperties` summaries) and plain leaf
+    /// relations already carry the member line themselves.
+    const fn union_member_nested_needs_header(reason: &tsz_solver::SubtypeFailureReason) -> bool {
+        matches!(
+            reason,
+            tsz_solver::SubtypeFailureReason::TupleElementTypeMismatch { .. }
+                | tsz_solver::SubtypeFailureReason::PropertyTypeMismatch { .. }
+        )
+    }
+
     /// Render a union-source mismatch: a union type that is not assignable to
     /// the target because one of its members fails.
     ///
@@ -875,8 +890,22 @@ impl<'a> CheckerState<'a> {
     ///   Type 'B' is not assignable to type 'T'.
     /// ```
     ///
-    /// The failing-member relation sits one indent level beneath the union
-    /// line, mirroring [`Self::render_type_argument_mismatch`].
+    /// When the member fails for a *structural* reason (a tuple element type
+    /// mismatch or an object property-type mismatch) tsc emits the member-type
+    /// header explicitly and then drills into the structural detail:
+    ///
+    /// ```text
+    /// Type 'A | B' is not assignable to type 'T'.
+    ///   Type 'B' is not assignable to type 'T'.
+    ///     Type at position 0 in source is not compatible with type at position 0 in target.
+    ///       Type 'number' is not assignable to type 'string'.
+    /// ```
+    ///
+    /// The structural renderers omit that header at depth >= 1 (they lead with
+    /// `Type at position N …` / `Types of property 'p' …`), so this path emits
+    /// it before recursing. Self-heading members (leaf relations, missing
+    /// property summaries) carry the member line themselves and are delegated
+    /// to [`Self::render_parent_with_child_relation`].
     pub(super) fn render_union_source_mismatch(
         &mut self,
         ctx: &RenderContext,
@@ -885,14 +914,82 @@ impl<'a> CheckerState<'a> {
         member_type: TypeId,
         nested_reason: &tsz_solver::SubtypeFailureReason,
     ) -> Diagnostic {
-        self.render_parent_with_child_relation(
-            ctx,
-            source_type,
-            target_type,
+        if !Self::union_member_nested_needs_header(nested_reason) {
+            return self.render_parent_with_child_relation(
+                ctx,
+                source_type,
+                target_type,
+                member_type,
+                target_type,
+                nested_reason,
+            );
+        }
+
+        let depth = ctx.depth;
+        // The member keeps its own alias (`C` stays `C`); the target keeps the
+        // diagnostic alias the rest of the chain uses (`A`), matching tsc for
+        // object/interface targets. (tsc additionally expands a *tuple* target
+        // alias to its structural form here, but tsz's shared formatter follows
+        // the tuple's lazy display alias; the chain shape, positions, and leaf
+        // relation are otherwise identical.) Format the target once; it heads
+        // both the (deep) outer union line and the member header below.
+        let target_str = self.format_type_diagnostic(target_type);
+
+        // Outer union line. At depth 0 it is the primary diagnostic, which
+        // reuses `render_type_mismatch` so the full union/alias surface is
+        // preserved; deeper, format the union/target pair structurally.
+        let mut diag = if depth == 0 {
+            self.render_type_mismatch(ctx)
+        } else {
+            let source_str = self.format_type_diagnostic(source_type);
+            let base = format_message(
+                diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+                &[&source_str, &target_str],
+            );
+            Diagnostic::error(
+                ctx.file_name.clone(),
+                ctx.start,
+                ctx.length,
+                base,
+                diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            )
+        };
+
+        if depth >= 5 {
+            return diag;
+        }
+
+        // The member header sits one indent beneath the union line; the
+        // structural drill sits one level beneath the header. At depth 0 the
+        // union line is the (un-indented) primary, so its first child is at
+        // related-depth 0.
+        let header_depth = if depth == 0 { 0 } else { depth + 1 };
+        let drill_depth = header_depth + 1;
+
+        let member_str = self.format_type_diagnostic(member_type);
+        diag.related_information.push(DiagnosticRelatedInformation {
+            file: diag.file.clone(),
+            start: ctx.start,
+            length: ctx.length,
+            message_text: format_message(
+                diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+                &[&member_str, &target_str],
+            ),
+            category: DiagnosticCategory::Message,
+            code: diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            depth: header_depth.min(u8::MAX as u32) as u8,
+        });
+
+        let nested_diag = self.render_failure_reason(
+            nested_reason,
             member_type,
             target_type,
-            nested_reason,
-        )
+            ctx.idx,
+            drill_depth,
+        );
+        Self::push_nested_chain(&mut diag, nested_diag, drill_depth);
+
+        diag
     }
 
     /// Render an outer `Type 'S' is not assignable to type 'T'.` line and

--- a/crates/tsz-checker/tests/union_source_structural_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/union_source_structural_elaboration_tests.rs
@@ -1,0 +1,243 @@
+//! Union-source *structural* elaboration (TS2322 + member header + drill).
+//!
+//! Structural rule: when a *union* value is assigned to a tuple or object
+//! target and the first failing member is rejected for a *structural* reason —
+//! a tuple element type mismatch or an object property-type mismatch — tsc
+//! keeps the top-level `Type 'A | B' is not assignable to type 'T'` (TS2322)
+//! and elaborates *which* member fails, leading with the member-type header and
+//! then drilling into the structural detail:
+//!
+//! ```text
+//! Type 'B' is not assignable to type 'A'.
+//!   Type '[id: number, count: number]' is not assignable to type '[id: string, count: number]'.
+//!     Type at position 0 in source is not compatible with type at position 0 in target.
+//!       Type 'number' is not assignable to type 'string'.
+//! ```
+//!
+//! ```text
+//! Type 'B' is not assignable to type 'A'.
+//!   Type '{ id: number; count: number; }' is not assignable to type 'A'.
+//!     Types of property 'id' are incompatible.
+//!       Type 'number' is not assignable to type 'string'.
+//! ```
+//!
+//! tsz previously surfaced union-source elaboration only for *self-heading*
+//! members (leaf relations and the `MissingProperty`/`MissingProperties`
+//! summaries); a member that failed structurally fell through to the bare
+//! top-level `Type 'A | B' is not assignable to type 'T'` line, hiding which
+//! member and which position/property was responsible. Routing tuple-element
+//! and property-type mismatches through `UnionSourceMismatch` with an explicit
+//! member header reproduces tsc's chain.
+//!
+//! These tests vary the binder names (alias/property spellings) so a fix keyed
+//! to a particular spelling would not satisfy them, and they assert
+//! structurally (the chain names the failing member, the position/property, and
+//! the leaf relation) rather than depending on exact type-printer rendering.
+
+use tsz_checker::test_utils::check_source_strict;
+use tsz_common::diagnostics::Diagnostic;
+
+fn diagnostics(source: &str) -> Vec<Diagnostic> {
+    check_source_strict(source)
+}
+
+/// Collect the nested elaboration lines (in chain order) of the first TS2322.
+fn ts2322_chain(diags: &[Diagnostic]) -> Vec<(u8, u32, String)> {
+    diags
+        .iter()
+        .find(|d| d.code == 2322)
+        .map(|d| {
+            d.related_information
+                .iter()
+                .map(|r| (r.depth, r.code, r.message_text.clone()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn chain_has<P: Fn(&str) -> bool>(chain: &[(u8, u32, String)], depth: u8, predicate: P) -> bool {
+    chain
+        .iter()
+        .any(|(d, _, msg)| *d == depth && predicate(msg))
+}
+
+/// Tuple union member failing on an element type mismatch elaborates the member
+/// header, the TS2626 positional line, and the leaf relation, each one indent
+/// deeper than the last.
+#[test]
+fn union_member_tuple_element_mismatch_emits_header_and_drill() {
+    let diags = diagnostics(
+        r#"
+type Target = [id: string, count: number];
+type Source = [id: number, count: number] | [id: string, count: string];
+declare const s: Source;
+const t: Target = s;
+"#,
+    );
+    let chain = ts2322_chain(&diags);
+    assert!(
+        chain_has(&chain, 0, |m| m.contains("is not assignable to type")
+            && m.contains("number")),
+        "expected a member-type header at depth 0 naming the failing tuple member; \
+         got {chain:?}"
+    );
+    assert!(
+        chain_has(&chain, 1, |m| m.contains("position 0")),
+        "expected the TS2626 positional line at depth 1; got {chain:?}"
+    );
+    assert!(
+        chain_has(&chain, 2, |m| m.contains("'number'")
+            && m.contains("'string'")
+            && m.contains("is not assignable")),
+        "expected the leaf element relation at depth 2; got {chain:?}"
+    );
+}
+
+/// Renamed binders: the same structural rule must hold with different alias and
+/// label spellings, so a name-hardcoded fix would not satisfy this.
+#[test]
+fn union_member_tuple_element_mismatch_renamed() {
+    let diags = diagnostics(
+        r#"
+type Row = [key: string, n: number];
+type Either = [key: boolean, n: number] | [key: string, n: boolean];
+declare const e: Either;
+const r: Row = e;
+"#,
+    );
+    let chain = ts2322_chain(&diags);
+    assert!(
+        chain_has(&chain, 0, |m| m.contains("is not assignable to type")),
+        "renamed tuple union should still emit a member header; got {chain:?}"
+    );
+    assert!(
+        chain_has(&chain, 1, |m| m.contains("position 0")),
+        "renamed tuple union should still emit the positional line; got {chain:?}"
+    );
+}
+
+/// Object union member failing on a property type mismatch elaborates the
+/// member header, the `Types of property 'p' are incompatible.` line, and the
+/// leaf relation.
+#[test]
+fn union_member_object_property_mismatch_emits_header_and_drill() {
+    let diags = diagnostics(
+        r#"
+type Target = { id: string; count: number };
+type Source = { id: number; count: number } | { id: string; count: string };
+declare const s: Source;
+const t: Target = s;
+"#,
+    );
+    let chain = ts2322_chain(&diags);
+    assert!(
+        chain_has(&chain, 0, |m| m.contains("is not assignable to type")
+            && m.contains("id")),
+        "expected a member-type header at depth 0 naming the failing object member; \
+         got {chain:?}"
+    );
+    assert!(
+        chain_has(&chain, 1, |m| m.contains("property 'id'")
+            && m.contains("incompatible")),
+        "expected the `Types of property 'id' are incompatible.` line at depth 1; \
+         got {chain:?}"
+    );
+    assert!(
+        chain_has(&chain, 2, |m| m.contains("'number'")
+            && m.contains("'string'")),
+        "expected the leaf property relation at depth 2; got {chain:?}"
+    );
+}
+
+/// Member selection matches `tsc`'s order-dependent rule: `tsc` (and tsz) pick
+/// the **first failing member in source order** and elaborate *that* member's
+/// position/leaf. The forward union (`[number, number] | [string, string]`)
+/// fails on its first member at position 0 (`number` -> `string`); the reversed
+/// union (`[string, string] | [number, number]`) fails on *its* first member at
+/// position 1 (`string` -> `number`). Asserting the concrete member type,
+/// position, and leaf relation per ordering proves the *right* member is
+/// selected (not merely that both chains share the TS2322/TS2626 shape, which
+/// would not catch a contradictory member pick).
+#[test]
+fn union_member_selection_matches_tsc_first_failing_member_per_order() {
+    let forward = ts2322_chain(&diagnostics(
+        r#"
+type Target = [id: string, count: number];
+type Source = [id: number, count: number] | [id: string, count: string];
+declare const s: Source;
+const t: Target = s;
+"#,
+    ));
+    // forward: first member `[id: number, count: number]`, position 0, number -> string
+    assert!(
+        chain_has(&forward, 0, |m| m.contains("number")) // member header names the number-keyed member
+            && chain_has(&forward, 1, |m| m.contains("position 0"))
+            && chain_has(&forward, 2, |m| m.contains("'number'") && m.contains("'string'")),
+        "forward union should select its first failing member at position 0 \
+         (number -> string); got {forward:?}"
+    );
+
+    let reversed = ts2322_chain(&diagnostics(
+        r#"
+type Target = [id: string, count: number];
+type Source = [id: string, count: string] | [id: number, count: number];
+declare const s: Source;
+const t: Target = s;
+"#,
+    ));
+    // reversed: first member `[id: string, count: string]`, position 1, string -> number
+    assert!(
+        chain_has(&reversed, 1, |m| m.contains("position 1"))
+            && chain_has(&reversed, 2, |m| m.contains("'string'")
+                && m.contains("'number'")),
+        "reversed union should select its first failing member at position 1 \
+         (string -> number); got {reversed:?}"
+    );
+}
+
+/// Determinism: the same union, checked twice, must produce a byte-identical
+/// elaboration chain. This is the actual anti-"contradictory" guarantee — the
+/// failing member/position/leaf must not alternate across runs due to traversal
+/// or cache-insertion order (the `checker-23-20` symptom).
+#[test]
+fn union_member_elaboration_is_deterministic_across_runs() {
+    let source = r#"
+type Target = [id: string, count: number];
+type Source = [id: number, count: number] | [id: string, count: string];
+declare const s: Source;
+const t: Target = s;
+"#;
+    let first = ts2322_chain(&diagnostics(source));
+    let second = ts2322_chain(&diagnostics(source));
+    assert!(
+        !first.is_empty(),
+        "expected an elaboration chain; got {first:?}"
+    );
+    assert_eq!(
+        first, second,
+        "the same union must elaborate an identical chain across runs \
+         (stable, non-contradictory member selection); \
+         first={first:?} second={second:?}"
+    );
+}
+
+/// Self-heading members are unchanged: a missing-property union member keeps the
+/// bare `Property 'a' is missing ...` elaboration with no spurious member header.
+#[test]
+fn union_member_missing_property_unchanged() {
+    let diags = diagnostics(
+        r#"
+interface Target { a: 1 }
+interface Other { b: 2 }
+declare const u: Target | Other;
+const v: Target = u;
+"#,
+    );
+    let chain = ts2322_chain(&diags);
+    assert!(
+        chain_has(&chain, 0, |m| m.contains("Property 'a' is missing")
+            && m.contains("but required in type")),
+        "missing-property union member should keep its self-heading elaboration \
+         with no extra member header; got {chain:?}"
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -828,18 +828,25 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     continue;
                 }
                 // Elaborate the first failing member beneath the union-to-target
-                // line, mirroring tsc which always drills into that member. Only
-                // *self-heading* reasons are surfaced: leaf relations
-                // (`undefined`/literal/intrinsic mismatch) and the property
-                // reasons (`MissingProperty`/`MissingProperties`), whose rendered
-                // message already names the member type (`Property 'a' is missing
-                // in type '{ b: 2; }' …` / `Type '{ c: 3; }' is missing the
-                // following properties …`). They need no extra `Type 'M' is not
-                // assignable …` header, so `UnionSourceMismatch` reproduces tsc's
-                // chain exactly. Richer structural reasons (property-type/tuple
-                // element mismatches) do require that header, which the renderer
-                // does not emit on this path, so they fall through to the bare
-                // union line rather than a mis-indented chain.
+                // line, mirroring tsc which always drills into that member. Two
+                // shapes are surfaced:
+                //
+                // * *Self-heading* reasons — leaf relations
+                //   (`undefined`/literal/intrinsic mismatch) and the property
+                //   reasons (`MissingProperty`/`MissingProperties`), whose
+                //   rendered message already names the member type
+                //   (`Property 'a' is missing in type '{ b: 2; }' …` /
+                //   `Type '{ c: 3; }' is missing the following properties …`).
+                //   They need no extra `Type 'M' is not assignable …` header.
+                //
+                // * *Header-led* structural reasons — tuple element type
+                //   mismatches and object property-type mismatches. tsc leads
+                //   their elaboration with an explicit
+                //   `Type 'M' is not assignable to type 'T'.` member header and
+                //   then drills (`Type at position 0 …` / `Types of property
+                //   'p' …`). The union-source renderer emits that header so the
+                //   chain stays correctly indented instead of collapsing to the
+                //   bare union line.
                 let nested = self.explain_failure_guarded(member, target);
                 if let Some(nested) = nested
                     && matches!(
@@ -849,6 +856,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                             | SubtypeFailureReason::LiteralTypeMismatch { .. }
                             | SubtypeFailureReason::MissingProperty { .. }
                             | SubtypeFailureReason::MissingProperties { .. }
+                            | SubtypeFailureReason::TupleElementTypeMismatch { .. }
+                            | SubtypeFailureReason::PropertyTypeMismatch { .. }
                     )
                 {
                     return Some(SubtypeFailureReason::UnionSourceMismatch {


### PR DESCRIPTION
## Agent

AgentName: M1-B
Track: checker / diagnostics (M1-B row witnesses)
Closes / Refs: #11582 (canonical tracker for `checker-23-20`: contradictory/dropped tuple diagnostics across equivalent unions)

_Body normalized to the canonical M1-B lane per review; implemented in session `Claude-UnionElab`._

## Invariant

`tsc` parity for the **union-source structural elaboration** of TS2322. When a union value is assigned to a tuple or object target and the first failing member is rejected for a *structural* reason — a tuple element type mismatch or an object property-type mismatch — `tsc` keeps the top-level `Type 'A | B' is not assignable to type 'T'.` (TS2322) and elaborates *which* member fails, leading with the member-type header and then drilling into the structural detail.

Member selection follows `tsc`'s **order-dependent** rule: the **first failing member in the union's member order** is elaborated (verified against `tsc` 6.0.2 — forward `[number,number] | [string,string]` reports the first member at position 0, the reversed spelling reports *its* first member at position 1). tsz selects from the interned union member order **deterministically**, so the same union always yields an identical chain across runs — eliminating the flaky/alternating member pick that is the `checker-23-20` "contradictory across equivalent unions" symptom.

## Structural rule

When `S <: T` fails, `S` is a union, and the first failing member `M` is rejected by a tuple-element or object-property *type* mismatch, `tsc` reports:

```
Type 'B' is not assignable to type 'A'.
  Type '[id: number, count: number]' is not assignable to type '[id: string, count: number]'.
    Type at position 0 in source is not compatible with type at position 0 in target.
      Type 'number' is not assignable to type 'string'.
```
```
Type 'B' is not assignable to type 'A'.
  Type '{ id: number; count: number; }' is not assignable to type 'A'.
    Types of property 'id' are incompatible.
      Type 'number' is not assignable to type 'string'.
```

tsz previously surfaced union-source elaboration only for *self-heading* members (leaf relations and the `MissingProperty`/`MissingProperties` summaries) and dropped the elaboration for structural members, stopping at the bare union line.

## Owner layer

- **solver `relations/subtype/explain.rs`** decides the failing-member reason: `TupleElementTypeMismatch` and `PropertyTypeMismatch` members are now surfaced through `UnionSourceMismatch` (previously they fell through to the bare `TypeMismatch`).
- **checker `error_reporter/render_failure/.../render_union_source_mismatch`** emits the explicit `Type 'M' is not assignable to type 'T'.` member header before recursing into the structural drill — the structural renderers omit that header at depth ≥ 1 (they lead with `Type at position N …` / `Types of property 'p' …`).

No checker-side type logic, no user-name/fixture/printer-string heuristics. The top-level TS2322 code/message/span are unchanged; only `related_information` gains the member header + drill.

## Scope

- **In scope:** tuple-element and object-property *type* mismatches in union members (the two structural shapes the row witnesses exercise).
- **Out of scope:** tuple **length** mismatch elaboration (TS2618/TS2619), owned by in-flight PR #12201; array-element members (they expose a separate pre-existing depth quirk in the shared parent/child renderer, left for a focused follow-up). One known minor display nuance: `tsc` additionally expands a *tuple* target alias to its structural form in the member header (`[id: string, count: number]`) while tsz keeps the diagnostic alias (`A`); the chain shape, codes, positions, and leaf relation are identical, and the **object case matches `tsc` exactly**. Expanding the tuple alias requires a deeper shared-formatter change (the formatter follows the tuple's lazy display alias).

## Adjacent-case matrix (new tests)

`crates/tsz-checker/tests/union_source_structural_elaboration_tests.rs`:
- tuple element mismatch → member header + TS2626 positional + leaf
- tuple element mismatch with **renamed** binders/labels (guards against a spelling fix)
- object property mismatch → member header + `Types of property` + leaf
- **member selection** matches `tsc`'s first-failing-member-in-order rule: forward asserts the number-keyed member / position 0 / `number`→`string`; reversed asserts position 1 / `string`→`number` (proves the *specific* member/position/leaf is selected, not merely a matching TS2322/TS2626 shape)
- **determinism**: the same union elaborates a byte-identical chain across runs (the real anti-"contradictory" guarantee)
- self-heading (`MissingProperty`) member **unchanged** (no spurious header)

## Project Corpus Impact

- Row: nextjs (#11582 canonical; consolidated row witnesses #10954/#10997/#11040/#11082/#11124/#11166/#11208/#11250/#11294/#11481)
- Bug family: checker-23-20 (union-source structural elaboration; dropped/contradictory tuple diagnostics across equivalent unions)

Diagnostic comparison is by error **code** and per-diagnostic **fingerprint** (code + location + normalized *main* message); the elaboration `related_information` chain is not part of the fingerprint. This change adds only `related_information` to the existing TS2322 (top-level code/message/span unchanged), so project-row fingerprints are unaffected while the rendered chain now matches `tsc`'s shape.

## Verification

- New suite `union_source_structural_elaboration_tests` (6 tests) passes.
- No regression in `union_source_missing_property_elaboration_tests`, `tuple_element_mismatch_tests`, `union_tuple_source_display_tests`, `object_union_assignability_fast_path_tests`, `tuple_union_contextual_typing_tests`.
- Ground truth captured from `tsc` 6.0.2 for tuple/object/array/length and forward/reversed-order shapes.
- `cargo fmt --check`, `python3 scripts/arch/arch_guard.py` pass.
- Rebased on refreshed `origin/main` (`bd0facd`); no conflicts. (A handful of unrelated `ts2322_tests` assertions fail *locally* with `TS2304 Cannot find name 'Error'` because the standard lib is not loaded in this sandbox's `compile_with_options`; they fail identically on clean `main` with and without this change and are not touched by it.)

## Coordination Notes

- Non-overlapping with #12201 (tuple length TS2618/TS2619) — that family is explicitly left out of scope.
- #11582 is the canonical M1-B tracker consolidating row witnesses; the shared explain/render path means those rows share this fix.
- GitHub auto-merge left disabled per review; landing through the repo-local `merge-queue` once the body gate, GitGuardian, fast gates, and `CI Summary` are green on the exact refreshed head.

https://claude.ai/code/session_01D5SHKqqXHzXphsN1iaD98T