### PR TITLE
fix(emit): close js declarations class parity

### DIFF
--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -570,7 +570,7 @@ pub struct Printer<'a> {
 
     /// For CommonJS class exports, emit `exports.X = X;` immediately after class
     /// declaration and before post-class lowered statements (static fields/blocks).
-    pub(crate) pending_commonjs_class_export_name: Option<(NodeIndex, String)>,
+    pub(crate) pending_commonjs_class_export_name: Option<(NodeIndex, String, Vec<String>)>,
 
     /// Names of namespaces already declared with `var name;` to avoid duplicates.
     pub(crate) declared_namespace_names: FxHashSet<String>,

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -1966,18 +1966,20 @@ impl<'a> Printer<'a> {
         if self
             .pending_commonjs_class_export_name
             .as_ref()
-            .is_some_and(|(class_idx, _)| *class_idx == _idx)
+            .is_some_and(|(class_idx, _, _)| *class_idx == _idx)
         {
-            let (_, class_name) = self
+            let (_, local_name, export_names) = self
                 .pending_commonjs_class_export_name
                 .take()
                 .expect("pending class export should be present");
-            self.write_line();
-            self.write("exports.");
-            self.write(&class_name);
-            self.write(" = ");
-            self.write(&class_name);
-            self.write(";");
+            for export_name in export_names {
+                self.write_line();
+                self.write("exports.");
+                self.write(&export_name);
+                self.write(" = ");
+                self.write(&local_name);
+                self.write(";");
+            }
         }
 
         self.emit_class_es6_after_body(ClassEs6AfterBody {

--- a/crates/tsz-emitter/src/emitter/module_emission/exports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/exports.rs
@@ -881,7 +881,7 @@ impl<'a> Printer<'a> {
                         // Keep named class export assignment immediately after the class
                         // declaration and before lowered static blocks/IIFEs.
                         self.pending_commonjs_class_export_name =
-                            Some((export.export_clause, name));
+                            Some((export.export_clause, name.clone(), vec![name]));
                         named_export_emitted_with_class = true;
                     }
 
@@ -1025,7 +1025,7 @@ impl<'a> Printer<'a> {
                                     None
                                 };
                                 self.pending_commonjs_class_export_name =
-                                    Some((export.export_clause, name.clone()));
+                                    Some((export.export_clause, name.clone(), vec![name.clone()]));
                                 self.emit_class_es6_with_options(
                                     clause_node,
                                     export.export_clause,

--- a/crates/tsz-emitter/src/emitter/source_file/commonjs_export_class_es5_computed_order_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/commonjs_export_class_es5_computed_order_tests.rs
@@ -129,3 +129,37 @@ fn export_class_es5_without_computed_members_still_emits_export() {
         "The class must be lowered to an ES5 IIFE binding.\nOutput:\n{output}"
     );
 }
+
+#[test]
+fn export_alias_before_es5_class_emits_alias_before_class_export() {
+    let source = "export { Renamed as Alias };\nexport class Renamed {}\n";
+    let output = emit_commonjs(source, ScriptTarget::ES5, false);
+
+    let alias_line = line_index_starts_with(&output, "exports.Alias = Renamed;");
+    let class_line = line_index_starts_with(&output, "exports.Renamed = Renamed;");
+    assert!(
+        alias_line.is_some() && class_line.is_some(),
+        "ES5 class export aliases should both emit at the class IIFE boundary.\nOutput:\n{output}"
+    );
+    assert!(
+        alias_line < class_line,
+        "A source-earlier alias export must precede the direct class export in ES5 output.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn export_alias_before_es2015_class_keeps_native_class_export_order() {
+    let source = "export { Later as Alias };\nexport class Later {}\n";
+    let output = emit_commonjs(source, ScriptTarget::ES2015, false);
+
+    let class_line = line_index_starts_with(&output, "exports.Later = Later;");
+    let alias_line = line_index_starts_with(&output, "exports.Alias = Later;");
+    assert!(
+        class_line.is_some() && alias_line.is_some(),
+        "ES2015 class export and alias export should both emit once.\nOutput:\n{output}"
+    );
+    assert!(
+        class_line < alias_line,
+        "ES2015 native class output should keep the direct class export before the later alias assignment.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/source_file/derived_constructor_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/derived_constructor_tests.rs
@@ -117,6 +117,23 @@ fn super_arg_this_without_fields_captures_this_es5_renamed() {
 }
 
 #[test]
+fn extends_null_constructor_without_super_uses_captured_this_recovery() {
+    let source =
+        "class NilDerived extends null {\n    constructor() {\n        this.value = 1;\n    }\n}\n";
+
+    let es5_output = emit(source, ScriptTarget::ES5);
+
+    assert!(
+        es5_output.contains("function NilDerived() {\n        _this.value = 1;\n    }"),
+        "`extends null` constructors without `super()` should preserve tsc's captured-this recovery shape.\nOutput:\n{es5_output}"
+    );
+    assert!(
+        !es5_output.contains("\n        this.value = 1;"),
+        "`extends null` no-super recovery should not leave constructor `this` unsubstituted.\nOutput:\n{es5_output}"
+    );
+}
+
+#[test]
 fn super_arg_without_this_keeps_inline_tail_return_es5() {
     // Negative / fallback case: a super-call argument that does NOT reference
     // `this` keeps the inline tail-super-return form, proving the capture is

--- a/crates/tsz-emitter/src/emitter/transform_dispatch.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch.rs
@@ -628,11 +628,22 @@ impl<'a> Printer<'a> {
                         // body but BEFORE any lowered static block IIFEs or static field
                         // initializers. emit_class_es6_with_options consumes this field
                         // at the class-body boundary.
-                        if let Some(name_id) = names.first()
-                            && let Some(ident) = self.arena.identifiers.get(*name_id as usize)
+                        if let Some(class) = self.arena.get_class(node)
+                            && let Some(local_name) = self.get_identifier_text_opt(class.name)
                         {
+                            let export_names = if self.ctx.target_es5 {
+                                self.commonjs_export_name_strings(names.as_ref())
+                            } else {
+                                vec![local_name.clone()]
+                            };
+                            for export_name in &export_names {
+                                self.ctx
+                                    .module_state
+                                    .inline_exported_names
+                                    .insert(export_name.clone());
+                            }
                             self.pending_commonjs_class_export_name =
-                                Some((idx, ident.escaped_text.clone()));
+                                Some((idx, local_name, export_names));
                         }
                         let export_name = names.first().copied();
                         self.with_cjs_export_body_mask(|this| {
@@ -641,18 +652,20 @@ impl<'a> Printer<'a> {
                         // If the deferred export was NOT consumed (e.g. the class had no
                         // static blocks/fields, so emit_class_es6_with_options was not
                         // reached, or the class was ambient), emit it now as a fallback.
-                        if let Some((_, class_name)) =
+                        if let Some((_, local_name, export_names)) =
                             self.pending_commonjs_class_export_name.take()
                         {
                             if !self.writer.is_at_line_start() {
                                 self.write_line();
                             }
-                            self.write("exports.");
-                            self.write(&class_name);
-                            self.write(" = ");
-                            self.write(&class_name);
-                            self.write(";");
-                            self.write_line();
+                            for export_name in export_names {
+                                self.write("exports.");
+                                self.write(&export_name);
+                                self.write(" = ");
+                                self.write(&local_name);
+                                self.write(";");
+                                self.write_line();
+                            }
                         }
                     } else {
                         let export_name = names.first().copied();
@@ -1222,7 +1235,7 @@ impl<'a> Printer<'a> {
                 emitter.set_function_name(name.to_string());
             } else if let Some(ref name) = self.anonymous_default_export_name {
                 emitter.set_function_name(name.clone());
-            } else if let Some((_, ref name)) = self.pending_commonjs_class_export_name {
+            } else if let Some((_, ref name, _)) = self.pending_commonjs_class_export_name {
                 emitter.set_function_name(name.clone());
             } else if let Some(name) = self.resolve_class_expr_binding_name(_idx) {
                 emitter.set_function_name(name);

--- a/crates/tsz-emitter/src/emitter/transform_dispatch.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch.rs
@@ -12,85 +12,15 @@ use std::sync::Arc;
 use tracing::debug;
 use tsz_parser::parser::node::NodeAccess;
 
+#[path = "transform_dispatch_directive.rs"]
+mod transform_dispatch_directive;
+use transform_dispatch_directive::EmitDirective;
+
 #[path = "transform_dispatch_chain.rs"]
 mod transform_dispatch_chain;
 
 #[path = "transform_dispatch_class_binding.rs"]
 mod transform_dispatch_class_binding;
-
-enum EmitDirective {
-    Identity,
-    ES5Class {
-        class_node: NodeIndex,
-    },
-    ES5ClassExpression {
-        class_node: NodeIndex,
-    },
-    ES5Namespace {
-        namespace_node: NodeIndex,
-        should_declare_var: bool,
-    },
-    ES5Enum {
-        enum_node: NodeIndex,
-    },
-    CommonJSExport {
-        names: Arc<[IdentifierId]>,
-        is_default: bool,
-        inner: Box<Self>,
-    },
-    CommonJSExportDefaultExpr,
-    CommonJSExportDefaultClassES5 {
-        class_node: NodeIndex,
-    },
-    ES5ArrowFunction {
-        arrow_node: NodeIndex,
-        captures_this: bool,
-        captures_arguments: bool,
-        class_alias: Option<Arc<str>>,
-    },
-    ES5AsyncFunction {
-        function_node: NodeIndex,
-    },
-    ES5GeneratorFunction {
-        function_node: NodeIndex,
-    },
-    ES5ForOf {
-        for_of_node: NodeIndex,
-    },
-    ES5ObjectLiteral {
-        object_literal: NodeIndex,
-    },
-    ES5ArrayLiteral {
-        array_literal: NodeIndex,
-    },
-    ES5CallSpread {
-        call_expr: NodeIndex,
-    },
-    ES5NewSpread {
-        new_expr: NodeIndex,
-    },
-    ES5VariableDeclarationList {
-        decl_list: NodeIndex,
-    },
-    ES5FunctionParameters {
-        function_node: NodeIndex,
-    },
-    ES5TemplateLiteral,
-    SubstituteThis {
-        capture_name: Arc<str>,
-    },
-    SubstituteArguments,
-    ES5SuperCall,
-    TC39Decorators {
-        class_node: NodeIndex,
-        function_name: Option<String>,
-    },
-    ModuleWrapper {
-        format: crate::context::transform::ModuleFormat,
-        dependencies: Arc<[String]>,
-    },
-    Chain(Vec<Self>),
-}
 
 impl<'a> Printer<'a> {
     // =========================================================================

--- a/crates/tsz-emitter/src/emitter/transform_dispatch_chain.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch_chain.rs
@@ -42,13 +42,14 @@ impl<'a> Printer<'a> {
                 if self
                     .pending_commonjs_class_export_name
                     .as_ref()
-                    .is_some_and(|(class_idx, _)| *class_idx == *class_node)
+                    .is_some_and(|(class_idx, _, _)| *class_idx == *class_node)
                 {
-                    let (_, export_name) = self
+                    let (_, local_name, export_names) = self
                         .pending_commonjs_class_export_name
                         .take()
                         .expect("pending class export should be present");
-                    es5_emitter.set_pending_commonjs_class_export_name(Some(export_name));
+                    es5_emitter
+                        .set_pending_commonjs_class_export_bindings(local_name, export_names);
                 }
                 let es5_output = self.emit_es5_class_output(
                     &mut es5_emitter,
@@ -254,11 +255,22 @@ impl<'a> Printer<'a> {
                 } else if !*is_default && node.kind == syntax_kind_ext::CLASS_DECLARATION {
                     // Use deferred export mechanism for class declarations so
                     // exports.X = X; appears before lowered static blocks/IIFEs.
-                    if let Some(name_id) = names.first()
-                        && let Some(ident) = self.arena.identifiers.get(*name_id as usize)
+                    if let Some(class) = self.arena.get_class(node)
+                        && let Some(local_name) = self.get_identifier_text_opt(class.name)
                     {
+                        let export_names = if self.ctx.target_es5 {
+                            self.commonjs_export_name_strings(names.as_ref())
+                        } else {
+                            vec![local_name.clone()]
+                        };
+                        for export_name in &export_names {
+                            self.ctx
+                                .module_state
+                                .inline_exported_names
+                                .insert(export_name.clone());
+                        }
                         self.pending_commonjs_class_export_name =
-                            Some((idx, ident.escaped_text.clone()));
+                            Some((idx, local_name, export_names));
                     }
                     let export_name = names.first().copied();
                     self.with_cjs_export_body_mask(|this| {
@@ -268,16 +280,20 @@ impl<'a> Printer<'a> {
                             this.emit_chained_directive(node, idx, directives, index - 1);
                         }
                     });
-                    if let Some((_, class_name)) = self.pending_commonjs_class_export_name.take() {
+                    if let Some((_, local_name, export_names)) =
+                        self.pending_commonjs_class_export_name.take()
+                    {
                         if !self.writer.is_at_line_start() {
                             self.write_line();
                         }
-                        self.write("exports.");
-                        self.write(&class_name);
-                        self.write(" = ");
-                        self.write(&class_name);
-                        self.write(";");
-                        self.write_line();
+                        for export_name in export_names {
+                            self.write("exports.");
+                            self.write(&export_name);
+                            self.write(" = ");
+                            self.write(&local_name);
+                            self.write(";");
+                            self.write_line();
+                        }
                     }
                 } else {
                     let export_name = names.first().copied();

--- a/crates/tsz-emitter/src/emitter/transform_dispatch_directive.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch_directive.rs
@@ -1,0 +1,78 @@
+use super::IdentifierId;
+use crate::context::transform::ModuleFormat;
+use std::sync::Arc;
+use tsz_parser::parser::NodeIndex;
+
+pub(super) enum EmitDirective {
+    Identity,
+    ES5Class {
+        class_node: NodeIndex,
+    },
+    ES5ClassExpression {
+        class_node: NodeIndex,
+    },
+    ES5Namespace {
+        namespace_node: NodeIndex,
+        should_declare_var: bool,
+    },
+    ES5Enum {
+        enum_node: NodeIndex,
+    },
+    CommonJSExport {
+        names: Arc<[IdentifierId]>,
+        is_default: bool,
+        inner: Box<Self>,
+    },
+    CommonJSExportDefaultExpr,
+    CommonJSExportDefaultClassES5 {
+        class_node: NodeIndex,
+    },
+    ES5ArrowFunction {
+        arrow_node: NodeIndex,
+        captures_this: bool,
+        captures_arguments: bool,
+        class_alias: Option<Arc<str>>,
+    },
+    ES5AsyncFunction {
+        function_node: NodeIndex,
+    },
+    ES5GeneratorFunction {
+        function_node: NodeIndex,
+    },
+    ES5ForOf {
+        for_of_node: NodeIndex,
+    },
+    ES5ObjectLiteral {
+        object_literal: NodeIndex,
+    },
+    ES5ArrayLiteral {
+        array_literal: NodeIndex,
+    },
+    ES5CallSpread {
+        call_expr: NodeIndex,
+    },
+    ES5NewSpread {
+        new_expr: NodeIndex,
+    },
+    ES5VariableDeclarationList {
+        decl_list: NodeIndex,
+    },
+    ES5FunctionParameters {
+        function_node: NodeIndex,
+    },
+    ES5TemplateLiteral,
+    SubstituteThis {
+        capture_name: Arc<str>,
+    },
+    SubstituteArguments,
+    ES5SuperCall,
+    TC39Decorators {
+        class_node: NodeIndex,
+        function_name: Option<String>,
+    },
+    ModuleWrapper {
+        format: ModuleFormat,
+        dependencies: Arc<[String]>,
+    },
+    Chain(Vec<Self>),
+}

--- a/crates/tsz-emitter/src/lowering/core.rs
+++ b/crates/tsz-emitter/src/lowering/core.rs
@@ -687,9 +687,15 @@ impl<'a> LoweringPass<'a> {
             return;
         }
 
+        let re_exported = self.ctx.options.target == ScriptTarget::ES5
+            && self
+                .get_identifier_text_ref(class.name)
+                .is_some_and(|n| self.re_exported_names.contains(n));
+
         let mut is_exported = self.is_commonjs()
             && !self.has_export_assignment
             && (force_export
+                || re_exported
                 || self
                     .arena
                     .has_modifier(&class.modifiers, SyntaxKind::ExportKeyword));
@@ -827,8 +833,10 @@ impl<'a> LoweringPass<'a> {
         // Wrap with CommonJS export if needed
         let final_directive = if is_exported {
             if let Some(export_name) = class_name {
+                let local_name = self.get_identifier_text_ref(class.name);
+                let export_names = self.commonjs_export_names_for_local(local_name, export_name);
                 let export_directive = TransformDirective::CommonJSExport {
-                    names: Arc::from(vec![export_name]),
+                    names: export_names,
                     is_default,
                     inner: Box::new(TransformDirective::Identity),
                 };

--- a/crates/tsz-emitter/src/lowering/helpers.rs
+++ b/crates/tsz-emitter/src/lowering/helpers.rs
@@ -6,6 +6,7 @@
 use super::*;
 use crate::emitter::JsxEmit;
 use crate::transforms::emit_utils;
+use tsz_common::ScriptTarget;
 use tsz_parser::parser::node::NodeAccess;
 
 impl<'a> LoweringPass<'a> {
@@ -45,9 +46,9 @@ impl<'a> LoweringPass<'a> {
         }
     }
 
-    /// Walk source-order statements once and record every export alias
-    /// attached to local enum/namespace IIFE bindings so the emitter can fold
-    /// every alias into the IIFE tail.
+    /// Walk source-order statements once and record every export alias attached
+    /// to local enum/namespace IIFE bindings or ES5-lowered class bindings so
+    /// the emitter can place every alias at the declaration boundary.
     fn collect_all_export_aliases_in_order(&mut self, statements: &tsz_parser::parser::NodeList) {
         let mut foldable_locals: rustc_hash::FxHashSet<String> = rustc_hash::FxHashSet::default();
         for &stmt_idx in &statements.nodes {
@@ -110,6 +111,13 @@ impl<'a> LoweringPass<'a> {
                         )
                 })
             }
+            k if k == syntax_kind_ext::CLASS_DECLARATION => {
+                self.ctx.options.target == ScriptTarget::ES5
+                    && self
+                        .arena
+                        .get_class(node)
+                        .is_some_and(|class_decl| !self.arena.is_declare(&class_decl.modifiers))
+            }
             _ => false,
         }
     }
@@ -126,6 +134,11 @@ impl<'a> LoweringPass<'a> {
                 let module_decl = self.arena.get_module(node)?;
                 self.get_module_root_name_text(module_decl.name)
             }
+            k if k == syntax_kind_ext::CLASS_DECLARATION => {
+                let class_decl = self.arena.get_class(node)?;
+                self.get_identifier_text_ref(class_decl.name)
+                    .map(str::to_string)
+            }
             _ => None,
         }
     }
@@ -141,6 +154,10 @@ impl<'a> LoweringPass<'a> {
                 let module_decl = self.arena.get_module(node)?;
                 self.get_module_root_name(module_decl.name)
             }
+            k if k == syntax_kind_ext::CLASS_DECLARATION => {
+                let class_decl = self.arena.get_class(node)?;
+                self.get_identifier_id(class_decl.name)
+            }
             _ => None,
         }
     }
@@ -155,6 +172,12 @@ impl<'a> LoweringPass<'a> {
             }
             k if k == syntax_kind_ext::MODULE_DECLARATION => {
                 self.arena.get_module(node).is_some_and(|decl| {
+                    self.arena
+                        .has_modifier(&decl.modifiers, SyntaxKind::ExportKeyword)
+                })
+            }
+            k if k == syntax_kind_ext::CLASS_DECLARATION => {
+                self.arena.get_class(node).is_some_and(|decl| {
                     self.arena
                         .has_modifier(&decl.modifiers, SyntaxKind::ExportKeyword)
                 })

--- a/crates/tsz-emitter/src/transforms/class_es5.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5.rs
@@ -140,8 +140,7 @@ impl<'a> ClassES5Emitter<'a> {
     /// Schedule a deferred CommonJS `exports.<name> = <name>;` assignment for a
     /// top-level `export class` lowered to an ES5 IIFE.
     pub fn set_pending_commonjs_class_export_name(&mut self, name: Option<String>) {
-        self.pending_commonjs_class_export_name =
-            name.clone().map(|name| (name.clone(), vec![name]));
+        self.pending_commonjs_class_export_name = name.map(|name| (name.clone(), vec![name]));
     }
 
     pub fn set_pending_commonjs_class_export_bindings(

--- a/crates/tsz-emitter/src/transforms/class_es5.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5.rs
@@ -94,7 +94,7 @@ pub struct ClassES5Emitter<'a> {
     /// Deferred CommonJS `exports.<name> = <name>;` assignment for a top-level
     /// `export class` lowered to an ES5 IIFE. Emitted right after the IIFE
     /// statement, before trailing computed-property side effects.
-    pending_commonjs_class_export_name: Option<String>,
+    pending_commonjs_class_export_name: Option<(String, Vec<String>)>,
 }
 
 impl<'a> ClassES5Emitter<'a> {
@@ -140,7 +140,16 @@ impl<'a> ClassES5Emitter<'a> {
     /// Schedule a deferred CommonJS `exports.<name> = <name>;` assignment for a
     /// top-level `export class` lowered to an ES5 IIFE.
     pub fn set_pending_commonjs_class_export_name(&mut self, name: Option<String>) {
-        self.pending_commonjs_class_export_name = name;
+        self.pending_commonjs_class_export_name =
+            name.clone().map(|name| (name.clone(), vec![name]));
+    }
+
+    pub fn set_pending_commonjs_class_export_bindings(
+        &mut self,
+        local_name: String,
+        export_names: Vec<String>,
+    ) {
+        self.pending_commonjs_class_export_name = Some((local_name, export_names));
     }
 
     pub fn set_block_scope_reserved_names(&mut self, names: Vec<String>) {
@@ -546,9 +555,9 @@ impl<'a> ClassES5Emitter<'a> {
         }
         printer.set_block_scope_shadowed_names(self.block_scope_shadowed_names.clone());
         printer.set_block_scope_reserved_names(self.block_scope_reserved_names.clone());
-        printer.set_pending_commonjs_class_export_name(
-            self.pending_commonjs_class_export_name.clone(),
-        );
+        if let Some((local_name, export_names)) = self.pending_commonjs_class_export_name.clone() {
+            printer.set_pending_commonjs_class_export_bindings(local_name, export_names);
+        }
         if !self.outer_reserved_for_generator_state.is_empty() {
             printer.set_outer_reserved_for_generator_state(
                 self.outer_reserved_for_generator_state.clone(),

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
@@ -1803,10 +1803,61 @@ impl<'a> AstToIr<'a> {
             .expect("NodeIndex must be valid in arena");
         // Both TYPE_ASSERTION and AS_EXPRESSION use TypeAssertionData
         if let Some(assertion) = self.arena.get_type_assertion(node) {
-            self.convert_expression(assertion.expression)
+            let expression = self.convert_expression(assertion.expression);
+            if let Some(comment) = self.leading_block_comment_before_node(node).or_else(|| {
+                self.leading_block_comments_before_expression(node, assertion.expression)
+            }) {
+                IRNode::LeadingCommentExpr {
+                    comment: comment.into(),
+                    expression: Box::new(expression),
+                }
+            } else {
+                expression
+            }
         } else {
             IRNode::ASTRef(idx)
         }
+    }
+
+    pub(super) fn leading_block_comments_before_expression(
+        &self,
+        node: &Node,
+        expression_idx: NodeIndex,
+    ) -> Option<String> {
+        let source_text = self.source_text?;
+        let expr_node = self.arena.get(expression_idx)?;
+        if node.pos >= expr_node.pos {
+            return None;
+        }
+        let start = node.pos as usize;
+        let end = (expr_node.pos as usize).min(source_text.len());
+        let mut comments = Vec::new();
+        for comment in tsz_common::comments::get_comment_ranges(source_text) {
+            let comment_start = comment.pos as usize;
+            let comment_end = comment.end as usize;
+            if comment_start >= end {
+                break;
+            }
+            if comment_start >= start && comment_end <= end && comment.is_multi_line {
+                comments.push(source_text[comment_start..comment_end].to_string());
+            }
+        }
+        (!comments.is_empty()).then(|| comments.join(" "))
+    }
+
+    pub(super) fn leading_block_comment_before_node(&self, node: &Node) -> Option<String> {
+        let source_text = self.source_text?;
+        let node_start = node.pos as usize;
+        let comment = tsz_common::comments::get_comment_ranges(source_text)
+            .into_iter()
+            .take_while(|comment| comment.end as usize <= node_start)
+            .filter(|comment| comment.is_multi_line)
+            .last()?;
+        let comment_end = comment.end as usize;
+        if comment_end > node_start || !source_text[comment_end..node_start].trim().is_empty() {
+            return None;
+        }
+        Some(source_text[comment.pos as usize..comment_end].to_string())
     }
 
     fn convert_non_null(&self, idx: NodeIndex) -> IRNode {

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
@@ -8,7 +8,7 @@ use crate::context::transform::TransformDirective;
 use crate::transforms::async_es5_ir::AsyncES5Transformer;
 use rustc_hash::FxHashSet;
 use tsz_common::common::ModuleKind;
-use tsz_parser::parser::node::{FunctionData, Node};
+use tsz_parser::parser::node::FunctionData;
 use tsz_parser::parser::node_flags;
 use tsz_parser::syntax::transform_utils::{
     collect_class_computed_name_this_references, contains_new_target_reference,
@@ -1794,70 +1794,6 @@ impl<'a> AstToIr<'a> {
         }
         // Await expressions are handled by the async transform.
         IRNode::ASTRef(idx)
-    }
-
-    fn convert_type_assertion(&self, idx: NodeIndex) -> IRNode {
-        let node = self
-            .arena
-            .get(idx)
-            .expect("NodeIndex must be valid in arena");
-        // Both TYPE_ASSERTION and AS_EXPRESSION use TypeAssertionData
-        if let Some(assertion) = self.arena.get_type_assertion(node) {
-            let expression = self.convert_expression(assertion.expression);
-            if let Some(comment) = self.leading_block_comment_before_node(node).or_else(|| {
-                self.leading_block_comments_before_expression(node, assertion.expression)
-            }) {
-                IRNode::LeadingCommentExpr {
-                    comment: comment.into(),
-                    expression: Box::new(expression),
-                }
-            } else {
-                expression
-            }
-        } else {
-            IRNode::ASTRef(idx)
-        }
-    }
-
-    pub(super) fn leading_block_comments_before_expression(
-        &self,
-        node: &Node,
-        expression_idx: NodeIndex,
-    ) -> Option<String> {
-        let source_text = self.source_text?;
-        let expr_node = self.arena.get(expression_idx)?;
-        if node.pos >= expr_node.pos {
-            return None;
-        }
-        let start = node.pos as usize;
-        let end = (expr_node.pos as usize).min(source_text.len());
-        let mut comments = Vec::new();
-        for comment in tsz_common::comments::get_comment_ranges(source_text) {
-            let comment_start = comment.pos as usize;
-            let comment_end = comment.end as usize;
-            if comment_start >= end {
-                break;
-            }
-            if comment_start >= start && comment_end <= end && comment.is_multi_line {
-                comments.push(source_text[comment_start..comment_end].to_string());
-            }
-        }
-        (!comments.is_empty()).then(|| comments.join(" "))
-    }
-
-    pub(super) fn leading_block_comment_before_node(&self, node: &Node) -> Option<String> {
-        let source_text = self.source_text?;
-        let node_start = node.pos as usize;
-        let comment = tsz_common::comments::get_comment_ranges(source_text)
-            .into_iter()
-            .take_while(|comment| comment.end as usize <= node_start)
-            .filter(|comment| comment.is_multi_line)
-            .last()?;
-        let comment_end = comment.end as usize;
-        if comment_end > node_start || !source_text[comment_end..node_start].trim().is_empty() {
-            return None;
-        }
-        Some(source_text[comment.pos as usize..comment_end].to_string())
     }
 
     fn convert_non_null(&self, idx: NodeIndex) -> IRNode {

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_comments.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_comments.rs
@@ -9,6 +9,8 @@
 
 use super::AstToIr;
 use crate::transforms::ir::IRNode;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::Node;
 use tsz_parser::parser::syntax_kind_ext;
 
 impl<'a> AstToIr<'a> {
@@ -242,6 +244,47 @@ impl<'a> AstToIr<'a> {
             i += 1;
         }
         None
+    }
+
+    pub(super) fn leading_block_comments_before_expression(
+        &self,
+        node: &Node,
+        expression_idx: NodeIndex,
+    ) -> Option<String> {
+        let source_text = self.source_text?;
+        let expr_node = self.arena.get(expression_idx)?;
+        if node.pos >= expr_node.pos {
+            return None;
+        }
+        let start = node.pos as usize;
+        let end = (expr_node.pos as usize).min(source_text.len());
+        let mut comments = Vec::new();
+        for comment in tsz_common::comments::get_comment_ranges(source_text) {
+            let comment_start = comment.pos as usize;
+            let comment_end = comment.end as usize;
+            if comment_start >= end {
+                break;
+            }
+            if comment_start >= start && comment_end <= end && comment.is_multi_line {
+                comments.push(source_text[comment_start..comment_end].to_string());
+            }
+        }
+        (!comments.is_empty()).then(|| comments.join(" "))
+    }
+
+    pub(super) fn leading_block_comment_before_node(&self, node: &Node) -> Option<String> {
+        let source_text = self.source_text?;
+        let node_start = node.pos as usize;
+        let comment = tsz_common::comments::get_comment_ranges(source_text)
+            .into_iter()
+            .take_while(|comment| comment.end as usize <= node_start)
+            .filter(|comment| comment.is_multi_line)
+            .last()?;
+        let comment_end = comment.end as usize;
+        if comment_end > node_start || !source_text[comment_end..node_start].trim().is_empty() {
+            return None;
+        }
+        Some(source_text[comment.pos as usize..comment_end].to_string())
     }
 }
 

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_expressions.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_expressions.rs
@@ -978,6 +978,29 @@ impl<'a> AstToIr<'a> {
         }
     }
 
+    pub(super) fn convert_type_assertion(&self, idx: NodeIndex) -> IRNode {
+        let node = self
+            .arena
+            .get(idx)
+            .expect("NodeIndex must be valid in arena");
+        // Both TYPE_ASSERTION and AS_EXPRESSION use TypeAssertionData
+        if let Some(assertion) = self.arena.get_type_assertion(node) {
+            let expression = self.convert_expression(assertion.expression);
+            if let Some(comment) = self.leading_block_comment_before_node(node).or_else(|| {
+                self.leading_block_comments_before_expression(node, assertion.expression)
+            }) {
+                IRNode::LeadingCommentExpr {
+                    comment: comment.into(),
+                    expression: Box::new(expression),
+                }
+            } else {
+                expression
+            }
+        } else {
+            IRNode::ASTRef(idx)
+        }
+    }
+
     /// True when a parenthesized expression directly wraps a type assertion
     /// (`as`/`<T>`/satisfies) whose underlying expression, after erasing the
     /// assertion, is a simple primary that does not require the parentheses.

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_expressions.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_expressions.rs
@@ -960,7 +960,19 @@ impl<'a> AstToIr<'a> {
             if self.parenthesized_wraps_erasable_simple_primary(paren.expression) {
                 return self.convert_expression(paren.expression);
             }
-            IRNode::Parenthesized(Box::new(self.convert_expression(paren.expression)))
+            let expression =
+                IRNode::Parenthesized(Box::new(self.convert_expression(paren.expression)));
+            if let Some(comment) = self
+                .leading_block_comment_before_node(node)
+                .or_else(|| self.leading_block_comments_before_expression(node, paren.expression))
+            {
+                IRNode::LeadingCommentExpr {
+                    comment: comment.into(),
+                    expression: Box::new(expression),
+                }
+            } else {
+                expression
+            }
         } else {
             IRNode::ASTRef(idx)
         }
@@ -1088,6 +1100,16 @@ mod optional_chain_in_class_member_tests {
         assert!(
             !output.contains("Widget.handle = _a.id;"),
             "Optional access must not be dropped to a plain property access.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn accessor_return_preserves_jsdoc_type_cast_comment() {
+        let output =
+            emit_es5("class Casts {\n    get value() { return /** @type {*} */(null); }\n}\n");
+        assert!(
+            output.contains("return /** @type {*} */ (null);"),
+            "ES5 class IR must preserve erased JSDoc type-cast comments.\nOutput:\n{output}"
         );
     }
 

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_constructor.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_constructor.rs
@@ -414,6 +414,7 @@ impl<'a> ES5ClassTransformer<'a> {
         let saved_temp_counter = self.temp_var_counter.get();
         self.temp_var_counter.set(0);
 
+        let capture_no_super_extends_null_this = self.extends_null && super_stmt_idx.is_none();
         if super_stmt_idx.is_some() && needs_pre_super_this_capture {
             body.push(IRNode::var_decl("_this", Some(IRNode::this())));
         }
@@ -430,7 +431,9 @@ impl<'a> ES5ClassTransformer<'a> {
                 self.emit_leading_statement_comments(body, prev_stmt_end, stmt_node.pos);
                 prev_stmt_end = stmt_node.end;
             }
-            let statement = if needs_pre_super_this_capture {
+            let statement = if capture_no_super_extends_null_this {
+                self.convert_statement_this_captured(stmt_idx)
+            } else if needs_pre_super_this_capture {
                 self.convert_statement_pre_super_this_captured(stmt_idx)
             } else {
                 self.convert_statement(stmt_idx)

--- a/crates/tsz-emitter/src/transforms/ir.rs
+++ b/crates/tsz-emitter/src/transforms/ir.rs
@@ -170,6 +170,13 @@ pub enum IRNode {
     /// Logical AND: `left && right`
     LogicalAnd { left: Box<Self>, right: Box<Self> },
 
+    /// Expression with a leading preserved source comment, such as an erased
+    /// JSDoc type assertion: `/** @type {*} */ expr`.
+    LeadingCommentExpr {
+        comment: Cow<'static, str>,
+        expression: Box<Self>,
+    },
+
     // =========================================================================
     // Statements
     // =========================================================================
@@ -973,6 +980,7 @@ impl IRNode {
                     || when_true.contains_identifier(name)
                     || when_false.contains_identifier(name)
             }
+            Self::LeadingCommentExpr { expression, .. } => expression.contains_identifier(name),
             Self::CommaExpr(nodes)
             | Self::CommaExprMultiline(nodes)
             | Self::CommaExprMultilineFlat(nodes)
@@ -1297,6 +1305,9 @@ impl IRNode {
                 condition.contains_captured_this_reference()
                     || when_true.contains_captured_this_reference()
                     || when_false.contains_captured_this_reference()
+            }
+            Self::LeadingCommentExpr { expression, .. } => {
+                expression.contains_captured_this_reference()
             }
             Self::CommaExpr(nodes)
             | Self::CommaExprMultiline(nodes)

--- a/crates/tsz-emitter/src/transforms/ir_printer.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer.rs
@@ -90,12 +90,7 @@ pub struct IRPrinter<'a> {
     namespace_ast_exported_names: rustc_hash::FxHashSet<String>,
     block_scope_shadowed_names: Vec<String>,
     block_scope_reserved_names: Vec<String>,
-    /// Deferred CommonJS `exports.<name> = <name>;` assignment for a top-level
-    /// `export class` lowered to an ES5 IIFE. When set, the assignment is
-    /// emitted immediately after the class IIFE statement and BEFORE any
-    /// trailing computed-property-name side-effect statements, mirroring the
-    /// ES2015+ class export ordering in `emit_es6.rs`.
-    pending_commonjs_class_export_name: Option<String>,
+    pending_commonjs_class_export_name: Option<(String, Vec<String>)>,
 }
 
 impl<'a> IRPrinter<'a> {
@@ -396,20 +391,25 @@ impl<'a> IRPrinter<'a> {
         }
     }
 
-    /// Schedule a deferred CommonJS `exports.<name> = <name>;` assignment for a
-    /// top-level `export class` lowered to an ES5 IIFE. Emitted right after the
-    /// class IIFE statement, before any trailing computed-property side effects.
     pub fn set_pending_commonjs_class_export_name(&mut self, name: Option<String>) {
-        self.pending_commonjs_class_export_name = name;
+        self.pending_commonjs_class_export_name =
+            name.clone().map(|name| (name.clone(), vec![name]));
     }
 
-    /// Consume the scheduled CommonJS class export name, clearing it so a single
-    /// IIFE statement emits the assignment exactly once.
-    pub(super) const fn take_pending_commonjs_class_export_name(&mut self) -> Option<String> {
+    pub fn set_pending_commonjs_class_export_bindings(
+        &mut self,
+        local_name: String,
+        export_names: Vec<String>,
+    ) {
+        self.pending_commonjs_class_export_name = Some((local_name, export_names));
+    }
+
+    pub(super) fn take_pending_commonjs_class_export_name(
+        &mut self,
+    ) -> Option<(String, Vec<String>)> {
         self.pending_commonjs_class_export_name.take()
     }
 
-    /// Set transform directives for `ASTRef` emission
     pub fn set_transforms(&mut self, transforms: TransformContext) {
         self.transforms = Some(transforms);
     }
@@ -1059,7 +1059,16 @@ impl<'a> IRPrinter<'a> {
                 self.write(" && ");
                 self.emit_node(right);
             }
-
+            IRNode::LeadingCommentExpr {
+                comment,
+                expression,
+            } => {
+                if !self.remove_comments {
+                    self.write(comment);
+                    self.write(" ");
+                }
+                self.emit_node(expression);
+            }
             // Statements
             IRNode::HoistedVarGroupBreak => {}
             IRNode::VarDecl { name, initializer } => {
@@ -1579,13 +1588,9 @@ impl<'a> IRPrinter<'a> {
 
             // Special
             IRNode::Raw(s) => {
-                // Comments stored as Raw nodes bypass IRNode::Comment guards.
-                // Detect and suppress them when removeComments is enabled.
                 if self.remove_comments {
                     let t = s.trim_start();
-                    if t.starts_with("//") || t.starts_with("/*") {
-                        // Skip comment-like Raw node
-                    } else {
+                    if !(t.starts_with("//") || t.starts_with("/*")) {
                         self.write(s);
                     }
                 } else {

--- a/crates/tsz-emitter/src/transforms/ir_printer.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer.rs
@@ -392,8 +392,7 @@ impl<'a> IRPrinter<'a> {
     }
 
     pub fn set_pending_commonjs_class_export_name(&mut self, name: Option<String>) {
-        self.pending_commonjs_class_export_name =
-            name.clone().map(|name| (name.clone(), vec![name]));
+        self.pending_commonjs_class_export_name = name.map(|name| (name.clone(), vec![name]));
     }
 
     pub fn set_pending_commonjs_class_export_bindings(
@@ -404,7 +403,7 @@ impl<'a> IRPrinter<'a> {
         self.pending_commonjs_class_export_name = Some((local_name, export_names));
     }
 
-    pub(super) fn take_pending_commonjs_class_export_name(
+    pub(super) const fn take_pending_commonjs_class_export_name(
         &mut self,
     ) -> Option<(String, Vec<String>)> {
         self.pending_commonjs_class_export_name.take()

--- a/crates/tsz-emitter/src/transforms/ir_printer_class_emit.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer_class_emit.rs
@@ -68,14 +68,16 @@ impl<'a> IRPrinter<'a> {
         // CommonJS export assignment. tsc emits `exports.X = X;` immediately
         // after the class statement and BEFORE any trailing computed-property
         // side-effect statements, matching the ES2015+ ordering in `emit_es6.rs`.
-        if let Some(export_name) = self.take_pending_commonjs_class_export_name() {
-            self.write_line();
-            self.write_indent();
-            self.write("exports.");
-            self.write(&export_name);
-            self.write(" = ");
-            self.write(&export_name);
-            self.write(";");
+        if let Some((local_name, export_names)) = self.take_pending_commonjs_class_export_name() {
+            for export_name in export_names {
+                self.write_line();
+                self.write_indent();
+                self.write("exports.");
+                self.write(&export_name);
+                self.write(" = ");
+                self.write(&local_name);
+                self.write(";");
+            }
         }
 
         for init in computed_prop_temp_inits {


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Emit/DTS parity: JavaScript class/JSDoc declaration fixture parity for `jsDeclarationsClasses` and class/private/accessor/decorator family burn-down.

## Invariant
When JS-input JSDoc type-cast comments appear in expression position inside ES5 class IR, `tsc` preserves the leading block comment before the erased expression; this PR carries that trivia through class AST-to-IR as output-layer comment metadata.

When a CommonJS ES5 class binding has source-ordered local export aliases, `tsc` emits those aliases at the class IIFE boundary in source order; this PR extends class export planning/pending export emission without adding semantic validation.

When an explicit `extends null` constructor has no `super()` recovery path, `tsc` routes constructor `this` references through `_this`; this PR applies that existing class-constructor output recovery only for the `extends null` no-super shape.

## Scope
- ES5 class AST-to-IR comment preservation for leading block comments on parenthesized/type-assertion expressions.
- CommonJS class export pending payloads for local binding plus ordered export aliases, ES5-only class alias folding, and duplicate local export suppression.
- ES5 derived-constructor `extends null` no-super recovery for constructor body `this` substitution.
- Focused regression tests plus baseline-style emit verification.
- Emit ratchet split: `EmitDirective` moved to a dispatch sibling module; type-assertion/comment helpers moved to expression/comment modules.

## Project Corpus Impact
- Row: n/a
- Bug family: class/private/accessor/decorator lowering; jsdoc/javascript declarations baseline fixture.
- Evidence: output-layer JS emit parity only; no checker/solver, project corpus, or semantic validation paths changed.

## Verification
- `cargo fmt --check -p tsz-emitter`
- `git diff --check`
- `cargo fmt --all --check`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-emitter --all-targets -- -D warnings`
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter accessor_return_preserves_jsdoc_type_cast_comment extends_null_constructor_without_super_uses_captured_this_recovery export_alias_before_es5_class_emits_alias_before_class_export export_alias_before_es2015_class_keeps_native_class_export_order`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=jsDeclarationsClasses --verbose --timeout=30000 --json-out=/tmp/studio-c-jsDeclarationsClasses-after-ratchet.json`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=class --js-only --verbose --timeout=30000 --json-out=/tmp/studio-c-class-after-ratchet.json`
- `python3 scripts/emit/audit-output-surgery.py`

## Coordination Notes
- No owned Studio-C PRs were open at intake.
- `scripts/agents/ensure-agent-labels.sh --audit` reports no open PR label problems; it still fails on pre-existing noncanonical issue labels outside this PR.
- Output-surgery audit remains unchanged at 20/20 allowlisted calls, with zero unallowlisted or stale findings.
- Previous CI failure was the emit architecture size ratchet; this head splits the ratcheted files and passes the local architecture guard.
- Ready for CI/manager review; exact-head local checks are listed above.
