### PR TITLE
test(checker): observe type reference argument cache reuse

### DIFF
--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -4,6 +4,8 @@
 //! the module entry point focused on type/struct definitions.
 
 use rustc_hash::{FxHashMap, FxHashSet};
+#[cfg(test)]
+use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::sync::Arc;
 
@@ -35,6 +37,12 @@ pub(crate) fn order_independent_resolution_disabled() -> bool {
             .map(|v| !v.is_empty() && v != "0")
             .unwrap_or(false)
     })
+}
+
+#[cfg(test)]
+thread_local! {
+    static TYPE_NODE_RESOLUTION_COUNTS: RefCell<FxHashMap<NodeIndex, u32>> =
+        RefCell::new(FxHashMap::default());
 }
 
 impl TypeCache {
@@ -122,6 +130,26 @@ impl TypeCache {
 }
 
 impl<'a> CheckerContext<'a> {
+    /// Clear test-observable type-node resolution counts for a fresh check.
+    #[cfg(test)]
+    pub(crate) fn reset_type_node_resolution_counts_for_test(&self) {
+        TYPE_NODE_RESOLUTION_COUNTS.with(|counts| counts.borrow_mut().clear());
+    }
+
+    /// Record a test-observable entry into type-node resolution.
+    #[cfg(test)]
+    pub(crate) fn record_type_node_resolution_for_test(&self, idx: NodeIndex) {
+        TYPE_NODE_RESOLUTION_COUNTS.with(|counts| {
+            *counts.borrow_mut().entry(idx).or_insert(0) += 1;
+        });
+    }
+
+    /// Return how often `idx` entered type-node resolution in this checker.
+    #[cfg(test)]
+    pub(crate) fn type_node_resolution_count_for_test(&self, idx: NodeIndex) -> u32 {
+        TYPE_NODE_RESOLUTION_COUNTS.with(|counts| counts.borrow().get(&idx).copied().unwrap_or(0))
+    }
+
     /// Resolve a `SymbolId` to its owning file index.
     ///
     /// Checks the layered `cross_file_symbol_targets` overlay first, then falls

--- a/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
+++ b/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
@@ -63,6 +63,9 @@ impl<'a> CheckerState<'a> {
     /// let c: { x: number };    // → Object type with property x: number
     /// ```
     pub fn get_type_from_type_node(&mut self, idx: NodeIndex) -> TypeId {
+        #[cfg(test)]
+        self.ctx.record_type_node_resolution_for_test(idx);
+
         // Delegate to TypeNodeChecker for type node handling.
         // TypeNodeChecker handles caching, type parameter scope, and recursion protection.
         //

--- a/crates/tsz-checker/src/test_utils.rs
+++ b/crates/tsz-checker/src/test_utils.rs
@@ -14,6 +14,8 @@ use tsz_binder::BinderState;
 use tsz_binder::lib_loader::LibFile;
 use tsz_common::position::LineMap;
 use tsz_parser::parser::ParserState;
+#[cfg(test)]
+use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 
 /// Parse, bind, and type-check a TypeScript source string, returning all diagnostics.
 ///
@@ -41,6 +43,59 @@ pub fn check_source_recovery_sites(
         snapshot.sort_by_key(|(idx, _)| *idx);
         snapshot
     })
+}
+
+/// Parse, bind, and type-check a source string, then return type-node
+/// resolution entry counts for type literals that contain computed members.
+#[cfg(test)]
+pub fn check_computed_type_argument_resolution_counts(source: &str) -> Vec<u32> {
+    with_checked_source(
+        source,
+        "test.ts",
+        CheckerOptions::default(),
+        None,
+        |checker| {
+            checker
+                .ctx
+                .arena
+                .nodes
+                .iter()
+                .enumerate()
+                .filter_map(|(raw_idx, node)| {
+                    if node.kind == syntax_kind_ext::TYPE_LITERAL
+                        && type_literal_has_computed_member(checker, node)
+                    {
+                        let idx = NodeIndex(raw_idx as u32);
+                        Some(checker.ctx.type_node_resolution_count_for_test(idx))
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        },
+    )
+}
+
+#[cfg(test)]
+fn type_literal_has_computed_member(
+    checker: &CheckerState<'_>,
+    node: &tsz_parser::parser::node::Node,
+) -> bool {
+    checker
+        .ctx
+        .arena
+        .get_type_literal(node)
+        .is_some_and(|literal| {
+            literal.members.nodes.iter().any(|&member_idx| {
+                checker
+                    .ctx
+                    .arena
+                    .get(member_idx)
+                    .and_then(|member| checker.ctx.arena.get_signature(member))
+                    .and_then(|signature| checker.ctx.arena.get(signature.name))
+                    .is_some_and(|name| name.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME)
+            })
+        })
 }
 
 /// Parse, bind, and type-check a source string with no lib contexts, source
@@ -85,6 +140,8 @@ fn with_checked_source<R>(
     checker.enable_source_file_test_pragmas();
     checker.ctx.set_lib_contexts(Vec::new());
     checker.ctx.file_is_esm = file_is_esm;
+    #[cfg(test)]
+    checker.ctx.reset_type_node_resolution_counts_for_test();
     checker.check_source_file(source_file);
     extract(&checker)
 }

--- a/crates/tsz-checker/src/tests/ref_type_params_cache_tests.rs
+++ b/crates/tsz-checker/src/tests/ref_type_params_cache_tests.rs
@@ -1,5 +1,8 @@
 use crate::context::CheckerOptions;
-use crate::test_utils::{check_multi_file_with_global_index, check_source_diagnostics};
+use crate::test_utils::{
+    check_computed_type_argument_resolution_counts, check_multi_file_with_global_index,
+    check_source_diagnostics,
+};
 
 /// When multiple type references in the same alias body refer to the same
 /// generic utility type, tsz must resolve that type's parameter list once per
@@ -19,17 +22,19 @@ fn alias_body_explicit_type_refs_use_validator_only_path() {
 
 #[test]
 fn type_reference_body_reuses_resolved_type_arguments() {
-    let checker_source =
-        std::fs::read_to_string("src/state/type_resolution/core.rs").expect("read type resolver");
-    assert!(
-        checker_source.contains("resolve_type_argument_nodes_once"),
-        "type-reference lowering should resolve explicit type arguments once \
-         for branches that need checker-owned TypeIds"
+    let counts = check_computed_type_argument_resolution_counts(
+        r#"
+declare const key: unique symbol;
+type Box<T> = { value: T };
+type Use = Box<{ [key](): string }>;
+declare const value: Use;
+"#,
     );
-    assert!(
-        checker_source.contains("if self.type_arg_needs_checker_resolution(arg_idx)"),
-        "Application rebuild should only replace explicit type-argument slots \
-         that need checker resolution, preserving lowered alias identity otherwise"
+
+    assert_eq!(
+        counts,
+        vec![1],
+        "computed type-literal arguments should be resolved once and reused; got {counts:?}"
     );
 }
 


### PR DESCRIPTION
## Agent
AgentName: MBMB4-Canary-B

## Track
Performance guardrail / checker test-harness follow-up for #12278 and #12280.

## Invariant
When a generic type reference has an explicit type-literal argument containing a computed member name, checker-owned type-node resolution should run once for that argument and the rebuilt `Application` should reuse the resulting `TypeId`; this PR changes test-only checker observability and the focused regression test.

## Scope
- `crates/tsz-checker/src/context/core.rs`: test-only type-node resolution entry counter.
- `crates/tsz-checker/src/state/type_environment/type_node_resolution.rs`: cfg-test recording at the checker type-node resolver entry.
- `crates/tsz-checker/src/test_utils.rs`: focused helper that returns counts for computed-member type literals.
- `crates/tsz-checker/src/tests/ref_type_params_cache_tests.rs`: replace source-string guard with observable cache-reuse regression.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: test-harness-only follow-up to checker cache reuse; no production compiler behavior path changes outside `#[cfg(test)]` observation.

## Verification
- RED: `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -E 'test(type_reference_body_reuses_resolved_type_arguments)'` failed before helper/instrumentation existed.
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -E 'test(type_reference_body_reuses_resolved_type_arguments)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib ref_type_params_cache_tests::`
- `cargo fmt --all --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh cargo check -p tsz-checker --lib`

## Coordination Notes
- Closes #12280.
- No open Studio-B PRs were found before publishing.
- Ready for manager/queue-owner review; not queued by this implementation agent.
