### PR TITLE
fix(checker): keep TS2741/TS2739 missing-property diagnostics for intersection sources

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker_mapped_type_tests.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker_mapped_type_tests.rs
@@ -255,15 +255,20 @@ const bad: M = { a: 1 };
 // ── Intersection-with-indexed-access source vs. mapped-type target ───────────
 //
 // When source is `T[K] & { a: string }` and target is a structural type (mapped,
-// intersection, conditional, or string intrinsic), the checker must
-// not suppress TS2322 — the solver checks property membership directly.
+// intersection, conditional, or string intrinsic), the checker must not suppress
+// the assignability error — the solver checks property membership directly.
 // Structural rule: `T[K] & { a: string } <: { [P in "a" | "b"]: string }` must
-// emit TS2322 because "b" is guaranteed absent from the source.
+// report that "b" is missing. `tsc` reports this as the missing-property
+// diagnostic (TS2741), NOT a bare generic TS2322 — an intersection source does
+// not downgrade a genuine missing required property to TS2322.
 
 /// Primary repro: indexed-access intersection against a two-key mapped type.
-/// tsc emits TS2322; tsz was incorrectly suppressing it.
+/// "b" is guaranteed absent from the source, so `tsc` reports it as a missing
+/// property (TS2741). tsz previously suppressed the error entirely, then
+/// over-corrected to a bare TS2322 for intersection sources; it must match
+/// `tsc`'s TS2741.
 #[test]
