### PR TITLE
feat(bench): surface 2x target readiness

### DIFF
--- a/crates/tsz-website/src/_data/benchmark_data.js
+++ b/crates/tsz-website/src/_data/benchmark_data.js
@@ -809,14 +809,16 @@ function readJsonIfExists(p) {
   }
 }
 
-function benchReadinessBanner(readiness) {
-  const messages = benchReadinessMessages(readiness);
+function benchReadinessBanner(readiness, winnerReport) {
+  const messages = benchReadinessMessages(readiness, winnerReport);
   if (messages.length === 0) return "";
   return `<p class="bench-readiness-warning">⚠️ ${escapeHtml(messages.join(" "))}</p>`;
 }
 
 let _benchReadinessStatus;
 let _benchmarkSourceKind = null;
+let _benchmarkArtifactPath = null;
+let _benchWinnerReport;
 
 function benchmarkArtifactFiles() {
   const artifactsDir = path.join(ROOT, "artifacts");
@@ -848,6 +850,18 @@ function loadBenchReadinessStatus() {
   return null;
 }
 
+function loadBenchWinnerReport() {
+  if (_benchWinnerReport !== undefined) return _benchWinnerReport;
+  if (!_benchmarkArtifactPath) {
+    _benchWinnerReport = null;
+    return _benchWinnerReport;
+  }
+
+  const winnerPath = _benchmarkArtifactPath.replace(/\.json$/, ".tsgo-winners.json");
+  _benchWinnerReport = readJsonIfExists(winnerPath) ?? null;
+  return _benchWinnerReport;
+}
+
 function sanitizeLegacyBenchmarkData(data) {
   if (data?.validation?.hyperfine_exit_codes_required === true) {
     return data;
@@ -867,6 +881,7 @@ function loadBenchmarks() {
     const data = readJsonIfExists(overrideArtifact);
     if (data?.results) {
       _benchmarkSourceKind = "override";
+      _benchmarkArtifactPath = overrideArtifact;
       return sanitizeLegacyBenchmarkData(data);
     }
   }
@@ -878,10 +893,12 @@ function loadBenchmarks() {
   ]);
   if (selectedArtifact) {
     _benchmarkSourceKind = selectedArtifact.file === snapshotPath ? "snapshot" : "artifact";
+    _benchmarkArtifactPath = selectedArtifact.file;
     return sanitizeLegacyBenchmarkData(selectedArtifact.data);
   }
 
   _benchmarkSourceKind = null;
+  _benchmarkArtifactPath = null;
   return null;
 }
 
@@ -1862,7 +1879,7 @@ export function getProjectCompatibilityDashboard() {
   };
 
   const readiness = loadBenchReadinessStatus();
-  const artifactBanner = benchReadinessBanner(readiness);
+  const artifactBanner = benchReadinessBanner(readiness, loadBenchWinnerReport());
 
   return `<section class="compat-dashboard">
   <h2>Compatibility</h2>

--- a/scripts/bench/bench-readiness-banner.mjs
+++ b/scripts/bench/bench-readiness-banner.mjs
@@ -1,42 +1,62 @@
-export function benchReadinessMessages(readiness) {
-  if (!readiness) return [];
-  if (readiness.artifact_absent) {
+export function benchReadinessMessages(readiness, winnerReport = null) {
+  if (readiness?.artifact_absent) {
     return [
       "No recent benchmark artifact - compatibility data shown from repository snapshot and may be stale.",
     ];
   }
 
   const messages = [];
-  const missing = Number(readiness.missing);
-  if (missing > 0) {
+  if (readiness) {
+    const missing = Number(readiness.missing);
+    if (missing > 0) {
+      messages.push(
+        `Benchmark artifact is missing ${missing} required row(s); shown data may be incomplete.`,
+      );
+    }
+
+    const duplicateRows = Array.isArray(readiness.duplicate_rows)
+      ? readiness.duplicate_rows
+      : [];
+    if (duplicateRows.length > 0) {
+      messages.push(
+        `Benchmark artifact has ${duplicateRows.length} duplicate required row(s); shown data may be unreliable.`,
+      );
+    }
+
+    if (readiness.source_freshness?.current === false) {
+      const warning = readiness.source_freshness.warning
+        ? `: ${readiness.source_freshness.warning}`
+        : "";
+      messages.push(
+        `Benchmark artifact source is stale${warning}; shown data is not current release truth.`,
+      );
+    }
+
+    const metadataWarnings = Number(readiness.metadata_warnings_total ?? 0);
+    if (readiness.metadata_clean === false || metadataWarnings > 0) {
+      const count = metadataWarnings > 0 ? `${metadataWarnings} ` : "";
+      messages.push(
+        `Benchmark artifact metadata has ${count}warning(s); shown data may not be comparable.`,
+      );
+    }
+  }
+
+  const target = winnerReport?.two_x_target;
+  const targetGaps = Number(target?.rows_below_target ?? 0);
+  if (targetGaps > 0) {
+    const eligibleRows = Number(target?.eligible_green_rows ?? 0);
+    const denominator = eligibleRows > 0 ? `/${eligibleRows}` : "";
     messages.push(
-      `Benchmark artifact is missing ${missing} required row(s); shown data may be incomplete.`,
+      `Benchmark companion report has ${targetGaps}${denominator} green row(s) below the 2x tsgo target; public speed claims are not launch-ready.`,
     );
   }
 
-  const duplicateRows = Array.isArray(readiness.duplicate_rows)
-    ? readiness.duplicate_rows
-    : [];
-  if (duplicateRows.length > 0) {
+  const missingAttribution = Array.isArray(target?.missing_attribution_rows)
+    ? target.missing_attribution_rows.length
+    : 0;
+  if (missingAttribution > 0) {
     messages.push(
-      `Benchmark artifact has ${duplicateRows.length} duplicate required row(s); shown data may be unreliable.`,
-    );
-  }
-
-  if (readiness.source_freshness?.current === false) {
-    const warning = readiness.source_freshness.warning
-      ? `: ${readiness.source_freshness.warning}`
-      : "";
-    messages.push(
-      `Benchmark artifact source is stale${warning}; shown data is not current release truth.`,
-    );
-  }
-
-  const metadataWarnings = Number(readiness.metadata_warnings_total ?? 0);
-  if (readiness.metadata_clean === false || metadataWarnings > 0) {
-    const count = metadataWarnings > 0 ? `${metadataWarnings} ` : "";
-    messages.push(
-      `Benchmark artifact metadata has ${count}warning(s); shown data may not be comparable.`,
+      `Benchmark companion report is missing attribution for ${missingAttribution} 2x target gap row(s).`,
     );
   }
 

--- a/scripts/bench/test-bench-readiness-banner.mjs
+++ b/scripts/bench/test-bench-readiness-banner.mjs
@@ -1,9 +1,26 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { benchReadinessMessages } from "./bench-readiness-banner.mjs";
 
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(SCRIPT_DIR, "..", "..");
+
 assert.deepEqual(benchReadinessMessages(null), []);
+
+assert.match(
+  benchReadinessMessages(null, {
+    two_x_target: {
+      eligible_green_rows: 2,
+      rows_below_target: 1,
+      missing_attribution_rows: [],
+    },
+  }).join(" "),
+  /1\/2 green row\(s\) below the 2x tsgo target/,
+);
 
 assert.match(
   benchReadinessMessages({ artifact_absent: true }).join(" "),
@@ -47,6 +64,52 @@ assert.doesNotMatch(
     source_freshness: { current: true },
   }).join(" "),
   /warning|stale|missing|duplicate/i,
+);
+
+assert.match(
+  benchReadinessMessages(
+    {
+      metadata_clean: true,
+      metadata_warnings_total: 0,
+      source_freshness: { current: true },
+    },
+    {
+      two_x_target: {
+        eligible_green_rows: 8,
+        rows_below_target: 3,
+        missing_attribution_rows: ["ts-toolbelt-project", "vite-vanilla-ts-app"],
+      },
+    },
+  ).join(" "),
+  /3\/8 green row\(s\) below the 2x tsgo target/,
+);
+
+assert.match(
+  benchReadinessMessages(
+    {},
+    {
+      two_x_target: {
+        rows_below_target: 1,
+        missing_attribution_rows: ["ts-toolbelt-project"],
+      },
+    },
+  ).join(" "),
+  /missing attribution for 1 2x target gap row\(s\)/,
+);
+
+const websiteBenchmarkData = fs.readFileSync(
+  path.join(ROOT, "crates", "tsz-website", "src", "_data", "benchmark_data.js"),
+  "utf8",
+);
+assert.match(
+  websiteBenchmarkData,
+  /benchReadinessBanner\(readiness, loadBenchWinnerReport\(\)\)/,
+  "website compatibility dashboard should pass the tsgo winner companion report into the readiness banner",
+);
+assert.match(
+  websiteBenchmarkData,
+  /replace\(\/\\\.json\$\/, "\.tsgo-winners\.json"\)/,
+  "website compatibility dashboard should load the selected artifact's tsgo winner companion report",
 );
 
 console.log("bench readiness banner tests passed");


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Track 7 / benchmark evidence infrastructure and release metric publication.

## Invariant
When a selected benchmark artifact has a `*.tsgo-winners.json` companion report, the public compatibility readiness banner should surface the canonical `two_x_target` release-gate status without inventing timing claims or re-running benchmarks.

## Scope
- Extend `scripts/bench/bench-readiness-banner.mjs` to accept an optional winner companion report.
- Add banner messages for green rows below the 2x tsgo target and missing attribution for target-gap rows.
- Wire `crates/tsz-website/src/_data/benchmark_data.js` to load the selected artifact's `.tsgo-winners.json` companion report and pass it into the compatibility dashboard banner.
- Extend focused banner tests and static website wiring assertions.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: benchmark/website reporting only; no compiler behavior, fixture metadata, benchmark execution, or row classification changes.

## Verification
- `node scripts/bench/test-bench-readiness-banner.mjs`
- `node scripts/bench/test-tsgo-winner-report.mjs`
- `node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs`
- `git diff --check`
- `wc -l scripts/bench/bench-readiness-banner.mjs scripts/bench/test-bench-readiness-banner.mjs crates/tsz-website/src/_data/benchmark_data.js`

## Coordination Notes
- Overlap checked against open PRs: #12411 and #12408 are Studio-C emit work; this PR only touches benchmark readiness/website reporting.
- `scripts/agents/ensure-agent-labels.sh --audit` found no open PR label issues, but did report unrelated open issue #12412 missing a canonical agent label.
- Ready for benchmark/website tooling review once CI is green.
