### PR TITLE
fix(dts): restore scoped regression surfaces

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_class_expression.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_class_expression.rs
@@ -232,8 +232,22 @@ impl<'a> DeclarationEmitter<'a> {
         } else {
             self.indent_level + 2
         };
+        let base_members = base_constraint_idx.and_then(|constraint_idx| {
+            self.constructor_constraint_base_instance_members_text(constraint_idx, instance_indent)
+                .map(|members| {
+                    (
+                        members,
+                        self.constructor_constraint_base_members_precede_class_members(
+                            constraint_idx,
+                        ),
+                    )
+                })
+        });
         let mut instance_scratch = self.scratch_object_type_body_emitter(instance_indent);
         let mut static_scratch = self.scratch_object_type_body_emitter(self.indent_level + 1);
+        if let Some((base_members, true)) = base_members.as_ref() {
+            instance_scratch.write(base_members);
+        }
         for member_idx in class.members.nodes.iter().copied() {
             let Some(member_node) = self.arena.get(member_idx) else {
                 continue;
@@ -247,11 +261,8 @@ impl<'a> DeclarationEmitter<'a> {
                 instance_scratch.emit_class_member_for_constructor_instance_type(member_idx);
             }
         }
-        if let Some(constraint_idx) = base_constraint_idx
-            && let Some(base_members) = self
-                .constructor_constraint_base_instance_members_text(constraint_idx, instance_indent)
-        {
-            instance_scratch.write(&base_members);
+        if let Some((base_members, false)) = base_members.as_ref() {
+            instance_scratch.write(base_members);
         }
         let members = instance_scratch.writer.take_output();
         let members = Self::strip_abstract_member_modifiers(members.trim_end());
@@ -700,22 +711,38 @@ impl<'a> DeclarationEmitter<'a> {
         constraint_idx: NodeIndex,
         indent_level: u32,
     ) -> Option<String> {
+        let instance_type_idx =
+            self.constructor_constraint_instance_type_node_idx(constraint_idx)?;
+        self.instance_type_node_members_text_at(instance_type_idx, indent_level)
+    }
+
+    fn constructor_constraint_base_members_precede_class_members(
+        &self,
+        constraint_idx: NodeIndex,
+    ) -> bool {
+        self.constructor_constraint_instance_type_node_idx(constraint_idx)
+            .and_then(|instance_type_idx| self.arena.get(instance_type_idx))
+            .is_some_and(|node| self.type_node_is_any(node))
+    }
+
+    fn constructor_constraint_instance_type_node_idx(
+        &self,
+        constraint_idx: NodeIndex,
+    ) -> Option<NodeIndex> {
         let constraint_node = self.arena.get(constraint_idx)?;
 
         if let Some(type_ref) = self.arena.get_type_ref(constraint_node)
             && let Some(type_arguments) = type_ref.type_arguments.as_ref()
             && let Some(instance_arg_index) =
                 self.constructor_type_reference_instance_arg_index(type_ref)
-            && let Some(instance_arg_idx) = type_arguments.nodes.get(instance_arg_index).copied()
         {
-            return self.instance_type_node_members_text_at(instance_arg_idx, indent_level);
+            return type_arguments.nodes.get(instance_arg_index).copied();
         }
 
         if constraint_node.kind == syntax_kind_ext::CONSTRUCTOR_TYPE
             && let Some(func_type) = self.arena.get_function_type(constraint_node)
         {
-            return self
-                .instance_type_node_members_text_at(func_type.type_annotation, indent_level);
+            return Some(func_type.type_annotation);
         }
 
         None

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_type_annotations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_type_annotations.rs
@@ -492,20 +492,135 @@ impl<'a> DeclarationEmitter<'a> {
             let decl_idx = Self::annotation_bearing_declaration_from_arena(source_arena, decl_idx)
                 .unwrap_or(decl_idx);
             let decl_node = source_arena.get(decl_idx)?;
-            let declared_type = source_arena.get_parameter(decl_node).and_then(|param| {
+            if let Some(declared_type) = source_arena.get_parameter(decl_node).and_then(|param| {
                 if param.type_annotation.is_some() {
                     Some(param.type_annotation)
                 } else {
                     None
                 }
-            })?;
+            }) {
+                return self.type_literal_member_declared_type_annotation_text(
+                    source_arena,
+                    declared_type,
+                    &member_name,
+                );
+            }
 
+            let declared_type = self
+                .declared_or_asserted_variable_type_node_from_arena(source_arena, decl_node)
+                .or_else(|| {
+                    self.declared_or_asserted_property_type_node_from_arena(source_arena, decl_node)
+                })?;
             if let Some(type_text) = self.type_literal_member_declared_type_annotation_text(
                 source_arena,
                 declared_type,
                 &member_name,
             ) {
                 return Some(type_text);
+            }
+            let binder = self.binder?;
+            let declared_type_sym_id =
+                self.declaration_type_symbol_from_type_node(source_arena, declared_type)?;
+            let declared_type_sym_id = self
+                .resolve_portability_import_alias(declared_type_sym_id, binder)
+                .unwrap_or(declared_type_sym_id);
+            let declared_type_sym_id =
+                self.resolve_portability_declaration_symbol(declared_type_sym_id, binder);
+            self.type_member_declared_source_type_annotation_text(
+                declared_type_sym_id,
+                &member_name,
+            )
+        })
+    }
+
+    fn declared_or_asserted_variable_type_node_from_arena(
+        &self,
+        source_arena: &NodeArena,
+        decl_node: &tsz_parser::parser::node::Node,
+    ) -> Option<NodeIndex> {
+        let decl = source_arena.get_variable_declaration(decl_node)?;
+        if decl.type_annotation.is_some() {
+            return Some(decl.type_annotation);
+        }
+        Self::explicit_asserted_type_node_from_arena(source_arena, decl.initializer)
+    }
+
+    fn declared_or_asserted_property_type_node_from_arena(
+        &self,
+        source_arena: &NodeArena,
+        decl_node: &tsz_parser::parser::node::Node,
+    ) -> Option<NodeIndex> {
+        let decl = source_arena.get_property_decl(decl_node)?;
+        if decl.type_annotation.is_some() {
+            return Some(decl.type_annotation);
+        }
+        Self::explicit_asserted_type_node_from_arena(source_arena, decl.initializer)
+    }
+
+    fn type_member_declared_source_type_annotation_text(
+        &self,
+        type_sym_id: SymbolId,
+        member_name: &str,
+    ) -> Option<String> {
+        self.with_symbol_declarations(type_sym_id, |source_arena, decl_idx| {
+            let decl_idx = Self::annotation_bearing_declaration_from_arena(source_arena, decl_idx)
+                .unwrap_or(decl_idx);
+            let decl_node = source_arena.get(decl_idx)?;
+            let mut members: Vec<NodeIndex> = Vec::new();
+            if let Some(interface) = source_arena.get_interface(decl_node) {
+                members.extend(interface.members.nodes.iter().copied());
+            }
+            if let Some(class_decl) = source_arena.get_class(decl_node) {
+                members.extend(class_decl.members.nodes.iter().copied());
+            }
+            if let Some(type_alias) = source_arena.get_type_alias(decl_node)
+                && let Some(type_node) = source_arena.get(type_alias.type_node)
+                && type_node.kind == syntax_kind_ext::TYPE_LITERAL
+                && let Some(type_literal) = source_arena.get_type_literal(type_node)
+            {
+                members.extend(type_literal.members.nodes.iter().copied());
+            }
+
+            for member_idx in members {
+                let Some(member_node) = source_arena.get(member_idx) else {
+                    continue;
+                };
+                if let Some(signature) = source_arena.get_signature(member_node)
+                    && self
+                        .property_name_text_from_arena(source_arena, signature.name)
+                        .as_deref()
+                        == Some(member_name)
+                    && signature.type_annotation.is_some()
+                {
+                    return self.type_annotation_text_from_arena_node(
+                        source_arena,
+                        signature.type_annotation,
+                    );
+                }
+                if let Some(prop_decl) = source_arena.get_property_decl(member_node)
+                    && self
+                        .property_name_text_from_arena(source_arena, prop_decl.name)
+                        .as_deref()
+                        == Some(member_name)
+                    && prop_decl.type_annotation.is_some()
+                {
+                    return self.type_annotation_text_from_arena_node(
+                        source_arena,
+                        prop_decl.type_annotation,
+                    );
+                }
+                if let Some(accessor) = source_arena.get_accessor(member_node)
+                    && self
+                        .property_name_text_from_arena(source_arena, accessor.name)
+                        .as_deref()
+                        == Some(member_name)
+                    && accessor.type_annotation.is_some()
+                {
+                    return self.type_annotation_text_from_arena_node(
+                        source_arena,
+                        accessor.type_annotation,
+                    );
+                }
             }
 
             None


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Track 9 emit/dts parity: declaration emit regression follow-up for #12398.

## Invariant
When a returned abstract mixin class extends a generic constructor constraint whose instance type is syntactically `any`, tsc emits the synthetic `[x: string]: any` catch-all before the returned class instance members; this PR restores that ordering through declaration-emitter class-expression source-summary printing while preserving the named/type-literal base-member ordering from #12378.

When a current-file property access is rooted in a variable/property with an explicit declared or asserted type, tsc preserves the declared source member surface for exported DTS, including mapped/intersection arms and optional `| undefined`; this PR restores that through a source-annotation-only declaration-emitter lookup without reopening declaration-file/property fallback walks from #12396.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_class_expression.rs`
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_type_annotations.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: DTS emit-suite-only regressions from #12398 (`mixinAbstractClassesReturnTypeInference`, `declarationEmitAliasFromIndirectFile`)
- Evidence: both reported DTS baseline rows now pass locally; no project-corpus compile behavior change expected.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter test_inline_abstract_any_mixin_inherits_index_signature_at_call_site test_inline_abstract_any_mixin_index_signature_is_name_independent test_anon_ctor_object_type_local_members_precede_base_constraint_members`
- `scripts/safe-run.sh scripts/emit/run.sh --dts-only --filter=mixinAbstractClassesReturnTypeInference --verbose --timeout=20000 --json-out=/tmp/studio-c-12398-fixed-mixinAbstractClassesReturnTypeInference.json`
- `scripts/safe-run.sh scripts/emit/run.sh --dts-only --filter=declarationEmitAliasFromIndirectFile --verbose --timeout=20000 --json-out=/tmp/studio-c-12398-fixed-declarationEmitAliasFromIndirectFile.json`
- Guard rows with `--skip-build`: `emitClassExpressionInDeclarationFile`, `genericRestParameters1`, `declarationMapsMultifile`, `declarationEmitUsingTypeAlias2`, `reactTransitiveImportHasValidDeclaration`, `jsDeclarationEmitExportedClassWithExtends`, `typeParametersAvailableInNestedScope3`, `strictFunctionTypes1`
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `python3 scripts/emit/audit-output-surgery.py` (passed; output-surgery allowlist now 4/6, no unallowlisted calls)
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-emitter --all-targets -- -D warnings`
- `wc -l crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_class_expression.rs crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_type_annotations.rs` => 1883 total

## Coordination Notes
- Fixes #12398.
- Draft initially so CI can run on the pushed branch while Studio-C verifies remote metadata and issue coordination.
- No checker imports, no JS emit changes, no semantic validation in emit, and no output-surgery expansion.
- Restores the two reported regressions while guarding the prior Studio-C DTS fixes from #12378, #12386/#12396, and #12389.