-fn intersection_indexed_access_vs_mapped_type_emits_ts2322() {
+fn intersection_indexed_access_vs_mapped_type_emits_ts2741() {
     let diagnostics = strict_diagnostics_for(
         r#"
 function test<T extends { a: string }, K extends keyof T>(x: T[K] & { a: string }): void {
@@ -271,16 +276,25 @@ function test<T extends { a: string }, K extends keyof T>(x: T[K] & { a: string 
 }
 "#,
     );
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.code == 2741)
+        .unwrap_or_else(|| panic!("expected TS2741 for the missing 'b' key; got: {diagnostics:?}"));
     assert!(
-        diagnostics.iter().any(|d| d.code == 2322),
-        "intersection with indexed-access source vs two-key mapped target must emit TS2322; got: {diagnostics:?}"
+        diag.message_text.contains("'b'"),
+        "TS2741 should name the missing 'b' key, got: {}",
+        diag.message_text
+    );
+    assert!(
+        !diagnostics.iter().any(|d| d.code == 2322),
+        "intersection source must not collapse to a bare TS2322; got: {diagnostics:?}"
     );
 }
 
 /// Anti-hardcoding: renamed type parameters (`U`/`I` instead of `T`/`K`).
-/// Confirms the fix is keyed on structural semantics, not parameter names.
+/// Confirms the behavior is keyed on structural semantics, not parameter names.
 #[test]
-fn intersection_indexed_access_vs_mapped_type_renamed_params_emits_ts2322() {
+fn intersection_indexed_access_vs_mapped_type_renamed_params_emits_ts2741() {
     let diagnostics = strict_diagnostics_for(
         r#"
 function test<U extends { a: string }, I extends keyof U>(x: U[I] & { a: string }): void {
@@ -288,9 +302,20 @@ function test<U extends { a: string }, I extends keyof U>(x: U[I] & { a: string 
 }
 "#,
     );
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.code == 2741)
+        .unwrap_or_else(|| {
+            panic!("renamed-param variant should emit TS2741; got: {diagnostics:?}")
+        });
     assert!(
-        diagnostics.iter().any(|d| d.code == 2322),
-        "renamed-param variant must also emit TS2322; got: {diagnostics:?}"
+        diag.message_text.contains("'b'"),
+        "TS2741 should name the missing 'b' key, got: {}",
+        diag.message_text
+    );
+    assert!(
+        !diagnostics.iter().any(|d| d.code == 2322),
+        "renamed-param intersection source must not collapse to a bare TS2322; got: {diagnostics:?}"
     );
 }
 

--- a/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
@@ -362,68 +362,6 @@ impl<'a> CheckerState<'a> {
         );
     }
 
-    /// Check if the diagnostic anchor node traces back to an assignment target
-    /// whose variable declaration has an intersection type annotation.
-    ///
-    /// For `y = a;` where `y: { a: string } & { b: string }`:
-    ///   anchor (`ExpressionStatement`) → expression (`BinaryExpression`) → left (Identifier)
-    ///   → symbol → `value_declaration` (`VariableDeclaration`) → `type_annotation` (`IntersectionType`)
-    /// Check if the SOURCE (RHS) of the assignment at the anchor has an intersection type
-    /// annotation on its declaration. This is needed because intersection types may be
-    /// flattened into Object types by the solver, losing the intersection structure.
-    pub(super) fn anchor_source_has_intersection_annotation(&self, anchor_idx: NodeIndex) -> bool {
-        self.anchor_source_intersection_check_inner(anchor_idx)
-            .unwrap_or(false)
-    }
-
-    fn anchor_source_intersection_check_inner(&self, anchor_idx: NodeIndex) -> Option<bool> {
-        use tsz_parser::parser::syntax_kind_ext;
-
-        let anchor_node = self.ctx.arena.get(anchor_idx)?;
-
-        // Walk from anchor to the assignment source (RHS) expression
-        let source_expr_idx = if anchor_node.kind == syntax_kind_ext::EXPRESSION_STATEMENT {
-            let expr_stmt = self.ctx.arena.get_expression_statement(anchor_node)?;
-            let expr_node = self.ctx.arena.get(expr_stmt.expression)?;
-            if expr_node.kind == syntax_kind_ext::BINARY_EXPRESSION {
-                let binary = self.ctx.arena.get_binary_expr(expr_node)?;
-                binary.right
-            } else {
-                return Some(false);
-            }
-        } else if anchor_node.kind == syntax_kind_ext::VARIABLE_DECLARATION {
-            // For `let x: T = source`, the source is the initializer
-            let var_decl = self.ctx.arena.get_variable_declaration(anchor_node)?;
-            var_decl.initializer
-        } else {
-            return Some(false);
-        };
-
-        // Check if the source is an identifier
-        let ident_node = self.ctx.arena.get(source_expr_idx)?;
-        if ident_node.kind != tsz_scanner::SyntaxKind::Identifier as u16 {
-            return Some(false);
-        }
-
-        // Resolve identifier to symbol
-        let sym_id = self.resolve_identifier_symbol(source_expr_idx)?;
-        let symbol = self.ctx.binder.get_symbol(sym_id)?;
-
-        // Get value declaration
-        let decl_node = self.ctx.arena.get(symbol.value_declaration)?;
-
-        // Check if it's a variable declaration with an intersection type annotation
-        if decl_node.kind == syntax_kind_ext::VARIABLE_DECLARATION {
-            let var_decl = self.ctx.arena.get_variable_declaration(decl_node)?;
-            if var_decl.type_annotation.is_some() {
-                let type_node = self.ctx.arena.get(var_decl.type_annotation)?;
-                return Some(type_node.kind == syntax_kind_ext::INTERSECTION_TYPE);
-            }
-        }
-
-        Some(false)
-    }
-
     pub(super) fn anchor_target_has_intersection_annotation(&self, anchor_idx: NodeIndex) -> bool {
         self.anchor_target_intersection_check_inner(anchor_idx)
             .unwrap_or(false)

--- a/crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs
@@ -265,93 +265,18 @@ impl<'a> CheckerState<'a> {
             return diag;
         }
 
-        // TSC emits TS2322 instead of TS2741 when the *source* type is an intersection.
-        // This covers type aliases like `LinkedList<T> = T & { next: ... }` that may have
-        // been evaluated to an intersection by the time we reach diagnostic rendering.
-        // Check both the type data and the source's declaration annotation, since
-        // intersections may be flattened into Object types by the solver.
-        let source_evaluated_for_intersection = self.evaluate_type_with_env(source);
-        if crate::query_boundaries::common::is_intersection_type(self.ctx.types, source)
-            || crate::query_boundaries::common::is_intersection_type(
-                self.ctx.types,
-                source_evaluated_for_intersection,
-            )
-            || (depth == 0 && self.anchor_source_has_intersection_annotation(idx))
-        {
-            let src_str = if depth == 0 {
-                self.format_type_for_diagnostic_role(
-                    source,
-                    DiagnosticTypeDisplayRole::AssignmentSource {
-                        target,
-                        anchor_idx: idx,
-                    },
-                )
-            } else {
-                self.format_type_diagnostic(source_type)
-            };
-            let tgt_str = if depth == 0 {
-                self.format_assignability_type_for_message(target, source)
-            } else {
-                self.format_type_diagnostic(target_type)
-            };
-            let message = format_message(
-                diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                &[&src_str, &tgt_str],
-            );
-            return Diagnostic::error(
-                file_name,
-                start,
-                length,
-                message,
-                diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-            );
-        }
-
-        // TSC emits TS2322 instead of TS2741 when the source is a type application
-        // (generic type alias) whose base type resolves to an intersection. For example,
-        // `LinkedList<Entity>` where `type LinkedList<T> = T & { next: LinkedList<T> }`.
-        // Named type aliases expanding to intersections are reported as general
-        // assignability failures, not property-level "missing" errors.
-        if let Some((base, _args)) =
-            crate::query_boundaries::common::application_info(self.ctx.types, source)
-        {
-            let base_eval = self.evaluate_type_with_env(base);
-            let base_is_intersection =
-                crate::query_boundaries::common::is_intersection_type(self.ctx.types, base)
-                    || crate::query_boundaries::common::is_intersection_type(
-                        self.ctx.types,
-                        base_eval,
-                    );
-            if base_is_intersection {
-                let src_str = if depth == 0 {
-                    self.format_type_for_diagnostic_role(
-                        source,
-                        DiagnosticTypeDisplayRole::AssignmentSource {
-                            target,
-                            anchor_idx: idx,
-                        },
-                    )
-                } else {
-                    self.format_type_diagnostic(source_type)
-                };
-                let tgt_str = if depth == 0 {
-                    self.format_assignability_type_for_message(target, source)
-                } else {
-                    self.format_type_diagnostic(target_type)
-                };
-                let message = format_message(
-                    diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                    &[&src_str, &tgt_str],
-                );
-                return Diagnostic::error(
-                    file_name,
-                    start,
-                    length,
-                    message,
-                    diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                );
-            }
-        }
+        // An intersection *source* (written directly, via an alias such as
+        // `Branded<T> = T & { __brand }`, or via a generic application whose base
+        // resolves to an intersection like `LinkedList<T> = T & { next }`) does NOT
+        // downgrade a genuine missing required named property to a generic TS2322.
+        // tsc reports the property-level miss (TS2741/TS2739) and displays the source
+        // as-written — e.g. `Property 'b' is missing in type 'LinkedList<{ a: number; }>'
+        // but required in type '{ a: number; b: string; }'`. The intersection-specific
+        // TS2322 elaboration applies to intersection *targets* (handled above), where
+        // tsc explains which member requires the property; it is not a source concern.
+        // Flattened plain-object intersections already reach the TS2741 path here, and
+        // the plural `render_missing_properties` path likewise never downgrades for
+        // intersection sources, so both singular and plural paths stay consistent.
 
         // Private brand properties handling
         let prop_name = self.ctx.types.resolve_atom_ref(property_name).to_string();

--- a/crates/tsz-checker/src/error_reporter/render_request_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/render_request_tests.rs
@@ -824,3 +824,125 @@ fn ts2345_property_chain_is_stable_across_repeated_checks() {
     let second = chain(&check_source_diagnostics(source));
     assert_eq!(first, second, "chain drifted between independent runs");
 }
+
+// =========================================================================
+// TS2741 / TS2739 — missing property through an intersection SOURCE
+//
+// Regression for #10962: an intersection source (written directly, via an
+// alias such as `Tagged<T> = T & { kind }`, or via a generic application whose
+// base resolves to an intersection) must NOT downgrade a genuine missing
+// required named property to a bare generic TS2322. tsc reports the
+// property-level miss (TS2741 single / TS2739 multiple) and displays the
+// source as-written. Binder names vary across cases so the behavior is keyed
+// to type structure, not identifiers.
+// =========================================================================
+
+#[test]
+fn missing_property_through_mapped_application_intersection_source_is_ts2741() {
+    // `Wrap<{ alpha }> & { beta }` is missing the required `gamma`. The mapped
+    // application member forces the source to stay an intersection at render
+    // time — the case that previously collapsed to generic TS2322.
+    let source = r#"
+type Wrap<T> = { [K in keyof T]: T[K] };
+declare const boxed: Wrap<{ alpha: number }> & { beta: string };
+const sink: { alpha: number; gamma: boolean } = boxed;
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let missing = diagnostics
+        .iter()
+        .find(|d| d.code == 2741)
+        .unwrap_or_else(|| {
+            panic!(
+                "expected TS2741 for missing property through intersection source, got: {:?}",
+                diagnostics
+                    .iter()
+                    .map(|d| (d.code, d.message_text.clone()))
+                    .collect::<Vec<_>>()
+            )
+        });
+    assert!(
+        missing.message_text.contains("'gamma'") && missing.message_text.contains("is missing"),
+        "TS2741 should name the missing property, got: {}",
+        missing.message_text
+    );
+    // The source must be shown as the as-written intersection, not collapsed.
+    assert!(
+        missing
+            .message_text
+            .contains("Wrap<{ alpha: number; }> & { beta: string; }"),
+        "TS2741 should display the intersection source as-written, got: {}",
+        missing.message_text
+    );
+    assert!(
+        !diagnostics.iter().any(|d| d.code == 2322),
+        "intersection-source missing property must not also emit generic TS2322, got: {:?}",
+        diagnostics.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn missing_property_through_alias_intersection_source_is_ts2741() {
+    // `Tagged<T> = T & { kind }` — an alias whose body is an intersection.
+    let source = r#"
+type Tagged<T> = T & { kind: "x" };
+declare const flagged: Tagged<{ epsilon: number }>;
+const drain: { epsilon: number; zeta: boolean } = flagged;
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let missing = diagnostics
+        .iter()
+        .find(|d| d.code == 2741)
+        .unwrap_or_else(|| {
+            panic!(
+                "expected TS2741 for missing property through alias-intersection source, got: {:?}",
+                diagnostics
+                    .iter()
+                    .map(|d| (d.code, d.message_text.clone()))
+                    .collect::<Vec<_>>()
+            )
+        });
+    assert!(
+        missing.message_text.contains("'zeta'")
+            && missing
+                .message_text
+                .contains("Tagged<{ epsilon: number; }>"),
+        "TS2741 should name the missing property and display the alias source, got: {}",
+        missing.message_text
+    );
+}
+
+#[test]
+fn multiple_missing_properties_through_intersection_source_is_ts2739() {
+    // Two missing required properties routes through the plural path (TS2739),
+    // which must likewise display the intersection source as-written.
+    let source = r#"
+type Shape<T> = { [K in keyof T]: T[K] };
+declare const parcel: Shape<{ mu: number }> & { nu: string };
+const consumer: { mu: number; xi: boolean; omicron: number } = parcel;
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let missing = diagnostics
+        .iter()
+        .find(|d| d.code == 2739)
+        .unwrap_or_else(|| {
+            panic!(
+                "expected TS2739 for multiple missing properties through intersection source, got: {:?}",
+                diagnostics
+                    .iter()
+                    .map(|d| (d.code, d.message_text.clone()))
+                    .collect::<Vec<_>>()
+            )
+        });
+    assert!(
+        missing.message_text.contains("xi") && missing.message_text.contains("omicron"),
+        "TS2739 should list the missing properties, got: {}",
+        missing.message_text
+    );
+    assert!(
+        missing
+            .message_text
+            .contains("Shape<{ mu: number; }> & { nu: string; }"),
+        "TS2739 should display the intersection source as-written, got: {}",
+        missing.message_text
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-D
Runner: claude-confident-hawking

## Track
Diagnostics / type-display parity for issue #10962 (`utility-types-project`, diagnostic-chain family).

## Invariant
When a required named property is genuinely absent from an intersection source, `tsc` reports the property-level miss (`TS2741` for one property, `TS2739` for multiple properties) and displays the source as written. This PR changes checker diagnostic rendering so source-side intersections keep the existing missing-property reason instead of being downgraded to a bare `TS2322`.

## Scope
- `crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs`: remove the over-broad source-intersection downgrade path.
- `crates/tsz-checker/src/error_reporter/assignability_helpers.rs`: support the diagnostic rendering path touched by the missing-property renderer.
- `crates/tsz-checker/src/error_reporter/render_request_tests.rs`: add intersection-source missing-property regression coverage.
- `crates/tsz-checker/src/assignability/assignment_checker_mapped_type_tests.rs`: update mapped/intersection expectations from the prior incorrect `TS2322` shape to the `tsc`-matching missing-property diagnostic.

## Project Corpus Impact
- Row: `utility-types-project`
- Bug family: diagnostics / type-display / diagnostic-chain, issue #10962.
- Evidence: the PR targets the mapped/intersection diagnostic shape that caused the row-family report. It changes only diagnostic rendering for already-failing assignments; no solver/relation or pass/fail behavior is intended to change.

## Verification
- Author reported: `cargo test -p tsz-checker --lib error_reporter::` -> 172 passed, 0 failed.
- Author reported: new `render_request_tests.rs` regressions for direct, alias, application, single-property, and multi-property intersection-source misses pass with this change and fail without it.
- Author reported: updated mapped-type assignment checker expectations were checked against `tsc 6.0.2`.
- Author reported: clean-main baseline vs this change over `ts2322` / `intersection` / `missing` filters showed only pre-existing failures and no new failures.
- CI currently has `project-corpus-pr-body` red from the previous body/label shape; rerun or wait for exact-head CI after this body/label repair.

## Coordination Notes
- Fixes #10962.
- The issue is owned by `agent:Studio-D`; this PR now uses canonical `AgentName: Studio-D` with runner metadata preserved separately.
- No `merge-queue` until the body gate is green, exact-head checks finish, and manager/queue-owner policy allows it.
- Out of scope per author: property-type-mismatch display provenance and nested intersection-target application rendering.
