### PR TITLE
chore(release): bump try-tsz publish version to 0.1.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-binder"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-checker"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "dashmap",
  "globset",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-cli"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-common"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "memchr",
  "rustc-hash",
@@ -1551,7 +1551,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-core"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-emitter"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "memchr",
  "rustc-hash",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-lowering"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "indexmap",
  "rustc-hash",
@@ -1607,7 +1607,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-lsp"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "globset",
  "json5",
@@ -1629,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-parser"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-scanner"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "serde",
  "tsz-common",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-solver"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "bitflags 2.11.0",
  "dashmap",
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-wasm"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-website"
-version = "0.1.13"
+version = "0.1.14"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/.target"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 repository = "https://github.com/mohsen1/tsz"
 homepage = "https://github.com/mohsen1/tsz"
@@ -16,16 +16,16 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Internal workspace crates
-tsz = { path = "crates/tsz-core", version = "0.1.13", package = "tsz-core" }
-tsz-common = { path = "crates/tsz-common", version = "0.1.13" }
-tsz-scanner = { path = "crates/tsz-scanner", version = "0.1.13" }
-tsz-parser = { path = "crates/tsz-parser", version = "0.1.13" }
-tsz-binder = { path = "crates/tsz-binder", version = "0.1.13" }
-tsz-solver = { path = "crates/tsz-solver", version = "0.1.13" }
-tsz-lowering = { path = "crates/tsz-lowering", version = "0.1.13" }
-tsz-checker = { path = "crates/tsz-checker", version = "0.1.13" }
-tsz-emitter = { path = "crates/tsz-emitter", version = "0.1.13", default-features = false }
-tsz-lsp = { path = "crates/tsz-lsp", version = "0.1.13" }
+tsz = { path = "crates/tsz-core", version = "0.1.14", package = "tsz-core" }
+tsz-common = { path = "crates/tsz-common", version = "0.1.14" }
+tsz-scanner = { path = "crates/tsz-scanner", version = "0.1.14" }
+tsz-parser = { path = "crates/tsz-parser", version = "0.1.14" }
+tsz-binder = { path = "crates/tsz-binder", version = "0.1.14" }
+tsz-solver = { path = "crates/tsz-solver", version = "0.1.14" }
+tsz-lowering = { path = "crates/tsz-lowering", version = "0.1.14" }
+tsz-checker = { path = "crates/tsz-checker", version = "0.1.14" }
+tsz-emitter = { path = "crates/tsz-emitter", version = "0.1.14", default-features = false }
+tsz-lsp = { path = "crates/tsz-lsp", version = "0.1.14" }
 
 # External dependencies (shared versions)
 anyhow = "1.0"

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -41,8 +41,11 @@ TypeScript/tests/cases/conformance/externalModules/circularReference.ts
 #     component's own signature in that case, so the early-return suppressed the
 #     legitimate TS2741 (and TS2322/excess). Removing it restores parity; the
 #     fixture now matches tsc 6.0.3 ([TS2741, TS2875]).
-# intersectionsOfLargeUnions2.ts oscillates; re-accepted after REGRESSED on PR #12243 exact head.
 # inferentialTypingWithFunctionTypeZip.ts: RESOLVED in PR #12342 aggregate run; removed.
+# intersectionsOfLargeUnions2.ts: RESOLVED in PR #12368 aggregate run; removed.
+# jsxIntrinsicUnions.tsx and jsxJsxsCjsTransformNestedSelfClosingChild.tsx:
+# accepted after REGRESSED on PR #12368 exact head 9ee797b6 / run 26906037226.
+# Tracked in #12376.
 # intersectionsOfLargeUnions.ts: TS2345/TS2677 fixed by PR #12326; TS2536 structural
 # logic confirmed correct by unit tests in PR #12342 (NarrowMap/WideMap pattern emits
 # exactly 2 TS2536). The aggregate conformance run with real lib types
@@ -50,5 +53,6 @@ TypeScript/tests/cases/conformance/externalModules/circularReference.ts
 # different code path. Tracked in #12260.
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
-TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
+TypeScript/tests/cases/compiler/jsxIntrinsicUnions.tsx
 TypeScript/tests/cases/conformance/es2019/importMeta/importMeta.ts
+TypeScript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformNestedSelfClosingChild.tsx


### PR DESCRIPTION
AgentName: Studio-Opus

## Track
Release / conformance gate hygiene

## Invariant
`try-tsz` npm package stays in sync with `main`, and release CI must not be blocked by stale accepted-regression metadata. Latest published is 0.1.13 (2026-06-03 15:08 UTC). The CLI fixes #12336 (`fix(cli): normalize try-tsz config deprecation spans`) and #12340 (`fix(cli): short-circuit fatal config deprecations`) plus general solver/emit improvements have landed on `main` after 0.1.13 and are not yet on npm. Cutting 0.1.14 pulls them.

## Scope
Release bump plus CI-backed conformance metadata refresh:
- `Cargo.toml`: `workspace.package.version` and all 10 in-tree `tsz-*` workspace dep pins move 0.1.13 -> 0.1.14.
- `Cargo.lock`: the 13 `tsz-*` workspace crate version lines (binder, checker, cli, common, core, emitter, lowering, lsp, parser, scanner, solver, wasm, website) move 0.1.13 -> 0.1.14.
- `scripts/conformance/conformance-accepted-regressions.txt`: remove resolved `intersectionsOfLargeUnions2.ts`; add current JSX aggregate failures `jsxIntrinsicUnions.tsx` and `jsxJsxsCjsTransformNestedSelfClosingChild.tsx`, tracked in #12376.

No checker, solver, emitter, or binder code changed. The conformance file update only reconciles the accepted-regression strictness gate with exact-head CI artifacts.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a

No project corpus row, benchmark, compile-guard, checker, solver, emitter, or binder implementation changed. The conformance metadata update affects the aggregate conformance gate only and is backed by CI run 26906037226.

## Verification
- `cargo check -p tsz-cli --offline` passes locally on the bumped tree (38.15s after rebase).
- `python3 scripts/conformance/test_link_regression_issues.py` passes (33 tests).
- `python3 scripts/ci/test_gcp_full_ci_conformance_artifacts.py` passes (6 tests).
- `python3 scripts/conformance/query-conformance.py --dashboard` reports accepted-regression gate `7` listed tests and stale checked detail warning.
- `git diff --check` passes.
- CI evidence: PR #12368 run 26906037226 conformance aggregate reported `12578/12585`, unlisted `jsxIntrinsicUnions.tsx` and `jsxJsxsCjsTransformNestedSelfClosingChild.tsx`, and resolved `intersectionsOfLargeUnions2.ts`; issue #12376 tracks the new JSX accepted-regression family.

## Coordination Notes
- Once merged, the npm publish workflow (`.github/workflows/npm-publish.yml`) will publish `try-tsz@0.1.14` plus the per-platform native helper packages.
- Follow-up bug-hunt work (issues #12369, #12370, #12371, #12372) runs against the previously-published 1.1.13 in parallel.
- JSX accepted-regression follow-up is tracked in #12376.
