### PR TITLE
fix(checker): only narrow unions by direct discriminant properties

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -31,6 +31,10 @@ web-time = { workspace = true }
 stacker = "0.1.23"
 
 [[test]]
+name = "nested_discriminant_narrowing_tests"
+path = "tests/nested_discriminant_narrowing_tests.rs"
+
+[[test]]
 name = "inference_placeholder_determinism_tests"
 path = "tests/inference_placeholder_determinism_tests.rs"
 

--- a/crates/tsz-checker/src/flow/control_flow/narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/narrowing.rs
@@ -1350,14 +1350,23 @@ impl<'a> FlowAnalyzer<'a> {
             current = effective_target;
         }
 
-        // Reverse the path to get correct order (["payload", "kind"] not ["kind", "payload"])
-        path.reverse();
-
-        if path.is_empty() {
+        // Discriminant narrowing only applies to a *direct* property of the
+        // narrowed reference. `tsc` narrows a union by `x.kind === "a"` (a
+        // discriminant property accessed directly on `x`), but it does NOT
+        // narrow the outer union through a nested access such as
+        // `x.meta.kind === "a"` — there the only references narrowed are
+        // `x.meta` and `x.meta.kind`, never `x`. Requiring a single-segment
+        // path keeps every consumer (truthiness, switch, assertion predicate)
+        // aligned with that rule; nested references are narrowed when they are
+        // themselves the target via the relative-path producers.
+        //
+        // A single collected segment needs no reversal, so reject multi-segment
+        // paths before paying for `Vec::reverse`.
+        if path.len() != 1 {
             return None;
         }
 
-        // current is now the base (e.g., "action" in action.payload.kind)
+        // current is now the base (e.g., "action" in action.kind)
         Some((path, is_optional, current))
     }
 
