### PR TITLE
fix(solver): widen fresh-literal reverse-mapped inference results

### DIFF
--- a/crates/tsz-checker/tests/reverse_mapped_inference_tests.rs
+++ b/crates/tsz-checker/tests/reverse_mapped_inference_tests.rs
@@ -764,3 +764,98 @@ const bad: string = r.a;
         "Project<T> with number value assigned to string must produce TS2322. Got: {codes:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Fresh-literal widening of reverse-mapped (homomorphic) inference results.
+//
+// tsc's `getCovariantInference` closes with an unconditional `getWidenedType`,
+// so a type parameter reverse-inferred from a *fresh* object literal through a
+// pure homomorphic mapped type widens its fresh literal property types:
+//
+//   declare function unbox<T>(b: { [K in keyof T]: { value: T[K] } }): T;
+//   const u = unbox({ c: { value: false } });   // tsc: u: { c: boolean }
+//
+// Before the fix tsz preserved `{ c: false }`, so a narrowing assignment to
+// `{ c: false }` was wrongly accepted. These are structural (binder names are
+// varied) and cover the positive widening, the negative narrowing guard, the
+// non-fresh source (no widening), and the intersection-keyspace constraint
+// (literals preserved — `reverseMappedTypeLimitedConstraint.ts` family).
+// ---------------------------------------------------------------------------
+
+/// A fresh boolean-literal property reverse-inferred through a homomorphic
+/// mapped type must widen `false` -> `boolean`, so assigning to the literal
+/// `{ c: false }` is rejected (TS2322).
+#[test]
+fn reverse_mapped_fresh_boolean_literal_widens_rejecting_literal_target() {
+    let code = r#"
+declare function unbox<T>(boxified: { [K in keyof T]: { value: T[K] } }): T;
+const u = unbox({ c: { value: false } });
+const narrow: { c: false } = u;
+"#;
+    let codes = check_and_get_codes(code);
+    assert!(
+        codes.contains(&2322),
+        "reverse-mapped fresh `false` must widen to `boolean`, rejecting `{{ c: false }}`. Got: {codes:?}"
+    );
+}
+
+/// The widened result is still assignable to the widened shape (no false
+/// positive). Renamed binders prove the rule is structural, not name-keyed.
+#[test]
+fn reverse_mapped_fresh_literal_widening_assignable_to_widened_shape() {
+    let code = r#"
+declare function rebuild<Shape>(boxed: { [Key in keyof Shape]: { value: Shape[Key] } }): Shape;
+const built = rebuild({ flag: { value: true }, count: { value: 7 } });
+const wide: { flag: boolean; count: number } = built;
+"#;
+    let codes = check_and_get_codes(code);
+    assert!(
+        !codes.contains(&2322),
+        "widened `{{ flag: boolean; count: number }}` must accept the inferred result. Got: {codes:?}"
+    );
+}
+
+/// A non-fresh source (a typed variable, not a literal expression) must NOT be
+/// widened — mirroring tsc's `RequiresWidening` gate. The literal `true` flows
+/// from the annotated type, so the result keeps `{ on: true }`.
+#[test]
+fn reverse_mapped_non_fresh_source_preserves_literal() {
+    let code = r#"
+declare function unbox<T>(boxified: { [K in keyof T]: { value: T[K] } }): T;
+const src: { on: { value: true } } = { on: { value: true } };
+const u = unbox(src);
+const keepLiteral: { on: true } = u;
+"#;
+    let codes = check_and_get_codes(code);
+    assert!(
+        !codes.contains(&2322),
+        "non-fresh annotated source must preserve the literal `true`. Got: {codes:?}"
+    );
+}
+
+/// Guard against over-widening: an intersection-keyspace mapped type
+/// (`{ [K in keyof U & keyof T]: U[K] }`) reconstructs a constraint-checking
+/// contextual target whose literal property types tsc preserves in the
+/// excess-property elaboration. The literal `"y"` must survive (no widening).
+#[test]
+fn reverse_mapped_intersection_keyspace_preserves_literal_in_ts2353() {
+    let code = r#"
+const checkShape = <T>() => <U extends T>(value: { [K in keyof U & keyof T]: U[K] }) => value;
+const checked = checkShape<{ x: number; y: string }>()({
+  x: 1 as number,
+  y: "y",
+  z: "z",
+});
+"#;
+    let diags = check_source_diagnostics(code);
+    let ts2353: Vec<_> = diags.iter().filter(|d| d.code == 2353).collect();
+    assert!(
+        !ts2353.is_empty(),
+        "expected TS2353 excess-property diagnostic for `z`, got: {diags:#?}"
+    );
+    assert!(
+        ts2353[0].message_text.contains("y: \"y\""),
+        "intersection-keyspace mapped type must preserve literal `\"y\"`, got: {}",
+        ts2353[0].message_text
+    );
+}

