### PR TITLE
fix(checker): reject concrete overrides of generic base methods in class extends chains

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics/argument_reports.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics/argument_reports.rs
@@ -530,7 +530,25 @@ impl<'a> CheckerState<'a> {
         {
             return true;
         }
-        if self.diagnostic_relation_boolean_guard_bivariant(source, target) {
+
+        // Strict relation first: keep the base method's method-local generics
+        // universally quantified (`NO_ERASE_GENERICS`) so a concrete override
+        // cannot silently satisfy a generic base signature. This mirrors the
+        // `implements` member-override path (`should_report_own_member_type_mismatch`),
+        // which uses `is_assignable_to_no_erase_generics`, while preserving the
+        // bivariant parameter behavior that class method overrides require.
+        if self.is_assignable_to_bivariant_no_erase_generics(source, target) {
+            return false;
+        }
+
+        // Safe erasure fallback: tsc only canonicalizes (erases) the target's
+        // method-local type parameters when the *source* signature carries its
+        // own (or the target has none). In those cases the generic-erasing
+        // bivariant relation is the correct authority — e.g. `any`-propagation
+        // shapes and generic-to-generic overrides where both sides quantify.
+        if crate::query_boundaries::class::generic_erasure_fallback_is_safe(self, source, target)
+            && self.diagnostic_relation_boolean_guard_bivariant(source, target)
+        {
             return false;
         }
 

--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -1428,6 +1428,38 @@ impl<'a> CheckerState<'a> {
     /// Follows the same pattern as `is_assignable_to` but calls `is_assignable_to_bivariant_callback`
     /// which disables `strict_function_types` for the check.
     pub fn is_assignable_to_bivariant(&mut self, source: TypeId, target: TypeId) -> bool {
+        self.is_assignable_to_bivariant_with_extra_flags(source, target, 0)
+    }
+
+    /// Bivariant assignability that additionally keeps method-local generic
+    /// type parameters opaque (`NO_ERASE_GENERICS`).
+    ///
+    /// Class method overrides are bivariant in their parameters, but the base
+    /// method's universal quantification must still be preserved: a concrete
+    /// `(x: string) => string` is not a valid override of a generic
+    /// `<T extends string>(x: T) => T`, because a caller could instantiate `T`
+    /// with a proper subtype of `string` and expect that subtype back. Erasing
+    /// the base type parameter to its constraint (the default bivariant path)
+    /// hides this `TS2416`. Mirrors the `no_erase_generics` relation used by the
+    /// `implements` member-override path while retaining bivariant parameters.
+    pub fn is_assignable_to_bivariant_no_erase_generics(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> bool {
+        self.is_assignable_to_bivariant_with_extra_flags(
+            source,
+            target,
+            crate::query_boundaries::assignability::RelationFlags::NO_ERASE_GENERICS,
+        )
+    }
+
+    fn is_assignable_to_bivariant_with_extra_flags(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+        extra_flags: u16,
+    ) -> bool {
         if source == target {
             return true;
         }
@@ -1446,8 +1478,11 @@ impl<'a> CheckerState<'a> {
 
         // For bivariant checks, we strip the strict_function_types flag
         // so the cache key is distinct from regular assignability checks.
-        let flags = self.ctx.pack_relation_flags()
-            & !crate::query_boundaries::assignability::RelationFlags::STRICT_FUNCTION_TYPES;
+        // `extra_flags` lets callers force additional policy (e.g.
+        // `NO_ERASE_GENERICS`) while keeping the bivariant parameter behavior.
+        let flags = (self.ctx.pack_relation_flags()
+            & !crate::query_boundaries::assignability::RelationFlags::STRICT_FUNCTION_TYPES)
+            | extra_flags;
 
         if is_cacheable {
             // Note: For assignability checks, we use AnyPropagationMode::All (0)

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -114,6 +114,9 @@ mod async_imported_promise_tests;
 #[path = "../tests/circular_accessor_annotation_tests.rs"]
 mod circular_accessor_annotation_tests;
 #[cfg(test)]
+#[path = "tests/class_extends_generic_override_variance_tests.rs"]
+mod class_extends_generic_override_variance_tests;
+#[cfg(test)]
 #[path = "tests/class_extends_index_relation_routing_arch_tests.rs"]
 mod class_extends_index_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/class_extends_generic_override_variance_tests.rs
+++ b/crates/tsz-checker/src/tests/class_extends_generic_override_variance_tests.rs
@@ -1,0 +1,245 @@
+//! Regression tests for issue #10869 — generic method override variance in
+//! class `extends` chains.
+//!
+//! When a class `extends` a base whose method is *generic* and the override
+//! drops or rewrites the method-local type parameter to a concrete type, the
+//! override must still satisfy the base method's universal quantification.
+//! A concrete `m(x: string): string` is not a valid override of a generic
+//! `m<T extends string>(x: T): T`, because a caller could instantiate `T` with
+//! a proper subtype of `string` and expect that subtype back. tsc reports
+//! TS2416 for these.
+//!
+//! The class `extends` override path checks methods bivariantly (method
+//! parameters are bivariant), but the previous bivariant relation *erased* the
+//! base method's method-local generics to their constraints, hiding the
+//! mismatch. The `implements` member-override path already used the strict
+//! `no_erase_generics` relation and did not have this hole. The fix routes the
+//! bivariant override decision through a no-erase-first relation with the same
+//! safe-erasure fallback used by the `implements` path, so both heritage forms
+//! make identical variance decisions while preserving method-parameter
+//! bivariance.
+
+use crate::test_utils::check_source_codes;
+
+fn assert_has_2416(src: &str) {
+    let codes = check_source_codes(src);
+    assert!(
+        codes.contains(&2416),
+        "expected TS2416, got none. Got: {codes:?}\nSource:\n{src}"
+    );
+}
+
+fn assert_no_2416(src: &str) {
+    let codes = check_source_codes(src);
+    assert!(
+        !codes.contains(&2416),
+        "unexpected TS2416 (false positive). Got: {codes:?}\nSource:\n{src}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Constrained method-local generic in the base, concrete override: tsc rejects
+// because the override pins the type parameter to its constraint and can no
+// longer return a narrower instantiation. (Was a false negative — bivariant
+// path erased the base type parameter.)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn keeps_2416_constrained_generic_dropped_in_extends_override() {
+    assert_has_2416(
+        "class Base { m<T extends string>(x: T): T { return x; } }
+         class Child extends Base { override m(x: string): string { return x; } }",
+    );
+}
+
+// Renamed type parameter — proves the rule is structural, not identifier-keyed.
+#[test]
+fn keeps_2416_constrained_generic_dropped_in_extends_override_renamed() {
+    assert_has_2416(
+        "class Base { m<K extends string>(x: K): K { return x; } }
+         class Child extends Base { override m(x: string): string { return x; } }",
+    );
+}
+
+// Without the `override` modifier the check must still fire (the modifier only
+// affects TS4114-style suggestions, not the compatibility relation).
+#[test]
+fn keeps_2416_constrained_generic_dropped_no_override_keyword() {
+    assert_has_2416(
+        "class Base { m<T extends string>(x: T): T { return x; } }
+         class Child extends Base { m(x: string): string { return x; } }",
+    );
+}
+
+// Unconstrained method-local generic (covered before the fix, kept as a guard).
+#[test]
+fn keeps_2416_unconstrained_generic_dropped_in_extends_override() {
+    assert_has_2416(
+        "class Base { m<T>(x: T): T { return x; } }
+         class Child extends Base { override m(x: string): string { return x; } }",
+    );
+}
+
+// Method-local generic in a covariant output position only (`T[]`): a concrete
+// `string[]` is not a valid override of `T[]` for all `T extends string`.
+#[test]
+fn keeps_2416_constrained_generic_covariant_array_return() {
+    assert_has_2416(
+        "class Base { m<T extends string>(x: number): T[] { return []; } }
+         class Child extends Base { override m(x: number): string[] { return []; } }",
+    );
+}
+
+// Bare method-local generic in return position.
+#[test]
+fn keeps_2416_bare_generic_return_in_extends_override() {
+    assert_has_2416(
+        "class Base { m<T>(): T { return {} as any; } }
+         class Child extends Base { override m(): string { return \"\"; } }",
+    );
+}
+
+// Abstract generic method, concrete implementation in the subclass.
+#[test]
+fn keeps_2416_abstract_generic_method_concrete_override() {
+    assert_has_2416(
+        "abstract class Base { abstract m<T extends string>(x: T): T; }
+         class Child extends Base { m(x: string): string { return x; } }",
+    );
+}
+
+// Generic base *class* plus generic method: the outer type argument is
+// substituted (`B = number`) and the method-local generic stays opaque.
+#[test]
+fn keeps_2416_generic_base_class_with_generic_method() {
+    assert_has_2416(
+        "class Base<B> { m<T extends string>(x: T, b: B): T { return x; } }
+         class Child extends Base<number> { override m(x: string, b: number): string { return x; } }",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Must STILL be accepted (no false positives).
+// ---------------------------------------------------------------------------
+
+// Override re-declares the same method-local generic: the universal
+// quantification is preserved, so the override is valid.
+#[test]
+fn no_false_2416_matching_generic_method_in_extends_override() {
+    assert_no_2416(
+        "class Base { m<T extends string>(x: T): T { return x; } }
+         class Child extends Base { override m<U extends string>(x: U): U { return x; } }",
+    );
+}
+
+// Renamed type parameters at both levels.
+#[test]
+fn no_false_2416_matching_generic_method_in_extends_override_renamed() {
+    assert_no_2416(
+        "class Base { m<P extends string>(x: P): P { return x; } }
+         class Child extends Base { override m<Q extends string>(x: Q): Q { return x; } }",
+    );
+}
+
+// Non-generic base, identical override — unchanged baseline.
+#[test]
+fn no_false_2416_identical_nongeneric_override() {
+    assert_no_2416(
+        "class Base<T> { method(v: T): T { return v; } }
+         class Child extends Base<string> { override method(v: string): string { return v; } }",
+    );
+}
+
+// Method-parameter bivariance must be preserved: narrowing a method parameter
+// is accepted by tsc (unsound but intentional), and the fix must not regress
+// it. (`NO_ERASE_GENERICS` only affects method-local generics, not parameter
+// variance, so non-generic overrides are unaffected.)
+#[test]
+fn no_false_2416_method_param_narrowing_stays_bivariant() {
+    assert_no_2416(
+        "class Animal {}
+         class Dog extends Animal {}
+         class Base { handle(x: Animal): void {} }
+         class Child extends Base { override handle(x: Dog): void {} }",
+    );
+}
+
+// Widening a method parameter is also accepted (covariant-safe direction).
+#[test]
+fn no_false_2416_method_param_widening_accepted() {
+    assert_no_2416(
+        "class Animal {}
+         class Dog extends Animal {}
+         class Base { handle(x: Dog): void {} }
+         class Child extends Base { override handle(x: Animal): void {} }",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// False-positive guards for the danger regime introduced by the stricter
+// `NO_ERASE_GENERICS` branch: the base member has a method-local generic the
+// override does NOT carry. In these shapes tsc still ACCEPTS the override, so
+// the no-erase relation must not over-report. (Verified against tsc 6.0.2.)
+// ---------------------------------------------------------------------------
+
+// Phantom/unused method-local generic: `T` appears nowhere in the signature,
+// so dropping it is sound. tsc accepts.
+#[test]
+fn no_false_2416_phantom_unused_generic_dropped() {
+    assert_no_2416(
+        "class Base { read<T>(): number { return 0; } }
+         class Child extends Base { override read(): number { return 0; } }",
+    );
+}
+
+// Renamed phantom parameter — structural rule, not identifier-keyed.
+#[test]
+fn no_false_2416_phantom_unused_generic_dropped_renamed() {
+    assert_no_2416(
+        "class Base { read<Z>(): number { return 0; } }
+         class Child extends Base { override read(): number { return 0; } }",
+    );
+}
+
+// Phantom constrained generic with a covariant (subtype) return: the override
+// returns `Child` where the base returns `Base`, and the dropped `T` is unused.
+// tsc accepts the covariant narrowing.
+#[test]
+fn no_false_2416_phantom_constrained_generic_covariant_return() {
+    assert_no_2416(
+        "class Base { create<T extends string>(): Base { return this; } }
+         class Child extends Base { override create(): Child { return this; } }",
+    );
+}
+
+// Constrained method-local generic in input-only position with a covariant
+// return: `with<K extends string>(k: K): Builder` overridden by
+// `with(k: string): SubBuilder`. The wider concrete parameter accepts any
+// `K extends string`, and the return narrows covariantly, so tsc accepts.
+#[test]
+fn no_false_2416_input_only_constrained_generic_covariant_return() {
+    assert_no_2416(
+        "class Builder { with<K extends string>(k: K): Builder { return this; } }
+         class SubBuilder extends Builder { override with(k: string): SubBuilder { return this; } }",
+    );
+}
+
+// Renamed input-only constrained generic.
+#[test]
+fn no_false_2416_input_only_constrained_generic_covariant_return_renamed() {
+    assert_no_2416(
+        "class Builder { with<C extends string>(k: C): Builder { return this; } }
+         class SubBuilder extends Builder { override with(k: string): SubBuilder { return this; } }",
+    );
+}
+
+// Override adds a `this` parameter while dropping a phantom method-local
+// generic. The `this` parameter must not be mistaken for an arity/variance
+// mismatch; tsc accepts.
+#[test]
+fn no_false_2416_added_this_param_with_dropped_phantom_generic() {
+    assert_no_2416(
+        "class Base { m<T extends string>(x: number): number { return x; } }
+         class Child extends Base { override m(this: Child, x: number): number { return x; } }",
+    );
+}


### PR DESCRIPTION
AgentName: Studio-B
Track: bug-family / type-inference / class-inheritance / generic-inference

Fixes #10869

## Invariant
Class method override compatibility (TS2416) must match tsc's variance
decisions for both `implements` and `extends` heritage. A concrete override
of a *generic* base method must preserve the base method's universal
quantification — exactly as tsc's `compareSignaturesRelated` does.

## Structural rule
When a class `extends` a base whose member is a generic method whose
method-local type parameters the override does **not** carry, tsc keeps those
parameters universally quantified and reports TS2416 if the concrete override
cannot satisfy every instantiation; tsz now does the same through the
`should_report_assignability_mismatch_bivariant` boundary.

Previously the class `extends` override path checked members through a single
generic-**erasing** bivariant relation, which collapsed a base generic method
`m<T extends string>(x: T): T` to its constraint `m(x: string): string`. A
concrete override `m(x: string): string` then looked compatible, so tsz
silently accepted it (false negative). The `implements` member-override path
(`should_report_own_member_type_mismatch`) already avoided this by using the
strict `no_erase_generics` relation with a `generic_erasure_fallback_is_safe`
gate; the `extends` / bivariant path did not.

## Scope / owner layer
- `crates/tsz-checker/src/assignability/assignability_relation.rs`: extract the
  existing bivariant relation body into `is_assignable_to_bivariant_with_extra_flags`
  and add `is_assignable_to_bivariant_no_erase_generics` (bivariant parameters +
  `NO_ERASE_GENERICS`).
- `crates/tsz-checker/src/assignability/assignability_diagnostics/argument_reports.rs`:
  route `should_report_assignability_mismatch_bivariant` through a
  no-erase-first relation plus the same `generic_erasure_fallback_is_safe`
  safe-erasure fallback the `implements` path uses, so both heritage forms make
  identical variance decisions while preserving the method-parameter bivariance
  class overrides require.
- New regression module `class_extends_generic_override_variance_tests.rs`.

No checker-side raw type-logic was added: the decision stays on the existing
assignability boundary helpers; the new method is a flag variant of the
existing bivariant relation.

## Adjacent-case matrix (verified against tsc 6.0.2)
Newly fixed false negatives (now TS2416, matching tsc):
- constrained method-local generic dropped: base `m<T extends string>(x:T):T`, override `m(x:string):string`
- same, renamed type parameter (proves no identifier keying)
- same, without the `override` keyword
- unconstrained generic dropped: base `m<T>(x:T):T`, override `m(x:string):string`
- covariant array return: base `m<T extends string>(x:number):T[]`, override `m(x:number):string[]`
- bare generic return: base `m<T>():T`, override `m():string`
- abstract generic method, concrete override
- generic base class with generic method

Still correctly accepted (no false positives — each has a checked-in
`assert_no_2416` guard, since these are the safety boundary for the stricter
`NO_ERASE_GENERICS` branch):
- matching generic override (and renamed)
- identical non-generic override
- method-parameter narrowing and widening (bivariance preserved)
- phantom / unused method-local generic (and renamed)
- phantom constrained generic with covariant return
- constrained method-local generic in input-only position with covariant return (and renamed)
- override that adds a `this` parameter while dropping a phantom generic

## Project Corpus Impact
- Row: large-ts-repo
- Bug family: generic-method-override-variance (class-inheritance / generic-inference)

Targets the large-ts-repo benchmark family (#10869); the same hole affected
generic builder / override shapes across the bench projects. No
accepted-regression drift introduced. The behavior change is confined to the
narrow regime where the base member has method-local generics the override
lacks; in that regime tsc also reports TS2416, so the change is a pure
false-negative repair.

## Verification
- New module `class_extends_generic_override_variance_tests`: **19/19 pass**,
  including the false-positive `assert_no_2416` guards for the phantom /
  input-only / `this`-parameter accepted shapes.
- Existing `generic_method_override_variance` + `generic_mixed_inheritance_chain`:
  51/51 pass (no regressions).
- Behavior matrix above cross-checked against `tsc 6.0.2 --strict`.
- Prior local comparison evidence (this workspace has no `cargo nextest`
  binary, so `cargo test -p tsz-checker --lib` was used for the local
  before/after diff): the full checker lib suite produced an **identical**
  failure set before and after the change — 53 pre-existing, unrelated failures,
  byte-for-byte equal; reverting only the two production files reproduces the
  same 53. The change introduces **zero** new test failures.
- Ready-review authority: the exact-head CI gates on this PR (unit, lint,
  conformance, emit, fourslash, project rows, etc.) are the authoritative broad
  verification; this PR is held off queue until those are green on the current
  head.

## Coordination Notes
Cleaned via `/simplify` (reuse / simplification / efficiency / altitude review).
The parallel strict+fallback structure intentionally mirrors the proven
`implements`-path `should_report_own_member_type_mismatch`; unifying the two
override decision functions into one shared helper is a viable follow-up but
spans `query_boundaries/class.rs` (outside this diff) and the two paths differ
in parameter variance, so it is left for a dedicated refactor.

https://claude.ai/code/session_01HWNML28MrS2rYjK4vrb3SN