### PR TITLE
fix(checker): suppress intrinsic JSX type-arg prop cascades

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
@@ -336,6 +336,7 @@ impl<'a> CheckerState<'a> {
         let effective_tag: Option<&str> = tag_name.or(namespaced_tag_owned.as_deref());
 
         if is_intrinsic {
+            let has_explicit_type_args = jsx_opening.type_arguments.is_some();
             if let Some(type_args) = jsx_opening.type_arguments.as_ref() {
                 self.validate_jsx_intrinsic_type_arguments(type_args);
             }
@@ -352,20 +353,25 @@ impl<'a> CheckerState<'a> {
                 // For intrinsic elements, the display target is just the props type
                 // (tsc doesn't wrap intrinsic element props in IntrinsicAttributes).
                 let display_target = self.build_jsx_display_target(evaluated_props, None);
-                self.check_jsx_attributes_against_props(
-                    super::super::props::resolution::JsxPropsCheckOpts {
-                        attributes_idx: jsx_opening.attributes,
-                        props_type: evaluated_props,
-                        tag_name_idx: jsx_opening.tag_name,
-                        component_type: None,
-                        special_attr_component_type: None,
-                        raw_props_has_type_params: false,
-                        display_target,
-                        preferred_target_display: None,
-                        request,
-                        children_ctx,
-                    },
-                );
+                if has_explicit_type_args {
+                    self.check_grammar_jsx_element(jsx_opening.attributes);
+                    self.evaluate_jsx_attribute_expressions(jsx_opening.attributes);
+                } else {
+                    self.check_jsx_attributes_against_props(
+                        super::super::props::resolution::JsxPropsCheckOpts {
+                            attributes_idx: jsx_opening.attributes,
+                            props_type: evaluated_props,
+                            tag_name_idx: jsx_opening.tag_name,
+                            component_type: None,
+                            special_attr_component_type: None,
+                            raw_props_has_type_params: false,
+                            display_target,
+                            preferred_target_display: None,
+                            request,
+                            children_ctx,
+                        },
+                    );
+                }
 
                 // tsc types ALL JSX expressions (both intrinsic and component) as
                 // JSX.Element. Returning IntrinsicElements["tag"] causes false TS2322
@@ -418,26 +424,7 @@ impl<'a> CheckerState<'a> {
             // Even when IntrinsicElements is missing, evaluate attribute expressions
             // to trigger definite-assignment checks (TS2454) and other diagnostics.
             // tsc evaluates these expressions regardless of JSX infrastructure availability.
-            if let Some(attrs_node) = self.ctx.arena.get(jsx_opening.attributes)
-                && let Some(attrs) = self.ctx.arena.get_jsx_attributes(attrs_node)
-            {
-                for &attr_idx in &attrs.properties.nodes {
-                    if let Some(attr_node) = self.ctx.arena.get(attr_idx) {
-                        if attr_node.kind == syntax_kind_ext::JSX_SPREAD_ATTRIBUTE {
-                            if let Some(spread_data) =
-                                self.ctx.arena.get_jsx_spread_attribute(attr_node)
-                            {
-                                self.compute_type_of_node(spread_data.expression);
-                            }
-                        } else if attr_node.kind == syntax_kind_ext::JSX_ATTRIBUTE
-                            && let Some(attr_data) = self.ctx.arena.get_jsx_attribute(attr_node)
-                            && attr_data.initializer.is_some()
-                        {
-                            self.compute_type_of_node(attr_data.initializer);
-                        }
-                    }
-                }
-            }
+            self.evaluate_jsx_attribute_expressions(jsx_opening.attributes);
             TypeId::ANY
         } else {
             // Component: resolve as variable expression
@@ -1146,6 +1133,7 @@ impl<'a> CheckerState<'a> {
             TypeId::ANY
         }
     }
+
     /// Emit TS7026 for a JSX closing element if no `JSX.IntrinsicElements` exists.
     /// Covers the closing tag; opening tag is handled by `get_type_of_jsx_opening_element`.
     pub(crate) fn check_jsx_closing_element_for_implicit_any(&mut self, idx: NodeIndex) {

--- a/crates/tsz-checker/src/checkers/jsx/props/attribute_expressions.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/attribute_expressions.rs
@@ -1,0 +1,32 @@
+use crate::state::CheckerState;
+use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
+
+impl<'a> CheckerState<'a> {
+    pub(in crate::checkers_domain::jsx) fn evaluate_jsx_attribute_expressions(
+        &mut self,
+        attributes_idx: NodeIndex,
+    ) {
+        let Some(attrs_node) = self.ctx.arena.get(attributes_idx) else {
+            return;
+        };
+        let Some(attrs) = self.ctx.arena.get_jsx_attributes(attrs_node) else {
+            return;
+        };
+        let attr_nodes = attrs.properties.nodes.clone();
+        for attr_idx in attr_nodes {
+            let Some(attr_node) = self.ctx.arena.get(attr_idx) else {
+                continue;
+            };
+            if attr_node.kind == syntax_kind_ext::JSX_SPREAD_ATTRIBUTE {
+                if let Some(spread_data) = self.ctx.arena.get_jsx_spread_attribute(attr_node) {
+                    self.compute_type_of_node(spread_data.expression);
+                }
+            } else if attr_node.kind == syntax_kind_ext::JSX_ATTRIBUTE
+                && let Some(attr_data) = self.ctx.arena.get_jsx_attribute(attr_node)
+                && attr_data.initializer.is_some()
+            {
+                self.compute_type_of_node(attr_data.initializer);
+            }
+        }
+    }
+}

--- a/crates/tsz-checker/src/checkers/jsx/props/mod.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/mod.rs
@@ -5,6 +5,7 @@
 
 mod attr_check_pipeline;
 mod attr_value;
+mod attribute_expressions;
 mod declaration_heritage;
 mod generic_spread;
 pub(crate) mod resolution;

--- a/crates/tsz-checker/tests/jsx_component_attribute_tests_parts/part_03.rs
+++ b/crates/tsz-checker/tests/jsx_component_attribute_tests_parts/part_03.rs
@@ -1520,6 +1520,45 @@ const l = <div<number>/>;
 }
 
 #[test]
+fn test_jsx_intrinsic_type_arg_errors_skip_react_required_props_noise() {
+    let Some(react_types) = load_typescript_fixture("TypeScript/tests/lib/react16.d.ts") else {
+        return;
+    };
+    let source = r#"
+import * as React from "react";
+type Record<K extends keyof any, T> = { [P in K]: T };
+
+const a = <div<>></div>;
+const b = <div<number,>></div>;
+const c = <div<Missing>></div>;
+const d = <div<Missing<AlsoMissing>>></div>;
+const e = <div<Record<object, object>>></div>;
+const f = <div<number>></div>;
+const g = <div<>/>;
+const h = <div<number,>/>;
+const i = <div<Missing>/>;
+const j = <div<Missing<AlsoMissing>>/>;
+const k = <div<Record<object, object>>/>;
+const l = <div<number>/>;
+"#;
+    let diags = cross_file_jsx_diagnostics_with_mode(&react_types, source, JsxMode::React);
+    assert!(
+        has_code(
+            &diags,
+            diagnostic_codes::EXPECTED_TYPE_ARGUMENTS_BUT_GOT
+        ),
+        "intrinsic JSX elements should still reject explicit type arguments, got: {diags:?}"
+    );
+    assert!(
+        !has_code(
+            &diags,
+            diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE
+        ),
+        "invalid intrinsic JSX type arguments should not also compare empty attrs against React intrinsic props, got: {diags:?}"
+    );
+}
+
+#[test]
 fn test_jsx_explicit_type_args_constraint_violation_emits_ts2344() {
     // <MyComp2<Prop> /> where MyComp2<P extends {a: string}> and Prop = {a: number}
     let source = format!(

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -24,11 +24,10 @@ TypeScript/tests/cases/conformance/externalModules/circularReference.ts
 # #12260. JSX/import.meta subset tracked in #12261 — re-verified against the
 # pinned TS 6.0.3 corpus, replacing the earlier vague "oscillates" notes with the
 # actual per-fixture fingerprints so each entry stays owner-visible:
-#   - jsxIntrinsicElementsTypeArgumentErrors.tsx: passes in an isolated harness
-#     run (3/3) but REGRESSES in the sharded ready-review aggregate, so the
-#     diagnostics on JSX type-argument recovery (TS1009/TS1099/TS2304/TS2344/
-#     TS2558) are resolution-order/shard sensitive. Kept allowlisted; the
-#     order-sensitivity is the bug to chase. Tracked in #12261.
+#   - jsxIntrinsicElementsTypeArgumentErrors.tsx: fixed by the intrinsic JSX
+#     type-argument cascade guard. Invalid or unsupported intrinsic type args
+#     still report TS1009/TS1099/TS2304/TS2344/TS2558, but no longer cascade into
+#     false React intrinsic-props TS2739 diagnostics.
 #   - importMeta.ts: diagnostic CODES already match [TS2339, TS2364, TS17012].
 #     The only remaining drift is one extra false TS2339 "Property 'appendChild'
 #     does not exist on type 'HTMLElement'" on `document.body.appendChild(...)`,
@@ -52,5 +51,4 @@ TypeScript/tests/cases/conformance/externalModules/circularReference.ts
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
-TypeScript/tests/cases/compiler/jsxIntrinsicElementsTypeArgumentErrors.tsx
 TypeScript/tests/cases/conformance/es2019/importMeta/importMeta.ts


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Checker diagnostic conformance accepted-regression burn-down; semantic campaign PR for issue #12261 JSX intrinsic type-argument drift.

## Invariant
When an intrinsic JSX element has explicit invalid or unsupported type arguments, `tsc` reports the JSX type-argument and parser diagnostics but does not also compare empty attributes against React intrinsic props; this PR makes tsz do that through checker JSX opening resolution while still evaluating attribute expressions.

## Scope
- `crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs`: skip intrinsic prop validation after explicit intrinsic JSX type arguments while preserving grammar and expression checks.
- `crates/tsz-checker/src/checkers/jsx/props/attribute_expressions.rs`: share attribute expression evaluation for skipped-prop-validation paths.
- `crates/tsz-checker/tests/jsx_component_attribute_tests_parts/part_03.rs`: add React intrinsic regression coverage for the false TS2739 cascade.
- `scripts/conformance/conformance-accepted-regressions.txt`: remove the fixed JSX row and keep the remaining `importMeta.ts` row justified.

## Project Corpus Impact
- Row: n/a.
- Bug family: checker diagnostic conformance, JSX intrinsic type-argument recovery.
- Evidence: focused conformance now passes `jsxIntrinsicElementsTypeArgumentErrors`; dashboard remains 12582/12582 with accepted-regression gate reduced to 6. `importMeta.ts` still has one fingerprint-only DOM lib TS2339 drift and remains listed for #12261 follow-up.

## Verification
- `git diff --check origin/main...HEAD`
- `cargo fmt -p tsz-checker -- --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test jsx_component_attribute_tests test_jsx_intrinsic_type_arg_errors_skip_react_required_props_noise --no-fail-fast`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter jsxIntrinsicElementsTypeArgumentErrors --workers 1 --verbose`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter importMeta --workers 1 --verbose` (expected remaining fingerprint-only importMeta drift)
- `python3 scripts/conformance/query-conformance.py --dashboard`

## Coordination Notes
- Refs #12261; this PR pays down the JSX accepted-regression entry only.
- Remaining #12261 work is `importMeta.ts`, currently same diagnostic codes `[TS2339, TS2364, TS17012]` with one extra `TS2339 example.ts:12:17 Property 'appendChild' does not exist on type 'HTMLElement'.`
- Rebased onto `origin/main` at 9142cd6a95 before publish.
- Publish audit: no open M1-A PRs; repo-wide label audit still has unrelated pre-existing findings, including #12363 missing an agent label.