### PR TITLE
fix(checker): elaborate more union-source member failures (TS2322)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -1065,6 +1065,19 @@ impl<'a> CheckerState<'a> {
                     depth: child_depth.min(u8::MAX as u32) as u8,
                 });
             } else {
+                // The nested reason is rendered at `child_depth.max(1)` (a
+                // structural renderer needs depth >= 1 to format its child lines
+                // structurally rather than as a top-level primary), but its
+                // *primary* line lands at `child_depth`. When `child_depth == 0`
+                // the two differ by one, so a multi-line nested reason (e.g. an
+                // array-element mismatch, whose own header doubles as the member
+                // line and which then drills into the element relation) would
+                // keep its drill lines one indent too deep. Rebase the whole
+                // sub-chain from its render depth down to `child_depth` so the
+                // drill lines sit directly beneath the member line. For
+                // `child_depth >= 1` the render depth already equals
+                // `child_depth`, so this is a no-op and deeper chains are
+                // unchanged.
                 let nested_diag = self.render_failure_reason(
                     nested_reason,
                     nested_source,
@@ -1072,7 +1085,12 @@ impl<'a> CheckerState<'a> {
                     idx,
                     child_depth.max(1),
                 );
-                Self::push_nested_chain(&mut diag, nested_diag, child_depth);
+                Self::push_rebased_subdiagnostic(
+                    &mut diag,
+                    nested_diag,
+                    child_depth.max(1),
+                    child_depth,
+                );
             }
         }
 

--- a/crates/tsz-checker/tests/union_source_structural_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/union_source_structural_elaboration_tests.rs
@@ -241,3 +241,107 @@ const v: Target = u;
          with no extra member header; got {chain:?}"
     );
 }
