### PR TITLE
fix(solver): substitute into object shapes during distributive conditional rewrite

### DIFF
--- a/crates/tsz-checker/tests/conformance_issues/types/distributive_tuple_union.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/distributive_tuple_union.rs
@@ -347,3 +347,105 @@ const allowed: 1 | 2 | 3 = sizes;
 "#,
     );
 }
+
+// ---------------------------------------------------------------------------
+// Object-valued distributive branches over a *deferred* union check side
+// (issue #10864). When the conditional's check type is a wrapping alias /
+// application (`Wrap<U>`, an inline `Id<U>` argument) rather than a literal
+// union, the per-member rewrite runs through `substitute_exact_type`. If that
+// rewrite does not reach into object property types, every union member
+// collapses to one widened object (`{ value: A | B }`) and the conditional
+// becomes over-constrained. Binder names are varied so no fixture-name path
+// can match.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn distributive_object_branch_through_inline_application_arg() {
+    no_assignability_errors(
+        r#"
+type Tag<Elem> = Elem extends unknown ? { value: Elem } : never;
+type Members = [string] | [number];
+
+// `Tag<Members>` is passed inline as an application argument; the outer
+// conditional's check side is therefore a deferred application, not a literal
+// union. tsc keeps per-member precision: { value: [string] } | { value: [number] }.
+type Same<Left, Right> = [Left] extends [Right]
+  ? ([Right] extends [Left] ? true : false)
+  : false;
+
+const exact: Same<
+  Tag<Members>,
+  { value: [string] } | { value: [number] }
+> = true;
+"#,
+    );
+}
+
+#[test]
+fn distributive_object_branch_through_wrapping_alias() {
+    no_assignability_errors(
+        r#"
+type Wrap<Inner> = Classify<Inner>;
+type Classify<Item> = Item extends unknown
+  ? Item extends string
+    ? { kind: "string"; value: Item }
+    : { kind: "other"; value: Item }
+  : never;
+
+type Inputs = [string, string] | [number, number] | [];
+
+type Equal<Lhs, Rhs> = [Lhs] extends [Rhs]
+  ? ([Rhs] extends [Lhs] ? true : false)
+  : false;
+
+// V's body is Application(Wrap, [Inputs]) — a deferred check side. Each tuple
+// arm classifies to { kind: "other"; value: <arm> }; precision must survive.
+const ok: Equal<
+  Wrap<Inputs>,
+  | { kind: "other"; value: [string, string] }
+  | { kind: "other"; value: [number, number] }
+  | { kind: "other"; value: [] }
+> = true;
+"#,
+    );
+}
+
+#[test]
+fn distributive_object_branch_inline_application_rejects_widening() {
+    // The widened collapse `{ value: [string] | [number] }` must NOT be
+    // accepted as the result, which would be the pre-fix (over-constrained)
+    // behavior. Assigning a widened-shaped value to the per-member union fails.
+    let source = r#"
+type Mark<Slot> = Slot extends unknown ? { value: Slot } : never;
+type Slots = [string] | [number];
+type Result = Mark<Slots>;
+
+declare const widened: { value: [string] | [number] };
+const back: Result = widened;
+"#;
+    let diagnostics = compile_and_get_diagnostics_with_lib(source);
+    assert!(
+        has_error(&diagnostics, 2322),
+        "widened single object must not satisfy the per-member distributed union. diagnostics: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn distributive_nested_object_branch_preserves_inner_variable() {
+    no_assignability_errors(
+        r#"
+type Deep<Elem> = Elem extends unknown ? { outer: { inner: Elem } } : never;
+type Arms = [string] | [number];
+type Pass<X> = Deep<X>;
+
+type Same<Left, Right> = [Left] extends [Right]
+  ? ([Right] extends [Left] ? true : false)
+  : false;
+
+const ok: Same<
+  Pass<Arms>,
+  { outer: { inner: [string] } } | { outer: { inner: [number] } }
+> = true;
+"#,
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/substitute.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/substitute.rs
@@ -11,11 +11,61 @@
 use crate::caches::db::TypeDatabase;
 use crate::relations::subtype::TypeResolver;
 use crate::types::{
-    ConditionalType, FunctionShape, ParamInfo, TemplateSpan, TupleElement, TypeData, TypeId,
+    ConditionalType, FunctionShape, IndexSignature, ObjectShape, ParamInfo, PropertyInfo,
+    TemplateSpan, TupleElement, TypeData, TypeId,
 };
 use rustc_hash::FxHashMap;
 
 use super::super::evaluate::TypeEvaluator;
+
+/// Rewrite `from -> to` inside every property's read and write type, keeping
+/// all declaration-site metadata (optionality, readonly, visibility, symbol,
+/// declaration order) intact. Returns the rebuilt list and whether any type
+/// changed so callers can preserve hash-consed identity on a no-op.
+fn substitute_properties_db(
+    db: &dyn TypeDatabase,
+    properties: &[PropertyInfo],
+    from: TypeId,
+    to: TypeId,
+    memo: &mut FxHashMap<TypeId, TypeId>,
+) -> (Vec<PropertyInfo>, bool) {
+    let mut changed = false;
+    let rebuilt = properties
+        .iter()
+        .map(|prop| {
+            let type_id = substitute_exact_type_db(db, prop.type_id, from, to, memo);
+            // Getter-only / plain properties share one type; reuse the result
+            // instead of re-walking the same node for the write slot.
+            let write_type = if prop.write_type == prop.type_id {
+                type_id
+            } else {
+                substitute_exact_type_db(db, prop.write_type, from, to, memo)
+            };
+            changed |= type_id != prop.type_id || write_type != prop.write_type;
+            PropertyInfo {
+                type_id,
+                write_type,
+                ..prop.clone()
+            }
+        })
+        .collect();
+    (rebuilt, changed)
+}
+
+/// Rewrite `from -> to` inside an index signature's value type, preserving the
+/// key type and `readonly`/cosmetic metadata. Returns the rebuilt signature and
+/// whether the value type changed.
+fn substitute_index_signature_db(
+    db: &dyn TypeDatabase,
+    idx: &IndexSignature,
+    from: TypeId,
+    to: TypeId,
+    memo: &mut FxHashMap<TypeId, TypeId>,
+) -> (IndexSignature, bool) {
+    let value_type = substitute_exact_type_db(db, idx.value_type, from, to, memo);
+    let changed = value_type != idx.value_type;
+    (IndexSignature { value_type, ..*idx }, changed)
+}
 
 /// Free-function form of [`TypeEvaluator::substitute_exact_type`] that walks
 /// the type graph using only a [`TypeDatabase`]. Crate-private so the
@@ -237,8 +287,51 @@ pub(crate) fn substitute_exact_type_db(
                 type_id
             }
         }
-        // Object/Function/Mapped/etc. — substitution does not reach into
-        // these in the original method either; preserve behaviour.
+        // Object literals reached as a distributive-conditional branch carry
+        // the distribution variable in their property/index value types — e.g.
+        // `T extends ... ? { kind: 'x'; value: T } : ...`. When the check side
+        // is a deferred union the per-member rewrite happens here (not at
+        // instantiation time), so the variable must be substituted inside the
+        // shape; otherwise every union member collapses to one widened object.
+        Some(TypeData::Object(shape_id)) => {
+            let shape = db.object_shape(shape_id);
+            let (properties, changed) =
+                substitute_properties_db(db, &shape.properties, from, to, memo);
+            if changed {
+                db.object_with_flags_and_symbol(properties, shape.flags, shape.symbol)
+            } else {
+                type_id
+            }
+        }
+        Some(TypeData::ObjectWithIndex(shape_id)) => {
+            let shape = db.object_shape(shape_id);
+            let (properties, mut changed) =
+                substitute_properties_db(db, &shape.properties, from, to, memo);
+            let string_index = shape.string_index.as_ref().map(|idx| {
+                let (sig, sig_changed) = substitute_index_signature_db(db, idx, from, to, memo);
+                changed |= sig_changed;
+                sig
+            });
+            let number_index = shape.number_index.as_ref().map(|idx| {
+                let (sig, sig_changed) = substitute_index_signature_db(db, idx, from, to, memo);
+                changed |= sig_changed;
+                sig
+            });
+            if changed {
+                db.object_with_index(ObjectShape {
+                    flags: shape.flags,
+                    properties,
+                    string_index,
+                    number_index,
+                    symbol: shape.symbol,
+                })
+            } else {
+                type_id
+            }
+        }
+        // Callable/Mapped/etc. — substitution does not reach into these; the
+        // distributive-conditional and mapped callers only place object,
+        // tuple, function, union, and intersection shapes in branch position.
         _ => type_id,
     };
 
@@ -403,6 +496,75 @@ mod tests {
         assert_eq!(
             result, expected,
             "distributive branch substitution must update T[K] and template-literal K spans"
+        );
+    }
+
+    /// Regression for the distributive-conditional-over-deferred-union family
+    /// (issue #10864): when a distributive conditional's check side is a
+    /// deferred union the per-member rewrite runs through
+    /// `substitute_exact_type`. The true branch is frequently an object literal
+    /// (`{ value: T }`, `{ kind; value: T }`), so substitution must reach into
+    /// object property read/write types — otherwise every union member collapses
+    /// to one widened object and the conditional becomes over-constrained.
+    #[test]
+    fn test_substitute_exact_type_reaches_object_property_types() {
+        let interner = TypeInterner::new();
+
+        let t_param = interner.type_param(TypeParamInfo {
+            name: interner.intern_string("T"),
+            constraint: None,
+            default: None,
+            is_const: false,
+        });
+        let value_atom = interner.intern_string("value");
+        let nested_atom = interner.intern_string("inner");
+
+        // `{ value: { inner: T } }` — the distribution variable is two object
+        // levels deep, so the rewrite must recurse structurally.
+        let inner = interner.object(vec![PropertyInfo::new(nested_atom, t_param)]);
+        let branch = interner.object(vec![PropertyInfo::new(value_atom, inner)]);
+
+        let mut evaluator =
+            TypeEvaluator::<crate::relations::subtype::NoopResolver>::new(&interner);
+        let mut memo: FxHashMap<TypeId, TypeId> = FxHashMap::default();
+        let result = evaluator.substitute_exact_type(branch, t_param, TypeId::NUMBER, &mut memo);
+
+        let expected_inner = interner.object(vec![PropertyInfo::new(nested_atom, TypeId::NUMBER)]);
+        let expected = interner.object(vec![PropertyInfo::new(value_atom, expected_inner)]);
+        assert_eq!(
+            result, expected,
+            "object-valued distributive branch must substitute the variable inside property types"
+        );
+        assert_ne!(
+            result, branch,
+            "pre-fix behaviour left object property types unsubstituted, widening the branch"
+        );
+    }
+
+    /// A no-op substitution (the variable does not occur in the object) must
+    /// return the original hash-consed `TypeId` so identity-based caches and
+    /// display aliases are preserved.
+    #[test]
+    fn test_substitute_exact_type_object_no_match_preserves_identity() {
+        let interner = TypeInterner::new();
+
+        let t_param = interner.type_param(TypeParamInfo {
+            name: interner.intern_string("T"),
+            constraint: None,
+            default: None,
+            is_const: false,
+        });
+        let value_atom = interner.intern_string("value");
+        let branch = interner.object(vec![PropertyInfo::new(value_atom, TypeId::STRING)]);
+
+        let mut evaluator =
+            TypeEvaluator::<crate::relations::subtype::NoopResolver>::new(&interner);
+        let mut memo: FxHashMap<TypeId, TypeId> = FxHashMap::default();
+        let result = evaluator.substitute_exact_type(branch, t_param, TypeId::NUMBER, &mut memo);
+
+        assert_eq!(
+            result, branch,
+            "object without the substituted variable must keep its original TypeId"
         );
     }
 }


