### PR TITLE
fix(solver): union repeated infer names across variadic tuple slots

### DIFF
--- a/crates/tsz-checker/tests/variadic_tuple_arity_inference_tests.rs
+++ b/crates/tsz-checker/tests/variadic_tuple_arity_inference_tests.rs
@@ -190,3 +190,192 @@ const ok: Desc<[boolean], object> = b;
         "consecutive variadic rest segments should preserve the remaining suffix, got {diagnostics:#?}",
     );
 }
+
+// =============================================================================
+// Repeated `infer` names across variadic tuple slots (conditional inference)
+// =============================================================================
+//
+// Structural rule: the fixed prefix and suffix slots of a tuple pattern
+// `[p…, ...R, s…]` are co-located *covariant* positions. When the same
+// `infer T` name appears in more than one of them, `tsc` unions the per-slot
+// candidates (e.g. `[infer A, ...unknown[], infer A]` against `[1, 2, 3]`
+// binds `A = 1 | 3`) instead of failing the second slot's mutual-subtype check
+// and collapsing to the false branch. A name shared between a fixed slot and
+// the rest slot itself (`[infer A, ...infer A]`) stays a conflict and takes
+// the false branch, matching `tsc`'s post-inference re-check. Binder names are
+// varied per case so the behavior is structural, not name-driven.
+
+/// Header providing an exact type-identity probe. `Eq<X, Y>` is `true` only
+/// when `X` and `Y` are mutually identical; `Assert<T extends true>` raises
+/// TS2344 when its argument is not exactly `true`, so a correct inference
+/// yields zero diagnostics and a wrong one yields exactly `[2344]`.
+const EQ_HEADER: &str = r#"
+type Eq<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends (<T>() => T extends Y ? 1 : 2) ? true : false;
+type Assert<T extends true> = T;
+"#;
+
+/// Each `body` ends in an `Assert<Eq<…>>` that encodes the type tsc produces
+/// (true or false branch). Matching tsc therefore means zero diagnostics; a
+/// wrong inference makes the `Eq` probe `false` and surfaces TS2344.
+fn assert_matches_tsc(body: &str, label: &str) {
+    let source = format!("{EQ_HEADER}{body}");
+    let codes = check_source_codes(&source);
+    assert!(
+        codes.is_empty(),
+        "{label}: expected the inferred type to match tsc (no diagnostics), got {codes:?}"
+    );
+}
+
+#[test]
+fn prefix_and_suffix_same_infer_unions_candidates() {
+    assert_matches_tsc(
+        r#"
+type FirstOrLast<Items extends unknown[]> =
+  Items extends [infer Edge, ...unknown[], infer Edge] ? Edge : "none";
+type _ = Assert<Eq<FirstOrLast<[1, 2, 3]>, 1 | 3>>;
+"#,
+        "prefix+suffix repeated infer over [1,2,3]",
+    );
+}
+
+#[test]
+fn prefix_and_suffix_same_infer_two_element_source() {
+    assert_matches_tsc(
+        r#"
+type Ends<Seq extends unknown[]> =
+  Seq extends [infer Mark, ...unknown[], infer Mark] ? Mark : "none";
+type _ = Assert<Eq<Ends<[1, 2]>, 1 | 2>>;
+"#,
+        "prefix+suffix repeated infer over a 2-tuple (empty middle)",
+    );
+}
+
+#[test]
+fn too_short_source_takes_false_branch() {
+    assert_matches_tsc(
+        r#"
+type Ends<Seq extends unknown[]> =
+  Seq extends [infer Mark, ...unknown[], infer Mark] ? Mark : "none";
+type _ = Assert<Eq<Ends<[1]>, "none">>;
+"#,
+        "single-element source cannot fill prefix+suffix, false branch",
+    );
+}
+
+#[test]
+fn repeated_infer_with_captured_middle_rest() {
+    assert_matches_tsc(
+        r#"
+type EdgesAndCore<List extends unknown[]> =
+  List extends [infer Side, ...infer Core, infer Side] ? [Side, Core] : "none";
+type _ = Assert<Eq<EdgesAndCore<[1, 2, 3, 4]>, [1 | 4, [2, 3]]>>;
+"#,
+        "repeated edge infer unions while distinct middle rest stays exact",
+    );
+}
+
+#[test]
+fn repeated_infer_with_extra_fixed_prefix_slot() {
+    assert_matches_tsc(
+        r#"
+type EdgePair<Row extends unknown[]> =
+  Row extends [infer Corner, infer Inner, ...unknown[], infer Corner]
+    ? [Corner, Inner]
+    : "none";
+type _ = Assert<Eq<EdgePair<[1, 2, 3, 4]>, [1 | 4, 2]>>;
+"#,
+        "repeated corner infer unions, distinct interior slot stays exact",
+    );
+}
+
+#[test]
+fn repeated_infer_in_two_prefix_slots() {
+    assert_matches_tsc(
+        r#"
+type FirstTwo<Tup extends unknown[]> =
+  Tup extends [infer Cell, infer Cell, ...unknown[]] ? Cell : "none";
+type _ = Assert<Eq<FirstTwo<[1, 2, 3]>, 1 | 2>>;
+"#,
+        "two adjacent prefix slots share an infer name",
+    );
+}
+
+#[test]
+fn repeated_infer_in_two_suffix_slots() {
+    assert_matches_tsc(
+        r#"
+type LastTwo<Tup extends unknown[]> =
+  Tup extends [...unknown[], infer Cell, infer Cell] ? Cell : "none";
+type _ = Assert<Eq<LastTwo<[1, 2, 3, 4]>, 3 | 4>>;
+"#,
+        "two adjacent suffix slots share an infer name",
+    );
+}
+
+#[test]
+fn infer_shared_between_fixed_slot_and_rest_slot_takes_false_branch() {
+    assert_matches_tsc(
+        r#"
+type FixedThenRest<Tup extends unknown[]> =
+  Tup extends [infer Cell, ...infer Cell] ? Cell : "none";
+type _ = Assert<Eq<FixedThenRest<[1, 2, 3]>, "none">>;
+"#,
+        "element-level vs array-level candidate conflict, false branch",
+    );
+}
+
+#[test]
+fn distinct_edge_infers_stay_exact() {
+    // Guard: the union only applies to repeated names; distinct names must keep
+    // their individual candidates exactly.
+    assert_matches_tsc(
+        r#"
+type BothEnds<Tup extends unknown[]> =
+  Tup extends [infer Head, ...unknown[], infer Tail] ? [Head, Tail] : "none";
+type _ = Assert<Eq<BothEnds<[1, 2, 3]>, [1, 3]>>;
+"#,
+        "distinct head/tail infers keep exact per-slot candidates",
+    );
+}
+
+#[test]
+fn three_way_repeated_infer_unions_all_slots() {
+    assert_matches_tsc(
+        r#"
+type TripleMark<Tup extends unknown[]> =
+  Tup extends [infer Mark, ...unknown[], infer Mark, infer Mark] ? Mark : "none";
+type _ = Assert<Eq<TripleMark<[1, 2, 3, 4]>, 1 | 3 | 4>>;
+"#,
+        "one prefix and two suffix slots share an infer name",
+    );
+}
+
+#[test]
+fn repeated_infer_in_readonly_tuple_pattern() {
+    // `readonly` tuples take a distinct relation path; the union over repeated
+    // edge infers must still apply.
+    assert_matches_tsc(
+        r#"
+type Edges<Seq extends readonly unknown[]> =
+  Seq extends readonly [infer Rim, ...unknown[], infer Rim] ? Rim : "none";
+type _ = Assert<Eq<Edges<readonly [1, 2, 3]>, 1 | 3>>;
+"#,
+        "readonly tuple repeated edge infer unions candidates",
+    );
+}
+
+#[test]
+fn repeated_infer_through_alias_indirection() {
+    // The pattern is reached through a second alias with a different type
+    // parameter name, guarding against any binder-environment reuse drift.
+    assert_matches_tsc(
+        r#"
+type Bookends<Seq extends unknown[]> =
+  Seq extends [infer Edge, ...unknown[], infer Edge] ? Edge : "none";
+type Probe<Row extends unknown[]> = Bookends<Row>;
+type _ = Assert<Eq<Probe<["a", "b", "c", "a"]>, "a">>;
+"#,
+        "repeated infer resolves identically through alias indirection",
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -1068,6 +1068,37 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         }
     }
 
