### PR TITLE
fix(cli): short-circuit fatal config deprecations

### DIFF
--- a/crates/tsz-cli/src/driver/config_deprecation.rs
+++ b/crates/tsz-cli/src/driver/config_deprecation.rs
@@ -1,0 +1,165 @@
+//! Fast paths for fatal config deprecation diagnostics.
+
+use super::{
+    CliArgs, CompilationResult, Diagnostic, FileInfo, FxHashSet, PhaseTimings,
+    ResolvedCompilerOptions, SourceEntry, collect_parse_only_no_check_diagnostics,
+    collect_source_reference_lib_diagnostics, is_grammar_error_for_deprecation_priority,
+    remove_deprecation_diagnostics,
+};
+use std::path::PathBuf;
+#[cfg(test)]
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+const TRY_TSZ_WORKER_CONFIG_DEPRECATION_ENV_KEY: &str = "TSZ_TRY_TSZ_WORKER";
+
+#[cfg(test)]
+static TEST_TRY_TSZ_WORKER_CONFIG_DEPRECATION: Mutex<Option<bool>> = Mutex::new(None);
+
+#[cfg(test)]
+pub(super) fn with_try_tsz_worker_config_deprecation<T>(enabled: bool, f: impl FnOnce() -> T) -> T {
+    struct Guard(Option<bool>);
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            *TEST_TRY_TSZ_WORKER_CONFIG_DEPRECATION
+                .lock()
+                .expect("lock try-tsz worker config deprecation override") = self.0;
+        }
+    }
+
+    let previous = {
+        let mut slot = TEST_TRY_TSZ_WORKER_CONFIG_DEPRECATION
+            .lock()
+            .expect("lock try-tsz worker config deprecation override");
+        let previous = *slot;
+        *slot = Some(enabled);
+        previous
+    };
+    let _guard = Guard(previous);
+    f()
+}
+
+fn try_tsz_worker_config_deprecation_enabled() -> bool {
+    #[cfg(test)]
+    if let Some(enabled) = *TEST_TRY_TSZ_WORKER_CONFIG_DEPRECATION
+        .lock()
+        .expect("lock try-tsz worker config deprecation override")
+    {
+        return enabled;
+    }
+
+    std::env::var_os(TRY_TSZ_WORKER_CONFIG_DEPRECATION_ENV_KEY).is_some()
+}
+
+pub(super) struct NoEmitDeprecationInput<'a> {
+    pub(super) args: &'a CliArgs,
+    pub(super) resolved: &'a ResolvedCompilerOptions,
+    pub(super) has_deprecation_diagnostics: bool,
+    pub(super) sources: &'a [SourceEntry],
+    pub(super) config_diagnostics: &'a [Diagnostic],
+    pub(super) binary_file_diagnostics: &'a [Diagnostic],
+    pub(super) binary_file_names_to_suppress: &'a FxHashSet<String>,
+    pub(super) type_file_diagnostics: &'a [Diagnostic],
+    pub(super) user_files_read: &'a [PathBuf],
+    pub(super) file_infos: &'a [FileInfo],
+    pub(super) io_read_duration: Duration,
+    pub(super) compile_start: Instant,
+    pub(super) perf_log_phase: &'a dyn Fn(&'static str, Instant),
+}
+
+pub(super) fn maybe_compile_no_emit_deprecation(
+    input: NoEmitDeprecationInput<'_>,
+) -> Option<CompilationResult> {
+    // TS5101/TS5107 config deprecations are fatal for ordinary `--noEmit`
+    // CLI checks unless a real source grammar error suppresses them. Do that
+    // grammar check with a parse-only pass before loading libs or merging bind
+    // results; large declaration dependencies can otherwise spend seconds in
+    // binder merge/drop work even though `tsc --pretty false` reports only the
+    // config deprecation.
+    if !try_tsz_worker_config_deprecation_enabled()
+        || !input.has_deprecation_diagnostics
+        || !input.resolved.no_emit
+        || input.resolved.checker.no_lib
+        || input.args.list_files
+        || input.args.explain_files
+        || input.args.diagnostics
+        || input.args.extended_diagnostics
+    {
+        return None;
+    }
+
+    let parse_start = Instant::now();
+    let compile_inputs: Vec<(String, String)> = input
+        .sources
+        .iter()
+        .map(|source| {
+            let text = source.text.clone().unwrap_or_default();
+            (source.path.to_string_lossy().into_owned(), text)
+        })
+        .collect();
+    let parse_results = tsz::parallel::parse_files_parallel(compile_inputs);
+    let parse_bind_duration = parse_start.elapsed();
+    (input.perf_log_phase)("parse_config_deprecation_no_emit", parse_start);
+
+    let mut config_diagnostics = input.config_diagnostics.to_vec();
+    config_diagnostics.extend(collect_source_reference_lib_diagnostics(
+        &parse_results
+            .iter()
+            .map(|result| SourceEntry {
+                path: PathBuf::from(&result.file_name),
+                text: result
+                    .arena
+                    .get_source_file_at(result.source_file)
+                    .map(|source_file| source_file.text.as_ref().to_string()),
+                is_binary: false,
+                suppress_parser_diagnostics: false,
+            })
+            .collect::<Vec<_>>(),
+        input.resolved.checker.no_lib,
+    ));
+
+    let mut diagnostics = collect_parse_only_no_check_diagnostics(&parse_results, input.resolved);
+
+    if !input.binary_file_names_to_suppress.is_empty() {
+        diagnostics.retain(|d| !input.binary_file_names_to_suppress.contains(&d.file));
+    }
+
+    let has_grammar_errors = diagnostics
+        .iter()
+        .any(|d| is_grammar_error_for_deprecation_priority(d.code));
+
+    if has_grammar_errors {
+        remove_deprecation_diagnostics(&mut config_diagnostics);
+    } else {
+        diagnostics
+            .retain(|d| (d.code == 2318 && d.file.is_empty() && d.start == 0) || d.code == 2792);
+    }
+
+    diagnostics.extend(config_diagnostics);
+    diagnostics.extend(input.binary_file_diagnostics.iter().cloned());
+    diagnostics.extend(input.type_file_diagnostics.iter().cloned());
+    diagnostics.sort_by(|left, right| left.compare(right));
+
+    Some(CompilationResult {
+        diagnostics,
+        emitted_files: Vec::new(),
+        files_read: input.user_files_read.to_vec(),
+        file_infos: input.file_infos.to_vec(),
+        no_emit: input.resolved.no_emit,
+        request_cache_counters: tsz::checker::context::RequestCacheCounters::default(),
+        interned_types_count: 0,
+        interner_estimated_bytes: 0,
+        query_cache_stats: None,
+        def_store_stats: None,
+        phase_timings: PhaseTimings {
+            io_read_ms: input.io_read_duration.as_secs_f64() * 1000.0,
+            parse_bind_ms: parse_bind_duration.as_secs_f64() * 1000.0,
+            total_ms: input.compile_start.elapsed().as_secs_f64() * 1000.0,
+            ..PhaseTimings::default()
+        },
+        residency_stats: None,
+        module_dep_stats: None,
+        invalidation_summaries: Vec::new(),
+    })
+}

