### PR TITLE
fix(dts): constrain computed object member recovery

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
@@ -686,8 +686,8 @@ impl<'a> DeclarationEmitter<'a> {
                     if let Some(acc) = self.arena.get_accessor(n) {
                         if let Some(name) = self.object_literal_member_name_text(acc.name) {
                             setter_names.insert(name);
-                        } else if let Some(name_node) = self.arena.get(acc.name)
-                            && name_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME
+                        } else if self.computed_property_name_is_symbol_access(acc.name)
+                            && let Some(name_node) = self.arena.get(acc.name)
                             && let Some(src) = self.get_source_slice(name_node.pos, name_node.end)
                         {
                             computed_setter_source_texts.insert(src.trim().to_string());
@@ -697,8 +697,8 @@ impl<'a> DeclarationEmitter<'a> {
                     if let Some(acc) = self.arena.get_accessor(n) {
                         if let Some(name) = self.object_literal_member_name_text(acc.name) {
                             getter_names.insert(name);
-                        } else if let Some(name_node) = self.arena.get(acc.name)
-                            && name_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME
+                        } else if self.computed_property_name_is_symbol_access(acc.name)
+                            && let Some(name_node) = self.arena.get(acc.name)
                             && let Some(src) = self.get_source_slice(name_node.pos, name_node.end)
                         {
                             computed_getter_source_texts.insert(src.trim().to_string());
@@ -722,7 +722,11 @@ impl<'a> DeclarationEmitter<'a> {
             // via infer_property_name_text for `[Symbol.isConcatSpreadable]`),
             // use it directly. Only fall through to the non-nameable index-
             // signature path when the name cannot be reproduced at all.
-            let name_text = self.object_literal_member_name_text(name_idx);
+            let name_text = self.object_literal_member_name_text(name_idx).or_else(|| {
+                (member_node.kind == syntax_kind_ext::METHOD_DECLARATION)
+                    .then(|| self.computed_identifier_or_access_name_text(name_idx))
+                    .flatten()
+            });
 
             // A computed key whose expression cannot be reproduced as a literal
             // property name (e.g. `[this.a]`) is not a named member in tsc's
@@ -1549,7 +1553,10 @@ impl<'a> DeclarationEmitter<'a> {
             || expr_node.kind == syntax_kind_ext::PREFIX_UNARY_EXPRESSION
     }
 
-    fn computed_property_name_is_symbol_access(&self, name_idx: NodeIndex) -> bool {
+    pub(in crate::declaration_emitter) fn computed_property_name_is_symbol_access(
+        &self,
+        name_idx: NodeIndex,
+    ) -> bool {
         let Some(name_node) = self.arena.get(name_idx) else {
             return false;
         };

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_members.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_members.rs
@@ -260,6 +260,33 @@ impl<'a> DeclarationEmitter<'a> {
         }
     }
 
+    pub(in crate::declaration_emitter) fn computed_identifier_or_access_name_text(
+        &self,
+        name_idx: NodeIndex,
+    ) -> Option<String> {
+        let name_node = self.arena.get(name_idx)?;
+        if name_node.kind != syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+            return None;
+        }
+        let computed = self.arena.get_computed_property(name_node)?;
+        let expr_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(computed.expression);
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind != SyntaxKind::Identifier as u16
+            && expr_node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+        {
+            return None;
+        }
+
+        let mut text = self.get_source_slice(name_node.pos, name_node.end)?;
+        if let Some(bracket_pos) = text.rfind(']') {
+            text.truncate(bracket_pos + 1);
+        }
+        let text = text.trim().to_string();
+        (!text.is_empty()).then_some(text)
+    }
+
     pub(in crate::declaration_emitter) fn resolved_computed_property_name_text(
         &self,
         name_idx: NodeIndex,
@@ -690,24 +717,12 @@ impl<'a> DeclarationEmitter<'a> {
                 k if k == SyntaxKind::Identifier as u16
                     || k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION =>
                 {
-                    // Use the COMPUTED_PROPERTY_NAME node's source slice.
-                    // Trim at `]` because node.end may include trailing property punctuation.
-                    if let Some(mut s) = self.get_source_slice(node.pos, node.end) {
-                        // Find the last `]` and truncate after it
-                        if let Some(bracket_pos) = s.rfind(']') {
-                            s.truncate(bracket_pos + 1);
-                        } else {
-                            // No brackets — trim trailing punctuation
-                            while s.ends_with(':') || s.ends_with('(') {
-                                s.pop();
-                                s = s.trim_end().to_string();
-                            }
-                        }
-                        if !s.is_empty() {
-                            return Some(s);
-                        }
+                    if self.computed_property_name_is_symbol_access(node_id)
+                        && let Some(text) = self.computed_identifier_or_access_name_text(node_id)
+                    {
+                        return Some(text);
                     }
-                    return None;
+                    return self.emittable_computed_property_name_text(node_id);
                 }
                 _ => return None,
             }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs
@@ -74,8 +74,8 @@ impl<'a> DeclarationEmitter<'a> {
                     if let Some(acc) = self.arena.get_accessor(n) {
                         if let Some(name) = self.object_literal_member_name_text(acc.name) {
                             setter_names.insert(name);
-                        } else if let Some(name_node) = self.arena.get(acc.name)
-                            && name_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME
+                        } else if self.computed_property_name_is_symbol_access(acc.name)
+                            && let Some(name_node) = self.arena.get(acc.name)
                             && let Some(src) = self.get_source_slice(name_node.pos, name_node.end)
                         {
                             computed_setter_source_texts.insert(src.trim().to_string());
@@ -85,8 +85,8 @@ impl<'a> DeclarationEmitter<'a> {
                     if let Some(acc) = self.arena.get_accessor(n) {
                         if let Some(name) = self.object_literal_member_name_text(acc.name) {
                             getter_names.insert(name);
-                        } else if let Some(name_node) = self.arena.get(acc.name)
-                            && name_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME
+                        } else if self.computed_property_name_is_symbol_access(acc.name)
+                            && let Some(name_node) = self.arena.get(acc.name)
                             && let Some(src) = self.get_source_slice(name_node.pos, name_node.end)
                         {
                             computed_getter_source_texts.insert(src.trim().to_string());
@@ -142,6 +142,11 @@ impl<'a> DeclarationEmitter<'a> {
             let Some(mut name_text) = self
                 .object_literal_member_name_text(name_idx)
                 .or_else(|| self.emittable_computed_property_name_text(name_idx))
+                .or_else(|| {
+                    (member_node.kind == syntax_kind_ext::METHOD_DECLARATION)
+                        .then(|| self.computed_identifier_or_access_name_text(name_idx))
+                        .flatten()
+                })
                 .or_else(|| {
                     // Fallback: when a getter and setter share the same computed
                     // property name source text but type info is unavailable, use


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Track 9 - declaration emit parity / DTS computed-property-name regression fix-forward for #12316.

## Invariant
When an object-literal computed key is not declaration-nameable, `tsc` emits the solver/index-signature surface instead of preserving raw computed source text. This PR keeps source-text recovery in declaration emit only for structurally valid cases: nameable Symbol accessors and late-bound computed method keys. It does not add checker/solver semantic validation or new output surgery.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_members.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: DTS computed-property-name / nameable-Symbol declaration emit
- Evidence: emit-suite-only DTS regression. Restores #12316's four regressed DTS baselines while preserving #12230's Symbol accessor-pair unit and late-bound computed-method DTS unit.

## Verification
- Repro before fix: `scripts/safe-run.sh scripts/emit/run.sh --dts-only --filter=computedPropertyNamesDeclarationEmit5 --verbose --concurrency=1 --json-out=/tmp/studio-c-12316-computed5-before.json` -> 0/3 passed.
- Repro before fix: `scripts/safe-run.sh scripts/emit/run.sh --dts-only --filter=checkingObjectWithThisInNamePositionNoCrash --verbose --concurrency=1 --json-out=/tmp/studio-c-12316-this-name-before.json` -> 0/1 passed.
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter test_simple_computed_names_match_declaration_baseline_shape test_object_literal_computed_accessor_pair_emits_writable_symbol_property` -> 2 passed, 4116 skipped.
- `scripts/safe-run.sh scripts/emit/run.sh --dts-only --filter=computedPropertyNamesDeclarationEmit5 --verbose --concurrency=1 --json-out=/tmp/studio-c-12316-computed5-after3.json` -> 3/3 passed.
- `scripts/safe-run.sh scripts/emit/run.sh --dts-only --filter=checkingObjectWithThisInNamePositionNoCrash --verbose --concurrency=1 --json-out=/tmp/studio-c-12316-this-name-after3.json` -> 1/1 passed.
- `cargo fmt --check -p tsz-emitter`
- `git diff --check`
- `python3 scripts/emit/audit-output-surgery.py` -> passed; no new output-surgery calls.

## Coordination Notes
- Fixes #12316.
- I checked the earlier WIP claim branch `claude/confident-hawking-eXOAB`; no open PR or remote branch existed, so this branch takes the Studio-C implementation path.
- Scope is DTS-only and does not touch checker/solver semantics, JS emit, or output-surgery allowlists.
