### PR TITLE
fix(dts): keep imported JS heritage nameable

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -1370,6 +1370,15 @@ impl<'a> DeclarationEmitter<'a> {
             if binder.lib_symbol_ids.contains(&sym_id) {
                 return true;
             }
+            // A value import is already a public, nameable heritage surface.
+            // Even when package `export *` metadata fails to resolve the target
+            // class, tsc keeps `extends ImportedName` instead of synthesizing
+            // `Derived_base`.
+            if binder.symbols.get(sym_id).is_some_and(|symbol| {
+                symbol.has_any_flags(symbol_flags::ALIAS) && symbol.import_module.is_some()
+            }) {
+                return true;
+            }
 
             // The heritage reference may be an import alias (e.g.
             // `import { EventEmitter } from "events"`) or a re-export alias
@@ -1405,9 +1414,17 @@ impl<'a> DeclarationEmitter<'a> {
         };
         symbol.flags & symbol_flags::CLASS != 0
             || symbol.declarations.iter().copied().any(|decl_idx| {
-                self.arena.get(decl_idx).is_some_and(|decl_node| {
-                    decl_node.kind == syntax_kind_ext::CLASS_DECLARATION
-                        || decl_node.kind == syntax_kind_ext::CLASS_EXPRESSION
+                let decl_node = self
+                    .arena
+                    .get(decl_idx)
+                    .or_else(|| binder.symbol_arenas.get(&sym_id)?.get(decl_idx))
+                    .or_else(|| self.global_symbol_arenas.get(&sym_id)?.get(decl_idx));
+                decl_node.is_some_and(|decl_node| {
+                    matches!(
+                        decl_node.kind,
+                        k if k == syntax_kind_ext::CLASS_DECLARATION
+                            || k == syntax_kind_ext::CLASS_EXPRESSION
+                    )
                 })
             })
     }

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations_parts/part_03.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations_parts/part_03.rs
@@ -1441,6 +1441,33 @@ declare var Error: ErrorConstructor;
 }
 
 #[test]
+fn test_js_class_extending_imported_class_keeps_nameable_heritage() {
+    let output = emit_js_dts_with_usage_analysis(
+        r#"
+declare module "lit" {
+    export class LitElement {}
+}
+import { LitElement, LitElement as LitElement2 } from "lit";
+export class ElementB extends LitElement {}
+export class ElementC extends LitElement2 {}
+"#,
+    );
+
+    assert!(
+        output.contains("export class ElementB extends LitElement {"),
+        "Expected imported class heritage to stay nameable: {output}"
+    );
+    assert!(
+        output.contains("export class ElementC extends LitElement {"),
+        "Expected renamed imported class heritage to use the imported name: {output}"
+    );
+    assert!(
+        !output.contains("ElementB_base") && !output.contains("ElementC_base"),
+        "Did not expect synthetic base aliases for imported class heritage: {output}"
+    );
+}
+
+#[test]
 fn test_js_class_property_type_resolves_semicolon_typedef_alias() {
     let output = emit_js_dts(
         r#"
@@ -1792,4 +1819,3 @@ point./*3*/x = 30;
         "Did not expect a synthetic anonymous object member in call initializer output: {output}"
     );
 }
-


### PR DESCRIPTION
AgentName: Studio-C

## Track
DTS emit parity

## Invariant
Preserve tsc declaration emit surfaces without fixture-name hacks or output-string surgery; keep JS heritage nameability structural and emitter-local.

## Scope
- Fix `jsDeclarationEmitExportedClassWithExtends` DTS output so JS classes extending imported ES class values keep `extends LitElement` instead of synthesizing `ElementB_base` / `ElementC_base` aliases.
- Treat value import aliases as public, nameable heritage surfaces for JS declaration emit, matching tsc when package `export *` metadata does not resolve through the binder alias chain.
- Make class-constructor declaration checks consult foreign/global symbol arenas when a resolved constructor declaration lives outside the current source arena.
- Add focused JS DTS unit coverage for imported and renamed imported class heritage.

## Project Corpus Impact
- Row: emit jsDeclarationEmitExportedClassWithExtends
- Bug family: DTS JS declaration emit / imported class heritage nameability
- Evidence: `scripts/emit/run.sh --filter=jsDeclarationEmitExportedClassWithExtends --dts-only --verbose --timeout=20000 --json-out=/tmp/studio-c-jsDeclarationEmitExportedClassWithExtends-after-import-alias-nameable.json` passed; repeated with `--skip-build` to `/tmp/studio-c-jsDeclarationEmitExportedClassWithExtends-after-unit.json`.

## Verification
- `cargo nextest run -p tsz-emitter test_js_class_extending_imported_class_keeps_nameable_heritage`
- `scripts/emit/run.sh --filter=jsDeclarationEmitExportedClassWithExtends --dts-only --verbose --timeout=20000 --json-out=/tmp/studio-c-jsDeclarationEmitExportedClassWithExtends-after-import-alias-nameable.json`
- `scripts/emit/run.sh --filter=jsDeclarationEmitExportedClassWithExtends --dts-only --verbose --timeout=20000 --skip-build --json-out=/tmp/studio-c-jsDeclarationEmitExportedClassWithExtends-after-unit.json`
- Stack guards with `--skip-build`: `declarationMapsMultifile`, `declarationEmitUsingTypeAlias2`, `typeParametersAvailableInNestedScope3`, `strictFunctionTypes1`, `genericRestParameters1`, `emitClassExpressionInDeclarationFile`
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `python3 scripts/emit/audit-output-surgery.py` (passed; existing allowlist budget remains exhausted, no unallowlisted calls)
- `wc -l` on touched files: `variable_decl.rs` 1807 lines, `part_03.rs` 1821 lines

## Coordination Notes
- Studio-C. #12386 landed on `main` at `1ec7849a2b8357a3db4a3ef48833400ba437dfda`; this PR is now the root DTS stack PR on base `main`.
- Restacked and force-pushed head `a0f51e5ed04d3eadea5374b72861037918229f2d`; `git diff --check origin/main..HEAD` passed on the refreshed stack.
- #12389 remains stacked above this PR on branch `codex/studio-c-dts-react-transitive-20260603`.
- Overlap check before coding found no open PRs or issues for `jsDeclarationEmitExportedClassWithExtends` / exported class extends DTS terms.
- No roadmap update: this is a narrow emit parity fix, not a durable direction change.
