### PR TITLE
fix(checker): attribute cross-file `import type` value-use to TS1361

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2032,3 +2032,7 @@ path = "tests/import_meta_module_support_diagnostics_tests.rs"
 
 [lints]
 workspace = true
+
+[[test]]
+name = "type_only_import_value_use_attribution_tests"
+path = "tests/type_only_import_value_use_attribution_tests.rs"

--- a/crates/tsz-checker/src/error_reporter/type_value.rs
+++ b/crates/tsz-checker/src/error_reporter/type_value.rs
@@ -633,26 +633,18 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
 
-            // Find the arena that owns this alias's declarations. Prefer the
-            // per-symbol override if registered; otherwise resolve via the
-            // owning file index (cross-binder alias case).
-            let arena = self
-                .ctx
-                .binder
-                .symbol_arenas
-                .get(&alias_sym_id)
-                .map(|arc| &**arc)
-                .or_else(|| {
-                    self.ctx
-                        .resolve_symbol_file_index(alias_sym_id)
-                        .map(|file_idx| self.ctx.get_arena_for_file(file_idx as u32))
-                })
-                .unwrap_or(self.ctx.arena);
-
             for &decl in &symbol.declarations {
                 if decl.is_none() {
                     continue;
                 }
+                // Resolve the arena that owns *this* declaration of the alias —
+                // the file where the alias is declared, not the file its import
+                // resolves to — so the `type` marker walk reads the correct
+                // file's nodes (avoids cross-binder declaration-root collisions).
+                let arena =
+                    self.ctx
+                        .binder
+                        .arena_for_declaration_or(alias_sym_id, decl, self.ctx.arena);
                 if let Some(kind) = Self::find_direct_type_only_marker(arena, decl) {
                     return Some(kind);
                 }
@@ -883,23 +875,19 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let arena = self
-            .ctx
-            .binder
-            .symbol_arenas
-            .get(&sym_id)
-            .map(|arc| &**arc)
-            .or_else(|| {
-                self.ctx
-                    .resolve_symbol_file_index(sym_id)
-                    .map(|file_idx| self.ctx.get_arena_for_file(file_idx as u32))
-            })
-            .unwrap_or(self.ctx.arena);
-
         for &decl in &symbol.declarations {
             if decl.is_none() {
                 continue;
             }
+            // A symbol's declaration nodes index into the file where the symbol
+            // is *declared*, not the file an import alias resolves to. Resolve
+            // the owning arena per declaration so the `type` marker walk reads
+            // the importing file's `import type { … }` clause rather than an
+            // unrelated node in the alias-target file.
+            let arena = self
+                .ctx
+                .binder
+                .arena_for_declaration_or(sym_id, decl, self.ctx.arena);
             if let Some(kind) = Self::find_direct_type_only_marker(arena, decl) {
                 return Some(kind);
             }
@@ -991,16 +979,15 @@ impl<'a> CheckerState<'a> {
                 return None;
             }
 
-            let decl_arena = target_binder
-                .symbol_arenas
-                .get(&current_sym_id)
-                .map(|arc| &**arc)
-                .unwrap_or(target_arena);
-
             for &decl in &sym.declarations {
                 if decl.is_none() {
                     continue;
                 }
+                // Resolve the arena owning *this* declaration of the export
+                // symbol within the target module, not a symbol-wide default,
+                // so the marker walk reads the file that actually declares it.
+                let decl_arena =
+                    target_binder.arena_for_declaration_or(current_sym_id, decl, target_arena);
                 if let Some(kind) = Self::find_direct_type_only_marker(decl_arena, decl) {
                     return Some(kind);
                 }

--- a/crates/tsz-checker/tests/type_only_import_value_use_attribution_tests.rs
+++ b/crates/tsz-checker/tests/type_only_import_value_use_attribution_tests.rs
@@ -1,0 +1,195 @@
+//! Cross-file attribution of "type-only binding used as a value" diagnostics.
+//!
+//! When a binding that is type-only is used in a value position, tsc reports
+//! one of two distinct diagnostics depending on *why* it is type-only:
+//!
+//! * **TS1361** — "'X' cannot be used as a value because it was imported using
+//!   'import type'." The type-only-ness comes from a local
+//!   `import type { X }` / `import { type X }` at the use site's file.
+//! * **TS1362** — "'X' cannot be used as a value because it was exported using
+//!   'export type'." The binding is a plain value import whose type-only-ness
+//!   is introduced *upstream* by an `export type { X }` / `export { type X }`
+//!   re-export.
+//!
+//! Regression: tsz used to resolve the arena for walking an import alias's
+//! *own* declaration via the alias's import-*target* file (the file the alias
+//! resolves to) instead of the alias's *declaring* file. The `import type`
+//! marker therefore could not be found on the local clause, so every cross-file
+//! `import type` use-as-value was misattributed to TS1362 ("export type"), even
+//! when no `export type` existed anywhere in the program. The fix walks each
+//! declaration in the arena that actually owns it
+//! (`BinderState::arena_for_declaration_or`).
+//!
+//! The rule is name-agnostic, so each case varies the binder spellings to prove
+//! the attribution is not keyed on any particular identifier.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{
+    check_multi_file_with_libs, diagnostic_code_messages, diagnostic_codes, load_lib_files,
+};
+
+fn check(files: &[(&str, &str)], entry: &str) -> Vec<tsz_checker::diagnostics::Diagnostic> {
+    let libs = load_lib_files(&["es5.d.ts"]);
+    check_multi_file_with_libs(
+        files,
+        entry,
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+        &libs,
+    )
+}
+
+fn codes(files: &[(&str, &str)], entry: &str) -> Vec<u32> {
+    diagnostic_codes(&check(files, entry))
+}
+
+fn messages(files: &[(&str, &str)], entry: &str) -> Vec<(u32, String)> {
+    diagnostic_code_messages(check(files, entry))
+}
+
+/// `import type { X }` of a name exported as *both* a value and a type, then
+/// used as a value, is attributed to the local `import type` -> TS1361.
+#[test]
+fn import_type_dual_namespace_source_attributes_ts1361() {
+    let c = codes(
+        &[
+            (
+                "shared.ts",
+                "export const Widget = { id: 1 };\nexport type Widget = { id: number };\n",
+            ),
+            (
+                "consumer.ts",
+                "import type { Widget } from \"./shared\";\nexport type WidgetMap = Widget & { tag: \"w\" };\nconst value = Widget;\n",
+            ),
+        ],
+        "consumer.ts",
+    );
+    assert!(
+        c.contains(&1361) && !c.contains(&1362),
+        "Expected TS1361 (imported using 'import type'), not TS1362: {c:?}"
+    );
+}
+
+/// The source exports the name as a *value only*; the importing file's
+/// `import type` is what makes the local binding type-only. There is no
+/// `export type` anywhere, so the attribution must be TS1361, never TS1362.
+#[test]
+fn import_type_value_only_source_attributes_ts1361() {
+    let m = messages(
+        &[
+            ("shared.ts", "export const Gadget = { id: 1 };\n"),
+            (
+                "consumer.ts",
+                "import type { Gadget } from \"./shared\";\nconst value = Gadget;\n",
+            ),
+        ],
+        "consumer.ts",
+    );
+    assert!(
+        m.iter()
+            .any(|(code, msg)| *code == 1361 && msg.contains("imported using 'import type'")),
+        "Expected TS1361 mentioning 'import type' (no 'export type' exists): {m:?}"
+    );
+    assert!(
+        !m.iter().any(|(code, _)| *code == 1362),
+        "Must not report TS1362 when no 'export type' exists anywhere: {m:?}"
+    );
+}
+
+/// Per-specifier `import { type X }` form is also a local `import type` marker.
+#[test]
+fn per_specifier_import_type_attributes_ts1361() {
+    let c = codes(
+        &[
+            (
+                "shared.ts",
+                "export const Sprocket = { id: 1 };\nexport type Sprocket = { id: number };\n",
+            ),
+            (
+                "consumer.ts",
+                "import { type Sprocket } from \"./shared\";\nconst value = Sprocket;\n",
+            ),
+        ],
+        "consumer.ts",
+    );
+    assert!(
+        c.contains(&1361) && !c.contains(&1362),
+        "Expected TS1361 for per-specifier `import {{ type X }}`: {c:?}"
+    );
+}
+
+/// A plain value import whose type-only-ness is introduced upstream by an
+/// `export type { X } from` re-export is attributed to TS1362.
+#[test]
+fn export_type_reexport_then_plain_import_attributes_ts1362() {
+    let m = messages(
+        &[
+            (
+                "origin.ts",
+                "export const Cog = { id: 1 };\nexport type Cog = { id: number };\n",
+            ),
+            ("barrel.ts", "export type { Cog } from \"./origin\";\n"),
+            (
+                "consumer.ts",
+                "import { Cog } from \"./barrel\";\nconst value = Cog;\n",
+            ),
+        ],
+        "consumer.ts",
+    );
+    assert!(
+        m.iter()
+            .any(|(code, msg)| *code == 1362 && msg.contains("exported using 'export type'")),
+        "Expected TS1362 (exported using 'export type') for upstream re-export: {m:?}"
+    );
+    assert!(
+        !m.iter().any(|(code, _)| *code == 1361),
+        "Must not report TS1361 when the type-only origin is an 'export type': {m:?}"
+    );
+}
+
+/// Inline `export { type X } from` re-export is likewise attributed to TS1362.
+#[test]
+fn inline_export_type_reexport_attributes_ts1362() {
+    let c = codes(
+        &[
+            (
+                "origin.ts",
+                "export const Lever = { id: 1 };\nexport type Lever = { id: number };\n",
+            ),
+            ("barrel.ts", "export { type Lever } from \"./origin\";\n"),
+            (
+                "consumer.ts",
+                "import { Lever } from \"./barrel\";\nconst value = Lever;\n",
+            ),
+        ],
+        "consumer.ts",
+    );
+    assert!(
+        c.contains(&1362) && !c.contains(&1361),
+        "Expected TS1362 for inline `export {{ type X }}` re-export: {c:?}"
+    );
+}
+
+/// A plain value import is usable as a value even if the same file *also*
+/// re-exports it type-only via `export type { X }` — the local value binding is
+/// unaffected, so no diagnostic fires.
+#[test]
+fn plain_import_with_local_export_type_reexport_is_value_usable() {
+    let c = codes(
+        &[
+            ("shared.ts", "export const Pulley = { id: 1 };\n"),
+            (
+                "consumer.ts",
+                "import { Pulley } from \"./shared\";\nexport type { Pulley };\nconst value = Pulley;\n",
+            ),
+        ],
+        "consumer.ts",
+    );
+    assert!(
+        !c.contains(&1361) && !c.contains(&1362) && !c.contains(&2749),
+        "A plain value import remains value-usable despite a local `export type` \
+         re-export: {c:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the cross-file declaration-root confusion behind the `module-resolution-17-20` family (#10948): when a name participates in both the type and value namespace and is brought across a module boundary, tsz walked an import alias's **own** declaration nodes in the arena of the file the alias *resolves to* (its import target) instead of the file where the alias is *declared*. The declaration index then landed on an unrelated node in the wrong file, so the local `import type { … }` marker was never found.

Concretely, every cross-file `import type { X } from "./m"; … const v = X;` was misattributed to **TS1362** ("…exported using 'export type'.") instead of **TS1361** ("…imported using 'import type'.") — even when no `export type` existed anywhere in the program.

Closes #10948.

AgentName: M4-D

## Track
Diagnostics / module-resolution — type-only (`import type` / `export type`) value-use attribution at the module/resolver boundary.

## Invariant
A symbol's declaration nodes belong to its **declaring** file, never to an alias's **target** file. The TS1361 vs TS1362 split is decided by where the type-only marker is declared:
> When a type-only binding is used as a value, `tsc` reports TS1361 if the local binding is `import type` / `import { type X }`, and TS1362 if the type-only-ness is introduced upstream by `export type` / `export { type X }`. tsz now resolves the marker against the arena that actually owns each declaration.

## Scope
- `crates/tsz-checker/src/error_reporter/type_value.rs` — replace `symbol_arenas.get(..).or_else(resolve_symbol_file_index(..))` arena selection with the canonical per-declaration `BinderState::arena_for_declaration_or(sym, decl, fallback)` at all three type-only marker walks:
  1. `direct_lexical_type_only_marker_for_identifier` (local lexical lookup),
  2. the alias-chain pass in `get_type_only_import_export_kind`,
  3. the target-module export walk in `classify_cross_file_type_only_kind`.
- `crates/tsz-checker/tests/type_only_import_value_use_attribution_tests.rs` — new, name-varied regression suite.
- `crates/tsz-checker/Cargo.toml` — register the test (crate uses `autotests = false`).

`arena_for_declaration_or` consults the precise `(symbol, declaration) → arena` map then the symbol-arena override then the current arena — it never reads the order-dependent alias-target file index. This is a generalization (use the canonical mechanism), not a special case.

## Adjacent-case matrix (all in the new test, binder names varied)
- TS1361: `import type { X }` of a dual value+type source; of a value-only source (no `export type` anywhere); per-specifier `import { type X }`.
- TS1362: upstream `export type { X } from`; inline `export { type X } from`.
- No diagnostic: plain value import that is also locally `export type { X }`-re-exported (local value binding stays value-usable).

## Project Corpus Impact
- Row: utility-types-project
- Bug family: module-resolution-17-20

No project-corpus row behavior intentionally changed beyond fixing the witnessed TS1361/TS1362 attribution. The fix is structural (arena ownership), name- and file-agnostic; no fixture-name or identifier fast-paths.

## Verification
- New suite `type_only_import_value_use_attribution_tests` — 6/6 pass; the 3 TS1361 cases fail on the base and pass with the source change (the 3 TS1362 / no-diagnostic cases are stable either way).
- Regression suites green with the change: `ts1361_chain_attribution_tests` (5), `ts1362_false_positive_tests` (11), `type_only_import_reexport_tests` (6), plus `ts136*` lib unit tests (11).
- `cargo clippy -p tsz-checker --tests` clean for the touched files.
- Pre-existing local failures in `import_type_utility_identity_tests` (2) and `order_independent_alias_resolution_tests` (1) were verified to fail identically on the untouched base — unrelated subsystems, not introduced here.
- Rebased onto current `main` (6996a0c); branch merges cleanly with no conflicts.

## Coordination Notes
- #10948 is claimed via its issue-level coordination label and tracked there; implementation and verification are complete and this is ready for review (not a draft).
- #10948 is the canonical tracker for the `module-resolution-17-20` family; if any sibling project-row witness still diverges after this structural fix, it should be reopened with its exact remaining `tsc` vs tsz diff per the issue's acceptance note.
- Broad conformance/emit suites are left to ready-review CI per repo policy.

https://claude.ai/code/session_01H5hHpAcoTVDgfjVHVdR87Y