### PR TITLE
fix(dts): preserve declaration map local surfaces

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
@@ -263,6 +263,7 @@ impl<'a> DeclarationEmitter<'a> {
                     self.value_reference_symbol_type_text(expr_idx)
                         .filter(|text| text != "any" && text != "unknown")
                 })
+                .or_else(|| self.property_access_declared_type_annotation_text(expr_idx))
                 .or_else(|| {
                     self.this_property_constructor_assignment_type_text(expr_idx, depth + 1)
                 })

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_type_annotations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_type_annotations.rs
@@ -504,6 +504,14 @@ impl<'a> DeclarationEmitter<'a> {
                     })
                 })?;
 
+            if let Some(type_text) = self.type_literal_member_declared_type_annotation_text(
+                source_arena,
+                declared_type,
+                &member_name,
+            ) {
+                return Some(type_text);
+            }
+
             let declared_type_sym_id =
                 self.declaration_type_symbol_from_type_node(source_arena, declared_type)?;
             let declared_type_sym_id = self
@@ -513,6 +521,56 @@ impl<'a> DeclarationEmitter<'a> {
                 self.resolve_portability_declaration_symbol(declared_type_sym_id, binder);
             self.type_member_declared_type_annotation_text(declared_type_sym_id, &member_name)
         })
+    }
+
+    fn type_literal_member_declared_type_annotation_text(
+        &self,
+        source_arena: &tsz_parser::parser::node::NodeArena,
+        type_idx: NodeIndex,
+        member_name: &str,
+    ) -> Option<String> {
+        let type_idx = source_arena.skip_parenthesized(type_idx);
+        let type_node = source_arena.get(type_idx)?;
+        if type_node.kind != syntax_kind_ext::TYPE_LITERAL {
+            return None;
+        }
+        let type_literal = source_arena.get_type_literal(type_node)?;
+        for &member_idx in &type_literal.members.nodes {
+            let Some(member_node) = source_arena.get(member_idx) else {
+                continue;
+            };
+            if let Some(signature) = source_arena.get_signature(member_node)
+                && self
+                    .property_name_text_from_arena(source_arena, signature.name)
+                    .as_deref()
+                    == Some(member_name)
+                && signature.type_annotation.is_some()
+            {
+                return self
+                    .type_annotation_text_from_arena_node(source_arena, signature.type_annotation);
+            }
+            if let Some(prop_decl) = source_arena.get_property_decl(member_node)
+                && self
+                    .property_name_text_from_arena(source_arena, prop_decl.name)
+                    .as_deref()
+                    == Some(member_name)
+                && prop_decl.type_annotation.is_some()
+            {
+                return self
+                    .type_annotation_text_from_arena_node(source_arena, prop_decl.type_annotation);
+            }
+            if let Some(accessor) = source_arena.get_accessor(member_node)
+                && self
+                    .property_name_text_from_arena(source_arena, accessor.name)
+                    .as_deref()
+                    == Some(member_name)
+                && accessor.type_annotation.is_some()
+            {
+                return self
+                    .type_annotation_text_from_arena_node(source_arena, accessor.type_annotation);
+            }
+        }
+        None
     }
 
     pub(in crate::declaration_emitter) fn type_member_declared_type_annotation_text(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -489,6 +489,9 @@ impl<'a> DeclarationEmitter<'a> {
                     .unwrap_or(type_text);
                 let type_text =
                     self.rewrite_initializer_import_equals_type_text(initializer, type_text);
+                let type_text = self
+                    .rewrite_current_source_named_import_type_text(&type_text)
+                    .unwrap_or(type_text);
                 self.write(&type_text);
             } else if has_initializer
                 && self.initializer_is_new_expression(initializer)
@@ -501,6 +504,9 @@ impl<'a> DeclarationEmitter<'a> {
                     .unwrap_or(type_text);
                 let type_text =
                     self.rewrite_initializer_import_equals_type_text(initializer, type_text);
+                let type_text = self
+                    .rewrite_current_source_named_import_type_text(&type_text)
+                    .unwrap_or(type_text);
                 self.write(&type_text);
             } else if has_initializer
                 && let Some(type_text) = self.json_import_reference_type_text(initializer)

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations_parts/part_06.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations_parts/part_06.rs
@@ -21,13 +21,13 @@ export class Foo {
     // return type's members sit at two levels (8 spaces) and the closing brace
     // at one level (4 spaces).
     assert!(
-        output.contains("    }): {\n        b: any;\n    };"),
+        output.contains("    }): {\n        b: number;\n    };"),
         "Expected inferred method object return type to nest one level deeper than the method: {output}"
     );
     // The bug emitted members at the base indent (4 spaces) with a column-0
     // closing brace; ensure that broken shape is gone.
     assert!(
-        !output.contains("    }): {\n    b: any;\n};"),
+        !output.contains("    }): {\n    b: number;\n};"),
         "Did not expect the inferred method object return type to ignore the member indent level: {output}"
     );
 }
@@ -50,7 +50,7 @@ export namespace Outer {
 
     // namespace (1) -> class (2) -> method members (3 -> 12 spaces), closing (2 -> 8 spaces).
     assert!(
-        output.contains("        }): {\n            size: any;\n        };"),
+        output.contains("        }): {\n            size: number;\n        };"),
         "Expected namespaced method object return type to track the namespace+class indent depth: {output}"
     );
 }
@@ -72,7 +72,7 @@ export class Box {
     // the nested object's own members sit at level 3 (12 spaces) with its
     // closing brace back at level 2 (8 spaces).
     assert!(
-        output.contains("        meta: {\n            tag: any;\n        };"),
+        output.contains("        meta: {\n            tag: number;\n        };"),
         "Expected nested inferred object members to indent recursively relative to the method: {output}"
     );
 }
@@ -91,11 +91,11 @@ export function make(x: { a: number }) {
     );
 
     assert!(
-        output.contains("): {\n    b: any;\n};"),
+        output.contains("): {\n    b: number;\n};"),
         "Expected a top-level function inferred object return type to keep base indentation: {output}"
     );
     assert!(
-        !output.contains("): {\n        b: any;\n    };"),
+        !output.contains("): {\n        b: number;\n    };"),
         "Did not expect a top-level function return type to be indented as a class member: {output}"
     );
 }


