### PR TITLE
fix(cli): apply tsc 6.0 esModuleInterop=true default on CLI-only path

### DIFF
--- a/crates/tsz-cli/src/driver/plan.rs
+++ b/crates/tsz-cli/src/driver/plan.rs
@@ -285,7 +285,20 @@ pub(super) fn apply_cli_overrides_with_config_options(
     if args.no_implicit_use_strict {
         options.checker.no_implicit_use_strict = true;
     }
-    if args.es_module_interop {
+    // tsc 6.0 defaults `esModuleInterop` to `true` unless it is explicitly set on
+    // the command line or in `tsconfig.json`. The config path already applies
+    // this default in `resolve_compiler_options`; mirror it here so the CLI-only
+    // path (no tsconfig) matches tsc instead of falling back to the historical
+    // `false`. An explicit `--esModuleInterop false` (recorded in
+    // `explicitly_disabled_bool_flags`) or a tsconfig value opts back out.
+    let es_module_interop_disabled = args
+        .explicitly_disabled_bool_flags
+        .iter()
+        .any(|name| name == "esModuleInterop");
+    if args.es_module_interop
+        || (!es_module_interop_disabled
+            && config_options.is_none_or(|config| config.es_module_interop.is_none()))
+    {
         options.es_module_interop = true;
         options.checker.es_module_interop = true;
         options.printer.es_module_interop = true;

--- a/crates/tsz-cli/src/driver/plan.rs
+++ b/crates/tsz-cli/src/driver/plan.rs
@@ -290,13 +290,21 @@ pub(super) fn apply_cli_overrides_with_config_options(
     // this default in `resolve_compiler_options`; mirror it here so the CLI-only
     // path (no tsconfig) matches tsc instead of falling back to the historical
     // `false`. An explicit `--esModuleInterop false` (recorded in
-    // `explicitly_disabled_bool_flags`) or a tsconfig value opts back out.
+    // `explicitly_disabled_bool_flags`), a tsconfig value, or a TS5024-invalid
+    // tsconfig value opts back out.
     let es_module_interop_disabled = args
         .explicitly_disabled_bool_flags
         .iter()
         .any(|name| name == "esModuleInterop");
+    let es_module_interop_invalidated = config_options.is_some_and(|config| {
+        config
+            .invalidated_options
+            .iter()
+            .any(|name| name == "esModuleInterop")
+    });
     if args.es_module_interop
         || (!es_module_interop_disabled
+            && !es_module_interop_invalidated
             && config_options.is_none_or(|config| config.es_module_interop.is_none()))
     {
         options.es_module_interop = true;

--- a/crates/tsz-cli/tests/driver_tests_parts/part_12.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_12.rs
@@ -903,10 +903,80 @@ fn cli_only_explicit_es_module_interop_false_keeps_classic_default_import() {
     args.explicitly_disabled_bool_flags
         .push("esModuleInterop".to_string());
 
-    let result = compile(&args, base).expect("compile should succeed");
+    let _result = compile(&args, base).expect("compile should succeed");
     let a_js = std::fs::read_to_string(base.join("out/a.js")).expect("read out/a.js");
     assert!(
         !a_js.contains("__importDefault"),
         "explicit --esModuleInterop false must not emit the interop helper, got:\n{a_js}"
+    );
+}
+
+#[test]
+fn invalid_config_es_module_interop_keeps_cli_file_emit_classic_unless_cli_enables() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "esModuleInterop": "invalid",
+            "module": "commonjs",
+            "target": "es2020"
+          }
+        }"#,
+    );
+    write_file(
+        &base.join("dep.ts"),
+        "export default { version: \"1.0.0\" };\n",
+    );
+    write_file(
+        &base.join("a.ts"),
+        "import dep from './dep';\nexport const v = dep.version;\n",
+    );
+
+    let args = parse_args(&[
+        "tsz",
+        "--module",
+        "commonjs",
+        "--target",
+        "es2020",
+        "--outDir",
+        "out-invalid",
+        "a.ts",
+    ]);
+
+    let result = compile(&args, base).expect("compile should recover through TS5024");
+    let codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+    assert!(codes.contains(&5024), "expected TS5024, got: {codes:?}");
+
+    let a_js = std::fs::read_to_string(base.join("out-invalid/a.js"))
+        .expect("read out-invalid/a.js");
+    assert!(
+        !a_js.contains("__importDefault"),
+        "invalid tsconfig esModuleInterop must suppress the tsc 6.0 default \
+         during CLI file emit recovery, got:\n{a_js}"
+    );
+
+    let args = parse_args(&[
+        "tsz",
+        "--esModuleInterop",
+        "--module",
+        "commonjs",
+        "--target",
+        "es2020",
+        "--outDir",
+        "out-cli",
+        "a.ts",
+    ]);
+
+    let result = compile(&args, base).expect("compile should recover through TS5024");
+    let codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+    assert!(codes.contains(&5024), "expected TS5024, got: {codes:?}");
+
+    let a_js = std::fs::read_to_string(base.join("out-cli/a.js")).expect("read out-cli/a.js");
+    assert!(
+        a_js.contains("__importDefault"),
+        "explicit --esModuleInterop must still enable the interop helper, got:\n{a_js}"
     );
 }

--- a/crates/tsz-cli/tests/driver_tests_parts/part_12.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_12.rs
@@ -823,3 +823,90 @@ fn ts1192_suppressed_for_js_default_import_without_check_js() {
         "TS1192 must not appear for unchecked JS, got: {codes:?}"
     );
 }
