### PR TITLE
feat(emit): add json family summary

### DIFF
--- a/docs/development/TOOLING.md
+++ b/docs/development/TOOLING.md
@@ -108,6 +108,30 @@ cargo install cargo-llvm-cov --version 0.8.7 --locked
 scripts/quality/run-coverage.sh
 ```
 
+## Emit Snapshot Tooling
+
+### `scripts/emit/query-emit.py`
+
+Reads the checked-in emit detail artifact without re-running the emit suite.
+Use text output for quick triage and JSON output when a PR, CI artifact, or
+handoff needs structured evidence.
+
+```bash
+# Human-readable failure families
+python3 scripts/emit/query-emit.py --families
+
+# Machine-readable failure families
+python3 scripts/emit/query-emit.py --families-json
+
+# Historical checked-detail rows when the public aggregate is newer
+python3 scripts/emit/query-emit.py --families-json --include-stale-detail
+```
+
+When the README/public aggregate is ahead of `scripts/emit/emit-detail.json`,
+family rows are suppressed by default. Pass `--include-stale-detail` only when
+the report is explicitly framed as historical checked-detail triage rather than
+the current public remaining set.
+
 ### Mutation Testing
 
 `cargo-mutants` is intentionally scoped by default. Use it to audit whether

--- a/scripts/emit/query-emit.py
+++ b/scripts/emit/query-emit.py
@@ -13,6 +13,9 @@ Usage:
   # Failure-family dashboard
   python3 scripts/emit/query-emit.py --families
 
+  # Machine-readable failure-family dashboard
+  python3 scripts/emit/query-emit.py --families-json
+
   # Include historical family rows even when emit-detail.json is stale
   python3 scripts/emit/query-emit.py --families --include-stale-detail
 
@@ -548,6 +551,71 @@ def collect_failures_by_family(data, surface):
     return families
 
 
+def family_rows(data, surface, top=None):
+    families = collect_failures_by_family(data, surface)
+    rows = sorted(
+        families.items(),
+        key=lambda item: (-len(item[1]), item[0]),
+    )
+    if top is not None:
+        rows = rows[:top]
+    return [
+        {
+            "family": family,
+            "count": len(results),
+            "examples": [
+                result["name"]
+                for result in sorted(results, key=lambda result: result["name"])[:3]
+            ],
+        }
+        for family, results in rows
+    ]
+
+
+def failure_count_by_surface(data, surface):
+    return sum(len(results) for results in collect_failures_by_family(data, surface).values())
+
+
+def failure_family_report(data, top=20, include_stale_detail=False):
+    detail_summary = emit_summary(data)
+    public_summary = emit_summary_from_readme()
+    freshness = emit_freshness_report(detail_summary, public_summary)
+    families_suppressed = freshness["state"] == "stale" and not include_stale_detail
+
+    surfaces = []
+    for surface, title in (("js", "JavaScript"), ("dts", "Declaration")):
+        rows = [] if families_suppressed else family_rows(data, surface, top)
+        surfaces.append(
+            {
+                "surface": surface,
+                "title": title,
+                "checkedDetailFailures": None
+                if families_suppressed
+                else failure_count_by_surface(data, surface),
+                "publicRemaining": emit_remaining_failures(public_summary, surface),
+                "checkedDetailRemaining": emit_remaining_failures(detail_summary, surface),
+                "families": rows,
+            }
+        )
+
+    return {
+        "freshness": freshness,
+        "familiesSuppressed": families_suppressed,
+        "includeStaleDetail": include_stale_detail,
+        "top": top,
+        "surfaces": surfaces,
+    }
+
+
+def print_failure_families_json(data, top=20, include_stale_detail=False):
+    print(
+        json.dumps(
+            failure_family_report(data, top=top, include_stale_detail=include_stale_detail),
+            sort_keys=True,
+        )
+    )
+
+
 def show_failure_families(data, top=20, include_stale_detail=False):
     print("Emit failure families")
     print()
@@ -639,6 +707,11 @@ def main():
         action="store_true",
         help="With --families, print historical family rows even when emit-detail.json is stale",
     )
+    parser.add_argument(
+        "--families-json",
+        action="store_true",
+        help="Show JS/DTS failure family counts as machine-readable JSON",
+    )
     parser.add_argument("--close", action="store_true", help="Show close-to-passing tests")
     parser.add_argument("--filter", type=str, help="Filter by substring in test name")
     parser.add_argument("--status", type=str, help="Filter by status (pass/fail/skip/timeout)")
@@ -675,6 +748,8 @@ def main():
         show_dts_failures(filtered_data, args.top, args.paths_only)
     elif args.top_errors:
         show_top_errors(filtered_data, args.top)
+    elif args.families_json:
+        print_failure_families_json(filtered_data, args.top, args.include_stale_detail)
     elif args.families:
         show_failure_families(filtered_data, args.top, args.include_stale_detail)
     elif args.close:

--- a/scripts/emit/test_query_emit_families.py
+++ b/scripts/emit/test_query_emit_families.py
@@ -333,6 +333,106 @@ after
         self.assertIn("class/private/accessor/decorator lowering", text)
         self.assertIn("generic/type-display declarations", text)
 
+    def test_failure_family_json_suppresses_stale_rows_by_default(self):
+        data = {
+            "summary": {
+                "jsPass": 13094,
+                "jsTotal": 13530,
+                "dtsPass": 1606,
+                "dtsTotal": 1669,
+            },
+            "results": [
+                make_result("classUsedBeforeInitializedVariables", js_error="+1/-1 lines"),
+                make_result("inferTypePredicates", dts_error="+1/-1 lines"),
+            ],
+        }
+        original = self.mod.emit_summary_from_readme
+        self.mod.emit_summary_from_readme = lambda: {
+            "jsPass": 13459,
+            "jsTotal": 13530,
+            "dtsPass": 1644,
+            "dtsTotal": 1669,
+        }
+        try:
+            report = self.mod.failure_family_report(data)
+        finally:
+            self.mod.emit_summary_from_readme = original
+
+        self.assertEqual(report["freshness"]["state"], "stale")
+        self.assertTrue(report["familiesSuppressed"])
+        self.assertFalse(report["includeStaleDetail"])
+        self.assertEqual(
+            [
+                (surface["surface"], surface["publicRemaining"], surface["checkedDetailRemaining"])
+                for surface in report["surfaces"]
+            ],
+            [("js", 71, 436), ("dts", 25, 63)],
+        )
+        self.assertEqual(report["surfaces"][0]["families"], [])
+        self.assertIsNone(report["surfaces"][0]["checkedDetailFailures"])
+
+    def test_failure_family_json_includes_explicit_stale_rows(self):
+        data = {
+            "summary": {
+                "jsPass": 13094,
+                "jsTotal": 13530,
+                "dtsPass": 1606,
+                "dtsTotal": 1669,
+            },
+            "results": [
+                {
+                    **make_result("classUsedBeforeInitializedVariables", js_error="+1/-1 lines"),
+                    "dtsStatus": "pass",
+                },
+                {
+                    **make_result("classWithStaticBlock", js_error="+1/-1 lines"),
+                    "dtsStatus": "pass",
+                },
+                {
+                    **make_result("inferTypePredicates", dts_error="+1/-1 lines"),
+                    "jsStatus": "pass",
+                },
+            ],
+        }
+        original = self.mod.emit_summary_from_readme
+        self.mod.emit_summary_from_readme = lambda: {
+            "jsPass": 13459,
+            "jsTotal": 13530,
+            "dtsPass": 1644,
+            "dtsTotal": 1669,
+        }
+        try:
+            report = self.mod.failure_family_report(
+                data,
+                top=1,
+                include_stale_detail=True,
+            )
+        finally:
+            self.mod.emit_summary_from_readme = original
+
+        self.assertFalse(report["familiesSuppressed"])
+        self.assertTrue(report["includeStaleDetail"])
+        self.assertEqual(report["top"], 1)
+        self.assertEqual(report["surfaces"][0]["checkedDetailFailures"], 2)
+        self.assertEqual(
+            report["surfaces"][0]["families"],
+            [
+                {
+                    "family": "class/private/accessor/decorator lowering",
+                    "count": 2,
+                    "examples": [
+                        "classUsedBeforeInitializedVariables",
+                        "classWithStaticBlock",
+                    ],
+                }
+            ],
+        )
+        self.assertEqual(report["surfaces"][1]["checkedDetailFailures"], 1)
+        self.assertEqual(
+            report["surfaces"][1]["families"][0]["family"],
+            "generic/type-display declarations",
+        )
+
     def test_current_failure_family_heading_keeps_plain_count(self):
         summary = {
             "jsPass": 13459,


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Track 9 / emit tooling evidence infrastructure.

## Invariant
When emit failure-family evidence is consumed by PRs or CI, the data should be structured and freshness-aware; this PR makes `scripts/emit/query-emit.py` expose the existing family classification and stale-detail guard through a JSON query mode without changing compiler behavior.

## Scope
- Add `--families-json` to `scripts/emit/query-emit.py`.
- Preserve the stale checked-detail suppression contract by default and require `--include-stale-detail` for historical family rows.
- Add focused unit tests for suppressed stale JSON and explicit stale-detail JSON.
- Document emit snapshot query usage in `docs/development/TOOLING.md`.

## Project Corpus Impact
- Row: n/a.
- Bug family: emit evidence/tooling only.
- No compiler, project-corpus, benchmark-runner, checker, solver, or emitter behavior change.

## Verification
- `python3 -m unittest scripts.emit.test_query_emit_families`
- `python3 scripts/emit/query-emit.py --families-json --top 3`
- `python3 scripts/emit/query-emit.py --families-json --include-stale-detail --top 2`
- `git diff --check`
- `wc -l scripts/emit/query-emit.py scripts/emit/test_query_emit_families.py docs/development/TOOLING.md`

## Coordination Notes
- AgentName: Studio-Opus
- Complements Studio-C #12403 by improving structured emit-family evidence; does not touch compiler emit logic or output-surgery budget.
- Opened as draft for CI/coordination; ready once light checks and PR body validation are clean.
