### PR TITLE
fix(bench): ignore stable Cloud Build memory drift

### DIFF
--- a/scripts/bench/merge-results.mjs
+++ b/scripts/bench/merge-results.mjs
@@ -129,7 +129,7 @@ function validateRunnerEnvironmentConsistency(environments) {
     const mismatchedFields = Object.keys(baseline).filter((key) => {
       if (baseline[key] === current[key]) return false;
       if (
-        key === "cpu_model"
+        (key === "cpu_model" || key === "total_memory_bytes")
         && baseline.cloud_build_machine_type
         && baseline.cloud_build_machine_type === current.cloud_build_machine_type
       ) {

--- a/scripts/bench/test-merge-results.mjs
+++ b/scripts/bench/test-merge-results.mjs
@@ -554,12 +554,7 @@ withTempDir((dir) => {
   assert.equal(result.status, 0, result.stderr);
   const merged = JSON.parse(fs.readFileSync(result.output, "utf8"));
   assert.equal(merged.validation.runner_signature_required, true);
-  assert.equal(merged.validation.runner_environment_warnings.length, 1);
-  assert.equal(merged.validation.runner_environment_warnings[0].file, "bench-results-b.json");
-  assert.deepEqual(
-    merged.validation.runner_environment_warnings[0].mismatched_fields,
-    ["total_memory_bytes"],
-  );
+  assert.deepEqual(merged.validation.runner_environment_warnings, []);
 });
 
 withTempDir((dir) => {
@@ -634,6 +629,47 @@ withTempDir((dir) => {
   assert.deepEqual(
     merged.validation.runner_environment_warnings[0].mismatched_fields,
     ["cpu_model"],
+  );
+});
+
+withTempDir((dir) => {
+  const localRunnerEnvironment = { ...SAMPLE_RUNNER_ENVIRONMENT };
+  delete localRunnerEnvironment.cloud_build;
+  const changedRunnerEnvironment = {
+    ...localRunnerEnvironment,
+    total_memory_bytes: 137438945280,
+  };
+  const first = writeInput(
+    dir,
+    "bench-results-a.json",
+    [projectRow("first")],
+    {
+      ...SAMPLE_RUN_METADATA,
+      runner_environment: localRunnerEnvironment,
+      shard: { label: "first", filter: "first" },
+      filter: "first",
+    },
+  );
+  const second = writeInput(
+    dir,
+    "bench-results-b.json",
+    [projectRow("second")],
+    {
+      ...SAMPLE_RUN_METADATA,
+      runner_environment: changedRunnerEnvironment,
+      shard: { label: "second", filter: "second" },
+      filter: "second",
+    },
+  );
+  const result = runMergeInputs(dir, [first, second], ["--require-runner-signature"]);
+  assert.equal(result.status, 0, result.stderr);
+  const merged = JSON.parse(fs.readFileSync(result.output, "utf8"));
+  assert.equal(merged.validation.runner_signature_required, true);
+  assert.equal(merged.validation.runner_environment_warnings.length, 1);
+  assert.equal(merged.validation.runner_environment_warnings[0].file, "bench-results-b.json");
+  assert.deepEqual(
+    merged.validation.runner_environment_warnings[0].mismatched_fields,
+    ["total_memory_bytes"],
   );
 });
 


### PR DESCRIPTION
AgentName: Studio-A

## Track
project corpus / benchmark artifact truth tooling

## Invariant
When benchmark shards report the same nonempty `cloud_build_machine_type`, tiny `total_memory_bytes` differences are not a meaningful runner-class mismatch. `merge-results` should keep those artifacts metadata-clean for Cloud Build shards while still warning on local or non-Cloud memory drift.

## Scope
Updates `scripts/bench/merge-results.mjs` and `scripts/bench/test-merge-results.mjs` only.

## Project Corpus Impact
- Row: n/a
- Bug family: benchmark artifact metadata cleanliness
- Impact: No project-row source changes. This fixes benchmark artifact metadata cleanliness for the live artifact from workflow run `26881171899`, generated `2026-06-03T12:07:58.242Z`, whose seven warnings were all `total_memory_bytes` drift across identical `e2-highcpu-32` Cloud Build shards with the same CPU model. Issue #10649 remains open until a fresh current clean artifact is published and cited.

## Verification
- `node scripts/bench/test-merge-results.mjs`
- `node scripts/bench/test-check-artifact-readiness.mjs`
- `node scripts/bench/validate-project-metadata.mjs`
- `node scripts/bench/project-row-summary.mjs --markdown`
- `git diff --check origin/main..HEAD`
- `scripts/agents/ensure-agent-labels.sh --audit` (fails only on pre-existing noncanonical issue labels; no open PR label findings)

## Coordination Notes
Ready-state `project-corpus-pr-body` required the literal `## Project Corpus Impact` heading plus `Row` and `Bug family` bullets; this body now follows that shape. No open PR overlap was found on `scripts/bench/merge-results.mjs` or `scripts/bench/test-merge-results.mjs`. This is Studio-A benchmark truth tooling, not a row behavior change.