### PR TITLE
fix(checker): recover TS2416 for construct-signature heritage calls

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1723,6 +1723,10 @@ name = "class_expression_implements_display_tests"
 path = "tests/class_expression_implements_display_tests.rs"
 
 [[test]]
+name = "class_expression_heritage_ts2416_tests"
+path = "tests/class_expression_heritage_ts2416_tests.rs"
+
+[[test]]
 name = "predicate_alias_generic_inference_tests"
 path = "tests/predicate_alias_generic_inference_tests.rs"
 

--- a/crates/tsz-checker/src/state/type_resolution/constructors.rs
+++ b/crates/tsz-checker/src/state/type_resolution/constructors.rs
@@ -1,4 +1,3 @@
-use crate::query_boundaries::common::call_signatures_for_type;
 use crate::query_boundaries::state::type_resolution as query;
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
@@ -10,6 +9,7 @@ use tsz_solver::TypeId;
 use tsz_solver::computation::TypeSubstitution;
 
 mod callable_type_arguments;
+mod heritage_call_returns;
 
 pub(super) const fn should_cache_base_expr_result(
     type_argument_count: usize,
@@ -545,22 +545,11 @@ impl<'a> CheckerState<'a> {
             let cached_expr_type = self.get_type_of_node(expr_idx);
             if let Some(expr_node) = self.ctx.arena.get(expr_idx) {
                 if let Some(call_expr) = self.ctx.arena.get_call_expr(expr_node) {
-                    if let Some(type_args) = call_expr.type_arguments.as_ref() {
-                        let callee_type = self.get_type_of_node(call_expr.expression);
-                        let invoked_type = self
-                            .apply_type_arguments_to_callable_type(callee_type, Some(type_args));
-                        if let Some(call_signatures) =
-                            call_signatures_for_type(self.ctx.types, invoked_type)
-                        {
-                            call_signatures
-                                .first()
-                                .map_or(cached_expr_type, |sig| sig.return_type)
-                        } else {
-                            cached_expr_type
-                        }
-                    } else {
-                        cached_expr_type
-                    }
+                    self.heritage_call_return_type_for_base_constructor(
+                        call_expr,
+                        type_arguments,
+                        cached_expr_type,
+                    )
                 } else {
                     cached_expr_type
                 }

--- a/crates/tsz-checker/src/state/type_resolution/constructors/heritage_call_returns.rs
+++ b/crates/tsz-checker/src/state/type_resolution/constructors/heritage_call_returns.rs
@@ -1,0 +1,193 @@
+use crate::query_boundaries::common::call_signatures_for_type;
+use crate::state::CheckerState;
+use tsz_parser::parser::node::CallExprData;
+use tsz_parser::parser::{NodeIndex, NodeList, syntax_kind_ext};
+use tsz_solver::TypeId;
+use tsz_solver::computation::TypeSubstitution;
+
+impl<'a> CheckerState<'a> {
+    pub(super) fn heritage_call_return_type_for_base_constructor(
+        &mut self,
+        call_expr: &CallExprData,
+        type_arguments: Option<&NodeList>,
+        cached_expr_type: TypeId,
+    ) -> TypeId {
+        let callee_expr_type_args = self
+            .ctx
+            .arena
+            .get(call_expr.expression)
+            .and_then(|callee_node| self.ctx.arena.get_expr_type_args(callee_node));
+        let callee_idx = callee_expr_type_args
+            .map(|expr_type_args| expr_type_args.expression)
+            .unwrap_or(call_expr.expression);
+        let call_type_args = call_expr
+            .type_arguments
+            .as_ref()
+            .or_else(|| {
+                callee_expr_type_args
+                    .and_then(|expr_type_args| expr_type_args.type_arguments.as_ref())
+            })
+            .or(type_arguments);
+        let Some(type_args) = call_type_args else {
+            return cached_expr_type;
+        };
+
+        let callee_type = self.get_type_of_node(callee_idx);
+        let invoked_type = self.apply_type_arguments_to_callable_type(callee_type, Some(type_args));
+        let signature_return = call_signatures_for_type(self.ctx.types, invoked_type)
+            .or_else(|| {
+                let value_type = self.value_type_for_heritage_call_callee(callee_idx)?;
+                let invoked_value_type =
+                    self.apply_type_arguments_to_callable_type(value_type, Some(type_args));
+                call_signatures_for_type(self.ctx.types, invoked_value_type)
+            })
+            .and_then(|call_signatures| call_signatures.first().map(|sig| sig.return_type));
+        let same_named_return =
+            self.same_named_heritage_function_return_type(callee_idx, type_args);
+        match (signature_return, same_named_return) {
+            (_, Some(alias_return)) => alias_return,
+            (Some(signature_return), _) => signature_return,
+            (None, None) => cached_expr_type,
+        }
+    }
+
+    fn value_type_for_heritage_call_callee(&mut self, callee_idx: NodeIndex) -> Option<TypeId> {
+        let callee_node = self.ctx.arena.get(callee_idx)?;
+        let ident = self.ctx.arena.get_identifier(callee_node)?;
+        let value_type = self.type_of_value_symbol_by_name(&ident.escaped_text);
+        if !matches!(value_type, TypeId::ERROR | TypeId::UNKNOWN)
+            && call_signatures_for_type(self.ctx.types, value_type).is_some()
+        {
+            return Some(value_type);
+        }
+
+        let function_declarations = self
+            .ctx
+            .arena
+            .source_files
+            .first()
+            .map(|source_file| {
+                source_file
+                    .statements
+                    .nodes
+                    .iter()
+                    .copied()
+                    .filter_map(|stmt_idx| {
+                        let stmt_node = self.ctx.arena.get(stmt_idx)?;
+                        let func = self.ctx.arena.get_function(stmt_node)?;
+                        let name_node = self.ctx.arena.get(func.name)?;
+                        let name = self.ctx.arena.get_identifier(name_node)?;
+                        (name.escaped_text == ident.escaped_text).then(|| {
+                            self.ctx
+                                .binder
+                                .get_node_symbol(stmt_idx)
+                                .or_else(|| self.ctx.binder.get_node_symbol(func.name))
+                                .map(|sym_id| (sym_id, stmt_idx))
+                        })?
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        for (sym_id, decl_idx) in function_declarations {
+            let value_type = self.type_of_value_declaration_for_symbol(sym_id, decl_idx);
+            if !matches!(value_type, TypeId::ERROR | TypeId::UNKNOWN)
+                && call_signatures_for_type(self.ctx.types, value_type).is_some()
+            {
+                return Some(value_type);
+            }
+        }
+
+        let sym_id = self.resolve_identifier_symbol(callee_idx)?;
+        let (value_decl, declarations) = self
+            .ctx
+            .binder
+            .get_symbol(sym_id)
+            .or_else(|| self.get_cross_file_symbol(sym_id))
+            .map(|symbol| (symbol.value_declaration, symbol.declarations.clone()))?;
+        for decl_idx in std::iter::once(value_decl).chain(declarations) {
+            let Some(decl_node) = self.ctx.arena.get(decl_idx) else {
+                continue;
+            };
+            if decl_node.kind != syntax_kind_ext::FUNCTION_DECLARATION && decl_idx != value_decl {
+                continue;
+            }
+            let value_type = self.type_of_value_declaration_for_symbol(sym_id, decl_idx);
+            if !matches!(value_type, TypeId::ERROR | TypeId::UNKNOWN)
+                && call_signatures_for_type(self.ctx.types, value_type).is_some()
+            {
+                return Some(value_type);
+            }
+        }
+        None
+    }
+
+    fn same_named_heritage_function_return_type(
+        &mut self,
+        callee_idx: NodeIndex,
+        type_arguments: &NodeList,
+    ) -> Option<TypeId> {
+        let ident = self.ctx.arena.get_identifier_at(callee_idx)?;
+        let callee_name = ident.escaped_text.as_str();
+        let candidates =
+            self.ctx
+                .arena
+                .source_files
+                .first()
+                .map(|source_file| {
+                    source_file
+                        .statements
+                        .nodes
+                        .iter()
+                        .copied()
+                        .filter_map(|stmt_idx| {
+                            let stmt_node = self.ctx.arena.get(stmt_idx)?;
+                            let func = self.ctx.arena.get_function(stmt_node)?;
+                            let function_name =
+                                self.ctx.arena.get(func.name).and_then(|name_node| {
+                                    self.ctx.arena.get_identifier(name_node)
+                                })?;
+                            if function_name.escaped_text != callee_name {
+                                return None;
+                            }
+                            let return_node = self.ctx.arena.get(func.type_annotation)?;
+                            let returns_callee_alias = self
+                                .ctx
+                                .arena
+                                .get_type_ref(return_node)
+                                .and_then(|type_ref| self.entity_name_text(type_ref.type_name))
+                                .is_some_and(|return_name| return_name == callee_name);
+                            returns_callee_alias
+                                .then(|| (func.type_parameters.clone(), func.type_annotation))
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+        for (type_parameters, return_annotation) in candidates {
+            let (params, updates) = self.push_type_parameters(&type_parameters);
+            let return_type = self.get_type_from_type_node(return_annotation);
+            self.pop_type_parameters(updates);
+            if matches!(return_type, TypeId::ERROR | TypeId::UNKNOWN) {
+                continue;
+            }
+            if params.is_empty() || type_arguments.nodes.is_empty() {
+                return Some(return_type);
+            }
+
+            let mut type_args = Vec::with_capacity(type_arguments.nodes.len());
+            for &arg_idx in &type_arguments.nodes {
+                type_args.push(self.get_type_from_type_node(arg_idx));
+            }
+            if type_args.len() > params.len() {
+                type_args.truncate(params.len());
+            }
+            let substitution = TypeSubstitution::from_args(self.ctx.types, &params, &type_args);
+            return Some(crate::query_boundaries::common::instantiate_type(
+                self.ctx.types,
+                return_type,
+                &substitution,
+            ));
+        }
+
+        None
+    }
+}

--- a/crates/tsz-checker/tests/class_expression_heritage_ts2416_tests.rs
+++ b/crates/tsz-checker/tests/class_expression_heritage_ts2416_tests.rs
@@ -1,0 +1,148 @@
+use tsz_checker::test_utils::check_source_code_messages;
+
+fn diagnostics(source: &str) -> Vec<(u32, String)> {
+    check_source_code_messages(source)
+}
+
+fn ts2416_messages(source: &str) -> Vec<String> {
+    diagnostics(source)
+        .into_iter()
+        .filter_map(|(code, message)| (code == 2416).then_some(message))
+        .collect()
+}
+
+#[test]
+fn construct_signature_expression_base_property_override_emits_ts2416() {
+    let messages = ts2416_messages(
+        r#"
+type Construct<T> = new () => T;
+declare function makeBase<T>(): Construct<T>;
+type Shape = { alpha: number };
+
+class Derived extends makeBase<Shape>() {
+    alpha!: string;
+}
+"#,
+    );
+
+    assert!(
+        messages.iter().any(|message| {
+            message.contains("Property 'alpha' in type 'Derived'")
+                && message.contains("base type 'Shape'")
+        }),
+        "expected TS2416 for construct-signature expression base, got {messages:?}"
+    );
+}
+
+#[test]
+fn same_named_constructor_function_and_type_alias_base_emits_ts2416() {
+    let messages = ts2416_messages(
+        r#"
+type Constructor<T> = new () => T;
+declare function Constructor<T>(): Constructor<T>;
+type Shape = { alpha: number };
+
+class Derived extends Constructor<Shape>() {
+    alpha: string;
+}
+"#,
+    );
+
+    assert!(
+        messages.iter().any(|message| {
+            message.contains("Property 'alpha' in type 'Derived'")
+                && message.contains("base type 'Shape'")
+        }),
+        "expected TS2416 for same-named constructor function/type alias base, got {messages:?}"
+    );
+}
+
+#[test]
+fn construct_signature_expression_base_declared_field_emits_ts2416() {
+    let messages = ts2416_messages(
+        r#"
+type Construct<T> = new () => T;
+declare function makeBase<T>(): Construct<T>;
+type Shape = { alpha: number };
+
+class Derived extends makeBase<Shape>() {
+    alpha: string;
+}
+"#,
+    );
+
+    assert!(
+        messages.iter().any(|message| {
+            message.contains("Property 'alpha' in type 'Derived'")
+                && message.contains("base type 'Shape'")
+        }),
+        "expected TS2416 for declared field without initializer, got {messages:?}"
+    );
+}
+
+#[test]
+fn renamed_construct_signature_expression_base_property_override_emits_ts2416() {
+    let messages = ts2416_messages(
+        r#"
+type Maker<Result> = new () => Result;
+declare function build<Result>(): Maker<Result>;
+type RecordLike = { payload: boolean };
+
+class Widget extends build<RecordLike>() {
+    payload!: { tag: "nope" };
+}
+"#,
+    );
+
+    assert!(
+        messages.iter().any(|message| {
+            message.contains("Property 'payload' in type 'Widget'")
+                && message.contains("base type 'RecordLike'")
+        }),
+        "expected TS2416 under renamed binders, got {messages:?}"
+    );
+}
+
+#[test]
+fn intersection_construct_signature_expression_base_property_override_emits_ts2416() {
+    let messages = ts2416_messages(
+        r#"
+type Construct<T> = new () => T;
+declare function makeBase<T>(): Construct<T>;
+type Left = { keep: number };
+type Right = { clash: string };
+
+class Derived extends makeBase<Left & Right>() {
+    clash!: number;
+}
+"#,
+    );
+
+    assert!(
+        messages.iter().any(|message| {
+            message.contains("Property 'clash' in type 'Derived'")
+                && message.contains("base type 'Left & Right'")
+        }),
+        "expected TS2416 for intersection instance base, got {messages:?}"
+    );
+}
+
+#[test]
+fn compatible_construct_signature_expression_base_property_override_has_no_ts2416() {
+    let messages = ts2416_messages(
+        r#"
+type Construct<T> = new () => T;
+declare function makeBase<T>(): Construct<T>;
+type Shape = { alpha: number };
+
+class Derived extends makeBase<Shape>() {
+    alpha!: number;
+}
+"#,
+    );
+
+    assert!(
+        messages.is_empty(),
+        "did not expect TS2416 for compatible construct-signature expression base, got {messages:?}"
+    );
+}

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -12,10 +12,11 @@
 # noUnusedLocals_writeOnly.ts was fixed in the write-only destructuring PR (#12243):
 # { x: x } = src did not emit TS6133 because is_window_and_global_this_declared_expression
 # called resolve_identifier_symbol on the write target, marking it as read.
+# interfaceExtendsObjectIntersectionErrors.ts is covered by the class heritage
+# TS2416 tests for construct-signature expression bases.
 # circularReference.ts oscillates; re-accepted after REGRESSED on PR #12243 exact head.
 TypeScript/tests/cases/compiler/exportDefaultInterface.ts
 TypeScript/tests/cases/conformance/externalModules/circularReference.ts
-TypeScript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts
 
 # Existing drift exposed by PR #12255 after resolving the previous #12247
 # accepted rows for coAndContraVariantInferences2/correlatedUnions; tracked in


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Diagnostic conformance accepted-regression burn-down; checker TS2416 behavior fix.

## Invariant
When a class heritage call has an explicit type-argument callee such as `Constructor<T>()`, and the value-side function returns the same construct-signature alias, the checker must instantiate that returned constructor alias and compare derived instance members against the constructed instance type. This PR changes the checker class-heritage constructor return path.

## Scope
- `crates/tsz-checker/src/state/type_resolution/constructors.rs`
- `crates/tsz-checker/src/state/type_resolution/constructors/heritage_call_returns.rs`
- `crates/tsz-checker/tests/class_expression_heritage_ts2416_tests.rs`
- `scripts/conformance/conformance-accepted-regressions.txt`

## Project Corpus Impact
- Row: n/a
- Bug family: diagnostic false-negative, TS2416 class heritage calls
- Evidence: removes the accepted-regression row for `interfaceExtendsObjectIntersectionErrors.ts`; focused conformance passes after the structural checker fix.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test class_expression_heritage_ts2416_tests --no-fail-fast`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test conformance_issues_types test_ts2416_type_level_base_class_constructor_call_type_arguments --no-fail-fast`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter interfaceExtendsObjectIntersectionErrors --workers 1 --verbose`
- `cargo fmt -p tsz-checker -- --check`
- `git diff --check -- crates/tsz-checker/Cargo.toml crates/tsz-checker/src/state/type_resolution/constructors.rs crates/tsz-checker/src/state/type_resolution/constructors/heritage_call_returns.rs crates/tsz-checker/tests/class_expression_heritage_ts2416_tests.rs scripts/conformance/conformance-accepted-regressions.txt`
- `python3 scripts/conformance/query-conformance.py --dashboard` -> 12582/12582, accepted-regression gate 7, snapshot stale delta +3
- GitHub head checks on `7563bb0653c942fab4f691ca8c17ed772e5f36fc`: `gate`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `unit-cloudbuild`, `lint`, `unit`, `dist-binaries`, `CI Light Summary`, and `GitGuardian Security Checks` passed on 2026-06-03.

## Coordination Notes
- Ready once draft CI evidence is recorded; queue testing still pending until enqueue.
- Local working tree has unrelated dirty lib-resolution files tied to the #12299 family; they are intentionally not staged or included.
- `python3 scripts/arch/arch_guard.py` is locally blocked by those unrelated dirty `CheckerContext` fields (`lib_type_resolution_in_progress`, `lib_resolution_incomplete`), not by this PRs committed diff.
- `scripts/agents/ensure-agent-labels.sh --audit` reports pre-existing noncanonical issue labels; no open PR is missing an agent label.
