### PR TITLE
perf(bench): cache project file-list discovery across row-mode invocations

### DIFF
--- a/scripts/bench/project-file-stats.mjs
+++ b/scripts/bench/project-file-stats.mjs
@@ -7,10 +7,18 @@
 //
 // Performance contract: when the same tsconfig is used across multiple
 // invocations within a single bench run (the project-row harness pattern),
-// unchanged files must not be re-opened or re-read. Set the
+// unchanged files must not be re-opened or re-read, AND the project file list
+// must not be re-discovered by re-walking the whole source tree. Set the
 // `TSZ_PROJECT_FILE_STATS_CACHE_DIR` env var (a writable directory) to enable
-// the on-disk cache. The cache key is the absolute tsconfig path; cache
-// entries are invalidated per file by `(mtime_ns, size)`.
+// the on-disk cache. The cache key is the absolute tsconfig path. Two layers
+// are cached:
+//   1. The resolved project file list (the recursive `include`/`exclude`
+//      directory walk done by TypeScript's `parseJsonConfigFileContent`).
+//      Invalidated by the tsconfig's own `(mtime_ns, size)` and by the
+//      `mtime_ns` of every directory that spans the resolved files, so a file
+//      added/removed/renamed anywhere in the tree re-triggers discovery while
+//      an unchanged tree skips loading TypeScript entirely.
+//   2. Per-file line counts, invalidated per file by `(mtime_ns, size)`.
 
 import fs from "node:fs";
 import path from "node:path";
@@ -224,12 +232,131 @@ export function resolveCachePath(tsconfigAbsolutePath) {
   return path.join(cacheDir, cacheKeyForTsconfig(tsconfigAbsolutePath) + ".json");
 }
 
