### PR TITLE
fix(checker): drop conditional-alias name when it reduces to a concrete type

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -499,6 +499,10 @@ name = "tuple_arity_elaboration_tests"
 path = "tests/tuple_arity_elaboration_tests.rs"
 
 [[test]]
+name = "conditional_alias_source_display_tests"
+path = "tests/conditional_alias_source_display_tests.rs"
+
+[[test]]
 name = "readonly_tuple_to_array_constraint_tests"
 path = "tests/readonly_tuple_to_array_constraint_tests.rs"
 

--- a/crates/tsz-checker/src/error_reporter/assignability_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_alias_display.rs
@@ -373,4 +373,39 @@ impl<'a> CheckerState<'a> {
                 .collect(),
         )
     }
+
+    /// True when `ty` is a concrete (already-reduced) type whose display-alias
+    /// provenance points at a generic application of a conditional-bodied type
+    /// alias. `tsc` drops the alias name in this case (showing the resolved
+    /// structural form), but the provenance must stay in the interner because
+    /// the solver's conditional evaluator reads it (the `Equal<X, Y>`
+    /// `any`-distinction trick depends on it); so the caller suppresses only the
+    /// application-alias chase when rendering.
+    ///
+    /// A still-deferred `Conditional`/`IndexAccess`/`Mapped`/generic-application
+    /// `ty` is excluded: `tsc` keeps `Tail<T>` for an unreduced generic
+    /// conditional.
+    pub(in crate::error_reporter) fn reduced_conditional_alias_display_should_skip_application(
+        &self,
+        ty: TypeId,
+    ) -> bool {
+        use crate::query_boundaries::common;
+        // Fast path: most formatted types carry no display alias, so this single
+        // map lookup short-circuits before the type-kind classification below.
+        let Some(alias) = self.ctx.types.get_display_alias(ty) else {
+            return false;
+        };
+        if common::is_conditional_type(self.ctx.types, ty)
+            || common::is_index_access_type(self.ctx.types, ty)
+            || common::is_mapped_type(self.ctx.types, ty)
+            || common::is_generic_application(self.ctx.types, ty)
+        {
+            return false;
+        }
+        crate::query_boundaries::diagnostics::application_base_has_conditional_alias_body(
+            self.ctx.types.as_type_database(),
+            &self.ctx.definition_store,
+            alias,
+        )
+    }
 }

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -248,6 +248,14 @@ impl<'a> CheckerState<'a> {
             return self.ctx.types.resolve_atom_ref(info.name).to_string();
         }
 
+        // A conditional-bodied type alias loses its name once the conditional
+        // reduces to a concrete type (`Tail<Src>` -> `[number, string]`); render
+        // the structural form, leaving the provenance intact for the evaluator.
+        // See `reduced_conditional_alias_display_should_skip_application`.
+        if self.reduced_conditional_alias_display_should_skip_application(ty) {
+            return self.format_type_for_assignability_message_skip_application_alias(ty);
+        }
+
         if let Some(def_id) = crate::query_boundaries::common::lazy_def_id(self.ctx.types, ty)
             && let Some(def) = self.ctx.definition_store.get(def_id)
             && def.kind == tsz_solver::def::DefKind::TypeAlias

