### PR TITLE
fix(dts): scope declaration map property fallback

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
@@ -108,6 +108,9 @@ impl<'a> DeclarationEmitter<'a> {
             return String::new();
         };
 
+        if self.current_file_path.is_none() {
+            self.current_file_path = Some(source_file.file_name.clone());
+        }
         self.source_file_text = Some(source_file.text.clone());
         if !self.source_file_is_js(source_file) {
             self.retain_synthetic_class_extends_alias_dependencies_in_statements(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_text.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_text.rs
@@ -88,6 +88,22 @@ impl<'a> DeclarationEmitter<'a> {
             .find_map(|node| arena.get_source_file(node))
     }
 
+    pub(in crate::declaration_emitter) fn source_file_for_node_from_arena<'arena>(
+        &self,
+        arena: &'arena NodeArena,
+        node_idx: NodeIndex,
+    ) -> Option<&'arena tsz_parser::parser::node::SourceFileData> {
+        let mut current = node_idx;
+        for _ in 0..256 {
+            let node = arena.get(current)?;
+            if let Some(source_file) = arena.get_source_file(node) {
+                return Some(source_file);
+            }
+            current = arena.parent_of(current)?;
+        }
+        None
+    }
+
     pub(in crate::declaration_emitter) fn source_slice_from_arena(
         &self,
         arena: &tsz_parser::parser::node::NodeArena,

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_type_annotations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_type_annotations.rs
@@ -365,11 +365,14 @@ impl<'a> DeclarationEmitter<'a> {
             .or(self.current_source_file_idx);
         scratch.source_file_text = source_file.map(|source_file| source_file.text.clone());
         scratch.current_file_path = self
-            .arena_to_path
-            .get(&(source_arena as *const NodeArena as usize))
-            .cloned()
-            .or_else(|| source_file.map(|source_file| source_file.file_name.clone()))
-            .or_else(|| self.current_file_path.clone());
+            .current_file_path
+            .clone()
+            .or_else(|| {
+                self.arena_to_path
+                    .get(&(source_arena as *const NodeArena as usize))
+                    .cloned()
+            })
+            .or_else(|| source_file.map(|source_file| source_file.file_name.clone()));
         scratch.current_arena = self.current_arena.clone();
         scratch.arena_to_path = self.arena_to_path.clone();
         scratch.emit_type(type_idx);
@@ -455,54 +458,47 @@ impl<'a> DeclarationEmitter<'a> {
         &self,
         expr_idx: NodeIndex,
     ) -> Option<String> {
-        let binder = self.binder?;
+        self.binder?;
         let expr_node = self.arena.get(expr_idx)?;
         if expr_node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
             return None;
         }
 
         let access = self.arena.get_access_expr(expr_node)?;
+        if self
+            .arena
+            .get(access.expression)
+            .is_none_or(|node| node.kind != SyntaxKind::Identifier as u16)
+        {
+            return None;
+        }
         let member_name = self.get_identifier_text(access.name_or_argument)?;
         let base_sym_id = self.value_reference_symbol(access.expression)?;
 
         self.with_symbol_declarations(base_sym_id, |source_arena, decl_idx| {
+            let current_path = self.current_file_path.as_deref()?;
+            let source_file = self.source_file_for_node_from_arena(source_arena, decl_idx)?;
+            let source_file_name = source_file.file_name.to_ascii_lowercase();
+            if source_file.is_declaration_file
+                || source_file_name.ends_with(".d.ts")
+                || source_file_name.ends_with(".d.mts")
+                || source_file_name.ends_with(".d.cts")
+            {
+                return None;
+            }
+            if !self.paths_refer_to_same_source_file(current_path, &source_file.file_name) {
+                return None;
+            }
             let decl_idx = Self::annotation_bearing_declaration_from_arena(source_arena, decl_idx)
                 .unwrap_or(decl_idx);
             let decl_node = source_arena.get(decl_idx)?;
-            let declared_type = source_arena
-                .get_variable_declaration(decl_node)
-                .and_then(|decl| {
-                    if decl.type_annotation.is_some() {
-                        Some(decl.type_annotation)
-                    } else if decl.initializer.is_some() {
-                        Self::explicit_asserted_type_node_from_arena(source_arena, decl.initializer)
-                    } else {
-                        None
-                    }
-                })
-                .or_else(|| {
-                    source_arena.get_parameter(decl_node).and_then(|param| {
-                        if param.type_annotation.is_some() {
-                            Some(param.type_annotation)
-                        } else {
-                            None
-                        }
-                    })
-                })
-                .or_else(|| {
-                    source_arena.get_property_decl(decl_node).and_then(|decl| {
-                        if decl.type_annotation.is_some() {
-                            Some(decl.type_annotation)
-                        } else if decl.initializer.is_some() {
-                            Self::explicit_asserted_type_node_from_arena(
-                                source_arena,
-                                decl.initializer,
-                            )
-                        } else {
-                            None
-                        }
-                    })
-                })?;
+            let declared_type = source_arena.get_parameter(decl_node).and_then(|param| {
+                if param.type_annotation.is_some() {
+                    Some(param.type_annotation)
+                } else {
+                    None
+                }
+            })?;
 
             if let Some(type_text) = self.type_literal_member_declared_type_annotation_text(
                 source_arena,
@@ -512,14 +508,7 @@ impl<'a> DeclarationEmitter<'a> {
                 return Some(type_text);
             }
 
-            let declared_type_sym_id =
-                self.declaration_type_symbol_from_type_node(source_arena, declared_type)?;
-            let declared_type_sym_id = self
-                .resolve_portability_import_alias(declared_type_sym_id, binder)
-                .unwrap_or(declared_type_sym_id);
-            let declared_type_sym_id =
-                self.resolve_portability_declaration_symbol(declared_type_sym_id, binder);
-            self.type_member_declared_type_annotation_text(declared_type_sym_id, &member_name)
+            None
         })
     }
 


### PR DESCRIPTION
AgentName: Studio-C

## Track
DTS emit parity

## Invariant
Preserve tsc declaration emit surfaces without fixture-name hacks, semantic validation in emit, or output-string surgery; source-text recovery must stay scoped to local declaration emit surfaces.

## Scope
- Follow up #12386 after it landed from the earlier head.
- Keep the `declarationMapsMultifile` recovery for direct local parameter property reads like `x.a` from `{ a: number }`.
- Scope the new property-access fallback to inline parameter type-literal members from the current emitted source file, excluding declaration-file/package surfaces.
- Preserve consumer-file context for scratch type-node printing so package declaration internals do not become local relative paths.

## Project Corpus Impact
- Row: `declarationMapsMultifile`; guard row `declarationEmitUsingTypeAlias2`.
- Bug family: DTS declaration maps / multi-file inferred local surfaces with package nameability guard coverage.
- Expected impact: keep the #12386 declaration-map win while preventing the property fallback from reintroducing package-internal type alias output.

## Verification
- `scripts/safe-run.sh scripts/emit/run.sh --filter=declarationMapsMultifile --dts-only --verbose --timeout=20000 --json-out=/tmp/studio-c-declarationMapsMultifile-clippy-fix.json`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=declarationEmitUsingTypeAlias2 --dts-only --verbose --timeout=20000 --json-out=/tmp/studio-c-declarationEmitUsingTypeAlias2-clippy-fix.json`
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter inferred_class_method_object_return_uses_member_relative_indent inferred_namespaced_method_object_return_uses_deeper_indent inferred_method_nested_object_return_scales_recursively inferred_top_level_function_object_return_keeps_base_indent`
- Earlier on this head family before final rebase: `strictFunctionTypes1`, `genericRestParameters1`, `emitClassExpressionInDeclarationFile`, `typeParametersAvailableInNestedScope3` all passed with `scripts/safe-run.sh scripts/emit/run.sh --dts-only --verbose --timeout=20000`.
- `cargo fmt --check`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-common -p tsz-scanner -p tsz-parser -p tsz-binder -p tsz-solver -p tsz-checker -p tsz-emitter -p tsz-lowering -p tsz-lsp --all-targets -- -D warnings`
- `git diff --check origin/main`
- `python3 scripts/emit/audit-output-surgery.py`

## Coordination Notes
- #12386 merged as `1ec7849a2b8357a3db4a3ef48833400ba437dfda`; this PR is the scoped follow-up over current `origin/main`.
- Latest pushed head: `74780e790d`.
- No roadmap update: this is a narrow emit parity/guard fix.
- No output-surgery changes; audit remains 5/6 allowlisted calls with one slot available.



