### PR TITLE
refactor(emit): thread generator receiver without output surgery

### DIFF
--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -1004,6 +1004,10 @@ pub struct Printer<'a> {
     /// receiver.
     pub(crate) es5_class_expression_extends_this_captured: bool,
 
+    /// Receiver to use for `__generator(<receiver>, ...)` when an embedded
+    /// async arrow is emitted from an IR-owned static class context.
+    pub(crate) async_arrow_generator_this_arg: Option<String>,
+
     pub(crate) tagged_template_var_map: FxHashMap<NodeIndex, String>,
 }
 

--- a/crates/tsz-emitter/src/emitter/core_setup.rs
+++ b/crates/tsz-emitter/src/emitter/core_setup.rs
@@ -415,6 +415,7 @@ impl<'a> Printer<'a> {
             scoped_class_expression_self_alias_ancestors: Vec::new(),
             pending_tc39_class_expression_name: None,
             es5_class_expression_extends_this_captured: false,
+            async_arrow_generator_this_arg: None,
             tagged_template_var_map: FxHashMap::default(),
         }
     }
@@ -431,6 +432,10 @@ impl<'a> Printer<'a> {
 
     pub(crate) const fn set_es5_class_expression_extends_this_captured(&mut self, captured: bool) {
         self.es5_class_expression_extends_this_captured = captured;
+    }
+
+    pub(crate) fn set_async_arrow_generator_this_arg(&mut self, arg: Option<String>) {
+        self.async_arrow_generator_this_arg = arg;
     }
 
     /// Emit an object-literal property node, marking accessor members to enable

--- a/crates/tsz-emitter/src/emitter/es5/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers.rs
@@ -933,6 +933,9 @@ impl<'a> Printer<'a> {
         if let Some(text) = self.source_text_for_map() {
             async_emitter.set_source_map_context(text, self.writer.current_source_index());
         }
+        if let Some(generator_this_arg) = &self.async_arrow_generator_this_arg {
+            async_emitter.set_generator_this_arg(generator_this_arg.clone());
+        }
         async_emitter.set_lexical_this(this_expr != "this");
         if self.ctx.options.import_helpers && self.ctx.is_effectively_commonjs() {
             async_emitter.set_tslib_prefix(true);

--- a/crates/tsz-emitter/src/transforms/async_es5.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5.rs
@@ -99,6 +99,7 @@ pub struct AsyncES5Emitter<'a> {
     tslib_prefix: bool,
     tslib_import_binding: String,
     system_import_meta: bool,
+    generator_this_arg: String,
 }
 
 impl<'a> AsyncES5Emitter<'a> {
@@ -116,6 +117,7 @@ impl<'a> AsyncES5Emitter<'a> {
             tslib_prefix: false,
             tslib_import_binding: "tslib_1".to_string(),
             system_import_meta: false,
+            generator_this_arg: "this".to_string(),
         }
     }
 
@@ -133,6 +135,10 @@ impl<'a> AsyncES5Emitter<'a> {
 
     pub const fn set_system_import_meta(&mut self, enabled: bool) {
         self.system_import_meta = enabled;
+    }
+
+    pub fn set_generator_this_arg(&mut self, arg: String) {
+        self.generator_this_arg = arg;
     }
 
     pub const fn set_module_kind(&mut self, kind: ModuleKind) {
@@ -237,6 +243,7 @@ impl<'a> AsyncES5Emitter<'a> {
         printer.set_tslib_prefix(self.tslib_prefix);
         printer.set_tslib_import_binding(self.tslib_import_binding.clone());
         printer.set_system_import_meta(self.system_import_meta);
+        printer.set_generator_this_arg(self.generator_this_arg.clone());
         printer.emit(&ir);
         printer.take_output()
     }
@@ -254,6 +261,7 @@ impl<'a> AsyncES5Emitter<'a> {
         printer.set_tslib_prefix(self.tslib_prefix);
         printer.set_tslib_import_binding(self.tslib_import_binding.clone());
         printer.set_system_import_meta(self.system_import_meta);
+        printer.set_generator_this_arg(self.generator_this_arg.clone());
         printer.emit(&ir);
         printer.take_output()
     }
@@ -324,6 +332,7 @@ impl<'a> AsyncES5Emitter<'a> {
         printer.set_tslib_prefix(self.tslib_prefix);
         printer.set_tslib_import_binding(self.tslib_import_binding.clone());
         printer.set_system_import_meta(self.system_import_meta);
+        printer.set_generator_this_arg(self.generator_this_arg.clone());
         let hoisted_names: Vec<&str> = hoisted
             .iter()
             .flat_map(|group| group.iter().map(String::as_str))

--- a/crates/tsz-emitter/src/transforms/ir_printer.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer.rs
@@ -82,6 +82,7 @@ pub struct IRPrinter<'a> {
     system_import_meta: bool,
     pub(crate) base_printer_options: Option<PrinterOptions>,
     generator_state_name: &'static str,
+    generator_this_arg: String,
     /// Outer names (e.g. a class-expression alias) excluded from generator state
     /// variable selection.  Treated as already-allocated hoisted vars so the
     /// state-name picker skips past them.
@@ -318,6 +319,7 @@ impl<'a> IRPrinter<'a> {
             system_import_meta: false,
             base_printer_options: None,
             generator_state_name: "_a",
+            generator_this_arg: "this".to_string(),
             outer_reserved_for_generator_state: Vec::new(),
             namespace_ast_name: None,
             namespace_ast_exported_names: rustc_hash::FxHashSet::default(),
@@ -350,6 +352,7 @@ impl<'a> IRPrinter<'a> {
             system_import_meta: false,
             base_printer_options: None,
             generator_state_name: "_a",
+            generator_this_arg: "this".to_string(),
             outer_reserved_for_generator_state: Vec::new(),
             namespace_ast_name: None,
             namespace_ast_exported_names: rustc_hash::FxHashSet::default(),
@@ -382,6 +385,7 @@ impl<'a> IRPrinter<'a> {
             system_import_meta: false,
             base_printer_options: None,
             generator_state_name: "_a",
+            generator_this_arg: "this".to_string(),
             outer_reserved_for_generator_state: Vec::new(),
             namespace_ast_name: None,
             namespace_ast_exported_names: rustc_hash::FxHashSet::default(),
@@ -519,6 +523,10 @@ impl<'a> IRPrinter<'a> {
 
     pub const fn set_generator_state_name(&mut self, name: &'static str) {
         self.generator_state_name = name;
+    }
+
+    pub fn set_generator_this_arg(&mut self, arg: String) {
+        self.generator_this_arg = arg;
     }
 
     /// Set names that must not be chosen as the `__generator` state variable.
@@ -1686,16 +1694,12 @@ impl<'a> IRPrinter<'a> {
             } => {
                 if let Some(arena) = self.arena {
                     let mut printer = self.build_nested_ast_printer(arena);
+                    printer.set_async_arrow_generator_this_arg(Some(generator_this.to_string()));
                     printer.emit_expression(*node);
                     self.merge_ast_printer_block_scope_reserved_names(&printer);
                     let output = printer.get_output();
-                    let rewritten = output.replacen(
-                        "__generator(this,",
-                        &format!("__generator({generator_this},"),
-                        1,
-                    );
                     self.write_embedded_output(&Self::rename_colliding_outer_generator_state(
-                        &rewritten,
+                        output,
                         generator_this,
                     ));
                     return;

--- a/crates/tsz-emitter/src/transforms/ir_printer_class_emit.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer_class_emit.rs
@@ -521,7 +521,10 @@ impl<'a> IRPrinter<'a> {
         };
         self.write("return ");
         self.write_helper("__generator");
-        self.write("(this, function (");
+        self.write("(");
+        let generator_this_arg = self.generator_this_arg.clone();
+        self.write(&generator_this_arg);
+        self.write(", function (");
         self.write(self.generator_state_name);
         self.write(") {");
         if !*has_await || cases.is_empty() {

--- a/scripts/emit/output-surgery-allowlist.txt
+++ b/scripts/emit/output-surgery-allowlist.txt
@@ -5,4 +5,3 @@
 crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs|dts-output-surgery|1|inferred type text parameter rewrite; migrate to declaration display request facts
 crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs|dts-output-surgery|2|manual object member line rebuilds after type printing; migrate to declaration summary member facts
 crates/tsz-emitter/src/emitter/source_file/top_level_using.rs|resource-region-output-surgery|16|top-level using region rewrites emitted strings; migrate to disposable-region plan
-crates/tsz-emitter/src/transforms/ir_printer.rs|ir-output-surgery|1|IR printer patches emitted class wrapper text; migrate to structured IR node/chunk


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Emit architecture / output-surgery ratchet

## Invariant
When an IR-owned ES5 static class context embeds an async arrow expression, the async lowering must pass the class-value alias to the inner __generator receiver structurally through emitter printer state. The IR printer must not patch already-emitted JavaScript text to replace __generator(this, ...).

## Scope
- Add a scoped async-arrow generator receiver override to the AST printer.
- Thread that receiver through AsyncES5Emitter into IRPrinter.
- Have IRPrinter emit __generator(<receiver>, ...) from structured state instead of hardcoded text.
- Remove the stale ir-output-surgery allowlist entry for crates/tsz-emitter/src/transforms/ir_printer.rs.

## Project Corpus Impact
- Row: n/a
- Bug family: output-surgery debt / ES5 static async-arrow class alias emit
- Evidence: no project-row fixture metadata or checker/solver/binder behavior changed. The affected surface is emitter-only printing of the existing class static alias unit case, plus narrow JS baseline filters for async arrows and class static output.

## Verification
- cargo fmt --all --check
- git diff --check
- python3 scripts/emit/audit-output-surgery.py -> total_findings=19, allowlisted_calls=19, stale_allowlist_files=0
- scripts/safe-run.sh cargo nextest run -p tsz-emitter es5_static_async_arrow_uses_local_class_alias_as_generator_this -> 1/1 pass before rebase
- scripts/safe-run.sh scripts/emit/run.sh --filter=asyncArrow --js-only --verbose --timeout=30000 --json-out=/tmp/studio-c-asyncArrow-generator-receiver.json -> JS 53/53 pass
- scripts/safe-run.sh scripts/emit/run.sh --filter=classStatic --js-only --verbose --timeout=30000 --json-out=/tmp/studio-c-classStatic-generator-receiver.json -> JS 82/82 pass
- scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-emitter --all-targets -- -D warnings
- Studio-Opus exact-head local verification at 723ab3330c: cargo fmt --all --check; git diff --check origin/main..HEAD; python3 scripts/emit/audit-output-surgery.py; scripts/safe-run.sh cargo nextest run -p tsz-emitter es5_static_async_arrow_uses_local_class_alias_as_generator_this; scripts/safe-run.sh cargo nextest run -p tsz-emitter async_arrow_arguments_capture_tests class_static_alias_tests
- Exact-head GitHub PR CI at 723ab3330c: CI Summary, GitGuardian Security Checks, lint, unit, unit-cloudbuild, cargo-deny, cargo-shear, dist-binaries, wasm, wasm-web, emit, conformance shards + aggregate, fourslash shards + aggregate, lsp-e2e, project-compile-guard, project-compile-canary, project-row-drift, project-corpus-pr-body, conformance-snapshot-gate all pass.

## Coordination Notes
- AgentName: Studio-Opus
- Studio-Opus took over #12344 from Studio-C after the PR duplicated the live Studio-Opus output-surgery blocker and exact-head CI passed, so the PR can enter the merge queue without parking a cross-Studio blocker.
- Current head: 723ab3330cfb26346d9e66eda091a550ca8bccf9
- Current base: origin/main 3572ae8b7e4852591f3d9381cfae574935e7c9e3
- No checker, solver, binder, DTS, or semantic validation changes.
- Output-surgery allowlist ratchets from 20 to 19 entries; remaining pressure is dts-output-surgery 3/3 and resource-region-output-surgery 16/16.
- scripts/agents/ensure-agent-labels.sh --audit still reports unrelated pre-existing noncanonical issue labels (agent:Reviewer, agent:Studio-D, etc.); no open PR label findings and this PR now uses the canonical agent:Studio-Opus label.
