### PR TITLE
fix(solver): resolve numeric-key infer patterns against tuples

### DIFF
--- a/crates/tsz-solver/Cargo.toml
+++ b/crates/tsz-solver/Cargo.toml
@@ -45,3 +45,7 @@ path = "tests/public_api_tests.rs"
 [[test]]
 name = "conditional_deferred_return_tests"
 path = "tests/conditional_deferred_return_tests.rs"
+
+[[test]]
+name = "conditional_infer_tuple_numeric_key_tests"
+path = "tests/conditional_infer_tuple_numeric_key_tests.rs"

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/object_infer.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/object_infer.rs
@@ -306,6 +306,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         prop_name: Atom,
         optional: bool,
     ) -> InferPropertyResolution {
+        // A `readonly` wrapper does not change a property's value type, so strip
+        // it before dispatching; otherwise a `readonly [...]`/`ReadonlyArray`
+        // source would miss the tuple/object arms below and defer. The union and
+        // intersection arms unwrap their members the same way.
+        let source = crate::type_queries::data::unwrap_readonly(self.interner(), source);
+
         // Absent property: an optional pattern position contributes no candidate
         // (tsc skips it), while a required one fails the match. Shared by every
         // "property not found" arm below.
@@ -401,6 +407,55 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     }
                 }
                 absent
