### PR TITLE
chore(emit): add strict output-surgery pressure gate

### DIFF
--- a/docs/architecture/EMIT_ARCHITECTURE.md
+++ b/docs/architecture/EMIT_ARCHITECTURE.md
@@ -280,13 +280,17 @@ strings. Existing semantic output surgery is migration debt tracked by:
 ```bash
 python3 scripts/emit/audit-output-surgery.py
 python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery.json
+python3 scripts/emit/audit-output-surgery.py --fail-on-warnings
 ```
 
 The audit ratchets current debt by file and category. New semantic
 `replace`/`replacen`/`replace_range` usage must either remove existing debt or
 be explicitly categorized with a removal reason in the allowlist. Use the JSON
 report when CI or agent handoffs need machine-readable counts for
-unallowlisted, over-allowlist, and stale-allowlist failures.
+unallowlisted, over-allowlist, and stale-allowlist failures. Use
+`--fail-on-warnings` in debt-removal PRs or focused gates that need exhausted
+category/global budget pressure to fail even when every call is still
+allowlisted.
 
 ### 7.1 SourceWriter
 

--- a/scripts/emit/audit-output-surgery.py
+++ b/scripts/emit/audit-output-surgery.py
@@ -416,6 +416,20 @@ def format_warning_metrics(file_summaries: list[dict[str, object]]) -> str:
     return f"warning_count={warning_count}, warning_status={warning_status}"
 
 
+def warning_failures(file_summaries: list[dict[str, object]]) -> list[str]:
+    warnings: list[str] = []
+    budget = summarize_budget(file_summaries)
+    exhausted_categories = exhausted_category_names(file_summaries)
+    pressure_status = classify_allowlist_pressure(budget, exhausted_categories)
+    if pressure_status not in {"available", "no_allowlist"}:
+        warnings.append(
+            "allowlist pressure is "
+            f"{pressure_status}; exhausted categories: "
+            f"{';'.join(exhausted_categories) if exhausted_categories else 'none'}"
+        )
+    return warnings
+
+
 def format_allowlist_pressure_metrics(file_summaries: list[dict[str, object]]) -> str:
     budget = summarize_budget(file_summaries)
     exhausted_categories = exhausted_category_names(file_summaries)
@@ -535,6 +549,14 @@ def main(argv: list[str] | None = None) -> int:
         type=pathlib.Path,
         help="write a machine-readable report before exiting",
     )
+    parser.add_argument(
+        "--fail-on-warnings",
+        action="store_true",
+        help=(
+            "return a non-zero status when the audit passes but warning metrics "
+            "show exhausted output-surgery budget pressure"
+        ),
+    )
     args = parser.parse_args(argv)
 
     findings = scan()
@@ -569,7 +591,15 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  - {failure}", file=sys.stderr)
         return 1
 
-    print(format_pass_summary(findings, failures, allowlist))
+    pass_summary = format_pass_summary(findings, failures, allowlist)
+    print(pass_summary)
+    file_summaries = build_file_summaries(grouped_counts(findings), allowlist)
+    warnings = warning_failures(file_summaries)
+    if args.fail_on_warnings and warnings:
+        print("\nOutput-surgery audit warnings failed by --fail-on-warnings:", file=sys.stderr)
+        for warning in warnings:
+            print(f"  - {warning}", file=sys.stderr)
+        return 2
     return 0
 
 

--- a/scripts/emit/test_output_surgery_audit.py
+++ b/scripts/emit/test_output_surgery_audit.py
@@ -1,9 +1,12 @@
 import importlib.util
+import io
 import json
 import pathlib
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from unittest.mock import patch
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
@@ -356,6 +359,80 @@ class OutputSurgeryAuditTests(unittest.TestCase):
             self.audit.classify_allowlist_pressure(budget, ["dts-output-surgery"]),
             "blocked",
         )
