### PR TITLE
fix(emit): lower private accessor object rest targets

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class_members.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class_members.rs
@@ -428,6 +428,13 @@ impl<'a> Printer<'a> {
             self.ctx.block_scope_state.enter_scope();
             self.push_temp_scope();
             let prev_declared = std::mem::take(&mut self.declared_namespace_names);
+            if let Some(body_node) = self.arena.get(method.body) {
+                let temp_count =
+                    self.estimate_assignment_destructuring_temps_in_constructor(body_node);
+                if temp_count > 0 {
+                    self.preallocate_assignment_temps(temp_count);
+                }
+            }
             self.prepare_logical_assignment_value_temps(method.body);
             self.ctx.flags.in_generator = has_generator_asterisk;
             self.emit(method.body);

--- a/crates/tsz-emitter/src/emitter/es5/bindings_assignment.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings_assignment.rs
@@ -467,6 +467,20 @@ impl<'a> Printer<'a> {
         })
     }
 
+    fn assignment_object_literal_has_own_rest(&self, idx: NodeIndex) -> bool {
+        let Some(node) = self.arena.get(idx) else {
+            return false;
+        };
+        node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+            && self.arena.get_literal_expr(node).is_some_and(|lit| {
+                lit.elements.nodes.iter().any(|&elem_idx| {
+                    self.arena
+                        .get(elem_idx)
+                        .is_some_and(|elem| elem.kind == syntax_kind_ext::SPREAD_ASSIGNMENT)
+                })
+            })
+    }
+
     fn assignment_object_rest_default_pattern(
         &self,
         idx: NodeIndex,
@@ -558,6 +572,9 @@ impl<'a> Printer<'a> {
         let mut first = true;
         let source_name = if is_simple {
             crate::transforms::emit_utils::identifier_text_or_empty(self.arena, effective_right_idx)
+        } else if !self.assignment_object_literal_has_own_rest(left_idx) {
+            let emit_idx = self.peel_assign_rhs_object_literal_paren(right_idx);
+            self.capture_emit(emit_idx)
         } else {
             let temp = self.make_unique_name_hoisted_assignment();
             self.emit_assignment_separator(&mut first);
@@ -661,7 +678,10 @@ impl<'a> Printer<'a> {
     }
 
     fn emit_assignment_object_rest_target(&mut self, target: NodeIndex) {
-        if self.assignment_object_rest_target_needs_temp(target) {
+        if self.emit_private_object_rest_assignment_target(target) {
+            // Private fields/accessors are not assignment targets after lowering,
+            // so use the same setter proxy target as native destructuring.
+        } else if self.assignment_object_rest_target_needs_temp(target) {
             let temp = self.make_unique_name_hoisted_assignment();
             self.write(&temp);
         } else if self.pattern_has_scoped_static_super_assignment_target(target) {
@@ -872,6 +892,7 @@ impl<'a> Printer<'a> {
                             let nested_source = self.object_key_access_text(source, &key);
                             let nested_simple = self.arena.get(prop.initializer).is_some_and(|n| {
                                 n.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
+                                    || self.assignment_object_literal_is_rest_only(prop.initializer)
                             });
                             self.emit_assignment_pattern_with_object_rest(
                                 prop.initializer,

--- a/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
@@ -366,6 +366,31 @@ impl<'a> Printer<'a> {
         self.write("; } }).value");
     }
 
+    pub(in crate::emitter) fn emit_private_object_rest_assignment_target(
+        &mut self,
+        target: NodeIndex,
+    ) -> bool {
+        let Some(access) = self.try_extract_private_field_access(target) else {
+            return false;
+        };
+        let receiver_temp = (!self.receiver_is_plain_identifier(access.expression))
+            .then(|| self.make_unique_name_hoisted_assignment());
+        if let Some(receiver_temp) = &receiver_temp {
+            self.write(receiver_temp);
+            self.write(" = ");
+            self.emit_private_receiver(access.expression, &access.clean_name);
+            self.write(", ");
+        }
+        let setter_value = self.peek_fresh_temp_name();
+        self.emit_private_destructuring_setter_target(&PrivateDestructuringTarget {
+            target,
+            access,
+            receiver_temp,
+            setter_value,
+        });
+        true
+    }
+
     fn emit_private_destructuring_pattern(
         &mut self,
         idx: NodeIndex,
@@ -993,15 +1018,6 @@ impl<'a> Printer<'a> {
             }
         }
 
-        // ES2015+ can keep native destructuring syntax, but private field
-        // assignment targets still need to route writes through the SET helper.
-        if !self.ctx.target_es5
-            && binary.operator_token == SyntaxKind::EqualsToken as u16
-            && self.emit_private_field_destructuring_assignment(binary.left, binary.right)
-        {
-            return;
-        }
-
         if self.emit_scoped_static_super_assignment(
             binary.left,
             binary.operator_token,
@@ -1019,6 +1035,15 @@ impl<'a> Printer<'a> {
             && self.assignment_pattern_has_object_rest(binary.left)
         {
             self.emit_assignment_object_rest_destructuring(binary.left, binary.right);
+            return;
+        }
+
+        // ES2015+ can keep native destructuring syntax, but private field
+        // assignment targets still need to route writes through the SET helper.
+        if !self.ctx.target_es5
+            && binary.operator_token == SyntaxKind::EqualsToken as u16
+            && self.emit_private_field_destructuring_assignment(binary.left, binary.right)
+        {
             return;
         }
 

--- a/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
@@ -221,6 +221,32 @@ class A3 {
 }
 
 #[test]
+fn private_accessor_object_rest_assignment_uses_setter_target() {
+    let source = r#"
+class Test {
+    set #value(v) {}
+    m(foo) {
+        ({ ...this.#value } = { foo });
+    }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains("__rest({ foo }, [])"),
+        "Object-rest assignment to a private setter should lower through __rest.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("({ set value(") && output.contains("__classPrivateFieldSet("),
+        "Object-rest private setter targets should use the setter proxy target.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("{ ...({ set value("),
+        "Object-rest lowering should run before native private destructuring fallback.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn private_compound_assignment_allocates_nested_receiver_temps_first() {
     let source = r#"
 class Test {


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Track 9 emit parity: JavaScript emit baseline burn-down for remaining private-accessor/object-rest rows.

## Invariant
When an ES2015 object-rest assignment writes through a private field or accessor target, tsc lowers the rest expression first and writes through the private setter-proxy target; this PR routes object-rest assignment targets through the existing private setter proxy and reserves method-body private destructuring temps before choosing setter parameter names.

## Scope
- `crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs`
- `crates/tsz-emitter/src/emitter/es5/bindings_assignment.rs`
- `crates/tsz-emitter/src/emitter/declarations/class_members.rs`
- `crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit-suite-only baseline row (`privateWriteOnlyAccessorRead`)
- Evidence: focused JS emit filter passes locally on rebased head `73f74654d9c1`; no project-corpus compile behavior change expected.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter private_accessor_object_rest_assignment_uses_setter_target es2015_private_field_destructuring_assignment_uses_setter_target es5_single_leaf_nested_destructuring_inlines_access_path`
- `scripts/safe-run.sh scripts/emit/run.sh --js-only --filter=privateWriteOnlyAccessorRead --verbose --timeout=20000 --json-out=/tmp/studio-c-js-private-accessor-rebased.json`
- `cargo fmt --check`
- `scripts/safe-run.sh cargo clippy -p tsz-emitter --all-targets -- -D warnings`
- `git diff --check origin/main..HEAD`
- `wc -l` on touched files; all touched files are under 2000 physical lines.

## Coordination Notes
- AgentName: Studio-C
- Rebased onto `origin/main` at `9a34604b26ee` after #12403 and #12405 landed.
- Draft light CI is being refreshed on rebased head `73f74654d9c1` before ready-review.
- No checker/solver changes and no output-surgery expansion.