### PR TITLE
refactor(cli): isolate tsc-compat arg preprocessing behind a side-effect-free outcome

### DIFF
--- a/crates/tsz-cli/src/bin/tsz.rs
+++ b/crates/tsz-cli/src/bin/tsz.rs
@@ -45,11 +45,11 @@ fn main() -> Result<()> {
 
     // Preprocessing is side-effect free: it either hands back normalized args
     // or an early-exit directive (help/version/--all/TS5023/TS6369) whose I/O
-    // we own here. The directive message already carries its trailing newline.
+    // we own here. The entrypoint adds the trailing newline.
     let preprocessed = match preprocess_args(std::env::args_os().collect()) {
         PreprocessOutcome::Continue(args) => args,
         PreprocessOutcome::EarlyExit(EarlyExit { message, code }) => {
-            print!("{message}");
+            println!("{message}");
             std::process::exit(code);
         }
     };

--- a/crates/tsz-cli/src/bin/tsz.rs
+++ b/crates/tsz-cli/src/bin/tsz.rs
@@ -15,7 +15,7 @@ use tsz_cli::help::{self, TSC_VERSION};
 use tsz_cli::{driver, locale, reporter::Reporter, watch};
 use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
 
-use arg_preprocess::{check_build_position, preprocess_args};
+use arg_preprocess::{EarlyExit, PreprocessOutcome, preprocess_args};
 use clap_errors::handle_clap_error;
 use diagnostics_report::print_diagnostics;
 
@@ -43,13 +43,16 @@ fn main() -> Result<()> {
     // Supports TSZ_LOG_FORMAT=tree|json|text (see src/tracing_config.rs).
     tsz_cli::tracing_config::init_tracing();
 
-    let preprocessed = preprocess_args(std::env::args_os().collect());
-
-    // Check for TS6369: --build must be the first argument
-    if let Some(msg) = check_build_position(&preprocessed) {
-        print!("{msg}");
-        std::process::exit(1);
-    }
+    // Preprocessing is side-effect free: it either hands back normalized args
+    // or an early-exit directive (help/version/--all/TS5023/TS6369) whose I/O
+    // we own here. The directive message already carries its trailing newline.
+    let preprocessed = match preprocess_args(std::env::args_os().collect()) {
+        PreprocessOutcome::Continue(args) => args,
+        PreprocessOutcome::EarlyExit(EarlyExit { message, code }) => {
+            print!("{message}");
+            std::process::exit(code);
+        }
+    };
 
     let args = match CliArgs::try_parse_from(&preprocessed) {
         Ok(args) => args,

--- a/crates/tsz-cli/src/bin/tsz/arg_preprocess.rs
+++ b/crates/tsz-cli/src/bin/tsz/arg_preprocess.rs
@@ -899,4 +899,13 @@ mod tests {
 
         assert!(is_continue(&["tsz", "--build", "file.ts"]));
     }
+
+    #[test]
+    fn ordinary_invocation_returns_continue_byte_stable() {
+        // A normal compile invocation triggers no early exit and needs no
+        // rewrite: it must come back as Continue with the argv unchanged.
+        let input = &["tsz", "--noEmit", "src/main.ts"];
+        assert!(is_continue(input));
+        assert_eq!(preprocess_strs(input), input.to_vec());
+    }
 }

--- a/crates/tsz-cli/src/bin/tsz/arg_preprocess.rs
+++ b/crates/tsz-cli/src/bin/tsz/arg_preprocess.rs
@@ -9,11 +9,23 @@ use super::{TSC_VERSION, help};
 /// Preprocessing never writes to stdout or terminates the process itself.
 /// When a tsc-compatible quirk requires printing and exiting before clap runs
 /// (help, version, `--all`, or a pre-parse rejection), it returns this value so
-/// the binary entrypoint owns the I/O. `message` is the exact text to write to
-/// stdout verbatim (it already carries any trailing newline).
+/// the binary entrypoint owns the I/O. `message` is a single line of text with
+/// no trailing newline — the entrypoint adds it.
 pub(super) struct EarlyExit {
     pub(super) message: String,
     pub(super) code: i32,
+}
+
+impl EarlyExit {
+    /// A success early exit (code 0): help, version, or `--all`.
+    const fn print(message: String) -> Self {
+        Self { message, code: 0 }
+    }
+
+    /// A pre-parse rejection (code 1): TS5023 / TS6369.
+    const fn reject(message: String) -> Self {
+        Self { message, code: 1 }
+    }
 }
 
 /// Outcome of tsc-compatibility argument preprocessing.
@@ -144,8 +156,7 @@ fn canonicalize_long_flags(args: &mut [OsString]) {
 /// Detect the help / `--all` / version pre-parse exits.
 ///
 /// `--all` takes precedence over `--help`, which takes precedence over
-/// version. Returns the matching [`EarlyExit`] (stdout text + code 0), or
-/// `None` when no exit applies. Newlines match the original `println!` form.
+/// version. Returns the matching [`EarlyExit`] (code 0), or `None`.
 fn preparse_exit_directive(args: &[OsString]) -> Option<EarlyExit> {
     let is_build_mode = is_build_mode(args);
     let mut has_help = false;
@@ -169,29 +180,21 @@ fn preparse_exit_directive(args: &[OsString]) -> Option<EarlyExit> {
 
     // --all takes precedence (with or without --help)
     if has_all {
-        return Some(EarlyExit {
-            message: format!(
-                "{}\n",
-                help::colorize_help(&help::render_help_all(TSC_VERSION))
-            ),
-            code: 0,
-        });
+        return Some(EarlyExit::print(help::colorize_help(
+            &help::render_help_all(TSC_VERSION),
+        )));
     }
 
     // --help / -h / -?
     if has_help {
-        return Some(EarlyExit {
-            message: format!("{}\n", help::colorize_help(&help::render_help(TSC_VERSION))),
-            code: 0,
-        });
+        return Some(EarlyExit::print(help::colorize_help(&help::render_help(
+            TSC_VERSION,
+        ))));
     }
 
     // --version / -v / -V
     if has_version {
-        return Some(EarlyExit {
-            message: format!("Version {TSC_VERSION}\n"),
-            code: 0,
-        });
+        return Some(EarlyExit::print(format!("Version {TSC_VERSION}")));
     }
 
     None
@@ -218,10 +221,7 @@ fn preparse_unknown_rejection(args: &[OsString]) -> Option<EarlyExit> {
 }
 
 fn unknown_option_exit(option: &str) -> EarlyExit {
-    EarlyExit {
-        message: format!("error TS5023: Unknown compiler option '{option}'.\n"),
-        code: 1,
-    }
+    EarlyExit::reject(format!("error TS5023: Unknown compiler option '{option}'."))
 }
 
 fn is_build_mode(args: &[OsString]) -> bool {
@@ -688,8 +688,6 @@ pub(super) fn split_response_line(line: &str) -> Vec<String> {
 ///   - `-b` (short form) not first → TS5023 ("unknown compiler option")
 ///
 /// Returns an [`EarlyExit`] (code 1) if either form appears but is not first.
-/// The message already carries its trailing newline (matching the original
-/// `print!` form used by the entrypoint).
 fn build_position_rejection(args: &[OsString]) -> Option<EarlyExit> {
     // Skip program name (index 0)
     let mut first_non_program = true;
@@ -698,21 +696,18 @@ fn build_position_rejection(args: &[OsString]) -> Option<EarlyExit> {
         let s = arg.to_string_lossy();
         if s == "--build" {
             if !first_non_program {
-                return Some(EarlyExit {
-                    message:
-                        "error TS6369: Option '--build' must be the first command line argument.\n"
-                            .to_string(),
-                    code: 1,
-                });
+                return Some(EarlyExit::reject(
+                    "error TS6369: Option '--build' must be the first command line argument."
+                        .to_string(),
+                ));
             }
             return None;
         }
         if s == "-b" {
             if !first_non_program {
-                return Some(EarlyExit {
-                    message: "error TS5023: Unknown compiler option '-b'.\n".to_string(),
-                    code: 1,
-                });
+                return Some(EarlyExit::reject(
+                    "error TS5023: Unknown compiler option '-b'.".to_string(),
+                ));
             }
             return None;
         }
@@ -726,8 +721,12 @@ fn build_position_rejection(args: &[OsString]) -> Option<EarlyExit> {
 mod tests {
     use super::*;
 
-    fn preprocess_strs(args: &[&str]) -> Vec<String> {
+    fn run(args: &[&str]) -> PreprocessOutcome {
         preprocess_args(args.iter().map(OsString::from).collect())
+    }
+
+    fn preprocess_strs(args: &[&str]) -> Vec<String> {
+        run(args)
             .into_continue()
             .into_iter()
             .map(|arg| arg.to_string_lossy().into_owned())
@@ -799,7 +798,7 @@ mod tests {
     /// whole point of this refactor: these paths used to call `process::exit`
     /// and so could not be asserted at all.
     fn early_exit(args: &[&str]) -> EarlyExit {
-        match preprocess_args(args.iter().map(OsString::from).collect()) {
+        match run(args) {
             PreprocessOutcome::EarlyExit(exit) => exit,
             PreprocessOutcome::Continue(args) => {
                 panic!("expected EarlyExit, got Continue({args:?})")
@@ -808,15 +807,12 @@ mod tests {
     }
 
     fn is_continue(args: &[&str]) -> bool {
-        matches!(
-            preprocess_args(args.iter().map(OsString::from).collect()),
-            PreprocessOutcome::Continue(_)
-        )
+        matches!(run(args), PreprocessOutcome::Continue(_))
     }
 
     #[test]
     fn version_flags_exit_zero_with_version_banner() {
-        let expected = format!("Version {TSC_VERSION}\n");
+        let expected = format!("Version {TSC_VERSION}");
         for input in [
             &["tsz", "--version"][..],
             &["tsz", "-V"][..],
@@ -839,7 +835,6 @@ mod tests {
         ] {
             let exit = early_exit(input);
             assert_eq!(exit.code, 0, "{input:?}");
-            assert!(exit.message.ends_with('\n'), "{input:?}");
             assert!(!exit.message.trim().is_empty(), "{input:?}");
         }
     }
@@ -871,7 +866,7 @@ mod tests {
             assert_eq!(exit.code, 1, "{opt}");
             assert_eq!(
                 exit.message,
-                format!("error TS5023: Unknown compiler option '{opt}'.\n"),
+                format!("error TS5023: Unknown compiler option '{opt}'."),
             );
         }
     }
@@ -884,7 +879,7 @@ mod tests {
         assert_eq!(exit.code, 1);
         assert_eq!(
             exit.message,
-            "error TS5023: Unknown compiler option '--noEmit=true'.\n"
+            "error TS5023: Unknown compiler option '--noEmit=true'."
         );
     }
 
@@ -895,15 +890,12 @@ mod tests {
         assert_eq!(long.code, 1);
         assert_eq!(
             long.message,
-            "error TS6369: Option '--build' must be the first command line argument.\n"
+            "error TS6369: Option '--build' must be the first command line argument."
         );
 
         let short = early_exit(&["tsz", "file.ts", "-b"]);
         assert_eq!(short.code, 1);
-        assert_eq!(
-            short.message,
-            "error TS5023: Unknown compiler option '-b'.\n"
-        );
+        assert_eq!(short.message, "error TS5023: Unknown compiler option '-b'.");
 
         assert!(is_continue(&["tsz", "--build", "file.ts"]));
     }

--- a/crates/tsz-cli/src/bin/tsz/arg_preprocess.rs
+++ b/crates/tsz-cli/src/bin/tsz/arg_preprocess.rs
@@ -4,27 +4,84 @@ use std::ffi::OsString;
 use super::clap_errors::KNOWN_TSC_OPTIONS;
 use super::{TSC_VERSION, help};
 
+/// A pre-clap exit directive produced by [`preprocess_args`].
+///
+/// Preprocessing never writes to stdout or terminates the process itself.
+/// When a tsc-compatible quirk requires printing and exiting before clap runs
+/// (help, version, `--all`, or a pre-parse rejection), it returns this value so
+/// the binary entrypoint owns the I/O. `message` is the exact text to write to
+/// stdout verbatim (it already carries any trailing newline).
+pub(super) struct EarlyExit {
+    pub(super) message: String,
+    pub(super) code: i32,
+}
+
+/// Outcome of tsc-compatibility argument preprocessing.
+///
+/// Keeping this side-effect free is what makes every rewrite and pre-parse
+/// diagnostic unit-testable: the early-exit paths can be asserted without a
+/// test terminating the process.
+pub(super) enum PreprocessOutcome {
+    /// Continue startup with these normalized arguments (handed to clap).
+    Continue(Vec<OsString>),
+    /// Print [`EarlyExit::message`] to stdout and exit before clap parsing.
+    EarlyExit(EarlyExit),
+}
+
+impl PreprocessOutcome {
+    /// Unwrap the normalized arguments for tests that exercise the rewrite
+    /// pipeline (inputs that never trigger an early exit). Panics otherwise.
+    #[cfg(test)]
+    pub(super) fn into_continue(self) -> Vec<OsString> {
+        match self {
+            PreprocessOutcome::Continue(args) => args,
+            PreprocessOutcome::EarlyExit(exit) => panic!(
+                "expected PreprocessOutcome::Continue, got EarlyExit(code={}): {:?}",
+                exit.code, exit.message
+            ),
+        }
+    }
+}
+
 /// Preprocess command-line arguments for tsc compatibility.
 ///
-/// Handles (BEFORE clap parsing):
-/// - `--version` / `-v` / `-V` → print version, exit 0
-/// - `--help` / `-h` / `-?` → print help, exit 0
-/// - `--all` (with or without `--help`) → print all options, exit 0
+/// Runs (BEFORE clap parsing), in order:
 /// - `@file` response file expansion (tsc reads args from response files)
+/// - Case-insensitive / kebab-case flag names: `--NoEmit` → `--noEmit` (tsc v6)
+/// - Pre-parse early exits, returned as [`PreprocessOutcome::EarlyExit`]:
+///   - `--all` (with or without `--help`) → print all options, exit 0
+///   - `--help` / `-h` / `-?` → print help, exit 0
+///   - `--version` / `-v` / `-V` → print version, exit 0 (`-v` is version only
+///     outside build mode; in build mode it means `--build-verbose`)
+///   - `--` / `-` / `--boolFlag=value` → TS5023 unknown option, exit 1
+///   - `--build`/`-b` not first → TS6369 / TS5023, exit 1
 /// - Build mode flag remapping: when `--build`/`-b` is the first argument,
 ///   `-v` maps to `--build-verbose`, `-d` maps to `--dry`, `-f` maps to `--force`
-/// - Case-insensitive flag names: `--NoEmit` → `--noEmit` (tsc v6 compat)
 /// - Boolean flag values: `--strict false` → strip the flag (tsc v6 compat)
 /// - Optional boolean flags: `--strictNullChecks file.ts` → `--strictNullChecks=true file.ts`
 /// - Duplicate flags: `--strict --strict` → deduplicated (tsc v6 compat)
-pub(super) fn preprocess_args(args: Vec<OsString>) -> Vec<OsString> {
+///
+/// The function is side-effect free: all stdout/exit I/O is owned by the
+/// caller via the returned [`PreprocessOutcome`].
+pub(super) fn preprocess_args(args: Vec<OsString>) -> PreprocessOutcome {
     let mut expanded = expand_response_files(args);
     canonicalize_long_flags(&mut expanded);
-    handle_preparse_exits(&expanded);
-    reject_preparse_unknowns(&expanded);
+
+    if let Some(exit) = preparse_exit_directive(&expanded) {
+        return PreprocessOutcome::EarlyExit(exit);
+    }
+    if let Some(exit) = preparse_unknown_rejection(&expanded) {
+        return PreprocessOutcome::EarlyExit(exit);
+    }
 
     let build_remapped = remap_build_mode_flags(expanded);
-    normalize_bool_values_and_deduplicate(build_remapped)
+    let normalized = normalize_bool_values_and_deduplicate(build_remapped);
+
+    if let Some(exit) = build_position_rejection(&normalized) {
+        return PreprocessOutcome::EarlyExit(exit);
+    }
+
+    PreprocessOutcome::Continue(normalized)
 }
 
 fn expand_response_files(args: Vec<OsString>) -> Vec<OsString> {
@@ -84,7 +141,12 @@ fn canonicalize_long_flags(args: &mut [OsString]) {
     }
 }
 
-fn handle_preparse_exits(args: &[OsString]) {
+/// Detect the help / `--all` / version pre-parse exits.
+///
+/// `--all` takes precedence over `--help`, which takes precedence over
+/// version. Returns the matching [`EarlyExit`] (stdout text + code 0), or
+/// `None` when no exit applies. Newlines match the original `println!` form.
+fn preparse_exit_directive(args: &[OsString]) -> Option<EarlyExit> {
     let is_build_mode = is_build_mode(args);
     let mut has_help = false;
     let mut has_all = false;
@@ -107,41 +169,58 @@ fn handle_preparse_exits(args: &[OsString]) {
 
     // --all takes precedence (with or without --help)
     if has_all {
-        println!(
-            "{}",
-            help::colorize_help(&help::render_help_all(TSC_VERSION))
-        );
-        std::process::exit(0);
+        return Some(EarlyExit {
+            message: format!(
+                "{}\n",
+                help::colorize_help(&help::render_help_all(TSC_VERSION))
+            ),
+            code: 0,
+        });
     }
 
     // --help / -h / -?
     if has_help {
-        println!("{}", help::colorize_help(&help::render_help(TSC_VERSION)));
-        std::process::exit(0);
+        return Some(EarlyExit {
+            message: format!("{}\n", help::colorize_help(&help::render_help(TSC_VERSION))),
+            code: 0,
+        });
     }
 
     // --version / -v / -V
     if has_version {
-        println!("Version {TSC_VERSION}");
-        std::process::exit(0);
+        return Some(EarlyExit {
+            message: format!("Version {TSC_VERSION}\n"),
+            code: 0,
+        });
     }
+
+    None
 }
 
-fn reject_preparse_unknowns(args: &[OsString]) {
+/// Detect the `--` / `-` / `--boolFlag=value` pre-parse rejections that tsc
+/// reports as TS5023 before clap parsing. Returns the matching [`EarlyExit`]
+/// (stdout text + code 1), or `None`.
+fn preparse_unknown_rejection(args: &[OsString]) -> Option<EarlyExit> {
     for arg in args.iter().skip(1) {
         let s = arg.to_string_lossy();
         if s == "--" || s == "-" {
-            println!("error TS5023: Unknown compiler option '{s}'.");
-            std::process::exit(1);
+            return Some(unknown_option_exit(&s));
         }
         // tsc treats --boolFlag=value as an unknown option (the whole --flag=value string)
         if let Some(eq_pos) = s.find('=') {
             let flag_part = &s[..eq_pos];
             if is_boolean_flag(flag_part) {
-                println!("error TS5023: Unknown compiler option '{s}'.");
-                std::process::exit(1);
+                return Some(unknown_option_exit(&s));
             }
         }
+    }
+    None
+}
+
+fn unknown_option_exit(option: &str) -> EarlyExit {
+    EarlyExit {
+        message: format!("error TS5023: Unknown compiler option '{option}'.\n"),
+        code: 1,
     }
 }
 
@@ -603,13 +682,15 @@ pub(super) fn split_response_line(line: &str) -> Vec<String> {
     args
 }
 
-/// Check that --build/-b is the first argument.
+/// Check that `--build`/`-b` is the first argument.
 /// tsc v6 behavior:
 ///   - `--build` (long form) not first → TS6369 ("must be first")
 ///   - `-b` (short form) not first → TS5023 ("unknown compiler option")
 ///
-/// Returns an error message if either form appears but is not first.
-pub(super) fn check_build_position(args: &[OsString]) -> Option<String> {
+/// Returns an [`EarlyExit`] (code 1) if either form appears but is not first.
+/// The message already carries its trailing newline (matching the original
+/// `print!` form used by the entrypoint).
+fn build_position_rejection(args: &[OsString]) -> Option<EarlyExit> {
     // Skip program name (index 0)
     let mut first_non_program = true;
 
@@ -617,16 +698,21 @@ pub(super) fn check_build_position(args: &[OsString]) -> Option<String> {
         let s = arg.to_string_lossy();
         if s == "--build" {
             if !first_non_program {
-                return Some(
-                    "error TS6369: Option '--build' must be the first command line argument.\n"
-                        .to_string(),
-                );
+                return Some(EarlyExit {
+                    message:
+                        "error TS6369: Option '--build' must be the first command line argument.\n"
+                            .to_string(),
+                    code: 1,
+                });
             }
             return None;
         }
         if s == "-b" {
             if !first_non_program {
-                return Some("error TS5023: Unknown compiler option '-b'.\n".to_string());
+                return Some(EarlyExit {
+                    message: "error TS5023: Unknown compiler option '-b'.\n".to_string(),
+                    code: 1,
+                });
             }
             return None;
         }
@@ -642,6 +728,7 @@ mod tests {
 
     fn preprocess_strs(args: &[&str]) -> Vec<String> {
         preprocess_args(args.iter().map(OsString::from).collect())
+            .into_continue()
             .into_iter()
             .map(|arg| arg.to_string_lossy().into_owned())
             .collect()
@@ -705,5 +792,119 @@ mod tests {
         for (input, expected) in cases {
             assert_eq!(split_response_line(input), expected);
         }
+    }
+
+    /// Extract the [`EarlyExit`] for inputs expected to short-circuit before
+    /// clap. Panics if preprocessing instead returned `Continue` — which is the
+    /// whole point of this refactor: these paths used to call `process::exit`
+    /// and so could not be asserted at all.
+    fn early_exit(args: &[&str]) -> EarlyExit {
+        match preprocess_args(args.iter().map(OsString::from).collect()) {
+            PreprocessOutcome::EarlyExit(exit) => exit,
+            PreprocessOutcome::Continue(args) => {
+                panic!("expected EarlyExit, got Continue({args:?})")
+            }
+        }
+    }
+
+    fn is_continue(args: &[&str]) -> bool {
+        matches!(
+            preprocess_args(args.iter().map(OsString::from).collect()),
+            PreprocessOutcome::Continue(_)
+        )
+    }
+
+    #[test]
+    fn version_flags_exit_zero_with_version_banner() {
+        let expected = format!("Version {TSC_VERSION}\n");
+        for input in [
+            &["tsz", "--version"][..],
+            &["tsz", "-V"][..],
+            &["tsz", "-v"][..],
+            &["tsz", "file.ts", "--version"][..],
+        ] {
+            let exit = early_exit(input);
+            assert_eq!(exit.code, 0, "{input:?}");
+            assert_eq!(exit.message, expected, "{input:?}");
+        }
+    }
+
+    #[test]
+    fn help_and_all_flags_exit_zero_with_nonempty_banner() {
+        for input in [
+            &["tsz", "--help"][..],
+            &["tsz", "-h"][..],
+            &["tsz", "-?"][..],
+            &["tsz", "--all"][..],
+        ] {
+            let exit = early_exit(input);
+            assert_eq!(exit.code, 0, "{input:?}");
+            assert!(exit.message.ends_with('\n'), "{input:?}");
+            assert!(!exit.message.trim().is_empty(), "{input:?}");
+        }
+    }
+
+    #[test]
+    fn all_takes_precedence_over_help() {
+        // `--all` and `--help` together must render the all-options banner,
+        // preserving the original precedence order.
+        let combined = early_exit(&["tsz", "--all", "--help"]);
+        let all_only = early_exit(&["tsz", "--all"]);
+        assert_eq!(combined.message, all_only.message);
+        assert_eq!(combined.code, 0);
+    }
+
+    #[test]
+    fn dash_v_is_build_verbose_not_version_in_build_mode() {
+        // In build mode `-v` means --build-verbose, so it must NOT early-exit
+        // as a version request; it stays in the normalized args.
+        assert!(is_continue(&["tsz", "--build", "-v"]));
+        let normalized = preprocess_strs(&["tsz", "--build", "-v"]);
+        assert!(normalized.iter().any(|a| a == "--build-verbose"));
+        assert!(!normalized.iter().any(|a| a == "--version"));
+    }
+
+    #[test]
+    fn unknown_bare_dashes_reject_with_ts5023() {
+        for opt in ["--", "-"] {
+            let exit = early_exit(&["tsz", opt]);
+            assert_eq!(exit.code, 1, "{opt}");
+            assert_eq!(
+                exit.message,
+                format!("error TS5023: Unknown compiler option '{opt}'.\n"),
+            );
+        }
+    }
+
+    #[test]
+    fn boolean_flag_with_equals_value_rejects_with_ts5023() {
+        // tsc treats `--noEmit=true` (a boolean flag in `--flag=value` form) as
+        // an unknown option, reported verbatim with the whole token.
+        let exit = early_exit(&["tsz", "--noEmit=true", "file.ts"]);
+        assert_eq!(exit.code, 1);
+        assert_eq!(
+            exit.message,
+            "error TS5023: Unknown compiler option '--noEmit=true'.\n"
+        );
+    }
+
+    #[test]
+    fn build_must_be_the_first_argument() {
+        // `--build` not first → TS6369; `-b` not first → TS5023; first → continue.
+        let long = early_exit(&["tsz", "file.ts", "--build"]);
+        assert_eq!(long.code, 1);
+        assert_eq!(
+            long.message,
+            "error TS6369: Option '--build' must be the first command line argument.\n"
+        );
+
+        let short = early_exit(&["tsz", "file.ts", "-b"]);
+        assert_eq!(short.code, 1);
+        assert_eq!(
+            short.message,
+            "error TS5023: Unknown compiler option '-b'.\n"
+        );
+
+        assert!(is_continue(&["tsz", "--build", "file.ts"]));
     }
 }

--- a/crates/tsz-cli/src/bin/tsz/tests.rs
+++ b/crates/tsz-cli/src/bin/tsz/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 
 fn preprocess_strs(args: &[&str]) -> Vec<String> {
     preprocess_args(args.iter().map(OsString::from).collect())
+        .into_continue()
         .into_iter()
         .map(|arg| arg.to_string_lossy().into_owned())
         .collect()
@@ -102,7 +103,7 @@ fn preprocess_case_insensitive_noemit() {
         OsString::from("--NoEmit"),
         OsString::from("file.ts"),
     ];
-    let result = preprocess_args(args);
+    let result = preprocess_args(args).into_continue();
     assert!(result.iter().any(|a| a == "--noEmit"));
 }
 
@@ -113,7 +114,7 @@ fn preprocess_case_insensitive_all_caps() {
         OsString::from("--STRICT"),
         OsString::from("file.ts"),
     ];
-    let result = preprocess_args(args);
+    let result = preprocess_args(args).into_continue();
     assert!(result.iter().any(|a| a == "--strict"));
 }
 
@@ -125,7 +126,7 @@ fn preprocess_case_insensitive_with_value() {
         OsString::from("ES2020"),
         OsString::from("file.ts"),
     ];
-    let result = preprocess_args(args);
+    let result = preprocess_args(args).into_continue();
     assert!(result.iter().any(|a| a == "--target"));
     // Value should be preserved as-is
     assert!(result.iter().any(|a| a == "ES2020"));
@@ -138,7 +139,7 @@ fn preprocess_case_insensitive_equals_form() {
         OsString::from("--Target=ES2020"),
         OsString::from("file.ts"),
     ];
-    let result = preprocess_args(args);
+    let result = preprocess_args(args).into_continue();
     assert!(result.iter().any(|a| a == "--target=ES2020"));
 }
 
@@ -151,7 +152,7 @@ fn preprocess_canonicalizes_kebab_case_aliases() {
         OsString::from("5.7"),
         OsString::from("file.ts"),
     ];
-    let result = preprocess_args(args);
+    let result = preprocess_args(args).into_continue();
     assert!(result.iter().any(|a| a == "--noEmit"));
     assert!(result.iter().any(|a| a == "--typesVersions"));
 }
@@ -165,7 +166,7 @@ fn preprocess_canonicalizes_cli_only_aliases() {
         OsString::from("--trace-dependencies"),
         OsString::from("--batch"),
     ];
-    let result = preprocess_args(args);
+    let result = preprocess_args(args).into_continue();
     assert!(result.iter().any(|a| a == "--build"));
     assert!(result.iter().any(|a| a == "--build-verbose"));
     assert!(result.iter().any(|a| a == "--traceDependencies"));
@@ -179,7 +180,7 @@ fn preprocess_file_paths_not_lowercased() {
         OsString::from("--noEmit"),
         OsString::from("MyFile.ts"),
     ];
-    let result = preprocess_args(args);
+    let result = preprocess_args(args).into_continue();
     assert!(result.iter().any(|a| a == "MyFile.ts"));
 }
 
@@ -193,7 +194,7 @@ fn preprocess_duplicate_boolean_flags() {
         OsString::from("--strict"),
         OsString::from("file.ts"),
     ];
-    let result = preprocess_args(args);
+    let result = preprocess_args(args).into_continue();
     let strict_count = result.iter().filter(|a| *a == "--strict").count();
     assert_eq!(strict_count, 1, "duplicate --strict should be deduplicated");
 }
@@ -208,7 +209,7 @@ fn preprocess_duplicate_valued_flags_last_wins() {
         OsString::from("ES2022"),
         OsString::from("file.ts"),
     ];
-    let result = preprocess_args(args);
+    let result = preprocess_args(args).into_continue();
     let target_count = result.iter().filter(|a| *a == "--target").count();
     assert_eq!(target_count, 1, "duplicate --target should be deduplicated");
     // Last value wins
@@ -226,7 +227,7 @@ fn preprocess_strict_false_forwards_explicit_disable() {
         OsString::from("false"),
         OsString::from("file.ts"),
     ];
-    let result = preprocess_args(args);
+    let result = preprocess_args(args).into_continue();
     // The bare `--strict` flag is dropped (clap's `bool` arg cannot represent
     // an explicit `false`).
     assert!(
@@ -258,7 +259,7 @@ fn preprocess_strict_true_keeps_flag() {
         OsString::from("true"),
         OsString::from("file.ts"),
     ];
-    let result = preprocess_args(args);
+    let result = preprocess_args(args).into_continue();
     assert!(
         result.iter().any(|a| a == "--strict"),
         "--strict true should keep the flag"
@@ -278,7 +279,7 @@ fn preprocess_noemit_false_forwards_explicit_disable() {
         OsString::from("false"),
         OsString::from("file.ts"),
     ];
-    let result = preprocess_args(args);
+    let result = preprocess_args(args).into_continue();
     assert!(
         !result.iter().any(|a| a == "--noEmit"),
         "--noEmit false should remove the bare flag"
@@ -327,7 +328,7 @@ fn preprocess_non_boolean_false_not_consumed() {
         OsString::from("false"),
         OsString::from("file.ts"),
     ];
-    let result = preprocess_args(args);
+    let result = preprocess_args(args).into_continue();
     assert!(result.iter().any(|a| a == "--outDir"));
     assert!(result.iter().any(|a| a == "false"));
 }
@@ -498,7 +499,7 @@ fn build_clean_removes_explicit_tsbuildinfo_file() {
 fn parse_args_for_init(extra: &[&str]) -> CliArgs {
     let mut argv: Vec<OsString> = vec![OsString::from("tsz"), OsString::from("--init")];
     argv.extend(extra.iter().map(OsString::from));
-    let preprocessed = preprocess_args(argv);
+    let preprocessed = preprocess_args(argv).into_continue();
     CliArgs::try_parse_from(&preprocessed).expect("clap should accept --init args")
 }
 


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
CLI tech-debt — isolate tsc-compatible argument preprocessing from CLI startup (#9407)

## Invariant
When tsc-compatibility preprocessing must print and exit before clap runs — `--help`/`-h`/`-?`, `--all`, `--version`/`-v`/`-V`, the TS5023 `--`/`-`/`--boolFlag=value` rejection, or the TS6369/TS5023 `--build`/`-b`-not-first rejection — tsz returns a `PreprocessOutcome::EarlyExit { message, code }` directive and the binary entrypoint owns the stdout write plus process exit. Normalized argument bytes and exit codes are unchanged.

## Scope
A prior change already extracted `preprocess_args` into `arg_preprocess.rs`, so the first acceptance criterion was met. The remaining criterion was the cleanup direction's narrow API that returns normalized args plus warnings/errors: the pre-parse steps still called `println!` plus `std::process::exit` inside preprocessing, so the help/version/`--all`/unknown-option/build-position paths could not be unit-tested.

- `crates/tsz-cli/src/bin/tsz/arg_preprocess.rs`: `preprocess_args` returns `PreprocessOutcome` (`Continue(args)` or `EarlyExit`) instead of printing/exiting mid-pipeline. The three pre-parse decision points — `preparse_exit_directive`, `preparse_unknown_rejection`, and `build_position_rejection` — are folded into that one narrow API.
- `crates/tsz-cli/src/bin/tsz.rs`: `main` maps the outcome to I/O.
- Tests: a table-driven matrix covers the previously untestable early-exit paths: version flags, help/`--all` precedence, build-mode `-v` versus version, bare-dash and `--boolFlag=value` TS5023, and build-must-be-first TS6369/TS5023.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CLI pre-parse plumbing only; no type-checking, inference, narrowing, emit, diagnostic-content semantics, project fixture, or project-row metadata changes. Output is intended to remain byte-identical.

## Verification
- `cargo check -p tsz-cli --bin tsz --tests` — clean
- `cargo nextest run -p tsz-cli --bin tsz` — `Summary [0.121s] 74 tests run: 74 passed, 0 skipped`
- `cargo fmt -p tsz-cli --check` — clean
- Rebased onto latest `origin/main` (clean, no conflicts).
- CI: the `unit` job (`cargo nextest run --profile ci`) is green on head `d127f83`, covering `tsz-cli` in the workspace nextest suite; `lint`, `wasm`, and `wasm-web` are green.
- Note: `tsz-cli` is not in the CI clippy crate list (`scripts/ci/gcp-full-ci.sh`); local clippy was also run and `missing_const_for_fn` was addressed on the new constructors.

## Coordination Notes
- AgentName: Studio-Opus
- Closes #9407.
- This PR was implemented by the remote session on branch `claude/confident-hawking-XaUzb`; Studio-Opus repaired the PR body contract after ready CI flagged the stale readiness note.
- Anti-hardcoding: no user-name/file-name literals drive logic; the flag tables are the pre-existing tsc-compat option lists; no rendered-output string is used as a semantic predicate.