### PR TITLE
fix(solver): specialize typeof-instantiation expressions in generic call-signature returns

### DIFF
--- a/crates/tsz-checker/tests/typeof_instantiation_expression_tests.rs
+++ b/crates/tsz-checker/tests/typeof_instantiation_expression_tests.rs
@@ -524,3 +524,122 @@ type Bad = typeof multi<string, number, boolean>;
         messages[0]
     );
 }
+
+// ── generic-method instantiation-expression return types (#10933) ──────────────
+//
+// When a generic call signature's return type contains an instantiation
+// expression `typeof f<U>` over that signature's own type parameter, the
+// instantiation must consume the signature-level type params per-signature
+// rather than route through the alias-style (shadowing) substitution path,
+// which would freeze the application and degrade `ReturnType<…>` to `unknown`.
+
+#[test]
+fn generic_method_returns_instantiation_expression_specializes() {
+    // The instantiation expression is the bare method return type.
+    let diags = check_source_diagnostics(
+        r#"
+declare function build<TValue>(value: TValue): { unwrap(): TValue };
+interface Pipeline {
+    step<TStep>(make: () => TStep): typeof build<TStep>;
+}
+declare const pipeline: Pipeline;
+
+const made = pipeline.step<{ label: string }>(() => ({ label: "x" }));
+const produced = made({ label: "y" });
+const ok: { label: string } = produced.unwrap();
+const bad: number = produced.unwrap();
+"#,
+    );
+    assert_no_false_typeof_instantiation_diagnostics(&diags);
+    // The only expected error is the deliberate `bad: number` mismatch.
+    assert_eq!(
+        diagnostic_count(&diags, 2322),
+        1,
+        "expected exactly the deliberate `bad: number` TS2322, got {diags:#?}"
+    );
+}
+
+#[test]
+fn generic_method_return_type_wraps_instantiation_expression() {
+    // The instantiation expression is nested inside `ReturnType<…>`, the
+    // exact shape from the #10933 witness. Binder names differ from the
+    // sibling test above so the fix is provably structural, not name-keyed.
+    let diags = check_source_diagnostics(
+        r#"
+type ReturnOf<F extends (...args: any[]) => any> =
+    F extends (...args: any[]) => infer R ? R : never;
+
+declare function factory<TItem>(seed: TItem): { collect(): TItem };
+interface Chain {
+    map<TMapped>(project: (value: number) => TMapped): ReturnOf<typeof factory<TMapped>>;
+}
+declare const chain: Chain;
+
+const mapped = chain.map<{ tag: string }>(() => ({ tag: "t" }));
+const ok: { tag: string } = mapped.collect();
+const bad: string = mapped.collect();
+"#,
+    );
+    assert_no_false_typeof_instantiation_diagnostics(&diags);
+    assert_eq!(
+        diagnostic_count(&diags, 2322),
+        1,
+        "expected exactly the deliberate `bad: string` TS2322, got {diags:#?}"
+    );
+}
+
+#[test]
+fn generic_method_instantiation_expression_via_object_type_alias() {
+    // Same rule reached through a generic object-type alias whose member is a
+    // generic method: the alias param and the method param both flow into the
+    // instantiation expression.
+    let diags = check_source_diagnostics(
+        r#"
+type ReturnOf<F extends (...args: any[]) => any> =
+    F extends (...args: any[]) => infer R ? R : never;
+
+declare function wrap<TWrapped>(value: TWrapped): { done(): TWrapped };
+type Builder<TState> = {
+    refine<TNext>(next: (state: TState) => TNext): ReturnOf<typeof wrap<TNext>>;
+};
+declare const builder: Builder<{ a: number }>;
+
+const refined = builder.refine<{ label: string }>((state) => ({ label: "x" }));
+const ok: { label: string } = refined.done();
+const bad: string = refined.done();
+"#,
+    );
+    assert_no_false_typeof_instantiation_diagnostics(&diags);
+    assert_eq!(
+        diagnostic_count(&diags, 2322),
+        1,
+        "expected exactly the deliberate `bad` TS2322, got {diags:#?}"
+    );
+}
+
+#[test]
+fn generic_method_instantiation_expression_does_not_overfire_for_standalone_function() {
+    // Guard the adjacent positive path: a standalone generic function whose
+    // return type is the same instantiation expression must keep working
+    // (it already did via the `Callable`-base path) so the hoisted
+    // `TypeQuery`-base handling does not change it.
+    let diags = check_source_diagnostics(
+        r#"
+type ReturnOf<F extends (...args: any[]) => any> =
+    F extends (...args: any[]) => infer R ? R : never;
+
+declare function source<TSeed>(seed: TSeed): { read(): TSeed };
+declare function lift<TLift>(produce: () => TLift): ReturnOf<typeof source<TLift>>;
+
+const lifted = lift<{ id: number }>(() => ({ id: 1 }));
+const ok: { id: number } = lifted.read();
+const bad: string = lifted.read();
+"#,
+    );
+    assert_no_false_typeof_instantiation_diagnostics(&diags);
+    assert_eq!(
+        diagnostic_count(&diags, 2322),
+        1,
+        "expected exactly the deliberate `bad: string` TS2322, got {diags:#?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -11,7 +11,7 @@
 //! - Handles deferred evaluation when type parameters are unknown
 //! - Supports distributivity for naked type parameters in unions
 
-mod application_types;
+pub(in crate::evaluation) mod application_types;
 mod array_methods;
 
 use crate::caches::db::QueryDatabase;
@@ -927,28 +927,10 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             return ApplicationEvalOutcome::Computed(call_return);
         }
 
-        // Instantiation expression `typeof f<Args>` / `typeof Class<Args>`
-        // (a `TypeQuery` base resolving to a `Callable`): the resolved
-        // callable's call/construct signatures DECLARE the applied type
-        // params, so they must be CONSUMED via per-signature instantiation.
-        // The alias-style known-params path below would `instantiate_generic`
-        // the callable body and `enter_shadowing_scope(&sig.type_params)`,
-        // treating those same names as bound and cancelling the substitution —
-        // freezing the instantiation expression (e.g. `ReturnType<typeof f<U>>`
-        // in a generic method never specializes, see #10933). This must run
-        // regardless of whether the resolver surfaces def-level type params:
-        // a generic function value reports `Some([T])` and would otherwise be
-        // routed through the shadowing path. Only divert when a signature
-        // actually consumes the arguments (`try_*` returns `Some`); a `None`
-        // means no signature matched the arity, so fall through to the
-        // existing param-based / opaque handling unchanged.
-        if ctx.base_is_type_query
-            && !args.is_empty()
-            && let Some(resolved) = ctx.resolved
-            && matches!(self.interner.lookup(resolved), Some(TypeData::Callable(_)))
-            && let Some(specialized) = self.try_instantiate_callable_type_params(resolved, args)
-        {
-            return ApplicationEvalOutcome::Computed(self.evaluate(specialized));
+        // `typeof f<Args>` instantiation expression: specialize per-signature
+        // (consume, not shadow, the callable's type params) — see helper (#10933).
+        if let Some(specialized) = self.try_specialize_typeof_instantiation_expression(ctx, args) {
+            return ApplicationEvalOutcome::Computed(specialized);
         }
 
         if let Some(type_params) = ctx.type_params.as_ref() {
@@ -1004,16 +986,11 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             )
         } else if let Some(resolved) = ctx.resolved {
             // Lite-resolver fallback: extract type parameters from the
-            // resolved type's properties.
-            //
-            // For `typeof ClassExpr<T>` (TypeQuery base, Callable resolved type)
-            // the instantiation-expression specialization at the top of this
-            // function already consumed any signature-level type params via
-            // `try_instantiate_callable_type_params`. Reaching here with such a
-            // base means no signature matched the arg arity, so the
-            // instantiation is invalid (non-generic value or wrong arity) and
-            // the application is kept opaque rather than fed to the
-            // extracted-params path.
+            // resolved type's properties. A `typeof X<Args>` base whose
+            // signatures could consume `Args` was already specialized at the
+            // top of this function; reaching here means the arity did not
+            // match, so keep it opaque (invalid instantiation, TS2635/TS2344
+            // parity) instead of feeding it to the extracted-params path.
             if ctx.base_is_type_query
                 && matches!(self.interner.lookup(resolved), Some(TypeData::Callable(_)))
                 && !args.is_empty()

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -926,6 +926,31 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         {
             return ApplicationEvalOutcome::Computed(call_return);
         }
+
+        // Instantiation expression `typeof f<Args>` / `typeof Class<Args>`
+        // (a `TypeQuery` base resolving to a `Callable`): the resolved
+        // callable's call/construct signatures DECLARE the applied type
+        // params, so they must be CONSUMED via per-signature instantiation.
+        // The alias-style known-params path below would `instantiate_generic`
+        // the callable body and `enter_shadowing_scope(&sig.type_params)`,
+        // treating those same names as bound and cancelling the substitution —
+        // freezing the instantiation expression (e.g. `ReturnType<typeof f<U>>`
+        // in a generic method never specializes, see #10933). This must run
+        // regardless of whether the resolver surfaces def-level type params:
+        // a generic function value reports `Some([T])` and would otherwise be
+        // routed through the shadowing path. Only divert when a signature
+        // actually consumes the arguments (`try_*` returns `Some`); a `None`
+        // means no signature matched the arity, so fall through to the
+        // existing param-based / opaque handling unchanged.
+        if ctx.base_is_type_query
+            && !args.is_empty()
+            && let Some(resolved) = ctx.resolved
+            && matches!(self.interner.lookup(resolved), Some(TypeData::Callable(_)))
+            && let Some(specialized) = self.try_instantiate_callable_type_params(resolved, args)
+        {
+            return ApplicationEvalOutcome::Computed(self.evaluate(specialized));
+        }
+
         if let Some(type_params) = ctx.type_params.as_ref() {
             let Some(resolved) = ctx.resolved else {
                 return ApplicationEvalOutcome::Computed(original_type_id);
@@ -981,21 +1006,18 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             // Lite-resolver fallback: extract type parameters from the
             // resolved type's properties.
             //
-            // For `typeof ClassExpr<T>` (TypeQuery base, Callable resolved type),
-            // use per-signature instantiation so that the class type parameters
-            // stored in `sig.type_params` are CONSUMED rather than SHADOWED.
-            // `instantiate_generic` calls `TypeInstantiator` which calls
-            // `enter_shadowing_scope(&sig.type_params)`, blocking substitution
-            // of those names from the outer substitution built from extracted params.
+            // For `typeof ClassExpr<T>` (TypeQuery base, Callable resolved type)
+            // the instantiation-expression specialization at the top of this
+            // function already consumed any signature-level type params via
+            // `try_instantiate_callable_type_params`. Reaching here with such a
+            // base means no signature matched the arg arity, so the
+            // instantiation is invalid (non-generic value or wrong arity) and
+            // the application is kept opaque rather than fed to the
+            // extracted-params path.
             if ctx.base_is_type_query
                 && matches!(self.interner.lookup(resolved), Some(TypeData::Callable(_)))
                 && !args.is_empty()
             {
-                if let Some(specialized) = self.try_instantiate_callable_type_params(resolved, args)
-                {
-                    let evaluated = self.evaluate(specialized);
-                    return ApplicationEvalOutcome::Computed(evaluated);
-                }
                 return ApplicationEvalOutcome::Computed(original_type_id);
             }
             let extracted_params = self.extract_type_params_from_type(resolved);

--- a/crates/tsz-solver/src/evaluation/evaluate/application_types.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/application_types.rs
@@ -6,14 +6,14 @@ use crate::types::{MappedType, TypeId, TypeParamInfo};
 /// evaluation. Built once by `TypeEvaluator::application_evaluation_context`
 /// so the rest of `evaluate_application` operates on a typed bundle rather
 /// than recomputing the same facts at multiple call sites.
-pub(super) struct ApplicationEvalContext {
+pub(in crate::evaluation) struct ApplicationEvalContext {
     /// Formal type parameters declared on the `DefId` resolved from
     /// `app.base`, when the resolver exposes them. `None` triggers the
     /// lite-resolver fallback that extracts parameters from the resolved
     /// body's structure.
     pub(super) type_params: Option<Vec<TypeParamInfo>>,
     /// The resolved body of the `DefId`, when known.
-    pub(super) resolved: Option<TypeId>,
+    pub(in crate::evaluation) resolved: Option<TypeId>,
     /// Set when `app.base` resolves to a `DefKind::TypeAlias` (vs a class
     /// or interface). Drives display-alias storage policy.
     pub(super) is_type_alias_def: bool,
@@ -24,7 +24,7 @@ pub(super) struct ApplicationEvalContext {
     /// For `TypeQuery`-based applications the caller wants the constructor
     /// type, not the instance type, so `extract_class_instance_body` must
     /// be skipped.
-    pub(super) base_is_type_query: bool,
+    pub(in crate::evaluation) base_is_type_query: bool,
 }
 
 /// Common opening preamble for the homomorphic-mapped shortcuts:

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -1375,6 +1375,46 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         }
     }
 
+    /// Specialize a `typeof f<Args>` / `typeof Class<Args>` instantiation
+    /// expression whose base is a `TypeQuery` that resolved (via a `DefId`) to
+    /// a `Callable`.
+    ///
+    /// The resolved callable's call/construct signatures DECLARE the applied
+    /// type params, so they must be CONSUMED by per-signature instantiation
+    /// ([`Self::try_instantiate_callable_type_params`]). Routing such a base
+    /// through the alias-style known-params path in `evaluate_application_body`
+    /// instead would `instantiate_generic` the callable body and
+    /// `enter_shadowing_scope(&sig.type_params)`, treating those names as bound
+    /// and cancelling the substitution — freezing the instantiation expression
+    /// (e.g. `ReturnType<typeof f<U>>` in a generic method never specializes
+    /// and degrades to `unknown`, see #10933). Hoisting this ahead of that
+    /// branch matters because a generic *function* value reports `Some([T])`
+    /// from the resolver, so it would otherwise take the shadowing path.
+    ///
+    /// Returns `Some(evaluated)` only when a signature actually consumes the
+    /// arguments. `None` (non-`TypeQuery` base, empty args, non-`Callable`
+    /// body, or arity mismatch) leaves the caller's existing param-based /
+    /// opaque handling unchanged, preserving the opaque-on-invalid
+    /// TS2635/TS2344 parity.
+    pub(in crate::evaluation) fn try_specialize_typeof_instantiation_expression(
+        &mut self,
+        ctx: &crate::evaluation::evaluate::application_types::ApplicationEvalContext,
+        args: &[TypeId],
+    ) -> Option<TypeId> {
+        if !ctx.base_is_type_query || args.is_empty() {
+            return None;
+        }
+        let resolved = ctx.resolved?;
+        if !matches!(
+            self.interner().lookup(resolved),
+            Some(TypeData::Callable(_))
+        ) {
+            return None;
+        }
+        let specialized = self.try_instantiate_callable_type_params(resolved, args)?;
+        Some(self.evaluate(specialized))
+    }
+
     /// Check if this is a primitive type vs Function/callable target.
     ///
     /// Primitive types (string, number, boolean, bigint, symbol) are never


### PR DESCRIPTION
AgentName: M4-A

Closes #10933 (re-diagnosed: solver instantiation, not parser).

## Structural rule

> When a generic call signature is instantiated and its return type contains an instantiation-expression type query `typeof f<Args>` / `typeof Class<Args>` (interned as `Application(TypeQuery(sym), Args)` over a generic value/class whose own call/construct signatures declare the applied type params), `tsc` reduces `f<Args>` to the specialized signature. tsz must **consume** those signature-level type params via per-signature instantiation, not route through the alias-style substitution path which `enter_shadowing_scope`s the signature's own params and cancels the substitution.

## Track

Track 1 — Solver instantiation / evaluation of instantiation-expression types.

## Invariant

`typeof f<Args>` evaluates to the same specialized callable whether the concrete arguments arrive by direct lowering or by later generic-signature instantiation. The standalone generic-function path (already correct via the `Callable` base) and the opaque-on-invalid-arity parity (TS2635/TS2344) are unchanged.

## Scope

- `crates/tsz-solver/src/evaluation/evaluate.rs` — `evaluate_application_body`: hoist the `TypeQuery`+`Callable` instantiation-expression specialization ahead of the `if let Some(type_params)` known-params branch, so it runs regardless of whether the resolver surfaces def-level type params. The same specialization previously lived only in the lite-resolver fallback (reached only when `get_lazy_type_params` returned `None`); a generic *function* value reports `Some([T])`, so it took the shadowing known-params path and the instantiation expression froze (`ReturnType<typeof f<U>>` in a generic method degraded to `unknown`). The later fallback block is reduced to its now-sole role (opaque on no-signature-match).
- `crates/tsz-checker/tests/typeof_instantiation_expression_tests.rs` — 4 regression tests.

## Owner layer

`tsz-solver`. The checker already evaluates monomorphic call-result applications; the gap was the solver freezing the nested instantiation expression during signature instantiation.

## Adjacent-case matrix (all verified against `tsc` 6.0.3, exit-parity)

- generic *method* returning `typeof f<U>` — was frozen (false error); now reduced.
- generic *method* returning `ReturnType<typeof f<U>>` (the #10933 witness) — was frozen → `unknown`; now reduced.
- generic object-type alias `Builder<T>` carrying a generic method — was frozen; now reduced.
- standalone generic function returning `ReturnType<typeof f<U>>` — already OK via the `Callable` base; unchanged.
- `typeof Class<Args>` instantiation expression — already OK; unchanged.
- invalid arity / non-generic value — stays opaque (TS2635/TS2344); unchanged.

Binder names are varied across the tests so the fix is provably structural, not name-keyed.

## Project Corpus Impact

- Row: utility-types-project (consolidated row siblings: #10975, #11018, #11061, #11103, #11145, #11187, #11272, #11315)
- Bug family: parser-2-20 (re-diagnosed — typeof-instantiation expressions in generic call-signature return types)

These witnesses all hit `satisfies` + chained generic-call shapes whose return types thread instantiation expressions. No fixture-name fast paths; the fix is a structural routing change in the solver evaluator.

## Verification

- Original issue repro and a reduced witness matrix (function/method/alias/class/nested-`ReturnType`/`satisfies`-terminated chain): tsz now matches `tsc` 6.0.3 exit codes.
- `cargo test -p tsz-checker --test typeof_instantiation_expression_tests` — 29 passed (4 new).
- `cargo test -p tsz-solver --lib` — 6507 passed, 0 failed.
- Targeted checker sweep: `ts2344_class_constructor_constraint_expr`, `ts2344_class_constructor_constraint_visibility`, `jsdoc_constructor_typeof_source_display_tests`, `conditional_alias_lib_application_tests`, `call_resolution_regression_tests`, `interface_call_signature_typeof_param_tests` — all green.
- `cargo fmt --check` clean; `cargo clippy -p tsz-solver` clean.
- The 2 pre-existing failures in `import_type_utility_identity_tests` are present on the base commit and unrelated to this change.

## Coordination Notes

#10933 carried no prior WIP claim or open PR (per M1-A's consolidation note it was "open for agent:M4-D ownership or handoff"); claimed and marked WIP before starting. Branch merges cleanly against current `main` (verified via `git merge-tree`). The cosmetic display-alias form (`pipe<{label}>` vs the expanded signature in unrelated forced-error messages) is a separate type-display concern and intentionally not touched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2sJr6nGNKPe3aDDJssipg)_