### PR TITLE
fix(checker): report object-literal property mismatch over excess (#10903)

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/mapped_object_literals.rs
+++ b/crates/tsz-checker/src/state/state_checking/mapped_object_literals.rs
@@ -462,6 +462,79 @@ impl<'a> CheckerState<'a> {
         )
     }
 
+    /// Whether `tsc` would report a present-in-target property mismatch
+    /// (`TS2322`) for this object literal instead of an excess-property error
+    /// (`TS2353`) from the same literal — so the excess-property checker must
+    /// skip its emission.
+    ///
+    /// First runs the mapped/`Partial` named-value emit-check (which reports the
+    /// `TS2322` itself for those targets). Then, **only when the literal has an
+    /// excess candidate** — a property that no normalized view of the target
+    /// accepts — a present property whose value is incompatible is detected by
+    /// relating a *freshness-widened* source (widening disables excess-property
+    /// checking, so the relation can only fail on a real structural mismatch).
+    /// Gating on an excess candidate matters: a clean literal (every property
+    /// present) has no `TS2353` to suppress, so probing it must not perturb its
+    /// diagnostics; and a mapped/reverse-mapped target that accepts the extra
+    /// key likewise has no candidate, so its own diagnostics are left intact.
+    ///
+    /// The probe is limited to a terminal primitive/literal (or union/
+    /// intersection of those) target property — the unambiguous `TS2322` leaf
+    /// case. A mismatch on a structural (object/array) property is left alone,
+    /// since relating against a deeply-nested or recursive schema can surface a
+    /// misleading object-level mismatch that would drop legitimate nested excess
+    /// errors. None of this changes which relation runs — only whether the
+    /// excess error defers to the relation's `TS2322`.
+    pub(super) fn object_literal_property_mismatch_preempts_excess(
+        &mut self,
+        source: TypeId,
+        obj_literal_idx: NodeIndex,
+        target: TypeId,
+    ) -> bool {
+        if self.check_object_literal_named_property_values_against_target(obj_literal_idx, target) {
+            return true;
+        }
+        let Some(source_shape) =
+            crate::query_boundaries::state::checking::object_shape(self.ctx.types, source)
+        else {
+            return false;
+        };
+        let source_prop_names: Vec<Atom> = source_shape
+            .properties
+            .iter()
+            .map(|prop| prop.name)
+            .collect();
+        let effective_target = self.normalized_target_for_excess_properties(target);
+        let resolved_target = self.prune_impossible_object_union_members_with_env(effective_target);
+        let resolved_for_access = self.resolve_type_for_property_access(resolved_target);
+        let has_excess_candidate = source_prop_names.iter().any(|&name| {
+            let prop_name = self.ctx.types.resolve_atom(name);
+            use tsz_solver::operations::property::PropertyAccessResult;
+            !matches!(
+                self.resolve_property_access_with_env(resolved_for_access, prop_name.as_ref()),
+                PropertyAccessResult::Success { .. }
+                    | PropertyAccessResult::PossiblyNullOrUndefined {
+                        property_type: Some(_),
+                        ..
+                    }
+            )
+        });
+        if !has_excess_candidate {
+            return false;
+        }
+        let widened = crate::query_boundaries::common::widen_freshness(self.ctx.types, source);
+        matches!(
+            self.assign_relation_outcome(widened, target).failure,
+            Some(crate::query_boundaries::relation_types::RelationFailure::IncompatiblePropertyValue {
+                target_property_type,
+                ..
+            }) if crate::query_boundaries::common::is_literal_or_primitive_or_compound_of_those(
+                self.ctx.types,
+                target_property_type,
+            )
+        )
+    }
+
     pub(crate) fn check_object_literal_named_property_values_against_any_target(
         &mut self,
         obj_literal_idx: NodeIndex,

--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -279,13 +279,12 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        // Run named-property value checks before excess-property reporting. When
-        // a known property is already invalid, tsc reports that assignability
-        // error instead of additionally reporting an excess property from the
-        // same object literal.
-        let emitted_named_property_value_error = self
-            .check_object_literal_named_property_values_against_target(object_literal_idx, target);
-        if emitted_named_property_value_error {
+        // When a present-in-target property is already invalid, tsc reports that
+        // assignability error (TS2322) instead of additionally reporting an
+        // excess property (TS2353) from the same object literal. See
+        // `object_literal_property_mismatch_preempts_excess`.
+        if self.object_literal_property_mismatch_preempts_excess(source, object_literal_idx, target)
+        {
             return;
         }
 

--- a/crates/tsz-checker/tests/ts2353_tests.rs
+++ b/crates/tsz-checker/tests/ts2353_tests.rs
@@ -1663,3 +1663,168 @@ function f(): I {
         "Expected excess-property diagnostic for 'b' returned in a conditional branch, got: {diags:?}",
     );
 }
+
+// ─── Excess-property vs property-type-mismatch precedence ─────────────────────
+//
+// tsc reports a present-in-target property type mismatch (TS2322) ahead of an
+// excess-property error (TS2353) from the same object literal, but the excess
+// error still preempts a missing-required-property failure. The resulting
+// precedence is: present-property mismatch > excess (TS2353) > missing required.
+// Binder names are varied across cases so the rule is exercised structurally
+// rather than against any fixed identifier.
+
+fn codes(diags: &[(u32, String)]) -> Vec<u32> {
+    diags.iter().map(|d| d.0).collect()
+}
+
+#[test]
+fn property_mismatch_outranks_excess_property() {
+    // `value: number` is a present-in-target mismatch; `extra` is excess.
+    // tsc reports only TS2322 for `value`.
+    let diags = get_diagnostics(
+        r#"
+declare let target: { value: string };
+target = { value: 1, extra: true };
+"#,
+    );
+    assert!(
+        codes(&diags).contains(&2322),
+        "Expected TS2322 for the value mismatch, got: {diags:?}",
+    );
+    assert!(
+        !codes(&diags).contains(&2353),
+        "Excess-property TS2353 must be suppressed when a present property mismatches, got: {diags:?}",
+    );
+}
+
+#[test]
+fn property_mismatch_outranks_excess_when_excess_listed_first() {
+    // Source-order independence: the excess property appears before the
+    // mismatching one, yet tsc still reports the mismatch and suppresses excess.
+    let diags = get_diagnostics(
+        r#"
+declare let widget: { label: string };
+widget = { junk: true, label: 42 };
+"#,
+    );
+    assert!(
+        codes(&diags).contains(&2322),
+        "Expected TS2322, got: {diags:?}"
+    );
+    assert!(
+        !codes(&diags).contains(&2353),
+        "Excess TS2353 must be suppressed regardless of property order, got: {diags:?}",
+    );
+}
+
+#[test]
+fn excess_property_reported_when_all_present_properties_match() {
+    // No present-property mismatch → tsc reports the excess property (TS2353).
+    let diags = get_diagnostics(
+        r#"
+declare let config: { mode: string };
+config = { mode: "fast", verbose: true };
+"#,
+    );
+    let ts2353: Vec<_> = diags.iter().filter(|d| d.0 == 2353).collect();
+    assert_eq!(
+        ts2353.len(),
+        1,
+        "Expected exactly one TS2353 for the excess property, got: {diags:?}",
+    );
+    assert!(
+        ts2353[0].1.contains("'verbose'"),
+        "Expected excess 'verbose', got: {ts2353:?}"
+    );
+    assert!(
+        !codes(&diags).contains(&2322),
+        "No TS2322 expected here, got: {diags:?}"
+    );
+}
+
+#[test]
+fn excess_property_outranks_missing_required_property() {
+    // The source lacks the required `name` AND has an excess `bogus`.
+    // tsc reports the excess property (TS2353), not the missing one.
+    let diags = get_diagnostics(
+        r#"
+declare let record: { name: string };
+record = { bogus: 1 };
+"#,
+    );
+    let ts2353: Vec<_> = diags.iter().filter(|d| d.0 == 2353).collect();
+    assert_eq!(
+        ts2353.len(),
+        1,
+        "Expected TS2353 to preempt the missing-property failure, got: {diags:?}",
+    );
+    assert!(
+        ts2353[0].1.contains("'bogus'"),
+        "Expected excess 'bogus', got: {ts2353:?}"
+    );
+}
+
+#[test]
+fn property_mismatch_outranks_excess_for_intersection_target() {
+    let diags = get_diagnostics(
+        r#"
+type Combined = { left: string } & { right: number };
+declare let slot: Combined;
+slot = { left: 1, right: 2, dangling: true };
+"#,
+    );
+    assert!(
+        codes(&diags).contains(&2322),
+        "Expected TS2322 for intersection member, got: {diags:?}"
+    );
+    assert!(
+        !codes(&diags).contains(&2353),
+        "Excess TS2353 must be suppressed for intersection targets too, got: {diags:?}",
+    );
+}
+
+#[test]
+fn property_mismatch_outranks_excess_for_mapped_target() {
+    let diags = get_diagnostics(
+        r#"
+type Pair = { [Key in "first" | "second"]: string };
+declare let pair: Pair;
+pair = { first: "ok", second: 7, third: true };
+"#,
+    );
+    assert!(
+        codes(&diags).contains(&2322),
+        "Expected TS2322 for mapped target member, got: {diags:?}"
+    );
+    assert!(
+        !codes(&diags).contains(&2353),
+        "Excess TS2353 must be suppressed for mapped targets too, got: {diags:?}",
+    );
+}
+
+#[test]
+fn nested_excess_still_reported_without_a_real_mismatch() {
+    // The nested object literal has an excess `noise` but no type mismatch, so
+    // the outer literal must NOT be wrongly suppressed — the nested excess is
+    // still reported.
+    let diags = get_diagnostics(
+        r#"
+declare let outer: { branch: { keep: string } };
+outer = { branch: { keep: "ok", noise: 1 } };
+"#,
+    );
+    let ts2353: Vec<_> = diags.iter().filter(|d| d.0 == 2353).collect();
+    assert_eq!(
+        ts2353.len(),
+        1,
+        "Expected the nested excess 'noise' to still be reported, got: {diags:?}",
+    );
+    assert!(
+        ts2353[0].1.contains("'noise'"),
+        "Expected excess 'noise', got: {ts2353:?}"
+    );
+    assert!(
+        !codes(&diags).contains(&2322),
+        "No spurious TS2322 expected, got: {diags:?}"
+    );
+}

--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -427,6 +427,35 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         )
     }
 