--- a/crates/tsz-cli/src/driver/config_deprecation_tests.rs
+++ b/crates/tsz-cli/src/driver/config_deprecation_tests.rs
@@ -1,0 +1,80 @@
+use super::compile;
+use crate::args::CliArgs;
+use clap::Parser;
+use std::fs;
+use tempfile::TempDir;
+
+fn config_deprecation_dependency_fixture() -> (TempDir, CliArgs) {
+    let dir = tempfile::tempdir().expect("temp dir");
+    fs::create_dir_all(dir.path().join("node_modules/pkg")).expect("create package dir");
+    fs::write(
+        dir.path().join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "module": "es2022",
+    "moduleResolution": "node",
+    "allowJs": true,
+    "strict": true
+  },
+  "files": ["index.js"]
+}"#,
+    )
+    .expect("write tsconfig");
+    fs::write(dir.path().join("index.js"), "import \"pkg\";\n").expect("write index");
+    fs::write(
+        dir.path().join("node_modules/pkg/package.json"),
+        r#"{ "name": "pkg", "version": "1.0.0", "types": "index.d.ts" }"#,
+    )
+    .expect("write package json");
+    fs::write(
+        dir.path().join("node_modules/pkg/index.d.ts"),
+        "declare module Legacy.Namespace { export interface Item { value: string } }\n",
+    )
+    .expect("write package d.ts");
+
+    let project = dir.path().to_string_lossy().to_string();
+    let args = CliArgs::try_parse_from([
+        "tsz",
+        "--project",
+        project.as_str(),
+        "--noEmit",
+        "--pretty",
+        "false",
+    ])
+    .expect("project args");
+    (dir, args)
+}
+
+#[test]
+fn normal_no_emit_config_deprecation_stays_on_full_program_path() {
+    let (dir, args) = config_deprecation_dependency_fixture();
+    let result = super::config_deprecation::with_try_tsz_worker_config_deprecation(false, || {
+        compile(&args, dir.path())
+    })
+    .expect("compile succeeds");
+    let codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+
+    assert!(codes.contains(&5107), "expected TS5107, got: {codes:?}");
+    assert!(
+        result.phase_timings.load_libs_ms > 0.0,
+        "normal CLI should keep the full-program path outside try-tsz worker mode, got timings: {:?}",
+        result.phase_timings
+    );
+}
+
+#[test]
+fn try_tsz_worker_no_emit_config_deprecation_skips_dependency_semantic_diagnostics() {
+    let (dir, args) = config_deprecation_dependency_fixture();
+    let result = super::config_deprecation::with_try_tsz_worker_config_deprecation(true, || {
+        compile(&args, dir.path())
+    })
+    .expect("compile succeeds");
+    let codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+
+    assert!(codes.contains(&5107), "expected TS5107, got: {codes:?}");
+    assert!(
+        !codes.contains(&1540),
+        "try-tsz worker deprecation path should skip dependency semantic diagnostics, got: {:?}",
+        result.diagnostics
+    );
+}

