### PR TITLE
ci: use npm trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -197,8 +197,6 @@ jobs:
 
       - name: Publish packages
         shell: bash
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
           publish_if_needed() {


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Release infrastructure / npm publish workflow

## Invariant
When npm packages have trusted GitHub publishers configured, the publish workflow should use GitHub OIDC/provenance rather than an npm token secret; this PR changes the npm publish workflow only.

## Scope
- Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from `.github/workflows/npm-publish.yml` so `npm publish --provenance` can use trusted publishing.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI-only release workflow change; no compiler behavior or project corpus rows are affected.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/npm-publish.yml"); puts "yaml ok"'`
- `git diff --check`
- Manual bootstrap published `try-tsz@0.1.9` and all `@mohsen-azimi/try-tsz-*` helpers.
- `scripts/build/setup-npm-trusted-publishers.sh` configured GitHub trusted publishing for all seven packages.
- Published package smoke: `npx --yes try-tsz@latest --json summary.json` in a temp TypeScript project reported `matched-clean`.

## Coordination Notes
- This follows the initial manual npm bootstrap because npm requires package records to exist before trusted publishers can be attached.
- Future publish runs should no longer require `secrets.NPM_TOKEN`.
