### PR TITLE
fix(readme): preserve current conformance metrics

### DIFF
--- a/scripts/ci/test_refresh_readme.py
+++ b/scripts/ci/test_refresh_readme.py
@@ -118,6 +118,56 @@ Declaration: [████████████████████] 98.5
         self.assertIn("preserving README emit metrics", stderr.getvalue())
         self.assertIn("scripts/emit/emit-detail.json", stderr.getvalue())
 
+    def test_existing_readme_conformance_block_is_not_downgraded_by_old_snapshot(self):
+        readme_summary = refresh_readme.conformance_summary_from_readme(
+            """<!-- CONFORMANCE_START -->
+```
+Progress: [████████████████████] 100.0% (12,581/12,585 tests)
+```
+<!-- CONFORMANCE_END -->""",
+        )
+        snapshot_summary = {
+            "passed": 12582,
+            "total": 12582,
+        }
+
+        selected = refresh_readme.prefer_readme_suite_summary(snapshot_summary, readme_summary)
+
+        self.assertEqual(selected["passed"], 12581)
+        self.assertEqual(selected["total"], 12585)
+
+    def test_conformance_fallback_warns_when_preserving_readme_summary(self):
+        with TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            snapshot_path = root / "scripts" / "conformance" / "conformance-snapshot.json"
+            snapshot_path.parent.mkdir(parents=True)
+            snapshot_path.write_text(json.dumps({
+                "summary": {
+                    "passed": 12582,
+                    "total_tests": 12582,
+                },
+            }))
+            args = types.SimpleNamespace(conformance_metrics_json=None)
+            readme_text = """<!-- CONFORMANCE_START -->
+```
+Progress: [████████████████████] 100.0% (12,581/12,585 tests)
+```
+<!-- CONFORMANCE_END -->"""
+
+            old_root = refresh_readme.ROOT
+            stderr = io.StringIO()
+            try:
+                refresh_readme.ROOT = root
+                with redirect_stderr(stderr):
+                    passed, total = refresh_readme.load_conformance(args, readme_text)
+            finally:
+                refresh_readme.ROOT = old_root
+
+        self.assertEqual(passed, 12581)
+        self.assertEqual(total, 12585)
+        self.assertIn("preserving README conformance metrics", stderr.getvalue())
+        self.assertIn("scripts/conformance/conformance-snapshot.json", stderr.getvalue())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/refresh-readme.py
+++ b/scripts/refresh-readme.py
@@ -93,16 +93,67 @@ def load_suite_counts(suite, explicit_path, default_paths):
     return None, None
 
 
-def load_conformance(args):
-    return load_suite_counts(
-        "conformance",
-        args.conformance_metrics_json,
-        [
-            ROOT / "ci-metrics" / "conformance.json",
-            ROOT / "scripts" / "conformance" / "conformance-snapshot.json",
-            ROOT / "scripts" / "conformance" / "conformance-detail.json",
-        ],
+def conformance_summary_from_readme(text):
+    section = text.split("<!-- CONFORMANCE_START -->", 1)
+    if len(section) != 2:
+        return None
+    section = section[1].split("<!-- CONFORMANCE_END -->", 1)[0]
+    match = re.search(r"\(([\d,]+)\s*/\s*([\d,]+)", section)
+    if not match:
+        return None
+    return {
+        "passed": int(match.group(1).replace(",", "")),
+        "total": int(match.group(2).replace(",", "")),
+    }
+
+
+def readme_suite_summary_is_ahead(candidate, readme_summary):
+    if readme_summary is None:
+        return False
+    if readme_summary.get("total", 0) > candidate.get("total", 0):
+        return True
+    return (
+        readme_summary.get("total") == candidate.get("total")
+        and readme_summary.get("passed", 0) >= candidate.get("passed", 0)
     )
+
+
+def prefer_readme_suite_summary(candidate, readme_summary):
+    if readme_suite_summary_is_ahead(candidate, readme_summary):
+        return readme_summary
+    return candidate
+
+
+def load_conformance(args, readme_text):
+    readme_summary = conformance_summary_from_readme(readme_text)
+    explicit_path = args.conformance_metrics_json
+    default_paths = [
+        ROOT / "ci-metrics" / "conformance.json",
+        ROOT / "scripts" / "conformance" / "conformance-snapshot.json",
+        ROOT / "scripts" / "conformance" / "conformance-detail.json",
+    ]
+    for p in suite_metric_candidates(explicit_path, default_paths):
+        if not p.exists():
+            continue
+        summary = normalize_suite_summary(load_metric_json(p), "conformance")
+        if summary is None:
+            continue
+        passed = summary.get("passed")
+        total = summary.get("total")
+        if passed is None or total is None:
+            continue
+        if explicit_path is None and p in default_paths[1:]:
+            candidate = {"passed": passed, "total": total}
+            if readme_suite_summary_is_ahead(candidate, readme_summary):
+                print(
+                    "warning: preserving README conformance metrics because "
+                    f"{p.relative_to(ROOT)} is behind the existing README conformance block",
+                    file=sys.stderr,
+                )
+            selected = prefer_readme_suite_summary(candidate, readme_summary)
+            return selected["passed"], selected["total"]
+        return passed, total
+    return None, None
 
 
 def normalize_emit_summary(data):
@@ -366,7 +417,7 @@ def main():
         )
 
     # Conformance
-    passed, total = load_conformance(args)
+    passed, total = load_conformance(args, original)
     if passed is not None:
         bar = progress_bar(passed, total)
         block = f"```\nProgress: {bar} ({passed:,}/{total:,} tests)\n```"


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Roadmap metric truth / tooling guardrail for public README metrics.

## Invariant
When the checked-in conformance snapshot is older than the existing README conformance block, `scripts/refresh-readme.py` must not downgrade public conformance totals; this PR changes README refresh tooling to preserve the newer public metric surface unless an explicit metrics artifact is provided.

## Scope
- `scripts/refresh-readme.py`
- `scripts/ci/test_refresh_readme.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: tooling-only metric reporting guard; `node scripts/bench/project-row-summary.mjs --markdown` still reports all 12 rows consistent across row metadata surfaces.

## Verification
- `python3 scripts/refresh-readme.py --skip-performance`
- `python3 scripts/ci/test_refresh_readme.py`
- `python3 scripts/conformance/query-conformance.py --dashboard`
- `python3 scripts/emit/query-emit.py --families`
- `node scripts/bench/project-row-summary.mjs --markdown`
- `git diff --check`

## Coordination Notes
- Studio-A owned PR #12315 landed before this PR started.
- This fixes a concrete stale-reporting path: dry-run previously wanted to replace README `12,581/12,585` with stale checked snapshot `12,582/12,582`.
- This PR does not refresh conformance artifacts; it prevents refresh tooling from rolling public README conformance backward when only stale checked snapshots are present.
- `scripts/agents/ensure-agent-labels.sh --audit` still reports pre-existing repo-wide label hygiene issues, including unowned release issue #12316; no broad label sweep is included here.
- Draft while CI starts; Studio-A will mark ready after remote body, label, and checks are verified.
