### PR TITLE
fix(dts): expand package indexed access surfaces

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_imported_indexed_access.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_imported_indexed_access.rs
@@ -39,12 +39,6 @@ impl<'a> DeclarationEmitter<'a> {
         let after_import = type_text.strip_prefix("import(\"")?;
         let module_end = after_import.find("\")")?;
         let module_specifier = &after_import[..module_end];
-        if !module_specifier.starts_with('.')
-            && !module_specifier.starts_with('/')
-            && Self::bare_package_specifier(module_specifier) == module_specifier
-        {
-            return None;
-        }
         let after_module = &after_import[module_end + "\")".len()..];
         let after_dot = after_module.strip_prefix('.')?;
         let export_len = after_dot
@@ -135,5 +129,72 @@ impl<'a> DeclarationEmitter<'a> {
             .collect();
         matches.sort_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)));
         matches
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::type_cache_view::TypeCacheView;
+    use std::sync::Arc;
+    use tsz_binder::{BinderState, SymbolTable};
+    use tsz_parser::ParserState;
+    use tsz_solver::construction::TypeInterner;
+
+    #[test]
+    fn package_root_imported_indexed_access_expands_member_annotation() {
+        let mut package_parser = ParserState::new(
+            "/project/node_modules/create-emotion-styled/index.d.ts".to_string(),
+            r#"
+export interface StyledOtherComponentList {
+    "div": import("react").DetailedHTMLProps<import("react").HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
+}
+"#
+            .to_string(),
+        );
+        let package_root = package_parser.parse_source_file();
+        let mut binder = BinderState::new();
+        binder.bind_source_file(&package_parser.arena, package_root);
+        let list_sym = binder
+            .symbols
+            .iter()
+            .find(|symbol| symbol.escaped_name == "StyledOtherComponentList")
+            .map(|symbol| symbol.id)
+            .expect("missing list symbol");
+        let package_arena = Arc::new(package_parser.arena.clone());
+        let mut symbol_arenas = rustc_hash::FxHashMap::default();
+        symbol_arenas.insert(list_sym, Arc::clone(&package_arena));
+        binder.symbol_arenas = Arc::new(symbol_arenas);
+        let mut exports = SymbolTable::new();
+        exports.set("StyledOtherComponentList".to_string(), list_sym);
+        let package_path = "/project/node_modules/create-emotion-styled/index.d.ts".to_string();
+        let mut module_exports = rustc_hash::FxHashMap::default();
+        module_exports.insert(package_path.clone(), exports);
+        binder.module_exports = Arc::new(module_exports);
+
+        let mut current_parser = ParserState::new("/project/index.ts".to_string(), String::new());
+        let _ = current_parser.parse_source_file();
+        let interner = TypeInterner::new();
+        let mut emitter = DeclarationEmitter::with_type_info(
+            &current_parser.arena,
+            TypeCacheView::default(),
+            &interner,
+            &binder,
+        );
+        emitter.current_file_path = Some("/project/index.ts".to_string());
+        let mut arena_to_path = rustc_hash::FxHashMap::default();
+        arena_to_path.insert(Arc::as_ptr(&package_arena) as usize, package_path);
+        emitter.set_arena_to_path(arena_to_path);
+
+        let expanded = emitter
+            .expand_imported_indexed_access_type_text(
+                r#"import("create-emotion-styled").StyledOtherComponentList["div"]"#,
+            )
+            .expect("expected package-root indexed access expansion");
+
+        assert_eq!(
+            expanded,
+            r#"import("react").DetailedHTMLProps<import("react").HTMLAttributes<HTMLDivElement>, HTMLDivElement>"#
+        );
     }
 }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_imported_indexed_access.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_imported_indexed_access.rs
@@ -139,7 +139,6 @@ mod tests {
     use std::sync::Arc;
     use tsz_binder::{BinderState, SymbolTable};
     use tsz_parser::ParserState;
-    use tsz_solver::construction::TypeInterner;
 
     #[test]
     fn package_root_imported_indexed_access_expands_member_annotation() {
@@ -174,7 +173,7 @@ export interface StyledOtherComponentList {
 
         let mut current_parser = ParserState::new("/project/index.ts".to_string(), String::new());
         let _ = current_parser.parse_source_file();
-        let interner = TypeInterner::new();
+        let interner = tsz_solver::construction::TypeInterner::new();
         let mut emitter = DeclarationEmitter::with_type_info(
             &current_parser.arena,
             TypeCacheView::default(),


### PR DESCRIPTION
AgentName: Studio-C

## Track
DTS emit parity

## Invariant
When a public declaration surface contains an imported indexed-access type rooted at a package export, DTS emit expands the nameable declared member annotation through declaration-emitter export/type-member lookup, without fixture-name hacks, output-string surgery, or semantic validation in emit.

## Scope
- Fix `reactTransitiveImportHasValidDeclaration` DTS output by expanding `import("create-emotion-styled").StyledOtherComponentList["div"]` to its declared transitive React member type.
- Remove the package-root early return in imported indexed-access expansion so the existing package-root module export lookup can resolve public package surfaces.
- Add a helper-level unit that seeds package-shaped `module_exports`, `symbol_arenas`, and `arena_to_path` data for the package-root indexed-access expansion path.

## Project Corpus Impact
- Row: emit reactTransitiveImportHasValidDeclaration
- Bug family: DTS transitive imported indexed-access expansion
- Evidence: `scripts/safe-run.sh scripts/emit/run.sh --filter=reactTransitiveImportHasValidDeclaration --dts-only --verbose --timeout=20000 --json-out=/tmp/studio-c-reactTransitiveImportHasValidDeclaration-rebased-12396.json` passed on the rebased root over current `origin/main`.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter package_root_imported_indexed_access_expands_member_annotation`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=reactTransitiveImportHasValidDeclaration --dts-only --verbose --timeout=20000 --json-out=/tmp/studio-c-reactTransitiveImportHasValidDeclaration-rebased-12396.json`
- Guard rows with `--skip-build`: `jsDeclarationEmitExportedClassWithExtends`, `declarationMapsMultifile`, `declarationEmitUsingTypeAlias2`, `typeParametersAvailableInNestedScope3`, `strictFunctionTypes1`, `genericRestParameters1`, `emitClassExpressionInDeclarationFile`
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `python3 scripts/emit/audit-output-surgery.py` (passed; existing allowlist has 5/6 calls, no unallowlisted calls)
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-emitter --all-targets -- -D warnings`
- `wc -l crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_imported_indexed_access.rs` => 199 lines

## Coordination Notes
- Studio-C.
- Rebased over current `origin/main` after #12396 landed and force-pushed head `2a6ad82ce6fc0443769308cae2dd8fd84f3668d8`.
- Diff scope is one declaration-emitter helper file; no checker imports, no JS emit changes, and no output-surgery expansion.
- Overlap check before coding found no open PRs or issues for `reactTransitiveImportHasValidDeclaration` / React transitive import declaration terms.
- No roadmap update: this is a narrow emit parity fix, not a durable direction change.