+    /// Validate one fixed (non-rest) tuple slot pair and, when valid, push its
+    /// `(source, pattern)` types onto `pairs` for co-located merge matching.
+    ///
+    /// Returns `false` when the source element cannot fill the pattern slot —
+    /// either side carrying a `rest` flag (a fixed slot must align with a fixed
+    /// slot), or an optional source against a required pattern slot. An optional
+    /// source widens with `undefined` so the slot can still bind `T | undefined`.
+    /// Shared by every fixed-slot collection loop (prefix, suffix, and the
+    /// non-rest pairwise zip) so the shape rules stay in one place.
+    fn push_fixed_tuple_pair(
+        &self,
+        source_elem: &TupleElement,
+        pattern_elem: &TupleElement,
+        pairs: &mut Vec<(TypeId, TypeId)>,
+    ) -> bool {
+        if source_elem.rest || pattern_elem.rest {
+            return false;
+        }
+        if source_elem.optional && !pattern_elem.optional {
+            return false;
+        }
+        let source_type = if source_elem.optional {
+            self.interner()
+                .union2(source_elem.type_id, TypeId::UNDEFINED)
+        } else {
+            source_elem.type_id
+        };
+        pairs.push((source_type, pattern_elem.type_id));
+        true
+    }
+
     /// Match tuple elements against a pattern, extracting infer bindings.
     pub(crate) fn match_tuple_elements(
         &self,
@@ -1104,63 +1135,62 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 return false;
             }
 