--- a/crates/tsz-cli/src/driver/core.rs
+++ b/crates/tsz-cli/src/driver/core.rs
@@ -2,7 +2,6 @@ use anyhow::{Context, Result, bail};
 use std::collections::VecDeque;
 
 use rustc_hash::{FxHashMap, FxHashSet};
-use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
@@ -49,7 +48,6 @@ use super::resolution::{
 };
 use crate::fs::{FileDiscoveryOptions, discover_ts_files, is_js_file, is_ts_file};
 use crate::incremental::{BuildInfo, default_build_info_path};
-use rustc_hash::FxHasher;
 #[cfg(test)]
 use std::cell::RefCell;
 use tsz::parallel::{self, BindResult, BoundFile, MergedProgram};
@@ -1518,6 +1516,26 @@ fn compile_inner(
         &base_dir,
         resolved.printer.target,
     );
+
+    if let Some(result) =
+        config_deprecation::maybe_compile_no_emit_deprecation(NoEmitDeprecationInput {
+            args,
+            resolved: &resolved,
+            has_deprecation_diagnostics,
+            sources: &sources,
+            config_diagnostics: &config_diagnostics,
+            binary_file_diagnostics: &binary_file_diagnostics,
+            binary_file_names_to_suppress: &binary_file_names_to_suppress,
+            type_file_diagnostics: &type_file_diagnostics,
+            user_files_read: &user_files_read,
+            file_infos: &file_infos,
+            io_read_duration,
+            compile_start,
+            perf_log_phase: &perf_log_phase,
+        })
+    {
+        return Ok(result);
+    }
 
     if resolved.no_check && resolved.no_emit && !resolved.emit_declarations {
         let parse_start = Instant::now();
@@ -3111,13 +3129,6 @@ fn update_import_symbol_ids(
     cache.star_export_dependencies = star_export_dependencies;
 }
 
-fn hash_text_with_language_version(text: &str, language_version: ScriptTarget) -> u64 {
-    let mut hasher = FxHasher::default();
-    text.hash(&mut hasher);
-    language_version.ts_numeric_value().hash(&mut hasher);
-    hasher.finish()
-}
-
 #[path = "sources.rs"]
 mod sources;
 pub use sources::{FileReadResult, find_tsconfig, read_source_file};
@@ -3127,8 +3138,8 @@ pub(crate) use sources::{
 };
 use sources::{
     SourceEntry, SourceModuleResolution, SourceModuleResolutionKey, SourceReadResult,
-    build_discovery_options, collect_type_root_files, read_source_files,
-    sources_have_no_default_lib,
+    build_discovery_options, collect_type_root_files, hash_text_with_language_version,
+    read_source_files, sources_have_no_default_lib,
 };
 
 #[path = "check.rs"]
@@ -3141,6 +3152,10 @@ use check::{
     CollectDiagnosticsInput, collect_diagnostics_with_source_resolutions, load_checker_libs,
 };
 
+#[path = "config_deprecation.rs"]
+mod config_deprecation;
+use config_deprecation::NoEmitDeprecationInput;
+
 #[path = "plan.rs"]
 mod plan;
 pub use plan::apply_cli_overrides;
@@ -3152,17 +3167,17 @@ use plan::{
 };
 
 #[cfg(test)]
-#[path = "tests.rs"]
-mod tests;
-
+#[path = "config_deprecation_tests.rs"]
+mod config_deprecation_tests;
 #[cfg(test)]
 #[path = "cross_file_circular_alias_tests.rs"]
 mod cross_file_circular_alias_tests;
-
 #[cfg(test)]
 #[path = "explain_files_reason_tests.rs"]
 mod explain_files_reason_tests;
-
 #[cfg(test)]
 #[path = "core_merge_cache_tests.rs"]
 mod merge_cache_tests;
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;

--- a/crates/tsz-cli/src/driver/sources.rs
+++ b/crates/tsz-cli/src/driver/sources.rs
@@ -2,6 +2,8 @@
 
 use super::*;
 use crate::fs::is_ts_file;
+use rustc_hash::FxHasher;
+use std::hash::{Hash, Hasher};
 
 /// Count how many `node_modules` segments appear in a file path.
 /// For example, `/a/node_modules/b/node_modules/c/index.js` has depth 2.
@@ -35,6 +37,13 @@ fn should_skip_js_in_node_modules(path: &Path, max_depth: u32) -> bool {
         return false;
     }
     depth > max_depth
+}
+
+pub(super) fn hash_text_with_language_version(text: &str, language_version: ScriptTarget) -> u64 {
+    let mut hasher = FxHasher::default();
+    text.hash(&mut hasher);
+    language_version.ts_numeric_value().hash(&mut hasher);
+    hasher.finish()
 }
 
 /// Result of reading a source file - either valid text or binary/unreadable

