### PR TITLE
Fix JSX and import.meta accepted regressions

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -421,6 +421,9 @@ impl<'a> CheckerState<'a> {
         let mut target = self.substitute_this_type_if_needed(target);
         let raw_source = source;
         let raw_target = target;
+        if self.actual_lib_interface_extends_relation(raw_source, raw_target) {
+            return true;
+        }
         source = self.normalize_awaited_application_args_for_variance(source);
         target = self.normalize_awaited_application_args_for_variance(target);
 
@@ -686,6 +689,47 @@ impl<'a> CheckerState<'a> {
         }
 
         result
+    }
+
+    fn actual_lib_interface_extends_relation(&self, source: TypeId, target: TypeId) -> bool {
+        let Some(source_sym) = self.relation_interface_symbol(source) else {
+            return false;
+        };
+        let Some(target_sym) = self.relation_interface_symbol(target) else {
+            return false;
+        };
+        if source_sym == target_sym {
+            return true;
+        }
+        let lib_binders = self.get_lib_binders();
+        let Some(source_symbol) = self
+            .ctx
+            .binder
+            .get_symbol_with_libs(source_sym, &lib_binders)
+        else {
+            return false;
+        };
+        let Some(target_symbol) = self
+            .ctx
+            .binder
+            .get_symbol_with_libs(target_sym, &lib_binders)
+        else {
+            return false;
+        };
+        if !source_symbol.has_any_flags(tsz_binder::symbol_flags::INTERFACE)
+            || !target_symbol.has_any_flags(tsz_binder::symbol_flags::INTERFACE)
+            || !self.ctx.symbol_is_from_actual_or_cloned_lib(source_sym)
+            || !self.ctx.symbol_is_from_actual_or_cloned_lib(target_sym)
+        {
+            return false;
+        }
+        self.interface_extends_symbol(source_sym, target_sym)
+    }
+
+    fn relation_interface_symbol(&self, type_id: TypeId) -> Option<tsz_binder::SymbolId> {
+        crate::query_boundaries::common::lazy_def_id(self.ctx.types, type_id)
+            .and_then(|def_id| self.ctx.def_to_symbol_id_with_fallback(def_id))
+            .or_else(|| crate::query_boundaries::common::type_shape_symbol(self.ctx.types, type_id))
     }
 
     pub(crate) fn type_predicate_type_assignable_to_parameter(

--- a/crates/tsz-checker/src/checkers/generic_checker/recursive_heritage_constraint.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/recursive_heritage_constraint.rs
@@ -72,7 +72,7 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Check if an interface symbol extends (directly or transitively) a target symbol.
-    pub(super) fn interface_extends_symbol(
+    pub(crate) fn interface_extends_symbol(
         &self,
         interface_sym_id: tsz_binder::SymbolId,
         target_sym_id: tsz_binder::SymbolId,

--- a/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
@@ -336,9 +336,13 @@ impl<'a> CheckerState<'a> {
         let effective_tag: Option<&str> = tag_name.or(namespaced_tag_owned.as_deref());
 
         if is_intrinsic {
-            if let Some(type_args) = jsx_opening.type_arguments.as_ref() {
-                self.validate_jsx_intrinsic_type_arguments(type_args);
-            }
+            let has_explicit_type_args =
+                if let Some(type_args) = jsx_opening.type_arguments.as_ref() {
+                    self.validate_jsx_intrinsic_type_arguments(type_args);
+                    true
+                } else {
+                    false
+                };
             let ie_type = self.get_intrinsic_elements_type();
             // Intrinsic elements: look up JSX.IntrinsicElements[tagName]
             if let Some(tag) = effective_tag
@@ -347,25 +351,25 @@ impl<'a> CheckerState<'a> {
                 let evaluated_props = self
                     .get_jsx_intrinsic_props_for_tag(idx, tag, true)
                     .unwrap_or(TypeId::ANY);
-
-                // Check JSX attributes against the resolved props type.
-                // For intrinsic elements, the display target is just the props type
-                // (tsc doesn't wrap intrinsic element props in IntrinsicAttributes).
-                let display_target = self.build_jsx_display_target(evaluated_props, None);
-                self.check_jsx_attributes_against_props(
-                    super::super::props::resolution::JsxPropsCheckOpts {
-                        attributes_idx: jsx_opening.attributes,
-                        props_type: evaluated_props,
-                        tag_name_idx: jsx_opening.tag_name,
-                        component_type: None,
-                        special_attr_component_type: None,
-                        raw_props_has_type_params: false,
-                        display_target,
-                        preferred_target_display: None,
-                        request,
-                        children_ctx,
-                    },
-                );
+                if has_explicit_type_args {
+                    self.check_grammar_jsx_element(jsx_opening.attributes);
+                } else {
+                    let display_target = self.build_jsx_display_target(evaluated_props, None);
+                    self.check_jsx_attributes_against_props(
+                        super::super::props::resolution::JsxPropsCheckOpts {
+                            attributes_idx: jsx_opening.attributes,
+                            props_type: evaluated_props,
+                            tag_name_idx: jsx_opening.tag_name,
+                            component_type: None,
+                            special_attr_component_type: None,
+                            raw_props_has_type_params: false,
+                            display_target,
+                            preferred_target_display: None,
+                            request,
+                            children_ctx,
+                        },
+                    );
+                }
 
                 // tsc types ALL JSX expressions (both intrinsic and component) as
                 // JSX.Element. Returning IntrinsicElements["tag"] causes false TS2322

--- a/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
@@ -262,9 +262,6 @@ impl<'a> CheckerState<'a> {
         // Grammar check: TS17000 for empty expressions in JSX attributes.
         // Matches tsc: only the first empty expression per element is reported.
         self.check_grammar_jsx_element(opts.attributes_idx);
-        if self.ctx.deferred_jsx_import_source_error.is_some() {
-            return;
-        }
 
         // Normalize managed/evaluated JSX props before any checks so conditional,
         // mapped, and application-based surfaces (e.g.

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -1660,7 +1660,7 @@ impl<'a> CheckerState<'a> {
                 self.apparent_enum_instance_type(object_type)
                     .unwrap_or_else(|| self.resolve_type_for_property_access(object_type))
             } else {
-                self.resolve_type_for_property_access(object_type)
+                self.resolve_property_access_base_materialized(object_type)
             };
             if object_type_for_access == TypeId::ANY
                 && is_this_access

--- a/crates/tsz-checker/src/types/queries/lib_resolution_member.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution_member.rs
@@ -10,9 +10,10 @@
 //!
 //! Scope (intentionally narrow for soundness — anything else returns `None` and
 //! falls back to the full-materialization path):
-//! - Plain property signatures only (`prop: T` / `prop?: T`). Methods,
-//!   accessors, index signatures, call/construct signatures, readonly writes,
-//!   and computed/symbol-named members take the full path.
+//! - Plain property signatures (`prop: T` / `prop?: T`) and single method
+//!   signatures. Accessors, index signatures, call/construct signatures,
+//!   readonly writes, computed/symbol-named members, and overloads take the
+//!   full path.
 //! - A single own declaration of the member. Members declared more than once
 //!   (overloads / split declarations) take the full path.
 //! - Heritage-inherited members can be resolved when the inherited annotation
@@ -23,7 +24,7 @@
 
 use tsz_lowering::TypeLowering;
 use tsz_parser::parser::node::NodeAccess;
-use tsz_parser::parser::syntax_kind_ext::{self, PROPERTY_SIGNATURE};
+use tsz_parser::parser::syntax_kind_ext::{self, METHOD_SIGNATURE, PROPERTY_SIGNATURE};
 use tsz_parser::parser::{NodeArena, NodeIndex};
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
@@ -104,7 +105,7 @@ impl CheckerState<'_> {
             Some(self.ctx.arena),
         );
 
-        // Find the single own plain-property-signature declaration of `prop_name`
+        // Find the single own plain-property or method declaration of `prop_name`
         // across the interface's declarations. Bail (None) on any ambiguity so
         // overloads/split declarations keep their full-path semantics.
         let mut member: Option<(NodeIndex, &NodeArena, Vec<SymbolId>)> = None;
@@ -135,7 +136,7 @@ impl CheckerState<'_> {
                 let Some(member_node) = arena.get(member_idx) else {
                     continue;
                 };
-                if member_node.kind != PROPERTY_SIGNATURE {
+                if member_node.kind != PROPERTY_SIGNATURE && member_node.kind != METHOD_SIGNATURE {
                     continue;
                 }
                 let Some(sig) = arena.get_signature(member_node) else {
@@ -222,17 +223,20 @@ impl CheckerState<'_> {
         };
         let member_node = member_arena.get(member_idx)?;
         let sig = member_arena.get_signature(member_node)?;
-        if sig.type_annotation == NodeIndex::NONE {
+        if member_node.kind == METHOD_SIGNATURE && sig.question_token {
+            return None;
+        }
+        if member_node.kind == PROPERTY_SIGNATURE && sig.type_annotation == NodeIndex::NONE {
             // `prop;` with no annotation lowers to `any` in the full path; that
             // is cheap, but keep the full path authoritative for the implicit
             // shape rather than reimplement the default here.
             return None;
         }
         if !type_param_symbols.is_empty()
-            && self.type_annotation_references_type_params(
+            && self.member_signature_references_type_params(
                 selected_binder,
                 member_arena,
-                sig.type_annotation,
+                member_idx,
                 &type_param_symbols,
                 &decls_with_arenas,
                 fallback_arena,
@@ -245,6 +249,28 @@ impl CheckerState<'_> {
         // properties are safe here because property access returns the read
         // annotation type; optionality itself is tracked by full object shapes.
         if self.has_readonly_modifier(&sig.modifiers) {
+            return None;
+        }
+        if member_node.kind == METHOD_SIGNATURE
+            && sig
+                .type_parameters
+                .as_ref()
+                .is_some_and(|params| !params.nodes.is_empty())
+        {
+            if let Some(base_type) = self.resolve_lib_type_by_name(name) {
+                self.ensure_relation_input_ready(base_type);
+                let base_type = self.resolve_type_for_property_access_force(base_type);
+                if let crate::query_boundaries::common::PropertyAccessResult::Success {
+                    type_id,
+                    ..
+                } = crate::query_boundaries::property_access::resolve_property_access(
+                    self.ctx.types,
+                    base_type,
+                    prop_name,
+                ) {
+                    return Some(type_id);
+                }
+            }
             return None;
         }
 
@@ -290,7 +316,7 @@ impl CheckerState<'_> {
 
         let member_type = lowering
             .with_arena(member_arena)
-            .lower_type(sig.type_annotation);
+            .lower_interface_member_simple_type(member_idx)?;
         if member_type == TypeId::ERROR {
             return None;
         }
@@ -316,7 +342,7 @@ impl CheckerState<'_> {
             .collect()
     }
 
-    fn type_annotation_references_type_params(
+    fn member_signature_references_type_params(
         &self,
         binder: &tsz_binder::BinderState,
         arena: &NodeArena,

--- a/crates/tsz-checker/tests/import_meta_module_support_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/import_meta_module_support_diagnostics_tests.rs
@@ -20,8 +20,10 @@
 //! varied across cases.
 
 use tsz_checker::context::CheckerOptions;
-use tsz_checker::test_utils::check_source;
-use tsz_common::common::ModuleKind;
+use tsz_checker::test_utils::{
+    check_multi_file_with_libs, check_source, load_compiled_lib_files, load_lib_files,
+};
+use tsz_common::common::{ModuleKind, ScriptTarget};
 
 const TS1343: u32 = 1343;
 const TS1470: u32 = 1470;
@@ -193,4 +195,151 @@ fn nodenext_commonjs_file_emits_ts1470() {
         !codes.contains(&TS1343),
         "nodenext must not report TS1343; got {codes:?}"
     );
+}
+
+#[test]
+fn document_body_append_child_uses_inherited_dom_node_member() {
+    for target in [ScriptTarget::ESNext, ScriptTarget::ES5] {
+        let options = CheckerOptions {
+            module: ModuleKind::ESNext,
+            target,
+            ..CheckerOptions::default()
+        };
+        let codes: Vec<u32> = check_source(
+            r#"
+export const image = new Image();
+document.body.appendChild(image);
+"#,
+            "dom-access.ts",
+            options,
+        )
+        .into_iter()
+        .map(|d| d.code)
+        .collect();
+        assert!(
+            !codes.contains(&2339),
+            "`HTMLElement` should inherit `Node.appendChild` under target {target:?}; got {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn document_body_append_child_survives_later_import_meta_global_augmentation() {
+    let lib_files = load_lib_files(&["es5.d.ts", "dom.d.ts"]);
+    let options = CheckerOptions {
+        module: ModuleKind::ESNext,
+        target: ScriptTarget::ES5,
+        ..CheckerOptions::default()
+    };
+    let diagnostics = check_multi_file_with_libs(
+        &[
+            (
+                "example.ts",
+                r##"
+export const image = new Image();
+document.body.appendChild(image);
+"##,
+            ),
+            (
+                "augmentations.ts",
+                r##"
+declare global {
+    interface ImportMeta {
+        wellKnownProperty: { a: number, b: string, c: boolean };
+    }
+}
+"##,
+            ),
+        ],
+        "example.ts",
+        options,
+        &lib_files,
+    );
+    let codes: Vec<_> = diagnostics.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&2339),
+        "global `ImportMeta` augmentation must not hide inherited `HTMLElement` DOM members; got {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn import_meta_fixture_keeps_document_body_append_child() {
+    let lib_files = load_compiled_lib_files(&["lib.es5.d.ts", "lib.dom.d.ts"]);
+    let files = [
+        (
+            "example.ts",
+            r##"
+(async () => {
+  const response = await fetch(new URL("../hamsters.jpg", import.meta.url).toString());
+  const blob = await response.blob();
+
+  const size = import.meta.scriptElement.dataset.size || 300;
+
+  const image = new Image();
+  image.src = URL.createObjectURL(blob);
+  image.width = image.height = size;
+
+  document.body.appendChild(image);
+})();
+"##,
+        ),
+        (
+            "moduleLookingFile01.ts",
+            r##"
+export let x = import.meta;
+export let y = import.metal;
+export let z = import.import.import.malkovich;
+"##,
+        ),
+        (
+            "scriptLookingFile01.ts",
+            r##"
+let globalA = import.meta;
+let globalB = import.metal;
+let globalC = import.import.import.malkovich;
+"##,
+        ),
+        (
+            "assignmentTargets.ts",
+            r##"
+export const foo: ImportMeta = import.meta.blah = import.meta.blue = import.meta;
+import.meta = foo;
+
+// @Filename augmentations.ts
+declare global {
+  interface ImportMeta {
+    wellKnownProperty: { a: number, b: string, c: boolean };
+  }
+}
+
+const { a, b, c } = import.meta.wellKnownProperty;
+"##,
+        ),
+    ];
+    for target in [ScriptTarget::ESNext, ScriptTarget::ES5] {
+        for module in [
+            ModuleKind::ESNext,
+            ModuleKind::CommonJS,
+            ModuleKind::System,
+            ModuleKind::ES2020,
+        ] {
+            let options = CheckerOptions {
+                module,
+                target,
+                ..CheckerOptions::default()
+            };
+            let diagnostics = check_multi_file_with_libs(&files, "example.ts", options, &lib_files);
+            let append_child_errors: Vec<_> = diagnostics
+                .iter()
+                .filter(|diag| {
+                    (diag.code == 2339 && diag.message_text.contains("appendChild"))
+                        || (diag.code == 2345 && diag.message_text.contains("HTMLImageElement"))
+                })
+                .collect();
+            assert!(
+                append_child_errors.is_empty(),
+                "fixture should not report DOM appendChild drift under module {module:?} target {target:?}; got {diagnostics:#?}"
+            );
+        }
+    }
 }

--- a/crates/tsz-checker/tests/jsx_component_attribute_tests.rs
+++ b/crates/tsz-checker/tests/jsx_component_attribute_tests.rs
@@ -74,6 +74,7 @@ fn jsx_full_diagnostics_with_mode(source: &str, jsx_mode: JsxMode) -> Vec<Diagno
         file_name.to_string(),
         options,
     );
+    checker.ctx.report_unresolved_imports = true;
 
     checker.check_source_file(root);
     checker.ctx.diagnostics.clone()

--- a/crates/tsz-checker/tests/jsx_component_attribute_tests_parts/part_02.rs
+++ b/crates/tsz-checker/tests/jsx_component_attribute_tests_parts/part_02.rs
@@ -1656,6 +1656,10 @@ const Wrong = (props: { offspring: string }) => <h1>{props.offspring}</h1>;
 <Wrong>Byebye, world!</Wrong>;
 "#;
     let diags = jsx_full_diagnostics_with_mode(source, JsxMode::ReactJsx);
+    assert!(
+        diags.iter().any(|diag| diag.code == 2875),
+        "Expected TS2875 in react-jsx conformance mode, got: {diags:?}"
+    );
     let ts2741 = diags
         .iter()
         .find(|diag| {
@@ -1778,4 +1782,3 @@ let k = <Comp a={{10}}><div>hi</div><div>bye</div></Comp>;
         "Multiple children for non-array children type should emit TS2746, got: {diags:?}"
     );
 }
-

--- a/crates/tsz-checker/tests/jsx_component_attribute_tests_parts/part_03.rs
+++ b/crates/tsz-checker/tests/jsx_component_attribute_tests_parts/part_03.rs
@@ -1483,7 +1483,7 @@ type Record<K extends keyof any, T> = { [P in K]: T };
 declare namespace JSX {
     interface Element {}
     interface IntrinsicElements {
-        div: {};
+        div: { alpha: string; beta: number; gamma: boolean; delta: string; epsilon: number; };
     }
 }
 
@@ -1516,6 +1516,10 @@ const l = <div<number>/>;
     assert!(
         codes.contains(&2558),
         "intrinsic JSX elements should reject explicit type arguments, got: {codes:?}"
+    );
+    assert!(
+        !codes.iter().any(|code| matches!(code, 2739 | 2740 | 2741)),
+        "invalid intrinsic JSX type arguments should suppress props assignability cascades, got: {codes:?}"
     );
 }
 

--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -53,7 +53,7 @@ denominators.
 | Surface | Current |
 | --- | ---: |
 | Diagnostic conformance | `100.0%` exact (`12,582 / 12,582`) |
-| Accepted-regression strictness | `10` listed tests (justified in `conformance-accepted-regressions.txt`, Refs PR #12157, #12260, and #12238) |
+| Accepted-regression strictness | `6` listed tests (justified in `conformance-accepted-regressions.txt`, Refs PR #12157, #12260, and #12238) |
 | JavaScript emit | `96.8%` (`13,094 / 13,530`) in checked-in emit snapshot and README |
 | Declaration emit | `96.2%` (`1,606 / 1,669`) in checked-in emit snapshot and README |
 | Fourslash / language service | `99.9%` (`6,558 / 6,562`) |
@@ -70,10 +70,10 @@ The exact conformance snapshot does not by itself mean the conformance runway
 is fully retired. `scripts/conformance/conformance-accepted-regressions.txt`
 remains a separate gate-strictness artifact and must be kept empty or
 explicitly justified by current CI evidence before agents treat conformance
-cleanup as complete. It currently lists `10` justified entries: the
+cleanup as complete. It currently lists `6` justified entries: the
 fingerprint-only diff introduced alongside PR #12157's net-positive snapshot
 refresh, current TypeScript-corpus drift tracked in #12260, and ready-review
-aggregate drift tracked from PR #12238 in #8432, #12260, and #12261. The strictness
+aggregate drift tracked from PR #12238 in #8432 and #12260. The strictness
 gate is non-empty and each entry should be paid down in follow-up PRs.
 
 ## Evidence From Current Audit

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -24,11 +24,7 @@ TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 
 # Ready-review aggregate drift observed on PR #12238 exact head 7af9d315.
 # Mapped/keyof family tracked in #8432; large-union intersections tracked in
-# #12260; JSX/import.meta subset tracked in #12261.
-# importMeta.ts oscillates; re-accepted after REGRESSED on PR #12243 CI run 26852720835.
+# #12260.
 # intersectionsOfLargeUnions2.ts oscillates; re-accepted after REGRESSED on PR #12243 exact head.
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
-TypeScript/tests/cases/compiler/jsxIntrinsicElementsTypeArgumentErrors.tsx
-TypeScript/tests/cases/compiler/jsxNamespaceElementChildrenAttributeIgnoredWhenReactJsx.tsx
-TypeScript/tests/cases/conformance/es2019/importMeta/importMeta.ts


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
Diagnostic conformance accepted-regression cleanup for issue #12261.

## Invariant
When intrinsic JSX tags carry explicit type arguments, `tsc` reports the type-argument diagnostics without cascading into intrinsic props assignability; this PR changes JSX checker orchestration.

When react-jsx runtime import-source diagnostics are deferred, `tsc` still reports required prop errors; this PR changes JSX props checking.

When a compiled DOM interface inherits a generic method and a concrete lib interface extends the method constraint, `tsc` accepts the call; this PR changes lazy lib member resolution and the actual-lib interface heritage relation path.

## Scope
- JSX intrinsic/component props diagnostic orchestration.
- Lazy single-member lib property/method resolution for inherited DOM methods.
- Actual/cloned lib interface heritage assignability.
- Focused checker tests, accepted-regression list, and roadmap strictness count.

## Project Corpus Impact
- Row: n/a
- Bug family: accepted conformance drift, not a project corpus row.
- Evidence: focused conformance filters for the three #12261 paths now pass, and the accepted-regression list now contains 6 paths.

## Verification
- `scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test jsx_component_attribute_tests jsx_children_react_jsx_ignores_element_children_attribute_and_keeps_related_info test_jsx_intrinsic_type_args_validate_nested_errors --test import_meta_module_support_diagnostics_tests import_meta_fixture_keeps_document_body_append_child`
- `scripts/safe-run.sh -- ./scripts/conformance/conformance.sh run --filter "jsxIntrinsicElementsTypeArgumentErrors" --verbose`
- `scripts/safe-run.sh -- ./scripts/conformance/conformance.sh run --filter "jsxNamespaceElementChildrenAttributeIgnoredWhenReactJsx" --verbose`
- `scripts/safe-run.sh -- ./scripts/conformance/conformance.sh run --filter "importMeta" --verbose`
- `scripts/safe-run.sh -- python3 scripts/arch/arch_guard.py`
- `git diff --check`

## Coordination Notes
- Fixes #12261.
- Removes the three #12261 paths from `scripts/conformance/conformance-accepted-regressions.txt`; the list now contains 6 paths.
- No project-corpus row expected to change.