### PR DESCRIPTION
## Agent

AgentName: `lucid-hopper`

## Track

Solver / distributive conditional evaluation — the per-member substitution walker (`substitute_exact_type`) used by `distribute_conditional` and mapped-type distribution.

## Invariant

When a distributive conditional distributes over a (possibly *deferred*) union and a branch is an `Object` / `ObjectWithIndex` shape that carries the distribution variable in a property or index-signature type, each union member must substitute the variable **inside that shape**. Otherwise every member collapses to one widened object and the conditional becomes over-constrained (wrong branch / spurious `extends` failure).

## Scope

Refs #10864 (`large-ts-repo`: distributive conditional evaluation over tuple-like unions can become over-constrained). This is the witness PR #12077 explicitly deferred as out-of-scope: *"aliases whose body is itself a generic application (`type V = Wrap<U>`)."*

### Root cause

`substitute_exact_type_db` (`crates/tsz-solver/src/evaluation/evaluate_rules/substitute.rs`) walks the type graph rewriting `from -> to`. It already recurses into `Application`, `Union`, `Intersection`, `Array`, `Tuple`, `Function`, `IndexAccess`, `Conditional`, `TemplateLiteral`, `KeyOf`, `ReadonlyType`, `NoInfer`, and `StringIntrinsic` — but `Object` / `ObjectWithIndex` fell into the catch-all `_ => type_id` and were returned **unchanged**.

