### PR TITLE
refactor(emit): render using TC39 class assignments structurally

### DIFF
--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -14,6 +14,11 @@ use tsz_solver::computation::TypeResolver;
 
 use crate::query_boundaries::state::type_environment::for_each_direct_referenced_type;
 
+pub(crate) use super::lazy_fuel::{
+    global_resolution_fuel_exhausted, global_resolution_fuel_value,
+    increment_global_resolution_fuel, reset_global_resolution_fuel, restore_global_resolution_fuel,
+};
+
 // Thread-local counters survive cross-arena child `CheckerContext`s, where
 // per-context counters would reset and defeat these recursion/fuel guards.
 thread_local! {
@@ -26,41 +31,6 @@ thread_local! {
     static REFS_RESOLUTION_ACTIVE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
     // Depth counter for recursive `evaluate_type_with_env_impl` calls.
     static EVAL_ENV_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
-    // Accumulating fuel that does not reset between top-level relation-input calls.
-    static GLOBAL_RESOLUTION_FUEL: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
-}
-
-// Maximum global resolution fuel across all top-level calls per thread. This
-// still allows large expression-heavy files while capping DOM/module explosions.
-const MAX_GLOBAL_RESOLUTION_FUEL: u32 = 50_000;
-
-/// Check if global resolution fuel is exhausted.
-pub(crate) fn global_resolution_fuel_exhausted() -> bool {
-    GLOBAL_RESOLUTION_FUEL.get() >= MAX_GLOBAL_RESOLUTION_FUEL
-}
-
-/// Increment the global resolution fuel counter.
-pub(crate) fn increment_global_resolution_fuel() {
-    GLOBAL_RESOLUTION_FUEL.set(GLOBAL_RESOLUTION_FUEL.get() + 1);
-}
-
-/// Reset global resolution fuel (call at the start of each file's type-checking).
-pub(crate) fn reset_global_resolution_fuel() {
-    GLOBAL_RESOLUTION_FUEL.set(0);
-}
-
-/// Read the current global resolution fuel counter (for snapshot/restore).
-pub(crate) fn global_resolution_fuel_value() -> u32 {
-    GLOBAL_RESOLUTION_FUEL.get()
-}
-
-/// Restore the global resolution fuel counter to a previously captured value.
-///
-/// Used by speculative sites (return-type inference) that should not bill
-/// their work against the global fuel budget when the speculation is rolled
-/// back — the work will be redone in the non-speculative pass.
-pub(crate) fn restore_global_resolution_fuel(value: u32) {
-    GLOBAL_RESOLUTION_FUEL.set(value);
 }
 
 /// Reset ALL thread-local state in the lazy resolution module.
@@ -71,7 +41,7 @@ pub(crate) fn reset_all_thread_local_state() {
     REFS_RESOLUTION_FUEL.set(0);
     REFS_RESOLUTION_ACTIVE.set(false);
     EVAL_ENV_DEPTH.set(0);
-    GLOBAL_RESOLUTION_FUEL.set(0);
+    reset_global_resolution_fuel();
 }
 
 // Maximum depth for nested `ensure_application_symbols_resolved` calls.

--- a/crates/tsz-checker/src/state/type_environment/lazy_fuel.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy_fuel.rs
@@ -1,0 +1,46 @@
+//! Global fuel bookkeeping for lazy type resolution.
+
+thread_local! {
+    // Global accumulating fuel counter that does NOT reset between top-level
+    // ensure_relation_input_ready calls. Prevents OOM when many top-level calls
+    // each reset per-call fuel but together create unbounded type data
+    // (e.g., DOM types + module augmentation in reactTransitiveImportHasValidDeclaration).
+    static GLOBAL_RESOLUTION_FUEL: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
+// Maximum global resolution fuel across all top-level calls per thread.
+// This must be high enough to process large files with many expressions
+// (e.g., unionSubtypeReductionErrors.ts has 6000+ lines requiring ~15K+
+// resolution ops). DOM-heavy React code with module augmentations can
+// explode to hundreds of thousands; this limit prevents that while
+// allowing legitimate large files.
+const MAX_GLOBAL_RESOLUTION_FUEL: u32 = 50_000;
+
+/// Check if global resolution fuel is exhausted.
+pub(crate) fn global_resolution_fuel_exhausted() -> bool {
+    GLOBAL_RESOLUTION_FUEL.get() >= MAX_GLOBAL_RESOLUTION_FUEL
+}
+
+/// Increment the global resolution fuel counter.
+pub(crate) fn increment_global_resolution_fuel() {
+    GLOBAL_RESOLUTION_FUEL.set(GLOBAL_RESOLUTION_FUEL.get() + 1);
+}
+
+/// Reset global resolution fuel (call at the start of each file's type-checking).
+pub(crate) fn reset_global_resolution_fuel() {
+    GLOBAL_RESOLUTION_FUEL.set(0);
+}
+
+/// Read the current global resolution fuel counter (for snapshot/restore).
+pub(crate) fn global_resolution_fuel_value() -> u32 {
+    GLOBAL_RESOLUTION_FUEL.get()
+}
+
+/// Restore the global resolution fuel counter to a previously captured value.
+///
+/// Used by speculative sites (return-type inference) that should not bill
+/// their work against the global fuel budget when the speculation is rolled
+/// back - the work will be redone in the non-speculative pass.
+pub(crate) fn restore_global_resolution_fuel(value: u32) {
+    GLOBAL_RESOLUTION_FUEL.set(value);
+}

--- a/crates/tsz-checker/src/state/type_environment/mod.rs
+++ b/crates/tsz-checker/src/state/type_environment/mod.rs
@@ -5,4 +5,5 @@ mod application;
 mod core;
 mod formatting;
 pub(crate) mod lazy;
+mod lazy_fuel;
 mod type_node_resolution;

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
@@ -13,6 +13,21 @@ use tsz_parser::parser::node::Node;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Tc39Es5ClassBindingMode {
+    Declare,
+    Assign,
+}
+
+impl Tc39Es5ClassBindingMode {
+    const fn declaration_prefix(self) -> &'static str {
+        match self {
+            Self::Declare => "var ",
+            Self::Assign => "",
+        }
+    }
+}
+
 impl<'a> Printer<'a> {
     /// Emit a class declaration.
     pub(in crate::emitter) fn emit_class_declaration(&mut self, node: &Node, idx: NodeIndex) {
@@ -481,6 +496,39 @@ impl<'a> Printer<'a> {
         binding_name: &str,
         display_name: &str,
     ) -> Option<String> {
+        self.render_simple_tc39_decorated_class_es5_with_binding_mode(
+            node,
+            idx,
+            binding_name,
+            display_name,
+            Tc39Es5ClassBindingMode::Declare,
+        )
+    }
+
+    pub(in crate::emitter) fn render_simple_tc39_decorated_class_es5_assignment(
+        &mut self,
+        node: &Node,
+        idx: NodeIndex,
+        binding_name: &str,
+        display_name: &str,
+    ) -> Option<String> {
+        self.render_simple_tc39_decorated_class_es5_with_binding_mode(
+            node,
+            idx,
+            binding_name,
+            display_name,
+            Tc39Es5ClassBindingMode::Assign,
+        )
+    }
+
+    fn render_simple_tc39_decorated_class_es5_with_binding_mode(
+        &mut self,
+        node: &Node,
+        idx: NodeIndex,
+        binding_name: &str,
+        display_name: &str,
+        binding_mode: Tc39Es5ClassBindingMode,
+    ) -> Option<String> {
         if !self.can_render_simple_tc39_decorated_class_es5(node) {
             return None;
         }
@@ -547,6 +595,9 @@ impl<'a> Printer<'a> {
         inner_output = inner_output.trim_end_matches('\n').to_string();
 
         if has_member_decorators {
+            if binding_mode == Tc39Es5ClassBindingMode::Assign {
+                return None;
+            }
             return es5_emitter.wrap_tc39_es5_class_decorated_output(
                 idx,
                 &inner_name,
@@ -566,14 +617,15 @@ impl<'a> Printer<'a> {
 
         let inner_prefix = format!("var {inner_name} = ");
         let indented_inner_prefix = format!("{body_indent}{inner_prefix}");
+        let binding_prefix = format!("var {binding_name} = ");
         if inner_output.starts_with(&inner_prefix) {
             inner_output = format!(
-                "{body_indent}var {binding_name} = _classThis = {}",
+                "{body_indent}{binding_prefix}_classThis = {}",
                 &inner_output[inner_prefix.len()..]
             );
         } else if inner_output.starts_with(&indented_inner_prefix) {
             inner_output = format!(
-                "{body_indent}var {binding_name} = _classThis = {}",
+                "{body_indent}{binding_prefix}_classThis = {}",
                 &inner_output[indented_inner_prefix.len()..]
             );
         } else if !inner_output.starts_with(&body_indent) {
@@ -598,7 +650,8 @@ impl<'a> Printer<'a> {
         };
 
         Some(format!(
-            "{base_indent}var {binding_name} = function () {{\n{body_indent}var _classDecorators = [{}];\n{body_indent}var _classDescriptor;\n{body_indent}var _classExtraInitializers = [];\n{body_indent}var _classThis;\n{inner_output}\n{body_indent}__setFunctionName(_classThis, \"{display_name}\");\n{body_indent}(function () {{\n{decorator_indent}var _metadata = typeof Symbol === \"function\" && Symbol.metadata ? Object.create(null) : void 0;\n{decorator_indent}__esDecorate(null, _classDescriptor = {{ value: _classThis }}, _classDecorators, {{ kind: \"class\", name: _classThis.name, metadata: _metadata }}, null, _classExtraInitializers);\n{decorator_indent}{binding_name} = _classThis = _classDescriptor.value;\n{decorator_indent}if (_metadata) Object.defineProperty(_classThis, Symbol.metadata, {{ enumerable: true, configurable: true, writable: true, value: _metadata }});\n{decorator_tail}{body_indent}}})();\n{after_decorator_initializers}{body_indent}return {binding_name} = _classThis;\n{base_indent}}}();",
+            "{base_indent}{}{binding_name} = function () {{\n{body_indent}var _classDecorators = [{}];\n{body_indent}var _classDescriptor;\n{body_indent}var _classExtraInitializers = [];\n{body_indent}var _classThis;\n{inner_output}\n{body_indent}__setFunctionName(_classThis, \"{display_name}\");\n{body_indent}(function () {{\n{decorator_indent}var _metadata = typeof Symbol === \"function\" && Symbol.metadata ? Object.create(null) : void 0;\n{decorator_indent}__esDecorate(null, _classDescriptor = {{ value: _classThis }}, _classDecorators, {{ kind: \"class\", name: _classThis.name, metadata: _metadata }}, null, _classExtraInitializers);\n{decorator_indent}{binding_name} = _classThis = _classDescriptor.value;\n{decorator_indent}if (_metadata) Object.defineProperty(_classThis, Symbol.metadata, {{ enumerable: true, configurable: true, writable: true, value: _metadata }});\n{decorator_tail}{body_indent}}})();\n{after_decorator_initializers}{body_indent}return {binding_name} = _classThis;\n{base_indent}}}();",
+            binding_mode.declaration_prefix(),
             decorator_exprs.join(", "),
         ))
     }

--- a/crates/tsz-emitter/src/emitter/source_file/top_level_using.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/top_level_using.rs
@@ -2335,14 +2335,14 @@ impl<'a> Printer<'a> {
                     export_name,
                     is_es_module_output,
                 ));
-            } else if let Some(mut rewritten) =
-                self.render_simple_tc39_decorated_class_es5(node, idx, &binding_name, &display_name)
+            } else if let Some(mut rewritten) = self
+                .render_simple_tc39_decorated_class_es5_assignment(
+                    node,
+                    idx,
+                    &binding_name,
+                    &display_name,
+                )
             {
-                rewritten = rewritten.replacen(
-                    &format!("var {binding_name} = "),
-                    &format!("{binding_name} = "),
-                    1,
-                );
                 if self.in_system_execute_body {
                     let leading_indent = "    ".repeat(self.writer.indent_level() as usize);
                     if let Some(stripped) = rewritten.strip_prefix(&leading_indent) {

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -43,11 +43,18 @@ TypeScript/tests/cases/conformance/externalModules/circularReference.ts
 #     fixture now matches tsc 6.0.3 ([TS2741, TS2875]).
 # inferentialTypingWithFunctionTypeZip.ts: RESOLVED in PR #12342 aggregate run; removed.
 # intersectionsOfLargeUnions2.ts: RESOLVED in PR #12368 aggregate run; removed.
-# jsxIntrinsicUnions.tsx was RESOLVED in PR #12289 exact head 22f57bd4,
-# then REGRESSED again on PR #12380 exact head 4c00c5259f. Tracked in #8432.
-# jsxJsxsCjsTransformNestedSelfClosingChild.tsx: RESOLVED in PR #12367
-# aggregate run on exact head 2dd802cf / run 26908103845, then reappeared on
-# PR #11890 ready-review heads below; tracked in #8432 while accepted here.
+# jsxIntrinsicUnions.tsx was RESOLVED in PR #12289 exact head 22f57bd4, then
+# REGRESSED again on PR #12380 exact head 4c00c5259f. It reappeared on PR
+# #12385 exact head db11a150d0 / merge head 7b90bd11 (CI run 26915616256):
+# all six conformance shards passed, aggregate strictness was 12569/12585
+# observed vs 12585/12585 expected with this one newly unlisted JSX-family
+# drift fixture. Re-accepted below and tracked by #8432.
+# jsxJsxsCjsTransformNestedSelfClosingChild.tsx was temporarily absent in PR
+# #12385 exact head db11a150d0 / merge head 7b90bd11 (CI run 26915616256),
+# then reappeared on exact head 561b03c609 / merge head 080e533f (CI run
+# 26916530564). This followed a RESOLVED PR #12367 aggregate run on exact head
+# 2dd802cf / run 26908103845; keep accepted under #8432 while this JSX drift
+# oscillates.
 # jsxImportForSideEffectsNonExtantNoError.tsx: accepted after REGRESSED in
 # the same PR #12367 aggregate run. Tracked in #12376.
 # inferentialTypingWithFunctionTypeZip.ts then reappeared on PR #11890 exact


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Track 9/10 emit architecture debt: output-surgery burn-down for top-level resource-management regions, plus a checker file-size lint unblock required after rebasing onto current `main`, plus exact-head conformance accepted-regression ledger drift discovered by CI.

## Invariant
When a top-level `using` region emits an ES5 TC39-decorated class that has already been hoisted into the resource region binding, `tsc` emits assignment form directly. This PR makes tsz produce that assignment form through the TC39 ES5 decorated-class renderer instead of rendering `var <binding> = ...` and rewriting the emitted string afterward.

For the checker lint unblock, global lazy-resolution fuel bookkeeping is split into `lazy_fuel.rs` and re-exported through the existing `lazy` module, preserving caller paths and behavior while keeping `lazy.rs` below the 2000-line gate.

## Scope
- Add an explicit outer binding mode to the simple TC39 ES5 decorated-class renderer.
- Use assignment mode from the top-level `using` resource-region class path while preserving the inner `var <binding> = _classThis` decorated-class binding required by `tsc` baselines.
- Remove one post-render `replacen` call from `top_level_using.rs`.
- Split global lazy-resolution fuel state from `lazy.rs` into `lazy_fuel.rs` after current `main` pushed `lazy.rs` over the CI line-count limit.
- Refresh accepted conformance JSX drift after CI runs 26915616256 and 26916530564: re-accept `jsxIntrinsicUnions.tsx` and keep the oscillating `jsxJsxsCjsTransformNestedSelfClosingChild.tsx` entry accepted on the current head.

## Project Corpus Impact
- Row: none directly; this is emit architecture debt burn-down and checker architecture hygiene, not a project-row compatibility claim.
- Bug family: output-surgery pressure / resource-management lowering; checker file-size architecture gate; accepted conformance JSX drift ledger.

## Verification
- `python3 scripts/emit/audit-output-surgery.py --list`
  - before: `resource-region-output-surgery=6/6:exhausted`, `allowlist_pressure_status=blocked`
  - after: `resource-region-output-surgery=5/6:available`, `remaining_allowlist_capacity=1`, `warning_status=clear`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check && scripts/check-crate-root-files.sh && scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh cargo check -p tsz-checker -p tsz-emitter`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=usingDeclarationsWithESClassDecorators --js-only --verbose --timeout=60000 --concurrency=4 --json-out=.tmp/emit-12385/local-using-detail-after-rebase.json` (108/108 JS emit cases passed)
- After rebase onto `origin/main` 0d78cbf8: `scripts/safe-run.sh scripts/emit/run.sh --filter=usingDeclarationsWithESClassDecorators --js-only --verbose --timeout=60000 --concurrency=4 --json-out=.tmp/emit-12385/local-using-detail-after-rebase2.json` (108/108 JS emit cases passed)
- After rebase onto latest `origin/main` at head `d09445a4a3`: `cargo fmt --all --check && scripts/check-crate-root-files.sh && scripts/arch/check-checker-boundaries.sh`; `python3 scripts/emit/audit-output-surgery.py --list`; `python3 scripts/arch/arch_guard.py`; `scripts/safe-run.sh cargo check -p tsz-checker -p tsz-emitter`; `scripts/safe-run.sh scripts/emit/run.sh --filter=usingDeclarationsWithESClassDecorators --js-only --verbose --timeout=60000 --concurrency=4 --json-out=.tmp/emit-12385/local-using-detail-after-rebase3.json` (108/108 JS emit cases passed); `python3 scripts/conformance/test_link_regression_issues.py`
- Replayed CI run 26915616256 conformance shard artifacts against `scripts/conformance/conformance-accepted-regressions.txt`: `failing=16 accepted=16 expected_deficit=16`
- Replayed CI run 26916530564 conformance shard artifacts against `scripts/conformance/conformance-accepted-regressions.txt`: `failing=17 accepted=17 expected_deficit=17`
- `python3 scripts/conformance/test_link_regression_issues.py`
- Earlier before rebasing onto current `main`: `scripts/safe-run.sh cargo nextest run -p tsz-emitter system_using`
- Earlier before rebasing onto current `main`: `scripts/safe-run.sh cargo nextest run -p tsz-emitter cjs_es5_tc39_named_export_in_using_no_extra_indent esnext_es5_tc39_named_export_in_using_correct_indent system_es5_tc39_named_export_in_using_no_extra_indent cjs_es5_tc39_top_level_class_unaffected`
- Local broad checker clippy/nextest attempts were blocked by machine disk exhaustion after cache-preserving cleanup; ready-review CI owns those broader checks.

## Coordination Notes
- Studio-C owns ordinary JS/DTS emit parity. This Studio-Opus slice relieves the shared output-surgery pressure gate.
- The checker split is behavior-preserving architecture hygiene required to clear the current-main lint gate after #11890.
- No semantic validation is added to the emitter. The change stays in output scheduling/rendering and keeps existing renderer callers on declaration mode by default.
- Remaining emit debt stays visible in `scripts/emit/audit-output-surgery.py --list` with five allowlisted resource-region rewrites.
- Conformance ledger refresh is limited to aggregate drift reported by exact-head CI runs 26915616256 and 26916530564; no compiler behavior is changed by that commit.



