### PR TITLE
fix(emit): recover reserved-word declaration skeletons

### DIFF
--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -788,6 +788,11 @@ pub struct Printer<'a> {
     /// the previous variable statement's emitted initializer.
     pub(crate) consumed_recovered_expression_statement_span: Option<(u32, u32, String)>,
 
+    /// A recovered reserved-word array binding can leave the following anonymous
+    /// enum on tsc's no-hoist path. Cleared by the source-file statement loop if
+    /// the next statement is not that enum.
+    pub(crate) suppress_next_anonymous_enum_var_after_recovered_array_binding: bool,
+
     /// Pending `super` capture declarations for lowered async arrows in a method body.
     pub(crate) pending_lowered_async_arrow_super_capture: Option<(
         crate::transforms::emit_utils::AsyncMethodSuperCapture,

--- a/crates/tsz-emitter/src/emitter/core_setup.rs
+++ b/crates/tsz-emitter/src/emitter/core_setup.rs
@@ -282,6 +282,7 @@ impl<'a> Printer<'a> {
             pending_object_rest_params: Vec::new(),
             pending_object_rest_param_defaults: Vec::new(),
             consumed_recovered_expression_statement_span: None,
+            suppress_next_anonymous_enum_var_after_recovered_array_binding: false,
             pending_lowered_async_arrow_super_capture: None,
             function_scope_depth: 0,
             arrow_function_scope_depth: 0,

--- a/crates/tsz-emitter/src/emitter/declarations/core.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/core.rs
@@ -580,6 +580,13 @@ impl<'a> Printer<'a> {
             } else {
                 String::new()
             };
+            if enum_name.is_empty()
+                && std::mem::take(
+                    &mut self.suppress_next_anonymous_enum_var_after_recovered_array_binding,
+                )
+            {
+                transformer.set_emit_var_declaration(false);
+            }
             let mut folded_export_name = None;
             if !enum_name.is_empty() {
                 if self.declared_namespace_names.contains(&enum_name) {

--- a/crates/tsz-emitter/src/emitter/declarations/core.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/core.rs
@@ -42,6 +42,9 @@ impl<'a> Printer<'a> {
             self.write_semicolon();
             return;
         }
+        if self.emit_recovered_reserved_function_declaration_name(node, func) {
+            return;
+        }
 
         let emit_invalid_namespace_static =
             self.should_emit_invalid_namespace_static_modifier(node, &func.modifiers);

--- a/crates/tsz-emitter/src/emitter/functions.rs
+++ b/crates/tsz-emitter/src/emitter/functions.rs
@@ -584,10 +584,26 @@ impl<'a> Printer<'a> {
                     && let Some(ident) = self.arena.get_identifier(name_node)
                     && ident.escaped_text.is_empty()
                 {
+                    if self.parameter_starts_with_hard_reserved_keyword(param_node)
+                        && !self.parameter_starts_with_literal_reserved_keyword(param_node)
+                    {
+                        self.remove_namespace_exported_parameter_name(param_idx);
+                        continue;
+                    }
                     let Some(recovered_name) = self.recovered_parameter_name_from_type_only(param)
                     else {
                         continue;
                     };
+                    if self.parameter_starts_with_literal_reserved_keyword(param_node) {
+                        if !first {
+                            self.write(", ");
+                        }
+                        first = false;
+                        self.write(", ");
+                        self.write(&recovered_name);
+                        self.remove_namespace_exported_parameter_name(param_idx);
+                        continue;
+                    }
                     if !first {
                         self.write(", ");
                     }
@@ -864,6 +880,35 @@ impl<'a> Printer<'a> {
                         .is_some_and(|node| node.kind == syntax_kind_ext::DECORATOR)
                 })
             })
+    }
+
+    fn parameter_starts_with_hard_reserved_keyword(&self, node: &Node) -> bool {
+        self.parameter_start_keyword(node)
+            .is_some_and(tsz_scanner::token_is_reserved_word)
+    }
+
+    fn parameter_starts_with_literal_reserved_keyword(&self, node: &Node) -> bool {
+        matches!(
+            self.parameter_start_keyword(node),
+            Some(
+                tsz_scanner::SyntaxKind::NullKeyword
+                    | tsz_scanner::SyntaxKind::TrueKeyword
+                    | tsz_scanner::SyntaxKind::FalseKeyword
+            )
+        )
+    }
+
+    fn parameter_start_keyword(&self, node: &Node) -> Option<tsz_scanner::SyntaxKind> {
+        let source = self.source_text?;
+        let start = self.skip_trivia_forward(node.pos, node.end) as usize;
+        let bytes = source.as_bytes();
+        let mut end = start;
+        while end < bytes.len() && matches!(bytes[end], b'a'..=b'z' | b'A'..=b'Z') {
+            end += 1;
+        }
+        let raw = crate::safe_slice::slice(source, start, end).ok()?.trim();
+        let token = tsz_scanner::string_to_token(raw);
+        tsz_scanner::token_is_keyword(token).then_some(token)
     }
 
     fn emit_native_parameter_decorators(&mut self, modifiers: Option<&NodeList>) {

--- a/crates/tsz-emitter/src/emitter/functions.rs
+++ b/crates/tsz-emitter/src/emitter/functions.rs
@@ -903,7 +903,7 @@ impl<'a> Printer<'a> {
         let start = self.skip_trivia_forward(node.pos, node.end) as usize;
         let bytes = source.as_bytes();
         let mut end = start;
-        while end < bytes.len() && matches!(bytes[end], b'a'..=b'z' | b'A'..=b'Z') {
+        while end < bytes.len() && bytes[end].is_ascii_alphabetic() {
             end += 1;
         }
         let raw = crate::safe_slice::slice(source, start, end).ok()?.trim();

--- a/crates/tsz-emitter/src/emitter/source_file/emit.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/emit.rs
@@ -1824,6 +1824,10 @@ impl<'a> Printer<'a> {
                     self.write_line();
                 }
                 if stmt_node.kind == syntax_kind_ext::MODULE_DECLARATION {
+                    if self.emit_recovered_reserved_namespace_declaration_name(stmt_node) {
+                        last_erased_was_shorthand_module = false;
+                        continue;
+                    }
                     let scan_end = next_stmt_node
                         .map_or_else(|| self.source_text_end_or(stmt_node.end), |n| n.pos);
                     self.emit_recovered_template_module_declaration(stmt_node, scan_end);

--- a/crates/tsz-emitter/src/emitter/source_file/emit.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/emit.rs
@@ -1769,37 +1769,8 @@ impl<'a> Printer<'a> {
             // "runtime module syntax" AFTER emit, because the emit step may decide
             // to erase it (e.g., text heuristic determines all imported names are
             // type-only and drops the import).
-            let is_module_indicating_stmt = if !is_erased {
-                let k = stmt_node.kind;
-                if k == syntax_kind_ext::IMPORT_DECLARATION
-                    || k == syntax_kind_ext::EXPORT_DECLARATION
-                    || k == syntax_kind_ext::EXPORT_ASSIGNMENT
-                {
-                    true
-                } else if k == syntax_kind_ext::IMPORT_EQUALS_DECLARATION {
-                    // External module imports (`import x = require("mod")`) and
-                    // exported aliases count as runtime module syntax. Plain
-                    // namespace aliases (`import x = M.A`) are erased and should
-                    // not suppress deferred `export {};` emission.
-                    self.arena
-                        .get_import_decl(stmt_node)
-                        .is_some_and(|import_data| {
-                            self.arena
-                                .has_modifier(&import_data.modifiers, SyntaxKind::ExportKeyword)
-                                || self.arena.get(import_data.module_specifier).is_some_and(
-                                    |spec_node| {
-                                        spec_node.is_string_literal()
-                                            || spec_node.kind
-                                                == syntax_kind_ext::EXTERNAL_MODULE_REFERENCE
-                                    },
-                                )
-                        })
-                } else {
-                    false
-                }
-            } else {
-                false
-            };
+            let is_module_indicating_stmt =
+                self.is_runtime_module_indicating_statement(stmt_node, is_erased);
 
             // Find the actual start of the statement's first token by
             // scanning forward from node.pos past ALL trivia (whitespace AND

--- a/crates/tsz-emitter/src/emitter/source_file/emit.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/emit.rs
@@ -1586,6 +1586,11 @@ impl<'a> Printer<'a> {
             let Some(stmt_node) = self.arena.get(stmt_idx) else {
                 continue;
             };
+            if self.suppress_next_anonymous_enum_var_after_recovered_array_binding
+                && stmt_node.kind != syntax_kind_ext::ENUM_DECLARATION
+            {
+                self.suppress_next_anonymous_enum_var_after_recovered_array_binding = false;
+            }
             if stmt_i < cjs_pre_preamble_prologue_count {
                 continue;
             }
@@ -1809,6 +1814,10 @@ impl<'a> Printer<'a> {
                 .get(stmt_i + 1)
                 .and_then(|&next_idx| self.arena.get(next_idx));
             if self.emit_recovered_invalid_numeric_declaration_name_statement(stmt_node) {
+                last_erased_was_shorthand_module = false;
+                continue;
+            }
+            if self.emit_recovered_reserved_import_equals_declaration_name(stmt_node) {
                 last_erased_was_shorthand_module = false;
                 continue;
             }

--- a/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
@@ -2124,6 +2124,79 @@ fn reserved_variable_name_emits_empty_decl_keyword_and_initializer_statements() 
 }
 
 #[test]
+fn reserved_import_equals_name_emits_recovered_require_and_keyword_loop() {
+    for (source, expected_tail) in [
+        (
+            "import while = require(\"dfdf\");",
+            "require();\nwhile ( = require(\"dfdf\"))\n    ;",
+        ),
+        (
+            "import for = require(\"dfdf\");",
+            "require();\nfor ( = require(\"dfdf\"))\n    ;",
+        ),
+    ] {
+        let (parser, root) = parse_test_source(source);
+        let mut printer = EmitterPrinter::with_options(
+            &parser.arena,
+            PrinterOptions {
+                always_strict: true,
+                target: ScriptTarget::ES2015,
+                module: ModuleKind::CommonJS,
+                ..Default::default()
+            },
+        );
+        printer.set_source_text(source);
+        printer.emit(root);
+        let output = printer.get_output().to_string();
+
+        assert_eq!(
+            output.trim_end(),
+            format!(
+                "\"use strict\";\nObject.defineProperty(exports, \"__esModule\", {{ value: true }});\n{expected_tail}"
+            ),
+            "{source}: reserved import-equals recovery should preserve tsc-compatible emit.\nOutput:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn reserved_array_binding_name_emits_recovered_keyword_statements() {
+    for (source, expected_tail) in [
+        (
+            "var [debugger, if] = [1, 2];",
+            "var [];\ndebugger;\nif ()\n    ;\n[1, 2];",
+        ),
+        (
+            "var [debugger, while] = value;",
+            "var [];\ndebugger;\nwhile ()\n    ;\nvalue;",
+        ),
+        (
+            "var [debugger, if] = [1, 2];\nenum void {}",
+            "var [];\ndebugger;\nif ()\n    ;\n[1, 2];\n(function () {\n})( || ( = {}));\nvoid {};",
+        ),
+    ] {
+        let (parser, root) = parse_test_source(source);
+        let mut printer = EmitterPrinter::with_options(
+            &parser.arena,
+            PrinterOptions {
+                always_strict: true,
+                target: ScriptTarget::ES2015,
+                ..Default::default()
+            },
+        );
+        printer.set_source_text(source);
+        printer.emit(root);
+        let output = printer.get_output().to_string();
+
+        assert_eq!(
+            output.trim_end(),
+            format!("\"use strict\";\n{expected_tail}"),
+            "{source}: reserved array-binding recovery should preserve tsc-compatible emit.\nOutput:\n{output}"
+        );
+    }
+}
+
+#[test]
 fn reserved_function_name_emits_anonymous_function_and_keyword_arrow_tail() {
     for (source, expected_tail) in [
         ("function throw() {}", "function () { }\nthrow () => { };"),
@@ -2176,6 +2249,36 @@ fn reserved_namespace_name_emits_keyword_and_recovered_body_statement() {
             output.trim_end(),
             format!("\"use strict\";\n{expected_tail}"),
             "{source}: reserved namespace-name recovery should preserve tsc-compatible emit.\nOutput:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn reserved_parameter_names_recover_without_semantic_type_proxy() {
+    for (source, expected_tail) in [
+        ("function f(default: number) {}", "function f() { }"),
+        (
+            "class C { m(null: string) {} }",
+            "class C {\n    m(, string) { }\n}",
+        ),
+    ] {
+        let (parser, root) = parse_test_source(source);
+        let mut printer = EmitterPrinter::with_options(
+            &parser.arena,
+            PrinterOptions {
+                always_strict: true,
+                target: ScriptTarget::ES2015,
+                ..Default::default()
+            },
+        );
+        printer.set_source_text(source);
+        printer.emit(root);
+        let output = printer.get_output().to_string();
+
+        assert_eq!(
+            output.trim_end(),
+            format!("\"use strict\";\n{expected_tail}"),
+            "{source}: reserved parameter recovery should preserve tsc-compatible emit.\nOutput:\n{output}"
         );
     }
 }

--- a/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
@@ -2170,6 +2170,15 @@ fn reserved_array_binding_name_emits_recovered_keyword_statements() {
             "var [debugger, while] = value;",
             "var [];\ndebugger;\nwhile ()\n    ;\nvalue;",
         ),
+        ("var [debugger] = value;", "var [];\ndebugger;\nvalue;"),
+        (
+            "var [debugger,\n if] = value;",
+            "var [];\ndebugger;\nif ()\n    ;\nvalue;",
+        ),
+        (
+            "var [debugger, if, while] = value;",
+            "var [];\ndebugger;\nif (, )\n    while ()\n        ;\nvalue;",
+        ),
         (
             "var [debugger, if] = [1, 2];\nenum void {}",
             "var [];\ndebugger;\nif ()\n    ;\n[1, 2];\n(function () {\n})( || ( = {}));\nvoid {};",

--- a/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
@@ -2096,6 +2096,91 @@ fn reserved_enum_name_emits_anonymous_enum_and_reserved_statement() {
 }
 
 #[test]
+fn reserved_variable_name_emits_empty_decl_keyword_and_initializer_statements() {
+    for (source, expected_tail) in [
+        ("var typeof = 10;", "var ;\ntypeof ;\n10;"),
+        ("var void = value;", "var ;\nvoid ;\nvalue;"),
+        ("var delete = target;", "var ;\ndelete ;\ntarget;"),
+    ] {
+        let (parser, root) = parse_test_source(source);
+        let mut printer = EmitterPrinter::with_options(
+            &parser.arena,
+            PrinterOptions {
+                always_strict: true,
+                target: ScriptTarget::ES2015,
+                ..Default::default()
+            },
+        );
+        printer.set_source_text(source);
+        printer.emit(root);
+        let output = printer.get_output().to_string();
+
+        assert_eq!(
+            output.trim_end(),
+            format!("\"use strict\";\n{expected_tail}"),
+            "{source}: reserved variable-name recovery should preserve tsc-compatible emit.\nOutput:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn reserved_function_name_emits_anonymous_function_and_keyword_arrow_tail() {
+    for (source, expected_tail) in [
+        ("function throw() {}", "function () { }\nthrow () => { };"),
+        (
+            "function return(value) {}",
+            "function (value) { }\nreturn () => { };",
+        ),
+    ] {
+        let (parser, root) = parse_test_source(source);
+        let mut printer = EmitterPrinter::with_options(
+            &parser.arena,
+            PrinterOptions {
+                always_strict: true,
+                target: ScriptTarget::ES2015,
+                ..Default::default()
+            },
+        );
+        printer.set_source_text(source);
+        printer.emit(root);
+        let output = printer.get_output().to_string();
+
+        assert_eq!(
+            output.trim_end(),
+            format!("\"use strict\";\n{expected_tail}"),
+            "{source}: reserved function-name recovery should preserve tsc-compatible emit.\nOutput:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn reserved_namespace_name_emits_keyword_and_recovered_body_statement() {
+    for (source, expected_tail) in [
+        ("namespace void {}", "namespace;\nvoid {};"),
+        ("namespace typeof {}", "namespace;\ntypeof {};"),
+    ] {
+        let (parser, root) = parse_test_source(source);
+        let mut printer = EmitterPrinter::with_options(
+            &parser.arena,
+            PrinterOptions {
+                always_strict: true,
+                target: ScriptTarget::ES2015,
+                ..Default::default()
+            },
+        );
+        printer.set_source_text(source);
+        printer.emit(root);
+        let output = printer.get_output().to_string();
+
+        assert_eq!(
+            output.trim_end(),
+            format!("\"use strict\";\n{expected_tail}"),
+            "{source}: reserved namespace-name recovery should preserve tsc-compatible emit.\nOutput:\n{output}"
+        );
+    }
+}
+
+#[test]
 fn unmatched_decorator_type_assertion_emits_empty_statement() {
     let source = "@<[[import(obju2c77,\n";
 

--- a/crates/tsz-emitter/src/emitter/source_file/mod.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/mod.rs
@@ -7,6 +7,7 @@ mod import_helpers_class_scan;
 mod import_helpers_class_scan_tests;
 #[cfg(test)]
 mod invalid_numeric_declaration_recovery_tests;
+mod module_syntax;
 #[cfg(test)]
 mod parser_recovery_tests;
 mod recovery;

--- a/crates/tsz-emitter/src/emitter/source_file/module_syntax.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/module_syntax.rs
@@ -1,0 +1,48 @@
+use crate::emitter::Printer;
+use tsz_parser::parser::node::Node;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
+
+impl<'a> Printer<'a> {
+    pub(in crate::emitter) fn is_runtime_module_indicating_statement(
+        &self,
+        stmt_node: &Node,
+        is_erased: bool,
+    ) -> bool {
+        if is_erased {
+            return false;
+        }
+
+        let kind = stmt_node.kind;
+        if matches!(
+            kind,
+            syntax_kind_ext::IMPORT_DECLARATION
+                | syntax_kind_ext::EXPORT_DECLARATION
+                | syntax_kind_ext::EXPORT_ASSIGNMENT
+        ) {
+            return true;
+        }
+
+        if kind != syntax_kind_ext::IMPORT_EQUALS_DECLARATION {
+            return false;
+        }
+
+        // External module imports (`import x = require("mod")`) and exported
+        // aliases count as runtime module syntax. Plain namespace aliases
+        // (`import x = M.A`) are erased and should not suppress deferred
+        // `export {};` emission.
+        self.arena
+            .get_import_decl(stmt_node)
+            .is_some_and(|import_data| {
+                self.arena
+                    .has_modifier(&import_data.modifiers, SyntaxKind::ExportKeyword)
+                    || self
+                        .arena
+                        .get(import_data.module_specifier)
+                        .is_some_and(|spec_node| {
+                            spec_node.is_string_literal()
+                                || spec_node.kind == syntax_kind_ext::EXTERNAL_MODULE_REFERENCE
+                        })
+            })
+    }
+}

--- a/crates/tsz-emitter/src/emitter/source_file/recovery.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/recovery.rs
@@ -2,6 +2,7 @@ use crate::emitter::Printer;
 use tsz_parser::parser::node::{FunctionData, Node};
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
+use tsz_scanner::scanner_impl::ScannerState;
 
 impl<'a> Printer<'a> {
     pub(in crate::emitter) fn recovered_yield_call_statement_text(
@@ -182,62 +183,98 @@ impl<'a> Printer<'a> {
         if name_node.kind != syntax_kind_ext::ARRAY_BINDING_PATTERN {
             return false;
         }
-        let Some((first_keyword, second_keyword, initializer_text)) =
-            self.recovered_reserved_array_binding_source_parts(node)
+        let Some((keywords, initializer_text)) = self.recovered_reserved_array_binding_parts(node)
         else {
             return false;
         };
+        if keywords.is_empty() || keywords.len() > 3 {
+            return false;
+        }
 
         if !self.writer.is_at_line_start() {
             self.write_line();
         }
         self.write("var [];");
         self.write_line();
-        self.write(first_keyword);
+        self.write(keywords[0]);
         self.write(";");
         self.write_line();
-        self.write(second_keyword);
+        match keywords.as_slice() {
+            [_] => {}
+            [_, second] => self.emit_recovered_reserved_array_binding_condition(second),
+            [_, second, third] => {
+                self.write(second);
+                self.write(" (, )");
+                self.write_line();
+                self.increase_indent();
+                self.emit_recovered_reserved_array_binding_condition(third);
+                self.decrease_indent();
+            }
+            _ => return false,
+        }
+        self.write(&initializer_text);
+        self.write_semicolon();
+        self.suppress_next_anonymous_enum_var_after_recovered_array_binding = true;
+        true
+    }
+
+    fn emit_recovered_reserved_array_binding_condition(&mut self, keyword: &str) {
+        self.write(keyword);
         self.write(" ()");
         self.write_line();
         self.increase_indent();
         self.write(";");
         self.write_line();
         self.decrease_indent();
-        self.write(&initializer_text);
-        self.write(";");
-        self.suppress_next_anonymous_enum_var_after_recovered_array_binding = true;
-        true
     }
 
-    fn recovered_reserved_array_binding_source_parts(
+    fn recovered_reserved_array_binding_parts(
         &self,
         node: &Node,
-    ) -> Option<(&'static str, &'static str, String)> {
+    ) -> Option<(Vec<&'static str>, String)> {
         let text = self.source_text?;
-        let line = self.source_line_from_node(node)?;
-        let open = line.find('[')?;
-        let close = line[open..].find(']')? + open;
-        let binding = &line[open + 1..close];
-        let mut parts = binding.split(',').map(str::trim);
-        let first = self.reserved_keyword_text(parts.next()?)?;
-        let second = self.reserved_keyword_text(parts.next()?)?;
-        if parts.next().is_some() {
+        let start = self.skip_trivia_forward(node.pos, node.end) as usize;
+        let source = text.get(start..)?;
+        let mut scanner = ScannerState::new(source.to_string(), true);
+        let mut keywords = Vec::new();
+        let mut in_array_binding = false;
+        let mut initializer_start = None;
+        let mut initializer_end = None;
+
+        loop {
+            let token = scanner.scan();
+            if token == SyntaxKind::EndOfFileToken {
+                break;
+            }
+            let token_start = scanner.get_token_start();
+            let token_end = scanner.get_token_end();
+            match token {
+                SyntaxKind::OpenBracketToken => in_array_binding = true,
+                SyntaxKind::CloseBracketToken if in_array_binding => in_array_binding = false,
+                SyntaxKind::EqualsToken => {
+                    initializer_start = Some(token_end);
+                }
+                SyntaxKind::SemicolonToken => {
+                    initializer_end = Some(token_start);
+                    break;
+                }
+                _ if in_array_binding && tsz_scanner::token_is_reserved_word(token) => {
+                    keywords.push(self.reserved_keyword_text(scanner.get_token_text_ref())?);
+                }
+                _ => {}
+            }
+        }
+
+        let initializer_start = initializer_start?;
+        let initializer_end = initializer_end.unwrap_or_else(|| scanner.get_pos());
+        let initializer_text = source
+            .get(initializer_start..initializer_end)?
+            .trim()
+            .to_string();
+        if initializer_text.is_empty() {
             return None;
         }
-        let equals = line[close..].find('=')? + close;
-        let initializer = line[equals + 1..].trim().trim_end_matches(';').trim();
-        if initializer.is_empty() {
-            return None;
-        }
-        let source_start = self.skip_trivia_forward(node.pos, node.end) as usize;
-        let absolute_initializer_start = text[source_start..].find(initializer)? + source_start;
-        let initializer_end = absolute_initializer_start + initializer.len();
-        let initializer_text =
-            crate::safe_slice::slice(text, absolute_initializer_start, initializer_end)
-                .ok()?
-                .trim()
-                .to_string();
-        Some((first, second, initializer_text))
+        Some((keywords, initializer_text))
     }
 
     pub(in crate::emitter) fn emit_recovered_reserved_import_equals_declaration_name(

--- a/crates/tsz-emitter/src/emitter/source_file/recovery.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/recovery.rs
@@ -295,7 +295,7 @@ impl<'a> Printer<'a> {
         let start = self.skip_trivia_forward(node.pos, node.end) as usize;
         let bytes = text.as_bytes();
         let mut end = start;
-        while end < bytes.len() && matches!(bytes[end], b'a'..=b'z' | b'A'..=b'Z') {
+        while end < bytes.len() && bytes[end].is_ascii_alphabetic() {
             end += 1;
         }
         let keyword = crate::safe_slice::slice(text, start, end).ok()?;

--- a/crates/tsz-emitter/src/emitter/source_file/recovery.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/recovery.rs
@@ -151,6 +151,145 @@ impl<'a> Printer<'a> {
         true
     }
 
+    pub(in crate::emitter) fn emit_recovered_reserved_array_binding_variable_statement(
+        &mut self,
+        node: &Node,
+    ) -> bool {
+        let Some(var_stmt) = self.arena.get_variable(node) else {
+            return false;
+        };
+        let [decl_list_idx] = var_stmt.declarations.nodes.as_slice() else {
+            return false;
+        };
+        let Some(decl_list_node) = self.arena.get(*decl_list_idx) else {
+            return false;
+        };
+        let Some(decl_list) = self.arena.get_variable(decl_list_node) else {
+            return false;
+        };
+        let [decl_idx] = decl_list.declarations.nodes.as_slice() else {
+            return false;
+        };
+        let Some(decl_node) = self.arena.get(*decl_idx) else {
+            return false;
+        };
+        let Some(decl) = self.arena.get_variable_declaration(decl_node) else {
+            return false;
+        };
+        let Some(name_node) = self.arena.get(decl.name) else {
+            return false;
+        };
+        if name_node.kind != syntax_kind_ext::ARRAY_BINDING_PATTERN {
+            return false;
+        }
+        let Some((first_keyword, second_keyword, initializer_text)) =
+            self.recovered_reserved_array_binding_source_parts(node)
+        else {
+            return false;
+        };
+
+        if !self.writer.is_at_line_start() {
+            self.write_line();
+        }
+        self.write("var [];");
+        self.write_line();
+        self.write(first_keyword);
+        self.write(";");
+        self.write_line();
+        self.write(second_keyword);
+        self.write(" ()");
+        self.write_line();
+        self.increase_indent();
+        self.write(";");
+        self.write_line();
+        self.decrease_indent();
+        self.write(&initializer_text);
+        self.write(";");
+        self.suppress_next_anonymous_enum_var_after_recovered_array_binding = true;
+        true
+    }
+
+    fn recovered_reserved_array_binding_source_parts(
+        &self,
+        node: &Node,
+    ) -> Option<(&'static str, &'static str, String)> {
+        let text = self.source_text?;
+        let line = self.source_line_from_node(node)?;
+        let open = line.find('[')?;
+        let close = line[open..].find(']')? + open;
+        let binding = &line[open + 1..close];
+        let mut parts = binding.split(',').map(str::trim);
+        let first = self.reserved_keyword_text(parts.next()?)?;
+        let second = self.reserved_keyword_text(parts.next()?)?;
+        if parts.next().is_some() {
+            return None;
+        }
+        let equals = line[close..].find('=')? + close;
+        let initializer = line[equals + 1..].trim().trim_end_matches(';').trim();
+        if initializer.is_empty() {
+            return None;
+        }
+        let source_start = self.skip_trivia_forward(node.pos, node.end) as usize;
+        let absolute_initializer_start = text[source_start..].find(initializer)? + source_start;
+        let initializer_end = absolute_initializer_start + initializer.len();
+        let initializer_text =
+            crate::safe_slice::slice(text, absolute_initializer_start, initializer_end)
+                .ok()?
+                .trim()
+                .to_string();
+        Some((first, second, initializer_text))
+    }
+
+    pub(in crate::emitter) fn emit_recovered_reserved_import_equals_declaration_name(
+        &mut self,
+        node: &Node,
+    ) -> bool {
+        if node.kind != syntax_kind_ext::IMPORT_EQUALS_DECLARATION {
+            return false;
+        }
+        let Some(import) = self.arena.get_import_decl(node) else {
+            return false;
+        };
+        if import.module_specifier.is_some() {
+            return false;
+        }
+        let Some(name_node) = self.arena.get(import.import_clause) else {
+            return false;
+        };
+        let Some(keyword) = self.reserved_keyword_text_from_source_span(name_node) else {
+            return false;
+        };
+        let Some(require_text) = self.recovered_import_equals_require_call_text(node) else {
+            return false;
+        };
+
+        if !self.writer.is_at_line_start() {
+            self.write_line();
+        }
+        self.write("require();");
+        self.write_line();
+        self.write(keyword);
+        self.write(" ( = ");
+        self.write(&require_text);
+        self.write(")");
+        self.write_line();
+        self.increase_indent();
+        self.write(";");
+        self.decrease_indent();
+        self.write_line();
+        true
+    }
+
+    fn recovered_import_equals_require_call_text(&self, node: &Node) -> Option<String> {
+        let line = self.source_line_from_node(node)?;
+        let equals = line.find('=')?;
+        let tail = line[equals + 1..].trim().trim_end_matches(';').trim();
+        if !tail.starts_with("require") {
+            return None;
+        }
+        Some(tail.to_string())
+    }
+
     fn reserved_keyword_text_at_declaration_start(&self, node: &Node) -> Option<&'static str> {
         let text = self.source_text?;
         let start = self.skip_trivia_forward(node.pos, node.end) as usize;
@@ -160,9 +299,24 @@ impl<'a> Printer<'a> {
             end += 1;
         }
         let keyword = crate::safe_slice::slice(text, start, end).ok()?;
+        self.reserved_keyword_text(keyword)
+    }
+
+    fn reserved_keyword_text(&self, keyword: &str) -> Option<&'static str> {
         let token = tsz_scanner::string_to_token(keyword);
         tsz_scanner::token_is_reserved_word(token)
             .then(|| tsz_scanner::keyword_to_text_static(token))?
+    }
+
+    fn source_line_from_node(&self, node: &Node) -> Option<&str> {
+        let text = self.source_text?;
+        let start = self.skip_trivia_forward(node.pos, node.end) as usize;
+        let bytes = text.as_bytes();
+        let mut end = start;
+        while end < bytes.len() && !matches!(bytes[end], b'\n' | b'\r') {
+            end += 1;
+        }
+        crate::safe_slice::slice(text, start, end).ok()
     }
 
     pub(in crate::emitter) fn emit_recovered_reserved_function_declaration_name(

--- a/crates/tsz-emitter/src/emitter/source_file/recovery.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/recovery.rs
@@ -1,5 +1,5 @@
 use crate::emitter::Printer;
-use tsz_parser::parser::node::Node;
+use tsz_parser::parser::node::{FunctionData, Node};
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
@@ -94,6 +94,171 @@ impl<'a> Printer<'a> {
             self.write(&statement);
             self.write_line();
         }
+        true
+    }
+
+    pub(in crate::emitter) fn emit_recovered_reserved_variable_declaration_name_statement(
+        &mut self,
+        node: &Node,
+    ) -> bool {
+        let Some(var_stmt) = self.arena.get_variable(node) else {
+            return false;
+        };
+        let [decl_list_idx] = var_stmt.declarations.nodes.as_slice() else {
+            return false;
+        };
+        let Some(decl_list_node) = self.arena.get(*decl_list_idx) else {
+            return false;
+        };
+        let Some(decl_list) = self.arena.get_variable(decl_list_node) else {
+            return false;
+        };
+        let [decl_idx] = decl_list.declarations.nodes.as_slice() else {
+            return false;
+        };
+        let Some(decl_node) = self.arena.get(*decl_idx) else {
+            return false;
+        };
+        let Some(decl) = self.arena.get_variable_declaration(decl_node) else {
+            return false;
+        };
+        if decl.initializer.is_none() {
+            return false;
+        }
+        let Some(name_node) = self.arena.get(decl.name) else {
+            return false;
+        };
+        if self.arena.get_identifier(name_node).is_none() {
+            return false;
+        }
+        if name_node.kind != SyntaxKind::Identifier as u16 {
+            return false;
+        }
+        let Some(keyword) = self.reserved_keyword_text_at_declaration_start(decl_node) else {
+            return false;
+        };
+
+        if !self.writer.is_at_line_start() {
+            self.write_line();
+        }
+        self.write("var ;");
+        self.write_line();
+        self.write(keyword);
+        self.write(" ;");
+        self.write_line();
+        self.emit_expression(decl.initializer);
+        self.write_semicolon();
+        true
+    }
+
+    fn reserved_keyword_text_at_declaration_start(&self, node: &Node) -> Option<&'static str> {
+        let text = self.source_text?;
+        let start = self.skip_trivia_forward(node.pos, node.end) as usize;
+        let bytes = text.as_bytes();
+        let mut end = start;
+        while end < bytes.len() && matches!(bytes[end], b'a'..=b'z' | b'A'..=b'Z') {
+            end += 1;
+        }
+        let keyword = crate::safe_slice::slice(text, start, end).ok()?;
+        let token = tsz_scanner::string_to_token(keyword);
+        tsz_scanner::token_is_reserved_word(token)
+            .then(|| tsz_scanner::keyword_to_text_static(token))?
+    }
+
+    pub(in crate::emitter) fn emit_recovered_reserved_function_declaration_name(
+        &mut self,
+        node: &Node,
+        func: &FunctionData,
+    ) -> bool {
+        let Some(name_node) = self.arena.get(func.name) else {
+            return false;
+        };
+        if name_node.kind != SyntaxKind::Identifier as u16 {
+            return false;
+        }
+        let Some(keyword) = self.reserved_keyword_text_from_source_span(name_node) else {
+            return false;
+        };
+        let Some(body_node) = self.arena.get(func.body) else {
+            return false;
+        };
+        if !self
+            .arena
+            .get_block(body_node)
+            .is_some_and(|block| block.statements.nodes.is_empty())
+        {
+            return false;
+        }
+
+        self.write("function ");
+        self.write("(");
+        let search_start = func
+            .parameters
+            .nodes
+            .first()
+            .and_then(|&idx| self.arena.get(idx))
+            .map_or(node.pos, |n| n.pos);
+        self.function_scope_depth += 1;
+        self.emit_function_parameters_with_trailing_comments(
+            &func.parameters.nodes,
+            name_node.end,
+            search_start,
+            body_node.pos,
+        );
+        self.function_scope_depth -= 1;
+        self.write(") { }");
+        self.write_line();
+        self.write(keyword);
+        self.write(" () => { };");
+        true
+    }
+
+    fn reserved_keyword_text_from_source_span(&self, node: &Node) -> Option<&'static str> {
+        let text = self.source_text?;
+        let keyword = crate::safe_slice::slice(text, node.pos as usize, node.end as usize)
+            .ok()?
+            .trim();
+        let token = tsz_scanner::string_to_token(keyword);
+        tsz_scanner::token_is_reserved_word(token)
+            .then(|| tsz_scanner::keyword_to_text_static(token))?
+    }
+
+    pub(in crate::emitter) fn emit_recovered_reserved_namespace_declaration_name(
+        &mut self,
+        node: &Node,
+    ) -> bool {
+        let Some(module) = self.arena.get_module(node) else {
+            return false;
+        };
+        let Some(name_node) = self.arena.get(module.name) else {
+            return false;
+        };
+        let Some(keyword) = self.reserved_keyword_text_from_source_span(name_node) else {
+            return false;
+        };
+        if module.body.is_none() {
+            return false;
+        }
+        let Some(body_node) = self.arena.get(module.body) else {
+            return false;
+        };
+        if !self.arena.get_module_block(body_node).is_some_and(|block| {
+            block
+                .statements
+                .as_ref()
+                .is_none_or(|stmts| stmts.nodes.is_empty())
+        }) {
+            return false;
+        }
+
+        if !self.writer.is_at_line_start() {
+            self.write_line();
+        }
+        self.write("namespace;");
+        self.write_line();
+        self.write(keyword);
+        self.write(" {};");
+        self.write_line();
         true
     }
 

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -894,6 +894,9 @@ impl<'a> Printer<'a> {
         if self.emit_recovered_template_property_name_variable_statement(node) {
             return;
         }
+        if self.emit_recovered_reserved_array_binding_variable_statement(node) {
+            return;
+        }
         if self.emit_recovered_reserved_variable_declaration_name_statement(node) {
             return;
         }

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -894,6 +894,9 @@ impl<'a> Printer<'a> {
         if self.emit_recovered_template_property_name_variable_statement(node) {
             return;
         }
+        if self.emit_recovered_reserved_variable_declaration_name_statement(node) {
+            return;
+        }
 
         let is_exported = self.ctx.is_commonjs()
             && self


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
emit / parser-recovery reserved-word parity (#9338, #9336)

## Invariant
When parser recovery leaves hard reserved keywords in declaration-name, import-alias, binding, parameter, namespace, or enum-adjacent recovery positions, tsc emits malformed JavaScript skeletons from parser recovery facts; this PR makes tsz do the same through dedicated emitter recovery helpers/facts, without checker/solver semantic validation or post-emit output surgery.

## Scope
- Adds recovery helpers/facts for hard-reserved variable names, import-equals names, array-binding elements, function names, namespace/module names, and reserved parameter names.
- Adds contextual anonymous enum hoist suppression needed by reservedWords2 after recovered reserved array bindings.
- Replaces the reserved array-binding source-line/comma split with a token pass bounded to the parsed variable statement; it recovers reserved tokens inside the array binding and the initializer span without consulting printer output or semantic state.
- Adds focused ES5 emit regression coverage with adjacent keyword/name variants, including single-element, multiline, and three-element reserved array-binding recovery.
- Splits source-file module-syntax classification out of the oversized emit loop to satisfy the architecture size ratchet without changing emit behavior.

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit reserved-word / parser-recovery emit
- Evidence: Narrow JS emit baseline family reservedWords is now 5/5 passing locally; no project-corpus row was run for this parser-recovery-only emit slice.

## Verification
- cargo fmt --all --check
- git diff --check
- scripts/arch/check-checker-boundaries.sh
- python3 scripts/emit/audit-output-surgery.py
- scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-emitter --all-targets -- -D warnings
- scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-common -p tsz-scanner -p tsz-parser -p tsz-binder -p tsz-solver -p tsz-checker -p tsz-emitter -p tsz-lowering -p tsz-lsp --all-targets -- -D warnings
- scripts/safe-run.sh cargo nextest run -p tsz-emitter reserved_array_binding_name_emits_recovered_keyword_statements
- scripts/safe-run.sh cargo nextest run -p tsz-emitter reserved_import_equals_name_emits_recovered_require_and_keyword_loop reserved_array_binding_name_emits_recovered_keyword_statements reserved_parameter_names_recover_without_semantic_type_proxy reserved_variable_name_emits_empty_decl_keyword_and_initializer_statements reserved_function_name_emits_anonymous_function_and_keyword_arrow_tail reserved_namespace_name_emits_keyword_and_recovered_body_statement reserved_enum_name_emits_anonymous_enum_and_reserved_statement
- scripts/safe-run.sh scripts/emit/run.sh --filter=reservedWords --js-only --verbose --timeout=30000 --json-out=/tmp/studio-c-reservedWords-closed.json (5/5 pass)
- scripts/safe-run.sh scripts/emit/run.sh --filter=reservedWords --js-only --verbose --workers=1 --timeout=60000 --json-out=/tmp/studio-c-reservedWords-closed-ratchet-serial.json (5/5 pass)
- scripts/safe-run.sh scripts/emit/run.sh --filter=reservedWords --js-only --verbose --timeout=60000 --json-out=/tmp/studio-c-reservedWords-ast-bounded.json (5/5 pass)

## Coordination Notes
- AgentName: Studio-C
- Closes the live reservedWords JS emit filter.
- No output-surgery allowlist changes; audit remains at 19 allowlisted findings.
- Manager blocker on array-binding source-line/comma-count recovery addressed in head 5114e43fb0.
- Related coordination trackers: #9338 and #9336.
