### PR TITLE
perf(checker): skip signature-only alias validation walks

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1991,6 +1991,10 @@ name = "type_literal_method_overload_tests"
 path = "tests/type_literal_method_overload_tests.rs"
 
 [[test]]
+name = "type_alias_signature_body_validation_tests"
+path = "tests/type_alias_signature_body_validation_tests.rs"
+
+[[test]]
 name = "overload_modifier_tests"
 path = "tests/overload_modifier_tests.rs"
 

--- a/crates/tsz-checker/src/types/type_checking/type_alias_body_validation.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_body_validation.rs
@@ -2,10 +2,56 @@
 
 use crate::state::CheckerState;
 use crate::state_type_analysis::cross_file_direct::is_builtin_lib_declaration_arena;
-use tsz_parser::parser::NodeIndex;
-use tsz_parser::parser::syntax_kind_ext;
+use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 
 impl<'a> CheckerState<'a> {
+    /// Validate the diagnostics not covered by type-literal construction and
+    /// return whether the normal alias-body validation walk can be skipped.
+    pub(crate) fn validate_signature_only_type_literal_alias_body(
+        &mut self,
+        type_node_idx: NodeIndex,
+    ) -> bool {
+        let Some(type_node) = self.ctx.arena.get(type_node_idx) else {
+            return false;
+        };
+        if type_node.kind != syntax_kind_ext::TYPE_LITERAL {
+            return false;
+        }
+        let Some(type_lit) = self.ctx.arena.get_type_literal(type_node) else {
+            return false;
+        };
+        if type_lit.members.nodes.is_empty() {
+            return false;
+        }
+
+        let members = type_lit.members.nodes.clone();
+        if !members.iter().copied().all(|member_idx| {
+            self.ctx.arena.get(member_idx).is_some_and(|member| {
+                member.kind == syntax_kind_ext::CALL_SIGNATURE
+                    || member.kind == syntax_kind_ext::CONSTRUCT_SIGNATURE
+            })
+        }) {
+            return false;
+        }
+
+        for member_idx in members {
+            let Some(member_node) = self.ctx.arena.get(member_idx) else {
+                continue;
+            };
+            let Some(signature) = self.ctx.arena.get_signature(member_node) else {
+                continue;
+            };
+            if let Some(parameters) = &signature.parameters {
+                let (_type_params, type_param_updates) =
+                    self.push_type_parameters(&signature.type_parameters);
+                self.check_rest_parameter_types(&parameters.nodes);
+                self.pop_type_parameters(type_param_updates);
+            }
+        }
+
+        true
+    }
+
     pub(crate) fn check_explicit_type_reference_for_alias_body_validation(
         &mut self,
         ref_idx: NodeIndex,

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -531,7 +531,7 @@ impl<'a> CheckerState<'a> {
             {
                 let _ = self.get_type_from_type_literal(alias.type_node);
             }
-        } else {
+        } else if !self.validate_signature_only_type_literal_alias_body(alias.type_node) {
             self.check_type_node(alias.type_node);
             if !self.type_alias_body_missing_names_covered_by_type_node_checking(alias.type_node) {
                 self.check_type_alias_body_for_missing_names_after_type_node_check(alias.type_node);

--- a/crates/tsz-checker/tests/type_alias_signature_body_validation_tests.rs
+++ b/crates/tsz-checker/tests/type_alias_signature_body_validation_tests.rs
@@ -1,0 +1,59 @@
+//! Guards for type-alias bodies whose type literal contains only signatures.
+
+use tsz_checker::test_utils::check_source_code_messages;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_code_messages(source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect()
+}
+
+#[test]
+fn signature_only_type_literal_alias_reports_rest_parameter_type_error() {
+    let diagnostics = codes(
+        r#"
+type Callable = {
+    (...args: string): void;
+};
+"#,
+    );
+
+    assert!(
+        diagnostics.contains(&2370),
+        "expected TS2370 for rest parameter in call signature, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn signature_only_type_literal_alias_reports_missing_type_names() {
+    let diagnostics = codes(
+        r#"
+type Callable = {
+    <Item>(value: MissingBox<Item>): Item;
+};
+"#,
+    );
+
+    assert!(
+        diagnostics.contains(&2304),
+        "expected TS2304 for missing type in call signature, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn signature_only_type_literal_alias_reports_type_argument_constraint_errors() {
+    let diagnostics = codes(
+        r#"
+type Box<Item extends string> = Item;
+type Callable = {
+    (value: Box<number>): void;
+};
+"#,
+    );
+
+    assert!(
+        diagnostics.contains(&2344),
+        "expected TS2344 for constrained type argument in call signature, got {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: MBMB4-Canary-B

## Track
Track 10 green-row performance; checker body-validation hot path.

## Invariant
When a type alias body is a type literal containing only call/construct signatures, type-literal construction already resolves signature type parameters, parameter annotations, and return annotations through checker/type-literal lowering. This PR keeps residual rest-parameter diagnostics in checker body validation, then skips the duplicate recursive type-node validation walk for that structural shape.

## Scope
- `crates/tsz-checker/src/types/type_checking/type_alias_body_validation.rs`
- `crates/tsz-checker/src/types/type_checking/type_alias_checking.rs`
- `crates/tsz-checker/tests/type_alias_signature_body_validation_tests.rs`
- `crates/tsz-checker/Cargo.toml`

## Project Corpus Impact
- Row: `ts-toolbelt-project`
- Bug family: overload-heavy signature-only type aliases spending duplicate checker time in alias `body_validation`; also fixes missing TS2370 for rest parameters in type-literal call signatures.
- Evidence: quick row improved from baseline `tsz_ms=1152.63`, `tsgo_ms=110.92`, gap `10.39x` to `/tmp/mbmb4-ts-toolbelt-signature-skip.json` `tsz_ms=972.97`, `tsgo_ms=109.00`, gap `8.93x`.
- Counter evidence: `/tmp/mbmb4-ts-toolbelt-signature-skip.perf.json` reports `Errors: 0`, `Check: 0.90s` versus baseline `Check: 1.09s`; prior Compose/Pipe signature aliases no longer appear in the slowest alias phase list.

## Verification
- `cargo fmt --package tsz-checker`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test type_alias_signature_body_validation_tests --test type_literal_method_overload_tests --test missing_name_type_parameter_reference_tests`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter 'ts-toolbelt-project' --json-file /tmp/mbmb4-ts-toolbelt-signature-skip.json --rebuild`
- `scripts/safe-run.sh env CARGO_TARGET_DIR=.target-perf-tools cargo build --profile dist -p tsz-cli --bin tsz --features perf-tools`
- `scripts/safe-run.sh env TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 .target-perf-tools/dist/tsz --extendedDiagnostics --perf-counters-json /tmp/mbmb4-ts-toolbelt-signature-skip.perf.json --diagnostics-json /tmp/mbmb4-ts-toolbelt-signature-skip.diag.json --noEmit -p .target-bench/external/ts-toolbelt/tsconfig.flat.json`

## Coordination Notes
- Open PRs inspected before publish; no owned `agent:Studio-B` PRs were open.
- `scripts/agents/ensure-agent-labels.sh --audit` passed before publish.
- Ownership label: `agent:Studio-B`.
- No solver, emitter, LSP, or project-fixture changes.
- Ready for PR-head CI/review; do not queue until exact-head checks pass.