+            }
+            Some(TypeData::Tuple(elements_id)) => {
+                // A numeric-index pattern property (`{ 0: infer A }`) reads the
+                // tuple's element at that index, mirroring tsc's structural
+                // `inferFromProperties` over the apparent (tuple) type. `length`
+                // is already served above by `implicit_sequence_property_type`.
+                // The dedicated `query_db` path above covers this when a query
+                // database is connected; this arm keeps the behaviour correct in
+                // pure-evaluation contexts (e.g. type-alias conditional infer)
+                // where `query_db` is `None`, instead of falling through to a
+                // spurious `NoMatch`/false-branch.
+                let prop_name_str = self.interner().resolve_atom_ref(prop_name);
+                let Some(index) = crate::operations::sequence_property::parse_numeric_index(
+                    prop_name_str.as_ref(),
+                ) else {
+                    // A non-numeric key (e.g. an array-prototype method) is not a
+                    // guaranteed tuple property; tuples are closed shapes, so a
+                    // missing key fails the structural match (false branch).
+                    return InferPropertyResolution::NoMatch;
+                };
+                let elements = self.interner().tuple_list(elements_id);
+                match crate::operations::sequence_property::tuple_fixed_slot(
+                    self.interner(),
+                    &elements,
+                    index,
+                ) {
+                    // Guaranteed (non-optional) slot present: contributes the
+                    // element type as the inference candidate, with no
+                    // optionality-`undefined`.
+                    Some((element_type, false)) => InferPropertyResolution::Candidate(element_type),
+                    // Optional slot present: the property is not guaranteed, so a
+                    // required pattern position (`{ 0: infer A }`) takes the false
+                    // branch — `[number?]` is not assignable to `{ 0: unknown }`.
+                    // An optional pattern position (`{ 0?: infer A }`) still binds
+                    // the bare element type.
+                    Some((element_type, true)) => {
+                        if optional {
+                            InferPropertyResolution::Candidate(element_type)
+                        } else {
+                            InferPropertyResolution::NoMatch
+                        }
+                    }
+                    // Index beyond the tuple's fixed slots (or inside an unbounded
+                    // rest): the property is absent. A tuple is a closed shape, so
+                    // a missing numeric key fails the match for both required and
+                    // optional pattern positions (`[] extends { 0?: infer A }` is
+                    // tsc's false branch), unlike an open object literal.
+                    None => InferPropertyResolution::NoMatch,
+                }
             }
             _ => {
                 // Fallback: try evaluating the source further and recursing.

--- a/crates/tsz-solver/src/operations/mod.rs
+++ b/crates/tsz-solver/src/operations/mod.rs
@@ -49,6 +49,7 @@ pub mod iterators;
 pub mod property;
 mod property_readonly;
 mod property_visitor;
+pub(crate) mod sequence_property;
 pub mod widening;
 
 // Re-exports from core implementation

--- a/crates/tsz-solver/src/operations/property_helpers.rs
+++ b/crates/tsz-solver/src/operations/property_helpers.rs
@@ -1380,8 +1380,8 @@ impl<'a> PropertyAccessEvaluator<'a> {
         }
 
         if let Some(TypeData::Tuple(elements_id)) = inner_data
-            && let Some(index_text) = crate::utils::canonicalize_numeric_name(prop_name)
-            && let Ok(index) = index_text.parse::<usize>()
+            && let Some(index) =
+                crate::operations::sequence_property::parse_numeric_index(prop_name)
         {
             let elements = self.interner().tuple_list(elements_id);
             if let Some(element_type) = self.tuple_fixed_element_type(&elements, index) {
@@ -1440,8 +1440,8 @@ impl<'a> PropertyAccessEvaluator<'a> {
         }
 
         if let Some(TypeData::Tuple(elements_id)) = self.interner().lookup(array_type)
-            && let Some(index_text) = crate::utils::canonicalize_numeric_name(prop_name)
-            && let Ok(index) = index_text.parse::<usize>()
+            && let Some(index) =
+                crate::operations::sequence_property::parse_numeric_index(prop_name)
         {
             let elements = self.interner().tuple_list(elements_id);
             if let Some(element_type) = self.tuple_fixed_element_type(&elements, index) {
@@ -1651,125 +1651,18 @@ impl<'a> PropertyAccessEvaluator<'a> {
     }
 
     fn tuple_fixed_element_type(&self, elements: &[TupleElement], index: usize) -> Option<TypeId> {
-        self.tuple_fixed_element_type_inner(elements, index, 0)
-    }
-
-    fn tuple_fixed_element_type_inner(
-        &self,
-        elements: &[TupleElement],
-        index: usize,
-        depth: usize,
-    ) -> Option<TypeId> {
-        const MAX_TUPLE_SPREAD_DEPTH: usize = 64;
-
-        if depth > MAX_TUPLE_SPREAD_DEPTH {
-            return None;
-        }
-
-        let mut position = 0usize;
-        for elem in elements {
-            if elem.rest {
-                let rest_id = elem.type_id;
-                if rest_id.is_intrinsic() {
-                    return None;
-                }
-                let inner_list_id = match self.interner().lookup(rest_id) {
-                    Some(TypeData::Tuple(id)) => id,
-                    _ => return None,
-                };
-                let inner = self.interner().tuple_list(inner_list_id);
-                let rest_index = index.checked_sub(position)?;
-                if let Some(ty) = self.tuple_fixed_element_type_inner(&inner, rest_index, depth + 1)
-                {
-                    return Some(ty);
-                }
-                let inner_len = self.compute_tuple_fixed_length(rest_id)?;
-                position = position.checked_add(inner_len)?;
-            } else {
-                if position == index {
-                    let ty = if elem.optional {
-                        self.element_type_with_undefined(elem.type_id)
-                    } else {
-                        elem.type_id
-                    };
-                    return Some(ty);
-                }
-                position = position.checked_add(1)?;
-            }
-
-            if position > index {
-                return None;
-            }
-        }
-
-        None
+        crate::operations::sequence_property::tuple_fixed_element_type(
+            self.interner(),
+            elements,
+            index,
+        )
     }
 
     fn element_type_with_undefined(&self, element_type: TypeId) -> TypeId {
-        self.interner().union2(element_type, TypeId::UNDEFINED)
-    }
-
-    /// Compute the fixed length of a tuple type, if it has one.
-    /// Returns `None` for arrays, variable-length tuples, or non-tuple types.
-    fn compute_tuple_fixed_length(&self, type_id: TypeId) -> Option<usize> {
-        const MAX_FIXED_LENGTH: usize = 1000;
-
-        if type_id.is_intrinsic() {
-            return None;
-        }
-        let list_id = match self.interner().lookup(type_id) {
-            Some(TypeData::Tuple(id)) => id,
-            _ => return None,
-        };
-
-        let elements = self.interner().tuple_list(list_id);
-        let mut total = 0usize;
-        let mut rest_type: Option<TypeId> = None;
-        let mut rest_count = 0;
-
-        for elem in elements.iter() {
-            if elem.rest {
-                rest_count += 1;
-                if rest_count > 1 {
-                    return None;
-                }
-                rest_type = Some(elem.type_id);
-            } else {
-                total += 1;
-                if total > MAX_FIXED_LENGTH {
-                    return None;
-                }
-            }
-        }
-
-        // Iteratively descend into single-rest chains (e.g., [T, ...Acc])
-        while let Some(rest_id) = rest_type.take() {
-            if rest_id.is_intrinsic() {
-                return None;
-            }
-            let inner_list_id = match self.interner().lookup(rest_id) {
-                Some(TypeData::Tuple(id)) => id,
-                _ => return None, // Rest spreads a non-tuple → variable length
-            };
-            let inner_elements = self.interner().tuple_list(inner_list_id);
-            let mut inner_rest_count = 0;
-            for elem in inner_elements.iter() {
-                if elem.rest {
-                    inner_rest_count += 1;
-                    if inner_rest_count > 1 {
-                        return None;
-                    }
-                    rest_type = Some(elem.type_id);
-                } else {
-                    total += 1;
-                    if total > MAX_FIXED_LENGTH {
-                        return None;
-                    }
-                }
-            }
-        }
-
-        Some(total)
+        crate::operations::sequence_property::element_type_with_undefined(
+            self.interner(),
+            element_type,
+        )
     }
 
     fn compute_tuple_length_type(&self, type_id: TypeId) -> Option<TypeId> {

--- a/crates/tsz-solver/src/operations/sequence_property.rs
+++ b/crates/tsz-solver/src/operations/sequence_property.rs
@@ -1,0 +1,176 @@
+//! Pure tuple/array index-property resolution shared by the property-access
+//! evaluator and the conditional `infer`-pattern resolver.
+//!
+//! These helpers read a numeric-index (or fixed-length) property off a tuple
+//! type using only the interner, so they can run in evaluation contexts that do
+//! not have a `QueryDatabase` wired up (for example, conditional `infer`-pattern
+//! matching during type-alias evaluation). Keeping them as free functions over
+//! `&dyn TypeDatabase` lets both call sites share one implementation instead of
+//! diverging.
+
+use crate::construction::TypeDatabase;
+use crate::types::{TupleElement, TypeData, TypeId};
+
+/// Upper bound on rest-spread recursion while walking nested variadic tuples.
+const MAX_TUPLE_SPREAD_DEPTH: usize = 64;
+/// Upper bound on the fixed length we will count out of a tuple.
+const MAX_FIXED_LENGTH: usize = 1000;
+
+/// Widen an element type to include `undefined`, matching the reading of an
+/// optional tuple slot.
+pub(crate) fn element_type_with_undefined(db: &dyn TypeDatabase, element_type: TypeId) -> TypeId {
+    db.union2(element_type, TypeId::UNDEFINED)
+}
+
+/// Parse a property name as a tuple/array element index, applying the same
+/// numeric-name canonicalization (`"01"`/`"1.0"` → `1`) used for indexed access.
+/// Returns `None` for non-numeric keys (e.g. array-prototype method names).
+pub(crate) fn parse_numeric_index(prop_name: &str) -> Option<usize> {
+    crate::utils::canonicalize_numeric_name(prop_name)?
+        .parse::<usize>()
+        .ok()
+}
+
+/// Resolve the type at a fixed numeric `index` of a tuple's element list,
+/// descending through single-rest variadic spreads. Returns `None` when the
+/// index is not a guaranteed fixed slot (e.g. it falls inside an unbounded rest
+/// element or beyond the tuple's fixed length).
+///
+/// An optional slot is widened to `T | undefined`, matching how an indexed read
+/// (`tuple[index]`) surfaces the slot's value type. Callers that care about the
+/// distinction between a guaranteed slot and a merely-optional one (for example
+/// structural presence in a conditional `infer` pattern) should use
+/// [`tuple_fixed_slot`] instead.
+pub(crate) fn tuple_fixed_element_type(
+    db: &dyn TypeDatabase,
+    elements: &[TupleElement],
+    index: usize,
+) -> Option<TypeId> {
+    let (type_id, optional) = tuple_fixed_slot(db, elements, index)?;
+    Some(if optional {
+        element_type_with_undefined(db, type_id)
+    } else {
+        type_id
+    })
+}
+
+/// Resolve the fixed slot at numeric `index` of a tuple's element list,
+/// returning the slot's declared element type together with whether the slot is
+/// optional. Descends through single-rest variadic spreads. Returns `None` when
+/// the index is not a fixed slot (it falls inside an unbounded rest element or
+/// beyond the tuple's fixed length).
+///
+/// Unlike [`tuple_fixed_element_type`], the element type is returned *without*
+/// the optionality `undefined` so a caller can decide how optionality affects
+/// its own semantics (an indexed read widens, structural presence rejects).
+pub(crate) fn tuple_fixed_slot(
+    db: &dyn TypeDatabase,
+    elements: &[TupleElement],
+    index: usize,
+) -> Option<(TypeId, bool)> {
+    tuple_fixed_slot_inner(db, elements, index, 0)
+}
+
+fn tuple_fixed_slot_inner(
+    db: &dyn TypeDatabase,
+    elements: &[TupleElement],
+    index: usize,
+    depth: usize,
+) -> Option<(TypeId, bool)> {
+    if depth > MAX_TUPLE_SPREAD_DEPTH {
+        return None;
+    }
+
+    let mut position = 0usize;
+    for elem in elements {
+        if elem.rest {
+            let rest_id = elem.type_id;
+            if rest_id.is_intrinsic() {
+                return None;
+            }
+            let inner_list_id = match db.lookup(rest_id) {
+                Some(TypeData::Tuple(id)) => id,
+                _ => return None,
+            };
+            let inner = db.tuple_list(inner_list_id);
+            let rest_index = index.checked_sub(position)?;
+            if let Some(slot) = tuple_fixed_slot_inner(db, &inner, rest_index, depth + 1) {
+                return Some(slot);
+            }
+            let inner_len = compute_tuple_fixed_length(db, rest_id)?;
+            position = position.checked_add(inner_len)?;
+        } else {
+            if position == index {
+                return Some((elem.type_id, elem.optional));
+            }
+            position = position.checked_add(1)?;
+        }
+
+        if position > index {
+            return None;
+        }
+    }
+
+    None
+}
+
+/// Compute the fixed length of a tuple type, if it has one. Returns `None` for
+/// arrays, variable-length tuples (with an unbounded rest), or non-tuple types.
+pub(crate) fn compute_tuple_fixed_length(db: &dyn TypeDatabase, type_id: TypeId) -> Option<usize> {
+    if type_id.is_intrinsic() {
+        return None;
+    }
+    let list_id = match db.lookup(type_id) {
+        Some(TypeData::Tuple(id)) => id,
+        _ => return None,
+    };
+
+    let elements = db.tuple_list(list_id);
+    let mut total = 0usize;
+    let mut rest_type: Option<TypeId> = None;
+    let mut rest_count = 0;
+
+    for elem in elements.iter() {
+        if elem.rest {
+            rest_count += 1;
+            if rest_count > 1 {
+                return None;
+            }
+            rest_type = Some(elem.type_id);
+        } else {
+            total += 1;
+            if total > MAX_FIXED_LENGTH {
+                return None;
+            }
+        }
+    }
+
+    // Iteratively descend into single-rest chains (e.g., [T, ...Acc])
+    while let Some(rest_id) = rest_type.take() {
+        if rest_id.is_intrinsic() {
+            return None;
+        }
+        let inner_list_id = match db.lookup(rest_id) {
+            Some(TypeData::Tuple(id)) => id,
+            _ => return None, // Rest spreads a non-tuple → variable length
+        };
+        let inner_elements = db.tuple_list(inner_list_id);
+        let mut inner_rest_count = 0;
+        for elem in inner_elements.iter() {
+            if elem.rest {
+                inner_rest_count += 1;
+                if inner_rest_count > 1 {
+                    return None;
+                }
+                rest_type = Some(elem.type_id);
+            } else {
+                total += 1;
+                if total > MAX_FIXED_LENGTH {
+                    return None;
+                }
+            }
+        }
+    }
+
+    Some(total)
+}

--- a/crates/tsz-solver/tests/conditional_infer_tuple_numeric_key_tests.rs
+++ b/crates/tsz-solver/tests/conditional_infer_tuple_numeric_key_tests.rs
@@ -1,0 +1,199 @@
+//! Regression tests for conditional `infer` patterns that read a numeric-index
+//! property off a tuple (`T extends { 0: infer A } ? A : F`).
+//!
+//! These exercise `evaluate_conditional` through the bare `TypeInterner`, i.e.
+//! the pure-evaluation path with **no** `QueryDatabase` attached — the same path
+//! type-alias evaluation uses. Before the fix the infer-property resolver had no
+//! tuple arm in that path, so every such conditional collapsed to its false
+//! branch (or deferred) instead of matching the tuple element. tsc resolves the
+//! numeric-index property against the tuple's apparent type, so the structural
+//! rule is:
+//!
+//! When the extends pattern is `{ <n>: infer A }` and the check type is a tuple,
+//! tsc reads the element at fixed index `<n>`; a guaranteed (non-optional) slot
+//! binds `A`, an optional or absent slot fails a required pattern position.
+
+use tsz_solver::computation::evaluate_conditional;
+use tsz_solver::construction::TypeInterner;
+use tsz_solver::type_handles::{
+    ConditionalType, PropertyInfo, TupleElement, TypeId, TypeParamInfo,
+};
+
+fn infer_param(interner: &TypeInterner, name: &str) -> TypeId {
+    interner.infer(TypeParamInfo {
+        name: interner.intern_string(name),
+        constraint: None,
+        default: None,
+        is_const: false,
+    })
+}
+
+/// Build the extends pattern `{ <key>: infer <infer_name> }`.
+fn numeric_key_infer_pattern(
+    interner: &TypeInterner,
+    key: &str,
+    infer_name: &str,
+    optional: bool,
+) -> (TypeId, TypeId) {
+    let inferred = infer_param(interner, infer_name);
+    let mut prop = PropertyInfo::new(interner.intern_string(key), inferred);
+    prop.optional = optional;
+    let pattern = interner.object(vec![prop]);
+    (pattern, inferred)
+}
+
+/// `T extends { 0: infer A } ? A : false_type`, evaluated with no query database.
+fn eval_numeric_key_conditional(
+    interner: &TypeInterner,
+    check_type: TypeId,
+    key: &str,
+    optional: bool,
+    false_type: TypeId,
+) -> TypeId {
+    let (extends_type, inferred) = numeric_key_infer_pattern(interner, key, "Elem", optional);
+    evaluate_conditional(
+        interner,
+        &ConditionalType {
+            check_type,
+            extends_type,
+            true_type: inferred,
+            false_type,
+            is_distributive: false,
+        },
+    )
+}
+
+#[test]
+fn numeric_key_infer_binds_fixed_tuple_element() {
+    // `[9, 8] extends { 0: infer A } ? A : 'no'` → A = 9.
+    let interner = TypeInterner::new();
+    let nine = interner.literal_number(9.0);
+    let eight = interner.literal_number(8.0);
+    let tuple = interner.tuple(vec![TupleElement::fixed(nine), TupleElement::fixed(eight)]);
+    let no = interner.literal_string("no");
+
+    let result = eval_numeric_key_conditional(&interner, tuple, "0", false, no);
+    assert_eq!(
+        result,
+        nine,
+        "index 0 of [9, 8] should bind the first element, got {:?}",
+        interner.lookup(result)
+    );
+
+    // Index 1 binds the second element.
+    let result1 = eval_numeric_key_conditional(&interner, tuple, "1", false, no);
+    assert_eq!(
+        result1, eight,
+        "index 1 of [9, 8] should bind the second element"
+    );
+}
+
+#[test]
+fn numeric_key_infer_binds_through_readonly_wrapper() {
+    // `readonly [9, 8] extends { 0: infer A } ? A : 'no'` → A = 9.
+    let interner = TypeInterner::new();
+    let nine = interner.literal_number(9.0);
+    let eight = interner.literal_number(8.0);
+    let tuple = interner.tuple(vec![TupleElement::fixed(nine), TupleElement::fixed(eight)]);
+    let readonly_tuple = interner.readonly_type(tuple);
+    let no = interner.literal_string("no");
+
+    let result = eval_numeric_key_conditional(&interner, readonly_tuple, "0", false, no);
+    assert_eq!(
+        result,
+        nine,
+        "readonly tuples must unwrap so index 0 still binds, got {:?}",
+        interner.lookup(result)
+    );
+}
+
+#[test]
+fn required_numeric_key_rejects_optional_slot() {
+    // `[number?] extends { 0: infer A } ? A : 'no'` → false branch ('no'),
+    // because an optional slot is not a guaranteed property.
+    let interner = TypeInterner::new();
+    let number = TypeId::NUMBER;
+    let mut optional_elem = TupleElement::fixed(number);
+    optional_elem.optional = true;
+    let tuple = interner.tuple(vec![optional_elem]);
+    let no = interner.literal_string("no");
+
+    let result = eval_numeric_key_conditional(&interner, tuple, "0", false, no);
+    assert_eq!(
+        result, no,
+        "a required numeric-key pattern must reject an optional tuple slot"
+    );
+}
+
+#[test]
+fn required_numeric_key_rejects_out_of_range_index() {
+    // `[42] extends { 1: infer A } ? A : 'no'` → false branch ('no').
+    let interner = TypeInterner::new();
+    let forty_two = interner.literal_number(42.0);
+    let tuple = interner.tuple(vec![TupleElement::fixed(forty_two)]);
+    let no = interner.literal_string("no");
+
+    let result = eval_numeric_key_conditional(&interner, tuple, "1", false, no);
+    assert_eq!(
+        result, no,
+        "index 1 of [42] is absent and must take the false branch"
+    );
+}
+
+#[test]
+fn numeric_key_infer_descends_into_fixed_rest_spread() {
+    // `[boolean, ...[number, string]] extends { 1: infer A } ? A : 'no'` → number.
+    let interner = TypeInterner::new();
+    let number = TypeId::NUMBER;
+    let string = TypeId::STRING;
+    let inner = interner.tuple(vec![
+        TupleElement::fixed(number),
+        TupleElement::fixed(string),
+    ]);
+    let tuple = interner.tuple(vec![
+        TupleElement::fixed(TypeId::BOOLEAN),
+        TupleElement::rest(inner),
+    ]);
+    let no = interner.literal_string("no");
+
+    let result = eval_numeric_key_conditional(&interner, tuple, "1", false, no);
+    assert_eq!(
+        result,
+        number,
+        "index 1 should descend into the fixed rest spread and bind number, got {:?}",
+        interner.lookup(result)
+    );
+}
+
+#[test]
+fn distributive_numeric_key_infer_preserves_per_variant() {
+    // `([1, 2] | ['x']) extends { 0: infer A } ? A : never` distributes to
+    // `1 | 'x'`. Built as a distributive conditional over the union.
+    let interner = TypeInterner::new();
+    let one = interner.literal_number(1.0);
+    let two = interner.literal_number(2.0);
+    let x = interner.literal_string("x");
+    let t12 = interner.tuple(vec![TupleElement::fixed(one), TupleElement::fixed(two)]);
+    let tx = interner.tuple(vec![TupleElement::fixed(x)]);
+    let union = interner.union(vec![t12, tx]);
+
+    let (extends_type, inferred) = numeric_key_infer_pattern(&interner, "0", "Elem", false);
+    let result = evaluate_conditional(
+        &interner,
+        &ConditionalType {
+            check_type: union,
+            extends_type,
+            true_type: inferred,
+            false_type: TypeId::NEVER,
+            is_distributive: true,
+        },
+    );
+
+    let expected = interner.union(vec![one, x]);
+    assert_eq!(
+        result,
+        expected,
+        "distribution should yield 1 | 'x', got {:?}",
+        interner.lookup(result)
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #10848.

A conditional `infer` pattern with a **numeric-key** property — e.g. `T extends { 0: infer A } ? A : F` — collapsed to its false branch (or deferred) whenever the check type was a **tuple**. This broke per-variant precision for distributive conditionals over tuple-like unions (the originally-reported family) and any numeric indexed-property inference over tuples.

### Root cause

`resolve_conditional_infer_property` (solver, `evaluate_rules/conditional/object_infer.rs`) has two paths:
- a `query_db`-backed path that delegates to the unified `resolve_property_access` (which already handles tuples), and
- a **pure-evaluation fallback** used when no `QueryDatabase` is wired up — the path type-alias conditional evaluation takes (`evaluate_conditional` builds a `TypeEvaluator` with `query_db = None`).

The fallback matched `Object`, `Callable`, `Union`, and `Intersection` sources but had **no `Tuple` arm**, so a tuple fell through to a spurious `NoMatch`. `length` happened to work (served earlier by `implicit_sequence_property_type`); numeric indices did not.

## Structural rule

> When the extends pattern is `{ <n>: infer A }` and the check type is a tuple, `tsc` reads the element at fixed index `<n>` off the apparent type. A guaranteed (non-optional) slot binds `A`; an optional slot fails a *required* pattern position (`[number?]` is not assignable to `{ 0: unknown }`); and because tuples are closed shapes, an absent index fails both required and optional pattern positions (`[] extends { 0?: infer A }` is `tsc`'s false branch), unlike an open object literal.

Owner layer: **solver** evaluation (`resolve_conditional_infer_property`), routed through a shared sequence-property helper. Checker is untouched.

## Changes

- Add a `TypeData::Tuple` arm to `resolve_conditional_infer_property` using optionality-aware fixed-slot lookup, and unwrap a `ReadonlyType` source up front via the existing `type_queries::unwrap_readonly` helper (so `readonly [...]` no longer defers).
- Extract the tuple index/length helpers into `operations::sequence_property` as `&dyn TypeDatabase` free functions, shared by the property-access evaluator and the infer resolver instead of duplicated. Adds `tuple_fixed_slot` (element + optionality) and a shared `parse_numeric_index`. Net **−120** lines from `property_helpers.rs`.
- Add solver regression tests (`conditional_infer_tuple_numeric_key_tests`) exercising the no-`query_db` path directly.

## Adjacent-case matrix (verified equal to `tsc` 6.0.x)

| Case | `tsc` / `tsz` |
| --- | --- |
| `[9,8] extends {0: infer A}` | `9` |
| `readonly [9,8] extends {0: infer A}` | `9` |
| `[number?] extends {0: infer A}` (required vs optional slot) | false branch |
| `[42] extends {1: infer A}` (out of range) | false branch |
| `[boolean, ...[number,string]] extends {1: infer A}` (fixed rest spread) | `number` |
| `([1,2] \| ['x']) extends {0: infer A}` (distributive) | `1 \| 'x'` |
| `[number] extends {0?: infer A}` / `[number?]` / `[]` (optional pattern) | candidate / candidate / false |

## Scope

`crates/tsz-solver` only. Behavior is unchanged for object/callable/union/intersection sources and for the `query_db`-backed path.

## Project Corpus Impact

- Row: vite-vanilla-ts-app
- Bug family: distributive-conditional-tuple-like-infer

Targets the distributive-conditional / tuple-like family flagged by the vite-vanilla-ts-app row in #10848. No new accepted-regressions; the change only adds previously-missing true-branch resolutions and per-variant precision (strictly closer to `tsc`). No required project row is moved off green; the change is additive precision in the solver conditional-infer path.

## Verification

> Note: `cargo nextest` is **not installed in this remote execution container** (`cargo nextest run` → `error: no such command: nextest`; no network to `cargo install` it), so the equivalent `cargo test` invocations below were run instead. CI's `unit` / `unit-cloudbuild` jobs cover the same suites under the repo's standard runner.

- Targeted new regression suite: `cargo test -p tsz-solver --test conditional_infer_tuple_numeric_key_tests` → **6/6 pass** (nextest equivalent: `cargo nextest run -p tsz-solver -E 'test(/conditional_infer_tuple_numeric_key/)'`).
- Crate lib suite: `cargo test -p tsz-solver --lib` → **6504 pass, 3 fail**; the 3 failures are **pre-existing on `main`** (confirmed by stashing this change and re-running the same three) and unrelated to this PR.
- Differential against `tsc` 6.0.2 across ~120 generated distributive-conditional / tuple-infer cases: all match (the only residual diffs are a pre-existing `TS2536` gap for indexing unconstrained type params, and array-prototype-method infer that needs the array interface — both out of scope, unchanged by this PR).
- `cargo clippy -p tsz-solver`: clean. Rebased on latest `main`; merges cleanly. Exact-head CI green on `7379956`.

## Coordination Notes

- Follow-up (not this PR): the no-`query_db` fallback still duplicates property-resolution arms that `resolve_property_access` owns; array-prototype-method infer against tuples/arrays (`{ push: infer P }`) remains a false branch in the no-`query_db` path because it needs the `Array<T>` interface. The deeper cleanup is to thread `query_db` into the convenience evaluation entry points so the unified resolver is always used — larger blast radius, deferred.

AgentName: Studio-B
Track: conformance / solver conditional-types
Invariant: distributive conditional + tuple-like infer matches `tsc` per-variant precision

https://claude.ai/code/session_01AN2ixLUmNFk3b5LDakpZd9