### PR TITLE
fix(checker): preserve nested tuple-literal shape in assignability source display

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/tuple_source_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/tuple_source_display.rs
@@ -69,6 +69,35 @@ impl<'a> CheckerState<'a> {
             }
 
             let element_type = self.get_type_of_node(element_idx);
+
+            // Nested array-literal element against a tuple-typed (or
+            // union-of-tuples) target slot: recurse so the inner literal renders
+            // with its contextually-typed tuple shape (e.g. `[1]`) instead of
+            // collapsing to the non-contextual widened array form (`number[]`).
+            // tsc keeps the structural tuple spelling at these positions, so the
+            // source type shown in the assignability message must too. When the
+            // inner target slot is not tuple-like, the recursive call returns
+            // `None` and we fall through to the widened-array fallback below.
+            if element_node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION {
+                let nested_target = self
+                    .target_tuple_element_for_literal_position(
+                        &target_elements,
+                        element_position,
+                        target_rest_layout,
+                    )
+                    .map(|element| element.type_id);
+                if let Some(nested_target) = nested_target
+                    && let Some(nested_display) = self.array_literal_tuple_source_type_display(
+                        element_idx,
+                        element_type,
+                        nested_target,
+                    )
+                {
+                    parts.push(nested_display);
+                    continue;
+                }
+            }
+
             let display_type = self.widen_type_for_display(element_type);
             parts.push(self.format_type_for_assignability_message(display_type));
         }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -825,6 +825,9 @@ mod mutable_binding_widening_from_const_literal_tests;
 #[path = "tests/namespace_property_mismatch_boundary_arch_tests.rs"]
 mod namespace_property_mismatch_boundary_arch_tests;
 #[cfg(test)]
+#[path = "tests/nested_tuple_literal_source_display_tests.rs"]
+mod nested_tuple_literal_source_display_tests;
+#[cfg(test)]
 #[path = "../tests/never_absorption_call_spread_tests.rs"]
 mod never_absorption_call_spread_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/nested_tuple_literal_source_display_tests.rs
