### PR TITLE
fix(solver): stop spurious TS2589 on counter-bounded recursive aliases

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2023,6 +2023,10 @@ name = "recursive_utility_alias_fanout_tests"
 path = "tests/recursive_utility_alias_fanout_tests.rs"
 
 [[test]]
+name = "recursive_alias_counter_convergence_ts2589_tests"
+path = "tests/recursive_alias_counter_convergence_ts2589_tests.rs"
+
+[[test]]
 name = "same_generic_application_assign_outcome_tests"
 path = "tests/same_generic_application_assign_outcome_tests.rs"
 

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -780,13 +780,26 @@ impl<'a> CheckerState<'a> {
         // `Application(alias, args)` is the norm, not proof of infinite expansion.
         // It is divergence evidence only when it makes no *progress*: at a use site
         // (the checked type is itself a concrete application of the alias) compare
-        // the structural argument weight of the input against each residual — a
-        // residual that strictly shrinks is converging toward the base case (a
-        // variadic tuple tail) and must not raise TS2589, while one that stays the
-        // same size (`Foo<unknown>` -> `Foo<unknown>`) or grows is divergent. When
-        // there is no input application to compare against (the definition-site
-        // pass evaluates the conditional body directly), any surviving concrete
-        // self-reference stays divergent, preserving definition-site TS2589.
+        // the structural argument weight of the input against each residual. A
+        // residual whose argument weight is strictly larger than the input grows on
+        // every step along an unbounded dimension (a template-literal string that
+        // gains characters, a tuple that gains elements) and is genuinely
+        // divergent. A residual that stays the same size or shrinks is *not* proof
+        // of divergence:
+        //   * it may shrink along a dimension the coarse metric scores flat — a
+        //     numeric depth counter (`N` -> `Exclude<N, 0>`) or a structural descent
+        //     into `T[K]` — and so terminate at a base case (e.g. `DeepObject<T, N>`);
+        //   * or it may tie a finite knot the way `tsc` defers recursive object and
+        //     mapped-property references (`{ [K in keyof T]: Rec<T[K]> }`), which is
+        //     accepted, not flagged.
+        // The same-identity stall (`Foo<unknown>` -> `Foo<unknown>`) that this check
+        // once caught here is already detected earlier as an Application cycle
+        // (`eval_result.depth_exceeded`), and any residual the weight metric cannot
+        // see is still bounded by the per-`DefId` instantiation-depth limit, so
+        // requiring strict growth here only removes false positives. When there is
+        // no input application to compare against (the definition-site pass evaluates
+        // the conditional body directly), any surviving concrete self-reference stays
+        // divergent, preserving definition-site TS2589.
         let result = eval_result.result;
         if result != type_id && result != TypeId::ERROR {
             let db = self.ctx.types.as_type_database();
@@ -808,7 +821,7 @@ impl<'a> CheckerState<'a> {
                             residual,
                             alias_def_id,
                         )
-                        .is_none_or(|residual_weight| residual_weight >= input_weight)
+                        .is_none_or(|residual_weight| residual_weight > input_weight)
                     });
                     if diverges {
                         return true;

--- a/crates/tsz-checker/tests/recursive_alias_counter_convergence_ts2589_tests.rs
+++ b/crates/tsz-checker/tests/recursive_alias_counter_convergence_ts2589_tests.rs
@@ -1,0 +1,133 @@
+//! Regression tests: a recursive generic type alias that terminates via a
+//! second (counter) type parameter, or that ties a finite knot through a
+//! homomorphic mapped type over a recursive object, must not raise a spurious
+//! TS2589 ("Type instantiation is excessively deep and possibly infinite").
+//!
+//! Structural rule: "When a use site instantiates a recursive alias and the
+//! evaluator leaves a residual self-application in a deferred position, that
+//! residual is divergence evidence only if its arguments grow strictly along an
+//! unbounded dimension (string length, tuple/template arity). A residual that
+//! stays the same size or shrinks is making progress — via a numeric depth
+//! counter (`N` -> `Exclude<N, 0>`) or a structural descent into `T[K]` — or is
+//! tying a finite knot the way tsc defers recursive object/mapped references, and
+//! must not raise TS2589."
+//!
+//! Owner layer: solver convergence metric (`self_application_arg_weight`) +
+//! checker use-site probe (`evaluate_type_for_ts2589_check`). The guard against
+//! over-correction (genuine string/tuple builders must still raise TS2589) is
+//! covered by the `*_still_diverges_*` cases below.
+
+use tsz_checker::test_utils::check_source_codes;
+
+/// A mapped-over-object recursion bounded by a numeric counter (`N`) terminates
+/// at the `N extends 0` base case. The counter and the structural descent into
+/// `T[K]` are the termination measure; neither is visible to the coarse growth
+/// metric, so the residual self-application must not be mistaken for divergence.
+#[test]
+fn numeric_counter_recursion_no_ts2589() {
+    let source = r#"
+type Prev = [never, 0, 1, 2, 3, 4, 5, 6];
+type DeepObject<T, N extends number> =
+    N extends 0 ? T : { [K in keyof T]: DeepObject<T[K], Prev[N]> };
+type Anchor = { value: string; nested?: Anchor };
+type Fixed = DeepObject<Anchor, 6>;
+declare const probe: Fixed;
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        !codes.contains(&2589),
+        "counter-bounded mapped recursion must not produce TS2589. Got: {codes:?}"
+    );
+}
+
+/// Same shape with renamed binders confirms the fix is structural, not keyed to
+/// any particular alias / type-parameter / property identifier.
+#[test]
+fn numeric_counter_recursion_no_ts2589_renamed() {
+    let source = r#"
+type StepDown = [never, 0, 1, 2, 3, 4, 5, 6];
+type WalkTree<Node, Budget extends number> =
+    Budget extends 0 ? Node : { [Field in keyof Node]: WalkTree<Node[Field], StepDown[Budget]> };
+type Branch = { label: string; child?: Branch };
+type Walked = WalkTree<Branch, 6>;
+declare const w: Walked;
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        !codes.contains(&2589),
+        "renamed counter-bounded recursion must not produce TS2589. Got: {codes:?}"
+    );
+}
+
+/// The literal issue-family shape (#10818/#10826/#10834/#10867/#10875): a
+/// `BuildTuple` length guard plus an `Exclude<N, 0>` counter (a no-op for a
+/// single literal) over a self-referential optional property. tsc accepts this
+/// by tying a finite knot for the recursive object/mapped reference.
+#[test]
+fn build_tuple_guarded_recursion_no_ts2589() {
+    let source = r#"
+type BuildTuple<N extends number, A extends any[] = []> =
+    A['length'] extends N ? A : BuildTuple<N, [...A, unknown]>;
+type DeepObject<T, N extends number> =
+    BuildTuple<N> extends []
+        ? T
+        : { [K in keyof T]: DeepObject<T[K], Exclude<N, 0>> };
+type Anchor = { value: string; nested?: Anchor };
+type Fixed = DeepObject<Anchor, 6>;
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        !codes.contains(&2589),
+        "BuildTuple-guarded object recursion must not produce TS2589. Got: {codes:?}"
+    );
+}
+
+/// A real-world `DeepPartial` with an explicit recursion budget must resolve to
+/// a usable optional-chained type without a spurious TS2589.
+#[test]
+fn deep_partial_with_budget_no_ts2589() {
+    let source = r#"
+type Prev = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+type DeepPartial<T, N extends number = 6> =
+    N extends 0 ? T : { [K in keyof T]?: DeepPartial<T[K], Prev[N]> };
+type Config = { a: { b: { c: { d: string } } } };
+type R = DeepPartial<Config>;
+declare const cfg: R;
+const leaf = cfg.a?.b?.c?.d;
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        !codes.contains(&2589),
+        "budgeted DeepPartial must not produce TS2589. Got: {codes:?}"
+    );
+}
+
+/// Guard against over-correction: a recursion that genuinely grows a
+/// template-literal string without bound must still raise TS2589.
+#[test]
+fn template_string_builder_still_diverges_ts2589() {
+    let source = r#"
+type Grow<S extends string> = S extends `${infer _}` ? Grow<`${S}x`> : never;
+type X = Grow<"a">;
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        codes.contains(&2589),
+        "unbounded template-string growth must still produce TS2589. Got: {codes:?}"
+    );
+}
+
+/// Guard against over-correction: a recursion that genuinely grows a tuple
+/// without bound must still raise TS2589.
+#[test]
+fn tuple_builder_still_diverges_ts2589() {
+    let source = r#"
+type Grow<A extends any[]> = A['length'] extends 0 ? never : Grow<[...A, 1]>;
+type X = Grow<[1]>;
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        codes.contains(&2589),
+        "unbounded tuple growth must still produce TS2589. Got: {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/visitors/visitor.rs
+++ b/crates/tsz-solver/src/visitors/visitor.rs
@@ -755,6 +755,34 @@ pub fn recursive_growth_weight(types: &dyn TypeDatabase, type_id: TypeId) -> u64
     }
 }
 
