### PR TITLE
fix(cli): use TypeScript 6 oracle for try-tsz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-binder"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-checker"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "dashmap",
  "globset",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-cli"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-common"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "memchr",
  "rustc-hash",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-core"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-emitter"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "memchr",
  "rustc-hash",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-lowering"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "indexmap",
  "rustc-hash",
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-lsp"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "globset",
  "json5",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-parser"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-scanner"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "serde",
  "tsz-common",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-solver"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "bitflags 2.11.0",
  "dashmap",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-wasm"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-website"
-version = "0.1.9"
+version = "0.1.10"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/.target"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 repository = "https://github.com/mohsen1/tsz"
 homepage = "https://github.com/mohsen1/tsz"
@@ -16,16 +16,16 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Internal workspace crates
-tsz = { path = "crates/tsz-core", version = "0.1.9", package = "tsz-core" }
-tsz-common = { path = "crates/tsz-common", version = "0.1.9" }
-tsz-scanner = { path = "crates/tsz-scanner", version = "0.1.9" }
-tsz-parser = { path = "crates/tsz-parser", version = "0.1.9" }
-tsz-binder = { path = "crates/tsz-binder", version = "0.1.9" }
-tsz-solver = { path = "crates/tsz-solver", version = "0.1.9" }
-tsz-lowering = { path = "crates/tsz-lowering", version = "0.1.9" }
-tsz-checker = { path = "crates/tsz-checker", version = "0.1.9" }
-tsz-emitter = { path = "crates/tsz-emitter", version = "0.1.9", default-features = false }
-tsz-lsp = { path = "crates/tsz-lsp", version = "0.1.9" }
+tsz = { path = "crates/tsz-core", version = "0.1.10", package = "tsz-core" }
+tsz-common = { path = "crates/tsz-common", version = "0.1.10" }
+tsz-scanner = { path = "crates/tsz-scanner", version = "0.1.10" }
+tsz-parser = { path = "crates/tsz-parser", version = "0.1.10" }
+tsz-binder = { path = "crates/tsz-binder", version = "0.1.10" }
+tsz-solver = { path = "crates/tsz-solver", version = "0.1.10" }
+tsz-lowering = { path = "crates/tsz-lowering", version = "0.1.10" }
+tsz-checker = { path = "crates/tsz-checker", version = "0.1.10" }
+tsz-emitter = { path = "crates/tsz-emitter", version = "0.1.10", default-features = false }
+tsz-lsp = { path = "crates/tsz-lsp", version = "0.1.10" }
 
 # External dependencies (shared versions)
 anyhow = "1.0"