+++ b/crates/tsz-checker/src/tests/nested_tuple_literal_source_display_tests.rs
@@ -1,0 +1,137 @@
+//! Tests for nested array-literal tuple source display in TS2322 assignability
+//! diagnostics.
+//!
+//! Structural rule: when an array literal is contextually typed against a tuple
+//! target and the overall assignment fails (e.g. an arity mismatch), the source
+//! type shown in the message must preserve the contextually-typed shape of every
+//! nested array-literal element. `tsc` renders the inner element as the tuple it
+//! was contextually typed as (e.g. `[1]`), not the non-contextual widened array
+//! form (`number[]`).
+//!
+//! Before the fix, only the *outer* tuple structure survived: each nested
+//! array-literal element was re-typed without its contextual tuple slot and
+//! widened to `number[]`, so `[[1], [2]]` displayed as `[number[], number[]]`.
+//! The fix recurses through `array_literal_tuple_source_type_display` so the
+//! inner literal is rendered against its own tuple target slot.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn ts2322_messages(source: &str) -> Vec<String> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .filter(|d| d.code == 2322)
+        .map(|d| d.message_text)
+        .collect()
+}
+
+#[test]
+fn nested_tuple_literal_fewer_elements_preserves_inner_tuples() {
+    // `[[1], [2]]` against `[[1], [2], [3]]`: arity mismatch. The source must
+    // render the inner literals as `[1]`, `[2]` (their contextual tuple slots),
+    // not the widened `number[]` form.
+    let messages = ts2322_messages(
+        r#"
+const bad: [[1], [2], [3]] = [[1], [2]];
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("Type '[[1], [2]]' is not assignable")),
+        "inner tuple literals must be preserved, got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("number[], number[]")),
+        "inner literals must not be array-widened, got: {messages:?}"
+    );
+}
+
+#[test]
+fn nested_tuple_literal_extra_element_widens_only_uncovered_slot() {
+    // `[[1], [2], [3], [4]]` against `[[1], [2], [3]]`: the first three inner
+    // literals keep their tuple slots; the fourth has no contextual slot and
+    // widens to `number[]` — matching `tsc` exactly.
+    let messages = ts2322_messages(
+        r#"
+const bad: [[1], [2], [3]] = [[1], [2], [3], [4]];
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("Type '[[1], [2], [3], number[]]' is not assignable")),
+        "covered slots preserved, uncovered slot widened, got: {messages:?}"
+    );
+}
+
+#[test]
+fn deeply_nested_tuple_literal_preserves_all_levels() {
+    // Two levels of nesting: the inner `[[1], [2], [3]]` keeps its full shape
+    // even though the outer literal is shorter than its tuple target.
+    let messages = ts2322_messages(
+        r#"
+const bad: [[[1], [2], [3]], string] = [[[1], [2], [3]]];
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("Type '[[[1], [2], [3]]]' is not assignable")),
+        "all nesting levels must be preserved, got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("number[][]")),
+        "nested literals must not collapse to arrays, got: {messages:?}"
+    );
+}
+
+#[test]
+fn nested_string_literal_tuple_preserved() {
+    // The rule is structural, not number-specific: string-literal tuples are
+    // preserved the same way.
+    let messages = ts2322_messages(
+        r#"
+const bad: [["a"], ["b"]] = [["a"]];
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains(r#"Type '[["a"]]' is not assignable"#)),
+        "string-literal inner tuples must be preserved, got: {messages:?}"
+    );
+}
+
+#[test]
+fn array_typed_target_slot_still_widens() {
+    // When the target slot is an array (not a tuple), the inner array literal is
+    // genuinely an array and must stay widened — the recursion declines and the
+    // existing widened-array fallback applies, matching `tsc`.
+    let messages = ts2322_messages(
+        r#"
+const bad: [number[], number[]] = [[1]];
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("Type '[number[]]' is not assignable")),
+        "array-typed slots keep the widened form, got: {messages:?}"
+    );
+}
+
+#[test]
+fn mixed_flat_and_nested_elements_preserved() {
+    // A tuple mixing a flat literal and a nested tuple element keeps both forms.
+    let messages = ts2322_messages(
+        r#"
+const bad: [1, [2, 3], 4] = [1, [2, 3]];
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("Type '[1, [2, 3]]' is not assignable")),
+        "flat and nested elements both preserved, got: {messages:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the diagnostic source-type rendering for nested array-literal/tuple
assignments. When an array literal is contextually typed against a tuple target
and the assignment fails (e.g. an arity mismatch), tsz collapsed each nested
array-literal element to its non-contextual widened array form, so

```ts
const bad: [[1], [2], [3]] = [[1], [2]];
```

reported the source as `[number[], number[]]` instead of tsc's `[[1], [2]]`.

Investigated under issue #10833 (variadic tuple spread inference). The solver's
variadic-tuple **inference and relation semantics were already correct** — every
type-level probe (`Zip`, leading/middle/trailing rests, both-sided variadics,
should-fail assignments) matched tsc. The only reproducible divergence was this
diagnostic source-display widening, which is broad (it affects every nested
array-literal assigned to a tuple) and confirmed against `tsc` 6.0.2.

## Structural rule

When the assignability source display walks an array literal against a tuple
target (`array_literal_tuple_source_type_display`), a nested array-literal
element whose target slot is a tuple (or union-of-tuples) is now rendered by
recursing against that slot, so the inner literal keeps its contextually-typed
tuple shape. Slots whose target is a plain array, and trailing positions with no
contextual slot, still fall through to the widened-array form — matching tsc
exactly (`[[1], [2], [3], [4]]` against `[[1], [2], [3]]` → `[[1], [2], [3], number[]]`).

`When an array literal is contextually typed as a tuple and the assignment is
reported as TS2322, tsc renders each nested array-literal element with its
contextual tuple shape; tsz now does the same through the
diagnostic-source-display gateway.`

## Owner layer

Checker / `error_reporter` diagnostic source display only. Type computation,
assignability outcomes, and the solver relation reason chain are untouched — the
computed initializer type was already correct (verified via tracing); only the
displayed source string was widened.

## Adjacent-case matrix (all verified against `tsc` 6.0.2)

| Case | Before | After / tsc |
| --- | --- | --- |
| `[[1],[2]]` vs `[[1],[2],[3]]` | `[number[], number[]]` | `[[1], [2]]` |
| `[[1],[2],[3],[4]]` vs `[[1],[2],[3]]` | all widened | `[[1], [2], [3], number[]]` |
| `[[[1],[2],[3]]]` vs `[[[1],[2],[3]], string]` | `[number[][]]` | `[[[1], [2], [3]]]` |
| `[["a"]]` vs `[["a"],["b"]]` | `[string[]]` | `[["a"]]` |
| `[1,[2,3]]` vs `[1,[2,3],4]` | widened inner | `[1, [2, 3]]` |
| array-typed target slot `[number[],number[]] = [[1]]` | `[number[]]` | `[number[]]` (unchanged) |
| flat tuple / plain array / object-literal slots | unchanged | unchanged |

## Fallback / scope

- Non-tuple target slots and uncovered trailing positions keep the widened-array
  form (the recursion declines and the existing fallback runs).
- Object-literal-in-tuple display (`[{x:1}]` → `{ x: number; }`) is a separate,
  pre-existing object-freshness display concern and is intentionally **not**
  touched here.

## Verification

- New unit tests: `nested_tuple_literal_source_display_tests` (6 cases,
  including string-literal tuples, array-typed slots, and deep nesting; names
  varied to keep the rule structural). All pass.
- Adjacent display modules (`as_const_nested_literal_display`,
  `fresh_const_array`, `literal_widening_policy`) — 28 tests pass.
- Hand-verified the full matrix above and the original #10833 repro against
  `tsc` 6.0.2.
- Broad conformance/emit suites are owned by ready-review CI.

## Project Corpus Impact

No semantic/relation change; affects only TS2322 source-type message text for
nested array-literal/tuple assignments. Moves tsz toward tsc parity, so any
baseline drift is a parity improvement.

- Row: n/a (diagnostic source-display only; no project row semantics changed)
- Bug family: nested array-literal/tuple assignability source-type display (variadic-tuples adjacent, #10833)
- Evidence: tsc 6.0.2 matrix plus new `nested_tuple_literal_source_display_tests`; no project row semantics changed.

## Coordination Notes

AgentName: M1-A
Track: conformance / diagnostics (variadic-tuples adjacent)
Invariant: assignability outcomes and relation reason chains unchanged; only the
displayed source-type string is corrected.
Scope: `array_literal_tuple_source_type_display` in checker `error_reporter`; one
recursion branch plus regression tests.

Closes #10833.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LJaxa8Nh2DMXqxnsHoWSJp)_