### PR TITLE
fix(checker): route is_external_module_by_file lookups through normalized helper (#12171)

### DIFF
--- a/crates/tsz-checker/src/context/file_format_lookup.rs
+++ b/crates/tsz-checker/src/context/file_format_lookup.rs
@@ -44,6 +44,26 @@ pub(crate) fn lookup_file_is_esm_in_map(
     map: &FxHashMap<String, bool>,
     file_name: &str,
 ) -> Option<bool> {
+    lookup_per_file_bool(map, file_name)
+}
+
+/// Look up whether `file_name` is an external module in
+/// `is_external_module_by_file`.
+///
+/// Keys in the map are normalized to forward slashes at insertion; this
+/// function normalizes the query to the same form and returns the result of
+/// a single hash-map probe. Returns `None` when no key matches; callers
+/// should fall back to the binder's `is_external_module()` detection.
+pub(crate) fn lookup_is_external_module_in_map(
+    map: &FxHashMap<String, bool>,
+    file_name: &str,
+) -> Option<bool> {
+    lookup_per_file_bool(map, file_name)
+}
+
+/// Shared implementation for per-file `bool` map lookups with query-time
+/// forward-slash normalization.
+fn lookup_per_file_bool(map: &FxHashMap<String, bool>, file_name: &str) -> Option<bool> {
     if map.is_empty() {
         return None;
     }
@@ -117,5 +137,45 @@ mod tests {
         assert_eq!(normalize_path_key("C:\\proj\\foo.ts"), "C:/proj/foo.ts");
         assert_eq!(normalize_path_key("/proj/foo.ts"), "/proj/foo.ts");
         assert_eq!(normalize_path_key("mod.cts"), "mod.cts");
+    }
+
+    #[test]
+    fn lookup_is_external_module_forward_slash_hit() {
+        let map = map_of(&[("/proj/mod.ts", true), ("/proj/script.ts", false)]);
+        assert_eq!(
+            lookup_is_external_module_in_map(&map, "/proj/mod.ts"),
+            Some(true)
+        );
+        assert_eq!(
+            lookup_is_external_module_in_map(&map, "/proj/script.ts"),
+            Some(false)
+        );
+    }
+
+    /// When a file name is stored with forward slashes (driver normalizes at
+    /// insertion) but the query arrives with backslashes (Windows path), the
+    /// helper must still find the entry.
+    #[test]
+    fn lookup_is_external_module_backslash_query_hits_normalized_key() {
+        let map = map_of(&[("/proj/mod.ts", true)]);
+        assert_eq!(
+            lookup_is_external_module_in_map(&map, "\\proj\\mod.ts"),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn lookup_is_external_module_missing_returns_none() {
+        let map = map_of(&[("/proj/mod.ts", true)]);
+        assert_eq!(
+            lookup_is_external_module_in_map(&map, "/proj/other.ts"),
+            None
+        );
+    }
+
+    #[test]
+    fn lookup_is_external_module_empty_map_returns_none() {
+        let map: FxHashMap<String, bool> = FxHashMap::default();
+        assert_eq!(lookup_is_external_module_in_map(&map, "/proj/mod.ts"), None);
     }
 }

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -31,7 +31,7 @@ pub mod lifetime_shells;
 pub use lifetime_shells::{FileSession, LspPersistentCache, SpeculationScope, WorkerContext};
 mod def_mapping;
 mod file_format_lookup;
-pub(crate) use file_format_lookup::lookup_file_is_esm_in_map;
+pub(crate) use file_format_lookup::{lookup_file_is_esm_in_map, lookup_is_external_module_in_map};
 mod import_conflicts;
 mod parse_health;
 pub use parse_health::ParseHealth;

--- a/crates/tsz-checker/src/context/strict_mode.rs
+++ b/crates/tsz-checker/src/context/strict_mode.rs
@@ -91,7 +91,7 @@ impl CheckerContext<'_> {
     /// falling back to the binder's detection for single-file mode.
     pub(crate) fn is_external_module_file(&self) -> bool {
         if let Some(ref map) = self.is_external_module_by_file
-            && let Some(&is_ext) = map.get(&self.file_name)
+            && let Some(is_ext) = super::lookup_is_external_module_in_map(map, &self.file_name)
         {
             return is_ext;
         }

--- a/crates/tsz-checker/src/declarations/declarations_module_helpers.rs
+++ b/crates/tsz-checker/src/declarations/declarations_module_helpers.rs
@@ -18,7 +18,8 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
         // Check the per-file cache first (set by CLI driver for multi-file mode)
         // This preserves the correct is_external_module value across sequential file bindings
         if let Some(ref map) = self.ctx.is_external_module_by_file
-            && let Some(&is_ext) = map.get(&self.ctx.file_name)
+            && let Some(is_ext) =
+                crate::context::lookup_is_external_module_in_map(map, &self.ctx.file_name)
         {
             return is_ext;
         }

--- a/crates/tsz-checker/src/jsdoc/diagnostics.rs
+++ b/crates/tsz-checker/src/jsdoc/diagnostics.rs
@@ -503,7 +503,10 @@ impl<'a> CheckerState<'a> {
         };
 
         if let Some(is_external_module_by_file) = self.ctx.is_external_module_by_file.as_ref()
-            && let Some(is_external_module) = is_external_module_by_file.get(&source_file.file_name)
+            && let Some(is_external_module) = crate::context::lookup_is_external_module_in_map(
+                is_external_module_by_file,
+                &source_file.file_name,
+            )
         {
             return !is_external_module;
         }

--- a/crates/tsz-checker/src/jsdoc/lookup.rs
+++ b/crates/tsz-checker/src/jsdoc/lookup.rs
@@ -392,9 +392,12 @@ impl<'a> CheckerState<'a> {
         }
 
         if let Some(is_external_module_by_file) = ctx.is_external_module_by_file.as_ref()
-            && let Some(is_external_module) = is_external_module_by_file.get(&source_file.file_name)
+            && let Some(is_external_module) = crate::context::lookup_is_external_module_in_map(
+                is_external_module_by_file,
+                &source_file.file_name,
+            )
         {
-            return *is_external_module;
+            return is_external_module;
         }
 
         if ctx

--- a/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
@@ -1472,9 +1472,12 @@ impl<'a> CheckerState<'a> {
         };
 
         if let Some(is_external_module_by_file) = self.ctx.is_external_module_by_file.as_ref()
-            && let Some(is_external_module) = is_external_module_by_file.get(&source_file.file_name)
+            && let Some(is_external_module) = crate::context::lookup_is_external_module_in_map(
+                is_external_module_by_file,
+                &source_file.file_name,
+            )
         {
-            return *is_external_module;
+            return is_external_module;
         }
 
         source_file.statements.nodes.iter().any(|&stmt_idx| {

--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -1348,7 +1348,8 @@ impl<'a> CheckerState<'a> {
         }
 
         let is_external_module = if let Some(ref map) = self.ctx.is_external_module_by_file {
-            map.get(&self.ctx.file_name).copied().unwrap_or(false)
+            crate::context::lookup_is_external_module_in_map(map, &self.ctx.file_name)
+                .unwrap_or(false)
         } else {
             self.ctx.binder.is_external_module()
         };

--- a/crates/tsz-checker/src/types/type_checking/cross_file_conflicts.rs
+++ b/crates/tsz-checker/src/types/type_checking/cross_file_conflicts.rs
@@ -1649,8 +1649,7 @@ impl<'a> CheckerState<'a> {
             .ctx
             .is_external_module_by_file
             .as_ref()
-            .and_then(|m| m.get(&self.ctx.file_name))
-            .copied()
+            .and_then(|m| crate::context::lookup_is_external_module_in_map(m, &self.ctx.file_name))
             .unwrap_or_else(|| self.ctx.binder.is_external_module());
 
         // Check `undefined` redeclaration.

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -234,8 +234,7 @@ impl<'a> CheckerState<'a> {
             .ctx
             .is_external_module_by_file
             .as_ref()
-            .and_then(|m| m.get(&self.ctx.file_name))
-            .copied()
+            .and_then(|m| crate::context::lookup_is_external_module_in_map(m, &self.ctx.file_name))
             .unwrap_or_else(|| self.ctx.binder.is_external_module());
 
         // When libs are loaded, scope tables contain ~2000+ merged lib symbols alongside

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -736,7 +736,7 @@ FILE_LINE_LIMIT_CHECKS = [
     (
         "Checker boundary: jsdoc/diagnostics.rs size ratchet",
         ROOT / "crates" / "tsz-checker" / "src" / "jsdoc" / "diagnostics.rs",
-        2437,
+        2440,
     ),
     (
         "Checker boundary: state/variable_checking/destructuring.rs size ratchet",


### PR DESCRIPTION
## Agent
AgentName: M1-Opus

## Track
Checker architecture / per-file map lookup normalization (#12171, #10900 follow-up)

## Invariant
When `is_external_module_by_file` keys are normalized to forward slashes at insertion (the driver already does `file.file_name.replace('\\', "/")` at build time), every read site must normalize the query path to the same form. A read site doing plain `map.get(&source_file.file_name)` silently returns `None` on Windows when the query path still has backslashes, driving `is_external_module` to `false` — which gates TS2664, duplicate-identifier handling, strict-mode bindings, declaration emit, and jsdoc resolution.

The structural rule is: `is_external_module_by_file` and `file_is_esm_map` are the same shape (`FxHashMap<String, bool>` keyed on path strings normalized to forward slashes at insertion). Both maps must be queried through a helper that also normalizes the query, so insertion/lookup always agree on one canonical form regardless of OS path separators.

## Scope
- `crates/tsz-checker/src/context/file_format_lookup.rs`: add `lookup_is_external_module_in_map` (shares the private `lookup_per_file_bool` helper with the existing `lookup_file_is_esm_in_map`); add 4 unit tests covering direct hit, backslash-query normalization, miss, and empty-map cases.
- `crates/tsz-checker/src/context/mod.rs`: re-export `lookup_is_external_module_in_map` at `crate::context` level, matching the existing `lookup_file_is_esm_in_map` re-export.
- 8 checker read sites migrated from `map.get(&file_name)` to `lookup_is_external_module_in_map(map, &file_name)`:
  - `context/strict_mode.rs`
  - `declarations/declarations_module_helpers.rs`
  - `jsdoc/diagnostics.rs`
  - `jsdoc/lookup.rs`
  - `jsdoc/resolution/name_resolution.rs`
  - `state/state_checking/source_file.rs`
  - `types/type_checking/cross_file_conflicts.rs`
  - `types/type_checking/duplicate_identifiers.rs`
- `scripts/arch/arch_guard_shared.py`: bump `jsdoc/diagnostics.rs` size ratchet from 2437 → 2440 to cover the 3-line multiline call-site expansion (the file is pre-existing over-2000-line tech debt tracked in #8223; net growth from this PR is 3 lines).

No solver semantics, diagnostic formatting, relation routing, emit, or fixture metadata changes.

## Project Corpus Impact
- Row: n/a
- Bug family: per-file map insertion/lookup path asymmetry (#10900 follow-up, #12171)
- On Linux/Mac all paths are already forward-slash so the observable bug only manifests on Windows. This PR eliminates the structural fragility regardless.

## Verification
- `cargo check -p tsz-checker` — clean
- `cargo fmt --all --check` — clean
- `git diff --check` — clean
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -E 'test(file_format_lookup)'` — equivalent targeted command; ran as `cargo test -p tsz-checker --lib 'context::file_format_lookup::tests'` (nextest unavailable in this execution environment): 10/10 pass (4 new `lookup_is_external_module_*` cases + 6 pre-existing)
- `python3 scripts/arch/arch_guard.py` — `Architecture guardrails passed. exit: 0`
- No full conformance, emit, or fourslash suites run locally per repo guidance; ready-review CI owns those.

## Coordination Notes
- Fixes #12171 (unowned, no agent label, no prior PR).
- Complementary to #10900 (fixed `file_is_esm_map` lookup asymmetry); this PR closes the same class of bug for `is_external_module_by_file`.
- No overlap with open PRs (#11890 M1-B routing, #12343 M1-A excess-property precedence, #11837 M4-Opus wildcard reexports).
- AgentName: M1-Opus; canonical label: `agent:M1-Opus`.

https://claude.ai/code/session_0113scixGp3nqwRjW6BZnbxZ