### PR TITLE
fix(checker): resolve Lazy alias index types before element-access query (#10669)

### DIFF
--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -189,7 +189,21 @@ impl<'a> CheckerState<'a> {
             // Numeric enum values are number-like at runtime.
             TypeId::NUMBER
         } else {
-            index_type
+            // Resolve `Lazy(DefId)` alias references on the index type before the
+            // solver query. The solver's element-access evaluator is
+            // resolver-less, so an index whose type is (or contains) a type-alias
+            // reference never matches the receiver's concrete keys and silently
+            // falls through to `undefined`. This surfaces as false TS2532/TS2722/
+            // TS18048 on `obj[expr]` whenever `expr`'s type is an alias — most
+            // commonly a property access of an alias-typed property
+            // (`obj[node.kind]` where `kind: SomeUnionAlias`), since a property
+            // read keeps the alias form while a plain variable read arrives
+            // already resolved. Resolve the top-level alias and any aliased union
+            // members here, mirroring `resolve_lazy_members_in_union` used for
+            // relation queries.
+            let resolved = self.resolve_lazy_type(index_type);
+            let resolved = self.evaluate_application_type(resolved);
+            self.resolve_lazy_members_in_union(resolved)
         };
 
         self.ctx

--- a/crates/tsz-checker/src/types/computation/tests/access.rs
+++ b/crates/tsz-checker/src/types/computation/tests/access.rs
@@ -200,3 +200,117 @@ value["size"];
         "Expected TS2576 for inherited static field and accessor element access, got: {errors:?}"
     );
 }
+
+// Regression: `obj[expr]` where the index expression's type is a `Lazy(DefId)`
+// type-alias reference must resolve the alias before the solver's resolver-less
+// element-access query. Otherwise the index never matches the receiver's keys and
+// the result silently gains `| undefined`, producing false TS2532/TS2722/TS18048
+// (and the resulting TS2322 against a non-nullable annotation). This reproduced in
+// kysely's dispatch-table / priority-table patterns (issue #10669): the key is a
+// *property access of an alias-typed property* (`node.kind` where
+// `kind: SomeUnionAlias`), which keeps the alias form, unlike a plain variable
+// read which arrives already resolved.
+
+#[test]
+fn element_access_alias_typed_property_index_no_false_undefined() {
+    // Record indexed by a property whose declared type is a union alias, plus the
+    // dispatch-table shape via `this[...]`. Binder names are deliberately varied to
+    // keep the rule name-agnostic.
+    let diags = check_source_with_default_libs(
+        r#"
+type Selector = 'alpha' | 'beta' | 'gamma';
+interface Carrier { tag: Selector; }
+
+declare const handlers: Record<Selector, (c: Carrier) => Carrier>;
+declare const carrier: Carrier;
+const transformed: Carrier = handlers[carrier.tag](carrier);
+
+type Priority = 'low' | 'high';
+declare const ranks: Record<Priority, number>;
+declare const entry: { level: Priority };
+const rank: number = ranks[entry.level];
+const ranked = ranks[entry.level] + 1;
+
+declare const plainObj: { alpha: 1; beta: 2; gamma: 3 };
+const plainValue: 1 | 2 | 3 = plainObj[carrier.tag];
+
+class Dispatcher {
+    routes: Record<Selector, () => number> = {
+        alpha: () => 1,
+        beta: () => 2,
+        gamma: () => 3,
+    };
+    run(c: Carrier): number {
+        return this.routes[c.tag]();
+    }
+}
+"#,
+    );
+    let errors = semantic_errors(&diags);
+    assert!(
+        errors.is_empty(),
+        "alias-typed property index must not introduce spurious `| undefined`; got: {errors:?}"
+    );
+}
+
+#[test]
+fn element_access_union_of_aliases_property_index_no_false_undefined() {
+    // The index type is a union whose members are themselves alias references.
+    let diags = check_source_with_default_libs(
+        r#"
+type Left = 'one' | 'two';
+type Right = 'three';
+type Combined = Left | Right;
+
+declare const lookup: Record<Combined, number>;
+declare const holder: { key: Combined };
+const picked: number = lookup[holder.key];
+"#,
+    );
+    let errors = semantic_errors(&diags);
+    assert!(
+        errors.is_empty(),
+        "union-of-aliases property index must not introduce spurious `| undefined`; got: {errors:?}"
+    );
+}
+
+#[test]
+fn element_access_alias_index_through_string_index_signature_resolves() {
+    // A `string`-alias index must still resolve through a string index signature
+    // to the value type rather than collapsing to a false `undefined` result.
+    let diags = check_source_with_default_libs(
+        r#"
+type Name = string;
+declare const dict: { [k: string]: number };
+declare const named: { id: Name };
+const value: number = dict[named.id];
+"#,
+    );
+    let errors = semantic_errors(&diags);
+    assert!(
+        errors.is_empty(),
+        "string-alias index through an index signature must resolve to the value type; got: {errors:?}"
+    );
+}
+
+#[test]
+fn element_access_optional_mapped_alias_index_keeps_optional_undefined() {
+    // Negative guard: resolving the alias index must NOT mask legitimate
+    // `| undefined` introduced by an optional member. tsc rejects assigning the
+    // optional member value to a non-nullable annotation here (TS2322). Uses an
+    // inline optional mapped type so the test does not depend on lib utilities.
+    let diags = check_source_with_default_libs(
+        r#"
+type Slot = 'x' | 'y' | 'z';
+type OptMap = { [K in Slot]?: number };
+declare const optional: OptMap;
+declare const holder: { slot: Slot };
+const value: number = optional[holder.slot];
+"#,
+    );
+    let errors = semantic_errors(&diags);
+    assert!(
+        has_code(&diags, 2322),
+        "optional mapped alias index must still surface the optional `| undefined` (TS2322); got: {errors:?}"
+    );
+}