+
+// tsc 6.0 defaults `esModuleInterop` to `true` when it is not set on the
+// command line or in tsconfig. The config path already applies this default in
+// `resolve_compiler_options`; the CLI-only path must mirror it so that
+// `tsz file.ts` (no tsconfig) emits the same default-import interop helper as
+// `tsc file.ts`. Regression for the divergence behind issue #11330.
+#[test]
+fn cli_only_default_import_uses_es_module_interop_default_true() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("dep.ts"),
+        "export default { version: \"1.0.0\" };\n",
+    );
+    write_file(
+        &base.join("a.ts"),
+        "import dep from './dep';\nexport const v = dep.version;\n",
+    );
+
+    let args = parse_args(&[
+        "tsz",
+        "--ignoreConfig",
+        "--module",
+        "commonjs",
+        "--target",
+        "es2020",
+        "--outDir",
+        "out",
+        "a.ts",
+    ]);
+
+    let result = compile(&args, base).expect("compile should succeed");
+    assert!(
+        result.diagnostics.is_empty(),
+        "expected clean compile, got: {:#?}",
+        result.diagnostics
+    );
+
+    let a_js = std::fs::read_to_string(base.join("out/a.js")).expect("read out/a.js");
+    assert!(
+        a_js.contains("__importDefault"),
+        "CLI-only commonjs emit must apply the tsc 6.0 esModuleInterop=true \
+         default and wrap the default import with __importDefault, got:\n{a_js}"
+    );
+}
+
+// The flip side: an explicit `--esModuleInterop false` must opt back out of the
+// tsc 6.0 default and keep the classic (no-helper) default-import lowering.
+#[test]
+fn cli_only_explicit_es_module_interop_false_keeps_classic_default_import() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("dep.ts"),
+        "export default { version: \"1.0.0\" };\n",
+    );
+    write_file(
+        &base.join("a.ts"),
+        "import dep from './dep';\nexport const v = dep.version;\n",
+    );
+
+    // `preprocess_args` (the real CLI entry point) forwards `--esModuleInterop
+    // false` into this side-channel; replicate it directly since the test builds
+    // `CliArgs` with clap's parser without the preprocessing pass.
+    let mut args = parse_args(&[
+        "tsz",
+        "--ignoreConfig",
+        "--module",
+        "commonjs",
+        "--target",
+        "es2020",
+        "--outDir",
+        "out",
+        "a.ts",
+    ]);
+    args.explicitly_disabled_bool_flags
+        .push("esModuleInterop".to_string());
+
+    let result = compile(&args, base).expect("compile should succeed");
+    let a_js = std::fs::read_to_string(base.join("out/a.js")).expect("read out/a.js");
+    assert!(
+        !a_js.contains("__importDefault"),
+        "explicit --esModuleInterop false must not emit the interop helper, got:\n{a_js}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-C
Runner: Claude-Web-EMI

## Track
Track 9 emit / CLI option resolution.

## Invariant
When `esModuleInterop` is not explicitly set on the CLI and no `tsconfig` value is present, `tsc` 6.0 treats it as `true`; this PR makes tsz do the same through the CLI plan path (`apply_cli_overrides_with_config_options`), matching the tsconfig path owned by `resolve_compiler_options`.

## Summary
`tsc` 6.0 defaults `esModuleInterop` to `true` unless it is explicitly set on the command line or in `tsconfig.json`. tsz's tsconfig path already applies this default in `resolve_compiler_options` (`crates/tsz-core/src/config/mod.rs`), but the CLI direct-args path (no tsconfig) fell back to the historical `false`.

As a result, `tsz file.ts` diverged from `tsc file.ts`:

- default imports under `commonjs`/`umd` were not wrapped with `__importDefault`;
- namespace imports were not routed through `__importStar`;
- the implied `allowSyntheticDefaultImports` stayed off.

The fix mirrors the config-path default inside `apply_cli_overrides_with_config_options`, using the same `config_options.is_none_or(...)` idiom the file already uses for other version/derived defaults such as `use_define_for_class_fields`. It honors an explicit `--esModuleInterop false` recorded in `explicitly_disabled_bool_flags` and any tsconfig-provided value, so only the genuinely unset CLI case flips.

This resolves the `commonjs` default-import witness behind #11330 and the broader CLI default-import interop divergence it represents.

## Scope
- `crates/tsz-cli/src/driver/plan.rs` applies the `tsc` 6.0 `esModuleInterop=true` default on the CLI-only path while honoring explicit-disable and tsconfig values.
- `crates/tsz-cli/tests/driver_tests_parts/part_12.rs` adds regressions for default-on `__importDefault` emit and explicit `--esModuleInterop false` classic lowering.

## Project Corpus Impact
- Row: n/a
- Bug family: emit-module-interop
- Evidence: large conformance, emit, and fourslash harnesses use synthetic `tsconfig.json` files and invoke tsz through the config path, which already defaulted `esModuleInterop=true`; this PR changes only the CLI direct-args path used by real `tsz file.ts` invocations and project compile guard style entry points.

## Verification
- Oracle: bundled `tsc 6.0.2`.
- Across plain, JSON-default, and JSON-with-attribute imports under `commonjs`, unset / `--esModuleInterop false` / `--esModuleInterop` now match `tsc` byte-for-byte according to runner evidence.
- `cargo test -p tsz-cli --lib` with the two new tests passing; runner reports remaining failures as pre-existing on the clean tree after rerunning with this change stashed.
- `cargo fmt -p tsz-cli -- --check`
- `cargo clippy -p tsz-cli --lib`

## Coordination Notes
- Anchored on #11330. The node16/nodenext ESM-format-detection and trailing-newline-on-UMD differences are separate, pre-existing issues and intentionally out of scope.
- Initial random triage landed on #10934, but the runner reports that 29 representative JSX/ambient remap cases parsed and checked identically to `tsc` 6.0.2, so that issue was released rather than force-fixed.
- Reviewer coordination repaired the original generated runner `AgentName` and missing ownership label to canonical `AgentName: Studio-C` / `agent:Studio-C`; runner identity is preserved above as metadata.

https://claude.ai/code/session_01Q7783z73jw4832sA9YMrvc
