### PR TITLE
fix(emit): scope reserved-word declaration recovery to name position

### DIFF
--- a/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
@@ -2206,6 +2206,75 @@ fn reserved_array_binding_name_emits_recovered_keyword_statements() {
 }
 
 #[test]
+fn array_binding_with_reserved_default_values_emits_normally() {
+    // Reserved words that appear as default values (`= true`) or inside the
+    // right-hand initializer (`= [.., null]`) are values, not binding names,
+    // so the reserved-array-binding error recovery must not fire.
+    for source in [
+        "var [a = true, b = false] = [1, 2];",
+        "var [c, d] = [undefined, null];",
+        "var [e = [null]] = [[1]];",
+        "var [f, g] = [1, 2, \"string\", true];",
+    ] {
+        let (parser, root) = parse_test_source(source);
+        let mut printer = EmitterPrinter::with_options(
+            &parser.arena,
+            PrinterOptions {
+                always_strict: true,
+                target: ScriptTarget::ES2015,
+                ..Default::default()
+            },
+        );
+        printer.set_source_text(source);
+        printer.emit(root);
+        let output = printer.get_output().to_string();
+
+        assert!(
+            !output.contains("var [];"),
+            "{source}: valid array binding must not trigger reserved-name recovery.\nOutput:\n{output}"
+        );
+        assert!(
+            output.contains('['),
+            "{source}: array binding pattern should still emit.\nOutput:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn identifier_beginning_with_keyword_emits_normally() {
+    // Ordinary identifiers that merely start with a reserved keyword
+    // (`var1`, `function1`, `typeofx`) must not be mistaken for reserved
+    // binding names by the variable-declaration error recovery.
+    for (source, expected_name) in [
+        ("var var1 = 0;", "var1"),
+        ("var function1 = 1;", "function1"),
+        ("var typeofx = 2;", "typeofx"),
+    ] {
+        let (parser, root) = parse_test_source(source);
+        let mut printer = EmitterPrinter::with_options(
+            &parser.arena,
+            PrinterOptions {
+                always_strict: true,
+                target: ScriptTarget::ES2015,
+                ..Default::default()
+            },
+        );
+        printer.set_source_text(source);
+        printer.emit(root);
+        let output = printer.get_output().to_string();
+
+        assert!(
+            !output.contains("var ;"),
+            "{source}: identifier starting with a keyword must not trigger recovery.\nOutput:\n{output}"
+        );
+        assert!(
+            output.contains(expected_name),
+            "{source}: declaration name should still emit.\nOutput:\n{output}"
+        );
+    }
+}
+
+#[test]
 fn reserved_function_name_emits_anonymous_function_and_keyword_arrow_tail() {
     for (source, expected_tail) in [
         ("function throw() {}", "function () { }\nthrow () => { };"),

--- a/crates/tsz-emitter/src/emitter/source_file/recovery.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/recovery.rs
@@ -183,7 +183,8 @@ impl<'a> Printer<'a> {
         if name_node.kind != syntax_kind_ext::ARRAY_BINDING_PATTERN {
             return false;
         }
-        let Some((keywords, initializer_text)) = self.recovered_reserved_array_binding_parts(node)
+        let Some((keywords, initializer_text)) =
+            self.recovered_reserved_array_binding_parts(node, name_node)
         else {
             return false;
         };
@@ -228,16 +229,38 @@ impl<'a> Printer<'a> {
         self.decrease_indent();
     }
 
+    /// Collect the reserved-word keywords that appear as *binding-element
+    /// names* inside an array binding pattern, plus the trailing initializer
+    /// text.
+    ///
+    /// Only reserved words at the top level of the pattern and in name
+    /// position are binding names. Reserved words sitting in a default-value
+    /// initializer (`[a = true]`) or in the right-hand initializer expression
+    /// (`= [1, null]`) are values, not names, and must be ignored. The scan
+    /// therefore tracks bracket/brace/paren depth, only collects reserved words
+    /// at the pattern's top level (depth 1) outside a default value, and stops
+    /// the name-collection phase at the matching `]`. The initializer text is
+    /// read from source (the AST is unreliable here because the malformed
+    /// pattern derails the parser).
+    ///
+    /// The scan window runs from the pattern's `[` to the end of the enclosing
+    /// variable statement. The statement span is reliable even when the
+    /// malformed pattern truncates `name_node.end`, and bounding it avoids
+    /// copying the rest of the file into the scanner for every array-binding
+    /// declaration.
     fn recovered_reserved_array_binding_parts(
         &self,
-        node: &Node,
+        statement: &Node,
+        name_node: &Node,
     ) -> Option<(Vec<&'static str>, String)> {
         let text = self.source_text?;
-        let start = self.skip_trivia_forward(node.pos, node.end) as usize;
-        let source = text.get(start..)?;
+        let start = self.skip_trivia_forward(name_node.pos, name_node.end) as usize;
+        let source = text.get(start..statement.end as usize)?;
         let mut scanner = ScannerState::new(source.to_string(), true);
         let mut keywords = Vec::new();
-        let mut in_array_binding = false;
+        let mut depth: i32 = 0;
+        let mut pattern_closed = false;
+        let mut in_default_value = false;
         let mut initializer_start = None;
         let mut initializer_end = None;
 
@@ -246,27 +269,45 @@ impl<'a> Printer<'a> {
             if token == SyntaxKind::EndOfFileToken {
                 break;
             }
-            let token_start = scanner.get_token_start();
-            let token_end = scanner.get_token_end();
-            match token {
-                SyntaxKind::OpenBracketToken => in_array_binding = true,
-                SyntaxKind::CloseBracketToken if in_array_binding => in_array_binding = false,
-                SyntaxKind::EqualsToken => {
-                    initializer_start = Some(token_end);
+            if !pattern_closed {
+                match token {
+                    SyntaxKind::OpenBracketToken
+                    | SyntaxKind::OpenBraceToken
+                    | SyntaxKind::OpenParenToken => depth += 1,
+                    SyntaxKind::CloseBracketToken
+                    | SyntaxKind::CloseBraceToken
+                    | SyntaxKind::CloseParenToken => {
+                        depth -= 1;
+                        if depth <= 0 {
+                            pattern_closed = true;
+                        }
+                    }
+                    SyntaxKind::EqualsToken if depth == 1 => in_default_value = true,
+                    SyntaxKind::CommaToken if depth == 1 => in_default_value = false,
+                    _ if depth == 1
+                        && !in_default_value
+                        && tsz_scanner::token_is_reserved_word(token) =>
+                    {
+                        keywords.extend(tsz_scanner::keyword_to_text_static(token));
+                    }
+                    _ => {}
                 }
-                SyntaxKind::SemicolonToken => {
-                    initializer_end = Some(token_start);
-                    break;
+            } else {
+                match token {
+                    SyntaxKind::EqualsToken if initializer_start.is_none() => {
+                        initializer_start = Some(scanner.get_token_end());
+                    }
+                    SyntaxKind::SemicolonToken => {
+                        initializer_end = Some(scanner.get_token_start());
+                        break;
+                    }
+                    _ => {}
                 }
-                _ if in_array_binding && tsz_scanner::token_is_reserved_word(token) => {
-                    keywords.push(self.reserved_keyword_text(scanner.get_token_text_ref())?);
-                }
-                _ => {}
             }
         }
 
         let initializer_start = initializer_start?;
-        let initializer_end = initializer_end.unwrap_or_else(|| scanner.get_pos());
+        let initializer_end = initializer_end.unwrap_or(scanner.get_pos());
         let initializer_text = source
             .get(initializer_start..initializer_end)?
             .trim()
@@ -327,19 +368,27 @@ impl<'a> Printer<'a> {
         Some(tail.to_string())
     }
 
+    /// Return the reserved keyword text when the declaration's name token is
+    /// *exactly* a reserved word (e.g. `var typeof = 10`).
+    ///
+    /// The whole leading identifier token is read — including the
+    /// digit/`_`/`$` characters that continue it — so ordinary identifiers
+    /// that merely begin with a keyword (`var1`, `function1`) read as a single
+    /// non-reserved identifier rather than matching the keyword prefix.
+    /// Reading from the source (rather than the name node's span) also works
+    /// when the parser synthesizes an empty name node for a keyword used in
+    /// name position.
     fn reserved_keyword_text_at_declaration_start(&self, node: &Node) -> Option<&'static str> {
         let text = self.source_text?;
         let start = self.skip_trivia_forward(node.pos, node.end) as usize;
         let bytes = text.as_bytes();
         let mut end = start;
-        while end < bytes.len() && bytes[end].is_ascii_alphabetic() {
+        while end < bytes.len()
+            && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'_' || bytes[end] == b'$')
+        {
             end += 1;
         }
         let keyword = crate::safe_slice::slice(text, start, end).ok()?;
-        self.reserved_keyword_text(keyword)
-    }
-
-    fn reserved_keyword_text(&self, keyword: &str) -> Option<&'static str> {
         let token = tsz_scanner::string_to_token(keyword);
         tsz_scanner::token_is_reserved_word(token)
             .then(|| tsz_scanner::keyword_to_text_static(token))?


### PR DESCRIPTION
AgentName: Studio-Opus
Track: Emit parity / regression recovery
Closes: #12388

## Scope
Emitter-only. Two over-broad reserved-word error-recovery triggers in
`crates/tsz-emitter/src/emitter/source_file/recovery.rs`, plus focused unit
tests. No solver/checker/parser changes; no behavior change for valid code
other than removing the spurious recovery.

## Invariant
`tsc`'s reserved-word declaration error-recovery output is reproduced **only**
for source that actually uses a reserved word as a binding/declaration name.
Valid declarations — including array destructuring whose defaults or
initializers happen to contain `true`/`false`/`null`, and identifiers that
merely begin with a keyword (`var1`, `function1`) — must emit normally.

## Structural rule
When a reserved word appears as a **binding-element name** in name position
(`var [debugger, if] = …`) or as an **exact** declaration name
(`var typeof = 10`), `tsc` emits its degenerate recovery form; tsz reproduces
it through the `source_file/recovery` reserved-name paths. Reserved words in
**value position** (a default `[a = true]`, the initializer expression
`= [1, null]`) and keyword **prefixes** of longer identifiers are not names and
must not trigger recovery.

## Root cause (regression from #12351)
`#12351` added two reserved-name recovery paths whose triggers were too broad,
producing the broad JS-emit regression in #12388 (40 new failures across
downlevel destructuring / array-binding / let-const / tuple / namespace emit —
the emit suite is not a merge gate, so it landed unnoticed). The prime suspect
named in the issue (#12344) was a red herring; bisecting the regressed
families points at #12351.

1. `recovered_reserved_array_binding_parts` scanned for reserved-word tokens
   anywhere between the brackets, and re-entered "array-binding" state on the
   initializer array literal. So `var [a, b] = [undefined, null]` collected
   `null`, and `var [b2 = 3, b3 = true] = …` collected `true`, emitting garbage
   like `var []; true; [...]`.
2. `reserved_keyword_text_at_declaration_start` matched a keyword as a *prefix*
   of a longer identifier (`var1` → `var`, `function1` → `function`), wrecking
   `let var1 = 0` and `var function1 = function () {}`.

## Fix (owner layer: emitter `source_file/recovery`)
- The array-binding scan tracks bracket/brace/paren **depth** and a
  **default-value** flag, collecting reserved words only in name position at
  the pattern's top level and stopping at the matching `]`; the initializer
  text is read from source after the pattern closes. The scan window is bounded
  to the enclosing statement rather than copied to EOF.
- The declaration-name check reads the **whole** leading identifier token
  (identifier-continue characters), so only an exact keyword name triggers
  recovery. No allocation; matches the original byte-scan shape.
- Genuine recovery (`reservedWords2`: `debugger`/`if`/`typeof`/`while`/`void`/…)
  is preserved.

## Adjacent-case matrix
- Array binding with reserved **default values** (`[a = true, b = false]`),
  reserved word in **initializer** (`= [undefined, null]`, `= [1,2,"string",true]`),
  nested default (`[e = [null]]`) → emit normally (new unit test).
- Identifiers **beginning with** a keyword (`var1`, `function1`, `typeofx`) →
  emit normally (new unit test).
- Genuine reserved **names** (`var [debugger, if] = [1,2]`, `var typeof = 10`)
  → recovery preserved (existing tests still green).

## Project Corpus Impact
- Row: n/a
- Bug family: downlevel-destructuring/array-binding-pattern/let-const/tuple/namespace-js-emit
- Evidence: emit-suite regression #12388 (40 new failures); not a project-corpus
  row. No required project row depends on this recovery path.

## Verification
- All 40 regressed families from #12388 now pass via
  `scripts/emit/run.sh --js-only --skip-build --filter=<family>`
  (`destructuringVariableDeclaration*`, `arrayLiterals*`, `wideningTuples*`,
  `letDeclarations-scopes-duplicates`, `unusedFunctionsinNamespaces`,
  `downlevelLetConst*`, `reservedWords2`, `iterableArrayPattern`,
  `declarationEmitDestructuringArrayPattern`, `indexSignatures`,
  `inferTupleFromBindingPattern`, `jsxParsingError`, `typeGuardsInFunction`,
  `esDecorators-classExpression-namedEvaluation`, …).
- `cargo test -p tsz-emitter --lib`: 3588 pass; the only failure
  (`test_inline_abstract_any_mixin_inherits_index_signature_at_call_site`) is
  pre-existing and unrelated (verified failing on a clean tree).
- Broad emit sample (`var`, `binding`, `namespace`, `enum`, `spread`, `tuple`,
  `class`, `const`, `let`, `function`, `async`, `destructuring`): no new
  failures; the residual `sourceMapValidation…DefaultValues2(es5)`,
  `constructorWithIncompleteTypeAnnotation`, `thisTypeInFunctionsNegative`
  failures were confirmed identical on a clean-tree build (pre-existing).
- `cargo fmt --check`, `cargo clippy -p tsz-emitter`, `git diff --check`,
  `scripts/arch/arch_guard.py` all clean. Rebased on latest `main`, no conflict.

## Coordination Notes
- Claimed #12388 (added `WIP`).
- Follow-up (noted, not done here to keep the regression fix scoped): the
  recovery still triggers off a source re-scan rather than an AST parse-error
  flag; gating `emit_recovered_reserved_*` on `this_or_subtree_has_error()`
  (and signalling reserved binding-element names structurally from the parser)
  would let valid declarations skip the scan entirely. Reasonable depth for a
  regression fix; a cleaner altitude for a separate refactor.
