### PR TITLE
docs: point users to try-tsz

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ The goal is a correct, fast, drop-in replacement for `tsc`, with both native and
 > Diagnostics, inference, and emit may differ from TypeScript today. Use for
 > experimentation only.
 
+To check whether `tsz` currently matches `tsc` on your project:
+
+```sh
+npx try-tsz
+```
+
 **macOS & Linux**
 
 ```sh

--- a/crates/tsz-website/src/install.njk
+++ b/crates/tsz-website/src/install.njk
@@ -84,6 +84,11 @@ permalink: /install.html
     <a href="https://github.com/mohsen1/tsz/issues">github.com/mohsen1/tsz/issues</a>.
   </div>
 
+  <section>
+    <h2>Try it on your project</h2>
+    <pre><button type="button" class="copy-btn" data-copy-target="try-tsz" aria-live="polite">Copy</button><code id="try-tsz">npx try-tsz</code></pre>
+  </section>
+
   <!-- UNIX_INSTALLATION_BEGIN -->
   <section>
     <h2>macOS &amp; Linux</h2>


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Docs / install guidance.

## Invariant
When users want to evaluate tsz before installing or switching workflows, docs should point them to the low-friction try-tsz comparison path; this PR changes only README/install-page text.

## Scope
- Add `npx try-tsz` to the README install section.
- Add a minimal "Try it on your project" block to the website install page.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only change; no compiler behavior changes.

## Verification
- `git diff --check`

## Coordination Notes
- Follow-up after publishing `try-tsz@0.1.12`, which verified executable native packages and TypeScript 6.0.3 oracle behavior.