--- a/crates/tsz-solver/src/operations/constraints/reverse_mapped.rs
+++ b/crates/tsz-solver/src/operations/constraints/reverse_mapped.rs
@@ -8,8 +8,8 @@ use crate::inference::infer::InferenceContext;
 use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::operations::{AssignabilityChecker, CallEvaluator};
 use crate::types::{
-    IntrinsicKind, LiteralValue, MappedModifier, ObjectShape, PropertyInfo, TupleElement, TypeData,
-    TypeId, TypeListId, Visibility,
+    IntrinsicKind, LiteralValue, MappedModifier, ObjectFlags, ObjectShape, PropertyInfo,
+    TupleElement, TypeData, TypeId, TypeListId, Visibility,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::RefCell;
@@ -475,14 +475,44 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
 
         // Build the reverse mapped object and constrain it against the placeholder T
         // using HomomorphicMappedType priority (lower than direct NakedTypeVariable inference).
+        //
+        // Propagate the source's freshness: when T is reverse-inferred from a
+        // *fresh* object literal argument through a pure homomorphic mapped type
+        // (`{ [K in keyof T]: ... }`), the reconstructed property types carry the
+        // widening obligation tsc applies via `getCovariantInference`'s closing
+        // `getWidenedType` — e.g. `unbox({ c: { value: false } })` infers
+        // `T = { c: boolean }`, not `{ c: false }`. Marking the candidate
+        // `FRESH_LITERAL` routes it through the resolver's fresh-literal-guarded
+        // deep-widen step (which still records literal display provenance for
+        // diagnostics). A non-fresh source (a typed variable / annotation) stays
+        // unwidened, matching tsc's `RequiresWidening` gate.
+        //
+        // The widening is restricted to a *bare* `keyof T` iteration constraint.
+        // An intersection/union keyspace such as `{ [K in keyof U & keyof T]: U[K] }`
+        // (`reverseMappedTypeLimitedConstraint.ts`) reconstructs the inferred type
+        // as a constraint-checking contextual target whose literal property types
+        // tsc preserves in the excess-property (TS2353) elaboration, so those must
+        // not be widened here.
+        let source_is_fresh = source_obj.flags.contains(ObjectFlags::FRESH_LITERAL)
+            && matches!(
+                self.interner.lookup(mapped.constraint),
+                Some(TypeData::KeyOf(inner)) if inner == target_placeholder
+            );
         let reverse_object = if reverse_string_index.is_some() || reverse_number_index.is_some() {
+            let flags = if source_is_fresh {
+                ObjectFlags::FRESH_LITERAL
+            } else {
+                ObjectFlags::empty()
+            };
             self.interner.object_with_index(ObjectShape {
-                flags: crate::types::ObjectFlags::empty(),
+                flags,
                 properties: reverse_properties,
                 string_index: reverse_string_index,
                 number_index: reverse_number_index,
                 symbol: None,
             })
+        } else if source_is_fresh {
+            self.interner.object_fresh(reverse_properties)
         } else {
             self.interner.object(reverse_properties)
         };


### PR DESCRIPTION
AgentName: Studio-B

Track: solver — generic inference / reverse-mapped (homomorphic) type inference

## Invariant
When a type parameter is reverse-inferred from a **fresh** object literal through a **pure** homomorphic mapped type (`{ [K in keyof T]: ... }`), tsz widens its fresh literal property types — matching tsc's `getCovariantInference`, which closes with an unconditional `getWidenedType`. A non-fresh source, or a non-bare (intersection/union) keyspace, preserves literals.

## Summary
Investigating the generic-inference substrate behind #10792 (and the reverse-mapped family tracked by #8432: `recursiveReverseMappedType.ts`, `reverseMappedType*`) surfaced a concrete divergence:

```ts
declare function unbox<T>(boxified: { [K in keyof T]: { value: T[K] } }): T;
const u = unbox({ c: { value: false } });
// tsc:  u: { c: boolean }   (fresh literal widened)
// tsz:  u: { c: false }     (literal wrongly preserved)
const narrow: { c: false } = u;  // tsz accepted (wrong); tsc errors (boolean !-> false)
```

The resolver already routes non-contextual (`HomomorphicMappedType`) priorities through a fresh-literal-guarded deep-widen step (`inference/infer_resolve.rs`), but the reconstructed reverse-mapped candidate object in `constrain_reverse_mapped_type` was built **non-fresh** (`ObjectFlags::empty()`), so that step never fired for it.

## Structural rule
> When `constrain_reverse_mapped_type` rebuilds the inferred `T` from a fresh object-literal source through a bare `keyof T` mapped constraint, the reconstructed candidate inherits `FRESH_LITERAL`; tsz then deep-widens its fresh literal leaves through the existing resolver step (which still records literal display provenance for diagnostics).

The freshness is gated to a bare `KeyOf(target_placeholder)` constraint. An intersection-keyspace mapped type such as `{ [K in keyof U & keyof T]: U[K] }` (`reverseMappedTypeLimitedConstraint.ts`) reconstructs a constraint-checking contextual target whose literal property types tsc preserves in the excess-property (TS2353) elaboration, so those are left unwidened.

## Owner layer & Scope
- `crates/tsz-solver/src/operations/constraints/reverse_mapped.rs` — propagate source freshness to the reverse-mapped candidate, gated on a bare `keyof T` constraint.
- `crates/tsz-checker/tests/reverse_mapped_inference_tests.rs` — 4 regression tests (renamed binders, anti-hardcoding).

The companion `infer_resolve.rs` reclassification of `HomomorphicMappedType` as non-contextual already landed on `main`; this PR builds on it and supplies the missing freshness so the real reverse-mapped path widens.

## Adjacent matrix
- Fresh boolean literal widened, narrowing target rejected (TS2322) ✅
- Renamed binders (`Shape`/`Key`), widened shape accepted, no false TS2322 ✅
- Non-fresh annotated source preserves the literal (`{ on: true }`) ✅
- Intersection-keyspace mapped type preserves `y: "y"` in TS2353 (no over-widening) ✅

## Project Corpus Impact
- Row: ts-essentials-project (#10792), plus reverse-mapped-using rows in the #8432 mapped/keyof/inference family.
- Bug family: generic inference — reverse-mapped literal widening parity with tsc.
- No new diagnostics on previously-accepted code; behavior moves toward tsc parity (adds a correct TS2322 on narrowing a widened result, removes wrongly-preserved literals).

## Verification
All via `cargo nextest run` (repo policy; nextest 0.9.137, installed in-sandbox from the upstream GitHub release):
- `cargo nextest run -p tsz-checker --test reverse_mapped_inference_tests --test co_contra_inference_tests --test homomorphic_mapped_keyof_modifier_tests --test homomorphic_mapped_union_distribution_tests` — **71 passed, 0 failed** (incl. the 4 new reverse-mapped regressions).
- `cargo nextest run -p tsz-solver --lib` — **6507 passed, 0 failed, 1 skipped** (rebased on latest `main`; includes the formerly-failing `test_deep_widen_object_candidate_homomorphic_mapped`, now green).
- `cargo nextest run -p tsz-checker --test generic_call_inference_tests` — 196 passed, 4 failed + 1 timed out; these 5 are **identical on clean `main`** (pre-existing, unrelated: contextual generator/constructor/kysely inference — verified by stash + re-run).
- `cargo clippy -p tsz-solver`, `cargo fmt -p tsz-solver -p tsz-checker --check`, `python3 scripts/arch/arch_guard.py` — clean.
- CLI oracle vs tsc on the issue repros (`unbox`, renamed `rebuild`, non-fresh source, intersection keyspace) — match.
- `/simplify` ran (round 1 applied: imported `ObjectFlags`, tightened the guard to `KeyOf(inner) if inner == target_placeholder`; rounds 2–3 clean).

## Coordination Notes
- Claimed #10792 (added `WIP` label, kept canonical `agent:Studio-B` lane); no open PR referenced it before or during this work.
- Rebased onto latest `origin/main`; the only overlap was the `infer_resolve.rs` `is_contextual_inference` arm, which `main` had already changed identically — resolved to `main`'s version so this PR contains only the novel reverse-mapped freshness fix + tests. `reverse_mapped.rs` was untouched by `main`.