### PR DESCRIPTION
AgentName: Studio-A

## Track
Checker / strictNullChecks indexed-access fidelity

**Closes:** #10669 (indexed-access root cause; the separate CFA witness in that thread was already fixed on `main` per #11997)

## Invariant
When the index expression of an element access `obj[expr]` has a type that is (or contains) an unresolved `Lazy(DefId)` type-alias reference, `tsc` resolves it to its concrete key type before indexing, so the access hits the receiver's known properties and does **not** gain a spurious `| undefined`. `tsz` must do the same in the checker, because the solver's element-access evaluator is **resolver-less by design** -- DefId->TypeId resolution is the checker's responsibility.

## Structural rule
`When an element-access index type is (or contains) a Lazy(DefId) alias reference, tsc resolves it to its concrete key type before indexing; tsz does X through the checker pre-resolving the index at the get_element_access_type -> resolve_element_access_type boundary.`

Before the solver query, the checker now resolves the top-level alias (`resolve_lazy_type`), evaluates any application revealed by that resolution (`evaluate_application_type`), and resolves aliased union members (`resolve_lazy_members_in_union`) -- the same checker->solver pre-resolution idiom already used for call resolution (`call/mod.rs`). The object/receiver type was already pre-resolved this way; this makes the index symmetric.

## Why kysely-only / why naive reductions passed
A plain variable read of an alias-typed value (`let m: K; obj[m]`) and an inline union key both arrive **already resolved**, so they worked. The failure needs the key to be a **property access of an alias-typed property** (`obj[node.kind]` where `kind: SomeUnionAlias`), which keeps the `Lazy` form -- precisely kysely's dispatch-table / priority-table pattern.

## Scope
Owner layer: **checker** (`crates/tsz-checker/src/types/computation/access_helpers.rs`, `get_element_access_type`). No solver change -- the resolver-less solver is intentional. Name-agnostic and broad.

Adjacent-case matrix (all verified vs `tsc`):
- `Record<K, V>` indexed by an alias-typed property access -> was false TS2722/TS2532, now clean.
- Plain object type indexed by an alias-typed property -> clean.
- Dispatch table via `this[node.kind]()` -> was false TS2722, now clean.
- Union-of-aliases index (`K1 | K2` aliases) -> clean.
- String-alias index through a `[k: string]` index signature -> resolves to the value type (was false `undefined`).
- **Negative guard:** optional member (`{ [K in S]?: V }`) still surfaces `| undefined` (TS2322) -- resolution must not mask legitimate optionality.

## Project Corpus Impact
- Row: kysely-project
- Bug family: strictNullChecks-indexed-access-false-positive (TS2532/TS2722/TS18048)

Targets the `kysely-project` row (false TS2722/TS2532/TS18048 family). The fix removes spurious `| undefined` on alias-keyed indexed access across rows generally; the optional/index-signature negative guards ensure no legitimate `| undefined` is dropped. No fixture-name fast paths.

## Verification
- New regression tests (varied binder names; positive matrix + negative guard): `cargo test -p tsz-checker --lib element_access_` -> 21 passed, 0 failed.
- `cargo fmt -p tsz-checker --check` -> clean.
- Manual `tsz` vs `tsc 5.x` on the reduced repros: previously-false TS2722/TS2532/TS18048/TS2322 are gone; `tsc`-clean cases stay clean and `tsc`-error cases (optional member) still error identically.
- Full `tsz-checker` lib suite run for broad regression confirmation; ready-review CI owns the broad conformance/emit suites.

## Coordination Notes
- Canonical owner is `Studio-A`, matching the owning issue label on #10669.
- Runner identity: `brave-volta`.
- Row tracker: #10663. The 5th diagnostic in #10669 (`mysql-introspector.ts(93)` TS18048) was a distinct control-flow bug already fixed on `main` and covered by #11997 -- out of scope here.
- No anti-hardcoding violations claimed by the implementation: no user-name/file-name literals, no formatted-message predicates; built-in resolution goes through existing checker DefId-resolution helpers.

Signed: Studio-A
