### PR TITLE
fix(emit): two-call exports_1 pattern for all ES5 legacy-decorated classes in System using-blocks

### DIFF
--- a/crates/tsz-emitter/src/emitter/module_wrapper/system_emit_using.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/system_emit_using.rs
@@ -315,13 +315,19 @@ impl<'a> Printer<'a> {
                                 .and_then(|class| self.get_identifier_text_opt(class.name))
                         };
                         if let Some(export_name) = export_name {
-                            // When a legacy-decorated ES5 class with value-position self-references
-                            // is inside a System module's top-level `using` try block, tsc uses the
-                            // outer-alias pattern (C_1) and emits two separate exports_1 calls:
-                            //   exports_1("C", C = C_1 = /** @class */ (...));
+                            // When a legacy-decorated ES5 class is inside a System module's
+                            // top-level `using` try block, tsc always emits two separate
+                            // exports_1 calls — one wrapping the IIFE and one wrapping
+                            // __decorate — regardless of whether the class has value-position
+                            // self-references:
+                            //   exports_1("C", C = /** @class */ (...));        // no alias
+                            //   exports_1("C", C = __decorate([dec], C));
+                            // When the class has self-references an outer alias is added:
+                            //   exports_1("C", C = C_1 = /** @class */ (...)); // with alias
                             //   exports_1("C", C = C_1 = __decorate([dec], C_1));
-                            // The generic emit_top_level_using_class_assignment path uses the
-                            // inline-alias pattern instead, producing a structural mismatch.
+                            // The generic emit_top_level_using_class_assignment path inlines
+                            // __decorate inside the IIFE, producing a structural mismatch for
+                            // both cases.
                             if !export.is_default_export
                                 && self.ctx.options.legacy_decorators
                                 && self.ctx.target_es5
@@ -349,18 +355,16 @@ impl<'a> Printer<'a> {
                                             &class_name,
                                             &members,
                                         );
-                                        if alias_name.is_some() {
-                                            self.emit_system_using_legacy_decorated_es5_class_export(
-                                                clause_node,
-                                                export.export_clause,
-                                                &export_name,
-                                                &class_name,
-                                                &decorators,
-                                                &members,
-                                                alias_name.as_deref(),
-                                            );
-                                            return true;
-                                        }
+                                        self.emit_system_using_legacy_decorated_es5_class_export(
+                                            clause_node,
+                                            export.export_clause,
+                                            &export_name,
+                                            &class_name,
+                                            &decorators,
+                                            &members,
+                                            alias_name.as_deref(),
+                                        );
+                                        return true;
                                     }
                                 }
                             }

--- a/crates/tsz-emitter/tests/system_top_level_using_class_name_reuse_tests.rs
+++ b/crates/tsz-emitter/tests/system_top_level_using_class_name_reuse_tests.rs
@@ -121,6 +121,40 @@ fn exported_decorated_class_in_top_level_using_region_exports_hoisted_name() {
         !output.contains("C_1"),
         "exported decorated class must not be renamed.\n{output}"
     );
+    // __decorate must appear in a SEPARATE exports_1 call, not inside the IIFE.
+    // tsc emits two exports_1 calls for the outer-split pattern:
+    //   exports_1("C", C = /** @class */ (function () { return C; }()));
+    //   exports_1("C", C = __decorate([dec], C));
+    assert!(
+        output.contains("exports_1(\"C\", C = __decorate("),
+        "exported decorated class must emit __decorate in a separate exports_1 call.\n{output}"
+    );
+}
+
+#[test]
+fn exported_decorated_class_no_self_ref_decorate_is_outside_iife() {
+    // When a legacy-decorated exported class has NO value-position self-references
+    // (no alias needed), tsc still uses the two-call pattern in a System using-block:
+    //   exports_1("C", C = /** @class */ (function () { …no __decorate… }()));
+    //   exports_1("C", C = __decorate([dec], C));
+    // The __decorate call must NOT appear inside the IIFE return body.
+    let source = "export {};\ndeclare var dec: any;\nusing res = null;\n@dec\nexport class Widget {\n    greet() { return 42; }\n}\n";
+    let output = parse_lower_emit(source, system_es5_opts(true));
+    // First exports_1 wraps the clean IIFE.
+    assert!(
+        output.contains("exports_1(\"Widget\", Widget = /** @class */ (function () {"),
+        "IIFE must be inside first exports_1.\n{output}"
+    );
+    // Second exports_1 wraps __decorate.
+    assert!(
+        output.contains("exports_1(\"Widget\", Widget = __decorate("),
+        "__decorate must appear in a separate exports_1 call.\n{output}"
+    );
+    // No outer alias: Widget should not be renamed.
+    assert!(
+        !output.contains("Widget_1"),
+        "class must not be renamed to Widget_1.\n{output}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Remove the `alias_name.is_some()` guard in `system_emit_using.rs` that caused legacy-decorated ES5 named-export classes without value-position self-references to fall through to the wrong emit path inside a System module top-level `using` try-block.
- Both the alias (self-referencing) and no-alias cases now go through `emit_system_using_legacy_decorated_es5_class_export`, which emits two separate `exports_1` calls matching tsc exactly.
- Add a regression test covering the no-self-reference case (`Widget` class with no alias).

---

AgentName: Studio-C

**Track:** Track 9 — JavaScript emit parity (resource-management lowering + System module using-blocks)

**Invariant:** When a legacy-decorated ES5 named-export class is inside a System module's top-level `using` try-block, tsc always emits two separate `exports_1` calls — one wrapping the class IIFE and one wrapping `__decorate` — regardless of whether the class has value-position self-references:
```js
// no self-references (no alias)
exports_1("C", C = /** @class */ (function () { … return C; }()));
exports_1("C", C = __decorate([dec], C));

// self-references (with alias C_1)
exports_1("C", C = C_1 = /** @class */ (function () { … }()));
exports_1("C", C = C_1 = __decorate([dec], C_1));
```
The generic `emit_top_level_using_class_assignment` path inlined `__decorate` inside the IIFE body, producing a structural mismatch for the no-alias case.

**Scope:**
- `crates/tsz-emitter/src/emitter/module_wrapper/system_emit_using.rs` — remove `alias_name.is_some()` guard; update comment.
- `crates/tsz-emitter/tests/system_top_level_using_class_name_reuse_tests.rs` — add assertion to `exported_decorated_class_in_top_level_using_region_exports_hoisted_name` verifying the `__decorate` separate call; add new test `exported_decorated_class_no_self_ref_decorate_is_outside_iife`.

**Project Corpus Impact:** Fixes the `usingDeclarationsWithLegacyClassDecorators.*` baseline family for `target=es5 module=system` configurations (tests 1,2,3,5,6,7,8,9,11,12 in that family). No other paths affected: the guard change only applies when `!is_default_export && legacy_decorators && target_es5`.

**Verification:**
```
cargo nextest run -p tsz-emitter
# 4100 passed, 2 pre-existing failures (declaration_emitter computed-names; unrelated), 1 skipped
cargo clippy -p tsz-emitter   # clean
cargo fmt --check -p tsz-emitter  # clean
```

**Coordination Notes:** No overlap with checker/solver/DTS paths. Does not touch the self-referencing (alias) code path — only the no-alias branch that previously fell through. The two pre-existing failures (`test_simple_computed_names_match_declaration_baseline_shape`, `test_object_literal_computed_accessor_pair_emits_writable_symbol_property`) are confirmed pre-existing on `main` before this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DA3LPkM28EA39d9vFu56cT)_