### PR TITLE
fix(parser): accept `from` as a name in export specifiers (#12297)

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -70,6 +70,9 @@ pub(crate) mod test_fixture;
 #[path = "../../tests/parser_async_arrow_context_tests.rs"]
 mod parser_async_arrow_context_tests;
 #[cfg(test)]
+#[path = "../../tests/parser_export_specifier_from_tests.rs"]
+mod parser_export_specifier_from_tests;
+#[cfg(test)]
 #[path = "../../tests/parser_improvement_arrow_recovery_tests.rs"]
 mod parser_improvement_arrow_recovery_tests;
 #[cfg(test)]

--- a/crates/tsz-parser/src/parser/state_declarations_exports.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_exports.rs
@@ -579,11 +579,10 @@ impl ParserState {
         while !self.is_token(SyntaxKind::CloseBraceToken)
             && !self.is_token(SyntaxKind::EndOfFileToken)
         {
-            // Pattern 4: Import/Export specifier brace mismatch cascading error suppression
-            // If we encounter 'from' keyword in the specifier list, it likely means we have:
-            // export { a from "module"  (missing closing brace)
-            // In this case, break the loop to avoid parsing 'from' as an identifier
-            if self.is_token(SyntaxKind::FromKeyword) {
+            // `from` here is an exported name (e.g. `export { from } from "m"`)
+            // unless the following token shows it is the from-clause keyword.
+            if self.is_token(SyntaxKind::FromKeyword) && !self.next_token_continues_specifier_name()
+            {
                 break;
             }
 

--- a/crates/tsz-parser/src/parser/state_declarations_modules.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_modules.rs
@@ -969,12 +969,9 @@ impl ParserState {
         while !self.is_token(SyntaxKind::CloseBraceToken)
             && !self.is_token(SyntaxKind::EndOfFileToken)
         {
-            // Pattern 4: Import/Export specifier brace mismatch cascading error suppression
-            // If we encounter 'from' keyword in the specifier list, it likely means we have:
-            // import { a from "module"  (missing closing brace)
-            // In this case, break the loop to avoid parsing 'from' as an identifier
-            if self.is_token(SyntaxKind::FromKeyword)
-                && !self.next_token_continues_import_specifier_name()
+            // `from` here is an imported name (e.g. `import { from } from "m"`)
+            // unless the following token shows it is the from-clause keyword.
+            if self.is_token(SyntaxKind::FromKeyword) && !self.next_token_continues_specifier_name()
             {
                 self.last_named_imports_recovered_to_from = true;
                 break;
@@ -1123,7 +1120,17 @@ impl ParserState {
         )
     }
 
-    fn next_token_continues_import_specifier_name(&mut self) -> bool {
+    /// Decide whether a `from` token currently sitting at a specifier-list
+    /// position is being used as an *exported/imported name* rather than the
+    /// from-clause keyword.
+    ///
+    /// `from` is a contextual keyword and a valid module export name, so
+    /// `import { from } from "m"` / `export { from } from "m"` are legal. It is
+    /// the from-clause keyword only when what follows cannot continue a
+    /// specifier name — i.e. the next token is not `as` (rename), `,` (more
+    /// specifiers), or `}` (end of the list). Shared by the import and export
+    /// specifier loops so both sides disambiguate identically.
+    pub(crate) fn next_token_continues_specifier_name(&mut self) -> bool {
         let saved_token = self.current_token;
         let saved_state = self.scanner.save_state();
         self.next_token();

--- a/crates/tsz-parser/tests/parser_export_specifier_from_tests.rs
+++ b/crates/tsz-parser/tests/parser_export_specifier_from_tests.rs
@@ -1,0 +1,130 @@
+//! Tests that the contextual keyword `from` is accepted as an *exported name*
+//! inside export specifier braces, matching `tsc`.
+//!
+//! Regression for the parser treating the first `from` in
+//! `export { from } from "./mod";` as the start of the from-clause instead of
+//! an exported identifier, which produced bogus `TS1005`/`TS1141`/`TS1434`.
+//!
+//! The disambiguation mirrors the import side: a `from` token is only the
+//! from-clause keyword when the following token cannot continue a specifier
+//! name (i.e. it is not `as`, `,`, or `}`). Otherwise `from` is a name.
+
+use crate::parser::syntax_kind_ext;
+use crate::parser::test_fixture::{assert_no_errors, parse_source};
+
+/// Every valid form where `from` (and other contextual keywords) appears as an
+/// exported name must parse with zero diagnostics, exactly like `tsc`.
+#[test]
+fn from_as_exported_name_parses_clean() {
+    let cases = [
+        // The canonical repro from rxjs `dist/types/index.d.ts`.
+        r#"export { from } from "./internal/observable/from";"#,
+        // Local re-export (no module specifier) of a binding named `from`.
+        r#"const from = 1; export { from };"#,
+        // `from` alongside ordinary names, in any position.
+        r#"export { a, from } from "./mod";"#,
+        r#"export { from, a } from "./mod";"#,
+        r#"export { a, from, b } from "./mod";"#,
+        // `from` renamed via `as`.
+        r#"export { from as origin } from "./mod";"#,
+        // `from` used as the *alias* target.
+        r#"export { origin as from } from "./mod";"#,
+        // String-literal module export name renamed to `from`.
+        r#"export { "x" as from } from "./mod";"#,
+        // Type-only re-export with `from` as the name.
+        r#"export type { from } from "./mod";"#,
+        // `from` together with a type-only modifier on the same name.
+        r#"export { type from } from "./mod";"#,
+        // Trailing comma must not change the disambiguation.
+        r#"export { from, } from "./mod";"#,
+    ];
+    for source in cases {
+        assert_no_errors(source);
+    }
+}
+
+/// The fix must not regress the import side, which already handled `from` as a
+/// specifier name. Kept here so import/export parity stays locked together.
+#[test]
+fn from_as_imported_name_parses_clean() {
+    let cases = [
+        r#"import { from } from "./mod";"#,
+        r#"import { from as origin } from "./mod";"#,
+        r#"import { a, from } from "./mod";"#,
+        r#"import { type from } from "./mod";"#,
+    ];
+    for source in cases {
+        assert_no_errors(source);
+    }
+}
+
+/// `from` parsed as an exported name must actually land in the AST as an export
+/// specifier (not be silently dropped), and the declaration must still capture
+/// the trailing from-clause module specifier.
+#[test]
+fn from_specifier_lands_in_ast_with_module_specifier() {
+    let source = r#"export { from } from "./internal/observable/from";"#;
+    let (parser, root) = parse_source(source);
+    assert!(
+        parser.get_diagnostics().is_empty(),
+        "expected clean parse, got {:?}",
+        parser.get_diagnostics()
+    );
+
+    let arena = parser.get_arena();
+    let root_node = arena.get(root).expect("source file node");
+    let source_file = arena.get_source_file(root_node).expect("source file data");
+
+    // Walk: source file -> export declaration -> named exports -> `from` specifier.
+    let export_decl = source_file
+        .statements
+        .nodes
+        .iter()
+        .filter_map(|&stmt| arena.get(stmt))
+        .find(|node| node.kind == syntax_kind_ext::EXPORT_DECLARATION)
+        .and_then(|node| arena.get_export_decl(node))
+        .expect("an export declaration");
+
+    assert!(
+        export_decl.module_specifier.is_some(),
+        "the trailing from-clause module specifier should be captured"
+    );
+
+    let clause_node = arena
+        .get(export_decl.export_clause)
+        .expect("export clause node");
+    let named_exports = arena
+        .get_named_imports(clause_node)
+        .expect("named exports data");
+    let names: Vec<&str> = named_exports
+        .elements
+        .nodes
+        .iter()
+        .filter_map(|&spec| arena.get(spec))
+        .filter_map(|node| arena.get_specifier(node))
+        .filter_map(|spec| arena.get(spec.name))
+        .map(|name_node| &source[name_node.pos as usize..name_node.end as usize])
+        .collect();
+    assert_eq!(
+        names,
+        vec!["from"],
+        "`from` should parse as the single export specifier name"
+    );
+}
+
+/// A genuinely malformed re-export where `from` is followed directly by the
+/// module string (missing both the name list payload and the closing brace)
+/// must still terminate the specifier list — `from` only acts as a name when
+/// the following token can continue one.
+#[test]
+fn bare_from_string_still_terminates_specifier_list() {
+    // `export { from "./mod" }` — `from` is followed by a string literal, which
+    // cannot continue a specifier name, so it is treated as the from-clause and
+    // the input is reported as malformed rather than silently accepted.
+    let source = r#"export { from "./mod";"#;
+    let (parser, _root) = parse_source(source);
+    assert!(
+        !parser.get_diagnostics().is_empty(),
+        "malformed `export {{ from \"./mod\"` should still report diagnostics"
+    );
+}


### PR DESCRIPTION
AgentName: claude-confident-hawking
Owner lane: agent:Studio-F — canonical ownership lane for #12297.
Track: Parser / module-syntax conformance

Closes #12297.

Invariant: a contextual keyword that is a valid module export name (`from`) parses as a specifier name wherever a name is grammatically valid, on both the import and export side, identically.

## Structural rule

When parsing a declaration export/import specifier list, `from` is a contextual keyword and a valid module export name. `tsc` treats the `from` in `export { from } from "./m"` (and `import { from } from "./m"`) as the *named* specifier, not the start of the from-clause. The from-clause keyword reading only applies when the token following `from` cannot continue a specifier name — i.e. it is not `as` (rename), `,` (more specifiers), or `}` (end of list). `tsz` now applies that disambiguation through the parser's named-imports/named-exports specifier loops.

## Root cause

`parse_named_exports` (`crates/tsz-parser/src/parser/state_declarations_exports.rs`) broke out of the specifier loop the moment it saw `from`, unconditionally treating it as the from-clause keyword. So `export { from } from "./internal/observable/from";` (as in `rxjs/dist/types/index.d.ts`) produced false `TS1005 '}' expected`, `TS1141 String literal expected`, and `TS1434 Unexpected keyword or identifier`. The import side (`parse_named_imports`) already handled this correctly via a private `next_token_continues_import_specifier_name` look-ahead; the export side was a divergent, less-correct copy.

## Owner layer & fix

Parser only. Promoted the import-side look-ahead to a shared `pub(crate)` helper `next_token_continues_specifier_name` and applied the identical guard on both specifier loops. No checker/binder/solver changes: the parser now emits a normal `EXPORT_SPECIFIER` named `from` plus the trailing module specifier, which downstream stages handle name-agnostically.

## Adjacent-case matrix

Covered by the new regression shard `parser_export_specifier_from_tests.rs`:
- `export { from } from "./m"` (the witness) and local re-export `export { from }`
- `from` in any position: `{ a, from }`, `{ from, a }`, `{ a, from, b }`, trailing comma `{ from, }`
- renames both ways: `{ from as origin }`, `{ origin as from }`
- string-literal export name renamed to `from`: `{ "x" as from }`
- type-only: `export type { from } from "./m"` and `{ type from }`
- import-side parity guard: `import { from }`, `{ from as origin }`, `{ a, from }`, `{ type from }`
- AST shape: the `from` specifier lands as an `EXPORT_SPECIFIER` name and the module specifier is captured
- fallback/negative: malformed `export { from "./m"` still terminates the list and reports diagnostics

## Project Corpus Impact

- Row: `rxjs` / try-tsz smoke (`mohsen1/claude-code-orchestrator`) — clears the three false parser diagnostics on `rxjs/dist/types/index.d.ts:43`. The `rootDir` diagnostics in that run are tracked separately by #12285.
- Bug family: parser contextual-keyword-as-specifier-name.

## Verification

- `cargo test -p tsz-parser --lib export_specifier_from` — 4/4 pass (red before the fix with the exact issue diagnostics, green after).
- `cargo test -p tsz-parser --lib` — full crate lib suite **1341 passed, 0 failed**.
- `cargo test -p tsz-parser --lib import_recovery` / `recover` — import/export recovery suites still green (malformed-input paths unchanged).
- `cargo clippy -p tsz-parser --tests` — clean.
- Rebased on latest `main`; no conflicts.

## Coordination Notes

- Claimed #12297 (`WIP` added) with a signed claim comment before coding.
- Pure parser fix; no overlap with the kysely/M4-C work (#10677/#10683 draft PR #12161) or the DOM-heritage cycle bug (#12299).
- `/simplify` run: reuse/simplification/efficiency/altitude review found the change clean; collapsed triplicated rule comments down to the shared helper doc.

https://claude.ai/code/session_012PXfuapHwTzqWLCosKCj9A