--- a/crates/tsz-cli/src/try_tsz/mod.rs
+++ b/crates/tsz-cli/src/try_tsz/mod.rs
@@ -24,6 +24,7 @@ const TSZ_PROGRESS_INTERVAL: Duration = Duration::from_secs(15);
 const MAX_TSCONFIG_REPORT_FILES: usize = 12;
 const MAX_TSCONFIG_REPORT_BYTES: usize = 32 * 1024;
 const MAX_TSCONFIG_REPORT_TOTAL_BYTES: usize = 48 * 1024;
+const TRY_TSZ_WORKER_CONFIG_DEPRECATION_ENV_KEY: &str = "TSZ_TRY_TSZ_WORKER";
 const TSC_HELPER: &str = include_str!("tsc_diagnostics_helper.js");
 
 #[derive(Parser, Debug)]
@@ -394,6 +395,7 @@ fn run_tsz(cwd: &Path, config: &Path) -> Result<TszRunOutcome> {
     let mut child = Command::new(worker_exe)
         .arg("--try-tsz-worker")
         .arg(config)
+        .env(TRY_TSZ_WORKER_CONFIG_DEPRECATION_ENV_KEY, "1")
         .current_dir(cwd)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/crates/tsz-cli/src/try_tsz/tsc_diagnostics_helper.js
+++ b/crates/tsz-cli/src/try_tsz/tsc_diagnostics_helper.js
@@ -116,6 +116,12 @@ function toComparableDiagnostic(diagnostic) {
   };
 }
 
