### PR TITLE
fix(checker): elaborate contravariant function-parameter chain for TS2345 arguments

### DIFF
--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -706,18 +706,7 @@ impl<'a> CheckerState<'a> {
                 // the right `code`, `message_text`, `depth`, and `file`, so only
                 // the category and the call-site anchor (`start`/`length`) need
                 // rewriting for the TS2345 surface.
-                let container_diag =
-                    self.render_failure_reason(reason, source, target, anchor_idx, 0);
-                container_diag
-                    .related_information
-                    .into_iter()
-                    .map(|mut rel| {
-                        rel.category = DiagnosticCategory::Message;
-                        rel.start = start;
-                        rel.length = length;
-                        rel
-                    })
-                    .collect()
+                self.reanchored_container_related(reason, source, target, anchor_idx, start, length)
             }
             SubtypeFailureReason::MissingIndexSignature { index_kind } => {
                 vec![DiagnosticRelatedInformation {
@@ -763,18 +752,27 @@ impl<'a> CheckerState<'a> {
                 // line, so reuse the TS2322 elaboration (`render_failure_reason`)
                 // as the single source of truth and re-anchor its child lines
                 // onto the call's TS2345 surface (category + start/length).
-                let container_diag =
-                    self.render_failure_reason(reason, source, target, anchor_idx, 0);
-                container_diag
-                    .related_information
-                    .into_iter()
-                    .map(|mut rel| {
-                        rel.category = DiagnosticCategory::Message;
-                        rel.start = start;
-                        rel.length = length;
-                        rel
-                    })
-                    .collect()
+                self.reanchored_container_related(reason, source, target, anchor_idx, start, length)
+            }
+            SubtypeFailureReason::ParameterTypeMismatch { .. } => {
+                // A function/callback argument that fails because one of its
+                // parameters is contravariantly incompatible. tsc explains the
+                // signature line (already supplied by the TS2345 head) with a
+                // `Types of parameters 'a' and 'b' are incompatible.` frame, the
+                // contravariant leaf, and any nested chain — exactly the
+                // elaboration the direct-assignment (TS2322) path renders via
+                // `render_failure_reason` -> `push_parameter_mismatch_elaboration`.
+                // When the offending parameter is itself callable that helper
+                // intentionally emits no frame, leaving an empty list; preserve
+                // the conservative signature-line-only rendering by returning
+                // `None` (rather than an empty related list) in that case.
+                let related = self.reanchored_container_related(
+                    reason, source, target, anchor_idx, start, length,
+                );
+                if related.is_empty() {
+                    return None;
+                }
+                related
             }
             _ => return None,
         };
@@ -784,6 +782,35 @@ impl<'a> CheckerState<'a> {
         // policy. Skipping the intermediate pass keeps the depth-aware sort
         // running exactly once on the final list.
         Some(related)
+    }
+
+    /// Re-anchor the child elaboration lines of [`Self::render_failure_reason`]
+    /// (the `TS2322` single source of truth) onto the call-argument (`TS2345`)
+    /// surface. The call already supplies the signature/container headline, so
+    /// only the reason's `related_information` is carried over — with its
+    /// category reset to `Message` and its anchor rewritten to the call site
+    /// (`start`/`length`). Reason variants whose `TS2322` elaboration is reused
+    /// verbatim (array element, type-argument, union-target, function parameter)
+    /// share this transform.
+    fn reanchored_container_related(
+        &mut self,
+        reason: &tsz_solver::SubtypeFailureReason,
+        source: TypeId,
+        target: TypeId,
+        anchor_idx: NodeIndex,
+        start: u32,
+        length: u32,
+    ) -> Vec<DiagnosticRelatedInformation> {
+        self.render_failure_reason(reason, source, target, anchor_idx, 0)
+            .related_information
+            .into_iter()
+            .map(|mut rel| {
+                rel.category = DiagnosticCategory::Message;
+                rel.start = start;
+                rel.length = length;
+                rel
+            })
+            .collect()
     }
 
     /// Build the child-relation elaboration line (`Type 'C' is not assignable

--- a/crates/tsz-checker/src/tests/function_parameter_mismatch_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/function_parameter_mismatch_elaboration_tests.rs
@@ -199,6 +199,108 @@ f = g;
     );
 }
 
