### PR TITLE
fix(checker): elaborate union-source function/index member mismatches (TS2322)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -866,16 +866,21 @@ impl<'a> CheckerState<'a> {
 
     /// Whether a failing union member's nested reason leads its elaboration
     /// with a specialized line (`Type at position 0 …`, `Types of property
-    /// 'p' …`) instead of self-heading with `Type 'M' is not assignable to
-    /// type 'T'.`. Such reasons need an explicit member-type header emitted
-    /// before the structural drill; self-heading reasons (the property
-    /// `MissingProperty`/`MissingProperties` summaries) and plain leaf
-    /// relations already carry the member line themselves.
+    /// 'p' …`, `'string' index signatures are incompatible.`, or — for a
+    /// function-return mismatch — the bare return-relation leaf) instead of
+    /// self-heading with `Type 'M' is not assignable to type 'T'.`. Such
+    /// reasons need an explicit member-type header emitted before the
+    /// structural drill; self-heading reasons (the property
+    /// `MissingProperty`/`MissingProperties` summaries, `ParameterTypeMismatch`
+    /// — whose own first line is the signature relation — and plain leaf
+    /// relations) already carry the member line themselves.
     const fn union_member_nested_needs_header(reason: &tsz_solver::SubtypeFailureReason) -> bool {
         matches!(
             reason,
             tsz_solver::SubtypeFailureReason::TupleElementTypeMismatch { .. }
                 | tsz_solver::SubtypeFailureReason::PropertyTypeMismatch { .. }
+                | tsz_solver::SubtypeFailureReason::IndexSignatureMismatch { .. }
+                | tsz_solver::SubtypeFailureReason::ReturnTypeMismatch { .. }
         )
     }
 
@@ -979,6 +984,50 @@ impl<'a> CheckerState<'a> {
             code: diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
             depth: header_depth.min(u8::MAX as u32) as u8,
         });