+/// Per-argument weight along the dimensions that genuinely grow *without bound*
+/// across recursion steps — concrete string-literal length, generic
+/// template-literal span count, and tuple arity. Used by the checker's use-site
+/// TS2589 convergence check to decide whether a residual self-application is
+/// diverging.
+///
+/// Unlike [`recursive_growth_weight`], it deliberately does **not** count
+/// union/intersection arity: a homomorphic mapped type over an object with
+/// optional properties reintroduces a *bounded* `| undefined` on each structural
+/// descent (`{ [K in keyof T]: Rec<T[K]> }`), which is not evidence of
+/// divergence — `tsc` ties a finite knot for such recursive object/mapped types.
+/// Genuine distributive union/intersection blow-ups are still caught earlier, in
+/// the first-pass evaluation, by the evaluator's `detect_recursive_growth` (which
+/// uses the full metric) and by the per-`DefId` instantiation-depth limit.
+/// Counting only the unbounded eager-growth dimensions here keeps real
+/// string/tuple/template builders flagged while leaving knot-tying object and
+/// counter-driven recursions (`DeepObject<T, N>`) alone.
+fn unbounded_growth_weight(types: &dyn TypeDatabase, type_id: TypeId) -> u64 {
+    match types.lookup(type_id) {
+        Some(TypeData::Literal(LiteralValue::String(atom))) => {
+            types.resolve_atom_ref(atom).as_ref().len() as u64
+        }
+        Some(TypeData::TemplateLiteral(spans)) => types.template_list(spans).len() as u64,
+        Some(TypeData::Tuple(list)) => types.tuple_list(list).len() as u64,
+        _ => 0,
+    }
+}
+
 /// Total structural weight of the arguments of a concrete `Application` of
 /// `target_def_id`, or `None` if `type_id` is not such an application.
 ///
