### PR TITLE
fix(checker): resolve false TS2315 on generic aliases imported through barrel re-exports

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2068,3 +2068,7 @@ path = "tests/type_only_import_value_use_attribution_tests.rs"
 [[test]]
 name = "distributive_callable_branch_tests"
 path = "tests/distributive_callable_branch_tests.rs"
+
+[[test]]
+name = "ts2315_imported_generic_tests"
+path = "tests/ts2315_imported_generic_tests.rs"

--- a/crates/tsz-checker/src/state/type_resolution/module/reexports.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module/reexports.rs
@@ -196,6 +196,64 @@ impl<'a> CheckerState<'a> {
         None
     }
 
+    /// Follow re-export alias chains from `start_file_idx`/`export_name` until reaching
+    /// the original non-alias declaration.
+    ///
+    /// Named re-exports (`export type { X } from './impl'`) create an alias symbol in
+    /// `module_exports` of the barrel file. `resolve_export_in_file` stops at that alias
+    /// because it prioritises `module_exports` over the `reexports` table. This helper
+    /// advances hop-by-hop: when the resolved symbol has `import_module` set it is itself
+    /// a re-export alias, so we follow to the next target file/name until `import_module`
+    /// is `None`. Cycles are detected via a `(file_idx, sym_id)` guard; the chain is
+    /// bounded to 32 hops.
+    pub(crate) fn resolve_reexport_chain_to_declaration(
+        &self,
+        start_file_idx: usize,
+        export_name: &str,
+    ) -> Option<(tsz_binder::SymbolId, usize)> {
+        let mut current_file = start_file_idx;
+        let mut current_name = export_name.to_owned();
+        let mut chain_visited: rustc_hash::FxHashSet<(usize, u32)> =
+            rustc_hash::FxHashSet::default();
+        for _ in 0..32 {
+            let mut visited = rustc_hash::FxHashSet::default();
+            let (sym_id, actual_file) =
+                self.resolve_export_in_file(current_file, &current_name, &mut visited)?;
+            if !chain_visited.insert((actual_file, sym_id.0)) {
+                return None;
+            }
+            let next_hop = self
+                .ctx
+                .get_binder_for_file(actual_file)
+                .and_then(|binder| binder.get_symbol(sym_id))
+                .and_then(|sym| {
+                    sym.import_module.as_ref().map(|m| {
+                        let next_name = sym
+                            .import_name
+                            .clone()
+                            .unwrap_or_else(|| current_name.clone());
+                        let decl_file = if sym.decl_file_idx == u32::MAX {
+                            actual_file
+                        } else {
+                            sym.decl_file_idx as usize
+                        };
+                        (m.clone(), next_name, decl_file)
+                    })
+                });
+            match next_hop {
+                None => return Some((sym_id, actual_file)),
+                Some((next_mod, next_name, decl_file)) => {
+                    let next_file = self
+                        .ctx
+                        .resolve_import_target_from_file(decl_file, &next_mod)?;
+                    current_file = next_file;
+                    current_name = next_name;
+                }
+            }
+        }
+        None
+    }
+
     /// Collect all symbols reachable through re-export chains into the given `SymbolTable`.
     pub(super) fn collect_reexported_symbols(
         &self,

--- a/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
+++ b/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
@@ -172,20 +172,12 @@ impl<'a> CheckerState<'a> {
         if let Some(target_file_idx) = self
             .ctx
             .resolve_import_target_from_file(source_file_idx, module_specifier)
+            && let Some((target_sym_id, actual_file_idx)) =
+                self.resolve_reexport_chain_to_declaration(target_file_idx, import_name)
         {
-            let mut visited = rustc_hash::FxHashSet::default();
-            if let Some((target_sym_id, actual_file_idx)) =
-                self.resolve_export_in_file(target_file_idx, import_name, &mut visited)
-                && self
-                    .ctx
-                    .get_binder_for_file(actual_file_idx)
-                    .and_then(|binder| binder.get_symbol(target_sym_id))
-                    .is_none_or(|symbol| symbol.import_module.is_none())
-            {
-                self.ctx
-                    .register_symbol_file_target(target_sym_id, actual_file_idx);
-                return Some((target_sym_id, Some(actual_file_idx)));
-            }
+            self.ctx
+                .register_symbol_file_target(target_sym_id, actual_file_idx);
+            return Some((target_sym_id, Some(actual_file_idx)));
         }
 
         let target_sym_id = self.resolve_cross_file_export_from_file(

--- a/crates/tsz-checker/tests/ts2315_imported_generic_tests.rs
+++ b/crates/tsz-checker/tests/ts2315_imported_generic_tests.rs
@@ -1,0 +1,180 @@
+//! Regression tests: no false TS2315 on imported generic type aliases.
+//!
+//! Structural rule: when a generic type alias is exported from one file and
+//! imported in another, applying type arguments to the import must not emit
+//! TS2315 ("Type 'X' is not generic").  The checker resolves the import alias
+//! to the original declaration's symbol before inspecting type parameters;
+//! `symbol_declaration_has_type_parameters` must find parameters in the
+//! cross-file arena for that resolved symbol.
+//!
+//! Reproduces the ts-toolbelt false-positive family where `HasPath<…>` and
+//! `ComputeRaw<…>` were incorrectly flagged as non-generic.
+
+use tsz_checker::test_utils::check_multi_file;
+use tsz_common::CheckerOptions;
+
+fn strict_opts() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        module: tsz_common::common::ModuleKind::CommonJS,
+        ..Default::default()
+    }
+}
+
+/// A simple mapped-type alias exported from one file and applied with type
+/// args in another must not produce TS2315.
+#[test]
+fn no_ts2315_on_imported_mapped_generic_alias() {
+    let diags = check_multi_file(
+        &[
+            (
+                "types.ts",
+                r#"
+export type Compute<O extends object> = { [K in keyof O]: O[K] };
+"#,
+            ),
+            (
+                "main.ts",
+                r#"
+import type { Compute } from './types';
+type A = Compute<{ x: number; y: string }>;
+"#,
+            ),
+        ],
+        "main.ts",
+        strict_opts(),
+    );
+    let ts2315: Vec<_> = diags.iter().filter(|d| d.code == 2315).collect();
+    assert!(
+        ts2315.is_empty(),
+        "False TS2315 on imported mapped generic; got: {ts2315:?}"
+    );
+}
+
+/// Conditional type alias with two type params.
+#[test]
+fn no_ts2315_on_imported_conditional_generic_alias() {
+    let diags = check_multi_file(
+        &[
+            (
+                "types.ts",
+                r#"
+export type HasPath<O extends object, P extends string> =
+    P extends keyof O ? true : false;
+"#,
+            ),
+            (
+                "main.ts",
+                r#"
+import type { HasPath } from './types';
+type B = HasPath<{ x: number }, 'x'>;
+type C = HasPath<{ x: number }, 'missing'>;
+"#,
+            ),
+        ],
+        "main.ts",
+        strict_opts(),
+    );
+    let ts2315: Vec<_> = diags.iter().filter(|d| d.code == 2315).collect();
+    assert!(
+        ts2315.is_empty(),
+        "False TS2315 on imported conditional generic with two params; got: {ts2315:?}"
+    );
+}
+
+/// Re-export through an intermediate barrel.  The declaration lives in
+/// `impl.ts`, is re-exported from `index.ts`, and imported in `main.ts`.
+#[test]
+fn no_ts2315_on_re_exported_generic_alias() {
+    let diags = check_multi_file(
+        &[
+            (
+                "impl.ts",
+                r#"
+export type ComputeRaw<A extends object> = A extends Function
+    ? A
+    : { [K in keyof A]: A[K] } & unknown;
+"#,
+            ),
+            (
+                "index.ts",
+                r#"
+export type { ComputeRaw } from './impl';
+"#,
+            ),
+            (
+                "main.ts",
+                r#"
+import type { ComputeRaw } from './index';
+type X = ComputeRaw<{ a: number }>;
+"#,
+            ),
+        ],
+        "main.ts",
+        strict_opts(),
+    );
+    let ts2315: Vec<_> = diags.iter().filter(|d| d.code == 2315).collect();
+    assert!(
+        ts2315.is_empty(),
+        "False TS2315 on re-exported generic alias through barrel; got: {ts2315:?}"
+    );
+}
+
+/// Multiple generic aliases imported at once — ensures the fix scales to
+/// several imports in the same file.
+#[test]
+fn no_ts2315_on_multiple_imported_generic_aliases() {
+    let diags = check_multi_file(
+        &[
+            (
+                "types.ts",
+                r#"
+export type Id<T> = T;
+export type Pair<A, B> = [A, B];
+export type Triple<A, B, C> = [A, B, C];
+"#,
+            ),
+            (
+                "main.ts",
+                r#"
+import type { Id, Pair, Triple } from './types';
+type X = Id<number>;
+type Y = Pair<string, boolean>;
+type Z = Triple<number, string, boolean>;
+"#,
+            ),
+        ],
+        "main.ts",
+        strict_opts(),
+    );
+    let ts2315: Vec<_> = diags.iter().filter(|d| d.code == 2315).collect();
+    assert!(
+        ts2315.is_empty(),
+        "False TS2315 on one of several imported generics; got: {ts2315:?}"
+    );
+}
+
+/// Negative: TS2315 MUST still fire when a non-generic alias is applied
+/// with type args across a module boundary.
+#[test]
+fn ts2315_fires_on_imported_non_generic_alias_with_type_args() {
+    let diags = check_multi_file(
+        &[
+            ("types.ts", "export type Plain = string;\n"),
+            (
+                "main.ts",
+                r#"
+import type { Plain } from './types';
+type X = Plain<number>;
+"#,
+            ),
+        ],
+        "main.ts",
+        strict_opts(),
+    );
+    let ts2315: Vec<_> = diags.iter().filter(|d| d.code == 2315).collect();
+    assert!(
+        !ts2315.is_empty(),
+        "TS2315 must fire on imported non-generic alias used with type args; got no TS2315 in: {diags:?}"
+    );
+}


### PR DESCRIPTION
AgentName: Studio-A
Track: Checker Correctness
Invariant: No false TS2315 ("Type X is not generic") for generic type aliases imported through named barrel re-exports.

## Scope

Single fix in `reference_import_alias_export_target` (checker, `reference_helpers.rs`) + new helper `resolve_reexport_chain_to_declaration` in `reexports.rs`. New integration test file covering 5 cases.

## Structural Rule

When `export type { X } from './impl'` appears in a barrel file, tsc resolves `X<T>` in a downstream importer by following the alias chain through the barrel to the original declaration's type parameters. tsz incorrectly emitted TS2315 ("Type 'X' is not generic") for such patterns because resolution stopped at the barrel's re-export alias symbol.

Owner layer: checker → `reference_helpers.rs` / `reexports.rs` (type-parameter extraction for cross-file symbol references).

## Root Cause

Named re-exports create an alias symbol in `module_exports` of the barrel binder with `import_module` set to the source path. `resolve_export_in_file` prioritises `module_exports` and returns that alias immediately. `reference_import_alias_export_target` detected this (guard: `symbol.import_module.is_none()`) but its fallback path — `resolve_cross_file_export_from_file` → `resolve_import_with_reexports_type_only` — also stops at `module_exports`, returning the same alias. The alias sym-id then reached `extract_declared_type_params_for_reference_symbol`, which found only an `EXPORT_SPECIFIER` node (not a `TYPE_ALIAS_DECLARATION`) and returned empty params. `symbol_declaration_has_type_parameters` also returned false (alias sym not in the current-file binder), so TS2315 fired falsely.

## Fix

Add `resolve_reexport_chain_to_declaration` (57 lines in `reexports.rs`) that iterates `resolve_export_in_file` hop-by-hop: when the resolved symbol has `import_module` set (re-export alias) it clones the relevant fields, advances to the next module/name via `resolve_import_target_from_file`, and repeats until `import_module` is `None` (original declaration). Cycle detection via `FxHashSet<(file_idx, sym_id)>`; bounded to 32 hops. `reference_import_alias_export_target` now calls this helper (replacing the 14-line guard + fallback) so multi-hop barrel chains correctly reach the original generic declaration.

## Adjacent Case Matrix

| Pattern | Before | After |
|---------|--------|-------|
| Direct 2-file import of mapped generic | ✓ no TS2315 | ✓ no TS2315 |
| Direct 2-file import of conditional generic (2 params) | ✓ no TS2315 | ✓ no TS2315 |
| 3-file barrel re-export (`impl → index → main`) | ✗ false TS2315 | ✓ no TS2315 |
| Multiple direct imports in same file | ✓ no TS2315 | ✓ no TS2315 |
| Non-generic alias imported with type args | ✓ TS2315 fires | ✓ TS2315 fires |

## Project Corpus Impact

- Row: ts-toolbelt (yellow) — `HasPath<…>` and `ComputeRaw<…>` false-positive family; this fix unblocks those false TS2315 diagnostics from that yellow row.
- Bug family: false TS2315 on barrel-re-exported generic type aliases.

## Verification

```
cargo nextest run -p tsz-checker --test ts2315_imported_generic_tests
# 5/5 PASS
cargo nextest run -p tsz-checker --test cross_file_lib_generic_heritage_tests --test ts2315_imported_generic_tests
# 12/12 PASS
```

## Coordination Notes

No overlapping PRs. File ceilings respected: `reference_helpers.rs` 1984 lines (was 1992, −8), `reexports.rs` 385 lines (was 327, +58).

https://claude.ai/code/session_01MNemV8ZuXpQCkitReEWjMy

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNemV8ZuXpQCkitReEWjMy)_