### PR TITLE
fix(parser): accept `from` as an exported name in export specifiers

### DIFF
--- a/crates/tsz-parser/src/parser/state_declarations_exports.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_exports.rs
@@ -582,8 +582,15 @@ impl ParserState {
             // Pattern 4: Import/Export specifier brace mismatch cascading error suppression
             // If we encounter 'from' keyword in the specifier list, it likely means we have:
             // export { a from "module"  (missing closing brace)
-            // In this case, break the loop to avoid parsing 'from' as an identifier
-            if self.is_token(SyntaxKind::FromKeyword) {
+            // In this case, break the loop to avoid parsing 'from' as an identifier.
+            // However, `from` is a contextual keyword valid as a specifier name:
+            //   export { from } from './from';          — `from` is the exported name
+            //   export { from as fromObservable } from './from';
+            // Use the same lookahead as parse_named_imports: only break when the token
+            // after `from` is NOT `as`, `,`, or `}` (which would continue a specifier).
+            if self.is_token(SyntaxKind::FromKeyword)
+                && !self.next_token_continues_import_specifier_name()
+            {
                 break;
             }
 

--- a/crates/tsz-parser/src/parser/state_declarations_modules.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_modules.rs
@@ -1123,7 +1123,7 @@ impl ParserState {
         )
     }
 
-    fn next_token_continues_import_specifier_name(&mut self) -> bool {
+    pub(crate) fn next_token_continues_import_specifier_name(&mut self) -> bool {
         let saved_token = self.current_token;
         let saved_state = self.scanner.save_state();
         self.next_token();

--- a/crates/tsz-parser/tests/state_declaration_tests.rs
+++ b/crates/tsz-parser/tests/state_declaration_tests.rs
@@ -644,6 +644,43 @@ import { from as fromObservable } from "./from";
 }
 
 #[test]
+fn export_specifier_can_use_from_as_exported_name() {
+    // `from` is a contextual keyword valid as an export specifier name.
+    // rxjs/dist/types/index.d.ts uses: export { from } from './internal/observable/from';
+    let (parser, _root) = parse_source(
+        r#"
+export { from } from "./from";
+export { from as fromObservable } from "./from";
+"#,
+    );
+    assert_eq!(
+        parser.get_diagnostics().len(),
+        0,
+        "`from` is valid as an export specifier name"
+    );
+}
+
+#[test]
+fn export_specifier_from_in_list_with_other_names() {
+    // `from` as one of several names in an export list
+    let (parser, _root) = parse_source(r#"export { a, from, b } from "./mod";"#);
+    assert_eq!(
+        parser.get_diagnostics().len(),
+        0,
+        "`from` is valid as an export specifier name alongside other names"
+    );
+}
+
+#[test]
+fn export_specifier_missing_brace_recovery_still_works() {
+    // Error-recovery case: missing closing brace; `from` here IS the clause keyword.
+    // The parser should still break early and not produce a runaway parse.
+    let (parser, _root) = parse_source(r#"export { a from "./mod";"#);
+    // We just need this not to panic; some diagnostics are expected.
+    let _ = parser.get_diagnostics();
+}
+
+#[test]
 fn conditional_tuple_element_inside_conditional_extends_type_parses() {
     let (parser, _root) = parse_source(
         r#"


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Track 9 (Emit/DTS Parity) / Parser — fixes rxjs benchmark project row.

## Invariant
When parsing `export { from } from './mod'`, `from` inside the braces is an
exported identifier, not the start of the `from` clause. `tsc` accepts this
without diagnostics; tsz was emitting spurious TS1005/TS1141/TS1434.

Structural rule: `from` inside an export specifier list continues a specifier
name when the next token is `as`, `,`, or `}`. Only break early (error
recovery for a missing `}`) when the next token would not continue a specifier.

## Scope
- `crates/tsz-parser/src/parser/state_declarations_exports.rs` — apply
  one-token lookahead guard in `parse_named_exports`, mirroring the guard
  already present in `parse_named_imports`.
- `crates/tsz-parser/src/parser/state_declarations_modules.rs` — promote
  `next_token_continues_import_specifier_name` to `pub(crate)` so it can be
  called from the exports parser.
- `crates/tsz-parser/tests/state_declaration_tests.rs` — 3 new tests:
  `export { from }`, `export { a, from, b }`, and missing-brace recovery.

## Project Corpus Impact
- Row: rxjs
- Bug family: parser contextual-keyword false positive (TS1005/TS1141/TS1434 on `export { from }`)

Fixes `node_modules/rxjs/dist/types/index.d.ts` line 43:
```ts
export { from } from './internal/observable/from';
```
This was producing three spurious parser diagnostics that tsc does not report.
Removes that false-positive family from the rxjs benchmark row.

Closes #12297.

## Verification
```
cargo test -p tsz-parser export_specifier   # 3 new tests pass
cargo test -p tsz-parser                    # 1341 tests pass, 0 regressions
```

## Coordination Notes
- No overlap with open draft PRs. #12288 (conditional types in extends
  position) is also a parser fix but addresses a completely separate
  production rule.
- The lookahead helper `next_token_continues_import_specifier_name` was
  already correct for exports; only visibility and the call site needed to
  change.
- Follow-up: re-run the rxjs benchmark row after this lands to confirm the
  spurious parser diagnostics are cleared.