--- a/crates/tsz-cli/src/try_tsz/mod.rs
+++ b/crates/tsz-cli/src/try_tsz/mod.rs
@@ -336,7 +336,7 @@ fn run_config(cwd: &Path, config: &Path) -> ConfigReport {
 }
 
 fn run_tsc(cwd: &Path, config: &Path) -> Result<CompilerRun> {
-    ensure_local_typescript(cwd, config)?;
+    ensure_typescript_oracle(cwd, config)?;
 
     let command = format!("node <try-tsz tsc helper> {}", config.display());
     println!("Running tsc --noEmit -p {} ...", relative_path(cwd, config));
@@ -347,7 +347,7 @@ fn run_tsc(cwd: &Path, config: &Path) -> Result<CompilerRun> {
         .arg(config)
         .current_dir(cwd)
         .output()
-        .context("failed to run node for the local TypeScript oracle")?;
+        .context("failed to run node for the TypeScript 6 oracle")?;
     let elapsed_ms = start.elapsed().as_millis();
 
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
@@ -599,12 +599,14 @@ fn should_visit_entry(entry: &DirEntry) -> bool {
     )
 }
 
-fn ensure_local_typescript(cwd: &Path, config: &Path) -> Result<()> {
-    if find_local_tsc(cwd, config).is_some() {
+fn ensure_typescript_oracle(cwd: &Path, config: &Path) -> Result<()> {
+    if std::env::var_os("TRY_TSZ_TYPESCRIPT_PACKAGE_JSON").is_some()
+        || find_local_tsc(cwd, config).is_some()
+    {
         Ok(())
     } else {
         bail!(
-            "try-tsz needs this project to have TypeScript installed locally; searched from {} and {} for {}",
+            "try-tsz needs TypeScript 6.0.3 or newer for the tsc oracle; the npm package provides it, or install TypeScript locally. Searched from {} and {} for {}",
             cwd.display(),
             config.parent().unwrap_or(cwd).display(),
             local_tsc_relative_path().display()
@@ -1438,29 +1440,29 @@ mod tests {
     }
 
     #[test]
-    fn local_typescript_preflight_accepts_hoisted_workspace_tsc() {
+    fn typescript_oracle_preflight_accepts_hoisted_workspace_tsc() {
         let temp = TempDir::new();
         let package_dir = temp.path.join("packages/foo");
         let config = package_dir.join("tsconfig.json");
         write_file(&config, "{}");
         write_file(&temp.path.join(local_tsc_relative_path()), "");
 
-        ensure_local_typescript(&package_dir, &config)
+        ensure_typescript_oracle(&package_dir, &config)
             .expect("hoisted workspace TypeScript should satisfy preflight");
     }
 
     #[test]
-    fn local_typescript_preflight_rejects_missing_tsc() {
+    fn typescript_oracle_preflight_rejects_missing_tsc() {
         let temp = TempDir::new();
         let package_dir = temp.path.join("packages/foo");
         let config = package_dir.join("tsconfig.json");
         write_file(&config, "{}");
 
-        let error = ensure_local_typescript(&package_dir, &config)
+        let error = ensure_typescript_oracle(&package_dir, &config)
             .expect_err("missing local TypeScript should be rejected")
             .to_string();
 
-        assert!(error.contains("TypeScript installed locally"));
+        assert!(error.contains("TypeScript 6.0.3 or newer"));
         assert!(error.contains("node_modules/.bin/tsc"));
     }
 

--- a/crates/tsz-cli/src/try_tsz/tsc_diagnostics_helper.js
+++ b/crates/tsz-cli/src/try_tsz/tsc_diagnostics_helper.js
@@ -1,10 +1,77 @@
 const path = require("node:path");
 const { createRequire } = require("node:module");
 
+const MIN_TYPESCRIPT_VERSION = "6.0.3";
 const configPath = path.resolve(process.argv[1]);
 const projectRoot = path.dirname(configPath);
 const projectRequire = createRequire(path.join(projectRoot, "package.json"));
-const ts = projectRequire("typescript");
+
+function versionParts(version) {
+  return version
+    .split(".")
+    .map((part) => Number.parseInt(part, 10))
+    .map((part) => (Number.isFinite(part) ? part : 0));
+}
+
+function versionAtLeast(version, minimum) {
+  const actual = versionParts(version);
+  const required = versionParts(minimum);
+  for (let index = 0; index < required.length; index += 1) {
+    const left = actual[index] ?? 0;
+    const right = required[index] ?? 0;
+    if (left > right) return true;
+    if (left < right) return false;
+  }
+  return true;
+}
+
+function candidateRequires() {
+  const candidates = [];
+  const packageJson = process.env.TRY_TSZ_TYPESCRIPT_PACKAGE_JSON;
+  if (packageJson) {
+    candidates.push({
+      label: packageJson,
+      require: createRequire(packageJson),
+    });
+  }
+  candidates.push({
+    label: path.join(projectRoot, "package.json"),
+    require: projectRequire,
+  });
+  return candidates;
+}
+
+function loadTypescript() {
+  const rejected = [];
+  const seen = new Set();
+  for (const candidate of candidateRequires()) {
+    if (seen.has(candidate.label)) continue;
+    seen.add(candidate.label);
+    try {
+      const ts = candidate.require("typescript");
+      if (versionAtLeast(ts.version, MIN_TYPESCRIPT_VERSION)) {
+        return ts;
+      }
+      rejected.push(`${candidate.label} has TypeScript ${ts.version}`);
+    } catch (error) {
+      rejected.push(
+        `${candidate.label} could not load TypeScript: ${error.message}`,
+      );
+    }
+  }
+  const details = rejected.join("; ");
+  throw new Error(
+    `try-tsz needs TypeScript ${MIN_TYPESCRIPT_VERSION} or newer for the tsc oracle. ${details}`,
+  );
+}
+
+let ts;
+try {
+  ts = loadTypescript();
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}
 
 function flattenMessage(messageText) {
   return ts.flattenDiagnosticMessageText(messageText, "\n");

--- a/docs/specs/TRY_TSZ.md
+++ b/docs/specs/TRY_TSZ.md
@@ -9,10 +9,10 @@ The user runs:
 npx try-tsz
 ```
 
-The tool finds the relevant `tsconfig.json`, runs the project's own `tsc` and
-the latest published `tsz` in a no-emit check, compares the complete diagnostic
-result, reports speed, and guides the user through an interactive, local-only
-bug-report flow when `tsz` differs.
+The tool finds the relevant `tsconfig.json`, runs a TypeScript `tsc` oracle at
+version `6.0.3` or newer and the latest published `tsz` in a no-emit check,
+compares the complete diagnostic result, reports speed, and guides the user
+through an interactive, local-only bug-report flow when `tsz` differs.
 
 This is not switch/migration messaging. The user-facing promise is:
 
@@ -23,7 +23,8 @@ This is not switch/migration messaging. The user-facing promise is:
 
 - Audience: any project that uses `tsc` for type checking or emit.
 - MVP scope: type-check parity only, always run both compilers with `--noEmit`.
-- Compatibility bar: `tsz` matches `tsc` exactly for exit status and diagnostics.
+- Compatibility bar: `tsz` matches TypeScript `tsc` `6.0.3` or newer exactly
+  for exit status and diagnostics.
 - Diagnostic comparison: compare file, line, column/span when available, code,
   message text, and order.
 - Correctness wins the headline. If `tsz` is faster but wrong, report mismatch
@@ -131,8 +132,9 @@ Repository layout:
 
 Compiler invocation:
 
-- Locate local TypeScript through `node_modules/.bin/tsc`; if missing, fail with
-  a setup message because the product assumes the project already has `tsc`.
+- Use a TypeScript `6.0.3` or newer oracle. The npm `try-tsz` package provides
+  that oracle dependency; if a non-npm/local build cannot find it, a project
+  TypeScript install at `6.0.3` or newer may be used.
 - Invoke `tsc --pretty false --noEmit -p <config>`.
 - Invoke the packaged latest `tsz` binary as `tsz --pretty false --noEmit -p
   <config>`.
@@ -146,10 +148,10 @@ Structured diagnostics:
 
 - Prefer adding a stable machine-readable diagnostic output mode to `tsz` for
   `try-tsz` rather than parsing `tsz` text forever.
-- For `tsc`, use a small Node helper with the project's installed `typescript`
-  package to parse the config and collect pre-emit diagnostics as structured
-  JSON. This avoids brittle text parsing and ensures the oracle is the user's
-  actual TypeScript version.
+- For `tsc`, use a small Node helper with TypeScript `6.0.3` or newer to parse
+  the config and collect pre-emit diagnostics as structured JSON. This avoids
+  brittle text parsing and keeps the oracle aligned with the `tsz` compatibility
+  target.
 - Compare the structured `tsc` diagnostics to structured `tsz` diagnostics.
 - Include the raw command output in `.try-tsz/raw/` only when the user chooses
   to generate a report.

--- a/scripts/build/build-npm-packages.sh
+++ b/scripts/build/build-npm-packages.sh
@@ -419,6 +419,9 @@ const pkg = {
   bin: {
     "try-tsz": "bin/try-tsz.js",
   },
+  dependencies: {
+    typescript: "^6.0.3",
+  },
   optionalDependencies,
   files: ["bin/", "LICENSE.txt"],
 };
@@ -480,9 +483,20 @@ try {
   process.exit(1);
 }
 
+let typescriptPackageJson;
+try {
+  typescriptPackageJson = require.resolve("typescript/package.json");
+} catch {
+  console.error("Missing try-tsz TypeScript oracle dependency");
+  process.exit(1);
+}
+
 const result = spawnSync(binary, process.argv.slice(2), {
   cwd: process.cwd(),
-  env: process.env,
+  env: {
+    ...process.env,
+    TRY_TSZ_TYPESCRIPT_PACKAGE_JSON: typescriptPackageJson,
+  },
   stdio: "inherit",
 });
 


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Release tooling / try-tsz npm probe

## Invariant
When `try-tsz` compares a project, the `tsc` oracle is TypeScript `6.0.3` or newer; this PR changes the `try-tsz` oracle helper, npm launcher packaging, and package version used for the next publish.

## Scope
- `crates/tsz-cli/src/try_tsz/tsc_diagnostics_helper.js` now loads TypeScript `>=6.0.3`, preferring the packaged npm oracle.
- `scripts/build/build-npm-packages.sh` adds `typescript: ^6.0.3` to the public `try-tsz` package and passes its package path to the native binary.
- `Cargo.toml` / `Cargo.lock` bump the workspace package version to `0.1.10` so npm can publish the fix-forward package.
- `docs/specs/TRY_TSZ.md` now documents the TypeScript `6.0.3+` oracle decision.

## Project Corpus Impact
- Row: n/a
- Bug family: try-tsz oracle/tooling only
- Evidence: no compiler semantics changed; real-project smoke was run through the `try-tsz` package path against public projects.

## Verification
- `bash -n scripts/build/build-npm-packages.sh && node --check crates/tsz-cli/src/try_tsz/tsc_diagnostics_helper.js && cargo fmt --check --package tsz-cli && git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-cli try_tsz`
- `cargo check -p tsz-cli --bin try-tsz`
- `scripts/safe-run.sh scripts/build/build-npm-packages.sh --local --native-only`
- Local package smoke in `mohsen1/json-formatter-js`: generated `try-tsz` package used `tscVersion: "6.0.3"` despite project-local TypeScript 5.5.2.
- Local package smoke in `mohsen1/yawn-yaml`: generated `try-tsz` package used `tscVersion: "6.0.3"` despite project-local TypeScript 5.4.5.

## Coordination Notes
- Corrected #12284 after confirming TypeScript 6 emits the TS5107 diagnostics.
- Corrected #12285 with TypeScript 6 oracle evidence.
- Follow-up after merge: publish `try-tsz@0.1.10`, rerun public-package real-project smoke, and continue filing/fixing real parity bugs.