+    /// Whether an object-literal excess-property error (TS2353) should be
+    /// surfaced ahead of the given structural failure reason.
+    ///
+    /// `tsc` reports excess properties through the general relation's
+    /// excess-property pass, but its object-literal elaboration
+    /// (`elaborateObjectLiteral`) runs first and short-circuits when a
+    /// *present-in-target* source property has an incompatible type — so a
+    /// `TS2322` property-type mismatch is reported instead of the excess error.
+    /// The excess error does, however, still take precedence over a failure
+    /// caused solely by a *missing required* property (`TS2741`/`TS2739`),
+    /// which the relation only reports after the excess pass. The resulting
+    /// precedence is:
+    ///
+    /// > present-property mismatch  >  excess (TS2353)  >  missing required property
+    ///
+    /// Excess therefore outranks an absent reason (the literal is otherwise
+    /// assignable) and the missing-property family, but never a reason that
+    /// pins the failure to a property the source actually provides.
+    const fn excess_outranks_structural(reason: &Option<SubtypeFailureReason>) -> bool {
+        matches!(
+            reason,
+            None | Some(
+                SubtypeFailureReason::MissingProperty { .. }
+                    | SubtypeFailureReason::MissingProperties { .. }
+                    | SubtypeFailureReason::MissingIndexSignature { .. }
+            )
+        )
+    }
+
     fn remap_failure_surface(
         reason: SubtypeFailureReason,
         source: TypeId,
@@ -1595,13 +1624,11 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             }
         }
 
