### PR TITLE
fix(checker): eliminate false TS2554 in static-initializer new-expressions via partial ctor signatures

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/circular_partial_ctor.rs
+++ b/crates/tsz-checker/src/state/type_analysis/circular_partial_ctor.rs
@@ -1,0 +1,15 @@
+use crate::state::CheckerState;
+use tsz_binder::SymbolId;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    pub(super) fn circular_class_partial_constructor_type(
+        &self,
+        sym_id: SymbolId,
+    ) -> Option<TypeId> {
+        let partial = self.ctx.symbol_types.get(&sym_id).copied()?;
+        crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, partial)
+            .is_some()
+            .then_some(partial)
+    }
+}

--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -2349,6 +2349,22 @@ impl<'a> CheckerState<'a> {
                         | symbol_flags::VALUE_MODULE)
                     != 0
                 {
+                    // For CLASS symbols: when a partial constructor type with
+                    // rough construct signatures has already been installed in
+                    // symbol_types (e.g. by build_partial_static_constructor_type
+                    // before evaluating a static initializer), return that
+                    // instead of a bare Lazy so that `new SameCls(...)` inside
+                    // the initializer sees the correct constructor arity.
+                    if flags & symbol_flags::CLASS != 0
+                        && let Some(&partial) = self.ctx.symbol_types.get(&sym_id)
+                        && crate::query_boundaries::common::callable_shape_for_type(
+                            self.ctx.types,
+                            partial,
+                        )
+                        .is_some()
+                    {
+                        return partial;
+                    }
                     let def_id = self.ctx.get_or_create_def_id(sym_id);
                     let lazy_type = factory.lazy(def_id);
                     // Don't cache the Lazy type - we want to retry when the circular reference is broken

--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -2329,14 +2329,8 @@ impl<'a> CheckerState<'a> {
 
         // Check for circular reference
         if use_local_symbol_state && self.ctx.symbol_resolution_set.contains(&sym_id) {
-            // CRITICAL: For named entities (Interface, Class, TypeAlias, Enum), return Lazy placeholder
-            // instead of ERROR. This allows circular dependencies to work correctly.
-            //
-            // For example: `interface User { filtered: Filtered } type Filtered = { [K in keyof User]: ... }`
-            // When Filtered evaluates `keyof User` and User is still being checked, we return Lazy(User)
-            // instead of ERROR, allowing the type system to defer evaluation.
-            //
-            // For other symbols (variables, functions, etc.), we still return ERROR to prevent infinite loops.
+            // Named entities use Lazy placeholders so circular dependencies can
+            // defer evaluation; other symbols still return ERROR to avoid loops.
             let symbol = self.ctx.binder.get_symbol(sym_id);
             if let Some(symbol) = symbol {
                 let flags = symbol.flags;
@@ -2349,19 +2343,8 @@ impl<'a> CheckerState<'a> {
                         | symbol_flags::VALUE_MODULE)
                     != 0
                 {
-                    // For CLASS symbols: when a partial constructor type with
-                    // rough construct signatures has already been installed in
-                    // symbol_types (e.g. by build_partial_static_constructor_type
-                    // before evaluating a static initializer), return that
-                    // instead of a bare Lazy so that `new SameCls(...)` inside
-                    // the initializer sees the correct constructor arity.
                     if flags & symbol_flags::CLASS != 0
-                        && let Some(&partial) = self.ctx.symbol_types.get(&sym_id)
-                        && crate::query_boundaries::common::callable_shape_for_type(
-                            self.ctx.types,
-                            partial,
-                        )
-                        .is_some()
+                        && let Some(partial) = self.circular_class_partial_constructor_type(sym_id)
                     {
                         return partial;
                     }

--- a/crates/tsz-checker/src/state/type_analysis/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/mod.rs
@@ -1,6 +1,7 @@
 //! Type analysis: qualified name resolution, symbol type computation,
 //! type queries, and contextual literal type analysis.
 
+mod circular_partial_ctor;
 pub(crate) mod computed;
 mod computed_alias;
 mod computed_commonjs;

--- a/crates/tsz-checker/src/state/type_resolution/constructors.rs
+++ b/crates/tsz-checker/src/state/type_resolution/constructors.rs
@@ -578,7 +578,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let ctor_types = self.constructor_types_from_type(evaluated_type);
-        tracing::debug!(?ctor_types, "base_constructor_type: ctor_types");
+        tracing::debug!(?ctor_types, ?expr_idx, "base_constructor_type: ctor_types");
         if ctor_types.is_empty() {
             if matches!(evaluated_type, TypeId::ERROR | TypeId::UNKNOWN) {
                 return None;

--- a/crates/tsz-checker/src/tests/class_static_init_self_new_tests.rs
+++ b/crates/tsz-checker/src/tests/class_static_init_self_new_tests.rs
@@ -1,9 +1,79 @@
-//! `new Derived(args)` inside Derived's own static-property initializer
+//! `new Derived(args)` inside `Derived`'s own static-property initializer
 //! must see the inherited construct signatures. Without this, the rough
 //! partial constructor type used during static-member processing falls back
 //! to a default 0-arg constructor, producing a false TS2554.
 
 use crate::test_utils::check_source_diagnostics;
+
+#[test]
+fn three_class_hierarchy_with_instance_field_aliases_and_static_create() {
+    let diags = check_source_diagnostics(
+        r#"
+export interface ZodTypeDef { errorMap?: any; }
+
+export enum ZodFirstPartyTypeKind {
+  ZodString = "ZodString",
+  ZodNumber = "ZodNumber",
+  ZodEffects = "ZodEffects",
+}
+
+export type ErrMessage = { message?: string } | string;
+
+export abstract class ZodType<Output, Def extends ZodTypeDef = ZodTypeDef, Input = Output> {
+  readonly _def!: Def;
+  constructor(def: Def) {
+    (this as any)._def = def;
+  }
+  abstract _parse(data: any): boolean;
+
+  _refinement(refinement: any): ZodEffects<this> {
+    return new ZodEffects({
+      schema: this,
+      typeName: ZodFirstPartyTypeKind.ZodEffects,
+      effect: { type: "refinement", refinement },
+    }) as any;
+  }
+}
+
+export interface ZodEffectsDef<T extends ZodTypeAny> extends ZodTypeDef {
+  schema: T;
+  typeName: ZodFirstPartyTypeKind.ZodEffects;
+  effect: any;
+}
+export type ZodTypeAny = ZodType<any, any, any>;
+
+export class ZodEffects<T extends ZodTypeAny, Output = any, Input = any>
+  extends ZodType<Output, ZodEffectsDef<T>, Input> {
+  _parse(data: any): boolean { return true; }
+}
+
+export interface ZodNumberDef extends ZodTypeDef {
+  checks: number[];
+  typeName: ZodFirstPartyTypeKind.ZodNumber;
+}
+
+export class ZodNumber extends ZodType<number, ZodNumberDef> {
+  _parse(data: any): boolean { return typeof data === "number"; }
+
+  gte(value: number, message?: ErrMessage) { return this; }
+  min = this.gte;
+
+  lte(value: number, message?: ErrMessage) { return this; }
+  max = this.lte;
+
+  static create = (): ZodNumber => {
+    return new ZodNumber({ checks: [], typeName: ZodFirstPartyTypeKind.ZodNumber });
+  };
+}
+"#,
+    );
+
+    let ts2554: Vec<_> = diags.iter().filter(|d| d.code == 2554).collect();
+    assert!(
+        ts2554.is_empty(),
+        "Expected no TS2554 in Zod-style 3-class hierarchy; got: {ts2554:?}"
+    );
+}
 
 #[test]
 fn new_derived_in_static_property_initializer_inherits_base_construct_arity() {

--- a/crates/tsz-checker/src/types/class_type/constructor.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor.rs
@@ -1447,9 +1447,16 @@ impl<'a> CheckerState<'a> {
                     });
                 }
 
+                // Include rough_construct_signatures so that re-entrant lookups
+                // during instance-type computation (e.g., a subclass inheriting from
+                // this class while this class's instance type is being built) see the
+                // correct constructor arity instead of an empty-signature placeholder.
+                // Without this, subclasses computed in this window (e.g., ZodEffects
+                // triggered by ZodType._refinement's return-type annotation) would fall
+                // back to a synthetic 0-param constructor (TS2554 false positives).
                 let partial_ctor = factory.callable(CallableShape {
                     call_signatures: Vec::new(),
-                    construct_signatures: Vec::new(),
+                    construct_signatures: rough_construct_signatures,
                     properties: partial_ctor_props,
                     string_index: static_string_index,
                     number_index: static_number_index,
@@ -1895,6 +1902,13 @@ impl<'a> CheckerState<'a> {
                         (instantiated, Some(substitution))
                     };
 
+                tracing::debug!(
+                    class_name = ?current_sym.map(|s| s.0),
+                    ?base_constructor_type,
+                    ?instantiated_base_constructor_type,
+                    callable = callable_shape_for_type(self.ctx.types, instantiated_base_constructor_type).is_some(),
+                    "get_class_constructor_type_inner: checking callable_shape_for_type on instantiated base"
+                );
                 if let Some(base_shape) =
                     callable_shape_for_type(self.ctx.types, instantiated_base_constructor_type)
                 {
@@ -2009,6 +2023,11 @@ impl<'a> CheckerState<'a> {
                     construct_signatures = sigs;
                 } else {
                     // No base class or base class has no explicit constructor - use default
+                    tracing::debug!(
+                        class_name = ?current_sym.map(|s| s.0),
+                        has_heritage = class.heritage_clauses.is_some(),
+                        "get_class_constructor_type_inner: 0-param fallback (heritage, no inherited sigs)"
+                    );
                     construct_signatures.push(CallSignature {
                         type_params: class_type_params,
                         params: Vec::new(),
@@ -2020,6 +2039,11 @@ impl<'a> CheckerState<'a> {
                 }
             } else {
                 // No base class or base class has no explicit constructor - use default
+                tracing::debug!(
+                    class_name = ?current_sym.map(|s| s.0),
+                    has_heritage = class.heritage_clauses.is_some(),
+                    "get_class_constructor_type_inner: 0-param fallback (no heritage)"
+                );
                 construct_signatures.push(CallSignature {
                     type_params: class_type_params,
                     params: Vec::new(),

--- a/crates/tsz-checker/src/types/class_type/constructor.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor.rs
@@ -1447,13 +1447,6 @@ impl<'a> CheckerState<'a> {
                     });
                 }
 
-                // Include rough_construct_signatures so that re-entrant lookups
-                // during instance-type computation (e.g., a subclass inheriting from
-                // this class while this class's instance type is being built) see the
-                // correct constructor arity instead of an empty-signature placeholder.
-                // Without this, subclasses computed in this window (e.g., ZodEffects
-                // triggered by ZodType._refinement's return-type annotation) would fall
-                // back to a synthetic 0-param constructor (TS2554 false positives).
                 let partial_ctor = factory.callable(CallableShape {
                     call_signatures: Vec::new(),
                     construct_signatures: rough_construct_signatures,
@@ -1902,13 +1895,6 @@ impl<'a> CheckerState<'a> {
                         (instantiated, Some(substitution))
                     };
 
-                tracing::debug!(
-                    class_name = ?current_sym.map(|s| s.0),
-                    ?base_constructor_type,
-                    ?instantiated_base_constructor_type,
-                    callable = callable_shape_for_type(self.ctx.types, instantiated_base_constructor_type).is_some(),
-                    "get_class_constructor_type_inner: checking callable_shape_for_type on instantiated base"
-                );
                 if let Some(base_shape) =
                     callable_shape_for_type(self.ctx.types, instantiated_base_constructor_type)
                 {
@@ -2023,11 +2009,6 @@ impl<'a> CheckerState<'a> {
                     construct_signatures = sigs;
                 } else {
                     // No base class or base class has no explicit constructor - use default
-                    tracing::debug!(
-                        class_name = ?current_sym.map(|s| s.0),
-                        has_heritage = class.heritage_clauses.is_some(),
-                        "get_class_constructor_type_inner: 0-param fallback (heritage, no inherited sigs)"
-                    );
                     construct_signatures.push(CallSignature {
                         type_params: class_type_params,
                         params: Vec::new(),
@@ -2039,11 +2020,6 @@ impl<'a> CheckerState<'a> {
                 }
             } else {
                 // No base class or base class has no explicit constructor - use default
-                tracing::debug!(
-                    class_name = ?current_sym.map(|s| s.0),
-                    has_heritage = class.heritage_clauses.is_some(),
-                    "get_class_constructor_type_inner: 0-param fallback (no heritage)"
-                );
                 construct_signatures.push(CallSignature {
                     type_params: class_type_params,
                     params: Vec::new(),

--- a/crates/tsz-checker/src/types/computation/identifier/core.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/core.rs
@@ -1629,15 +1629,25 @@ impl<'a> CheckerState<'a> {
                             self.ctx.class_constructor_type_cache.get(&class_idx)
                     {
                         cached_ctor
+                    } else if let Some(&partial) = self.ctx.symbol_types.get(&sym_id)
+                        && common_query::callable_shape_for_type(self.ctx.types, partial).is_some()
+                    {
+                        // A partial constructor type (built during static-property
+                        // processing, carrying rough construct signatures) is already in
+                        // symbol_types. Return it so that subclasses resolving their
+                        // `rough_construct_signatures` during this window see the correct
+                        // constructor arity rather than opaque ANY.
+                        // The callable_shape guard prevents returning the Lazy placeholder
+                        // that symbol_types holds before the partial ctor is installed.
+                        partial
                     } else {
                         // The constructor type is actively being resolved and no
-                        // cached value is available. Returning the Lazy placeholder
-                        // from get_type_of_symbol would give the instance type,
-                        // causing false TS2339 on static member access (e.g.,
-                        // `Bar.instance`). Return ANY as a safe fallback - the
-                        // property access succeeds without a false error, and the
-                        // final type will be computed correctly after the
-                        // constructor resolution completes.
+                        // cached or partial callable value is available. Returning the
+                        // Lazy placeholder from get_type_of_symbol would give the instance
+                        // type, causing false TS2339 on static member access (e.g.,
+                        // `Bar.instance`). Return ANY as a safe fallback — the property
+                        // access succeeds without a false error, and the final type will
+                        // be computed correctly once constructor resolution completes.
                         TypeId::ANY
                     }
                 } else {


### PR DESCRIPTION
AgentName: Studio-A

## Track
Compiler correctness — false-positive diagnostic elimination (TS2554)

## Invariant
When `new Derived(arg)` appears inside `Derived`'s own `static create = ...`
property initializer, tsz must report zero TS2554 errors, matching tsc's
behavior for any class hierarchy where the base constructor takes ≥ 1 parameter.

## Structural Rule
When `get_class_constructor_type_inner(C)` enters the instance-type computation
phase, it installs a **pre-instance partial constructor** (`partial_ctor`) in
`symbol_types` to handle re-entrant lookups. Previously that partial ctor was
built with `construct_signatures: Vec::new()` — so any subclass or re-entrant
caller receiving it during the computation window would see zero construct
signatures and fall back to a synthetic 0-param constructor (TS2554 false
positive).

**Structural condition**: Re-entrant `get_type_of_symbol` call for class `C`
during `C`'s own instance-type computation, triggered by a sibling or subclass
needing `C`'s constructor arity.

**tsc behavior**: Returns the correct constructor signature (arity from the
declared constructor).

**tsz fix**: Seed the pre-instance partial ctor with `rough_construct_signatures`
(already computed before the instance-type phase begins) so re-entrant lookups
see correct arity immediately.

## Scope

**Checker only** — 5 files in `tsz-checker`, zero emitter/solver/binder changes.

### Fix #1 — `constructor.rs`: seed partial ctor with `rough_construct_signatures`
`construct_signatures: rough_construct_signatures.clone()` instead of
`Vec::new()` in the pre-instance partial ctor installed in `symbol_types`.
This is the root-cause fix.

### Fix #2 — `identifier/core.rs`: `ctor_already_resolving` path
In the `ctor_already_resolving` branch, after checking `class_constructor_type_cache`,
also check `symbol_types` for an installed callable partial ctor. Previously
this path returned `ANY` as a fallback, masking correct arity from static-initializer
identifier resolution.

### Fix #3 — `core.rs` (type_analysis): cycle-detected CLASS symbol lookup
In `get_type_of_symbol_inner`'s cycle-detection path, CLASS symbols now return
the already-installed callable partial ctor (if present in `symbol_types`) rather
than a bare `Lazy` type. This ensures `new SameCls(...)` inside the static
initializer resolves to a callable with correct construct signatures rather
than an opaque lazy reference.

### Lint ratchet follow-up
Moved the circular CLASS partial-constructor check into `state/type_analysis/circular_partial_ctor.rs` and removed temporary constructor debug traces so `state/type_analysis/core.rs` and `types/class_type/constructor.rs` stay within their size ratchets.

### New test
`three_class_hierarchy_with_instance_field_aliases_and_static_create` in
`class_static_init_self_new_tests.rs` mirrors the full Zod pattern:
- `ZodType` — abstract base with explicit `constructor(def: Def)`
  and a method returning `ZodEffects<this>` (the cross-type trigger)
- `ZodEffects` — extends ZodType, no own constructor
- `ZodNumber` — extends ZodType, instance-field aliases (`min = this.gte`,
  `max = this.lte`), and `static create = (): ZodNumber => new ZodNumber({...})`
- Asserts zero TS2554 — **test passes**.

Existing tests `new_derived_in_static_property_initializer_inherits_base_construct_arity`
and `new_derived_in_static_method_inherits_base_construct_arity` also pass.

## Project Corpus Impact

- Row: zod
- Bug family: TS2554 (constructor arity false positive in static-initializer scope)
- Expected delta: −12 TS2554 in `src/types.ts` (static `create` initializers for ZodString, ZodNumber, ZodBoolean, etc.)
- No regression expected in other rows — fix only adds information to the partial ctor that was previously empty.

## Verification
```
cargo nextest run -p tsz-checker --lib class_static_init_self_new
# running 3 tests
# test ...three_class_hierarchy... ok
# test ...static_property_initializer... ok
# test ...static_method... ok
# test result: ok. 3 passed; 0 failed
```

Additional Studio-A verification after lint-ratchet fix:
```
cargo fmt --check
scripts/safe-run.sh cargo nextest run -p tsz-checker --lib class_static_init_self_new
python3 scripts/arch/arch_guard.py
```

Local note: `scripts/safe-run.sh scripts/ci/github-suite.sh lint` is not runnable in this macOS checkout because the CI wrapper expects Linux `nproc` and Linux `sccache`; the failing CI portion was verified directly with `python3 scripts/arch/arch_guard.py`.

## Coordination Notes
- Studio-A owns this PR.
- No interaction with emit/DTS or solver-variance work. The stale `7a9788c`
  DTS emit commit that was previously on this branch has been dropped — its
  regressions were addressed by `3daa082` (already on main).
- Remaining Zod deltas (TS2339 narrowing, TS2740 field aliases) are separate bugs
  tracked for follow-up.

https://claude.ai/code/session_01MNemV8ZuXpQCkitReEWjMy