@@ -1374,16 +1383,18 @@ impl<'a> FlowAnalyzer<'a> {
         // (discriminant_property_info returns the full path from the root, which is wrong when
         //  target is not the root — e.g., returns path=["test","type"] base=this for `this.test.type`
         //  when we need path=["type"] base=this.test relative to target=this.test)
+        // Single-segment relative path only (see `discriminant_property_info`):
+        // a nested access narrows the inner reference, never the outer `target`.
         if let Some(literal) = self.discriminant_literal_candidate(right)
             && let Some((rel_path, is_optional)) = self.relative_discriminant_path(left, target)
-            && !rel_path.is_empty()
+            && rel_path.len() == 1
         {
             return Some((rel_path, literal, is_optional, target));
         }
 
         if let Some(literal) = self.discriminant_literal_candidate(left)
             && let Some((rel_path, is_optional)) = self.relative_discriminant_path(right, target)
-            && !rel_path.is_empty()
+            && rel_path.len() == 1
         {
             return Some((rel_path, literal, is_optional, target));
         }
@@ -1482,8 +1493,10 @@ impl<'a> FlowAnalyzer<'a> {
                 || init_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
             {
                 // Walk from `init_expr` towards the root, collecting segments until we hit `target`.
+                // Single-segment path only: `const k = s.meta.kind` does not narrow `s` in `tsc`.
                 if let Some((rel_path, is_optional)) =
                     self.relative_discriminant_path(init_expr, target)
+                    && rel_path.len() == 1
                 {
                     return Some((rel_path, literal, is_optional, target));
                 }
@@ -1594,10 +1607,12 @@ impl<'a> FlowAnalyzer<'a> {
         right: NodeIndex,
         target: NodeIndex,
     ) -> Option<(Vec<Atom>, bool, &str)> {
+        // Single-segment path only (see `discriminant_property_info`):
+        // `typeof s.meta.x === "string"` narrows `s.meta`, never the outer union `s`.
         // Try left = typeof expr, right = string literal
         if let Some(operand) = self.get_typeof_operand(self.skip_parenthesized(left))
             && let Some((path, is_optional)) = self.relative_discriminant_path(operand, target)
-            && !path.is_empty()
+            && path.len() == 1
             && let Some(lit) = self.literal_string_from_node(right)
         {
             return Some((path, is_optional, lit));
@@ -1605,7 +1620,7 @@ impl<'a> FlowAnalyzer<'a> {
         // Try right = typeof expr, left = string literal
         if let Some(operand) = self.get_typeof_operand(self.skip_parenthesized(right))
             && let Some((path, is_optional)) = self.relative_discriminant_path(operand, target)
-            && !path.is_empty()
+            && path.len() == 1
             && let Some(lit) = self.literal_string_from_node(left)
         {
             return Some((path, is_optional, lit));

--- a/crates/tsz-checker/tests/nested_discriminant_narrowing_tests.rs
+++ b/crates/tsz-checker/tests/nested_discriminant_narrowing_tests.rs
@@ -1,0 +1,265 @@
+//! Regression coverage for discriminated-union narrowing through *nested*
+//! property accesses.
+//!
+//! Structural rule (matches TypeScript 6.0.x): a union reference is narrowed
+//! only by a discriminant property accessed **directly** on that reference
+//! (`x.kind === "a"`). TypeScript does NOT narrow an outer union through a
+//! nested discriminant access — `x.meta.kind === "a"` narrows `x.meta` (and
+//! `x.meta.kind`) but never `x`. Previously tsz walked the full property path
+//! (`["meta", "kind"]`) and narrowed the outer reference, accepting code that
+//! `tsc` rejects with TS2339/TS2322.
+//!
+//! Binder names are varied per case so the rule is structural, not keyed to a
+//! particular identifier.
+
+use tsz_checker::test_utils::check_source_strict_codes;
+
+const TS2339: u32 = 2339; // Property does not exist on type
+const TS2322: u32 = 2322; // Type not assignable
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_strict_codes(source)
+}
+
+// ---------------------------------------------------------------------------
+// Positive cases: legitimate direct-discriminant narrowing must keep working.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn top_level_discriminant_still_narrows() {
+    // `tsc`: clean.
+    let diags = codes(
+        r#"
+type Shape = { kind: "circle"; radius: number } | { kind: "square"; side: string };
+function area(shape: Shape): number | string {
+    if (shape.kind === "circle") return shape.radius;
+    return shape.side;
+}
+"#,
+    );
+    assert!(
+        !diags.contains(&TS2339),
+        "direct discriminant `shape.kind` must still narrow `shape`, got {diags:?}"
+    );
+}
+
+#[test]
+fn unit_typed_intermediate_property_is_a_direct_discriminant() {
+    // `meta` itself is the unit discriminant (`"on" | "off"`), a direct property.
+    // `tsc`: clean.
+    let diags = codes(
+        r#"
+type Toggle = { meta: "on"; power: number } | { meta: "off"; reason: string };
+function read(node: Toggle): number | string {
+    if (node.meta === "on") return node.power;
+    return node.reason;
+}
+"#,
+    );
+    assert!(
+        !diags.contains(&TS2339),
+        "unit-typed direct property `node.meta` must narrow `node`, got {diags:?}"
+    );
+}
+
+#[test]
+fn narrowing_the_inner_reference_still_works() {
+    // The discriminant is direct *relative to the inner reference* `holder.inner`,
+    // so `tsc` narrows `holder.inner` and both branches type-check.
+    let diags = codes(
+        r#"
+type Inner = { kind: "a"; av: number } | { kind: "b"; bv: string };
+function pick(holder: { inner: Inner }): number | string {
+    if (holder.inner.kind === "a") return holder.inner.av;
+    return holder.inner.bv;
+}
+"#,
+    );
+    assert!(
+        !diags.contains(&TS2339),
+        "inner reference `holder.inner` must still narrow by its direct discriminant, got {diags:?}"
+    );
+}
+
+#[test]
+fn aliased_top_level_discriminant_still_narrows() {
+    // Aliased *direct* discriminant (TS 4.4 feature). `tsc`: clean.
+    let diags = codes(
+        r#"
+type Signal = { tag: "click"; x: number } | { tag: "key"; code: string };
+function handle(ev: Signal): number | string {
+    const t = ev.tag;
+    if (t === "click") return ev.x;
+    return ev.code;
+}
+"#,
+    );
+    assert!(
+        !diags.contains(&TS2339),
+        "aliased direct discriminant `const t = ev.tag` must narrow `ev`, got {diags:?}"
+    );
+}
+
+#[test]
+fn switch_on_direct_discriminant_still_narrows() {
+    // `tsc`: clean.
+    let diags = codes(
+        r#"
+type Cmd = { op: "add"; lhs: number } | { op: "neg"; value: string };
+function run(cmd: Cmd): number | string {
+    switch (cmd.op) {
+        case "add": return cmd.lhs;
+        case "neg": return cmd.value;
+    }
+}
+"#,
+    );
+    assert!(
+        !diags.contains(&TS2339),
+        "switch on direct discriminant `cmd.op` must narrow `cmd`, got {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative cases: nested discriminants must NOT narrow the outer union.
+// Each mirrors a `tsc` TS2339/TS2322 result.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nested_discriminant_does_not_narrow_outer_union() {
+    // `tsc`: TS2339 on `node.a` and `node.b` (no narrowing of `node`).
+    let diags = codes(
+        r#"
+type Variant = { meta: { kind: "a" }; a: number } | { meta: { kind: "b" }; b: string };
+function visit(node: Variant): number | string {
+    if (node.meta.kind === "a") return node.a;
+    return node.b;
+}
+"#,
+    );
+    assert!(
+        diags.contains(&TS2339),
+        "nested discriminant `node.meta.kind` must NOT narrow `node`; expected TS2339, got {diags:?}"
+    );
+}
+
+#[test]
+fn deeply_nested_discriminant_does_not_narrow_outer_union() {
+    // `tsc`: TS2339 (two levels of nesting).
+    let diags = codes(
+        r#"
+type Wrap =
+    | { outer: { inner: { kind: "a" } }; a: number }
+    | { outer: { inner: { kind: "b" } }; b: string };
+function take(w: Wrap): number | string {
+    if (w.outer.inner.kind === "a") return w.a;
+    return w.b;
+}
+"#,
+    );
+    assert!(
+        diags.contains(&TS2339),
+        "deep nested discriminant must NOT narrow the root; expected TS2339, got {diags:?}"
+    );
+}
+
+#[test]
+fn aliased_nested_discriminant_does_not_narrow_outer_union() {
+    // `const disc = action.meta.type` does not narrow `action`. `tsc`: TS2339.
+    let diags = codes(
+        r#"
+type Action = { meta: { type: "inc" }; amount: number } | { meta: { type: "dec" }; id: string };
+function reduce(action: Action): number | string {
+    const disc = action.meta.type;
+    if (disc === "inc") return action.amount;
+    return action.id;
+}
+"#,
+    );
+    assert!(
+        diags.contains(&TS2339),
+        "aliased nested discriminant must NOT narrow the root; expected TS2339, got {diags:?}"
+    );
+}
+
+#[test]
+fn aliased_intermediate_object_does_not_narrow_outer_union() {
+    // `const m = item.meta; if (m.kind === ...)` narrows `m`, not `item`. `tsc`: TS2339.
+    let diags = codes(
+        r#"
+type Item = { meta: { kind: "a" }; a: number } | { meta: { kind: "b" }; b: string };
+function use(item: Item): number | string {
+    const m = item.meta;
+    if (m.kind === "a") return item.a;
+    return item.b;
+}
+"#,
+    );
+    assert!(
+        diags.contains(&TS2339),
+        "aliasing the intermediate object must NOT narrow the root; expected TS2339, got {diags:?}"
+    );
+}
+
+#[test]
+fn switch_on_nested_discriminant_does_not_narrow_outer_union() {
+    // `tsc`: TS2339 — switching on `state.meta.phase` does not narrow `state`.
+    let diags = codes(
+        r#"
+type State = { meta: { phase: "load" }; progress: number } | { meta: { phase: "done" }; result: string };
+function summarize(state: State): number | string {
+    switch (state.meta.phase) {
+        case "load": return state.progress;
+        case "done": return state.result;
+    }
+    return 0;
+}
+"#,
+    );
+    assert!(
+        diags.contains(&TS2339),
+        "switch on nested discriminant must NOT narrow the root; expected TS2339, got {diags:?}"
+    );
+}
+
+#[test]
+fn nested_discriminant_does_not_assign_narrowed_member() {
+    // The narrowed member is not assignable from the un-narrowed union. `tsc`: TS2322.
+    let diags = codes(
+        r#"
+type Add = { meta: { kind: "a" }; a: number };
+type Op = Add | { meta: { kind: "b" }; b: string };
+function go(op: Op): void {
+    if (op.meta.kind === "a") {
+        const only: Add = op;
+        void only;
+    }
+}
+"#,
+    );
+    assert!(
+        diags.contains(&TS2322),
+        "outer union must stay un-narrowed through a nested discriminant; expected TS2322, got {diags:?}"
+    );
+}
+
+#[test]
+fn typeof_nested_property_does_not_narrow_outer_union() {
+    // `typeof box.payload.value === "string"` narrows `box.payload`, never `box`.
+    // `tsc`: TS2339 on `box.s` / `box.n`.
+    let diags = codes(
+        r#"
+type Box =
+    | { payload: { value: string }; s: number }
+    | { payload: { value: number }; n: string };
+function unwrap(box: Box): number | string {
+    if (typeof box.payload.value === "string") return box.s;
+    return box.n;
+}
+"#,
+    );
+    assert!(
+        diags.contains(&TS2339),
+        "typeof on a nested property must NOT narrow the root; expected TS2339, got {diags:?}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-Opus

## Track
Checker conformance / control-flow narrowing parity.

## Invariant
When a condition tests a discriminant property through a nested access
(`x.meta.kind === "a"`, and the aliased / `switch` / `typeof` forms), `tsc`
narrows only the **direct parent reference** of the discriminant property
(`x.meta`) by the single property `kind`; it never narrows the outer union `x`
through a multi-segment discriminant path. tsz now narrows a union target by a
discriminant only when the property path relative to that target has length 1,
matching `tsc`.

## Scope
Solver-backed flow analysis in
`crates/tsz-checker/src/flow/control_flow/narrowing.rs`. The four discriminant
path producers — `discriminant_property_info`, `discriminant_comparison`,
`aliased_discriminant`, and `typeof_discriminant_path` — previously walked the
full property chain and applied a multi-segment path to the outer target. They
now require a single-segment path. All discriminant-narrowing application sites
in the flow layer (`condition_narrowing.rs` truthiness/equality/typeof/switch,
`type_guards.rs`, `core.rs` assertion predicates) funnel through these four
producers, so the rule is enforced once at the chokepoint; truthiness
destructuring aliases are single-segment by construction.

## Project Corpus Impact
- Row: none directly (this is a false-negative — tsz accepted programs `tsc`
  rejects — so it did not surface as a project-compile failure). Parity bug.
- Bug family: discriminated-union narrowing through nested discriminants.
- Fixes #12345.

### Before / after (TypeScript 6.0.2, `--strict`)
```ts
type Variant = { meta: { kind: "a" }; a: number } | { meta: { kind: "b" }; b: string };
function visit(node: Variant): number | string {
  if (node.meta.kind === "a") return node.a; // tsc TS2339; tsz before: accepted
  return node.b;                             // tsc TS2339; tsz before: accepted
}
```
`tsc` emits two `TS2339`; tsz now matches. The narrowing was confirmed (not a
lenient property lookup) — before the fix tsz reported the narrowed member type
`{ meta: { kind: "a" }; a: number }` when the other member's property was
accessed inside the branch.

## Adjacent matrix (all verified against `tsc`)
Negative (now emit `tsc`-exact diagnostics):
- equality `s.meta.kind === "a"` → TS2339
- deeply nested `s.outer.inner.kind === "a"` → TS2339
- aliased value `const d = s.meta.kind; if (d === "a")` → TS2339
- aliased object `const m = s.meta; if (m.kind === "a") s.a` → TS2339
- `switch (s.meta.phase)` → TS2339
- `typeof s.payload.value === "string"` → TS2339
- narrowed-member assignment → TS2322

Positive controls (stay clean, narrowing preserved):
- direct discriminant `s.kind === "a"`
- unit-typed direct property `s.meta === "a"` (`meta: "a" | "b"`)
- aliased top-level `const t = s.tag`
- switch on direct discriminant
- inner reference `holder.inner.kind === "a"` still narrows `holder.inner`

Regression test names vary binder/type identifiers so the rule is structural,
not keyed to a particular name.

## Verification
Targeted `cargo nextest run` per repo guidance. Note: the `cargo-nextest`
binary is not installed in this remote execution environment (`cargo nextest`
returns "no such command"), so the runs below were executed locally with
`cargo test` — the same compiled test binary and assertions; CI runs `nextest`.
- `cargo nextest run -p tsz-checker --test nested_discriminant_narrowing_tests` → 12 passed (new file).
- Narrowing/flow integration suites green: `control_flow_type_guard_tests`,
  `closure_boundary_property_narrowing_tests`, `assignment_branch_merge_narrowing_tests`,
  `array_isarray_mutual_subtype_narrowing_tests`, `const_alias_discriminant_narrowing_tests`,
  `discriminant_literal_reference_narrowing_tests`, `unique_symbol_discriminant_narrowing_tests`,
  `discriminant_narrow_function_lazy_preserved_tests`, `enum_equality_narrowing_tests`,
  `destructuring_default_target_narrow_tests`, `typeof_function_like_flow_tests`,
  `in_chain_narrows_unconstrained_type_param_tests`, `ts2339_union_narrow_display_tests`,
  and others — e.g.
  `cargo nextest run -p tsz-checker --test control_flow_type_guard_tests`.
- `cargo fmt -p tsz-checker --check`, `git diff --check`, `python3 scripts/arch/arch_guard.py` all pass.
- Oracle: TypeScript 6.0.2 `tsc --strict --noEmit` for every matrix case.
- Pre-existing `--lib` architecture-contract failures (e.g. `test_checker_file_size_ceiling`:
  `types/property_access_type/resolve.rs` is 3164 &gt; 3160 ceiling) are unrelated to this diff
  and present on `main`; ready-review CI owns the broad suites.

## Coordination Notes
Structural rule lives in the checker flow layer; no solver/emitter semantic
policy changed, no new solver imports (arch guard clean). Efficiency: the
single-segment check now precedes `Vec::reverse` in `discriminant_property_info`,
skipping the reversal for rejected multi-segment paths. Rebased onto current
`main` (`1abcd91`); `narrowing.rs` is untouched by intervening commits, merge is
clean.

Re Studio-manager: updated Verification to the canonical `cargo nextest run`
form (with a note that `nextest` is unavailable in this remote environment, so
`cargo test` ran the identical binary locally). Exact-head CI is green for
`b8c123f`; the PR is non-WIP/non-draft and I reviewed the latest head, so it is
ready for `merge-queue`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014yiFjcEqz9tM9W47bjPC52)_