+/// A function passed as a *call argument* (TS2345 surface) whose parameter is
+/// contravariantly incompatible must surface the same `Types of parameters`
+/// frame and contravariant leaf that the direct-assignment (TS2322) surface
+/// already renders. Previously the call-argument path dropped the entire chain
+/// and stopped at the bare `Argument of type … is not assignable …` headline.
+#[test]
+fn call_argument_function_parameter_mismatch_elaborates_parameter_chain() {
+    let text = elaboration(
+        r#"
+declare function take(cb: (value: number) => void): void;
+take((value: string) => {});
+"#,
+        2345,
+    );
+    assert!(
+        text.contains("Types of parameters 'value' and 'value' are incompatible."),
+        "Expected the parameter-incompatibility frame under TS2345. Got: {text:?}"
+    );
+    // Parameters are contravariant: the leaf compares the target parameter
+    // (`number`) against the source parameter (`string`).
+    assert!(
+        text.contains("Type 'number' is not assignable to type 'string'."),
+        "Expected the contravariant parameter leaf under TS2345. Got: {text:?}"
+    );
+}
+
+/// The offending parameter index is reported on the call-argument surface too,
+/// and identifiers are taken from the signatures (not hard-coded), proving the
+/// rule is structural.
+#[test]
+fn call_argument_second_parameter_mismatch_names_the_correct_parameter() {
+    let text = elaboration(
+        r#"
+declare function reg(handler: (a: string, b: number) => void): void;
+reg((a: string, b: string) => {});
+"#,
+        2345,
+    );
+    assert!(
+        text.contains("Types of parameters 'b' and 'b' are incompatible."),
+        "Expected the second parameter to be named under TS2345. Got: {text:?}"
+    );
+    assert!(
+        text.contains("Type 'number' is not assignable to type 'string'."),
+        "Expected the contravariant leaf for the second parameter. Got: {text:?}"
+    );
+}
+
+/// A callback argument to an interface *method* elaborates the same chain,
+/// proving the rule does not depend on the callee being a free function.
+#[test]
+fn call_argument_interface_method_callback_parameter_mismatch_elaborates_chain() {
+    let text = elaboration(
+        r#"
+interface Emitter { listen(cb: (payload: number) => void): void; }
+declare const em: Emitter;
+em.listen((payload: string) => {});
+"#,
+        2345,
+    );
+    assert!(
+        text.contains("Types of parameters 'payload' and 'payload' are incompatible."),
+        "Expected the parameter frame for a method callback argument. Got: {text:?}"
+    );
+    assert!(
+        text.contains("Type 'number' is not assignable to type 'string'."),
+        "Expected the contravariant parameter leaf. Got: {text:?}"
+    );
+}
+
+/// The architectural invariant: for the *same* function-parameter mismatch the
+/// call-argument (TS2345) and direct-assignment (TS2322) surfaces must render
+/// the same elaboration chain (the renderer routes both through the shared
+/// `render_failure_reason` source of truth). Only the headline code differs.
+#[test]
+fn call_argument_and_assignment_render_identical_parameter_chain() {
+    let argument_chain = elaboration(
+        r#"
+declare function take(cb: (value: number) => void): void;
+take((value: string) => {});
+"#,
+        2345,
+    );
+    let assignment_chain = elaboration(
+        r#"
+let target: (value: number) => void;
+let source: (value: string) => void;
+target = source;
+"#,
+        2322,
+    );
+    // Drop each headline (first line); the related-information chain beneath it
+    // must be identical across the two surfaces.
+    let related = |text: &str| text.split('\n').skip(1).collect::<Vec<_>>().join("\n");
+    assert_eq!(
+        related(&argument_chain),
+        related(&assignment_chain),
+        "TS2345 and TS2322 must elaborate the same parameter chain. \
+         argument={argument_chain:?} assignment={assignment_chain:?}"
+    );
+}
+
 #[test]
 fn class_method_with_fewer_params_implements_interface_with_more_params() {
     // TypeScript allows a class method to implement an interface method with


### PR DESCRIPTION
AgentName: M1-A
Runner: opus-variance-elab

**Track:** Conformance / diagnostics parity (checker error reporting)
**Closes / advances:** #10796 (claimed there)

## Invariant
When a value fails assignability, `tsz` must reproduce `tsc`'s full elaboration chain. For the `TS2345` (call argument) and `TS2322` (assignment) surfaces, the **same** `SubtypeFailureReason` must render the **same** related-information chain — only the headline code differs.

## Structural rule
When an argument is a function/callback and the assignability failure is rooted in a **contravariant parameter** mismatch, `tsc` emits:

```
error TS2345: Argument of type '(value: string) => void' is not assignable to parameter of type '(value: number) => void'.
  Types of parameters 'value' and 'value' are incompatible.
    Type 'number' is not assignable to type 'string'.
```

`tsz` previously emitted only the bare headline and **dropped the entire nested chain**.

`tsc` does X (the chain above); `tsz` now does X through the checker `error_reporter` reason→diagnostic elaborator, routed to the shared `tsz_solver` failure-reason source of truth.

## Root cause & owner layer
- Owner: `crates/tsz-checker/src/error_reporter` (diagnostic rendering; semantics unchanged).
- `related_from_failure_reason` (the reason→`related_information` elaborator used by the `TS2345` / simple-message path) had **no arm** for `SubtypeFailureReason::ParameterTypeMismatch`, so it fell through to `_ => return None` and emitted nothing beneath the headline.
- The direct-assignment (`TS2322`) path already renders it correctly via `render_failure_reason` → `push_parameter_mismatch_elaboration`. Object-property and function-**return** mismatches already elaborated under `TS2345`; only the contravariant **parameter** position was missing.

## Fix
- Add a `ParameterTypeMismatch` arm that reuses `render_failure_reason` (the single source of truth) and re-anchors its child lines onto the `TS2345` surface — so `TS2345` now elaborates identically to `TS2322`.
- When the offending parameter is itself callable, the shared helper intentionally emits no frame; the arm returns `None` to preserve the conservative signature-line-only rendering for that case.
- DRY cleanup (from `/simplify`): extracted the `render_failure_reason` + re-anchor transform — already duplicated across the `ArrayElementMismatch`/`TypeArgumentMismatch` and `UnionTargetMismatch` arms — into `reanchored_container_related`.

## Adjacent-case matrix (verified vs `tsc` 6.0.2)
| Case | Before | After |
| --- | --- | --- |
| primitive callback param (`(value: string)` → `(value: number)`) | bare headline | exact `tsc` chain ✅ |
| second-parameter mismatch (names correct param) | bare headline | exact `tsc` chain ✅ |
| interface **method** callback argument | bare headline | exact `tsc` chain ✅ |
| function-**return** mismatch arg (`() => string` → `() => number`) | already correct | unchanged ✅ |
| plain object arg property mismatch | already correct | unchanged ✅ |
| `TS2322` assignment of same shape | already correct | unchanged ✅ |

Renamed binders are exercised (param names are read from the signatures, not hard-coded).

Out of scope (pre-existing, **shared with the `TS2322` path**, equal on both surfaces): when the contravariant parameter is itself an object with a *nested* property mismatch, the leaf collapses slightly differently from `tsc` (skips the intermediate object-to-object line / dotted `a.b` collapse). This fix makes `TS2345` consistent with `TS2322`; correcting that leaf shape is a separate elaboration-shape change to the shared depth-0 object renderer.

## Repro triage for #10796
The issue's literal minimal repro (`Base_15`/`Derived_15` generic `parse` override) is **clean in tsz** and matches `tsc` exactly, as does a broad battery of generic method-override / variance / mixed-inheritance cases I differential-tested. The genuine, broad divergence I isolated in that variance surface is this contravariant-parameter elaboration gap.

## Scope
- `crates/tsz-checker/src/error_reporter/fingerprint_policy.rs` (+ helper, 3 arms DRY'd)
- `crates/tsz-checker/src/tests/function_parameter_mismatch_elaboration_tests.rs` (+4 regression tests, incl. the TS2345≡TS2322 invariant)

## Project Corpus Impact
- Row: n/a (diagnostics-only; affects callback-heavy rows kysely-project / rxjs-project but changes no row counts)
- Bug family: TS2345 contravariant-callback-parameter elaboration (related-information chain)
- Semantic change: none — adds related-information lines to existing `TS2345` errors and removes none. Diagnostic **counts** are unchanged; elaboration moves toward `tsc`.

## Verification
- `cargo build -p tsz-cli --bin tsz` — clean; `cargo clippy -p tsz-checker --lib` — no new warnings on changed code; `cargo fmt --check` — clean.
- `cargo test -p tsz-checker --lib function_parameter_mismatch_elaboration` → 11 passed (7 pre-existing + 4 new).
- `cargo test -p tsz-checker --lib error_reporter::` → 172 passed (covers the two refactored sibling arms).
- `strict_callback_param_method` (7), `render_request` (33) → all pass.
- CLI differential vs `tsc` 6.0.2 on the matrix above — exact match on all handled cases.
- (3 unrelated `*callback*` tests fail locally only because the standard TS lib isn't checked out — `Promise`/`Response`/`Symbol.iterator`/module resolution — confirmed identical failures on a clean tree.)

## Coordination Notes
Claimed #10796 with a signed triage comment. Ready-review CI owns the broad conformance/emit baseline suites; will reconcile any baseline drift that surfaces. Auto-merge (SQUASH) requested.

---
_Generated by [Claude Code](https://claude.ai/code)_


