### PR TITLE
chore(release): bump try-tsz publish version to 0.1.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-binder"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-checker"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "dashmap",
  "globset",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-cli"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-common"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "memchr",
  "rustc-hash",
@@ -1551,7 +1551,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-core"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-emitter"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "memchr",
  "rustc-hash",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-lowering"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "indexmap",
  "rustc-hash",
@@ -1607,7 +1607,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-lsp"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "globset",
  "json5",
@@ -1629,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-parser"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-scanner"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "serde",
  "tsz-common",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-solver"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "bitflags 2.11.0",
  "dashmap",
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-wasm"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-website"
-version = "0.1.12"
+version = "0.1.13"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/.target"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.12"
+version = "0.1.13"
 edition = "2024"
 repository = "https://github.com/mohsen1/tsz"
 homepage = "https://github.com/mohsen1/tsz"
@@ -16,16 +16,16 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Internal workspace crates
-tsz = { path = "crates/tsz-core", version = "0.1.12", package = "tsz-core" }
-tsz-common = { path = "crates/tsz-common", version = "0.1.12" }
-tsz-scanner = { path = "crates/tsz-scanner", version = "0.1.12" }
-tsz-parser = { path = "crates/tsz-parser", version = "0.1.12" }
-tsz-binder = { path = "crates/tsz-binder", version = "0.1.12" }
-tsz-solver = { path = "crates/tsz-solver", version = "0.1.12" }
-tsz-lowering = { path = "crates/tsz-lowering", version = "0.1.12" }
-tsz-checker = { path = "crates/tsz-checker", version = "0.1.12" }
-tsz-emitter = { path = "crates/tsz-emitter", version = "0.1.12", default-features = false }
-tsz-lsp = { path = "crates/tsz-lsp", version = "0.1.12" }
+tsz = { path = "crates/tsz-core", version = "0.1.13", package = "tsz-core" }
+tsz-common = { path = "crates/tsz-common", version = "0.1.13" }
+tsz-scanner = { path = "crates/tsz-scanner", version = "0.1.13" }
+tsz-parser = { path = "crates/tsz-parser", version = "0.1.13" }
+tsz-binder = { path = "crates/tsz-binder", version = "0.1.13" }
+tsz-solver = { path = "crates/tsz-solver", version = "0.1.13" }
+tsz-lowering = { path = "crates/tsz-lowering", version = "0.1.13" }
+tsz-checker = { path = "crates/tsz-checker", version = "0.1.13" }
+tsz-emitter = { path = "crates/tsz-emitter", version = "0.1.13", default-features = false }
+tsz-lsp = { path = "crates/tsz-lsp", version = "0.1.13" }
 
 # External dependencies (shared versions)
 anyhow = "1.0"


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Release / npm publishing.

## Invariant
When try-tsz changes need to reach npm, the workspace publish version must advance before tagging; this PR changes only Cargo workspace/package versions for the 0.1.13 publish.

## Scope
- Bump workspace package version and internal workspace dependency requirements from 0.1.12 to 0.1.13.
- Bump workspace package versions in Cargo.lock from 0.1.12 to 0.1.13.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: release metadata only; no compiler or CLI behavior changes.

## Verification
- `git diff --check`
- `npm view try-tsz version` returned `0.1.12`, confirming `0.1.13` is unpublished.

## Coordination Notes
- Follow-up to #12314 so trusted publishing can publish try-tsz with the report-timeout fixes.
- After merge, create/push tag `v0.1.13` to trigger `.github/workflows/npm-publish.yml`.