### PR TITLE
docs(conformance): clarify accepted-regression retirement

### DIFF
--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -73,7 +73,10 @@ remains a separate gate-strictness artifact and must be kept empty or
 explicitly justified by current CI evidence before agents treat conformance
 cleanup as complete. It currently lists `13` accepted-regression entries even
 though the dashboard is exact, so the strictness gate is non-empty and each
-entry should be paid down or re-justified in follow-up PRs.
+entry should be paid down or re-justified in follow-up PRs. A checked-in detail
+snapshot that no longer lists these tests as failures is not enough to retire
+entries; removal must be backed by exact-head aggregate CI showing the tests no
+longer appear in the shard failure set.
 
 ## Evidence From Current Audit
 


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Track 1 / conformance strictness process guardrail.

## Invariant
When checked-in conformance detail no longer lists an accepted-regression entry as failing, that is only stale snapshot evidence. The entry may be retired only after exact-head aggregate CI shows the fixture no longer appears in the shard failure set.

## Scope
- Add the exact-head aggregate CI requirement to the accepted-regression strictness section of `docs/plan/ROADMAP.md`.
- Preserve the existing 13 accepted-regression entries because PR #12402 exact-head CI run `26924186114` still observed all 13 as aggregate regressions when the list was removed.

## Project Corpus Impact
- Row: n/a
- Bug family: conformance accepted-regression strictness
- No project-row behavior change. This is roadmap/process documentation for conformance gate retirement.

## Verification
- `python3 scripts/conformance/query-conformance.py --dashboard`
- `python3 scripts/conformance/link-regression-issues.py --from-file /tmp/tsz-accepted-regressions.txt`
- `git diff --check origin/main...HEAD`
- CI evidence from PR #12402 run `26924186114`: all conformance shards passed, but `conformance-aggregate` reported `12572/12585` and listed the same 13 fixtures as unlisted regressions when the accepted list was removed. The final branch preserves those entries and documents that exact-head aggregate CI is required before removal.

## Coordination Notes
- AgentName: Studio-Opus.
- Independent of Studio-B PR #12393 and Studio-C PR #12401; this does not touch checker, solver, emitter, benchmark metadata, or DTS surfaces.
- Follow-up strictness burn-down should fix or re-justify the 13 entries through owning M1/M4 lanes before any accepted-list removal PR.