### PR TITLE
conformance: document JSX/import.meta accepted-regression drift accurately (#12261)

### DIFF
--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -24,8 +24,24 @@ TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 
 # Ready-review aggregate drift observed on PR #12238 exact head 7af9d315.
 # Mapped/keyof family tracked in #8432; large-union intersections tracked in
-# #12260; JSX/import.meta subset tracked in #12261.
-# importMeta.ts oscillates; re-accepted after REGRESSED on PR #12243 CI run 26852720835.
+# #12260. JSX/import.meta subset tracked in #12261 — re-verified against the
+# pinned TS 6.0.3 corpus, replacing the earlier vague "oscillates" notes with the
+# actual per-fixture fingerprints so each entry stays owner-visible:
+#   - jsxIntrinsicElementsTypeArgumentErrors.tsx: passes in an isolated harness
+#     run (3/3) but REGRESSES in the sharded ready-review aggregate, so the
+#     diagnostics on JSX type-argument recovery (TS1009/TS1099/TS2304/TS2344/
+#     TS2558) are resolution-order/shard sensitive. Kept allowlisted; the
+#     order-sensitivity is the bug to chase. Tracked in #12261.
+#   - importMeta.ts: diagnostic CODES already match [TS2339, TS2364, TS17012].
+#     The only remaining drift is one extra false TS2339 "Property 'appendChild'
+#     does not exist on type 'HTMLElement'" on `document.body.appendChild(...)`,
+#     a lib-interface heritage cycle-drop bug tracked in #12299 (not genuine
+#     oscillation).
+#   - jsxNamespaceElementChildrenAttributeIgnoredWhenReactJsx.tsx: tsz emits
+#     [TS2875] but misses TS2741. Under react-jsx the custom
+#     JSX.ElementChildrenAttribute ("offspring") is ignored, so body children map
+#     to `children` and the required `offspring` prop must be reported missing.
+#     Tracked in #12261.
 # intersectionsOfLargeUnions2.ts oscillates; re-accepted after REGRESSED on PR #12243 exact head.
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts


### PR DESCRIPTION
AgentName: claude-confident-hawking
Owner lane: agent:M1-C — canonical ownership lane for #12261 (assigned on this PR). `claude-confident-hawking` is the stable signed runner/owner of this change; `agent:M1-C` owns the follow-up `TS2741` work tracked in #12261.
Track: Conformance / accepted-regression hygiene
Invariant: `conformance-accepted-regressions.txt` entries are owner-visible — each carries an accurate fingerprint and tracker, never vague/misleading churn.

## Scope

Documentation-only update to the JSX/`import.meta` subset of #12261. Re-verified all three fixtures against the pinned TypeScript 6.0.3 corpus and replaced the vague "oscillates" notes with accurate per-fixture fingerprints. **All three entries remain allowlisted** (no entries added or removed; no compiler/solver changes):

- **`jsxIntrinsicElementsTypeArgumentErrors.tsx`** — passes in an isolated harness run (3/3) but **REGRESSES in the sharded ready-review aggregate** (confirmed on this PR's first push, where delisting it failed `conformance-aggregate`). Its JSX type-argument recovery diagnostics (`TS1009`/`TS1099`/`TS2304`/`TS2344`/`TS2558`) are resolution-order/shard sensitive — that order-sensitivity is the real bug. Kept allowlisted; tracked in #12261.
- **`importMeta.ts`** — diagnostic *codes* already match `tsc` (`[TS2339, TS2364, TS17012]`). The sole remaining drift is one extra false `TS2339 Property 'appendChild' does not exist on type 'HTMLElement'` on `document.body.appendChild(...)`, root-caused to a lib-interface heritage **cycle-drop** bug filed as **#12299** (not genuine oscillation). Kept allowlisted with the accurate fingerprint.
- **`jsxNamespaceElementChildrenAttributeIgnoredWhenReactJsx.tsx`** — tsz emits `[TS2875]` but misses **`TS2741`**: under `react-jsx` a custom `JSX.ElementChildrenAttribute` (`offspring`) must be ignored, so body children map to `children` and the required `offspring` prop is left unsatisfied. Kept allowlisted; tracked in #12261.

## Project Corpus Impact

- Row: n/a
- Bug family: conformance accepted-regression allowlist documentation (JSX / `import.meta`)

None. Only comments in `scripts/conformance/conformance-accepted-regressions.txt` change; no allowlist entries are added or removed, so the aggregate gate is unchanged. `conformance-snapshot-gate` and `conformance-aggregate` are green on the comment-only head.

## Verification

- `scripts/conformance/conformance.sh run --filter <fixture>` on the pinned TS 6.0.3 corpus:
  - `jsxIntrinsicElementsTypeArgumentErrors` → 1/1 PASS isolated, but REGRESSED in the sharded aggregate (this PR's first push) → correctly kept allowlisted.
  - `importMeta` → codes match; single fingerprint-only extra `TS2339` (`appendChild`).
  - `jsxNamespace…` → missing `TS2741` only.
- 2-line minimal repro for #12299 (`declare const h: HTMLElement; h.appendChild`) reproduces the false `TS2339` on default lib.

## Coordination Notes

- #12261 stays open for the `jsxNamespace` `TS2741` parity gap and the `jsxIntrinsic` shard-order sensitivity; owned by `agent:M1-C`.
- #12299 opened for the broad DOM heritage cycle-drop bug (subsumes the `importMeta` `appendChild` drift).
- #10680 (kysely false `TS2339` on `string | NoMigrations`) was verified already fixed on `main` and closed with evidence during this investigation.

https://claude.ai/code/session_014XgxDfBKc9BHwQc2zP8tVt