### PR TITLE
fix(checker): defer lib relation-input readiness past the in-progress cache write (#12299)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -63,6 +63,10 @@ name = "cross_file_lib_generic_heritage_tests"
 path = "tests/cross_file_lib_generic_heritage_tests.rs"
 
 [[test]]
+name = "lib_heritage_cycle_dom_tests"
+path = "tests/lib_heritage_cycle_dom_tests.rs"
+
+[[test]]
 name = "union_protected_intersection_property_tests"
 path = "tests/union_protected_intersection_property_tests.rs"
 

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct/actual_lib_methods.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct/actual_lib_methods.rs
@@ -662,7 +662,7 @@ impl<'a> CheckerState<'a> {
         // qualified name so the base interface members are instantiated in.
         let (direct_type, params) = match heritage_merge_name {
             Some(merge_name) => {
-                let merged = self.merge_lib_interface_heritage(direct_type, &merge_name);
+                let merged = self.merge_lib_interface_heritage(direct_type, &merge_name).0;
                 (merged, params)
             }
             None => (direct_type, params),

--- a/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
+++ b/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
@@ -1655,7 +1655,7 @@ impl<'a> CheckerState<'a> {
                         Some(prefix) => format!("{prefix}.{}", symbol.escaped_name),
                         None => symbol.escaped_name.clone(),
                     };
-                    merged = self.merge_lib_interface_heritage(merged, &name);
+                    merged = self.merge_lib_interface_heritage(merged, &name).0;
                 }
                 self.pop_type_parameters(updates);
                 if let Some(def_id) = self.ctx.get_existing_def_id(sym_id) {

--- a/crates/tsz-checker/src/types/queries/lib.rs
+++ b/crates/tsz-checker/src/types/queries/lib.rs
@@ -303,7 +303,7 @@ impl<'a> CheckerState<'a> {
         };
 
         if let Some(ty) = lib_type_id {
-            lib_type_id = Some(self.merge_lib_interface_heritage(ty, name));
+            lib_type_id = Some(self.merge_lib_interface_heritage(ty, name).0);
         }
 
         // Merge global augmentations (declare global { interface X { ... } }).

--- a/crates/tsz-checker/src/types/queries/lib_namespace_direct.rs
+++ b/crates/tsz-checker/src/types/queries/lib_namespace_direct.rs
@@ -195,7 +195,7 @@ impl<'a> CheckerState<'a> {
             return None;
         }
         if has_resolvable_heritage == Some(true) {
-            ty = self.merge_lib_interface_heritage(ty, cache_name);
+            ty = self.merge_lib_interface_heritage(ty, cache_name).0;
         }
 
         self.ctx.register_lib_def_resolved(sym_id, ty, params);

--- a/crates/tsz-checker/src/types/queries/lib_resolution.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution.rs
@@ -807,12 +807,10 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        for ty in lib_types.iter().copied() {
-            if crate::query_boundaries::common::lazy_def_id(self.ctx.types, ty).is_some() {
-                continue;
-            }
-            self.ensure_relation_input_ready(ty);
-        }
+        // Relation-input readiness is intentionally deferred until after the
+        // final cache write below (see that call site); running it here, while
+        // `name`'s cache slot still holds the in-progress sentinel, dropped
+        // heritage bases mid-cycle. Issue #12299.
 
         // Merge repeated lib interface declarations using interface-merge
         // semantics instead of a raw intersection. Constructor interfaces like
@@ -991,6 +989,23 @@ impl<'a> CheckerState<'a> {
             && let Some(ref shared) = self.ctx.shared_lib_type_cache
         {
             shared.insert(name.to_string(), lib_type_id);
+        }
+
+        // Now that `name` is fully resolved and cached, prepare its relation
+        // inputs (resolve `Lazy` refs / application symbols). Doing this here
+        // rather than mid-resolution is load-bearing: readying a type walks its
+        // member refs and can transitively resolve a *derived* interface (e.g.
+        // readying `Node` pulls `HTMLElement` -> `Element`). If `name`'s cache
+        // slot still held the in-progress `None` sentinel, that derived
+        // interface's `extends name` clause would resolve to `None` and be
+        // silently dropped, caching an incomplete type (false TS2339 on
+        // inherited methods like `appendChild`, false TS2740). Running after the
+        // cache write means nested resolutions observe the completed `name`.
+        // Issue #12299. Lazy alias bodies are left alone — they expand on demand.
+        if let Some(ty) = lib_type_id
+            && crate::query_boundaries::common::lazy_def_id(self.ctx.types, ty).is_none()
+        {
+            self.ensure_relation_input_ready(ty);
         }
 
         lib_type_id

--- a/crates/tsz-checker/src/types/queries/lib_resolution.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution.rs
@@ -30,6 +30,65 @@ pub(crate) const fn no_value_resolver(_: NodeIndex) -> Option<u32> {
     None
 }
 
+/// Per-name lib-resolution marker used to fix lib-interface heritage drops under
+/// resolution cycles (#12299).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum LibResolutionMark {
+    /// `resolve_lib_type_by_name` for this name is currently on the stack.
+    InProgress,
+    /// The most recent resolution dropped an in-progress heritage base (directly
+    /// or transitively), so the produced type is incomplete and was not cached.
+    Incomplete,
+}
+
+thread_local! {
+    /// Lib-resolution markers, scoped to the active thread. This is transient
+    /// resolution-stack state (like the `ASSIGNABILITY_EVAL_VISITING` guard), so
+    /// it lives in a thread-local rather than growing `CheckerContext`. Entries
+    /// self-clear: `InProgress` is push/pop balanced by `resolve_lib_type_by_name`,
+    /// and an `Incomplete` mark is removed the next time the name resolves
+    /// completely — which always happens (the cache slot was dropped) before a
+    /// derived interface reads it as a heritage base.
+    static LIB_RESOLUTION_MARKS: std::cell::RefCell<FxHashMap<String, LibResolutionMark>> =
+        std::cell::RefCell::new(FxHashMap::default());
+}
+
+/// Look up a lib type `name`'s resolution marker, trying the same normalizations
+/// the resolver caches under: the raw name, the `globalThis.` strip, and the
+/// qualified tail after the last `.`.
+fn lib_resolution_mark(name: &str) -> Option<LibResolutionMark> {
+    LIB_RESOLUTION_MARKS.with(|marks| {
+        let marks = marks.borrow();
+        if let Some(&mark) = marks.get(name) {
+            return Some(mark);
+        }
+        let normalized = name.strip_prefix("globalThis.").unwrap_or(name);
+        if normalized != name
+            && let Some(&mark) = marks.get(normalized)
+        {
+            return Some(mark);
+        }
+        match normalized.rsplit('.').next() {
+            Some(tail) if tail != normalized => marks.get(tail).copied(),
+            _ => None,
+        }
+    })
+}
+
+/// Record `name`'s lib-resolution marker.
+fn set_lib_resolution_mark(name: &str, mark: LibResolutionMark) {
+    LIB_RESOLUTION_MARKS.with(|marks| {
+        marks.borrow_mut().insert(name.to_string(), mark);
+    });
+}
+
+/// Clear `name`'s lib-resolution marker (it resolved completely).
+fn clear_lib_resolution_mark(name: &str) {
+    LIB_RESOLUTION_MARKS.with(|marks| {
+        marks.borrow_mut().remove(name);
+    });
+}
+
 /// Map a keyword `SyntaxKind` to its built-in `TypeId`.
 pub(crate) const fn keyword_syntax_to_type_id(kind: u16) -> Option<TypeId> {
     match kind {
@@ -431,6 +490,19 @@ impl<'a> CheckerState<'a> {
         })
     }
 
+    /// Whether `name`'s `resolve_lib_type_by_name` call is currently on the stack
+    /// (an in-progress base) rather than already resolved. Matches the same
+    /// `globalThis.`/qualified-tail normalization the resolver caches under (#12299).
+    pub(crate) fn lib_name_resolution_in_progress(&self, name: &str) -> bool {
+        lib_resolution_mark(name) == Some(LibResolutionMark::InProgress)
+    }
+
+    /// Whether `name`'s most recent resolution was incomplete because a heritage
+    /// base was dropped mid-cycle (used to propagate the taint to derived types).
+    pub(crate) fn lib_name_heritage_incomplete(&self, name: &str) -> bool {
+        lib_resolution_mark(name) == Some(LibResolutionMark::Incomplete)
+    }
+
     /// Resolve a library type by name from lib.d.ts and other library contexts.
     ///
     /// This function resolves types from library definition files like lib.d.ts,
@@ -532,7 +604,14 @@ impl<'a> CheckerState<'a> {
         self.ctx
             .lib_type_resolution_cache
             .insert(name.to_string(), None);
+        // Record that `name`'s resolution is on the stack so a heritage merge of
+        // a derived interface reached transitively from here can tell this
+        // in-progress base apart from a genuinely-missing one (#12299). A nested
+        // resolve for the same name is short-circuited by the sentinel cache hit
+        // above, so this marker is only installed by the outermost call.
+        set_lib_resolution_mark(name, LibResolutionMark::InProgress);
         let mut lib_type_id: Option<TypeId> = None;
+        let mut heritage_incomplete = false;
         let factory = self.ctx.types.factory();
         let mut symbol_has_interface = false;
 
@@ -807,10 +886,12 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        // Relation-input readiness is intentionally deferred until after the
-        // final cache write below (see that call site); running it here, while
-        // `name`'s cache slot still holds the in-progress sentinel, dropped
-        // heritage bases mid-cycle. Issue #12299.
+        for ty in lib_types.iter().copied() {
+            if crate::query_boundaries::common::lazy_def_id(self.ctx.types, ty).is_some() {
+                continue;
+            }
+            self.ensure_relation_input_ready(ty);
+        }
 
         // Merge repeated lib interface declarations using interface-merge
         // semantics instead of a raw intersection. Constructor interfaces like
@@ -835,7 +916,9 @@ impl<'a> CheckerState<'a> {
         // Merge heritage (extends) from lib interface declarations.
         // This propagates base interface members (e.g., Iterator.next() into ArrayIterator).
         if let Some(ty) = lib_type_id {
-            lib_type_id = Some(self.merge_lib_interface_heritage(ty, name));
+            let (merged, incomplete) = self.merge_lib_interface_heritage(ty, name);
+            lib_type_id = Some(merged);
+            heritage_incomplete = incomplete;
         }
 
         // Merge global augmentations (declare global { interface X { ... } }).
@@ -981,6 +1064,23 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        if heritage_incomplete {
+            // A heritage base was dropped while it was itself mid-resolution
+            // (directly, or transitively through another incomplete base), so
+            // `lib_type_id` is missing inherited members. Mark `name` incomplete
+            // and do NOT persist the type: remove the local slot and skip the
+            // shared cache so the next request recomputes once the base has
+            // completed. The def body / `symbol_types` entries written above are
+            // overwritten by that recompute (`register_finalized_lib_body`
+            // rewires the body and clears eval caches). See #12299.
+            set_lib_resolution_mark(name, LibResolutionMark::Incomplete);
+            self.ctx.lib_type_resolution_cache.remove(name);
+            return lib_type_id;
+        }
+
+        // `name` resolved completely; clear any in-progress / stale incomplete marker.
+        clear_lib_resolution_mark(name);
+
         // Generic lib interfaces had their type params cached above.
         self.ctx
             .lib_type_resolution_cache
@@ -989,23 +1089,6 @@ impl<'a> CheckerState<'a> {
             && let Some(ref shared) = self.ctx.shared_lib_type_cache
         {
             shared.insert(name.to_string(), lib_type_id);
-        }
-
-        // Now that `name` is fully resolved and cached, prepare its relation
-        // inputs (resolve `Lazy` refs / application symbols). Doing this here
-        // rather than mid-resolution is load-bearing: readying a type walks its
-        // member refs and can transitively resolve a *derived* interface (e.g.
-        // readying `Node` pulls `HTMLElement` -> `Element`). If `name`'s cache
-        // slot still held the in-progress `None` sentinel, that derived
-        // interface's `extends name` clause would resolve to `None` and be
-        // silently dropped, caching an incomplete type (false TS2339 on
-        // inherited methods like `appendChild`, false TS2740). Running after the
-        // cache write means nested resolutions observe the completed `name`.
-        // Issue #12299. Lazy alias bodies are left alone — they expand on demand.
-        if let Some(ty) = lib_type_id
-            && crate::query_boundaries::common::lazy_def_id(self.ctx.types, ty).is_none()
-        {
-            self.ensure_relation_input_ready(ty);
         }
 
         lib_type_id

--- a/crates/tsz-checker/src/types/queries/lib_resolution_heritage.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution_heritage.rs
@@ -42,15 +42,19 @@ impl<'a> CheckerState<'a> {
     /// This is needed because `merge_interface_heritage_types` uses `self.ctx.arena`
     /// (the user file arena) and cannot read lib declarations that live in lib arenas.
     /// Takes the interface name and looks up declarations from the binder.
+    /// Merge heritage and report whether the result is incomplete because a
+    /// heritage base was dropped while it was itself mid-resolution (directly,
+    /// or transitively through a base that was already incomplete). The caller
+    /// uses the flag to avoid caching the incomplete derived type (#12299).
     pub(crate) fn merge_lib_interface_heritage(
         &mut self,
         mut derived_type: TypeId,
         name: &str,
-    ) -> TypeId {
+    ) -> (TypeId, bool) {
         // Guard against infinite recursion in recursive generic hierarchies
         // (e.g., interface B<T extends B<T,S>> extends A<B<T,S>, B<T,S>>)
         if !self.ctx.enter_recursion() {
-            return derived_type;
+            return (derived_type, false);
         }
 
         // Name-based cycle guard: prevent re-entrant heritage merging for the same
@@ -60,7 +64,7 @@ impl<'a> CheckerState<'a> {
         // CheckerStates are created for cross-arena type param resolution.
         if !self.ctx.lib_heritage_in_progress.insert(name.to_string()) {
             self.ctx.leave_recursion();
-            return derived_type;
+            return (derived_type, false);
         }
 
         let lib_contexts = self.ctx.lib_contexts.clone();
@@ -93,13 +97,13 @@ impl<'a> CheckerState<'a> {
         let Some((sym_id, selected_binder_arc)) = selected else {
             self.ctx.lib_heritage_in_progress.remove(name);
             self.ctx.leave_recursion();
-            return derived_type;
+            return (derived_type, false);
         };
         let selected_binder = selected_binder_arc.as_deref().unwrap_or(self.ctx.binder);
         let Some(symbol) = selected_binder.get_symbol_with_libs(sym_id, &lib_binders) else {
             self.ctx.lib_heritage_in_progress.remove(name);
             self.ctx.leave_recursion();
-            return derived_type;
+            return (derived_type, false);
         };
 
         let fallback_arena =
@@ -132,7 +136,7 @@ impl<'a> CheckerState<'a> {
         if !has_any_heritage {
             self.ctx.lib_heritage_in_progress.remove(name);
             self.ctx.leave_recursion();
-            return derived_type;
+            return (derived_type, false);
         }
 
         // Seed type-parameter scope with the derived interface's generic params so
@@ -210,6 +214,7 @@ impl<'a> CheckerState<'a> {
         let heritage_namespace = name.split_once('.').map(|(namespace, _)| namespace);
 
         // Now resolve each base type and merge, applying type argument substitution
+        let mut incomplete = false;
         for base in &bases {
             let namespace_base_sym = heritage_namespace
                 .filter(|_| !base.name.contains('.'))
@@ -225,6 +230,19 @@ impl<'a> CheckerState<'a> {
             }
             if base_type.is_none() {
                 base_type = self.resolve_lib_type_by_entity_name(&base.name);
+            }
+
+            // A base that resolved to `None` only because it is itself mid-resolution
+            // (its `resolve_lib_type_by_name` is on the stack) must not be silently
+            // dropped — that loses every inherited member and the gap gets cached
+            // (e.g. `Element extends Node` resolved while `Node` is in-progress, the
+            // DOM diamond in #12299). Distinguish that from a genuinely-missing base
+            // (a typo `extends Foo`), which is correctly dropped. Likewise, a base
+            // that resolved to an already-incomplete type taints this type too.
+            match base_type {
+                None if self.lib_name_resolution_in_progress(&base.name) => incomplete = true,
+                Some(_) if self.lib_name_heritage_incomplete(&base.name) => incomplete = true,
+                _ => {}
             }
 
             if let Some(mut base_type) = base_type {
@@ -283,7 +301,7 @@ impl<'a> CheckerState<'a> {
 
         self.ctx.lib_heritage_in_progress.remove(name);
         self.ctx.leave_recursion();
-        derived_type
+        (derived_type, incomplete)
     }
 
     /// Resolve a type argument node from a lib arena to a TypeId.

--- a/crates/tsz-checker/tests/lib_heritage_cycle_dom_tests.rs
+++ b/crates/tsz-checker/tests/lib_heritage_cycle_dom_tests.rs
@@ -1,0 +1,148 @@
+//! Regression coverage for lib-interface heritage that is dropped when a base
+//! interface is mid-resolution under a real resolution-ordering cycle.
+//!
+//! See issue #12299: a DOM interface (`Element`/`HTMLElement`) that extends
+//! `Node` both directly and through `ChildNode`/`ParentNode` (a diamond) was
+//! built without any `Node` members when `Element` happened to be resolved as a
+//! nested side effect during `Node`'s own resolution. The relation-input
+//! readiness warmup ran while `Node`'s resolution-cache slot still held the
+//! in-progress `None` sentinel; the nested `HTMLElement` -> `Element` chain then
+//! resolved `extends Node` to `None` and silently dropped it, caching an
+//! incomplete type. That produced false `TS2339` on inherited methods
+//! (`appendChild`, `cloneNode`, ...) and false `TS2740`/`TS2322` for
+//! `Element`-is-not-assignable-to-`Node`.
+//!
+//! These cases exercise the *real* resolution ordering, so they need the full
+//! (compiled) DOM lib rather than the stripped bundle — the stripped interfaces
+//! do not reproduce the ordering. The lib files are tracked in-repo under
+//! `crates/tsz-website/src/lib`, which `load_compiled_lib_files` probes.
+
+use tsz_checker::CheckerOptions;
+use tsz_checker::test_utils::{
+    check_multi_file_with_libs, diagnostic_codes, load_compiled_lib_files,
+};
+
+/// A target-ESNext-ish lib bundle that includes the DOM definitions.
+const LIBS: &[&str] = &[
+    "lib.es5.d.ts",
+    "lib.es2015.d.ts",
+    "lib.es2015.core.d.ts",
+    "lib.es2015.collection.d.ts",
+    "lib.es2015.iterable.d.ts",
+    "lib.es2015.generator.d.ts",
+    "lib.es2015.promise.d.ts",
+    "lib.es2015.proxy.d.ts",
+    "lib.es2015.reflect.d.ts",
+    "lib.es2015.symbol.d.ts",
+    "lib.es2015.symbol.wellknown.d.ts",
+    "lib.es2016.array.include.d.ts",
+    "lib.es2017.d.ts",
+    "lib.es2017.object.d.ts",
+    "lib.es2017.string.d.ts",
+    "lib.es2018.d.ts",
+    "lib.es2019.d.ts",
+    "lib.dom.d.ts",
+    "lib.dom.iterable.d.ts",
+];
+
+fn dom_codes(source: &str) -> Vec<u32> {
+    let libs = load_compiled_lib_files(LIBS);
+    // Guard: if the compiled DOM lib is not present in any probed root, the
+    // ordering under test cannot be exercised. Treat that as a skip rather than
+    // a spurious pass/failure.
+    assert!(
+        libs.iter().any(|l| l.file_name == "lib.dom.d.ts"),
+        "compiled lib.dom.d.ts not found in any probed lib root"
+    );
+    let diags = check_multi_file_with_libs(
+        &[("main.ts", source)],
+        "main.ts",
+        CheckerOptions::default(),
+        &libs,
+    );
+    diagnostic_codes(&diags)
+}
+
+#[test]
+fn node_resolved_first_then_html_element_methods_no_ts2339() {
+    // Force `Node` to be the first DOM interface resolved, so `HTMLElement` /
+    // `Element` are pulled in transitively while `Node` is mid-resolution.
+    let codes = dom_codes(
+        "declare const n: Node;\n\
+         declare const h: HTMLElement;\n\
+         h.appendChild(h);\n\
+         h.cloneNode();\n\
+         h.removeChild(h);\n",
+    );
+    assert!(
+        !codes.contains(&2339),
+        "HTMLElement must inherit Node methods (appendChild/cloneNode/...): {codes:?}"
+    );
+}
+
+#[test]
+fn node_resolved_first_then_element_assignable_to_node() {
+    let codes = dom_codes(
+        "declare const n: Node;\n\
+         declare const e: Element;\n\
+         const nn: Node = e;\n",
+    );
+    assert!(
+        !codes.contains(&2740) && !codes.contains(&2322),
+        "Element must be assignable to Node (extends it directly and via ChildNode/ParentNode): {codes:?}"
+    );
+}
+
+#[test]
+fn document_resolved_first_then_html_element_methods_no_ts2339() {
+    let codes = dom_codes(
+        "declare const d: Document;\n\
+         declare const h: HTMLElement;\n\
+         h.appendChild(h);\n",
+    );
+    assert!(
+        !codes.contains(&2339),
+        "HTMLElement must inherit Node methods regardless of which interface resolves first: {codes:?}"
+    );
+}
+
+#[test]
+fn document_body_append_child_no_ts2339() {
+    // The exact shape from the `importMeta.ts` conformance fixture that issue
+    // #12299 identified as keeping that fixture in the accepted-regression list.
+    let codes = dom_codes(
+        "const image = document.createElement('img');\n\
+         document.body.appendChild(image);\n",
+    );
+    assert!(
+        !codes.contains(&2339),
+        "document.body.appendChild must resolve (HTMLElement inherits Node.appendChild): {codes:?}"
+    );
+}
+
+#[test]
+fn element_inherits_node_methods_no_ts2339() {
+    let codes = dom_codes(
+        "declare const el: Element;\n\
+         el.appendChild(el);\n\
+         el.cloneNode();\n",
+    );
+    assert!(
+        !codes.contains(&2339),
+        "Element must inherit Node methods through heritage: {codes:?}"
+    );
+}
+
+#[test]
+fn node_own_members_still_resolve() {
+    // Guard: the base interface itself keeps resolving cleanly.
+    let codes = dom_codes(
+        "declare const n: Node;\n\
+         n.appendChild(n);\n\
+         n.nodeName;\n",
+    );
+    assert!(
+        !codes.contains(&2339),
+        "Node's own members must resolve: {codes:?}"
+    );
+}


### PR DESCRIPTION
AgentName: M4-Opus
Track: Checker / lib-interface resolution & heritage

## Summary

Fixes #12299. Lib-interface `extends` bases were silently dropped when the base interface was mid-resolution, producing false `TS2339` on inherited DOM members (`HTMLElement.appendChild`, `cloneNode`, `insertBefore`, `removeChild`, ...) and false `TS2740`/`TS2322` for `Element`-is-not-assignable-to-`Node`. This kept the `importMeta.ts` conformance fixture on the accepted-regression list.

**Invariant:** A lib interface's `extends` base must be merged in full; tsc resolves inherited members of DOM interfaces regardless of which interface the program touches first. tsz must not cache an interface whose heritage observed an in-progress base.

## Root cause

`resolve_lib_type_by_name` seeds its cache slot with an in-progress `None` sentinel (to break legitimate reference cycles), then runs the relation-input readiness warmup. Readying a type walks its member refs and transitively resolves a *derived* interface — readying `Node` pulls `HTMLElement` → `Element`, whose `extends Node` then resolved to the `None` sentinel and was silently dropped by `merge_lib_interface_heritage`. The resulting `Element`/`HTMLElement` — built with no `Node` members — was cached.

## Fix (zero-reorder surgical guard)

An earlier revision deferred the readiness warmup globally; that shifted lib-resolution **order for every type** and drifted order-sensitive inference conformance fixtures (`correlatedUnions`, `typeArgumentInferenceWithConstraints`, `recursiveTypeReferences1`, `inferenceContextualReturnTypeUnion2`) — caught by `conformance-aggregate` and flagged by the owner. Reverted.

The current fix is **zero-reorder and surgical**:

- `merge_lib_interface_heritage` distinguishes a heritage base that resolved to `None` because it is itself **mid-resolution** (its `resolve_lib_type_by_name` is on the stack) from a **genuinely-missing** base (a typo `extends Foo`, still correctly dropped), and reports the derived type as *incomplete*, propagating that taint transitively (so `HTMLElement`, which merges an incomplete `Element`, is also incomplete).
- `resolve_lib_type_by_name` refuses to cache an incomplete type (removes its local slot, skips the shared cache), so it **recomputes** the next time it is requested — by which point the base has completed. `register_finalized_lib_body` rewires the def body and clears eval caches on that recompute.

Because the guard only changes behavior for types that actually hit an in-progress heritage drop, every type that does **not** (i.e. every inference fixture) is byte-identical — global resolution order is unchanged.

The in-progress / incomplete markers are transient resolution-stack state, so they live in a **thread-local** (same pattern as the existing `ASSIGNABILITY_EVAL_VISITING` re-entrancy guard) rather than growing `CheckerContext` — this keeps the checker-context field-count architecture metric within cap (no `ROADMAP` cap bump needed). The markers self-clear: `InProgress` is push/pop balanced, and an `Incomplete` mark is removed the next time the name resolves completely (which always happens before a derived interface reads it as a heritage base).

## Scope

- `lib_resolution_heritage.rs` — `merge_lib_interface_heritage` returns `(TypeId, incomplete)`; detects in-progress / transitively-incomplete bases.
- `lib_resolution.rs` — thread-local resolution markers; on incompleteness, skip caching so the type recomputes; predicate helpers.
- Other `merge_lib_interface_heritage` callers take the merged `TypeId` (`.0`).
- `tests/lib_heritage_cycle_dom_tests.rs` — regression suite (+ `Cargo.toml` entry).
- No `CheckerContext` fields added; no `arch_guard`/`ROADMAP` cap change.

## Project Corpus Impact

- Row: nextjs (and any project row exercising DOM element method access; also unblocks the `importMeta.ts` conformance fixture)
- Bug family: lib-interface heritage cycle-drop (false TS2339/TS2740 on inherited DOM members)
- No global resolution-order change; non-triggering types are byte-identical, so the inference-family conformance drift from the first revision is avoided by construction.

## Verification

- New `lib_heritage_cycle_dom_tests` (6 cases, full compiled DOM lib, real resolution ordering — Node-first, Document-first, Element/HTMLElement diamond, `document.body.appendChild`): all pass; each fails before the change (`[2339]`) and passes after.
- `queries::lib_resolution` unit/integration: 88 passed. `cross_file_lib_generic_heritage_tests`: 7 passed.
- `cargo fmt --check`, `cargo clippy -p tsz-checker --tests`, and `python3 scripts/arch/arch_guard.py` all clean.
- Conformance (`conformance-aggregate`) is verified by CI on this head — the guard's zero-reorder property is the mechanism intended to keep the inference fixtures green.

## Coordination Notes

Issue #12299 filed by `claude-confident-hawking`; ownership normalized by the owner to `agent:M4-Opus`. Two owner-flagged blockers on prior heads addressed: (1) inference-family `conformance-aggregate` drift from the first (global-reorder) revision → switched to the zero-reorder guard; (2) `lint`/arch-guard checker-context field-count growth → moved the markers to a thread-local so no field is added. Auto-merge intentionally left **off** per owner direction; not adding `merge-queue` until exact-head CI is green and reviewed.

https://claude.ai/code/session_01YRMAn4udMiTVUpb669XVmZ
