### PR TITLE
fix(dts): collapse boxed Object primitive intersections

### DIFF
--- a/crates/tsz-emitter/src/emitter/types/printer/type_printing.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/type_printing.rs
@@ -1343,8 +1343,9 @@ impl<'a> TypePrinter<'a> {
 
 #[cfg(test)]
 mod tests {
+    use tsz_solver::DefId;
     use tsz_solver::construction::TypeInterner;
-    use tsz_solver::types::{TupleElement, TypeId, TypeParamInfo};
+    use tsz_solver::types::{IntrinsicKind, TupleElement, TypeId, TypeParamInfo};
 
     use super::TypePrinter;
 
@@ -1408,6 +1409,24 @@ mod tests {
         let printer = TypePrinter::new(&interner).with_outer_type_params(vec![t_atom]);
         let intersection_swapped = interner.intersection2(empty, t);
         assert_eq!(printer.print_type(intersection_swapped), "NonNullable<T>");
+    }
+
+    #[test]
+    fn boxed_object_intersection_prints_primitive_surface() {
+        let interner = TypeInterner::new();
+        let object_def = DefId(1);
+        let object_type = interner.lazy(object_def);
+        interner.set_boxed_type(IntrinsicKind::Object, object_type);
+        interner.register_boxed_def_id(IntrinsicKind::Object, object_def);
+
+        let text = TypePrinter::new(&interner)
+            .print_type(interner.intersection(vec![object_type, TypeId::STRING]));
+        assert_eq!(text, "string");
+
+        let literal = interner.literal_string("def");
+        let text = TypePrinter::new(&interner)
+            .print_type(interner.intersection(vec![object_type, literal]));
+        assert_eq!(text, "\"def\"");
     }
 
     #[test]

--- a/crates/tsz-emitter/src/emitter/types/printer/type_printing_composites.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/type_printing_composites.rs
@@ -1,7 +1,6 @@
 use super::{TypeId, TypePrinter, TypeSubstitution, instantiate_type_cached, visitor};
 use tsz_binder::{SymbolId, symbol_flags};
 use tsz_common::interner::Atom;
-use tsz_solver::types::IntrinsicKind;
 
 impl<'a> TypePrinter<'a> {
     pub(crate) fn print_union(
@@ -173,15 +172,14 @@ impl<'a> TypePrinter<'a> {
     pub(crate) fn print_intersection(&self, type_list_id: tsz_solver::types::TypeListId) -> String {
         let original_types = self.interner.type_list(type_list_id);
         let mut filtered_types = Vec::new();
-        let types =
-            if self.intersection_should_drop_global_object(&original_types) {
-                filtered_types.extend(original_types.iter().copied().filter(|&member| {
-                    !self.is_registered_boxed_type(member, IntrinsicKind::Object)
-                }));
-                filtered_types.as_slice()
-            } else {
-                original_types.as_ref()
-            };
+        let types = if self.intersection_should_drop_global_object(&original_types) {
+            filtered_types.extend(original_types.iter().copied().filter(|&member| {
+                !self.is_registered_boxed_type(member, tsz_solver::types::IntrinsicKind::Object)
+            }));
+            filtered_types.as_slice()
+        } else {
+            original_types.as_ref()
+        };
         if types.is_empty() {
             return "unknown".to_string(); // Intersection of 0 types is unknown
         }
@@ -252,10 +250,9 @@ impl<'a> TypePrinter<'a> {
     }
 
     fn intersection_should_drop_global_object(&self, types: &[TypeId]) -> bool {
-        let has_global_object = types
-            .iter()
-            .copied()
-            .any(|member| self.is_registered_boxed_type(member, IntrinsicKind::Object));
+        let has_global_object = types.iter().copied().any(|member| {
+            self.is_registered_boxed_type(member, tsz_solver::types::IntrinsicKind::Object)
+        });
         if !has_global_object {
             return false;
         }
@@ -266,7 +263,11 @@ impl<'a> TypePrinter<'a> {
             .any(|member| self.has_primitive_declaration_surface(member))
     }
 
-    fn is_registered_boxed_type(&self, type_id: TypeId, kind: IntrinsicKind) -> bool {
+    fn is_registered_boxed_type(
+        &self,
+        type_id: TypeId,
+        kind: tsz_solver::types::IntrinsicKind,
+    ) -> bool {
         self.interner.get_boxed_type(kind) == Some(type_id)
             || visitor::lazy_def_id(self.interner, type_id)
                 .is_some_and(|def_id| self.interner.is_boxed_def_id(def_id, kind))
@@ -276,11 +277,11 @@ impl<'a> TypePrinter<'a> {
         matches!(
             visitor::apparent_intrinsic_kind(self.interner, type_id),
             Some(
-                IntrinsicKind::String
-                    | IntrinsicKind::Number
-                    | IntrinsicKind::Boolean
-                    | IntrinsicKind::Bigint
-                    | IntrinsicKind::Symbol
+                tsz_solver::types::IntrinsicKind::String
+                    | tsz_solver::types::IntrinsicKind::Number
+                    | tsz_solver::types::IntrinsicKind::Boolean
+                    | tsz_solver::types::IntrinsicKind::Bigint
+                    | tsz_solver::types::IntrinsicKind::Symbol
             )
         )
     }

--- a/crates/tsz-emitter/src/emitter/types/printer/type_printing_composites.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/type_printing_composites.rs
@@ -1,6 +1,7 @@
 use super::{TypeId, TypePrinter, TypeSubstitution, instantiate_type_cached, visitor};
 use tsz_binder::{SymbolId, symbol_flags};
 use tsz_common::interner::Atom;
+use tsz_solver::types::IntrinsicKind;
 
 impl<'a> TypePrinter<'a> {
     pub(crate) fn print_union(
@@ -170,7 +171,17 @@ impl<'a> TypePrinter<'a> {
     }
 
     pub(crate) fn print_intersection(&self, type_list_id: tsz_solver::types::TypeListId) -> String {
-        let types = self.interner.type_list(type_list_id);
+        let original_types = self.interner.type_list(type_list_id);
+        let mut filtered_types = Vec::new();
+        let types =
+            if self.intersection_should_drop_global_object(&original_types) {
+                filtered_types.extend(original_types.iter().copied().filter(|&member| {
+                    !self.is_registered_boxed_type(member, IntrinsicKind::Object)
+                }));
+                filtered_types.as_slice()
+            } else {
+                original_types.as_ref()
+            };
         if types.is_empty() {
             return "unknown".to_string(); // Intersection of 0 types is unknown
         }
@@ -238,6 +249,40 @@ impl<'a> TypePrinter<'a> {
             .map(|(_, text)| text)
             .collect::<Vec<_>>()
             .join(" & ")
+    }
+
+    fn intersection_should_drop_global_object(&self, types: &[TypeId]) -> bool {
+        let has_global_object = types
+            .iter()
+            .copied()
+            .any(|member| self.is_registered_boxed_type(member, IntrinsicKind::Object));
+        if !has_global_object {
+            return false;
+        }
+
+        types
+            .iter()
+            .copied()
+            .any(|member| self.has_primitive_declaration_surface(member))
+    }
+
+    fn is_registered_boxed_type(&self, type_id: TypeId, kind: IntrinsicKind) -> bool {
+        self.interner.get_boxed_type(kind) == Some(type_id)
+            || visitor::lazy_def_id(self.interner, type_id)
+                .is_some_and(|def_id| self.interner.is_boxed_def_id(def_id, kind))
+    }
+
+    fn has_primitive_declaration_surface(&self, type_id: TypeId) -> bool {
+        matches!(
+            visitor::apparent_intrinsic_kind(self.interner, type_id),
+            Some(
+                IntrinsicKind::String
+                    | IntrinsicKind::Number
+                    | IntrinsicKind::Boolean
+                    | IntrinsicKind::Bigint
+                    | IntrinsicKind::Symbol
+            )
+        )
     }
 
     pub(crate) fn print_recursive_expansion_limit(&self, return_type: TypeId) -> String {

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -43,7 +43,8 @@ TypeScript/tests/cases/conformance/externalModules/circularReference.ts
 #     fixture now matches tsc 6.0.3 ([TS2741, TS2875]).
 # inferentialTypingWithFunctionTypeZip.ts: RESOLVED in PR #12342 aggregate run; removed.
 # intersectionsOfLargeUnions2.ts: RESOLVED in PR #12368 aggregate run; removed.
-# jsxIntrinsicUnions.tsx was RESOLVED in PR #12289 exact head 22f57bd4.
+# jsxIntrinsicUnions.tsx was RESOLVED in PR #12289 exact head 22f57bd4,
+# then REGRESSED again on PR #12380 exact head 4c00c5259f. Tracked in #8432.
 # jsxJsxsCjsTransformNestedSelfClosingChild.tsx: RESOLVED in PR #12367
 # aggregate run on exact head 2dd802cf / run 26908103845, then reappeared on
 # PR #11890 ready-review heads below; tracked in #8432 while accepted here.
@@ -77,6 +78,7 @@ TypeScript/tests/cases/conformance/externalModules/circularReference.ts
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/jsxImportForSideEffectsNonExtantNoError.tsx
+TypeScript/tests/cases/compiler/jsxIntrinsicUnions.tsx
 TypeScript/tests/cases/conformance/es2019/importMeta/importMeta.ts
 TypeScript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformNestedSelfClosingChild.tsx
 


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Track 9 emit/dts parity: declaration emit strict-function type surface printing.

## Invariant
When declaration type printing sees an intersection whose registered boxed `Object` member is paired with a direct primitive or primitive-literal member, `tsc` prints the primitive surface. This PR makes tsz do the same in the declaration type-printer surface layer without normalizing solver intersections or adding checker/solver semantic validation to emit.

## Scope
- Drop registered boxed `Object` from declaration intersection display when another direct primitive or primitive literal member determines the emitted surface.
- Add TypePrinter coverage for `Object & string` and `Object & "def"` style intersections.
- Fixes `strictFunctionTypes1` DTS output where tsz emitted `Object & string` / `Object & "def"` and tsc emits `string` / `"def"`.
- Preserve the remote accepted-regression update for `jsxIntrinsicUnions.tsx`, which reappeared in CI conformance aggregate on exact head `4c00c5259f` while the focused local single-fixture conformance check passes.

## Project Corpus Impact
- Row: n/a
- Bug family: DTS declaration-surface intersection printing for strict-function inference.
- Evidence: targeted TypeScript baseline `strictFunctionTypes1` passes in DTS-only emit mode on the rebased stack.

## Verification
- `scripts/agents/show-goal.sh Studio-C`
- `scripts/agents/disk-preflight.sh Studio-C`
- `scripts/agents/list-owned-work.sh Studio-C`
- `python3 scripts/emit/query-emit.py --families`
- `python3 scripts/emit/audit-output-surgery.py`
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter boxed_object_intersection_prints_primitive_surface`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=strictFunctionTypes1 --dts-only --verbose --timeout=20000 --json-out=/tmp/studio-c-strictFunctionTypes1-rebased-object-surface.json`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=genericRestParameters1 --dts-only --verbose --timeout=20000 --skip-build --json-out=/tmp/studio-c-genericRestParameters1-strict-rebased.json`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=emitClassExpressionInDeclarationFile --dts-only --verbose --timeout=20000 --skip-build --json-out=/tmp/studio-c-emitClassExpressionInDeclarationFile-strict-rebased.json`
- `scripts/safe-run.sh scripts/conformance/conformance.sh run --filter jsxIntrinsicUnions --verbose --workers 1`
- `scripts/safe-run.sh scripts/conformance/conformance.sh run --filter jsxIntrinsicUnions --verbose --workers 8`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-emitter --all-targets -- -D warnings`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `python3 scripts/emit/audit-output-surgery.py`
- `wc -l crates/tsz-emitter/src/emitter/types/printer/type_printing.rs crates/tsz-emitter/src/emitter/types/printer/type_printing_composites.rs crates/tsz-checker/src/state/type_environment/lazy.rs`

## Coordination Notes
- Rebased onto latest `origin/main` after #12378 landed and after #12289 landed as `0d78cbf8b39acb9ed5cc964662df9da9866a0a7b`.
- A temporary checker line-count cleanup was dropped during the latest rebase because current `main` already brings `lazy.rs` below the architecture guard cap (`1986` lines).
- PR head later advanced remotely to `b3f61de755172d2d97831d6846dd752166b974ae` with an accepted-regression entry for `jsxIntrinsicUnions.tsx`; the local focused conformance reruns for that exact fixture pass, so the accepted entry is being preserved as the current remote branch state rather than expanded with compiler logic.
- This PR is now based directly on `main`; #12383, #12384, #12386, #12387, and #12389 remain stacked above and should be refreshed after this lands.
- Output-surgery audit remains green with no unallowlisted calls; the existing `resource-region-output-surgery` allowlist budget remains exhausted at `6/6`.
- Local disk remains low but the focused DTS baseline and adjacent smoke checks passed after release-artifact cleanup.