+
+        // A union member that is a function failing on its *return* type drills
+        // straight into the return relation beneath the member header, with no
+        // intermediate `Return type 'X' is not assignable to 'Y'.` frame — `tsc`
+        // relates the return types directly:
+        //
+        // ```text
+        //   Type '(x: string) => string' is not assignable to type 'Target'.
+        //     Type 'string' is not assignable to type 'number'.
+        // ```
+        //
+        // Rendering the `ReturnTypeMismatch` reason itself would emit the
+        // `Return type …` frame (a non-`tsc` line at depth >= 1), so recurse into
+        // the carried return relation instead.
+        if let tsz_solver::SubtypeFailureReason::ReturnTypeMismatch {
+            source_return,
+            target_return,
+            nested_reason: inner,
+        } = nested_reason
+        {
+            // When the return relation has no structured sub-reason, drill it as
+            // a plain leaf so both arms render the return types through the same
+            // path (`render_failure_reason` → `render_type_mismatch`).
+            let leaf;
+            let return_reason = match inner.as_deref() {
+                Some(inner) => inner,
+                None => {
+                    leaf = tsz_solver::SubtypeFailureReason::TypeMismatch {
+                        source_type: *source_return,
+                        target_type: *target_return,
+                    };
+                    &leaf
+                }
+            };
+            let return_diag = self.render_failure_reason(
+                return_reason,
+                *source_return,
+                *target_return,
+                ctx.idx,
+                drill_depth,
+            );
+            Self::push_nested_chain(&mut diag, return_diag, drill_depth);
+            return diag;
+        }
 
         let nested_diag = self.render_failure_reason(
             nested_reason,

--- a/crates/tsz-checker/tests/union_source_structural_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/union_source_structural_elaboration_tests.rs
@@ -345,3 +345,241 @@ const ys: boolean[] = xs;
          got {chain:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Function-signature and index-signature union members.
+//
+// `tsc` elaborates a failing union member that is a function or an
+// index-signatured object exactly like the non-union case, beneath the member
+// header. Before this slice, tsz dropped these member shapes entirely (the
+// solver's union-source walk only surfaced tuple/property/array members), so a
+// function-return, function-parameter, or index-signature member collapsed the
+// chain to the bare top-level union line and hid which member — and which
+// position/signature — was responsible.
+//
+// Ground truth (`tsc` 6.0.2):
+//
+// ```text
+// Type 'Source' is not assignable to type 'Target'.
+//   Type '(x: string) => string' is not assignable to type 'Target'.
+//     Type 'string' is not assignable to type 'number'.
+// ```
+// ```text
+// Type 'Source' is not assignable to type 'Target'.
+//   Type '(x: number) => void' is not assignable to type 'Target'.
+//     Types of parameters 'x' and 'x' are incompatible.
+//       Type 'string' is not assignable to type 'number'.
+// ```
+// ```text
+// Type 'Source' is not assignable to type 'Target'.
+//   Type '{ [k: string]: string; }' is not assignable to type 'Target'.
+//     'string' index signatures are incompatible.
+//       Type 'string' is not assignable to type 'number'.
+// ```
+// ---------------------------------------------------------------------------
+
+/// Function-return union member: the member header (the function type) sits one
+/// indent beneath the union line and the return relation drills directly
+/// beneath it — `tsc` emits no intermediate `Return type …` frame for a direct
+/// function-to-function return mismatch.
+#[test]
+fn union_member_function_return_mismatch_emits_header_and_drill() {
+    let diags = diagnostics(
+        r#"
+type Target = (x: string) => number;
+type Source = ((x: string) => string) | ((x: string) => boolean);
+declare const s: Source;
+const t: Target = s;
+"#,
+    );
+    let chain = ts2322_chain(&diags);
+    assert!(
+        chain_has(&chain, 0, |m| m.contains("=> string")
+            && m.contains("is not assignable to type")),
+        "expected the function member header (the `=> string` member) at depth 0; \
+         got {chain:?}"
+    );
+    assert!(
+        chain_has(&chain, 1, |m| m.contains("'string'")
+            && m.contains("'number'")
+            && m.contains("is not assignable")),
+        "expected the return relation leaf at depth 1, directly beneath the member \
+         header (no `Return type …` frame); got {chain:?}"
+    );
+    assert!(
+        !chain.iter().any(|(_, _, m)| m.starts_with("Return type ")),
+        "tsc relates the return types directly; no `Return type …` frame should \
+         appear; got {chain:?}"
+    );
+}
+
+/// Member selection for function-return unions follows `tsc`'s first-failing
+/// member rule: reversing the union order changes which member (and which
+/// return type) heads the drill, but the chain stays internally consistent.
+#[test]
+fn union_member_function_return_selection_matches_tsc_order() {
+    let reversed = ts2322_chain(&diagnostics(
+        r#"
+type Target = (x: string) => number;
+type Source = ((x: string) => boolean) | ((x: string) => string);
+declare const s: Source;
+const t: Target = s;
+"#,
+    ));
+    // reversed: first failing member is the `=> boolean` function.
+    assert!(
+        chain_has(&reversed, 0, |m| m.contains("=> boolean")),
+        "reversed function union should head with the `=> boolean` member; \
+         got {reversed:?}"
+    );
+    assert!(
+        chain_has(&reversed, 1, |m| m.contains("'boolean'")
+            && m.contains("'number'")),
+        "reversed function union should drill `boolean` -> `number` at depth 1; \
+         got {reversed:?}"
+    );
+}
+
+/// Function-parameter union member self-heads with the signature relation (its
+/// own first line doubles as the member header), then drills the
+/// contravariant `Types of parameters 'a' and 'b' are incompatible.` frame and
+/// the parameter leaf — each one indent deeper.
+#[test]
+fn union_member_function_parameter_mismatch_emits_header_and_drill() {
+    let diags = diagnostics(
+        r#"
+type Target = (x: string) => void;
+type Source = ((x: number) => void) | ((x: boolean) => void);
+declare const s: Source;
+const t: Target = s;
+"#,
+    );
+    let chain = ts2322_chain(&diags);
+    assert!(
+        chain_has(&chain, 0, |m| m.contains("(x: number) => void")
+            && m.contains("is not assignable to type")),
+        "expected the function member header at depth 0; got {chain:?}"
+    );
+    assert!(
+        chain_has(&chain, 1, |m| m.contains("parameters 'x' and 'x'")
+            && m.contains("incompatible")),
+        "expected the `Types of parameters 'x' and 'x' are incompatible.` frame at \
+         depth 1; got {chain:?}"
+    );
+    assert!(
+        chain_has(&chain, 2, |m| m.contains("'string'")
+            && m.contains("'number'")),
+        "expected the contravariant parameter leaf at depth 2; got {chain:?}"
+    );
+}
+
+/// Renamed binders: the function-parameter rule must hold regardless of alias
+/// or parameter-name spelling, so a name-keyed fix would not satisfy this.
+#[test]
+fn union_member_function_parameter_mismatch_renamed() {
+    let diags = diagnostics(
+        r#"
+type Handler = (value: string) => void;
+type Either = ((value: number) => void) | ((value: boolean) => void);
+declare const e: Either;
+const h: Handler = e;
+"#,
+    );
+    let chain = ts2322_chain(&diags);
+    assert!(
+        chain_has(&chain, 0, |m| m.contains("=> void")
+            && m.contains("is not assignable")),
+        "renamed function union should still emit the member header; got {chain:?}"
+    );
+    assert!(
+        chain_has(&chain, 1, |m| m.contains("parameters 'value' and 'value'")
+            && m.contains("incompatible")),
+        "renamed function union should still emit the parameters frame; got {chain:?}"
+    );
+}
+
+/// Index-signature union member: the member header sits beneath the union line,
+/// then `'string' index signatures are incompatible.` and the value-type leaf
+/// drill one indent deeper each.
+#[test]
+fn union_member_index_signature_mismatch_emits_header_and_drill() {
+    let diags = diagnostics(
+        r#"
+type Target = { [k: string]: number };
+type Source = { [k: string]: string } | { [k: string]: boolean };
+declare const s: Source;
+const t: Target = s;
+"#,
+    );
+    let chain = ts2322_chain(&diags);
+    assert!(
+        chain_has(&chain, 0, |m| m.contains("[k: string]")
+            && m.contains("is not assignable to type")),
+        "expected the index-signature member header at depth 0; got {chain:?}"
+    );
+    assert!(
+        chain_has(&chain, 1, |m| m.contains("'string' index signatures")
+            && m.contains("incompatible")),
+        "expected the `'string' index signatures are incompatible.` line at depth 1; \
+         got {chain:?}"
+    );
+    assert!(
+        chain_has(&chain, 2, |m| m.contains("'string'")
+            && m.contains("'number'")),
+        "expected the value-type leaf at depth 2; got {chain:?}"
+    );
+}
+
+/// Number-keyed index signatures elaborate the same way, with the `'number'`
+/// index-kind reflected in the incompatibility line.
+#[test]
+fn union_member_number_index_signature_mismatch() {
+    let diags = diagnostics(
+        r#"
+type Target = { [k: number]: number };
+type Source = { [k: number]: string } | { [k: number]: boolean };
+declare const s: Source;
+const t: Target = s;
+"#,
+    );
+    let chain = ts2322_chain(&diags);
+    assert!(
+        chain_has(&chain, 1, |m| m.contains("'number' index signatures")
+            && m.contains("incompatible")),
+        "expected the `'number' index signatures are incompatible.` line at depth 1; \
+         got {chain:?}"
+    );
+}
+
+/// Determinism for the new member shapes: the same function/index union checked
+/// twice must produce a byte-identical chain (the anti-"contradictory"
+/// guarantee — the failing member/position/leaf must not alternate across runs).
+#[test]
+fn union_member_function_and_index_elaboration_is_deterministic() {
+    for source in [
+        r#"
+type Target = (x: string) => number;
+type Source = ((x: string) => string) | ((x: string) => boolean);
+declare const s: Source;
+const t: Target = s;
+"#,
+        r#"
+type Target = { [k: string]: number };
+type Source = { [k: string]: string } | { [k: string]: boolean };
+declare const s: Source;
+const t: Target = s;
+"#,
+    ] {
+        let first = ts2322_chain(&diagnostics(source));
+        let second = ts2322_chain(&diagnostics(source));
+        assert!(
+            !first.is_empty(),
+            "expected an elaboration chain; got {first:?}"
+        );
+        assert_eq!(
+            first, second,
+            "the same union must elaborate an identical chain across runs; \
+             first={first:?} second={second:?}"
+        );
+    }
+}

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -963,11 +963,17 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 //     (`Property 'a' is missing in type '{ b: 2; }' …`,
                 //     `Type 'number[]' is not assignable to type 'string[]' …`,
                 //     `The type 'readonly [number]' is 'readonly' …`).
-                //   * the tuple/property element-type mismatches are header-led;
-                //     the union-source renderer supplies the
-                //     `Type 'M' is not assignable to type 'T'.` member header
-                //     before drilling (`Type at position 0 …` / `Types of
-                //     property 'p' …`).
+                //   * the tuple/property element-type, index-signature, and
+                //     function-return mismatches are header-led; the union-source
+                //     renderer supplies the `Type 'M' is not assignable to type
+                //     'T'.` member header before drilling (`Type at position 0 …`
+                //     / `Types of property 'p' …` / `'string' index signatures are
+                //     incompatible.` / the bare return-relation leaf).
+                //   * `ParameterTypeMismatch` self-heads with the signature
+                //     relation line at depth >= 1, so the renderer routes it
+                //     through the self-heading path (its own first line doubles as
+                //     the member header), then drills `Types of parameters 'a' and
+                //     'b' are incompatible.` + the contravariant leaf.
                 // Without this the chain collapses to the bare union-to-target
                 // line and hides which member fails.
                 //
@@ -978,9 +984,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 //     target requires/allows only M`) leaf render is owned
                 //     separately; surfacing it before that lands emits a non-tsc
                 //     line.
-                //   * `ReturnTypeMismatch`/`ParameterTypeMismatch` — the function
-                //     renderers self-head with the signature relation, so they
-                //     would double-state the member signature here.
                 //   * `OptionalPropertyRequired`/`ReadonlyPropertyMismatch` — `tsc`
                 //     leads these with the member header (and they only arise in
                 //     narrow `exactOptionalPropertyTypes` / readonly-index shapes),
@@ -997,6 +1000,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                             | SubtypeFailureReason::TupleElementTypeMismatch { .. }
                             | SubtypeFailureReason::PropertyTypeMismatch { .. }
                             | SubtypeFailureReason::ArrayElementMismatch { .. }
+                            | SubtypeFailureReason::IndexSignatureMismatch { .. }
+                            | SubtypeFailureReason::ReturnTypeMismatch { .. }
+                            | SubtypeFailureReason::ParameterTypeMismatch { .. }
                             | SubtypeFailureReason::ReadonlyToMutableAssignment { .. }
                     )
                 {


### PR DESCRIPTION
## Agent
AgentName: M1-B

Contributor: Claude-UnionElab

## Track
Bug family `checker-23-20` (#11582) — union-source TS2322 elaboration parity. Follows the merged tuple/object/array slice (#12272); this PR closes the function-signature and index-signature member shapes that were still dropped.

## Invariant
When a **union** value is assigned to a target and the first failing member is rejected for a **function-return**, **function-parameter**, or **index-signature** reason, `tsc` keeps the top-level `Type 'A | B' is not assignable to type 'T'.` (TS2322) and elaborates *which* member fails — leading with the member-type header and drilling into the structural detail. tsz must emit the same chain instead of collapsing to the bare union-to-target line.

Ground truth (`tsc` 6.0.2), now matched exactly:

```
Type 'Source' is not assignable to type 'Target'.
  Type '(x: string) => string' is not assignable to type 'Target'.
    Type 'string' is not assignable to type 'number'.
```
```
Type 'Source' is not assignable to type 'Target'.
  Type '(x: number) => void' is not assignable to type 'Target'.
    Types of parameters 'x' and 'x' are incompatible.
      Type 'string' is not assignable to type 'number'.
```
```
Type 'Source' is not assignable to type 'Target'.
  Type '{ [k: string]: string; }' is not assignable to type 'Target'.
    'string' index signatures are incompatible.
      Type 'string' is not assignable to type 'number'.
```

## Structural rule
`When a union source fails because its first failing member (in canonical interned order) is rejected by a function-return / function-parameter / index-signature relation, tsc emits the member header beneath the union line and drills the signature/index detail; tsz now does the same through the solver UnionSourceMismatch reason + the checker union-source renderer.`

- **Owner layer (solver):** `relations/subtype/explain.rs` — the union-member walk now surfaces `ReturnTypeMismatch`, `ParameterTypeMismatch`, and `IndexSignatureMismatch` failing members through `UnionSourceMismatch` (previously only tuple-element / object-property / array-element / leaf members).
- **Owner layer (checker):** `error_reporter/render_failure/nested_application_property_mismatch.rs` —
  - index-signature and function-return members route through the **header-led** path (`union_member_nested_needs_header`);
  - function-parameter members keep the **self-heading** path (their own depth≥1 render emits the signature relation line, which doubles as the member header);
  - function-return members drill straight into the carried return relation beneath the member header, so no non-`tsc` `Return type …` frame leaks at depth ≥ 1.

Member selection is unchanged (first failing member in canonical interned order), so equivalent unions written in different member order elaborate the identical, non-contradictory chain — the core `checker-23-20` guarantee.

## Scope
- `crates/tsz-solver/src/relations/subtype/explain.rs`: +3 reasons in the union-member allowlist; comment refreshed.
- `crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs`: extend `union_member_nested_needs_header`; add the `ReturnTypeMismatch` drill-into-inner branch.
- `crates/tsz-checker/tests/union_source_structural_elaboration_tests.rs`: +7 focused regression tests (function-return + selection/order, function-parameter + renamed, string/number index signature, determinism across runs). Renamed binders and structural (depth + substring) assertions guard against name/spelling-keyed fixes.

No relation/inference/evaluation semantics change — **acceptance (error vs no-error) is identical**; only the TS2322 `related_information` elaboration chain gains lines where tsz previously dropped them.

## Project Corpus Impact
- Row: `nextjs` (`checker-23-20` canonical witness, #11582) and the consolidated cross-row witnesses.
- Bug family: checker-23-20 (#11582) — union-source diagnostics lose the failing-member elaboration.
- This is a `yellow-row` diagnostic-display parity item (both compilers already agree on accept/reject), so no required-row acceptance flips are expected.

## Verification
Oracle: TypeScript `6.0.2` (matches the pinned bench `tsc`), flags `--noEmit --strict --target es2020`.

- New + existing union-source tests: `cargo test -p tsz-checker --profile dist-fast --test union_source_structural_elaboration_tests` → **17 passed, 0 failed**.
- Regression sweep (`intersection_target_missing_property_elaboration_tests`, `elaboration_wrapper_init_tests`, `function_bivariance`, `intersection_signatures`, `index_signature_argument_assignability_tests`, `covariant_callbacks_tests`, `contextual_method_index_signature_tests`, `union_source_missing_property_elaboration_tests`, `union_origin_display_tests`) → **all green**.
- CLI `tsc`-parity spot checks: simple function-return, function-parameter, string/number index, reversed-order selection, and deep-parameter union members all **exact-match** `tsc 6.0.2`.
- `cargo fmt --check`, `cargo clippy` (both crates), `python3 scripts/arch/arch_guard.py`: clean.
- M1-B queue review on head `8bf11cf8d07da08c1d313c9289808180e6b8b98d`: local focused merge-ref check `./scripts/conformance/conformance.sh run --filter "inferentialTypingWithFunctionTypeZip" --verbose` → **1/1 passed**.
- Exact-head CI run `26881074678`: `CI Summary`, `conformance-aggregate`, `fourslash-aggregate`, `emit`, `project-compile-guard`, and `project-compile-canary` all passed on 2026-06-03.

Out-of-scope (separate pre-existing, non-union gaps in the shared renderers, identical in non-union form): the `Call signature return types … are incompatible.` (TS2202) frame for **deep**-return mismatches, the index value-type header line for **deep**-index value mismatches, and tuple length-mismatch elaboration (TS2618/TS2619, owned by #12201). This PR delegates to the shared structural renderers, so union members are exactly as correct as those renderers already are — strictly more informative than the previous bare-union line, with no new divergence introduced.

## Coordination Notes
- M1-B verified the latest head and removed stale queue-blocking coordination text before enqueue.
- Claimed #11582; no other open PR references it.
- Non-overlapping with #12201 (tuple length-mismatch render, owned by Claude-Project-Corpus) — that path is untouched here.

Refs #11582
