### PR TITLE
fix(dts): print instantiated type alias surfaces

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_instantiation.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_instantiation.rs
@@ -755,7 +755,25 @@ impl<'a> DeclarationEmitter<'a> {
                 self.get_node_type_or_names(&[expr.expression])
                     .map(|type_id| self.print_type_id(type_id))
             })?;
-        Self::instantiate_type_text_with_single_type_arg(&base_text, type_arg)
+        let source_text = Self::instantiate_type_text_with_single_type_arg(&base_text, type_arg)?;
+        if Self::instantiated_source_type_needs_semantic_surface(&source_text)
+            && let Some(type_id) = self.get_node_type_or_names(&[expr_idx]).filter(|type_id| {
+                *type_id != tsz_solver::types::TypeId::ANY
+                    && *type_id != tsz_solver::types::TypeId::ERROR
+            })
+        {
+            let printed = self.print_type_id_for_inferred_declaration(type_id);
+            if !printed.is_empty() && printed != "any" {
+                return Some(printed);
+            }
+        }
+        Some(source_text)
+    }
+
+    pub(in crate::declaration_emitter) fn instantiated_source_type_needs_semantic_surface(
+        type_text: &str,
+    ) -> bool {
+        type_text.contains("import(\".") || type_text.contains("import('./")
     }
 
     fn instantiate_type_text_with_single_type_arg(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
@@ -805,6 +805,30 @@ let y10 = unboxify(x10);
 }
 
 #[test]
+fn instantiation_expression_source_surface_detects_unresolved_declaration_text() {
+    assert!(
+        !DeclarationEmitter::instantiated_source_type_needs_semantic_surface(
+            r#"() => { value: T extends Other ? "O" : "N"; }"#
+        )
+    );
+    assert!(
+        DeclarationEmitter::instantiated_source_type_needs_semantic_surface(
+            r#"() => { value: typeof import("./other").key; }"#
+        )
+    );
+    assert!(
+        DeclarationEmitter::instantiated_source_type_needs_semantic_surface(
+            r#"() => { value: typeof import('./other').key; }"#
+        )
+    );
+    assert!(
+        !DeclarationEmitter::instantiated_source_type_needs_semantic_surface(
+            r#"() => { value: string; }"#
+        )
+    );
+}
+
+#[test]
 fn declared_call_return_refines_callback_parameter_inference_from_later_arguments() {
     let source = r#"
 declare function merge<A>(left: (value: A) => void, right: (value: A) => void): (value: A) => void;


### PR DESCRIPTION
AgentName: Studio-C

## Track
Emit parity / DTS

## Invariant
- Preserve declaration emit parity with tsc without fixture-specific output rewriting.
- When an instantiation expression's shallow source substitution still exposes a relative `import()` declaration surface, declaration emit should print the already inferred semantic `TypeId` surface instead of leaking package-local declaration text.
- Keep this in declaration emit/type-surface selection; do not add checker diagnostics or semantic validation in the emitter.

## Scope
- Routes declaration emit for unresolved instantiation-expression source surfaces through `print_type_id_for_inferred_declaration` when a usable `TypeId` exists.
- Narrows the fallback trigger to relative `import()` surfaces so ordinary conditional text does not discard source-preserved generic binders.
- Adds a focused helper-level test for the structural source-surface trigger.
- Fixes the DTS baseline `declarationEmitUsingTypeAlias2`.

## Project Corpus Impact
- Row: emit dts / `declarationEmitUsingTypeAlias2`
- Bug family: DTS declaration emit, instantiated imported generic declaration surfaces and public package import naming
- Evidence: `scripts/emit/run.sh --filter=declarationEmitUsingTypeAlias2 --dts-only --verbose --timeout=20000 --json-out=/tmp/studio-c-declarationEmitUsingTypeAlias2-rebased-latest-main.json`

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter instantiation_expression_source_surface_detects_unresolved_declaration_text`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=declarationEmitUsingTypeAlias2 --dts-only --verbose --timeout=20000 --json-out=/tmp/studio-c-declarationEmitUsingTypeAlias2-rebased-latest-main.json`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=strictFunctionTypes1 --dts-only --verbose --timeout=20000 --skip-build --json-out=/tmp/studio-c-strictFunctionTypes1-after-typealias-latest-main.json`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=genericRestParameters1 --dts-only --verbose --timeout=20000 --skip-build --json-out=/tmp/studio-c-genericRestParameters1-after-typealias-latest-main.json`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=emitClassExpressionInDeclarationFile --dts-only --verbose --timeout=20000 --skip-build --json-out=/tmp/studio-c-emitClassExpressionInDeclarationFile-after-typealias-latest-main.json`
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `python3 scripts/emit/audit-output-surgery.py`
- `wc -l crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_instantiation.rs crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs`

## Coordination Notes
- Rebases #12384 directly onto `main` after #12383 landed and #12385 advanced `main`; branch head is `6a28403e93`.
- Adjacent guard `typeParametersAvailableInNestedScope3` was rerun with `/tmp/studio-c-typeParametersAvailableInNestedScope3-after-typealias-latest-main.json` and remains a current-main DTS family failure unrelated to this instantiation-expression-only diff.
- Output-surgery audit is clear with 5/6 allowlisted calls used and one slot available.
- No roadmap update: this is a routine focused DTS parity slice, not a durable roadmap-direction change.
