### PR TITLE
fix(emit): use write_raw_text for pre-indented TC39 ES5 class blocks

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -75,6 +75,10 @@ name = "tc39_decorator_extends_multiline_reindent_tests"
 path = "tests/tc39_decorator_extends_multiline_reindent_tests.rs"
 
 [[test]]
+name = "tc39_es5_using_block_indent_tests"
+path = "tests/tc39_es5_using_block_indent_tests.rs"
+
+[[test]]
 name = "async_method_super_write_tests"
 path = "tests/async_method_super_write_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/transform_dispatch.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch.rs
@@ -278,13 +278,6 @@ impl<'a> Printer<'a> {
                         binding_name,
                         &class_name,
                     ) {
-                        // `render_simple_tc39_decorated_class_es5` produces a
-                        // fully indented block (leading `base_indent` already
-                        // embedded). Use `write_raw_text` so the writer's
-                        // `ensure_indent()` doesn't prepend a second level
-                        // when the class appears inside a non-zero-indent
-                        // context (e.g. the try-block of a top-level `using`
-                        // region).
                         self.writer.write_raw_text(&output);
                         self.skip_comments_for_erased_node(node);
                         return;

--- a/crates/tsz-emitter/src/emitter/transform_dispatch.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch.rs
@@ -278,7 +278,14 @@ impl<'a> Printer<'a> {
                         binding_name,
                         &class_name,
                     ) {
-                        self.write(&output);
+                        // `render_simple_tc39_decorated_class_es5` produces a
+                        // fully indented block (leading `base_indent` already
+                        // embedded). Use `write_raw_text` so the writer's
+                        // `ensure_indent()` doesn't prepend a second level
+                        // when the class appears inside a non-zero-indent
+                        // context (e.g. the try-block of a top-level `using`
+                        // region).
+                        self.writer.write_raw_text(&output);
                         self.skip_comments_for_erased_node(node);
                         return;
                     }
@@ -1188,7 +1195,7 @@ impl<'a> Printer<'a> {
                     &binding_name,
                     &display_name,
                 ) {
-                    self.write(&output);
+                    self.writer.write_raw_text(&output);
                     self.skip_comments_for_erased_node(node);
                     self.track_decorated_class_namespace_binding(node);
                     return;

--- a/crates/tsz-emitter/tests/tc39_es5_using_block_indent_tests.rs
+++ b/crates/tsz-emitter/tests/tc39_es5_using_block_indent_tests.rs
@@ -1,0 +1,100 @@
+//! Regression tests: TC39 (non-legacy) ES5 decorated named-export classes
+//! inside a top-level `using` block must not be double-indented.
+//!
+//! `render_simple_tc39_decorated_class_es5` produces a fully pre-indented
+//! string (embedding its own `base_indent`). When that string is written to
+//! the output via the transform dispatch, the writer's `ensure_indent()` must
+//! NOT prepend a second level of indentation. Previously the dispatch used
+//! `write(&output)` which triggered `ensure_indent()` at line-start, yielding
+//! e.g. `exports.C =     C = function ()` (4 extra spaces) instead of the
+//! correct `exports.C = C = function ()`.
+//!
+//! Structural rule: the transform dispatch writes pre-indented TC39 ES5
+//! decorated class blocks with `write_raw_text`, not `write`, so the
+//! `base_indent` already present in the string is the sole indentation source.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::context::emit::EmitContext;
+use tsz_emitter::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use tsz_emitter::lowering::LoweringPass;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+fn emit(source: &str, module: ModuleKind, target: ScriptTarget) -> String {
+    let opts = PrinterOptions {
+        module,
+        target,
+        no_emit_helpers: true,
+        ..Default::default()
+    };
+    let (parser, root) = test_support::parse_source(source);
+    let ctx = EmitContext::with_options(opts.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer = EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, opts);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+const SRC_NAMED: &str =
+    "export {};\ndeclare var dec: any;\nusing before = null;\n@dec\nexport class C {\n}\n";
+
+/// CommonJS + ES5: no extra indentation inside the CJS try-block.
+#[test]
+fn cjs_es5_tc39_named_export_in_using_no_extra_indent() {
+    let out = emit(SRC_NAMED, ModuleKind::CommonJS, ScriptTarget::ES5);
+    assert!(
+        out.contains("exports.C = C = function () {"),
+        "TC39 ES5 named-export class in CJS using-block must assign without extra indent.\n{out}"
+    );
+    assert!(
+        !out.contains("exports.C =  "),
+        "must not have spaces between `exports.C =` and `C =`.\n{out}"
+    );
+}
+
+/// ESNext + ES5: `C = function ()` at the correct one-level indent.
+#[test]
+fn esnext_es5_tc39_named_export_in_using_correct_indent() {
+    let out = emit(SRC_NAMED, ModuleKind::ESNext, ScriptTarget::ES5);
+    // ESNext has no inline export prefix; the class is emitted as `C = function () {`.
+    // The line must start with exactly one indent level (4 spaces), not two (8 spaces).
+    assert!(
+        out.contains("    C = function () {") && !out.contains("        C = function () {"),
+        "TC39 ES5 named-export class in ESNext using-block must be at one indent level.\n{out}"
+    );
+}
+
+/// System + ES5: `exports_1("C", C = function () {` on one clean line.
+#[test]
+fn system_es5_tc39_named_export_in_using_no_extra_indent() {
+    let out = emit(SRC_NAMED, ModuleKind::System, ScriptTarget::ES5);
+    assert!(
+        out.contains("exports_1(\"C\", C = function () {"),
+        "TC39 ES5 named-export class in System using-block must not have extra spaces.\n{out}"
+    );
+    assert!(
+        !out.contains("exports_1(\"C\",  "),
+        "must not have extra spaces after `exports_1(\"C\",`.\n{out}"
+    );
+}
+
+/// Top-level (no using block): the fix must not change top-level emission.
+/// At top-level (indent=0), `write` and `write_raw_text` are identical since
+/// `ensure_indent()` writes nothing. tsc uses the two-statement pattern
+/// `var C = …(); exports.C = C;` at top-level, not the inline-export pattern.
+#[test]
+fn cjs_es5_tc39_top_level_class_unaffected() {
+    // No `using` — class is at indent=0, no double-indent was ever possible.
+    let src = "declare var dec: any;\n@dec\nexport class C {\n}\n";
+    let out = emit(src, ModuleKind::CommonJS, ScriptTarget::ES5);
+    assert!(
+        out.contains("var C = function () {"),
+        "Top-level TC39 ES5 class must emit the standard `var C = function` form.\n{out}"
+    );
+    assert!(
+        out.contains("exports.C = C;"),
+        "Top-level TC39 ES5 class must still re-export after the fix.\n{out}"
+    );
+}

--- a/crates/tsz-emitter/tests/tc39_es5_using_block_indent_tests.rs
+++ b/crates/tsz-emitter/tests/tc39_es5_using_block_indent_tests.rs
@@ -54,7 +54,7 @@ fn cjs_es5_tc39_named_export_in_using_no_extra_indent() {
     );
 }
 
-/// ESNext + ES5: `C = function ()` at the correct one-level indent.
+/// `ESNext` + ES5: `C = function ()` at the correct one-level indent.
 #[test]
 fn esnext_es5_tc39_named_export_in_using_correct_indent() {
     let out = emit(SRC_NAMED, ModuleKind::ESNext, ScriptTarget::ES5);


### PR DESCRIPTION
AgentName: Studio-C

Track: JS emit parity — `usingDeclarationsWithESClassDecorators` family

Invariant: When a transform produces a complete, pre-indented block it must be written with `write_raw_text` (bypasses `ensure_indent`) rather than `write`. At indent=0 the two are identical; above zero `write` would add a spurious extra level.

## Scope

- `crates/tsz-emitter/src/emitter/transform_dispatch.rs`: two call sites changed from `self.write(&output)` to `self.writer.write_raw_text(&output)` where `render_simple_tc39_decorated_class_es5` output is written
- `crates/tsz-emitter/tests/tc39_es5_using_block_indent_tests.rs`: new regression tests (4 tests covering CJS/ESNext/System modules and top-level unaffected case)
- `crates/tsz-emitter/Cargo.toml`: register new test binary

## Problem

`render_simple_tc39_decorated_class_es5` produces a fully pre-indented string — it embeds its own `base_indent = "    ".repeat(writer.indent_level())`. When that string was written via `self.write(&output)`, the writer's `ensure_indent()` was also called at line-start, prepending a second level of indentation. At top-level (indent=0) both paths are identical; inside a non-zero-indent context (e.g. the `try`-block of a top-level `using` region) this doubled the indentation, producing output like:

```
exports.C =     C = function () {   // 4 extra spaces — WRONG
```

instead of:

```
exports.C = C = function () {       // correct
```

## Fix

Replace `self.write(&output)` with `self.writer.write_raw_text(&output)` at the two dispatch sites that consume `render_simple_tc39_decorated_class_es5` output. `write_raw_text` calls only `raw_write`, not `ensure_indent`, so the `base_indent` already embedded in the string is the sole indentation source.

## Failure Family

`usingDeclarationsWithESClassDecorators` — TC39 (non-legacy) ES5 decorated classes inside a top-level `using` block:
- tests 3, 4 (module=commonjs,esnext,system, target=es5) — directly addressed
- tests 5, 6, 8, 9 (module=system, target=es5) — potentially addressed

## Adjacent Matrix

| condition | before | after |
|---|---|---|
| CJS + ES5 + TC39 + `using` block | `exports.C =     C =` (double-indent) | `exports.C = C =` (correct) |
| ESNext + ES5 + TC39 + `using` block | 8-space indent on `C = function` | 4-space (one level, correct) |
| System + ES5 + TC39 + `using` block | `exports_1("C",  C =` (extra spaces) | `exports_1("C", C =` (correct) |
| CJS + ES5 + TC39 + top-level (no `using`) | unaffected (indent=0) | same |

## Project Corpus Impact

- Row: n/a
- Bug family: `usingDeclarationsWithESClassDecorators` (TC39 ES5 double-indent in using blocks)

No regression expected. The fix only changes the indentation path for pre-indented TC39 ES5 class blocks, and at indent=0 `write` and `write_raw_text` are identical. All 4121 emitter tests pass.

## Verification

```
cargo nextest run -p tsz-emitter
# 4121 tests passed, 0 failed
```

New regression tests in `tc39_es5_using_block_indent_tests.rs` guard the fixed behavior.

## Coordination Notes

Does not overlap with legacy-decorator or System-ES2015 work. PR #12311 (wrong fix, removed `alias_name` guard in `system_emit_using.rs`) was closed by repo owner — this PR does not touch `system_emit_using.rs`.
