### PR TITLE
fix(solver/checker): remove orphaned constraint-violation CallResult bypass (#10901)

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
@@ -868,22 +868,6 @@ impl<'a> CheckerState<'a> {
                         });
                     }
                 }
-                CallResult::TypeParameterConstraintViolation { return_type, .. } => {
-                    // Constraint violation from callback return - overload matched
-                    // but with constraint error. If there are more overloads to try,
-                    // continue to the next one (e.g., Object.freeze overload 0 is
-                    // `T extends Function` which is violated for object args — we
-                    // must try overload 1 `T extends {[idx:string]:U}`).
-                    if signatures.len() > 1 {
-                        continue;
-                    }
-                    self.ctx.node_types.merge(&temp_node_types);
-                    return Some(OverloadResolution {
-                        arg_types: arg_types.clone(),
-                        result: CallResult::Success(return_type),
-                        selected_type_predicate,
-                    });
-                }
                 _ => {}
             }
         }
@@ -907,10 +891,6 @@ impl<'a> CheckerState<'a> {
         // type callback/object-literal arguments correctly. The union pass above can
         // miss those, producing false negatives and downstream false TS2345/TS2322.
         let mut failures = Vec::new();
-        // When a signature returns TypeParameterConstraintViolation and there are more
-        // overloads to try, store it as a fallback and continue. Used for Object.freeze
-        // where overload 0 (T extends Function) is violated but overload 1 works.
-        let _constraint_violation_fallback: Option<(TypeId, Vec<TypeId>)> = None;
         let mut all_arg_count_mismatches = true;
         let mut any_has_rest = false;
         let mut exact_expected_counts = std::collections::BTreeSet::new();
@@ -929,11 +909,6 @@ impl<'a> CheckerState<'a> {
         // as an overload mismatch. When no overload resolves cleanly we commit to
         // this candidate and surface its diagnostics instead of silently recovering.
         let mut callback_body_only_success: Option<BestTypeMismatch> = None;
-        // When an overload returns TypeParameterConstraintViolation and there are
-        // more overloads to try, we store it as a fallback and continue. If no
-        // later overload succeeds, we use this fallback (e.g., for single-overload
-        // constraint violations that must still resolve to a return type).
-        let mut constraint_violation_fallback: Option<(TypeId, Vec<TypeId>)> = None;
         for (idx, original_sig) in signatures.iter().enumerate() {
             let sig = self.overload_signature_for_inference(
                 original_sig,
@@ -1457,9 +1432,7 @@ impl<'a> CheckerState<'a> {
                     selected_type_predicate = retry_predicate;
                 }
                 match retry_result {
-                    CallResult::Success(_)
-                    | CallResult::ArgumentTypeMismatch { .. }
-                    | CallResult::TypeParameterConstraintViolation { .. } => {
+                    CallResult::Success(_) | CallResult::ArgumentTypeMismatch { .. } => {
                         sig_arg_types = refreshed_arg_types;
                         result = retry_result;
                     }
@@ -1782,41 +1755,6 @@ impl<'a> CheckerState<'a> {
                         actual,
                     ));
                 }
-                CallResult::TypeParameterConstraintViolation { return_type, .. } => {
-                    // If more overloads remain, store this as a fallback and try next.
-                    // This handles cases like Object.freeze where overload 0
-                    // (T extends Function) is violated for object args but overload 1
-                    // (T extends {[idx:string]:U}) should be tried next.
-                    if signatures.len() > 1 && constraint_violation_fallback.is_none() {
-                        constraint_violation_fallback = Some((return_type, sig_arg_types.clone()));
-                        self.ctx
-                            .rollback_diagnostics_filtered(&candidate_snap, |diag| {
-                                Self::should_preserve_speculative_call_diagnostic(diag)
-                            });
-                        continue;
-                    }
-                    let preserved_first_pass_diags = self.collect_non_callback_diagnostics_between(
-                        args,
-                        &overload_snap.diag,
-                        &candidate_snap,
-                    );
-                    let kept_candidate_diags =
-                        self.ctx.take_speculative_diagnostics(&candidate_snap);
-                    let mut merged =
-                        self.preserved_speculative_call_diagnostics(&overload_snap.diag);
-                    self.extend_unique_diagnostics(&mut merged, preserved_first_pass_diags);
-                    self.extend_unique_diagnostics(&mut merged, kept_candidate_diags);
-                    self.ctx
-                        .rollback_and_replace_diagnostics(&overload_snap.diag, merged);
-                    let sig_node_types = std::mem::take(&mut self.ctx.node_types);
-                    self.ctx.node_types = std::mem::take(&mut original_node_types);
-                    self.ctx.node_types.merge_owned(sig_node_types);
-                    return Some(OverloadResolution {
-                        arg_types: sig_arg_types,
-                        result: CallResult::Success(return_type),
-                        selected_type_predicate,
-                    });
-                }
                 _ => {
                     all_arg_count_mismatches = false;
                     has_non_count_non_type_failure = true;
@@ -1852,23 +1790,6 @@ impl<'a> CheckerState<'a> {
             self.ctx.node_types = std::mem::take(&mut original_node_types);
             self.ctx.node_types.merge_owned(sig_node_types);
             return Some(best_type_mismatch);
-        }
-
-        // If we encountered a TypeParameterConstraintViolation while trying overloads
-        // but no later overload succeeded cleanly, use the constraint-violation result
-        // as a successful resolution (the return type is still valid; only the
-        // constraint check itself failed, which is reported separately).
-        if let Some((fallback_return_type, fallback_arg_types)) = constraint_violation_fallback {
-            self.ctx
-                .rollback_diagnostics_filtered(&overload_snap.diag, |diag| {
-                    Self::should_preserve_speculative_call_diagnostic(diag)
-                });
-            self.ctx.node_types = original_node_types;
-            return Some(OverloadResolution {
-                arg_types: fallback_arg_types,
-                result: CallResult::Success(fallback_return_type),
-                selected_type_predicate: None,
-            });
         }
 
         // No overload resolved cleanly, but at least one matched at the signature

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -519,6 +519,9 @@ mod call_architecture_tests;
 #[path = "tests/call_context_relation_routing_arch_tests.rs"]
 mod call_context_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/call_result_constraint_violation_gateway_arch_tests.rs"]
+mod call_result_constraint_violation_gateway_arch_tests;
+#[cfg(test)]
 #[path = "tests/call_spread_constructor_parameters_tests.rs"]
 mod call_spread_constructor_parameters_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_00.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_00.rs
@@ -1101,9 +1101,11 @@ fn test_assignment_and_binding_default_assignability_use_central_gateway_helpers
         type_computation_complex_src.contains("check_argument_assignable_or_report("),
         "computation/complex argument mismatch checks should route through check_argument_assignable_or_report"
     );
-    // TypeParameterConstraintViolation is now handled as an argument-level
-    // mismatch (TS2345), matching tsc behavior. The handler uses
-    // check_argument_assignable_or_report, which is already asserted above.
+    // Type-parameter constraint violations are reported as argument-level
+    // mismatches (TS2345) through the canonical `CallResult::ArgumentTypeMismatch`
+    // path, which routes through `check_argument_assignable_or_report`
+    // (asserted above). There is no separate constraint-violation `CallResult`
+    // variant that could bypass the assignability gateway.
     assert!(
         type_computation_complex_src.contains("ensure_relation_input_ready(")
             && type_computation_complex_src.contains("ensure_relation_inputs_ready("),

--- a/crates/tsz-checker/src/tests/call_result_constraint_violation_gateway_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/call_result_constraint_violation_gateway_arch_tests.rs
@@ -1,0 +1,60 @@
+//! Architecture guard: type-parameter constraint violations are reported only
+//! through the shared assignability gateway, never through a dedicated
+//! `CallResult` bypass variant.
+//!
+//! Regression guard for #10901 ("TS2322 family path bypasses query boundaries
+//! in nested conditional calls"). The orphaned
+//! `CallResult::TypeParameterConstraintViolation` arm in
+//! `types/computation/call_result.rs` emitted TS2345 through the raw
+//! `error_argument_not_assignable_at` emitter, bypassing
+//! `query_boundaries::assignability`, while the equivalent `new`-expression arm
+//! in `types/computation/complex.rs` routed through the gateway. That asymmetry
+//! is exactly the "one path emits false errors while another returns success"
+//! symptom the issue describes.
+//!
+//! Constraint violations now flow solely through
+//! `CallResult::ArgumentTypeMismatch`, whose checker dispatch routes through
+//! `check_argument_assignable_or_report` (relation -> reason -> diagnostic).
+//! These guards keep the bypass variant from being reintroduced on either the
+//! solver (where the variant lived) or the checker (where it was matched).
+
+use std::fs;
+
+/// The solver must not reintroduce a dedicated constraint-violation `CallResult`
+/// variant. Constraint violations are surfaced as `ArgumentTypeMismatch` so the
+/// checker re-checks them through the assignability gateway (which evaluates
+/// conditional/generic constraints in the proper environment) instead of
+/// emitting unconditionally.
+///
+/// The solver crate sets `autotests = false`, so this cross-crate invariant is
+/// asserted here, alongside the checker dispatch guard it pairs with.
+#[test]
+fn no_type_parameter_constraint_violation_callresult_variant() {
+    let solver_src = fs::read_to_string("../tsz-solver/src/operations/core/call_evaluator.rs")
+        .expect("failed to read solver call_evaluator.rs for architecture guard");
+    assert!(
+        !solver_src.contains("TypeParameterConstraintViolation"),
+        "the orphaned `CallResult::TypeParameterConstraintViolation` bypass variant must \
+         not be reintroduced; constraint violations route through \
+         `CallResult::ArgumentTypeMismatch` and the assignability gateway"
+    );
+}
+
+/// Neither call-expression dispatch site may match a dedicated
+/// constraint-violation arm and emit through the raw argument emitter.
+#[test]
+fn call_dispatch_has_no_constraint_violation_bypass_arm() {
+    for path in [
+        "src/types/computation/call_result.rs",
+        "src/types/computation/complex.rs",
+    ] {
+        let src = fs::read_to_string(path)
+            .unwrap_or_else(|err| panic!("failed to read {path} for architecture guard: {err}"));
+        assert!(
+            !src.contains("TypeParameterConstraintViolation"),
+            "{path} must not match a `TypeParameterConstraintViolation` arm; constraint \
+             violations are handled through `CallResult::ArgumentTypeMismatch`, which routes \
+             through `check_argument_assignable_or_report`"
+        );
+    }
+}

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -1428,30 +1428,6 @@ impl<'a> CheckerState<'a> {
                     TypeId::ERROR
                 }
             }
-            CallResult::TypeParameterConstraintViolation {
-                inferred_type,
-                constraint_type,
-                return_type,
-            } => {
-                // For regular function calls with arguments, report as TS2345
-                // ("Argument of type X is not assignable to parameter of type Y")
-                // at the argument position. tsc treats type parameter constraint
-                // violations from regular arguments as TS2345, not TS2322.
-                // We emit directly (bypassing check_argument_assignable_or_report)
-                // because the solver has already confirmed the constraint violation
-                // and the checker's re-check may disagree due to different context.
-                if !args.is_empty() {
-                    self.error_argument_not_assignable_at(inferred_type, constraint_type, args[0]);
-                } else {
-                    let _ = self.check_assignable_or_report_generic_at(
-                        inferred_type,
-                        constraint_type,
-                        call_idx,
-                        call_idx,
-                    );
-                }
-                return_type
-            }
             CallResult::NoOverloadMatch {
                 failures,
                 fallback_return,

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -1901,21 +1901,6 @@ impl<'a> CheckerState<'a> {
                     TypeId::ERROR
                 }
             }
-            CallResult::TypeParameterConstraintViolation {
-                inferred_type,
-                constraint_type,
-                return_type,
-            } => {
-                // Type parameter constraint violations are argument-level
-                // mismatches. tsc reports TS2345 at the argument.
-                let anchor = args.first().copied().unwrap_or(idx);
-                let _ = self.check_argument_assignable_or_report(
-                    inferred_type,
-                    constraint_type,
-                    anchor,
-                );
-                return_type
-            }
             CallResult::NoOverloadMatch {
                 failures,
                 fallback_return,

--- a/crates/tsz-checker/tests/speculation_rollback_tests.rs
+++ b/crates/tsz-checker/tests/speculation_rollback_tests.rs
@@ -243,8 +243,8 @@ fn overload_generic_candidate_contextual_refresh_clean() {
     );
 }
 
-/// Ensure that `TypeParameterConstraintViolation` during overload resolution
-/// correctly rolls back and tries the next candidate.
+/// Ensure that a type-parameter constraint violation during overload
+/// resolution correctly rolls back and tries the next candidate.
 #[test]
 fn overload_constraint_violation_tries_next_candidate() {
     let diags = check(

--- a/crates/tsz-solver/src/operations/constructors.rs
+++ b/crates/tsz-solver/src/operations/constructors.rs
@@ -170,9 +170,6 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
 
             match self.resolve_function_call(&func, arg_types) {
                 CallResult::Success(ret) => return CallResult::Success(ret),
-                CallResult::TypeParameterConstraintViolation { return_type, .. } => {
-                    return CallResult::Success(return_type);
-                }
                 CallResult::ArgumentTypeMismatch {
                     index,
                     expected,

--- a/crates/tsz-solver/src/operations/core/call_evaluator.rs
+++ b/crates/tsz-solver/src/operations/core/call_evaluator.rs
@@ -168,19 +168,6 @@ pub enum CallResult {
     /// legitimately return `any` from construct signatures.
     VoidFunctionCalledWithNew,
 
-    /// Type parameter constraint violation (TS2322, not TS2345).
-    /// Used when inference from callback return types produces a type that
-    /// violates the type parameter's constraint. tsc reports TS2322 on the
-    /// return expression, not TS2345 on the whole callback argument.
-    TypeParameterConstraintViolation {
-        /// The inferred type that violated the constraint
-        inferred_type: TypeId,
-        /// The constraint type that was violated
-        constraint_type: TypeId,
-        /// The return type of the call (for type computation to continue)
-        return_type: TypeId,
-    },
-
     /// No overload matched (for overloaded functions)
     NoOverloadMatch {
         func_type: TypeId,

--- a/crates/tsz-solver/src/operations/core/call_resolution.rs
+++ b/crates/tsz-solver/src/operations/core/call_resolution.rs
@@ -1621,11 +1621,6 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
 
             match self.resolve_function_call(&func, arg_types) {
                 CallResult::Success(ret) => return CallResult::Success(ret),
-                CallResult::TypeParameterConstraintViolation { return_type, .. } => {
-                    // Constraint violation is a "near match" - return the type
-                    // for overload resolution (treat as success with error)
-                    return CallResult::Success(return_type);
-                }
                 CallResult::ArgumentTypeMismatch {
                     index,
                     expected,


### PR DESCRIPTION
AgentName: M1-Opus
Track: bug / conformance / solver-checker

## Summary

Closes #10901: "utility-types-project: TS2322 family path bypasses query boundaries in nested conditional calls".

Type-parameter constraint violations had two divergent reporting paths:

- The `new`-expression dispatch in `types/computation/complex.rs` routed the `CallResult::TypeParameterConstraintViolation` arm through the shared `query_boundaries::assignability` gateway (`check_argument_assignable_or_report`), which re-checks the relation and evaluates conditional/generic constraints in the proper environment.
- The regular-call dispatch in `types/computation/call_result.rs` instead emitted TS2345 through the raw `error_argument_not_assignable_at` emitter, bypassing the gateway.

That asymmetry is exactly the issue's symptom: "one check path emits false errors while another path returns success." The bypass directly violates the TSZ contract: "Assignability paths for TS2322/TS2345/TS2416 use the shared `query_boundaries/assignability` gateway: relation -> reason -> diagnostic."

The `CallResult::TypeParameterConstraintViolation` variant was orphaned by #12326: it is never constructed anywhere. The live constraint-violation path now produces `CallResult::ArgumentTypeMismatch`, which the checker dispatches through the gateway. This PR removes the dead variant and all its now-unreachable handling across the solver and checker, including the dead `constraint_violation_fallback` overload machinery it fed, so type-parameter constraint violations can flow only through the gateway-routed `ArgumentTypeMismatch` path. It adds an architecture regression guard preventing reintroduction.

## Structural Rule

When a generic call argument violates a type parameter's constraint, `tsc` reports TS2345 at the argument. `tsz` reports it through `CallResult::ArgumentTypeMismatch` -> `check_argument_assignable_or_report` (relation -> reason -> diagnostic), never through a dedicated bypass variant. The gateway evaluates conditional/generic constraints in the proper environment, so nested conditional calls cannot produce a false positive that the raw emitter would have emitted unconditionally.

## Owner Layer

Solver (`CallResult` definition and dead match arms) and Checker (call/`new` dispatch and overload resolution). No new type semantics: the single surviving path already routes through the existing solver-backed gateway.

## Scope

- `crates/tsz-solver/src/operations/core/call_evaluator.rs`: remove the `TypeParameterConstraintViolation` variant.
- `crates/tsz-solver/src/operations/core/call_resolution.rs`, `operations/constructors.rs`: remove dead solver match arms.
- `crates/tsz-checker/src/types/computation/call_result.rs`, `complex.rs`: remove the dead checker dispatch arms (the bypass and the gateway-routed twin).
- `crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs`: remove the three dead arms and the `constraint_violation_fallback` machinery.
- `crates/tsz-checker/src/tests/call_result_constraint_violation_gateway_arch_tests.rs` (new, registered in `lib.rs`): regression guard asserting the bypass variant is not reintroduced on either the solver definition or the two checker dispatch sites.
- Comment refresh in `architecture_contract_tests_parts/part_00.rs` and `speculation_rollback_tests.rs`.

Net: -145 / +71 (overwhelmingly dead-code removal).

## Invariant

Behavior-preserving: the removed variant was never constructed, so no diagnostic output changes. The surviving `ArgumentTypeMismatch` -> gateway path is unchanged.

## Project Corpus Impact

- Row: utility-types-project
- Bug family: TS2322/TS2345 constraint-violation path bypassing the assignability query boundary in nested conditional calls
- Impact: none expected (behavior-preserving dead-code removal). No diagnostic output changes on any project row; the contract is now enforced structurally rather than relying on a path that happened to be unreachable.

## Verification

- Built the `tsz` CLI and confirmed parity with `tsc` on adversarial nested conditional calls, constrained generics, and `Object.freeze` overloads (the overload `constraint_violation_fallback` referenced `Object.freeze`):
  - all-valid nested conditional calls -> no errors;
  - genuine mismatches -> expected TS2345/TS2322 at the right positions;
  - `Object.freeze({...})` -> readonly props typed correctly + TS2540 on write; `Object.freeze([...])` works; `f(42)` -> TS2345.
- `cargo check` and `cargo clippy --tests` clean on `tsz-solver` + `tsz-checker` (no warnings).
- `speculation_rollback_tests` (40 tests incl. `overload_constraint_violation_tries_next_candidate`) pass; call-result relation-routing arch tests pass; new guard tests pass.
- Rebased onto latest `main`; recompiled clean. Pre-existing architecture-contract failures on the base branch are unrelated to this change (confirmed via `git stash`: identical set with and without these edits).

## Coordination Notes

Generated runner identity: cloud-opus48-1m-lucid-hopper-RcTn2.
Builds on #12326, which rewired the live constraint path to `ArgumentTypeMismatch`.