### PR TITLE
fix(solver): preserve readonly/optional modifiers when simplifying intersections

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -91,6 +91,10 @@ name = "homomorphic_mapped_index_display_tests"
 path = "tests/homomorphic_mapped_index_display_tests.rs"
 
 [[test]]
+name = "intersection_modifier_merge_tests"
+path = "tests/intersection_modifier_merge_tests.rs"
+
+[[test]]
 name = "array_declaration_display_summary_tests"
 path = "tests/array_declaration_display_summary_tests.rs"
 

--- a/crates/tsz-checker/tests/intersection_modifier_merge_tests.rs
+++ b/crates/tsz-checker/tests/intersection_modifier_merge_tests.rs
@@ -1,0 +1,148 @@
+//! Regression tests for intersection modifier merging through evaluated
+//! (aliased) intersections, including homomorphic mapped types over them.
+//!
+//! tsc merges a shared property's `readonly`/optional modifiers across
+//! intersection constituents with AND semantics: the property is readonly
+//! (optional) only when *all* contributors are readonly (optional). A
+//! structural subtype constituent (`{ readonly a: number }` is a subtype of
+//! `{ a?: number }`) must not let intersection simplification drop the
+//! writable/optional constituent and silently keep the more-restrictive one.
+//!
+//! See issue #10863: "mapped key operations can lose optional/readonly
+//! modifier intent after merges."
+
+use tsz_checker::test_utils::check_source_strict_messages_without_missing_libs as check_strict;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_strict(source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect()
+}
+
+/// `{ readonly a } & { a? }` merges to a writable, required `a`. Writing to it
+/// must not raise TS2540 (read-only) and reading must not require an undefined
+/// check (the property is required, not optional).
+#[test]
+fn aliased_readonly_required_and_optional_intersection_is_writable_required() {
+    let source = r#"
+type A = { readonly a: number };
+type B = { a?: number };
+declare const m: A & B;
+m.a = 1;
+const r: number = m.a;
+"#;
+    assert!(
+        !codes(source).contains(&2540),
+        "writable+optional intersection member must keep `a` writable, got: {:?}",
+        check_strict(source)
+    );
+    assert!(
+        !codes(source).contains(&2322),
+        "intersection of required and optional `a` must stay required, got: {:?}",
+        check_strict(source)
+    );
+}
+
+/// The same merge must survive a homomorphic mapped copy with an identity
+/// `as K` key remap — the witness from issue #10863.
+#[test]
+fn homomorphic_mapped_over_intersection_preserves_writable_required() {
+    let source = r#"
+type Id<T> = { [K in keyof T as K]: T[K] };
+type A = { readonly a: number };
+type B = { a?: number };
+declare const m: Id<A & B>;
+m.a = 1;
+const r: number = m.a;
+"#;
+    assert!(
+        !codes(source).contains(&2540),
+        "mapped copy of writable+optional intersection must keep `a` writable, got: {:?}",
+        check_strict(source)
+    );
+    assert!(
+        !codes(source).contains(&2322),
+        "mapped copy must keep `a` required, got: {:?}",
+        check_strict(source)
+    );
+}
+
+/// A plain (no `as`) homomorphic mapped type must merge modifiers identically.
+#[test]
+fn plain_homomorphic_mapped_over_intersection_preserves_writable() {
+    let source = r#"
+type Id<T> = { [K in keyof T]: T[K] };
+type A = { readonly a: number };
+type B = { a?: number };
+declare const m: Id<A & B>;
+m.a = 1;
+"#;
+    assert!(
+        !codes(source).contains(&2540),
+        "plain mapped copy must keep `a` writable, got: {:?}",
+        check_strict(source)
+    );
+}
+
+/// When *all* constituents agree on readonly, the merged property stays
+/// readonly — the guard must not over-relax legitimately readonly properties.
+#[test]
+fn all_readonly_intersection_stays_readonly() {
+    let source = r#"
+type Id<T> = { [K in keyof T as K]: T[K] };
+type A = { readonly a: number };
+type B = { readonly a: number };
+declare const m: Id<A & B>;
+m.a = 1;
+"#;
+    assert!(
+        codes(source).contains(&2540),
+        "all-readonly intersection must remain readonly, got: {:?}",
+        check_strict(source)
+    );
+}
+
+/// Renaming key remaps (non-identity) still merge modifiers homomorphically.
+#[test]
+fn rename_mapped_over_intersection_merges_readonly() {
+    let source = r#"
+type Prefix<T> = { [K in keyof T as `p_${string & K}`]: T[K] };
+type A = { readonly a: number };
+type B = { a?: number };
+declare const m: Prefix<A & B>;
+m.p_a = 1;
+"#;
+    assert!(
+        !codes(source).contains(&2540),
+        "renamed mapped copy must keep `p_a` writable, got: {:?}",
+        check_strict(source)
+    );
+}
+
+/// Larger intersection mixing modifiers per property: `a` writable+required,
+/// `b` and `c` carried through. Only the genuinely readonly cases stay readonly.
+#[test]
+fn mixed_modifier_intersection_merges_per_property() {
+    let source = r#"
+type Id<T> = { [K in keyof T as K]: T[K] };
+type A = { readonly a?: number; b: string };
+type B = { a: number; c: boolean };
+declare const m: Id<A & B>;
+m.a = 1;        // a: readonly? AND writable -> writable (ok)
+m.b = "x";      // b: writable (ok)
+m.c = true;     // c: writable (ok)
+const z: number = m.a; // a: optional? AND required -> required (ok)
+"#;
+    let result = codes(source);
+    assert!(
+        !result.contains(&2540),
+        "mixed intersection must keep `a` writable, got: {:?}",
+        check_strict(source)
+    );
+    assert!(
+        !result.contains(&2322),
+        "mixed intersection must keep `a` required, got: {:?}",
+        check_strict(source)
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate/support.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/support.rs
@@ -10,6 +10,12 @@ use super::*;
 /// this ceiling only fires for malformed or pathological input.
 const MAX_LAZY_CHAIN_DEPTH: usize = 32;
 
+/// Per-property `(optional, readonly)` modifier map keyed by property-name atom,
+/// or `None` for members that contribute no object properties. Used by
+/// intersection simplification to AND-merge modifiers when deciding whether a
+/// structurally subsumed member can be dropped.
+type MemberModifierMap = Option<FxHashMap<u32, (bool, bool)>>;
+
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     #[inline]
     pub(super) fn cached_generic_instantiation(
@@ -729,6 +735,25 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             })
             .collect();
 
+        // Pre-compute per-member property modifier maps once for the intersection
+        // direction, mirroring the `prop_names` precompute above. The modifier
+        // guard below then reduces to O(1) cached lookups instead of re-walking
+        // shapes on every candidate pair. Union simplification never consults
+        // these, so skip the work entirely in that direction.
+        let prop_mods: Vec<MemberModifierMap> =
+            if matches!(direction, SubtypeDirection::OtherSubsumedBySource) {
+                members
+                    .iter()
+                    .map(|&id| {
+                        let mut mods = FxHashMap::default();
+                        Self::collect_property_modifiers(self.interner, id, &mut mods);
+                        if mods.is_empty() { None } else { Some(mods) }
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            };
+
         // Use mark-and-compact instead of Vec::remove() which is O(N) per removal.
         // Since max size is 25 (from guard above), a u32 bitset avoids heap allocation.
         let len = members.len();
@@ -791,6 +816,20 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         !Self::is_opaque_under_bypass_eval(self.interner, members[i])
                             && checker.is_subtype_of(members[j], members[i])
                             && !Self::has_unique_properties_cached(&prop_names[i], &prop_names[j])
+                            // Modifier-preservation guard: in an intersection a shared
+                            // property is readonly/optional only when ALL contributors
+                            // agree (AND semantics). Dropping member[i] because the
+                            // structural subtype member[j] subsumes it would keep only
+                            // member[j]'s modifiers — silently turning a writable
+                            // (or required) property readonly (or optional) when the
+                            // dropped member relaxed it. `{ readonly a: number }` is a
+                            // subtype of `{ a?: number }`, but their intersection is a
+                            // writable, required `a` — not readonly. Keep both members
+                            // so `try_merge_objects_in_intersection` can AND-merge them.
+                            && !Self::intersection_drop_changes_modifiers(
+                                &prop_mods[i],
+                                &prop_mods[j],
+                            )
                             // Index-signature guard: when member[i] carries an index
                             // signature that member[j] lacks, member[i] is NOT redundant
                             // even though its declared property set is structurally
@@ -1009,6 +1048,66 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             }
             _ => {}
         }
+    }
+
+    /// Collect per-property `(optional, readonly)` modifiers for an object-like
+    /// member, merging nested intersection members with tsc's AND semantics
+    /// (a property is optional/readonly only when ALL contributors agree).
+    fn collect_property_modifiers(
+        db: &dyn crate::caches::db::TypeDatabase,
+        type_id: TypeId,
+        mods: &mut FxHashMap<u32, (bool, bool)>,
+    ) {
+        if type_id.is_intrinsic() {
+            return;
+        }
+        match db.lookup(type_id) {
+            Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
+                let shape = db.object_shape(shape_id);
+                for prop in &shape.properties {
+                    let entry = mods
+                        .entry(prop.name.0)
+                        .or_insert((prop.optional, prop.readonly));
+                    entry.0 = entry.0 && prop.optional;
+                    entry.1 = entry.1 && prop.readonly;
+                }
+            }
+            Some(TypeData::Intersection(list_id)) => {
+                for &sub in db.type_list(list_id).iter() {
+                    Self::collect_property_modifiers(db, sub, mods);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Returns true when dropping the `dropped` member from an intersection
+    /// while keeping `kept` would change a shared property's readonly/optional
+    /// modifier relative to tsc's AND-merge semantics. Both arguments are the
+    /// precomputed `(optional, readonly)` modifier maps for the two members.
+    ///
+    /// In an intersection a property is readonly (optional) only when ALL
+    /// contributors are readonly (optional). When `kept` structurally subsumes
+    /// `dropped`, `kept` can still be the *more restrictive* member on a shared
+    /// property: readonly does not affect assignability, so `{ readonly a: T }`
+    /// is a subtype of `{ a?: T }` even though the intersection of the two is a
+    /// writable, required `a`. Keeping only `kept` would lose `dropped`'s
+    /// relaxing contribution, so such drops must be skipped.
+    fn intersection_drop_changes_modifiers(
+        dropped: &MemberModifierMap,
+        kept: &MemberModifierMap,
+    ) -> bool {
+        let (Some(dropped), Some(kept)) = (dropped, kept) else {
+            return false;
+        };
+        kept.iter().any(
+            |(name, &(kept_optional, kept_readonly))| match dropped.get(name) {
+                Some(&(dropped_optional, dropped_readonly)) => {
+                    (kept_readonly && !dropped_readonly) || (kept_optional && !dropped_optional)
+                }
+                None => false,
+            },
+        )
     }
 
     // =========================================================================


### PR DESCRIPTION
AgentName: Studio-B

## Summary

Fixes #10863. Homomorphic mapped types over an aliased intersection lost a shared property's `readonly`/optional modifier intent. The witness:

```ts
type Id<T> = { [K in keyof T as K]: T[K] };
type A = { readonly a: number };
type B = { a?: number };
declare const m: Id<A & B>;
m.a = 1; // tsz wrongly reported TS2540 (read-only); tsc accepts it
```

`tsc` merges a shared property's modifiers across intersection constituents with **AND** semantics — a property is `readonly`/optional only when *all* contributors are. So `A & B` has a writable, required `a`.

## Structural rule

When an object property is shared across intersection constituents, `tsc` computes its `readonly`/optional flag as the AND over contributors (writable/required wins). tsz owns this in the solver's intersection construction (`try_merge_objects_in_intersection`) and evaluation (`evaluate_intersection`).

## Owner layer

Solver. The bug was in `evaluation/evaluate/support.rs::remove_redundant_members` (intersection direction). It dropped member `B` because `A` is a *structural subtype* of `B` (readonly does not affect assignability), keeping only `A`'s readonly modifier and bypassing the AND-merge. The concrete-construction path (`intern/intersection.rs::normalize_intersection`) was already correct because it merges objects **before** reducing subtypes; only the evaluator's `simplify_intersection_members` reduced first and lost the modifier.

The fix adds a modifier-preservation guard: do not drop a structurally subsumed member when doing so would change a shared property's `readonly`/optional modifier versus the AND-merge. Per-member modifier maps are precomputed once (mirroring the existing `prop_names` precompute) so the guard is an O(1) cached lookup. Scoped to the intersection direction only — union OR-merge semantics are untouched.

## Adjacent-case matrix (regression tests in `intersection_modifier_merge_tests.rs`)

- Direct aliased `A & B` (`{readonly a}` and `{a?}`): writable + required.
- Identity-remap mapped copy `Id<A & B>` (the witness).
- Plain (no-`as`) homomorphic mapped copy.
- All-readonly intersection still stays readonly (guard does not over-relax).
- Renaming key remap (`` as `p_${K}` ``) still merges modifiers.
- Mixed per-property modifiers (readonly?+writable, writable-only) merged per property.

Each case was confirmed against `tsc` 6.0.2 (writable/required vs read-only/optional parity), plus required/optional parity via TS2322 absence.

## Track
Solver — conditional/mapped + intersection simplification.

## Invariant
Evaluated intersections preserve tsc's AND-merge of `readonly`/optional modifiers; subtype-based member removal never silently tightens a shared property's modifier.

## Scope
- `crates/tsz-solver/src/evaluation/evaluate/support.rs`: modifier-aware drop guard + precomputed per-member modifier maps + `MemberModifierMap` alias.
- `crates/tsz-checker/tests/intersection_modifier_merge_tests.rs` (+ Cargo.toml registration): regression coverage.

## Project Corpus Impact
- Row: n/a (no required project row touched)
- Bug family: mapped/intersection readonly-optional modifier preservation
- Change is a correctness tightening of an existing simplification guard; legitimate reductions (`{a:1} & {a:1|number}` -> `{a:1}`, `{a} & {a;b}` -> `{a;b}`, all-readonly -> readonly) verified unchanged against tsc.

## Verification
- `cargo build -p tsz-cli`: ok.
- `cargo clippy -p tsz-solver`: clean.
- `cargo test -p tsz-solver --lib`: 6501 passed; same 3 pre-existing failures as the clean base (`test_contra_candidate_basic`, `test_deep_widen_object_candidate_homomorphic_mapped`, `test_infer_generic_object_with_contextual_callbacks_prefers_schema_property_type`) — **zero new failures**, confirmed by stashing the change.
- `cargo test -p tsz-checker --test intersection_modifier_merge_tests`: 6 passed.
- Related checker suites (`homomorphic_mapped_index_display_tests`, `homomorphic_mapped_keyof_modifier_tests`, `static_readonly_unique_symbol_tests`): all green.
- Probe matrix (8 fixtures + extras) diffed against `tsc` 6.0.2: all MATCH.

## Coordination Notes
Rebased on latest `origin/main` (no conflicts; upstream changes do not touch the edited files). Continues issue #10863 (`agent:Studio-B`).
