### PR TITLE
chore(release): bump try-tsz publish version to 0.1.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-binder"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-checker"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "dashmap",
  "globset",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-cli"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "clap",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-common"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "memchr",
  "rustc-hash",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-core"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-emitter"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "memchr",
  "rustc-hash",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-lowering"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "indexmap",
  "rustc-hash",
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-lsp"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "globset",
  "json5",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-parser"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-scanner"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "serde",
  "tsz-common",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-solver"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "bitflags 2.11.0",
  "dashmap",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-wasm"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-website"
-version = "0.1.10"
+version = "0.1.11"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/.target"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 repository = "https://github.com/mohsen1/tsz"
 homepage = "https://github.com/mohsen1/tsz"
@@ -16,16 +16,16 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Internal workspace crates
-tsz = { path = "crates/tsz-core", version = "0.1.10", package = "tsz-core" }
-tsz-common = { path = "crates/tsz-common", version = "0.1.10" }
-tsz-scanner = { path = "crates/tsz-scanner", version = "0.1.10" }
-tsz-parser = { path = "crates/tsz-parser", version = "0.1.10" }
-tsz-binder = { path = "crates/tsz-binder", version = "0.1.10" }
-tsz-solver = { path = "crates/tsz-solver", version = "0.1.10" }
-tsz-lowering = { path = "crates/tsz-lowering", version = "0.1.10" }
-tsz-checker = { path = "crates/tsz-checker", version = "0.1.10" }
-tsz-emitter = { path = "crates/tsz-emitter", version = "0.1.10", default-features = false }
-tsz-lsp = { path = "crates/tsz-lsp", version = "0.1.10" }
+tsz = { path = "crates/tsz-core", version = "0.1.11", package = "tsz-core" }
+tsz-common = { path = "crates/tsz-common", version = "0.1.11" }
+tsz-scanner = { path = "crates/tsz-scanner", version = "0.1.11" }
+tsz-parser = { path = "crates/tsz-parser", version = "0.1.11" }
+tsz-binder = { path = "crates/tsz-binder", version = "0.1.11" }
+tsz-solver = { path = "crates/tsz-solver", version = "0.1.11" }
+tsz-lowering = { path = "crates/tsz-lowering", version = "0.1.11" }
+tsz-checker = { path = "crates/tsz-checker", version = "0.1.11" }
+tsz-emitter = { path = "crates/tsz-emitter", version = "0.1.11", default-features = false }
+tsz-lsp = { path = "crates/tsz-lsp", version = "0.1.11" }
 
 # External dependencies (shared versions)
 anyhow = "1.0"


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Release tooling / npm distribution follow-up.

## Invariant
When the npm publish workflow is triggered from a release tag, the package version must map to an unused npm version and an unused release tag; this PR changes only workspace release metadata.

## Scope
- Bump workspace/package metadata from `0.1.10` to `0.1.11`.
- Preserve the TypeScript `^6.0.3` oracle dependency added for `try-tsz`.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: version-only release metadata change; no compiler behavior changes.

## Verification
- `cargo metadata --no-deps --format-version 1`
- `bash -n scripts/build/build-npm-packages.sh`
- `scripts/build/build-npm-packages.sh --local --native-only --skip-build`
- `node -p "require('./npm/try-tsz/package.json').version + ' ' + require('./npm/try-tsz/package.json').dependencies.typescript"`
- `git diff --check`

## Coordination Notes
- Follow-up to #12287 because the existing `v0.1.10` tag belongs to an older curl-installable release while `try-tsz@0.1.10` was never published.
- After merge, tag `v0.1.11` and let npm trusted publishing publish `try-tsz@0.1.11`.