### PR DESCRIPTION
AgentName: Studio-C

## Track
DTS emit parity

## Invariant
Preserve tsc declaration emit surfaces without fixture-name hacks or output-string surgery; keep emitter changes inside declaration emit helpers and under the 2000-line file cap.

## Scope
- Fix `declarationMapsMultifile` DTS output so inline parameter type literal property access (`x.a` from `{ a: number }`) emits `number` instead of `any` in inferred object return members.
- Reuse current-source named imports when new-expression constructor return text prints as `import("./a").Foo`, matching tsc’s `declare const c: Foo` surface in the importing file.
- Update existing emitter unit coverage for the declarationMapsMultifile return-shape family from the old `any` fallback to the typed `number` result.

## Project Corpus Impact
- Row: emit declarationMapsMultifile
- Bug family: DTS declaration maps / multi-file inferred local surfaces
- Evidence: `scripts/emit/run.sh --filter=declarationMapsMultifile --dts-only --verbose --timeout=20000 --json-out=/tmp/studio-c-declarationMapsMultifile-after-trimmed.json` passed; repeated after unit update with `--skip-build` to `/tmp/studio-c-declarationMapsMultifile-after-unit-update.json`.

## Verification
- `cargo nextest run -p tsz-emitter inferred_class_method_object_return_uses_member_relative_indent inferred_namespaced_method_object_return_uses_deeper_indent inferred_method_nested_object_return_scales_recursively inferred_top_level_function_object_return_keeps_base_indent`
- `scripts/emit/run.sh --filter=declarationMapsMultifile --dts-only --verbose --timeout=20000 --json-out=/tmp/studio-c-declarationMapsMultifile-after-trimmed.json`
- `scripts/emit/run.sh --filter=declarationMapsMultifile --dts-only --verbose --timeout=20000 --skip-build --json-out=/tmp/studio-c-declarationMapsMultifile-after-unit-update.json`
- Stack guards with `--skip-build`: `declarationEmitUsingTypeAlias2`, `typeParametersAvailableInNestedScope3`, `strictFunctionTypes1`, `genericRestParameters1`, `emitClassExpressionInDeclarationFile`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/emit/audit-output-surgery.py` (passed; existing allowlist budget remains exhausted, no unallowlisted calls)
- `wc -l` on touched files: 1779, 769, 1794, 101 lines respectively

## Coordination Notes
- #12384 landed on `main` at merge commit `afe180b500a771801958378c23ea2415736e4739`; this PR is retargeted to `main` on refreshed head `7e8a61ba3abf9f523922141a2dea2e73a1ed9183`.
- #12387 and #12389 remain stacked draft PRs above this branch.
- Overlap check before coding found no active PR/issue for `declarationMapsMultifile` beyond unrelated binder work (#11837), which has since landed.
- No roadmap update: this is a narrow emit parity fix, not a durable direction change.
