### PR TITLE
docs(conformance): require aggregate evidence for stale accepts

### DIFF
--- a/docs/development/TOOLING.md
+++ b/docs/development/TOOLING.md
@@ -271,11 +271,12 @@ posts comments on its own — it only reads checked-in artifacts.
 **Closure pattern for stale regression issues.** When the helper reports
 `stale: passing in current snapshot`, close the regression issue with
 `not planned (stale)` and paste the helper output as the closing comment.
-When it reports `stale: accepted-regression entry no longer fails`, also
-open a follow-up to drop the entry from
-`scripts/conformance/conformance-accepted-regressions.txt`. When it reports
-`aggregate: no single snapshot row`, reply with the dashboard categories
-the helper points to instead of pretending a single row exists.
+When it reports `stale: accepted-regression entry no longer fails`, treat that
+as checked-in snapshot evidence only: first verify exact-head aggregate CI no
+longer lists the test in shard failures, then open a follow-up to drop the entry
+from `scripts/conformance/conformance-accepted-regressions.txt`. When it reports
+`aggregate: no single snapshot row`, reply with the dashboard categories the
+helper points to instead of pretending a single row exists.
 
 #### `scripts/conformance/conformance.sh`
 

--- a/scripts/conformance/link-regression-issues.py
+++ b/scripts/conformance/link-regression-issues.py
@@ -28,7 +28,9 @@ Status taxonomy
 
 ``stale-accepted``
     The test is in the accepted-regression list but no longer appears in
-    ``conformance-detail.json`` failures. The accepted entry can be retired.
+    ``conformance-detail.json`` failures. Treat this as checked-in snapshot
+    evidence only; exact-head aggregate CI must also show the test absent from
+    shard failures before the accepted entry can be retired.
 
 ``passing``
     The test passes in the baseline and is not accepted as a regression.
@@ -95,8 +97,10 @@ SNAPSHOT_REGEN_HINT = "./scripts/conformance/conformance.sh snapshot"
 STATUSES: dict[str, tuple[str, str]] = {
     "stale-accepted": (
         "stale: accepted-regression entry no longer fails",
-        "Remove the entry from `conformance-accepted-regressions.txt`, then "
-        "close the regression issue with `not planned (stale)`.",
+        "Do not remove the entry from `conformance-accepted-regressions.txt` "
+        "from this checked-in snapshot alone. First verify exact-head "
+        "aggregate CI no longer lists the test in shard failures, then retire "
+        "the entry and close the regression issue with `not planned (stale)`.",
     ),
     "passing": (
         "stale: passing in current snapshot",

--- a/scripts/conformance/test_link_regression_issues.py
+++ b/scripts/conformance/test_link_regression_issues.py
@@ -370,6 +370,7 @@ class TestRendering(unittest.TestCase):
         md = helper.render_markdown(results, self.index)
         self.assertIn("`tsxGenericAttributesType6.tsx`", md)
         self.assertIn(helper.STATUSES["stale-accepted"][0], md)
+        self.assertIn("exact-head aggregate CI", md)
 
     def test_markdown_includes_dashboard_hint_only_when_aggregate(self) -> None:
         aggregate_md = helper.render_markdown(


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Track 1 / conformance strictness tooling guardrail.

## Invariant
When `link-regression-issues.py` reports an accepted-regression entry as stale, that conclusion is only based on checked-in snapshot artifacts. Removing the accepted entry is valid only after exact-head aggregate CI confirms the fixture is absent from shard failures.

## Scope
- Update `scripts/conformance/link-regression-issues.py` stale-accepted taxonomy and closure guidance.
- Add a focused rendering assertion for the exact-head aggregate CI warning.
- Update `docs/development/TOOLING.md` with the same closure rule.

## Project Corpus Impact
- Row: n/a
- Bug family: conformance accepted-regression strictness
- No project-row behavior change. This changes conformance triage tooling guidance and docs only.

## Verification
- `python3 -m unittest scripts.conformance.test_link_regression_issues`
- `python3 scripts/conformance/link-regression-issues.py --from-file /tmp/tsz-accepted-regressions.txt`
- `git diff --check`

## Coordination Notes
- AgentName: Studio-Opus.
- Follow-up to PR #12402: exact-head CI showed the checked-in snapshot alone was insufficient evidence to delete accepted-regression entries.
- Independent of Studio-C PRs #12401/#12403; this does not touch checker, solver, emitter, benchmark metadata, or DTS surfaces.