### PR TITLE
fix(cli): normalize try-tsz config deprecation spans

### DIFF
--- a/crates/tsz-cli/src/try_tsz/mod.rs
+++ b/crates/tsz-cli/src/try_tsz/mod.rs
@@ -747,7 +747,7 @@ fn is_typescript_family_file(path: &Path) -> bool {
 }
 
 fn normalize_tsc_diagnostic(cwd: &Path, diagnostic: TscDiagnosticJson) -> ComparableDiagnostic {
-    ComparableDiagnostic {
+    let mut comparable = ComparableDiagnostic {
         file: diagnostic
             .file
             .map(|file| normalize_path_label(cwd, Path::new(&file))),
@@ -758,7 +758,9 @@ fn normalize_tsc_diagnostic(cwd: &Path, diagnostic: TscDiagnosticJson) -> Compar
         code: diagnostic.code,
         category: diagnostic.category,
         message: diagnostic.message,
-    }
+    };
+    normalize_config_deprecation_location(&mut comparable);
+    comparable
 }
 
 fn normalize_tsz_diagnostic(cwd: &Path, diagnostic: &Diagnostic) -> ComparableDiagnostic {
@@ -772,7 +774,7 @@ fn normalize_tsz_diagnostic(cwd: &Path, diagnostic: &Diagnostic) -> ComparableDi
         .and_then(|label| line_column_for_path_label(cwd, label, diagnostic.start))
         .unwrap_or((None, None));
 
-    ComparableDiagnostic {
+    let mut comparable = ComparableDiagnostic {
         file,
         start: Some(diagnostic.start),
         length: Some(diagnostic.length),
@@ -781,6 +783,18 @@ fn normalize_tsz_diagnostic(cwd: &Path, diagnostic: &Diagnostic) -> ComparableDi
         code: diagnostic.code,
         category: category_label(diagnostic.category).to_string(),
         message: diagnostic.message_text.clone(),
+    };
+    normalize_config_deprecation_location(&mut comparable);
+    comparable
+}
+
+fn normalize_config_deprecation_location(diagnostic: &mut ComparableDiagnostic) {
+    if matches!(diagnostic.code, 5101 | 5107) {
+        diagnostic.file = None;
+        diagnostic.start = None;
+        diagnostic.length = None;
+        diagnostic.line = None;
+        diagnostic.column = None;
     }
 }
 
@@ -1735,6 +1749,34 @@ mod tests {
         assert!(diff.extra_tsz.is_empty());
         assert!(diff.missing_tsc.is_empty());
         assert_eq!(diff.order_mismatches, 2);
+    }
+
+    #[test]
+    fn config_deprecation_diagnostics_ignore_location_for_try_tsz_diff() {
+        let message = concat!(
+            "Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0.",
+            " Specify compilerOption '\"ignoreDeprecations\": \"6.0\"' to silence this error.",
+            "\n  Visit https://aka.ms/ts6 for migration information.",
+        );
+        let mut tsc = ComparableDiagnostic {
+            file: None,
+            start: None,
+            length: None,
+            line: None,
+            column: None,
+            code: 5107,
+            category: "error".to_string(),
+            message: message.to_string(),
+        };
+        let mut tsz = diag(5107, "tsconfig.json", message);
+
+        normalize_config_deprecation_location(&mut tsc);
+        normalize_config_deprecation_location(&mut tsz);
+        let diff = diff_diagnostics(&[tsc], &[tsz]);
+
+        assert!(diff.extra_tsz.is_empty());
+        assert!(diff.missing_tsc.is_empty());
+        assert_eq!(diff.order_mismatches, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Track 7 CLI / project corpus smoke infrastructure

## Invariant
When a TypeScript API oracle reports TS5101/TS5107 config deprecation diagnostics without a source span, `try-tsz` compares the deprecation by code/category/message rather than treating the tsz config-file span as a project mismatch. This PR changes only the `try-tsz` comparison/reporting surface; the `tsz` CLI still prints the config span, matching `tsc --pretty false`.

## Scope
- Normalize TS5101/TS5107 locations in `try-tsz` comparable diagnostics.
- Add a unit regression for the yawn-yaml TS5107 one-for-one location mismatch.

## Project Corpus Impact
- Row: n/a.
- Bug family: try-tsz real-project diagnostic comparison.
- Evidence: `mohsen1/yawn-yaml` moved from `mismatch` to `matched-diagnostics` on the rebased head with TypeScript 6.0.3; artifact `/tmp/try-tsz-yawn-yaml-issue12285-rebased.json` reports 0 extra tsz diagnostics, 0 missing tsc diagnostics, and 0 order mismatches.

## Verification
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- `scripts/safe-run.sh cargo nextest run -p tsz-cli try_tsz`
- `scripts/safe-run.sh cargo nextest run -p tsz-cli config_deprecation_diagnostics_ignore_location_for_try_tsz_diff`
- `python3 scripts/arch/arch_guard.py`
- `/Users/mohsen/code/tsz-studio-opus-output-surgery-20260603/scripts/safe-run.sh cargo run --manifest-path /Users/mohsen/code/tsz-studio-opus-output-surgery-20260603/Cargo.toml -p tsz-cli --bin try-tsz -- --json /tmp/try-tsz-yawn-yaml-issue12285-rebased.json` from `/tmp/tsz-yawn-yaml-issue12285`

## Coordination Notes
- Addresses the remaining TS5107 location-only mismatch in #12285 after #12324 removed the rootDir/declaration-dependency extras.
- `scripts/agents/ensure-agent-labels.sh --audit` still reports pre-existing noncanonical labels/issues, but no open PR is missing or has conflicting agent ownership.
