### PR TITLE
refactor(emit): guard stale family dashboards

### DIFF
--- a/scripts/emit/query-emit.py
+++ b/scripts/emit/query-emit.py
@@ -13,6 +13,9 @@ Usage:
   # Failure-family dashboard
   python3 scripts/emit/query-emit.py --families
 
+  # Include historical family rows even when emit-detail.json is stale
+  python3 scripts/emit/query-emit.py --families --include-stale-detail
+
   # Filter by substring in test name
   python3 scripts/emit/query-emit.py --filter class
 
@@ -336,6 +339,31 @@ def failure_family_surface_heading(surface, title, detail_total, detail_summary,
     )
 
 
+def print_stale_failure_family_guard(detail_summary, public_summary):
+    print(emit_freshness_status_line_from_status(
+        emit_freshness_status(detail_summary, public_summary)
+    ))
+    print(
+        "Failure-family rows are suppressed because scripts/emit/emit-detail.json "
+        "does not match the README/public aggregate."
+    )
+    print()
+    for surface, title in (("js", "JavaScript"), ("dts", "Declaration")):
+        public_remaining = emit_remaining_failures(public_summary, surface)
+        detail_remaining = emit_remaining_failures(detail_summary, surface)
+        if public_remaining is None or detail_remaining is None:
+            continue
+        print(
+            f"{title}: public aggregate remaining {public_remaining:,}; "
+            f"checked-detail remaining {detail_remaining:,}"
+        )
+    print()
+    print(
+        "Refresh with `./scripts/emit/run.sh --json-out`, or pass "
+        "`--include-stale-detail` to view historical checked-detail triage."
+    )
+
+
 def print_emit_freshness_status(data):
     print(emit_freshness_status_line(data))
 
@@ -520,12 +548,17 @@ def collect_failures_by_family(data, surface):
     return families
 
 
-def show_failure_families(data, top=20):
+def show_failure_families(data, top=20, include_stale_detail=False):
     print("Emit failure families")
     print()
-    print_emit_freshness_note(data)
     detail_summary = emit_summary(data)
     public_summary = emit_summary_from_readme()
+    freshness_status = emit_freshness_status(detail_summary, public_summary)
+    if freshness_status["state"] == "stale" and not include_stale_detail:
+        print_stale_failure_family_guard(detail_summary, public_summary)
+        return
+
+    print_emit_freshness_note(data)
     for surface, title in (("js", "JavaScript"), ("dts", "Declaration")):
         families = collect_failures_by_family(data, surface)
         rows = sorted(
@@ -601,6 +634,11 @@ def main():
     parser.add_argument("--dts-failures", action="store_true", help="Show DTS failures")
     parser.add_argument("--top-errors", action="store_true", help="Show top error messages")
     parser.add_argument("--families", action="store_true", help="Show JS/DTS failure family counts")
+    parser.add_argument(
+        "--include-stale-detail",
+        action="store_true",
+        help="With --families, print historical family rows even when emit-detail.json is stale",
+    )
     parser.add_argument("--close", action="store_true", help="Show close-to-passing tests")
     parser.add_argument("--filter", type=str, help="Filter by substring in test name")
     parser.add_argument("--status", type=str, help="Filter by status (pass/fail/skip/timeout)")
@@ -638,7 +676,7 @@ def main():
     elif args.top_errors:
         show_top_errors(filtered_data, args.top)
     elif args.families:
-        show_failure_families(filtered_data, args.top)
+        show_failure_families(filtered_data, args.top, args.include_stale_detail)
     elif args.close:
         show_close(filtered_data, args.top)
     elif args.status:

--- a/scripts/emit/test_query_emit_families.py
+++ b/scripts/emit/test_query_emit_families.py
@@ -240,6 +240,73 @@ after
         self.assertIn("public aggregate remaining: 71", heading)
         self.assertIn("detail aggregate remaining: 436", heading)
 
+    def test_stale_failure_families_are_suppressed_by_default(self):
+        data = {
+            "summary": {
+                "jsPass": 13094,
+                "jsTotal": 13530,
+                "dtsPass": 1606,
+                "dtsTotal": 1669,
+            },
+            "results": [
+                make_result("classUsedBeforeInitializedVariables", js_error="+1/-1 lines"),
+                make_result("inferTypePredicates", dts_error="+1/-1 lines"),
+            ],
+        }
+        original = self.mod.emit_summary_from_readme
+        self.mod.emit_summary_from_readme = lambda: {
+            "jsPass": 13459,
+            "jsTotal": 13530,
+            "dtsPass": 1644,
+            "dtsTotal": 1669,
+        }
+        try:
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                self.mod.show_failure_families(data)
+        finally:
+            self.mod.emit_summary_from_readme = original
+
+        text = out.getvalue()
+        self.assertIn("Failure-family rows are suppressed", text)
+        self.assertIn("JavaScript: public aggregate remaining 71", text)
+        self.assertIn("Declaration: public aggregate remaining 25", text)
+        self.assertIn("--include-stale-detail", text)
+        self.assertNotIn("class/private/accessor/decorator lowering", text)
+        self.assertNotIn("generic/type-display declarations", text)
+
+    def test_stale_failure_families_can_be_included_explicitly(self):
+        data = {
+            "summary": {
+                "jsPass": 13094,
+                "jsTotal": 13530,
+                "dtsPass": 1606,
+                "dtsTotal": 1669,
+            },
+            "results": [
+                make_result("classUsedBeforeInitializedVariables", js_error="+1/-1 lines"),
+                make_result("inferTypePredicates", dts_error="+1/-1 lines"),
+            ],
+        }
+        original = self.mod.emit_summary_from_readme
+        self.mod.emit_summary_from_readme = lambda: {
+            "jsPass": 13459,
+            "jsTotal": 13530,
+            "dtsPass": 1644,
+            "dtsTotal": 1669,
+        }
+        try:
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                self.mod.show_failure_families(data, include_stale_detail=True)
+        finally:
+            self.mod.emit_summary_from_readme = original
+
+        text = out.getvalue()
+        self.assertIn("historical checked-detail triage only", text)
+        self.assertIn("class/private/accessor/decorator lowering", text)
+        self.assertIn("generic/type-display declarations", text)
+
     def test_current_failure_family_heading_keeps_plain_count(self):
         summary = {
             "jsPass": 13459,


### PR DESCRIPTION
AgentName: Studio-Opus

## Track
Emit metric/tooling guardrail / evidence hygiene.

## Invariant
When `scripts/emit/emit-detail.json` is stale relative to the README/public aggregate, the normal failure-family dashboard must not present stale checked-detail family rows as the default view. Historical checked-detail families remain available only through explicit `--include-stale-detail` opt-in.

## Scope
Updates `scripts/emit/query-emit.py` to suppress stale family rows by default and add the explicit stale-detail opt-in; extends `scripts/emit/test_query_emit_families.py` with default-suppression and opt-in coverage.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: emit tooling only; no compiler behavior or project-row semantics changed.

## Verification
- `python3 scripts/emit/test_query_emit_families.py`
- `python3 scripts/emit/query-emit.py --families`
- `python3 scripts/emit/query-emit.py --families --include-stale-detail | sed -n '1,40p'`
- `git diff --check`

## Coordination Notes
This avoids the Studio-C `top_level_using.rs` output-surgery lane in #12359 and leaves that owner’s branch untouched. It complements that work by making the Studio start-cycle emit family command report the current public remaining counts plus a refresh hint when checked-detail data is stale, instead of defaulting to historical family rows.
