### PR TITLE
fix(dts): restore source-text for identifier/access computed keys; guard `this`

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
@@ -722,11 +722,7 @@ impl<'a> DeclarationEmitter<'a> {
             // via infer_property_name_text for `[Symbol.isConcatSpreadable]`),
             // use it directly. Only fall through to the non-nameable index-
             // signature path when the name cannot be reproduced at all.
-            let name_text = self.object_literal_member_name_text(name_idx).or_else(|| {
-                (member_node.kind == syntax_kind_ext::METHOD_DECLARATION)
-                    .then(|| self.computed_identifier_or_access_name_text(name_idx))
-                    .flatten()
-            });
+            let name_text = self.object_literal_member_name_text(name_idx);
 
             // A computed key whose expression cannot be reproduced as a literal
             // property name (e.g. `[this.a]`) is not a named member in tsc's

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_members.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_members.rs
@@ -260,33 +260,6 @@ impl<'a> DeclarationEmitter<'a> {
         }
     }
 
-    pub(in crate::declaration_emitter) fn computed_identifier_or_access_name_text(
-        &self,
-        name_idx: NodeIndex,
-    ) -> Option<String> {
-        let name_node = self.arena.get(name_idx)?;
-        if name_node.kind != syntax_kind_ext::COMPUTED_PROPERTY_NAME {
-            return None;
-        }
-        let computed = self.arena.get_computed_property(name_node)?;
-        let expr_idx = self
-            .arena
-            .skip_parenthesized_and_assertions_and_comma(computed.expression);
-        let expr_node = self.arena.get(expr_idx)?;
-        if expr_node.kind != SyntaxKind::Identifier as u16
-            && expr_node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
-        {
-            return None;
-        }
-
-        let mut text = self.get_source_slice(name_node.pos, name_node.end)?;
-        if let Some(bracket_pos) = text.rfind(']') {
-            text.truncate(bracket_pos + 1);
-        }
-        let text = text.trim().to_string();
-        (!text.is_empty()).then_some(text)
-    }
-
     pub(in crate::declaration_emitter) fn resolved_computed_property_name_text(
         &self,
         name_idx: NodeIndex,
@@ -717,12 +690,35 @@ impl<'a> DeclarationEmitter<'a> {
                 k if k == SyntaxKind::Identifier as u16
                     || k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION =>
                 {
-                    if self.computed_property_name_is_symbol_access(node_id)
-                        && let Some(text) = self.computed_identifier_or_access_name_text(node_id)
-                    {
-                        return Some(text);
+                    // `[this.prop]` — the object is `this`; not a stable property name
+                    // in a .d.ts without type info, so omit it here and let the caller
+                    // route it through the synthesized index-signature path.
+                    if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+                        if let Some(access) = self.arena.get_access_expr(expr_node) {
+                            if let Some(obj) = self.arena.get(access.expression) {
+                                if obj.kind == SyntaxKind::ThisKeyword as u16 {
+                                    return None;
+                                }
+                            }
+                        }
                     }
-                    return self.emittable_computed_property_name_text(node_id);
+                    // Return the COMPUTED_PROPERTY_NAME source slice (e.g. `[someVar]`,
+                    // `[Symbol.iterator]`). Trim at `]` because node.end can include
+                    // trailing punctuation from the surrounding member.
+                    if let Some(mut s) = self.get_source_slice(node.pos, node.end) {
+                        if let Some(bracket_pos) = s.rfind(']') {
+                            s.truncate(bracket_pos + 1);
+                        } else {
+                            while s.ends_with(':') || s.ends_with('(') {
+                                s.pop();
+                                s = s.trim_end().to_string();
+                            }
+                        }
+                        if !s.is_empty() {
+                            return Some(s.trim().to_string());
+                        }
+                    }
+                    return None;
                 }
                 _ => return None,
             }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs
@@ -143,11 +143,6 @@ impl<'a> DeclarationEmitter<'a> {
                 .object_literal_member_name_text(name_idx)
                 .or_else(|| self.emittable_computed_property_name_text(name_idx))
                 .or_else(|| {
-                    (member_node.kind == syntax_kind_ext::METHOD_DECLARATION)
-                        .then(|| self.computed_identifier_or_access_name_text(name_idx))
-                        .flatten()
-                })
-                .or_else(|| {
                     // Fallback: when a getter and setter share the same computed
                     // property name source text but type info is unavailable, use
                     // the source text directly so the pair emits as one property.

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations_parts/part_06.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations_parts/part_06.rs
@@ -1,3 +1,73 @@
+// Regression coverage for Issue #12328: two DTS conformance tests
+// (`dynamicNamesErrors`, `indexSignatures1`) regressed in PR #12321 because
+// the METHOD_DECLARATION fallback that was added there made non-Symbol computed
+// method keys (like `[someVar]()`) skip the index-signature path even when the
+// key is a bare identifier. The fix restores source-text return for
+// identifier/property-access computed keys and adds a `this`-keyword guard.
+
+#[test]
+fn computed_method_key_bare_identifier_emits_as_named_member() {
+    // A method with a computed bare-identifier key (`[someVar]()`) must appear
+    // in the inferred object return type as a named member using the source text
+    // `[someVar]`, not be silently dropped or routed to an index signature.
+    // (Regression from PR #12321 METHOD_DECLARATION fallback removal.)
+    let output = emit_dts_with_usage_analysis(
+        r#"
+declare const someVar: unique symbol;
+export function make() {
+    return { [someVar]() { return 1; } };
+}
+"#,
+    );
+
+    assert!(
+        output.contains("[someVar]"),
+        "Expected computed bare-identifier method key [someVar] to appear as a named member: {output}"
+    );
+}
+
+#[test]
+fn computed_this_property_key_routes_to_index_signature() {
+    // A method whose computed key is `[this.prop]` cannot be reproduced as a
+    // stable property name in a .d.ts without type info. The emitter must
+    // route it through the synthesized index-signature path, not emit it as a
+    // named member. (Regression guard: `this` is a keyword, not an identifier.)
+    let output = emit_dts_with_usage_analysis(
+        r#"
+export class Container {
+    key = "x";
+    build() {
+        return { [this.key]() { return 1; } };
+    }
+}
+"#,
+    );
+
+    // The inferred return type must not produce a named member `[this.key]`.
+    assert!(
+        !output.contains("[this.key]"),
+        "Did not expect [this.key] to appear as a named member (should go to index sig): {output}"
+    );
+}
+
+#[test]
+fn computed_symbol_access_key_emits_as_named_member() {
+    // `[Symbol.iterator]()` is a known unique-symbol access and must always
+    // appear as a named member regardless of the source-text path.
+    let output = emit_dts_with_usage_analysis(
+        r#"
+export function make() {
+    return { [Symbol.iterator]() { return 1; } };
+}
+"#,
+    );
+
+    assert!(
+        output.contains("[Symbol.iterator]"),
+        "Expected [Symbol.iterator] computed method key to appear as a named member: {output}"
+    );
+}
+
 // Inferred object-literal return types must be indented relative to the
 // emitter's current `indent_level`. A class method (or a namespaced function)
 // nests its synthesized return shape one level deeper than a top-level


### PR DESCRIPTION
## Summary

Fixes #12328 — two DTS conformance regressions (`dynamicNamesErrors`, `indexSignatures1`) introduced by PR #12321.

AgentName: Studio-C
Track: Emit / DTS
Invariant: Computed object-literal property keys that are bare identifiers or property-access expressions (other than `this.x`) must appear as named members in the inferred `.d.ts` type, using their source-text slice as the property name.
Scope: `declaration_emitter` helpers — `infer_property_name_text`, `type_inference_expression_literals`, `type_inference_object_rewrites`. No semantic validation or output surgery.

## Root Cause

PR #12321 narrowed `infer_property_name_text` to return source text only for `Symbol.xxx` accesses, then compensated with a `METHOD_DECLARATION`-specific fallback via a new `computed_identifier_or_access_name_text` function. The fallback was not reached by property/data-member computed keys, so `[someVar]: 1` and similar patterns stopped appearing as named members and fell through to the index-signature path incorrectly.

## Structural Rule

> When a `COMPUTED_PROPERTY_NAME`'s expression is an `Identifier` or `PropertyAccessExpression`, tsc returns the source-text slice as the property name — **unless** the access object is `this` (which is not reproducible as a stable name without type info). `this`-keyed members route to the synthesized index-signature path via `is_non_nameable_computed_member_key`.

Owner layer: `infer_property_name_text` in `type_inference_object_members`.

## Changes

- **`type_inference_object_members.rs`**: Restore source-text return for `Identifier | PropertyAccess` computed keys, with an explicit `ThisKeyword` guard. Remove `computed_identifier_or_access_name_text` (now unnecessary).
- **`type_inference_expression_literals.rs`**: Revert `name_text` to `self.object_literal_member_name_text(name_idx)` — drop the `METHOD_DECLARATION` fallback.
- **`type_inference_object_rewrites.rs`**: Remove the `METHOD_DECLARATION` fallback from the name-text resolution chain. The getter/setter pair fallback is unchanged.
- **`part_06.rs`**: Add 3 regression tests:
  - `computed_method_key_bare_identifier_emits_as_named_member` — `[someVar]()` appears as a named member
  - `computed_this_property_key_routes_to_index_signature` — `[this.key]()` does NOT appear as a named member
  - `computed_symbol_access_key_emits_as_named_member` — `[Symbol.iterator]()` appears as a named member

## Adjacent Case Matrix

| Computed key form | Before #12321 | After #12321 (broken) | This PR |
|---|---|---|---|
| `[Symbol.iterator]()` | named ✓ | named ✓ | named ✓ |
| `[someVar]()` method | named ✓ | named ✓ (via fallback) | named ✓ (via source text) |
| `[someVar]: 1` property | named ✓ | **dropped** ✗ | named ✓ |
| `[this.x]()` method | index-sig ✓ | index-sig ✓ | index-sig ✓ |
| `["str"]` | named ✓ | named ✓ | named ✓ |
| `[42]` | named ✓ | named ✓ | named ✓ |

## Project Corpus Impact

- Row: DTS conformance
- Bug family: declaration emit computed property source-text recovery

Fixes `dynamicNamesErrors` and `indexSignatures1` DTS conformance failures without regressing the 4 `computedPropertyNames*` tests and `checkingObjectWithThisInNamePositionNoCrash` already fixed by #12321.

## Verification

```
cargo test -p tsz-emitter --lib
# 3581 passed; 0 failed
```

## Coordination Notes

Depends on #12321 (already merged to main). Branch based on `eeca294`. Closes #12328.

https://claude.ai/code/session_01MNemV8ZuXpQCkitReEWjMy

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNemV8ZuXpQCkitReEWjMy)_