### PR TITLE
fix(dts): trim computed object member names

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_members.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_members.rs
@@ -253,8 +253,7 @@ impl<'a> DeclarationEmitter<'a> {
                 if !is_unique_symbol_key && !is_usable_property_name {
                     return None;
                 }
-                self.get_source_slice(name_node.pos, name_node.end)
-                    .map(|text| text.trim().to_string())
+                self.computed_identifier_or_access_name_text(name_idx)
             }
             _ => None,
         }


### PR DESCRIPTION
AgentName: Studio-C
Track: Declaration emit parity / computed object members
Invariant: DTS emit may recover source spelling for nameable computed keys, but it must pass a punctuation-free computed key to member formatting and must not add semantic validation to emit.

## Scope

Fixes #12328 by trimming emittable computed identifier/property-access object member names to the bracketed key before object member type formatting. This preserves the #12316 non-nameable index-signature recovery while preventing duplicate malformed members such as [sym]:: 4 and [y]((): number.

## Project Corpus Impact

- Row: n/a
- Bug family: DTS computed object member source-name recovery

No project corpus row impact expected. This is a declaration-emitter spelling recovery fix for computed object members and does not touch project corpus fixtures or semantic checking.

## Verification

- scripts/safe-run.sh scripts/emit/run.sh --dts-only --filter=dynamicNamesErrors --verbose --concurrency=1 --json-out=/tmp/studio-c-12328-dynamic-after.json -> 1/1 pass
- scripts/safe-run.sh scripts/emit/run.sh --dts-only --filter=indexSignatures1 --verbose --concurrency=1 --json-out=/tmp/studio-c-12328-index-after.json -> 1/1 pass
- scripts/safe-run.sh scripts/emit/run.sh --dts-only --filter=computedPropertyNamesDeclarationEmit5 --verbose --concurrency=1 --json-out=/tmp/studio-c-12328-computed5-after.json -> 3/3 pass
- scripts/safe-run.sh scripts/emit/run.sh --dts-only --filter=checkingObjectWithThisInNamePositionNoCrash --verbose --concurrency=1 --json-out=/tmp/studio-c-12328-this-name-after.json -> 1/1 pass
- scripts/safe-run.sh cargo nextest run -p tsz-emitter test_simple_computed_names_match_declaration_baseline_shape test_object_literal_computed_accessor_pair_emits_writable_symbol_property -> 2/2 pass
- cargo fmt --check -p tsz-emitter -> pass
- git diff --check -> pass
- python3 scripts/emit/audit-output-surgery.py -> pass, 20/20 allowlist unchanged and no unallowlisted calls

## Coordination Notes

Fixes #12328. Structural rule: when an object-literal computed key is an emittable identifier or property access, tsc prints the bracketed computed key as the member name; tsz does this through declaration-emitter name recovery before formatting, with no checker/solver semantic policy added to emit.

Exact-head CI passed on 3af038110d before enqueue; first queue attempt exposed this PR-body format fix only.