### PR TITLE
fix(emit): preallocate es5 for assignment temps

### DIFF
--- a/crates/tsz-emitter/src/emitter/es5/for_of_destructure_prealloc.rs
+++ b/crates/tsz-emitter/src/emitter/es5/for_of_destructure_prealloc.rs
@@ -1,29 +1,28 @@
-//! ES5 for-of assignment-target destructuring temp pre-pass.
+//! ES5 assignment-target destructuring temp pre-pass.
 //!
 //! Extracted from `bindings_for_of.rs` / `helpers.rs` so the `emit.rs` and
-//! `helpers.rs` monoliths stay under their §19 size ratchet. Behavior is
-//! unchanged: this module owns the temp pre-allocation that reserves the
-//! hoisted destructuring temps for assignment-target `for-of` loops before any
-//! for-of loop-control (index/array) temp.
+//! `helpers.rs` monoliths stay under their §19 size ratchet. This module owns
+//! temp pre-allocation that reserves hoisted assignment-destructuring temps in
+//! source order before non-hoisted ES5 temps in the same scope consume names.
 
 use super::super::Printer;
 use tsz_parser::parser::NodeIndex;
-use tsz_parser::parser::node::ForInOfData;
+use tsz_parser::parser::node::{ForInOfData, Node};
 use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
 
 impl<'a> Printer<'a> {
-    /// Pre-pass that allocates the hoisted destructuring-assignment temps for all
-    /// ES5 array-indexing assignment-target `for-of` statements in `statements`,
-    /// in source order, before any loop is emitted.
+    /// Pre-pass that allocates hoisted destructuring-assignment temps for ES5
+    /// statement scopes in source order, before any statement is emitted.
     ///
     /// tsc assigns auto-generated temp names at print time in source order: the
     /// hoisted `var _a, _b, ...;` declaration prints at the top of the scope, so
-    /// every assignment-target for-of destructuring temp claims a low number
-    /// before any for-of loop-control (index/array) temp. tsz allocates names
-    /// eagerly while emitting, so without this pre-pass the destructuring and
-    /// loop-control temps interleave. Running the real destructuring lowering for
-    /// each such for-of into a throwaway writer reserves those temps in the exact
-    /// order the later emit consumes them.
+    /// every hoisted assignment-destructuring temp claims a low number before
+    /// non-hoisted temps from block-scoped declarations or for-of loop-control.
+    /// tsz allocates names eagerly while emitting, so without this pre-pass those
+    /// temps can interleave. Running the real destructuring lowering for each
+    /// hoisted assignment target into a throwaway writer reserves temps in the
+    /// exact order the later emit consumes them.
     ///
     /// Runs at a scope boundary where `hoisted_assignment_temps` is empty (source
     /// file / function body). The dry-run lowering allocates names through the
@@ -69,6 +68,14 @@ impl<'a> Printer<'a> {
             return;
         }
 
+        if node.kind == syntax_kind_ext::FOR_STATEMENT {
+            if let Some(loop_data) = self.arena.get_loop(node) {
+                self.prealloc_for_initializer_assignment_destructure_temps(loop_data.initializer);
+                self.visit_for_of_assignment_temp_prealloc(loop_data.statement);
+            }
+            return;
+        }
+
         // Descend into nested statement containers, but stop at function/class
         // boundaries — those introduce their own temp scope and hoist pool.
         match node.kind {
@@ -97,8 +104,7 @@ impl<'a> Printer<'a> {
                     self.visit_for_of_assignment_temp_prealloc(catch_clause.block);
                 }
             }
-            k if k == syntax_kind_ext::FOR_STATEMENT
-                || k == syntax_kind_ext::FOR_IN_STATEMENT
+            k if k == syntax_kind_ext::FOR_IN_STATEMENT
                 || k == syntax_kind_ext::WHILE_STATEMENT
                 || k == syntax_kind_ext::DO_STATEMENT =>
             {
@@ -164,5 +170,89 @@ impl<'a> Printer<'a> {
         self.emit_for_of_assignment_target_destructuring_es5(init_node, "_");
 
         self.writer = real_writer;
+    }
+
+    /// Reserve hoisted assignment-destructuring temps created by an ordinary
+    /// `for` initializer expression. The block-scoped binding declaration in
+    /// `for (let [x] = value; ...)` uses inline temps in the header, not hoisted
+    /// assignment temps, so this only descends into declaration initializers and
+    /// expression initializers.
+    fn prealloc_for_initializer_assignment_destructure_temps(&mut self, initializer: NodeIndex) {
+        if initializer.is_none() {
+            return;
+        }
+        let Some(init_node) = self.arena.get(initializer) else {
+            return;
+        };
+
+        if init_node.kind == syntax_kind_ext::VARIABLE_DECLARATION_LIST {
+            if let Some(decl_list) = self.arena.get_variable(init_node) {
+                for &decl_idx in &decl_list.declarations.nodes {
+                    let Some(decl_node) = self.arena.get(decl_idx) else {
+                        continue;
+                    };
+                    let Some(decl) = self.arena.get_variable_declaration(decl_node) else {
+                        continue;
+                    };
+                    self.prealloc_expression_assignment_destructure_temps(decl.initializer);
+                }
+            }
+            return;
+        }
+
+        self.prealloc_expression_assignment_destructure_temps(initializer);
+    }
+
+    fn prealloc_expression_assignment_destructure_temps(&mut self, idx: NodeIndex) {
+        if idx.is_none() {
+            return;
+        }
+        let Some(node) = self.arena.get(idx) else {
+            return;
+        };
+
+        if node.kind == syntax_kind_ext::BINARY_EXPRESSION {
+            let Some(binary) = self.arena.get_binary_expr(node) else {
+                return;
+            };
+            if binary.operator_token == SyntaxKind::CommaToken as u16 {
+                self.prealloc_expression_assignment_destructure_temps(binary.left);
+                self.prealloc_expression_assignment_destructure_temps(binary.right);
+                return;
+            }
+
+            if binary.operator_token == SyntaxKind::EqualsToken as u16
+                && let Some(left_node) = self.arena.get(binary.left)
+                && Self::is_assignment_destructure_pattern(left_node)
+            {
+                self.prealloc_assignment_destructure_expression(left_node, binary.right);
+            }
+        }
+    }
+
+    const fn is_assignment_destructure_pattern(node: &Node) -> bool {
+        matches!(
+            node.kind,
+            k if k == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
+                || k == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                || k == syntax_kind_ext::ARRAY_BINDING_PATTERN
+                || k == syntax_kind_ext::OBJECT_BINDING_PATTERN
+        )
+    }
+
+    fn prealloc_assignment_destructure_expression(&mut self, left_node: &Node, right: NodeIndex) {
+        let scratch = crate::output::source_writer::SourceWriter::new();
+        let real_writer = std::mem::replace(&mut self.writer, scratch);
+        let saved_pending_source_pos = self.pending_source_pos.take();
+        let saved_pending_block_comment_space = self.pending_block_comment_space;
+        let saved_comment_emit_idx = self.comment_emit_idx;
+
+        self.pending_block_comment_space = false;
+        self.emit_assignment_destructuring_es5(left_node, right);
+
+        self.writer = real_writer;
+        self.pending_source_pos = saved_pending_source_pos;
+        self.pending_block_comment_space = saved_pending_block_comment_space;
+        self.comment_emit_idx = saved_comment_emit_idx;
     }
 }

--- a/crates/tsz-emitter/src/emitter/source_file/es5_for_assignment_destructure_temp_order_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/es5_for_assignment_destructure_temp_order_tests.rs
@@ -1,0 +1,60 @@
+//! ES5 ordinary `for` assignment-target destructuring temp-ordering tests.
+//!
+//! Structural rule: hoisted assignment-destructuring temps created by ordinary
+//! `for` initializer expressions claim their auto-temp names before inline temps
+//! from block-scoped `for` header declarations in the same function/file scope.
+
+use crate::context::emit::EmitContext;
+use crate::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use crate::lowering::LoweringPass;
+use tsz_common::ScriptTarget;
+use tsz_parser::ParserState;
+
+fn emit_es5(source: &str) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        target: ScriptTarget::ES5,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+#[test]
+fn assignment_for_temps_precede_block_scoped_header_temps() {
+    let source = "let a, b, c, i;\n\
+         let source = [1, [2, 3]];\n\
+         for ([a, [b, c] = [0, 0]] = source, i = 0; i < 1; i++) { }\n\
+         for (let [a = 0, [b = 1, c = 2] = [0, 0]] = source, i = 0; i < 1; i++) { }\n\
+         for ([a, [b, c] = [0, 0]] = getSource(), i = 0; i < 1; i++) { }\n";
+    let output = emit_es5(source);
+
+    assert!(
+        output.contains("var _a, _b, _c, _d, _e;"),
+        "Hoisted ordinary-for assignment temps should reserve the low names.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "for (a = source[0], _a = source[1], _b = _a === void 0 ? [0, 0] : _a, b = _b[0], c = _b[1], i = 0;"
+        ),
+        "First assignment loop should replay the first reserved temps.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "for (var _f = source[0], a_1 = _f === void 0 ? 0 : _f, _g = source[1], _h = _g === void 0 ? [0, 0] : _g, _j = _h[0], b_1 = _j === void 0 ? 1 : _j, _k = _h[1], c_1 = _k === void 0 ? 2 : _k, i_1 = 0;"
+        ),
+        "Block-scoped header temps should follow all hoisted assignment temps.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "for (_c = getSource(), a = _c[0], _d = _c[1], _e = _d === void 0 ? [0, 0] : _d, b = _e[0], c = _e[1], i = 0;"
+        ),
+        "Later assignment loop should replay the remaining reserved source temp.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/source_file/mod.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/mod.rs
@@ -60,6 +60,8 @@ mod es5_emit_recovery_tail_tests;
 #[cfg(test)]
 mod es5_emit_tests;
 #[cfg(test)]
+mod es5_for_assignment_destructure_temp_order_tests;
+#[cfg(test)]
 mod es5_for_of_destructure_temp_order_tests;
 #[cfg(test)]
 mod es5_super_recovery_tests;


### PR DESCRIPTION
AgentName: Studio-C

## Track
Emit parity, JS emit recovery

## Invariant
Match `tsc` ES5 temp-name ordering for hoisted assignment-destructuring temps. When an ordinary `for` initializer contains assignment-target destructuring and a later block-scoped `for` header in the same function scope needs inline temps, `tsc` reserves the hoisted assignment destructuring temps first; tsz does that through the ES5 output-layer preallocation pass, without semantic validation in emit.

## Scope
- Extend the existing ES5 assignment-target destructuring temp pre-pass so ordinary `for` initializer assignment destructuring reserves hoisted temps before statement emission.
- Keep real emission unchanged: the pre-pass dry-runs lowering into a scratch writer and preserves only temp allocation state.
- Add a focused regression for assignment destructuring loops surrounding a block-scoped destructuring `for` header.
- Rebased onto `origin/main` `4edf1e415de1563050ad1ae579263cbee72d72dd`; PR head `f76f7daa9d35c7304a5ad678b9f259be7412560b`.

## Project Corpus Impact
- Row: `sourceMapValidationDestructuringForArrayBindingPatternDefaultValues2(target=es5)`
- Bug family: JS emit ES5 destructuring temp ordering / source-map baseline text
- Evidence: `scripts/safe-run.sh scripts/emit/run.sh --js-only --filter=sourceMapValidationDestructuringForArrayBindingPatternDefaultValues2 --verbose --timeout=20000 --json-out=/tmp/studio-c-js-sourcemap-destr-main.json` passes 2/2 locally on the unstacked head.

## Verification
- `cargo fmt --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter assignment_for_temps_precede_block_scoped_header_temps`
- `scripts/safe-run.sh scripts/emit/run.sh --js-only --filter=sourceMapValidationDestructuringForArrayBindingPatternDefaultValues2 --verbose --timeout=20000 --json-out=/tmp/studio-c-js-sourcemap-destr-main.json`
- `git diff --check origin/main..HEAD`
- `scripts/safe-run.sh cargo clippy -p tsz-emitter --all-targets -- -D warnings`
- Line counts: `for_of_destructure_prealloc.rs` 258, `es5_for_assignment_destructure_temp_order_tests.rs` 60, `mod.rs` 69.

## Coordination Notes
- AgentName: Studio-C.
- #12415 has landed in `main`; this PR is now unstacked and targets `main` directly.
- Non-overlapping with #12415 (`privateNameFieldDestructuredBinding`) and #12408 (`privateFieldAssignabilityFromUnknown(target=es5)`).
- Ready exact-head CI should run on `f76f7daa9d35c7304a5ad678b9f259be7412560b` after this retarget/body update.
