### PR TITLE
fix(dts): order class expression mixin members

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_class_expression.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_class_expression.rs
@@ -234,12 +234,6 @@ impl<'a> DeclarationEmitter<'a> {
         };
         let mut instance_scratch = self.scratch_object_type_body_emitter(instance_indent);
         let mut static_scratch = self.scratch_object_type_body_emitter(self.indent_level + 1);
-        if let Some(constraint_idx) = base_constraint_idx
-            && let Some(base_members) = self
-                .constructor_constraint_base_instance_members_text(constraint_idx, instance_indent)
-        {
-            instance_scratch.write(&base_members);
-        }
         for member_idx in class.members.nodes.iter().copied() {
             let Some(member_node) = self.arena.get(member_idx) else {
                 continue;
@@ -252,6 +246,12 @@ impl<'a> DeclarationEmitter<'a> {
             } else {
                 instance_scratch.emit_class_member_for_constructor_instance_type(member_idx);
             }
+        }
+        if let Some(constraint_idx) = base_constraint_idx
+            && let Some(base_members) = self
+                .constructor_constraint_base_instance_members_text(constraint_idx, instance_indent)
+        {
+            instance_scratch.write(&base_members);
         }
         let members = instance_scratch.writer.take_output();
         let members = Self::strip_abstract_member_modifiers(members.trim_end());

--- a/crates/tsz-emitter/src/declaration_emitter/tests/type_info_constructor_objects.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/type_info_constructor_objects.rs
@@ -136,6 +136,43 @@ export const BrandedThing = Branded(Thing);
 }
 
 #[test]
+fn test_anon_ctor_object_type_local_members_precede_base_constraint_members() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+type Constructor<T = {}> = new (...args: any[]) => T;
+interface BaseSurface {
+    foo(): void;
+    name?: string;
+}
+export function Tagged<T extends Constructor<BaseSurface>>(Base: T) {
+    return class extends Base {
+        static getTags(): void {}
+        tags(): void {}
+    };
+}
+class Item {
+    foo(): void {}
+    name?: string;
+}
+export const TaggedItem = Tagged(Item);
+"#,
+    );
+
+    assert!(
+        output.contains(
+            "new (...args: any[]): {\n        tags(): void;\n        foo(): void;\n        name?: string;\n    };"
+        ),
+        "Expected constructor object instance body to emit local class members before base constraint members: {output}"
+    );
+    assert!(
+        output.contains(
+            "export declare function Tagged<T extends Constructor<BaseSurface>>(Base: T): {\n    new (...args: any[]): {\n        tags(): void;\n        foo(): void;\n        name?: string;\n    };"
+        ),
+        "Expected exported function return to emit local class members before base constraint members: {output}"
+    );
+}
+
+#[test]
 fn test_top_level_class_declaration_still_uses_eq_initializer_form() {
     // Negative case: regular class declarations (not inside an anonymous
     // constructor object type) must still emit `readonly name = value`


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Track 9 emit/dts parity: declaration emit class-expression mixin member ordering.

## Invariant
When declaration emit synthesizes an anonymous constructor object type for a class returned from a generic mixin, instance members declared by the returned class must appear before instance members recovered from the generic constructor constraint. This matches `tsc` for `emitClassExpressionInDeclarationFile`: the local `tags()` member is emitted before inherited `FooItem` members (`foo`, `name`) in both the exported mixin return type and the synthetic `*_base` class heritage alias.

Owner layer: declaration emit source-summary/class-expression surface selection. No checker/solver semantic validation is added, and no output surgery is introduced.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_class_expression.rs`
- `crates/tsz-emitter/src/declaration_emitter/tests/type_info_constructor_objects.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: DTS class-expression mixin constructor object member-order parity; no project-corpus compile behavior change expected.
- Evidence: targeted TypeScript baseline `emitClassExpressionInDeclarationFile` passes in DTS-only emit mode on the rebased head.

## Verification
- `scripts/agents/show-goal.sh Studio-C`
- `scripts/agents/disk-preflight.sh Studio-C`
- `scripts/agents/list-owned-work.sh Studio-C`
- `python3 scripts/emit/query-emit.py --families`
- `python3 scripts/emit/audit-output-surgery.py`
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter test_anon_ctor_object_type_local_members_precede_base_constraint_members`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=emitClassExpressionInDeclarationFile --dts-only --verbose --json-out=/tmp/studio-c-emitClassExpressionInDeclarationFile-rebased.json`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=genericRestParameters1 --dts-only --verbose --skip-build --json-out=/tmp/studio-c-genericRestParameters1-class-expr-rebased.json`
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `python3 scripts/emit/audit-output-surgery.py`
- `wc -l crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_class_expression.rs crates/tsz-emitter/src/declaration_emitter/tests/type_info_constructor_objects.rs`

## Coordination Notes
- Rebased the bottom Studio-C DTS stack PR onto `origin/main` after #12373 landed as `75664213f52c3d4c7fdf1d8884b9af04b346673f`.
- This PR is now based directly on `main`; #12380, #12383, and #12384 remain stacked above this branch and should be refreshed after this lands.
- Output-surgery audit remains green with no unallowlisted calls; the existing `resource-region-output-surgery` allowlist budget remains exhausted at `6/6`.
- No full emit/conformance/fourslash run was performed locally; ready PR CI owns broad validation.
