### PR TITLE
fix(checker): suppress transparent alias depth cascades

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/core.rs
+++ b/crates/tsz-checker/src/state/type_resolution/core.rs
@@ -135,6 +135,25 @@ impl<'a> CheckerState<'a> {
             .is_some_and(|body| self.ctx.type_involves_depth_poisoned_def(body))
     }
 
+    fn def_body_can_own_ambient_depth(&self, def_id: tsz_solver::DefId) -> bool {
+        let Some(body) = self
+            .ctx
+            .type_env
+            .try_borrow()
+            .ok()
+            .and_then(|env| env.get_def(def_id))
+            .or_else(|| self.ctx.definition_store.get_body(def_id))
+        else {
+            return false;
+        };
+
+        let db = self.ctx.types.as_type_database();
+        crate::query_boundaries::common::contains_conditional_type(db, body)
+            || crate::query_boundaries::common::contains_keyof_type(db, body)
+            || tsz_solver::type_queries::contains_index_access_type(db, body)
+            || crate::query_boundaries::common::is_mapped_type(db, body)
+    }
+
     /// Get type from a type reference node (e.g., "number", "string", "`MyType`").
     pub(crate) fn get_type_from_type_reference(&mut self, idx: NodeIndex) -> TypeId {
         // Fuel check: prevent infinite loops in circular type references
@@ -506,24 +525,28 @@ impl<'a> CheckerState<'a> {
                         // body's recursive sub-call uses the default, possibly
                         // re-triggering fan-out). When all args are explicit the
                         // body's sub-call hits the base case immediately.
-                        let (exceeded, tuple_too_large) = if (computed_recursive_alias
+                        let default_omitting_alias_omits_arg = default_omitting_recursive_alias
+                            && self.type_reference_omits_defaulted_alias_arg(sym_id, type_ref);
+                        let alias_uses_ts2589_evaluator = computed_recursive_alias
                             || same_input_recursive_union_alias
                             || default_reset_recursive_alias
-                            || (default_omitting_recursive_alias
-                                && self.type_reference_omits_defaulted_alias_arg(sym_id, type_ref)))
-                            && let Some(base_def_id) = base_def_id
-                        {
-                            (
-                                self.evaluate_type_for_ts2589_check(type_id, base_def_id),
-                                self.ctx.types.take_tuple_too_large(),
-                            )
-                        } else {
-                            self.evaluate_type_with_env_uncached(type_id);
-                            (
-                                self.ctx.depth_exceeded.get(),
-                                self.ctx.types.take_tuple_too_large(),
-                            )
-                        };
+                            || default_omitting_alias_omits_arg;
+                        let alias_can_own_ambient_depth = alias_uses_ts2589_evaluator
+                            || base_def_id
+                                .is_some_and(|def_id| self.def_body_can_own_ambient_depth(def_id));
+                        let (exceeded, tuple_too_large) =
+                            if alias_uses_ts2589_evaluator && let Some(base_def_id) = base_def_id {
+                                (
+                                    self.evaluate_type_for_ts2589_check(type_id, base_def_id),
+                                    self.ctx.types.take_tuple_too_large(),
+                                )
+                            } else {
+                                self.evaluate_type_with_env_uncached(type_id);
+                                (
+                                    self.ctx.depth_exceeded.get() && alias_can_own_ambient_depth,
+                                    self.ctx.types.take_tuple_too_large(),
+                                )
+                            };
 
                         // Also detect circular mapped-type aliases that the evaluator
                         // can't expand: if the alias body is a mapped type that
@@ -1440,13 +1463,17 @@ impl<'a> CheckerState<'a> {
                             // body's sub-call hits the base case immediately.
                             let app_def_id = query::get_application_info(self.ctx.types, result)
                                 .and_then(|(base, _)| query::get_lazy_def_id(self.ctx.types, base));
-                            let (exceeded, tuple_too_large) = if (computed_recursive_alias
+                            let default_omitting_alias_omits_arg = default_omitting_recursive_alias
+                                && self.type_reference_omits_defaulted_alias_arg(sym_id, type_ref);
+                            let alias_uses_ts2589_evaluator = computed_recursive_alias
                                 || same_input_recursive_union_alias
                                 || default_reset_recursive_alias
-                                || (default_omitting_recursive_alias
-                                    && self.type_reference_omits_defaulted_alias_arg(
-                                        sym_id, type_ref,
-                                    )))
+                                || default_omitting_alias_omits_arg;
+                            let alias_can_own_ambient_depth = alias_uses_ts2589_evaluator
+                                || app_def_id.is_some_and(|def_id| {
+                                    self.def_body_can_own_ambient_depth(def_id)
+                                });
+                            let (exceeded, tuple_too_large) = if alias_uses_ts2589_evaluator
                                 && let Some(app_def_id) = app_def_id
                             {
                                 (
@@ -1456,7 +1483,7 @@ impl<'a> CheckerState<'a> {
                             } else {
                                 self.evaluate_type_with_env_uncached(result);
                                 (
-                                    self.ctx.depth_exceeded.get(),
+                                    self.ctx.depth_exceeded.get() && alias_can_own_ambient_depth,
                                     self.ctx.types.take_tuple_too_large(),
                                 )
                             };

--- a/crates/tsz-checker/src/test_utils.rs
+++ b/crates/tsz-checker/src/test_utils.rs
@@ -1067,8 +1067,8 @@ pub fn check_source_with_libs_code_messages(
 /// `test_utils::check_multi_file*` call sites are unchanged.
 mod multi_file;
 pub use multi_file::{
-    check_multi_file, check_multi_file_with_global_index, check_multi_file_with_libs,
-    check_multi_file_with_type_params_cache,
+    check_all_multi_file_with_global_index, check_multi_file, check_multi_file_with_global_index,
+    check_multi_file_with_libs, check_multi_file_with_type_params_cache,
 };
 
 #[cfg(test)]

--- a/crates/tsz-checker/src/test_utils/multi_file.rs
+++ b/crates/tsz-checker/src/test_utils/multi_file.rs
@@ -147,6 +147,73 @@ pub fn check_multi_file_with_global_index(
     checker.ctx.diagnostics.clone()
 }
 
+/// Parse, bind, and type-check every file in a multi-file project with the
+/// production `global_symbol_file_index` wired up.
+///
+/// This mirrors project checks more closely than entry-only helpers when a
+/// regression depends on earlier files populating shared project state.
+pub fn check_all_multi_file_with_global_index(
+    files: &[(&str, &str)],
+    options: CheckerOptions,
+) -> Vec<Diagnostic> {
+    let mut arenas = Vec::with_capacity(files.len());
+    let mut binders = Vec::with_capacity(files.len());
+    let mut roots = Vec::with_capacity(files.len());
+    let file_names: Vec<String> = files.iter().map(|(name, _)| (*name).to_string()).collect();
+
+    for (name, source) in files {
+        let mut parser = ParserState::new((*name).to_string(), (*source).to_string());
+        let root = parser.parse_source_file();
+        let mut binder = BinderState::new();
+        binder.bind_source_file(parser.get_arena(), root);
+        arenas.push(Arc::new(parser.get_arena().clone()));
+        binders.push(Arc::new(binder));
+        roots.push(root);
+    }
+
+    let (resolved_module_paths, resolved_modules) =
+        crate::module_resolution::build_module_resolution_maps(&file_names);
+    let resolved_module_paths = Arc::new(resolved_module_paths);
+    let all_arenas = Arc::new(arenas);
+    let all_binders = Arc::new(binders);
+
+    let mut symbol_file_index = rustc_hash::FxHashMap::default();
+    for (file_idx, binder) in all_binders.iter().enumerate() {
+        for symbol in binder.symbols.iter() {
+            symbol_file_index.entry(symbol.id).or_insert(file_idx);
+        }
+    }
+    let symbol_file_index = Arc::new(symbol_file_index);
+
+    let types = TypeInterner::new();
+    let mut diagnostics = Vec::new();
+    for (file_idx, file_name) in file_names.iter().enumerate() {
+        let mut checker = CheckerState::new(
+            all_arenas[file_idx].as_ref(),
+            all_binders[file_idx].as_ref(),
+            &types,
+            file_name.clone(),
+            options.clone(),
+        );
+        checker.ctx.set_all_arenas(Arc::clone(&all_arenas));
+        checker.ctx.set_all_binders(Arc::clone(&all_binders));
+        checker.ctx.set_current_file_idx(file_idx);
+        checker.ctx.set_lib_contexts(Vec::new());
+        checker
+            .ctx
+            .set_resolved_module_paths(Arc::clone(&resolved_module_paths));
+        checker.ctx.set_resolved_modules(resolved_modules.clone());
+        checker
+            .ctx
+            .set_global_symbol_file_index(Arc::clone(&symbol_file_index));
+
+        checker.check_source_file(roots[file_idx]);
+        diagnostics.extend(checker.ctx.diagnostics.clone());
+    }
+
+    diagnostics
+}
+
 /// Parse, bind, and type-check a multi-file project with lib contexts loaded.
 ///
 /// This is the lib-aware counterpart to [`check_multi_file`]. Each project

--- a/crates/tsz-checker/tests/generic_default_recursive_alias_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/generic_default_recursive_alias_diagnostics_tests.rs
@@ -7,7 +7,11 @@
 //! should recover through the error type instead of cascading another TS2589 at
 //! the reference site.
 
-use tsz_checker::test_utils::{check_source_strict, diagnostic_codes, diagnostics_without_codes};
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{
+    check_all_multi_file_with_global_index, check_multi_file_with_global_index,
+    check_source_strict, diagnostic_codes, diagnostics_without_codes,
+};
 
 fn semantic_codes(source: &str) -> Vec<u32> {
     diagnostic_codes(&diagnostics_without_codes(
@@ -151,7 +155,6 @@ interface ReadonlyArray<T> {
     readonly length: number;
     readonly [n: number]: T;
 }
-
 type List<A = any> = ReadonlyArray<A>;
 type Cast<A1 extends any, A2 extends any> = A1 extends A2 ? A1 : A2;
 type Extends<A1 extends any, A2 extends any> =
@@ -191,5 +194,193 @@ type Result = MergeAll<[{}], [[{ value: 1 }]]>;
     assert!(
         !codes.contains(&2589),
         "bounded recursive merge through a non-recursive List wrapper must not emit TS2589; got {codes:?}"
+    );
+}
+
+#[test]
+fn generic_recursive_merge_cast_to_list_alias_no_declaration_ts2589() {
+    let codes = semantic_codes(
+        r##"
+interface ReadonlyArray<T> {
+    readonly length: number;
+    readonly [n: number]: T;
+}
+
+type List<A = any> = ReadonlyArray<A>;
+type Cast<A1 extends any, A2 extends any> = A1 extends A2 ? A1 : A2;
+type Extends<A1 extends any, A2 extends any> =
+    [A1] extends [never] ? 0 : A1 extends A2 ? 1 : 0;
+
+type Iteration = [
+    value: number,
+    next: keyof IterationMap,
+];
+type IterationMap = {
+    "__": [number, "__"],
+    "0": [0, "1"],
+    "1": [1, "__"],
+};
+type IterationOf<N extends keyof IterationMap> = IterationMap[N];
+type Next<I extends Iteration> = IterationMap[I[1]];
+type Pos<I extends Iteration> = I[0];
+type Length<L extends List> = L["length"];
+type Depth = "flat" | "deep";
+type BuiltIn = Function | Date | Error | RegExp;
+
+type Merge<O extends object, O1 extends object> = O & O1;
+type __MergeAll<
+    O extends object,
+    Os extends List<object>,
+    depth extends Depth,
+    ignore extends object,
+    fill extends any,
+    I extends Iteration = IterationOf<"0">,
+> = {
+    0: __MergeAll<Merge<O, Os[Pos<I>] & object>, Os, depth, ignore, fill, Next<I>>;
+    1: O;
+}[Extends<Pos<I>, Length<Os>>];
+type _MergeAll<
+    O extends object,
+    Os extends List<object>,
+    depth extends Depth,
+    ignore extends object,
+    fill extends any,
+> = __MergeAll<O, Os, depth, ignore, fill> extends infer X
+    ? Cast<X, object>
+    : never;
+type ObjectMergeAll<
+    O extends object,
+    Os extends List<object>,
+    depth extends Depth = "flat",
+    ignore extends object = BuiltIn,
+    fill extends any = undefined,
+> = O extends unknown
+    ? Os extends unknown
+        ? _MergeAll<O, Os, depth, ignore, fill>
+        : never
+    : never;
+type MergeAll<
+    L extends List,
+    Ls extends List<List>,
+    depth extends Depth = "flat",
+    ignore extends object = BuiltIn,
+    fill extends any = undefined,
+> = Cast<ObjectMergeAll<L, Ls, depth, ignore, fill>, List>;
+"##,
+    );
+
+    assert!(
+        !codes.contains(&2589),
+        "generic list wrapper declaration around bounded recursive merge must not emit TS2589; got {codes:?}"
+    );
+}
+
+#[test]
+fn imported_generic_recursive_merge_cast_to_list_alias_no_declaration_ts2589() {
+    let files = [
+        (
+            "list.ts",
+            r#"
+export interface ReadonlyArray<T> {
+    readonly length: number;
+    readonly [n: number]: T;
+}
+export type List<A = any> = ReadonlyArray<A>;
+"#,
+        ),
+        (
+            "cast.ts",
+            r#"
+export type Cast<A1 extends any, A2 extends any> = A1 extends A2 ? A1 : A2;
+export type Extends<A1 extends any, A2 extends any> =
+    [A1] extends [never] ? 0 : A1 extends A2 ? 1 : 0;
+"#,
+        ),
+        (
+            "objectMergeAll.ts",
+            r##"
+import {Cast, Extends} from "./cast";
+import {List} from "./list";
+
+type Iteration = [
+    value: number,
+    next: keyof IterationMap,
+];
+type IterationMap = {
+    "__": [number, "__"],
+    "0": [0, "1"],
+    "1": [1, "__"],
+};
+type IterationOf<N extends keyof IterationMap> = IterationMap[N];
+type Next<I extends Iteration> = IterationMap[I[1]];
+type Pos<I extends Iteration> = I[0];
+type Length<L extends List> = L["length"];
+export type Depth = "flat" | "deep";
+export type BuiltIn = { readonly __brand?: never };
+
+type Merge<O extends object, O1 extends object> = O & O1;
+type __MergeAll<
+    O extends object,
+    Os extends List<object>,
+    depth extends Depth,
+    ignore extends object,
+    fill extends any,
+    I extends Iteration = IterationOf<"0">,
+> = {
+    0: __MergeAll<Merge<O, Os[Pos<I>] & object>, Os, depth, ignore, fill, Next<I>>;
+    1: O;
+}[Extends<Pos<I>, Length<Os>>];
+type _MergeAll<
+    O extends object,
+    Os extends List<object>,
+    depth extends Depth,
+    ignore extends object,
+    fill extends any,
+> = __MergeAll<O, Os, depth, ignore, fill> extends infer X
+    ? Cast<X, object>
+    : never;
+export type ObjectMergeAll<
+    O extends object,
+    Os extends List<object>,
+    depth extends Depth = "flat",
+    ignore extends object = BuiltIn,
+    fill extends any = undefined,
+> = O extends unknown
+    ? Os extends unknown
+        ? _MergeAll<O, Os, depth, ignore, fill>
+        : never
+    : never;
+"##,
+        ),
+        (
+            "mergeAll.ts",
+            r#"
+import {Cast} from "./cast";
+import {List} from "./list";
+import {BuiltIn, Depth, ObjectMergeAll} from "./objectMergeAll";
+
+export type MergeAll<
+    L extends List,
+    Ls extends List<List>,
+    depth extends Depth = "flat",
+    ignore extends object = BuiltIn,
+    fill extends any = undefined,
+> = Cast<ObjectMergeAll<L, Ls, depth, ignore, fill>, List>;
+"#,
+        ),
+    ];
+    let entry_diagnostics =
+        check_multi_file_with_global_index(&files, "mergeAll.ts", CheckerOptions::default());
+    let diagnostics = check_all_multi_file_with_global_index(&files, CheckerOptions::default());
+    let entry_codes = diagnostic_codes(&diagnostics_without_codes(&entry_diagnostics, &[2318]));
+    let codes = diagnostic_codes(&diagnostics_without_codes(&diagnostics, &[2318]));
+
+    assert!(
+        !entry_codes.contains(&2589),
+        "entry-only imported generic list wrapper declaration must not emit TS2589; got {entry_codes:?}"
+    );
+    assert!(
+        !codes.contains(&2589),
+        "project-style imported generic list wrapper declaration around bounded recursive merge must not emit TS2589; got {codes:?}"
     );
 }


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Studio-B performance / project-row correctness unblocker for a tsgo-winning benchmark row.

## Invariant
When a transparent type-reference alias such as `List<A> = ReadonlyArray<A>` is applied with explicit type arguments, depth reached while evaluating the argument or callee environment must not make that wrapper own TS2589. TS2589 remains owned by recursive/defaulted/conditional/indexed alias bodies through the checker type-resolution explicit-argument gateway.

## Scope
- `crates/tsz-checker/src/state/type_resolution/core.rs`: split special TS2589 evaluator ownership from broader ambient-depth ownership and suppress transparent alias cascades.
- `crates/tsz-checker/src/test_utils/multi_file.rs`: add an all-files global-index helper for project-shaped multi-file diagnostics tests.
- `crates/tsz-checker/tests/generic_default_recursive_alias_diagnostics_tests.rs`: add ts-toolbelt-shaped wrapper coverage and retain direct/deep TS2589 ownership cases.

## Project Corpus Impact
- Row: `ts-toolbelt-project`
- Bug family: recursive type evaluation pressure / transparent alias TS2589 cascade
- Evidence: before artifact `/private/tmp/studio-b-ts-toolbelt-cache-scope-baseline.json` was yellow with TS2589 at `List/MergeAll.ts(20,49)` and `List/PatchAll.ts(20,49)` while tsc/tsgo exited 0. After artifact `/private/tmp/studio-b-ts-toolbelt-cache-scope-after.json` is green: tsz 7987ms, tsgo 159.3ms, tsgo still wins 50.14x, so this PR restores parity but does not claim speed. Winner report `/private/tmp/studio-b-ts-toolbelt-cache-scope-after.tsgo-winners.json` still records one 2x target gap and missing JSON attribution; perf text is `/private/tmp/studio-b-ts-toolbelt-cache-scope-after.perf.txt`.

## Verification
- `cargo fmt`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test generic_default_recursive_alias_diagnostics_tests -E 'test(imported_generic_recursive_merge_cast_to_list_alias_no_declaration_ts2589) or test(generic_recursive_merge_cast_to_list_alias_no_declaration_ts2589) or test(bounded_recursive_merge_wrapped_in_list_alias_no_ts2589) or test(direct_recursive_alias_use_still_reports_ts2589) or test(ordinary_conditional_tuple_builder_still_reports_depth_at_deep_use) or test(awaited_style_recursive_thenable_reports_depth_at_use)'`
- `scripts/safe-run.sh cargo build --bin tsz && scripts/safe-run.sh env TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 .target/debug/tsz --noEmit -p .target-bench/external/ts-toolbelt/tsconfig.flat.json`
- `scripts/safe-run.sh ./scripts/bench/perf-hotspots.sh --filter '^ts-toolbelt-project$' --json-file /private/tmp/studio-b-ts-toolbelt-cache-scope-after.json`
- `scripts/safe-run.sh env TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 TSZ_PERF_COUNTERS=1 .target-bench/dist/tsz --extendedDiagnostics --noEmit -p .target-bench/external/ts-toolbelt/tsconfig.flat.json > /private/tmp/studio-b-ts-toolbelt-cache-scope-after.perf.txt 2>&1`
- PR-head CI light checks on `b7811e47f05ac6035bcb569c3317cc0f1d597202`: `CI Light Summary`, `lint`, `unit`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `queue-one-pr`, `unit-cloudbuild`, and `GitGuardian Security Checks` passed.

## Coordination Notes
- Ready for manager review/queue handoff after exact-head checks passed on `b7811e47f05ac6035bcb569c3317cc0f1d597202`.
- No owned Studio-B PRs were open at intake.
- No speed claim: the row is green again but remains the current Studio-B target gap.
- Follow-up performance work should continue from the `Record`/`_Pick`/cross-arena hotspots in the perf text artifact.