-export function computeProjectFileStats(tsconfigAbsolutePath) {
-  const files = resolveTsconfigFiles(tsconfigAbsolutePath);
+// True when `child` is `parent` itself or nested somewhere beneath it. Uses a
+// relative-path probe so it is robust to mixed separators and trailing
+// slashes without touching the filesystem.
+function isPathUnder(child, parent) {
+  const relative = path.relative(parent, child);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+// The set of directories whose `mtime` governs whether the resolved file list
+// is still current: the parent directory of every file, plus — for files that
+// live under the tsconfig directory — every intermediate directory up to and
+// including the tsconfig directory. A file added, removed, or renamed in any
+// of these directories bumps that directory's `mtime`, which lets us detect a
+// stale file list without re-walking the tree. Returned sorted for stable
+// cache contents.
+export function contributingDirectories(files, rootDir) {
+  const root = path.resolve(rootDir);
+  const dirs = new Set();
+  for (const file of files) {
+    let dir = path.dirname(path.resolve(file));
+    dirs.add(dir);
+    // Walk up to `root` for in-tree files; `root` itself is added by the loop
+    // when descending from a deeper file, or by the `dirs.add(dir)` above when
+    // the file sits directly in it.
+    if (isPathUnder(dir, root)) {
+      while (dir !== root) {
+        const parent = path.dirname(dir);
+        if (parent === dir) break; // reached the filesystem root
+        dir = parent;
+        dirs.add(dir);
+      }
+    }
+  }
+  return [...dirs].sort();
+}
+
+// Stat every directory in `dirs` and return a `{ dir: mtimeNs }` map, or `null`
+// if any directory cannot be stat'd (a vanished directory means the file list
+// is stale and must be re-resolved).
+export function directoryFingerprint(dirs) {
+  const fingerprint = {};
+  for (const dir of dirs) {
+    let stat;
+    try {
+      stat = fs.statSync(dir);
+    } catch {
+      return null;
+    }
+    fingerprint[dir] = mtimeNsKey(stat);
+  }
+  return fingerprint;
+}
+
+// True when the cached file list is still valid: the tsconfig's own
+// `(mtimeNs, size)` is unchanged (catches `include`/`exclude`/config edits) and
+// every recorded directory `mtime` is unchanged (catches file additions,
+// removals, and renames anywhere the file list spans).
+export function fileListCacheValid(cache, tsconfigAbsolutePath) {
+  const fileList = cache && cache.fileList;
+  if (!fileList || !fileList.tsconfig || !fileList.dirs || !Array.isArray(fileList.files)) {
+    return false;
+  }
+  let tsconfigStat;
+  try {
+    tsconfigStat = fs.statSync(tsconfigAbsolutePath);
+  } catch {
+    return false;
+  }
+  if (
+    fileList.tsconfig.size !== tsconfigStat.size ||
+    fileList.tsconfig.mtimeNs !== mtimeNsKey(tsconfigStat)
+  ) {
+    return false;
+  }
+  // Re-stat the recorded directories through the same helper used to build the
+  // fingerprint, so the stat-and-compare logic lives in exactly one place.
+  const current = directoryFingerprint(Object.keys(fileList.dirs));
+  if (current === null) return false;
+  for (const [dir, mtimeNs] of Object.entries(fileList.dirs)) {
+    if (current[dir] !== mtimeNs) return false;
+  }
+  return true;
+}
+
+// Resolve the project file list, reusing a cached list when the tsconfig and
+// the directories spanning the project are unchanged. On a cache hit this
+// skips loading TypeScript and re-walking the source tree entirely; on a miss
+// it records a fresh fingerprint and sets `cache.fileListDirty` so the caller
+// persists the updated cache. `resolve` is injectable for tests so the file
+// discovery can be exercised without the TypeScript package installed.
+export function resolveTsconfigFilesCached(tsconfigAbsolutePath, { cache, resolve } = {}) {
+  const resolveFiles = resolve ?? resolveTsconfigFiles;
+  if (cache && fileListCacheValid(cache, tsconfigAbsolutePath)) {
+    cache.fileListDirty = false;
+    return cache.fileList.files.slice();
+  }
+
+  const files = resolveFiles(tsconfigAbsolutePath);
+  if (cache) {
+    const rootDir = path.dirname(path.resolve(tsconfigAbsolutePath));
+    const dirFingerprint = directoryFingerprint(contributingDirectories(files, rootDir));
+    let tsconfigStat = null;
+    try {
+      const stat = fs.statSync(tsconfigAbsolutePath);
+      tsconfigStat = { size: stat.size, mtimeNs: mtimeNsKey(stat) };
+    } catch {
+      // Leave null; without a tsconfig stat the list cannot be cached safely.
+    }
+    if (dirFingerprint && tsconfigStat) {
+      cache.fileList = { tsconfig: tsconfigStat, dirs: dirFingerprint, files: files.slice() };
+    } else {
+      delete cache.fileList;
+    }
+    cache.fileListDirty = true;
+  }
+  return files;
+}
+
+export function computeProjectFileStats(tsconfigAbsolutePath, { resolve } = {}) {
   const cachePath = resolveCachePath(tsconfigAbsolutePath);
   const cache = cachePath ? (loadStatsCache(cachePath) ?? { entries: {} }) : null;
+  const files = resolveTsconfigFilesCached(tsconfigAbsolutePath, { cache, resolve });
+  const fileListDirty = cache?.fileListDirty === true;
   const stats = aggregateProjectStats(files, { cache });
-  if (cache && cache.dirty) saveStatsCache(cachePath, cache);
+  if (cache && (cache.dirty || fileListDirty)) saveStatsCache(cachePath, cache);
   return stats;
 }
 

--- a/scripts/bench/project-file-stats.mjs
+++ b/scripts/bench/project-file-stats.mjs
@@ -285,6 +285,18 @@ export function directoryFingerprint(dirs) {
   return fingerprint;
 }
 
+// Stat the tsconfig and return its `{ size, mtimeNs }` invalidation key, or
+// null when it cannot be stat'd. Mirrors `statFileEntry` for the file list's
+// own config key, keeping the stat-to-key shape in one place.
+function tsconfigStatKey(tsconfigAbsolutePath) {
+  try {
+    const stat = fs.statSync(tsconfigAbsolutePath);
+    return { size: stat.size, mtimeNs: mtimeNsKey(stat) };
+  } catch {
+    return null;
+  }
+}
+
 // True when the cached file list is still valid: the tsconfig's own
 // `(mtimeNs, size)` is unchanged (catches `include`/`exclude`/config edits) and
 // every recorded directory `mtime` is unchanged (catches file additions,
@@ -294,15 +306,11 @@ export function fileListCacheValid(cache, tsconfigAbsolutePath) {
   if (!fileList || !fileList.tsconfig || !fileList.dirs || !Array.isArray(fileList.files)) {
     return false;
   }
-  let tsconfigStat;
-  try {
-    tsconfigStat = fs.statSync(tsconfigAbsolutePath);
-  } catch {
-    return false;
-  }
+  const tsconfigStat = tsconfigStatKey(tsconfigAbsolutePath);
   if (
+    tsconfigStat === null ||
     fileList.tsconfig.size !== tsconfigStat.size ||
-    fileList.tsconfig.mtimeNs !== mtimeNsKey(tsconfigStat)
+    fileList.tsconfig.mtimeNs !== tsconfigStat.mtimeNs
   ) {
     return false;
   }
@@ -333,13 +341,9 @@ export function resolveTsconfigFilesCached(tsconfigAbsolutePath, { cache, resolv
   if (cache) {
     const rootDir = path.dirname(path.resolve(tsconfigAbsolutePath));
     const dirFingerprint = directoryFingerprint(contributingDirectories(files, rootDir));
-    let tsconfigStat = null;
-    try {
-      const stat = fs.statSync(tsconfigAbsolutePath);
-      tsconfigStat = { size: stat.size, mtimeNs: mtimeNsKey(stat) };
-    } catch {
-      // Leave null; without a tsconfig stat the list cannot be cached safely.
-    }
+    // Null when the tsconfig vanished mid-resolve; without it the list cannot
+    // be cached safely, so fall through to `delete cache.fileList`.
+    const tsconfigStat = tsconfigStatKey(tsconfigAbsolutePath);
     if (dirFingerprint && tsconfigStat) {
       cache.fileList = { tsconfig: tsconfigStat, dirs: dirFingerprint, files: files.slice() };
     } else {

--- a/scripts/bench/project-file-stats.mjs
+++ b/scripts/bench/project-file-stats.mjs
@@ -15,9 +15,11 @@
 //   1. The resolved project file list (the recursive `include`/`exclude`
 //      directory walk done by TypeScript's `parseJsonConfigFileContent`).
 //      Invalidated by the tsconfig's own `(mtime_ns, size)` and by the
-//      `mtime_ns` of every directory that spans the resolved files, so a file
-//      added/removed/renamed anywhere in the tree re-triggers discovery while
-//      an unchanged tree skips loading TypeScript entirely.
+//      `mtime_ns` of every directory in the tree TypeScript watches for this
+//      config (its `wildcardDirectories`, expanded recursively), so a file
+//      added/removed/renamed anywhere in the watched tree — including under a
+//      previously empty included directory — re-triggers discovery, while an
+//      unchanged tree skips loading TypeScript and re-globbing entirely.
 //   2. Per-file line counts, invalidated per file by `(mtime_ns, size)`.
 
 import fs from "node:fs";
@@ -207,6 +209,19 @@ function loadTypeScript() {
   throw new Error("Unable to load the TypeScript package for tsconfig parsing");
 }
 
+// TypeScript's `WatchDirectoryFlags.Recursive`. `parseJsonConfigFileContent`
+// reports each `include`-derived wildcard directory with this flag set when the
+// glob descends into subdirectories (e.g. `"src"` or `"src/**"`); a flat glob
+// like `"src/*.ts"` reports the directory with no recursive flag.
+const TS_WATCH_DIRECTORY_RECURSIVE = 1;
+
+// Resolve the project file list AND the directories TypeScript watches for this
+// config. The watched directories (TypeScript's `wildcardDirectories`) are what
+// determine when the file list can change: a file added/removed under a watched
+// directory alters the result even when no currently resolved file lives there
+// (e.g. a previously empty included directory). Returning them lets the cache
+// invalidate correctly instead of inferring directories from resolved files
+// only.
 export function resolveTsconfigFiles(tsconfigAbsolutePath) {
   const ts = loadTypeScript();
   const config = ts.readConfigFile(tsconfigAbsolutePath, ts.sys.readFile);
@@ -220,10 +235,14 @@ export function resolveTsconfigFiles(tsconfigAbsolutePath) {
     {},
     tsconfigAbsolutePath,
   );
-  return [...new Set(parsed.fileNames)]
+  const files = [...new Set(parsed.fileNames)]
     .filter(isTypeScriptFile)
     .filter(isLocalProjectFile)
     .sort();
+  const watchDirectories = Object.entries(parsed.wildcardDirectories ?? {}).map(
+    ([dir, flag]) => ({ dir, recursive: flag === TS_WATCH_DIRECTORY_RECURSIVE }),
+  );
+  return { files, watchDirectories };
 }
 
 export function resolveCachePath(tsconfigAbsolutePath) {
@@ -232,40 +251,59 @@ export function resolveCachePath(tsconfigAbsolutePath) {
   return path.join(cacheDir, cacheKeyForTsconfig(tsconfigAbsolutePath) + ".json");
 }
 
-// True when `child` is `parent` itself or nested somewhere beneath it. Uses a
-// relative-path probe so it is robust to mixed separators and trailing
-// slashes without touching the filesystem.
-function isPathUnder(child, parent) {
-  const relative = path.relative(parent, child);
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+function isExcludedDirectory(dirPath) {
+  const normalized = dirPath.split(path.sep).join("/") + "/";
+  return EXCLUDED_PATH_SEGMENTS.some((segment) => normalized.includes(segment));
 }
 
-// The set of directories whose `mtime` governs whether the resolved file list
-// is still current: the parent directory of every file, plus — for files that
-// live under the tsconfig directory — every intermediate directory up to and
-// including the tsconfig directory. A file added, removed, or renamed in any
-// of these directories bumps that directory's `mtime`, which lets us detect a
-// stale file list without re-walking the tree. Returned sorted for stable
-// cache contents.
-export function contributingDirectories(files, rootDir) {
-  const root = path.resolve(rootDir);
+// Expand the resolver's watched directories into the full set of directories
+// whose `mtime` must be fingerprinted to detect a changed file list.
+//
+// A directory's `mtime` only advances when an entry is added, removed, or
+// renamed directly inside it — not when a descendant changes. So a recursive
+// watch (TypeScript descends into subdirectories) must contribute every
+// existing directory in its subtree, otherwise a file added under a previously
+// empty subdirectory would go unnoticed. A non-recursive watch contributes only
+// the watched directory itself. `node_modules`/`.next` subtrees are skipped to
+// match the project-file filter. Returned sorted for stable cache contents.
+export function expandWatchedDirectories(watchDirectories) {
   const dirs = new Set();
-  for (const file of files) {
-    let dir = path.dirname(path.resolve(file));
-    dirs.add(dir);
-    // Walk up to `root` for in-tree files; `root` itself is added by the loop
-    // when descending from a deeper file, or by the `dirs.add(dir)` above when
-    // the file sits directly in it.
-    if (isPathUnder(dir, root)) {
-      while (dir !== root) {
-        const parent = path.dirname(dir);
-        if (parent === dir) break; // reached the filesystem root
-        dir = parent;
-        dirs.add(dir);
+  for (const { dir, recursive } of watchDirectories ?? []) {
+    const root = path.resolve(dir);
+    if (!recursive) {
+      dirs.add(root);
+      continue;
+    }
+    const stack = [root];
+    while (stack.length > 0) {
+      const current = stack.pop();
+      if (dirs.has(current)) continue;
+      let entries;
+      try {
+        entries = fs.readdirSync(current, { withFileTypes: true });
+      } catch {
+        // A vanished/unreadable directory is simply not tracked; if it had been
+        // recorded previously its absence surfaces as a fingerprint mismatch.
+        continue;
+      }
+      dirs.add(current);
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const child = path.join(current, entry.name);
+        if (!isExcludedDirectory(child)) stack.push(child);
       }
     }
   }
   return [...dirs].sort();
+}
+
+function fingerprintsMatch(a, b) {
+  const aKeys = Object.keys(a);
+  if (aKeys.length !== Object.keys(b).length) return false;
+  for (const key of aKeys) {
+    if (a[key] !== b[key]) return false;
+  }
+  return true;
 }
 
 // Stat every directory in `dirs` and return a `{ dir: mtimeNs }` map, or `null`
@@ -299,11 +337,18 @@ function tsconfigStatKey(tsconfigAbsolutePath) {
 
 // True when the cached file list is still valid: the tsconfig's own
 // `(mtimeNs, size)` is unchanged (catches `include`/`exclude`/config edits) and
-// every recorded directory `mtime` is unchanged (catches file additions,
-// removals, and renames anywhere the file list spans).
+// re-fingerprinting the recorded watched directories yields an identical map
+// (catches file additions, removals, renames, and new/removed subdirectories
+// anywhere the watched tree spans, including previously empty directories).
 export function fileListCacheValid(cache, tsconfigAbsolutePath) {
   const fileList = cache && cache.fileList;
-  if (!fileList || !fileList.tsconfig || !fileList.dirs || !Array.isArray(fileList.files)) {
+  if (
+    !fileList ||
+    !fileList.tsconfig ||
+    !fileList.dirs ||
+    !Array.isArray(fileList.files) ||
+    !Array.isArray(fileList.watch)
+  ) {
     return false;
   }
   const tsconfigStat = tsconfigStatKey(tsconfigAbsolutePath);
@@ -314,22 +359,20 @@ export function fileListCacheValid(cache, tsconfigAbsolutePath) {
   ) {
     return false;
   }
-  // Re-stat the recorded directories through the same helper used to build the
-  // fingerprint, so the stat-and-compare logic lives in exactly one place.
-  const current = directoryFingerprint(Object.keys(fileList.dirs));
-  if (current === null) return false;
-  for (const [dir, mtimeNs] of Object.entries(fileList.dirs)) {
-    if (current[dir] !== mtimeNs) return false;
-  }
-  return true;
+  // Re-expand and re-stat the watched directories. Expanding from the recorded
+  // watch roots rediscovers any newly created subdirectory; comparing the full
+  // map then catches both mtime changes and added/removed directories.
+  const current = directoryFingerprint(expandWatchedDirectories(fileList.watch));
+  return current !== null && fingerprintsMatch(fileList.dirs, current);
 }
 
 // Resolve the project file list, reusing a cached list when the tsconfig and
-// the directories spanning the project are unchanged. On a cache hit this
-// skips loading TypeScript and re-walking the source tree entirely; on a miss
-// it records a fresh fingerprint and sets `cache.fileListDirty` so the caller
-// persists the updated cache. `resolve` is injectable for tests so the file
-// discovery can be exercised without the TypeScript package installed.
+// the watched directory tree are unchanged. On a cache hit this skips loading
+// TypeScript and re-globbing the source tree (only a directory-only walk runs);
+// on a miss it records a fresh fingerprint and sets `cache.fileListDirty` so
+// the caller persists the updated cache. `resolve` is injectable for tests so
+// file discovery can be exercised without the TypeScript package installed; it
+// returns `{ files, watchDirectories }`.
 export function resolveTsconfigFilesCached(tsconfigAbsolutePath, { cache, resolve } = {}) {
   const resolveFiles = resolve ?? resolveTsconfigFiles;
   if (cache && fileListCacheValid(cache, tsconfigAbsolutePath)) {
@@ -337,15 +380,20 @@ export function resolveTsconfigFilesCached(tsconfigAbsolutePath, { cache, resolv
     return cache.fileList.files.slice();
   }
 
-  const files = resolveFiles(tsconfigAbsolutePath);
+  const { files, watchDirectories = [] } = resolveFiles(tsconfigAbsolutePath);
   if (cache) {
-    const rootDir = path.dirname(path.resolve(tsconfigAbsolutePath));
-    const dirFingerprint = directoryFingerprint(contributingDirectories(files, rootDir));
-    // Null when the tsconfig vanished mid-resolve; without it the list cannot
-    // be cached safely, so fall through to `delete cache.fileList`.
+    const dirFingerprint = directoryFingerprint(expandWatchedDirectories(watchDirectories));
+    // Null when a watched directory or the tsconfig vanished mid-resolve;
+    // without a complete fingerprint the list cannot be cached safely, so fall
+    // through to `delete cache.fileList`.
     const tsconfigStat = tsconfigStatKey(tsconfigAbsolutePath);
     if (dirFingerprint && tsconfigStat) {
-      cache.fileList = { tsconfig: tsconfigStat, dirs: dirFingerprint, files: files.slice() };
+      cache.fileList = {
+        tsconfig: tsconfigStat,
+        watch: watchDirectories,
+        dirs: dirFingerprint,
+        files: files.slice(),
+      };
     } else {
       delete cache.fileList;
     }

--- a/scripts/bench/test-project-file-stats.mjs
+++ b/scripts/bench/test-project-file-stats.mjs
@@ -21,8 +21,8 @@ import {
   aggregateProjectStats,
   cacheKeyForTsconfig,
   computeProjectFileStats,
-  contributingDirectories,
   countNewlinesStream,
+  expandWatchedDirectories,
   isLocalProjectFile,
   isTypeScriptFile,
   loadStatsCache,
@@ -210,33 +210,36 @@ assert.equal(
 }
 
 // --------------------------------------------------------------------------
-// contributingDirectories: parent dirs plus ancestors up to the tsconfig dir.
+// expandWatchedDirectories: recursive watches contribute every existing
+// subdirectory (including empty ones); non-recursive watches contribute only
+// the watched directory; node_modules subtrees are skipped.
 
 {
-  const root = path.join(path.sep, "proj");
-  const dirs = contributingDirectories(
-    [
-      path.join(root, "src", "a.ts"),
-      path.join(root, "src", "nested", "deep", "b.ts"),
-      path.join(root, "lib", "c.ts"),
-    ],
-    root,
-  );
-  for (const expected of [
-    root,
-    path.join(root, "src"),
-    path.join(root, "src", "nested"),
-    path.join(root, "src", "nested", "deep"),
-    path.join(root, "lib"),
-  ]) {
-    assert.ok(dirs.includes(expected), `expected ${expected} in contributing dirs`);
-  }
+  const dir = makeTempDir("tsz-stats-watchdirs-");
+  try {
+    const srcDir = path.join(dir, "src");
+    writeFile(srcDir, "a.ts", "alpha\n");
+    fs.mkdirSync(path.join(srcDir, "empty"), { recursive: true });
+    writeFile(path.join(srcDir, "nested"), "b.ts", "beta\n");
+    writeFile(path.join(dir, "node_modules", "pkg"), "leak.ts", "leak\n");
 
-  // Files outside the tsconfig directory contribute their parent directory but
-  // do not pull in the (unrelated) tsconfig-dir ancestor chain.
-  const outsideDirs = contributingDirectories([path.join(path.sep, "other", "x.ts")], root);
-  assert.ok(outsideDirs.includes(path.join(path.sep, "other")));
-  assert.ok(!outsideDirs.includes(root), "out-of-tree files do not track the tsconfig dir");
+    const recursive = expandWatchedDirectories([{ dir: srcDir, recursive: true }]);
+    assert.ok(recursive.includes(srcDir));
+    assert.ok(
+      recursive.includes(path.join(srcDir, "empty")),
+      "recursive watch tracks a currently empty included directory",
+    );
+    assert.ok(recursive.includes(path.join(srcDir, "nested")));
+    assert.ok(
+      !recursive.some((d) => d.split(path.sep).join("/").includes("/node_modules/")),
+      "node_modules subtrees are excluded from the watched directory set",
+    );
+
+    const flat = expandWatchedDirectories([{ dir: srcDir, recursive: false }]);
+    assert.deepEqual(flat, [srcDir], "a non-recursive watch tracks only the watched directory");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -250,12 +253,13 @@ assert.equal(
     const fileA = writeFile(srcDir, "a.ts", "alpha\n");
     const fileB = writeFile(srcDir, "b.ts", "beta\n");
     const tsconfig = writeFile(dir, "tsconfig.json", JSON.stringify({ include: ["src"] }));
+    const watchDirectories = [{ dir: srcDir, recursive: true }];
 
     let resolveCalls = 0;
     let currentFiles = [fileA, fileB];
     const resolve = () => {
       resolveCalls += 1;
-      return currentFiles.slice().sort();
+      return { files: currentFiles.slice().sort(), watchDirectories };
     };
 
     const cache = { entries: {} };
@@ -289,11 +293,39 @@ assert.equal(
     resolveTsconfigFilesCached(tsconfig, { cache, resolve });
     assert.equal(resolveCalls, 2, "the refreshed file list is reused while the tree is stable");
 
+    // Regression (review #12277): a file added under a previously EMPTY included
+    // subdirectory must invalidate the cache even though no resolved file lived
+    // there. The recursive watch tracks `src/empty`, so writing into it bumps a
+    // fingerprinted directory.
+    const emptyDir = path.join(srcDir, "empty");
+    fs.mkdirSync(emptyDir, { recursive: true });
+    // Re-resolve so the (now-tracked) empty directory is part of the fingerprint.
+    resolveTsconfigFilesCached(tsconfig, { cache, resolve });
+    const resolveCallsBeforeEmptyAdd = resolveCalls;
+    const beforeEmptyMtime = statFileEntry(emptyDir).mtimeNs;
+    let fileD;
+    let emptyCounter = 0;
+    do {
+      fileD = writeFile(emptyDir, `d${emptyCounter++}.ts`, "delta\n");
+    } while (statFileEntry(emptyDir).mtimeNs === beforeEmptyMtime);
+    currentFiles = [fileA, fileB, fileC, fileD];
+    resolveTsconfigFilesCached(tsconfig, { cache, resolve });
+    assert.equal(
+      resolveCalls,
+      resolveCallsBeforeEmptyAdd + 1,
+      "a file added under a previously empty included directory re-resolves the list",
+    );
+
     // Editing the tsconfig (its size changes here) re-resolves even when the
     // source tree is otherwise unchanged, since include/exclude may differ.
     fs.writeFileSync(tsconfig, JSON.stringify({ include: ["src", "lib"] }));
+    const resolveCallsBeforeTsconfigEdit = resolveCalls;
     resolveTsconfigFilesCached(tsconfig, { cache, resolve });
-    assert.equal(resolveCalls, 3, "editing the tsconfig re-resolves the file list");
+    assert.equal(
+      resolveCalls,
+      resolveCallsBeforeTsconfigEdit + 1,
+      "editing the tsconfig re-resolves the file list",
+    );
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -320,7 +352,7 @@ assert.equal(
     let resolveCalls = 0;
     const resolve = () => {
       resolveCalls += 1;
-      return [fileA, fileB];
+      return { files: [fileA, fileB], watchDirectories: [{ dir: srcDir, recursive: true }] };
     };
 
     const first = computeProjectFileStats(tsconfig, { resolve });

--- a/scripts/bench/test-project-file-stats.mjs
+++ b/scripts/bench/test-project-file-stats.mjs
@@ -20,10 +20,13 @@ import { fileURLToPath } from "node:url";
 import {
   aggregateProjectStats,
   cacheKeyForTsconfig,
+  computeProjectFileStats,
+  contributingDirectories,
   countNewlinesStream,
   isLocalProjectFile,
   isTypeScriptFile,
   loadStatsCache,
+  resolveTsconfigFilesCached,
   saveStatsCache,
   statFileEntry,
 } from "./project-file-stats.mjs";
@@ -203,6 +206,147 @@ assert.equal(
     assert.equal(cache.dirty, true, "removal of a file dirties the cache");
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// --------------------------------------------------------------------------
+// contributingDirectories: parent dirs plus ancestors up to the tsconfig dir.
+
+{
+  const root = path.join(path.sep, "proj");
+  const dirs = contributingDirectories(
+    [
+      path.join(root, "src", "a.ts"),
+      path.join(root, "src", "nested", "deep", "b.ts"),
+      path.join(root, "lib", "c.ts"),
+    ],
+    root,
+  );
+  for (const expected of [
+    root,
+    path.join(root, "src"),
+    path.join(root, "src", "nested"),
+    path.join(root, "src", "nested", "deep"),
+    path.join(root, "lib"),
+  ]) {
+    assert.ok(dirs.includes(expected), `expected ${expected} in contributing dirs`);
+  }
+
+  // Files outside the tsconfig directory contribute their parent directory but
+  // do not pull in the (unrelated) tsconfig-dir ancestor chain.
+  const outsideDirs = contributingDirectories([path.join(path.sep, "other", "x.ts")], root);
+  assert.ok(outsideDirs.includes(path.join(path.sep, "other")));
+  assert.ok(!outsideDirs.includes(root), "out-of-tree files do not track the tsconfig dir");
+}
+
+// --------------------------------------------------------------------------
+// resolveTsconfigFilesCached: skip re-walking an unchanged tree, re-resolve on
+// file-list-affecting changes.
+
+{
+  const dir = makeTempDir("tsz-stats-filelist-");
+  try {
+    const srcDir = path.join(dir, "src");
+    const fileA = writeFile(srcDir, "a.ts", "alpha\n");
+    const fileB = writeFile(srcDir, "b.ts", "beta\n");
+    const tsconfig = writeFile(dir, "tsconfig.json", JSON.stringify({ include: ["src"] }));
+
+    let resolveCalls = 0;
+    let currentFiles = [fileA, fileB];
+    const resolve = () => {
+      resolveCalls += 1;
+      return currentFiles.slice().sort();
+    };
+
+    const cache = { entries: {} };
+    const first = resolveTsconfigFilesCached(tsconfig, { cache, resolve });
+    assert.equal(resolveCalls, 1, "cold cache resolves the file list once");
+    assert.deepEqual(first, [fileA, fileB].sort());
+    assert.equal(cache.fileListDirty, true, "cold resolve dirties the file-list cache");
+    assert.ok(cache.fileList && cache.fileList.files.length === 2, "file list is cached");
+
+    const second = resolveTsconfigFilesCached(tsconfig, { cache, resolve });
+    assert.equal(resolveCalls, 1, "an unchanged tree reuses the cached file list");
+    assert.deepEqual(second, first);
+    assert.equal(cache.fileListDirty, false, "a cache hit leaves the file-list cache clean");
+
+    // Adding a file bumps the tracked source directory's mtime. Use uniquely
+    // named files so the directory mtime is guaranteed to advance even on a
+    // coarse-resolution filesystem.
+    const beforeDirMtime = statFileEntry(srcDir).mtimeNs;
+    let fileC;
+    let counter = 0;
+    do {
+      fileC = writeFile(srcDir, `c${counter++}.ts`, "gamma\n");
+    } while (statFileEntry(srcDir).mtimeNs === beforeDirMtime);
+    currentFiles = [fileA, fileB, fileC];
+    const third = resolveTsconfigFilesCached(tsconfig, { cache, resolve });
+    assert.equal(resolveCalls, 2, "a new file in a tracked directory re-resolves the list");
+    assert.equal(third.length, 3, "the freshly discovered file appears in the list");
+    assert.equal(cache.fileListDirty, true);
+
+    // A subsequent unchanged pass is a hit again.
+    resolveTsconfigFilesCached(tsconfig, { cache, resolve });
+    assert.equal(resolveCalls, 2, "the refreshed file list is reused while the tree is stable");
+
+    // Editing the tsconfig (its size changes here) re-resolves even when the
+    // source tree is otherwise unchanged, since include/exclude may differ.
+    fs.writeFileSync(tsconfig, JSON.stringify({ include: ["src", "lib"] }));
+    resolveTsconfigFilesCached(tsconfig, { cache, resolve });
+    assert.equal(resolveCalls, 3, "editing the tsconfig re-resolves the file list");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// --------------------------------------------------------------------------
+// computeProjectFileStats: the persisted file-list cache survives a fresh
+// cache load (the cross-process row-mode pattern) and skips file discovery.
+
+{
+  const dir = makeTempDir("tsz-stats-filelist-stats-");
+  const cacheHome = makeTempDir("tsz-stats-filelist-cache-");
+  const prevCacheDir = process.env.TSZ_PROJECT_FILE_STATS_CACHE_DIR;
+  try {
+    const srcDir = path.join(dir, "src");
+    const fileA = writeFile(srcDir, "a.ts", "alpha\nbeta\n");
+    const fileB = writeFile(srcDir, "b.ts", "gamma\n");
+    const tsconfig = writeFile(dir, "tsconfig.json", "{}");
+    // The cache directory lives outside the project tree (as in the real
+    // harness, where it sits under TMPDIR) so writing it does not perturb the
+    // tracked project directory mtimes.
+    process.env.TSZ_PROJECT_FILE_STATS_CACHE_DIR = cacheHome;
+
+    let resolveCalls = 0;
+    const resolve = () => {
+      resolveCalls += 1;
+      return [fileA, fileB];
+    };
+
+    const first = computeProjectFileStats(tsconfig, { resolve });
+    assert.equal(resolveCalls, 1, "first invocation discovers the file list");
+    assert.equal(first.fileCount, 2);
+    assert.equal(first.lines, 3);
+
+    const cacheFile = path.join(cacheHome, cacheKeyForTsconfig(path.resolve(tsconfig)) + ".json");
+    const persisted = JSON.parse(fs.readFileSync(cacheFile, "utf8"));
+    assert.ok(persisted.fileList, "the fileList section is persisted to disk");
+    assert.equal(persisted.fileList.files.length, 2);
+
+    // Second invocation reloads the cache from disk (simulating a separate
+    // process) and must not re-discover the file list.
+    resolveCalls = 0;
+    const second = computeProjectFileStats(tsconfig, { resolve });
+    assert.equal(resolveCalls, 0, "an unchanged tree skips file discovery on cache reload");
+    assert.deepEqual(second, first, "stats are identical across the cached invocations");
+  } finally {
+    if (prevCacheDir === undefined) {
+      delete process.env.TSZ_PROJECT_FILE_STATS_CACHE_DIR;
+    } else {
+      process.env.TSZ_PROJECT_FILE_STATS_CACHE_DIR = prevCacheDir;
+    }
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(cacheHome, { recursive: true, force: true });
   }
 }
 


### PR DESCRIPTION
Closes #11618.

AgentName: claude-opus-48-1m-brave-volta

Track: Performance / project-bench (agent:Studio-B)

Invariant: Benchmark `(lines, bytes, fileCount)` output for a project row is byte-identical whether the file-list cache is cold, warm, or invalidated; the harness never re-loads TypeScript or re-globs an unchanged tree, but always re-discovers when the tsconfig changes or any file/subdirectory under the watched tree changes.

## Structural rule

When the same `tsconfig` is compiled across multiple row-mode invocations within a single bench run, and its config plus the directory tree TypeScript watches for it are unchanged, the harness must reuse the previously discovered file list instead of re-loading TypeScript and re-running `parseJsonConfigFileContent` (which recursively walks the entire `include`/`exclude` source tree). tsz does this through the on-disk cache owned by `scripts/bench/project-file-stats.mjs`.

## Scope

`project-file-stats.mjs` already cached per-file line counts keyed by `(mtimeNs, size)`, so unchanged file contents were not re-read. But `resolveTsconfigFiles` still loaded the TypeScript package and re-globbed the full directory tree on every invocation to rediscover the (unchanged) file list — the exact "repeatedly traverses unchanged files in row mode" symptom in the issue, and one shared by every project row, not just `performance-39-20`.

This change adds a second cache layer in the same on-disk cache file:

- `resolveTsconfigFiles` now returns the resolved files together with the directories TypeScript watches for the config (`parseJsonConfigFileContent`'s `wildcardDirectories`). The file list is fingerprinted by the `tsconfig`'s own `(mtimeNs, size)` plus an `mtime` map of those watched directories, with recursive watches expanded by `expandWatchedDirectories` to every existing subdirectory — including currently empty included directories.
- On a cache hit (tsconfig unchanged + the re-expanded watched-directory map matches) the harness returns the cached list and skips loading TypeScript and re-globbing the tree; only a cheap directory-only walk runs.
- On any change — a file added/removed/renamed (bumps a watched directory's `mtime`), a new or removed subdirectory (alters the directory map), or an `include`/`exclude` edit (bumps the tsconfig `(mtimeNs, size)`) — discovery re-runs and the fingerprint is refreshed.

Invalidation degrades safely: any uncertainty (a vanished directory, an unstat'able tsconfig, any mtime/map difference) falls back to a full re-resolve, so a false invalidation only costs a re-walk and never yields stale stats. The cache stays gated behind the existing `TSZ_PROJECT_FILE_STATS_CACHE_DIR` env var, so non-bench callers are unaffected.

This generalizes the existing per-file cache up to the file-list / watched-tree level, rather than special-casing one row.

## Project Corpus Impact

- Row: type-challenges-solutions-project (and every project row that re-stats the same tsconfig in row mode)
- Bug family: performance / project-harness redundant traversal (performance-39-20)

Harness-only change to benchmark stat collection (`scripts/bench/`). No compiler crate, diagnostic, inference, narrowing, or emit behavior is touched. Project-row `(lines, bytes, fileCount)` outputs are unchanged; only the redundant TypeScript load and directory re-glob are eliminated on warm invocations. No required project-corpus row semantics are affected.

## Verification

- `node scripts/bench/test-project-file-stats.mjs` — passes, including new coverage for:
  - `expandWatchedDirectories` (recursive watch tracks every existing subdirectory including empty ones; non-recursive tracks only the watched directory; `node_modules` excluded).
  - `resolveTsconfigFilesCached` cache hit (no re-resolve on an unchanged tree), re-resolve on a new file in a tracked directory, re-resolve on a file added under a previously empty included directory, and re-resolve on a tsconfig edit.
  - `computeProjectFileStats` reusing a persisted file-list cache across a fresh cache load (the cross-process row-mode pattern) with identical stats.
- `node --check` on both files; module exports verified.
- The pre-existing cross-process script test that requires the installed TypeScript package still skips gracefully when that package is absent; the new tests use an injected resolver so they run without it.

## Coordination Notes

Issue #11618 is the canonical tracker for this symptom and is labeled for lane coordination while the change lands. A prior claim comment (2026-06-01) left no open pull request and the coordination label had since been cleared, so the issue was unclaimed at pickup. Ran `/simplify` three times (unified the directory stat-and-compare into a single `directoryFingerprint` helper, extracted a `tsconfigStatKey` helper). Review on this PR found a stale-cache hole — directories were inferred from resolved files, missing previously empty included directories — now fixed by fingerprinting TypeScript's `wildcardDirectories` (recursive watch roots) instead. Branch synced to current `origin/main`.

https://claude.ai/code/session_016MVZeCdguwz3Ny5yxLcsyC