+
+/// Array-element union member: a `number[]` member assigned where `string[]` is
+/// required self-heads with its own `Type 'number[]' is not assignable to type
+/// 'string[]'.` line (which doubles as the member header) and then drills into
+/// the element relation one indent deeper — matching tsc. Before the fix the
+/// chain stopped at the bare top-level union line.
+#[test]
+fn union_member_array_element_mismatch_emits_header_and_drill() {
+    let diags = diagnostics(
+        r#"
+declare const s: string[] | number[];
+const t: string[] = s;
+"#,
+    );
+    let chain = ts2322_chain(&diags);
+    assert!(
+        chain_has(&chain, 0, |m| m.contains("'number[]'")
+            && m.contains("'string[]'")
+            && m.contains("is not assignable")),
+        "expected the array member header at depth 0; got {chain:?}"
+    );
+    assert!(
+        chain_has(&chain, 1, |m| m.contains("'number'")
+            && m.contains("'string'")
+            && m.contains("is not assignable")),
+        "expected the element leaf relation at depth 1 (directly beneath the \
+         member header, not over-indented); got {chain:?}"
+    );
+}
+
+/// Array-of-object union member drills member header -> element header ->
+/// `Types of property` -> leaf, each exactly one indent deeper. This pins the
+/// depth composition (the element drill must sit beneath the member line, not a
+/// level too deep).
+#[test]
+fn union_member_array_of_object_drills_each_level_one_indent() {
+    let diags = diagnostics(
+        r#"
+declare const s: { a: string }[] | { a: number }[];
+const t: { a: string }[] = s;
+"#,
+    );
+    let chain = ts2322_chain(&diags);
+    assert!(
+        chain_has(&chain, 0, |m| m.contains("is not assignable")
+            && m.contains("[]")),
+        "expected the array member header at depth 0; got {chain:?}"
+    );
+    assert!(
+        chain_has(&chain, 2, |m| m.contains("property 'a'")
+            && m.contains("incompatible")),
+        "expected `Types of property 'a' are incompatible.` at depth 2; \
+         got {chain:?}"
+    );
+    assert!(
+        chain_has(&chain, 3, |m| m.contains("'number'")
+            && m.contains("'string'")),
+        "expected the leaf property relation at depth 3; got {chain:?}"
+    );
+}
+
+/// Readonly-tuple union member self-heads with the readonly elaboration (no
+/// extra member header), matching tsc.
+#[test]
+fn union_member_readonly_tuple_self_heads() {
+    let diags = diagnostics(
+        r#"
+declare const s: readonly [number] | [string];
+const t: [string] = s;
+"#,
+    );
+    let chain = ts2322_chain(&diags);
+    assert!(
+        chain_has(&chain, 0, |m| m.contains("'readonly'")
+            && m.contains("cannot be assigned to the mutable type")),
+        "expected the readonly-to-mutable self-heading line at depth 0; \
+         got {chain:?}"
+    );
+}
+
+/// Renamed binders: the array-element rule must hold regardless of the alias
+/// spelling, so a name-keyed fix would not satisfy this.
+#[test]
+fn union_member_array_element_mismatch_renamed() {
+    let diags = diagnostics(
+        r#"
+type Elems = boolean[] | string[];
+declare const xs: Elems;
+const ys: boolean[] = xs;
+"#,
+    );
+    let chain = ts2322_chain(&diags);
+    assert!(
+        chain_has(&chain, 0, |m| m.contains("'string[]'")
+            && m.contains("'boolean[]'")),
+        "renamed array union should still emit the member header; got {chain:?}"
+    );
+    assert!(
+        chain_has(&chain, 1, |m| m.contains("'string'")
+            && m.contains("'boolean'")),
+        "renamed array union should still drill the element leaf at depth 1; \
+         got {chain:?}"
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -10,8 +10,7 @@ use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::relations::subtype::SubtypeChecker;
 use crate::type_queries::data::get_object_symbol;
 use crate::types::{
-    IntrinsicKind, LiteralValue, ObjectShape, ObjectShapeId, PropertyInfo, TupleElement, TypeId,
-    Visibility,
+    IntrinsicKind, LiteralValue, ObjectShape, ObjectShapeId, PropertyInfo, TypeId, Visibility,
 };
 use crate::utils;
 use crate::visitor::is_type_parameter;
@@ -957,12 +956,13 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // line, mirroring tsc which always drills into that member. Each
                 // arm below is a member-failure reason whose render composes
                 // under the union line:
-                //   * leaf relations and property summaries
-                //     (`MissingProperty`/`MissingProperties`), the readonly /
-                //     optional property modifiers, and the array-element reason
-                //     self-head — their rendered line already names the member
+                //   * leaf relations, property summaries
+                //     (`MissingProperty`/`MissingProperties`), and the
+                //     array-element and readonly-to-mutable reasons self-head —
+                //     their rendered line already names the member
                 //     (`Property 'a' is missing in type '{ b: 2; }' …`,
-                //     `Type 'number[]' is not assignable to type 'string[]' …`).
+                //     `Type 'number[]' is not assignable to type 'string[]' …`,
+                //     `The type 'readonly [number]' is 'readonly' …`).
                 //   * the tuple/property element-type mismatches are header-led;
                 //     the union-source renderer supplies the
                 //     `Type 'M' is not assignable to type 'T'.` member header
@@ -971,8 +971,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // Without this the chain collapses to the bare union-to-target
                 // line and hides which member fails.
                 //
-                // Two families are deliberately excluded because their leaf
-                // render does not yet compose here:
+                // The set is intentionally limited to member-failure shapes whose
+                // render composes exactly with `tsc` here. Notably excluded:
                 //   * `TupleElementMismatch` (fixed-arity count mismatch) — its
                 //     nested `TS2618`/`TS2619` (`Source has N element(s) but
                 //     target requires/allows only M`) leaf render is owned
@@ -981,6 +981,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 //   * `ReturnTypeMismatch`/`ParameterTypeMismatch` — the function
                 //     renderers self-head with the signature relation, so they
                 //     would double-state the member signature here.
+                //   * `OptionalPropertyRequired`/`ReadonlyPropertyMismatch` — `tsc`
+                //     leads these with the member header (and they only arise in
+                //     narrow `exactOptionalPropertyTypes` / readonly-index shapes),
+                //     so they need the header-led path, not this self-heading one.
                 let nested = self.explain_failure_guarded(member, target);
                 if let Some(nested) = nested
                     && matches!(
@@ -994,8 +998,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                             | SubtypeFailureReason::PropertyTypeMismatch { .. }
                             | SubtypeFailureReason::ArrayElementMismatch { .. }
                             | SubtypeFailureReason::ReadonlyToMutableAssignment { .. }
-                            | SubtypeFailureReason::OptionalPropertyRequired { .. }
-                            | SubtypeFailureReason::ReadonlyPropertyMismatch { .. }
                     )
                 {
                     return Some(SubtypeFailureReason::UnionSourceMismatch {
@@ -1795,273 +1797,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 {
                     return self.make_index_sig_reason("string", prop_type, string_idx.value_type);
                 }
-            }
-        }
-
-        None
-    }
-
-    /// Explain why a function type assignment failed.
-    /// Build a `TupleElementTypeMismatch` for a failing element pair, recursing
-    /// into the element failure so the rendered chain carries the inner reason
-    /// (matching tsc, which walks a tuple element exactly like a numerically
-    /// keyed object property).
-    fn tuple_element_type_mismatch(
-        &mut self,
-        index: usize,
-        source_element: TypeId,
-        target_element: TypeId,
-        multi_element: bool,
-    ) -> SubtypeFailureReason {
-        let nested_reason = self
-            .explain_failure(source_element, target_element)
-            .map(Box::new);
-        SubtypeFailureReason::TupleElementTypeMismatch {
-            index,
-            source_element,
-            target_element,
-            nested_reason,
-            multi_element,
-        }
-    }
-
-    /// Explain why a tuple type assignment failed.
-    fn explain_tuple_failure(
-        &mut self,
-        source: &[TupleElement],
-        target: &[TupleElement],
-    ) -> Option<SubtypeFailureReason> {
-        let source_required = crate::utils::required_element_count(source);
-        let target_required = crate::utils::required_element_count(target);
-
-        if source_required < target_required {
-            return Some(SubtypeFailureReason::TupleElementMismatch {
-                source_count: source.len(),
-                target_count: target.len(),
-            });
-        }
-
-        // When both source and target are closed tuples (no rest elements) and
-        // source has more elements than target allows, prefer the arity-mismatch
-        // reason over an element-level type mismatch. This matches tsc, which
-        // reports the outer "Source has N element(s) but target allows only M"
-        // diagnostic instead of drilling into a specific element when the
-        // length already disqualifies the relation.
-        let target_has_rest = target.iter().any(|e| e.rest);
-        let source_has_rest = source.iter().any(|e| e.rest);
-        if !target_has_rest && !source_has_rest && source.len() > target.len() {
-            return Some(SubtypeFailureReason::TupleElementMismatch {
-                source_count: source.len(),
-                target_count: target.len(),
-            });
-        }
-
-        for (i, t_elem) in target.iter().enumerate() {
-            if t_elem.rest {
-                let expansion = self.expand_tuple_rest(t_elem.type_id);
-                let outer_tail = &target[i + 1..];
-                // Combined suffix = expansion.tail + outer_tail
-                let combined_suffix: Vec<_> = expansion
-                    .tail
-                    .iter()
-                    .chain(outer_tail.iter())
-                    .cloned()
-                    .collect();
-
-                let mut source_end = source.len();
-                for tail_elem in combined_suffix.iter().rev() {
-                    if source_end <= i {
-                        if !tail_elem.optional {
-                            return Some(SubtypeFailureReason::TupleElementMismatch {
-                                source_count: source.len(),
-                                target_count: target.len(),
-                            });
-                        }
-                        break;
-                    }
-                    // Type parameter rest spread requires matching rest in source
-                    if tail_elem.rest && is_type_parameter(self.interner, tail_elem.type_id) {
-                        let s_elem = &source[source_end - 1];
-                        if s_elem.rest {
-                            let tp_array = self.interner.array(tail_elem.type_id);
-                            if !self.check_subtype(s_elem.type_id, tp_array).is_true() {
-                                return Some(self.tuple_element_type_mismatch(
-                                    source_end - 1,
-                                    s_elem.type_id,
-                                    tail_elem.type_id,
-                                    // Rest/variadic tuples are multi-position;
-                                    // keep the positional disambiguation line.
-                                    true,
-                                ));
-                            }
-                            source_end -= 1;
-                            continue;
-                        }
-                        return Some(SubtypeFailureReason::TypeMismatch {
-                            source_type: source.first().map(|e| e.type_id).unwrap_or(TypeId::NEVER),
-                            target_type: tail_elem.type_id,
-                        });
-                    }
-                    let s_elem = &source[source_end - 1];
-                    if s_elem.rest {
-                        if !tail_elem.optional {
-                            return Some(SubtypeFailureReason::TupleElementMismatch {
-                                source_count: source.len(),
-                                target_count: target.len(),
-                            });
-                        }
-                        break;
-                    }
-                    let assignable = self
-                        .check_subtype(s_elem.type_id, tail_elem.type_id)
-                        .is_true();
-                    if tail_elem.optional && !assignable {
-                        break;
-                    }
-                    if !assignable {
-                        return Some(self.tuple_element_type_mismatch(
-                            source_end - 1,
-                            s_elem.type_id,
-                            tail_elem.type_id,
-                            true,
-                        ));
-                    }
-                    source_end -= 1;
-                }
-
-                let mut source_iter = source.iter().enumerate().take(source_end).skip(i);
-
-                for t_fixed in &expansion.fixed {
-                    match source_iter.next() {
-                        Some((j, s_elem)) => {
-                            if s_elem.rest {
-                                return Some(SubtypeFailureReason::TupleElementMismatch {
-                                    source_count: source.len(),
-                                    target_count: target.len(),
-                                });
-                            }
-                            if !self
-                                .check_subtype(s_elem.type_id, t_fixed.type_id)
-                                .is_true()
-                            {
-                                return Some(self.tuple_element_type_mismatch(
-                                    j,
-                                    s_elem.type_id,
-                                    t_fixed.type_id,
-                                    true,
-                                ));
-                            }
-                        }
-                        None => {
-                            if !t_fixed.optional {
-                                return Some(SubtypeFailureReason::TupleElementMismatch {
-                                    source_count: source.len(),
-                                    target_count: target.len(),
-                                });
-                            }
-                        }
-                    }
-                }
-
-                if let Some(variadic) = expansion.variadic {
-                    let variadic_is_type_param = is_type_parameter(self.interner, variadic);
-                    let variadic_array = self.interner.array(variadic);
-                    for (j, s_elem) in source_iter {
-                        if s_elem.rest {
-                            if !self.check_subtype(s_elem.type_id, variadic_array).is_true() {
-                                return Some(self.tuple_element_type_mismatch(
-                                    j,
-                                    s_elem.type_id,
-                                    variadic_array,
-                                    true,
-                                ));
-                            }
-                        } else if variadic_is_type_param {
-                            return Some(SubtypeFailureReason::TypeMismatch {
-                                source_type: s_elem.type_id,
-                                target_type: variadic,
-                            });
-                        } else if !self.check_subtype(s_elem.type_id, variadic).is_true() {
-                            return Some(self.tuple_element_type_mismatch(
-                                j,
-                                s_elem.type_id,
-                                variadic,
-                                true,
-                            ));
-                        }
-                    }
-                    return None;
-                }
-
-                if source_iter.next().is_some() {
-                    return Some(SubtypeFailureReason::TupleElementMismatch {
-                        source_count: source.len(),
-                        target_count: target.len(),
-                    });
-                }
-                return None;
-            }
-
-            if let Some(s_elem) = source.get(i) {
-                if s_elem.rest {
-                    // Source has rest but target expects fixed element
-                    return Some(SubtypeFailureReason::TupleElementMismatch {
-                        source_count: source.len(), // Approximate "infinity"
-                        target_count: target.len(),
-                    });
-                }
-
-                if !self.check_subtype(s_elem.type_id, t_elem.type_id).is_true() {
-                    // Drill into the nested failure: if the element mismatch is due to a
-                    // missing property (e.g., {} vs {a: string}), return MissingProperty
-                    // to produce TS2741 instead of generic TS2322. This matches tsc behavior
-                    // for tuple literals where elements have missing properties.
-                    // Reuse the single `explain_failure` walk both to detect the
-                    // missing-property short-circuit and as the element's nested
-                    // reason, avoiding a second recursive type walk.
-                    let nested = self.explain_failure(s_elem.type_id, t_elem.type_id);
-                    if matches!(
-                        nested,
-                        Some(
-                            SubtypeFailureReason::MissingProperty { .. }
-                                | SubtypeFailureReason::MissingProperties { .. }
-                        )
-                    ) {
-                        return nested;
-                    }
-                    return Some(SubtypeFailureReason::TupleElementTypeMismatch {
-                        index: i,
-                        source_element: s_elem.type_id,
-                        target_element: t_elem.type_id,
-                        nested_reason: nested.map(Box::new),
-                        // Single-element tuples have no position to disambiguate,
-                        // so tsc omits the TS2626 positional line and relates the
-                        // element types directly.
-                        multi_element: target.len() > 1,
-                    });
-                }
-            } else if !t_elem.optional {
-                return Some(SubtypeFailureReason::TupleElementMismatch {
-                    source_count: source.len(),
-                    target_count: target.len(),
-                });
-            }
-        }
-
-        // Target is closed. Check for extra elements in source.
-        if source.len() > target.len() {
-            return Some(SubtypeFailureReason::TupleElementMismatch {
-                source_count: source.len(),
-                target_count: target.len(),
-            });
-        }
-
-        for s_elem in source {
-            if s_elem.rest {
-                return Some(SubtypeFailureReason::TupleElementMismatch {
-                    source_count: source.len(), // implies open
-                    target_count: target.len(),
-                });
             }
         }
 

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -954,25 +954,33 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     continue;
                 }
                 // Elaborate the first failing member beneath the union-to-target
-                // line, mirroring tsc which always drills into that member. Two
-                // shapes are surfaced:
+                // line, mirroring tsc which always drills into that member. Each
+                // arm below is a member-failure reason whose render composes
+                // under the union line:
+                //   * leaf relations and property summaries
+                //     (`MissingProperty`/`MissingProperties`), the readonly /
+                //     optional property modifiers, and the array-element reason
+                //     self-head — their rendered line already names the member
+                //     (`Property 'a' is missing in type '{ b: 2; }' …`,
+                //     `Type 'number[]' is not assignable to type 'string[]' …`).
+                //   * the tuple/property element-type mismatches are header-led;
+                //     the union-source renderer supplies the
+                //     `Type 'M' is not assignable to type 'T'.` member header
+                //     before drilling (`Type at position 0 …` / `Types of
+                //     property 'p' …`).
+                // Without this the chain collapses to the bare union-to-target
+                // line and hides which member fails.
                 //
-                // * *Self-heading* reasons — leaf relations
-                //   (`undefined`/literal/intrinsic mismatch) and the property
-                //   reasons (`MissingProperty`/`MissingProperties`), whose
-                //   rendered message already names the member type
-                //   (`Property 'a' is missing in type '{ b: 2; }' …` /
-                //   `Type '{ c: 3; }' is missing the following properties …`).
-                //   They need no extra `Type 'M' is not assignable …` header.
-                //
-                // * *Header-led* structural reasons — tuple element type
-                //   mismatches and object property-type mismatches. tsc leads
-                //   their elaboration with an explicit
-                //   `Type 'M' is not assignable to type 'T'.` member header and
-                //   then drills (`Type at position 0 …` / `Types of property
-                //   'p' …`). The union-source renderer emits that header so the
-                //   chain stays correctly indented instead of collapsing to the
-                //   bare union line.
+                // Two families are deliberately excluded because their leaf
+                // render does not yet compose here:
+                //   * `TupleElementMismatch` (fixed-arity count mismatch) — its
+                //     nested `TS2618`/`TS2619` (`Source has N element(s) but
+                //     target requires/allows only M`) leaf render is owned
+                //     separately; surfacing it before that lands emits a non-tsc
+                //     line.
+                //   * `ReturnTypeMismatch`/`ParameterTypeMismatch` — the function
+                //     renderers self-head with the signature relation, so they
+                //     would double-state the member signature here.
                 let nested = self.explain_failure_guarded(member, target);
                 if let Some(nested) = nested
                     && matches!(
@@ -984,6 +992,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                             | SubtypeFailureReason::MissingProperties { .. }
                             | SubtypeFailureReason::TupleElementTypeMismatch { .. }
                             | SubtypeFailureReason::PropertyTypeMismatch { .. }
+                            | SubtypeFailureReason::ArrayElementMismatch { .. }
+                            | SubtypeFailureReason::ReadonlyToMutableAssignment { .. }
+                            | SubtypeFailureReason::OptionalPropertyRequired { .. }
+                            | SubtypeFailureReason::ReadonlyPropertyMismatch { .. }
                     )
                 {
                     return Some(SubtypeFailureReason::UnionSourceMismatch {

--- a/crates/tsz-solver/src/relations/subtype/explain_tuple.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain_tuple.rs
@@ -1,0 +1,281 @@
+//! Tuple-failure explanation for subtype checking.
+//!
+//! Split out of `explain.rs` to keep that module under the source-shard cap:
+//! it computes the structured `SubtypeFailureReason` for a failed tuple-to-tuple
+//! relation (arity mismatch vs. a specific element-type mismatch, including
+//! variadic/rest expansion). `explain_tuple_failure` is the entry point used by
+//! `explain_failure_inner`.
+
+use crate::def::resolver::TypeResolver;
+use crate::diagnostics::SubtypeFailureReason;
+use crate::relations::subtype::SubtypeChecker;
+use crate::types::{TupleElement, TypeId};
+use crate::visitor::is_type_parameter;
+
+impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
+    /// Build a `TupleElementTypeMismatch` for a failing element pair, recursing
+    /// into the element failure so the rendered chain carries the inner reason
+    /// (matching tsc, which walks a tuple element exactly like a numerically
+    /// keyed object property).
+    fn tuple_element_type_mismatch(
+        &mut self,
+        index: usize,
+        source_element: TypeId,
+        target_element: TypeId,
+        multi_element: bool,
+    ) -> SubtypeFailureReason {
+        let nested_reason = self
+            .explain_failure(source_element, target_element)
+            .map(Box::new);
+        SubtypeFailureReason::TupleElementTypeMismatch {
+            index,
+            source_element,
+            target_element,
+            nested_reason,
+            multi_element,
+        }
+    }
+
+    /// Explain why a tuple type assignment failed.
+    pub(super) fn explain_tuple_failure(
+        &mut self,
+        source: &[TupleElement],
+        target: &[TupleElement],
+    ) -> Option<SubtypeFailureReason> {
+        let source_required = crate::utils::required_element_count(source);
+        let target_required = crate::utils::required_element_count(target);
+
+        if source_required < target_required {
+            return Some(SubtypeFailureReason::TupleElementMismatch {
+                source_count: source.len(),
+                target_count: target.len(),
+            });
+        }
+
+        // When both source and target are closed tuples (no rest elements) and
+        // source has more elements than target allows, prefer the arity-mismatch
+        // reason over an element-level type mismatch. This matches tsc, which
+        // reports the outer "Source has N element(s) but target allows only M"
+        // diagnostic instead of drilling into a specific element when the
+        // length already disqualifies the relation.
+        let target_has_rest = target.iter().any(|e| e.rest);
+        let source_has_rest = source.iter().any(|e| e.rest);
+        if !target_has_rest && !source_has_rest && source.len() > target.len() {
+            return Some(SubtypeFailureReason::TupleElementMismatch {
+                source_count: source.len(),
+                target_count: target.len(),
+            });
+        }
+
+        for (i, t_elem) in target.iter().enumerate() {
+            if t_elem.rest {
+                let expansion = self.expand_tuple_rest(t_elem.type_id);
+                let outer_tail = &target[i + 1..];
+                // Combined suffix = expansion.tail + outer_tail
+                let combined_suffix: Vec<_> = expansion
+                    .tail
+                    .iter()
+                    .chain(outer_tail.iter())
+                    .cloned()
+                    .collect();
+
+                let mut source_end = source.len();
+                for tail_elem in combined_suffix.iter().rev() {
+                    if source_end <= i {
+                        if !tail_elem.optional {
+                            return Some(SubtypeFailureReason::TupleElementMismatch {
+                                source_count: source.len(),
+                                target_count: target.len(),
+                            });
+                        }
+                        break;
+                    }
+                    // Type parameter rest spread requires matching rest in source
+                    if tail_elem.rest && is_type_parameter(self.interner, tail_elem.type_id) {
+                        let s_elem = &source[source_end - 1];
+                        if s_elem.rest {
+                            let tp_array = self.interner.array(tail_elem.type_id);
+                            if !self.check_subtype(s_elem.type_id, tp_array).is_true() {
+                                return Some(self.tuple_element_type_mismatch(
+                                    source_end - 1,
+                                    s_elem.type_id,
+                                    tail_elem.type_id,
+                                    // Rest/variadic tuples are multi-position;
+                                    // keep the positional disambiguation line.
+                                    true,
+                                ));
+                            }
+                            source_end -= 1;
+                            continue;
+                        }
+                        return Some(SubtypeFailureReason::TypeMismatch {
+                            source_type: source.first().map(|e| e.type_id).unwrap_or(TypeId::NEVER),
+                            target_type: tail_elem.type_id,
+                        });
+                    }
+                    let s_elem = &source[source_end - 1];
+                    if s_elem.rest {
+                        if !tail_elem.optional {
+                            return Some(SubtypeFailureReason::TupleElementMismatch {
+                                source_count: source.len(),
+                                target_count: target.len(),
+                            });
+                        }
+                        break;
+                    }
+                    let assignable = self
+                        .check_subtype(s_elem.type_id, tail_elem.type_id)
+                        .is_true();
+                    if tail_elem.optional && !assignable {
+                        break;
+                    }
+                    if !assignable {
+                        return Some(self.tuple_element_type_mismatch(
+                            source_end - 1,
+                            s_elem.type_id,
+                            tail_elem.type_id,
+                            true,
+                        ));
+                    }
+                    source_end -= 1;
+                }
+
+                let mut source_iter = source.iter().enumerate().take(source_end).skip(i);
+
+                for t_fixed in &expansion.fixed {
+                    match source_iter.next() {
+                        Some((j, s_elem)) => {
+                            if s_elem.rest {
+                                return Some(SubtypeFailureReason::TupleElementMismatch {
+                                    source_count: source.len(),
+                                    target_count: target.len(),
+                                });
+                            }
+                            if !self
+                                .check_subtype(s_elem.type_id, t_fixed.type_id)
+                                .is_true()
+                            {
+                                return Some(self.tuple_element_type_mismatch(
+                                    j,
+                                    s_elem.type_id,
+                                    t_fixed.type_id,
+                                    true,
+                                ));
+                            }
+                        }
+                        None => {
+                            if !t_fixed.optional {
+                                return Some(SubtypeFailureReason::TupleElementMismatch {
+                                    source_count: source.len(),
+                                    target_count: target.len(),
+                                });
+                            }
+                        }
+                    }
+                }
+
+                if let Some(variadic) = expansion.variadic {
+                    let variadic_is_type_param = is_type_parameter(self.interner, variadic);
+                    let variadic_array = self.interner.array(variadic);
+                    for (j, s_elem) in source_iter {
+                        if s_elem.rest {
+                            if !self.check_subtype(s_elem.type_id, variadic_array).is_true() {
+                                return Some(self.tuple_element_type_mismatch(
+                                    j,
+                                    s_elem.type_id,
+                                    variadic_array,
+                                    true,
+                                ));
+                            }
+                        } else if variadic_is_type_param {
+                            return Some(SubtypeFailureReason::TypeMismatch {
+                                source_type: s_elem.type_id,
+                                target_type: variadic,
+                            });
+                        } else if !self.check_subtype(s_elem.type_id, variadic).is_true() {
+                            return Some(self.tuple_element_type_mismatch(
+                                j,
+                                s_elem.type_id,
+                                variadic,
+                                true,
+                            ));
+                        }
+                    }
+                    return None;
+                }
+
+                if source_iter.next().is_some() {
+                    return Some(SubtypeFailureReason::TupleElementMismatch {
+                        source_count: source.len(),
+                        target_count: target.len(),
+                    });
+                }
+                return None;
+            }
+
+            if let Some(s_elem) = source.get(i) {
+                if s_elem.rest {
+                    // Source has rest but target expects fixed element
+                    return Some(SubtypeFailureReason::TupleElementMismatch {
+                        source_count: source.len(), // Approximate "infinity"
+                        target_count: target.len(),
+                    });
+                }
+
+                if !self.check_subtype(s_elem.type_id, t_elem.type_id).is_true() {
+                    // Drill into the nested failure: if the element mismatch is due to a
+                    // missing property (e.g., {} vs {a: string}), return MissingProperty
+                    // to produce TS2741 instead of generic TS2322. This matches tsc behavior
+                    // for tuple literals where elements have missing properties.
+                    // Reuse the single `explain_failure` walk both to detect the
+                    // missing-property short-circuit and as the element's nested
+                    // reason, avoiding a second recursive type walk.
+                    let nested = self.explain_failure(s_elem.type_id, t_elem.type_id);
+                    if matches!(
+                        nested,
+                        Some(
+                            SubtypeFailureReason::MissingProperty { .. }
+                                | SubtypeFailureReason::MissingProperties { .. }
+                        )
+                    ) {
+                        return nested;
+                    }
+                    return Some(SubtypeFailureReason::TupleElementTypeMismatch {
+                        index: i,
+                        source_element: s_elem.type_id,
+                        target_element: t_elem.type_id,
+                        nested_reason: nested.map(Box::new),
+                        // Single-element tuples have no position to disambiguate,
+                        // so tsc omits the TS2626 positional line and relates the
+                        // element types directly.
+                        multi_element: target.len() > 1,
+                    });
+                }
+            } else if !t_elem.optional {
+                return Some(SubtypeFailureReason::TupleElementMismatch {
+                    source_count: source.len(),
+                    target_count: target.len(),
+                });
+            }
+        }
+
+        // Target is closed. Check for extra elements in source.
+        if source.len() > target.len() {
+            return Some(SubtypeFailureReason::TupleElementMismatch {
+                source_count: source.len(),
+                target_count: target.len(),
+            });
+        }
+
+        for s_elem in source {
+            if s_elem.rest {
+                return Some(SubtypeFailureReason::TupleElementMismatch {
+                    source_count: source.len(), // implies open
+                    target_count: target.len(),
+                });
+            }
+        }
+
+        None
+    }
+}

--- a/crates/tsz-solver/src/relations/subtype/mod.rs
+++ b/crates/tsz-solver/src/relations/subtype/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod cache;
 pub(crate) mod core;
 pub(crate) mod explain;
 pub(crate) mod explain_function;
+pub(crate) mod explain_tuple;
 pub(crate) mod helpers;
 pub(crate) mod overlap;
 pub(crate) mod rules;


### PR DESCRIPTION
AgentName: Studio-B

## AgentName
Studio-B

## Track
Bug burn-down — issue #10823 family (`bench`, `conditional-types`, `solver`):
distributive-conditional / tuple-like-union diagnostics. The conditional
*evaluation* in this family already matches `tsc` (verified, see below); the
residual divergence is the union-source diagnostic chain, which this PR closes.

## Invariant
When a **union** value fails to assign to a target, `tsc` keeps the `TS2322`
headline (`Type 'A | B' is not assignable to type 'T'.`) and drills into the
**first failing member's own relation**. tsz must reproduce the member
elaboration chain instead of collapsing to the bare union-to-target line.

## Scope
- **solver** — `crates/tsz-solver/src/relations/subtype/explain.rs`: the
  union-source drill previously wrapped only a hand-picked allowlist of member
  reasons in `UnionSourceMismatch`. Widen it to also cover the two families that
  render exactly like `tsc` for a union member: `ArrayElementMismatch` (an array
  member self-heads with `Type 'se[]' …'te[]'` then drills the element relation)
  and `ReadonlyToMutableAssignment` (a `readonly` tuple member self-heads with
  the TS4104-style line). Member selection (first failing, source order) is
  unchanged.
  - Deliberately excluded (documented in code): `TupleElementMismatch`
    (fixed-arity `TS2618`/`TS2619` leaf render is owned by separate in-flight
    work), `ReturnTypeMismatch`/`ParameterTypeMismatch` (function renderers
    self-head with the signature relation → would double-state it), and
    `OptionalPropertyRequired`/`ReadonlyPropertyMismatch` (`tsc` leads these with
    the member header and they only arise in narrow
    `exactOptionalPropertyTypes` / readonly-index shapes → need the header-led
    path, not this self-heading one; the common optional/readonly cases already
    route through `PropertyTypeMismatch`/`MissingProperty`).
- **solver split** — extracted `explain_tuple_failure`/`tuple_element_type_mismatch`
  into a sibling `explain_tuple.rs` (pure relocation): `explain.rs` was already
  over the 2000-line source-shard cap on `main` (2058) and the union-source
  change pushed it to 2070; the split brings it back to **1806**.
- **checker** — `crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs`:
  fix a latent off-by-one in `render_parent_with_child_relation`. A nested
  reason is rendered at `child_depth.max(1)` (structural renderers need depth ≥ 1
  to format child lines) but its *primary* line lands at `child_depth`; when
  `child_depth == 0` a multi-line nested reason (e.g. an array member's element
  drill) kept its drill lines one indent too deep. Rebase the sub-chain via the
  existing `push_rebased_subdiagnostic`. No-op for `child_depth ≥ 1`.
- **tests** — `crates/tsz-checker/tests/union_source_structural_elaboration_tests.rs`:
  4 new cases (array-element header+drill, array-of-object per-level indent,
  readonly-tuple self-heading, renamed-binder array) asserting the member header
  and drill depths; binder/alias spellings are varied so a name-keyed fix would
  not satisfy them.

### Structural rule
`When a union source fails against a target T, tsc elaborates the first failing
member M as 'Type M is not assignable to type T.' then drills into M's own
relation; tsz does so through the solver UnionSourceMismatch reason + the checker
render boundary.` No relation/evaluation semantics change — accept/reject is
identical before and after; only the elaboration chain is added.

## Project Corpus Impact
- Row: zod-project (witness for #10823); broader distributive-conditional /
  tuple-union family.
- Bug family: #10823 (and #12175 distributive-conditional-over-tuple-union).
- Evidence: `yellow-row` diagnostic-display parity item, not an acceptance
  change. Across 40 reduced distributive-conditional-over-tuple-union cases
  (head/tail/last/middle extraction, `Box`/rebuild, readonly arms, nested
  classify, variadic, recursive), tsz and `tsc 6.0.2` agree on the evaluated
  type in every case (display-independent `Expect<Equal<…>>` oracle), so the
  "over-constrained" evaluation hypothesis does not reproduce at this version;
  the residual is the union-source diagnostic chain this PR fixes. Matches the
  out-of-scope follow-ups noted on #12201.

## Verification
Oracle: TypeScript `6.0.2` (`scripts/conformance/typescript-versions.json`),
installed locally; flags `--noEmit --strict`.

Minimal repros — tsz now EXACT-MATCHES `tsc 6.0.2`:
- `string[] | number[]` → `string[]`: `TS2322` + `Type 'number[]' is not
  assignable to type 'string[]'.` + `Type 'number' is not assignable to type
  'string'.` (element leaf now at the correct indent).
- `{ a: string }[] | { a: number }[]` → `{ a: string }[]`: member → element →
  `Types of property 'a'` → leaf chain, each one indent deeper.
- `readonly [number] | [string]` → `[string]`: member self-heads with
  `The type 'readonly [number]' is 'readonly' and cannot be assigned to the
  mutable type '[number]'.`

Local tests (no full conformance/emit/fourslash locally, per AGENTS.md;
`nextest` unavailable here → `cargo test --profile dist-fast`):
- `union_source_structural_elaboration_tests` **10 passed** (incl. 4 new),
  `union_source_missing_property_elaboration_tests` **5 passed**,
  `union_tuple_source_display_tests` **8 passed**.
- `ts2322_tests` **287 passed / 4 failed** — the 4 failures
  (`*_mapped_application_generic_indexed_call_preserves_key_correlation`,
  `test_private_public_intersection_reduces_to_never_for_asserts_this`,
  `test_ts2322_async_return_via_return_type_promise_infer`) are **proven
  pre-existing**: re-running with this PR's source stashed reverts to the
  identical 287/4. They route through different `SubtypeFailureReason` arms.
  All `test_ts2322_array_*` rendering tests pass.
- `cargo fmt` clean; `git diff --check` clean; `explain.rs` 1806 lines (under
  the 2000 cap); rebased onto current `main` (no conflicts).

## Coordination Notes
- AgentName: Studio-B. Claims issue #10823 (labeled WIP).
- Complementary to #12286 (union-**target** missing-property elaboration, just
  merged) — this PR is union-**source** elaboration; different region of
  `explain.rs`, rebased cleanly on top.
- Non-overlapping with #12201 (renders the `TupleElementMismatch` `TS2618`/`TS2619`
  *leaf*): this PR deliberately excludes `TupleElementMismatch` from the union
  drill so it does not depend on or touch that renderer.
- Addressed M5Manager-Studio-Review findings: (1) `explain.rs` split back under
  the source-shard cap; (2) PR body now carries the literal `AgentName:`/`Row:`/
  `Bug family:` fields the `project-corpus-pr-body` gate requires; (3) narrowed
  the allowlist to the two verified families rather than ship the two unverified
  modifier reasons. Leaving native auto-merge off; this lands through the
  repo-local merge queue.
