### PR TITLE
fix(parser): allow conditional types in delimited contexts within an extends position (#11348)

### DIFF
--- a/crates/tsz-parser/src/parser/state_types_advanced.rs
+++ b/crates/tsz-parser/src/parser/state_types_advanced.rs
@@ -1309,6 +1309,18 @@ impl ParserState {
     pub(crate) fn parse_type_literal_rest(&mut self, start_pos: u32) -> NodeIndex {
         let saved_type_member_depth = self.type_member_container_depth;
         self.type_member_container_depth += 1;
+
+        // A `{ ... }` type literal opens a fresh, braced sub-type scope. Clear the
+        // scope-barrier flags so member types may contain conditional types even when
+        // the literal appears in an outer `extends` position (e.g.
+        // `T extends { a: A extends B ? C : D } ? 1 : 2`), and a postfix `?` on a member
+        // type is not mis-reserved for a tuple-level optional when the literal is nested
+        // in a tuple element. Matches tsc, where members are parsed by a fresh `parseType`
+        // so the one-level `noConditionalTypes` block does not leak past the brace.
+        let saved_flags = self.context_flags;
+        self.context_flags &= !(crate::parser::state::CONTEXT_FLAG_DISALLOW_CONDITIONAL_TYPES
+            | crate::parser::state::CONTEXT_FLAG_IN_TUPLE_ELEMENT);
+
         let mut members = Vec::new();
 
         while !self.is_token(SyntaxKind::CloseBraceToken)
@@ -1320,6 +1332,7 @@ impl ParserState {
             {
                 let mapped_type = self.parse_mapped_type_with_members(start_pos, members);
                 self.type_member_container_depth = saved_type_member_depth;
+                self.context_flags = saved_flags;
                 return mapped_type;
             }
 
@@ -1344,6 +1357,7 @@ impl ParserState {
 
         let end_pos = self.finish_type_member_container_close_brace();
         self.type_member_container_depth = saved_type_member_depth;
+        self.context_flags = saved_flags;
 
         self.arena.add_type_literal(
             syntax_kind_ext::TYPE_LITERAL,
@@ -1411,7 +1425,19 @@ impl ParserState {
 
     fn parse_type_argument_in_type_arguments(&mut self) -> NodeIndex {
         if !self.is_token(SyntaxKind::QuestionToken) {
-            return self.parse_type();
+            // Each type argument is a fresh, complete type-expression scope. Clear the
+            // scope-barrier flags so a conditional type is permitted even when the
+            // reference appears in an outer `extends` position (e.g.
+            // `T extends Foo<A extends B ? C : D> ? 1 : 2`), and a postfix `?` is not
+            // mis-reserved for a tuple-level optional when the reference is nested in a
+            // tuple element. Matches tsc, where every type argument is parsed by a fresh
+            // `parseType`, so the one-level `noConditionalTypes` block does not leak in.
+            let saved_flags = self.context_flags;
+            self.context_flags &= !(crate::parser::state::CONTEXT_FLAG_DISALLOW_CONDITIONAL_TYPES
+                | crate::parser::state::CONTEXT_FLAG_IN_TUPLE_ELEMENT);
+            let type_node = self.parse_type();
+            self.context_flags = saved_flags;
+            return type_node;
         }
 
         use tsz_common::diagnostics::diagnostic_codes;

--- a/crates/tsz-parser/tests/state_type_tests.rs
+++ b/crates/tsz-parser/tests/state_type_tests.rs
@@ -1264,3 +1264,56 @@ fn test_issue_10937_three_rest_elements_in_tuple() {
         "...A",
     );
 }
+
+/// Regression: a conditional type used as a type argument (or inside an object-type
+/// member / tuple element) must parse even when the enclosing type reference sits in
+/// the `extends` position of an outer conditional type. The `extends`-position block on
+/// top-level conditionals is one level deep in tsc (`noConditionalTypes`), so it must
+/// not leak past a `<...>`, `{...}`, or `[...]` boundary. Previously tsz threaded this as
+/// a persistent context flag that leaked into type arguments and type-literal members,
+/// producing spurious `TS1005` diagnostics (e.g. `'>' expected.`).
+#[test]
+fn parse_conditional_type_in_delimited_context_within_extends_position() {
+    let cases: &[&str] = &[
+        "type R1<T> = T extends Foo<A extends B ? C : D> ? 1 : 2;",
+        "type R2<Src> = Src extends Container<Lhs extends Rhs ? Yes : No> ? 1 : 2;",
+        "type R3<T> = T extends Wrap<P extends Q ? X : Y, M extends N ? U : V> ? 1 : 2;",
+        "type R4<T> = T extends Outer<Inner<P extends Q ? X : Y>> ? 1 : 2;",
+        "type R5<T> = T extends Box<P extends Q ? R extends S ? X : Y : Z> ? 1 : 2;",
+        "type R6<T> = T extends Box<P extends infer U ? U : never> ? 1 : 2;",
+        "type R7<T> = T extends { value: P extends Q ? X : Y } ? 1 : 2;",
+        "type R8<T> = T extends [P extends Q ? X : Y] ? 1 : 2;",
+        "type R9<T> = T extends Box<{ [K in keyof Src]: Src[K] } & (Src extends Q ? X : Y)> ? 1 : 2;",
+        "type R10<T> = T extends { [K in keyof T]: Box<T[K] extends object ? 1 : 0> } ? 1 : 2;",
+    ];
+    for src in cases {
+        let (parser, _root) = parse_source(src);
+        assert!(
+            parser.get_diagnostics().is_empty(),
+            "expected no parse diagnostics for {src:?}, got {:?}",
+            parser.get_diagnostics()
+        );
+    }
+}
+
+/// Structural lock: the inner `A extends B ? C : D` must materialize as a real
+/// `CONDITIONAL_TYPE` node nested inside the type argument, not be truncated to its
+/// check type with the `extends` left dangling.
+#[test]
+fn conditional_type_argument_in_extends_position_builds_nested_conditional_node() {
+    assert_span(
+        "type R<T> = T extends Foo<A extends B ? C : D> ? 1 : 2;",
+        syntax_kind_ext::CONDITIONAL_TYPE,
+        "A extends B ? C : D",
+    );
+}
+
+/// Regression guard: clearing the conditional block for delimited contexts must not
+/// disturb the `infer U extends X ? ...` disambiguation. In an `extends` position the
+/// `extends number` is the infer constraint and the `? 1 : 0` belongs to the outer
+/// conditional, so the whole type still parses cleanly.
+#[test]
+fn infer_constraint_disambiguation_unaffected_by_delimited_context_fix() {
+    assert_no_errors("type R<T> = T extends infer U extends number ? 1 : 0;");
+    assert_no_errors("type R<T> = T extends infer U extends Foo<A extends B ? C : D> ? U : never;");
+}


### PR DESCRIPTION
## Summary

Fixes #11348 (utility-types-project: parser fails on nested conditional + mapped intersections).

A conditional type nested inside a **delimited type context** (a type-argument list or a brace-delimited type literal) that itself appears in the **`extends` position** of an outer conditional type was rejected with spurious `TS1005` diagnostics. Minimal witnesses (angle brackets escaped so they render):

- type A&lt;T&gt; = T extends Foo&lt;A extends B ? C : D&gt; ? 1 : 2; &nbsp; &rarr; previously errored with `'>' expected.`
- type B&lt;T&gt; = T extends { a: A extends B ? C : D } ? 1 : 2; &nbsp; &rarr; previously errored with `';' expected.`

## Structural rule

When a conditional type appears inside a type-argument list (`&lt;...&gt;`), a brace type literal (`{...}`), a tuple element (`[...]`), parentheses, or a template span, `tsc` parses it with a fresh `parseType`, so a conditional type is permitted there even when the enclosing reference sits in an outer `extends` position. tsz must do the same through the **parser** (owner layer: `crates/tsz-parser`).

## Root cause / owner layer

`tsc` has two distinct mechanisms:
- a one-level `noConditionalTypes` **parameter** that blocks only the immediate `parseTypeWorker` frame from consuming a top-level `extends`; and
- a persistent `DisallowConditionalTypesContext` flag used only by the `infer T extends X ?` disambiguation.

tsz collapses both into a single **persistent** `CONTEXT_FLAG_DISALLOW_CONDITIONAL_TYPES`. The persistent flag (correct for the infer case) wrongly leaked the one-level `extends` block into nested delimited contexts. The established tsz convention already clears the flag for tuple elements, parenthesized types, and template spans — but **type arguments and type-literal members were missed**. This is the fundamental cause, not the specific repro: the fix re-enables conditionals across the whole family of nested delimited contexts, not just the reported witness.

## Scope

- `parse_type_argument_in_type_arguments`: clear `DISALLOW_CONDITIONAL_TYPES | IN_TUPLE_ELEMENT` for each fresh type argument.
- `parse_type_literal_rest`: clear the same flags once at the brace-type-literal boundary (covers property/method/index/call/construct signatures and the mixed mapped-type path), restored at both exit points.

No checker/solver/emitter changes. The parser now produces a correct `CONDITIONAL_TYPE` node where it previously truncated to the check type and errored, so the change can only fix previously-erroring inputs.

## Adjacent-case matrix

Verified parsing clean across: single/multiple/nested type arguments, conditional chains, `infer`-in-type-argument, object-type members, tuple elements, mapped-intersection type arguments, index signatures, method/construct signatures, function-type parameter annotations, indexed-access of a conditional type argument, and template spans. Binder names are varied across cases (`Foo`/`Container`/`Wrap`/`Box`, `A`/`Lhs`/`P`...). Regression guard confirms the `infer U extends X ? ...` disambiguation is unaffected (both the direct form and a conditional type argument inside the infer constraint).

## Project Corpus Impact

- Row: utility-types-project
- Bug family: parser-nested-conditional-mapped-intersection

Parser-only parity fix on the utility-types-project row family (nested conditional/mapped over intersections). Re-enables previously-rejected valid TypeScript; no diagnostic suppression or output surgery. Broad conformance/project-row suites are owned by ready-review CI.

## Verification

- `cargo test -p tsz-parser --lib` &rarr; 1341 passed, 0 failed (3 new regression tests included).
- `cargo clippy -p tsz-parser --tests` &rarr; clean.
- Rebased onto latest `main` (`c55c66c`); no conflicts.

## Coordination Notes

Issue #11348 is owned by `agent:M4-D` (the maintainer added the matching `agent:M4-D` label to this PR). I am a contributor session into that lane — `AgentName` below is contributor identity, per `docs/plan/agents/README.md` (generated runner names are contributor identity, not ownership). No second `agent:*` label was added. No open PR referenced this issue. Happy to hand off to the M4-D lane for the owner review.

AgentName: claude-confident-hawking
Track: parser conformance / project-row parity
Invariant: parser matches tsc grammar for conditional types in delimited contexts
Scope: `crates/tsz-parser` type-argument and type-literal parsing
