### PR TITLE
fix(bench): infer readiness source commit

### DIFF
--- a/scripts/bench/check-artifact-readiness.mjs
+++ b/scripts/bench/check-artifact-readiness.mjs
@@ -22,6 +22,7 @@
  */
 
 import fs from "node:fs";
+import { execFileSync } from "node:child_process";
 
 import {
   REQUIRED_PROJECT_ROWS,
@@ -72,9 +73,23 @@ const {
   requireGreen,
   requireCleanMetadata,
   requireSourceCurrent,
-  expectedSourceCommit,
+  expectedSourceCommit: rawExpectedSourceCommit,
   filePath,
 } = parseArgs(args);
+
+function currentGitHead() {
+  try {
+    return execFileSync("git", ["rev-parse", "HEAD"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+const expectedSourceCommit =
+  rawExpectedSourceCommit ?? (requireSourceCurrent ? currentGitHead() : null);
 
 function loadArtifact() {
   if (!filePath) {

--- a/scripts/bench/test-check-artifact-readiness.mjs
+++ b/scripts/bench/test-check-artifact-readiness.mjs
@@ -210,6 +210,30 @@ withTempDir((dir) => {
 console.log("✅ --require-source-current fails on stale artifact source");
 
 // ---------------------------------------------------------------------------
+// Test: --require-source-current infers HEAD when no explicit expected commit
+// is supplied, so local release-truth checks cannot silently skip freshness.
+// ---------------------------------------------------------------------------
+withTempDir((dir) => {
+  const file = path.join(dir, "bench.json");
+  const rows = REQUIRED_PROJECT_ROWS.map((name) => makeRow(name, "green"));
+  writeJson(file, makeArtifact(rows, {
+    measurement_profile: SAMPLE_MEASUREMENT_PROFILE,
+    source_commit: "1111111111111111111111111111111111111111",
+  }));
+  const result = run(file, ["--json", "--require-source-current"]);
+  assert.equal(result.status, 1, "source-current gate should infer HEAD and fail stale artifacts");
+  const parsed = JSON.parse(result.stdout.trim());
+  const head = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: ROOT,
+    encoding: "utf8",
+  }).stdout.trim().toLowerCase();
+  assert.equal(parsed.source_freshness.expected_source_commit, head, "JSON should record inferred HEAD");
+  assert.equal(parsed.source_freshness.current, false, "JSON should mark inferred stale source not current");
+  assert.match(result.stderr, /source freshness failed/);
+});
+console.log("✅ --require-source-current infers HEAD when no expected source is passed");
+
+// ---------------------------------------------------------------------------
 // Test: modern artifact without measurement_profile still exits 0 but reports
 // the missing profile so dashboards can surface the metadata gap.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Project corpus / benchmark artifact truth tooling.

## Invariant
When `scripts/bench/check-artifact-readiness.mjs --require-source-current` is used without an explicit expected SHA, the readiness gate must still compare the artifact source against the current checkout; this PR changes the benchmark readiness script so local release-truth checks cannot silently report source freshness as not checked.

## Scope
- `scripts/bench/check-artifact-readiness.mjs`
- `scripts/bench/test-check-artifact-readiness.mjs`

## Project Corpus Impact
- Row: n/a; this changes readiness validation, not project-row definitions or benchmark measurements.
- Bug family: benchmark artifact freshness reporting.
- Evidence: the checked-in `crates/tsz-website/bench-snapshot.json` now reports source `d13c6b872599` differs from expected current `e9fc9d086cd5` when `--require-source-current` is used locally without `--expect-source-commit`.

## Verification
- `node scripts/bench/test-check-artifact-readiness.mjs`
- `node scripts/bench/test-ci-health-benchmark-readiness.mjs`
- `node scripts/bench/validate-project-metadata.mjs`
- `node scripts/bench/project-row-summary.mjs --markdown`
- `node scripts/bench/check-artifact-readiness.mjs crates/tsz-website/bench-snapshot.json --json --require-clean-metadata --require-source-current` (expected exit 1; now reports stale source against `e9fc9d086cd5` plus the known runner metadata warning)
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit` (fails only on pre-existing noncanonical open issue labels; no open PRs or release issues are missing agent labels)
- PR-head CI on `341b57d646`: CI Light Summary, lint, cargo-deny, cargo-shear, project-row-drift, gate, GitGuardian passed.

## Coordination Notes
- Ready for review/queue on head `341b57d646`.
- No overlap with open PRs found in the benchmark readiness script.
- Follow-up remains #10649: checked-in benchmark snapshot is still stale/unclean until a fresh completed Bench artifact is available, but this PR makes the local freshness gate authoritative instead of silently skipping the comparison.