@@ -776,7 +804,7 @@ pub fn self_application_arg_weight(
             return Some(
                 app.args
                     .iter()
-                    .map(|&a| recursive_growth_weight(types, a))
+                    .map(|&a| unbounded_growth_weight(types, a))
                     .sum(),
             );
         }


### PR DESCRIPTION
AgentName: claude-code-remote
Track: solver / recursive-types (compiler conformance)
Invariant: tsz matches `tsc` on `TS2589` emission for recursive type-alias use sites — no false positive on terminating / knot-tying recursion, no false negative on genuinely unbounded recursion.

## Summary

A recursive generic type alias that terminates via a **numeric counter type
parameter** (`N extends 0 ? T : Rec<T[K], Prev[N]>`) or that ties a finite knot
through a **homomorphic mapped type over a recursive object** was wrongly
reported as `TS2589` ("Type instantiation is excessively deep and possibly
infinite"). `tsc` accepts these. Minimal witness:

```ts
type DeepObject<T, N extends number> =
  N extends 0 ? T : { [K in keyof T]: DeepObject<T[K], 0> };
type Fixed = DeepObject<{ a: { b: string } }, 1>;   // tsz: TS2589, tsc: ok
```

## Structural rule

When a use site instantiates a recursive alias and the evaluator leaves a
residual self-application in a deferred position, that residual is divergence
evidence **only if its arguments grow strictly along an unbounded dimension**
(string-literal length, template-span count, tuple arity). A residual that stays
the same size or shrinks is *not* proof of divergence: it may shrink along a
dimension the coarse metric scores flat — a numeric depth counter
(`N -> Exclude<N, 0>`) or a structural descent into `T[K]` — or it may tie a
finite knot the way `tsc` defers recursive object/mapped references
(`{ [K in keyof T]: Rec<T[K]> }`).

## Owner layer & fix

- `crates/tsz-solver/src/visitors/visitor.rs`: add `unbounded_growth_weight`, a
  convergence-specific metric that counts only the genuinely unbounded
  eager-growth dimensions (string length, template spans, tuple arity) and
  excludes union/intersection arity (a homomorphic mapped type reintroduces a
  *bounded* `| undefined` per optional-property descent). `self_application_arg_weight`
  now uses it. The full `recursive_growth_weight` is unchanged and still used by
  the evaluator's first-pass `detect_recursive_growth`.
- `crates/tsz-checker/src/state/type_environment/lazy.rs`: require **strict**
  growth (`residual_weight > input_weight`) for the divergence decision.

Backstops preserved: same-identity stalls (`Foo<unknown> -> Foo<unknown>`) are
still caught earlier as Application cycles (`eval_result.depth_exceeded`),
genuine string/tuple/template builders still grow strictly and still raise
`TS2589`, distributive union/intersection blow-ups stay covered by the
evaluator's first-pass detector, and the per-`DefId` instantiation-depth limit
remains the catch-all.

## Adjacent-case matrix

- Counter-bounded mapped recursion (`DeepObject<T, N>`) — no TS2589 ✅
- Same shape, renamed alias / type-param / property binders — no TS2589 ✅
- `BuildTuple`-guarded + `Exclude<N, 0>` over self-referential optional
  property (the literal issue-family witness) — no TS2589 ✅
- Real-world budgeted `DeepPartial<T, N>` resolves to a usable optional-chained
  type — no TS2589 ✅
- Guard: unbounded template-string builder — **still** TS2589 ✅
- Guard: unbounded tuple builder — **still** TS2589 ✅

Resolves the shared root cause behind #10818, #10867, #10875, #10826, #10834
(the "recursive utility expansion can over-instantiate" witnesses).

## Project Corpus Impact

- Row: ts-toolbelt-project, large-ts-repo, zod-project, kysely-project, nextjs (multi-row; shared recursive-utility root cause)
- Bug family: solver recursive-utility expansion — false TS2589 on counter-bounded / knot-tying recursive aliases

Removes false `TS2589` diagnostics on recursive utility aliases (DeepPartial /
DeepReadonly / counter-bounded walkers) seen across the ts-toolbelt, type-fest,
utility-types, zod, kysely and nextjs rows. No new diagnostics introduced;
behavior moves toward `tsc` parity. Pure diagnostic-suppression on
previously-accepted-by-`tsc` code, so no emit/runtime change.

## Verification

- New suite `recursive_alias_counter_convergence_ts2589_tests` (6 tests) — pass.
- `cargo test -p tsz-checker --test deeply_nested_conditional_mapped_recursion_tests --test infer_match_recursive_wrapper_termination_tests --test recursive_utility_alias_fanout_tests`: no new failures (1 pre-existing failure on `main`, unrelated: NestedRecord leaf TS2322).
- `cargo clippy -p tsz-solver -p tsz-checker`: clean.
- Manual oracle diff against `tsc` 6.0.2 on all five issue repros + a ~15-case matrix (terminating, knot-tying, and genuinely-divergent) — all match.

## Coordination Notes

These five issues carry `agent:Studio-B`. They share one root cause; this PR
fixes it at the metric/comparison layer rather than per-row. No overlap with the
in-flight perf work on the same rows (this is a correctness/diagnostic change,
not an evaluation-fuel change). The shared `recursive_growth_weight` used by the
evaluator's hang-prevention is intentionally left untouched.
