### PR TITLE
fix(solver/diagnostics): render computed-bodied alias scalars structurally

### DIFF
--- a/crates/tsz-solver/src/diagnostics/format/key.rs
+++ b/crates/tsz-solver/src/diagnostics/format/key.rs
@@ -832,9 +832,44 @@ impl<'a> TypeFormatter<'a> {
             }
             match self.interner.lookup(body) {
                 Some(TypeData::Lazy(next_def)) => current_def = next_def,
+                // A non-generic alias whose body is a *computed* form — a
+                // conditional, a utility-type application, or an indexed
+                // access — may still resolve to a shared singleton. tsc
+                // attaches no `aliasSymbol` to such a result, so it renders the
+                // underlying `string`/`42`/`never`/… rather than the alias
+                // name. The syntactic checks above never see this because the
+                // body is e.g. `true extends true ? string : number`, so
+                // evaluate the body and display the resolved scalar.
+                Some(
+                    TypeData::Conditional(_)
+                    | TypeData::Application(_)
+                    | TypeData::IndexAccess(_, _),
+                ) => return self.alias_computed_body_underlying(body),
                 _ => return None,
             }
         }
+    }
+
+    /// Evaluate a computed alias body (conditional / utility application /
+    /// indexed access) and return the resolved type to display **only** when it
+    /// collapses to a concrete primitive, literal, or `never` — the shared
+    /// singletons tsc renders structurally instead of by the alias name.
+    ///
+    /// Returns `None` when the body stays generic, deferred, structural
+    /// (union/object/tuple/…), errors, or does not change under evaluation, so
+    /// those aliases keep their declared name exactly as before.
+    fn alias_computed_body_underlying(&self, body: TypeId) -> Option<TypeId> {
+        let evaluated = crate::evaluation::evaluate::evaluate_type(self.interner, body);
+        if evaluated == body
+            || evaluated == TypeId::ERROR
+            || crate::type_queries::contains_type_parameters_db(self.interner, evaluated)
+        {
+            return None;
+        }
+        (crate::visitor::is_primitive_type(self.interner, evaluated)
+            || matches!(self.interner.lookup(evaluated), Some(TypeData::Literal(_)))
+            || evaluated == TypeId::NEVER)
+            .then_some(evaluated)
     }
 
     fn format_in_operator_record(&mut self, shape: &ObjectShape) -> Option<String> {

--- a/crates/tsz-solver/src/diagnostics/format/keyof_alias_display_tests.rs
+++ b/crates/tsz-solver/src/diagnostics/format/keyof_alias_display_tests.rs
@@ -127,3 +127,128 @@ fn lazy_union_alias_keeps_its_name() {
         "A union-bodied alias must keep its name"
     );
 }