That walker is the per-member rewrite path for `distribute_conditional` (`substitute_exact_type(true_type, original_check_type, member)`). When the conditional's check side is a **literal union**, distribution already happens earlier inside `TypeInstantiator` (per-member instantiation), so this walker is never the deciding step. But when the check side is a **deferred union** — a wrapping alias (`type V = Wrap<U>`) or an inline generic application argument (`FwdD<Id<U>, EU>`) that the limited instantiator-resolver cannot expand to a `Union` — the instantiator falls through to a non-distributing fallback that substitutes the still-`Lazy`/`Application` union value into both the check and the branches, then leaves a deferred distributive conditional for the full evaluator. The full evaluator distributes via `distribute_conditional`, which relies on `substitute_exact_type` to push each union member into the branch.

For object-valued branches — the issue's own `Classify<T>` returns `{ kind; value: T }`, and the reduced witness is `T extends X ? { value: T } : never` — the distribution variable lives inside an object property. The walker skipped objects, so the per-member substitution was a no-op and **every member produced the same widened `{ value: A | B }`**. The widened single object is not assignable to the per-member union, so the conditional took the wrong branch.

### Structural rule

> When a distributive conditional distributes over a (possibly deferred) union and a branch is an object/index-signature shape carrying the distribution variable, tsc rewrites the variable per member inside that shape; tsz does this through the solver's `substitute_exact_type` walker.