-            // Match prefix elements (before rest) from start of source
+            let rest_source_end = source_len - suffix_len;
+
+            // Collect the fixed prefix and suffix `(source, pattern)` pairs.
+            // These are all co-located *covariant* tuple positions: when the
+            // same `infer T` name appears in more than one of them (whether two
+            // prefix slots, two suffix slots, or one of each across the rest),
+            // tsc unions the per-slot candidates instead of failing the second
+            // slot's mutual-subtype check. Route them through the same
+            // co-located union merge the non-rest path uses so, e.g.,
+            // `[infer A, ...unknown[], infer A]` against `[1, 2, 3]` binds
+            // `A = 1 | 3` (true branch) rather than collapsing to the false
+            // branch. The fixed-slot validity checks (no nested rest, optional
+            // source cannot fill a required slot) stay eager so an invalid
+            // shape rejects before any inference work.
+            let mut fixed_pairs: Vec<(TypeId, TypeId)> = Vec::with_capacity(fixed_count);
             for i in 0..prefix_len {
-                let source_elem = &source_elems[i];
-                let pattern_elem = &pattern_elems[i];
-                if source_elem.rest || pattern_elem.rest {
-                    return false;
-                }
-                // Optional source cannot fill a required pattern slot.
-                if source_elem.optional && !pattern_elem.optional {
-                    return false;
-                }
-                let source_type = if source_elem.optional {
-                    self.interner()
-                        .union2(source_elem.type_id, TypeId::UNDEFINED)
-                } else {
-                    source_elem.type_id
-                };
-                if !self.match_infer_pattern(
-                    source_type,
-                    pattern_elem.type_id,
-                    bindings,
-                    visited,
-                    checker,
+                if !self.push_fixed_tuple_pair(
+                    &source_elems[i],
+                    &pattern_elems[i],
+                    &mut fixed_pairs,
                 ) {
                     return false;
                 }
             }
-
-            // Match suffix elements (after rest) from end of source
-            let rest_source_end = source_len - suffix_len;
             for i in 0..suffix_len {
-                let source_elem = &source_elems[rest_source_end + i];
-                let pattern_elem = &pattern_elems[rest_index + 1 + i];
-                if source_elem.rest || pattern_elem.rest {
-                    return false;
-                }
-                if source_elem.optional && !pattern_elem.optional {
-                    return false;
-                }
-                let source_type = if source_elem.optional {
-                    self.interner()
-                        .union2(source_elem.type_id, TypeId::UNDEFINED)
-                } else {
-                    source_elem.type_id
-                };
-                if !self.match_infer_pattern(
-                    source_type,
-                    pattern_elem.type_id,
-                    bindings,
-                    visited,
-                    checker,
+                if !self.push_fixed_tuple_pair(
+                    &source_elems[rest_source_end + i],
+                    &pattern_elems[rest_index + 1 + i],
+                    &mut fixed_pairs,
                 ) {
                     return false;
                 }
+            }
+            // A purely `[...rest]` pattern has no fixed slots; skip the merge
+            // (which would otherwise clone `bindings` twice for an empty pair
+            // set) and fall straight through to the residual match.
+            if !fixed_pairs.is_empty()
+                && !self.match_co_located_with_merge(
+                    &fixed_pairs,
+                    bindings,
+                    visited,
+                    checker,
+                    CoLocatedMerge::Union,
+                )
+            {
+                return false;
             }
 
             // Match the residual source slice against the pattern's rest slot.
+            // This runs *after* the merged prefix/suffix bindings so a name
+            // shared between a fixed position and the rest slot (e.g.
+            // `[infer A, ...infer A]`) is still rejected: the residual's
+            // `bind_infer` mutual-subtype check sees the element-level
+            // candidate already bound and fails against the array/tuple-level
+            // one, taking the false branch exactly as tsc does (tsc reaches the
+            // same outcome via its post-inference structural re-check).
             // The residual may itself contain rest elements (when the source is
             // a variadic tuple like `[a, ...b[]]`), so the helpers preserve
             // each source element's `rest`/`optional` flags and structurally
@@ -1189,21 +1219,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let shared = std::cmp::min(source_len, pattern_len);
         let mut pairs: Vec<(TypeId, TypeId)> = Vec::with_capacity(pattern_len);
         for i in 0..shared {
-            let source_elem = &source_elems[i];
-            let pattern_elem = &pattern_elems[i];
-            if source_elem.rest || pattern_elem.rest {
+            if !self.push_fixed_tuple_pair(&source_elems[i], &pattern_elems[i], &mut pairs) {
                 return false;
             }
-            if source_elem.optional && !pattern_elem.optional {
-                return false;
-            }
-            let source_type = if source_elem.optional {
-                self.interner()
-                    .union2(source_elem.type_id, TypeId::UNDEFINED)
-            } else {
-                source_elem.type_id
-            };
-            pairs.push((source_type, pattern_elem.type_id));
         }
 
         if source_len < pattern_len {


### PR DESCRIPTION
Closes #10866.

AgentName: Studio-B

**Track:** Solver — variadic-tuple conditional inference

## Invariant
For a conditional-type tuple pattern, the fixed prefix and suffix positions are co-located **covariant** slots. When the same `infer T` name appears in more than one of them, `tsc` **unions** the per-slot candidates; tsz must match. A name shared between a fixed slot and the rest slot itself remains a conflict (false branch).

## Structural Rule
When a tuple pattern with a rest element (`[p…, ...R, s…]`) repeats an `infer` name across its fixed prefix/suffix slots, `tsc` unions the candidates (e.g. `[infer A, ...unknown[], infer A]` against `[1, 2, 3]` binds `A = 1 | 3` and takes the true branch); tsz now does the same through the solver's `match_co_located_with_merge(.., Union)` gateway. When the same name is shared between a fixed slot and the rest slot (`[infer A, ...infer A]`), the element-level and array-level candidates conflict and both compilers take the false branch.

## Root Cause
`match_tuple_elements` (conditional-type infer matching) had a co-located union merge wired into its **non-rest** path only. The **rest** path matched prefix and suffix slots sequentially into shared `bindings` via direct `match_infer_pattern` calls, so a repeated `infer` name failed `bind_infer`'s mutual-subtype check on its second occurrence and the conditional collapsed to the false branch. tsz has no post-inference structural re-check, so the premature failure was final.

## Scope
- Route the fixed prefix+suffix pairs through the existing `match_co_located_with_merge(.., Union)` helper the non-rest path already uses, then run the residual-rest match **afterward** so a fixed/rest name conflict still fails via the residual's mutual-subtype check (reproducing tsc's post-inference re-check without a separate verification pass).
- Consolidate the per-slot validity + optional-`undefined` widening into a shared `push_fixed_tuple_pair` helper used by all three fixed-slot loops (prefix, suffix, non-rest pairwise zip).
- Skip the co-located merge entirely for a purely `[...rest]` pattern (no fixed slots) so the empty-pair case avoids two needless `bindings` clones.
- Owner layer: **solver** (`crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs`, 1834 lines, under the 2000-line shard cap). No checker/emitter changes; no name/file-string predicates.

## Adjacent-Case Matrix
Added to the existing registered target `crates/tsz-checker/tests/variadic_tuple_arity_inference_tests.rs` (381 lines, under the shard cap) — 12 new repeated-`infer` cases alongside the 12 existing arity cases (24 total in the file). All 12 new cases verified against `tsc` 6.0.2:
- prefix+suffix repeated infer unions (`[1,2,3] → 1|3`, `[1,2] → 1|2`)
- too-short source → false branch
- repeated edge infer + distinct captured middle rest stays exact
- repeated infer with an extra interior fixed slot
- two prefix slots / two suffix slots / one-prefix-two-suffix sharing a name
- fixed+rest shared name → false branch (negative/fallback)
- distinct head/tail names stay exact (guard against over-unioning)
- readonly-tuple variant (distinct relation path)
- alias-indirection variant (renamed binder)

Binder names are varied per case so the behavior is structural, not name-driven. No new `[[test]]` manifest entry — `crates/tsz-checker/Cargo.toml` is byte-identical to `origin/main`.

## Project Corpus Impact
- Row: large-ts-repo
- Bug family: variadic-tuples (conditional infer arity)
- Targets the `large-ts-repo` variadic-tuple row family (recursive zip/edge utilities). No required-row diagnostics change in local smoke; existing `variadic_tuple_recursive_zip_tests` remains green.

## Verification
- `variadic_tuple_arity_inference_tests` (now hosting the relocated cases): 24 passed (12 existing arity + 12 new repeated-infer), 0 failed.
- Regression (local `cargo test`): `variadic_tuple_recursive_zip_tests` (2), `tuple_infer_mapped_recursive_tests` (9), plus 87 tests across 8 inference-related suites (`conditional_optional_infer_default`, `infer_constraint_whole_candidate`, `infer_extends_constraint_substitution`, `curry_recursive_conditional_infer`, `array_element_naked_inference`, `co_contra_inference`, `contextual_tuple`, `destructuring_spread_rest_tuple_source_display`) — all green.
- 36-case `tsc` vs `tsz` differential battery: all match.
- `cargo clippy -p tsz-solver`: clean.
- Pre-existing unrelated failures confirmed present on the branch base (not introduced here): `conditional_infer_tests::{equal_any_array_element_is_false, equal_nested_any_object_property_is_false}` and `spread_rest_tests::test_array_like_rest_rejects_aggregate_rest_arguments`.

## Coordination Notes
Solver-only behavior change behind the existing co-located-merge gateway; no API or layering boundary moved. Cases live in the existing `variadic_tuple_arity_inference_tests` target so the over-cap `tsz-checker` manifest does not grow. `cargo nextest` is unavailable in this environment, so local verification used `cargo test` with narrow filters; ready-review CI owns the broad suites.

https://claude.ai/code/session_01LSHUa5KP1jqaYjEAZVU1M2