--- a/crates/tsz-checker/tests/conditional_alias_source_display_tests.rs
+++ b/crates/tsz-checker/tests/conditional_alias_source_display_tests.rs
@@ -1,0 +1,179 @@
+//! Conditional-bodied type-alias applications lose their alias name in
+//! diagnostics once the conditional reduces to a concrete type, matching `tsc`.
+//!
+//! `type Tail<T extends any[]> = T extends [any, ...infer R] ? R : []` applied
+//! as `Tail<Src>` displays as the resolved `[number, string]`, not `Tail<Src>`,
+//! independent of whether the argument is spelled inline or via a named alias.
+//! Before the fix tsz kept the unreduced alias-application form whenever the
+//! argument was a named alias (`Lazy(DefId)`), because the reduced result
+//! retained an application display alias the `tsc` policy
+//! (`prefer_application_display_alias = !resolved_has_conditional_body`)
+//! withholds.
+//!
+//! Negative controls confirm the gate is scoped to *reduced* conditional
+//! bodies: mapped-type aliases keep their name, and a still-deferred generic
+//! conditional keeps its `Alias<T>` form.
+//!
+//! Binder/type-parameter/alias names are varied across cases so the rendering
+//! is proven structural, not keyed on a fixture identifier.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_common::diagnostics::Diagnostic;
+
+fn check_strict(source: &str) -> Vec<Diagnostic> {
+    let options = CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..Default::default()
+    };
+    tsz_checker::test_utils::check_source(source, "test.ts", options)
+}
+
+fn single(diags: &[Diagnostic], code: u32) -> &Diagnostic {
+    let matches: Vec<&Diagnostic> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matches.len(),
+        1,
+        "expected exactly one TS{code}, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    matches[0]
+}
+
+/// Core fix: a conditional alias applied to a *named* tuple alias displays the
+/// reduced tuple, not the `Tail<Src>` application form.
+#[test]
+fn conditional_alias_named_tuple_arg_shows_resolved_tuple() {
+    let diags = check_strict(
+        "type Tail<L extends any[]> = L extends [any, ...infer Rest] ? Rest : [];\n\
+         type Triple = [boolean, number, string];\n\
+         const bad: [number] = (null as any as Tail<Triple>);\n",
+    );
+    let diag = single(&diags, 2322);
+    assert!(
+        diag.message_text
+            .contains("Type '[number, string]' is not assignable to type '[number]'"),
+        "named-alias argument should resolve to the tuple, not the alias form; got: {}",
+        diag.message_text
+    );
+    assert!(
+        !diag.message_text.contains("Tail<"),
+        "the reduced conditional must drop its alias name; got: {}",
+        diag.message_text
+    );
+}
+
+/// Regression guard: the inline-argument form already resolved and must keep
+/// doing so — the named-alias fix must not regress it.
+#[test]
+fn conditional_alias_inline_tuple_arg_shows_resolved_tuple() {
+    let diags = check_strict(
+        "type Drop<S extends any[]> = S extends [unknown, ...infer Tail] ? Tail : [];\n\
+         const bad: [number] = (null as any as Drop<[boolean, number, string]>);\n",
+    );
+    let diag = single(&diags, 2322);
+    assert!(
+        diag.message_text
+            .contains("Type '[number, string]' is not assignable to type '[number]'"),
+        "inline-argument conditional should resolve to the tuple; got: {}",
+        diag.message_text
+    );
+}
+
+/// A non-distributive conditional (wrapped check type) over a named argument
+/// also resolves — the gate is keyed on the conditional body, not on
+/// distributivity.
+#[test]
+fn non_distributive_conditional_named_arg_shows_resolved_tuple() {
+    let diags = check_strict(
+        "type Rest<A extends any[]> = [A] extends [[any, ...infer R]] ? R : [];\n\
+         type Items = [boolean, number, string];\n\
+         const bad: [number] = (null as any as Rest<Items>);\n",
+    );
+    let diag = single(&diags, 2322);
+    assert!(
+        diag.message_text
+            .contains("Type '[number, string]' is not assignable to type '[number]'"),
+        "non-distributive conditional should resolve to the tuple; got: {}",
+        diag.message_text
+    );
+}
+
+/// Conditional alias reducing to an object: the resolved object shape is shown
+/// (TS2741), not the `Wrap<Arg>` application form.
+#[test]
+fn conditional_alias_named_arg_reducing_to_object_shows_resolved_object() {
+    let diags = check_strict(
+        "type Wrap<V> = V extends string ? { s: V } : { n: V };\n\
+         type ArgT = number;\n\
+         const bad: { q: 1 } = (null as any as Wrap<ArgT>);\n",
+    );
+    let diag = single(&diags, 2741);
+    assert!(
+        diag.message_text.contains("type '{ n: number; }'"),
+        "conditional reducing to an object should show the resolved shape; got: {}",
+        diag.message_text
+    );
+    assert!(
+        !diag.message_text.contains("Wrap<"),
+        "the reduced conditional must drop its alias name; got: {}",
+        diag.message_text
+    );
+}
+
+/// Conditional alias reducing to a union over a named argument resolves to the
+/// union, not the application form.
+#[test]
+fn conditional_alias_named_arg_reducing_to_union_shows_resolved_union() {
+    let diags = check_strict(
+        "type Either<P> = P extends [infer X, infer Y] ? X | Y : never;\n\
+         type PairT = [number, string];\n\
+         const bad: boolean = (null as any as Either<PairT>);\n",
+    );
+    let diag = single(&diags, 2322);
+    assert!(
+        diag.message_text
+            .contains("Type 'string | number' is not assignable to type 'boolean'"),
+        "conditional reducing to a union should show the resolved union; got: {}",
+        diag.message_text
+    );
+}
+
+/// Negative control: a *mapped* type alias keeps its name (matching `tsc`).
+/// The conditional-body gate must not strip aliases for non-conditional bodies.
+#[test]
+fn mapped_alias_named_arg_keeps_alias_name() {
+    let diags = check_strict(
+        "type MyReadonly<T> = { readonly [K in keyof T]: T[K] };\n\
+         interface Shape { a: number; }\n\
+         const bad: { z: number } = (null as any as MyReadonly<Shape>);\n",
+    );
+    let diag = single(&diags, 2741);
+    assert!(
+        diag.message_text.contains("type 'MyReadonly<Shape>'"),
+        "a mapped alias must keep its name; got: {}",
+        diag.message_text
+    );
+}
+
+/// Negative control: a still-deferred generic conditional (free type parameter)
+/// keeps its `Alias<T>` form because it has not reduced to a concrete type.
+#[test]
+fn deferred_generic_conditional_keeps_alias_name() {
+    let diags = check_strict(
+        "type Tail<T extends any[]> = T extends [any, ...infer R] ? R : [];\n\
+         function f<U extends any[]>(u: U): [number] {\n\
+         return null as any as Tail<U>;\n\
+         }\n",
+    );
+    let diag = single(&diags, 2322);
+    assert!(
+        diag.message_text
+            .contains("Type 'Tail<U>' is not assignable to type '[number]'"),
+        "a deferred generic conditional must keep its alias form; got: {}",
+        diag.message_text
+    );
+}

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -1551,6 +1551,23 @@ impl<'a> TypeFormatter<'a> {
                     ))
                 || (self.skip_application_alias_names
                     && self.display_alias_application_base_has_conditional_body(alias_origin))
