### PR TITLE
fix(dts): preserve nested generic function scopes

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
@@ -1086,6 +1086,22 @@ impl<'a> DeclarationEmitter<'a> {
                         let _ = self.emit_non_portable_function_return_diagnostics(
                             &type_text, func_body, func_name,
                         );
+                    } else if func
+                        .type_parameters
+                        .as_ref()
+                        .is_some_and(|type_params| !type_params.nodes.is_empty())
+                        && let Some(type_text) = func_body
+                            .is_some()
+                            .then(|| {
+                                self.returned_object_literal_local_function_type_text(func_body)
+                            })
+                            .flatten()
+                    {
+                        self.write(": ");
+                        self.write(&type_text);
+                        let _ = self.emit_non_portable_function_return_diagnostics(
+                            &type_text, func_body, func_name,
+                        );
                     } else if let Some(type_text) = func_body
                         .is_some()
                         .then(|| self.returned_late_bound_function_typeof_text(func_body))

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
@@ -1176,6 +1176,43 @@ impl<'a> DeclarationEmitter<'a> {
         ))
     }
 
+    pub(in crate::declaration_emitter) fn returned_object_literal_local_function_type_text(
+        &self,
+        body_idx: NodeIndex,
+    ) -> Option<String> {
+        let object_expr_idx = self.direct_returned_object_literal(body_idx)?;
+        self.object_literal_has_local_function_declaration_member(object_expr_idx)
+            .then(|| self.infer_object_literal_type_text_at(object_expr_idx, 0))
+            .flatten()
+    }
+
+    fn object_literal_has_local_function_declaration_member(
+        &self,
+        object_expr_idx: NodeIndex,
+    ) -> bool {
+        let Some(object_node) = self.arena.get(object_expr_idx) else {
+            return false;
+        };
+        let Some(object) = self.arena.get_literal_expr(object_node) else {
+            return false;
+        };
+
+        object.elements.nodes.iter().copied().any(|member_idx| {
+            let Some(member_node) = self.arena.get(member_idx) else {
+                return false;
+            };
+            let value_idx = if let Some(data) = self.arena.get_shorthand_property(member_node) {
+                data.name
+            } else if let Some(prop) = self.arena.get_property_assignment(member_node) {
+                prop.initializer
+            } else {
+                return false;
+            };
+            self.local_function_declaration_identifier_type_text(value_idx)
+                .is_some()
+        })
+    }
+
     pub(in crate::declaration_emitter) fn infer_object_member_type_text_named_at(
         &self,
         member_idx: NodeIndex,


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Track 9 emit/dts parity: declaration emit nested generic function scope printing.

## Invariant
When a generic function returns an object literal whose member value is a local function declaration, `tsc` prints that returned object surface with source-local function type parameter names. This PR keeps that decision in the DTS declaration emitter, using AST-owned object literal/function-declaration structure before the generic solver-rendered return fallback, without adding checker/solver semantic validation to emit.

## Scope
- Adds a structural object-literal helper that detects returned object members backed by local function declarations.
- Uses that helper before the late-bound/generic return fallback so nested local function type parameters stay scoped like `tsc`.
- Fixes the DTS baseline `typeParametersAvailableInNestedScope3`.

## Project Corpus Impact
- Row: n/a
- Bug family: DTS declaration emit, nested generic local function shadowing in returned object literals.
- Evidence: targeted TypeScript baseline `typeParametersAvailableInNestedScope3` passes in DTS-only emit mode on the rebased branch.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter test_returned_object_literal_local_function_declarations_inline`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=typeParametersAvailableInNestedScope3 --dts-only --verbose --timeout=20000 --json-out=/tmp/studio-c-typeParametersAvailableInNestedScope3-rebased-main.json`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=strictFunctionTypes1 --dts-only --verbose --timeout=20000 --skip-build --json-out=/tmp/studio-c-strictFunctionTypes1-after-nested-rebase.json`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=genericRestParameters1 --dts-only --verbose --timeout=20000 --skip-build --json-out=/tmp/studio-c-genericRestParameters1-after-nested-rebase.json`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=emitClassExpressionInDeclarationFile --dts-only --verbose --timeout=20000 --skip-build --json-out=/tmp/studio-c-emitClassExpressionInDeclarationFile-after-nested-rebase.json`
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `python3 scripts/emit/audit-output-surgery.py`
- `wc -l crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs`

## Coordination Notes
- Rebased and retargeted directly onto `main` after #12380 landed as `1a0f814efcc34cdeef3496e7f86b64bec453365c`.
- Branch now has a single PR-local commit, `e6dd1d1cb0 fix(dts): preserve nested generic function scopes`.
- #12384, #12386, #12387, and #12389 remain stacked above this branch and should be refreshed after this lands.
- Output-surgery audit remains green with no unallowlisted calls; the existing `resource-region-output-surgery` allowlist budget remains exhausted at `6/6`.
- No roadmap update: this is a focused DTS parity slice, not a durable roadmap-direction change.
