### PR TITLE
feat(bench): add project row json summary

### DIFF
--- a/scripts/bench/project-row-summary.mjs
+++ b/scripts/bench/project-row-summary.mjs
@@ -8,9 +8,10 @@
  * Exit 2: usage error.
  *
  * Usage:
- *   node scripts/bench/project-row-summary.mjs [--markdown]
+ *   node scripts/bench/project-row-summary.mjs [--markdown] [--json]
  *
- * Without --markdown, outputs plain text.  With --markdown, outputs GFM.
+ * Without --markdown or --json, outputs plain text. With --markdown, outputs
+ * GFM. With --json, outputs a machine-readable coverage report.
  * When $GITHUB_STEP_SUMMARY is set, the markdown table is also appended to
  * that file automatically (regardless of --markdown) so the coverage is
  * visible in the PR checks UI without a separate step.
@@ -284,6 +285,22 @@ export function formatPlainText(coverage) {
   return lines.join("\n");
 }
 
+export function buildJsonReport(coverage) {
+  const { rows, drift } = coverage;
+  return {
+    ok: drift.length === 0,
+    status: drift.length === 0 ? "passed" : "failed",
+    rowCount: rows.length,
+    driftCount: drift.length,
+    drift,
+    rows,
+  };
+}
+
+export function formatJson(coverage) {
+  return JSON.stringify(buildJsonReport(coverage), null, 2);
+}
+
 export function appendStepSummary(coverage, stepSummaryPath) {
   if (!stepSummaryPath) return;
   fs.appendFileSync(stepSummaryPath, `${formatMarkdown(coverage)}\n`);
@@ -292,16 +309,23 @@ export function appendStepSummary(coverage, stepSummaryPath) {
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const args = process.argv.slice(2);
   const markdown = args.includes("--markdown");
-  const unknownArgs = args.filter((a) => a !== "--markdown");
+  const json = args.includes("--json");
+  const unknownArgs = args.filter((a) => a !== "--markdown" && a !== "--json");
   if (unknownArgs.length > 0) {
     process.stderr.write(`Unknown arguments: ${unknownArgs.join(", ")}\n`);
-    process.stderr.write("Usage: project-row-summary.mjs [--markdown]\n");
+    process.stderr.write("Usage: project-row-summary.mjs [--markdown] [--json]\n");
+    process.exit(2);
+  }
+  if (markdown && json) {
+    process.stderr.write("Choose only one stdout format: --markdown or --json\n");
     process.exit(2);
   }
 
   const surfaces = readSurfaceData();
   const coverage = computeCoverage(surfaces);
-  const output = markdown ? formatMarkdown(coverage) : formatPlainText(coverage);
+  const output = json
+    ? formatJson(coverage)
+    : (markdown ? formatMarkdown(coverage) : formatPlainText(coverage));
   process.stdout.write(`${output}\n`);
 
   // When running in GitHub Actions, also append the markdown table to the

--- a/scripts/bench/test-project-row-summary.mjs
+++ b/scripts/bench/test-project-row-summary.mjs
@@ -7,11 +7,13 @@ import {
   BENCH_RUNNER_EXCLUDED_ROWS,
   COMPILE_GUARD_EXCLUDED_ROWS,
   appendStepSummary,
+  buildJsonReport,
   computeCoverage,
   extractBenchRunnerRows,
   extractCompileGuardFallbackRows,
   extractCompileGuardRows,
   extractFixtureSourceRows,
+  formatJson,
   formatMarkdown,
   formatPlainText,
   rowRequiresFixtureSource,
@@ -270,6 +272,36 @@ function baseSurfaces() {
   const cleanSummary = `All ${PROJECT_ROW_DEFINITIONS.length} rows consistent`;
   assert.ok(text.includes("Project Row Coverage"), "plain text missing heading");
   assert.ok(text.includes(cleanSummary), "plain text missing clean summary");
+}
+
+// JSON format exposes machine-readable row coverage and drift counters.
+{
+  const coverage = computeCoverage(baseSurfaces());
+  const report = buildJsonReport(coverage);
+  assert.equal(report.ok, true);
+  assert.equal(report.status, "passed");
+  assert.equal(report.rowCount, PROJECT_ROW_DEFINITIONS.length);
+  assert.equal(report.driftCount, 0);
+  assert.deepEqual(report.drift, []);
+  assert.equal(report.rows[0].name, PROJECT_ROW_DEFINITIONS[0].name);
+
+  const parsed = JSON.parse(formatJson(coverage));
+  assert.equal(parsed.status, "passed");
+  assert.equal(parsed.rowCount, PROJECT_ROW_DEFINITIONS.length);
+}
+
+// JSON format carries drift details without parsing markdown.
+{
+  const surfaces = baseSurfaces();
+  surfaces.benchRunnerRows = surfaces.benchRunnerRows.filter((r) => r !== REQUIRED_PROJECT_ROWS[0]);
+  const report = buildJsonReport(computeCoverage(surfaces));
+  assert.equal(report.ok, false);
+  assert.equal(report.status, "failed");
+  assert.ok(report.driftCount > 0, "drift count should be nonzero");
+  assert.ok(
+    report.drift.some((issue) => issue.includes(REQUIRED_PROJECT_ROWS[0])),
+    "json drift should include the drifted row name",
+  );
 }
 
 // Step summary appends markdown regardless of the selected stdout format.


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Track 7 / benchmark and project-row evidence infrastructure.

## Invariant
When project-row coverage is used by CI, PR handoffs, or release evidence, row drift should be available as structured data; this PR adds a JSON stdout mode to `scripts/bench/project-row-summary.mjs` while preserving the existing text, markdown, exit-code, and GitHub step-summary behavior.

## Scope
- Add `--json` stdout mode to `scripts/bench/project-row-summary.mjs`.
- Add `buildJsonReport` / `formatJson` helpers with `ok`, `status`, row count, drift count, drift details, and row coverage.
- Reject simultaneous `--markdown --json` usage with the existing usage-error exit code.
- Extend focused project-row summary tests.

## Project Corpus Impact
- Row: all project rows, metadata/reporting only.
- Bug family: project-row evidence tooling.
- No compiler, benchmark execution, fixture, checker, solver, emitter, or project-corpus behavior change.

## Verification
- `node scripts/bench/test-project-row-summary.mjs`
- `node scripts/bench/project-row-summary.mjs --json`
- `node scripts/bench/project-row-summary.mjs --markdown`
- `node scripts/bench/project-row-summary.mjs --markdown --json; test $? -eq 2`
- `git diff --check`
- `wc -l scripts/bench/project-row-summary.mjs scripts/bench/test-project-row-summary.mjs`

## Coordination Notes
- AgentName: Studio-Opus
- Complements row-drift CI by making the same coverage result machine-readable for follow-up automation and PR evidence.
- Does not overlap active Studio-B checker work or Studio-C emit PRs.
- Opened as draft for CI/coordination; ready once light checks are clean.
