### PR TITLE
fix(bench): catch up after stale active publishes

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1669,10 +1669,10 @@ jobs:
             sleep 60
           done
 
-          if [[ "$(gh run view "${ACTIVE_RUN_ID}" --repo "${GITHUB_REPOSITORY}" --json jobs --jq '[.jobs[] | select(.name == "bench-publish" and .conclusion == "success")] | length')" -gt 0 ]]; then
-            echo "Active Bench run ${ACTIVE_RUN_ID} published benchmark data; skipping catch-up dispatch."
-            exit 0
-          fi
+          active_published="$(
+            gh run view "${ACTIVE_RUN_ID}" --repo "${GITHUB_REPOSITORY}" --json jobs \
+              --jq '[.jobs[] | select(.name == "bench-publish" and .conclusion == "success")] | length'
+          )"
 
           main_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha' 2>/dev/null || true)"
           if [[ -z "${main_sha}" ]]; then
@@ -1682,6 +1682,13 @@ jobs:
           if [[ "${target_sha}" != "${main_sha}" ]]; then
             echo "Skipped Bench target ${target_sha} is behind current main ${main_sha}; a newer main Bench event owns catch-up."
             exit 0
+          fi
+          if [[ "${active_published}" -gt 0 && "${ACTIVE_RUN_SHA}" == "${target_sha}" ]]; then
+            echo "Active Bench run ${ACTIVE_RUN_ID} published benchmark data for ${target_sha}; skipping catch-up dispatch."
+            exit 0
+          fi
+          if [[ "${active_published}" -gt 0 ]]; then
+            echo "Active Bench run ${ACTIVE_RUN_ID} published ${ACTIVE_RUN_SHA}, but skipped target ${target_sha} is still current main; dispatching catch-up."
           fi
 
           active_dispatches="$(

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -230,14 +230,20 @@ assert.match(
 
 assert.match(
   workflow,
-  /select\(\.name == "bench-publish" and \.conclusion == "success"\)[\s\S]+Active Bench run \$\{ACTIVE_RUN_ID\} published benchmark data; skipping catch-up dispatch\./,
-  "active-run catch-up should stand down when the blocking Bench run published data",
+  /active_published="\$\([\s\S]+select\(\.name == "bench-publish" and \.conclusion == "success"\)[\s\S]+if \[\[ "\$\{active_published\}" -gt 0 && "\$\{ACTIVE_RUN_SHA\}" == "\$\{target_sha\}" \]\]; then[\s\S]+Active Bench run \$\{ACTIVE_RUN_ID\} published benchmark data for \$\{target_sha\}; skipping catch-up dispatch\./,
+  "active-run catch-up should stand down when the blocking Bench run published the skipped target",
 );
 
 assert.match(
   workflow,
   /if \[\[ "\$\{target_sha\}" != "\$\{main_sha\}" \]\]; then[\s\S]+Skipped Bench target \$\{target_sha\} is behind current main \$\{main_sha\}; a newer main Bench event owns catch-up\./,
   "active-run catch-up should only dispatch from the skipped duplicate that still represents current main",
+);
+
+assert.match(
+  workflow,
+  /if \[\[ "\$\{active_published\}" -gt 0 \]\]; then[\s\S]+Active Bench run \$\{ACTIVE_RUN_ID\} published \$\{ACTIVE_RUN_SHA\}, but skipped target \$\{target_sha\} is still current main; dispatching catch-up\./,
+  "active-run catch-up should not let an older active publish suppress a current-main catch-up",
 );
 
 assert.match(


### PR DESCRIPTION
AgentName: Studio-A

## Track
project corpus / benchmark artifact truth tooling

## Invariant
A skipped automatic Bench run for current `main` must not stand down merely because an older active Bench run published. The active publish is sufficient only when it published the same target SHA; otherwise, if the skipped target is still current `main`, the catch-up path must dispatch a fresh benchmark.

## Scope
Updates `.github/workflows/bench.yml` and `scripts/bench/test-bench-workflow-cloudbuild-prep.mjs` only.

## Project Corpus Impact
- Row: n/a
- Bug family: benchmark artifact freshness / catch-up scheduling
- Impact: No project-row definitions or compiler behavior changed. This fixes benchmark artifact truth after the observed #10649 chain where active publisher `26884030166` for `eeca294605` published successfully, causing catch-up watcher `26886626347` for newer target `86cb1e5980` to skip dispatch even though public `latest.json` remained older than current `main` and pre-#12330.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`
- `node scripts/bench/validate-project-metadata.mjs`
- `node scripts/bench/project-row-summary.mjs --markdown`
- `git diff --check origin/main..HEAD`

## Coordination Notes
Opened as draft for CI. No open overlapping Bench catch-up PR was found; #12289 is a Studio-B performance PR and does not touch this workflow path. #10649 remains open until a fresh current benchmark artifact is published and cited.