### PR TITLE
perf(solver): zero-copy TypeIdList for union/intersection member queries

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/children.rs
+++ b/crates/tsz-checker/src/checkers/jsx/children.rs
@@ -1513,7 +1513,7 @@ impl<'a> CheckerState<'a> {
         } else if let Some(members) =
             crate::query_boundaries::common::union_members(self.ctx.types, type_id)
         {
-            members
+            members.to_vec()
         } else {
             return type_id;
         };

--- a/crates/tsz-checker/src/checkers/jsx/extraction.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction.rs
@@ -467,7 +467,7 @@ impl<'a> CheckerState<'a> {
         {
             (members, true)
         } else {
-            (vec![component_type], false)
+            (vec![component_type].into(), false)
         };
 
         let has_signatures = types_to_check.iter().any(|&ty| {

--- a/crates/tsz-checker/src/checkers/jsx/props/validation.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/validation.rs
@@ -1488,7 +1488,7 @@ impl<'a> CheckerState<'a> {
         let component_type = self.evaluate_type_with_env(component_type);
         let members =
             crate::query_boundaries::common::union_members(self.ctx.types, component_type)
-                .unwrap_or_else(|| vec![component_type]);
+                .unwrap_or_else(|| vec![component_type].into());
 
         let mut has_construct = false;
         let mut has_call = false;
@@ -1539,7 +1539,7 @@ impl<'a> CheckerState<'a> {
         let component_type = self.evaluate_type_with_env(component_type);
         let members =
             crate::query_boundaries::common::union_members(self.ctx.types, component_type)
-                .unwrap_or_else(|| vec![component_type]);
+                .unwrap_or_else(|| vec![component_type].into());
 
         !members.into_iter().any(|member| {
             let member = self.resolve_type_for_property_access(member);

--- a/crates/tsz-checker/src/classes/class_abstract_checker.rs
+++ b/crates/tsz-checker/src/classes/class_abstract_checker.rs
@@ -194,7 +194,7 @@ impl<'a> CheckerState<'a> {
         let mut missing: Vec<String> = Vec::new();
         let type_ids_to_check =
             crate::query_boundaries::common::intersection_members(self.ctx.types, instance_type)
-                .unwrap_or_else(|| vec![instance_type]);
+                .unwrap_or_else(|| vec![instance_type].into());
 
         for type_id in type_ids_to_check {
             let Some(shape) =

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
@@ -1313,7 +1313,7 @@ impl<'a> CheckerState<'a> {
                         self.ctx.types,
                         object_type,
                     )
-                    .unwrap_or_else(|| vec![object_type]);
+                    .unwrap_or_else(|| vec![object_type].into());
                     Some(object_members.into_iter().any(|member| {
                         crate::query_boundaries::common::find_property_in_object(
                             self.ctx.types,

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -1827,7 +1827,7 @@ impl<'a> CheckerState<'a> {
         }
         let narrowed_members =
             crate::query_boundaries::common::union_members(self.ctx.types, narrowed)
-                .unwrap_or_else(|| vec![narrowed]);
+                .unwrap_or_else(|| vec![narrowed].into());
         if narrowed_members.is_empty() || narrowed_members.len() >= declared_members.len() {
             return false;
         }
@@ -1866,7 +1866,7 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let mut ordered = source_members;
+        let mut ordered = source_members.to_vec();
         ordered.sort_by_key(|member| {
             std::cmp::Reverse(
                 declared_members

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -1975,9 +1975,8 @@ impl<'a> CheckerState<'a> {
         ) {
             return None;
         }
-        let extends_members: Vec<TypeId> =
-            crate::query_boundaries::common::union_members(db, cond.extends_type)
-                .unwrap_or_else(|| vec![cond.extends_type]);
+        let extends_members = crate::query_boundaries::common::union_members(db, cond.extends_type)
+            .unwrap_or_else(|| vec![cond.extends_type].into());
         let has_overlap = extends_members.iter().any(|&m| {
             crate::query_boundaries::assignability::is_fresh_subtype_of(db, m, constraint)
         });

--- a/crates/tsz-checker/src/error_reporter/properties.rs
+++ b/crates/tsz-checker/src/error_reporter/properties.rs
@@ -405,7 +405,7 @@ impl<'a> CheckerState<'a> {
                 .or_else(|| {
                     crate::query_boundaries::common::union_members(self.ctx.types, key_type)
                 })
-                .unwrap_or_else(|| vec![evaluated_key_type]);
+                .unwrap_or_else(|| vec![evaluated_key_type].into());
         if keys.len() != shape.properties.len() {
             return None;
         }

--- a/crates/tsz-checker/src/flow/control_flow/call_condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/call_condition_narrowing.rs
@@ -176,7 +176,7 @@ impl<'a> FlowAnalyzer<'a> {
             }
 
             let members = flow_query::union_members_for_type(self.interner, type_id)
-                .unwrap_or_else(|| vec![type_id]);
+                .unwrap_or_else(|| vec![type_id].into());
             let excluded_members: SmallVec<[TypeId; 4]> = members
                 .iter()
                 .copied()

--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -1029,7 +1029,7 @@ impl<'a> FlowAnalyzer<'a> {
             return narrowed_type;
         }
 
-        let mut remaining_members = source_members.clone();
+        let mut remaining_members = source_members.to_vec();
         let original_member_count = remaining_members.len();
 
         for (sib_sym, sib_info) in siblings {

--- a/crates/tsz-checker/src/flow/control_flow/predicate_resolution.rs
+++ b/crates/tsz-checker/src/flow/control_flow/predicate_resolution.rs
@@ -358,8 +358,8 @@ impl<'a> FlowAnalyzer<'a> {
             .collect();
 
         // Get union members of the argument type (or treat as single-member)
-        let arg_members =
-            union_members_for_type(self.interner, arg_type).unwrap_or_else(|| vec![arg_type]);
+        let arg_members = union_members_for_type(self.interner, arg_type)
+            .unwrap_or_else(|| vec![arg_type].into());
 
         // Subtract the fixed members from the argument type
         let remaining: Vec<TypeId> = arg_members

--- a/crates/tsz-checker/src/flow/flow_analysis/definite.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/definite.rs
@@ -422,7 +422,7 @@ impl<'a> CheckerState<'a> {
 
         let union_members = union_members_for_type(self.ctx.types, declared_type)?;
         let initial_count = union_members.len();
-        let mut remaining = union_members;
+        let mut remaining = union_members.to_vec();
 
         for (binding_sym, prop_name) in &bound_from_source {
             // tsc only correlates top-level single-property destructuring.
@@ -788,7 +788,7 @@ impl<'a> CheckerState<'a> {
 
         // Start with the full source type members
         let source_member_count = source_members.len();
-        let mut remaining_members = source_members;
+        let mut remaining_members = source_members.to_vec();
         let member_binding_type = |member: TypeId,
                                    binding: &crate::context::DestructuredBindingInfo|
          -> Option<TypeId> {

--- a/crates/tsz-checker/src/query_boundaries/application_keyof.rs
+++ b/crates/tsz-checker/src/query_boundaries/application_keyof.rs
@@ -34,7 +34,10 @@ pub(crate) fn type_param_info(db: &dyn TypeDatabase, type_id: TypeId) -> Option<
     super::common::type_param_info(db, type_id)
 }
 
-pub(crate) fn union_members(db: &dyn TypeDatabase, type_id: TypeId) -> Option<Vec<TypeId>> {
+pub(crate) fn union_members(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<super::common::TypeIdList> {
     super::common::union_members(db, type_id)
 }
 

--- a/crates/tsz-checker/src/query_boundaries/checkers/jsx.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/jsx.rs
@@ -164,7 +164,10 @@ pub(crate) fn type_parameter_constraint(db: &dyn TypeDatabase, type_id: TypeId) 
     crate::query_boundaries::common::type_parameter_constraint(db, type_id)
 }
 
-pub(crate) fn union_members(db: &dyn TypeDatabase, type_id: TypeId) -> Option<Vec<TypeId>> {
+pub(crate) fn union_members(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<crate::query_boundaries::common::TypeIdList> {
     crate::query_boundaries::common::union_members(db, type_id)
 }
 
@@ -190,7 +193,7 @@ pub(crate) fn element_type_allows_intrinsic_tag(
     tag: &str,
 ) -> bool {
     let members = crate::query_boundaries::common::union_members(db, element_type)
-        .unwrap_or_else(|| vec![element_type]);
+        .unwrap_or_else(|| vec![element_type].into());
     members.into_iter().any(|member| {
         if crate::query_boundaries::common::is_string_type(db, member) {
             return true;

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -14,8 +14,9 @@ pub(crate) use tsz_solver::operations::{AssignabilityChecker, CallResult};
 pub(crate) use tsz_solver::relations::judge::{DefaultJudge, Judge, JudgeConfig};
 pub(crate) use tsz_solver::relations::subtype::{TypeEnvironment, TypeResolver};
 pub(crate) use tsz_solver::type_queries::{
-    RemappedMappedIndexAccessResult, TypeTraversalKind, constraint_allows_mutable_array_like,
-    is_remapped_mapped_index_access, remapped_mapped_index_access_result,
+    RemappedMappedIndexAccessResult, TypeIdList, TypeTraversalKind,
+    constraint_allows_mutable_array_like, is_remapped_mapped_index_access,
+    remapped_mapped_index_access_result,
 };
 pub(crate) use tsz_solver::{
     FunctionShape, IntrinsicKind, MappedType, ObjectFlags, ParamInfo, PendingDiagnostic,
@@ -101,7 +102,14 @@ pub(crate) fn has_function_shape(db: &dyn TypeDatabase, type_id: TypeId) -> bool
     tsz_solver::type_queries::get_function_shape(db, type_id).is_some()
 }
 
-pub(crate) fn union_members(db: &dyn TypeDatabase, type_id: TypeId) -> Option<Vec<TypeId>> {
+/// Members of a union type, or `None` if `type_id` is not a union.
+///
+/// Returns a [`TypeIdList`] — a zero-copy shared view over the interned
+/// member list (an O(1) refcount bump) rather than copying into a fresh
+/// `Vec` on every call. `TypeIdList` is a drop-in for `Vec<TypeId>` in
+/// read-only contexts; the rare caller that needs an owned, mutable buffer
+/// calls `.to_vec()`.
+pub(crate) fn union_members(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeIdList> {
     tsz_solver::type_queries::get_union_members(db, type_id)
 }
 
@@ -338,7 +346,10 @@ pub(crate) fn array_element_type(db: &dyn TypeDatabase, type_id: TypeId) -> Opti
     tsz_solver::type_queries::get_array_element_type(db, type_id)
 }
 
-pub(crate) fn intersection_members(db: &dyn TypeDatabase, type_id: TypeId) -> Option<Vec<TypeId>> {
+/// Members of an intersection type, or `None` if `type_id` is not an
+/// intersection. Returns a zero-copy [`TypeIdList`]; see `union_members`
+/// for the allocation rationale.
+pub(crate) fn intersection_members(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeIdList> {
     tsz_solver::type_queries::get_intersection_members(db, type_id)
 }
 

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -911,7 +911,7 @@ mod tests {
         let Some(domain) = typeof_switch_domain(&db, None, operand) else {
             panic!("expected typeof domain for string | number");
         };
-        let members = union_members_for_type(&db, domain).unwrap_or_else(|| vec![domain]);
+        let members = union_members_for_type(&db, domain).unwrap_or_else(|| vec![domain].into());
         assert_eq!(members.len(), 2);
         assert!(members.contains(&db.literal_string("string")));
         assert!(members.contains(&db.literal_string("number")));
@@ -933,7 +933,7 @@ mod tests {
         let union = db.union(vec![enum_member, TypeId::NUMBER]);
 
         let domain = enum_member_union_domain(&db, union);
-        let members = union_members_for_type(&db, domain).unwrap_or_else(|| vec![domain]);
+        let members = union_members_for_type(&db, domain).unwrap_or_else(|| vec![domain].into());
 
         assert_eq!(members.len(), 2);
         assert!(members.contains(&literal));
@@ -1018,7 +1018,7 @@ mod tests {
         let Some(domain) = nullish_coalescing_switch_domain(&db, left, TypeId::STRING) else {
             panic!("expected switch domain for number | null ?? string");
         };
-        let members = union_members_for_type(&db, domain).unwrap_or_else(|| vec![domain]);
+        let members = union_members_for_type(&db, domain).unwrap_or_else(|| vec![domain].into());
         assert_eq!(members.len(), 2);
         assert!(members.contains(&TypeId::NUMBER));
         assert!(members.contains(&TypeId::STRING));

--- a/crates/tsz-checker/src/query_boundaries/state/type_environment.rs
+++ b/crates/tsz-checker/src/query_boundaries/state/type_environment.rs
@@ -133,7 +133,10 @@ pub(crate) fn literal_string(db: &dyn TypeDatabase, type_id: TypeId) -> Option<A
     tsz_solver::visitor::literal_string(db, type_id)
 }
 
-pub(crate) fn union_members(db: &dyn TypeDatabase, type_id: TypeId) -> Option<Vec<TypeId>> {
+pub(crate) fn union_members(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<tsz_solver::type_queries::TypeIdList> {
     tsz_solver::type_queries::get_union_members(db, type_id)
 }
 
@@ -347,7 +350,7 @@ pub(crate) fn substitute_this_type(
 pub(crate) fn get_intersection_members(
     db: &dyn TypeDatabase,
     type_id: TypeId,
-) -> Option<Vec<TypeId>> {
+) -> Option<tsz_solver::type_queries::TypeIdList> {
     tsz_solver::type_queries::get_intersection_members(db, type_id)
 }
 

--- a/crates/tsz-checker/src/query_boundaries/type_checking_utilities.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_checking_utilities.rs
@@ -99,14 +99,17 @@ pub(crate) fn classify_for_union_members(
     tsz_solver::type_queries::classify_for_union_members(db, type_id)
 }
 
-pub(crate) fn union_members(db: &dyn TypeDatabase, type_id: TypeId) -> Option<Vec<TypeId>> {
+pub(crate) fn union_members(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<tsz_solver::type_queries::TypeIdList> {
     tsz_solver::type_queries::get_union_members(db, type_id)
 }
 
 pub(crate) fn get_intersection_members(
     db: &dyn TypeDatabase,
     type_id: TypeId,
-) -> Option<Vec<TypeId>> {
+) -> Option<tsz_solver::type_queries::TypeIdList> {
     tsz_solver::type_queries::get_intersection_members(db, type_id)
 }
 

--- a/crates/tsz-checker/src/query_boundaries/type_computation/core.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_computation/core.rs
@@ -312,7 +312,9 @@ mod tests {
     }
 
     fn union_members(db: &TypeInterner, ty: TypeId) -> Vec<TypeId> {
-        tsz_solver::type_queries::get_union_members(db, ty).unwrap_or_else(|| vec![ty])
+        tsz_solver::type_queries::get_union_members(db, ty)
+            .map(|m| m.to_vec())
+            .unwrap_or_else(|| vec![ty])
     }
 
     fn tuple(db: &TypeInterner, type_id: TypeId) -> TypeId {

--- a/crates/tsz-checker/src/query_boundaries/type_predicates.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_predicates.rs
@@ -47,7 +47,7 @@ const PRIMITIVE_INDEX_KEYS: [TypeId; 3] = [TypeId::STRING, TypeId::NUMBER, TypeI
 /// `string | number`. Operating on `TypeId` structure keeps the decision
 /// per-key and independent of how a type is spelled or aliased.
 pub(crate) fn present_primitive_index_keys(db: &dyn TypeDatabase, forms: &[TypeId]) -> Vec<TypeId> {
-    let form_members: Vec<Option<Vec<TypeId>>> = forms
+    let form_members: Vec<Option<tsz_solver::type_queries::TypeIdList>> = forms
         .iter()
         .map(|&form| tsz_solver::type_queries::get_union_members(db, form))
         .collect();

--- a/crates/tsz-checker/src/state/state_checking/property_access.rs
+++ b/crates/tsz-checker/src/state/state_checking/property_access.rs
@@ -66,8 +66,8 @@ impl<'a> CheckerState<'a> {
     ) -> Option<tsz_solver::operations::property::PropertyAccessResult> {
         let name_type = mapped.name_type?;
         let prop_atom = self.ctx.types.intern_string(prop_name);
-        let source_members =
-            query::union_members(self.ctx.types, constraint).unwrap_or_else(|| vec![constraint]);
+        let source_members = query::union_members(self.ctx.types, constraint)
+            .unwrap_or_else(|| vec![constraint].into());
         if source_members.is_empty() {
             return None;
         }

--- a/crates/tsz-checker/src/state/type_environment/core.rs
+++ b/crates/tsz-checker/src/state/type_environment/core.rs
@@ -985,7 +985,7 @@ impl<'a> CheckerState<'a> {
                 );
         if string_keys.is_empty() && allow_concrete_remapped_fallback {
             let source_members =
-                query::union_members(self.ctx.types, keys).unwrap_or_else(|| vec![keys]);
+                query::union_members(self.ctx.types, keys).unwrap_or_else(|| vec![keys].into());
             let mut properties = Vec::new();
             for source_member in source_members {
                 if matches!(

--- a/crates/tsz-checker/src/types/computation/object_literal_context.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_context.rs
@@ -380,19 +380,19 @@ impl<'a> CheckerState<'a> {
             .or_else(|| common::union_members(self.ctx.types, evaluated))
             .or_else(
                 || match classify_for_excess_properties(self.ctx.types, type_id) {
-                    ExcessPropertiesKind::Union(members) => Some(members),
+                    ExcessPropertiesKind::Union(members) => Some(members.into()),
                     _ => None,
                 },
             )
             .or_else(
                 || match classify_for_excess_properties(self.ctx.types, resolved) {
-                    ExcessPropertiesKind::Union(members) => Some(members),
+                    ExcessPropertiesKind::Union(members) => Some(members.into()),
                     _ => None,
                 },
             )
             .or_else(
                 || match classify_for_excess_properties(self.ctx.types, evaluated) {
-                    ExcessPropertiesKind::Union(members) => Some(members),
+                    ExcessPropertiesKind::Union(members) => Some(members.into()),
                     _ => None,
                 },
             );
@@ -776,7 +776,7 @@ impl<'a> CheckerState<'a> {
                 ) {
                     crate::query_boundaries::assignability::ExcessPropertiesKind::Union(
                         members,
-                    ) => Some(members),
+                    ) => Some(members.into()),
                     _ => None,
                 }
             })?;

--- a/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
@@ -459,7 +459,8 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
     /// literal regardless of where the indexed access appears syntactically.
     fn literal_index_keys(&self, index_type: TypeId, index_node: NodeIndex) -> Vec<String> {
         use crate::query_boundaries::common::{string_literal_value, union_members};
-        let members = union_members(self.ctx.types, index_type).unwrap_or_else(|| vec![index_type]);
+        let members =
+            union_members(self.ctx.types, index_type).unwrap_or_else(|| vec![index_type].into());
         let keys: Vec<String> = members
             .iter()
             .filter_map(|&member| string_literal_value(self.ctx.types, member))

--- a/crates/tsz-checker/tests/state_checking.rs
+++ b/crates/tsz-checker/tests/state_checking.rs
@@ -53,7 +53,7 @@ fn exposes_state_checking_boundary_queries() {
     assert_eq!(tuple_elements(&types, tuple).map(|v| v.len()), Some(2));
     assert_eq!(unwrap_readonly_deep(&types, readonly_array), array);
     assert_eq!(
-        union_members(&types, union),
+        union_members(&types, union).map(|m| m.to_vec()),
         Some(vec![TypeId::STRING, TypeId::NUMBER])
     );
     assert!(is_type_parameter_like(&types, type_param));

--- a/crates/tsz-checker/tests/state_type_environment.rs
+++ b/crates/tsz-checker/tests/state_type_environment.rs
@@ -29,7 +29,7 @@ fn classifies_and_extracts_environment_resolution_shapes() {
         Some((TypeId::STRING, vec![TypeId::NUMBER]))
     );
     assert_eq!(
-        tsz_solver::type_queries::get_union_members(&types, union),
+        tsz_solver::type_queries::get_union_members(&types, union).map(|m| m.to_vec()),
         Some(vec![TypeId::STRING, TypeId::NUMBER])
     );
     assert_eq!(

--- a/crates/tsz-solver/src/relations/compat_overrides.rs
+++ b/crates/tsz-solver/src/relations/compat_overrides.rs
@@ -303,7 +303,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
 
             let mut all_same_enum = true;
             let mut has_non_enum = false;
-            for &member in &union_members {
+            for &member in union_members.iter() {
                 if let Some((member_def, _)) = visitor::enum_components(self.interner, member) {
                     // Check if this member belongs to the target enum.
                     // Members have their own DefIds (different from parent enum's DefId),

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -961,7 +961,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 let source_has_rest = source_params_unpacked.last().is_some_and(|p| p.rest);
                 let require_all_variants = !is_method;
                 let mut matched_any_variant = false;
-                for member_type_id in &union_members {
+                for member_type_id in union_members.iter() {
                     // When the union member is a readonly tuple and the source has
                     // individual (non-rest) parameters (forming a mutable tuple),
                     // the readonly tuple cannot be assigned to the mutable param tuple

--- a/crates/tsz-solver/src/type_queries/data/accessors.rs
+++ b/crates/tsz-solver/src/type_queries/data/accessors.rs
@@ -755,7 +755,7 @@ fn union_member_has_branch_only_keys(db: &dyn TypeDatabase, type_id: TypeId) -> 
     }
 
     let mut first_keys: Option<FxHashSet<_>> = None;
-    for branch in &union_members {
+    for branch in union_members.iter() {
         let Some(shape) = get_object_shape(db, *branch) else {
             return false;
         };
@@ -783,7 +783,7 @@ pub fn is_discriminated_object_intersection(db: &dyn TypeDatabase, type_id: Type
     };
 
     let mut candidate_names = FxHashSet::default();
-    for &member in &members {
+    for &member in members.iter() {
         if get_union_members(db, member).is_some() {
             continue;
         }
@@ -812,7 +812,7 @@ pub fn is_discriminated_object_intersection(db: &dyn TypeDatabase, type_id: Type
 
         candidate_names.iter().copied().any(|prop_name| {
             let mut seen = FxHashSet::default();
-            for branch in &union_members {
+            for branch in union_members.iter() {
                 let Some(shape) = get_object_shape(db, *branch) else {
                     return false;
                 };
@@ -1046,7 +1046,7 @@ fn unpack_union_of_prefix_tuples(
     // Collect each member's tuple elements; bail on any non-tuple or any tuple
     // containing a rest/spread element (variadic shape can't be flattened).
     let mut tuples: Vec<Vec<crate::types::TupleElement>> = Vec::with_capacity(members.len());
-    for &m in &members {
+    for &m in members.iter() {
         let elems = get_tuple_elements(db, m)?;
         if elems.iter().any(|e| e.rest) {
             return None;
@@ -1219,12 +1219,12 @@ pub fn numeric_literal_index_valid_for_object(
     // Collect union members; treat a non-union as a single-element slice.
     let members = match get_union_members(db, index_type) {
         Some(ms) => ms,
-        None => vec![index_type],
+        None => vec![index_type].into(),
     };
     if members.is_empty() {
         return false;
     }
-    for &member in &members {
+    for &member in members.iter() {
         // Each member must be a numeric literal. Intrinsics that resolve to
         // Literal (BOOLEAN_TRUE/FALSE) are Boolean, never Number — skip lookup.
         if member.is_intrinsic() {

--- a/crates/tsz-solver/src/type_queries/data/content_predicates.rs
+++ b/crates/tsz-solver/src/type_queries/data/content_predicates.rs
@@ -3,6 +3,7 @@
 //! Contains `contains_*`, `is_*` predicates, union/intersection member access,
 //! array/tuple extraction, and compound member mapping.
 
+use super::type_id_list::TypeIdList;
 use crate::construction::TypeDatabase;
 use crate::def::DefinitionStore;
 use crate::types::{IntrinsicKind, TypeData, TypeId};
@@ -1119,16 +1120,14 @@ pub fn contains_conditional_with_application_extends(
 
 /// Get the members of a union type.
 ///
-/// Returns None if the type is not a union.
-pub fn get_union_members(db: &dyn TypeDatabase, type_id: TypeId) -> Option<Vec<TypeId>> {
+/// Returns None if the type is not a union. See [`TypeIdList`] for why this
+/// returns a shared, zero-copy view rather than an owned `Vec<TypeId>`.
+pub fn get_union_members(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeIdList> {
     if type_id.is_intrinsic() {
         return None;
     }
     match db.lookup(type_id) {
-        Some(TypeData::Union(list_id)) => {
-            let members = db.type_list(list_id);
-            Some(members.to_vec())
-        }
+        Some(TypeData::Union(list_id)) => Some(TypeIdList::new(db.type_list(list_id))),
         _ => None,
     }
 }
@@ -1197,15 +1196,15 @@ pub fn is_literal_or_literal_union_type(db: &dyn TypeDatabase, type_id: TypeId) 
 /// Get the members of an intersection type.
 ///
 /// Returns None if the type is not an intersection.
-pub fn get_intersection_members(db: &dyn TypeDatabase, type_id: TypeId) -> Option<Vec<TypeId>> {
+pub fn get_intersection_members(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeIdList> {
     if type_id.is_intrinsic() {
         return None;
     }
     match db.lookup(type_id) {
-        Some(TypeData::Intersection(list_id)) => {
-            let members = db.type_list(list_id);
-            Some(members.to_vec())
-        }
+        // See `get_union_members` / `TypeIdList`: return a zero-copy view of
+        // the interned member list to avoid a per-call allocation + copy on
+        // a hot checker-boundary query.
+        Some(TypeData::Intersection(list_id)) => Some(TypeIdList::new(db.type_list(list_id))),
         _ => None,
     }
 }

--- a/crates/tsz-solver/src/type_queries/data/mod.rs
+++ b/crates/tsz-solver/src/type_queries/data/mod.rs
@@ -9,7 +9,9 @@ mod content_predicates;
 mod signatures_and_advanced;
 #[cfg(test)]
 mod tests;
+mod type_id_list;
 
 pub use accessors::*;
 pub use content_predicates::*;
 pub use signatures_and_advanced::*;
+pub use type_id_list::{TypeIdList, TypeIdListIter};

--- a/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
+++ b/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
@@ -284,7 +284,7 @@ pub fn get_call_signatures(
     // For intersection types, collect call signatures from all members
     if let Some(members) = get_intersection_members(db, type_id) {
         let mut all_sigs = Vec::new();
-        for member in &members {
+        for member in members.iter() {
             if let Some(shape) = get_callable_shape(db, *member) {
                 all_sigs.extend(shape.call_signatures.iter().cloned());
             }
@@ -311,7 +311,7 @@ pub fn get_construct_signatures(
     // For intersection types, collect construct signatures from all members
     if let Some(members) = get_intersection_members(db, type_id) {
         let mut all_sigs = Vec::new();
-        for member in &members {
+        for member in members.iter() {
             if let Some(shape) = get_callable_shape(db, *member) {
                 all_sigs.extend(shape.construct_signatures.iter().cloned());
             }

--- a/crates/tsz-solver/src/type_queries/data/tests.rs
+++ b/crates/tsz-solver/src/type_queries/data/tests.rs
@@ -1366,3 +1366,104 @@ fn contains_type_parameters_db_is_name_agnostic_and_cache_stable() {
         assert!(!contains_type_parameters_db(&interner, concrete));
     }
 }
+
+/// `get_union_members` hands back a zero-copy view of the interned member
+/// list: the returned `Arc` must point at the *same* allocation that
+/// `db.type_list` returns, not a fresh `to_vec()` copy. This is the
+/// allocation-churn fix's core invariant.
+#[test]
+fn union_members_returns_zero_copy_view_of_interned_list() {
+    let interner = TypeInterner::new();
+    let union = interner.union2(TypeId::STRING, TypeId::NUMBER);
+
+    let list_id = match interner.lookup(union) {
+        Some(crate::types::TypeData::Union(id)) => id,
+        other => panic!("expected union, got {other:?}"),
+    };
+    let interned = interner.type_list(list_id);
+
+    let members = get_union_members(&interner, union).expect("union has members");
+
+    // Same backing allocation — a refcount bump, not a copy.
+    assert!(
+        std::sync::Arc::ptr_eq(members.as_arc(), &interned),
+        "union_members must reuse the interned Arc, not allocate a fresh Vec",
+    );
+    // A second query also reuses the same allocation.
+    let members2 = get_union_members(&interner, union).expect("union has members");
+    assert!(std::sync::Arc::ptr_eq(members.as_arc(), members2.as_arc()));
+}
+
+/// `TypeIdList` must behave like the `Vec<TypeId>` it replaced for all the
+/// read patterns callers rely on: slice deref, by-value and by-reference
+/// iteration, double-ended iteration (`.rev()`), and `==` against a `Vec`.
+#[test]
+fn type_id_list_is_a_drop_in_for_vec_read_patterns() {
+    let interner = TypeInterner::new();
+    let a = interner.literal_string("a");
+    let b = interner.literal_string("b");
+    let c = interner.literal_string("c");
+    let union = interner.union(vec![a, b, c]);
+    let expected = vec![a, b, c];
+
+    let members = get_union_members(&interner, union).expect("union has members");
+
+    // Deref-to-slice surface.
+    assert_eq!(members.len(), 3);
+    assert!(!members.is_empty());
+    assert_eq!(members[0], a);
+    assert!(members.contains(&b));
+    assert_eq!(members.first(), Some(&a));
+    assert_eq!(members.last(), Some(&c));
+    assert_eq!(members.to_vec(), expected);
+
+    // Equality with `Vec<TypeId>` works from both sides.
+    assert_eq!(members, expected);
+    assert_eq!(expected, members);
+
+    // By-reference iteration yields `&TypeId` (like `&Vec`).
+    let by_ref: Vec<TypeId> = (&members).into_iter().copied().collect();
+    assert_eq!(by_ref, expected);
+    let by_iter: Vec<TypeId> = members.iter().copied().collect();
+    assert_eq!(by_iter, expected);
+
+    // Forward by-value iteration yields owned `TypeId` (like `Vec::into_iter`).
+    let forward: Vec<TypeId> = members.clone().into_iter().collect();
+    assert_eq!(forward, expected);
+
+    // Double-ended iteration matches `Vec`'s `.rev()`.
+    let reversed: Vec<TypeId> = members.clone().into_iter().rev().collect();
+    assert_eq!(reversed, vec![c, b, a]);
+
+    // Mixed front/back consumption drains every element exactly once.
+    let mut it = members.into_iter();
+    assert_eq!(it.next(), Some(a));
+    assert_eq!(it.next_back(), Some(c));
+    assert_eq!(it.next(), Some(b));
+    assert_eq!(it.next(), None);
+    assert_eq!(it.next_back(), None);
+}
+
+/// `ExactSizeIterator::len` and `size_hint` stay accurate as the iterator
+/// is consumed from both ends — relied on by callers that pre-size buffers.
+#[test]
+fn type_id_list_iter_reports_exact_remaining_len() {
+    let interner = TypeInterner::new();
+    let union = interner.union(vec![
+        interner.literal_string("x"),
+        interner.literal_string("y"),
+        interner.literal_string("z"),
+    ]);
+    let members = get_union_members(&interner, union).expect("union has members");
+
+    let mut it = members.into_iter();
+    assert_eq!(it.len(), 3);
+    assert_eq!(it.size_hint(), (3, Some(3)));
+    it.next();
+    assert_eq!(it.len(), 2);
+    it.next_back();
+    assert_eq!(it.len(), 1);
+    assert_eq!(it.size_hint(), (1, Some(1)));
+    it.next();
+    assert_eq!(it.len(), 0);
+}

--- a/crates/tsz-solver/src/type_queries/data/type_id_list.rs
+++ b/crates/tsz-solver/src/type_queries/data/type_id_list.rs
@@ -1,0 +1,176 @@
+//! `TypeIdList`: a shared, zero-copy view over an interned list of `TypeId`s.
+//!
+//! Used as the return type of the union/intersection member queries
+//! (`get_union_members` / `get_intersection_members`). It wraps the
+//! `Arc<[TypeId]>` the solver already owns so member inspection — one of the
+//! hottest checker-boundary queries in alias- and union-heavy code — is an
+//! O(1) refcount bump instead of a per-call heap allocation + element copy.
+
+use crate::types::TypeId;
+use std::sync::Arc;
+
+/// A shared, read-only view over a list of `TypeId`s — the members of a
+/// union or intersection type.
+///
+/// This wraps the interned `Arc<[TypeId]>` that the solver already owns, so
+/// constructing one is an O(1) refcount bump rather than the per-call heap
+/// allocation + element copy that returning a fresh `Vec<TypeId>` would
+/// impose. Union/intersection member inspection is one of the hottest
+/// checker-boundary queries in alias- and union-heavy code, so eliminating
+/// that allocation removes a large source of heap churn that compounds
+/// across every relation, narrowing, and display pass.
+///
+/// `TypeIdList` is a drop-in replacement for `Vec<TypeId>` in read-only
+/// contexts: it `Deref`s to `[TypeId]` (so `.iter()`, `.len()`,
+/// `.is_empty()`, indexing, slicing, `.contains()`, `.to_vec()`, etc. all
+/// work), and it iterates exactly like `Vec<TypeId>` — `for m in list`
+/// yields owned `TypeId`, `for m in &list` yields `&TypeId`. Callers that
+/// need an owned, mutable buffer call `.to_vec()`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TypeIdList(Arc<[TypeId]>);
+
+impl TypeIdList {
+    /// Wrap an already-interned member list (O(1) refcount bump).
+    #[inline]
+    pub const fn new(members: Arc<[TypeId]>) -> Self {
+        Self(members)
+    }
+
+    /// The backing shared `Arc`. Exposed so callers can prove zero-copy
+    /// sharing (e.g. `Arc::ptr_eq`) without copying the slice.
+    #[inline]
+    pub const fn as_arc(&self) -> &Arc<[TypeId]> {
+        &self.0
+    }
+
+    /// Borrow the members as a slice. Mirrors `Vec<TypeId>::as_slice`.
+    #[inline]
+    pub fn as_slice(&self) -> &[TypeId] {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for TypeIdList {
+    type Target = [TypeId];
+
+    #[inline]
+    fn deref(&self) -> &[TypeId] {
+        &self.0
+    }
+}
+
+impl AsRef<[TypeId]> for TypeIdList {
+    #[inline]
+    fn as_ref(&self) -> &[TypeId] {
+        &self.0
+    }
+}
+
+impl From<Arc<[TypeId]>> for TypeIdList {
+    #[inline]
+    fn from(members: Arc<[TypeId]>) -> Self {
+        Self(members)
+    }
+}
+
+impl From<Vec<TypeId>> for TypeIdList {
+    #[inline]
+    fn from(members: Vec<TypeId>) -> Self {
+        Self(members.into())
+    }
+}
+
+// Element-wise equality with `Vec<TypeId>` from either side, so a
+// `TypeIdList` compares like the `Vec<TypeId>` it replaced regardless of
+// which operand of `==` it is.
+impl PartialEq<Vec<TypeId>> for TypeIdList {
+    #[inline]
+    fn eq(&self, other: &Vec<TypeId>) -> bool {
+        self.0.as_ref() == other.as_slice()
+    }
+}
+
+impl PartialEq<TypeIdList> for Vec<TypeId> {
+    #[inline]
+    fn eq(&self, other: &TypeIdList) -> bool {
+        self.as_slice() == other.0.as_ref()
+    }
+}
+
+/// Owning iterator that yields each `TypeId` by value without allocating —
+/// it walks the shared slice by index while holding the `Arc` alive. This
+/// mirrors `Vec<TypeId>::into_iter()` so `for m in list { /* m: TypeId */ }`
+/// behaves identically to the previous `Vec`-returning API, including
+/// double-ended consumption (`.rev()`, `.next_back()`).
+pub struct TypeIdListIter {
+    members: Arc<[TypeId]>,
+    /// Inclusive front cursor.
+    idx: usize,
+    /// Exclusive back cursor; the live window is `[idx, end)`.
+    end: usize,
+}
+
+impl Iterator for TypeIdListIter {
+    type Item = TypeId;
+
+    #[inline]
+    fn next(&mut self) -> Option<TypeId> {
+        if self.idx < self.end {
+            let value = self.members[self.idx];
+            self.idx += 1;
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.end - self.idx;
+        (remaining, Some(remaining))
+    }
+}
+
+impl DoubleEndedIterator for TypeIdListIter {
+    #[inline]
+    fn next_back(&mut self) -> Option<TypeId> {
+        if self.idx < self.end {
+            self.end -= 1;
+            Some(self.members[self.end])
+        } else {
+            None
+        }
+    }
+}
+
+impl ExactSizeIterator for TypeIdListIter {
+    #[inline]
+    fn len(&self) -> usize {
+        self.end - self.idx
+    }
+}
+
+impl IntoIterator for TypeIdList {
+    type Item = TypeId;
+    type IntoIter = TypeIdListIter;
+
+    #[inline]
+    fn into_iter(self) -> TypeIdListIter {
+        let end = self.0.len();
+        TypeIdListIter {
+            members: self.0,
+            idx: 0,
+            end,
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a TypeIdList {
+    type Item = &'a TypeId;
+    type IntoIter = std::slice::Iter<'a, TypeId>;
+
+    #[inline]
+    fn into_iter(self) -> std::slice::Iter<'a, TypeId> {
+        self.0.iter()
+    }
+}

--- a/crates/tsz-solver/src/type_queries/mapped.rs
+++ b/crates/tsz-solver/src/type_queries/mapped.rs
@@ -753,7 +753,7 @@ pub fn get_finite_mapped_property_display_type(
             .and_then(|(object_type, index_type)| {
                 let prop_atom = crate::visitor::literal_string(db, index_type)?;
                 let object_members = crate::type_queries::get_intersection_members(db, object_type)
-                    .unwrap_or_else(|| vec![object_type]);
+                    .unwrap_or_else(|| vec![object_type].into());
                 Some(object_members.into_iter().any(|member| {
                     crate::type_queries::find_property_in_object(db, member, prop_atom)
                         .is_some_and(|prop| prop.optional)

--- a/crates/tsz-solver/tests/mapped_key_remap_tests.rs
+++ b/crates/tsz-solver/tests/mapped_key_remap_tests.rs
@@ -232,7 +232,7 @@ fn test_mapped_keyof_intersection_prunes_impossible_discriminant_branch() {
 
     let keyof_intersection = evaluate_type(&interner, interner.keyof(intersection));
     let keyof_members = crate::type_queries::get_union_members(&interner, keyof_intersection)
-        .unwrap_or_else(|| vec![keyof_intersection]);
+        .unwrap_or_else(|| vec![keyof_intersection].into());
 
     assert!(
         keyof_members.contains(&interner.literal_string("v")),
@@ -324,7 +324,7 @@ fn test_mapped_keyof_intersection_prunes_impossible_enum_discriminant_branch() {
 
     let keyof_intersection = evaluate_type(&interner, interner.keyof(intersection));
     let keyof_members = crate::type_queries::get_union_members(&interner, keyof_intersection)
-        .unwrap_or_else(|| vec![keyof_intersection]);
+        .unwrap_or_else(|| vec![keyof_intersection].into());
 
     assert!(
         keyof_members.contains(&interner.literal_string("v")),
@@ -442,19 +442,19 @@ fn test_mapped_keyof_intersection_prunes_impossible_distinct_enum_member_branch(
     assert_eq!(narrowed, branch_a);
     let branch_a_keyof = evaluate_type(&interner, interner.keyof(branch_a));
     let branch_a_keys = crate::type_queries::get_union_members(&interner, branch_a_keyof)
-        .unwrap_or_else(|| vec![branch_a_keyof]);
+        .unwrap_or_else(|| vec![branch_a_keyof].into());
     assert!(branch_a_keys.contains(&interner.literal_string("v")));
     assert!(branch_a_keys.contains(&interner.literal_string("a")));
     let fixed_keyof = evaluate_type(&interner, interner.keyof(fixed_v_a));
     let merged_keyof = interner.union(vec![fixed_keyof, branch_a_keyof]);
     let merged_keys = crate::type_queries::get_union_members(&interner, merged_keyof)
-        .unwrap_or_else(|| vec![merged_keyof]);
+        .unwrap_or_else(|| vec![merged_keyof].into());
     assert!(merged_keys.contains(&interner.literal_string("v")));
     assert!(merged_keys.contains(&interner.literal_string("a")));
 
     let keyof_intersection = evaluate_type(&interner, interner.keyof(intersection));
     let keyof_members = crate::type_queries::get_union_members(&interner, keyof_intersection)
-        .unwrap_or_else(|| vec![keyof_intersection]);
+        .unwrap_or_else(|| vec![keyof_intersection].into());
 
     assert!(
         keyof_members.contains(&interner.literal_string("v")),
@@ -531,7 +531,7 @@ fn test_instantiated_generic_discriminant_intersection_preserves_keyof_branch_ke
     );
     let keyof_instantiated = evaluate_type(&interner, interner.keyof(instantiated));
     let keys = crate::type_queries::get_union_members(&interner, keyof_instantiated)
-        .unwrap_or_else(|| vec![keyof_instantiated]);
+        .unwrap_or_else(|| vec![keyof_instantiated].into());
 
     assert!(
         keys.contains(&interner.literal_string("v")),
@@ -599,7 +599,7 @@ fn test_instantiated_generic_same_enum_discriminant_intersection_preserves_keyof
     );
     let keyof_instantiated = evaluate_type(&interner, interner.keyof(instantiated));
     let keys = crate::type_queries::get_union_members(&interner, keyof_instantiated)
-        .unwrap_or_else(|| vec![keyof_instantiated]);
+        .unwrap_or_else(|| vec![keyof_instantiated].into());
 
     assert!(
         keys.contains(&interner.literal_string("v")),
@@ -824,8 +824,8 @@ fn test_finite_mapped_property_type_specializes_key_filtered_template() {
     let foo_ty =
         get_finite_mapped_property_type(&interner, mapped_id, "FOO").expect("expected FOO type");
     let foo_ty = evaluate_type(&interner, foo_ty);
-    let foo_members =
-        crate::type_queries::get_union_members(&interner, foo_ty).unwrap_or_else(|| vec![foo_ty]);
+    let foo_members = crate::type_queries::get_union_members(&interner, foo_ty)
+        .unwrap_or_else(|| vec![foo_ty].into());
     assert_eq!(foo_members, vec![foo_event]);
 
     assert!(
@@ -970,7 +970,7 @@ fn test_finite_mapped_property_type_resolves_infer_conditional_keys() {
         get_finite_mapped_property_type(&interner, mapped_id, "A").expect("expected A property");
     let a_type = evaluate_type(&interner, a_type);
     let function_type = crate::type_queries::get_union_members(&interner, a_type)
-        .unwrap_or_else(|| vec![a_type])
+        .unwrap_or_else(|| vec![a_type].into())
         .into_iter()
         .find(|&member| member != TypeId::UNDEFINED)
         .expect("expected callable member");
@@ -986,7 +986,7 @@ fn test_finite_mapped_property_type_resolves_infer_conditional_keys() {
     let param_type = interner.function_shape(shape_id).params[0].type_id;
     let param_type = evaluate_type(&interner, param_type);
     let members = crate::type_queries::get_union_members(&interner, param_type)
-        .unwrap_or_else(|| vec![param_type]);
+        .unwrap_or_else(|| vec![param_type].into());
     assert_eq!(members, vec![a_value]);
 }
 
@@ -1210,8 +1210,8 @@ fn assert_union_members(
     expected: &[TypeId],
     context: &str,
 ) {
-    let members =
-        crate::type_queries::get_union_members(interner, actual).unwrap_or_else(|| vec![actual]);
+    let members = crate::type_queries::get_union_members(interner, actual)
+        .unwrap_or_else(|| vec![actual].into());
     assert_eq!(
         members.len(),
         expected.len(),


### PR DESCRIPTION
Closes #10922.

AgentName: Studio-B

Track: Performance / checker-boundary allocation hygiene

Invariant: Behavior-preserving. The change is a pure allocation/return-type
refactor — the same member `TypeId`s are returned in the same order. No
relation, inference, narrowing, or diagnostic outcome changes.

## Scope

`get_union_members` / `get_intersection_members` (the canonical solver queries
behind the checker's `query_boundaries::*::union_members` /
`intersection_members` wrappers) previously did `members.to_vec()` on **every**
call — a fresh heap allocation plus an element copy of the interned member
list. These are among the hottest checker-boundary queries in alias- and
union-heavy code, so the per-call allocation was a broad source of heap churn
and GC-like pressure that compounds across every relation, narrowing, and
display pass (the failure family described in #10922:
"Checker boundary allocations are recreated for each alias-heavy row pass").

Structural rule: *When the checker inspects the members of a union or
intersection, `tsc` walks the interned member list in place; `tsz` now returns
a shared zero-copy view of that interned list through the
`type_queries` member-query boundary, instead of cloning it into a fresh
`Vec` each call.*

### What changed

- New `TypeIdList` newtype (`crates/tsz-solver/src/type_queries/data/type_id_list.rs`)
  wraps the `Arc<[TypeId]>` the solver already owns. Construction is an O(1)
  refcount bump rather than an allocation + copy.
- `get_union_members` / `get_intersection_members` now return
  `Option<TypeIdList>`; the checker query-boundary wrappers propagate it so the
  win reaches the checker boundary, not just solver internals.
- `TypeIdList` is a drop-in for `Vec<TypeId>` in read-only contexts: it
  `Deref`s to `[TypeId]` and implements by-value + by-ref `IntoIterator`,
  `DoubleEndedIterator`, `ExactSizeIterator`, and `PartialEq<Vec<TypeId>>`, so
  the migration is mechanical. The few sites that genuinely mutate the result
  call `.to_vec()` explicitly; single-element fallbacks use `vec[x].into()`.

This is broad rather than repro-scoped: it removes the allocation for **every**
union/intersection member inspection across the whole checker/solver, not just
one fixture row.

## Project Corpus Impact

- Row: n/a — this is a workspace-wide allocation/return-type refactor, not tied
  to a single project-corpus row; no row baselines are expected to move.
- Bug family: checker-boundary allocation churn on alias/union-heavy passes
  (#10922).

No diagnostics added or removed. Pure perf/allocation change with identical
member data and order. Broad conformance/bench rows are owned by ready-review
CI.

## Verification

- `cargo check --workspace --tests` — clean (libs, bins, tests).
- `cargo clippy -p tsz-solver --lib` / `-p tsz-checker --lib` — clean.
- New regression tests in `type_queries::data::tests`:
  - `union_members_returns_zero_copy_view_of_interned_list` — asserts the
    returned `Arc` is pointer-equal to `db.type_list(...)` (no copy), on
    repeated calls.
  - `type_id_list_is_a_drop_in_for_vec_read_patterns` — locks slice deref,
    by-value/by-ref iteration, `.rev()`, mixed front/back consumption, and
    `==` against `Vec<TypeId>`.
  - `type_id_list_iter_reports_exact_remaining_len` — `ExactSizeIterator` /
    `size_hint` stay exact under double-ended consumption.
- Solver lib suite: the 3 pre-existing failures on the base branch
  (`test_contra_candidate_basic`,
  `test_deep_widen_object_candidate_homomorphic_mapped`,
  `test_infer_generic_object_with_contextual_callbacks_prefers_schema_property_type`)
  are unchanged by this PR (verified by running them on the base with this work
  stashed); all other solver lib tests pass.

## Coordination Notes

Rebased onto latest `main`; no conflicts. The public path
`tsz_solver::type_queries::TypeIdList` is stable. Follow-up opportunity (not in
this PR, to keep scope tight): `ExcessPropertiesKind` and similar classifier
enums still `to_vec()` their member lists and could adopt `TypeIdList` for the
same win.