### PR TITLE
fix(dts): truncate emittable computed key recovery at `]`

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_members.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_members.rs
@@ -253,8 +253,9 @@ impl<'a> DeclarationEmitter<'a> {
                 if !is_unique_symbol_key && !is_usable_property_name {
                     return None;
                 }
-                self.get_source_slice(name_node.pos, name_node.end)
-                    .map(|text| text.trim().to_string())
+                // Reuse the `]`-truncating extractor: a raw slice would keep the
+                // following punctuation (`[x]:`, `[y](`) and corrupt the key.
+                self.computed_identifier_or_access_name_text(name_idx)
             }
             _ => None,
         }

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations_parts/part_04.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations_parts/part_04.rs
@@ -73,6 +73,89 @@ var obj = {
 }
 
 #[test]
+fn bare_unique_symbol_computed_member_name_is_not_garbled() {
+    // Regression for #12328: a bare-identifier `unique symbol` key (`[x]`) is
+    // recovered through `emittable_computed_property_name_text`. That path must
+    // truncate the source slice at `]`, so the member reads `[x]: number` and
+    // never a garbled `[x]:: number` (which previously duplicated the
+    // solver-printed member because the raw slice kept the trailing `:`).
+    let source = r#"
+declare const x: unique symbol;
+const obj = {
+    [x]: 0
+};
+"#;
+    let (parser, root) = parse_test_source(source);
+
+    let obj_decl = parser
+        .arena
+        .nodes
+        .iter()
+        .find_map(|node| {
+            parser
+                .arena
+                .get_variable_declaration(node)
+                .filter(|decl| parser.arena.get_identifier_text(decl.name) == Some("obj"))
+        })
+        .expect("missing obj declaration");
+    let object_literal = parser
+        .arena
+        .get(obj_decl.initializer)
+        .and_then(|node| parser.arena.get_literal_expr(node))
+        .expect("missing obj object literal");
+    let prop_assignment = parser
+        .arena
+        .get(object_literal.elements.nodes[0])
+        .and_then(|node| parser.arena.get_property_assignment(node))
+        .expect("missing computed property assignment");
+    let computed = parser
+        .arena
+        .get(prop_assignment.name)
+        .and_then(|node| parser.arena.get_computed_property(node))
+        .expect("missing computed property name");
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+
+    let interner = TypeInterner::new();
+    let unique_symbol_type = interner.unique_symbol(SymbolRef(0));
+    let object_type = interner.object_with_index(ObjectShape {
+        flags: ObjectFlags::default(),
+        properties: vec![],
+        string_index: None,
+        number_index: None,
+        symbol: None,
+    });
+
+    let mut type_cache = crate::type_cache_view::TypeCacheView::default();
+    type_cache
+        .node_types
+        .insert(obj_decl.initializer.0, object_type);
+    type_cache
+        .node_types
+        .insert(computed.expression.0, unique_symbol_type);
+    type_cache
+        .node_types
+        .insert(prop_assignment.name.0, unique_symbol_type);
+    type_cache
+        .node_types
+        .insert(prop_assignment.initializer.0, TypeId::NUMBER);
+
+    let mut emitter =
+        DeclarationEmitter::with_type_info(&parser.arena, type_cache, &interner, &binder);
+    let output = emitter.emit(root);
+
+    assert!(
+        !output.contains("[x]::"),
+        "Did not expect a garbled computed key with a doubled separator: {output}"
+    );
+    assert!(
+        output.contains("[x]:"),
+        "Expected a bare unique-symbol computed key to recover as a clean `[x]` member: {output}"
+    );
+}
+
+#[test]
 fn symbol_observer_computed_member_drops_redundant_index_signature() {
     let source = r#"
 interface SymbolConstructor {


### PR DESCRIPTION
## Agent
AgentName: Studio-C

Fixes #12328.

## Track
declaration-emit / computed-object-member name recovery (consolidating the #12230 → #12316 → #12321 path).

## Invariant
When declaration emit recovers a computed object-member key whose expression is a bare-identifier or property-access reference (`[x]`, `[sym]`, `[Symbol.iterator]`), the recovered name must be the `]`-truncated bracketed form (`[x]`), never the raw `COMPUTED_PROPERTY_NAME` source slice that also captures the following punctuation (`[x]:`, `[y](`).

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_members.rs` — `emittable_computed_property_name_text` now delegates its final slice extraction to the existing `]`-truncating helper `computed_identifier_or_access_name_text` instead of slicing `name_node.pos..name_node.end` verbatim.
- `crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations_parts/part_04.rs` — adds `bare_unique_symbol_computed_member_name_is_not_garbled`, a unit regression that drives a bare-identifier `unique symbol` key through `emittable_computed_property_name_text` and asserts the recovered member is `[x]:` and not the garbled `[x]::`.

### Root cause / structural rule
A `COMPUTED_PROPERTY_NAME` node's span includes the trailing punctuation that follows `]` (the `:` of a property, the `(` of a method/accessor). `infer_property_name_text` and `computed_identifier_or_access_name_text` already compensate by truncating at the last `]`; `emittable_computed_property_name_text` did not — it returned `get_source_slice(..).trim()`. #12321 newly routed bare-identifier `unique symbol` keys (`[x]`, `[sym]`) through `emittable`, so its un-truncated `[x]:` / `[y](` was injected **on top of** the already-correct solver-printed member, producing garbled duplicates:

```
[x]: number;        [x]:: number;
[y](): number;  →   [y]((): number;
readonly [z]: number;   readonly [z](: number;
[w]: number;        [w](: number;
```

The fix puts the `]`-truncation in one place (`computed_identifier_or_access_name_text`, which `infer_property_name_text` already delegates to), so the recovered key matches the solver-printed member and collapses to a single entry.

## Project Corpus Impact
- Row: n/a (emit-suite-only / DTS regression).
- Bug family: DTS object-member / computed-name / index-signature inference emit.
- Evidence: TS 6.0.3 (`050880ce`) `--dts-only` per-test runs below.

## Verification
- `scripts/emit/run.sh --dts-only --filter=dynamicNamesErrors` → **1/1** (was 0/1)
- `scripts/emit/run.sh --dts-only --filter=indexSignatures1` → **1/1** (was 0/1)
- `scripts/emit/run.sh --dts-only --filter=computedPropertyNamesDeclarationEmit5` → **3/3** (kept)
- `scripts/emit/run.sh --dts-only --filter=checkingObjectWithThisInNamePositionNoCrash` → **1/1** (kept)
- Adjacent families: `computedPropertyNames` 18/18, `symbolProperty` 4/4, `uniqueSymbol` 8/8. `declarationEmit` 372/374 — the two remaining (`declarationEmitUsingTypeAlias2`, `jsDeclarationEmitExportedClassWithExtends`) are pre-existing failures with no computed/symbol keys, unrelated to this change.
- `cargo test -p tsz-emitter --lib` → 3578 passed, 0 failed. New regression test confirmed to fail (`[x]:: number;`) when the fix is reverted.

## Coordination Notes
- #12316 (the prior 4-test regression) was already cleared on `main` by #12321 and is now closed completed; I released my WIP claim there to avoid duplicated work and moved to this consolidated follow-up.
- This is the root-cause fix for the third trade on this path (#12230 → #12316 → #12321 → here): one missing `]`-truncation, fixed by reuse rather than another point narrowing. No checker/solver semantics touched; no output surgery.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BtZxf5n25XMfdsUrpZo4GN)_