+                // A conditional-bodied type alias loses its name in `tsc`
+                // diagnostics once the conditional reduces to a concrete type:
+                // `Tail<Src>` displays as the resolved `[number, string]`, not
+                // `Tail<Src>`, independent of whether the argument was spelled
+                // inline or via a named alias. A still-deferred result keeps the
+                // alias (e.g. an unreduced generic `Tail<T>` whose `key` is a
+                // `Conditional`/`IndexAccess`/`Mapped`). The provenance record
+                // is left intact so the conditional evaluator can still recover
+                // the application form (the `Equal<X, Y>` `any`-distinction
+                // trick depends on it); only this display read is gated.
+                || (self.display_alias_application_base_has_conditional_body(alias_origin)
+                    && !matches!(
+                        &key,
+                        TypeData::Conditional(_)
+                            | TypeData::IndexAccess(_, _)
+                            | TypeData::Mapped(_)
+                    ))
                 || (is_empty_object
                     && self.display_alias_application_base_is_type_alias(alias_origin));
             if (!is_simple_type


### PR DESCRIPTION
AgentName: M1-A

## Track
Track 1 (Project Corpus Dashboard And Fixture Truth) — project-row diagnostic parity. Bug family #12179 (`project-row diagnostics lose root context, stable display, or source span`), the **source-position application-alias under-expansion** sub-defect identified in that issue's verified-reduction comment.

## Invariant
When a generic type-alias application whose body is a **conditional** type reduces to a concrete (non-deferred) type, `tsc` displays the resolved structural form and drops the alias name — independent of whether the type argument is spelled inline or via a named alias. A still-deferred generic conditional keeps its `Alias<T>` form, and non-conditional alias bodies (mapped `Partial<T>`, etc.) keep their name.

```ts
type Tail<T extends any[]> = T extends [any, ...infer R] ? R : [];
type Src1 = [boolean, number, string];
const bad1: [number] = (null as any as Tail<Src1>);
```
- tsz (before): `Type 'Tail<Src1>' is not assignable to type '[number]'.`
- tsz (after) / tsc 6.0.2: `Type '[number, string]' is not assignable to type '[number]'.`

## Scope
The relation engine already reduces the type (it reports the correct `Source has 2 element(s)…` arity). The reduced result carries an application display-alias provenance that the diagnostic formatter chased, so any **named-alias** argument printed the unreduced `Tail<Src1>` form; inline-argument forms happened to match because their reduction loses the provenance at construction.

The provenance must stay in the interner — the solver's conditional evaluator recovers it (the `Equal<X, Y>` `any`-distinction trick reads it), so the fix gates only the **display read**:

- `crates/tsz-solver/src/diagnostics/format/mod.rs` (`TypeFormatter::skip_alias_chase`): skip the application-alias chase whenever the display alias is an application of a conditional-bodied type alias and the rendered type has reduced to a concrete (non-`Conditional`/`IndexAccess`/`Mapped`) form. This is the **general mechanism** covering every diagnostic display path. Reuses the existing `display_alias_application_base_has_conditional_body`.
- `crates/tsz-checker/src/error_reporter/core_formatting.rs` + `assignability_alias_display.rs`: the checker renders source/target via its own application-alias logic before reaching the solver chase, so it applies the same gate up front via a small helper that reuses the existing `query_boundaries::diagnostics::application_base_has_conditional_alias_body` query.

No relation, inference, or evaluation semantics change is intended — the display-alias provenance map is untouched.

## Project Corpus Impact
- Row: cross-row diagnostic-display family (`type-display` / `diagnostics`); the witnesses reproduce on the project-corpus rows that feed #12179.
- Bug family: #12179 — source-position application-alias under-expansion.
- This is a diagnostic display-parity (yellow-row) fix; acceptance was already correct.

## Verification
Pinned oracle: TypeScript `6.0.2` (system `tsc`); flags `--noEmit --strict --target es2020 --moduleResolution bundler --skipLibCheck`; tsz `dist-fast`.

- 11/11 hand-built reductions now EXACT-MATCH `tsc` — distributive conditional, non-distributive (`[T] extends [[…]]`) conditional, alias-chained argument, return-position source, conditional→object, conditional→union, inline-argument control, and indexed-access control. Renamed binders across cases.
- Negative controls match `tsc`: mapped alias keeps `MyReadonly<Shape>`; deferred generic conditional keeps `Tail<U>`.
- New regression suite `crates/tsz-checker/tests/conditional_alias_source_display_tests.rs` (7 cases, renamed binders + positive/negative controls) — `7 passed`.
- Adjacent suites green: `tuple_arity_elaboration_tests`, `readonly_tuple_source_display_tests`, `conditional_alias_lib_application_tests`, `distributive_alias_wrapped_conditional_tests`, `bare_alias_display_tests`, `generic_alias_assignability_pollution_tests`, `generic_type_alias_deferred_eval_tests`.
- Broad regression diff: 163 checker display/conditional/mapped/generic/alias/tuple test targets run with `--no-fail-fast` against clean `main` — **zero new failures** introduced by this change (pre-existing `main` failures unchanged).
- Solver unit tests: `diagnostics::format` (205) and `evaluation::` (1133) pass. The `Equal` `any`-distinction tests are unaffected because provenance is preserved.
- `cargo fmt -p tsz-checker -p tsz-solver -- --check` → passed.
- `python3 scripts/arch/arch_guard.py` → passed (no file exceeds the LOC cap; helper placed in `assignability_alias_display.rs`).

## Coordination Notes
- Display-only parity fix; no semantic/relation change. Non-overlapping with active solver/inference lanes.
- Rebased cleanly onto `origin/main` (`9142cd6`).
- Anti-hardcoding: decision is structural (display-alias provenance + alias body kind via shared query boundaries); no user-name/file-name literals, no formatted-string predicates; tests vary binder/alias/type-parameter names.

Closes the source-position under-expansion witness in #12179.