+
+    def test_warning_failures_report_pressure_for_strict_mode(self):
+        file_summaries = [
+            {
+                "path": "a.rs",
+                "count": 1,
+                "category": "dts-output-surgery",
+                "max_count": 1,
+                "reason": "existing debt",
+                "status": "allowlisted",
+            }
+        ]
+
+        self.assertEqual(
+            self.audit.warning_failures(file_summaries),
+            [
+                "allowlist pressure is blocked; exhausted categories: "
+                "dts-output-surgery"
+            ],
+        )
+
+    def test_warning_failures_allow_available_budget(self):
+        file_summaries = [
+            {
+                "path": "a.rs",
+                "count": 1,
+                "category": "dts-output-surgery",
+                "max_count": 2,
+                "reason": "existing debt",
+                "status": "allowlisted",
+            }
+        ]
+
+        self.assertEqual(self.audit.warning_failures(file_summaries), [])
+
+    def test_fail_on_warnings_returns_distinct_status(self):
+        findings = [
+            self.audit.Finding("a.rs", 1, "replacen", "output = output.replacen(&a, &b, 1);"),
+        ]
+        allowlist = {
+            "a.rs": self.audit.AllowEntry("dts-output-surgery", 1, "existing debt"),
+        }
+
+        with (
+            patch.object(self.audit, "scan", return_value=findings),
+            patch.object(self.audit, "load_allowlist", return_value=allowlist),
+            redirect_stdout(io.StringIO()) as stdout,
+            redirect_stderr(io.StringIO()) as stderr,
+        ):
+            status = self.audit.main(["--fail-on-warnings"])
+
+        self.assertEqual(status, 2)
+        self.assertIn("allowlist_pressure_status=blocked", stdout.getvalue())
+        self.assertIn("Output-surgery audit warnings failed", stderr.getvalue())
+
+    def test_default_mode_allows_warnings(self):
+        findings = [
+            self.audit.Finding("a.rs", 1, "replacen", "output = output.replacen(&a, &b, 1);"),
+        ]
+        allowlist = {
+            "a.rs": self.audit.AllowEntry("dts-output-surgery", 1, "existing debt"),
+        }
+
+        with (
+            patch.object(self.audit, "scan", return_value=findings),
+            patch.object(self.audit, "load_allowlist", return_value=allowlist),
+            redirect_stdout(io.StringIO()) as stdout,
+            redirect_stderr(io.StringIO()) as stderr,
+        ):
+            status = self.audit.main([])
+
+        self.assertEqual(status, 0)
+        self.assertIn("warning_status=warn", stdout.getvalue())
+        self.assertEqual(stderr.getvalue(), "")
 
     def test_write_json_report_creates_parent_and_writes_json(self):
         with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Studio infrastructure / emit audit guardrail tooling.

## Invariant
When output-surgery calls are all allowlisted but category or global budget capacity is exhausted, routine audits should remain backward-compatible while focused debt-removal gates can fail mechanically through the audit script surface.

## Scope
- Add `--fail-on-warnings` to `scripts/emit/audit-output-surgery.py`.
- Cover warning-pressure behavior in `scripts/emit/test_output_surgery_audit.py`.
- Document strict-mode usage in `docs/architecture/EMIT_ARCHITECTURE.md`.

## Project Corpus Impact
- Row: n/a
- Bug family: output-surgery pressure / emit infrastructure
- Evidence: tooling-only change; `node scripts/bench/project-row-summary.mjs --markdown` reports all 12 rows consistent across surfaces before this PR.

## Verification
- `python3 -m unittest scripts.emit.test_output_surgery_audit`
- `python3 scripts/emit/audit-output-surgery.py`
- `python3 scripts/emit/audit-output-surgery.py --fail-on-warnings` exits 2 on current exhausted budgets and reports `dts-output-surgery;ir-output-surgery;resource-region-output-surgery`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`

## Coordination Notes
- Ready for review after draft CI passed. This does not add output-surgery debt or change compiler output.
- Pre-existing agent-label audit failures remain outside this PR: noncanonical M4/M1/Reviewer/Studio-D/E/F labels on older issues/PRs.