### Fix (owning layer = solver)

Add `Object` and `ObjectWithIndex` arms to the existing `substitute_exact_type_db` structural walker:

- `Object`: rewrite each property's read (`type_id`) and write (`write_type`) type, preserving all declaration-site metadata (optionality, readonly, visibility, symbol, declaration order, flags).
- `ObjectWithIndex`: same, plus the string/number index-signature value types.
- Both preserve hash-consed identity on a no-op (return the original `TypeId` when nothing changed), matching the other arms.

Object shapes were the lone composite-type gap in the walker; this is a generalization of the existing mechanism, not a special case. No checker changes. Parity-preserving on the literal-union hot path (that path distributes at instantiation time and never reaches this arm).

This is a class fix, not a fixture-name patch: it keys off the structural type shape, never a binder/alias/property name.

## Adjacent matrix

`crates/tsz-checker/tests/conformance_issues/types/distributive_tuple_union.rs` (+4 integration tests, binder names varied so no fixture-name fast path matches):

- `distributive_object_branch_through_inline_application_arg` — inline `Tag<Members>` application argument (deferred check side).
- `distributive_object_branch_through_wrapping_alias` — `type Wrap<X> = Classify<X>` over a tuple union; the original #10864 `Classify` `{ kind; value }` shape, well-formed with renamed binders.
- `distributive_object_branch_inline_application_rejects_widening` — negative: the widened `{ value: A | B }` collapse must **not** satisfy the per-member distributed union (locks out the pre-fix behavior).
- `distributive_nested_object_branch_preserves_inner_variable` — variable two object levels deep (`{ outer: { inner: T } }`).