+
+#[test]
+fn lazy_conditional_alias_resolving_to_intrinsic_renders_underlying() {
+    // `type X = string extends string ? string : number` reduces to the shared
+    // `string` singleton. tsc attaches no `aliasSymbol` to a conditional result,
+    // so the diagnostic surface is `string`, never `X`. The body is a
+    // `Conditional`, so the syntactic intrinsic/literal check does not catch it;
+    // the formatter must evaluate the computed body to discover the scalar.
+    let db = TypeInterner::new();
+    let def_store = crate::def::DefinitionStore::new();
+
+    let body = db.conditional(crate::types::ConditionalType {
+        check_type: TypeId::STRING,
+        extends_type: TypeId::STRING,
+        true_type: TypeId::STRING,
+        false_type: TypeId::NUMBER,
+        is_distributive: false,
+    });
+    let def = def_store.register(crate::def::DefinitionInfo::type_alias(
+        db.intern_string("X"),
+        vec![],
+        body,
+    ));
+    let lazy = db.lazy(def);
+
+    let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+    assert_eq!(
+        fmt.format(lazy),
+        "string",
+        "A conditional-bodied alias that reduces to an intrinsic must render structurally"
+    );
+}
+
+#[test]
+fn lazy_conditional_alias_resolving_to_literal_renders_underlying() {
+    // `type Y = string extends string ? "yes" : "no"` reduces to the literal
+    // `"yes"`; tsc shows `"yes"`, not `Y`.
+    let db = TypeInterner::new();
+    let def_store = crate::def::DefinitionStore::new();
+
+    let body = db.conditional(crate::types::ConditionalType {
+        check_type: TypeId::STRING,
+        extends_type: TypeId::STRING,
+        true_type: db.literal_string("yes"),
+        false_type: db.literal_string("no"),
+        is_distributive: false,
+    });
+    let def = def_store.register(crate::def::DefinitionInfo::type_alias(
+        db.intern_string("Y"),
+        vec![],
+        body,
+    ));
+    let lazy = db.lazy(def);
+
+    let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+    assert_eq!(fmt.format(lazy), "\"yes\"");
+}
+
+#[test]
+fn lazy_conditional_alias_resolving_to_never_renders_underlying() {
+    // A conditional that reduces to `never` displays as `never`, not the alias.
+    let db = TypeInterner::new();
+    let def_store = crate::def::DefinitionStore::new();
+
+    let body = db.conditional(crate::types::ConditionalType {
+        check_type: TypeId::STRING,
+        extends_type: TypeId::NUMBER,
+        true_type: TypeId::BOOLEAN,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    });
+    let def = def_store.register(crate::def::DefinitionInfo::type_alias(
+        db.intern_string("Z"),
+        vec![],
+        body,
+    ));
+    let lazy = db.lazy(def);
+
+    let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+    assert_eq!(fmt.format(lazy), "never");
+}
+
+#[test]
+fn lazy_conditional_alias_resolving_to_tuple_keeps_alias_name() {
+    // A conditional that reduces to a *structural* result (here a tuple) keeps
+    // its alias name: only shared-singleton scalars drop the `aliasSymbol`.
+    // This guards the scalar gate against over-reaching into structural results.
+    let db = TypeInterner::new();
+    let def_store = crate::def::DefinitionStore::new();
+
+    let tuple = db.tuple(vec![
+        crate::types::TupleElement {
+            type_id: TypeId::STRING,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        crate::types::TupleElement {
+            type_id: TypeId::NUMBER,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+    ]);
+    let body = db.conditional(crate::types::ConditionalType {
+        check_type: TypeId::STRING,
+        extends_type: TypeId::STRING,
+        true_type: tuple,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    });
+    let def = def_store.register(crate::def::DefinitionInfo::type_alias(
+        db.intern_string("Pair"),
+        vec![],
+        body,
+    ));
+    let lazy = db.lazy(def);
+
+    let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+    assert_eq!(
+        fmt.format(lazy),
+        "Pair",
+        "A conditional alias that reduces to a tuple must keep its declared name"
+    );
+}


### PR DESCRIPTION
AgentName: M1-A

**Track:** Conformance / diagnostic display parity (solver display boundary)
**Refs:** #10799
**Implementing branch:** `claude/brave-volta-zTwv5`

## Invariant
`When a non-generic type alias's body is a computed type operation — a conditional, a utility-type application, or an indexed access — that fully evaluates to a shared-singleton primitive, literal, or never, tsc renders the underlying scalar (string/42/never) rather than the alias name, because the evaluated result carries no aliasSymbol; tsz must do the same through the solver display boundary.`

## Scope
Single owner layer: the solver diagnostic formatter (`crates/tsz-solver/src/diagnostics/format/key.rs`). The existing `type_alias_body_displayed_as_underlying` already mirrors tsc's `aliasSymbol` display policy for alias bodies that are *syntactically* a primitive/literal (or a `Lazy` chain to one), but it never evaluated computed bodies. So a `Lazy(alias)` whose body is e.g. `true extends true ? string : number` kept its alias name in nested elaboration positions, where tsc shows `string`.

The fix evaluates the computed body and returns the resolved type only when it collapses to a concrete primitive / literal / `never` (no residual type parameters, not `error`, and actually changed under evaluation). Structural results (objects / tuples / unions) and generic/deferred bodies keep the alias name exactly as before — verified by an added guard test.

No checker, binder, or emitter changes. No new user-name/file-name literals; the decision is purely structural (`TypeData` kind + evaluated-type classification via existing solver predicates).

### Investigation summary (#10799)
The reported repro ("distributive conditional evaluation over tuple-like unions can become over-constrained") does **not** reproduce against tsc 6.0.2: tsz's conditional/tuple/distribution **semantics and assignability are correct** in every probe (head/tail `infer`, filtering, re-collection, nested/constrained `infer`, distribution over mixed unions). The only divergences in this family are diagnostic **display**:
1. Union member ordering (tsc lazy creation-order vs tsz canonical sort) — architectural, out of scope.
2. Type-alias display of computed bodies that resolve to scalars — fixed here.

## Project Corpus Impact
- Row: n/a (display-only; surfaced under rxjs-project #10799 family, no row pass/fail flip expected)
- Bug family: diagnostic display parity for computed alias bodies (`aliasSymbol` policy)
- Evidence: display-only solver formatter change; no project-row pass/fail flips expected. `cargo test -p tsz-solver --lib diagnostics::format` green (214/214); 4 new targeted alias-display tests pass.

Display-only, narrowing the gap to tsc on conditional/utility/indexed aliases that reduce to scalars. No semantic/assignability behavior changes, so no project-row pass/fail flips are expected; net effect is closer diagnostic text parity. No required project-corpus row is semantically affected.

## Verification
- `cargo test -p tsz-solver --lib lazy_conditional_alias` → 4/4 pass (intrinsic, literal, `never` render structurally; tuple keeps its name).
- `cargo test -p tsz-solver --lib diagnostics::format` → 214/214 pass (no display regressions).
- `cargo fmt --check`, `cargo clippy -p tsz-solver --lib` (clean), `python3 scripts/arch/arch_guard.py` (passed).
- Manual tsz-vs-tsc spot checks: `type X = true extends true ? string : number` and `type N = Awaited<Promise<number>>` now match tsc structurally in nested elaboration.

## Coordination Notes
Investigation/implementation by `brave-volta-zTwv5`; ownership assigned to canonical lane `agent:M1-A` per Studio-manager (diagnostic conformance/display debt). The solver-evaluation in the formatter is bounded (non-generic aliases, scalar-only result gate, existing `evaluate_type` guards) and stays within the solver display boundary; no M4 inference coordination required. Claimed #10799 (added `WIP`, signed comment). The top-level variable-initializer source display (`const e: 0 = x1` showing the alias name) flows through a separate AST/relation-reason path and remains a known follow-up, documented in the issue; this PR lands the solver-boundary display-policy part as a self-contained, tested unit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExvhC9cuGbfSDd21Y1MUhi)_