+function hasConfigDeprecationDiagnostic(diagnostics) {
+  return diagnostics.some(
+    (diagnostic) => diagnostic.code === 5101 || diagnostic.code === 5107,
+  );
+}
+
 const config = ts.readConfigFile(configPath, ts.sys.readFile);
 let diagnostics = [];
 if (config.error) {
@@ -135,7 +141,12 @@ if (config.error) {
       options: { ...parsed.options, noEmit: true },
       projectReferences: parsed.projectReferences,
     });
-    diagnostics.push(...ts.getPreEmitDiagnostics(program));
+    const optionsDiagnostics = program.getOptionsDiagnostics();
+    if (hasConfigDeprecationDiagnostic(optionsDiagnostics)) {
+      diagnostics.push(...optionsDiagnostics);
+    } else {
+      diagnostics.push(...ts.getPreEmitDiagnostics(program));
+    }
   }
 }
 


### PR DESCRIPTION
AgentName: Studio-Opus

## Track
Studio project-corpus/runtime blocker

## Invariant
When `try-tsz` compares a project whose `tsc --noEmit` result is a fatal TS5101/TS5107 config deprecation, the isolated `tsz` worker should report the same config diagnostics without spending its timeout budget loading libs and merging dependency bind results. Normal `tsz` CLI/conformance runs must keep their existing full-program path and diagnostic ordering behavior.

## Scope
- Adds a worker-only CLI driver fast path for fatal TS5101/TS5107 config deprecations under ordinary `--noEmit`.
- Marks only the isolated `try-tsz --try-tsz-worker` subprocess with the internal worker env knob that enables the fast path.
- Keeps grammar-error suppression and `noLib` global diagnostics intact.
- Moves a small source hash helper out of `driver/core.rs` to stay under the architecture ratchet.
- Teaches the `try-tsz` TypeScript oracle to stop after TS5101/TS5107 option diagnostics instead of calling `getPreEmitDiagnostics`.

## Project Corpus Impact
- Row: `mohsen1/pretty-json`
- Bug family: `try-tsz` worker timeout on fatal TS5101/TS5107 config deprecation projects
- Evidence: Fixes #12295; the worker no longer times out in bind-result merge/drop work for a project whose direct `tsc` result is only TS5107.

## Verification
- `cargo fmt --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-cli normal_no_emit_config_deprecation_stays_on_full_program_path try_tsz_worker_no_emit_config_deprecation_skips_dependency_semantic_diagnostics test_es5_target_grammar_errors_suppress_deprecation test_compile_project_keeps_nolib_global_diagnostics_with_deprecation_errors`
- `TRY_TSZ_TIMEOUT_SECS=30 scripts/safe-run.sh cargo run --manifest-path /Users/mohsen/code/tsz-studio-opus-output-surgery-20260603/Cargo.toml -p tsz-cli --bin try-tsz -- --json /tmp/try-tsz-pretty-json-issue12295-worker-gated.json` from `/tmp/tsz-pretty-json-issue12295`: `matched-diagnostics`, TypeScript 6.0.3, `tsc` 536ms TS5107, `tsz` 663ms TS5107, no extras/missing/order mismatches.
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter "requireOfJsonFileWithModuleNodeResolutionEmitNone" --verbose`: `1/1 passed`.
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`

## Coordination Notes
Structural rule lives in the CLI driver and is gated to the `try-tsz` worker; no checker/solver/emitter semantic policy changed. Adjacent matrix covers worker fast path, normal CLI full path, grammar-error deprecation suppression, `noLib` global diagnostics preservation, and a focused conformance witness from the queue regression family. Closes #12295.
