### PR TITLE
fix(emit): bound reserved recovery to declaration names

### DIFF
--- a/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
@@ -2124,6 +2124,30 @@ fn reserved_variable_name_emits_empty_decl_keyword_and_initializer_statements() 
 }
 
 #[test]
+fn reserved_variable_recovery_ignores_identifier_prefixes() {
+    for source in ["let var1 = 0;", "var typeofValue = 10;"] {
+        let (parser, root) = parse_test_source(source);
+        let mut printer = EmitterPrinter::with_options(
+            &parser.arena,
+            PrinterOptions {
+                always_strict: true,
+                target: ScriptTarget::ES2015,
+                ..Default::default()
+            },
+        );
+        printer.set_source_text(source);
+        printer.emit(root);
+        let output = printer.get_output().to_string();
+
+        assert_eq!(
+            output.trim_end(),
+            format!("\"use strict\";\n{source}"),
+            "{source}: reserved-name recovery must not match identifier prefixes.\nOutput:\n{output}"
+        );
+    }
+}
+
+#[test]
 fn reserved_import_equals_name_emits_recovered_require_and_keyword_loop() {
     for (source, expected_tail) in [
         (

--- a/crates/tsz-emitter/src/emitter/source_file/recovery.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/recovery.rs
@@ -237,7 +237,9 @@ impl<'a> Printer<'a> {
         let source = text.get(start..)?;
         let mut scanner = ScannerState::new(source.to_string(), true);
         let mut keywords = Vec::new();
-        let mut in_array_binding = false;
+        let mut array_depth = 0_u32;
+        let mut at_element_start = false;
+        let mut binding_pattern_closed = false;
         let mut initializer_start = None;
         let mut initializer_end = None;
 
@@ -249,18 +251,41 @@ impl<'a> Printer<'a> {
             let token_start = scanner.get_token_start();
             let token_end = scanner.get_token_end();
             match token {
-                SyntaxKind::OpenBracketToken => in_array_binding = true,
-                SyntaxKind::CloseBracketToken if in_array_binding => in_array_binding = false,
+                SyntaxKind::OpenBracketToken if !binding_pattern_closed => {
+                    array_depth += 1;
+                    if array_depth == 1 {
+                        at_element_start = true;
+                    } else if array_depth > 1 {
+                        at_element_start = false;
+                    }
+                }
+                SyntaxKind::CloseBracketToken if array_depth > 0 => {
+                    array_depth -= 1;
+                    if array_depth == 0 {
+                        binding_pattern_closed = true;
+                    }
+                    at_element_start = false;
+                }
+                SyntaxKind::CommaToken if array_depth == 1 => {
+                    at_element_start = true;
+                }
+                SyntaxKind::DotDotDotToken if array_depth == 1 && at_element_start => {}
                 SyntaxKind::EqualsToken => {
                     initializer_start = Some(token_end);
+                    at_element_start = false;
                 }
                 SyntaxKind::SemicolonToken => {
                     initializer_end = Some(token_start);
                     break;
                 }
-                _ if in_array_binding && tsz_scanner::token_is_reserved_word(token) => {
+                _ if array_depth == 1
+                    && at_element_start
+                    && tsz_scanner::token_is_reserved_word(token) =>
+                {
                     keywords.push(self.reserved_keyword_text(scanner.get_token_text_ref())?);
+                    at_element_start = false;
                 }
+                _ if array_depth == 1 && at_element_start => at_element_start = false,
                 _ => {}
             }
         }
@@ -332,7 +357,7 @@ impl<'a> Printer<'a> {
         let start = self.skip_trivia_forward(node.pos, node.end) as usize;
         let bytes = text.as_bytes();
         let mut end = start;
-        while end < bytes.len() && bytes[end].is_ascii_alphabetic() {
+        while end < bytes.len() && is_identifier_continue(&bytes[end]) {
             end += 1;
         }
         let keyword = crate::safe_slice::slice(text, start, end).ok()?;


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Track 9/10 emit architecture debt and JS emit parity stop-the-line for #12388.

## Invariant
When a valid declaration name is an array binding pattern or an identifier that merely starts with a reserved word, `tsc` emits the declaration normally. tsz should enter reserved-word recovery only when the declaration name token itself is a recovered reserved keyword. This PR keeps that decision in the emitter recovery owner layer.

## Scope
- Constrain recovered reserved array-binding detection to top-level binding-element start tokens in the declaration name pattern.
- Stop scanning initializer arrays/default expressions as if they were binding names.
- Consume the full identifier token before reserved-keyword matching so `var1`/`typeofValue` do not match `var`/`typeof`.
- Add adjacent unit coverage for valid reserved-prefix identifiers.
- No checker/solver semantic validation and no new output surgery.

## Project Corpus Impact
- Row: n/a; this is a broad JS emit-suite regression, not a project-row compatibility claim.
- Bug family: downlevel destructuring / array binding pattern / let-const JS emit regression from over-broad reserved-word recovery.

## Verification
- `python3 scripts/emit/audit-output-surgery.py --list` (passes: resource-region-output-surgery 5/6, no new IR surgery)
- `cargo fmt --all --check && git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-emitter`
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter reserved_array_binding_name_emits_recovered_keyword_statements reserved_variable_recovery_ignores_identifier_prefixes`
- `scripts/safe-run.sh scripts/emit/run.sh --js-only --filter=destructuringVariableDeclaration1ES6 --verbose --timeout=60000 --concurrency=4 --json-out=.tmp/emit-12391/destructuringVariableDeclaration1ES6-predicate-prefix.json` (1/1)
- `scripts/safe-run.sh scripts/emit/run.sh --js-only --filter=downlevelLetConst14 --verbose --timeout=60000 --concurrency=4 --json-out=.tmp/emit-12391/downlevelLetConst14-predicate-prefix.json` (2/2)
- `scripts/safe-run.sh scripts/emit/run.sh --js-only --filter=letDeclarations-scopes-duplicates2 --verbose --timeout=60000 --concurrency=4 --json-out=.tmp/emit-12391/letDeclarations-scopes-duplicates2-predicate-prefix.json` (1/1)
- Adjacent smoke: `destructuringVariableDeclaration` (5/5), `declarationEmitDestructuringArrayPattern` (5/5), `letDeclarations-scopes-duplicates` (7/7), `downlevelLetConst15` (2/2)
- Broader #12388 sweep: `arrayLiterals` (12/12), `declarationsAndAssignments` (1/1), `contextualTypeWithTuple` (1/1), `indexSignatures1` (1/1), `inferTupleFromBindingPattern` (1/1), `iterableArrayPattern30` (1/1), `noImplicitAnyDestructuringVarDeclaration2` (1/1), `wideningTuples` (7/7), `unusedFunctionsinNamespaces` (6/6), `jsxParsingError1` (1/1), `typeGuardsInFunction` (2/2)

## Coordination Notes
- Ready for CI after local targeted verification; full emit CI owns the broad suite.
- #12388 originally pointed at #12344 from bisect notes, but current-main reproduction showed the broad revert did not fix `destructuringVariableDeclaration1ES6`; the current failing operation is #12351 reserved recovery overmatching ordinary binding/default/initializer tokens.
- The abandoned revert path would have reopened `ir-output-surgery`; this targeted fix keeps output-surgery audit at 5/6.

Refs #12388

