### PR TITLE
perf(checker): skip any constraints for type args

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
@@ -108,6 +108,9 @@ impl<'a> CheckerState<'a> {
 
                 if let Some(&arg_idx) = type_args_list.nodes.get(i) {
                     let constraint_resolved = self.resolve_lazy_type(constraint);
+                    if constraint_resolved == TypeId::ANY {
+                        continue;
+                    }
                     if self.required_mapped_constraint_source_is_required_and_arg_satisfies(
                         type_arg,
                         constraint_resolved,


### PR DESCRIPTION
## Agent
AgentName: MBMB4-Canary-B

## Track
Studio-B / Track 10 performance, ts-toolbelt project canary

## Invariant
When an explicit type parameter constraint resolves exactly to `any`, the checker should accept that type argument without running the later constraint relation/evaluation path. Earlier cascade guards for error, arity, value-as-type, and `this` still run before this fast path.

## Scope
- One checker change in `generic_checker::constraint_validation`.
- No solver, binder, emitter, or diagnostic formatting changes.

## Project Corpus Impact
- Row: `ts-toolbelt-project`
- Bug family: performance / `any`-constrained type argument validation
- Evidence: quick row improved from baseline `tsz_ms=3007.61`, `tsgo_ms=108.71`, tsgo `27.67x` faster to minimal-patch `tsz_ms=1144.26`, `tsgo_ms=108.33`, tsgo `10.56x` faster. Perf counters on the same project moved `Check` from `3.08s` to `1.06s`; the previous slowest type-alias phase `List/Update.ts` / `Update` body dropped from `1789.82ms` and no longer appears in the top hotspots, with current slowest body phase `Object/Exclude.ts` / `Exclude` at `30.19ms`. Diagnostics stayed at 0.

## Verification
- `cargo fmt --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test ts2344_keyof_bare_tparam_defer_tests --test lib_merge_indexed_access_no_cascade_tests --test ts2344_any_key_mapped_constraint_tests --test ts2344_generic_ref_scoped_param_concrete_constraint -- --skip test_computed_unique_prefix_property_stays_string_key`
- `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter 'ts-toolbelt-project' --json-file /tmp/mbmb4-ts-toolbelt-any-minimal-post.json`
- `scripts/safe-run.sh env TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 .target-perf-tools/dist/tsz --extendedDiagnostics --perf-counters-json /tmp/mbmb4-ts-toolbelt-any-minimal-post.perf.json --diagnostics-json /tmp/mbmb4-ts-toolbelt-any-minimal-post.diag.json --noEmit -p .target-bench/external/ts-toolbelt/tsconfig.flat.json`
- `python3 scripts/perf/query-perf-counters.py --json /tmp/mbmb4-ts-toolbelt-any-minimal-post.perf.json --baseline /tmp/mbmb4-ts-toolbelt-baseline.perf.json`

Note: `test_computed_unique_prefix_property_stays_string_key` is skipped because it already fails on clean `main` in `/Users/mohsen/code/tsz` with the same exact-test command; it is not introduced by this branch.

## Coordination Notes
- Owned PR runway was drained before this branch.
- Marked ready for CI/review after rebasing on `origin/main` at `bd0facd7610`.
- Follow-up performance work can target the new ts-toolbelt hotspots (`Number/Add.ts`, `Function/ValidPath.ts`, async compose/pipe bodies).