### PR TITLE
fix(npm): preserve executable bits for native packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-binder"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-checker"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "dashmap",
  "globset",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-cli"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "clap",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-common"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "memchr",
  "rustc-hash",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-core"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-emitter"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "memchr",
  "rustc-hash",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-lowering"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "indexmap",
  "rustc-hash",
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-lsp"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "globset",
  "json5",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-parser"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-scanner"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "serde",
  "tsz-common",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-solver"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "bitflags 2.11.0",
  "dashmap",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-wasm"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-website"
-version = "0.1.11"
+version = "0.1.12"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/.target"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.11"
+version = "0.1.12"
 edition = "2024"
 repository = "https://github.com/mohsen1/tsz"
 homepage = "https://github.com/mohsen1/tsz"
@@ -16,16 +16,16 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Internal workspace crates
-tsz = { path = "crates/tsz-core", version = "0.1.11", package = "tsz-core" }
-tsz-common = { path = "crates/tsz-common", version = "0.1.11" }
-tsz-scanner = { path = "crates/tsz-scanner", version = "0.1.11" }
-tsz-parser = { path = "crates/tsz-parser", version = "0.1.11" }
-tsz-binder = { path = "crates/tsz-binder", version = "0.1.11" }
-tsz-solver = { path = "crates/tsz-solver", version = "0.1.11" }
-tsz-lowering = { path = "crates/tsz-lowering", version = "0.1.11" }
-tsz-checker = { path = "crates/tsz-checker", version = "0.1.11" }
-tsz-emitter = { path = "crates/tsz-emitter", version = "0.1.11", default-features = false }
-tsz-lsp = { path = "crates/tsz-lsp", version = "0.1.11" }
+tsz = { path = "crates/tsz-core", version = "0.1.12", package = "tsz-core" }
+tsz-common = { path = "crates/tsz-common", version = "0.1.12" }
+tsz-scanner = { path = "crates/tsz-scanner", version = "0.1.12" }
+tsz-parser = { path = "crates/tsz-parser", version = "0.1.12" }
+tsz-binder = { path = "crates/tsz-binder", version = "0.1.12" }
+tsz-solver = { path = "crates/tsz-solver", version = "0.1.12" }
+tsz-lowering = { path = "crates/tsz-lowering", version = "0.1.12" }
+tsz-checker = { path = "crates/tsz-checker", version = "0.1.12" }
+tsz-emitter = { path = "crates/tsz-emitter", version = "0.1.12", default-features = false }
+tsz-lsp = { path = "crates/tsz-lsp", version = "0.1.12" }
 
 # External dependencies (shared versions)
 anyhow = "1.0"

--- a/scripts/build/build-npm-packages.sh
+++ b/scripts/build/build-npm-packages.sh
@@ -521,6 +521,12 @@ for entry in "${PLATFORMS[@]}"; do
   cp "$PROJECT_ROOT/LICENSE.txt" "$try_platform_pkg/LICENSE.txt"
 done
 
+# GitHub artifact upload/download does not preserve executable bits reliably.
+# Restore them during package assembly so npm packs native binaries as runnable.
+if [ "$WASM_ONLY" -ne 1 ]; then
+  find "$NPM_DIR/@mohsen-azimi" -path "*/bin/*" -type f -exec chmod +x {} +
+fi
+
 echo ""
 echo "==> Build complete!"
 echo "    Main package: $MAIN_PKG"


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Release tooling / npm distribution fix-forward.

## Invariant
When npm packages contain native binaries copied from CI artifacts, package assembly must restore executable bits before `npm pack`/`npm publish`; this PR changes npm assembly and bumps the release version to an unused publish target.

## Scope
- Restore executable bits for native package `bin/*` files during npm package assembly.
- Bump workspace/package metadata from `0.1.11` to `0.1.12` so the fixed packages can publish.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: packaging-only release fix; no compiler behavior changes.

## Verification
- `cargo metadata --no-deps --format-version 1`
- `bash -n scripts/build/build-npm-packages.sh`
- `scripts/build/build-npm-packages.sh --local --native-only --skip-build`
- `node -p "require('./npm/try-tsz/package.json').version + ' ' + require('./npm/try-tsz/package.json').dependencies.typescript"`
- Simulated a CI artifact copied as mode `0644`; package assembly changed it to `-rwxr-xr-x` and `npm pack` preserved `package/bin/try-tsz` as executable.
- `git diff --check`

## Coordination Notes
- Fix-forward after published `try-tsz@0.1.11` failed on macOS with `spawnSync .../bin/try-tsz EACCES`.
- Root cause: GitHub artifact upload/download did not preserve executable mode for native binary artifacts before publish.
- After merge, tag `v0.1.12`, publish via trusted publishing, then re-run `npx try-tsz@latest`.
