### PR TITLE
fix(emit): close remaining import recovery rows

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6_members.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6_members.rs
@@ -362,6 +362,7 @@ impl<'a> Printer<'a> {
                     k if k == syntax_kind_ext::METHOD_DECLARATION => {
                         self.arena.get_method_decl(member_node).is_some_and(|m| {
                             m.body.is_none()
+                                && !self.is_recovered_optional_bodyless_class_method(member_node)
                                 && !self.has_recovered_declaration_trailing_comma(member_node)
                         })
                     }

--- a/crates/tsz-emitter/src/emitter/declarations/class_members.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class_members.rs
@@ -168,6 +168,57 @@ impl<'a> Printer<'a> {
         }
     }
 
+    pub(in crate::emitter) fn is_recovered_optional_bodyless_class_method(
+        &self,
+        node: &Node,
+    ) -> bool {
+        let Some(method) = self.arena.get_method_decl(node) else {
+            return false;
+        };
+        if method.body.is_some() || method.question_token {
+            return false;
+        }
+        let Some(text) = self.source_text else {
+            return false;
+        };
+
+        let search_start = if let Some(ref tp) = method.type_parameters {
+            tp.nodes
+                .last()
+                .and_then(|&idx| self.arena.get(idx))
+                .map_or(node.pos, |n| n.end)
+        } else if method.name.is_some() {
+            self.arena.get(method.name).map_or(node.pos, |n| n.end)
+        } else {
+            node.pos
+        } as usize;
+        let search_end = if method.type_annotation.is_some() {
+            self.arena
+                .get(method.type_annotation)
+                .map_or(node.end, |n| n.pos)
+        } else {
+            node.end
+        } as usize;
+        let bytes = text.as_bytes();
+        let search_start = search_start.min(bytes.len());
+        let search_end = search_end.min(bytes.len());
+        if search_start >= search_end {
+            return false;
+        }
+
+        let Some(close_paren_offset) = bytes[search_start..search_end]
+            .iter()
+            .rposition(|&byte| byte == b')')
+        else {
+            return false;
+        };
+        let mut cursor = search_start + close_paren_offset + 1;
+        while cursor < search_end && bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+        cursor < search_end && bytes[cursor] == b'?'
+    }
+
     pub(in crate::emitter) fn emit_method_declaration(&mut self, node: &Node) {
         let Some(method) = self.arena.get_method_decl(node) else {
             return;
@@ -183,11 +234,17 @@ impl<'a> Printer<'a> {
         let is_quoted_constructor_name =
             self.class_member_emit_depth > 0 && self.is_quoted_constructor_method_name(method.name);
 
-        // Skip method declarations without bodies (TypeScript-only overloads)
+        // Skip method declarations without bodies (TypeScript-only overloads).
+        // Recovered optional class methods like `x()?: number;` are syntax
+        // errors, but tsc keeps a runtime empty method body for them.
         if method.body.is_none() {
             // Keep parse-recovery emit for invalid generator member `*() {}`.
             if method.asterisk_token && has_recovery_missing_name {
                 self.write("*() { }");
+            } else if self.class_member_emit_depth > 0
+                && self.is_recovered_optional_bodyless_class_method(node)
+            {
+                self.emit_recovered_object_method_without_body(node);
             } else if self.has_recovered_declaration_trailing_comma(node) {
                 self.emit_recovered_object_method_without_body(node);
             } else {

--- a/crates/tsz-emitter/src/emitter/declarations/class_members.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class_members.rs
@@ -241,11 +241,10 @@ impl<'a> Printer<'a> {
             // Keep parse-recovery emit for invalid generator member `*() {}`.
             if method.asterisk_token && has_recovery_missing_name {
                 self.write("*() { }");
-            } else if self.class_member_emit_depth > 0
-                && self.is_recovered_optional_bodyless_class_method(node)
+            } else if (self.class_member_emit_depth > 0
+                && self.is_recovered_optional_bodyless_class_method(node))
+                || self.has_recovered_declaration_trailing_comma(node)
             {
-                self.emit_recovered_object_method_without_body(node);
-            } else if self.has_recovered_declaration_trailing_comma(node) {
                 self.emit_recovered_object_method_without_body(node);
             } else {
                 self.skip_comments_for_erased_node(node);

--- a/crates/tsz-emitter/src/emitter/declarations/class_members_tests.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class_members_tests.rs
@@ -219,6 +219,26 @@ fn single_line_constructor_body_with_return() {
 }
 
 #[test]
+fn bodyless_optional_class_methods_emit_empty_bodies_for_recovery() {
+    let output = emit_ts_with_options(
+        "class C {\n    x()?: number;\n}\nclass C2<T> {\n    x()?: T;\n}\n",
+        PrinterOptions {
+            target: ScriptTarget::ES2015,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        output.contains("class C {\n    x() { }\n}"),
+        "Recovered optional class methods should keep an empty runtime body.\nOutput: {output}"
+    );
+    assert!(
+        output.contains("class C2 {\n    x() { }\n}"),
+        "Recovered generic optional class methods should erase types and keep an empty runtime body.\nOutput: {output}"
+    );
+}
+
+#[test]
 fn object_literal_accessor_empty_body_has_space_braces() {
     let source = "export const t = {\n    set setter(v) {},\n};";
     let output = emit_ts(source);

--- a/crates/tsz-emitter/src/emitter/module_emission/core/tests/cjs_module_exports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/tests/cjs_module_exports.rs
@@ -22,6 +22,36 @@ fn emit_commonjs_es_module_interop(source: &str) -> String {
     printer.get_output().to_string()
 }
 
+fn emit_es2015_module(source: &str) -> String {
+    let (parser, root) = parse_test_source(source);
+    let options = PrinterOptions {
+        module: ModuleKind::ES2015,
+        target: ScriptTarget::ES2015,
+        ..Default::default()
+    };
+    let mut printer = Printer::with_options(&parser.arena, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+#[test]
+fn es2015_attached_reference_before_elided_import_is_stripped() {
+    let source = r#"/// <reference path="/.lib/react16.d.ts" />
+import * as React from "react";
+
+type Props = React.ComponentProps<any>;
+"#;
+
+    let output = emit_es2015_module(source);
+
+    assert!(
+        !output.contains("<reference"),
+        "Reference attached to an elided import should be stripped.\nOutput:\n{output}"
+    );
+    assert_eq!(output.trim(), "export {};");
+}
+
 #[test]
 fn commonjs_unused_classic_jsx_factory_name_elides_namespace_import_without_jsx() {
     let source = r#"import * as React from "react";

--- a/crates/tsz-emitter/src/emitter/module_emission/imports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/imports.rs
@@ -91,9 +91,9 @@ impl<'a> Printer<'a> {
             &value_haystack,
             &self.ctx.options.external_const_enum_bindings,
         );
-        let appears_in_value_haystack = names
-            .iter()
-            .any(|name| crate::import_usage::contains_identifier_occurrence(&value_haystack, name));
+        let appears_in_value_haystack = names.iter().any(|name| {
+            crate::import_usage::contains_identifier_value_occurrence(&value_haystack, name)
+        });
         if appears_in_value_haystack {
             return true;
         }
@@ -350,7 +350,7 @@ impl<'a> Printer<'a> {
             &value_haystack,
             &self.ctx.options.external_const_enum_bindings,
         );
-        if crate::import_usage::contains_identifier_occurrence(&value_haystack, &local_name) {
+        if crate::import_usage::contains_identifier_value_occurrence(&value_haystack, &local_name) {
             return true;
         }
         // Under `--emitDecoratorMetadata`, decorated-member type
@@ -393,7 +393,7 @@ impl<'a> Printer<'a> {
             &value_haystack,
             &self.ctx.options.external_const_enum_bindings,
         );
-        if crate::import_usage::contains_identifier_occurrence(&value_haystack, &local_name) {
+        if crate::import_usage::contains_identifier_value_occurrence(&value_haystack, &local_name) {
             return true;
         }
         // Under `--emitDecoratorMetadata`, decorated-member type annotations are
@@ -448,8 +448,10 @@ impl<'a> Printer<'a> {
                 if jsx_factory_roots.iter().any(|root| root == &local_name) {
                     return true;
                 }
-                if crate::import_usage::contains_identifier_occurrence(&value_haystack, &local_name)
-                {
+                if crate::import_usage::contains_identifier_value_occurrence(
+                    &value_haystack,
+                    &local_name,
+                ) {
                     return true;
                 }
                 // Under `--emitDecoratorMetadata`, decorated-member type
@@ -489,7 +491,7 @@ impl<'a> Printer<'a> {
             &self.ctx.options.external_const_enum_bindings,
         );
 
-        if crate::import_usage::contains_identifier_occurrence(&value_haystack, &name)
+        if crate::import_usage::contains_identifier_value_occurrence(&value_haystack, &name)
             || (self.ctx.options.emit_decorator_metadata
                 && crate::import_usage::name_appears_in_decorator_metadata_type(&haystack, &name))
         {
@@ -521,7 +523,7 @@ impl<'a> Printer<'a> {
             &value_haystack,
             &self.ctx.options.external_const_enum_bindings,
         );
-        crate::import_usage::contains_identifier_occurrence(&value_haystack, &name)
+        crate::import_usage::contains_identifier_value_occurrence(&value_haystack, &name)
     }
 
     /// Check if an external import-equals alias is only value-used through a

--- a/crates/tsz-emitter/src/emitter/statement_erasure.rs
+++ b/crates/tsz-emitter/src/emitter/statement_erasure.rs
@@ -175,38 +175,10 @@ impl<'a> Printer<'a> {
                         return true;
                     }
                 }
-                // When JSX mode requires a factory, check if any binding
-                // matches the factory root name — JSX elements reference
-                // it implicitly and the text heuristic won't find it.
-                if matches!(
-                    self.ctx.options.jsx,
-                    JsxEmit::Preserve | JsxEmit::React | JsxEmit::ReactNative
-                ) {
-                    let factory_root = self
-                        .ctx
-                        .options
-                        .jsx_factory
-                        .as_deref()
-                        .and_then(|f| f.split('.').next())
-                        .unwrap_or("React");
-                    // Check default import name
-                    if clause.name.is_some() {
-                        let name = self.get_identifier_text_idx(clause.name);
-                        if name == factory_root {
-                            return false;
-                        }
-                    }
-                    // Check namespace import name (`import * as React`)
-                    if let Some(bindings_node) = self.arena.get(clause.named_bindings)
-                        && let Some(named) = self.arena.get_named_imports(bindings_node)
-                        && named.name.is_some()
-                        && named.elements.nodes.is_empty()
-                    {
-                        let ns_name = self.get_identifier_text_idx(named.name);
-                        if ns_name == factory_root {
-                            return false;
-                        }
-                    }
+                // JSX factory imports are only runtime imports when this file
+                // actually contains JSX that needs the classic factory.
+                if self.is_jsx_factory_import_clause(clause) {
+                    return false;
                 }
                 // With --verbatimModuleSyntax, non-type-only imports are
                 // always preserved (no heuristic elision).

--- a/crates/tsz-emitter/src/import_usage.rs
+++ b/crates/tsz-emitter/src/import_usage.rs
@@ -39,6 +39,26 @@ pub fn contains_identifier_occurrence(haystack: &str, ident: &str) -> bool {
     false
 }
 
+/// Check if `haystack` contains `ident` as a standalone identifier in a
+/// non-binding position.
+pub fn contains_identifier_value_occurrence(haystack: &str, ident: &str) -> bool {
+    if ident.is_empty() {
+        return false;
+    }
+
+    let mut search_from = 0usize;
+    while let Some(rel) = haystack[search_from..].find(ident) {
+        let pos = search_from + rel;
+        if is_standalone_identifier_at(haystack, ident, pos)
+            && !identifier_occurrence_is_binding(haystack, pos)
+        {
+            return true;
+        }
+        search_from = pos + ident.len();
+    }
+    false
+}
+
 /// Check if `haystack` contains `ident` as a value reference before a local
 /// binding shadows it. A duplicate `import <ident> = ...` declaration does not
 /// count as shadowing because `TypeScript` still treats later value references

--- a/crates/tsz-emitter/tests/import_usage.rs
+++ b/crates/tsz-emitter/tests/import_usage.rs
@@ -15,8 +15,9 @@
 //! boundaries where the emitter's value-usage decision changes.
 
 use super::{
-    contains_identifier_occurrence, name_appears_in_decorator_metadata_type,
-    strip_qualified_accesses_for_names, strip_type_declaration_lines, strip_type_only_content,
+    contains_identifier_occurrence, contains_identifier_value_occurrence,
+    name_appears_in_decorator_metadata_type, strip_qualified_accesses_for_names,
+    strip_type_declaration_lines, strip_type_only_content,
 };
 
 // ----------------------------------------------------------------------
@@ -67,6 +68,18 @@ fn contains_identifier_occurrence_empty_needle_is_false() {
 #[test]
 fn contains_identifier_occurrence_empty_haystack() {
     assert!(!contains_identifier_occurrence("", "foo"));
+}
+
+#[test]
+fn contains_identifier_value_occurrence_ignores_bindings() {
+    assert!(!contains_identifier_value_occurrence(
+        "for (const _ of []) { }\nfor (const _ in []) { }\nnamespace _ns { let _; }",
+        "_",
+    ));
+    assert!(contains_identifier_value_occurrence(
+        "for (const _ of []) { }\nconsole.log(_);",
+        "_",
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Track 9 emit parity: JavaScript emit baseline burn-down for remaining import/recovery rows.

## Invariant
When invalid optional class method syntax is parsed as a bodyless method signature, tsc emits an empty runtime method body instead of erasing the member; this PR keeps that recovery path in class member emit while preserving overload erasure.

When ES import bindings are only present as local bindings or type-only references, tsc elides the import but still preserves module semantics with `export {}`; this PR aligns noCheck import usage and statement-erasure classification so attached reference directives and unused underscore imports match tsc output.

## Scope
- `crates/tsz-emitter/src/emitter/declarations/class_members.rs`
- `crates/tsz-emitter/src/emitter/declarations/class/emit_es6_members.rs`
- `crates/tsz-emitter/src/emitter/module_emission/imports.rs`
- `crates/tsz-emitter/src/emitter/statement_erasure.rs`
- `crates/tsz-emitter/src/import_usage.rs`
- Focused unit tests for class recovery, import usage, and elided-import reference comments.

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit-suite-only baseline rows (`objectTypesWithOptionalProperties2`, `unusedLocalsStartingWithUnderscore`, `styledComponentsInstantiaionLimitNotReached`)
- Evidence: focused JS emit filters pass locally on head `92316ed3aa5b047199727c00f28362242821a660`; no project-corpus compile behavior change expected.

## Verification
- `cargo nextest run -p tsz-emitter bodyless_optional_class_methods_emit_empty_bodies_for_recovery contains_identifier_value_occurrence_ignores_bindings es2015_attached_reference_before_elided_import_is_stripped`
- `scripts/emit/run.sh --js-only --filter=objectTypesWithOptionalProperties2 --verbose --timeout=20000 --json-out=/tmp/studio-c-js-object-final-main.json`
- `scripts/emit/run.sh --js-only --filter=unusedLocalsStartingWithUnderscore --verbose --timeout=20000 --json-out=/tmp/studio-c-js-unused-final-main.json`
- `scripts/emit/run.sh --js-only --filter=styledComponentsInstantiaionLimitNotReached --verbose --timeout=20000 --json-out=/tmp/studio-c-js-styled-final-main.json`
- `cargo fmt --check`
- `scripts/safe-run.sh cargo clippy -p tsz-emitter --all-targets -- -D warnings`
- `git diff --check origin/main..HEAD`
- `wc -l` on touched files; all touched files are under 2000 physical lines.

## Coordination Notes
- AgentName: Studio-C
- Rebased and pushed on top of `origin/main` at `b78ea8501a3e6664a61b3a7d045c95caf624ff5f`, which includes merged #12401.
- Opened as draft so light CI can validate the pushed branch before ready handoff.
- No checker/solver changes and no output-surgery expansion.