`crates/tsz-solver/src/evaluation/evaluate_rules/substitute.rs` (+2 unit tests):

- `test_substitute_exact_type_reaches_object_property_types` — nested object property substitution.
- `test_substitute_exact_type_object_no_match_preserves_identity` — no-op keeps the original `TypeId` (identity/cache/display preservation).

## Project Corpus Impact

- Row: `large-ts-repo` (originating issue), plus any row where a non-generic alias' body is a distributive conditional with a deferred check side and an object-valued branch.
- Bug family: distributive-conditional-over-deferred-union collapse (#12175 family; witnesses #10799 #10815 #10823 #10848 #10864 #10872).
- No row should regress: literal-union distribution is unchanged; the only behavior change is that deferred-union object branches now distribute per member instead of widening.

## Verification

- `cargo build -p tsz-cli` — clean.
- `cargo clippy -p tsz-solver -p tsz-checker --tests` — clean.
- `python3 scripts/arch/arch_guard.py` — `Architecture guardrails passed.`
- `cargo fmt --check` — clean.
- `cargo test -p tsz-solver --lib substitute` — 7/7 pass (incl. 2 new).
- `cargo test -p tsz-checker --test conformance_issues_types distributive_tuple_union` — 23/23 pass (incl. 4 new).
- `cargo test -p tsz-solver --lib` — 6496 pass; the only failures (`constraint_tests::test_contra_candidate_basic`, `…::test_deep_widen_object_candidate_homomorphic_mapped`, `operations::tests::test_infer_generic_object_with_contextual_callbacks_prefers_schema_property_type`) reproduce identically on clean `main` with this change stashed, and are unrelated.
- `cargo test -p tsz-checker --test conformance_issues_types` — same 2 pre-existing failures (`core::fixtures::test_generic_indexed_access_variance_failure_preserves_ts2322`, `types::optional_chain::test_ts2416_…`) on clean `main`; no new failures.
- CLI parity vs `tsc` 6.0.2 on the issue repro, the `Classify`/`Wrap` shapes, function/nested-object/index-signature/optional-readonly branches, renamed binders, and the negative non-distributive case — all match.

Broad conformance / emit / fourslash / WASM suites run on ready-review CI.

## Coordination Notes

- Rebased onto latest `origin/main` (`61d9ee7`) before push; clean rebase, no conflicts.
- Reviewed via 3 `/simplify` rounds (reuse / simplification / efficiency / altitude): factored the duplicated string/number index-signature substitution into `substitute_index_signature_db`; skip the redundant `write_type` re-walk when `write_type == type_id` (the getter-only common case); folded `PropertyInfo` / `IndexSignature` / `ObjectShape` into the module import to drop inline `crate::types::` qualifiers.
- Skipped findings (with rationale): the unconditional `Vec` allocation in `substitute_properties_db` on a no-op rewrite was kept to match the established convention of every other arm in the same function (Union/Tuple/Intersection all map+collect then discard on `!changed`); `TypeData::Callable` is left unhandled, consistent with the rest of the walker (no arm handles it) and outside the object/tuple/function/union/intersection shapes these callers place in branch position — noted in an updated comment.

https://claude.ai/code/session_015VePqizumTTuubjAwugxEk

---
_Generated by [Claude Code](https://claude.ai/code/session_015VePqizumTTuubjAwugxEk)_