### PR TITLE
refactor(emit): use class assignment output for using default

### DIFF
--- a/crates/tsz-emitter/src/emitter/source_file/mod.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/mod.rs
@@ -15,6 +15,8 @@ mod recovery;
 mod tc39_decorator_tests;
 mod top_level_using;
 mod top_level_using_decorated;
+#[cfg(test)]
+mod top_level_using_decorated_tests;
 
 #[cfg(test)]
 mod class_es5_field_initializer_tests;

--- a/crates/tsz-emitter/src/emitter/source_file/top_level_using.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/top_level_using.rs
@@ -2003,13 +2003,8 @@ impl<'a> Printer<'a> {
                 has_member_decorators: false,
                 emit_decorator_metadata: self.ctx.options.emit_decorator_metadata,
             });
-            let mut output = es5_emitter.emit_class_with_name(idx, &binding_name);
+            let mut output = es5_emitter.emit_class_assignment_with_name(idx, &binding_name);
             self.sync_es5_class_emitter_state(&mut es5_emitter);
-            output = output.replacen(
-                &format!("var {binding_name} = "),
-                &format!("{binding_name} = "),
-                1,
-            );
             if self.in_system_execute_body {
                 let leading_indent = "    ".repeat(self.writer.indent_level() as usize);
                 if let Some(stripped) = output.strip_prefix(&leading_indent) {

--- a/crates/tsz-emitter/src/emitter/source_file/top_level_using_decorated_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/top_level_using_decorated_tests.rs
@@ -1,0 +1,41 @@
+use crate::emitter::{ModuleKind, Printer as EmitterPrinter, PrinterOptions};
+use tsz_common::ScriptTarget;
+
+fn parse_test_source(source: &str) -> (tsz_parser::ParserState, tsz_parser::parser::NodeIndex) {
+    let mut parser = tsz_parser::ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    (parser, root)
+}
+
+#[test]
+fn commonjs_top_level_using_anonymous_default_legacy_class_uses_assignment_output() {
+    let source =
+        "export {};\ndeclare var dec: any;\nusing before = null;\n@dec\nexport default class {}\n";
+
+    let (parser, root) = parse_test_source(source);
+    let mut printer = EmitterPrinter::with_options(
+        &parser.arena,
+        PrinterOptions {
+            module: ModuleKind::CommonJS,
+            legacy_decorators: true,
+            target: ScriptTarget::ES5,
+            ..Default::default()
+        },
+    );
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert!(
+        output.contains("default_1 = /** @class */"),
+        "Anonymous default legacy class should assign the ES5 class IIFE to the hoisted binding.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("default_1 = __decorate(["),
+        "Anonymous default legacy class should decorate the hoisted binding.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("var default_1 = /** @class */"),
+        "Top-level using should not rely on rewriting a rendered variable declaration.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
AgentName: Studio-Opus
Track: Emit architecture / output-surgery ratchet
Invariant: When a top-level `using` block emits an anonymous default legacy-decorated class for ES5, the emitter asks the ES5 class transform for assignment-form output instead of rendering a variable declaration and rewriting the text afterward.

Scope:
- `crates/tsz-emitter/src/emitter/source_file/top_level_using.rs`
- `crates/tsz-emitter/src/emitter/source_file/top_level_using_decorated_tests.rs`
- `crates/tsz-emitter/src/emitter/source_file/mod.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: output-surgery/resource-region emit architecture debt
- Impact: emit architecture debt only. This does not change checker/solver semantics or benchmark row metadata.
- Output-surgery audit ratchets resource-region allowlisted calls from `5/6` to `4/6` and increases remaining capacity from `1` to `2`.

Verification:
- `cargo fmt --all --check && git diff --check`
- `python3 scripts/emit/audit-output-surgery.py --list`
- `scripts/safe-run.sh cargo check -p tsz-emitter`
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter commonjs_top_level_using_anonymous_default_legacy_class_uses_assignment_output commonjs_top_level_using_direct_exported_legacy_class_stays_inline esm_top_level_using_real_export_suppresses_export_empty default_tc39_decorated_named_class_keeps_class_1_binding`

Coordination Notes:
- Started after #12394 superseded and closed #12391; owned Studio-Opus runway was clear.
- No new output-surgery debt. This removes one existing resource-region surgery by moving the policy to the existing `ClassES5Emitter::emit_class_assignment_with_name` owner.
- New test coverage is in a dedicated small shard rather than growing the already oversized `es5_emit_tests.rs` file.
