### PR TITLE
fix(solver): report tsc-exact arity for variadic tuple length mismatches

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -784,6 +784,47 @@ impl<'a> CheckerState<'a> {
                     Diagnostic::error(file_name, start, length, message, reason.diagnostic_code())
                 }
             }
+            SubtypeFailureReason::TupleArityMismatch(arity) => {
+                // tsc's arity gate (`TS2618`–`TS2621`) resolves the message
+                // family, diagnostic code, and argument count up front in the
+                // solver; the renderer just formats the recorded arguments into
+                // the catalog template the solver selected.
+                let arity_code = arity.diagnostic_code();
+                let arity_args: Vec<String> =
+                    arity.message_args().iter().map(|n| n.to_string()).collect();
+                let arity_arg_refs: Vec<&str> = arity_args.iter().map(String::as_str).collect();
+                let arity_text = format_message(arity.diagnostic_message(), &arity_arg_refs);
+                if depth == 0 {
+                    // Top level: keep the `TS2322` headline and attach the arity
+                    // reason as a nested elaboration line, matching the sibling
+                    // `TupleElementMismatch` rendering above.
+                    let (source_str, target_str) =
+                        self.format_top_level_assignability_message_types_at(source, target, idx);
+                    let base = format_message(
+                        diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+                        &[&source_str, &target_str],
+                    );
+                    let mut diag = Diagnostic::error(
+                        file_name.clone(),
+                        start,
+                        length,
+                        base,
+                        diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+                    );
+                    diag.related_information.push(DiagnosticRelatedInformation {
+                        file: file_name,
+                        start,
+                        length,
+                        message_text: arity_text,
+                        category: DiagnosticCategory::Message,
+                        code: arity_code,
+                        depth: 0,
+                    });
+                    diag
+                } else {
+                    Diagnostic::error(file_name, start, length, arity_text, arity_code)
+                }
+            }
             SubtypeFailureReason::TupleElementTypeMismatch {
                 index,
                 source_element,

--- a/crates/tsz-checker/src/query_boundaries/relation_types.rs
+++ b/crates/tsz-checker/src/query_boundaries/relation_types.rs
@@ -187,6 +187,29 @@ impl RelationFailure {
                 source_count,
                 target_count,
             },
+            // The pre-classified arity families already carry tsc's exact
+            // numbers; collapse them to the checker-facing `(source, target)`
+            // count pair for classification purposes (the live elaboration is
+            // rendered from the solver reason directly). The `may-have`
+            // single-argument families leave the unknown side at `0`.
+            SubtypeFailureReason::TupleArityMismatch(arity) => {
+                let (source_count, target_count) = match arity {
+                    tsz_solver::TupleArity::SourceTooFew {
+                        source_arity,
+                        target_min,
+                    } => (source_arity, target_min),
+                    tsz_solver::TupleArity::SourceTooMany {
+                        source_min,
+                        target_arity,
+                    } => (source_min, target_arity),
+                    tsz_solver::TupleArity::TargetRequiresMore { target_min } => (0, target_min),
+                    tsz_solver::TupleArity::TargetAllowsFewer { target_arity } => (target_arity, 0),
+                };
+                Self::TupleArityMismatch {
+                    source_count,
+                    target_count,
+                }
+            }
             SubtypeFailureReason::ReturnTypeMismatch {
                 source_return,
                 target_return,

--- a/crates/tsz-solver/src/diagnostics/core.rs
+++ b/crates/tsz-solver/src/diagnostics/core.rs
@@ -88,6 +88,84 @@ impl<T: SubtypeTracer> DynSubtypeTracer for T {
 /// Some variants include `nested_reason` to capture failures in nested types.
 /// For example, a property type mismatch might include why the property types
 /// themselves don't match.
+///
+/// Pre-classified tuple arity mismatch family (`TS2618`–`TS2621`).
+///
+/// `tsc` (`tupleTypesRelated` in `checker.ts`) gates a tuple-to-tuple relation
+/// on four length comparisons that use the *arity* (total element slots,
+/// including a single variadic/rest slot) and *minimum length* (count of
+/// required elements) of each side together with whether each side carries a
+/// rest element. Each branch reports a distinct message with its own wording,
+/// argument count, and diagnostic code, so the failing relation records the
+/// resolved family here rather than re-deriving it from raw element counts in
+/// the renderer (which cannot distinguish a fixed slot from a variadic slot).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TupleArity {
+    /// `TS2618` — "Source has {0} element(s) but target requires {1}." The
+    /// source is a closed tuple too short to satisfy the target's required
+    /// elements. Carries `(source_arity, target_min)`.
+    SourceTooFew {
+        source_arity: usize,
+        target_min: usize,
+    },
+    /// `TS2619` — "Source has {0} element(s) but target allows only {1}." The
+    /// target is a closed tuple and the source's minimum length already exceeds
+    /// it. Carries `(source_min, target_arity)`.
+    SourceTooMany {
+        source_min: usize,
+        target_arity: usize,
+    },
+    /// `TS2620` — "Target requires {0} element(s) but source may have fewer."
+    /// The target is closed and requires more elements than the (variadic)
+    /// source is guaranteed to provide. Carries `target_min`.
+    TargetRequiresMore { target_min: usize },
+    /// `TS2621` — "Target allows only {0} element(s) but source may have more."
+    /// The target is closed and the variadic source may overflow it. Carries
+    /// `target_arity`.
+    TargetAllowsFewer { target_arity: usize },
+}
+
+impl TupleArity {
+    /// The diagnostic code for this arity family.
+    pub const fn diagnostic_code(self) -> u32 {
+        match self {
+            Self::SourceTooFew { .. } => codes::SOURCE_HAS_ELEMENT_S_BUT_TARGET_REQUIRES,
+            Self::SourceTooMany { .. } => codes::SOURCE_HAS_ELEMENT_S_BUT_TARGET_ALLOWS_ONLY,
+            Self::TargetRequiresMore { .. } => {
+                codes::TARGET_REQUIRES_ELEMENT_S_BUT_SOURCE_MAY_HAVE_FEWER
+            }
+            Self::TargetAllowsFewer { .. } => {
+                codes::TARGET_ALLOWS_ONLY_ELEMENT_S_BUT_SOURCE_MAY_HAVE_MORE
+            }
+        }
+    }
+
+    /// The catalog message template for this arity family. Derived from the
+    /// shared diagnostic catalog via [`diagnostic_code`](Self::diagnostic_code)
+    /// so the wording and code can never drift apart, and so the rendering layer
+    /// does not need its own variant-to-message mapping.
+    pub fn diagnostic_message(self) -> &'static str {
+        get_message_template(self.diagnostic_code())
+    }
+
+    /// The numeric message arguments, in catalog order. `SourceTooFew` and
+    /// `SourceTooMany` take two; the `may-have` variants take one.
+    pub fn message_args(self) -> Vec<usize> {
+        match self {
+            Self::SourceTooFew {
+                source_arity,
+                target_min,
+            } => vec![source_arity, target_min],
+            Self::SourceTooMany {
+                source_min,
+                target_arity,
+            } => vec![source_min, target_arity],
+            Self::TargetRequiresMore { target_min } => vec![target_min],
+            Self::TargetAllowsFewer { target_arity } => vec![target_arity],
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum SubtypeFailureReason {
     /// A required property is missing in the source type.
@@ -149,6 +227,15 @@ pub enum SubtypeFailureReason {
         source_count: usize,
         target_count: usize,
     },
+    /// Tuple arity mismatch pre-classified to tsc's `TS2618`–`TS2621` family.
+    ///
+    /// Unlike [`Self::TupleElementMismatch`] (which only carries raw element
+    /// counts and so cannot tell a fixed slot from a variadic one), this variant
+    /// records the exact `tsc` branch — including whether the count refers to a
+    /// minimum length or a full arity — so a variadic source like
+    /// `[boolean, ...number[]]` reports its required length (`1`) rather than its
+    /// slot count (`2`).
+    TupleArityMismatch(TupleArity),
     /// Tuple element type mismatch.
     ///
     /// When the related tuple has **more than one** element (`multi_element`),
@@ -586,6 +673,12 @@ pub mod codes {
     pub use dc::TYPE_AT_POSITION_IN_SOURCE_IS_NOT_COMPATIBLE_WITH_TYPE_AT_POSITION_IN_TARGET as TUPLE_ELEMENT_POSITION_MISMATCH;
     pub use dc::TYPES_OF_PROPERTY_ARE_INCOMPATIBLE as PROPERTY_TYPE_MISMATCH;
 
+    // Tuple arity mismatch family (TS2618–TS2621).
+    pub use dc::SOURCE_HAS_ELEMENT_S_BUT_TARGET_ALLOWS_ONLY;
+    pub use dc::SOURCE_HAS_ELEMENT_S_BUT_TARGET_REQUIRES;
+    pub use dc::TARGET_ALLOWS_ONLY_ELEMENT_S_BUT_SOURCE_MAY_HAVE_MORE;
+    pub use dc::TARGET_REQUIRES_ELEMENT_S_BUT_SOURCE_MAY_HAVE_FEWER;
+
     // Function/call errors
     pub use dc::CANNOT_FIND_NAME;
     pub use dc::CANNOT_FIND_NAME_DO_YOU_NEED_TO_CHANGE_YOUR_TARGET_LIBRARY_TRY_CHANGING_THE_LIB as CANNOT_FIND_NAME_TARGET_LIB;
@@ -709,6 +802,7 @@ impl SubtypeFailureReason {
             | Self::UnionTargetMismatch { .. }
             | Self::ConditionalBranchMismatch { .. }
             | Self::AbstractConstructorAssignment => codes::TYPE_NOT_ASSIGNABLE,
+            Self::TupleArityMismatch(arity) => arity.diagnostic_code(),
             Self::NoCommonProperties { .. } => codes::NO_COMMON_PROPERTIES,
             Self::ExcessProperty { .. } => codes::EXCESS_PROPERTY,
             Self::ReadonlyToMutableAssignment { .. } => codes::READONLY_TO_MUTABLE,
@@ -885,6 +979,15 @@ impl SubtypeFailureReason {
             .with_related(PendingDiagnostic::error(
                 codes::ARG_COUNT_MISMATCH,
                 vec![(*target_count).into(), (*source_count).into()],
+            )),
+
+            Self::TupleArityMismatch(arity) => PendingDiagnostic::error(
+                codes::TYPE_NOT_ASSIGNABLE,
+                vec![source.into(), target.into()],
+            )
+            .with_related(PendingDiagnostic::error(
+                arity.diagnostic_code(),
+                arity.message_args().into_iter().map(|n| n.into()).collect(),
             )),
 
             Self::TupleElementTypeMismatch {

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -72,7 +72,7 @@ pub mod type_handles {
     pub use crate::diagnostics::format::TypeFormatter;
     pub use crate::diagnostics::{
         DiagnosticArg, DiagnosticSeverity, PendingDiagnostic, PendingDiagnosticBuilder, SourceSpan,
-        SubtypeFailureReason,
+        SubtypeFailureReason, TupleArity,
     };
     pub use crate::types::{
         CallSignature, CallableShape, CallableShapeId, ConditionalType, ConditionalTypeId,
@@ -246,7 +246,6 @@ pub use def::{
     FileChange, FileChangeSet, InvalidationSummary, StoreStatistics, diff_fingerprints,
     incremental, resolver,
 };
-pub use diagnostics::SubtypeFailureReason;
 pub use diagnostics::builders::{
     DiagnosticBuilder, DiagnosticCollector, SourceLocation, SpannedDiagnosticBuilder,
 };
@@ -256,6 +255,7 @@ pub use diagnostics::reduce::deep_reduce_for_display;
 pub use diagnostics::{
     DiagnosticArg, DiagnosticSeverity, PendingDiagnostic, PendingDiagnosticBuilder, SourceSpan,
 };
+pub use diagnostics::{SubtypeFailureReason, TupleArity};
 #[cfg(test)]
 #[allow(unused_imports)]
 pub(crate) use evaluation::evaluate::{

--- a/crates/tsz-solver/src/relations/subtype/explain_tuple.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain_tuple.rs
@@ -42,29 +42,40 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         source: &[TupleElement],
         target: &[TupleElement],
     ) -> Option<SubtypeFailureReason> {
-        let source_required = crate::utils::required_element_count(source);
-        let target_required = crate::utils::required_element_count(target);
-
-        if source_required < target_required {
-            return Some(SubtypeFailureReason::TupleElementMismatch {
-                source_count: source.len(),
-                target_count: target.len(),
-            });
-        }
-
-        // When both source and target are closed tuples (no rest elements) and
-        // source has more elements than target allows, prefer the arity-mismatch
-        // reason over an element-level type mismatch. This matches tsc, which
-        // reports the outer "Source has N element(s) but target allows only M"
-        // diagnostic instead of drilling into a specific element when the
-        // length already disqualifies the relation.
-        let target_has_rest = target.iter().any(|e| e.rest);
+        // tsc gates a tuple-to-tuple relation on an arity check *before* it
+        // compares individual elements (`tupleTypesRelated` in `checker.ts`).
+        //
+        // The historical bug (#10874) is confined to *variadic* tuples: when a
+        // side carries a rest element, the old length comparison counted that
+        // rest slot as a fixed element, over-reporting the source length and
+        // emitting only two of tsc's four arity messages. So the tsc-faithful
+        // classifier runs **only when a rest element is present**; purely closed
+        // tuples keep their established reason and rendering exactly (closed
+        // tuples have `arity == len`, so they were never affected by the bug,
+        // and tsc resolves their optional-element mismatches per-element, not
+        // through this length gate).
         let source_has_rest = source.iter().any(|e| e.rest);
-        if !target_has_rest && !source_has_rest && source.len() > target.len() {
-            return Some(SubtypeFailureReason::TupleElementMismatch {
-                source_count: source.len(),
-                target_count: target.len(),
-            });
+        let target_has_rest = target.iter().any(|e| e.rest);
+
+        if source_has_rest || target_has_rest {
+            if let Some(arity) = crate::utils::classify_tuple_arity(source, target) {
+                return Some(SubtypeFailureReason::TupleArityMismatch(arity));
+            }
+        } else {
+            // Closed-tuple length mismatch: preserve the prior structured
+            // `TupleElementMismatch` reason (and its alias-preserving render
+            // path). A source that cannot supply the target's required elements,
+            // or a source longer than a closed target, is reported here rather
+            // than drilled into element-by-element, matching the established
+            // baseline.
+            let source_required = crate::utils::required_element_count(source);
+            let target_required = crate::utils::required_element_count(target);
+            if source_required < target_required || source.len() > target.len() {
+                return Some(SubtypeFailureReason::TupleElementMismatch {
+                    source_count: source.len(),
+                    target_count: target.len(),
+                });
+            }
         }
 
         for (i, t_elem) in target.iter().enumerate() {

--- a/crates/tsz-solver/src/utils/mod.rs
+++ b/crates/tsz-solver/src/utils/mod.rs
@@ -20,6 +20,55 @@ pub(crate) fn required_element_count(elements: &[TupleElement]) -> usize {
     elements.iter().filter(|e| e.is_required()).count()
 }
 
+/// Classify a tuple-to-tuple length incompatibility into tsc's `TS2618`–`TS2621`
+/// family, or return `None` when the two arities are compatible (so the caller
+/// proceeds to per-element comparison).
+///
+/// This mirrors the arity gate in `tupleTypesRelated` (`checker.ts`) exactly,
+/// using each side's *arity* (slot count, where a variadic/rest element is a
+/// single slot) and *minimum length* (count of required elements) together with
+/// whether each side carries a rest element. Crucially, a variadic source
+/// contributes its required length — not its slot count — to the reported
+/// numbers, so `[boolean, ...number[]]` against `[]` reports `1`, not `2`.
+///
+/// The branch order matches tsc so that, e.g., a closed source that is simply
+/// too long is reported as "Source has N but target allows only M" rather than
+/// the "source may have more" wording reserved for genuinely open-ended sources.
+pub(crate) fn classify_tuple_arity(
+    source: &[TupleElement],
+    target: &[TupleElement],
+) -> Option<crate::diagnostics::TupleArity> {
+    use crate::diagnostics::TupleArity;
+
+    let source_arity = source.len();
+    let target_arity = target.len();
+    let source_min = required_element_count(source);
+    let target_min = required_element_count(target);
+    let source_has_rest = source.iter().any(|e| e.rest);
+    let target_has_rest = target.iter().any(|e| e.rest);
+
+    if !source_has_rest && source_arity < target_min {
+        return Some(TupleArity::SourceTooFew {
+            source_arity,
+            target_min,
+        });
+    }
+    if !target_has_rest && target_arity < source_min {
+        return Some(TupleArity::SourceTooMany {
+            source_min,
+            target_arity,
+        });
+    }
+    if !target_has_rest && (source_has_rest || target_arity < source_arity) {
+        return Some(if source_min < target_min {
+            TupleArity::TargetRequiresMore { target_min }
+        } else {
+            TupleArity::TargetAllowsFewer { target_arity }
+        });
+    }
+    None
+}
+
 /// Checks if a property name is numeric by resolving the atom and checking its string representation.
 ///
 /// This function consolidates the previously duplicated `is_numeric_property_name` implementations

--- a/crates/tsz-solver/tests/compat_tests_parts/part_03.rs
+++ b/crates/tsz-solver/tests/compat_tests_parts/part_03.rs
@@ -1213,6 +1213,10 @@ fn test_explain_tuple_arity_takes_priority_over_element_mismatch() {
 
     assert!(!checker.is_assignable(source, target));
 
+    // Both sides are closed (no rest element), so the arity-family classifier is
+    // intentionally not consulted: the closed-tuple length mismatch keeps its
+    // established `TupleElementMismatch` reason, which still takes priority over
+    // the inner element-type mismatch.
     match checker.explain_failure(source, target) {
         Some(SubtypeFailureReason::TupleElementMismatch {
             source_count,
@@ -1225,6 +1229,89 @@ fn test_explain_tuple_arity_takes_priority_over_element_mismatch() {
             "Expected TupleElementMismatch (arity) to take priority over an inner \
              TupleElementTypeMismatch, got: {other:?}"
         ),
+    }
+}
+
+/// A required tuple element plus a variadic tail (`[boolean, ...number[]]`)
+/// assigned to the empty tuple. tsc reports its *required* length (1), not its
+/// slot count (2): "Source has 1 element(s) but target allows only 0."
+/// (`SourceTooMany`). This is the core variadic-tail arity bug from #10874.
+#[test]
+fn test_explain_variadic_source_reports_required_length_not_slot_count() {
+    let interner = TypeInterner::new();
+    let mut checker = CompatChecker::new(&interner);
+
+    let number_rest = interner.array(TypeId::NUMBER);
+    let source = interner.tuple(vec![
+        TupleElement {
+            type_id: TypeId::BOOLEAN,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: number_rest,
+            name: None,
+            optional: false,
+            rest: true,
+        },
+    ]);
+    let target = interner.tuple(vec![]);
+
+    assert!(!checker.is_assignable(source, target));
+    match checker.explain_failure(source, target) {
+        Some(SubtypeFailureReason::TupleArityMismatch(crate::TupleArity::SourceTooMany {
+            source_min,
+            target_arity,
+        })) => {
+            assert_eq!(source_min, 1, "variadic source must report required length");
+            assert_eq!(target_arity, 0);
+        }
+        other => panic!("expected SourceTooMany {{1, 0}}, got: {other:?}"),
+    }
+}
+
+/// A variadic source that may be too short (`[string, ...string[]]`) assigned to
+/// a longer closed tuple reports the target's required length and the
+/// "source may have fewer" wording (`TS2620`, `TargetRequiresMore`).
+#[test]
+fn test_explain_variadic_source_target_requires_more() {
+    let interner = TypeInterner::new();
+    let mut checker = CompatChecker::new(&interner);
+
+    let string_rest = interner.array(TypeId::STRING);
+    let source = interner.tuple(vec![
+        TupleElement {
+            type_id: TypeId::STRING,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: string_rest,
+            name: None,
+            optional: false,
+            rest: true,
+        },
+    ]);
+    let req = |type_id| TupleElement {
+        type_id,
+        name: None,
+        optional: false,
+        rest: false,
+    };
+    let target = interner.tuple(vec![
+        req(TypeId::STRING),
+        req(TypeId::STRING),
+        req(TypeId::STRING),
+    ]);
+
+    assert!(!checker.is_assignable(source, target));
+    match checker.explain_failure(source, target) {
+        Some(SubtypeFailureReason::TupleArityMismatch(crate::TupleArity::TargetRequiresMore {
+            target_min,
+        })) => assert_eq!(target_min, 3),
+        other => panic!("expected TargetRequiresMore {{3}}, got: {other:?}"),
     }
 }
 


### PR DESCRIPTION
AgentName: Studio-B

Closes #10874.

## Summary

Variadic tuple length-mismatch diagnostics counted a rest/variadic element as a
fixed element and only emitted two of tsc's four arity messages. A variadic
source such as `[boolean, ...number[]]` assigned to `[]` reported "Source has
**2** element(s)..." where tsc reports "Source has **1** element(s)...". The
underlying *inference* (e.g. `Tail<[string, ...number[]]> = number[]`) was
verified correct against tsc — the divergence was purely the arity elaboration.

## Structural rule

When a tuple side carries a **rest** element, `explain_tuple_failure` routes
through `crate::utils::classify_tuple_arity`, which mirrors tsc's
`tupleTypesRelated` arity gate exactly: it uses each side's *arity* (slot count,
where a variadic/rest element is one slot) and *minimum length* (required-element
count) plus rest flags to select the correct one of TS2618–TS2621, reporting the
required length rather than the raw slot count.

## Scope discipline (why this is tightly bounded)

The classifier is invoked **only for rest-bearing tuples** — the family the bug
lives in. Closed tuples have `arity == len`, so they were never affected by the
miscount; they keep their established `TupleElementMismatch` reason and
alias-preserving rendering unchanged (tsc resolves their optional-element
mismatches per-element, not through this length gate). This keeps
`optionalTupleElements1` and `mappedTypeWithAny` (and every other closed-tuple /
array-source baseline) byte-identical to before.

## Owner layer

Solver (relation failure reason). New `SubtypeFailureReason::TupleArityMismatch(TupleArity)`
records the resolved family; message template and code are single-sourced on the
`TupleArity` enum. The checker renderer only formats the recorded arguments.

## Track

Conformance / diagnostics — variadic-tuple arity parity.

## Invariant

`tsc` parity for variadic tuple length-mismatch elaboration; closed-tuple and
array-source behavior unchanged.

## Adjacent-case matrix (verified byte-identical vs tsc 6.0.2)

| source | target | message |
|---|---|---|
| `[boolean, ...number[]]` | `[]` | Source has 1 … allows only 0 (TS2619) |
| `[string, string, ...number[]]` | `[string]` | Source has 2 … allows only 1 |
| `[string, ...number[]]` | `[string]` | Target allows only 1 … may have more (TS2621) |
| `[string, ...string[]]` | `[string, string, string]` | Target requires 3 … may have fewer (TS2620) |
| `[number, number, ...boolean[]]` | `[number]` | Source has 2 … allows only 1 |
| `[string]` | `[string, string, string]` | Source has 1 … target requires 3 (TS2618) |
| `[string, string, string]` (closed) | `[string, string]` | unchanged |

## Project Corpus Impact

- Row: n/a (diagnostic-elaboration parity; no single project-corpus row gate; benefits variadic-heavy rows nextjs / type-challenges-solutions / kysely / ts-toolbelt)
- Bug family: variadic-tuple arity elaboration (TS2618–TS2621)

## Verification

- `cargo build --bin tsz`; oracle diff vs `tsc 6.0.2` across the matrix — identical.
- Confirmed `optionalTupleElements1.ts` and `mappedTypeWithAny.ts` reproduce
  their prior (passing) output exactly (compared against the parent commit's
  binary and the tsc baselines).
- Solver unit tests: `test_explain_variadic_source_reports_required_length_not_slot_count`,
  `test_explain_variadic_source_target_requires_more`; closed-tuple priority test
  retains its `TupleElementMismatch` assertion. `cargo test -p tsz-solver --lib tuple` green (568).
- Rebased cleanly onto latest `main`.

## Coordination Notes

GitHub auto-merge left off; staying off `merge-queue` until exact-head checks are
green and the maintainer gives the go-ahead. No overlap with the other open
variadic-tuple solver issues (those target inference/instantiation).