-        // Excess property checking (TS2353)
-        if let Some(excess_prop) = self.find_excess_property(source, target) {
-            return Some(SubtypeFailureReason::ExcessProperty {
-                property_name: excess_prop,
-                target_type: target,
-            });
-        }
+        // Excess property checking (TS2353) is deferred until after the
+        // structural failure reason is known: `tsc` reports a present-in-target
+        // property-type mismatch (TS2322) ahead of the excess-property error,
+        // while the excess error still preempts a missing-required-property
+        // failure. See `excess_outranks_structural` below.
 
         // Private brand incompatibility: remember the result but don't short-circuit.
         // Let the structural explain path run first — it may find real missing properties
@@ -1647,6 +1674,20 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
                     ));
                 }
             }
+        }
+
+        // Excess property checking (TS2353), ordered to match tsc. The excess
+        // error is surfaced only when the structural reason does not already
+        // pin the failure to a present-in-target property mismatch (which
+        // outranks it) — but it does take precedence over a missing-required
+        // property failure or an otherwise-assignable literal.
+        if Self::excess_outranks_structural(&structural_result)
+            && let Some(excess_prop) = self.find_excess_property(source, target)
+        {
+            return Some(SubtypeFailureReason::ExcessProperty {
+                property_name: excess_prop,
+                target_type: target,
+            });
         }
 
         // If the structural path found a useful reason, use it.


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Checker / solver assignability diagnostics — object-literal excess-property vs property-type-mismatch precedence (#10903).

## Invariant
When a fresh object literal is assigned (or passed) to a target and it has **both** a present-in-target property whose value type is incompatible **and** an excess property, `tsc` reports the property-type mismatch (`TS2322`) and suppresses the excess-property error (`TS2353`). The excess error still preempts a failure caused solely by a *missing required* property (`TS2741`/`TS2739`). The structural precedence is:

> present-property mismatch (TS2322)  >  excess property (TS2353)  >  missing required property (TS2741)

This holds independently of the property/identifier names and the target form (plain object, intersection, mapped), so it is enforced structurally rather than against any fixed name.

## Scope
- `crates/tsz-solver/src/relations/compat.rs` — `CompatChecker::explain_failure`: defer the excess-property check until after the structural failure reason is computed, surfacing `ExcessProperty` only when the structural reason is absent or a missing-property kind (`excess_outranks_structural`). This corrects the relation-level failure *reason* (used by call-argument and `satisfies` elaboration) so a present-property mismatch is reported instead of the excess.
- `crates/tsz-checker/src/state/state_checking/mapped_object_literals.rs` — `object_literal_property_mismatch_preempts_excess`: the shared helper that decides whether the checker's standalone `TS2353` emission should defer to the relation's `TS2322`. It (1) runs the existing mapped/`Partial` named-value emit-check, then (2) **only when the literal has an excess candidate** — a property that is `PropertyNotFound` on the resolved target — relates a **freshness-widened** source (widening disables excess checking) and defers when the relation pins the failure to an incompatible present property whose target type is a terminal primitive/literal. Gating on an excess candidate is what keeps clean literals and mapped/reverse-mapped targets (which accept the extra key) untouched, so their diagnostics are unchanged.
- `crates/tsz-checker/src/state/state_checking/property.rs` — `check_object_literal_excess_properties` calls the helper before excess reporting (kept under the file-size ratchet by housing the logic in the adjacent module).
- `crates/tsz-checker/tests/ts2353_tests.rs` — regression suite for the precedence rule (varied binder names; intersection/mapped targets; excess-only, missing+excess, and nested-excess-still-reported cases).

No relation/inference/narrowing/evaluation semantics change — only **which** diagnostic is surfaced (and at which span), matching `tsc`.

## Project Corpus Impact
- Row: utility-types-project (and any row asserting object-literal assignment diagnostics).
- Bug family: diagnostic fallback hiding the actual offending property (#10903) — the excess-property error masking the real `TS2322` property mismatch.
- The fix is general (not row- or name-scoped).

## Verification
Oracle: bundled `tsc` **6.0.2** (`--noEmit --strict`). A precedence battery + adjacency battery (varied binder names, deep nesting, intersection/mapped/class/readonly targets, call arguments, array-of-objects) all match `tsc` after the change. Representative diffs that previously diverged and now match:
- `{ value: string } ← { value: 1, extra: true }` → `TS2322` on `value` (was `TS2353` on `extra`).
- `({a:string}&{b:number}) ← { a:1, b:2, extra:true }` → `TS2322` on `a` (was `TS2353`).
- mapped `{[K in "a"|"b"]: string} ← { a:"ok", b:1, extra:true }` → `TS2322` (was `TS2353`).
- preserved: excess-only and missing+excess still report `TS2353`; nested-only excess still reported.

Conformance: the two fixtures flagged on an earlier head — `compiler/contextualTyping21.ts` and `compiler/reverseMappedTypeIntersectionConstraint.ts` — now match `tsc` exactly (the excess-candidate gate stops the probe from perturbing clean literals / rerouting mapped-target diagnostics).

Local tests, rebased onto latest `origin/main` (`cargo nextest run`, nextest 0.9.137):
- `cargo nextest run -p tsz-checker --test ts2353_tests --test excess_property_check_recursive_intersection_tests` → **89 tests run, 89 passed, 0 skipped** (ts2353 precedence suite 74 + recursive-intersection 15).
- `cargo test -p tsz-solver --lib` (excess 11 + relations 1347) — all pass. (`nextest -E` over `tsz-checker` compiles every test target and is killed by `scripts/safe-run.sh` resource caps, so the checker suites are run with `--test` target selection, which is the targeted-filter equivalent.)
- `ts2322_tests`: the only failures are **pre-existing on clean `main`** (verified on a pristine tree), unrelated to this change.
- `cargo fmt --check` clean for both crates; `python3 scripts/arch/arch_guard.py` passes (`property.rs` 1479 ≤ 1480 ratchet); `cargo build` green on the rebased head.

Known residual divergences (strictly smaller than before; left to follow-up): a plain **union** target assignment (`{a:string}|{b:number} ← {a:1,extra}`) and a **nested object-typed** present-property mismatch with a sibling excess still report `TS2353`, because the present-property probe is restricted to terminal-leaf property targets for reliability.

No full conformance/emit/fourslash run locally per repo guidance; ready-review CI owns the broad suites.

## Coordination Notes
- Fixes #10903 (lane `agent:M1-A`). This is the concrete diagnostic-precedence fix; it is orthogonal to the in-flight relation-routing refactor #11890 (which does not change excess-vs-mismatch ordering) and touches different code.
- Also closed the already-fixed #11345 (JSX generic-component spread) with evidence during triage.

https://claude.ai/code/session_015t7S64pvvKc7YmPb4D3ZxD

---
_Generated by [Claude Code](https://claude.ai/code/session_015t7S64pvvKc7YmPb4D3ZxD)_